### PR TITLE
[5.1] make() creates a new collection

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -36,7 +36,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
-     * Create a new collection instance if the value isn't one already.
+     * Create a new collection.
      *
      * @param  mixed  $items
      * @return static


### PR DESCRIPTION
`Collection::make()` has been identical to `Collection::__construct()` for a while. I guess it can be deprecated in 5.3.
