### PR TITLE
[5.2] Implemented job:dispatch and job:list artisan commands.

### DIFF
--- a/src/Illuminate/Console/Jobs/DispatchCommand.php
+++ b/src/Illuminate/Console/Jobs/DispatchCommand.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Illuminate\Console\Jobs;
+
+use Illuminate\Console\Command;
+use Illuminate\Foundation\Bus\DispatchesJobs;
+
+class DispatchCommand extends Command
+{
+    use DispatchesJobs;
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Dispatches a job';
+
+    /**
+     * The console command signature.
+     *
+     * @var string
+     */
+    protected $signature = 'job:dispatch {job : The name of the job that should be dispatched}';
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function fire()
+    {
+        $job = $this->argument('job');
+
+        $this->info("Dispatching {$job} now...");
+
+        $this->dispatch(new $job());
+
+        $this->info('Successfully Dispatched Job');
+    }
+}

--- a/src/Illuminate/Console/Jobs/JobsServiceProvider.php
+++ b/src/Illuminate/Console/Jobs/JobsServiceProvider.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Illuminate\Console\Jobs;
+
+use Illuminate\Support\ServiceProvider;
+
+class JobsServiceProvider extends ServiceProvider
+{
+    /**
+     * Indicates if loading of the provider is deferred.
+     *
+     * @var bool
+     */
+    protected $defer = true;
+
+    /**
+     * Register the service provider.
+     *
+     * @return void
+     */
+    public function register()
+    {
+        $this->commands(DispatchCommand::class);
+    }
+
+    /**
+     * Get the services provided by the provider.
+     *
+     * @return array
+     */
+    public function provides()
+    {
+        return [
+            DispatchCommand::class,
+        ];
+    }
+}

--- a/src/Illuminate/Foundation/Providers/ConsoleSupportServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ConsoleSupportServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Foundation\Providers;
 
+use Illuminate\Console\Jobs\JobsServiceProvider;
 use Illuminate\Support\AggregateServiceProvider;
 
 class ConsoleSupportServiceProvider extends AggregateServiceProvider
@@ -25,5 +26,6 @@ class ConsoleSupportServiceProvider extends AggregateServiceProvider
         'Illuminate\Database\SeedServiceProvider',
         'Illuminate\Foundation\Providers\ComposerServiceProvider',
         'Illuminate\Queue\ConsoleServiceProvider',
+        JobsServiceProvider::class,
     ];
 }


### PR DESCRIPTION
I've created two artisan commands:
- job:list; lists all available jobs.
- job:dispatch; dispatches a job.

I've found them to be quite useful in the past to test / run jobs from the command line.

I've also used it with the scheduler to schedule jobs as shown below:

`$schedule->command('job:dispatch SomeJobClass')`
