### PR TITLE
[5.3] Allow to use different/alternative instance of `Illuminate\Notifications\Channels\Notification` when extending `ChannelManager`.

### DIFF
--- a/src/Illuminate/Auth/Notifications/ResetPassword.php
+++ b/src/Illuminate/Auth/Notifications/ResetPassword.php
@@ -39,7 +39,7 @@ class ResetPassword extends Notification
      * Get the notification message.
      *
      * @param  mixed  $notifiable
-     * @return array
+     * @return \Illuminate\Notifications\MessageBuilder
      */
     public function message($notifiable)
     {

--- a/src/Illuminate/Notifications/ChannelManager.php
+++ b/src/Illuminate/Notifications/ChannelManager.php
@@ -127,4 +127,18 @@ class ChannelManager extends Manager implements FactoryContract
     {
         $this->defaultChannels = (array) $channels;
     }
+
+    /**
+     * Build a new channel notification from the given object.
+     *
+     * @param  mixed  $notifiable
+     * @param  mixed  $notification
+     * @param  array|null  $channels
+     *
+     * @return array
+     */
+    public function notificationsFromInstance($notifiable, $notification, $channels = null)
+    {
+        return Channels\Notification::notificationsFromInstance($notifiable, $notification, $channels);
+    }
 }

--- a/src/Illuminate/Notifications/ChannelManager.php
+++ b/src/Illuminate/Notifications/ChannelManager.php
@@ -134,7 +134,6 @@ class ChannelManager extends Manager implements FactoryContract
      * @param  mixed  $notifiable
      * @param  mixed  $notification
      * @param  array|null  $channels
-     *
      * @return array
      */
     public function notificationsFromInstance($notifiable, $notification, $channels = null)

--- a/src/Illuminate/Notifications/RoutesNotifications.php
+++ b/src/Illuminate/Notifications/RoutesNotifications.php
@@ -17,7 +17,7 @@ trait RoutesNotifications
     {
         $manager = app(ChannelManager::class);
 
-        $notifications = Channels\Notification::notificationsFromInstance(
+        $notifications = $manager->notificationsFromInstance(
             $this, $instance
         );
 
@@ -41,7 +41,7 @@ trait RoutesNotifications
     {
         $manager = app(ChannelManager::class);
 
-        $notifications = Channels\Notification::notificationsFromInstance(
+        $notifications = $manager->notificationsFromInstance(
             $this, $instance, (array) $channels
         );
 


### PR DESCRIPTION
Without this changes, We have to manually override the whole `Illuminate\Notifications\RoutesNotifications` trait.

Signed-off-by: crynobone crynobone@gmail.com
