### PR TITLE
[5.3] Refactored the pop method and subsequent dependant methods.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -77,7 +77,8 @@
         "phpunit/phpunit": "~5.4",
         "predis/predis": "~1.0",
         "symfony/css-selector": "3.1.*",
-        "symfony/dom-crawler": "3.1.*"
+        "symfony/dom-crawler": "3.1.*",
+        "symfony/phpunit-bridge": "3.0.*"
     },
     "autoload": {
         "classmap": [

--- a/src/Illuminate/Queue/ExcessiveBlockException.php
+++ b/src/Illuminate/Queue/ExcessiveBlockException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Illuminate\Queue;
+
+class ExcessiveBlockException extends \Exception
+{
+}


### PR DESCRIPTION
Eliminated the use of locks and transactions when "popping".
- This should stop the occurrence of any locking/timeout exceptions when running multiple daemon workers.
- Includes integration tests.
- Requires new dev dependancy that supports mocking of the sleep method in php; reduces time taken to run tests.
- Created new exception class.

Previously when running multiple daemon workers a locking/timeout exception would be thrown infrequently. I believe this is because the next available job is locked but not reserved within the same statement (not possible) and so any workers that look for a job before this job is reserved, will find this job and wait for this job to become available.

I've tested this solution and don't get any exceptions. And the number of times that a worker is blocked seems to stay quite low with 15 workers; though admittedly they are on one server, so the more i get the more they begin to slow down; would be better to test with say 3 workers, on 5 servers, so that they stay fast.

Anyways, let me know what you think :)
