### PR TITLE
[5.2] Add `last` Builder function

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -285,7 +285,7 @@ class Builder
     {
         return $this->take(1)->get($columns)->first();
     }
-    
+
     /**
      * Execute the query and get the last result.
      *

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -285,6 +285,17 @@ class Builder
     {
         return $this->take(1)->get($columns)->first();
     }
+    
+    /**
+     * Execute the query and get the last result.
+     *
+     * @param  array  $columns
+     * @return \Illuminate\Database\Eloquent\Model|static|null
+     */
+    public function last($columns = ['*'])
+    {
+        return $this->query->last($columns, $this->model->getKeyName());
+    }
 
     /**
      * Execute the query and get the first result or throw an exception.

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1562,16 +1562,20 @@ class Builder
     public function last($columns = ['*'], $defaultOrderColumnName = 'id')
     {
         $orderPropertyName = $this->unions ? 'unionOrders' : 'orders';
-        $this->$orderPropertyName = collect($this->$orderPropertyName)->map(function($orderArray) {
-            $orderArray['direction'] = ($orderArray['direction'] == 'asc' ? 'desc' : 'asc');
-            return $orderArray;
-        });
+
+        if (is_array($this->$orderPropertyName)) {
+            $this->$orderPropertyName = array_map(function($orderArray) {
+                $orderArray['direction'] = ($orderArray['direction'] == 'asc' ? 'desc' : 'asc');
+                return $orderArray;
+            }, $this->$orderPropertyName);
+        }
+
         if (! count($this->$orderPropertyName)) {
             $this->orderBy($defaultOrderColumnName, 'desc');
         }
-        return $this->take(1)->get($columns)->first();
-    }
 
+        return $this->first($columns);
+    }
 
     /**
      * Execute the query as a "select" statement.

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1553,6 +1553,27 @@ class Builder
     }
 
     /**
+     * Execute the query and get the last result.
+     *
+     * @param  array $columns
+     * @param  string $defaultOrderColumnName
+     * @return array|null|\stdClass
+     */
+    public function last($columns = ['*'], $defaultOrderColumnName = 'id')
+    {
+        $orderPropertyName = $this->unions ? 'unionOrders' : 'orders';
+        $this->$orderPropertyName = collect($this->$orderPropertyName)->map(function($orderArray) {
+            $orderArray['direction'] = ($orderArray['direction'] == 'asc' ? 'desc' : 'asc');
+            return $orderArray;
+        });
+        if (! count($this->$orderPropertyName)) {
+            $this->orderBy($defaultOrderColumnName, 'desc');
+        }
+        return $this->take(1)->get($columns)->first();
+    }
+
+
+    /**
      * Execute the query as a "select" statement.
      *
      * @param  array  $columns

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1564,8 +1564,9 @@ class Builder
         $orderPropertyName = $this->unions ? 'unionOrders' : 'orders';
 
         if (is_array($this->$orderPropertyName)) {
-            $this->$orderPropertyName = array_map(function($orderArray) {
+            $this->$orderPropertyName = array_map(function ($orderArray) {
                 $orderArray['direction'] = ($orderArray['direction'] == 'asc' ? 'desc' : 'asc');
+
                 return $orderArray;
             }, $this->$orderPropertyName);
         }

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -139,6 +139,9 @@ class DatabaseEloquentIntegrationTest extends PHPUnit_Framework_TestCase
         foreach ($records as $record) {
             $this->assertEquals(1, $record->id);
         }
+
+        $this->assertEquals(1, EloquentTestUser::first()->id);
+        $this->assertEquals(2, EloquentTestUser::last()->id);
     }
 
     public function testBasicModelCollectionRetrieval()

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -894,6 +894,28 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(['foo' => 'bar'], $results);
     }
 
+    public function testLastMethodReturnsLastResult()
+    {
+        $builder = $this->getBuilder();
+        $builder->getConnection()->shouldReceive('select')->once()->with('select * from "users" where "id" = ? order by "id" desc limit 1', [1], true)->andReturn([['foo' => 'bar']]);
+        $builder->getProcessor()->shouldReceive('processSelect')->once()->with($builder, [['foo' => 'bar']])->andReturnUsing(function ($query, $results) {
+            return $results;
+        });
+        $results = $builder->from('users')->where('id', '=', 1)->last();
+        $this->assertEquals(['foo' => 'bar'], $results);
+    }
+
+    public function testLastMethodReturnsLastResultWhenUsingAnOrderByClause()
+    {
+        $builder = $this->getBuilder();
+        $builder->getConnection()->shouldReceive('select')->once()->with('select * from "users" order by "foo" asc limit 1', [], true)->andReturn([['foo' => 'bar']]);
+        $builder->getProcessor()->shouldReceive('processSelect')->once()->with($builder, [['foo' => 'bar']])->andReturnUsing(function ($query, $results) {
+            return $results;
+        });
+        $results = $builder->from('users')->orderBy('foo', 'desc')->last();
+        $this->assertEquals(['foo' => 'bar'], $results);
+    }
+
     public function testListMethodsGetsArrayOfColumnValues()
     {
         $builder = $this->getBuilder();


### PR DESCRIPTION
This PR adds a `last` function to `/Illuminate/Database/Eloquent/Builder` and `/Illuminate/Database/Query/Builder`. 

With it you can do this:

``` php
EloquentTestUser::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']);
EloquentTestUser::create(['id' => 2, 'email' => 'abigailotwell@gmail.com']);

EloquentTestUser::first()->id; //return 1
EloquentTestUser::last()->id; //returns 2
```

It also works when there is an `orderBy` applied. In that case it'll just flip the `desc`'s and `asc`'s and return the first result.
