### PR TITLE
[5.3] Decouple Kernel from concrete Router

### DIFF
--- a/src/Illuminate/Foundation/Http/Kernel.php
+++ b/src/Illuminate/Foundation/Http/Kernel.php
@@ -4,9 +4,9 @@ namespace Illuminate\Foundation\Http;
 
 use Exception;
 use Throwable;
-use Illuminate\Routing\Router;
 use Illuminate\Routing\Pipeline;
 use Illuminate\Support\Facades\Facade;
+use Illuminate\Contracts\Routing\Registrar;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Contracts\Http\Kernel as KernelContract;
@@ -24,7 +24,7 @@ class Kernel implements KernelContract
     /**
      * The router instance.
      *
-     * @var \Illuminate\Routing\Router
+     * @var \Illuminate\Contracts\Routing\Registrar
      */
     protected $router;
 
@@ -68,10 +68,10 @@ class Kernel implements KernelContract
      * Create a new HTTP kernel instance.
      *
      * @param  \Illuminate\Contracts\Foundation\Application  $app
-     * @param  \Illuminate\Routing\Router  $router
+     * @param  \Illuminate\Contracts\Routing\Registrar       $router
      * @return void
      */
-    public function __construct(Application $app, Router $router)
+    public function __construct(Application $app, Registrar $router)
     {
         $this->app = $app;
         $this->router = $router;

--- a/src/Illuminate/Foundation/Support/Providers/RouteServiceProvider.php
+++ b/src/Illuminate/Foundation/Support/Providers/RouteServiceProvider.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\Foundation\Support\Providers;
 
-use Illuminate\Routing\Router;
+use Illuminate\Contracts\Routing\Registrar;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Contracts\Routing\UrlGenerator;
 
@@ -18,10 +18,10 @@ class RouteServiceProvider extends ServiceProvider
     /**
      * Bootstrap any application services.
      *
-     * @param  \Illuminate\Routing\Router  $router
+     * @param  \Illuminate\Contracts\Routing\Registrar  $router
      * @return void
      */
-    public function boot(Router $router)
+    public function boot(Registrar $router)
     {
         $this->setRootControllerNamespace();
 
@@ -80,13 +80,13 @@ class RouteServiceProvider extends ServiceProvider
      */
     protected function loadRoutesFrom($path)
     {
-        $router = $this->app->make(Router::class);
+        $router = $this->app->make(Registrar::class);
 
         if (is_null($this->namespace)) {
             return require $path;
         }
 
-        $router->group(['namespace' => $this->namespace], function (Router $router) use ($path) {
+        $router->group(['namespace' => $this->namespace], function (Registrar $router) use ($path) {
             require $path;
         });
     }
@@ -110,6 +110,6 @@ class RouteServiceProvider extends ServiceProvider
      */
     public function __call($method, $parameters)
     {
-        return call_user_func_array([$this->app->make(Router::class), $method], $parameters);
+        return call_user_func_array([$this->app->make(Registrar::class), $method], $parameters);
     }
 }


### PR DESCRIPTION
Right now the concrete Router implementation is typehinted in both Kernel and RouteServiceProvider. As a Registrar contract exists for that, I think the Registrar contract should be typehinted. This would allow the user to swap router implementation.
- The RouteServiceProvider provided in laravel/laravel should be updated accordingly if this change gets merged.
- The user can't rebind the router in a normal service provider, the router gets resolved before the service providers are registered/booted. Meaning the kernel won't know about the new router.  The user can rebind the router by doing so before the kernel gets resolved (`$app->register()` or `$app['router'] =` in bootstrap.php).

This change would be a small breaking change when upgrading from 5.x to 5.3, as the user will have to update the RouteServiceProvider in his project.
