### PR TITLE
[5.2] Add optional return parameters to MessageBag

### DIFF
--- a/src/Illuminate/Support/MessageBag.php
+++ b/src/Illuminate/Support/MessageBag.php
@@ -108,6 +108,7 @@ class MessageBag implements Arrayable, Countable, Jsonable, JsonSerializable, Me
         if ($this->first($key) !== '') {
             return $true;
         }
+
         return $false;
     }
 

--- a/src/Illuminate/Support/MessageBag.php
+++ b/src/Illuminate/Support/MessageBag.php
@@ -99,11 +99,16 @@ class MessageBag implements Arrayable, Countable, Jsonable, JsonSerializable, Me
      * Determine if messages exist for a given key.
      *
      * @param  string  $key
-     * @return bool
+     * @param  mixed   $true     The return value if true
+     * @param  mixed   $false    The return value if false
+     * @return bool|string
      */
-    public function has($key = null)
+    public function has($key = null, $true = true, $false = false)
     {
-        return $this->first($key) !== '';
+        if ($this->first($key) !== '') {
+            return $true;
+        }
+        return $false;
     }
 
     /**


### PR DESCRIPTION
Add optional return parameters. By default this is true or false. 

With this feature you're able to do this:

```
<div class="{{ $errors->has('firstname', 'has-error') }}"></div>
```

instead of

```
<div class="{{ ($errors->has('firstname') ? 'has-error', '') }}"></div>
```
