### PR TITLE
[5.3] Fix cache get minutes

### DIFF
--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -490,7 +490,7 @@ class Repository implements CacheContract, ArrayAccess
             $duration = Carbon::now()->diffInSeconds(Carbon::instance($duration), false) / 60;
         }
 
-        return $duration > 0 ? $duration : null;
+        return (int) ($duration * 60) > 0 ? $duration : null;
     }
 
     /**


### PR DESCRIPTION
Cache::put() will never Call Store::put() when $minutes is too close to zero, which can mean caching forever, or for 1 second, or for zero second. If someone needs to cache forever, he/she should call Cache::forever(). If someone do Cache::getStore()->put(), the behavior varies across different stores. Maybe no one does that!
