### PR TITLE
[5.2] AppNameCommand : Only iterate through files that contain a namespace.

### DIFF
--- a/src/Illuminate/Foundation/Console/AppNameCommand.php
+++ b/src/Illuminate/Foundation/Console/AppNameCommand.php
@@ -95,6 +95,7 @@ class AppNameCommand extends Command
     {
         $files = Finder::create()
                             ->in($this->laravel['path'])
+                            ->contains($this->currentRoot)
                             ->name('*.php');
 
         foreach ($files as $file) {


### PR DESCRIPTION
`\Illuminate\Foundation\Console\AppNameCommand` : only iterate through files that contain a namespace.
