### PR TITLE
[5.2] Added 'count' option to revert specific number of migrations.

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/RollbackCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/RollbackCommand.php
@@ -60,7 +60,9 @@ class RollbackCommand extends Command
 
         $pretend = $this->input->getOption('pretend');
 
-        $this->migrator->rollback($pretend);
+        $count = (int) $this->input->getOption('count');
+
+        $this->migrator->rollback($count, $pretend);
 
         // Once the migrator has run we will grab the note output and send it out to
         // the console screen, since the migrator itself functions without having
@@ -83,6 +85,8 @@ class RollbackCommand extends Command
             ['force', null, InputOption::VALUE_NONE, 'Force the operation to run when in production.'],
 
             ['pretend', null, InputOption::VALUE_NONE, 'Dump the SQL queries that would be run.'],
+
+            ['count', null, InputOption::VALUE_OPTIONAL, 'Number of migrations to be reverted.'],
         ];
     }
 }

--- a/src/Illuminate/Database/Migrations/DatabaseMigrationRepository.php
+++ b/src/Illuminate/Database/Migrations/DatabaseMigrationRepository.php
@@ -54,6 +54,19 @@ class DatabaseMigrationRepository implements MigrationRepositoryInterface
     }
 
     /**
+     * Get list of migrations.
+     *
+     * @param $count
+     * @return array
+     */
+    public function getMigrations($count)
+    {
+        $query = $this->table()->where('batch', '>=', '1');
+
+        return $query->orderBy('migration', 'desc')->take($count)->get();
+    }
+
+    /**
      * Get the last migration batch.
      *
      * @return array

--- a/src/Illuminate/Database/Migrations/MigrationRepositoryInterface.php
+++ b/src/Illuminate/Database/Migrations/MigrationRepositoryInterface.php
@@ -12,6 +12,14 @@ interface MigrationRepositoryInterface
     public function getRan();
 
     /**
+     * Get list of migrations.
+     *
+     * @param $count
+     * @return array
+     */
+    public function getMigrations($count);
+
+    /**
      * Get the last migration batch.
      *
      * @return array

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -157,17 +157,22 @@ class Migrator
     /**
      * Rollback the last migration operation.
      *
+     * @param  int   $count
      * @param  bool  $pretend
      * @return int
      */
-    public function rollback($pretend = false)
+    public function rollback($count = 0, $pretend = false)
     {
         $this->notes = [];
 
         // We want to pull in the last batch of migrations that ran on the previous
         // migration operation. We'll then reverse those migrations and run each
         // of them "down" to reverse the last migration "operation" which ran.
-        $migrations = $this->repository->getLast();
+        if (is_int($count) && ($count > 0)) {
+            $migrations = $this->repository->getMigrations($count);
+        } else {
+            $migrations = $this->repository->getLast();
+        }
 
         $count = count($migrations);
 

--- a/tests/Database/DatabaseMigrationRollbackCommandTest.php
+++ b/tests/Database/DatabaseMigrationRollbackCommandTest.php
@@ -16,7 +16,18 @@ class DatabaseMigrationRollbackCommandTest extends PHPUnit_Framework_TestCase
         $command = new RollbackCommand($migrator = m::mock('Illuminate\Database\Migrations\Migrator'));
         $command->setLaravel(new AppDatabaseMigrationRollbackStub());
         $migrator->shouldReceive('setConnection')->once()->with(null);
-        $migrator->shouldReceive('rollback')->once()->with(false);
+        $migrator->shouldReceive('rollback')->once()->with(0,false);
+        $migrator->shouldReceive('getNotes')->andReturn([]);
+
+        $this->runCommand($command);
+    }
+
+    public function testRollbackCommandCallsMigratorWithCountArguments()
+    {
+        $command = new RollbackCommand($migrator = m::mock('Illuminate\Database\Migrations\Migrator'));
+        $command->setLaravel(new AppDatabaseMigrationRollbackStub());
+        $migrator->shouldReceive('setConnection')->once()->with(null);
+        $migrator->shouldReceive('rollback')->once()->with(2,false);
         $migrator->shouldReceive('getNotes')->andReturn([]);
 
         $this->runCommand($command);
@@ -27,7 +38,18 @@ class DatabaseMigrationRollbackCommandTest extends PHPUnit_Framework_TestCase
         $command = new RollbackCommand($migrator = m::mock('Illuminate\Database\Migrations\Migrator'));
         $command->setLaravel(new AppDatabaseMigrationRollbackStub());
         $migrator->shouldReceive('setConnection')->once()->with('foo');
-        $migrator->shouldReceive('rollback')->once()->with(true);
+        $migrator->shouldReceive('rollback')->once()->with(0, true);
+        $migrator->shouldReceive('getNotes')->andReturn([]);
+
+        $this->runCommand($command, ['--pretend' => true, '--database' => 'foo']);
+    }
+
+    public function testRollbackCommandCanBePretendedWithCountArguments()
+    {
+        $command = new RollbackCommand($migrator = m::mock('Illuminate\Database\Migrations\Migrator'));
+        $command->setLaravel(new AppDatabaseMigrationRollbackStub());
+        $migrator->shouldReceive('setConnection')->once()->with('foo');
+        $migrator->shouldReceive('rollback')->once()->with(2, true);
         $migrator->shouldReceive('getNotes')->andReturn([]);
 
         $this->runCommand($command, ['--pretend' => true, '--database' => 'foo']);


### PR DESCRIPTION
This PR allows user to revert a specific numbers of migrations by providing a **count** option to the artisan **migrate:rollback** command. For example:

```
php artisan migrate:rollback --count=3 // Reverts last three migrations
```
