### PR TITLE
[5.2] Correct formatting of updatedAt timestamp when calling touch() on BelongsToMany

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -1242,7 +1242,7 @@ class BelongsToMany extends Relation
      */
     public function getRelatedFreshUpdate()
     {
-        return [$this->related->getUpdatedAtColumn() => $this->related->freshTimestamp()];
+        return [$this->related->getUpdatedAtColumn() => $this->related->freshTimestampString()];
     }
 
     /**

--- a/tests/Database/DatabaseEloquentBelongsToManyTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyTest.php
@@ -521,13 +521,13 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase
     {
         $relation = $this->getRelation();
         $relation->getRelated()->shouldReceive('getUpdatedAtColumn')->andReturn('updated_at');
-        $relation->getRelated()->shouldReceive('freshTimestampString')->andReturn(100);
+        $relation->getRelated()->shouldReceive('freshTimestampString')->andReturn('100');
         $relation->getRelated()->shouldReceive('getQualifiedKeyName')->andReturn('table.id');
         $relation->getQuery()->shouldReceive('select')->once()->with('table.id')->andReturn($relation->getQuery());
         $relation->getQuery()->shouldReceive('pluck')->once()->with('id')->andReturn([1, 2, 3]);
         $relation->getRelated()->shouldReceive('newQuery')->once()->andReturn($query = m::mock('StdClass'));
         $query->shouldReceive('whereIn')->once()->with('id', [1, 2, 3])->andReturn($query);
-        $query->shouldReceive('update')->once()->with(['updated_at' => 100]);
+        $query->shouldReceive('update')->once()->with(['updated_at' => '100']);
 
         $relation->touch();
     }

--- a/tests/Database/DatabaseEloquentBelongsToManyTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyTest.php
@@ -521,7 +521,7 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase
     {
         $relation = $this->getRelation();
         $relation->getRelated()->shouldReceive('getUpdatedAtColumn')->andReturn('updated_at');
-        $relation->getRelated()->shouldReceive('freshTimestamp')->andReturn(100);
+        $relation->getRelated()->shouldReceive('freshTimestampString')->andReturn(100);
         $relation->getRelated()->shouldReceive('getQualifiedKeyName')->andReturn('table.id');
         $relation->getQuery()->shouldReceive('select')->once()->with('table.id')->andReturn($relation->getQuery());
         $relation->getQuery()->shouldReceive('pluck')->once()->with('id')->andReturn([1, 2, 3]);


### PR DESCRIPTION
currently when calling touch() on a BelongsToMany relationship the dateFormat property is not respected. This changes the BelongsToMany relationship to call the same method as the Relationship class to obtain a fresh timestamp
