### PR TITLE
[5.2] PDO::beginTransaction() MySQL server has gone away

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -571,9 +571,14 @@ class Connection implements ConnectionInterface
             try {
                 $this->getPdo()->beginTransaction();
             } catch (Exception $e) {
-                --$this->transactions;
-
-                throw $e;
+                if ($this->causedByLostConnection($e)) {
+                    --$this->transactions;
+                    $this->reconnect();
+                    $this->getPdo()->beginTransaction();
+                }
+                if ($this->transactions >= 1) {
+                    throw $e;
+                }
             }
         } elseif ($this->transactions > 1 && $this->queryGrammar->supportsSavepoints()) {
             $this->getPdo()->exec(


### PR DESCRIPTION
bug exception 'ErrorException' with message 'PDO::beginTransaction(): MySQL server has gone away'

To solve when beginTransaction Because the database connection suddenly disconnected and throw a exception of "server has gone away" ,Generally occur in Resident process
