### PR TITLE
[5.2] Redis Tagged Cache - Minor change

### DIFF
--- a/src/Illuminate/Cache/RedisTaggedCache.php
+++ b/src/Illuminate/Cache/RedisTaggedCache.php
@@ -93,7 +93,7 @@ class RedisTaggedCache extends TaggedCache
      */
     protected function pushKeys($namespace, $key, $reference)
     {
-        $fullKey = $this->getPrefix().sha1($namespace).':'.$key;
+        $fullKey = $this->store->getPrefix().sha1($namespace).':'.$key;
 
         foreach (explode('|', $namespace) as $segment) {
             $this->store->connection()->sadd($this->referenceKey($segment, $reference), $fullKey);
@@ -159,6 +159,6 @@ class RedisTaggedCache extends TaggedCache
      */
     protected function referenceKey($segment, $suffix)
     {
-        return $this->getPrefix().$segment.':'.$suffix;
+        return $this->store->getPrefix().$segment.':'.$suffix;
     }
 }


### PR DESCRIPTION
Calling `getPrefix()` directly instead of let it fall through to `__call`.

See: https://github.com/laravel/framework/blob/5.2/src/Illuminate/Cache/Repository.php#L487

I have tested this change and worked fine.
