### PR TITLE
[5.3] Add missing @throws

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -50,6 +50,7 @@ class Handler implements ExceptionHandlerContract
      * Report or log an exception.
      *
      * @param  \Exception  $e
+     * @throws \Exception  $e
      * @return void
      */
     public function report(Exception $e)


### PR DESCRIPTION
The method `report` is missing a @throws tag in the PHPDoc comment
