### PR TITLE
[5.3] Option to revert/refresh specific number of migrations.

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/RefreshCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/RefreshCommand.php
@@ -41,9 +41,17 @@ class RefreshCommand extends Command
 
         $path = $this->input->getOption('path');
 
-        $this->call('migrate:reset', [
-            '--database' => $database, '--force' => $force,
-        ]);
+        $step = (int) $this->input->getOption('step');
+
+        if (is_int($step) && ($step > 0)) {
+            $this->call('migrate:rollback', [
+                '--database' => $database, '--force' => $force, '--step' => $step,
+            ]);
+        } else {
+            $this->call('migrate:reset', [
+                '--database' => $database, '--force' => $force,
+            ]);
+        }
 
         // The refresh command is essentially just a brief aggregate of a few other of
         // the migration commands and just provides a convenient wrapper to execute
@@ -99,6 +107,8 @@ class RefreshCommand extends Command
             ['force', null, InputOption::VALUE_NONE, 'Force the operation to run when in production.'],
 
             ['path', null, InputOption::VALUE_OPTIONAL, 'The path of migrations files to be executed.'],
+
+            ['step', null, InputOption::VALUE_OPTIONAL, 'Number of migrations to be reverted & re-run.'],
 
             ['seed', null, InputOption::VALUE_NONE, 'Indicates if the seed task should be re-run.'],
 

--- a/src/Illuminate/Database/Console/Migrations/RollbackCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/RollbackCommand.php
@@ -58,6 +58,12 @@ class RollbackCommand extends BaseCommand
 
         $this->migrator->setConnection($this->option('database'));
 
+        $step = (int) $this->input->getOption('step');
+
+        if (is_int($step) && ($step > 0)) {
+            $this->migrator->setRollBackSteps($step);
+        }
+
         $this->migrator->rollback(
             $this->getMigrationPaths(), $this->option('pretend')
         );
@@ -83,6 +89,8 @@ class RollbackCommand extends BaseCommand
             ['force', null, InputOption::VALUE_NONE, 'Force the operation to run when in production.'],
 
             ['pretend', null, InputOption::VALUE_NONE, 'Dump the SQL queries that would be run.'],
+
+            ['step', null, InputOption::VALUE_OPTIONAL, 'Number of migrations to be reverted.'],
         ];
     }
 }

