### PR TITLE
[5.2] Bugfix for too long key name in migrations

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -943,7 +943,7 @@ class Blueprint
      */
     protected function createIndexName($type, array $columns)
     {
-        $index = strtolower($this->table.'_'.implode('_', $columns).'_'.$type);
+        $index = str_limit(strtolower($this->table.'_'.implode('_', $columns).'_'.$type), 64, '');
 
         return str_replace(['-', '.'], '_', $index);
     }


### PR DESCRIPTION
Fix the bug when the key name is longer than 64 chars throwing the error "SQLSTATE[42000]: Syntax error or access violation: 1059 Identifier name '(...)' is too long"
