### PR TITLE
[master] Broadcaster : avoid using same name for class and interface

### DIFF
--- a/src/Illuminate/Broadcasting/Broadcasters/Broadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/Broadcaster.php
@@ -3,10 +3,10 @@
 namespace Illuminate\Broadcasting\Broadcasters;
 
 use Illuminate\Support\Str;
-use Illuminate\Contracts\Broadcasting\Broadcaster;
 use Symfony\Component\HttpKernel\Exception\HttpException;
+use Illuminate\Contracts\Broadcasting\Broadcaster as BroadcasterContract;
 
-abstract class Broadcaster implements Broadcaster
+abstract class Broadcaster implements BroadcasterContract
 {
     /**
      * The registered channel authenticators.


### PR DESCRIPTION
Avoid using same name for class and interface

---

Required by https://github.com/laravel/framework/pull/14057
See https://github.com/sebastianbergmann/php-code-coverage/issues/383
