### PR TITLE
[5.3] Allow any arrayable item in Collection::whereIn

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -263,12 +263,14 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      * Filter items by the given key value pair.
      *
      * @param  string  $key
-     * @param  array  $values
+     * @param  mixed  $values
      * @param  bool  $strict
      * @return static
      */
-    public function whereIn($key, array $values, $strict = false)
+    public function whereIn($key, $values, $strict = false)
     {
+        $values = $this->getArrayableItems($values);
+
         return $this->filter(function ($item) use ($key, $values, $strict) {
             return in_array(data_get($item, $key), $values, $strict);
         });
@@ -278,10 +280,10 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      * Filter items by the given key value pair using strict comparison.
      *
      * @param  string  $key
-     * @param  array  $values
+     * @param  mixed  $values
      * @return static
      */
-    public function whereInStrict($key, array $values)
+    public function whereInStrict($key, $values)
     {
         return $this->whereIn($key, $values, true);
     }


### PR DESCRIPTION
Currently whereIn and whereInLoose only accept arrays. This change allows anything arrayable to be passed in, which keeps it consistent with the query builder method and removes the need for toArray calls when working with collections.

Breaking change since it removes some `array` typehints.
