### PR TITLE
[5.2] New methods: SessionStore::increment and SessionStore::decrement

### DIFF
--- a/src/Illuminate/Session/Store.php
+++ b/src/Illuminate/Session/Store.php
@@ -414,6 +414,34 @@ class Store implements SessionInterface
     }
 
     /**
+     * Increment the value of an item in the session.
+     *
+     * @param  string  $key
+     * @param  mixed   $amount
+     * @return mixed
+     */
+    public function increment($key, $amount = 1)
+    {
+        $value = $this->get($key, 0) + $amount;
+
+        $this->put($key, $value);
+
+        return $value;
+    }
+
+    /**
+     * Decrement the value of an item in the session.
+     *
+     * @param  string  $key
+     * @param  mixed   $amount
+     * @return int
+     */
+    public function decrement($key, $amount = 1)
+    {
+        return $this->increment($key, $amount * -1);
+    }
+
+    /**
      * Flash a key / value pair to the session.
      *
      * @param  string  $key

--- a/tests/Session/SessionStoreTest.php
+++ b/tests/Session/SessionStoreTest.php
@@ -251,6 +251,40 @@ class SessionStoreTest extends PHPUnit_Framework_TestCase
         $this->assertFalse($session->getBag('bagged')->has('qu'));
     }
 
+    public function testIncrement()
+    {
+        $session = $this->getSession();
+
+        $session->set('foo', 5);
+        $foo = $session->increment('foo');
+        $this->assertEquals(6, $foo);
+        $this->assertEquals(6, $session->get('foo'));
+
+        $foo = $session->increment('foo', 4);
+        $this->assertEquals(10, $foo);
+        $this->assertEquals(10, $session->get('foo'));
+
+        $session->increment('bar');
+        $this->assertEquals(1, $session->get('bar'));
+    }
+
+    public function testDecrement()
+    {
+        $session = $this->getSession();
+
+        $session->set('foo', 5);
+        $foo = $session->decrement('foo');
+        $this->assertEquals(4, $foo);
+        $this->assertEquals(4, $session->get('foo'));
+
+        $foo = $session->decrement('foo', 4);
+        $this->assertEquals(0, $foo);
+        $this->assertEquals(0, $session->get('foo'));
+
+        $session->decrement('bar');
+        $this->assertEquals(-1, $session->get('bar'));
+    }
+
     public function testHasOldInputWithoutKey()
     {
         $session = $this->getSession();


### PR DESCRIPTION
Several stores in the framework offer increment and decrement
methods as a convenient helper method for get/set.

This change implements such methods in the session store,
to ease the tracking of a state into a session.

For example you can:

```
        $redirectsCount = Session::increment('auth.redirects');
        if ($redirectsCount < 3) {
            // Retry to authenticate user to an external service.
        }
```
