### PR TITLE
[5.3] Implement object casting

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -3620,6 +3620,18 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     }
 
     /**
+     * Prepare the object for serialization.
+     *
+     * @return array
+     */
+    public function __sleep()
+    {
+        $this->mergeAttributesFromClassCasts();
+
+        return array_keys(get_object_vars($this));
+    }
+
+    /**
      * When a model is being unserialized, check if it needs to be booted.
      *
      * @return void

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -155,6 +155,13 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     protected $casts = [];
 
     /**
+     * The attributes that have been cast to classes.
+     *
+     * @var array
+     */
+    protected $classCastCache = [];
+
+    /**
      * The relationships that should be touched on save.
      *
      * @var array
@@ -251,6 +258,16 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      * @var array
      */
     public static $manyMethods = ['belongsToMany', 'morphToMany', 'morphedByMany'];
+
+    /**
+     * All of the valid primitive cast types.
+     *
+     * @var array
+     */
+    protected static $primitiveCastTypes = [
+        'int', 'integer', 'real', 'float', 'double', 'string', 'bool', 'boolean',
+        'object', 'array', 'json', 'collection', 'date', 'datetime', 'timestamp',
+    ];
 
     /**
      * The name of the "created at" column.
@@ -1097,6 +1114,8 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public function delete()
     {
+        $this->mergeAttributesFromClassCasts();
+
         if (is_null($this->getKeyName())) {
             throw new Exception('No primary key defined on model.');
         }
@@ -1448,6 +1467,8 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public function save(array $options = [])
     {
+        $this->mergeAttributesFromClassCasts();
+
         $query = $this->newQueryWithoutScopes();
 
         // If the "saving" event returns false we'll bail out of the save and return
@@ -2461,7 +2482,8 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         // will not perform the cast on those attributes to avoid any confusion.
         foreach ($this->getCasts() as $key => $value) {
             if (! array_key_exists($key, $attributes) ||
-                in_array($key, $mutatedAttributes)) {
+                in_array($key, $mutatedAttributes) ||
+                $this->isClassCastable($key)) {
                 continue;
             }
 
@@ -2491,7 +2513,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     protected function getArrayableAttributes()
     {
-        return $this->getArrayableItems($this->attributes);
+        return $this->getArrayableItems($this->getAttributes());
     }
 
     /**
@@ -2587,7 +2609,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public function getAttribute($key)
     {
-        if (array_key_exists($key, $this->attributes) || $this->hasGetMutator($key)) {
+        if (array_key_exists($key, $this->attributes) || $this->hasGetMutator($key) || $this->isClassCastable($key)) {
             return $this->getAttributeValue($key);
         }
 
@@ -2659,8 +2681,8 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     protected function getAttributeFromArray($key)
     {
-        if (array_key_exists($key, $this->attributes)) {
-            return $this->attributes[$key];
+        if (array_key_exists($key, $attributes = $this->getAttributes())) {
+            return $attributes[$key];
         }
     }
 
@@ -2718,7 +2740,11 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     protected function mutateAttributeForArray($key, $value)
     {
-        $value = $this->mutateAttribute($key, $value);
+        if ($this->isClassCastable($key)) {
+            $value = $this->castToClass($key);
+        } else {
+            $value = $this->mutateAttribute($key, $value);
+        }
 
         return $value instanceof Arrayable ? $value->toArray() : $value;
     }
@@ -2778,6 +2804,37 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     }
 
     /**
+     * Determine whether a value is JSON castable for inbound manipulation.
+     *
+     * @param  string  $key
+     * @return bool
+     */
+    protected function isClassCastable($key)
+    {
+        if (! array_key_exists($key, $this->getCasts())) {
+            return false;
+        }
+
+        $class = $this->getCasts()[$key];
+
+        return class_exists($class) && ! in_array($class, static::$primitiveCastTypes);
+    }
+
+    /**
+     * Merge the cast class attributes back into the model.
+     *
+     * @return void
+     */
+    protected function mergeAttributesFromClassCasts()
+    {
+        foreach ($this->classCastCache as $key => $value) {
+            $this->attributes = array_merge(
+                $this->attributes, $value->toModelAttributes($this, $this->attributes)
+            );
+        }
+    }
+
+    /**
      * Get the type of cast for a model attribute.
      *
      * @param  string  $key
@@ -2797,11 +2854,13 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     protected function castAttribute($key, $value)
     {
-        if (is_null($value)) {
+        $castType = $this->getCastType($key);
+
+        if (is_null($value) && in_array($castType, static::$primitiveCastTypes)) {
             return $value;
         }
 
-        switch ($this->getCastType($key)) {
+        switch ($castType) {
             case 'int':
             case 'integer':
                 return (int) $value;
@@ -2826,8 +2885,29 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
                 return $this->asDateTime($value);
             case 'timestamp':
                 return $this->asTimeStamp($value);
-            default:
-                return $value;
+        }
+
+        if ($this->isClassCastable($key)) {
+            return $this->castToClass($key);
+        }
+
+        return $value;
+    }
+
+    /**
+     * Cast the given attribute to a class.
+     *
+     * @param  string  $key
+     * @return mixed
+     */
+    protected function castToClass($key)
+    {
+        if (isset($this->classCastCache[$key])) {
+            return $this->classCastCache[$key];
+        } else {
+            return $this->classCastCache[$key] = forward_static_call(
+                [$this->getCasts()[$key], 'fromModelAttributes'], $this, $this->attributes
+            );
         }
     }
 
