### PR TITLE
[5.2] Allow custom column types in Schema Builder

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -863,6 +863,18 @@ class Blueprint
     }
 
     /**
+     * Create a custom typed column on the table.
+     *
+     * @param  string  $type
+     * @param  string  $name
+     * @return \Illuminate\Support\Fluent
+     */
+    public function custom($type, $name)
+    {
+        return $this->addColumn($type, $name, ['custom' => true]);
+    }
+
+    /**
      * Add the proper columns for a polymorphic table.
      *
      * @param  string  $name

--- a/src/Illuminate/Database/Schema/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/Grammar.php
@@ -190,6 +190,10 @@ abstract class Grammar extends BaseGrammar
      */
     protected function getType(Fluent $column)
     {
+        if ($column->custom) {
+            return $this->customType($column);
+        }
+
         return $this->{'type'.ucfirst($column->type)}($column);
     }
 

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -628,6 +628,17 @@ class MySqlGrammar extends Grammar
     }
 
     /**
+     * Create a custom typed column.
+     *
+     * @param  \Illuminate\Support\Fluent  $column
+     * @return string
+     */
+    protected function customType(Fluent $column)
+    {
+        return $column->type;
+    }
+
+    /**
      * Get the SQL for a generated virtual column modifier.
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -581,6 +581,17 @@ class PostgresGrammar extends Grammar
     }
 
     /**
+     * Create a custom typed column.
+     *
+     * @param  \Illuminate\Support\Fluent  $column
+     * @return string
+     */
+    protected function customType(Fluent $column)
+    {
+        return $column->type;
+    }
+
+    /**
      * Get the SQL for a nullable column modifier.
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint

--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -634,6 +634,17 @@ class SQLiteGrammar extends Grammar
     }
 
     /**
+     * Create a custom typed column.
+     *
+     * @param  \Illuminate\Support\Fluent  $column
+     * @return string
+     */
+    protected function customType(Fluent $column)
+    {
+        return $column->type;
+    }
+
+    /**
      * Get the SQL for a nullable column modifier.
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -585,6 +585,17 @@ class SqlServerGrammar extends Grammar
     }
 
     /**
+     * Create a custom typed column.
+     *
+     * @param  \Illuminate\Support\Fluent  $column
+     * @return string
+     */
+    protected function customType(Fluent $column)
+    {
+        return $column->type;
+    }
+
+    /**
      * Get the SQL for a nullable column modifier.
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint


### PR DESCRIPTION
In #13740 I was advised to push into 5.2. So here is the same PR allowing custom column types in Schema Builder.

Instead of using a raw query after the Schema Builder in a migration

```
Schema::create('foo', function (Blueprint $table) {
    $table->increments('id');
    $table->string('title');
    $table->timestamps();
});
DB::statement('ALTER TABLE foo ADD COLUMN bar MEDIUMBLOB AFTER title');
```

it allows to include a custom type

```
Schema::create('foo', function (Blueprint $table) {
    $table->increments('id');
    $table->string('title');
    $table->custom('MEDIUMBLOB', 'bar');
    $table->timestamps();
});
```

If the custom type needs attributes, these should be included directly as well: `$table->custom('VARBINARY(42)', 'bar');`.

The PR includes this for `Grammars/MySqlGrammar` as an example. I'm looking for some feedback and will add Postgres, SQLite and SqlServer afterwards as well.
