### PR TITLE
[5.2] Fix dimensions validation when string is provided

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1561,7 +1561,7 @@ class Validator implements ValidatorContract
      */
     protected function validateDimensions($attribute, $value, $parameters)
     {
-        if (! $sizeDetails = getimagesize($value->getRealPath())) {
+        if (! $this->isAValidFileInstance($value) || ! $sizeDetails = getimagesize($value->getRealPath())) {
             return false;
         }
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1665,8 +1665,11 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
     public function testValidateImageDimensions()
     {
         // Knowing that demo image.gif has width = 3 and height = 2
-        $uploadedFile = new \Symfony\Component\HttpFoundation\File\UploadedFile(__DIR__.'/fixtures/image.gif', '');
+        $uploadedFile = new \Symfony\Component\HttpFoundation\File\UploadedFile(__DIR__.'/fixtures/image.gif', '', null, null, null, true);
         $trans = $this->getRealTranslator();
+
+        $v = new Validator($trans, ['x' => 'file'], ['x' => 'dimensions']);
+        $this->assertTrue($v->fails());
 
         $v = new Validator($trans, [], ['x' => 'dimensions:min_width=1']);
         $v->setFiles(['x' => $uploadedFile]);


### PR DESCRIPTION
When you are using `dimensions` rule the validation should fail when a string is provided instead of a file, however this will happen 

> Error: Call to a member function getRealPath() on string
