### PR TITLE
[5.2] Don't hit rate limiting when running unit tests by default

### DIFF
--- a/src/Illuminate/Routing/Middleware/ThrottleRequests.php
+++ b/src/Illuminate/Routing/Middleware/ThrottleRequests.php
@@ -4,10 +4,18 @@ namespace Illuminate\Routing\Middleware;
 
 use Closure;
 use Illuminate\Cache\RateLimiter;
+use Illuminate\Foundation\Application;
 use Symfony\Component\HttpFoundation\Response;
 
 class ThrottleRequests
 {
+    /**
+     * The application instance.
+     *
+     * @var \Illuminate\Foundation\Application
+     */
+    protected $app;
+
     /**
      * The rate limiter instance.
      *
@@ -18,11 +26,13 @@ class ThrottleRequests
     /**
      * Create a new request throttler.
      *
+     * @param  \Illuminate\Foundation\Application  $app
      * @param  \Illuminate\Cache\RateLimiter  $limiter
      * @return void
      */
-    public function __construct(RateLimiter $limiter)
+    public function __construct(Application $app, RateLimiter $limiter)
     {
+        $this->app = $app;
         $this->limiter = $limiter;
     }
 
@@ -37,6 +47,10 @@ class ThrottleRequests
      */
     public function handle($request, Closure $next, $maxAttempts = 60, $decayMinutes = 1)
     {
+        if ($this->runningUnitTests()) {
+            return $next($request);
+        }
+        
         $key = $this->resolveRequestSignature($request);
 
         if ($this->limiter->tooManyAttempts($key, $maxAttempts, $decayMinutes)) {
@@ -125,4 +139,14 @@ class ThrottleRequests
 
         return $this->limiter->retriesLeft($key, $maxAttempts);
     }
+
+    /**
+     * Determine if the application is running unit tests.
+     *
+     * @return bool
+     */
+    protected function runningUnitTests()
+    {
+        return $this->app->runningInConsole() && $this->app->runningUnitTests();
+    }    
 }

--- a/src/Illuminate/Routing/Middleware/ThrottleRequests.php
+++ b/src/Illuminate/Routing/Middleware/ThrottleRequests.php
@@ -50,7 +50,7 @@ class ThrottleRequests
         if ($this->runningUnitTests()) {
             return $next($request);
         }
-        
+
         $key = $this->resolveRequestSignature($request);
 
         if ($this->limiter->tooManyAttempts($key, $maxAttempts, $decayMinutes)) {
@@ -148,5 +148,5 @@ class ThrottleRequests
     protected function runningUnitTests()
     {
         return $this->app->runningInConsole() && $this->app->runningUnitTests();
-    }    
+    }
 }


### PR DESCRIPTION
I think when running unit tests rate limiting should be disabled by default the same way as VerifyCsrfToken is. Otherwise when running multiple tests you might get strange issues hard to detect in some cases (Please look at https://laradevtips.com/2016/06/30/partial-mocking-and-issues-you-dont-expect/ for details)
