### PR TITLE
[5.2] Properly support PDO::FETCH_CLASS in cursor()

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -359,10 +359,12 @@ class Connection implements ConnectionInterface
 
             $statement = $this->getPdoForSelect($useReadPdo)->prepare($query);
 
-            if ($me->getFetchMode() === PDO::FETCH_CLASS) {
-                $statement->setFetchMode($me->getFetchMode(), 'StdClass');
+            $fetchMode = $me->getFetchMode();
+
+            if ($fetchMode === PDO::FETCH_CLASS) {
+                $statement->setFetchMode($fetchMode, 'StdClass');
             } else {
-                $statement->setFetchMode($me->getFetchMode());
+                $statement->setFetchMode($fetchMode);
             }
 
             $statement->execute($me->prepareBindings($bindings));

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -360,9 +360,10 @@ class Connection implements ConnectionInterface
             $statement = $this->getPdoForSelect($useReadPdo)->prepare($query);
 
             $fetchMode = $me->getFetchMode();
+            $fetchArgument = $me->getFetchArgument();
 
             if ($fetchMode === PDO::FETCH_CLASS) {
-                $statement->setFetchMode($fetchMode, 'StdClass');
+                $statement->setFetchMode($fetchMode, $fetchArgument ?: 'StdClass', $me->getFetchConstructorArgument());
             } else {
                 $statement->setFetchMode($fetchMode);
             }

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -334,11 +334,16 @@ class Connection implements ConnectionInterface
 
             $statement->execute($me->prepareBindings($bindings));
 
+            $fetchMode = $me->getFetchMode();
             $fetchArgument = $me->getFetchArgument();
 
-            return isset($fetchArgument) ?
-                $statement->fetchAll($me->getFetchMode(), $fetchArgument, $me->getFetchConstructorArgument()) :
-                $statement->fetchAll($me->getFetchMode());
+            if ($fetchMode === PDO::FETCH_CLASS && ! isset($fetchArgument)) {
+                $fetchArgument = 'StdClass';
+            }
+
+            return isset($fetchArgument)
+                ? $statement->fetchAll($fetchMode, $fetchArgument, $me->getFetchConstructorArgument())
+                : $statement->fetchAll($fetchMode);
         });
     }
 
@@ -362,8 +367,12 @@ class Connection implements ConnectionInterface
             $fetchMode = $me->getFetchMode();
             $fetchArgument = $me->getFetchArgument();
 
-            if ($fetchMode === PDO::FETCH_CLASS) {
-                $statement->setFetchMode($fetchMode, $fetchArgument ?: 'StdClass', $me->getFetchConstructorArgument());
+            if ($fetchMode === PDO::FETCH_CLASS && ! isset($fetchArgument)) {
+                $fetchArgument = 'StdClass';
+            }
+
+            if (isset($fetchArgument)) {
+                $statement->setFetchMode($fetchMode, $fetchArgument, $me->getFetchConstructorArgument());
             } else {
                 $statement->setFetchMode($fetchMode);
             }

--- a/tests/Database/DatabaseConnectionTest.php
+++ b/tests/Database/DatabaseConnectionTest.php
@@ -300,7 +300,7 @@ class DatabaseConnectionTest extends PHPUnit_Framework_TestCase
         $stmt->expects($this->exactly(3))->method('fetchAll')->withConsecutive(
             [PDO::FETCH_ASSOC],
             [PDO::FETCH_COLUMN, 3, []],
-            [PDO::FETCH_CLASS, 'stdClass', [1, 2, 3]]
+            [PDO::FETCH_CLASS, 'ClassName', [1, 2, 3]]
         );
         $pdo = $this->getMock('DatabaseConnectionTestMockPDO');
         $pdo->expects($this->any())->method('prepare')->will($this->returnValue($stmt));
@@ -309,7 +309,7 @@ class DatabaseConnectionTest extends PHPUnit_Framework_TestCase
         $connection->select('SELECT * FROM foo');
         $connection->setFetchMode(PDO::FETCH_COLUMN, 3);
         $connection->select('SELECT * FROM foo');
-        $connection->setFetchMode(PDO::FETCH_CLASS, 'stdClass', [1, 2, 3]);
+        $connection->setFetchMode(PDO::FETCH_CLASS, 'ClassName', [1, 2, 3]);
         $connection->select('SELECT * FROM foo');
     }
 


### PR DESCRIPTION
Fixes the issue I have pointed in these [comments](https://github.com/laravel/framework/commit/d48e5312550e7df050f63c5040c3043cde96f369#commitcomment-17917096).
