### PR TITLE
Adding the 'dblib' option to the ConnectionFactory for Linux + MSSQL

### DIFF
--- a/src/Illuminate/Database/Connectors/ConnectionFactory.php
+++ b/src/Illuminate/Database/Connectors/ConnectionFactory.php
@@ -189,6 +189,8 @@ class ConnectionFactory
                 return new SQLiteConnector;
             case 'sqlsrv':
                 return new SqlServerConnector;
+            case 'dblib':
+                return new SqlServerConnector;
         }
 
         throw new InvalidArgumentException("Unsupported driver [{$config['driver']}]");
@@ -220,6 +222,8 @@ class ConnectionFactory
             case 'sqlite':
                 return new SQLiteConnection($connection, $database, $prefix, $config);
             case 'sqlsrv':
+                return new SqlServerConnection($connection, $database, $prefix, $config);
+            case 'dblib':
                 return new SqlServerConnection($connection, $database, $prefix, $config);
         }
 


### PR DESCRIPTION
I'm developing an app that is running on Ubuntu, with PHP 5.6, but has to connect to a MS SQL Server.

By installing the correct modules, you can use dblib driver to connect to a MSSQL database but, by default, there is no dblib driver to be utilized by laravel.

This is my first project with laravel and it took me about 2 hours to notice why it wasn't working. This little update is enough to spare other new Laravel dev's of that suffering.

There is no need to create a new SqlServerConnection class, since dblib behaves the same as sqlsrv.
