### PR TITLE
[5.2] Remove unnecessary code

### DIFF
--- a/tests/Database/DatabaseEloquentMorphToTest.php
+++ b/tests/Database/DatabaseEloquentMorphToTest.php
@@ -83,17 +83,6 @@ class DatabaseEloquentMorphToTest extends PHPUnit_Framework_TestCase
     public function getRelation($parent = null, $builder = null)
     {
         $builder = $builder ?: m::mock('Illuminate\Database\Eloquent\Builder');
-        $builder->shouldReceive('toBase')->andReturn($builder);
-        $builder->shouldReceive('removedScopes')->andReturn([]);
-        $builder->shouldReceive('withoutGlobalScopes')->with([])->andReturn($builder);
-        $builder->shouldReceive('getRawBindings')->andReturn([
-            'select' => [],
-            'join'   => [],
-            'where'  => [],
-            'having' => [],
-            'order'  => [],
-            'union'  => [],
-        ]);
         $builder->shouldReceive('where')->with('relation.id', '=', 'foreign.value');
         $related = m::mock('Illuminate\Database\Eloquent\Model');
         $related->shouldReceive('getKeyName')->andReturn('id');

--- a/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
@@ -2,11 +2,11 @@
 
 use Carbon\Carbon;
 use Illuminate\Database\Connection;
-use Illuminate\Database\Eloquent\SoftDeletingScope;
 use Illuminate\Pagination\Paginator;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Capsule\Manager as DB;
+use Illuminate\Database\Eloquent\SoftDeletingScope;
 use Illuminate\Database\Eloquent\Model as Eloquent;
 
 class DatabaseEloquentSoftDeletesIntegrationTest extends PHPUnit_Framework_TestCase


### PR DESCRIPTION
This just removes some unneeded code from #13724, and fixes an alignment issue in use statements ¯_(ツ)_/¯
