### PR TITLE
[5.2] Add tightenco/collect to replace section

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -68,7 +68,8 @@
         "illuminate/support": "self.version",
         "illuminate/translation": "self.version",
         "illuminate/validation": "self.version",
-        "illuminate/view": "self.version"
+        "illuminate/view": "self.version",
+        "tightenco/collect": "self.version"
     },
     "require-dev": {
         "aws/aws-sdk-php": "~3.0",


### PR DESCRIPTION
Since tightenco/collect is just standalone illuminate collections from support, this replace should be added.
