### PR TITLE
[5.2] Removed accidently left in method

### DIFF
--- a/src/Illuminate/Cache/ArrayStore.php
+++ b/src/Illuminate/Cache/ArrayStore.php
@@ -42,18 +42,6 @@ class ArrayStore extends TaggableStore implements Store
     }
 
     /**
-     * Store multiple items in the cache for a given number of minutes.
-     *
-     * @param  array  $values
-     * @param  int  $minutes
-     * @return void
-     */
-    public function putMultiple(array $values, $minutes)
-    {
-        $this->storage += $values;
-    }
-
-    /**
      * Increment the value of an item in the cache.
      *
      * @param  string  $key


### PR DESCRIPTION
`putMultiple` appears nowhere in the code apart from there. It appears this was left in by mistake after the `pullMany` refactor.
