### PR TITLE
[5.2] fix bug when morphTo return null

### DIFF
--- a/src/Illuminate/Database/Eloquent/SoftDeletingScope.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletingScope.php
@@ -20,7 +20,9 @@ class SoftDeletingScope implements Scope
      */
     public function apply(Builder $builder, Model $model)
     {
-        $builder->whereNull($model->getQualifiedDeletedAtColumn());
+        if (in_array(SoftDeletes::class, class_uses($model))) {
+            $builder->whereNull($model->getQualifiedDeletedAtColumn());
+        }
     }
 
     /**


### PR DESCRIPTION
When I have a relationship:
class User extends \Illuminate\Foundation\Auth\User
{
    use SoftDeletes;

```
public function owner()
{
    return $this->morphTo();
}
```

}

Table users: (id, name, ... owner_type, owner_id}, and for some reason the owner_type can be null, it tries to search the deleted_at column in the relationship, only that does not even exist.

Perhaps the most suitable place for this correction is not here, but is the site faster than I thought.
