### PR TITLE
[5.2] Fix chained eager loading

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -187,7 +187,7 @@ class MorphTo extends BelongsTo
 
         $query = $this->replayMacros($instance->newQuery())
             ->mergeModelDefinedRelationConstraints($this->getQuery())
-            ->setEagerLoads($eagerLoads);
+            ->with($eagerLoads);
 
         return $query->whereIn($key, $this->gatherKeysByType($type)->all())->get();
     }


### PR DESCRIPTION
This fixes a bug in eager loading chained morphedTo relationships (i.e `model A` eager loads `Model B`, `model B` eager loads `Model C`) - reported on Slack.

I also added another integration test for this scenario and extracted `seedData` helper function to clean things up a little.
