### PR TITLE
[5.2] Fix illuminate support composer

### DIFF
--- a/src/Illuminate/Support/composer.json
+++ b/src/Illuminate/Support/composer.json
@@ -20,6 +20,9 @@
         "illuminate/contracts": "5.2.*",
         "paragonie/random_compat": "~1.4"
     },
+    "replace": {
+	"tightenco/collect": "self.version"
+    },
     "autoload": {
         "psr-4": {
             "Illuminate\\Support\\": ""

--- a/src/Illuminate/Support/composer.json
+++ b/src/Illuminate/Support/composer.json
@@ -21,7 +21,7 @@
         "paragonie/random_compat": "~1.4"
     },
     "replace": {
-	"tightenco/collect": "self.version"
+        "tightenco/collect": "self.version"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This adds the replace-Block for tightenco/collect to the illuminate/support package as discussed in #14118 
