### PR TITLE
[5.2] Fix updated_at ignoring $options

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -524,11 +524,12 @@ class Builder
      * Update a record in the database.
      *
      * @param  array  $values
+     * @param  array  $options
      * @return int
      */
-    public function update(array $values)
+    public function update(array $values, array $options = [])
     {
-        return $this->toBase()->update($this->addUpdatedAtColumn($values));
+        return $this->toBase()->update($this->addUpdatedAtColumn($values, $options));
     }
 
     /**
@@ -537,11 +538,12 @@ class Builder
      * @param  string  $column
      * @param  int  $amount
      * @param  array  $extra
+     * @param  array  $options
      * @return int
      */
-    public function increment($column, $amount = 1, array $extra = [])
+    public function increment($column, $amount = 1, array $extra = [], array $options = [])
     {
-        $extra = $this->addUpdatedAtColumn($extra);
+        $extra = $this->addUpdatedAtColumn($extra, $options);
 
         return $this->toBase()->increment($column, $amount, $extra);
     }
@@ -552,11 +554,12 @@ class Builder
      * @param  string  $column
      * @param  int  $amount
      * @param  array  $extra
+     * @param  array  $options
      * @return int
      */
-    public function decrement($column, $amount = 1, array $extra = [])
+    public function decrement($column, $amount = 1, array $extra = [], array $options = [])
     {
-        $extra = $this->addUpdatedAtColumn($extra);
+        $extra = $this->addUpdatedAtColumn($extra, $options);
 
         return $this->toBase()->decrement($column, $amount, $extra);
     }
@@ -565,17 +568,18 @@ class Builder
      * Add the "updated at" column to an array of values.
      *
      * @param  array  $values
+     * @param  array  $options
      * @return array
      */
