### PR TITLE
[5.2] Refactor relations and scopes

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1166,7 +1166,7 @@ class Builder
         $builder = clone $this;
 
         foreach ($this->scopes as $scope) {
-            $builder->callScope(function(Builder $builder) use ($scope) {
+            $builder->callScope(function (Builder $builder) use ($scope) {
                 if ($scope instanceof Closure) {
                     $scope($builder);
                 } elseif ($scope instanceof Scope) {

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -385,7 +385,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
             $scope = get_class($scope);
         }
 
-        return Arr::get(static::$globalScopes, static::class . '.' . $scope);
+        return Arr::get(static::$globalScopes, static::class.'.'.$scope);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -381,15 +381,11 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public static function getGlobalScope($scope)
     {
-        $modelScopes = Arr::get(static::$globalScopes, static::class, []);
-
-        if (is_string($scope)) {
-            return isset($modelScopes[$scope]) ? $modelScopes[$scope] : null;
+        if (! is_string($scope)) {
+            $scope = get_class($scope);
         }
 
-        return Arr::first($modelScopes, function ($key, $value) use ($scope) {
-            return $scope instanceof $value;
-        });
+        return Arr::get(static::$globalScopes, static::class . '.' . $scope);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -2,11 +2,9 @@
 
 namespace Illuminate\Database\Eloquent\Relations;
 
-use Illuminate\Support\Str;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
-use Illuminate\Support\Collection as BaseCollection;
 
 class MorphTo extends BelongsTo
 {

--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -177,46 +177,12 @@ class MorphTo extends BelongsTo
 
         $key = $instance->getTable().'.'.$instance->getKeyName();
 
-        $query = $instance->newQuery();
+        $eagerLoads = $this->getQuery()->nestedRelations($this->relation);
 
-        $query->setEagerLoads($this->getEagerLoadsForInstance($instance));
-
-        $this->mergeRelationWheresToMorphQuery($this->query, $query);
+        $query = $instance->newQuery()->setEagerLoads($eagerLoads)
+            ->mergeModelDefinedRelationConstraints($this->getQuery());
 
         return $query->whereIn($key, $this->gatherKeysByType($type)->all())->get();
-    }
-
-    /**
-     * Get the relationships that should be eager loaded for the given model.
-     *
-     * @param  \Illuminate\Database\Eloquent\Model  $instance
-     * @return array
-     */
-    protected function getEagerLoadsForInstance(Model $instance)
-    {
-        $relations = BaseCollection::make($this->query->getEagerLoads());
-
-        return $relations->filter(function ($constraint, $relation) {
-            return Str::startsWith($relation, $this->relation.'.');
-        })->keyBy(function ($constraint, $relation) {
-            return Str::replaceFirst($this->relation.'.', '', $relation);
-        })->merge($instance->getEagerLoads())->all();
-    }
-
-    /**
-     * Merge the "wheres" from a relation query to a morph query.
-     *
-     * @param  \Illuminate\Database\Eloquent\Builder  $relationQuery
-     * @param  \Illuminate\Database\Eloquent\Builder  $morphQuery
-     * @return void
-     */
-    protected function mergeRelationWheresToMorphQuery(Builder $relationQuery, Builder $morphQuery)
-    {
-        $removedScopes = $relationQuery->removedScopes();
-
-        $morphQuery->withoutGlobalScopes($removedScopes)->mergeWheres(
-            $relationQuery->getQuery()->wheres, $relationQuery->getBindings()
-        );
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/SoftDeletes.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletes.php
@@ -104,30 +104,6 @@ trait SoftDeletes
     }
 
     /**
-     * Get a new query builder that includes soft deletes.
-     *
-     * @return \Illuminate\Database\Eloquent\Builder|static
-     */
-    public static function withTrashed()
-    {
-        return (new static)->newQueryWithoutScope(new SoftDeletingScope);
-    }
-
-    /**
-     * Get a new query builder that only includes soft deletes.
-     *
-     * @return \Illuminate\Database\Eloquent\Builder|static
-     */
-    public static function onlyTrashed()
-    {
-        $instance = new static;
-
-        $column = $instance->getQualifiedDeletedAtColumn();
-
-        return $instance->newQueryWithoutScope(new SoftDeletingScope)->whereNotNull($column);
-    }
-
-    /**
      * Register a restoring model event with the dispatcher.
      *
      * @param  \Closure|string  $callback


### PR DESCRIPTION
As discussed on Slack, I refactored some stuff that was recently made overly complex by some pull requests. All in all, I managed to shave off around 100 lines of code and all tests still pass. I didn't touch any public methods so this shouldn't break anything.

Summary of scope refactoring:
- I merged `applyCallbackToQuery` and `callScope` in a single more general method called `callScope`
- I generalized `mergeModelDefinedRelationWheresToHasQuery`, made it public, and renamed it to `mergeModelDefinedRelationConstraints` so it can now be used from relations as well.
- I managed to greatly simplify `applyScopes` (which applies global scopes) by utilizing the new `callScope` method. As a result the `applyScope` helper method is not needed any more.
- Some minor refactoring of `getGlobalScope` on the Model to match the logic of `withoutGlobalScope` on the Builder.

Summary of morphTo refactoring:
- `getEagerLoadsForInstance` was deleted and replaced with a call to`nestedRelations` on the Builder (which is now public).
- `mergeRelationWheresToMorphQuery` was deleted as well. The new public Builder method `mergeModelDefinedRelationConstraints` is used instead.

Summary of SoftDeletes refactoring:
- I deleted `withTrashed` and `onlyTrashed` static helpers from the `SoftDeletes` trait, since the call is redirected to query macro anyway.
