### PR TITLE
[5.2] Add a method to map keys

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -194,15 +194,12 @@ class MorphTo extends BelongsTo
      */
     protected function getEagerLoadsForInstance(Model $instance)
     {
-        $eagers = BaseCollection::make($this->query->getEagerLoads());
-
-        $eagers = $eagers->filter(function ($constraint, $relation) {
-            return Str::startsWith($relation, $this->relation.'.');
-        });
-
-        return $eagers->keys()->map(function ($key) {
-            return Str::replaceFirst($this->relation.'.', '', $key);
-        })->combine($eagers)->merge($instance->getEagerLoads())->all();
+        return BaseCollection::make($this->query->getEagerLoads())
+            ->filter(function ($constraint, $relation) {
+                return Str::startsWith($relation, $this->relation.'.');
+            })->mapKeys(function ($key) {
+                return Str::replaceFirst($this->relation.'.', '', $key);
+            })->merge($instance->getEagerLoads())->all();
     }
 
     /**

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -506,6 +506,21 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
+     * Run a map over each of the keys.
+     *
+     * @param  callable  $callback
+     * @return static
+     */
+    public function mapKeys(callable $callback)
+    {
+        $keys = array_keys($this->items);
+
+        $keys = array_map($callback, $keys, $this->items);
+
+        return new static(array_combine($keys, $this->items));
+    }
+
+    /**
      * Map a collection and flatten the result by a single level.
      *
      * @param  callable  $callback

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -774,6 +774,13 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(['first' => 'first-rolyat', 'last' => 'last-llewto'], $data->all());
     }
 
+    public function testMapKeys()
+    {
+        $data = new Collection(['first' => 'taylor', 'last' => 'otwell']);
+        $data = $data->mapKeys(function ($key, $item) { return $key.'-'.strrev($item); });
+        $this->assertEquals(['first-rolyat' => 'taylor', 'last-llewto' => 'otwell'], $data->all());
+    }
+
     public function testFlatMap()
     {
         $data = new Collection([


### PR DESCRIPTION
This PR introduces `mapKeys` to the `Collection`, to allow you to modify keys rather than values. A prime use case for this is in https://github.com/laravel/framework/blob/5.2/src/Illuminate/Database/Eloquent/Relations/MorphTo.php#L197-L205 where that code could be replaced by

```
return BaseCollection::make($this->query->getEagerLoads())
    ->filter(function ($constraint, $relation) {
        return Str::startsWith($relation, $this->relation.'.');
    })->mapKeys(function ($key) {
        return Str::replaceFirst($this->relation.'.', '', $key);
    })->merge($instance->getEagerLoads())->all();
```

In this PR, I also decided to do just that, because why not. This also makes #13741 unnecessary.
