### PR TITLE
[5.2] Removed the "reserved" column from the jobs table.

### DIFF
--- a/src/Illuminate/Queue/Console/stubs/jobs.stub
+++ b/src/Illuminate/Queue/Console/stubs/jobs.stub
@@ -17,11 +17,10 @@ class Create{{tableClassName}}Table extends Migration
             $table->string('queue');
             $table->longText('payload');
             $table->tinyInteger('attempts')->unsigned();
-            $table->tinyInteger('reserved')->unsigned();
             $table->unsignedInteger('reserved_at')->nullable();
             $table->unsignedInteger('available_at');
             $table->unsignedInteger('created_at');
-            $table->index(['queue', 'reserved', 'reserved_at']);
+            $table->index(['queue', 'reserved_at']);
         });
     }
 

--- a/tests/Queue/QueueDatabaseQueueIntegrationTest.php
+++ b/tests/Queue/QueueDatabaseQueueIntegrationTest.php
@@ -60,11 +60,10 @@ class QueueDatabaseQueueIntegrationTest extends PHPUnit_Framework_TestCase
             $table->string('queue');
             $table->longText('payload');
             $table->tinyInteger('attempts')->unsigned();
-            $table->tinyInteger('reserved')->unsigned();
             $table->unsignedInteger('reserved_at')->nullable();
             $table->unsignedInteger('available_at');
             $table->unsignedInteger('created_at');
-            $table->index(['queue', 'reserved', 'reserved_at']);
+            $table->index(['queue', 'reserved_at']);
         });
     }
 
@@ -110,7 +109,6 @@ class QueueDatabaseQueueIntegrationTest extends PHPUnit_Framework_TestCase
                 'queue' => $mock_queue_name = 'mock_queue_name',
                 'payload' => 'mock_payload',
                 'attempts' => 0,
-                'reserved' => 0,
                 'reserved_at' => null,
                 'available_at' => Carbon::now()->subSeconds(1)->getTimestamp(),
                 'created_at' => Carbon::now()->getTimestamp(),
@@ -131,7 +129,6 @@ class QueueDatabaseQueueIntegrationTest extends PHPUnit_Framework_TestCase
             'queue' => 'mock_queue_name',
             'payload' => 'mock_payload',
             'attempts' => 0,
-            'reserved' => 0,
             'reserved_at' => null,
             'available_at' => Carbon::now()->subSeconds(1)->getTimestamp(),
             'created_at' => Carbon::now()->getTimestamp(),
@@ -159,7 +156,6 @@ class QueueDatabaseQueueIntegrationTest extends PHPUnit_Framework_TestCase
                 'queue' => $mock_queue_name = 'mock_queue_name',
                 'payload' => 'mock_payload',
                 'attempts' => 0,
-                'reserved' => 0,
                 'reserved_at' => null,
                 'available_at' => Carbon::now()->addSeconds(60)->getTimestamp(),
                 'created_at' => Carbon::now()->getTimestamp(),
@@ -182,7 +178,6 @@ class QueueDatabaseQueueIntegrationTest extends PHPUnit_Framework_TestCase
                 'queue' => $mock_queue_name = 'mock_queue_name',
                 'payload' => 'mock_payload',
                 'attempts' => 0,
-                'reserved' => 1,
                 'reserved_at' => Carbon::now()->subDay()->getTimestamp(),
                 'available_at' => Carbon::now()->addDay()->getTimestamp(),
                 'created_at' => Carbon::now()->getTimestamp(),
@@ -205,7 +200,6 @@ class QueueDatabaseQueueIntegrationTest extends PHPUnit_Framework_TestCase
                 'queue' => $mock_queue_name = 'mock_queue_name',
                 'payload' => 'mock_payload',
                 'attempts' => 0,
-                'reserved' => 1,
                 'reserved_at' => Carbon::now()->addDay()->getTimestamp(),
                 'available_at' => Carbon::now()->subDay()->getTimestamp(),
                 'created_at' => Carbon::now()->getTimestamp(),

--- a/tests/Queue/QueueDatabaseQueueUnitTest.php
+++ b/tests/Queue/QueueDatabaseQueueUnitTest.php
@@ -18,7 +18,6 @@ class QueueDatabaseQueueUnitTest extends PHPUnit_Framework_TestCase
             $this->assertEquals('default', $array['queue']);
             $this->assertEquals(json_encode(['job' => 'foo', 'data' => ['data']]), $array['payload']);
             $this->assertEquals(0, $array['attempts']);
-            $this->assertEquals(0, $array['reserved']);
             $this->assertNull($array['reserved_at']);
             $this->assertInternalType('int', $array['available_at']);
         });
@@ -39,7 +38,6 @@ class QueueDatabaseQueueUnitTest extends PHPUnit_Framework_TestCase
             $this->assertEquals('default', $array['queue']);
             $this->assertEquals(json_encode(['job' => 'foo', 'data' => ['data']]), $array['payload']);
             $this->assertEquals(0, $array['attempts']);
-            $this->assertEquals(0, $array['reserved']);
             $this->assertNull($array['reserved_at']);
             $this->assertInternalType('int', $array['available_at']);
         });
@@ -59,7 +57,6 @@ class QueueDatabaseQueueUnitTest extends PHPUnit_Framework_TestCase
                 'queue' => 'queue',
                 'payload' => json_encode(['job' => 'foo', 'data' => ['data']]),
                 'attempts' => 0,
-                'reserved' => 0,
                 'reserved_at' => null,
                 'available_at' => 'available',
                 'created_at' => 'created',
@@ -67,7 +64,6 @@ class QueueDatabaseQueueUnitTest extends PHPUnit_Framework_TestCase
                 'queue' => 'queue',
                 'payload' => json_encode(['job' => 'bar', 'data' => ['data']]),
                 'attempts' => 0,
-                'reserved' => 0,
                 'reserved_at' => null,
                 'available_at' => 'available',
                 'created_at' => 'created',


### PR DESCRIPTION
The same information can be interpreted from the "reserved_at" column.
