### PR TITLE
[5.2] Added 'count' option to revert specific number of migrations.

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/RollbackCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/RollbackCommand.php
@@ -60,7 +60,14 @@ class RollbackCommand extends Command
 
         $pretend = $this->input->getOption('pretend');
 
-        $this->migrator->rollback($pretend);
+        $count = (int) $this->input->getOption('count');
+
+        if (is_int($count) && ($count > 0)) {
+            $this->migrator->setRollBackCount($count);
+            $this->migrator->rollback($pretend);
+        } else {
+            $this->migrator->rollback($pretend);
+        }
 
         // Once the migrator has run we will grab the note output and send it out to
         // the console screen, since the migrator itself functions without having
@@ -83,6 +90,8 @@ class RollbackCommand extends Command
             ['force', null, InputOption::VALUE_NONE, 'Force the operation to run when in production.'],
 
             ['pretend', null, InputOption::VALUE_NONE, 'Dump the SQL queries that would be run.'],
+
+            ['count', null, InputOption::VALUE_OPTIONAL, 'Number of migrations to be reverted.'],
         ];
     }
 }

--- a/src/Illuminate/Database/Migrations/DatabaseMigrationRepository.php
+++ b/src/Illuminate/Database/Migrations/DatabaseMigrationRepository.php
@@ -54,6 +54,19 @@ class DatabaseMigrationRepository implements MigrationRepositoryInterface
     }
 
     /**
+     * Get list of migrations.
+     *
+     * @param $count
+     * @return array
+     */
+    public function getMigrations($count)
+    {
+        $query = $this->table()->where('batch', '>=', '1');
+
+        return $query->orderBy('migration', 'desc')->take($count)->get();
+    }
+
+    /**
      * Get the last migration batch.
      *
      * @return array

--- a/src/Illuminate/Database/Migrations/MigrationRepositoryInterface.php
+++ b/src/Illuminate/Database/Migrations/MigrationRepositoryInterface.php
@@ -12,6 +12,14 @@ interface MigrationRepositoryInterface
     public function getRan();
 
     /**
+     * Get list of migrations.
+     *
+     * @param $count
+     * @return array
+     */
+    public function getMigrations($count);
+
+    /**
      * Get the last migration batch.
      *
      * @return array

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -45,6 +45,13 @@ class Migrator
     protected $notes = [];
 
     /**
+     * Number of migrations to rollback.
+     *
+     * @var int
+     */
+    protected $rollBackCount = 0;
+
+    /**
      * Create a new migrator instance.
      *
      * @param  \Illuminate\Database\Migrations\MigrationRepositoryInterface  $repository
@@ -167,7 +174,11 @@ class Migrator
         // We want to pull in the last batch of migrations that ran on the previous
         // migration operation. We'll then reverse those migrations and run each
         // of them "down" to reverse the last migration "operation" which ran.
-        $migrations = $this->repository->getLast();
+        if ($this->rollBackCount) {
+            $migrations = $this->repository->getMigrations($this->rollBackCount);
+        } else {
+            $migrations = $this->repository->getLast();
+        }
 
         $count = count($migrations);
 
@@ -238,6 +249,19 @@ class Migrator
         $this->repository->delete($migration);
 
         $this->note("<info>Rolled back:</info> $file");
+    }
+
+    /**
+     * Set value to rollback specific number of migrations.
+     *
+     * @param  int  $count
+     * @return int
+     */
+    public function setRollBackCount($count)
+    {
+        $this->rollBackCount = $count;
+
+        return $this->rollBackCount;
     }
 
     /**

--- a/tests/Database/DatabaseMigrationRollbackCommandTest.php
+++ b/tests/Database/DatabaseMigrationRollbackCommandTest.php
@@ -33,6 +33,30 @@ class DatabaseMigrationRollbackCommandTest extends PHPUnit_Framework_TestCase
         $this->runCommand($command, ['--pretend' => true, '--database' => 'foo']);
     }
 
+    public function testRollbackCommandCallsMigratorWithProperAndCountArguments()
+    {
+        $command = new RollbackCommand($migrator = m::mock('Illuminate\Database\Migrations\Migrator'));
+        $command->setLaravel(new AppDatabaseMigrationRollbackStub());
+        $migrator->shouldReceive('setConnection')->once()->with(null);
+        $migrator->shouldReceive('setRollBackCount')->once()->with(2);
+        $migrator->shouldReceive('rollback')->once()->with(false);
+        $migrator->shouldReceive('getNotes')->andReturn([]);
+
+        $this->runCommand($command);
+    }
+
+    public function testRollbackCommandCanBePretendedWithCountArguments()
+    {
+        $command = new RollbackCommand($migrator = m::mock('Illuminate\Database\Migrations\Migrator'));
+        $command->setLaravel(new AppDatabaseMigrationRollbackStub());
+        $migrator->shouldReceive('setConnection')->once()->with('foo');
+        $migrator->shouldReceive('setRollBackCount')->once()->with(2);
+        $migrator->shouldReceive('rollback')->once()->with(true);
+        $migrator->shouldReceive('getNotes')->andReturn([]);
+
+        $this->runCommand($command, ['--pretend' => true, '--database' => 'foo']);
+    }
+
     protected function runCommand($command, $input = [])
     {
         return $command->run(new Symfony\Component\Console\Input\ArrayInput($input), new Symfony\Component\Console\Output\NullOutput);


### PR DESCRIPTION
This PR allows user to revert a specific numbers of migrations by providing a **count** option to the artisan **migrate:rollback** command.

For example, if the user ran ten migrations in one batch, but wants to amend a couple of migrations without rolling back all migrations. This will allow user to only revert a specific number of migrations.

Lets say, if a user wants to revert last three run migrations:

```
php artisan migrate:rollback --count=3
```
