### PR TITLE
rewrite redis job to one json_decode()

### DIFF
--- a/src/Illuminate/Queue/Jobs/RedisJob.php
+++ b/src/Illuminate/Queue/Jobs/RedisJob.php
@@ -17,11 +17,18 @@ class RedisJob extends Job implements JobContract
     protected $redis;
 
     /**
-     * The Redis job payload.
+     * The Redis raw job payload.
      *
      * @var string
      */
     protected $job;
+
+    /**
+     * The Redis decoded job payload.
+     *
+     * @var array
+     */
+    protected $decodedJob;
 
     /**
      * Create a new job instance.
@@ -35,6 +42,7 @@ class RedisJob extends Job implements JobContract
     public function __construct(Container $container, RedisQueue $redis, $job, $queue)
     {
         $this->job = $job;
+        $this->decodedJob = json_decode($job, true);
         $this->redis = $redis;
         $this->queue = $queue;
         $this->container = $container;
@@ -47,7 +55,7 @@ class RedisJob extends Job implements JobContract
      */
     public function fire()
     {
-        $this->resolveAndFire(json_decode($this->getRawBody(), true));
+        $this->resolveAndFire($this->decodedJob);
     }
 
     /**
@@ -94,7 +102,7 @@ class RedisJob extends Job implements JobContract
      */
     public function attempts()
     {
-        return Arr::get(json_decode($this->job, true), 'attempts');
+        return Arr::get($this->decodedJob, 'attempts');
     }
 
     /**
@@ -104,7 +112,7 @@ class RedisJob extends Job implements JobContract
      */
     public function getJobId()
     {
-        return Arr::get(json_decode($this->job, true), 'id');
+        return Arr::get($this->decodedJob, 'id');
     }
 
     /**
@@ -125,15 +133,5 @@ class RedisJob extends Job implements JobContract
     public function getRedisQueue()
     {
         return $this->redis;
-    }
-
-    /**
-     * Get the underlying Redis job.
-     *
-     * @return string
-     */
-    public function getRedisJob()
-    {
-        return $this->job;
     }
 }

--- a/tests/Queue/QueueRedisJobTest.php
+++ b/tests/Queue/QueueRedisJobTest.php
@@ -21,7 +21,7 @@ class QueueRedisJobTest extends PHPUnit_Framework_TestCase
     public function testDeleteRemovesTheJobFromRedis()
     {
         $job = $this->getJob();
-        $job->getRedisQueue()->shouldReceive('deleteReserved')->once()->with('default', $job->getRedisJob());
+        $job->getRedisQueue()->shouldReceive('deleteReserved')->once()->with('default', $job->getRawBody());
 
         $job->delete();
     }
@@ -29,8 +29,8 @@ class QueueRedisJobTest extends PHPUnit_Framework_TestCase
     public function testReleaseProperlyReleasesJobOntoRedis()
     {
         $job = $this->getJob();
-        $job->getRedisQueue()->shouldReceive('deleteReserved')->once()->with('default', $job->getRedisJob());
-        $job->getRedisQueue()->shouldReceive('release')->once()->with('default', $job->getRedisJob(), 1, 2);
+        $job->getRedisQueue()->shouldReceive('deleteReserved')->once()->with('default', $job->getRawBody());
+        $job->getRedisQueue()->shouldReceive('release')->once()->with('default', $job->getRawBody(), 1, 2);
 
         $job->release(1);
     }


### PR DESCRIPTION
In some cases we need to use huge payload and redis queue, and i think `json_decode()` every time when we need to access some info from payload can take much time.
