### PR TITLE
[5.1] Make alias resolution recursive

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -1062,7 +1062,12 @@ class Container implements ArrayAccess, ContainerContract
      */
     protected function getAlias($abstract)
     {
-        return isset($this->aliases[$abstract]) ? $this->aliases[$abstract] : $abstract;
+        if (! isset($this->aliases[$abstract])) {
+            return $abstract;
+        }
+        $abstract = $this->aliases[$abstract];
+
+        return $this->getAlias($abstract);
     }
 
     /**

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -114,8 +114,10 @@ class ContainerContainerTest extends PHPUnit_Framework_TestCase
         $container = new Container;
         $container['foo'] = 'bar';
         $container->alias('foo', 'baz');
+        $container->alias('baz', 'bat');
         $this->assertEquals('bar', $container->make('foo'));
         $this->assertEquals('bar', $container->make('baz'));
+        $this->assertEquals('bar', $container->make('bat'));
         $container->bind(['bam' => 'boom'], function () {
             return 'pow';
         });


### PR DESCRIPTION
If you have a service `foo`, which has an alias `baz`, which itself has an alias `bat`, then trying to resolve `bat` with the `Container` will fail.

Now in practice that's not much of an issue, because you more commonly using `Application` which extends `Container`, and `Application::make()` will try to resolve the alias _first_, before calling its parent `make()` method. So the scenario above is actually resolved.

However there is still two cases where it will fail:
- When you are using more than 2 alias, i.e. we would have another alias `bap` for `bat` for example. [1]
- When your original service is declared in a deferred provider. [2]

[1]: Not very common as you rarely need _that_ many aliases.

[2]: If `foo` is declared in a deferred provider, when making `bat`, the abstract got will be `baz`, which may not be declared as a service provided by the deferred provider, resulting in a service not found.

A simple fix would be to make the alias resolution recursive, not big changes required, no BC break AFAICS and no big (if any) performance impact either.
