### PR TITLE
[5.3] Remove the guard parameter from AuthenticationException

### DIFF
--- a/src/Illuminate/Auth/AuthenticationException.php
+++ b/src/Illuminate/Auth/AuthenticationException.php
@@ -7,31 +7,12 @@ use Exception;
 class AuthenticationException extends Exception
 {
     /**
-     * The guard instance.
-     *
-     * @var \Illuminate\Contracts\Auth\Guard
-     */
-    protected $guard;
-
-    /**
      * Create a new authentication exception.
      *
-     * @param \Illuminate\Contracts\Auth\Guard|null  $guard
+     * @param string  $message
      */
-    public function __construct($guard = null)
+    public function __construct($message = 'Unauthenticated.')
     {
-        $this->guard = $guard;
-
-        parent::__construct('Unauthenticated.');
-    }
-
-    /**
-     * Get the guard instance.
-     *
-     * @return \Illuminate\Contracts\Auth\Guard|null
-     */
-    public function guard()
-    {
-        return $this->guard;
+        parent::__construct($message);
     }
 }

--- a/src/Illuminate/Auth/GuardHelpers.php
+++ b/src/Illuminate/Auth/GuardHelpers.php
@@ -36,7 +36,7 @@ trait GuardHelpers
             return $user;
         }
 
-        throw new AuthenticationException($this);
+        throw new AuthenticationException;
     }
 
     /**

--- a/src/Illuminate/Auth/Middleware/Authenticate.php
+++ b/src/Illuminate/Auth/Middleware/Authenticate.php
@@ -53,10 +53,8 @@ class Authenticate
      */
     protected function authenticate(array $guards)
     {
-        if (count($guards) <= 1) {
-            $this->auth->guard($guard = array_first($guards))->authenticate();
-
-            return $this->auth->shouldUse($guard);
+        if (! $guards) {
+            return $this->auth->authenticate();
         }
 
         foreach ($guards as $guard) {


### PR DESCRIPTION
It's anyhow not reliable, since we can't specify the guard when authenticating against multiple guards.

Removing it simplifies the `Authenticate` middleware, so I believe that to be a net win.
