### PR TITLE
[5.2] Added fix for tags array

### DIFF
--- a/src/Illuminate/Foundation/Console/VendorPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/VendorPublishCommand.php
@@ -58,6 +58,8 @@ class VendorPublishCommand extends Command
 
         $tags = $tags ?: [null];
 
+        $tags = is_string($tags) ? [$tags] : $tags;
+
         foreach ($tags as $tag) {
             $this->publishTag($tag);
         }


### PR DESCRIPTION
Added tags array fix for `php artisan vendor:publish` command. The problem is when `artisan`command from another `artisan`command with **tags** is called.  `$tags` is returned as string. So it must be returned as array.
