### PR TITLE
[5.2] Builder: Remove code duplication, Add code comments

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -722,6 +722,8 @@ class Builder
      */
     public function when($value, $callback)
     {
+        // The callback will be passed this Eloquent Builder instance
+        // as a parameter, and has to return it.
         $builder = $this;
 
         if ($value) {

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -355,33 +355,6 @@ class Builder
     }
 
     /**
-     * Chunk the results of the query.
-     *
-     * @param  int  $count
-     * @param  callable  $callback
-     * @return bool
-     */
-    public function chunk($count, callable $callback)
-    {
-        $results = $this->forPage($page = 1, $count)->get();
-
-        while (count($results) > 0) {
-            // On each chunk result set, we will pass them to the callback and then let the
-            // developer take care of everything within the callback, which allows us to
-            // keep the memory low for spinning through large result sets for working.
-            if (call_user_func($callback, $results) === false) {
-                return false;
-            }
-
-            $page++;
-
-            $results = $this->forPage($page, $count)->get();
-        }
-
-        return true;
-    }
-
-    /**
      * Chunk the results of a query by comparing numeric IDs.
      *
      * @param  int  $count

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -465,6 +465,8 @@ class Builder
      */
     public function when($value, $callback)
     {
+        // The callback will be passed this Query Builder instance
+        // as a parameter, and has to return it.
         $builder = $this;
 
         if ($value) {


### PR DESCRIPTION
- Remove duplicate code of `chunk()`. Added in https://github.com/laravel/framework/commit/11d3e9850dc6139850d5e81c71067ae2d7a894d9. Spotted by n7olkachev in https://github.com/laravel/framework/pull/13726#issuecomment-222077447. I can't think of any purpose for this duplication.
- Add code comments about `when()` callback (sorry no "-3" comments, I don't get how you manage to write them). See #12878 for the query builder, then #13726 for the eloquent builder. There is also the late #13091 :cry:
