### PR TITLE
[5.3] Create factory modifiers

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factory.php
@@ -34,6 +34,13 @@ class Factory implements ArrayAccess
     protected $definitions = [];
 
     /**
+     * The model modifiers in the container.
+     *
+     * @var array
+     */
+    protected $modifiers = [];
+
+    /**
      * Create a new factory container.
      *
      * @param  \Faker\Generator  $faker
@@ -71,6 +78,19 @@ class Factory implements ArrayAccess
     public function define($class, callable $attributes, $name = 'default')
     {
         $this->definitions[$class][$name] = $attributes;
+    }
+
+    /**
+     * Define a modifier with a given set of attributes.
+     *
+     * @param  string  $class
+     * @param  string  $name
+     * @param  callable  $attributes
+     * @return void
+     */
+    public function defineModifier($class, $name, callable $attributes)
+    {
+        $this->modifiers[$class][$name] = $attributes;
     }
 
     /**
@@ -179,7 +199,7 @@ class Factory implements ArrayAccess
      */
     public function of($class, $name = 'default')
     {
-        return new FactoryBuilder($class, $name, $this->definitions, $this->faker);
+        return new FactoryBuilder($class, $name, $this->definitions, $this->faker, $this->modifiers);
     }
 
     /**


### PR DESCRIPTION
i've come to find that I would would like to use factories a little different than is currently available. Currently you can `define` and `defineAs` factories.  This works okay, but where I run into issues is where  I have a lot of variable types.  For example, I may have a `Blog` that has a `published_at` field and an `user_id` field.  The `Blog` can be published or unpublished, and it can have an author or be written by anonymous. I could have a published authored Blog, an unpublished authored Blog, a published anonymous Blog, and an unpublished anonymous Blog.  Currently, I would have to write 5 different factory types for this.

Ideally what I would like is 'modifiers' for each factory. To define them I would:

``` php
$factory->define(App\Blog::class, function (Faker\Generator $faker) {
    return [
        'title'        => $faker->word,
        'body'         => $faker->paragraph(2),
        'published_at' => null,
        'user_id'      => null,
    ];
});

$factory->defineModifier(\App\Blog::class, 'published', function (\Faker\Generator $faker) {

    return [
        'published_at' => $faker->dateTime,
    ];
});

$factory->defineModifier(\App\Blog::class, 'authored', function (\Faker\Generator $faker) {

    return [
        'user_id' => $faker->numberBetween(1, 10),
    ];
});

```

This would allow me to mix and match modifiers as needed.  Then to use the factories I would 

``` php
factory(\App\Blog::class, 5)->create();
factory(\App\Blog::class, 5)->modifiers('published')->create();
factory(\App\Blog::class, 5)->modifiers('authored')->create();
factory(\App\Blog::class, 5)->modifiers(['authored', 'published'])->create();
```

I believe this offers a lot more flexibility, and still allows people to do it the current way if they prefer.
