### PR TITLE
[5.2] Fix bug in the route:list command with authorizes resource

### DIFF
--- a/src/Illuminate/Foundation/Auth/Access/AuthorizesResources.php
+++ b/src/Illuminate/Foundation/Auth/Access/AuthorizesResources.php
@@ -17,19 +17,29 @@ trait AuthorizesResources
      */
     public function authorizeResource($model, $name = null, array $options = [], $request = null)
     {
+        $map = $this->resourceAbilityMap();
+
         $route = with($request ?: request())->route();
 
         if ($route == null) {
+            foreach ($map as $method => $ability) {
+                $this->assignMiddleware($model, $method, $name, $options);
+            }
+
             return new ControllerMiddlewareOptions($options);
         }
 
         $method = array_last(explode('@', $route->getActionName()));
 
-        $map = $this->resourceAbilityMap();
-
         if (! in_array($method, array_keys($map))) {
             return new ControllerMiddlewareOptions($options);
         }
+
+    }
+
+    public function assignMiddleware($model, $method, $name = null, array $options = [])
+    {
+        $map = $this->resourceAbilityMap();
 
         if (! in_array($method, ['index', 'create', 'store'])) {
             $model = $name ?: strtolower(class_basename($model));

--- a/src/Illuminate/Foundation/Auth/Access/AuthorizesResources.php
+++ b/src/Illuminate/Foundation/Auth/Access/AuthorizesResources.php
@@ -17,7 +17,13 @@ trait AuthorizesResources
      */
     public function authorizeResource($model, $name = null, array $options = [], $request = null)
     {
-        $method = array_last(explode('@', with($request ?: request())->route()->getActionName()));
+        $route = with($request ?: request())->route();
+
+        if ($route == null) {
+            return new ControllerMiddlewareOptions($options);
+        }
+
+        $method = array_last(explode('@', $route->getActionName()));
 
         $map = $this->resourceAbilityMap();
 

--- a/src/Illuminate/Foundation/Auth/Access/AuthorizesResources.php
+++ b/src/Illuminate/Foundation/Auth/Access/AuthorizesResources.php
@@ -35,6 +35,7 @@ trait AuthorizesResources
             return new ControllerMiddlewareOptions($options);
         }
 
+        return $this->assignMiddleware($model, $method, $name, $options);
     }
 
     public function assignMiddleware($model, $method, $name = null, array $options = [])

--- a/src/Illuminate/Foundation/Auth/Access/AuthorizesResources.php
+++ b/src/Illuminate/Foundation/Auth/Access/AuthorizesResources.php
@@ -22,9 +22,7 @@ trait AuthorizesResources
         $route = with($request ?: request())->route();
 
         if ($route == null) {
-            foreach ($map as $method => $ability) {
-                $this->assignMiddleware($model, $method, $name, $options);
-            }
+            $this->assignMiddlewareToAllMethods($model, $name, $options);
 
             return new ControllerMiddlewareOptions($options);
         }
@@ -38,7 +36,7 @@ trait AuthorizesResources
         return $this->assignMiddleware($model, $method, $name, $options);
     }
 
-    public function assignMiddleware($model, $method, $name = null, array $options = [])
+    protected function assignMiddleware($model, $method, $name = null, array $options = [])
     {
         $map = $this->resourceAbilityMap();
 
@@ -47,6 +45,17 @@ trait AuthorizesResources
         }
 
         return $this->middleware("can:{$map[$method]},{$model}", $options);
+    }
+
+    protected function assignMiddlewareToAllMethods($model, $name = null, array $options = [])
+    {
+        $map = $this->resourceAbilityMap();
+
+        foreach ($map as $method => $ability) {
+            if (method_exists($this, $method)) {
+                $this->assignMiddleware($model, $method, $name, $options)->only($method);
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
I get this error when trying to run `php artisan route:list`:

```
[Symfony\Component\Debug\Exception\FatalThrowableError]
  Fatal error: Call to a member function getActionName() on null
```

The error is thrown in the authorises resource trait. If I don't use that trait, no error is thrown. Can someone please confirm this? If it is a bug indeed, this PR seems to fix the problem. 
