### PR TITLE
[5.3] Use relation name instead of pivot

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -294,7 +294,7 @@ class BelongsToMany extends Relation
         foreach ($models as $model) {
             $pivot = $this->newExistingPivot($this->cleanPivotAttributes($model));
 
-            $model->setRelation('pivot', $pivot);
+            $model->setRelation($this->getRelationName(), $pivot);
         }
     }
 

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -85,7 +85,7 @@ class BelongsToMany extends Relation
      * @param  string  $relationName
      * @return void
      */
-    public function __construct(Builder $query, Model $parent, $table, $foreignKey, $otherKey, $relationName = null)
+    public function __construct(Builder $query, Model $parent, $table, $foreignKey, $otherKey, $relationName = 'pivot')
     {
         $this->table = $table;
         $this->otherKey = $otherKey;


### PR DESCRIPTION
Use relation name which is set by fifth parameter of method Model::belongsToMany() instead of hardcoding 'pivot'
