### PR TITLE
[5.2] Fix authorizes resources

### DIFF
--- a/src/Illuminate/Foundation/Auth/Access/AuthorizesResources.php
+++ b/src/Illuminate/Foundation/Auth/Access/AuthorizesResources.php
@@ -16,11 +16,15 @@ trait AuthorizesResources
     {
         $parameter = $parameter ?: strtolower(class_basename($model));
 
+        $middleware = [];
+
         foreach ($this->resourceAbilityMap() as $method => $ability) {
             $modelName = in_array($method, ['index', 'create', 'store']) ? $model : $parameter;
 
-            $this->middleware("can:{$ability},{$modelName}", $options)->only($method);
+            $middleware[] = "can:{$ability},{$modelName}";
         }
+
+        return $this->middleware($middleware, $options);
     }
 
     /**


### PR DESCRIPTION
Since in the controller, the developer could try something like:

```
    public function __construct()
    {
        $this->authorizeResource(Post::class, 'post')->only('something');
    }
```

Then it is important to always return the ControllerMiddlewareOptions object.