@@ -2856,13 +2936,35 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
             $value = $this->fromDateTime($value);
         }
 
-        if ($this->isJsonCastable($key) && ! is_null($value)) {
-            $value = $this->asJson($value);
+        if ($this->isClassCastable($key)) {
+            $this->setClassCastableAttribute($key, $value);
+        } elseif ($this->isJsonCastable($key) && ! is_null($value)) {
+            $this->attributes[$key] = $this->asJson($value);
+        } else {
+            $this->attributes[$key] = $value;
         }
 
-        $this->attributes[$key] = $value;
-
         return $this;
+    }
+
+    /**
+     * Set the value of a class castable attribute.
+     *
+     * @param  string  $key
+     * @param  mixed  $value
+     * @return void
+     */
+    protected function setClassCastableAttribute($key, $value)
+    {
+        if (is_null($value)) {
+            $this->attributes = array_merge($this->attributes, array_map(
+                function () { return null; }, $this->castToClass($key)->toModelAttributes($this)
+            ));
+
+            unset($this->classCastCache[$key]);
+        } else {
+            $this->classCastCache[$key] = $value;
+        }
     }
 
     /**
@@ -3023,11 +3125,13 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public function replicate(array $except = null)
     {
-        $except = $except ?: [
+        $defaults = [
             $this->getKeyName(),
             $this->getCreatedAtColumn(),
             $this->getUpdatedAtColumn(),
         ];
+
+        $except = $except ? array_unique(array_merge($except, $defaults)) : $defaults;
 
         $attributes = Arr::except($this->attributes, $except);
 
@@ -3045,6 +3149,8 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public function getAttributes()
     {
+        $this->mergeAttributesFromClassCasts();
+
         return $this->attributes;
     }
 

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -844,6 +844,11 @@ class DatabaseEloquentIntegrationTest extends PHPUnit_Framework_TestCase
         $model->forceFill(['address' => null]);
         $this->assertNull($model->line_one);
         $this->assertNull($model->line_two);
+
+        $model->address = new EloquentTestAddressValueObject('Fresh Line 1', 'Fresh Line 2');
+        $model->address->lineOne = 'Mutated Line 1';
+        $model = unserialize(serialize($model));
+        $this->assertEquals('Mutated Line 1', $model->line_one);
     }
 
     /**

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -839,6 +839,11 @@ class DatabaseEloquentIntegrationTest extends PHPUnit_Framework_TestCase
         $model->address = null;
         $this->assertNull($model->line_one);
         $this->assertNull($model->line_two);
+
+        $model->address = new EloquentTestAddressValueObject('Fresh Line 1', 'Fresh Line 2');
+        $model->forceFill(['address' => null]);
+        $this->assertNull($model->line_one);
+        $this->assertNull($model->line_two);
     }
 
     /**

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -818,6 +818,29 @@ class DatabaseEloquentIntegrationTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(1, count($results));
     }
 
+    public function testAttributesMayBeCastToValueObjects()
+    {
+        $model = new EloquentTestValueObjectCast;
+        $model->line_one = 'Address Line 1';
+        $model->line_two = 'Address Line 2';
+
+        $this->assertInstanceOf('EloquentTestAddressValueObject', $model->address);
+        $this->assertEquals('Address Line 1', $model->address->lineOne);
+        $this->assertEquals('Address Line 2', $model->address->lineTwo);
+
+        $model->address->lineOne = 'Modified Line 1';
+        $this->assertEquals('Modified Line 1', $model->line_one);
+        $this->assertEquals('Modified Line 1', $model->toArray()['line_one']);
+
+        $model->address = new EloquentTestAddressValueObject('Fresh Line 1', 'Fresh Line 2');
+        $this->assertEquals('Fresh Line 1', $model->line_one);
+        $this->assertEquals('Fresh Line 2', $model->line_two);
+
+        $model->address = null;
+        $this->assertNull($model->line_one);
+        $this->assertNull($model->line_two);
+    }
+
     /**
      * Helpers...
      */
