### PR TITLE
[5.2] Remove unnecessary nesting in Macroable trait

### DIFF
--- a/src/Illuminate/Support/Traits/Macroable.php
+++ b/src/Illuminate/Support/Traits/Macroable.php
@@ -48,15 +48,15 @@ trait Macroable
      */
     public static function __callStatic($method, $parameters)
     {
-        if (static::hasMacro($method)) {
-            if (static::$macros[$method] instanceof Closure) {
-                return call_user_func_array(Closure::bind(static::$macros[$method], null, static::class), $parameters);
-            } else {
-                return call_user_func_array(static::$macros[$method], $parameters);
-            }
+        if (! static::hasMacro($method)) {
+            throw new BadMethodCallException("Method {$method} does not exist.");
         }
 
-        throw new BadMethodCallException("Method {$method} does not exist.");
+        if (static::$macros[$method] instanceof Closure) {
+            return call_user_func_array(Closure::bind(static::$macros[$method], null, static::class), $parameters);
+        }
+
+        return call_user_func_array(static::$macros[$method], $parameters);
     }
 
     /**
@@ -70,14 +70,14 @@ trait Macroable
      */
     public function __call($method, $parameters)
     {
-        if (static::hasMacro($method)) {
-            if (static::$macros[$method] instanceof Closure) {
-                return call_user_func_array(static::$macros[$method]->bindTo($this, static::class), $parameters);
-            } else {
-                return call_user_func_array(static::$macros[$method], $parameters);
-            }
+        if (! static::hasMacro($method)) {
+            throw new BadMethodCallException("Method {$method} does not exist.");
         }
 
-        throw new BadMethodCallException("Method {$method} does not exist.");
+        if (static::$macros[$method] instanceof Closure) {
+            return call_user_func_array(static::$macros[$method]->bindTo($this, static::class), $parameters);
+        }
+
+        return call_user_func_array(static::$macros[$method], $parameters);
     }
 }


### PR DESCRIPTION
This PR removes unnecessary nesting in the `Macroable` trait
