### PR TITLE
[5.2] Allowing passing along transmission options to SparkPost

### DIFF
--- a/src/Illuminate/Mail/Transport/SparkPostTransport.php
+++ b/src/Illuminate/Mail/Transport/SparkPostTransport.php
@@ -22,16 +22,25 @@ class SparkPostTransport extends Transport
     protected $key;
 
     /**
+     * Transmission options.
+     *
+     * @var array
+     */
+    protected $options = [];
+
+    /**
      * Create a new SparkPost transport instance.
      *
      * @param  \GuzzleHttp\ClientInterface  $client
      * @param  string  $key
+     * @param  array  $options
      * @return void
      */
-    public function __construct(ClientInterface $client, $key)
+    public function __construct(ClientInterface $client, $key, $options = [])
     {
         $this->client = $client;
         $this->key = $key;
+        $this->options = $options;
     }
 
     /**
@@ -56,6 +65,10 @@ class SparkPostTransport extends Transport
                 ],
             ],
         ];
+
+        if ($this->options) {
+            $options['json']['options'] = $this->options;
+        }
 
         return $this->client->post('https://api.sparkpost.com/api/v1/transmissions', $options);
     }

--- a/src/Illuminate/Mail/TransportManager.php
+++ b/src/Illuminate/Mail/TransportManager.php
@@ -134,7 +134,9 @@ class TransportManager extends Manager
         $config = $this->app['config']->get('services.sparkpost', []);
 
         return new SparkPostTransport(
-            $this->getHttpClient($config), $config['secret']
+            $this->getHttpClient($config),
+            $config['secret'],
+            Arr::get($config, 'options', [])
         );
     }
 


### PR DESCRIPTION
This PR allows specifying an `options` array in Laravel's `services.php` to be included in the transmission API request.

``` php
'sparkpost' => [
    'secret' => env('SPARKPOST_SECRET'),
    'options' => [
        'open_tracking' => false,
        'click_tracking' => false,
        'transactional' => true,
    ],
],
```

This is useful for enabling / disabling SparkPost features such as [open and click tracking](https://developers.sparkpost.com/api/transmissions#header-options-attributes).  SparkPost defaults to modifying URLs for click tracking.  In my particular Laravel project, we only send transactional emails and would rather not have SparkPost change our links for click tracking.  Unfortunately, the only way to disable this functionality (without using SparkPost templates) is to include `click_tracking: false` in the `options` JSON attribute for the transmission API request.

Being able to set other options such as marking an email as transactional may be useful to developers as well.  Right now, developers would have to extend / override `SparkPostTransport` for this functionality.
