### PR TITLE
[5.2] Fix morphTo macro calls

### DIFF
--- a/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
@@ -536,6 +536,12 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends PHPUnit_Framework_TestC
         }])->first();
 
         $this->assertEquals($abigail->email, $comment->owner->email);
+
+        $comment = TestCommentWithoutSoftDelete::with(['owner' => function ($q) {
+            $q->withTrashed();
+        }])->first();
+
+        $this->assertEquals($abigail->email, $comment->owner->email);
     }
 
     public function testMorphToWithConstraints()
@@ -700,6 +706,20 @@ class SoftDeletesTestPost extends Eloquent
     public function comments()
     {
         return $this->hasMany(SoftDeletesTestComment::class, 'post_id');
+    }
+}
+
+/**
+ * Eloquent Models...
+ */
+class TestCommentWithoutSoftDelete extends Eloquent
+{
+    protected $table = 'comments';
+    protected $guarded = [];
+
+    public function owner()
+    {
+        return $this->morphTo();
     }
 }
 


### PR DESCRIPTION
This fixes another edge case, where we want to call a query macro (like `withTrashed`, `onlyTrashed`) on a `morphTo` relation, but the macro only exists on the related model.

Before we had a hack that only handled `withTrashed` calls (https://github.com/laravel/framework/blob/5.1/src/Illuminate/Database/Eloquent/Relations/MorphTo.php#L240:L267) now I generalized the idea, so that all macro calls are captured and replayed when we have an actual related instance.
