### PR TITLE
[5.2] Allow any arrayable item in Collection::whereIn

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -243,12 +243,14 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      * Filter items by the given key value pair.
      *
      * @param  string  $key
-     * @param  array  $values
+     * @param  mixed  $values
      * @param  bool  $strict
      * @return static
      */
-    public function whereIn($key, array $values, $strict = true)
+    public function whereIn($key, $values, $strict = true)
     {
+        $values = $this->getArrayableItems($values);
+
         return $this->filter(function ($item) use ($key, $values, $strict) {
             return in_array(data_get($item, $key), $values, $strict);
         });
@@ -258,11 +260,13 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      * Filter items by the given key value pair using loose comparison.
      *
      * @param  string  $key
-     * @param  array  $values
+     * @param  mixed  $values
      * @return static
      */
-    public function whereInLoose($key, array $values)
+    public function whereInLoose($key, $values)
     {
+        $values = $this->getArrayableItems($values);
+
         return $this->whereIn($key, $values, false);
     }
 


### PR DESCRIPTION
Currently `whereIn` and `whereInLoose` only accept arrays. This change allows anything arrayable to be passed in, which keeps it consistent with the query builder method and removes the need for `toArray` calls when working with collections.

The `array` typehint in the method is gone, but I don't think that's considered breaking. If it is, I'll create a new PR for 5.3.

Would this need it's own unit test, or should I keep those as is?
