### PR TITLE
[5.2] Allow the shuffle() method to be seeded

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -766,13 +766,21 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Shuffle the items in the collection.
      *
+     * @param int $seed
      * @return static
      */
-    public function shuffle()
+    public function shuffle($seed = null)
     {
         $items = $this->items;
 
-        shuffle($items);
+        if (is_null($seed)) {
+            shuffle($items);
+        } else {
+            srand($seed);
+            usort($items, function ($a, $b) {
+                return rand(-1, 1);
+            });
+        }
 
         return new static($items);
     }


### PR DESCRIPTION
We often need to display items in a random order, but only random on a daily basis i.e. the order is static for a day, then the following day, the order changes.

This PR adds the ability to seed the `shuffle()` method.
