### PR TITLE
[5.1] Change redis ref keys to avoid breaking upgrades

### DIFF
--- a/src/Illuminate/Cache/RedisTaggedCache.php
+++ b/src/Illuminate/Cache/RedisTaggedCache.php
@@ -9,13 +9,13 @@ class RedisTaggedCache extends TaggedCache
      *
      * @var string
      */
-    const REFERENCE_KEY_FOREVER = 'forever';
+    const REFERENCE_KEY_FOREVER = 'forever_ref';
     /**
      * Standard reference key.
      *
      * @var string
      */
-    const REFERENCE_KEY_STANDARD = 'standard';
+    const REFERENCE_KEY_STANDARD = 'standard_ref';
 
     /**
      * Store an item in the cache.


### PR DESCRIPTION
To go up alongside https://github.com/laravel/framework/pull/12733 to prevent breaking upgrades as per discussion at https://github.com/laravel/framework/issues/13675
