### PR TITLE
[5.3] Add notification payload

### DIFF
--- a/src/Illuminate/Notifications/Channels/MailChannel.php
+++ b/src/Illuminate/Notifications/Channels/MailChannel.php
@@ -53,6 +53,8 @@ class MailChannel
             return;
         }
 
+        $view = data_get($notification, 'payload.view', 'notifications::email');
+
         $this->mailer->send('notifications::email', $data, function ($m) use ($notification, $emails) {
             count($notification->notifiables) === 1
                         ? $m->to($emails) : $m->bcc($emails);

--- a/src/Illuminate/Notifications/Channels/MailChannel.php
+++ b/src/Illuminate/Notifications/Channels/MailChannel.php
@@ -53,7 +53,7 @@ class MailChannel
             return;
         }
 
-        $view = data_get($notification, 'payload.view', 'notifications::email');
+        $view = data_get($notification, 'options.view', 'notifications::email');
 
         $this->mailer->send('notifications::email', $data, function ($m) use ($notification, $emails) {
             count($notification->notifiables) === 1

--- a/src/Illuminate/Notifications/Channels/MailChannel.php
+++ b/src/Illuminate/Notifications/Channels/MailChannel.php
@@ -55,7 +55,7 @@ class MailChannel
 
         $view = data_get($notification, 'options.view', 'notifications::email');
 
-        $this->mailer->send('notifications::email', $data, function ($m) use ($notification, $emails) {
+        $this->mailer->send($view, $data, function ($m) use ($notification, $emails) {
             count($notification->notifiables) === 1
                         ? $m->to($emails) : $m->bcc($emails);
 

--- a/src/Illuminate/Notifications/Channels/Notification.php
+++ b/src/Illuminate/Notifications/Channels/Notification.php
@@ -82,6 +82,13 @@ class Notification implements Arrayable
     public $actionUrl;
 
     /**
+     * The data payload of the notification.
+     *
+     * @var array
+     */
+    public $payload = [];
+
+    /**
      * Create a new notification instance.
      *
      * @param  array  $notifiables
@@ -187,6 +194,21 @@ class Notification implements Arrayable
         return $this;
     }
 
+
+
+    /**
+     * Set the data payload of the notification.
+     *
+     * @param  array  $payload
+     * @return $this
+     */
+    public function payload(array $payload)
+    {
+        $this->payload = $payload;
+
+        return $this;
+    }
+
     /**
      * Configure the "call to action" button.
      *
@@ -253,6 +275,10 @@ class Notification implements Arrayable
             foreach ($instance->{$method}($notifiable)->elements as $element) {
                 $notification->with($element);
             }
+
+            $method = static::payloadMethod($instance, $channel);
+
+            $notification->payload($instance->{$method}($notifiable));
         }
 
         return $notifications;
@@ -270,6 +296,20 @@ class Notification implements Arrayable
         return method_exists(
             $instance, $channelMethod = Str::camel($channel).'Message'
         ) ? $channelMethod : 'message';
+    }
+
+    /**
+     * Get the proper data method for the given instance and channel.
+     *
+     * @param  mixed  $instance
+     * @param  string  $channel
+     * @return string
+     */
+    protected static function payloadMethod($instance, $channel)
+    {
+        return method_exists(
+            $instance, $channelMethod = Str::camel($channel).'Payload'
+        ) ? $channelMethod : 'payload';
     }
 
     /**

--- a/src/Illuminate/Notifications/Channels/Notification.php
+++ b/src/Illuminate/Notifications/Channels/Notification.php
@@ -86,7 +86,7 @@ class Notification implements Arrayable
      *
      * @var array
      */
-    public $payload = [];
+    public $options = [];
 
     /**
      * Create a new notification instance.
@@ -195,14 +195,14 @@ class Notification implements Arrayable
     }
 
     /**
-     * Set the data payload of the notification.
+     * Set the data options of the notification.
      *
-     * @param  array  $payload
+     * @param  array  $options
      * @return $this
      */
-    public function payload(array $payload)
+    public function options(array $options)
     {
-        $this->payload = $payload;
+        $this->options = $options;
 
         return $this;
     }
@@ -274,9 +274,9 @@ class Notification implements Arrayable
                 $notification->with($element);
             }
 
-            $method = static::payloadMethod($instance, $channel);
+            $method = static::optionsMethod($instance, $channel);
 
-            $notification->payload($instance->{$method}($notifiable));
+            $notification->options($instance->{$method}($notifiable));
         }
 
         return $notifications;
@@ -303,11 +303,11 @@ class Notification implements Arrayable
      * @param  string  $channel
      * @return string
      */
-    protected static function payloadMethod($instance, $channel)
+    protected static function optionsMethod($instance, $channel)
     {
         return method_exists(
-            $instance, $channelMethod = Str::camel($channel).'Payload'
-        ) ? $channelMethod : 'payload';
+            $instance, $channelMethod = Str::camel($channel).'Options'
+        ) ? $channelMethod : 'options';
     }
 
     /**

--- a/src/Illuminate/Notifications/Channels/Notification.php
+++ b/src/Illuminate/Notifications/Channels/Notification.php
@@ -194,8 +194,6 @@ class Notification implements Arrayable
         return $this;
     }
 
-
-
     /**
      * Set the data payload of the notification.
      *

--- a/src/Illuminate/Notifications/Notification.php
+++ b/src/Illuminate/Notifications/Notification.php
@@ -28,7 +28,7 @@ class Notification
                         : Str::title(Str::snake(class_basename($this), ' '));
     }
 
-     /**
+    /**
      * Get the notification channel payload data.
      *
      * @return array

--- a/src/Illuminate/Notifications/Notification.php
+++ b/src/Illuminate/Notifications/Notification.php
@@ -29,14 +29,14 @@ class Notification
     }
 
     /**
-     * Get the notification channel payload data.
+     * Get the notification channel options data.
      *
      * @return array
      */
-    public function payload()
+    public function options()
     {
-        return property_exists($this, 'payload')
-                        ? $this->payload
+        return property_exists($this, 'options')
+                        ? $this->options
                         : [];
     }
 

--- a/src/Illuminate/Notifications/Notification.php
+++ b/src/Illuminate/Notifications/Notification.php
@@ -28,6 +28,18 @@ class Notification
                         : Str::title(Str::snake(class_basename($this), ' '));
     }
 
+     /**
+     * Get the notification channel payload data.
+     *
+     * @return array
+     */
+    public function payload()
+    {
+        return property_exists($this, 'payload')
+                        ? $this->payload
+                        : [];
+    }
+
     /**
      * Create a new message builder instance.
      *


### PR DESCRIPTION
This would allow us to define additional data payload globally or depending on which channel. As an example we might want to set a different view for sending email notification or set sound, alert type for push notification (if we add one).

As an example:

``` php
<?php

namespace App\Notifications;

use Illuminate\Bus\Queueable;
use Illuminate\Notifications\Notification;
use Illuminate\Contracts\Queue\ShouldQueue;

class SendNotification extends Notification
{
    use Queueable;

    /**
     * Get the notification channels.
     *
     * @return array|string
     */
    public function via($notifiable)
    {
        return ['firebase'];
    }

    /**
     * Get the notification message.
     *
     * @return \Illuminate\Notifications\MessageBuilder
     */
    public function message()
    {
        return $this->line('The introduction to the notification.')
                    ->action('Notification Action', 'https://laravel.com')
                    ->line('Thank you for using our application!');
    }

    /**
     * Get the notification options.
     *
     * @return \Illuminate\Notifications\MessageBuilder
     */
    public function options()
    {
        return [
            'priority' => 'high',
            'sound' => 'beep.aiff',
        ];
    }

    /**
     * Get the notification options.
     *
     * @return \Illuminate\Notifications\MessageBuilder
     */
    public function nexmoOptions()
    {
        return [ /* etc */ ];
    }
}
```

Signed-off-by: crynobone crynobone@gmail.com
