### PR TITLE
[5.2] Add method to implement multiple scopes with variable names 

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1143,6 +1143,28 @@ class Builder
     }
 
     /**
+     * Add the given scopes to the current builder instance.
+     *
+     * @param  array  $scopes
+     * @return mixed
+     */
+    public function scopes(array $scopes)
+    {
+        $builder = $this;
+
+        foreach ($scopes as $scope => $parameters) {
+            if (is_int($scope)) {
+                $scope = $parameters;
+                $parameters = [];
+            }
+
+            $builder = $builder->callScope('scope'.ucfirst($scope), (array) $parameters);
+        }
+
+        return $builder;
+    }
+
+    /**
      * Apply the given scope on the current builder instance.
      *
      * @param  callable $scope


### PR DESCRIPTION
Proposal to add the method `scopes` to allow the implementation of multiple variable scopes at once, for example:

`Post::scopes(['question', 'pending' => true])->get()` is the same as:

`Post::questions()->pending(true)->get()` 
