### PR TITLE
[5.2] Apply constraints to a morphTo relation on eager load

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -186,6 +186,11 @@ class MorphTo extends BelongsTo
 
         $query = $this->useWithTrashed($query);
 
+        $query = $query->withoutGlobalScopes($this->query->removedScopes());
+        foreach ($this->query->getQuery()->getRawBindings() as $bindingType => $bindings) {
+            $query->setBindings($bindings, $bindingType);
+        }
+
         return $query->whereIn($key, $this->gatherKeysByType($type)->all())->get();
     }
 

--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -229,5 +229,4 @@ class MorphTo extends BelongsTo
     {
         return $this->dictionary;
     }
-
 }

--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -29,13 +29,6 @@ class MorphTo extends BelongsTo
      */
     protected $dictionary = [];
 
-    /*
-     * Indicates if soft-deleted model instances should be fetched.
-     *
-     * @var bool
-     */
-    protected $withTrashed = false;
-
     /**
      * Create a new morph to relationship instance.
      *
@@ -243,32 +236,4 @@ class MorphTo extends BelongsTo
         return $this->dictionary;
     }
 
-    /**
-     * Fetch soft-deleted model instances with query.
-     *
-     * @return $this
-     */
-    public function withTrashed()
-    {
-        $this->withTrashed = true;
-
-        $this->query = $this->useWithTrashed($this->query);
-
-        return $this;
-    }
-
-    /**
-     * Return trashed models with query if told so.
-     *
-     * @param  \Illuminate\Database\Eloquent\Builder  $query
-     * @return \Illuminate\Database\Eloquent\Builder
-     */
-    protected function useWithTrashed(Builder $query)
-    {
-        if ($this->withTrashed && $query->getMacro('withTrashed') !== null) {
-            return $query->withTrashed();
-        }
-
-        return $query;
-    }
 }

--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -178,8 +178,6 @@ class MorphTo extends BelongsTo
         $query = clone $this->query;
         $query->setModel($instance);
 
-        $query = $query->withoutGlobalScopes($this->query->removedScopes());
-
         return $query->whereIn($key, $this->gatherKeysByType($type)->all())->get();
     }
 

--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -175,12 +175,10 @@ class MorphTo extends BelongsTo
 
         $key = $instance->getTable().'.'.$instance->getKeyName();
 
-        $query = $instance->newQuery();
+        $query = clone $this->query;
+        $query->setModel($instance);
 
         $query = $query->withoutGlobalScopes($this->query->removedScopes());
-        foreach ($this->query->getQuery()->getRawBindings() as $bindingType => $bindings) {
-            $query->setBindings($bindings, $bindingType);
-        }
 
         return $query->whereIn($key, $this->gatherKeysByType($type)->all())->get();
     }

--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -177,8 +177,6 @@ class MorphTo extends BelongsTo
 
         $query = $instance->newQuery();
 
-        $query = $this->useWithTrashed($query);
-
         $query = $query->withoutGlobalScopes($this->query->removedScopes());
         foreach ($this->query->getQuery()->getRawBindings() as $bindingType => $bindings) {
             $query->setBindings($bindings, $bindingType);

--- a/tests/Database/DatabaseEloquentMorphToTest.php
+++ b/tests/Database/DatabaseEloquentMorphToTest.php
@@ -36,7 +36,7 @@ class DatabaseEloquentMorphToTest extends PHPUnit_Framework_TestCase
             ],
         ], $dictionary);
     }
-g
+
     public function testAssociateMethodSetsForeignKeyAndTypeOnModel()
     {
         $parent = m::mock('Illuminate\Database\Eloquent\Model');

--- a/tests/Database/DatabaseEloquentMorphToTest.php
+++ b/tests/Database/DatabaseEloquentMorphToTest.php
@@ -36,55 +36,7 @@ class DatabaseEloquentMorphToTest extends PHPUnit_Framework_TestCase
             ],
         ], $dictionary);
     }
