### PR TITLE
[5.2] Move implements QueueContract in correct place

### DIFF
--- a/src/Illuminate/Queue/BeanstalkdQueue.php
+++ b/src/Illuminate/Queue/BeanstalkdQueue.php
@@ -7,7 +7,7 @@ use Pheanstalk\Job as PheanstalkJob;
 use Illuminate\Queue\Jobs\BeanstalkdJob;
 use Illuminate\Contracts\Queue\Queue as QueueContract;
 
-class BeanstalkdQueue extends Queue implements QueueContract
+class BeanstalkdQueue extends Queue
 {
     /**
      * The Pheanstalk instance.

--- a/src/Illuminate/Queue/BeanstalkdQueue.php
+++ b/src/Illuminate/Queue/BeanstalkdQueue.php
@@ -5,7 +5,6 @@ namespace Illuminate\Queue;
 use Pheanstalk\Pheanstalk;
 use Pheanstalk\Job as PheanstalkJob;
 use Illuminate\Queue\Jobs\BeanstalkdJob;
-use Illuminate\Contracts\Queue\Queue as QueueContract;
 
 class BeanstalkdQueue extends Queue
 {

--- a/src/Illuminate/Queue/DatabaseQueue.php
+++ b/src/Illuminate/Queue/DatabaseQueue.php
@@ -8,7 +8,6 @@ use Illuminate\Support\Collection;
 use Illuminate\Database\Connection;
 use Illuminate\Queue\Jobs\DatabaseJob;
 use Illuminate\Database\Query\Expression;
-use Illuminate\Contracts\Queue\Queue as QueueContract;
 
 class DatabaseQueue extends Queue
 {

--- a/src/Illuminate/Queue/DatabaseQueue.php
+++ b/src/Illuminate/Queue/DatabaseQueue.php
@@ -10,7 +10,7 @@ use Illuminate\Queue\Jobs\DatabaseJob;
 use Illuminate\Database\Query\Expression;
 use Illuminate\Contracts\Queue\Queue as QueueContract;
 
-class DatabaseQueue extends Queue implements QueueContract
+class DatabaseQueue extends Queue
 {
     /**
      * The database connection instance.

--- a/src/Illuminate/Queue/NullQueue.php
+++ b/src/Illuminate/Queue/NullQueue.php
@@ -2,8 +2,6 @@
 
 namespace Illuminate\Queue;
 
-use Illuminate\Contracts\Queue\Queue as QueueContract;
-
 class NullQueue extends Queue
 {
     /**

--- a/src/Illuminate/Queue/NullQueue.php
+++ b/src/Illuminate/Queue/NullQueue.php
@@ -4,7 +4,7 @@ namespace Illuminate\Queue;
 
 use Illuminate\Contracts\Queue\Queue as QueueContract;
 
-class NullQueue extends Queue implements QueueContract
+class NullQueue extends Queue
 {
     /**
      * Push a new job onto the queue.

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -9,8 +9,9 @@ use SuperClosure\Serializer;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Queue\QueueableEntity;
 use Illuminate\Contracts\Encryption\Encrypter as EncrypterContract;
+use Illuminate\Contracts\Queue\Queue as QueueContract;
 
-abstract class Queue
+abstract class Queue implements QueueContract
 {
     /**
      * The IoC container instance.

--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -8,7 +8,7 @@ use Illuminate\Redis\Database;
 use Illuminate\Queue\Jobs\RedisJob;
 use Illuminate\Contracts\Queue\Queue as QueueContract;
 
-class RedisQueue extends Queue implements QueueContract
+class RedisQueue extends Queue
 {
     /**
      * The Redis database instance.

--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -6,7 +6,6 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Redis\Database;
 use Illuminate\Queue\Jobs\RedisJob;
-use Illuminate\Contracts\Queue\Queue as QueueContract;
 
 class RedisQueue extends Queue
 {

--- a/src/Illuminate/Queue/SqsQueue.php
+++ b/src/Illuminate/Queue/SqsQueue.php
@@ -6,7 +6,7 @@ use Aws\Sqs\SqsClient;
 use Illuminate\Queue\Jobs\SqsJob;
 use Illuminate\Contracts\Queue\Queue as QueueContract;
 
-class SqsQueue extends Queue implements QueueContract
+class SqsQueue extends Queue
 {
     /**
      * The Amazon SQS instance.

--- a/src/Illuminate/Queue/SqsQueue.php
+++ b/src/Illuminate/Queue/SqsQueue.php
@@ -4,7 +4,6 @@ namespace Illuminate\Queue;
 
 use Aws\Sqs\SqsClient;
 use Illuminate\Queue\Jobs\SqsJob;
-use Illuminate\Contracts\Queue\Queue as QueueContract;
 
 class SqsQueue extends Queue
 {

--- a/src/Illuminate/Queue/SyncQueue.php
+++ b/src/Illuminate/Queue/SyncQueue.php
@@ -6,7 +6,6 @@ use Exception;
 use Throwable;
 use Illuminate\Queue\Jobs\SyncJob;
 use Illuminate\Contracts\Queue\Job;
-use Illuminate\Contracts\Queue\Queue as QueueContract;
 
 class SyncQueue extends Queue
 {

--- a/src/Illuminate/Queue/SyncQueue.php
+++ b/src/Illuminate/Queue/SyncQueue.php
@@ -8,7 +8,7 @@ use Illuminate\Queue\Jobs\SyncJob;
 use Illuminate\Contracts\Queue\Job;
 use Illuminate\Contracts\Queue\Queue as QueueContract;
 
-class SyncQueue extends Queue implements QueueContract
+class SyncQueue extends Queue
 {
     /**
      * Push a new job onto the queue.


### PR DESCRIPTION
Because the abstract `Queue` class relies on methods from the `QueueContract` that abstract class should implement the contract, rather than it's children. 

This will make the `Queue` class more extendable, if user-land wants to add and use more Queue drivers. 
