### PR TITLE
[5.4] Allow custom column types in Schema Builder

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -866,6 +866,18 @@ class Blueprint
     }
 
     /**
+     * Create a custom typed column on the table.
+     *
+     * @param  string  $type
+     * @param  string  $name
+     * @return \Illuminate\Support\Fluent
+     */
+    public function custom($type, $name)
+    {
+        return $this->addColumn($type, $name, ['custom' => true]);
+    }
+
+    /**
      * Add the proper columns for a polymorphic table.
      *
      * @param  string  $name

--- a/src/Illuminate/Database/Schema/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/Grammar.php
@@ -190,6 +190,10 @@ abstract class Grammar extends BaseGrammar
      */
     protected function getType(Fluent $column)
     {
+        if ($column->custom) {
+            return $this->customType($column);
+        }
+
         return $this->{'type'.ucfirst($column->type)}($column);
     }
 

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -630,6 +630,17 @@ class MySqlGrammar extends Grammar
     }
 
     /**
+     * Create a custom typed column.
+     *
+     * @param  \Illuminate\Support\Fluent  $column
+     * @return string
+     */
+    protected function customType(Fluent $column)
+    {
+        return $column->type;
+    }
+
+    /**
      * Get the SQL for a generated virtual column modifier.
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint


### PR DESCRIPTION
Since there are some column types in various databases not supportet by Laravel (like [Mediumblob in MySQL](/laravel/framework/issues/3544)), I think it would be nice to add such columns via Schema Builder anyways.

So instead of using a raw query after the Schema Builder in a migration 

```
Schema::create('foo', function (Blueprint $table) {
    $table->increments('id');
    $table->string('title');
    $table->timestamps();
});
DB::statement('ALTER TABLE foo ADD COLUMN bar MEDIUMBLOB AFTER title');
```

it would maybe make sense to include a custom type

```
Schema::create('foo', function (Blueprint $table) {
    $table->increments('id');
    $table->string('title');
    $table->custom('MEDIUMBLOB', 'bar');
    $table->timestamps();
});
```

Or is this idea totally against the agnostic and unified idea of the Schema Builder?
