### PR TITLE
[5.2] More logical way of defining key and column of pluck()

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1811,7 +1811,7 @@ class Builder
     public function pluck($column, $key = null)
     {
         if(is_array($column)) {
-            $column = $column[0];
+            $column = array_values($column)[0];
             $key = array_keys($column)[0];
         }
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1804,12 +1804,17 @@ class Builder
     /**
      * Get an array with the values of a given column.
      *
-     * @param  string  $column
+     * @param  string|array  $column
      * @param  string|null  $key
      * @return array
      */
     public function pluck($column, $key = null)
     {
+        if(is_array($column)) {
+            $column = $column[0];
+            $key = array_keys($column)[0];
+        }
+
         $results = $this->get(is_null($key) ? [$column] : [$column, $key]);
 
         // If the columns are qualified with a table or have an alias, we cannot use

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1810,7 +1810,7 @@ class Builder
      */
     public function pluck($column, $key = null)
     {
-        if(is_array($column)) {
+        if (is_array($column)) {
             $column = array_values($column)[0];
             $key = array_keys($column)[0];
         }

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -895,6 +895,14 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase
         });
         $results = $builder->from('users')->where('id', '=', 1)->pluck('foo', 'id');
         $this->assertEquals([1 => 'bar', 10 => 'baz'], $results);
+
+        $builder = $this->getBuilder();
+        $builder->getConnection()->shouldReceive('select')->once()->andReturn([['id' => 1, 'foo' => 'bar'], ['id' => 10, 'foo' => 'baz']]);
+        $builder->getProcessor()->shouldReceive('processSelect')->once()->with($builder, [['id' => 1, 'foo' => 'bar'], ['id' => 10, 'foo' => 'baz']])->andReturnUsing(function ($query, $results) {
+            return $results;
+        });
+        $results = $builder->from('users')->where('id', '=', 1)->pluck(['id' => 'foo']);
+        $this->assertEquals([1 => 'bar', 10 => 'baz'], $results);
     }
 
     public function testImplode()


### PR DESCRIPTION
When using $queryBuilder->pluck() the order of defining the key and column feels a bit unlogical, because you first define the column, and as second param the key: 

``` php
pluck('user_name', 'user_id')

// results in [user_id => user_name] array
```

I think it would be nicer if this order would be the same as the resulting array: 

``` php
pluck(['user_id' => 'user_name'])

// results in [user_id => user_name] array
```
