### PR TITLE
[5.2] Introducing the ability to escape blade closing tags

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -361,7 +361,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
      */
     protected function compileRegularEchos($value)
     {
-        $pattern = sprintf('/(@)?%s\s*(.+?)\s*%s(\r?\n)?/s', $this->contentTags[0], $this->contentTags[1]);
+        $pattern = sprintf('/(@)?%s\s*(.+?)\s*(?<!\\\)%s(\r?\n)?/s', $this->contentTags[0], $this->contentTags[1]);
 
         $callback = function ($matches) {
             $whitespace = empty($matches[3]) ? '' : $matches[3].$matches[3];
@@ -401,6 +401,8 @@ class BladeCompiler extends Compiler implements CompilerInterface
      */
     public function compileEchoDefaults($value)
     {
+        $value = str_replace('\\'.$this->contentTags[1], $this->contentTags[1], $value);
+
         return preg_replace('/^(?=\$)(.+?)(?:\s+or\s+)(.+?)$/s', 'isset($1) ? $1 : $2', $value);
     }
 

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -124,6 +124,7 @@ class ViewBladeCompilerTest extends PHPUnit_Framework_TestCase
             $age or 90
         }}'));
 
+        $this->assertEquals('<?php echo e("{{js_stuff}}"); ?>', $compiler->compileString('{{ "{{js_stuff\}}" }}'));
         $this->assertEquals('<?php echo e("Hello world or foo"); ?>', $compiler->compileString('{{ "Hello world or foo" }}'));
         $this->assertEquals('<?php echo e("Hello world or foo"); ?>', $compiler->compileString('{{"Hello world or foo"}}'));
         $this->assertEquals('<?php echo e($foo + $or + $baz); ?>', $compiler->compileString('{{$foo + $or + $baz}}'));


### PR DESCRIPTION
As reported in https://github.com/laravel/framework/issues/13655

`{{ "{{js_stuff}}" }}` was compiled to `<?php echo e("{{js_stuff"); ?>" }}`, in this PR I added the ability to escape blade's closing tags.

`{{ "{{js_stuff\}}" }}` will be compiled to `<?php echo e("{{js_stuff}}"); ?>`
