### PR TITLE
[5.2] Connection.php

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -572,7 +572,9 @@ class Connection implements ConnectionInterface
                 $this->getPdo()->beginTransaction();
             } catch (Exception $e) {
                 --$this->transactions;
-
+                if ($this->causedByLostConnection($e)) {
+                    $this->reconnect();
+                }
                 throw $e;
             }
         } elseif ($this->transactions > 1 && $this->queryGrammar->supportsSavepoints()) {


### PR DESCRIPTION
To solve when beginTransaction Because the database connection suddenly disconnected and throw a exception of "server has gone away" ,Generally occur in Resident process
