### PR TITLE
[5.1] Fix possible key overlap in cache of Str::snake

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -365,10 +365,10 @@ class Str
      */
     public static function snake($value, $delimiter = '_')
     {
-        $key = $value.$delimiter;
+        $key = $value;
 
-        if (isset(static::$snakeCache[$key])) {
-            return static::$snakeCache[$key];
+        if (isset(static::$snakeCache[$key][$delimiter])) {
+            return static::$snakeCache[$key][$delimiter];
         }
 
         if (! ctype_lower($value)) {
@@ -377,7 +377,7 @@ class Str
             $value = static::lower(preg_replace('/(.)(?=[A-Z])/u', '$1'.$delimiter, $value));
         }
 
-        return static::$snakeCache[$key] = $value;
+        return static::$snakeCache[$key][$delimiter] = $value;
     }
 
     /**

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -147,6 +147,9 @@ class SupportStrTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('laravel php framework', Str::snake('LaravelPhpFramework', ' '));
         $this->assertEquals('laravel_php_framework', Str::snake('Laravel Php Framework'));
         $this->assertEquals('laravel_php_framework', Str::snake('Laravel    Php      Framework   '));
+        // ensure cache keys don't overlap
+        $this->assertEquals('laravel__php__framework', Str::snake('LaravelPhpFramework', '__'));
+        $this->assertEquals('laravel_php_framework_', Str::snake('LaravelPhpFramework_', '_'));
     }
 
     public function testStudly()


### PR DESCRIPTION
Not a very practical example, but this PR avoids such a collision:

```
Str::snake('foo', '--');
Str::snake('foo-', '-');
```
