### PR TITLE
[5.3] Adding Redis support for new Broadcast Support Provider

### DIFF
--- a/src/Illuminate/Broadcasting/BroadcastManager.php
+++ b/src/Illuminate/Broadcasting/BroadcastManager.php
@@ -86,7 +86,7 @@ class BroadcastManager implements FactoryContract
         }
 
         return $this->app['cache']->get(
-            'pusher:socket:'.$request->session()->getId()
+            'broadcast:socket:'.$request->session()->getId()
         );
     }
 
@@ -105,7 +105,7 @@ class BroadcastManager implements FactoryContract
         $request = $request ?: $this->app['request'];
 
         $this->app['cache']->forever(
-            'pusher:socket:'.$request->session()->getId(), $request->socket_id
+            'broadcast:socket:'.$request->session()->getId(), $request->socket_id
         );
     }
 

--- a/src/Illuminate/Broadcasting/Broadcasters/Broadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/Broadcaster.php
@@ -67,7 +67,12 @@ abstract class Broadcaster implements Broadcaster
             return json_encode($result);
         }
 
-        return json_encode(['channel_data' => $result]);
+        $channel_data = [
+            'user_id' => $request->user()->getKey(),
+            'user_info' => $result,
+        ];
+
+        return json_encode(compact('channel_data'));
     }
 
     /**

--- a/src/Illuminate/Broadcasting/Broadcasters/Broadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/Broadcaster.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Illuminate\Broadcasting\Broadcasters;
+
+use Illuminate\Support\Str;
+use Illuminate\Contracts\Broadcasting\Broadcaster;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+abstract class Broadcaster implements Broadcaster
+{
+    /**
+     * The registered channel authenticators.
+     *
+     * @var array
+     */
+    protected $channels = [];
+
+    /**
+     * Register a channel authenticator.
+     *
+     * @param  string  $channel
+     * @param  callable  $callback
+     * @return $this
+     */
+    public function auth($channel, callable $callback)
+    {
+        $this->channels[$channel] = $callback;
+
+        return $this;
+    }
+
+    /**
+     * Authenticate the incoming request for a given channel.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return mixed
+     */
+    public function check($request)
+    {
+        $channel = str_replace(['private-', 'presence-'], '', $request->channel_name);
+
+        foreach ($this->channels as $pattern => $callback) {
+            if (! Str::is($pattern, $channel)) {
+                continue;
+            }
+
+            $parameters = $this->extractAuthParameters($pattern, $channel);
+
+            if ($result = $callback($request->user(), ...$parameters)) {
+                return $this->validAuthenticationResponse($request, $result);
+            }
+        }
+
+        throw new HttpException(403);
+    }
+
+    /**
+     * Return the valid Pusher authentication response.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  mixed  $result
+     * @return mixed
+     */
+    protected function validAuthenticationResponse($request, $result)
+    {
+        if (is_bool($result)) {
+            return json_encode($result);
+        }
+
+        return json_encode(['channel_data' => $result]);
+    }
+
+    /**
+     * Extract the parameters from the given pattern and channel.
+     *
+     * @param  string  $pattern
+     * @param  string  $channel
+     * @return array
+     */
+    protected function extractAuthParameters($pattern, $channel)
+    {
+        if (! Str::contains($pattern, '*')) {
+            return [];
+        }
+
+        $pattern = str_replace('\*', '([^\.]+)', preg_quote($pattern));
+
+        if (preg_match('/^'.$pattern.'/', $channel, $keys)) {
+            array_shift($keys);
+
+            return $keys;
+        }
+
+        return [];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    abstract public function broadcast(array $channels, $event, array $payload = []);
+}

--- a/src/Illuminate/Broadcasting/Broadcasters/LogBroadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/LogBroadcaster.php
@@ -3,9 +3,8 @@
 namespace Illuminate\Broadcasting\Broadcasters;
 
 use Psr\Log\LoggerInterface;
-use Illuminate\Contracts\Broadcasting\Broadcaster;
 
