### PR TITLE
[5.2] Ensure encrypter exists

### DIFF
--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -230,5 +230,4 @@ abstract class Queue
 
         return $this->crypt;
     }
-
 }

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -225,7 +225,7 @@ abstract class Queue
     public function getEncrypter()
     {
         if (null === $this->crypt) {
-            throw new EncryptException("No encrypter set for Queue");
+            throw new EncryptException('No encrypter set for Queue');
         }
 
         return $this->crypt;

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -4,6 +4,7 @@ namespace Illuminate\Queue;
 
 use Closure;
 use DateTime;
+use Illuminate\Contracts\Encryption\EncryptException;
 use Illuminate\Support\Arr;
 use SuperClosure\Serializer;
 use Illuminate\Container\Container;
@@ -18,6 +19,11 @@ abstract class Queue
      * @var \Illuminate\Container\Container
      */
     protected $container;
+
+    /**
+     * @var \Illuminate\Contracts\Encryption\Encrypter
+     */
+    protected $crypt;
 
     /**
      * Push a new job onto the queue.
@@ -144,7 +150,7 @@ abstract class Queue
      */
     protected function createClosurePayload($job, $data)
     {
-        $closure = $this->crypt->encrypt((new Serializer)->serialize($job));
+        $closure = $this->getEncrypter()->encrypt((new Serializer)->serialize($job));
 
         return ['job' => 'IlluminateQueueClosure', 'data' => compact('closure')];
     }
@@ -210,4 +216,20 @@ abstract class Queue
     {
         $this->crypt = $crypt;
     }
+
+
+    /**
+     * @return EncrypterContract
+     *
+     * @throws EncryptException
+     */
+    public function getEncrypter()
+    {
+        if (null === $this->crypt) {
+            throw new EncryptException("No encrypter set for Queue");
+        }
+
+        return $this->crypt;
+    }
+
 }

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -222,7 +222,7 @@ abstract class Queue
      *
      * @throws EncryptException
      */
-    public function getEncrypter()
+    protected function getEncrypter()
     {
         if (null === $this->crypt) {
             throw new EncryptException('No encrypter set for Queue');

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -217,7 +217,6 @@ abstract class Queue
         $this->crypt = $crypt;
     }
 
-
     /**
      * @return EncrypterContract
      *


### PR DESCRIPTION
This PR: 
- [x] declares encrypter as a proper property on the `Queue` class
- [x] ensures that encrypter exists, or throws an exception if it doesn't. 

Without that guard in place there's the possibility of getting "function `encrypt` called on null" error. 
