### PR TITLE
[5.2] Allow Blade to recognize '::' in directive names

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -331,7 +331,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
             return isset($match[3]) ? $match[0] : $match[0].$match[2];
         };
 
-        return preg_replace_callback('/\B@(@?\w+)([ \t]*)(\( ( (?>[^()]+) | (?3) )* \))?/x', $callback, $value);
+        return preg_replace_callback('/\B@(@?\w+(?:::\w+)?)([ \t]*)(\( ( (?>[^()]+) | (?3) )* \))?/x', $callback, $value);
     }
 
     /**


### PR DESCRIPTION
[Issue #14264]
Updated the regex pattern so that it will match directive names in '@' statements to capture a string postfixed with '::someOtherString' in it as the name for a Blade directive, to allow for more elegant and organized directive naming (e.g. allow for '@Package::directive')

This will still capture directive names without the '::someString'.
