### PR TITLE
[5.3] delete @ parent feature from blade

### DIFF
--- a/src/Illuminate/View/Factory.php
+++ b/src/Illuminate/View/Factory.php
@@ -630,7 +630,7 @@ class Factory implements FactoryContract
     protected function extendSection($section, $content)
     {
         if (isset($this->sections[$section])) {
-            $content = str_replace('@parent', $content, $this->sections[$section]);
+            $content = $this->sections[$section];
         }
 
         $this->sections[$section] = $content;
@@ -651,11 +651,7 @@ class Factory implements FactoryContract
             $sectionContent = $this->sections[$section];
         }
 
-        $sectionContent = str_replace('@@parent', '--parent--holder--', $sectionContent);
-
-        return str_replace(
-            '--parent--holder--', '@parent', str_replace('@parent', '', $sectionContent)
-        );
+        return $sectionContent;
     }
 
     /**

--- a/tests/View/ViewFactoryTest.php
+++ b/tests/View/ViewFactoryTest.php
@@ -250,7 +250,7 @@ class ViewFactoryTest extends PHPUnit_Framework_TestCase
         $factory->startSection('foo');
         echo 'there';
         $factory->stopSection();
-        $this->assertEquals('hi there', $factory->yieldContent('foo'));
+        $this->assertEquals('hi @parent', $factory->yieldContent('foo'));
     }
 
     public function testSectionMultipleExtending()
@@ -265,7 +265,7 @@ class ViewFactoryTest extends PHPUnit_Framework_TestCase
         $factory->startSection('foo');
         echo 'friend';
         $factory->stopSection();
-        $this->assertEquals('hello my friend nice to see you my friend', $factory->yieldContent('foo'));
+        $this->assertEquals('hello @parent nice to see you @parent', $factory->yieldContent('foo'));
     }
 
     public function testSingleStackPush()

--- a/tests/View/ViewFlowTest.php
+++ b/tests/View/ViewFlowTest.php
@@ -148,7 +148,7 @@ child
 @endsection'));
 
         $factory = $this->prepareCommonFactory();
-        $this->assertEquals("yield:\ndad\n\nchild\n", $factory->make('extends-child')->render());
+        $this->assertEquals("yield:\n@parent\nchild\n", $factory->make('extends-child')->render());
     }
 
     public function testExtendsWithVariable()
@@ -180,7 +180,7 @@ dad
 
         $factory = $this->prepareCommonFactory();
         $this->assertEquals("yield:\ntitle\n", $factory->make('extends-variable-child-a', ['title' => 'title'])->render());
-        $this->assertEquals("yield:\ndad\n\n", $factory->make('extends-variable-child-b', ['title' => '@parent'])->render());
+        $this->assertEquals("yield:\n@parent\n", $factory->make('extends-variable-child-b', ['title' => '@parent'])->render());
     }
 
     protected function prepareCommonFactory()


### PR DESCRIPTION
`@parent` feature is a bug, and it is there even for those who don't use it. I only can try to remove it. So here you are.
