### PR TITLE
[5.3] Add exists method to Session Store

### DIFF
--- a/src/Illuminate/Session/SessionInterface.php
+++ b/src/Illuminate/Session/SessionInterface.php
@@ -28,4 +28,13 @@ interface SessionInterface extends BaseSessionInterface
      * @return void
      */
     public function setRequestOnHandler(Request $request);
+
+    /**
+     * Checks if an attribute exists.
+     *
+     * @param  string|array  $key
+     *
+     * @return bool
+     */
+    public function exists($key);
 }

--- a/src/Illuminate/Session/SessionInterface.php
+++ b/src/Illuminate/Session/SessionInterface.php
@@ -33,7 +33,6 @@ interface SessionInterface extends BaseSessionInterface
      * Checks if an attribute exists.
      *
      * @param  string|array  $key
-     *
      * @return bool
      */
     public function exists($key);

--- a/src/Illuminate/Session/Store.php
+++ b/src/Illuminate/Session/Store.php
@@ -324,6 +324,22 @@ class Store implements SessionInterface
     /**
      * {@inheritdoc}
      */
+    public function exists($key)
+    {
+        $keys = is_array($key) ? $key : func_get_args();
+
+        foreach ($keys as $value) {
+            if (! Arr::exists($this->attributes, $value)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function get($name, $default = null)
     {
         return Arr::get($this->attributes, $name, $default);

--- a/tests/Session/SessionStoreTest.php
+++ b/tests/Session/SessionStoreTest.php
@@ -296,6 +296,19 @@ class SessionStoreTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($session->getName(), 'foo');
     }
 
+    public function testKeyExists()
+    {
+        $session = $this->getSession();
+        $session->set('foo', 'bar');
+        $this->assertTrue($session->exists('foo'));
+        $session->set('baz', null);
+        $this->assertFalse($session->has('baz'));
+        $this->assertTrue($session->exists('baz'));
+        $this->assertFalse($session->exists('bogus'));
+        $this->assertTrue($session->exists(['foo', 'baz']));
+        $this->assertFalse($session->exists(['foo', 'baz', 'bogus']));
+    }
+
     public function getSession()
     {
         $reflection = new ReflectionClass('Illuminate\Session\Store');


### PR DESCRIPTION
Currently, there is no way to test if a session variable exists and its value is `null`, as the `has` method will return `false` for any `null` value.

This PR introduces the `exists` method into `SessionStore`, as well as `SessionInterface` and relevant tests to account for this functionality, which is present in other classes (`Request`, `Arr`, etc.)
