### PR TITLE
[5.2] Add failed login attempt event

### DIFF
--- a/src/Illuminate/Auth/Events/Failed.php
+++ b/src/Illuminate/Auth/Events/Failed.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Illuminate\Auth\Events;
+
+class Failed
+{
+    /**
+     * The credentials for the user.
+     *
+     * @var array
+     */
+    public $credentials;
+
+    /**
+     * Indicates if the user should be "remembered".
+     *
+     * @var bool
+     */
+    public $remember;
+
+    /**
+     * The authenticated user.
+     *
+     * @var \Illuminate\Contracts\Auth\Authenticatable|null
+     */
+    public $user;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  array  $credentials
+     * @param  bool  $remember
+     * @param  \Illuminate\Contracts\Auth\Authenticatable|null  $user
+     */
+    public function __construct($credentials, $remember, $user = null)
+    {
+        $this->credentials = $credentials;
+        $this->remember = $remember;
+        $this->user = $user;
+    }
+}

--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -363,6 +363,10 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
             return true;
         }
 
+        if ($login) {
+            $this->fireFailedEvent($credentials, $remember, $user);
+        }
+
         return false;
     }
 
@@ -391,6 +395,24 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
         if (isset($this->events)) {
             $this->events->fire(new Events\Attempting(
                 $credentials, $remember, $login
+            ));
+        }
+    }
+
+    /**
+     * Fire the failed login attempt event with the arguments.
+     *
+     * @param  array  $credentials
+     * @param  bool  $remember
+     * @param  bool  $login
+     * @param  \Illuminate\Contracts\Auth\Authenticatable|null  $user
+     * @return void
+     */
+    protected function fireFailedEvent(array $credentials, $remember, $user = null)
+    {
+        if (isset($this->events)) {
+            $this->events->fire(new Events\Failed(
+                $credentials, $remember, $user
             ));
         }
     }

--- a/tests/Auth/AuthGuardTest.php
+++ b/tests/Auth/AuthGuardTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Mockery as m;
-use Symfony\Component\HttpFoundation\Request;
+use Illuminate\Auth\Events\Failed;
 use Illuminate\Auth\Events\Attempting;
+use Symfony\Component\HttpFoundation\Request;
 
 class AuthGuardTest extends PHPUnit_Framework_TestCase
 {
@@ -66,6 +67,7 @@ class AuthGuardTest extends PHPUnit_Framework_TestCase
         $guard = $this->getGuard();
         $guard->setDispatcher($events = m::mock('Illuminate\Contracts\Events\Dispatcher'));
         $events->shouldReceive('fire')->once()->with(m::type(Attempting::class));
+        $events->shouldReceive('fire')->once()->with(m::type(Failed::class));
         $guard->getProvider()->shouldReceive('retrieveByCredentials')->once()->with(['foo']);
         $guard->attempt(['foo']);
     }
@@ -88,6 +90,7 @@ class AuthGuardTest extends PHPUnit_Framework_TestCase
         $mock = $this->getGuard();
         $mock->setDispatcher($events = m::mock('Illuminate\Contracts\Events\Dispatcher'));
         $events->shouldReceive('fire')->once()->with(m::type(Attempting::class));
+        $events->shouldReceive('fire')->once()->with(m::type(Failed::class));
         $mock->getProvider()->shouldReceive('retrieveByCredentials')->once()->andReturn(null);
         $this->assertFalse($mock->attempt(['foo']));
     }
@@ -116,6 +119,16 @@ class AuthGuardTest extends PHPUnit_Framework_TestCase
         $mock->getSession()->shouldReceive('set')->with('foo', 'bar')->once();
         $session->shouldReceive('migrate')->once();
         $mock->login($user);
+    }
+
+    public function testFailedAttemptFiresFailedEvent()
+    {
+        $guard = $this->getGuard();
+        $guard->setDispatcher($events = m::mock('Illuminate\Contracts\Events\Dispatcher'));
+        $events->shouldReceive('fire')->once()->with(m::type(Attempting::class));
+        $events->shouldReceive('fire')->once()->with(m::type(Failed::class));
+        $guard->getProvider()->shouldReceive('retrieveByCredentials')->once()->with(['foo'])->andReturn(null);
+        $guard->attempt(['foo']);
     }
 
     public function testAuthenticateReturnsUserWhenUserIsNotNull()


### PR DESCRIPTION
Laravel includes an attempt event which does not include information about whether the login succeeded or not.

and there is a login event that is trigger only if the login succeeded.

With this PR I'm adding an event that will trigger if the login attempt failed, this way a user can be informed that someone is trying to access their account, or the information could be log in an auth_activity table, etc. 
