### PR TITLE
[5.3] Dynamic Add Return Model Method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -3362,6 +3362,24 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     }
 
     /**
+     * Handles dynamic "AndReturn" method access which allows the chaining of methods which
+     * otherwise wouldn't return the existing instance of your Model. An example of this
+     * is when you call the save() method you would receive a boolean response. Using
+     * the saveAndReturn() dynamic method would return your Model instance instead.
+     *
+     * @param  string  $method
+     * @param  string  $parameters
+     *
+     * @return $this
+     */
+    public function dynamicReturn($method, $parameters)
+    {
+        call_user_func_array([$this, str_replace('AndReturn', '', $method)], $parameters);
+
+        return $this;
+    }
+
+    /**
      * Dynamically retrieve attributes on the model.
      *
      * @param  string  $key
@@ -3460,6 +3478,10 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public function __call($method, $parameters)
     {
+        if (Str::endsWith($method, 'AndReturn')) {
+            return $this->dynamicReturn($method, $parameters);
+        }
+
         if (in_array($method, ['increment', 'decrement'])) {
             return call_user_func_array([$this, $method], $parameters);
         }


### PR DESCRIPTION
Not sure if this is a good idea or not, so feel free to shoot this down, but there's many occassions where I'd like to chain methods of an Eloquent Model together but am unable to due to the return not being an instance of itself.

This PR would allow chaining of methods so that the following would be possible:

``` php
public function handle()
{
    return $user
        ->fill(['some' => 'attributes'])
        ->team()->associate($team)
        ->organisation()->associate($organisation)
        ->medals()->sync($awards)
        ->saveAndReturn();
}
```

Or alternatively:

``` php
return $user->fill([])->saveOrFailAndReturn();
```

Potentially a dynamic method for this is overkill, given that as far as I can determine the only useful methods for this to enhance are save and saveOrFail(). So perhaps two additional methods would be better suited?

Keen to hear thoughts Mr Otwell (@taylorotwell), as something of this variety would be a handy addition.
