### PR TITLE
Fix Multiple File Upload validations issue on php7

### DIFF
--- a/src/Illuminate/Http/RedirectResponse.php
+++ b/src/Illuminate/Http/RedirectResponse.php
@@ -77,7 +77,7 @@ class RedirectResponse extends BaseRedirectResponse
                 $value = array_filter($value, $callback);
             }
 
-            if(! $value instanceof SymfonyUploadedFile)
+            if (! $value instanceof SymfonyUploadedFile)
             {
                 return $value;
             }

--- a/src/Illuminate/Http/RedirectResponse.php
+++ b/src/Illuminate/Http/RedirectResponse.php
@@ -77,8 +77,7 @@ class RedirectResponse extends BaseRedirectResponse
                 $value = array_filter($value, $callback);
             }
 
-            if (! $value instanceof SymfonyUploadedFile)
-            {
+            if (! $value instanceof SymfonyUploadedFile) {
                 return $value;
             }
         }));

--- a/src/Illuminate/Http/RedirectResponse.php
+++ b/src/Illuminate/Http/RedirectResponse.php
@@ -77,7 +77,10 @@ class RedirectResponse extends BaseRedirectResponse
                 $value = array_filter($value, $callback);
             }
 
-            return ! $value instanceof SymfonyUploadedFile;
+            if(! $value instanceof SymfonyUploadedFile)
+            {
+                return $value;
+            }
         }));
 
         return $this;


### PR DESCRIPTION
the issue appear on laravel 5.2.\* that run on php7 when array
validation fails on multiple file object this issue lead to all
sessions to be deleted and redirect back with error on laravel.log file
`local.ERROR: Exception: Serialization of
'Illuminate\Http\UploadedFile' is not allowed`
for more info on the issue please see issue #14143
