### PR TITLE
[5.2] Adding JSON_UNESCAPED_UNICODE to the method `asJson` in the `Model`

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -3011,7 +3011,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     protected function asJson($value)
     {
-        return json_encode($value);
+        return json_encode($value, JSON_UNESCAPED_UNICODE);
     }
 
     /**

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1353,7 +1353,7 @@ class EloquentModelStub extends Model
 
     public function setListItemsAttribute($value)
     {
-        $this->attributes['list_items'] = json_encode($value);
+        $this->attributes['list_items'] = json_encode($value, JSON_UNESCAPED_UNICODE);
     }
 
     public function getPasswordAttribute()


### PR DESCRIPTION
Need for correct JSON encoding of non-ASCII chars
