### PR TITLE
[5.2] Touch owners on save only if model is dirty

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1478,7 +1478,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         // that is already in this database using the current IDs in this "where"
         // clause to only update this model. Otherwise, we'll just insert them.
         if ($this->exists) {
-            $saved = $this->performUpdate($query, $options);
+            $saved = $this->isDirty() ? $this->performUpdate($query, $options) : false;
         }
 
         // If the model is brand new, we'll insert it into our database and set the
@@ -1536,33 +1536,29 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     protected function performUpdate(Builder $query, array $options = [])
     {
+        // If the updating event returns false, we will cancel the update operation so
+        // developers can hook Validation systems into their models and cancel this
+        // operation if the model does not pass validation. Otherwise, we update.
+        if ($this->fireModelEvent('updating') === false) {
+            return false;
+        }
+
+        // First we need to create a fresh query instance and touch the creation and
+        // update timestamp on the model which are maintained by us for developer
+        // convenience. Then we will just continue saving the model instances.
+        if ($this->timestamps && Arr::get($options, 'timestamps', true)) {
+            $this->updateTimestamps();
+        }
+
+        // Once we have run the update operation, we will fire the "updated" event for
+        // this model instance. This will allow developers to hook into these after
+        // models are updated, giving them a chance to do any special processing.
         $dirty = $this->getDirty();
 
         if (count($dirty) > 0) {
-            // If the updating event returns false, we will cancel the update operation so
-            // developers can hook Validation systems into their models and cancel this
-            // operation if the model does not pass validation. Otherwise, we update.
-            if ($this->fireModelEvent('updating') === false) {
-                return false;
-            }
+            $numRows = $this->setKeysForSaveQuery($query)->update($dirty);
 
-            // First we need to create a fresh query instance and touch the creation and
-            // update timestamp on the model which are maintained by us for developer
-            // convenience. Then we will just continue saving the model instances.
-            if ($this->timestamps && Arr::get($options, 'timestamps', true)) {
-                $this->updateTimestamps();
-            }
-
-            // Once we have run the update operation, we will fire the "updated" event for
-            // this model instance. This will allow developers to hook into these after
-            // models are updated, giving them a chance to do any special processing.
-            $dirty = $this->getDirty();
-
-            if (count($dirty) > 0) {
-                $numRows = $this->setKeysForSaveQuery($query)->update($dirty);
-
-                $this->fireModelEvent('updated', false);
-            }
+            $this->fireModelEvent('updated', false);
         }
 
         return true;


### PR DESCRIPTION
It seems that the model `save()` method not behave correctly when saving model that is NOT dirty and the model set to touch its owners.

So lets say we have posts and comments 

``` php

$comment = Comment::find(1);

// do something ...

// $comment->isDirty() == false

$comment->save();

/** owner post timestamp is updating **/
```

It results with the saved model `updated_at` attribute not changing but the owner model `updated_at` is changed.

This is a suggestion for fixing this issue. In this change the `save` method will return `false` if the model is not dirty.
