### PR TITLE
[5.2] Fix morphTo without SoftDeletes

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -204,7 +204,7 @@ class MorphTo extends BelongsTo
     }
 
     /**
-     * Merge the "wheres" from a relation query to a has query.
+     * Merge the "wheres" from a relation query to a morph query.
      *
      * @param  \Illuminate\Database\Eloquent\Builder  $relationQuery
      * @param  \Illuminate\Database\Eloquent\Builder  $morphQuery

--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -177,13 +177,11 @@ class MorphTo extends BelongsTo
 
         $key = $instance->getTable().'.'.$instance->getKeyName();
 
-        $query = clone $this->query;
+        $query = $instance->newQuery();
 
         $query->setEagerLoads($this->getEagerLoadsForInstance($instance));
 
-        $query->setModel($instance);
-
-        $query->useConnection($instance->getConnection());
+        $this->mergeRelationWheresToMorphQuery($this->query, $query);
 
         return $query->whereIn($key, $this->gatherKeysByType($type)->all())->get();
     }
@@ -203,6 +201,22 @@ class MorphTo extends BelongsTo
         })->keyBy(function ($constraint, $relation) {
             return Str::replaceFirst($this->relation.'.', '', $relation);
         })->merge($instance->getEagerLoads())->all();
+    }
+
+    /**
+     * Merge the "wheres" from a relation query to a has query.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder  $relationQuery
+     * @param  \Illuminate\Database\Eloquent\Builder  $morphQuery
+     * @return void
+     */
+    protected function mergeRelationWheresToMorphQuery(Builder $relationQuery, Builder $morphQuery)
+    {
+        $removedScopes = $relationQuery->removedScopes();
+
+        $morphQuery->withoutGlobalScopes($removedScopes)->mergeWheres(
+            $relationQuery->getQuery()->wheres, $relationQuery->getBindings()
+        );
     }
 
     /**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2322,23 +2322,6 @@ class Builder
     }
 
     /**
-     * Use a different connection for the query.
-     *
-     * @param  \Illuminate\Database\ConnectionInterface  $connection
-     * @param  \Illuminate\Database\Query\Grammars\Grammar  $grammar
-     * @param  \Illuminate\Database\Query\Processors\Processor  $processor
-     * @return void
-     */
-    public function useConnection(ConnectionInterface $connection,
-                                  Grammar $grammar = null,
-                                  Processor $processor = null)
-    {
-        $this->connection = $connection;
-        $this->grammar = $grammar ?: $connection->getQueryGrammar();
-        $this->processor = $processor ?: $connection->getPostProcessor();
-    }
-
-    /**
      * Handle dynamic method calls into the method.
      *
      * @param  string  $method


### PR DESCRIPTION
The whole approach with the cloned query sadly doesn't work in some edge cases. Instead we need to take a similar approach approach as we do with "has" queries (merging where clauses manually).

I added one more test to expose the issue (https://github.com/laravel/framework/issues/13762) and refactored the implementation.

@taylorotwell @phroggyy 
