### PR TITLE
[5.2] check for getUrl method on the adapter before throwing exception - Filesystem

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -238,7 +238,7 @@ class FilesystemAdapter implements FilesystemContract, CloudFilesystemContract
             return $adapter->getClient()->getObjectUrl($adapter->getBucket(), $path);
         } elseif ($adapter instanceof LocalAdapter) {
             return '/storage/'.$path;
-        } elseif (method_exists($adapter,'getUrl')) {
+        } elseif (method_exists($adapter, 'getUrl')) {
             return $adapter->getUrl($path);
         } else {
             throw new RuntimeException('This driver does not support retrieving URLs.');

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -240,7 +240,6 @@ class FilesystemAdapter implements FilesystemContract, CloudFilesystemContract
             return '/storage/'.$path;
         } elseif (method_exists($adapter,'getUrl')) {
             return $adapter->getUrl($path);
-        }
         } else {
             throw new RuntimeException('This driver does not support retrieving URLs.');
         }

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -238,6 +238,9 @@ class FilesystemAdapter implements FilesystemContract, CloudFilesystemContract
             return $adapter->getClient()->getObjectUrl($adapter->getBucket(), $path);
         } elseif ($adapter instanceof LocalAdapter) {
             return '/storage/'.$path;
+        } elseif (method_exists($adapter,'getUrl')) {
+            return $adapter->getUrl($path);
+        }
         } else {
             throw new RuntimeException('This driver does not support retrieving URLs.');
         }


### PR DESCRIPTION
It is better to check if the $adapter supports a getUrl function instead of telling without looking that "this driver does not support retrieving URLs."

By that any custom driver should be able to forge URLs for files. So if you're using a custom (non aws) S3 server that supports getting an URL you can still use Storage::url() happily.
