### PR TITLE
[5.3] Event Payload now carries Public Properties

### DIFF
--- a/src/Illuminate/Broadcasting/BroadcastEvent.php
+++ b/src/Illuminate/Broadcasting/BroadcastEvent.php
@@ -57,14 +57,14 @@ class BroadcastEvent
      */
     protected function getPayloadFromEvent($event)
     {
-        if (method_exists($event, 'broadcastWith')) {
-            return $event->broadcastWith();
-        }
-
         $payload = [];
 
         foreach ((new ReflectionClass($event))->getProperties(ReflectionProperty::IS_PUBLIC) as $property) {
             $payload[$property->getName()] = $this->formatProperty($property->getValue($event));
+        }
+
+        if (method_exists($event, 'broadcastWith')) {
+            return $payload + $event->broadcastWith();
         }
 
         return $payload;


### PR DESCRIPTION
Before when a user used `$this->broadcastWith()` it would stop other public properties of Broadcasted events from being sent along with the data payload which would negate the effects of `InteractsWithSockets` methods.
