### PR TITLE
[5.2] I change the boundaries of sampling units

### DIFF
--- a/src/Illuminate/Pagination/Paginator.php
+++ b/src/Illuminate/Pagination/Paginator.php
@@ -66,7 +66,7 @@ class Paginator extends AbstractPaginator implements Arrayable, ArrayAccess, Cou
     {
         $this->hasMore = count($this->items) > ($this->perPage);
 
-        $this->items = $this->items->slice(0, $this->perPage);
+        $this->items = $this->items->slice($this->firstItem() - 1, $this->perPage);
     }
 
     /**


### PR DESCRIPTION
In the previous version at number Paginator page changes are displayed starting with the first elements . Now the elements are chosen In accordance with the selected page and select the number of elements onto a page.
