### PR TITLE
[5.2] Make getConnectionName Overridable

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -521,7 +521,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 
         $model->setRawAttributes((array) $attributes, true);
 
-        $model->setConnection($connection ?: $this->connection);
+        $model->setConnection($connection ?: $this->getConnectionName());
 
         return $model;
     }


### PR DESCRIPTION
Use function call in newFromBuilder instead of class variable to allow for override of getConnectionName function

I have a system that allows the user to connect to different databases and i wanted to be able to override the getConnectionName function to be able to achieve this, the only issue was newFromBuilder uses the variable and not the method. 
