### PR TITLE
[5.2] Convert response into a JsonResponse if the request is asking for a json

### DIFF
--- a/src/Illuminate/Foundation/Http/Kernel.php
+++ b/src/Illuminate/Foundation/Http/Kernel.php
@@ -6,6 +6,7 @@ use Exception;
 use Throwable;
 use Illuminate\Routing\Router;
 use Illuminate\Routing\Pipeline;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Facade;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Contracts\Debug\ExceptionHandler;
@@ -105,6 +106,14 @@ class Kernel implements KernelContract
             $this->reportException($e = new FatalThrowableError($e));
 
             $response = $this->renderException($request, $e);
+        }
+
+        if($this->shouldMakeJsonResponse($request, $response))
+        {
+            $response = new JsonResponse(
+                $response->getContent(),
+                $response->getStatusCode()
+            );
         }
 
         $this->app['events']->fire('kernel.handled', [$request, $response]);
@@ -289,6 +298,18 @@ class Kernel implements KernelContract
     protected function renderException($request, Exception $e)
     {
         return $this->app[ExceptionHandler::class]->render($request, $e);
+    }
+
+    /**
+     * Returns true if the request is asking for a json response and the response is not a JsonResponse.
+     *
+     * @param \Illuminate\Http\Request $request
+     * @param \Symfony\Component\HttpFoundation\Response $response
+     * @return bool
+     */
+    protected function shouldMakeJsonResponse($request, $response)
+    {
+        return ($request->ajax() || $request->wantsJson()) && (!$response instanceof JsonResponse);
     }
 
     /**


### PR DESCRIPTION
Example:
A FormRequest’s `forbiddenResponse` method always returns a `Response`. Shouldn’t the application return a JsonResponse if the request is asking for JSON? I can override that method in my requests, or I can catch the `HttpResponseException` in my apps exception handler class, but it seems like I shouldn’t have to do that if the request asks for JSON.
