### PR TITLE
Add dmp() function for only dumping arguments, without ending the script

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -498,6 +498,21 @@ if (! function_exists('data_set')) {
     }
 }
 
+if (! function_exists('dmp')) {
+    /**
+     * Dump the passed variables
+     *
+     * @param  mixed
+     * @return void
+     */
+    function dmp()
+    {
+        array_map(function ($x) {
+            (new Dumper)->dump($x);
+        }, func_get_args());
+    }
+}
+
 if (! function_exists('dd')) {
     /**
      * Dump the passed variables and end the script.
@@ -507,10 +522,7 @@ if (! function_exists('dd')) {
      */
     function dd()
     {
-        array_map(function ($x) {
-            (new Dumper)->dump($x);
-        }, func_get_args());
-
+        call_user_func_array('dmp', func_get_args());
         die(1);
     }
 }


### PR DESCRIPTION
This is my first PR so tell me if I did something wrong.

I almost always recreate this function for every new Laravel project and I thought it may be a part of Laravel core.
