### PR TITLE
[5.2] Ability to declare which columns to get in chunk, chunkById and each methods

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -359,11 +359,12 @@ class Builder
      *
      * @param  int  $count
      * @param  callable  $callback
+     * @param  array  $columns
      * @return bool
      */
-    public function chunk($count, callable $callback)
+    public function chunk($count, callable $callback, $columns = ['*'])
     {
-        $results = $this->forPage($page = 1, $count)->get();
+        $results = $this->forPage($page = 1, $count)->get($columns);
 
         while (count($results) > 0) {
             // On each chunk result set, we will pass them to the callback and then let the
@@ -375,7 +376,7 @@ class Builder
 
             $page++;
 
-            $results = $this->forPage($page, $count)->get();
+            $results = $this->forPage($page, $count)->get($columns);
         }
 
         return true;
@@ -387,13 +388,14 @@ class Builder
      * @param  int  $count
      * @param  callable  $callback
      * @param  string  $column
+     * @param  array  $columns
      * @return bool
      */
-    public function chunkById($count, callable $callback, $column = 'id')
+    public function chunkById($count, callable $callback, $column = 'id', $columns = ['*'])
     {
         $lastId = null;
 
-        $results = $this->forPageAfterId($count, 0, $column)->get();
+        $results = $this->forPageAfterId($count, 0, $column)->get($columns);
 
         while (! $results->isEmpty()) {
             if (call_user_func($callback, $results) === false) {
@@ -402,7 +404,7 @@ class Builder
 
             $lastId = $results->last()->{$column};
 
-            $results = $this->forPageAfterId($count, $lastId, $column)->get();
+            $results = $this->forPageAfterId($count, $lastId, $column)->get($columns);
         }
 
         return true;
@@ -413,9 +415,10 @@ class Builder
      *
      * @param  callable  $callback
      * @param  int  $count
+     * @param  array  $columns
      * @return bool
      */
-    public function each(callable $callback, $count = 1000)
+    public function each(callable $callback, $count = 1000, $columns = ['*'])
     {
         if (is_null($this->query->orders) && is_null($this->query->unionOrders)) {
             $this->orderBy($this->model->getQualifiedKeyName(), 'asc');
@@ -427,7 +430,7 @@ class Builder
                     return false;
                 }
             }
-        });
+        }, $columns);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -267,9 +267,10 @@ class BelongsToMany extends Relation
      *
      * @param  int  $count
      * @param  callable  $callback
+     * @param  array  $columns
      * @return bool
      */
-    public function chunk($count, callable $callback)
+    public function chunk($count, callable $callback, $columns = ['*'])
     {
         $this->query->addSelect($this->getSelectColumns());
 
@@ -277,7 +278,7 @@ class BelongsToMany extends Relation
             $this->hydratePivotRelation($results->all());
 
             return $callback($results);
-        });
+        }, $columns);
     }
 
     /**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1728,11 +1728,12 @@ class Builder
      *
      * @param  int  $count
      * @param  callable  $callback
+     * @param  array  $columns
      * @return  bool
      */
-    public function chunk($count, callable $callback)
+    public function chunk($count, callable $callback, $columns = ['*'])
     {
-        $results = $this->forPage($page = 1, $count)->get();
+        $results = $this->forPage($page = 1, $count)->get($columns);
 
         while (count($results) > 0) {
             // On each chunk result set, we will pass them to the callback and then let the
@@ -1744,7 +1745,7 @@ class Builder
 
             $page++;
 
-            $results = $this->forPage($page, $count)->get();
+            $results = $this->forPage($page, $count)->get($columns);
         }
 
         return true;
@@ -1756,13 +1757,14 @@ class Builder
      * @param  int  $count
      * @param  callable  $callback
      * @param  string  $column
+     * @param  array  $columns
      * @return bool
      */
-    public function chunkById($count, callable $callback, $column = 'id')
+    public function chunkById($count, callable $callback, $column = 'id', $columns = ['*'])
     {
         $lastId = null;
 
-        $results = $this->forPageAfterId($count, 0, $column)->get();
+        $results = $this->forPageAfterId($count, 0, $column)->get($columns);
 
         while (! empty($results)) {
             if (call_user_func($callback, $results) === false) {
@@ -1771,7 +1773,7 @@ class Builder
 
             $lastId = last($results)->{$column};
 
-            $results = $this->forPageAfterId($count, $lastId, $column)->get();
+            $results = $this->forPageAfterId($count, $lastId, $column)->get($columns);
         }
 
         return true;
@@ -1782,11 +1784,12 @@ class Builder
      *
      * @param  callable  $callback
      * @param  int  $count
+     * @param  array  $columns
      * @return bool
      *
      * @throws \RuntimeException
      */
-    public function each(callable $callback, $count = 1000)
+    public function each(callable $callback, $count = 1000, $columns = ['*'])
     {
         if (is_null($this->orders) && is_null($this->unionOrders)) {
             throw new RuntimeException('You must specify an orderBy clause when using the "each" function.');
@@ -1798,7 +1801,7 @@ class Builder
                     return false;
                 }
             }
-        });
+        }, $columns);
     }
 
     /**


### PR DESCRIPTION
Currently the very useful `chunk`, `chunkById` and `each` methods on the database builders are a little bit less useful than they could be as they just call `get` without letting the user pass an array of columns to get, unlike e.g. the `paginate` method does. This pull request fixes that.
