### PR TITLE
[5.2] test case for morphTo relations

### DIFF
--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -35,6 +35,18 @@ class DatabaseEloquentIntegrationTest extends PHPUnit_Framework_TestCase
 
     protected function createSchema()
     {
+            $this->schema('default')->create('test_orders', function ($table) {
+                $table->increments('id');
+                $table->string('item_type');
+                $table->integer('item_id');
+                $table->timestamps();
+            });
+
+            $this->schema('second_connection')->create('test_items', function ($table) {
+                $table->increments('id');
+                $table->timestamps();
+            });
+
         foreach (['default', 'second_connection'] as $connection) {
             $this->schema($connection)->create('users', function ($table) {
                 $table->increments('id');
@@ -811,6 +823,24 @@ class DatabaseEloquentIntegrationTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+    *
+    */
+    public function testMorphToRelationsAcrossDatabaseConnections()
+    {
+        $item = null;
+
+        EloquentTestItem::create(['id'=>1]);
+        EloquentTestOrder::create(['id'=>1, 'item_type'=>EloquentTestItem::class, 'item_id'=>1]);
+        try{
+            $item = EloquentTestOrder::first()->item;
+        } catch (Exception $e) {
+            // ignore the exception
+        }
+
+        $this->assertInstanceOf('EloquentTestItem', $item);
+    }
+
+    /**
      * Helpers...
      */
 
@@ -928,4 +958,23 @@ class EloquentTestUserWithStringCastId extends EloquentTestUser
     protected $casts = [
         'id' => 'string',
     ];
+}
+
+class EloquentTestOrder extends Eloquent
+{
+    protected $guarded = [];
+    protected $table = 'test_orders';
+    protected $with = ['item'];
+
+    public function item()
+    {
+        return $this->morphTo();
+    }
+}
+
+class EloquentTestItem extends Eloquent
+{
+    protected $guarded = [];
+    protected $table = 'test_items';
+    protected $connection = 'second_connection';
 }

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -822,15 +822,12 @@ class DatabaseEloquentIntegrationTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(1, count($results));
     }
 
-    /**
-    *
-    */
     public function testMorphToRelationsAcrossDatabaseConnections()
     {
         $item = null;
 
-        EloquentTestItem::create(['id'=>1]);
-        EloquentTestOrder::create(['id'=>1, 'item_type'=>EloquentTestItem::class, 'item_id'=>1]);
+        EloquentTestItem::create(['id' => 1]);
+        EloquentTestOrder::create(['id' => 1, 'item_type' => EloquentTestItem::class, 'item_id' => 1]);
         try{
             $item = EloquentTestOrder::first()->item;
         } catch (Exception $e) {

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -828,7 +828,7 @@ class DatabaseEloquentIntegrationTest extends PHPUnit_Framework_TestCase
 
         EloquentTestItem::create(['id' => 1]);
         EloquentTestOrder::create(['id' => 1, 'item_type' => EloquentTestItem::class, 'item_id' => 1]);
-        try{
+        try {
             $item = EloquentTestOrder::first()->item;
         } catch (Exception $e) {
             // ignore the exception

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -35,17 +35,17 @@ class DatabaseEloquentIntegrationTest extends PHPUnit_Framework_TestCase
 
     protected function createSchema()
     {
-            $this->schema('default')->create('test_orders', function ($table) {
-                $table->increments('id');
-                $table->string('item_type');
-                $table->integer('item_id');
-                $table->timestamps();
-            });
+        $this->schema('default')->create('test_orders', function ($table) {
+            $table->increments('id');
+            $table->string('item_type');
+            $table->integer('item_id');
+            $table->timestamps();
+        });
 
-            $this->schema('second_connection')->create('test_items', function ($table) {
-                $table->increments('id');
-                $table->timestamps();
-            });
+        $this->schema('second_connection')->create('test_items', function ($table) {
+            $table->increments('id');
+            $table->timestamps();
+        });
 
         foreach (['default', 'second_connection'] as $connection) {
             $this->schema($connection)->create('users', function ($table) {


### PR DESCRIPTION
added failing test for morphTo relations across database connections.

@phroggyy is working on a fix for an issue introduced in 5.2.34
