### PR TITLE
[5.3] Allow callable classes as route actions to support ADR out of the box

### DIFF
--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -803,7 +803,9 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase
     public function testInvalidActionException()
     {
         $router = $this->getRouter();
-        $router->get('/', ['uses' => 'Controller']);
+        $router->get('/', ['uses' => 'RouteTestControllerStub']);
+
+        $router->dispatch(Request::create('/'));
     }
 
     public function testResourceRouting()
@@ -1064,6 +1066,20 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase
         $router->dispatch(Request::create('bar', 'GET'))->getContent();
     }
 
+    public function testDispatchingCallableActionClasses()
+    {
+        $router = $this->getRouter();
+        $router->get('foo/bar', 'ActionStub');
+
+        $this->assertEquals('hello', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
+
+        $router->get('foo/bar2', [
+            'uses' => 'ActionStub',
+        ]);
+
+        $this->assertEquals('hello', $router->dispatch(Request::create('foo/bar2', 'GET'))->getContent());
+    }
+
     protected function getRouter()
     {
         $container = new Container;
@@ -1263,5 +1279,13 @@ class RoutingTestUserModel extends Model
     public function firstOrFail()
     {
         return $this;
+    }
+}
+
+class ActionStub
+{
+    public function __invoke()
+    {
+        return 'hello';
     }
 }


### PR DESCRIPTION
@taylorotwell recently made an example implementation for ADR to work with the Laravel router (https://gist.github.com/taylorotwell/68f614deb9538f2e30108c2698266fda) 

It works well and is pretty easy to use, however it can probably have an easier syntax - supported completely out of the box - requiring less characters on each action definition (which would fit in with the pretty syntax philosophy of Laravel i.m.o). 

Defining an action can be as easy as:

``` php
$router->get('/', 'WelcomeAction');
$router->get('/', [
    'uses' => 'WelcomeAction'
]);
```

``` php
class WelcomeAction
{
    /**
     * @var WelcomeResponder
     */
    private $responder;

    /**
     * @param WelcomeResponder $responder
     */
    public function __construct(WelcomeResponder $responder)
    {
        $this->responder = $responder;
    }

    /**
     * @param SomeFormRequest $request
     * @return \Illuminate\Http\Response
     */
    public function __invoke(SomeFormRequest $request)
    {
        return $this->responder->handle();
    }
}
```

The Action should be a callable class (by using __invoke) and will have both constructor as method injection. In the method you can e.g. inject the FormRequest/Request and in the constructor the responder and domain service.

In the past the Router would throw an exception if you pass a string without a method (@), this is still the case, but is now only thrown if the class is not callable. 

This implementation runs the action as a closure, meaning the callable action class is a POPO and won't call any controller/middleware methods on the class. 

I targeted this to 5.3, not sure where you're at with adding new features to that release. It should be a non-breaking change as the original behaviour is still in place. It only adds functionality when the given action class is callable.
