### PR TITLE
Sql Grammar for datetime2 format

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
@@ -266,7 +266,7 @@ class SqlServerGrammar extends Grammar
      */
     public function getDateFormat()
     {
-        return 'Y-m-d H:i:s.000';
+        return 'Y-m-d H:i:s.0000000';
     }
 
     /**


### PR DESCRIPTION
Laravel on MSSQL is using by default datetime format to dates, but as I
learn, the date format returned by the mssql can change by server to
server, so the ideal is use the new format datetime2, on datetime2 the
default lenght is 7, so I think it is logical to update the
getDateFormat function to deal with the default value
