### PR TITLE
[5.2] modify $job type from string to mixed

### DIFF
--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -64,7 +64,7 @@ abstract class Queue
     /**
      * Create a payload string from the given job and data.
      *
-     * @param  string  $job
+     * @param  mixed  $job
      * @param  mixed   $data
      * @param  string  $queue
      * @return string


### PR DESCRIPTION
doc type error 
