### PR TITLE
[5.2] Allow passing along options to the S3 client

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemManager.php
+++ b/src/Illuminate/Filesystem/FilesystemManager.php
@@ -188,7 +188,7 @@ class FilesystemManager implements FactoryContract
         $root = isset($s3Config['root']) ? $s3Config['root'] : null;
 
         return $this->adapt($this->createFlysystem(
-            new S3Adapter(new S3Client($s3Config), $s3Config['bucket'], $root, $config['options'] ?: []), $config
+            new S3Adapter(new S3Client($s3Config), $s3Config['bucket'], $root, isset($config['options']) ? $config['options'] : []), $config
         ));
     }
 

--- a/src/Illuminate/Filesystem/FilesystemManager.php
+++ b/src/Illuminate/Filesystem/FilesystemManager.php
@@ -188,7 +188,7 @@ class FilesystemManager implements FactoryContract
         $root = isset($s3Config['root']) ? $s3Config['root'] : null;
 
         return $this->adapt($this->createFlysystem(
-            new S3Adapter(new S3Client($s3Config), $s3Config['bucket'], $root), $config
+            new S3Adapter(new S3Client($s3Config), $s3Config['bucket'], $root, $config['options'] ?: []), $config
         ));
     }
 


### PR DESCRIPTION
I found it impossible (un-necessarily clunky) to add cache headers or similar to S3 objects. This allows you to.

A new key in filesystems.php and you're good to go. Example:

```
 's3' => [
            'driver' => 's3',
            'key'    => env('S3_KEY'),
            'secret' => env('S3_SECRET'),
            'region' => 'eu-central-1',
            'bucket' => 'my-demo-bucket',
            'options' => [
                'CacheControl' => 'max_age=2592000'
            ]
        ],
```

——

Any other solution would be great though 👍 
