### PR TITLE
[5.2] Allow to pass multiple arguments to Authorize

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/Authorize.php
+++ b/src/Illuminate/Foundation/Http/Middleware/Authorize.php
@@ -68,6 +68,7 @@ class Authorize
                 $gate_args[] = $request->route($model);
             }
         }
+
         return $gate_args;
     }
 }

--- a/src/Illuminate/Foundation/Http/Middleware/Authorize.php
+++ b/src/Illuminate/Foundation/Http/Middleware/Authorize.php
@@ -31,14 +31,15 @@ class Authorize
      * @param  \Illuminate\Http\Request  $request
      * @param  \Closure  $next
      * @param  string  $ability
-     * @param  string|null  $model
      * @return mixed
      *
      * @throws \Illuminate\Auth\Access\AuthorizationException
      */
-    public function handle($request, Closure $next, $ability, $model = null)
+    public function handle($request, Closure $next, $ability)
     {
-        $this->gate->authorize($ability, $this->getGateArguments($request, $model));
+        $args = func_get_args();
+        $model_args = array_slice($args, 3);
+        $this->gate->authorize($ability, $this->getGateArguments($request, $model_args));
 
         return $next($request);
     }
@@ -47,22 +48,28 @@ class Authorize
      * Get the arguments parameter for the gate.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @param  string|null  $model
+     * @param  array|null  $model_args
      * @return array|string|\Illuminate\Database\Eloquent\Model
      */
-    protected function getGateArguments($request, $model)
+    protected function getGateArguments($request, $model_args)
     {
         // If there's no model, we'll pass an empty array to the gate. If it
         // looks like a FQCN of a model, we'll send it to the gate as is.
         // Otherwise, we'll resolve the Eloquent model from the route.
-        if (is_null($model)) {
+        if (is_null($model_args)) {
             return [];
         }
 
-        if (strpos($model, '\\') !== false) {
-            return $model;
-        }
+        $gate_args = [];
+        foreach ($model_args as $model) {
 
-        return $request->route($model);
+            if (strpos($model, '\\') !== FALSE) {
+                $gate_args[] = $model;
+            }
+            else {
+                $gate_args[] = $request->route($model);
+            }
+        }
+        return $gate_args;
     }
 }

--- a/src/Illuminate/Foundation/Http/Middleware/Authorize.php
+++ b/src/Illuminate/Foundation/Http/Middleware/Authorize.php
@@ -62,10 +62,9 @@ class Authorize
 
         $gate_args = [];
         foreach ($model_args as $model) {
-            if (strpos($model, '\\') !== FALSE) {
+            if (strpos($model, '\\') !== false) {
                 $gate_args[] = $model;
-            }
-            else {
+            } else {
                 $gate_args[] = $request->route($model);
             }
         }

--- a/src/Illuminate/Foundation/Http/Middleware/Authorize.php
+++ b/src/Illuminate/Foundation/Http/Middleware/Authorize.php
@@ -62,7 +62,6 @@ class Authorize
 
         $gate_args = [];
         foreach ($model_args as $model) {
-
             if (strpos($model, '\\') !== FALSE) {
                 $gate_args[] = $model;
             }


### PR DESCRIPTION
My first pull request to Laravel so if I'm doing things wrong, please be gentle ;-)

I have a situation where I have a policy where user X is allowed to do an action on user Y only if user X has a specific role and user Y has a relation to user X. So for this policy I need both objects.

My url is: user/{user}/disconnect/{professional}

So I have this for a route (I'm using laravel collective annotations):

```
    /**
     * @Get("{user}/disconnect/{professional}", as="users.disconnectProfessional")
     * @Middleware("can:disconnect-professional,user,professional")
     */
```

As far as I've tried it's not possible to do this with the current Authorize middleware. Therefore my patch.
