### PR TITLE
[5.3] Sort middleware by priority

### DIFF
--- a/src/Illuminate/Foundation/Http/Kernel.php
+++ b/src/Illuminate/Foundation/Http/Kernel.php
@@ -44,6 +44,20 @@ class Kernel implements KernelContract
     ];
 
     /**
+     * The priority-sorted list of middleware.
+     *
+     * @var array
+     */
+    protected $middlewarePriority = [
+        \Illuminate\Session\Middleware\StartSession::class,
+        \Illuminate\View\Middleware\ShareErrorsFromSession::class,
+        \App\Http\Middleware\VerifyCsrfToken::class,
+        \Illuminate\Auth\Middleware\Authenticate::class,
+        \Illuminate\Routing\Middleware\SubstituteBindings::class,
+        \Illuminate\Auth\Middleware\Authorize::class,
+    ];
+
+    /**
      * The application's middleware stack.
      *
      * @var array
@@ -83,6 +97,8 @@ class Kernel implements KernelContract
         foreach ($this->routeMiddleware as $key => $middleware) {
             $router->middleware($key, $middleware);
         }
+
+        $router->middlewarePriority = $this->middlewarePriority;
     }
 
     /**


### PR DESCRIPTION
Some middleware require other middleware to run first, _if present_.

For example, the `SubstituteBindings` middleware should always run after the `Authenticate` middleware (if present), so that model scopes that use the current user should have access to it.

Likewise, the `Authorize` middleware should always run _after_ the `SubstituteBindings` middleware, so that the authorization can happen against an actual model.

The change in this PR makes sure that these middleware are always run in the correct order. To opt out, set the `$middlewarePriority` property of your http kernel to an empty array.
