### PR TITLE
[5.3] Use default auth driver when guards array is empty

### DIFF
--- a/src/Illuminate/Auth/Middleware/Authenticate.php
+++ b/src/Illuminate/Auth/Middleware/Authenticate.php
@@ -54,7 +54,9 @@ class Authenticate
     protected function authenticate(array $guards)
     {
         if (count($guards) <= 1) {
-            $this->auth->guard($guard = array_first($guards))->authenticate();
+            $guard = array_first($guards) ?: $this->auth->getDefaultDriver();
+
+            $this->auth->guard($guard)->authenticate();
 
             return $this->auth->shouldUse($guard);
         }


### PR DESCRIPTION
Prior to this, trying to use the `auth` middleware without providing any guards would completely break.

This is what would happen when using the default auth scaffolding for example and hitting the `/home` route which uses the `auth` middleware:

![image](https://cloud.githubusercontent.com/assets/4323180/16044044/d3c9ddd2-3210-11e6-9b43-7a5e5c13888d.png)
