### PR TITLE
[5.2] Fix multi-upload validations issues on php7

### DIFF
--- a/src/Illuminate/Http/RedirectResponse.php
+++ b/src/Illuminate/Http/RedirectResponse.php
@@ -76,8 +76,8 @@ class RedirectResponse extends BaseRedirectResponse
             if (is_array($value)) {
                 $value = array_filter($value, $callback);
             }
-
-            return ! $value instanceof SymfonyUploadedFile;
+            
+            return $value instanceof SymfonyUploadedFile ? false : $value;
         }));
 
         return $this;

--- a/src/Illuminate/Http/RedirectResponse.php
+++ b/src/Illuminate/Http/RedirectResponse.php
@@ -76,7 +76,7 @@ class RedirectResponse extends BaseRedirectResponse
             if (is_array($value)) {
                 $value = array_filter($value, $callback);
             }
-            
+
             return $value instanceof SymfonyUploadedFile ? false : $value;
         }));
 


### PR DESCRIPTION
validating multiple files that stored in single input as array if validations fails and your project run on php7 you end up with this error
local.ERROR: Exception: Serialization of 'Illuminate\Http\UploadedFile' is not allowed since the files object will never be removed from the stored array

for full details on this issue see issue report #14143
