### PR TITLE
MakesHttpRequests dump don't die

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Foundation\Testing\Concerns;
 
 use Illuminate\Support\Arr;
+use Illuminate\Support\Debug\Dumper;
 use Illuminate\Support\Str;
 use Illuminate\Http\Request;
 use Illuminate\Contracts\View\View;
@@ -759,7 +760,7 @@ trait MakesHttpRequests
     /**
      * Dump the content from the last response.
      *
-     * @return void
+     * @return $this
      */
     public function dump()
     {
@@ -771,6 +772,8 @@ trait MakesHttpRequests
             $content = $json;
         }
 
-        dd($content);
+        (new Dumper)->dump($content);
+
+        return $this;
     }
 }


### PR DESCRIPTION
This is my first PR here, and I'm completely new to Laravel.

While doing tests, it was fun to add `->dump()`, but it dies :( I like to put the dump where ever, so it won't execute subsequent `->seeJson` for example.

What you think? 
