### PR TITLE
[5.1] Adding support for StreamOptions

### DIFF
--- a/src/Illuminate/Mail/TransportManager.php
+++ b/src/Illuminate/Mail/TransportManager.php
@@ -44,6 +44,10 @@ class TransportManager extends Manager
 
             $transport->setPassword($config['password']);
         }
+        
+        if (isset($config['stream'])) {
+            $transport->setStreamOptions($config['stream']);
+        }
 
         return $transport;
     }


### PR DESCRIPTION
5.2 ist already supporting this. Since 5.1 uses the same SwiftMailer Version, we should support this too.

Needed for PHP 5.6 because in combination with OpenSSL PHP 5.6 denied using self-signed certificates, as long as it was not specified separately.