-    protected function addUpdatedAtColumn(array $values)
+    protected function addUpdatedAtColumn(array $values, array $options = [])
     {
-        if (! $this->model->usesTimestamps()) {
-            return $values;
+        if ($this->model->usesTimestamps() && Arr::get($options, 'timestamps', true)) {
+            $column = $this->model->getUpdatedAtColumn();
+
+            return Arr::add($values, $column, $this->model->freshTimestampString());
         }
 
-        $column = $this->model->getUpdatedAtColumn();
-
-        return Arr::add($values, $column, $this->model->freshTimestampString());
+        return $values;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1356,11 +1356,12 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      * @param  string  $column
      * @param  int  $amount
      * @param  array  $extra
+     * @param  array  $options
      * @return int
      */
-    protected function increment($column, $amount = 1, array $extra = [])
+    protected function increment($column, $amount = 1, array $extra = [], array $options = [])
     {
-        return $this->incrementOrDecrement($column, $amount, $extra, 'increment');
+        return $this->incrementOrDecrement($column, $amount, $extra, 'increment', $options);
     }
 
     /**
@@ -1369,11 +1370,12 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      * @param  string  $column
      * @param  int  $amount
      * @param  array  $extra
+     * @param  array  $options
      * @return int
      */
-    protected function decrement($column, $amount = 1, array $extra = [])
+    protected function decrement($column, $amount = 1, array $extra = [], array $options = [])
     {
-        return $this->incrementOrDecrement($column, $amount, $extra, 'decrement');
+        return $this->incrementOrDecrement($column, $amount, $extra, 'decrement', $options);
     }
 
     /**
@@ -1383,19 +1385,20 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      * @param  int  $amount
      * @param  array  $extra
      * @param  string  $method
+     * @param  array  $options
      * @return int
      */
-    protected function incrementOrDecrement($column, $amount, $extra, $method)
+    protected function incrementOrDecrement($column, $amount, $extra, $method, $options)
     {
         $query = $this->newQuery();
 
         if (! $this->exists) {
-            return $query->{$method}($column, $amount, $extra);
+            return $query->{$method}($column, $amount, $extra, $options);
         }
 
         $this->incrementOrDecrementAttributeValue($column, $amount, $method);
 
-        return $query->where($this->getKeyName(), $this->getKey())->{$method}($column, $amount, $extra);
+        return $query->where($this->getKeyName(), $this->getKey())->{$method}($column, $amount, $extra, $options);
     }
 
     /**
@@ -1559,7 +1562,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
             $dirty = $this->getDirty();
 
             if (count($dirty) > 0) {
-                $numRows = $this->setKeysForSaveQuery($query)->update($dirty);
+                $numRows = $this->setKeysForSaveQuery($query)->update($dirty, $options);
 
                 $this->fireModelEvent('updated', false);
             }

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -143,7 +143,7 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
         $model = $this->getMock('EloquentModelStub', ['newQueryWithoutScopes', 'updateTimestamps']);
         $query = m::mock('Illuminate\Database\Eloquent\Builder');
         $query->shouldReceive('where')->once()->with('id', '=', 1);
-        $query->shouldReceive('update')->once()->with(['name' => 'taylor'])->andReturn(1);
+        $query->shouldReceive('update')->once()->with(['name' => 'taylor'], [])->andReturn(1);
         $model->expects($this->once())->method('newQueryWithoutScopes')->will($this->returnValue($query));
         $model->expects($this->once())->method('updateTimestamps');
         $model->setEventDispatcher($events = m::mock('Illuminate\Contracts\Events\Dispatcher'));
@@ -166,7 +166,7 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
         $model = $this->getMock('EloquentModelStub', ['newQueryWithoutScopes']);
         $query = m::mock('Illuminate\Database\Eloquent\Builder');
         $query->shouldReceive('where')->once()->with('id', '=', 1);
-        $query->shouldReceive('update')->once()->with(['created_at' => 'foo', 'updated_at' => 'bar'])->andReturn(1);
+        $query->shouldReceive('update')->once()->with(['created_at' => 'foo', 'updated_at' => 'bar'], [])->andReturn(1);
         $model->expects($this->once())->method('newQueryWithoutScopes')->will($this->returnValue($query));
         $model->setEventDispatcher($events = m::mock('Illuminate\Contracts\Events\Dispatcher'));
         $events->shouldReceive('until');
@@ -212,7 +212,7 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
         $model->timestamps = false;
         $query = m::mock('Illuminate\Database\Eloquent\Builder');
         $query->shouldReceive('where')->once()->with('id', '=', 1);
-        $query->shouldReceive('update')->once()->with(['name' => 'taylor'])->andReturn(1);
+        $query->shouldReceive('update')->once()->with(['name' => 'taylor'], [])->andReturn(1);
         $model->expects($this->once())->method('newQueryWithoutScopes')->will($this->returnValue($query));
         $model->expects($this->never())->method('updateTimestamps');
         $model->expects($this->any())->method('fireModelEvent')->will($this->returnValue(true));
@@ -229,7 +229,7 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
         $model = $this->getMock('EloquentModelStub', ['newQueryWithoutScopes', 'updateTimestamps']);
         $query = m::mock('Illuminate\Database\Eloquent\Builder');
         $query->shouldReceive('where')->once()->with('id', '=', 1);
-        $query->shouldReceive('update')->once()->with(['id' => 2, 'foo' => 'bar'])->andReturn(1);
+        $query->shouldReceive('update')->once()->with(['id' => 2, 'foo' => 'bar'], [])->andReturn(1);
         $model->expects($this->once())->method('newQueryWithoutScopes')->will($this->returnValue($query));
         $model->expects($this->once())->method('updateTimestamps');
         $model->setEventDispatcher($events = m::mock('Illuminate\Contracts\Events\Dispatcher'));
@@ -1185,7 +1185,7 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
         $model = m::mock('EloquentModelStub[newQueryWithoutScopes]');
         $query = m::mock('Illuminate\Database\Eloquent\Builder');
         $query->shouldReceive('where')->once()->with('id', '=', 1);
-        $query->shouldReceive('update')->once()->with(['name' => 'taylor'])->andReturn(1);
+        $query->shouldReceive('update')->once()->with(['name' => 'taylor'], ['timestamps' => false])->andReturn(1);
         $model->shouldReceive('newQueryWithoutScopes')->once()->andReturn($query);
 
         $model->id = 1;


### PR DESCRIPTION
If you pass `['timestamps' => false]` in `save` method, `updated_at` column will nevertheless be updated because `update` method in `Eloquent\Builder` just ignores `$options`.
