### PR TITLE
[5.2] Make Model::fresh() convert multiple args to array before passing to with()

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -654,6 +654,10 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
             return;
         }
 
+        if (is_string($with)) {
+            $with = func_get_args();
+        }
+
         $key = $this->getKeyName();
 
         return static::with($with)->where($key, $this->getKey())->first();


### PR DESCRIPTION
closes #13933

This allows the following:

``` php
$user->fresh('roles', 'branches');
```

Before, you must provide an array:

``` php
$user->fresh(['roles', 'branches']);
```
