### PR TITLE
[5.2] Fix FileStore expiration

### DIFF
--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -219,7 +219,7 @@ class FileStore implements Store
             return 9999999999;
         }
 
-        return $time;
+        return (int) $time;
     }
 
     /**


### PR DESCRIPTION
Specifying a float cache expiration breaks the FileStore cache, as the unserialize call in the getPayload method fails if the timestamp is greater than 10 characters. This PR prevents this by casting the expiration to int to ensure a 10 character timestamp
