### PR TITLE
[5.2] Update ProviderRepository.php

### DIFF
--- a/src/Illuminate/Foundation/ProviderRepository.php
+++ b/src/Illuminate/Foundation/ProviderRepository.php
@@ -3,8 +3,8 @@
 namespace Illuminate\Foundation;
 
 use Illuminate\Filesystem\Filesystem;
-use Illuminate\Contracts\Foundation\Application as ApplicationContract;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Contracts\Foundation\Application as ApplicationContract;
 
 class ProviderRepository
 {

--- a/src/Illuminate/Foundation/ProviderRepository.php
+++ b/src/Illuminate/Foundation/ProviderRepository.php
@@ -51,6 +51,7 @@ class ProviderRepository
      */
     public function load(array $providers)
     {
+        $eagerProviderInstances = [];
         $manifest = $this->loadManifest();
 
         // First we will load the service manifest, which contains information on all
@@ -71,7 +72,13 @@ class ProviderRepository
         // application so their services can be registered with the application as
         // a provided service. Then we will set the deferred service list on it.
         foreach ($manifest['eager'] as $provider) {
-            $this->app->register($this->createProvider($provider));
+            $providerInstance = $this->createProvider($provider);
+            $eagerProviderInstances[get_class($providerInstance)] = $providerInstance;
+            $this->postContructProvider($providerInstance);
+        }
+
+        foreach ($eagerProviderInstances[] as $providerInstance) {
+            $this->app->register($providerInstance);
         }
 
         $this->app->addDeferredServices($manifest['deferred']);
@@ -144,6 +151,19 @@ class ProviderRepository
     public function createProvider($provider)
     {
         return new $provider($this->app);
+    }
+
+    /**
+     * Call method right after the given service provider created.
+     *
+     * @param  \Illuminate\Support\ServiceProvider  $provider
+     * @return mixed
+     */
+    protected function postContructProvider(ServiceProvider $provider)
+    {
+        if (method_exists($provider, 'postContruct')) {
+            return $this->call([$provider, 'postContruct']);
+        }
     }
 
     /**

--- a/src/Illuminate/Foundation/ProviderRepository.php
+++ b/src/Illuminate/Foundation/ProviderRepository.php
@@ -77,7 +77,7 @@ class ProviderRepository
             $this->postContructProvider($providerInstance);
         }
 
-        foreach ($eagerProviderInstances[] as $providerInstance) {
+        foreach ($eagerProviderInstances as $providerInstance) {
             $this->app->register($providerInstance);
         }
 

--- a/src/Illuminate/Foundation/ProviderRepository.php
+++ b/src/Illuminate/Foundation/ProviderRepository.php
@@ -4,6 +4,7 @@ namespace Illuminate\Foundation;
 
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Contracts\Foundation\Application as ApplicationContract;
+use Illuminate\Support\ServiceProvider;
 
 class ProviderRepository
 {


### PR DESCRIPTION
Add postContructProvider method calling for provider right after it created. It can be used, for example, for register global event listeners and in other cases.
