### PR TITLE
[5.3] Let INF means forever and 0 means don't cache

### DIFF
--- a/src/Illuminate/Cache/ApcStore.php
+++ b/src/Illuminate/Cache/ApcStore.php
@@ -60,7 +60,17 @@ class ApcStore extends TaggableStore implements Store
      */
     public function put($key, $value, $minutes)
     {
-        $this->apc->put($this->prefix.$key, $value, (int) ($minutes * 60));
+        $seconds = (int) ($minutes * 60);
+
+        if ($seconds <= 0) {
+            return;
+        }
+
+        if ($minutes === INF) {
+            $seconds = 0;
+        }
+
+        $this->apc->put($this->prefix.$key, $value, $seconds);
     }
 
     /**
@@ -85,18 +95,6 @@ class ApcStore extends TaggableStore implements Store
     public function decrement($key, $value = 1)
     {
         return $this->apc->decrement($this->prefix.$key, $value);
-    }
-
-    /**
-     * Store an item in the cache indefinitely.
-     *
-     * @param  string  $key
-     * @param  mixed   $value
-     * @return array|bool
-     */
-    public function forever($key, $value)
-    {
-        return $this->put($key, $value, 0);
     }
 
     /**

--- a/src/Illuminate/Cache/ArrayStore.php
+++ b/src/Illuminate/Cache/ArrayStore.php
@@ -80,18 +80,6 @@ class ArrayStore extends TaggableStore implements Store
     }
 
     /**
-     * Store an item in the cache indefinitely.
-     *
-     * @param  string  $key
-     * @param  mixed   $value
-     * @return void
-     */
-    public function forever($key, $value)
-    {
-        $this->put($key, $value, 0);
-    }
-
-    /**
      * Remove an item from the cache.
      *
      * @param  string  $key

--- a/src/Illuminate/Cache/DatabaseStore.php
+++ b/src/Illuminate/Cache/DatabaseStore.php
@@ -97,6 +97,17 @@ class DatabaseStore implements Store
      */
     public function put($key, $value, $minutes)
     {
+        if ($minutes >= 5256000) {
+            // 10 Years.
+            $minutes = 5256000;
+        }
+
+        $seconds = (int) ($minutes * 60);
+
+        if ($seconds <= 0) {
+            return;
+        }
+
         $key = $this->prefix.$key;
 
         // All of the cached values in the database are encrypted in case this is used
@@ -104,7 +115,7 @@ class DatabaseStore implements Store
         // time and place that on the table so we will check it on our retrieval.
         $value = $this->encrypter->encrypt($value);
 
-        $expiration = $this->getTime() + (int) ($minutes * 60);
+        $expiration = $this->getTime() + $seconds;
 
         try {
             $this->table()->insert(compact('key', 'value', 'expiration'));
@@ -187,18 +198,6 @@ class DatabaseStore implements Store
     protected function getTime()
     {
         return time();
-    }
-
-    /**
-     * Store an item in the cache indefinitely.
-     *
-     * @param  string  $key
-     * @param  mixed   $value
-     * @return void
-     */
-    public function forever($key, $value)
-    {
-        $this->put($key, $value, 5256000);
     }
 
     /**

--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -99,6 +99,10 @@ class FileStore implements Store
      */
     public function put($key, $value, $minutes)
     {
+        if ((int) ($minutes * 60) <= 0) {
+            return;
+        }
+
         $value = $this->expiration($minutes).serialize($value);
 
         $this->createCacheDirectory($path = $this->path($key));
@@ -147,18 +151,6 @@ class FileStore implements Store
     public function decrement($key, $value = 1)
     {
         return $this->increment($key, $value * -1);
-    }
-
-    /**
-     * Store an item in the cache indefinitely.
-     *
-     * @param  string  $key
-     * @param  mixed   $value
-     * @return void
-     */
-    public function forever($key, $value)
-    {
-        $this->put($key, $value, 0);
     }
 
     /**
@@ -215,7 +207,7 @@ class FileStore implements Store
     {
         $time = time() + ($minutes * 60);
 
-        if ($minutes === 0 || $time > 9999999999) {
+        if ($time > 9999999999) {
             return 9999999999;
         }
 

--- a/src/Illuminate/Cache/MemcachedStore.php
+++ b/src/Illuminate/Cache/MemcachedStore.php
@@ -82,7 +82,17 @@ class MemcachedStore extends TaggableStore implements Store
      */
     public function put($key, $value, $minutes)
     {
-        $this->memcached->set($this->prefix.$key, $value, (int) ($minutes * 60));
+        $seconds = (int) ($minutes * 60);
+
+        if ($seconds <= 0) {
+            return;
+        }
+
+        if ($minutes === INF) {
+            $seconds = 0;
+        }
+
+        $this->memcached->set($this->prefix.$key, $value, $seconds);
     }
 
     /**
@@ -138,18 +148,6 @@ class MemcachedStore extends TaggableStore implements Store
     public function decrement($key, $value = 1)
     {
         return $this->memcached->decrement($this->prefix.$key, $value);
-    }
-
-    /**
-     * Store an item in the cache indefinitely.
-     *
-     * @param  string  $key
-     * @param  mixed   $value
-     * @return void
-     */
-    public function forever($key, $value)
-    {
-        $this->put($key, $value, 0);
     }
 
     /**

--- a/src/Illuminate/Cache/NullStore.php
+++ b/src/Illuminate/Cache/NullStore.php
@@ -64,18 +64,6 @@ class NullStore extends TaggableStore implements Store
     }
 
     /**
-     * Store an item in the cache indefinitely.
-     *
-     * @param  string  $key
-     * @param  mixed   $value
-     * @return void
-     */
-    public function forever($key, $value)
-    {
-        //
-    }
-
-    /**
      * Remove an item from the cache.
      *
      * @param  string  $key

--- a/src/Illuminate/Cache/RedisStore.php
+++ b/src/Illuminate/Cache/RedisStore.php
@@ -91,9 +91,19 @@ class RedisStore extends TaggableStore implements Store
      */
     public function put($key, $value, $minutes)
     {
+        $seconds = (int) ($minutes * 60);
+
+        if ($seconds <= 0) {
+            return;
+        }
+
         $value = is_numeric($value) ? $value : serialize($value);
 
-        $this->connection()->setex($this->prefix.$key, (int) max(1, $minutes * 60), $value);
+        if ($minutes === INF) {
+            $this->connection()->set($this->prefix.$key, $value);
+        } else {
+            $this->connection()->setex($this->prefix.$key, $seconds, $value);
+        }
     }
 
     /**
@@ -136,20 +146,6 @@ class RedisStore extends TaggableStore implements Store
     public function decrement($key, $value = 1)
     {
         return $this->connection()->decrby($this->prefix.$key, $value);
-    }
-
-    /**
-     * Store an item in the cache indefinitely.
-     *
-     * @param  string  $key
-     * @param  mixed   $value
-     * @return void
-     */
-    public function forever($key, $value)
-    {
-        $value = is_numeric($value) ? $value : serialize($value);
-
-        $this->connection()->set($this->prefix.$key, $value);
     }
 
     /**

--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -196,7 +196,7 @@ class Repository implements CacheContract, ArrayAccess
      */
     public function put($key, $value, $minutes = null)
     {
-        if (is_array($key) && filter_var($value, FILTER_VALIDATE_INT) !== false) {
+        if (is_array($key)) {
             return $this->putMany($key, $value);
         }
 
@@ -291,7 +291,7 @@ class Repository implements CacheContract, ArrayAccess
      */
     public function forever($key, $value)
     {
-        $this->store->forever($this->itemKey($key), $value);
+        $this->store->put($this->itemKey($key), $value, INF);
 
         $this->fireCacheEvent('write', [$key, $value, 0]);
     }
@@ -490,7 +490,7 @@ class Repository implements CacheContract, ArrayAccess
             $duration = Carbon::now()->diffInSeconds(Carbon::instance($duration), false) / 60;
         }
 
-        return $duration > 0 ? $duration : null;
+        return (int) ($duration * 60) > 0 ? $duration : null;
     }
 
     /**

--- a/src/Illuminate/Contracts/Cache/Store.php
+++ b/src/Illuminate/Contracts/Cache/Store.php
@@ -60,15 +60,6 @@ interface Store
     public function decrement($key, $value = 1);
 
     /**
-     * Store an item in the cache indefinitely.
-     *
-     * @param  string  $key
-     * @param  mixed   $value
-     * @return void
-     */
-    public function forever($key, $value);
-
-    /**
      * Remove an item from the cache.
      *
      * @param  string  $key


### PR DESCRIPTION
``` php
Cache::put('key', 'value', INF) //means cache forever
Cache::put('key', 'value', 0.001 /* or anything less than 1/60*/) //means don't cache
```

`Illuminate\Contracts\Cache::forever()` is removed.

This is not complete yet.
