### PR TITLE
[5.2] Fixed the remaining attempts calculation

### DIFF
--- a/src/Illuminate/Routing/Middleware/ThrottleRequests.php
+++ b/src/Illuminate/Routing/Middleware/ThrottleRequests.php
@@ -75,10 +75,12 @@ class ThrottleRequests
     {
         $response = new Response('Too Many Attempts.', 429);
 
+        $retryAfter = $this->limiter->availableIn($key);
+
         return $this->addHeaders(
             $response, $maxAttempts,
-            $this->calculateRemainingAttempts($key, $maxAttempts),
-            $this->limiter->availableIn($key)
+            $this->calculateRemainingAttempts($key, $maxAttempts, $retryAfter),
+            $retryAfter
         );
     }
 
@@ -112,10 +114,15 @@ class ThrottleRequests
      *
      * @param  string  $key
      * @param  int  $maxAttempts
+     * @param  int|null  $retryAfter
      * @return int
      */
-    protected function calculateRemainingAttempts($key, $maxAttempts)
+    protected function calculateRemainingAttempts($key, $maxAttempts, $retryAfter = null)
     {
-        return $maxAttempts - $this->limiter->attempts($key) + 1;
+        if ($retryAfter) {
+            return 0;
+        }
+
+        return $this->limiter->retriesLeft($key, $maxAttempts);
     }
 }


### PR DESCRIPTION
I'm not sure why we're not already using the `retriesLeft` method on the rate limiter object and were duplicating that code. I've changed the middleware to call that method.

I've also forced it to say `0` attempts remaining if we've bust the rate limit, instead of giving 101, if the limit was 100, for example.
