### PR TITLE
[5.2] Cast unique validation exclude id to integer

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1296,7 +1296,7 @@ class Validator implements ValidatorContract
             if (strtolower($id) == 'null') {
                 $id = null;
             }
-            
+
             if (filter_var($id, FILTER_VALIDATE_INT) !== false) {
                 $id = intval($id);
             }

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1296,6 +1296,10 @@ class Validator implements ValidatorContract
             if (strtolower($id) == 'null') {
                 $id = null;
             }
+            
+            if (filter_var($id, FILTER_VALIDATE_INT) !== false) {
+                $id = intval($id);
+            }
         }
 
         // The presence verifier is responsible for counting rows within this store


### PR DESCRIPTION
I have this quite complex validation rule and I use with mongodb:

`unique:mongodb.responses,RY7bC4VBFdzFWBS3.age,123,visitor_id,survey_id,564ce591c560ca2c6a8b4568`

The problem occurs that in MongoDB `where = 123` and `where = '123'` are two different queries, where in MySQL there is no difference.

Therefore I really need to cast ID attribute to integer to have it return the correct count for unique validation and  I suppose that it can only be done from here.
