### PR TITLE
[5.4] Make ServiceProvider::register a non-abstract method

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -551,7 +551,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
             $provider = $this->resolveProviderClass($provider);
         }
 
-        $provider->register();
+        $this->registerProvider($provider);
 
         // Once we have registered the service we will iterate through the options
         // and set each of them on the application so they will be available on
@@ -596,6 +596,19 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     public function resolveProviderClass($provider)
     {
         return new $provider($this);
+    }
+
+    /**
+     * Register the given service provider.
+     *
+     * @param  \Illuminate\Support\ServiceProvider  $provider
+     * @return mixed
+     */
+    protected function registerProvider($provider)
+    {
+        if (method_exists($provider, 'register')) {
+            return $this->call([$provider, 'register']);
+        }
     }
 
     /**

--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -47,13 +47,6 @@ abstract class ServiceProvider
     }
 
     /**
-     * Register the service provider.
-     *
-     * @return void
-     */
-    abstract public function register();
-
-    /**
      * Merge the given configuration with the existing configuration.
      *
      * @param  string  $path


### PR DESCRIPTION
Sometimes service providers don't need to register anything and only use the boot method. (e.g. if your service just needs to register some event listeners)

If `register` isn't abstract anymore, it removes the need to implement an empty method.

The failing test is caused by a mock depending on the method. If this would get merged, how should that be resolved?
