### PR TITLE
[5.2] Confirm Ajax request is not Pjax

### DIFF
--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -133,7 +133,7 @@ class FormRequest extends Request implements ValidatesWhenResolved
      */
     public function response(array $errors)
     {
-        if ($this->ajax() || $this->wantsJson()) {
+        if (($this->ajax() && ! $this->pjax()) || $this->wantsJson()) {
             return new JsonResponse($errors, 422);
         }
 


### PR DESCRIPTION
This brings the response requirements in the `FormRequest` into line with the `ValidatesRequest` trait. See issue #13997 for more information.
