### PR TITLE
[5.2] Use keyBy instead of flatMap

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -194,12 +194,12 @@ class MorphTo extends BelongsTo
      */
     protected function getEagerLoadsForInstance(Model $instance)
     {
-        $eagers = BaseCollection::make($this->query->getEagerLoads());
+        $relations = BaseCollection::make($this->query->getEagerLoads());
 
-        return $eagers->filter(function ($constraint, $relation) {
+        return $relations->filter(function ($constraint, $relation) {
             return Str::startsWith($relation, $this->relation.'.');
-        })->flatMap(function ($constraint, $relation) {
-            return [Str::replaceFirst($this->relation.'.', '', $relation) => $constraint];
+        })->keyBy(function ($constraint, $relation) {
+            return Str::replaceFirst($this->relation.'.', '', $relation);
         })->merge($instance->getEagerLoads())->all();
     }
 


### PR DESCRIPTION
One less operation.

This is similar to [this](https://github.com/laravel/framework/pull/13743), but without adding a new collection method.
