### PR TITLE
[5.2] Bad mapping from Controller's Destroy action to Ability / Policy action

### DIFF
--- a/src/Illuminate/Foundation/Auth/Access/AuthorizesResources.php
+++ b/src/Illuminate/Foundation/Auth/Access/AuthorizesResources.php
@@ -40,13 +40,13 @@ trait AuthorizesResources
     protected function resourceAbilityMap()
     {
         return [
-            'index'  => 'view',
-            'create' => 'create',
-            'store'  => 'create',
-            'show'   => 'view',
-            'edit'   => 'update',
-            'update' => 'update',
-            'delete' => 'delete',
+            'index'   => 'view',
+            'create'  => 'create',
+            'store'   => 'create',
+            'show'    => 'view',
+            'edit'    => 'update',
+            'update'  => 'update',
+            'destroy' => 'delete',
         ];
     }
 }

--- a/tests/Auth/AuthorizesResourcesTest.php
+++ b/tests/Auth/AuthorizesResourcesTest.php
@@ -51,7 +51,7 @@ class AuthorizesResourcesTest extends PHPUnit_Framework_TestCase
 
     public function testDeleteMethod()
     {
-        $controller = new AuthorizesResourcesController($this->request('delete'));
+        $controller = new AuthorizesResourcesController($this->request('destroy'));
 
         $this->assertHasMiddleware($controller, 'can:delete,user');
     }


### PR DESCRIPTION
Laravel's Resource Controller doesn't have delete action, when I generate Controller Resource with `php artisan make:controller --resource TestController`, so there is only destroy action.
