### PR TITLE
[5.3] Add loop variable to @forelse loops

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -624,7 +624,17 @@ class BladeCompiler extends Compiler implements CompilerInterface
     {
         $empty = '$__empty_'.++$this->forelseCounter;
 
-        return "<?php {$empty} = true; foreach{$expression}: {$empty} = false; ?>";
+        preg_match('/\( *(.*) *as *([^\)]*)/', $expression, $matches);
+
+        $iteratee = trim($matches[1]);
+
+        $iteration = trim($matches[2]);
+
+        $initLoop = "\$__currentLoopData = {$iteratee}; \$__env->addLoop(\$__currentLoopData);";
+
+        $iterateLoop = '$__env->incrementLoopIndices(); $loop = $__env->getFirstLoop();';
+
+        return "<?php {$empty} = true; {$initLoop} foreach(\$__currentLoopData as {$iteration}): {$iterateLoop} {$empty} = false; ?>";
     }
 
     /**
@@ -703,7 +713,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
     {
         $empty = '$__empty_'.$this->forelseCounter--;
 
-        return "<?php endforeach; if ({$empty}): ?>";
+        return "<?php endforeach; \$__env->popLoop(); \$loop = \$__env->getFirstLoop(); if ({$empty}): ?>";
     }
 
     /**

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -499,9 +499,9 @@ breeze
 @empty
 empty
 @endforelse';
-        $expected = '<?php $__empty_1 = true; foreach($this->getUsers() as $user): $__empty_1 = false; ?>
+        $expected = '<?php $__empty_1 = true; $__currentLoopData = $this->getUsers(); $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $user): $__env->incrementLoopIndices(); $loop = $__env->getFirstLoop(); $__empty_1 = false; ?>
 breeze
-<?php endforeach; if ($__empty_1): ?>
+<?php endforeach; $__env->popLoop(); $loop = $__env->getFirstLoop(); if ($__empty_1): ?>
 empty
 <?php endif; ?>';
         $this->assertEquals($expected, $compiler->compileString($string));
@@ -519,13 +519,13 @@ tag empty
 @empty
 empty
 @endforelse';
-        $expected = '<?php $__empty_1 = true; foreach($this->getUsers() as $user): $__empty_1 = false; ?>
-<?php $__empty_2 = true; foreach($user->tags as $tag): $__empty_2 = false; ?>
+        $expected = '<?php $__empty_1 = true; $__currentLoopData = $this->getUsers(); $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $user): $__env->incrementLoopIndices(); $loop = $__env->getFirstLoop(); $__empty_1 = false; ?>
+<?php $__empty_2 = true; $__currentLoopData = $user->tags; $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $tag): $__env->incrementLoopIndices(); $loop = $__env->getFirstLoop(); $__empty_2 = false; ?>
 breeze
-<?php endforeach; if ($__empty_2): ?>
+<?php endforeach; $__env->popLoop(); $loop = $__env->getFirstLoop(); if ($__empty_2): ?>
 tag empty
 <?php endif; ?>
-<?php endforeach; if ($__empty_1): ?>
+<?php endforeach; $__env->popLoop(); $loop = $__env->getFirstLoop(); if ($__empty_1): ?>
 empty
 <?php endif; ?>';
         $this->assertEquals($expected, $compiler->compileString($string));


### PR DESCRIPTION
Same as https://github.com/laravel/framework/pull/12867 but for @.forelse loops

``` php
@forelse($items as $item)
     {{ $loop->index }} // The current iteration starting 1.
     {{ $loop->remaining }} // The number of iterations left till the end. Ends with 0.
     {{ $loop->count }} // The size of the iteratee.
     {{ $loop->first }} // If the current iteration is the first. (boolean)
     {{ $loop->last }} // If the current iteration is the last. (boolean)
     {{ $loop->depth }} // The depth inside a nested loop.
     {{ $loop->parent }} // The direct parent loop information.

    {{ $loop->parent->first }} // This checks if the parent loop is at the first iteration.
@empty

@endforelse
```
