### PR TITLE
[5.2] Shedule empty options were incorrectly parsed.

### DIFF
--- a/src/Illuminate/Console/Scheduling/Schedule.php
+++ b/src/Illuminate/Console/Scheduling/Schedule.php
@@ -78,9 +78,19 @@ class Schedule
      */
     protected function compileParameters(array $parameters)
     {
-        return collect($parameters)->map(function ($value, $key) {
-            return is_numeric($key) ? $value : $key.'='.(is_numeric($value) ? $value : ProcessUtils::escapeArgument($value));
-        })->implode(' ');
+        $compiled = [];
+        foreach ($parameters as $key => $value) {
+            if (! is_bool($value)){
+                $compiled[] = is_numeric($key) ? $value : $key.'='.(is_numeric($value) ? $value : ProcessUtils::escapeArgument($value));
+                continue;
+            }
+
+            if ($value) {
+                $compiled[] = $key;
+            }
+        }
+
+        return implode(' ', $compiled);
     }
 
     /**

--- a/src/Illuminate/Console/Scheduling/Schedule.php
+++ b/src/Illuminate/Console/Scheduling/Schedule.php
@@ -80,7 +80,7 @@ class Schedule
     {
         $compiled = [];
         foreach ($parameters as $key => $value) {
-            if (! is_bool($value)){
+            if (! is_bool($value)) {
                 $compiled[] = is_numeric($key) ? $value : $key.'='.(is_numeric($value) ? $value : ProcessUtils::escapeArgument($value));
                 continue;
             }

--- a/tests/Console/Scheduling/ScheduleTest.php
+++ b/tests/Console/Scheduling/ScheduleTest.php
@@ -26,7 +26,7 @@ class ScheduleTest extends PHPUnit_Framework_TestCase
         $command = $this->schedule->command('command', $options)->command;
 
         $command = preg_split('/\s+/', $command);
-        $command = array_slice($command,-3, 3);
+        $command = array_slice($command, -3, 3);
 
         $commandExpected = [
             '--empty-option',

--- a/tests/Console/Scheduling/ScheduleTest.php
+++ b/tests/Console/Scheduling/ScheduleTest.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Console\Scheduling\Schedule;
+
+class ScheduleTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var \Illuminate\Console\Scheduling\Schedule
+     */
+    private $schedule;
+
+    protected function setUp()
+    {
+        $this->schedule = new Schedule();
+    }
+
+    public function testParsesOptiong()
+    {
+        $options = [
+            '--empty-option'         => true,
+            '--empty-option-missing' => false,
+            '--integer'              => 123,
+            '--string'               => 'word',
+        ];
+
+        $command = $this->schedule->command('command', $options)->command;
+
+        $command = preg_split('/\s+/', $command);
+        array_splice($command, 0, 3);
+
+        $commandExpected = [
+            '--empty-option',
+            '--integer=123',
+            "--string='word'",
+        ];
+
+        $this->assertEquals($commandExpected, $command);
+    }
+}

--- a/tests/Console/Scheduling/ScheduleTest.php
+++ b/tests/Console/Scheduling/ScheduleTest.php
@@ -26,7 +26,7 @@ class ScheduleTest extends PHPUnit_Framework_TestCase
         $command = $this->schedule->command('command', $options)->command;
 
         $command = preg_split('/\s+/', $command);
-        array_splice($command, 0, 3);
+        $command = array_slice($command,-3, 3);
 
         $commandExpected = [
             '--empty-option',


### PR DESCRIPTION
Reference from [manual](https://laravel.com/docs/master/artisan#calling-commands-via-code):

> If you need to specify the value of an option that does not accept string values, such as the `--force` flag on the `migrate:refresh` command, you may pass a boolean `true` or `false`.

Though after doing something like this:

```
$schedule->command('users:pause', ['--mail' => true]);
```

I get an exception:

```
exception 'Symfony\Component\Console\Exception\RuntimeException' with message 'The "--mail" option does not accept a value.'
```
