### PR TITLE
[5.2] Make debugging collections easier

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -113,6 +113,14 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
+     * Dump the collection and end the script.
+     */
+    public function dd()
+    {
+        dd($this);
+    }
+
+    /**
      * Get the items in the collection that are not present in the given items.
      *
      * @param  mixed  $items


### PR DESCRIPTION
This PR adds a `dd` function to `Illuminate\Support\Collection` to make debugging collection chains a lot easier.

Image you are debugging a chain of collection methods. You want to see what the values are after the `map` function in the example below. To do that you could wrap the code starting from the collection call until right after the `map` function in a `dd` function.

``` php
dd(collect($items)
  ->filter(function() { 
     ... 
   })
   ->unique(function() { 
      ... 
   })
   ->map(function() {
     ... 
   }))
   ->sortBy(function() { 
      ...
   });
```

Sure enough, the contents of the collection after the `map` function will get dumped to the screen. But there's some work involved: you have to insert code a the beginning of the collection and an extra closing parenthesis after the `map` function. To my eyes this isn't very readable. It's also a bit of a hassle to remove the `dd` statement, that closing parenthesis is easily forgotten. I'm exaggerating the problems a bit, but when working with collections a lot this workflow gets tiresome really fast.

This PR adds a `dd` function to the `Collection` class so you can do this:

``` php
collect($items)
  ->filter(function() { 
     ... 
   })
   ->unique(function() { 
      ... 
   })
   ->map(function() {
     ... 
   })
   ->dd()
   ->sortBy(function() { 
      ...
   });
```

To see the values after a particular step in the chain you simply have to add one line of code. It's perfectly readable. After you've done your debugging there's only one line to remove.

I didn't add a test for the `dd` function because I was unsure on how to test this properly.

Fyi: there is already [a issue on the internals repo](https://github.com/laravel/internals/issues/117) that discusses this proposal.
