### PR TITLE
[5.4] Add code coverage

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,2 @@
+comment: off
+strict_yaml_branch: master

--- a/.gitattributes
+++ b/.gitattributes
@@ -2,6 +2,7 @@
 
 /build export-ignore
 /tests export-ignore
+.codecov.yml export-ignore
 .editorconfig export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,12 @@ language: php
 
 php:
   - 5.6
-  - 7.0
   - hhvm
 
 env:
   global:
     - setup=basic
+    - coverage=false
 
 matrix:
   include:
@@ -15,6 +15,8 @@ matrix:
       env: setup=lowest
     - php: 5.6
       env: setup=stable
+    - php: 7.0
+      env: coverage=true
 
 sudo: false
 
@@ -29,4 +31,9 @@ install:
   - if [[ $setup = 'stable' ]]; then travis_retry composer update --prefer-dist --no-interaction --prefer-stable; fi
   - if [[ $setup = 'lowest' ]]; then travis_retry composer update --prefer-dist --no-interaction --prefer-lowest --prefer-stable; fi
 
-script: vendor/bin/phpunit
+script:
+  - if [[ $coverage = 'false' ]]; then vendor/bin/phpunit; fi
+  - if [[ $coverage = 'true' ]]; then vendor/bin/phpunit --verbose --coverage-text --coverage-clover=coverage.xml; fi
+
+after_success:
+  - if [[ $coverage != 'true' ]]; then bash <(curl -s https://codecov.io/bash); fi

--- a/readme.md
+++ b/readme.md
@@ -2,6 +2,7 @@
 
 [![StyleCI](https://styleci.io/repos/7548986/shield?style=flat)](https://styleci.io/repos/7548986)
 [![Build Status](https://travis-ci.org/laravel/framework.svg)](https://travis-ci.org/laravel/framework)
+[![Codecov](https://codecov.io/gh/laravel/framework/branch/master/graph/badge.svg)](https://codecov.io/gh/laravel/framework)
 [![Total Downloads](https://poser.pugx.org/laravel/framework/d/total.svg)](https://packagist.org/packages/laravel/framework)
 [![Latest Stable Version](https://poser.pugx.org/laravel/framework/v/stable.svg)](https://packagist.org/packages/laravel/framework)
 [![Latest Unstable Version](https://poser.pugx.org/laravel/framework/v/unstable.svg)](https://packagist.org/packages/laravel/framework)


### PR DESCRIPTION
I feel like providing code coverage data makes more and more sense, as this is often a key aspect when choosing a framework and/or convincing customers for whom CC is important.

This PR provides a free codecov support.

Notes:
- annoying PR comments are muted so that only the status appears.
- only run on PHP7 for build speed purposes
- codecov will always use `.codecov.yml` from master branch (`strict_yaml_branch`)

---

Replaces #14050
Requires #14061 to pass
