### PR TITLE
[5.2] Allow array as value in withHeaders to set replace

### DIFF
--- a/src/Illuminate/Http/ResponseTrait.php
+++ b/src/Illuminate/Http/ResponseTrait.php
@@ -50,7 +50,11 @@ trait ResponseTrait
     public function withHeaders(array $headers)
     {
         foreach ($headers as $key => $value) {
-            $this->headers->set($key, $value);
+            if (is_array($value)) {
+                $this->headers->set($key, $value[0], $value[1]);
+            } else {
+                $this->headers->set($key, $value);
+            }
         }
 
         return $this;


### PR DESCRIPTION
Allows for setting the replace parameter on headers added by the `ResponseTrait::withHeaders` method.

``` php
return response($content)
            ->withHeaders([
                'Content-Type' => $type,
                'X-Header-One' => 'Header Value',
                'X-Header-One' => ['Header Value', false],
            ]);
```
