### PR TITLE
[5.2] Add missing postgresql-specific operators

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -195,7 +195,7 @@ class Builder
         '&', '|', '^', '<<', '>>',
         'rlike', 'regexp', 'not regexp',
         '~', '~*', '!~', '!~*', 'similar to',
-        'not similar to', 'not ilike', '~~*', '!~~*'
+        'not similar to', 'not ilike', '~~*', '!~~*',
     ];
 
     /**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -195,7 +195,7 @@ class Builder
         '&', '|', '^', '<<', '>>',
         'rlike', 'regexp', 'not regexp',
         '~', '~*', '!~', '!~*', 'similar to',
-        'not similar to',
+        'not similar to', 'not ilike', '~~*', '!~~*'
     ];
 
     /**


### PR DESCRIPTION
Belated PR to #12580 issue.
Add "not ilike" operator and shortcuts for 'not ilike' and 'ilike'.
Referring to [Postgresql docs](https://www.postgresql.org/docs/9.5/static/functions-matching.html)
