### PR TITLE
[5.2] Add hasAny and hasAll methods to MessageBag

### DIFF
--- a/src/Illuminate/Support/MessageBag.php
+++ b/src/Illuminate/Support/MessageBag.php
@@ -116,7 +116,7 @@ class MessageBag implements Arrayable, Countable, Jsonable, JsonSerializable, Me
      */
     public function hasAll($keys = [], $true = true, $false = false)
     {
-        foreach($keys as $key) {
+        foreach ($keys as $key) {
             if ($this->first($key) === '') {
                 return $false;
             }
@@ -135,7 +135,7 @@ class MessageBag implements Arrayable, Countable, Jsonable, JsonSerializable, Me
      */
     public function hasAny($keys = [], $true = true, $false = false)
     {
-        foreach($keys as $key) {
+        foreach ($keys as $key) {
             if ($this->first($key) !== '') {
                 return $true;
             }

--- a/src/Illuminate/Support/MessageBag.php
+++ b/src/Illuminate/Support/MessageBag.php
@@ -107,6 +107,44 @@ class MessageBag implements Arrayable, Countable, Jsonable, JsonSerializable, Me
     }
 
     /**
+     * Determine if messages exist for all given keys.
+     *
+     * @param  array  $keys
+     * @param  mixed  $true
+     * @param  mixed  $false
+     * @return bool
+     */
+    public function hasAll($keys = [], $true = true, $false = false)
+    {
+        foreach($keys as $key) {
+            if ($this->first($key) === '') {
+                return $false;
+            }
+        }
+
+        return $true;
+    }
+
+    /**
+     * Determine if messages exist for any given key.
+     *
+     * @param  array  $keys
+     * @param  mixed  $true
+     * @param  mixed  $false
+     * @return bool
+     */
+    public function hasAny($keys = [], $true = true, $false = false)
+    {
+        foreach($keys as $key) {
+            if ($this->first($key) !== '') {
+                return $true;
+            }
+        }
+
+        return $false;
+    }
+
+    /**
      * Get the first message from the bag for a given key.
      *
      * @param  string  $key

--- a/tests/Support/SupportMessageBagTest.php
+++ b/tests/Support/SupportMessageBagTest.php
@@ -74,6 +74,30 @@ class SupportMessageBagTest extends PHPUnit_Framework_TestCase
         $this->assertFalse($container->has('bar'));
     }
 
+    public function testHasAnyIndicatesExistence()
+    {
+        $container = new MessageBag;
+        $container->setFormat(':message');
+        $container->add('foo', 'bar');
+        $container->add('bar', 'foo');
+        $container->add('boom', 'baz');
+        $this->assertTrue($container->hasAny(['foo', 'bar']));
+        $this->assertTrue($container->hasAny(['boom', 'baz']));
+        $this->assertFalse($container->hasAny(['baz']));
+    }
+
+    public function testHasAllIndicatesExistence()
+    {
+        $container = new MessageBag;
+        $container->setFormat(':message');
+        $container->add('foo', 'bar');
+        $container->add('bar', 'foo');
+        $container->add('boom', 'baz');
+        $this->assertTrue($container->hasAll(['foo', 'bar', 'boom']));
+        $this->assertFalse($container->hasAll(['foo', 'bar', 'boom', 'baz']));
+        $this->assertFalse($container->hasAll(['foo', 'baz']));
+    }
+
     public function testAllReturnsAllMessages()
     {
         $container = new MessageBag;


### PR DESCRIPTION
Also applies optional $true and $false parameters from PR https://github.com/laravel/framework/pull/14141 by @mro95

Examples:
Shortens (in blade) 

`{{ $errors->has('field_1') && $errors->has('field_2') ? 'has-errors' : '' }}` 
to 
`{{ $errors->hasAll(['field_1', 'field_2'], 'has-errors') }}`

and

`{{ $errors->has('field_1') || $errors->has('field_2') ? 'has-errors' : '' }}` 
to 
`{{ $errors->hasAny(['field_1', 'field_2'], 'has-errors') }}`
