### PR TITLE
German chars now convert right

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -804,6 +804,19 @@ if (! function_exists('str_slug')) {
      */
     function str_slug($title, $separator = '-')
     {
+        // Special chars
+        $title = strtr($title,
+			[
+				// Germany
+				"ä" => "ae",
+				"ü" => "ue",
+				"ö" => "oe",
+				"Ä" => "Ae",
+				"Ü" => "Ue",
+				"Ö" => "Oe",
+				"ß" => "ss"
+			]
+		);
         return Str::slug($title, $separator);
     }
 }


### PR DESCRIPTION
That means ä is ae and not just a.
