### PR TITLE
Update whoops to fix issues with PHP7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "classpreloader/classpreloader": "~1.0.2",
         "d11wtq/boris": "~1.0",
         "ircmaxell/password-compat": "~1.0",
-        "filp/whoops": "1.1.*",
+        "filp/whoops": "2.1.*",
         "jeremeamia/superclosure": "~1.0.1",
         "monolog/monolog": "~1.6",
         "nesbot/carbon": "~1.0",


### PR DESCRIPTION
Whoops 1.\* doesn't work well with PHP7. Update to current latest whoops to fix.
