### PR TITLE
[5.2] Fix #13632 by returning false on exception

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -3480,8 +3480,12 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
             return true;
         }
 
-        if (method_exists($this, $key) && $this->$key && isset($this->relations[$key])) {
-            return true;
+        try {
+            if (method_exists($this, $key) && $this->$key && isset($this->relations[$key])) {
+                return true;
+            }
+        } catch (Exception $e) {
+            return false;
         }
 
         return $this->hasGetMutator($key) && ! is_null($this->getAttributeValue($key));

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1312,6 +1312,12 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
         $model = new EloquentModelStub;
         $this->assertFalse(isset($model->nonexistent));
 
+        // Existing method names
+        $this->assertFalse(isset($model->saved));
+
+        $model->saved = 'some_value';
+        $this->assertTrue(isset($model->saved));
+
         $model->some_attribute = 'some_value';
         $this->assertTrue(isset($model->some_attribute));
 


### PR DESCRIPTION
Calling `isset($this->saved)` on a model, while saved is a name of an existing method inside the model class, throws an exception.

This PR will catch that exception and return false instead. It'd be better if there's a way to determine whether the method being called is a relationship method or not without actually calling it, but afaik there isn't.
