### PR TITLE
[5.2] fix morphTo relatons across database connections

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -183,6 +183,8 @@ class MorphTo extends BelongsTo
 
         $query->setModel($instance);
 
+        $query->useConnection($instance->getConnection());
+
         return $query->whereIn($key, $this->gatherKeysByType($type)->all())->get();
     }
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2322,6 +2322,23 @@ class Builder
     }
 
     /**
+     * Use a different connection for the query.
+     *
+     * @param  \Illuminate\Database\ConnectionInterface  $connection
+     * @param  \Illuminate\Database\Query\Grammars\Grammar  $grammar
+     * @param  \Illuminate\Database\Query\Processors\Processor  $processor
+     * @return void
+     */
+    public function useConnection(ConnectionInterface $connection,
+                                  Grammar $grammar = null,
+                                  Processor $processor = null)
+    {
+        $this->connection = $connection;
+        $this->grammar = $grammar ?: $connection->getQueryGrammar();
+        $this->processor = $processor ?: $connection->getPostProcessor();
+    }
+
+    /**
      * Handle dynamic method calls into the method.
      *
      * @param  string  $method

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -35,6 +35,18 @@ class DatabaseEloquentIntegrationTest extends PHPUnit_Framework_TestCase
 
     protected function createSchema()
     {
+        $this->schema('default')->create('test_orders', function ($table) {
+            $table->increments('id');
+            $table->string('item_type');
+            $table->integer('item_id');
+            $table->timestamps();
+        });
+
+        $this->schema('second_connection')->create('test_items', function ($table) {
+            $table->increments('id');
+            $table->timestamps();
+        });
+
         foreach (['default', 'second_connection'] as $connection) {
             $this->schema($connection)->create('users', function ($table) {
                 $table->increments('id');
@@ -810,6 +822,21 @@ class DatabaseEloquentIntegrationTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(1, count($results));
     }
 
+    public function testMorphToRelationsAcrossDatabaseConnections()
+    {
+        $item = null;
+
+        EloquentTestItem::create(['id' => 1]);
+        EloquentTestOrder::create(['id' => 1, 'item_type' => EloquentTestItem::class, 'item_id' => 1]);
+        try {
+            $item = EloquentTestOrder::first()->item;
+        } catch (Exception $e) {
+            // ignore the exception
+        }
+
+        $this->assertInstanceOf('EloquentTestItem', $item);
+    }
+
     /**
      * Helpers...
      */
@@ -928,4 +955,23 @@ class EloquentTestUserWithStringCastId extends EloquentTestUser
     protected $casts = [
         'id' => 'string',
     ];
+}
+
+class EloquentTestOrder extends Eloquent
+{
+    protected $guarded = [];
+    protected $table = 'test_orders';
+    protected $with = ['item'];
+
+    public function item()
+    {
+        return $this->morphTo();
+    }
+}
+
+class EloquentTestItem extends Eloquent
+{
+    protected $guarded = [];
+    protected $table = 'test_items';
+    protected $connection = 'second_connection';
 }


### PR DESCRIPTION
I went ahead and fixed https://github.com/laravel/framework/pull/13783

This PR already contains tests from https://github.com/laravel/framework/pull/13783. I only added the fix and squashed the commits.
