### PR TITLE
[5.2] Add Arr::unDot() method

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -116,7 +116,7 @@ class Arr
     }
 
     /**
-     * Expand a dotted array. Acts the opposite way of Arr::dot()
+     * Expand a dotted array. Acts the opposite way of Arr::dot().
      *
      * @param  array  $array
      * @param  bool  $recursively

--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -116,6 +116,36 @@ class Arr
     }
 
     /**
+     * Expand a dotted array. Acts the opposite way of Arr::dot()
+     *
+     * @param  array  $array
+     * @param  bool  $recursively
+     * @return array
+     */
+    public static function unDot($array, $recursively = true)
+    {
+        $results = [];
+
+        foreach ($array as $key => $value) {
+            if (count($dottedKeys = explode('.', $key, 2)) > 1) {
+                $results[$dottedKeys[0]][$dottedKeys[1]] = $value;
+            } else {
+                $results[$key] = $value;
+            }
+        }
+
+        if ($recursively) {
+            foreach ($results as $key => $value) {
+                if (is_array($value) && ! empty($value)) {
+                    $results[$key] = self::unDot($value, $recursively);
+                }
+            }
+        }
+
+        return $results;
+    }
+
+    /**
      * Get all of the given array except for a specified array of items.
      *
      * @param  array  $array

--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -119,10 +119,10 @@ class Arr
      * Expand a dotted array. Acts the opposite way of Arr::dot().
      *
      * @param  array  $array
-     * @param  bool  $recursively
+     * @param  int  $depth
      * @return array
      */
-    public static function unDot($array, $recursively = true)
+    public static function unDot($array, $depth = INF)
     {
         $results = [];
 
@@ -134,11 +134,9 @@ class Arr
             }
         }
 
-        if ($recursively) {
-            foreach ($results as $key => $value) {
-                if (is_array($value) && ! empty($value)) {
-                    $results[$key] = static::unDot($value, $recursively);
-                }
+        foreach ($results as $key => $value) {
+            if (is_array($value) && ! empty($value) && $depth > 1) {
+                $results[$key] = static::unDot($value, $depth - 1);
             }
         }
 

--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -137,7 +137,7 @@ class Arr
         if ($recursively) {
             foreach ($results as $key => $value) {
                 if (is_array($value) && ! empty($value)) {
-                    $results[$key] = self::unDot($value, $recursively);
+                    $results[$key] = static::unDot($value, $recursively);
                 }
             }
         }

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -67,6 +67,28 @@ class SupportArrTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(['foo' => ['bar' => 'baz', 'bar1' => 'baz1'], 'foo2' => 'bar2'], $array);
     }
 
+    public function testUnDotWithDepth()
+    {
+        // Without specifying depth it expands recursively.
+        $array = Arr::unDot(['foo.bar.baz' => 'baz-value']);
+        $this->assertEquals(['foo' => ['bar' => ['baz' => 'baz-value']]], $array);
+
+        $array = Arr::unDot(['foo.bar.baz.bizz' => 'baz-value'], 1);
+        $this->assertEquals(['foo' => ['bar.baz.bizz' => 'baz-value']], $array);
+
+        $array = Arr::unDot(['foo.bar.baz.bizz' => 'baz-value'], 2);
+        $this->assertEquals(['foo' => ['bar' => ['baz.bizz' => 'baz-value']]], $array);
+
+        $array = Arr::unDot(['foo.bar.baz.bizz' => 'baz-value'], 3);
+        $this->assertEquals(['foo' => ['bar' => ['baz' => ['bizz' => 'baz-value']]]], $array);
+
+        $array = Arr::unDot(['foo.bar' => 'baz', 'foo.bar1.bizz' => 'baz1', 'foo2' => 'bar2'], 2);
+        $this->assertEquals(['foo' => ['bar' => 'baz', 'bar1' => ['bizz' => 'baz1']], 'foo2' => 'bar2'], $array);
+
+        $array = Arr::unDot(['foo.bar' => 'baz', 'foo.bar1.bizz' => 'baz1', 'foo2' => 'bar2'], 1);
+        $this->assertEquals(['foo' => ['bar' => 'baz', 'bar1.bizz' => 'baz1'], 'foo2' => 'bar2'], $array);
+    }
+
     public function testExcept()
     {
         $array = ['name' => 'Desk', 'price' => 100];

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -52,6 +52,21 @@ class SupportArrTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(['foo.bar' => []], $array);
     }
 
+    public function testUnDot()
+    {
+        $array = Arr::unDot(['foo.bar' => 'baz']);
+        $this->assertEquals(['foo' => ['bar' => 'baz']], $array);
+
+        $array = Arr::unDot([]);
+        $this->assertEquals([], $array);
+
+        $array = Arr::unDot(['foo.bar' => 'baz', 'foo1' => 'bar1']);
+        $this->assertEquals(['foo' => ['bar' => 'baz'], 'foo1' => 'bar1'], $array);
+
+        $array = Arr::unDot(['foo.bar' => 'baz', 'foo.bar1' => 'baz1', 'foo2' => 'bar2']);
+        $this->assertEquals(['foo' => ['bar' => 'baz', 'bar1' => 'baz1'], 'foo2' => 'bar2'], $array);
+    }
+
     public function testExcept()
     {
         $array = ['name' => 'Desk', 'price' => 100];


### PR DESCRIPTION
Expand a dotted-key array. It acts the opposite way of Arr::dot(). 

**Note:** I am not sure about the method name itself (is it good or not). If acceptable for merge, then we can change the method name.
