### PR TITLE
[5.4] FormRequest should fail with ValidationException

### DIFF
--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -9,6 +9,7 @@ use Illuminate\Routing\Redirector;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Http\Exception\HttpResponseException;
+use Illuminate\Validation\ValidationException;
 use Illuminate\Validation\ValidatesWhenResolvedTrait;
 use Illuminate\Contracts\Validation\ValidatesWhenResolved;
 use Illuminate\Contracts\Validation\Factory as ValidationFactory;
@@ -90,11 +91,11 @@ class FormRequest extends Request implements ValidatesWhenResolved
      * @param  \Illuminate\Contracts\Validation\Validator  $validator
      * @return void
      *
-     * @throws \Illuminate\Http\Exception\HttpResponseException
+     * @throws \Illuminate\Validation\ValidationException
      */
     protected function failedValidation(Validator $validator)
     {
-        throw new HttpResponseException($this->response(
+        throw new ValidationException($validator, $this->response(
             $this->formatErrors($validator)
         ));
     }

--- a/tests/Foundation/FoundationFormRequestTest.php
+++ b/tests/Foundation/FoundationFormRequestTest.php
@@ -25,9 +25,9 @@ class FoundationFormRequestTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException \Illuminate\Http\Exception\HttpResponseException
+     * @expectedException \Illuminate\Validation\ValidationException
      */
-    public function testValidateFunctionThrowsHttpResponseExceptionIfValidationFails()
+    public function testValidateFunctionThrowsValidationExceptionIfValidationFails()
     {
         $request = m::mock('FoundationTestFormRequestStub[response]');
         $request->initialize(['name' => null]);


### PR DESCRIPTION
The FormRequest class is outlined in documentation as an alternative to validation via trait for more complex validation rules.
But while the trait based validation throws a ValidationException the FormRequest throws an HttpResponseException.
That's inconsistent, undocumented and unexpected for anyone working with validations.

On one hand this is a bugfix, but on the other hand this is obviously a backwards incompatible change due to the very nature of the bug (throwing the wrong exception).

Also, see issue  #12276 for a discussion about the problem.
