### PR TITLE
[5.3] [WIP] Batch update with a single query

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -352,11 +352,16 @@ class Collection extends BaseCollection implements QueueableCollection
         return new BaseCollection($this->items);
     }
 
+    /**
+     * Batch update the dirty records of models.
+     *
+     * @return int|null
+     */
     public function update()
     {
         $dirties = [];
         $dirtyColumns = [];
-        /** @var Model $model */
+
         foreach ($this->items as $model) {
             $dirty = $model->getDirty();
             if (count($dirty)) {
@@ -378,6 +383,7 @@ class Collection extends BaseCollection implements QueueableCollection
         $keyName = $model->getKeyName();
         $params = [];
         $columnUpdates = [];
+
         foreach ($dirtyColumns as $column => $rows) {
             $columnUpdate = "`$column` =  CASE";
             foreach ($rows as $row) {

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -351,4 +351,50 @@ class Collection extends BaseCollection implements QueueableCollection
     {
         return new BaseCollection($this->items);
     }
+
+    public function update()
+    {
+        $dirties = [];
+        $dirtyColumns = [];
+        /** @var Model $model */
+        foreach ($this->items as $model) {
+            $dirty = $model->getDirty();
+            if (count($dirty)) {
+                $dirties[$model->getKey()] = $dirty;
+                foreach ($dirty as $column => $value) {
+                    if (! array_key_exists($column, $dirtyColumns)) {
+                        $dirtyColumns[$column] = [];
+                    }
+                    $dirtyColumns[$column][] = [$model->getKey(), $value];
+                }
+
+            }
+        }
+
+        if (! count($dirties)) {
+            return;
+        }
+
+        $keyName = $model->getKeyName();
+        $params = [];
+        $columnUpdates = [];
+        foreach ($dirtyColumns as $column => $rows) {
+            $columnUpdate = "`$column` =  CASE";
+            foreach ($rows as $row) {
+                $columnUpdate .= " WHEN `$keyName` = ? THEN ?";
+                $params[] = $row[0];
+                $params[] = $row[1];
+            }
+            $columnUpdate .= " ELSE `$column` END";
+            $columnUpdates[] = $columnUpdate;
+        }
+
+        $table = $model->newQuery()->getQuery()->getGrammar()->wrapTable($model->getTable());
+        $sql = "UPDATE $table SET ".join(',', $columnUpdates)." WHERE $keyName IN (".join(',', array_fill(0, count($dirties), '?')).')';
+
+        $statement = $model->getConnection()->getPdo()->prepare($sql);
+        if ($statement->execute(array_merge($params, array_keys($dirties)))) {
+            return $statement->rowCount();
+        }
+    }
 }


### PR DESCRIPTION
Please don't merge. It is just an idea to be considered for possibly more careful and clean implementations.

Sometimes I face situations when it is important to update multiple rows of a table at once, and performance does matter, especially in terms of the number of queries. Here is an attempt to generally solve the problem using CASE WHEN THEN statements:
## Example

``` php
$newSensorData = [
    12 => ['value' => 32, 'observed_at' => '2016-06-30 12:30:01'],
    13 => ['value' => 33, 'observed_at' => '2016-06-30 12:30:05'],
    16 => ['value' => 30, 'observed_at' => '2016-06-30 12:30:05'],
];
$sensors = Sensor::whereIn('id', array_keys($newSensorData))->get();
foreach($sensors as $sensor) {
    //some calculations then save the new values
    $sensor->value = $newSensorData[$sensor->id]['value'];
    $sensor->observed_at = $newSensorData[$sensor->id]['observed_at'];
}
$sensors->update();
```

The resulting SQL statement (assuming that the old value for sensor#12 is 32):

``` sql
UPDATE `sensors` SET
`value` = CASE 
    WHEN `id` = 13 THEN 33
    WHEN `id` = 16 THEN 30
ELSE `value` END,
`observed_at` = CASE
    WHEN `id` = 12 THEN  '2016-06-30 12:30:01'
    WHEN `id` = 13 THEN '2016-06-30 12:30:05'
    WHEN `id` = 16 THEN '2016-06-30 12:30:05'
ELSE `observed_at` END
WHERE id in (12, 13, 16)
```

I don't know how general is the problem, but when someone face it, it will be hard and messy to generate such a query.

What do you think about the functionality and the best way to implement it?
