### PR TITLE
[5.2] Add stream_options to config

### DIFF
--- a/src/Illuminate/Mail/TransportManager.php
+++ b/src/Illuminate/Mail/TransportManager.php
@@ -45,7 +45,7 @@ class TransportManager extends Manager
 
             $transport->setPassword($config['password']);
         }
-        
+
         if (isset($config['stream_options'])) {
             $transport->setStreamOptions($config['stream_options']);
         }

--- a/src/Illuminate/Mail/TransportManager.php
+++ b/src/Illuminate/Mail/TransportManager.php
@@ -45,6 +45,10 @@ class TransportManager extends Manager
 
             $transport->setPassword($config['password']);
         }
+        
+        if (isset($config['stream_options'])) {
+            $transport->setStreamOptions($config['stream_options']);
+        }
 
         return $transport;
     }


### PR DESCRIPTION
Swiftmailer has now been updated to include an option for setting the stream options. This is required in newer PHP versions for dealing with unsigned certificates.

This adds a configuration option `stream_options`.
