### PR TITLE
[5.3] Update $loop helper regex to be more strict and fix #14068

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -579,7 +579,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
      */
     protected function compileForeach($expression)
     {
-        preg_match('/\( *(.*) *as *([^\)]*)/', $expression, $matches);
+        preg_match('/\( *(.*) +as *([^\)]*)/', $expression, $matches);
 
         $iteratee = trim($matches[1]);
 
@@ -624,7 +624,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
     {
         $empty = '$__empty_'.++$this->forelseCounter;
 
-        preg_match('/\( *(.*) *as *([^\)]*)/', $expression, $matches);
+        preg_match('/\( *(.*) +as *([^\)]*)/', $expression, $matches);
 
         $iteratee = trim($matches[1]);
 

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -483,6 +483,10 @@ tag info
         $string = '@foreach (   $users as $user)';
         $expected = '<?php $__currentLoopData = $users; $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $user): $__env->incrementLoopIndices(); $loop = $__env->getFirstLoop(); ?>';
         $this->assertEquals($expected, $compiler->compileString($string));
+
+        $string = '@foreach ($tasks as $task)';
+        $expected = '<?php $__currentLoopData = $tasks; $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $task): $__env->incrementLoopIndices(); $loop = $__env->getFirstLoop(); ?>';
+        $this->assertEquals($expected, $compiler->compileString($string));
     }
 
     public function testForelseStatementsAreCompiled()


### PR DESCRIPTION
Fixes https://github.com/laravel/framework/issues/14068 when variables contain `as` in between.
