### PR TITLE
[5.3] Rename "make:console" to "make:command"

### DIFF
--- a/src/Illuminate/Foundation/Console/ConsoleMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ConsoleMakeCommand.php
@@ -13,7 +13,7 @@ class ConsoleMakeCommand extends GeneratorCommand
      *
      * @var string
      */
-    protected $name = 'make:console';
+    protected $name = 'make:command';
 
     /**
      * The console command description.


### PR DESCRIPTION
Since commands have been renamed to jobs, we can go back to calling this command `make:command`.

`make:console` never seemed right. You're not making a console, you're making a console command.
