### PR TITLE
[5.3] Rewrite redis job to one json_decode()

### DIFF
--- a/src/Illuminate/Queue/Jobs/RedisJob.php
+++ b/src/Illuminate/Queue/Jobs/RedisJob.php
@@ -17,11 +17,18 @@ class RedisJob extends Job implements JobContract
     protected $redis;
 
     /**
-     * The Redis job payload.
+     * The Redis raw job payload.
      *
      * @var string
      */
     protected $job;
+
+    /**
+     * The Redis decoded job payload.
+     *
+     * @var array
+     */
+    protected $decodedJob;
 
     /**
      * The Redis job payload inside the reserved queue.
@@ -42,6 +49,7 @@ class RedisJob extends Job implements JobContract
     public function __construct(Container $container, RedisQueue $redis, $job, $reserved, $queue)
     {
         $this->job = $job;
+        $this->decodedJob = json_decode($job, true);
         $this->redis = $redis;
         $this->queue = $queue;
         $this->reserved = $reserved;
@@ -55,7 +63,7 @@ class RedisJob extends Job implements JobContract
      */
     public function fire()
     {
-        $this->resolveAndFire(json_decode($this->getRawBody(), true));
+        $this->resolveAndFire($this->decodedJob);
     }
 
     /**
@@ -100,7 +108,7 @@ class RedisJob extends Job implements JobContract
      */
     public function attempts()
     {
-        return Arr::get(json_decode($this->job, true), 'attempts');
+        return Arr::get($this->decodedJob, 'attempts');
     }
 
     /**
@@ -110,7 +118,7 @@ class RedisJob extends Job implements JobContract
      */
     public function getJobId()
     {
-        return Arr::get(json_decode($this->job, true), 'id');
+        return Arr::get($this->decodedJob, 'id');
     }
 
     /**
@@ -131,16 +139,6 @@ class RedisJob extends Job implements JobContract
     public function getRedisQueue()
     {
         return $this->redis;
-    }
-
-    /**
-     * Get the underlying Redis job.
-     *
-     * @return string
-     */
-    public function getRedisJob()
-    {
-        return $this->job;
     }
 
     /**

--- a/tests/Queue/RedisQueueIntegrationTest.php
+++ b/tests/Queue/RedisQueueIntegrationTest.php
@@ -77,7 +77,7 @@ class RedisQueueIntegrationTest extends PHPUnit_Framework_TestCase
         $redisJob = $this->queue->pop();
         $after = time();
 
-        $this->assertEquals($job, unserialize(json_decode($redisJob->getRedisJob())->data->command));
+        $this->assertEquals($job, unserialize(json_decode($redisJob->getRawBody())->data->command));
         $this->assertEquals(1, $redisJob->attempts());
         $this->assertEquals($job, unserialize(json_decode($redisJob->getReservedJob())->data->command));
         $this->assertEquals(2, json_decode($redisJob->getReservedJob())->attempts);


### PR DESCRIPTION
In some cases we need to use huge payload and redis queue, and i think `json_decode()` every time when we need to access some info from payload can take much time.
