### PR TITLE
[5.2] Remove a redundant condition in Arr::get()

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -282,7 +282,7 @@ class Arr
         }
 
         foreach (explode('.', $key) as $segment) {
-            if (static::accessible($array) && static::exists($array, $segment)) {
+            if (static::exists($array, $segment)) {
                 $array = $array[$segment];
             } else {
                 return value($default);


### PR DESCRIPTION
I feel like I might cause [some more anger](https://github.com/laravel/framework/pull/12975#issuecomment-204624876) here by proposing yet another change to `Arr::get()`.

However, assuming that this passes the tests, this change simply removes pointless code. (This condition was pulled out to the beginning of the method in #12975.)

Sending to 5.2 as the code is very different in 5.1.
