### PR TITLE
[5.3] Move the Authorize middleware into Auth

### DIFF
--- a/src/Illuminate/Auth/Middleware/Authorize.php
+++ b/src/Illuminate/Auth/Middleware/Authorize.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Illuminate\Foundation\Http\Middleware;
+namespace Illuminate\Auth\Middleware;
 
 use Closure;
 use Illuminate\Contracts\Auth\Access\Gate;
-use Illuminate\Contracts\Auth\Factory as AuthFactory;
+use Illuminate\Contracts\Auth\Factory as Auth;
 
 class Authorize
 {
@@ -29,7 +29,7 @@ class Authorize
      * @param  \Illuminate\Contracts\Auth\Access\Gate  $gate
      * @return void
      */
-    public function __construct(AuthFactory $auth, Gate $gate)
+    public function __construct(Auth $auth, Gate $gate)
     {
         $this->auth = $auth;
         $this->gate = $gate;

--- a/tests/Auth/AuthorizeMiddlewareTest.php
+++ b/tests/Auth/AuthorizeMiddlewareTest.php
@@ -6,14 +6,14 @@ use Illuminate\Routing\Router;
 use Illuminate\Auth\Access\Gate;
 use Illuminate\Events\Dispatcher;
 use Illuminate\Container\Container;
+use Illuminate\Auth\Middleware\Authorize;
 use Illuminate\Contracts\Routing\Registrar;
 use Illuminate\Contracts\Auth\Factory as Auth;
 use Illuminate\Auth\Access\AuthorizationException;
-use Illuminate\Foundation\Http\Middleware\Authorize;
 use Illuminate\Routing\Middleware\SubstituteBindings;
 use Illuminate\Contracts\Auth\Access\Gate as GateContract;
 
-class FoundationAuthorizeMiddlewareTest extends PHPUnit_Framework_TestCase
+class AuthorizeMiddlewareTest extends PHPUnit_Framework_TestCase
 {
     protected $container;
     protected $user;


### PR DESCRIPTION
...so that it's next to the `Authenticate` and `AuthenticateWithBasicAuth` middleware.

Technically we should probably nest it under `Access`, but that would mean creating another `Middleware` directory. I don't think it's that bad to have it here; in fact, it makes sense here since it also handles authentication.
