### PR TITLE
[5.2] Add loadOnly() method to only load specified relations

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -49,6 +49,28 @@ class Collection extends BaseCollection implements QueueableCollection
     }
 
     /**
+     * Load only the specified relationships onto the collection.
+     *
+     * @param  mixed  $relations
+     * @return $this
+     */
+    public function loadOnly($relations)
+    {
+        if (count($this->items) > 0) {
+            if (is_string($relations)) {
+                $relations = func_get_args();
+            }
+
+            $model = $this->first();
+            $query = $model->newQuery()->with($relations)->without($model->with);
+
+            $this->items = $query->eagerLoadRelations($this->items);
+        }
+
+        return $this;
+    }
+
+    /**
      * Add an item to the collection.
      *
      * @param  mixed  $item

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -62,7 +62,14 @@ class Collection extends BaseCollection implements QueueableCollection
             }
 
             $model = $this->first();
-            $query = $model->newQuery()->with($relations)->without($model->with);
+
+            $without = array_diff($model->with, $relations);
+
+            if (empty($without)) {
+                $query = $model->newQuery()->with($relations);
+            } else {
+                $query = $model->newQuery()->with($relations)->without($model->with);
+            }
 
             $this->items = $query->eagerLoadRelations($this->items);
         }

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -701,7 +701,13 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
             $relations = func_get_args();
         }
 
-        $query = $this->newQuery();
+        $without = array_diff($this->with, $relations);
+
+        if (empty($without)) {
+            $query = $this->newQuery()->with($relations);
+        } else {
+            $query = $this->newQuery()->with($relations)->without($this->with);
+        }
 
         $query->eagerLoadRelations([$this]);
 

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -690,6 +690,25 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     }
 
     /**
+     * Eager load only the specified relations on the model.
+     *
+     * @param  array|string  $relations
+     * @return $this
+     */
+    public function loadOnly($relations)
+    {
+        if (is_string($relations)) {
+            $relations = func_get_args();
+        }
+
+        $query = $this->newQuery();
+
+        $query->eagerLoadRelations([$this]);
+
+        return $this;
+    }
+
+    /**
      * Begin querying a model with eager loading.
      *
      * @param  array|string  $relations

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -113,6 +113,21 @@ class DatabaseEloquentCollectionTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(['results'], $c->all());
     }
 
+    public function testLoadOnlyMethodEagerLoadsOnlyGivenRelationships()
+    {
+        $c = $this->getMock('Illuminate\Database\Eloquent\Collection', ['first'], [['foo']]);
+        $mockItem = m::mock('StdClass');
+        $mockItem->with = ['qux'];
+        $c->expects($this->once())->method('first')->will($this->returnValue($mockItem));
+        $mockItem->shouldReceive('newQuery')->once()->andReturn($mockItem);
+        $mockItem->shouldReceive('with')->with(['bar', 'baz'])->andReturn($mockItem);
+        $mockItem->shouldReceive('without')->with(['qux'])->andReturn($mockItem);
+        $mockItem->shouldReceive('eagerLoadRelations')->once()->with(['foo'])->andReturn(['results']);
+        $c->loadOnly('bar', 'baz');
+
+        $this->assertEquals(['results'], $c->all());
+    }
+
     public function testCollectionDictionaryReturnsModelKeys()
     {
         $one = m::mock('Illuminate\Database\Eloquent\Model');
@@ -284,4 +299,5 @@ class TestEloquentCollectionModel extends Illuminate\Database\Eloquent\Model
 {
     protected $visible = ['visible'];
     protected $hidden = ['hidden'];
+    public $with = ['foo'];
 }


### PR DESCRIPTION
Following on from #14031

Say we have three Models `User`, `UserData` and `UserComments`.

`User` has a `userData` relationship that we _always_ want to eager load, so we define that in the `$with` attribute. It also has a `userComments` relationship that we eager load as required.

Now, consider this...

``` php
$users = User::without('userData')->get();

$users->load('userComments');
```

This will eager load the specified `userComments` relationship **AND** also load the `userData` relationship. This is perhaps a little confusing, because that is not what we wanted to do.

Not sure if this is expected behaviour, or an oversight in the behaviour of the `load()` method...current behaviour seems counter intuitive.

To maintain backwards compatibility, I suggest a new method called `loadOnly()`, which will actually load **ONLY** the specified relationships.
