### PR TITLE
[5.1] Use write database connection when validating uniqueness

### DIFF
--- a/src/Illuminate/Validation/DatabasePresenceVerifier.php
+++ b/src/Illuminate/Validation/DatabasePresenceVerifier.php
@@ -104,7 +104,7 @@ class DatabasePresenceVerifier implements PresenceVerifierInterface
      */
     protected function table($table)
     {
-        return $this->db->connection($this->connection)->table($table);
+        return $this->db->connection($this->connection)->table($table)->useWritePdo();
     }
 
     /**

--- a/tests/Validation/ValidationDatabasePresenceVerifierTest.php
+++ b/tests/Validation/ValidationDatabasePresenceVerifierTest.php
@@ -15,6 +15,7 @@ class ValidationDatabasePresenceVerifierTest extends PHPUnit_Framework_TestCase
         $verifier->setConnection('connection');
         $db->shouldReceive('connection')->once()->with('connection')->andReturn($conn = m::mock('StdClass'));
         $conn->shouldReceive('table')->once()->with('table')->andReturn($builder = m::mock('StdClass'));
+        $builder->shouldReceive('useWritePdo')->once()->andReturn($builder);
         $builder->shouldReceive('where')->with('column', '=', 'value')->andReturn($builder);
         $extra = ['foo' => 'NULL', 'bar' => 'NOT_NULL', 'baz' => 'taylor', 'faz' => true];
         $builder->shouldReceive('whereNull')->with('foo');


### PR DESCRIPTION
It would be possible that when an application have a huge latency
between master and slave that a novice user would reattempt to recreate
an entry which is now only available on the master connection.

When he/she create the record again which require unique value such as email
it currently would only fetch from the slave database connection and
would return pass, however when the application try to save the actual
entry to the database it would fail due to unique (if we set it on the
database).

This solve the issue by always checking against master (write)
connection.

Signed-off-by: crynobone crynobone@gmail.com
