### PR TITLE
[5.3] Add Windows support to the storage:link command

### DIFF
--- a/src/Illuminate/Foundation/Console/StorageLinkCommand.php
+++ b/src/Illuminate/Foundation/Console/StorageLinkCommand.php
@@ -31,8 +31,22 @@ class StorageLinkCommand extends Command
             return $this->error('The "public/storage" directory already exists.');
         }
 
-        symlink(storage_path('app/public'), public_path('storage'));
+        if ($this->isWindows()) {
+            exec('mklink /J "'.public_path('storage').'" "'.storage_path('app/public').'"');
+        } else {
+            symlink(storage_path('app/public'), public_path('storage'));
+        }
 
         $this->info('The [public/storage] directory has been linked.');
+    }
+
+    /**
+     * Checks whether the system is running on Windows.
+     *
+     * @return bool
+     */
+    protected function isWindows()
+    {
+        return DIRECTORY_SEPARATOR == '\\';
     }
 }


### PR DESCRIPTION
Even though Windows support for PHP's `symlink` function was supposedly added in 5.3, in practice [it does't work](https://bugs.php.net/bug.php?id=48975).
