### PR TITLE
[5.3] Check for dates/other casts when plucking

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -445,7 +445,7 @@ class Builder
         // If the model has a mutator for the requested column, we will spin through
         // the results and mutate the values so that the mutated version of these
         // columns are returned as you would expect from these Eloquent models.
-        if (! $this->model->hasGetMutator($column)) {
+        if (! $this->model->hasGetMutator($column) && ! $this->model->hasCast($column) && ! in_array($column, $this->model->getDates())) {
             return $results;
         }
 


### PR DESCRIPTION
As per request in #14040, I've applied this to the 5.3 branch instead.

Let me know if you think the logic in the pluck method should be broken out into another method, like `hasMutatorOrCast`.
