### PR TITLE
[5.2] Fallback parameter for UrlGenerator::previous

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -138,8 +138,9 @@ class UrlGenerator implements UrlGeneratorContract
         $referrer = $this->request->headers->get('referer');
 
         $url = $referrer ? $this->to($referrer) : $this->getPreviousUrlFromSession();
+        $fallback = value($fallback) ?: $this->to('/');
 
-        return $url ?: (value($fallback) ?: $this->to('/'));
+        return $url ?: $fallback;
     }
 
     /**

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -130,15 +130,16 @@ class UrlGenerator implements UrlGeneratorContract
     /**
      * Get the URL for the previous request.
      *
+     * @param  mixed  $fallback
      * @return string
      */
-    public function previous()
+    public function previous($fallback = false)
     {
         $referrer = $this->request->headers->get('referer');
 
         $url = $referrer ? $this->to($referrer) : $this->getPreviousUrlFromSession();
 
-        return $url ?: $this->to('/');
+        return $url ?: (value($fallback) ?: $this->to('/'));
     }
 
     /**

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -369,6 +369,10 @@ class RoutingUrlGeneratorTest extends PHPUnit_Framework_TestCase
 
         $url->getRequest()->headers->remove('referer');
         $this->assertEquals($url->to('/'), $url->previous());
+        
+        $this->assertEquals($url->to('/foo'), $url->previous(function () use ($url) {
+            return $url->to('/foo');
+        }));
     }
 }
 

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -369,7 +369,7 @@ class RoutingUrlGeneratorTest extends PHPUnit_Framework_TestCase
 
         $url->getRequest()->headers->remove('referer');
         $this->assertEquals($url->to('/'), $url->previous());
-        
+
         $this->assertEquals($url->to('/foo'), $url->previous(function () use ($url) {
             return $url->to('/foo');
         }));


### PR DESCRIPTION
Allows passing a fallback value to the `UrlGenerator::previous()` method. This parameter is optional, and if not provided will still fall back to `UrlGenerator::to('/')`.
