### PR TITLE
[5.1] BeanstalkdJob bury function delete job unexpectedly

### DIFF
--- a/src/Illuminate/Queue/Jobs/BeanstalkdJob.php
+++ b/src/Illuminate/Queue/Jobs/BeanstalkdJob.php
@@ -98,7 +98,7 @@ class BeanstalkdJob extends Job implements JobContract
     public function bury()
     {
         parent::release();
-        
+
         $this->pheanstalk->bury($this->job);
     }
 

--- a/src/Illuminate/Queue/Jobs/BeanstalkdJob.php
+++ b/src/Illuminate/Queue/Jobs/BeanstalkdJob.php
@@ -97,6 +97,8 @@ class BeanstalkdJob extends Job implements JobContract
      */
     public function bury()
     {
+        parent::release();
+        
         $this->pheanstalk->bury($this->job);
     }
 


### PR DESCRIPTION
Job will be deleted whenever bury job function is called.

Due to the release flag is not mark, every job goin to bury will be delete eventually.

``` php
        if (! $job->isDeletedOrReleased()) {
            $job->delete();
        }
```
