### PR TITLE
PostgresProcessor::proccessInsertGetId | array cast fix when fetch mode is set to  PDO::FETCH_CLASS

### DIFF
--- a/src/Illuminate/Database/Query/Processors/PostgresProcessor.php
+++ b/src/Illuminate/Database/Query/Processors/PostgresProcessor.php
@@ -6,40 +6,40 @@ use Illuminate\Database\Query\Builder;
 
 class PostgresProcessor extends Processor
 {
-    /**
-     * Process an "insert get ID" query.
-     *
-     * @param  \Illuminate\Database\Query\Builder  $query
-     * @param  string  $sql
-     * @param  array   $values
-     * @param  string  $sequence
-     * @return int
-     */
-    public function processInsertGetId(Builder $query, $sql, $values, $sequence = null)
-    {
-        $result = $query->getConnection()->selectFromWriteConnection($sql, $values)[0];
+	/**
+	 * Process an "insert get ID" query.
+	 *
+	 * @param  \Illuminate\Database\Query\Builder  $query
+	 * @param  string  $sql
+	 * @param  array   $values
+	 * @param  string  $sequence
+	 * @return int
+	 */
+	public function processInsertGetId(Builder $query, $sql, $values, $sequence = null)
+	{
+		$result = $query->getConnection()->selectFromWriteConnection($sql, $values)[0];
 
-        $sequence = $sequence ?: 'id';
-        
-        $id = is_object($result) ? $result->$sequence : $result[$sequence];
+		$sequence = $sequence ?: 'id';
+		
+		$id = is_object($result) ? $result->$sequence : $result[$sequence];
 
-        return is_numeric($id) ? (int) $id : $id;
-    }
+		return is_numeric($id) ? (int) $id : $id;
+	}
 
-    /**
-     * Process the results of a column listing query.
-     *
-     * @param  array  $results
-     * @return array
-     */
-    public function processColumnListing($results)
-    {
-        $mapping = function ($r) {
-            $r = (object) $r;
+	/**
+	 * Process the results of a column listing query.
+	 *
+	 * @param  array  $results
+	 * @return array
+	 */
+	public function processColumnListing($results)
+	{
+		$mapping = function ($r) {
+			$r = (object) $r;
 
-            return $r->column_name;
-        };
+			return $r->column_name;
+		};
 
-        return array_map($mapping, $results);
-    }
+		return array_map($mapping, $results);
+	}
 }

--- a/src/Illuminate/Database/Query/Processors/PostgresProcessor.php
+++ b/src/Illuminate/Database/Query/Processors/PostgresProcessor.php
@@ -17,13 +17,11 @@ class PostgresProcessor extends Processor
      */
     public function processInsertGetId(Builder $query, $sql, $values, $sequence = null)
     {
-        $results = $query->getConnection()->selectFromWriteConnection($sql, $values);
+        $result = $query->getConnection()->selectFromWriteConnection($sql, $values)[0];
 
         $sequence = $sequence ?: 'id';
-
-        $result = (array) $results[0];
-
-        $id = $result[$sequence];
+        
+        $id = is_object($result) ? $result->$sequence : $result[$sequence];
 
         return is_numeric($id) ? (int) $id : $id;
     }


### PR DESCRIPTION
`function processInsertGetId`

**How to reproduce:**
- Enable PDO fetch mode set to `PDO::FETCH_CLASS` choosing it to cast to a Class that does not have the attributes set directly to the object, like Eloquent models that uses the `$attributes` property
- Use `processInsertGetId`

**Description:**
Casting the `$results[0]` to an array having PDO fetch mode set to `PDO::FETCH_CLASS` and the chosen class implements magic methods to handle attributes getters and setters (like Eloquent Models) the function would throw an error `Undefined index {$sequence}` on the assignment:

``` php
$id = $result[$sequence];
```

The problem occurs because the given object would be cast to an array that doesn't have the `"id"` key on its first level of keys.

**About the solution:**
On my use cases _$result_ is always an object (on any PDO fetch method) but I still tested it because I was not sure I was covering all the use cases.

Feel free to comment, improve or create a test for this function & PR.