--- a/src/Illuminate/Database/Migrations/DatabaseMigrationRepository.php
+++ b/src/Illuminate/Database/Migrations/DatabaseMigrationRepository.php
@@ -54,6 +54,19 @@ class DatabaseMigrationRepository implements MigrationRepositoryInterface
     }
 
     /**
+     * Get list of migrations.
+     *
+     * @param  int  $steps
+     * @return array
+     */
+    public function getMigrations($steps)
+    {
+        $query = $this->table()->where('batch', '>=', '1');
+
+        return $query->orderBy('migration', 'desc')->take($steps)->get()->all();
+    }
+
+    /**
      * Get the last migration batch.
      *
      * @return array

--- a/src/Illuminate/Database/Migrations/MigrationRepositoryInterface.php
+++ b/src/Illuminate/Database/Migrations/MigrationRepositoryInterface.php
@@ -12,6 +12,14 @@ interface MigrationRepositoryInterface
     public function getRan();
 
     /**
+     * Get list of migrations.
+     *
+     * @param  int  $steps
+     * @return array
+     */
+    public function getMigrations($steps);
+
+    /**
      * Get the last migration batch.
      *
      * @return array

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -53,6 +53,13 @@ class Migrator
     protected $paths = [];
 
     /**
+     * Number of migrations to rollback.
+     *
+     * @var int
+     */
+    protected $rollBackSteps = 0;
+
+    /**
      * Create a new migrator instance.
      *
      * @param  \Illuminate\Database\Migrations\MigrationRepositoryInterface  $repository
@@ -185,7 +192,11 @@ class Migrator
         // We want to pull in the last batch of migrations that ran on the previous
         // migration operation. We'll then reverse those migrations and run each
         // of them "down" to reverse the last migration "operation" which ran.
-        $migrations = $this->repository->getLast();
+        if ($this->rollBackSteps) {
+            $migrations = $this->repository->getMigrations($this->rollBackSteps);
+        } else {
+            $migrations = $this->repository->getLast();
+        }
 
         $count = count($migrations);
 
@@ -278,6 +289,19 @@ class Migrator
         $this->repository->delete($migration);
 
         $this->note("<info>Rolled back:</info> $file");
+    }
+
+    /**
+     * Set value to rollback specific number of migrations.
+     *
+     * @param  int  $step
+     * @return int
+     */
+    public function setRollBackSteps($step)
+    {
+        $this->rollBackSteps = $step;
+
+        return $this->rollBackSteps;
     }
 
     /**

--- a/tests/Database/DatabaseMigrationRollbackCommandTest.php
+++ b/tests/Database/DatabaseMigrationRollbackCommandTest.php
@@ -25,6 +25,21 @@ class DatabaseMigrationRollbackCommandTest extends PHPUnit_Framework_TestCase
         $this->runCommand($command);
     }
 
+    public function testRollbackCommandCallsMigratorWithStepOption()
+    {
+        $command = new RollbackCommand($migrator = m::mock('Illuminate\Database\Migrations\Migrator'));
+        $app = new ApplicationDatabaseRollbackStub(['path.database' => __DIR__]);
+        $app->useDatabasePath(__DIR__);
+        $command->setLaravel($app);
+        $migrator->shouldReceive('paths')->once()->andReturn([]);
+        $migrator->shouldReceive('setConnection')->once()->with(null);
+        $migrator->shouldReceive('setRollBackSteps')->once()->with(2);
+        $migrator->shouldReceive('rollback')->once()->with([__DIR__.'/migrations'], false);
+        $migrator->shouldReceive('getNotes')->andReturn([]);
+
+        $this->runCommand($command, ['--step' => 2]);
+    }
+
     public function testRollbackCommandCanBePretended()
     {
         $command = new RollbackCommand($migrator = m::mock('Illuminate\Database\Migrations\Migrator'));
@@ -37,6 +52,21 @@ class DatabaseMigrationRollbackCommandTest extends PHPUnit_Framework_TestCase
         $migrator->shouldReceive('getNotes')->andReturn([]);
 
         $this->runCommand($command, ['--pretend' => true, '--database' => 'foo']);
+    }
+
+    public function testRollbackCommandCanBePretendedWithStepOption()
+    {
+        $command = new RollbackCommand($migrator = m::mock('Illuminate\Database\Migrations\Migrator'));
+        $app = new ApplicationDatabaseRollbackStub(['path.database' => __DIR__]);
+        $app->useDatabasePath(__DIR__);
+        $command->setLaravel($app);
+        $migrator->shouldReceive('paths')->once()->andReturn([]);
+        $migrator->shouldReceive('setConnection')->once()->with('foo');
+        $migrator->shouldReceive('setRollBackSteps')->once()->with(2);
+        $migrator->shouldReceive('rollback')->once()->with([__DIR__.'/migrations'], true);
+        $migrator->shouldReceive('getNotes')->andReturn([]);
+
+        $this->runCommand($command, ['--pretend' => true, '--database' => 'foo', '--step' => 2]);
     }
 
     protected function runCommand($command, $input = [])


### PR DESCRIPTION
This PR allows user to revert/refresh a specific numbers of migrations by providing a `step` option to the artisan `migrate:rollback` & `migrate:refresh` command.

For example, if the user ran ten migrations in one batch, but wants to amend a couple of migrations without rolling back all migrations. This will allow user to only revert/redo a specific number of migrations. 

Lets say, if a user wants to revert last three run migrations:

```
php artisan migrate:rollback --step=3
```

If the user wants to revert & re-run last five migrations:

```
php artisan migrate:refresh --step=5
```

Yii2 has a simiar feature which allows a user to revert/redo a specific number of migrations. I thought it will be a nifty little feature to have in laravel as well.
