### PR TITLE
[5.3] Fixed incorrect logging error suppression

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -59,10 +59,12 @@ class Handler implements ExceptionHandlerContract
         }
 
         try {
-            $this->container->make(LoggerInterface::class)->error($e);
+            $logger = $this->container->make(LoggerInterface::class);
         } catch (Exception $ex) {
             throw $e; // throw the original exception
         }
+
+        $logger->error($e);
     }
 
     /**


### PR DESCRIPTION
We don't want to suppress errors like when the file permissions are incorrect on the storage folder, for example.
