### PR TITLE
[5.2] Remove unnecessary else

### DIFF
--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -73,7 +73,9 @@ abstract class Queue
     {
         if ($job instanceof Closure) {
             return json_encode($this->createClosurePayload($job, $data));
-        } elseif (is_object($job)) {
+        }
+
+        if (is_object($job)) {
             return json_encode([
                 'job' => 'Illuminate\Queue\CallQueuedHandler@call',
                 'data' => ['commandName' => get_class($job), 'command' => serialize(clone $job)],


### PR DESCRIPTION
This PR: 
- [x] Removes an unnecessary else. Since you're returning in the if block above, you don't need an else statement. 
