### PR TITLE
[5.2] Update http_build_query

### DIFF
--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -132,7 +132,7 @@ abstract class AbstractPaginator implements Htmlable
 
         return $this->path
                         .(Str::contains($this->path, '?') ? '&' : '?')
-                        .http_build_query($parameters, null, '&')
+                        .http_build_query($parameters, '', '&')
                         .$this->buildFragment();
     }
 


### PR DESCRIPTION
Fix error in strict mode on hhvm.

The error: "TypeError: Argument 2 passed to http_build_query() must be an instance of string, null given"
