### PR TITLE
[5.2] Use Instance query instead of cloned parent query

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -177,11 +177,9 @@ class MorphTo extends BelongsTo
 
         $key = $instance->getTable().'.'.$instance->getKeyName();
 
-        $query = clone $this->query;
+        $query = $instance->newQuery();
 
         $query->setEagerLoads($this->getEagerLoadsForInstance($instance));
-
-        $query->setModel($instance);
 
         $query->useConnection($instance->getConnection());
 


### PR DESCRIPTION
This fixes https://github.com/laravel/framework/issues/13762
