### PR TITLE
[5.2] Add failed job ID when dispatching a JobFailed event

### DIFF
--- a/src/Illuminate/Queue/Events/JobFailed.php
+++ b/src/Illuminate/Queue/Events/JobFailed.php
@@ -26,17 +26,26 @@ class JobFailed
     public $data;
 
     /**
+     * The failed job ID.
+     *
+     * @var int
+     */
+    public $failedId;
+
+    /**
      * Create a new event instance.
      *
      * @param  string  $connectionName
      * @param  \Illuminate\Contracts\Queue\Job  $job
      * @param  array  $data
+     * @param  int  $failedId
      * @return void
      */
-    public function __construct($connectionName, $job, $data)
+    public function __construct($connectionName, $job, $data, $failedId = null)
     {
         $this->job = $job;
         $this->data = $data;
+        $this->failedId = $failedId;
         $this->connectionName = $connectionName;
     }
 }

--- a/src/Illuminate/Queue/Events/JobFailed.php
+++ b/src/Illuminate/Queue/Events/JobFailed.php
@@ -28,7 +28,7 @@ class JobFailed
     /**
      * The failed job ID.
      *
-     * @var int
+     * @var int|null
      */
     public $failedId;
 
@@ -38,7 +38,7 @@ class JobFailed
      * @param  string  $connectionName
      * @param  \Illuminate\Contracts\Queue\Job  $job
      * @param  array  $data
-     * @param  int  $failedId
+     * @param  int|null  $failedId
      * @return void
      */
     public function __construct($connectionName, $job, $data, $failedId = null)

--- a/src/Illuminate/Queue/Failed/DatabaseFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/DatabaseFailedJobProvider.php
@@ -49,13 +49,13 @@ class DatabaseFailedJobProvider implements FailedJobProviderInterface
      * @param  string  $connection
      * @param  string  $queue
      * @param  string  $payload
-     * @return void
+     * @return int
      */
     public function log($connection, $queue, $payload)
     {
         $failed_at = Carbon::now();
 
-        $this->getTable()->insert(compact('connection', 'queue', 'payload', 'failed_at'));
+        return $this->getTable()->insertGetId(compact('connection', 'queue', 'payload', 'failed_at'));
     }
 
     /**

--- a/src/Illuminate/Queue/Failed/DatabaseFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/DatabaseFailedJobProvider.php
@@ -49,7 +49,7 @@ class DatabaseFailedJobProvider implements FailedJobProviderInterface
      * @param  string  $connection
      * @param  string  $queue
      * @param  string  $payload
-     * @return int
+     * @return int|null
      */
     public function log($connection, $queue, $payload)
     {

--- a/src/Illuminate/Queue/Failed/FailedJobProviderInterface.php
+++ b/src/Illuminate/Queue/Failed/FailedJobProviderInterface.php
@@ -10,7 +10,7 @@ interface FailedJobProviderInterface
      * @param  string  $connection
      * @param  string  $queue
      * @param  string  $payload
-     * @return int
+     * @return int|null
      */
     public function log($connection, $queue, $payload);
 

--- a/src/Illuminate/Queue/Failed/FailedJobProviderInterface.php
+++ b/src/Illuminate/Queue/Failed/FailedJobProviderInterface.php
@@ -10,7 +10,7 @@ interface FailedJobProviderInterface
      * @param  string  $connection
      * @param  string  $queue
      * @param  string  $payload
-     * @return void
+     * @return int
      */
     public function log($connection, $queue, $payload);
 

--- a/src/Illuminate/Queue/Failed/NullFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/NullFailedJobProvider.php
@@ -10,11 +10,11 @@ class NullFailedJobProvider implements FailedJobProviderInterface
      * @param  string  $connection
      * @param  string  $queue
      * @param  string  $payload
-     * @return int
+     * @return int|null
      */
     public function log($connection, $queue, $payload)
     {
-        return -1;
+        //
     }
 
     /**

--- a/src/Illuminate/Queue/Failed/NullFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/NullFailedJobProvider.php
@@ -10,11 +10,11 @@ class NullFailedJobProvider implements FailedJobProviderInterface
      * @param  string  $connection
      * @param  string  $queue
      * @param  string  $payload
-     * @return void
+     * @return int
      */
     public function log($connection, $queue, $payload)
     {
-        //
+        return false;
     }
 
     /**

--- a/src/Illuminate/Queue/Failed/NullFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/NullFailedJobProvider.php
@@ -14,7 +14,7 @@ class NullFailedJobProvider implements FailedJobProviderInterface
      */
     public function log($connection, $queue, $payload)
     {
-        return false;
+        return -1;
     }
 
     /**

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -310,13 +310,13 @@ class Worker
     protected function logFailedJob($connection, Job $job)
     {
         if ($this->failer) {
-            $this->failer->log($connection, $job->getQueue(), $job->getRawBody());
+            $failedId = $this->failer->log($connection, $job->getQueue(), $job->getRawBody());
 
             $job->delete();
 
             $job->failed();
 
-            $this->raiseFailedJobEvent($connection, $job);
+            $this->raiseFailedJobEvent($connection, $job, $failedId);
         }
 
         return ['job' => $job, 'failed' => true];
@@ -327,14 +327,15 @@ class Worker
      *
      * @param  string  $connection
      * @param  \Illuminate\Contracts\Queue\Job  $job
+     * @param  int
      * @return void
      */
-    protected function raiseFailedJobEvent($connection, Job $job)
+    protected function raiseFailedJobEvent($connection, Job $job, $failedId)
     {
         if ($this->events) {
             $data = json_decode($job->getRawBody(), true);
 
-            $this->events->fire(new Events\JobFailed($connection, $job, $data));
+            $this->events->fire(new Events\JobFailed($connection, $job, $data, $failedId));
         }
     }
 

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -327,7 +327,7 @@ class Worker
      *
      * @param  string  $connection
      * @param  \Illuminate\Contracts\Queue\Job  $job
-     * @param  int
+     * @param  int|null  $failedId
      * @return void
      */
     protected function raiseFailedJobEvent($connection, Job $job, $failedId)


### PR DESCRIPTION
We wrote a piece of code in our Laravel application which allows us to add exception information in a separate table when a job fails. The purpose of this is was to be able to have more knowledge on what happened to a specific failed job before rerunning it with `php artisan queue:retry <id>`. The new table has columns like the exception message, backtrace, data and some user information.

The problem that we were facing was that the ID from the _failed_job_ table wasn't recoverable once the _failer_ instance was inserting a record in the database because that function wasn't returning anything (void).

This could allow people to check and play with the failed job ID when a _JobFailed_ event is dispatched in the application. I also added a default value of NULL to make sure that this isn't breaking the previous event class definition.
