### PR TITLE
[5.2] Fix test method name

### DIFF
--- a/tests/Auth/AuthorizesResourcesTest.php
+++ b/tests/Auth/AuthorizesResourcesTest.php
@@ -49,7 +49,7 @@ class AuthorizesResourcesTest extends PHPUnit_Framework_TestCase
         $this->assertHasMiddleware($controller, 'can:update,user');
     }
 
-    public function testDeleteMethod()
+    public function testDestroyMethod()
     {
         $controller = new AuthorizesResourcesController($this->request('destroy'));
 


### PR DESCRIPTION
Fixes the method name, since [it now checks the `destroy` method](https://github.com/laravel/framework/pull/13716).
