### PR TITLE
[5.2] Adding carbon helper function

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -191,6 +191,20 @@ if (! function_exists('bcrypt')) {
     }
 }
 
+if (! function_exists('carbon')) {
+    /**
+     * Create a new Carbon instance.
+     *
+     * @param string|null              $time
+     * @param DateTimeZone|string|null $tz
+     * @return \Carbon\Carbon
+     */
+    function carbon($time = null, $tz = null)
+    {
+        return new \Carbon\Carbon($time, $tz);
+    }
+}
+
 if (! function_exists('config')) {
     /**
      * Get / set the specified configuration value.


### PR DESCRIPTION
Allows for a cleaner syntax when dealing with Carbon instances. You can easily use any of the Carbon methods:

``` php
$now = carbon();

$date = carbon('2016-07-27');

$formatted = carbon()->format('Y-m-d H:i:s');
```
