### PR TITLE
[5.3] Allow scopes return null

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1145,7 +1145,7 @@ class Builder
         // query as their own isolated nested where statement and avoid issues.
         $originalWhereCount = count($query->wheres);
 
-        $result = call_user_func_array($scope, $parameters) ?: $this;
+        $result = call_user_func_array($scope, $parameters);
 
         if ($this->shouldNestWheresForScope($query, $originalWhereCount)) {
             $this->nestWheresForScope($query, $originalWhereCount);

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -690,7 +690,7 @@ class EloquentBuilderTestScopeStub extends Illuminate\Database\Eloquent\Model
 {
     public function scopeApproved($query)
     {
-        $query->where('foo', 'bar');
+        return $query->where('foo', 'bar');
     }
 }
 


### PR DESCRIPTION
This is an example from Laracasts, Monstrous Code serie, Consider Normalizing episode.

``` php
class Coupon extends Eloquent\Model
{
    public function scopeHavingCode($code)
    {
        return $query->where('code', $code);
    }
}
```

I can perfectly use it like this:

``` php
$coupon = Coupon::havingCode('1234')->first();
```

If I use this line many times, I can use it other way:

``` php
public function scopeHavingCode($code)
{
    return $query->where('code', $code)->first();
}
```

and then:

``` php
$coupon = Coupon::havingCode('1234');
```

It is working. I have a Coupon object, what is totally expected and usefull.

But what if there are no coupons with given code?
I can expect that `$coupon` is `null`, but it is not.
`$coupon` will be instance of Illuminate\Database\Eloquent\Builder, and this is not super consistent for me. And it is not going to work as @JeffreyWay expected.

I propose to allow local scopes return `null`.

It also forces to return Builder object in the rest of local scopes, but it is consistent with current documentation.

``` php
// For example this will not be working:
public function scopeHavingCode($code)
{
    $query->where('code', $code);
}
// because of missing `return`
```
