### PR TITLE
[5.3] Add full stubbing to policy generator

### DIFF
--- a/src/Illuminate/Foundation/Console/PolicyMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/PolicyMakeCommand.php
@@ -2,7 +2,9 @@
 
 namespace Illuminate\Foundation\Console;
 
+use Illuminate\Support\Str;
 use Illuminate\Console\GeneratorCommand;
+use Symfony\Component\Console\Input\InputOption;
 
 class PolicyMakeCommand extends GeneratorCommand
 {
@@ -28,13 +30,48 @@ class PolicyMakeCommand extends GeneratorCommand
     protected $type = 'Policy';
 
     /**
+     * Build the class with the given name.
+     *
+     * @param  string  $name
+     * @return string
+     */
+    protected function buildClass($name)
+    {
+        $stub = parent::buildClass($name);
+
+        $model = $this->option('model');
+
+        return $model ? $this->replaceModel($stub, $model) : $stub;
+    }
+
+    /**
+     * Replace the model for the given stub.
+     *
+     * @param  string  $stub
+     * @param  string  $model
+     * @return string
+     */
+    protected function replaceModel($stub, $model)
+    {
+        $stub = str_replace('DummyModel', $model, $stub);
+
+        $stub = str_replace('dummyModelName', Str::lower($model), $stub);
+
+        return str_replace('dummyPluralModelName', Str::plural(Str::lower($model)), $stub);
+    }
+
+    /**
      * Get the stub file for the generator.
      *
      * @return string
      */
     protected function getStub()
     {
-        return __DIR__.'/stubs/policy.stub';
+        if ($this->option('model')) {
+            return __DIR__.'/stubs/policy.stub';
+        }
+
+        return __DIR__.'/stubs/policy.plain.stub';
     }
 
     /**
@@ -46,5 +83,17 @@ class PolicyMakeCommand extends GeneratorCommand
     protected function getDefaultNamespace($rootNamespace)
     {
         return $rootNamespace.'\Policies';
+    }
+
+    /**
+     * Get the console command arguments.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [
+            ['model', 'm', InputOption::VALUE_OPTIONAL, 'The model that the policy applies to.'],
+        ];
     }
 }

--- a/src/Illuminate/Foundation/Console/stubs/policy.plain.stub
+++ b/src/Illuminate/Foundation/Console/stubs/policy.plain.stub
@@ -1,0 +1,21 @@
+<?php
+
+namespace DummyNamespace;
+
+use DummyRootNamespaceUser;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
+class DummyClass
+{
+    use HandlesAuthorization;
+
+    /**
+     * Create a new policy instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        //
+    }
+}

--- a/src/Illuminate/Foundation/Console/stubs/policy.stub
+++ b/src/Illuminate/Foundation/Console/stubs/policy.stub
@@ -2,6 +2,8 @@
 
 namespace DummyNamespace;
 
+use DummyRootNamespaceUser;
+use DummyRootNamespaceDummyModel;
 use Illuminate\Auth\Access\HandlesAuthorization;
 
 class DummyClass
@@ -9,11 +11,70 @@ class DummyClass
     use HandlesAuthorization;
 
     /**
-     * Create a new policy instance.
+     * Determine whether the given user can view dummyPluralModelName.
      *
-     * @return void
+     * @param  DummyRootNamespaceUser  $user
+     * @return mixed
      */
-    public function __construct()
+    public function viewAny(User $user)
+    {
+        //
+    }
+
+    /**
+     * Determine whether the given user can view the specified dummyModelName.
+     *
+     * @param  DummyRootNamespaceUser  $user
+     * @param  DummyRootNamespaceDummyModel  $dummyModelName
+     * @return mixed
+     */
+    public function view(User $user, DummyModel $dummyModelName)
+    {
+        //
+    }
+
+    /**
+     * Determine whether the given user can create dummyPluralModelName.
+     *
+     * @param  DummyRootNamespaceUser  $user
+     * @return mixed
+     */
+    public function createAny(User $user)
+    {
+        //
+    }
+
+    /**
+     * Determine whether the given user can update dummyPluralModelName.
+     *
+     * @param  DummyRootNamespaceUser  $user
+     * @return mixed
+     */
+    public function updateAny(User $user)
+    {
+        //
+    }
+
+    /**
+     * Determine whether the given user can update the specified dummyModelName.
+     *
+     * @param  DummyRootNamespaceUser  $user
+     * @param  DummyRootNamespaceDummyModel  $dummyModelName
+     * @return mixed
+     */
+    public function update(User $user, DummyModel $dummyModelName)
+    {
+        //
+    }
+
+    /**
+     * Determine whether the given user can delete the specified dummyModelName.
+     *
+     * @param  DummyRootNamespaceUser  $user
+     * @param  DummyRootNamespaceDummyModel  $dummyModelName
+     * @return mixed
+     */
+    public function delete(User $user, DummyModel $dummyModelName)
     {
         //
     }


### PR DESCRIPTION
Running the following command:

```
php artisan make:policy CompanyPolicy --model=Company
```

Will generate this policy file:

``` php
<?php

namespace App\Policies;

use App\User;
use App\Company;
use Illuminate\Auth\Access\HandlesAuthorization;

class CompanyPolicy
{
    use HandlesAuthorization;

    /**
     * Determine whether the given user can view companies.
     *
     * @param  App\User  $user
     * @return mixed
     */
    public function viewAny(User $user)
    {
        //
    }

    /**
     * Determine whether the given user can view the specified company.
     *
     * @param  App\User  $user
     * @param  App\Company  $company
     * @return mixed
     */
    public function view(User $user, Company $company)
    {
        //
    }

    /**
     * Determine whether the given user can create companies.
     *
     * @param  App\User  $user
     * @return mixed
     */
    public function createAny(User $user)
    {
        //
    }

    /**
     * Determine whether the given user can update companies.
     *
     * @param  App\User  $user
     * @return mixed
     */
    public function updateAny(User $user)
    {
        //
    }

    /**
     * Determine whether the given user can update the specified company.
     *
     * @param  App\User  $user
     * @param  App\Company  $company
     * @return mixed
     */
    public function update(User $user, Company $company)
    {
        //
    }

    /**
     * Determine whether the given user can delete the specified company.
     *
     * @param  App\User  $user
     * @param  App\Company  $company
     * @return mixed
     */
    public function delete(User $user, Company $company)
    {
        //
    }
}
```
