### PR TITLE
[5.2] Fix `Invalid text representation: invalid input syntax for uuid: "0"` with Postgres and BelongsTo

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
@@ -174,7 +174,7 @@ class BelongsTo extends Relation
         // null or 0 in (depending on if incrementing keys are in use) so the query wont
         // fail plus returns zero results, which should be what the developer expects.
         if (count($keys) === 0) {
-            return [$this->related->incrementing ? 0 : null];
+            return [$this->related->getIncrementing() ? 0 : null];
         }
 
         return array_values(array_unique($keys));

--- a/tests/Database/DatabaseEloquentBelongsToTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToTest.php
@@ -111,6 +111,7 @@ class DatabaseEloquentBelongsToTest extends PHPUnit_Framework_TestCase
         $builder->shouldReceive('where')->with('relation.id', '=', 'foreign.value');
         $related = m::mock('Illuminate\Database\Eloquent\Model');
         $related->incrementing = $incrementing;
+        $related->shouldReceive('getIncrementing')->andReturn($incrementing);
         $related->shouldReceive('getKeyName')->andReturn('id');
         $related->shouldReceive('getTable')->andReturn('relation');
         $builder->shouldReceive('getModel')->andReturn($related);


### PR DESCRIPTION
I currently use a trait to use UUIDs on my models as primary keys. This trait overrides the `Model::getIncrementing()` method, but you can't override a class attribute from your trait.

It creates an issue when loading a BelongsTo relation, but your foreign key is null, because the `BelongsTo::getEagerModelKeys()` method directly access the `incrementing` attribute.

This fixes it, using the accessor instead.
