### PR TITLE
[5.2] Read CSRF token from the cookie automatically

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
+++ b/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
@@ -114,6 +114,10 @@ class VerifyCsrfToken
             $token = $this->encrypter->decrypt($header);
         }
 
+        if (! $token) {
+            $token = $request->cookie('XSRF-TOKEN');
+        }
+
         if (! is_string($sessionToken) || ! is_string($token)) {
             return false;
         }


### PR DESCRIPTION
I don't know whether this is a bug, something intentionally or a missing feature.

But if I can read the encrypted XSRF-COOKIE in JAVASCRIPT and I can pass it to the request header with JS, I don't know why Laravel doesn't check this automatically from the cookie in the request.

Since a "XSRF-TOKEN" cookie is already being sent in the request header.

Again I don't know if this is a missing feature or I'm doing something silly. 
