### PR TITLE
[5.2] Support\Collection: Allow value-retrieving callbacks to be passed to avg(), max() and min() aggregate methods.

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -59,20 +59,27 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Get the average value of a given key.
      *
-     * @param  string|null  $key
+     * @param  string|callable|null  $key
      * @return mixed
      */
     public function avg($key = null)
     {
         if ($count = $this->count()) {
-            return $this->sum($key) / $count;
+            $callback = $this->valueRetriever($key);
+            $sum = $this->reduce(function ($result, $item) use ($callback) {
+                $value = $callback($item);
+
+                return is_null($result) ? $value : $result + $value;
+            });
+
+            return $sum / $count;
         }
     }
 
     /**
      * Alias for the "avg" method.
      *
-     * @param  string|null  $key
+     * @param  string|callable|null  $key
      * @return mixed
      */
     public function average($key = null)
@@ -519,13 +526,15 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Get the max value of a given key.
      *
-     * @param  string|null  $key
+     * @param  string|callable|null  $key
      * @return mixed
      */
     public function max($key = null)
     {
-        return $this->reduce(function ($result, $item) use ($key) {
-            $value = data_get($item, $key);
+        $callback = $this->valueRetriever($key);
+
+        return $this->reduce(function ($result, $item) use ($callback) {
+            $value = $callback($item);
 
             return is_null($result) || $value > $result ? $value : $result;
         });
@@ -567,13 +576,15 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Get the min value of a given key.
      *
-     * @param  string|null  $key
+     * @param  string|callable|null  $key
      * @return mixed
      */
     public function min($key = null)
     {
-        return $this->reduce(function ($result, $item) use ($key) {
-            $value = data_get($item, $key);
+        $callback = $this->valueRetriever($key);
+
+        return $this->reduce(function ($result, $item) use ($callback) {
+            $value = $callback($item);
 
             return is_null($result) || $value < $result ? $value : $result;
         });


### PR DESCRIPTION
It's currently possible to pass value-retrieving closures to _Support\Collection_ methods such as **sum()** and **sortBy()** but not **avg()**, **max()** and **min()**.

This PR aims to add this functionality which might be especially useful in the future if castable value objects are added to Eloquent.

There _might_ be a unacceptable BC break here for individuals who have extended _Support\Collection_. I've tried to mitigate it by keeping the method signatures the same but the parameter names are ambiguous as a result.
