### PR TITLE
[5.1] Auth::id() don't get $id from Recaller

### DIFF
--- a/src/Illuminate/Auth/Guard.php
+++ b/src/Illuminate/Auth/Guard.php
@@ -180,7 +180,7 @@ class Guard implements GuardContract
             return;
         }
 
-        $id = $this->session->get($this->getName(), $this->getRecallerId());
+        $id = $this->session->get($this->getName());
 
         if (is_null($id) && $this->user()) {
             $id = $this->user()->getAuthIdentifier();


### PR DESCRIPTION
The `id` function note: Get the ID for the currently **authenticated** user.

if get id from `remember` cookie, the cookie may invalid.(If a user sign out in other browsers)
