### PR TITLE
[5.2] collection pipe method + test.

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1154,6 +1154,17 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
+     * Passes the collection into the callback, and returns the result.
+     * @param  callable $callback
+     * @return callable
+     */
+    public function pipe(callable $callback)
+    {
+        $callback($this);
+        return $this;
+    }
+
+    /**
      * Results array of items from Collection or Arrayable.
      *
      * @param  mixed  $items

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1273,6 +1273,38 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
         $data = new Collection([1, 2, 3]);
         $data->random(4);
     }
+
+    public function testPipe()
+    {
+        $data = new Collection([
+            'a' => [
+                'po_01' => 'value in pos 01',
+                'po_02' => 'value in pos 01'
+            ],
+
+            'b' => [
+                'po_01' => 'value in pos 01',
+                'po_02' => 'value in pos 01',
+                'sub' => [
+                    'c' => [
+                        'po_01' => 'value in pos 01',
+                        'po_02' => 'value in pos 01',
+                    ]
+                ]
+            ],
+        ]);
+
+        $data->filter(function ($item) {
+            return collect($item)->has('sub');
+        })->map(function ($item, $key) {
+            return $item['sub'];
+        //pipe implementation.
+        })->pipe(function ($items) {
+            //do something amazing within the chain.
+        })->pipe(function ($items) {
+           //because it is fluent, it can add as much as it is needed.
+        });
+    }
 }
 
 class TestAccessorEloquentTestStub


### PR DESCRIPTION
Passes the collection into the callback, and returns the result.

When you are working into a `collection chain`, you might need keeping track of some result. Right now, this is possible dong something like so: 

**_Collection**_

``` php
$data = new Collection([
            'a' => [
                'po_01' => 'value in pos 01',
                'po_02' => 'value in pos 01'
            ],

            'b' => [
                'po_01' => 'value in pos 01',
                'po_02' => 'value in pos 01',
                'sub' => [
                    'c' => [
                        'po_01' => 'value in pos 01',
                        'po_02' => 'value in pos 01',
                    ]
                ]
            ],
        ]);
```

**_Operations**_

``` php

$result = $data->filter(function ($item) {
     return collect($item)->has('sub');
})->map(function ($item, $key) {
     return $item['sub'];
});

// Now you will be able to operate using $result

```

**_Using the pipe method**_

You can do the operation within the chain, like so: 

``` php
$data->filter(function ($item) {
     return collect($item)->has('sub');
})->map(function ($item, $key) {
     return $item['sub'];
})->pipe(function ($items) {
      //do something amazing within the chain.
})->pipe(function ($items) {
      //because it is fluent, it can add as much as it is needed.
 });
```

Note: I thought this was not necessary until I crossed to this situation 30 this morning. 

@adamwathan calls this approach "something pretty neat" in his book!

I would like to know what you guys think about this. Please, take in account this is my first contribution!