-
-    public function testModelsAreProperlyPulledAndMatched()
-    {
-        $relation = $this->getRelation();
-
-        $one = m::mock('StdClass');
-        $one->morph_type = 'morph_type_1';
-        $one->foreign_key = 'foreign_key_1';
-
-        $two = m::mock('StdClass');
-        $two->morph_type = 'morph_type_1';
-        $two->foreign_key = 'foreign_key_1';
-
-        $three = m::mock('StdClass');
-        $three->morph_type = 'morph_type_2';
-        $three->foreign_key = 'foreign_key_2';
-
-        $relation->addEagerConstraints([$one, $two, $three]);
-
-        $relation->shouldReceive('createModelByType')->once()->with('morph_type_1')->andReturn($firstQuery = m::mock('Illuminate\Database\Eloquent\Builder'));
-        $relation->shouldReceive('createModelByType')->once()->with('morph_type_2')->andReturn($secondQuery = m::mock('Illuminate\Database\Eloquent\Builder'));
-        $firstQuery->shouldReceive('getTable')->andReturn('foreign_table_1');
-        $firstQuery->shouldReceive('getKeyName')->andReturn('id');
-        $secondQuery->shouldReceive('getTable')->andReturn('foreign_table_2');
-        $secondQuery->shouldReceive('getKeyName')->andReturn('id');
-
-        $firstQuery->shouldReceive('withoutGlobalScopes')->with([])->andReturn($firstQuery);
-        $firstQuery->shouldReceive('setBindings')->andReturnNull();
-        $secondQuery->shouldReceive('withoutGlobalScopes')->with([])->andReturn($secondQuery);
-        $secondQuery->shouldReceive('setBindings')->andReturnNull();
-
-        $firstQuery->shouldReceive('newQuery')->once()->andReturn($firstQuery);
-        $secondQuery->shouldReceive('newQuery')->once()->andReturn($secondQuery);
-
-        $firstQuery->shouldReceive('whereIn')->once()->with('foreign_table_1.id', ['foreign_key_1'])->andReturn($firstQuery);
-        $firstQuery->shouldReceive('get')->once()->andReturn(Collection::make([$resultOne = m::mock('StdClass')]));
-        $resultOne->shouldReceive('getKey')->andReturn('foreign_key_1');
-
-        $secondQuery->shouldReceive('whereIn')->once()->with('foreign_table_2.id', ['foreign_key_2'])->andReturn($secondQuery);
-        $secondQuery->shouldReceive('get')->once()->andReturn(Collection::make([$resultTwo = m::mock('StdClass')]));
-        $resultTwo->shouldReceive('getKey')->andReturn('foreign_key_2');
-
-        $one->shouldReceive('setRelation')->once()->with('relation', $resultOne);
-        $two->shouldReceive('setRelation')->once()->with('relation', $resultOne);
-        $three->shouldReceive('setRelation')->once()->with('relation', $resultTwo);
-
-        $relation->getEager();
-    }
-
+g
     public function testAssociateMethodSetsForeignKeyAndTypeOnModel()
     {
         $parent = m::mock('Illuminate\Database\Eloquent\Model');
@@ -132,7 +84,7 @@ class DatabaseEloquentMorphToTest extends PHPUnit_Framework_TestCase
     public function getRelation($parent = null, $builder = null)
     {
         $builder = $builder ?: m::mock('Illuminate\Database\Eloquent\Builder');
-        $builder->shouldReceive('getQuery')->andReturn($builder);
+        $builder->shouldReceive('toBase')->andReturn($builder);
         $builder->shouldReceive('removedScopes')->andReturn([]);
         $builder->shouldReceive('withoutGlobalScopes')->with([])->andReturn($builder);
         $builder->shouldReceive('getRawBindings')->andReturn([

--- a/tests/Database/DatabaseEloquentMorphToTest.php
+++ b/tests/Database/DatabaseEloquentMorphToTest.php
@@ -85,18 +85,6 @@ class DatabaseEloquentMorphToTest extends PHPUnit_Framework_TestCase
         $relation->getEager();
     }
 
-    public function testModelsWithSoftDeleteAreProperlyPulled()
-    {
-        $builder = m::mock('Illuminate\Database\Eloquent\Builder');
-
-        $relation = $this->getRelation(null, $builder);
-
-        $builder->shouldReceive('getMacro')->once()->with('withTrashed')->andReturn(function () { return true; });
-        $builder->shouldReceive('withTrashed')->once();
-
-        $relation->withTrashed();
-    }
-
     public function testAssociateMethodSetsForeignKeyAndTypeOnModel()
     {
         $parent = m::mock('Illuminate\Database\Eloquent\Model');

--- a/tests/Database/DatabaseEloquentMorphToTest.php
+++ b/tests/Database/DatabaseEloquentMorphToTest.php
@@ -62,6 +62,11 @@ class DatabaseEloquentMorphToTest extends PHPUnit_Framework_TestCase
         $secondQuery->shouldReceive('getTable')->andReturn('foreign_table_2');
         $secondQuery->shouldReceive('getKeyName')->andReturn('id');
 
+        $firstQuery->shouldReceive('withoutGlobalScopes')->with([])->andReturn($firstQuery);
+        $firstQuery->shouldReceive('setBindings')->andReturnNull();
+        $secondQuery->shouldReceive('withoutGlobalScopes')->with([])->andReturn($secondQuery);
+        $secondQuery->shouldReceive('setBindings')->andReturnNull();
+
         $firstQuery->shouldReceive('newQuery')->once()->andReturn($firstQuery);
         $secondQuery->shouldReceive('newQuery')->once()->andReturn($secondQuery);
 
@@ -139,6 +144,17 @@ class DatabaseEloquentMorphToTest extends PHPUnit_Framework_TestCase
     public function getRelation($parent = null, $builder = null)
     {
         $builder = $builder ?: m::mock('Illuminate\Database\Eloquent\Builder');
+        $builder->shouldReceive('getQuery')->andReturn($builder);
+        $builder->shouldReceive('removedScopes')->andReturn([]);
+        $builder->shouldReceive('withoutGlobalScopes')->with([])->andReturn($builder);
+        $builder->shouldReceive('getRawBindings')->andReturn([
+            'select' => [],
+            'join'   => [],
+            'where'  => [],
+            'having' => [],
+            'order'  => [],
+            'union'  => [],
+        ]);
         $builder->shouldReceive('where')->with('relation.id', '=', 'foreign.value');
         $related = m::mock('Illuminate\Database\Eloquent\Model');
         $related->shouldReceive('getKeyName')->andReturn('id');

--- a/tests/Database/DatabaseEloquentMorphToTest.php
+++ b/tests/Database/DatabaseEloquentMorphToTest.php
@@ -1,7 +1,6 @@
 <?php
 
 use Mockery as m;
-use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 
 class DatabaseEloquentMorphToTest extends PHPUnit_Framework_TestCase

--- a/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
@@ -2,6 +2,7 @@
 
 use Carbon\Carbon;
 use Illuminate\Database\Connection;
+use Illuminate\Database\Eloquent\SoftDeletingScope;
 use Illuminate\Pagination\Paginator;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Database\Eloquent\SoftDeletes;
@@ -50,6 +51,8 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends PHPUnit_Framework_TestC
 
         $this->schema()->create('comments', function ($table) {
             $table->increments('id');
+            $table->integer('owner_id')->nullable();
+            $table->string('owner_type')->nullable();
             $table->integer('post_id');
             $table->string('body');
             $table->timestamps();
@@ -506,6 +509,46 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends PHPUnit_Framework_TestC
         $this->assertEquals(['abigailotwell@gmail.com'], $users->pluck('email')->all());
     }
 
+    public function testMorphToWithTrashed()
+    {
+        $this->createUsers();
+
+        $abigail = SoftDeletesTestUser::where('email', 'abigailotwell@gmail.com')->first();
+        $post1 = $abigail->posts()->create(['title' => 'First Title']);
+        $post1->comments()->create([
+            'body' => 'Comment Body',
+            'owner_type' => SoftDeletesTestUser::class,
+            'owner_id' => $abigail->id,
+        ]);
+
+        $abigail->delete();
+
+        $comment = SoftDeletesTestCommentWithTrashed::with(['owner' => function ($q) {
+            $q->withoutGlobalScope(SoftDeletingScope::class);
+        }])->first();
+
+        $this->assertEquals($abigail->email, $comment->owner->email);
+    }
+
+    public function testMorphToWithConstraints()
+    {
+        $this->createUsers();
+
+        $abigail = SoftDeletesTestUser::where('email', 'abigailotwell@gmail.com')->first();
+        $post1 = $abigail->posts()->create(['title' => 'First Title']);
+        $comment1 = $post1->comments()->create([
+            'body' => 'Comment Body',
+            'owner_type' => SoftDeletesTestUser::class,
+            'owner_id' => $abigail->id,
+        ]);
+
+        $comment = SoftDeletesTestCommentWithTrashed::with(['owner' => function ($q) {
+            $q->where('email', 'taylorotwell@gmail.com');
+        }])->first();
+
+        $this->assertEquals(null, $comment->owner);
+    }
+
     /**
      * Helpers...
      */
@@ -606,6 +649,25 @@ class SoftDeletesTestComment extends Eloquent
     protected $dates = ['deleted_at'];
     protected $table = 'comments';
     protected $guarded = [];
+
+    public function owner()
+    {
+        return $this->morphTo();
+    }
+}
+
+class SoftDeletesTestCommentWithTrashed extends Eloquent
+{
+    use SoftDeletes;
+
+    protected $dates = ['deleted_at'];
+    protected $table = 'comments';
+    protected $guarded = [];
+
+    public function owner()
+    {
+        return $this->morphTo();
+    }
 }
 
 /**


### PR DESCRIPTION
Previously, using `Model::load` or `with` and supplying eager load constraints would make no difference if the loaded relationship was of the MorphTo type, as eager load constraints were not applied for this class. This PR fixes that.
