### PR TITLE
[5.3] Revert "Use default driver when guards array is empty (#13979)"

### DIFF
--- a/src/Illuminate/Auth/Middleware/Authenticate.php
+++ b/src/Illuminate/Auth/Middleware/Authenticate.php
@@ -54,9 +54,7 @@ class Authenticate
     protected function authenticate(array $guards)
     {
         if (count($guards) <= 1) {
-            $guard = array_first($guards) ?: $this->auth->getDefaultDriver();
-
-            $this->auth->guard($guard)->authenticate();
+            $this->auth->guard($guard = array_first($guards))->authenticate();
 
             return $this->auth->shouldUse($guard);
         }


### PR DESCRIPTION
This has [been implemented in `shouldUse` itself](https://github.com/laravel/framework/commit/997c74052c860a5e41e833a4079d4aeb5c48046d), and [we now have test coverage for it](https://github.com/laravel/framework/blob/5.3/tests/Auth/AuthenticateMiddlewareTest.php#L47).
