### PR TITLE
[5.1] Display the correct exception when a syntax error is found in a config file

### DIFF
--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -117,7 +117,7 @@ class Kernel implements KernelContract
     }
 
     /**
-     * Render and report the exception
+     * Render and report the exception.
      *
      * @param  \Exception|\Throwable  $exception
      * @param  \Symfony\Component\Console\Output\OutputInterface  $output


### PR DESCRIPTION
Prevent an `Uncaught ReflectionException: Class log does not exist in ...` with a broken config file.

I've read in https://github.com/laravel/framework/issues/14009 that it's been fixed in 5.3 but as 5.1 is an LTS version, I think there should also be a fix for 5.1.
As the error isn't being reported anyway (The `Class does not exist in ...` is caused by `LoggingInterface` in the error handler), this will only show the original exception message as opposed to the message caused by the exception handler.