@@ -935,5 +958,35 @@ class EloquentTestUserWithStringCastId extends EloquentTestUser
 {
     protected $casts = [
         'id' => 'string',
+    ];
+}
+
+class EloquentTestAddressValueObject implements Illuminate\Contracts\Support\Arrayable {
+    public $lineOne, $lineTwo;
+    public function __construct($lineOne, $lineTwo)
+    {
+        $this->lineOne = $lineOne;
+        $this->lineTwo = $lineTwo;
+    }
+    public static function fromModelAttributes($model, $attributes)
+    {
+        return new static($attributes['line_one'], $attributes['line_two']);
+    }
+    public function toModelAttributes()
+    {
+        return [
+            'line_one' => $this->lineOne,
+            'line_two' => $this->lineTwo,
+        ];
+    }
+    public function toArray()
+    {
+        return $this->toModelAttributes();
+    }
+}
+
+class EloquentTestValueObjectCast extends Eloquent {
+    protected $casts = [
+        'address' => 'EloquentTestAddressValueObject',
     ];
 }


### PR DESCRIPTION
This PR implements the ability to cast Eloquent values to arbitrary value objects. You may also cast an "attribute" that doesn't actually exist in the database which will allow you to create aggregate value objects that consist of multiple actual fields. Modifying the value object will affect the base model's attributes as you access them, so the model will always "feel" updated.

Value objects MUST implement two methods:

``` php
class User extends Eloquent
{
    protected $casts = ['address' => Address::class];
}


class Address
{
    public $lineOne, $lineTwo;

    public function __construct($lineOne, $lineTwo)
    {
        $this->lineOne = $lineOne;
        $this->lineTwo = $lineTwo;
    }

    public static function fromModelAttributes($model, $attributes)
    {
        return new static($attributes['line_one'], $attributes['line_two']);
    }

    public function toModelAttributes()
    {
        return [
            'line_one' => $this->lineOne,
            'line_two' => $this->lineTwo,
        ];
    }
}
```

The `fromModelAttributes` will be called when Eloquent needs to create an instance of the value object. The model instance and raw attribute array will be passed to the method and you may construct the value object however you wish. You have total freedom here.

The `toModelAttributes` method will be called by Eloquent when it needs to persist the value object's state back into the model. In this method you should return an array that maps back onto the Eloquent object's actual attributes that are stored in the database.

Using the example value object above, the following is perfectly valid:

``` php
$user->address->lineOne = 'New Line 1';
$user->save();
```

Eloquent will sync the value object's state back into its attributes using the `toModelAttributes` automatically before saving.

If a value object is set to `null`, all of the attributes returned by `toModelAttributes` will be set to `null`:

``` php
$user->address = null;
$user->save();

$user->line_one; // null
$user->line_two; // null
```

When a value object cast object is resolved, the same instance will be returned each time you access it:

``` php
$user->address
$user->address // same instance
```
