### PR TITLE
[5.2] Fix fullUrlWithQuery inconsistent slash behaviour

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -119,9 +119,11 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
      */
     public function fullUrlWithQuery(array $query)
     {
+        $question = $this->getBaseUrl().$this->getPathInfo() == '/' ? '/?' : '?';
+
         return count($this->query()) > 0
-                        ? $this->url().'/?'.http_build_query(array_merge($this->query(), $query))
-                        : $this->fullUrl().'?'.http_build_query($query);
+                        ? $this->url().$question.http_build_query(array_merge($this->query(), $query))
+                        : $this->fullUrl().$question.http_build_query($query);
     }
 
     /**

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -122,7 +122,7 @@ class HttpRequestTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('https://foo.com', $request->fullUrl());
 
         $request = Request::create('https://foo.com', 'GET');
-        $this->assertEquals('https://foo.com?coupon=foo', $request->fullUrlWithQuery(['coupon' => 'foo']));
+        $this->assertEquals('https://foo.com/?coupon=foo', $request->fullUrlWithQuery(['coupon' => 'foo']));
 
         $request = Request::create('https://foo.com?a=b', 'GET');
         $this->assertEquals('https://foo.com/?a=b', $request->fullUrl());
@@ -132,6 +132,12 @@ class HttpRequestTest extends PHPUnit_Framework_TestCase
 
         $request = Request::create('https://foo.com?a=b', 'GET');
         $this->assertEquals('https://foo.com/?a=c', $request->fullUrlWithQuery(['a' => 'c']));
+
+        $request = Request::create('http://foo.com/foo/bar?name=taylor', 'GET');
+        $this->assertEquals('http://foo.com/foo/bar?name=graham', $request->fullUrlWithQuery(['name' => 'graham']));
+
+        $request = Request::create('http://foo.com/foo/bar/?name=taylor', 'GET');
+        $this->assertEquals('http://foo.com/foo/bar?name=graham', $request->fullUrlWithQuery(['name' => 'graham']));
     }
 
     public function testIsMethod()


### PR DESCRIPTION
This fixes https://github.com/laravel/framework/issues/13561.