-class LogBroadcaster implements Broadcaster
+class LogBroadcaster extends Broadcaster
 {
     /**
      * The logger implementation.

--- a/src/Illuminate/Broadcasting/Broadcasters/PusherBroadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/PusherBroadcaster.php
@@ -17,6 +17,7 @@ class PusherBroadcaster extends Broadcaster
 
     /**
      * Create a new broadcaster instance.
+     *
      * @param  \Pusher  $pusher
      * @return void
      */

--- a/src/Illuminate/Broadcasting/Broadcasters/PusherBroadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/PusherBroadcaster.php
@@ -5,10 +5,8 @@ namespace Illuminate\Broadcasting\Broadcasters;
 use Pusher;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
-use Illuminate\Contracts\Broadcasting\Broadcaster;
-use Symfony\Component\HttpKernel\Exception\HttpException;
 
-class PusherBroadcaster implements Broadcaster
+class PusherBroadcaster extends Broadcaster
 {
     /**
      * The Pusher SDK instance.
@@ -18,60 +16,13 @@ class PusherBroadcaster implements Broadcaster
     protected $pusher;
 
     /**
-     * The registered channel authenticators.
-     *
-     * @var array
-     */
-    protected $channels = [];
-
-    /**
      * Create a new broadcaster instance.
-     *
      * @param  \Pusher  $pusher
      * @return void
      */
     public function __construct(Pusher $pusher)
     {
         $this->pusher = $pusher;
-    }
-
-    /**
-     * Register a channel authenticator.
-     *
-     * @param  string  $channel
-     * @param  callable  $callback
-     * @return $this
-     */
-    public function auth($channel, callable $callback)
-    {
-        $this->channels[$channel] = $callback;
-
-        return $this;
-    }
-
-    /**
-     * Authenticate the incoming request for a given channel.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @return mixed
-     */
-    public function check($request)
-    {
-        $channel = str_replace(['private-', 'presence-'], '', $request->channel_name);
-
-        foreach ($this->channels as $pattern => $callback) {
-            if (! Str::is($pattern, $channel)) {
-                continue;
-            }
-
-            $parameters = $this->extractAuthParameters($pattern, $channel);
-
-            if ($result = $callback($request->user(), ...$parameters)) {
-                return $this->validAuthenticationResponse($request, $result);
-            }
-        }
-
-        throw new HttpException(403);
     }
 
     /**
@@ -90,30 +41,6 @@ class PusherBroadcaster implements Broadcaster
                 $request->channel_name, $request->socket_id, $request->user()->id, $result
             );
         }
-    }
-
-    /**
-     * Extract the parameters from the given pattern and channel.
-     *
-     * @param  string  $pattern
-     * @param  string  $channel
-     * @return array
-     */
-    protected function extractAuthParameters($pattern, $channel)
-    {
-        if (! Str::contains($pattern, '*')) {
-            return [];
-        }
-
-        $pattern = str_replace('\*', '([^\.]+)', preg_quote($pattern));
-
-        if (preg_match('/^'.$pattern.'/', $channel, $keys)) {
-            array_shift($keys);
-
-            return $keys;
-        }
-
-        return [];
     }
 
     /**

--- a/src/Illuminate/Broadcasting/Broadcasters/RedisBroadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/RedisBroadcaster.php
@@ -2,10 +2,10 @@
 
 namespace Illuminate\Broadcasting\Broadcasters;
 
-use Illuminate\Contracts\Broadcasting\Broadcaster;
+use Illuminate\Support\Arr;
 use Illuminate\Contracts\Redis\Database as RedisDatabase;
 
-class RedisBroadcaster implements Broadcaster
+class RedisBroadcaster extends Broadcaster
 {
     /**
      * The Redis instance.
@@ -41,7 +41,13 @@ class RedisBroadcaster implements Broadcaster
     {
         $connection = $this->redis->connection($this->connection);
 
-        $payload = json_encode(['event' => $event, 'data' => $payload]);
+        $socket = Arr::pull($payload, 'socket');
+
+        $payload = json_encode([
+            'event' => $event,
+            'data' => $payload,
+            'socket' => $socket,
+        ]);
 
         foreach ($channels as $channel) {
             $connection->publish($channel, $payload);


### PR DESCRIPTION
Squashed commits:
[d8cc1ee] Forgot to add json_encode to return a string.
[5ef6fce] Fixed docs.
[1ac510e] Style fix.
[a5fba3a] Removed parent construct from broadcasters.
[b7047c8] Updates.
[22900c1] Style fixes.
[ddf4ba4] Added an abstract class for Broadcasters.
[1c23e53] Updated Broadcast Manager to cache a socket_id as "broadcast:socket..." instead of "pusher:socket..."
[180934c] Updated the validAuthenticationResponse method to send back data as "channel_data"
[0712630] Update RedisBroadcaster.php

Added support for `$this->dontBroadcastToCurrentUser();`

With the addition of the socket_id in the payload, socket.io can broadcast the event as the requesting user.
[6e43303] Code style updates
[237cacd] Adding support for new Broadcast Support Provider
