### PR TITLE
[5.2] Fix logout when user doesn't use the "remember me" functionality

### DIFF
--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -561,7 +561,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
         // listening for anytime a user signs out of this application manually.
         $this->clearUserDataFromStorage();
 
-        if (! is_null($this->user)) {
+        if (! is_null($user) && ! empty($user->getRememberToken())) {
             $this->refreshRememberToken($user);
         }
 

--- a/tests/Auth/AuthGuardTest.php
+++ b/tests/Auth/AuthGuardTest.php
@@ -200,7 +200,7 @@ class AuthGuardTest extends PHPUnit_Framework_TestCase
         $mock->setCookieJar($cookies = m::mock('Illuminate\Cookie\CookieJar'));
         $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');
         $user->shouldReceive('setRememberToken')->once();
-        $user->shouldReceive('getRememberToken')->once();
+        $user->shouldReceive('getRememberToken')->once()->andReturn('foo');
         $mock->expects($this->once())->method('getName')->will($this->returnValue('foo'));
         $mock->expects($this->once())->method('getRecallerName')->will($this->returnValue('bar'));
         $mock->expects($this->once())->method('getRecaller')->will($this->returnValue('non-null-cookie'));
@@ -222,7 +222,7 @@ class AuthGuardTest extends PHPUnit_Framework_TestCase
         $mock->setCookieJar($cookies = m::mock('Illuminate\Cookie\CookieJar'));
         $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');
         $user->shouldReceive('setRememberToken')->once();
-        $user->shouldReceive('getRememberToken')->once();
+        $user->shouldReceive('getRememberToken')->once()->andReturn('foo');
         $mock->expects($this->once())->method('getName')->will($this->returnValue('foo'));
         $mock->expects($this->once())->method('getRecaller')->will($this->returnValue(null));
         $provider->shouldReceive('updateRememberToken')->once();
@@ -241,7 +241,7 @@ class AuthGuardTest extends PHPUnit_Framework_TestCase
         $mock->setDispatcher($events = m::mock('Illuminate\Contracts\Events\Dispatcher'));
         $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');
         $user->shouldReceive('setRememberToken')->once();
-        $user->shouldReceive('getRememberToken')->once();
+        $user->shouldReceive('getRememberToken')->once()->andReturn('foo');
         $provider->shouldReceive('updateRememberToken')->once();
         $mock->setUser($user);
         $events->shouldReceive('fire')->once()->with(m::type('Illuminate\Auth\Events\Logout'));

--- a/tests/Auth/AuthGuardTest.php
+++ b/tests/Auth/AuthGuardTest.php
@@ -200,6 +200,7 @@ class AuthGuardTest extends PHPUnit_Framework_TestCase
         $mock->setCookieJar($cookies = m::mock('Illuminate\Cookie\CookieJar'));
         $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');
         $user->shouldReceive('setRememberToken')->once();
+        $user->shouldReceive('getRememberToken')->once();
         $mock->expects($this->once())->method('getName')->will($this->returnValue('foo'));
         $mock->expects($this->once())->method('getRecallerName')->will($this->returnValue('bar'));
         $mock->expects($this->once())->method('getRecaller')->will($this->returnValue('non-null-cookie'));
@@ -221,6 +222,7 @@ class AuthGuardTest extends PHPUnit_Framework_TestCase
         $mock->setCookieJar($cookies = m::mock('Illuminate\Cookie\CookieJar'));
         $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');
         $user->shouldReceive('setRememberToken')->once();
+        $user->shouldReceive('getRememberToken')->once();
         $mock->expects($this->once())->method('getName')->will($this->returnValue('foo'));
         $mock->expects($this->once())->method('getRecaller')->will($this->returnValue(null));
         $provider->shouldReceive('updateRememberToken')->once();
@@ -239,6 +241,7 @@ class AuthGuardTest extends PHPUnit_Framework_TestCase
         $mock->setDispatcher($events = m::mock('Illuminate\Contracts\Events\Dispatcher'));
         $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');
         $user->shouldReceive('setRememberToken')->once();
+        $user->shouldReceive('getRememberToken')->once();
         $provider->shouldReceive('updateRememberToken')->once();
         $mock->setUser($user);
         $events->shouldReceive('fire')->once()->with(m::type('Illuminate\Auth\Events\Logout'));


### PR DESCRIPTION
Fixes: https://github.com/laravel/framework/issues/12054
