### PR TITLE
[5.2] Fix trans capitalization when replacement is numerical array

### DIFF
--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -158,8 +158,8 @@ class Translator extends NamespacedItemResolver implements TranslatorInterface
 
         foreach ($replace as $key => $value) {
             $line = str_replace(
-                [':'.Str::upper($key), ':'.Str::ucfirst($key), ':'.$key],
-                [Str::upper($value), Str::ucfirst($value), $value],
+                [':'.$key, ':'.Str::upper($key), ':'.Str::ucfirst($key)],
+                [$value, Str::upper($value), Str::ucfirst($value)],
                 $line
             );
         }

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -2077,8 +2077,8 @@ class Validator implements ValidatorContract
         $value = $this->getAttribute($attribute);
 
         $message = str_replace(
-            [':ATTRIBUTE', ':Attribute', ':attribute'],
-            [Str::upper($value), Str::ucfirst($value), $value],
+            [':attribute', ':ATTRIBUTE', ':Attribute'],
+            [$value, Str::upper($value), Str::ucfirst($value)],
             $message
         );
 

--- a/tests/Translation/TranslationTranslatorTest.php
+++ b/tests/Translation/TranslationTranslatorTest.php
@@ -46,6 +46,14 @@ class TranslationTranslatorTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('foo', $t->get('foo::bar.foo'));
     }
 
+    public function testGetMethodProperlyLoadsAndRetrievesItemWithCapitalization()
+    {
+        $t = $this->getMock('Illuminate\Translation\Translator', null, [$this->getLoader(), 'en']);
+        $t->getLoader()->shouldReceive('load')->once()->with('en', 'bar', 'foo')->andReturn(['foo' => 'foo', 'baz' => 'breeze :Foo :BAR']);
+        $this->assertEquals('breeze Bar FOO', $t->get('foo::bar.baz', ['foo' => 'bar', 'bar' => 'foo'], 'en'));
+        $this->assertEquals('foo', $t->get('foo::bar.foo'));
+    }
+
     public function testGetMethodProperlyLoadsAndRetrievesItemWithLongestReplacementsFirst()
     {
         $t = $this->getMock('Illuminate\Translation\Translator', null, [$this->getLoader(), 'en']);


### PR DESCRIPTION
Related issue: #11337

Reorders the 3 search terms from `[':ATTRIBUTE', ':Attribute', ':attribute']` to `[':attribute', ':ATTRIBUTE', ':Attribute']`, so that replacements indexed numerically (undocumented) would not get capitalized.

This change should not affect normal use (associative array). A test has been added to test the original behavior.

Translation string: `'Hello, :0!'`
Replacement array: `['World']`
Now gives `'Hello, World!'` instead of `Hello, WORLD!`
