### PR TITLE
[5.2] Adds idType to model in order to prevent assumptions about ids

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -71,6 +71,13 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     public $incrementing = true;
 
     /**
+     * Sets the type used by the ID
+     *
+     * @var string
+     */
+    public $idType = 'int';
+
+    /**
      * Indicates if the model should be timestamped.
      *
      * @var bool
@@ -2402,6 +2409,29 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     }
 
     /**
+     * Get the type of the ID
+     *
+     * @return string
+     */
+    public function getIdType()
+    {
+        return $this->idType;
+    }
+
+    /**
+     * Set ID type
+     *
+     * @param  string  $value
+     * @return $this
+     */
+    public function setIdType($value)
+    {
+        $this->idType = $value;
+
+        return $this;
+    }
+
+    /**
      * Convert the model instance to JSON.
      *
      * @param  int  $options
@@ -2763,7 +2793,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     {
         if ($this->getIncrementing()) {
             return array_merge([
-                $this->getKeyName() => 'int',
+                $this->getKeyName() => $this->getIdType(),
             ], $this->casts);
         }
 

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2770,7 +2770,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     {
         if ($this->getIncrementing()) {
             return array_merge([
-                $this->getKeyName() => $this->getIdType(),
+                $this->getKeyName() => $this->idType,
             ], $this->casts);
         }
 

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -71,7 +71,8 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     public $incrementing = true;
 
     /**
-     * Sets the type used by the ID.
+     * Sets the type used by the ID. Note that this property is ignored unless
+     * $incrementing is set to true.
      *
      * @var string
      */
@@ -2404,29 +2405,6 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     public function setIncrementing($value)
     {
         $this->incrementing = $value;
-
-        return $this;
-    }
-
-    /**
-     * Get the type of the ID.
-     *
-     * @return string
-     */
-    public function getIdType()
-    {
-        return $this->idType;
-    }
-
-    /**
-     * Set ID type.
-     *
-     * @param  string  $value
-     * @return $this
-     */
-    public function setIdType($value)
-    {
-        $this->idType = $value;
 
         return $this;
     }

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -71,7 +71,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     public $incrementing = true;
 
     /**
-     * Sets the type used by the ID
+     * Sets the type used by the ID.
      *
      * @var string
      */
@@ -2409,7 +2409,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     }
 
     /**
-     * Get the type of the ID
+     * Get the type of the ID.
      *
      * @return string
      */
@@ -2419,7 +2419,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     }
 
     /**
-     * Set ID type
+     * Set ID type.
      *
      * @param  string  $value
      * @return $this

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -71,8 +71,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     public $incrementing = true;
 
     /**
-     * Sets the type used by the ID. Note that this property is ignored unless
-     * $incrementing is set to true.
+     * The type used by the incrementing ID.
      *
      * @var string
      */

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1334,11 +1334,11 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
     {
         $model = $this->getMock('EloquentIdTypeModelStub', ['newQueryWithoutScopes', 'updateTimestamps', 'refresh']);
         $query = m::mock('Illuminate\Database\Eloquent\Builder');
-        $query->shouldReceive('insertGetId')->once()->with([], 'id')->andReturn("string id");
+        $query->shouldReceive('insertGetId')->once()->with([], 'id')->andReturn('string id');
         $model->expects($this->once())->method('newQueryWithoutScopes')->will($this->returnValue($query));
 
         $this->assertTrue($model->save());
-        $this->assertEquals("string id", $model->id);
+        $this->assertEquals('string id', $model->id);
     }
 
     protected function addMockConnection($model)
@@ -1455,7 +1455,7 @@ class EloquentModelSaveStub extends Model
 
 class EloquentIdTypeModelStub extends EloquentModelStub
 {
-    public $idType = "string";
+    public $idType = 'string';
 }
 
 class EloquentModelFindWithWritePdoStub extends Model

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1319,6 +1319,28 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
         $this->assertTrue(isset($model->some_relation));
     }
 
+    public function testIntIdTypePreserved()
+    {
+        $model = $this->getMock('EloquentModelStub', ['newQueryWithoutScopes', 'updateTimestamps', 'refresh']);
+        $query = m::mock('Illuminate\Database\Eloquent\Builder');
+        $query->shouldReceive('insertGetId')->once()->with([], 'id')->andReturn(1);
+        $model->expects($this->once())->method('newQueryWithoutScopes')->will($this->returnValue($query));
+
+        $this->assertTrue($model->save());
+        $this->assertEquals(1, $model->id);
+    }
+
+    public function testStringIdTypePreserved()
+    {
+        $model = $this->getMock('EloquentIdTypeModelStub', ['newQueryWithoutScopes', 'updateTimestamps', 'refresh']);
+        $query = m::mock('Illuminate\Database\Eloquent\Builder');
+        $query->shouldReceive('insertGetId')->once()->with([], 'id')->andReturn("string id");
+        $model->expects($this->once())->method('newQueryWithoutScopes')->will($this->returnValue($query));
+
+        $this->assertTrue($model->save());
+        $this->assertEquals("string id", $model->id);
+    }
+
     protected function addMockConnection($model)
     {
         $model->setConnectionResolver($resolver = m::mock('Illuminate\Database\ConnectionResolverInterface'));
@@ -1429,6 +1451,11 @@ class EloquentModelSaveStub extends Model
     {
         $this->incrementing = $value;
     }
+}
+
+class EloquentIdTypeModelStub extends EloquentModelStub
+{
+    public $idType = "string";
 }
 
 class EloquentModelFindWithWritePdoStub extends Model


### PR DESCRIPTION
Hi there,

We recently upgraded to Laravel 5.2 and noticed some weird behavior when trying to save models and tracked it down to an incorrect assumption made in a recent change to `\Illuminate\Database\Model`, namely in the `getCasts()` function:

``` php
    /**
     * Get the casts array.
     *
     * @return array
     */
    public function getCasts()
    {
        if ($this->getIncrementing()) {
            return array_merge([
                $this->getKeyName() => 'int', // This was our culprit
            ], $this->casts);
        }

        return $this->casts;
    }
```

Our codebase uses string uuids generated at the database layer (postgres) rather than the application layer, so technically we needed `$incrementing` to be set to true (since the database was handling "incrementing" in our case), however our ID type was `string` rather than `int`.

As an interim solution we just added the following to a `BaseModel` class we created which all of our models inherit from:

``` php
public function getCasts()
{
    return $this->casts;
}
```

this just overrides Laravel's getCasts function to get rid of the `int` typecast on the primary key. It worked but felt kind of jank, and we're sure we're not the _only_ ones who have this use case. This PR proposes a solution which keeps Laravel's defaults, but adds the option to set `$idType` on models and override the default type (`int`) which is currently assumed to be true.

This shouldn't break anything for anyone else, it just adds this extra option which helps people with non-`int` ID types that are generated by the database rather than the application.

Let me know if you have any thoughts, questions, etc. I'd love to get this merged in (or at least start a discussion on how to best handle the issue). Thanks!
