### PR TITLE
[5.2] Use a single collection chain to reduce code

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -196,13 +196,11 @@ class MorphTo extends BelongsTo
     {
         $eagers = BaseCollection::make($this->query->getEagerLoads());
 
-        $eagers = $eagers->filter(function ($constraint, $relation) {
+        return $eagers->filter(function ($constraint, $relation) {
             return Str::startsWith($relation, $this->relation.'.');
-        });
-
-        return $eagers->keys()->map(function ($key) {
-            return Str::replaceFirst($this->relation.'.', '', $key);
-        })->combine($eagers)->merge($instance->getEagerLoads())->all();
+        })->flatMap(function ($constraint, $relation) {
+            return [Str::replaceFirst($this->relation.'.', '', $relation) => $constraint];
+        })->merge($instance->getEagerLoads())->all();
     }
 
     /**


### PR DESCRIPTION
This PR modifies some code added in #13737 in order to do the same computation through one collection chain. As a bonus, I’m quite certain it’s also more efficient.
