### PR TITLE
[5.2] Add additional return types to auth() helper docblock

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -138,7 +138,7 @@ if (! function_exists('auth')) {
      * Get the available auth instance.
      *
      * @param  string|null  $guard
-     * @return \Illuminate\Contracts\Auth\Factory
+     * @return \Illuminate\Contracts\Auth\Factory|\Illuminate\Contracts\Auth\Guard|\Illuminate\Contracts\Auth\StatefulGuard
      */
     function auth($guard = null)
     {


### PR DESCRIPTION
The `auth()` helper can return a `Guard` as well as a `Factory`, so this adds the appropriate return types so that IDEs pick this up.
