### PR TITLE
[5.3] Add the ability to disable caching of compiled Blade templates

### DIFF
--- a/src/Illuminate/View/Compilers/Compiler.php
+++ b/src/Illuminate/View/Compilers/Compiler.php
@@ -21,16 +21,25 @@ abstract class Compiler
     protected $cachePath;
 
     /**
+     * Whether or not compiled views should be cached.
+     *
+     * @var bool
+     */
+    protected $shouldCache;
+
+    /**
      * Create a new compiler instance.
      *
      * @param  \Illuminate\Filesystem\Filesystem  $files
      * @param  string  $cachePath
+     * @param  bool  $shouldCache
      * @return void
      */
-    public function __construct(Filesystem $files, $cachePath)
+    public function __construct(Filesystem $files, $cachePath, $shouldCache = true)
     {
         $this->files = $files;
         $this->cachePath = $cachePath;
+        $this->shouldCache = $shouldCache;
     }
 
     /**
@@ -52,6 +61,11 @@ abstract class Compiler
      */
     public function isExpired($path)
     {
+        // If the app is configured to not cache compiled views, return as expired.
+        if (! $this->shouldCache) {
+            return true;
+        }
+
         $compiled = $this->getCompiledPath($path);
 
         // If the compiled file doesn't exist we will indicate that the view is expired

--- a/src/Illuminate/View/ViewServiceProvider.php
+++ b/src/Illuminate/View/ViewServiceProvider.php
@@ -73,8 +73,9 @@ class ViewServiceProvider extends ServiceProvider
         // instance to pass into the engine so it can compile the views properly.
         $app->singleton('blade.compiler', function ($app) {
             $cache = $app['config']['view.compiled'];
+            $shouldCache = $app['config']['view.should_cache'];
 
-            return new BladeCompiler($app['files'], $cache);
+            return new BladeCompiler($app['files'], $cache, $shouldCache);
         });
 
         $resolver->register('blade', function () use ($app) {

--- a/src/Illuminate/View/ViewServiceProvider.php
+++ b/src/Illuminate/View/ViewServiceProvider.php
@@ -73,7 +73,7 @@ class ViewServiceProvider extends ServiceProvider
         // instance to pass into the engine so it can compile the views properly.
         $app->singleton('blade.compiler', function ($app) {
             $cache = $app['config']['view.compiled'];
-            $shouldCache = $app['config']['view.should_cache'];
+            $shouldCache = $app['config']['view.should_cache'] ?: true;
 
             return new BladeCompiler($app['files'], $cache, $shouldCache);
         });

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -17,6 +17,14 @@ class ViewBladeCompilerTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($compiler->isExpired('foo'));
     }
 
+    public function testItDoesNotCacheTemplatesIfTheApplicationIsConfiguredNotTo()
+    {
+        $compiler = new BladeCompiler($files = $this->getFiles(), __DIR__, false);
+        $files->shouldReceive('getCompiledPath')->never();
+        $files->shouldReceive('exists')->never();
+        $this->assertTrue($compiler->isExpired('foo'));
+    }
+
     public function testIsExpiredReturnsTrueIfCachePathIsNull()
     {
         $compiler = new BladeCompiler($files = $this->getFiles(), null);


### PR DESCRIPTION
Under some circumstances, such as when in development, you may opt to disable caching of compiled Blade templates. This change allows caching to be overwritten via a view configuration option.
