### PR TITLE
[5.2] Transaction count cannot be negative

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -583,7 +583,7 @@ class Connection implements ConnectionInterface
             $this->getPdo()->commit();
         }
 
-        --$this->transactions;
+        $this->transactions = max(0, $this->transactions - 1);
 
         $this->fireConnectionEvent('committed');
     }


### PR DESCRIPTION
As per `->rollback`, the `$this->transactions` should not go into negative values.

If calling `->commit()` without an active transaction will cause the next number to be incorrect.
