### PR TITLE
@inject annotation for injecting named services from Laravel 5 Container

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -779,9 +779,12 @@ class Container implements ArrayAccess, ContainerContract {
 			$parameters
 		);
 
+		$annotations = $this->fetchInjectAnnotations( $constructor );
+
 		$instances = $this->getDependencies(
 			$dependencies,
-			$parameters
+			$parameters,
+			$annotations
 		);
 
 		array_pop( $this->buildStack );
@@ -795,9 +798,12 @@ class Container implements ArrayAccess, ContainerContract {
 	 * @param  array $parameters
 	 * @param  array $primitives
 	 *
+	 * @param array  $injectAnnotations
+	 *
 	 * @return array
+	 * @throws BindingResolutionException
 	 */
-	protected function getDependencies( array $parameters, array $primitives = [ ] ) {
+	protected function getDependencies( array $parameters, array $primitives = [ ], array $injectAnnotations = [ ] ) {
 		$dependencies = [ ];
 
 		foreach ( $parameters as $parameter ) {
@@ -808,6 +814,8 @@ class Container implements ArrayAccess, ContainerContract {
 			// we will just bomb out with an error since we have no-where to go.
 			if ( array_key_exists( $parameter->name, $primitives ) ) {
 				$dependencies[] = $primitives[ $parameter->name ];
+			} elseif ( array_key_exists( $parameter->name, $injectAnnotations ) ) {
+				$dependencies[] = $this->make( $injectAnnotations[ $parameter->name ] );
 			} elseif ( is_null( $dependency ) ) {
 				$dependencies[] = $this->resolveNonClass( $parameter );
 			} else {

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -2,1236 +2,1262 @@
 
 namespace Illuminate\Container;
 
-use Closure;
 use ArrayAccess;
-use ReflectionClass;
-use ReflectionMethod;
-use ReflectionFunction;
-use ReflectionParameter;
-use InvalidArgumentException;
+use Closure;
 use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Contracts\Container\Container as ContainerContract;
-
-class Container implements ArrayAccess, ContainerContract
-{
-    /**
-     * The current globally available container (if any).
-     *
-     * @var static
-     */
-    protected static $instance;
-
-    /**
-     * An array of the types that have been resolved.
-     *
-     * @var array
-     */
-    protected $resolved = [];
-
-    /**
-     * The container's bindings.
-     *
-     * @var array
-     */
-    protected $bindings = [];
-
-    /**
-     * The container's shared instances.
-     *
-     * @var array
-     */
-    protected $instances = [];
-
-    /**
-     * The registered type aliases.
-     *
-     * @var array
-     */
-    protected $aliases = [];
-
-    /**
-     * The extension closures for services.
-     *
-     * @var array
-     */
-    protected $extenders = [];
-
-    /**
-     * All of the registered tags.
-     *
-     * @var array
-     */
-    protected $tags = [];
-
-    /**
-     * The stack of concretions currently being built.
-     *
-     * @var array
-     */
-    protected $buildStack = [];
-
-    /**
-     * The contextual binding map.
-     *
-     * @var array
-     */
-    public $contextual = [];
-
-    /**
-     * All of the registered rebound callbacks.
-     *
-     * @var array
-     */
-    protected $reboundCallbacks = [];
-
-    /**
-     * All of the global resolving callbacks.
-     *
-     * @var array
-     */
-    protected $globalResolvingCallbacks = [];
-
-    /**
-     * All of the global after resolving callbacks.
-     *
-     * @var array
-     */
-    protected $globalAfterResolvingCallbacks = [];
-
-    /**
-     * All of the resolving callbacks by class type.
-     *
-     * @var array
-     */
-    protected $resolvingCallbacks = [];
-
-    /**
-     * All of the after resolving callbacks by class type.
-     *
-     * @var array
-     */
-    protected $afterResolvingCallbacks = [];
-
-    /**
-     * Define a contextual binding.
-     *
-     * @param  string  $concrete
-     * @return \Illuminate\Contracts\Container\ContextualBindingBuilder
-     */
-    public function when($concrete)
-    {
-        $concrete = $this->normalize($concrete);
-
-        return new ContextualBindingBuilder($this, $concrete);
-    }
-
-    /**
-     * Determine if the given abstract type has been bound.
-     *
-     * @param  string  $abstract
-     * @return bool
-     */
-    public function bound($abstract)
-    {
-        $abstract = $this->normalize($abstract);
-
-        return isset($this->bindings[$abstract]) || isset($this->instances[$abstract]) || $this->isAlias($abstract);
-    }
-
-    /**
-     * Determine if the given abstract type has been resolved.
-     *
-     * @param  string  $abstract
-     * @return bool
-     */
-    public function resolved($abstract)
-    {
-        $abstract = $this->normalize($abstract);
-
-        if ($this->isAlias($abstract)) {
-            $abstract = $this->getAlias($abstract);
-        }
-
-        return isset($this->resolved[$abstract]) || isset($this->instances[$abstract]);
-    }
-
-    /**
-     * Determine if a given string is an alias.
-     *
-     * @param  string  $name
-     * @return bool
-     */
-    public function isAlias($name)
-    {
-        return isset($this->aliases[$this->normalize($name)]);
-    }
-
-    /**
-     * Register a binding with the container.
-     *
-     * @param  string|array  $abstract
-     * @param  \Closure|string|null  $concrete
-     * @param  bool  $shared
-     * @return void
-     */
-    public function bind($abstract, $concrete = null, $shared = false)
-    {
-        $abstract = $this->normalize($abstract);
-
-        $concrete = $this->normalize($concrete);
-
-        // If the given types are actually an array, we will assume an alias is being
-        // defined and will grab this "real" abstract class name and register this
-        // alias with the container so that it can be used as a shortcut for it.
-        if (is_array($abstract)) {
-            list($abstract, $alias) = $this->extractAlias($abstract);
-
-            $this->alias($abstract, $alias);
-        }
-
-        // If no concrete type was given, we will simply set the concrete type to the
-        // abstract type. After that, the concrete type to be registered as shared
-        // without being forced to state their classes in both of the parameters.
-        $this->dropStaleInstances($abstract);
-
-        if (is_null($concrete)) {
-            $concrete = $abstract;
-        }
-
-        // If the factory is not a Closure, it means it is just a class name which is
-        // bound into this container to the abstract type and we will just wrap it
-        // up inside its own Closure to give us more convenience when extending.
-        if (! $concrete instanceof Closure) {
-            $concrete = $this->getClosure($abstract, $concrete);
-        }
-
-        $this->bindings[$abstract] = compact('concrete', 'shared');
-
-        // If the abstract type was already resolved in this container we'll fire the
-        // rebound listener so that any objects which have already gotten resolved
-        // can have their copy of the object updated via the listener callbacks.
-        if ($this->resolved($abstract)) {
-            $this->rebound($abstract);
-        }
-    }
-
-    /**
-     * Get the Closure to be used when building a type.
-     *
-     * @param  string  $abstract
-     * @param  string  $concrete
-     * @return \Closure
-     */
-    protected function getClosure($abstract, $concrete)
-    {
-        return function ($c, $parameters = []) use ($abstract, $concrete) {
-            $method = ($abstract == $concrete) ? 'build' : 'make';
-
-            return $c->$method($concrete, $parameters);
-        };
-    }
-
-    /**
-     * Add a contextual binding to the container.
-     *
-     * @param  string  $concrete
-     * @param  string  $abstract
-     * @param  \Closure|string  $implementation
-     * @return void
-     */
-    public function addContextualBinding($concrete, $abstract, $implementation)
-    {
-        $this->contextual[$this->normalize($concrete)][$this->normalize($abstract)] = $this->normalize($implementation);
-    }
-
-    /**
-     * Register a binding if it hasn't already been registered.
-     *
-     * @param  string  $abstract
-     * @param  \Closure|string|null  $concrete
-     * @param  bool  $shared
-     * @return void
-     */
-    public function bindIf($abstract, $concrete = null, $shared = false)
-    {
-        if (! $this->bound($abstract)) {
-            $this->bind($abstract, $concrete, $shared);
-        }
-    }
-
-    /**
-     * Register a shared binding in the container.
-     *
-     * @param  string|array  $abstract
-     * @param  \Closure|string|null  $concrete
-     * @return void
-     */
-    public function singleton($abstract, $concrete = null)
-    {
-        $this->bind($abstract, $concrete, true);
-    }
-
-    /**
-     * Wrap a Closure such that it is shared.
-     *
-     * @param  \Closure  $closure
-     * @return \Closure
-     */
-    public function share(Closure $closure)
-    {
-        return function ($container) use ($closure) {
-            // We'll simply declare a static variable within the Closures and if it has
-            // not been set we will execute the given Closures to resolve this value
-            // and return it back to these consumers of the method as an instance.
-            static $object;
-
-            if (is_null($object)) {
-                $object = $closure($container);
-            }
-
-            return $object;
-        };
-    }
-
-    /**
-     * "Extend" an abstract type in the container.
-     *
-     * @param  string    $abstract
-     * @param  \Closure  $closure
-     * @return void
-     *
-     * @throws \InvalidArgumentException
-     */
-    public function extend($abstract, Closure $closure)
-    {
-        $abstract = $this->normalize($abstract);
-
-        if (isset($this->instances[$abstract])) {
-            $this->instances[$abstract] = $closure($this->instances[$abstract], $this);
-
-            $this->rebound($abstract);
-        } else {
-            $this->extenders[$abstract][] = $closure;
-        }
-    }
-
-    /**
-     * Register an existing instance as shared in the container.
-     *
-     * @param  string  $abstract
-     * @param  mixed   $instance
-     * @return void
-     */
-    public function instance($abstract, $instance)
-    {
-        $abstract = $this->normalize($abstract);
-
-        // First, we will extract the alias from the abstract if it is an array so we
-        // are using the correct name when binding the type. If we get an alias it
-        // will be registered with the container so we can resolve it out later.
-        if (is_array($abstract)) {
-            list($abstract, $alias) = $this->extractAlias($abstract);
-
-            $this->alias($abstract, $alias);
-        }
-
-        unset($this->aliases[$abstract]);
-
-        // We'll check to determine if this type has been bound before, and if it has
-        // we will fire the rebound callbacks registered with the container and it
-        // can be updated with consuming classes that have gotten resolved here.
-        $bound = $this->bound($abstract);
-
-        $this->instances[$abstract] = $instance;
-
-        if ($bound) {
-            $this->rebound($abstract);
-        }
-    }
-
-    /**
-     * Assign a set of tags to a given binding.
-     *
-     * @param  array|string  $abstracts
-     * @param  array|mixed   ...$tags
-     * @return void
-     */
-    public function tag($abstracts, $tags)
-    {
-        $tags = is_array($tags) ? $tags : array_slice(func_get_args(), 1);
-
-        foreach ($tags as $tag) {
-            if (! isset($this->tags[$tag])) {
-                $this->tags[$tag] = [];
-            }
-
-            foreach ((array) $abstracts as $abstract) {
-                $this->tags[$tag][] = $this->normalize($abstract);
-            }
-        }
-    }
-
-    /**
-     * Resolve all of the bindings for a given tag.
-     *
-     * @param  string  $tag
-     * @return array
-     */
-    public function tagged($tag)
-    {
-        $results = [];
-
-        if (isset($this->tags[$tag])) {
-            foreach ($this->tags[$tag] as $abstract) {
-                $results[] = $this->make($abstract);
-            }
-        }
-
-        return $results;
-    }
-
-    /**
-     * Alias a type to a different name.
-     *
-     * @param  string  $abstract
-     * @param  string  $alias
-     * @return void
-     */
-    public function alias($abstract, $alias)
-    {
-        $this->aliases[$alias] = $this->normalize($abstract);
-    }
-
-    /**
-     * Extract the type and alias from a given definition.
-     *
-     * @param  array  $definition
-     * @return array
-     */
-    protected function extractAlias(array $definition)
-    {
-        return [key($definition), current($definition)];
-    }
-
-    /**
-     * Bind a new callback to an abstract's rebind event.
-     *
-     * @param  string    $abstract
-     * @param  \Closure  $callback
-     * @return mixed
-     */
-    public function rebinding($abstract, Closure $callback)
-    {
-        $this->reboundCallbacks[$this->normalize($abstract)][] = $callback;
-
-        if ($this->bound($abstract)) {
-            return $this->make($abstract);
-        }
-    }
-
-    /**
-     * Refresh an instance on the given target and method.
-     *
-     * @param  string  $abstract
-     * @param  mixed   $target
-     * @param  string  $method
-     * @return mixed
-     */
-    public function refresh($abstract, $target, $method)
-    {
-        return $this->rebinding($this->normalize($abstract), function ($app, $instance) use ($target, $method) {
-            $target->{$method}($instance);
-        });
-    }
-
-    /**
-     * Fire the "rebound" callbacks for the given abstract type.
-     *
-     * @param  string  $abstract
-     * @return void
-     */
-    protected function rebound($abstract)
-    {
-        $instance = $this->make($abstract);
-
-        foreach ($this->getReboundCallbacks($abstract) as $callback) {
-            call_user_func($callback, $this, $instance);
-        }
-    }
-
-    /**
-     * Get the rebound callbacks for a given type.
-     *
-     * @param  string  $abstract
-     * @return array
-     */
-    protected function getReboundCallbacks($abstract)
-    {
-        if (isset($this->reboundCallbacks[$abstract])) {
-            return $this->reboundCallbacks[$abstract];
-        }
-
-        return [];
-    }
-
-    /**
-     * Wrap the given closure such that its dependencies will be injected when executed.
-     *
-     * @param  \Closure  $callback
-     * @param  array  $parameters
-     * @return \Closure
-     */
-    public function wrap(Closure $callback, array $parameters = [])
-    {
-        return function () use ($callback, $parameters) {
-            return $this->call($callback, $parameters);
-        };
-    }
-
-    /**
-     * Call the given Closure / class@method and inject its dependencies.
-     *
-     * @param  callable|string  $callback
-     * @param  array  $parameters
-     * @param  string|null  $defaultMethod
-     * @return mixed
-     */
-    public function call($callback, array $parameters = [], $defaultMethod = null)
-    {
-        if ($this->isCallableWithAtSign($callback) || $defaultMethod) {
-            return $this->callClass($callback, $parameters, $defaultMethod);
-        }
-
-        $dependencies = $this->getMethodDependencies($callback, $parameters);
-
-        return call_user_func_array($callback, $dependencies);
-    }
-
-    /**
-     * Determine if the given string is in Class@method syntax.
-     *
-     * @param  mixed  $callback
-     * @return bool
-     */
-    protected function isCallableWithAtSign($callback)
-    {
-        return is_string($callback) && strpos($callback, '@') !== false;
-    }
-
-    /**
-     * Get all dependencies for a given method.
-     *
-     * @param  callable|string  $callback
-     * @param  array  $parameters
-     * @return array
-     */
-    protected function getMethodDependencies($callback, array $parameters = [])
-    {
-        $dependencies = [];
-
-        foreach ($this->getCallReflector($callback)->getParameters() as $parameter) {
-            $this->addDependencyForCallParameter($parameter, $parameters, $dependencies);
-        }
-
-        return array_merge($dependencies, $parameters);
-    }
-
-    /**
-     * Get the proper reflection instance for the given callback.
-     *
-     * @param  callable|string  $callback
-     * @return \ReflectionFunctionAbstract
-     */
-    protected function getCallReflector($callback)
-    {
-        if (is_string($callback) && strpos($callback, '::') !== false) {
-            $callback = explode('::', $callback);
-        }
-
-        if (is_array($callback)) {
-            return new ReflectionMethod($callback[0], $callback[1]);
-        }
-
-        return new ReflectionFunction($callback);
-    }
-
-    /**
-     * Get the dependency for the given call parameter.
-     *
-     * @param  \ReflectionParameter  $parameter
-     * @param  array  $parameters
-     * @param  array  $dependencies
-     * @return mixed
-     */
-    protected function addDependencyForCallParameter(ReflectionParameter $parameter, array &$parameters, &$dependencies)
-    {
-        if (array_key_exists($parameter->name, $parameters)) {
-            $dependencies[] = $parameters[$parameter->name];
-
-            unset($parameters[$parameter->name]);
-        } elseif ($parameter->getClass()) {
-            $dependencies[] = $this->make($parameter->getClass()->name);
-        } elseif ($parameter->isDefaultValueAvailable()) {
-            $dependencies[] = $parameter->getDefaultValue();
-        }
-    }
-
-    /**
-     * Call a string reference to a class using Class@method syntax.
-     *
-     * @param  string  $target
-     * @param  array  $parameters
-     * @param  string|null  $defaultMethod
-     * @return mixed
-     *
-     * @throws \InvalidArgumentException
-     */
-    protected function callClass($target, array $parameters = [], $defaultMethod = null)
-    {
-        $segments = explode('@', $target);
-
-        // If the listener has an @ sign, we will assume it is being used to delimit
-        // the class name from the handle method name. This allows for handlers
-        // to run multiple handler methods in a single class for convenience.
-        $method = count($segments) == 2 ? $segments[1] : $defaultMethod;
-
-        if (is_null($method)) {
-            throw new InvalidArgumentException('Method not provided.');
-        }
-
-        return $this->call([$this->make($segments[0]), $method], $parameters);
-    }
-
-    /**
-     * Resolve the given type from the container.
-     *
-     * @param  string  $abstract
-     * @param  array   $parameters
-     * @return mixed
-     */
-    public function make($abstract, array $parameters = [])
-    {
-        $abstract = $this->getAlias($this->normalize($abstract));
-
-        // If an instance of the type is currently being managed as a singleton we'll
-        // just return an existing instance instead of instantiating new instances
-        // so the developer can keep using the same objects instance every time.
-        if (isset($this->instances[$abstract])) {
-            return $this->instances[$abstract];
-        }
-
-        $concrete = $this->getConcrete($abstract);
-
-        // We're ready to instantiate an instance of the concrete type registered for
-        // the binding. This will instantiate the types, as well as resolve any of
-        // its "nested" dependencies recursively until all have gotten resolved.
-        if ($this->isBuildable($concrete, $abstract)) {
-            $object = $this->build($concrete, $parameters);
-        } else {
-            $object = $this->make($concrete, $parameters);
-        }
-
-        // If we defined any extenders for this type, we'll need to spin through them
-        // and apply them to the object being built. This allows for the extension
-        // of services, such as changing configuration or decorating the object.
-        foreach ($this->getExtenders($abstract) as $extender) {
-            $object = $extender($object, $this);
-        }
-
-        // If the requested type is registered as a singleton we'll want to cache off
-        // the instances in "memory" so we can return it later without creating an
-        // entirely new instance of an object on each subsequent request for it.
-        if ($this->isShared($abstract)) {
-            $this->instances[$abstract] = $object;
-        }
-
-        $this->fireResolvingCallbacks($abstract, $object);
-
-        $this->resolved[$abstract] = true;
-
-        return $object;
-    }
-
-    /**
-     * Get the concrete type for a given abstract.
-     *
-     * @param  string  $abstract
-     * @return mixed   $concrete
-     */
-    protected function getConcrete($abstract)
-    {
-        if (! is_null($concrete = $this->getContextualConcrete($abstract))) {
-            return $concrete;
-        }
-
-        // If we don't have a registered resolver or concrete for the type, we'll just
-        // assume each type is a concrete name and will attempt to resolve it as is
-        // since the container should be able to resolve concretes automatically.
-        if (! isset($this->bindings[$abstract])) {
-            return $abstract;
-        }
-
-        return $this->bindings[$abstract]['concrete'];
-    }
-
-    /**
-     * Get the contextual concrete binding for the given abstract.
-     *
-     * @param  string  $abstract
-     * @return string|null
-     */
-    protected function getContextualConcrete($abstract)
-    {
-        if (isset($this->contextual[end($this->buildStack)][$abstract])) {
-            return $this->contextual[end($this->buildStack)][$abstract];
-        }
-    }
-
-    /**
-     * Normalize the given class name by removing leading slashes.
-     *
-     * @param  mixed  $service
-     * @return mixed
-     */
-    protected function normalize($service)
-    {
-        return is_string($service) ? ltrim($service, '\\') : $service;
-    }
-
-    /**
-     * Get the extender callbacks for a given type.
-     *
-     * @param  string  $abstract
-     * @return array
-     */
-    protected function getExtenders($abstract)
-    {
-        if (isset($this->extenders[$abstract])) {
-            return $this->extenders[$abstract];
-        }
-
-        return [];
-    }
-
-    /**
-     * Instantiate a concrete instance of the given type.
-     *
-     * @param  string  $concrete
-     * @param  array   $parameters
-     * @return mixed
-     *
-     * @throws \Illuminate\Contracts\Container\BindingResolutionException
-     */
-    public function build($concrete, array $parameters = [])
-    {
-        // If the concrete type is actually a Closure, we will just execute it and
-        // hand back the results of the functions, which allows functions to be
-        // used as resolvers for more fine-tuned resolution of these objects.
-        if ($concrete instanceof Closure) {
-            return $concrete($this, $parameters);
-        }
-
-        $reflector = new ReflectionClass($concrete);
-
-        // If the type is not instantiable, the developer is attempting to resolve
-        // an abstract type such as an Interface of Abstract Class and there is
-        // no binding registered for the abstractions so we need to bail out.
-        if (! $reflector->isInstantiable()) {
-            if (! empty($this->buildStack)) {
-                $previous = implode(', ', $this->buildStack);
-
-                $message = "Target [$concrete] is not instantiable while building [$previous].";
-            } else {
-                $message = "Target [$concrete] is not instantiable.";
-            }
-
-            throw new BindingResolutionException($message);
-        }
-
-        $this->buildStack[] = $concrete;
-
-        $constructor = $reflector->getConstructor();
-
-        // If there are no constructors, that means there are no dependencies then
-        // we can just resolve the instances of the objects right away, without
-        // resolving any other types or dependencies out of these containers.
-        if (is_null($constructor)) {
-            array_pop($this->buildStack);
-
-            return new $concrete;
-        }
-
-        $dependencies = $constructor->getParameters();
-
-        // Once we have all the constructor's parameters we can create each of the
-        // dependency instances and then use the reflection instances to make a
-        // new instance of this class, injecting the created dependencies in.
-        $parameters = $this->keyParametersByArgument(
-            $dependencies, $parameters
-        );
-
-        $instances = $this->getDependencies(
-            $dependencies, $parameters
-        );
-
-        array_pop($this->buildStack);
-
-        return $reflector->newInstanceArgs($instances);
-    }
-
-    /**
-     * Resolve all of the dependencies from the ReflectionParameters.
-     *
-     * @param  array  $parameters
-     * @param  array  $primitives
-     * @return array
-     */
-    protected function getDependencies(array $parameters, array $primitives = [])
-    {
-        $dependencies = [];
-
-        foreach ($parameters as $parameter) {
-            $dependency = $parameter->getClass();
-
-            // If the class is null, it means the dependency is a string or some other
-            // primitive type which we can not resolve since it is not a class and
-            // we will just bomb out with an error since we have no-where to go.
-            if (array_key_exists($parameter->name, $primitives)) {
-                $dependencies[] = $primitives[$parameter->name];
-            } elseif (is_null($dependency)) {
-                $dependencies[] = $this->resolveNonClass($parameter);
-            } else {
-                $dependencies[] = $this->resolveClass($parameter);
-            }
-        }
-
-        return $dependencies;
-    }
-
-    /**
-     * Resolve a non-class hinted dependency.
-     *
-     * @param  \ReflectionParameter  $parameter
-     * @return mixed
-     *
-     * @throws \Illuminate\Contracts\Container\BindingResolutionException
-     */
-    protected function resolveNonClass(ReflectionParameter $parameter)
-    {
-        if (! is_null($concrete = $this->getContextualConcrete('$'.$parameter->name))) {
-            if ($concrete instanceof Closure) {
-                return call_user_func($concrete, $this);
-            } else {
-                return $concrete;
-            }
-        }
-
-        if ($parameter->isDefaultValueAvailable()) {
-            return $parameter->getDefaultValue();
-        }
-
-        $message = "Unresolvable dependency resolving [$parameter] in class {$parameter->getDeclaringClass()->getName()}";
-
-        throw new BindingResolutionException($message);
-    }
-
-    /**
-     * Resolve a class based dependency from the container.
-     *
-     * @param  \ReflectionParameter  $parameter
-     * @return mixed
-     *
-     * @throws \Illuminate\Contracts\Container\BindingResolutionException
-     */
-    protected function resolveClass(ReflectionParameter $parameter)
-    {
-        try {
-            return $this->make($parameter->getClass()->name);
-        }
-
-        // If we can not resolve the class instance, we will check to see if the value
-        // is optional, and if it is we will return the optional parameter value as
-        // the value of the dependency, similarly to how we do this with scalars.
-        catch (BindingResolutionException $e) {
-            if ($parameter->isOptional()) {
-                return $parameter->getDefaultValue();
-            }
-
-            throw $e;
-        }
-    }
-
-    /**
-     * If extra parameters are passed by numeric ID, rekey them by argument name.
-     *
-     * @param  array  $dependencies
-     * @param  array  $parameters
-     * @return array
-     */
-    protected function keyParametersByArgument(array $dependencies, array $parameters)
-    {
-        foreach ($parameters as $key => $value) {
-            if (is_numeric($key)) {
-                unset($parameters[$key]);
-
-                $parameters[$dependencies[$key]->name] = $value;
-            }
-        }
-
-        return $parameters;
-    }
-
-    /**
-     * Register a new resolving callback.
-     *
-     * @param  string    $abstract
-     * @param  \Closure|null  $callback
-     * @return void
-     */
-    public function resolving($abstract, Closure $callback = null)
-    {
-        if ($callback === null && $abstract instanceof Closure) {
-            $this->resolvingCallback($abstract);
-        } else {
-            $this->resolvingCallbacks[$this->normalize($abstract)][] = $callback;
-        }
-    }
-
-    /**
-     * Register a new after resolving callback for all types.
-     *
-     * @param  string   $abstract
-     * @param  \Closure|null $callback
-     * @return void
-     */
-    public function afterResolving($abstract, Closure $callback = null)
-    {
-        if ($abstract instanceof Closure && $callback === null) {
-            $this->afterResolvingCallback($abstract);
-        } else {
-            $this->afterResolvingCallbacks[$this->normalize($abstract)][] = $callback;
-        }
-    }
-
-    /**
-     * Register a new resolving callback by type of its first argument.
-     *
-     * @param  \Closure  $callback
-     * @return void
-     */
-    protected function resolvingCallback(Closure $callback)
-    {
-        $abstract = $this->getFunctionHint($callback);
-
-        if ($abstract) {
-            $this->resolvingCallbacks[$abstract][] = $callback;
-        } else {
-            $this->globalResolvingCallbacks[] = $callback;
-        }
-    }
-
-    /**
-     * Register a new after resolving callback by type of its first argument.
-     *
-     * @param  \Closure  $callback
-     * @return void
-     */
-    protected function afterResolvingCallback(Closure $callback)
-    {
-        $abstract = $this->getFunctionHint($callback);
-
-        if ($abstract) {
-            $this->afterResolvingCallbacks[$abstract][] = $callback;
-        } else {
-            $this->globalAfterResolvingCallbacks[] = $callback;
-        }
-    }
-
-    /**
-     * Get the type hint for this closure's first argument.
-     *
-     * @param  \Closure  $callback
-     * @return mixed
-     */
-    protected function getFunctionHint(Closure $callback)
-    {
-        $function = new ReflectionFunction($callback);
-
-        if ($function->getNumberOfParameters() == 0) {
-            return;
-        }
-
-        $expected = $function->getParameters()[0];
-
-        if (! $expected->getClass()) {
-            return;
-        }
-
-        return $expected->getClass()->name;
-    }
-
-    /**
-     * Fire all of the resolving callbacks.
-     *
-     * @param  string  $abstract
-     * @param  mixed   $object
-     * @return void
-     */
-    protected function fireResolvingCallbacks($abstract, $object)
-    {
-        $this->fireCallbackArray($object, $this->globalResolvingCallbacks);
-
-        $this->fireCallbackArray(
-            $object, $this->getCallbacksForType(
-                $abstract, $object, $this->resolvingCallbacks
-            )
-        );
-
-        $this->fireCallbackArray($object, $this->globalAfterResolvingCallbacks);
-
-        $this->fireCallbackArray(
-            $object, $this->getCallbacksForType(
-                $abstract, $object, $this->afterResolvingCallbacks
-            )
-        );
-    }
-
-    /**
-     * Get all callbacks for a given type.
-     *
-     * @param  string  $abstract
-     * @param  object  $object
-     * @param  array   $callbacksPerType
-     *
-     * @return array
-     */
-    protected function getCallbacksForType($abstract, $object, array $callbacksPerType)
-    {
-        $results = [];
-
-        foreach ($callbacksPerType as $type => $callbacks) {
-            if ($type === $abstract || $object instanceof $type) {
-                $results = array_merge($results, $callbacks);
-            }
-        }
-
-        return $results;
-    }
-
-    /**
-     * Fire an array of callbacks with an object.
-     *
-     * @param  mixed  $object
-     * @param  array  $callbacks
-     * @return void
-     */
-    protected function fireCallbackArray($object, array $callbacks)
-    {
-        foreach ($callbacks as $callback) {
-            $callback($object, $this);
-        }
-    }
-
-    /**
-     * Determine if a given type is shared.
-     *
-     * @param  string  $abstract
-     * @return bool
-     */
-    public function isShared($abstract)
-    {
-        $abstract = $this->normalize($abstract);
-
-        if (isset($this->instances[$abstract])) {
-            return true;
-        }
-
-        if (! isset($this->bindings[$abstract]['shared'])) {
-            return false;
-        }
-
-        return $this->bindings[$abstract]['shared'] === true;
-    }
-
-    /**
-     * Determine if the given concrete is buildable.
-     *
-     * @param  mixed   $concrete
-     * @param  string  $abstract
-     * @return bool
-     */
-    protected function isBuildable($concrete, $abstract)
-    {
-        return $concrete === $abstract || $concrete instanceof Closure;
-    }
-
-    /**
-     * Get the alias for an abstract if available.
-     *
-     * @param  string  $abstract
-     * @return string
-     */
-    protected function getAlias($abstract)
-    {
-        if (! isset($this->aliases[$abstract])) {
-            return $abstract;
-        }
-
-        return $this->getAlias($this->aliases[$abstract]);
-    }
-
-    /**
-     * Get the container's bindings.
-     *
-     * @return array
-     */
-    public function getBindings()
-    {
-        return $this->bindings;
-    }
-
-    /**
-     * Drop all of the stale instances and aliases.
-     *
-     * @param  string  $abstract
-     * @return void
-     */
-    protected function dropStaleInstances($abstract)
-    {
-        unset($this->instances[$abstract], $this->aliases[$abstract]);
-    }
-
-    /**
-     * Remove a resolved instance from the instance cache.
-     *
-     * @param  string  $abstract
-     * @return void
-     */
-    public function forgetInstance($abstract)
-    {
-        unset($this->instances[$this->normalize($abstract)]);
-    }
-
-    /**
-     * Clear all of the instances from the container.
-     *
-     * @return void
-     */
-    public function forgetInstances()
-    {
-        $this->instances = [];
-    }
-
-    /**
-     * Flush the container of all bindings and resolved instances.
-     *
-     * @return void
-     */
-    public function flush()
-    {
-        $this->aliases = [];
-        $this->resolved = [];
-        $this->bindings = [];
-        $this->instances = [];
-    }
-
-    /**
-     * Set the globally available instance of the container.
-     *
-     * @return static
-     */
-    public static function getInstance()
-    {
-        return static::$instance;
-    }
-
-    /**
-     * Set the shared instance of the container.
-     *
-     * @param  \Illuminate\Contracts\Container\Container  $container
-     * @return void
-     */
-    public static function setInstance(ContainerContract $container)
-    {
-        static::$instance = $container;
-    }
-
-    /**
-     * Determine if a given offset exists.
-     *
-     * @param  string  $key
-     * @return bool
-     */
-    public function offsetExists($key)
-    {
-        return $this->bound($key);
-    }
-
-    /**
-     * Get the value at a given offset.
-     *
-     * @param  string  $key
-     * @return mixed
-     */
-    public function offsetGet($key)
-    {
-        return $this->make($key);
-    }
-
-    /**
-     * Set the value at a given offset.
-     *
-     * @param  string  $key
-     * @param  mixed   $value
-     * @return void
-     */
-    public function offsetSet($key, $value)
-    {
-        // If the value is not a Closure, we will make it one. This simply gives
-        // more "drop-in" replacement functionality for the Pimple which this
-        // container's simplest functions are base modeled and built after.
-        if (! $value instanceof Closure) {
-            $value = function () use ($value) {
-                return $value;
-            };
-        }
-
-        $this->bind($key, $value);
-    }
-
-    /**
-     * Unset the value at a given offset.
-     *
-     * @param  string  $key
-     * @return void
-     */
-    public function offsetUnset($key)
-    {
-        $key = $this->normalize($key);
-
-        unset($this->bindings[$key], $this->instances[$key], $this->resolved[$key]);
-    }
-
-    /**
-     * Dynamically access container services.
-     *
-     * @param  string  $key
-     * @return mixed
-     */
-    public function __get($key)
-    {
-        return $this[$key];
-    }
-
-    /**
-     * Dynamically set container services.
-     *
-     * @param  string  $key
-     * @param  mixed   $value
-     * @return void
-     */
-    public function __set($key, $value)
-    {
-        $this[$key] = $value;
-    }
+use InvalidArgumentException;
+use ReflectionClass;
+use ReflectionFunction;
+use ReflectionMethod;
+use ReflectionParameter;
+
+class Container implements ArrayAccess, ContainerContract {
+	/**
+	 * The current globally available container (if any).
+	 *
+	 * @var static
+	 */
+	protected static $instance;
+
+	/**
+	 * An array of the types that have been resolved.
+	 *
+	 * @var array
+	 */
+	protected $resolved = [ ];
+
+	/**
+	 * The container's bindings.
+	 *
+	 * @var array
+	 */
+	protected $bindings = [ ];
+
+	/**
+	 * The container's shared instances.
+	 *
+	 * @var array
+	 */
+	protected $instances = [ ];
+
+	/**
+	 * The registered type aliases.
+	 *
+	 * @var array
+	 */
+	protected $aliases = [ ];
+
+	/**
+	 * The extension closures for services.
+	 *
+	 * @var array
+	 */
+	protected $extenders = [ ];
+
+	/**
+	 * All of the registered tags.
+	 *
+	 * @var array
+	 */
+	protected $tags = [ ];
+
+	/**
+	 * The stack of concretions currently being built.
+	 *
+	 * @var array
+	 */
+	protected $buildStack = [ ];
+
+	/**
+	 * The contextual binding map.
+	 *
+	 * @var array
+	 */
+	public $contextual = [ ];
+
+	/**
+	 * All of the registered rebound callbacks.
+	 *
+	 * @var array
+	 */
+	protected $reboundCallbacks = [ ];
+
+	/**
+	 * All of the global resolving callbacks.
+	 *
+	 * @var array
+	 */
+	protected $globalResolvingCallbacks = [ ];
+
+	/**
+	 * All of the global after resolving callbacks.
+	 *
+	 * @var array
+	 */
+	protected $globalAfterResolvingCallbacks = [ ];
+
+	/**
+	 * All of the resolving callbacks by class type.
+	 *
+	 * @var array
+	 */
+	protected $resolvingCallbacks = [ ];
+
+	/**
+	 * All of the after resolving callbacks by class type.
+	 *
+	 * @var array
+	 */
+	protected $afterResolvingCallbacks = [ ];
+
+	/**
+	 * Define a contextual binding.
+	 *
+	 * @param  string $concrete
+	 *
+	 * @return \Illuminate\Contracts\Container\ContextualBindingBuilder
+	 */
+	public function when( $concrete ) {
+		$concrete = $this->normalize( $concrete );
+
+		return new ContextualBindingBuilder( $this, $concrete );
+	}
+
+	/**
+	 * Determine if the given abstract type has been bound.
+	 *
+	 * @param  string $abstract
+	 *
+	 * @return bool
+	 */
+	public function bound( $abstract ) {
+		$abstract = $this->normalize( $abstract );
+
+		return isset( $this->bindings[ $abstract ] ) || isset( $this->instances[ $abstract ] ) || $this->isAlias( $abstract );
+	}
+
+	/**
+	 * Determine if the given abstract type has been resolved.
+	 *
+	 * @param  string $abstract
+	 *
+	 * @return bool
+	 */
+	public function resolved( $abstract ) {
+		$abstract = $this->normalize( $abstract );
+
+		if ( $this->isAlias( $abstract ) ) {
+			$abstract = $this->getAlias( $abstract );
+		}
+
+		return isset( $this->resolved[ $abstract ] ) || isset( $this->instances[ $abstract ] );
+	}
+
+	/**
+	 * Determine if a given string is an alias.
+	 *
+	 * @param  string $name
+	 *
+	 * @return bool
+	 */
+	public function isAlias( $name ) {
+		return isset( $this->aliases[ $this->normalize( $name ) ] );
+	}
+
+	/**
+	 * Register a binding with the container.
+	 *
+	 * @param  string|array         $abstract
+	 * @param  \Closure|string|null $concrete
+	 * @param  bool                 $shared
+	 *
+	 * @return void
+	 */
+	public function bind( $abstract, $concrete = null, $shared = false ) {
+		$abstract = $this->normalize( $abstract );
+
+		$concrete = $this->normalize( $concrete );
+
+		// If the given types are actually an array, we will assume an alias is being
+		// defined and will grab this "real" abstract class name and register this
+		// alias with the container so that it can be used as a shortcut for it.
+		if ( is_array( $abstract ) ) {
+			list( $abstract, $alias ) = $this->extractAlias( $abstract );
+
+			$this->alias( $abstract, $alias );
+		}
+
+		// If no concrete type was given, we will simply set the concrete type to the
+		// abstract type. After that, the concrete type to be registered as shared
+		// without being forced to state their classes in both of the parameters.
+		$this->dropStaleInstances( $abstract );
+
+		if ( is_null( $concrete ) ) {
+			$concrete = $abstract;
+		}
+
+		// If the factory is not a Closure, it means it is just a class name which is
+		// bound into this container to the abstract type and we will just wrap it
+		// up inside its own Closure to give us more convenience when extending.
+		if ( ! $concrete instanceof Closure ) {
+			$concrete = $this->getClosure( $abstract, $concrete );
+		}
+
+		$this->bindings[ $abstract ] = compact( 'concrete', 'shared' );
+
+		// If the abstract type was already resolved in this container we'll fire the
+		// rebound listener so that any objects which have already gotten resolved
+		// can have their copy of the object updated via the listener callbacks.
+		if ( $this->resolved( $abstract ) ) {
+			$this->rebound( $abstract );
+		}
+	}
+
+	/**
+	 * Get the Closure to be used when building a type.
+	 *
+	 * @param  string $abstract
+	 * @param  string $concrete
+	 *
+	 * @return \Closure
+	 */
+	protected function getClosure( $abstract, $concrete ) {
+		return function ( $c, $parameters = [ ] ) use ( $abstract, $concrete ) {
+			$method = ( $abstract == $concrete ) ? 'build' : 'make';
+
+			return $c->$method( $concrete, $parameters );
+		};
+	}
+
+	/**
+	 * Add a contextual binding to the container.
+	 *
+	 * @param  string          $concrete
+	 * @param  string          $abstract
+	 * @param  \Closure|string $implementation
+	 *
+	 * @return void
+	 */
+	public function addContextualBinding( $concrete, $abstract, $implementation ) {
+		$this->contextual[ $this->normalize( $concrete ) ][ $this->normalize( $abstract ) ] = $this->normalize( $implementation );
+	}
+
+	/**
+	 * Register a binding if it hasn't already been registered.
+	 *
+	 * @param  string               $abstract
+	 * @param  \Closure|string|null $concrete
+	 * @param  bool                 $shared
+	 *
+	 * @return void
+	 */
+	public function bindIf( $abstract, $concrete = null, $shared = false ) {
+		if ( ! $this->bound( $abstract ) ) {
+			$this->bind( $abstract, $concrete, $shared );
+		}
+	}
+
+	/**
+	 * Register a shared binding in the container.
+	 *
+	 * @param  string|array         $abstract
+	 * @param  \Closure|string|null $concrete
+	 *
+	 * @return void
+	 */
+	public function singleton( $abstract, $concrete = null ) {
+		$this->bind( $abstract, $concrete, true );
+	}
+
+	/**
+	 * Wrap a Closure such that it is shared.
+	 *
+	 * @param  \Closure $closure
+	 *
+	 * @return \Closure
+	 */
+	public function share( Closure $closure ) {
+		return function ( $container ) use ( $closure ) {
+			// We'll simply declare a static variable within the Closures and if it has
+			// not been set we will execute the given Closures to resolve this value
+			// and return it back to these consumers of the method as an instance.
+			static $object;
+
+			if ( is_null( $object ) ) {
+				$object = $closure( $container );
+			}
+
+			return $object;
+		};
+	}
+
+	/**
+	 * "Extend" an abstract type in the container.
+	 *
+	 * @param  string   $abstract
+	 * @param  \Closure $closure
+	 *
+	 * @return void
+	 *
+	 * @throws \InvalidArgumentException
+	 */
+	public function extend( $abstract, Closure $closure ) {
+		$abstract = $this->normalize( $abstract );
+
+		if ( isset( $this->instances[ $abstract ] ) ) {
+			$this->instances[ $abstract ] = $closure( $this->instances[ $abstract ], $this );
+
+			$this->rebound( $abstract );
+		} else {
+			$this->extenders[ $abstract ][] = $closure;
+		}
+	}
+
+	/**
+	 * Register an existing instance as shared in the container.
+	 *
+	 * @param  string $abstract
+	 * @param  mixed  $instance
+	 *
+	 * @return void
+	 */
+	public function instance( $abstract, $instance ) {
+		$abstract = $this->normalize( $abstract );
+
+		// First, we will extract the alias from the abstract if it is an array so we
+		// are using the correct name when binding the type. If we get an alias it
+		// will be registered with the container so we can resolve it out later.
+		if ( is_array( $abstract ) ) {
+			list( $abstract, $alias ) = $this->extractAlias( $abstract );
+
+			$this->alias( $abstract, $alias );
+		}
+
+		unset( $this->aliases[ $abstract ] );
+
+		// We'll check to determine if this type has been bound before, and if it has
+		// we will fire the rebound callbacks registered with the container and it
+		// can be updated with consuming classes that have gotten resolved here.
+		$bound = $this->bound( $abstract );
+
+		$this->instances[ $abstract ] = $instance;
+
+		if ( $bound ) {
+			$this->rebound( $abstract );
+		}
+	}
+
+	/**
+	 * Assign a set of tags to a given binding.
+	 *
+	 * @param  array|string $abstracts
+	 * @param  array|mixed  ...$tags
+	 *
+	 * @return void
+	 */
+	public function tag( $abstracts, $tags ) {
+		$tags = is_array( $tags ) ? $tags : array_slice( func_get_args(), 1 );
+
+		foreach ( $tags as $tag ) {
+			if ( ! isset( $this->tags[ $tag ] ) ) {
+				$this->tags[ $tag ] = [ ];
+			}
+
+			foreach ( (array) $abstracts as $abstract ) {
+				$this->tags[ $tag ][] = $this->normalize( $abstract );
+			}
+		}
+	}
+
+	/**
+	 * Resolve all of the bindings for a given tag.
+	 *
+	 * @param  string $tag
+	 *
+	 * @return array
+	 */
+	public function tagged( $tag ) {
+		$results = [ ];
+
+		if ( isset( $this->tags[ $tag ] ) ) {
+			foreach ( $this->tags[ $tag ] as $abstract ) {
+				$results[] = $this->make( $abstract );
+			}
+		}
+
+		return $results;
+	}
+
+	/**
+	 * Alias a type to a different name.
+	 *
+	 * @param  string $abstract
+	 * @param  string $alias
+	 *
+	 * @return void
+	 */
+	public function alias( $abstract, $alias ) {
+		$this->aliases[ $alias ] = $this->normalize( $abstract );
+	}
+
+	/**
+	 * Extract the type and alias from a given definition.
+	 *
+	 * @param  array $definition
+	 *
+	 * @return array
+	 */
+	protected function extractAlias( array $definition ) {
+		return [ key( $definition ), current( $definition ) ];
+	}
+
+	/**
+	 * Bind a new callback to an abstract's rebind event.
+	 *
+	 * @param  string   $abstract
+	 * @param  \Closure $callback
+	 *
+	 * @return mixed
+	 */
+	public function rebinding( $abstract, Closure $callback ) {
+		$this->reboundCallbacks[ $this->normalize( $abstract ) ][] = $callback;
+
+		if ( $this->bound( $abstract ) ) {
+			return $this->make( $abstract );
+		}
+	}
+
+	/**
+	 * Refresh an instance on the given target and method.
+	 *
+	 * @param  string $abstract
+	 * @param  mixed  $target
+	 * @param  string $method
+	 *
+	 * @return mixed
+	 */
+	public function refresh( $abstract, $target, $method ) {
+		return $this->rebinding( $this->normalize( $abstract ),
+			function ( $app, $instance ) use ( $target, $method ) {
+				$target->{$method}( $instance );
+			} );
+	}
+
+	/**
+	 * Fire the "rebound" callbacks for the given abstract type.
+	 *
+	 * @param  string $abstract
+	 *
+	 * @return void
+	 */
+	protected function rebound( $abstract ) {
+		$instance = $this->make( $abstract );
+
+		foreach ( $this->getReboundCallbacks( $abstract ) as $callback ) {
+			call_user_func( $callback, $this, $instance );
+		}
+	}
+
+	/**
+	 * Get the rebound callbacks for a given type.
+	 *
+	 * @param  string $abstract
+	 *
+	 * @return array
+	 */
+	protected function getReboundCallbacks( $abstract ) {
+		if ( isset( $this->reboundCallbacks[ $abstract ] ) ) {
+			return $this->reboundCallbacks[ $abstract ];
+		}
+
+		return [ ];
+	}
+
+	/**
+	 * Wrap the given closure such that its dependencies will be injected when executed.
+	 *
+	 * @param  \Closure $callback
+	 * @param  array    $parameters
+	 *
+	 * @return \Closure
+	 */
+	public function wrap( Closure $callback, array $parameters = [ ] ) {
+		return function () use ( $callback, $parameters ) {
+			return $this->call( $callback, $parameters );
+		};
+	}
+
+	/**
+	 * Call the given Closure / class@method and inject its dependencies.
+	 *
+	 * @param  callable|string $callback
+	 * @param  array           $parameters
+	 * @param  string|null     $defaultMethod
+	 *
+	 * @return mixed
+	 */
+	public function call( $callback, array $parameters = [ ], $defaultMethod = null ) {
+		if ( $this->isCallableWithAtSign( $callback ) || $defaultMethod ) {
+			return $this->callClass( $callback, $parameters, $defaultMethod );
+		}
+
+		$dependencies = $this->getMethodDependencies( $callback, $parameters );
+
+		return call_user_func_array( $callback, $dependencies );
+	}
+
+	/**
+	 * Determine if the given string is in Class@method syntax.
+	 *
+	 * @param  mixed $callback
+	 *
+	 * @return bool
+	 */
+	protected function isCallableWithAtSign( $callback ) {
+		return is_string( $callback ) && strpos( $callback, '@' ) !== false;
+	}
+
+	/**
+	 * Get all dependencies for a given method.
+	 *
+	 * @param  callable|string $callback
+	 * @param  array           $parameters
+	 *
+	 * @return array
+	 */
+	protected function getMethodDependencies( $callback, array $parameters = [ ] ) {
+		$dependencies = [ ];
+
+		$reflectionFunction = $this->getCallReflector( $callback );
+		$annotations        = $this->fetchInjectAnnotations( $reflectionFunction );
+		foreach ( $reflectionFunction->getParameters() as $parameter ) {
+			$this->addDependencyForCallParameter( $parameter, $parameters, $dependencies, $annotations );
+		}
+
+		return array_merge( $dependencies, $parameters );
+	}
+
+	/**
+	 * Get the proper reflection instance for the given callback.
+	 *
+	 * @param  callable|string $callback
+	 *
+	 * @return \ReflectionFunctionAbstract
+	 */
+	protected function getCallReflector( $callback ) {
+		if ( is_string( $callback ) && strpos( $callback, '::' ) !== false ) {
+			$callback = explode( '::', $callback );
+		}
+
+		if ( is_array( $callback ) ) {
+			return new ReflectionMethod( $callback[0], $callback[1] );
+		}
+
+		return new ReflectionFunction( $callback );
+	}
+
+	/**
+	 * Get the dependency for the given call parameter.
+	 *
+	 * @param  \ReflectionParameter $parameter
+	 * @param  array                $parameters
+	 * @param  array                $dependencies
+	 *
+	 * @param array                 $injectAnnotations
+	 *
+	 * @return mixed
+	 */
+	protected function addDependencyForCallParameter( ReflectionParameter $parameter, array &$parameters, &$dependencies, array $injectAnnotations = [ ] ) {
+		if ( array_key_exists( $parameter->name, $parameters ) ) {
+			$dependencies[] = $parameters[ $parameter->name ];
+
+			unset( $parameters[ $parameter->name ] );
+		} elseif ( array_key_exists( $parameter->name, $injectAnnotations ) ) {
+			$dependencies[] = $this->make( $injectAnnotations[ $parameter->name ] );
+		} elseif ( $parameter->getClass() ) {
+			$dependencies[] = $this->make( $parameter->getClass()->name );
+		} elseif ( $parameter->isDefaultValueAvailable() ) {
+			$dependencies[] = $parameter->getDefaultValue();
+		}
+	}
+
+	/**
+	 * Call a string reference to a class using Class@method syntax.
+	 *
+	 * @param  string      $target
+	 * @param  array       $parameters
+	 * @param  string|null $defaultMethod
+	 *
+	 * @return mixed
+	 *
+	 * @throws \InvalidArgumentException
+	 */
+	protected function callClass( $target, array $parameters = [ ], $defaultMethod = null ) {
+		$segments = explode( '@', $target );
+
+		// If the listener has an @ sign, we will assume it is being used to delimit
+		// the class name from the handle method name. This allows for handlers
+		// to run multiple handler methods in a single class for convenience.
+		$method = count( $segments ) == 2 ? $segments[1] : $defaultMethod;
+
+		if ( is_null( $method ) ) {
+			throw new InvalidArgumentException( 'Method not provided.' );
+		}
+
+		return $this->call( [ $this->make( $segments[0] ), $method ], $parameters );
+	}
+
+	/**
+	 * Resolve the given type from the container.
+	 *
+	 * @param  string $abstract
+	 * @param  array  $parameters
+	 *
+	 * @return mixed
+	 */
+	public function make( $abstract, array $parameters = [ ] ) {
+		$abstract = $this->getAlias( $this->normalize( $abstract ) );
+
+		// If an instance of the type is currently being managed as a singleton we'll
+		// just return an existing instance instead of instantiating new instances
+		// so the developer can keep using the same objects instance every time.
+		if ( isset( $this->instances[ $abstract ] ) ) {
+			return $this->instances[ $abstract ];
+		}
+
+		$concrete = $this->getConcrete( $abstract );
+
+		// We're ready to instantiate an instance of the concrete type registered for
+		// the binding. This will instantiate the types, as well as resolve any of
+		// its "nested" dependencies recursively until all have gotten resolved.
+		if ( $this->isBuildable( $concrete, $abstract ) ) {
+			$object = $this->build( $concrete, $parameters );
+		} else {
+			$object = $this->make( $concrete, $parameters );
+		}
+
+		// If we defined any extenders for this type, we'll need to spin through them
+		// and apply them to the object being built. This allows for the extension
+		// of services, such as changing configuration or decorating the object.
+		foreach ( $this->getExtenders( $abstract ) as $extender ) {
+			$object = $extender( $object, $this );
+		}
+
+		// If the requested type is registered as a singleton we'll want to cache off
+		// the instances in "memory" so we can return it later without creating an
+		// entirely new instance of an object on each subsequent request for it.
+		if ( $this->isShared( $abstract ) ) {
+			$this->instances[ $abstract ] = $object;
+		}
+
+		$this->fireResolvingCallbacks( $abstract, $object );
+
+		$this->resolved[ $abstract ] = true;
+
+		return $object;
+	}
+
+	/**
+	 * Get the concrete type for a given abstract.
+	 *
+	 * @param  string $abstract
+	 *
+	 * @return mixed   $concrete
+	 */
+	protected function getConcrete( $abstract ) {
+		if ( ! is_null( $concrete = $this->getContextualConcrete( $abstract ) ) ) {
+			return $concrete;
+		}
+
+		// If we don't have a registered resolver or concrete for the type, we'll just
+		// assume each type is a concrete name and will attempt to resolve it as is
+		// since the container should be able to resolve concretes automatically.
+		if ( ! isset( $this->bindings[ $abstract ] ) ) {
+			return $abstract;
+		}
+
+		return $this->bindings[ $abstract ]['concrete'];
+	}
+
+	/**
+	 * Get the contextual concrete binding for the given abstract.
+	 *
+	 * @param  string $abstract
+	 *
+	 * @return string|null
+	 */
+	protected function getContextualConcrete( $abstract ) {
+		if ( isset( $this->contextual[ end( $this->buildStack ) ][ $abstract ] ) ) {
+			return $this->contextual[ end( $this->buildStack ) ][ $abstract ];
+		}
+	}
+
+	/**
+	 * Normalize the given class name by removing leading slashes.
+	 *
+	 * @param  mixed $service
+	 *
+	 * @return mixed
+	 */
+	protected function normalize( $service ) {
+		return is_string( $service ) ? ltrim( $service, '\\' ) : $service;
+	}
+
+	/**
+	 * Get the extender callbacks for a given type.
+	 *
+	 * @param  string $abstract
+	 *
+	 * @return array
+	 */
+	protected function getExtenders( $abstract ) {
+		if ( isset( $this->extenders[ $abstract ] ) ) {
+			return $this->extenders[ $abstract ];
+		}
+
+		return [ ];
+	}
+
+	/**
+	 * Instantiate a concrete instance of the given type.
+	 *
+	 * @param  string $concrete
+	 * @param  array  $parameters
+	 *
+	 * @return mixed
+	 *
+	 * @throws \Illuminate\Contracts\Container\BindingResolutionException
+	 */
+	public function build( $concrete, array $parameters = [ ] ) {
+		// If the concrete type is actually a Closure, we will just execute it and
+		// hand back the results of the functions, which allows functions to be
+		// used as resolvers for more fine-tuned resolution of these objects.
+		if ( $concrete instanceof Closure ) {
+			return $concrete( $this, $parameters );
+		}
+
+		$reflector = new ReflectionClass( $concrete );
+
+		// If the type is not instantiable, the developer is attempting to resolve
+		// an abstract type such as an Interface of Abstract Class and there is
+		// no binding registered for the abstractions so we need to bail out.
+		if ( ! $reflector->isInstantiable() ) {
+			if ( ! empty( $this->buildStack ) ) {
+				$previous = implode( ', ', $this->buildStack );
+
+				$message = "Target [$concrete] is not instantiable while building [$previous].";
+			} else {
+				$message = "Target [$concrete] is not instantiable.";
+			}
+
+			throw new BindingResolutionException( $message );
+		}
+
+		$this->buildStack[] = $concrete;
+
+		$constructor = $reflector->getConstructor();
+
+		// If there are no constructors, that means there are no dependencies then
+		// we can just resolve the instances of the objects right away, without
+		// resolving any other types or dependencies out of these containers.
+		if ( is_null( $constructor ) ) {
+			array_pop( $this->buildStack );
+
+			return new $concrete;
+		}
+
+		$dependencies = $constructor->getParameters();
+
+		// Once we have all the constructor's parameters we can create each of the
+		// dependency instances and then use the reflection instances to make a
+		// new instance of this class, injecting the created dependencies in.
+		$parameters = $this->keyParametersByArgument(
+			$dependencies,
+			$parameters
+		);
+
+		$instances = $this->getDependencies(
+			$dependencies,
+			$parameters
+		);
+
+		array_pop( $this->buildStack );
+
+		return $reflector->newInstanceArgs( $instances );
+	}
+
+	/**
+	 * Resolve all of the dependencies from the ReflectionParameters.
+	 *
+	 * @param  array $parameters
+	 * @param  array $primitives
+	 *
+	 * @return array
+	 */
+	protected function getDependencies( array $parameters, array $primitives = [ ] ) {
+		$dependencies = [ ];
+
+		foreach ( $parameters as $parameter ) {
+			$dependency = $parameter->getClass();
+
+			// If the class is null, it means the dependency is a string or some other
+			// primitive type which we can not resolve since it is not a class and
+			// we will just bomb out with an error since we have no-where to go.
+			if ( array_key_exists( $parameter->name, $primitives ) ) {
+				$dependencies[] = $primitives[ $parameter->name ];
+			} elseif ( is_null( $dependency ) ) {
+				$dependencies[] = $this->resolveNonClass( $parameter );
+			} else {
+				$dependencies[] = $this->resolveClass( $parameter );
+			}
+		}
+
+		return $dependencies;
+	}
+
+	/**
+	 * Resolve a non-class hinted dependency.
+	 *
+	 * @param  \ReflectionParameter $parameter
+	 *
+	 * @return mixed
+	 *
+	 * @throws \Illuminate\Contracts\Container\BindingResolutionException
+	 */
+	protected function resolveNonClass( ReflectionParameter $parameter ) {
+		if ( ! is_null( $concrete = $this->getContextualConcrete( '$' . $parameter->name ) ) ) {
+			if ( $concrete instanceof Closure ) {
+				return call_user_func( $concrete, $this );
+			} else {
+				return $concrete;
+			}
+		}
+
+		if ( $parameter->isDefaultValueAvailable() ) {
+			return $parameter->getDefaultValue();
+		}
+
+		$message = "Unresolvable dependency resolving [$parameter] in class {$parameter->getDeclaringClass()->getName()}";
+
+		throw new BindingResolutionException( $message );
+	}
+
+	/**
+	 * Resolve a class based dependency from the container.
+	 *
+	 * @param  \ReflectionParameter $parameter
+	 *
+	 * @return mixed
+	 *
+	 * @throws \Illuminate\Contracts\Container\BindingResolutionException
+	 */
+	protected function resolveClass( ReflectionParameter $parameter ) {
+		try {
+			return $this->make( $parameter->getClass()->name );
+		}
+
+			// If we can not resolve the class instance, we will check to see if the value
+			// is optional, and if it is we will return the optional parameter value as
+			// the value of the dependency, similarly to how we do this with scalars.
+		catch ( BindingResolutionException $e ) {
+			if ( $parameter->isOptional() ) {
+				return $parameter->getDefaultValue();
+			}
+
+			throw $e;
+		}
+	}
+
+	/**
+	 * If extra parameters are passed by numeric ID, rekey them by argument name.
+	 *
+	 * @param  array $dependencies
+	 * @param  array $parameters
+	 *
+	 * @return array
+	 */
+	protected function keyParametersByArgument( array $dependencies, array $parameters ) {
+		foreach ( $parameters as $key => $value ) {
+			if ( is_numeric( $key ) ) {
+				unset( $parameters[ $key ] );
+
+				$parameters[ $dependencies[ $key ]->name ] = $value;
+			}
+		}
+
+		return $parameters;
+	}
+
+	/**
+	 * Register a new resolving callback.
+	 *
+	 * @param  string        $abstract
+	 * @param  \Closure|null $callback
+	 *
+	 * @return void
+	 */
+	public function resolving( $abstract, Closure $callback = null ) {
+		if ( $callback === null && $abstract instanceof Closure ) {
+			$this->resolvingCallback( $abstract );
+		} else {
+			$this->resolvingCallbacks[ $this->normalize( $abstract ) ][] = $callback;
+		}
+	}
+
+	/**
+	 * Register a new after resolving callback for all types.
+	 *
+	 * @param  string        $abstract
+	 * @param  \Closure|null $callback
+	 *
+	 * @return void
+	 */
+	public function afterResolving( $abstract, Closure $callback = null ) {
+		if ( $abstract instanceof Closure && $callback === null ) {
+			$this->afterResolvingCallback( $abstract );
+		} else {
+			$this->afterResolvingCallbacks[ $this->normalize( $abstract ) ][] = $callback;
+		}
+	}
+
+	/**
+	 * Register a new resolving callback by type of its first argument.
+	 *
+	 * @param  \Closure $callback
+	 *
+	 * @return void
+	 */
+	protected function resolvingCallback( Closure $callback ) {
+		$abstract = $this->getFunctionHint( $callback );
+
+		if ( $abstract ) {
+			$this->resolvingCallbacks[ $abstract ][] = $callback;
+		} else {
+			$this->globalResolvingCallbacks[] = $callback;
+		}
+	}
+
+	/**
+	 * Register a new after resolving callback by type of its first argument.
+	 *
+	 * @param  \Closure $callback
+	 *
+	 * @return void
+	 */
+	protected function afterResolvingCallback( Closure $callback ) {
+		$abstract = $this->getFunctionHint( $callback );
+
+		if ( $abstract ) {
+			$this->afterResolvingCallbacks[ $abstract ][] = $callback;
+		} else {
+			$this->globalAfterResolvingCallbacks[] = $callback;
+		}
+	}
+
+	/**
+	 * Get the type hint for this closure's first argument.
+	 *
+	 * @param  \Closure $callback
+	 *
+	 * @return mixed
+	 */
+	protected function getFunctionHint( Closure $callback ) {
+		$function = new ReflectionFunction( $callback );
+
+		if ( $function->getNumberOfParameters() == 0 ) {
+			return;
+		}
+
+		$expected = $function->getParameters()[0];
+
+		if ( ! $expected->getClass() ) {
+			return;
+		}
+
+		return $expected->getClass()->name;
+	}
+
+	/**
+	 * Fire all of the resolving callbacks.
+	 *
+	 * @param  string $abstract
+	 * @param  mixed  $object
+	 *
+	 * @return void
+	 */
+	protected function fireResolvingCallbacks( $abstract, $object ) {
+		$this->fireCallbackArray( $object, $this->globalResolvingCallbacks );
+
+		$this->fireCallbackArray(
+			$object,
+			$this->getCallbacksForType(
+				$abstract,
+				$object,
+				$this->resolvingCallbacks
+			)
+		);
+
+		$this->fireCallbackArray( $object, $this->globalAfterResolvingCallbacks );
+
+		$this->fireCallbackArray(
+			$object,
+			$this->getCallbacksForType(
+				$abstract,
+				$object,
+				$this->afterResolvingCallbacks
+			)
+		);
+	}
+
+	/**
+	 * Get all callbacks for a given type.
+	 *
+	 * @param  string $abstract
+	 * @param  object $object
+	 * @param  array  $callbacksPerType
+	 *
+	 * @return array
+	 */
+	protected function getCallbacksForType( $abstract, $object, array $callbacksPerType ) {
+		$results = [ ];
+
+		foreach ( $callbacksPerType as $type => $callbacks ) {
+			if ( $type === $abstract || $object instanceof $type ) {
+				$results = array_merge( $results, $callbacks );
+			}
+		}
+
+		return $results;
+	}
+
+	/**
+	 * Fire an array of callbacks with an object.
+	 *
+	 * @param  mixed $object
+	 * @param  array $callbacks
+	 *
+	 * @return void
+	 */
+	protected function fireCallbackArray( $object, array $callbacks ) {
+		foreach ( $callbacks as $callback ) {
+			$callback( $object, $this );
+		}
+	}
+
+	/**
+	 * Determine if a given type is shared.
+	 *
+	 * @param  string $abstract
+	 *
+	 * @return bool
+	 */
+	public function isShared( $abstract ) {
+		$abstract = $this->normalize( $abstract );
+
+		if ( isset( $this->instances[ $abstract ] ) ) {
+			return true;
+		}
+
+		if ( ! isset( $this->bindings[ $abstract ]['shared'] ) ) {
+			return false;
+		}
+
+		return $this->bindings[ $abstract ]['shared'] === true;
+	}
+
+	/**
+	 * Determine if the given concrete is buildable.
+	 *
+	 * @param  mixed  $concrete
+	 * @param  string $abstract
+	 *
+	 * @return bool
+	 */
+	protected function isBuildable( $concrete, $abstract ) {
+		return $concrete === $abstract || $concrete instanceof Closure;
+	}
+
+	/**
+	 * Get the alias for an abstract if available.
+	 *
+	 * @param  string $abstract
+	 *
+	 * @return string
+	 */
+	protected function getAlias( $abstract ) {
+		if ( ! isset( $this->aliases[ $abstract ] ) ) {
+			return $abstract;
+		}
+
+		return $this->getAlias( $this->aliases[ $abstract ] );
+	}
+
+	/**
+	 * Get the container's bindings.
+	 *
+	 * @return array
+	 */
+	public function getBindings() {
+		return $this->bindings;
+	}
+
+	/**
+	 * Drop all of the stale instances and aliases.
+	 *
+	 * @param  string $abstract
+	 *
+	 * @return void
+	 */
+	protected function dropStaleInstances( $abstract ) {
+		unset( $this->instances[ $abstract ], $this->aliases[ $abstract ] );
+	}
+
+	/**
+	 * Remove a resolved instance from the instance cache.
+	 *
+	 * @param  string $abstract
+	 *
+	 * @return void
+	 */
+	public function forgetInstance( $abstract ) {
+		unset( $this->instances[ $this->normalize( $abstract ) ] );
+	}
+
+	/**
+	 * Clear all of the instances from the container.
+	 *
+	 * @return void
+	 */
+	public function forgetInstances() {
+		$this->instances = [ ];
+	}
+
+	/**
+	 * Flush the container of all bindings and resolved instances.
+	 *
+	 * @return void
+	 */
+	public function flush() {
+		$this->aliases   = [ ];
+		$this->resolved  = [ ];
+		$this->bindings  = [ ];
+		$this->instances = [ ];
+	}
+
+	/**
+	 * Set the globally available instance of the container.
+	 *
+	 * @return static
+	 */
+	public static function getInstance() {
+		return static::$instance;
+	}
+
+	/**
+	 * Set the shared instance of the container.
+	 *
+	 * @param  \Illuminate\Contracts\Container\Container $container
+	 *
+	 * @return void
+	 */
+	public static function setInstance( ContainerContract $container ) {
+		static::$instance = $container;
+	}
+
+	/**
+	 * Determine if a given offset exists.
+	 *
+	 * @param  string $key
+	 *
+	 * @return bool
+	 */
+	public function offsetExists( $key ) {
+		return $this->bound( $key );
+	}
+
+	/**
+	 * Get the value at a given offset.
+	 *
+	 * @param  string $key
+	 *
+	 * @return mixed
+	 */
+	public function offsetGet( $key ) {
+		return $this->make( $key );
+	}
+
+	/**
+	 * Set the value at a given offset.
+	 *
+	 * @param  string $key
+	 * @param  mixed  $value
+	 *
+	 * @return void
+	 */
+	public function offsetSet( $key, $value ) {
+		// If the value is not a Closure, we will make it one. This simply gives
+		// more "drop-in" replacement functionality for the Pimple which this
+		// container's simplest functions are base modeled and built after.
+		if ( ! $value instanceof Closure ) {
+			$value = function () use ( $value ) {
+				return $value;
+			};
+		}
+
+		$this->bind( $key, $value );
+	}
+
+	/**
+	 * Unset the value at a given offset.
+	 *
+	 * @param  string $key
+	 *
+	 * @return void
+	 */
+	public function offsetUnset( $key ) {
+		$key = $this->normalize( $key );
+
+		unset( $this->bindings[ $key ], $this->instances[ $key ], $this->resolved[ $key ] );
+	}
+
+	/**
+	 * Dynamically access container services.
+	 *
+	 * @param  string $key
+	 *
+	 * @return mixed
+	 */
+	public function __get( $key ) {
+		return $this[ $key ];
+	}
+
+	/**
+	 * Dynamically set container services.
+	 *
+	 * @param  string $key
+	 * @param  mixed  $value
+	 *
+	 * @return void
+	 */
+	public function __set( $key, $value ) {
+		$this[ $key ] = $value;
+	}
+
+	/**
+	 * @param $reflectionFunction
+	 *
+	 * @return array
+	 */
+	protected function fetchInjectAnnotations( $reflectionFunction ) {
+		$phpDoc      = $reflectionFunction->getDocComment();
+		$annotations = [ ];
+		$matches     = [ ];
+		preg_match( "/@inject\('(\w+)', '(\w+)'\)/", $phpDoc, $matches );
+		for ( $i = 0, $l = count( $matches ); $i < $l; $i += 3 ) {
+			$annotations[ $matches[ $i + 1 ] ] = $matches[ $i + 2 ];
+		}
+
+		return $annotations;
+	}
 }

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -649,6 +649,16 @@ class ContainerContainerTest extends PHPUnit_Framework_TestCase {
 		$this->assertInstanceOf( 'ContainerConcreteStub', $result[0] );
 		$this->assertEquals( 'taylor', $result[1] );
 	}
+
+	/**
+	 * @group testCallWithGlobalMethodNameAnnotationWithHint
+	 */
+	public function testCallWithGlobalMethodNameAnnotationWithHint() {
+		$container = new Container;
+		$result    = $container->call( 'containerTestInjectAnnotationWithHint' );
+		$this->assertInstanceOf( 'ContainerImplementationStub', $result[0] );
+		$this->assertEquals( 'taylor', $result[1] );
+	}
 }
 
 class ContainerConcreteStub {
@@ -770,5 +780,17 @@ function containerTestInject( ContainerConcreteStub $stub, $default = 'taylor' )
  * @inject('stub', 'ContainerConcreteStub')
  */
 function containerTestInjectAnnotation( $stub, $default = 'taylor' ) {
+	return func_get_args();
+}
+
+/**
+ * @param IContainerContractStub $stub
+ * @param string                 $default
+ *
+ * @return array
+ *
+ * @inject('stub', 'ContainerImplementationStub')
+ */
+function containerTestInjectAnnotationWithHint( IContainerContractStub $stub, $default = 'taylor' ) {
 	return func_get_args();
 }

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -464,6 +464,23 @@ class ContainerContainerTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals( [ 'foo', 'bar' ], $result );
 	}
 
+	/**
+	 * @group  testCallWithAtSignBasedClassReferencesAnnotation
+	 */
+	public function testCallWithAtSignBasedClassReferencesAnnotation() {
+		$container = new Container;
+		$result    = $container->call( 'ContainerConcreteStubAnnotation@inject' );
+		$this->assertInstanceOf( 'ContainerImplementationStub', $result[0] );
+		$this->assertInstanceOf( 'ContainerConcreteStub', $result[1] );
+		$this->assertEquals( 'taylor', $result[2] );
+
+		$container = new Container;
+		$result    = $container->call( 'ContainerConcreteStubAnnotation@inject', [ 'default' => 'foo' ] );
+		$this->assertInstanceOf( 'ContainerImplementationStub', $result[0] );
+		$this->assertInstanceOf( 'ContainerConcreteStub', $result[1] );
+		$this->assertEquals( 'foo', $result[2] );
+	}
+
 	public function testCallWithCallableArray() {
 		$container = new Container;
 		$stub      = new ContainerTestCallStub();
@@ -657,7 +674,8 @@ class ContainerContainerTest extends PHPUnit_Framework_TestCase {
 		$container = new Container;
 		$result    = $container->call( 'containerTestInjectAnnotationWithHint' );
 		$this->assertInstanceOf( 'ContainerImplementationStub', $result[0] );
-		$this->assertEquals( 'taylor', $result[1] );
+		$this->assertInstanceOf( 'ContainerConcreteStub', $result[1] );
+		$this->assertEquals( 'taylor', $result[2] );
 	}
 }
 
@@ -737,6 +755,23 @@ class ContainerTestCallStub {
 	}
 }
 
+class ContainerConcreteStubAnnotation {
+
+	/**
+	 * @param IContainerContractStub $stub
+	 * @param                        $stub2
+	 * @param string                 $default
+	 *
+	 * @return array
+	 *
+	 * @inject('stub', 'ContainerImplementationStub')
+	 * @inject('stub2', 'ContainerConcreteStub')
+	 */
+	public function inject( IContainerContractStub $stub, $stub2, $default = 'taylor' ) {
+		return func_get_args();
+	}
+}
+
 class ContainerTestContextInjectOne {
 	public $impl;
 
@@ -785,12 +820,13 @@ function containerTestInjectAnnotation( $stub, $default = 'taylor' ) {
 
 /**
  * @param IContainerContractStub $stub
+ * @param                        $stub2
  * @param string                 $default
  *
  * @return array
- *
  * @inject('stub', 'ContainerImplementationStub')
+ * @inject('stub2', 'ContainerConcreteStub')
  */
-function containerTestInjectAnnotationWithHint( IContainerContractStub $stub, $default = 'taylor' ) {
+function containerTestInjectAnnotationWithHint( IContainerContractStub $stub, $stub2, $default = 'taylor' ) {
 	return func_get_args();
 }

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -262,10 +262,22 @@ class ContainerContainerTest extends PHPUnit_Framework_TestCase {
 	public function testResolutionOfDefaultParametersAnnotation() {
 		$container = new Container;
 		$instance  = $container->make( 'ContainerDefaultValueStubAnnotation' );
-		var_dump($instance);
 		$this->assertInstanceOf( 'ContainerImplementationStub', $instance->stub1 );
 		$this->assertInstanceOf( 'ContainerImplementationStubTwo', $instance->stub2 );
 		$this->assertInstanceOf( 'ContainerConcreteStub', $instance->stub3 );
+		$this->assertEquals( 'taylor', $instance->default );
+	}
+
+	/**
+	 * @group testResolutionOfDefaultParametersAndSetterAnnotation
+	 */
+	public function testResolutionOfDefaultParametersAndSetterAnnotation() {
+		$container = new Container;
+		$instance  = $container->make( 'ContainerDefaultValueStubAnnotation' );
+		$this->assertInstanceOf( 'ContainerImplementationStub', $instance->stub1 );
+		$this->assertInstanceOf( 'ContainerImplementationStubTwo', $instance->stub2 );
+		$this->assertInstanceOf( 'ContainerConcreteStub', $instance->stub3 );
+		$this->assertInstanceOf( 'ContainerConcreteStub', $instance->stub4 );
 		$this->assertEquals( 'taylor', $instance->default );
 	}
 
@@ -734,6 +746,7 @@ class ContainerDefaultValueStubAnnotation {
 	public $stub1;
 	public $stub2;
 	public $stub3;
+	public $stub4;
 	public $default;
 
 	/**
@@ -752,6 +765,16 @@ class ContainerDefaultValueStubAnnotation {
 		$this->stub2   = $stub2;
 		$this->stub3   = $stub3;
 		$this->default = $default;
+		$this->stub4   = null;
+	}
+
+	/**
+	 * @param  $stub4
+	 *
+	 * @inject('stub4', 'ContainerConcreteStub')
+	 */
+	public function setStub4( $stub4 ) {
+		$this->stub4 = $stub4;
 	}
 }
 

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -2,792 +2,773 @@
 
 use Illuminate\Container\Container;
 
-class ContainerContainerTest extends PHPUnit_Framework_TestCase
-{
-    public function testClosureResolution()
-    {
-        $container = new Container;
-        $container->bind('name', function () {
-            return 'Taylor';
-        });
-        $this->assertEquals('Taylor', $container->make('name'));
-    }
-
-    public function testBindIfDoesntRegisterIfServiceAlreadyRegistered()
-    {
-        $container = new Container;
-        $container->bind('name', function () {
-            return 'Taylor';
-        });
-        $container->bindIf('name', function () {
-            return 'Dayle';
-        });
-
-        $this->assertEquals('Taylor', $container->make('name'));
-    }
-
-    public function testSharedClosureResolution()
-    {
-        $container = new Container;
-        $class = new stdClass;
-        $container->singleton('class', function () use ($class) {
-            return $class;
-        });
-        $this->assertSame($class, $container->make('class'));
-    }
-
-    public function testAutoConcreteResolution()
-    {
-        $container = new Container;
-        $this->assertInstanceOf('ContainerConcreteStub', $container->make('ContainerConcreteStub'));
-    }
-
-    public function testSlashesAreHandled()
-    {
-        $container = new Container;
-        $container->bind('\Foo', function () {
-            return 'hello';
-        });
-        $this->assertEquals('hello', $container->make('Foo'));
-    }
-
-    public function testParametersCanOverrideDependencies()
-    {
-        $container = new Container;
-        $stub = new ContainerDependentStub($mock = $this->getMock('IContainerContractStub'));
-        $resolved = $container->make('ContainerNestedDependentStub', [$stub]);
-        $this->assertInstanceOf('ContainerNestedDependentStub', $resolved);
-        $this->assertEquals($mock, $resolved->inner->impl);
-    }
-
-    public function testSharedConcreteResolution()
-    {
-        $container = new Container;
-        $container->singleton('ContainerConcreteStub');
-
-        $var1 = $container->make('ContainerConcreteStub');
-        $var2 = $container->make('ContainerConcreteStub');
-        $this->assertSame($var1, $var2);
-    }
-
-    public function testAbstractToConcreteResolution()
-    {
-        $container = new Container;
-        $container->bind('IContainerContractStub', 'ContainerImplementationStub');
-        $class = $container->make('ContainerDependentStub');
-        $this->assertInstanceOf('ContainerImplementationStub', $class->impl);
-    }
-
-    public function testNestedDependencyResolution()
-    {
-        $container = new Container;
-        $container->bind('IContainerContractStub', 'ContainerImplementationStub');
-        $class = $container->make('ContainerNestedDependentStub');
-        $this->assertInstanceOf('ContainerDependentStub', $class->inner);
-        $this->assertInstanceOf('ContainerImplementationStub', $class->inner->impl);
-    }
-
-    public function testContainerIsPassedToResolvers()
-    {
-        $container = new Container;
-        $container->bind('something', function ($c) {
-            return $c;
-        });
-        $c = $container->make('something');
-        $this->assertSame($c, $container);
-    }
-
-    public function testArrayAccess()
-    {
-        $container = new Container;
-        $container['something'] = function () {
-            return 'foo';
-        };
-        $this->assertTrue(isset($container['something']));
-        $this->assertEquals('foo', $container['something']);
-        unset($container['something']);
-        $this->assertFalse(isset($container['something']));
-    }
-
-    public function testAliases()
-    {
-        $container = new Container;
-        $container['foo'] = 'bar';
-        $container->alias('foo', 'baz');
-        $container->alias('baz', 'bat');
-        $this->assertEquals('bar', $container->make('foo'));
-        $this->assertEquals('bar', $container->make('baz'));
-        $this->assertEquals('bar', $container->make('bat'));
-        $container->bind(['bam' => 'boom'], function () {
-            return 'pow';
-        });
-        $this->assertEquals('pow', $container->make('bam'));
-        $this->assertEquals('pow', $container->make('boom'));
-        $container->instance(['zoom' => 'zing'], 'wow');
-        $this->assertEquals('wow', $container->make('zoom'));
-        $this->assertEquals('wow', $container->make('zing'));
-    }
-
-    public function testShareMethod()
-    {
-        $container = new Container;
-        $closure = $container->share(function () {
-            return new stdClass;
-        });
-        $class1 = $closure($container);
-        $class2 = $closure($container);
-        $this->assertSame($class1, $class2);
-    }
-
-    public function testBindingsCanBeOverridden()
-    {
-        $container = new Container;
-        $container['foo'] = 'bar';
-        $foo = $container['foo'];
-        $container['foo'] = 'baz';
-        $this->assertEquals('baz', $container['foo']);
-    }
-
-    public function testExtendedBindings()
-    {
-        $container = new Container;
-        $container['foo'] = 'foo';
-        $container->extend('foo', function ($old, $container) {
-            return $old.'bar';
-        });
-
-        $this->assertEquals('foobar', $container->make('foo'));
-
-        $container = new Container;
-
-        $container['foo'] = $container->share(function () {
-            return (object) ['name' => 'taylor'];
-        });
-        $container->extend('foo', function ($old, $container) {
-            $old->age = 26;
-
-            return $old;
-        });
-
-        $result = $container->make('foo');
-
-        $this->assertEquals('taylor', $result->name);
-        $this->assertEquals(26, $result->age);
-        $this->assertSame($result, $container->make('foo'));
-    }
-
-    public function testMultipleExtends()
-    {
-        $container = new Container;
-        $container['foo'] = 'foo';
-        $container->extend('foo', function ($old, $container) {
-            return $old.'bar';
-        });
-        $container->extend('foo', function ($old, $container) {
-            return $old.'baz';
-        });
-
-        $this->assertEquals('foobarbaz', $container->make('foo'));
-    }
-
-    public function testExtendInstancesArePreserved()
-    {
-        $container = new Container;
-        $container->bind('foo', function () {
-            $obj = new StdClass;
-            $obj->foo = 'bar';
-
-            return $obj;
-        });
-        $obj = new StdClass;
-        $obj->foo = 'foo';
-        $container->instance('foo', $obj);
-        $container->extend('foo', function ($obj, $container) {
-            $obj->bar = 'baz';
-
-            return $obj;
-        });
-        $container->extend('foo', function ($obj, $container) {
-            $obj->baz = 'foo';
-
-            return $obj;
-        });
-
-        $this->assertEquals('foo', $container->make('foo')->foo);
-        $this->assertEquals('baz', $container->make('foo')->bar);
-        $this->assertEquals('foo', $container->make('foo')->baz);
-    }
-
-    public function testExtendIsLazyInitialized()
-    {
-        $container = new Container;
-        $container->bind('ContainerLazyExtendStub');
-        $container->extend('ContainerLazyExtendStub', function ($obj, $container) {
-            $obj->init();
-
-            return $obj;
-        });
-        $this->assertFalse(ContainerLazyExtendStub::$initialized);
-        $container->make('ContainerLazyExtendStub');
-        $this->assertTrue(ContainerLazyExtendStub::$initialized);
-    }
-
-    public function testExtendCanBeCalledBeforeBind()
-    {
-        $container = new Container;
-        $container->extend('foo', function ($old, $container) {
-            return $old.'bar';
-        });
-        $container['foo'] = 'foo';
-
-        $this->assertEquals('foobar', $container->make('foo'));
-    }
-
-    public function testParametersCanBePassedThroughToClosure()
-    {
-        $container = new Container;
-        $container->bind('foo', function ($c, $parameters) {
-            return $parameters;
-        });
-
-        $this->assertEquals([1, 2, 3], $container->make('foo', [1, 2, 3]));
-    }
-
-    public function testResolutionOfDefaultParameters()
-    {
-        $container = new Container;
-        $instance = $container->make('ContainerDefaultValueStub');
-        $this->assertInstanceOf('ContainerConcreteStub', $instance->stub);
-        $this->assertEquals('taylor', $instance->default);
-    }
-
-    public function testResolvingCallbacksAreCalledForSpecificAbstracts()
-    {
-        $container = new Container;
-        $container->resolving('foo', function ($object) {
-            return $object->name = 'taylor';
-        });
-        $container->bind('foo', function () {
-            return new StdClass;
-        });
-        $instance = $container->make('foo');
-
-        $this->assertEquals('taylor', $instance->name);
-    }
-
-    public function testResolvingCallbacksAreCalled()
-    {
-        $container = new Container;
-        $container->resolving(function ($object) {
-            return $object->name = 'taylor';
-        });
-        $container->bind('foo', function () {
-            return new StdClass;
-        });
-        $instance = $container->make('foo');
-
-        $this->assertEquals('taylor', $instance->name);
-    }
-
-    public function testResolvingCallbacksAreCalledForType()
-    {
-        $container = new Container;
-        $container->resolving('StdClass', function ($object) {
-            return $object->name = 'taylor';
-        });
-        $container->bind('foo', function () {
-            return new StdClass;
-        });
-        $instance = $container->make('foo');
-
-        $this->assertEquals('taylor', $instance->name);
-    }
-
-    public function testUnsetRemoveBoundInstances()
-    {
-        $container = new Container;
-        $container->instance('object', new StdClass);
-        unset($container['object']);
-
-        $this->assertFalse($container->bound('object'));
-    }
-
-    public function testBoundInstanceAndAliasCheckViaArrayAccess()
-    {
-        $container = new Container;
-        $container->instance('object', new StdClass);
-        $container->alias('object', 'alias');
-
-        $this->assertTrue(isset($container['object']));
-        $this->assertTrue(isset($container['alias']));
-    }
-
-    public function testReboundListeners()
-    {
-        unset($_SERVER['__test.rebind']);
-
-        $container = new Container;
-        $container->bind('foo', function () {
-        });
-        $container->rebinding('foo', function () {
-            $_SERVER['__test.rebind'] = true;
-        });
-        $container->bind('foo', function () {
-        });
-
-        $this->assertTrue($_SERVER['__test.rebind']);
-    }
-
-    public function testReboundListenersOnInstances()
-    {
-        unset($_SERVER['__test.rebind']);
-
-        $container = new Container;
-        $container->instance('foo', function () {
-        });
-        $container->rebinding('foo', function () {
-            $_SERVER['__test.rebind'] = true;
-        });
-        $container->instance('foo', function () {
-        });
-
-        $this->assertTrue($_SERVER['__test.rebind']);
-    }
-
-    public function testPassingSomePrimitiveParameters()
-    {
-        $container = new Container;
-        $value = $container->make('ContainerMixedPrimitiveStub', ['first' => 'taylor', 'last' => 'otwell']);
-        $this->assertInstanceOf('ContainerMixedPrimitiveStub', $value);
-        $this->assertEquals('taylor', $value->first);
-        $this->assertEquals('otwell', $value->last);
-        $this->assertInstanceOf('ContainerConcreteStub', $value->stub);
-
-        $container = new Container;
-        $value = $container->make('ContainerMixedPrimitiveStub', [0 => 'taylor', 2 => 'otwell']);
-        $this->assertInstanceOf('ContainerMixedPrimitiveStub', $value);
-        $this->assertEquals('taylor', $value->first);
-        $this->assertEquals('otwell', $value->last);
-        $this->assertInstanceOf('ContainerConcreteStub', $value->stub);
-    }
-
-    public function testCreatingBoundConcreteClassPassesParameters()
-    {
-        $container = new Container;
-        $container->bind('TestAbstractClass', 'ContainerConstructorParameterLoggingStub');
-        $parameters = ['First', 'Second'];
-        $instance = $container->make('TestAbstractClass', $parameters);
-        $this->assertEquals($parameters, $instance->receivedParameters);
-    }
-
-    /**
-     * @expectedException Illuminate\Contracts\Container\BindingResolutionException
-     * @expectedExceptionMessage Unresolvable dependency resolving [Parameter #0 [ <required> $first ]] in class ContainerMixedPrimitiveStub
-     */
-    public function testInternalClassWithDefaultParameters()
-    {
-        $container = new Container;
-        $container->make('ContainerMixedPrimitiveStub', []);
-    }
-
-    /**
-     * @expectedException Illuminate\Contracts\Container\BindingResolutionException
-     * @expectedExceptionMessage Target [IContainerContractStub] is not instantiable.
-     */
-    public function testBindingResolutionExceptionMessage()
-    {
-        $container = new Container;
-        $container->make('IContainerContractStub', []);
-    }
-
-    /**
-     * @expectedException Illuminate\Contracts\Container\BindingResolutionException
-     * @expectedExceptionMessage Target [IContainerContractStub] is not instantiable while building [ContainerTestContextInjectOne].
-     */
-    public function testBindingResolutionExceptionMessageIncludesBuildStack()
-    {
-        $container = new Container;
-        $container->make('ContainerTestContextInjectOne', []);
-    }
-
-    public function testCallWithDependencies()
-    {
-        $container = new Container;
-        $result = $container->call(function (StdClass $foo, $bar = []) {
-            return func_get_args();
-        });
-
-        $this->assertInstanceOf('stdClass', $result[0]);
-        $this->assertEquals([], $result[1]);
-
-        $result = $container->call(function (StdClass $foo, $bar = []) {
-            return func_get_args();
-        }, ['bar' => 'taylor']);
-
-        $this->assertInstanceOf('stdClass', $result[0]);
-        $this->assertEquals('taylor', $result[1]);
-
-        /*
-         * Wrap a function...
-         */
-        $result = $container->wrap(function (StdClass $foo, $bar = []) {
-            return func_get_args();
-        }, ['bar' => 'taylor']);
-
-        $this->assertInstanceOf('Closure', $result);
-        $result = $result();
-
-        $this->assertInstanceOf('stdClass', $result[0]);
-        $this->assertEquals('taylor', $result[1]);
-    }
-
-    /**
-     * @expectedException ReflectionException
-     */
-    public function testCallWithAtSignBasedClassReferencesWithoutMethodThrowsException()
-    {
-        $container = new Container;
-        $result = $container->call('ContainerTestCallStub');
-    }
-
-    public function testCallWithAtSignBasedClassReferences()
-    {
-        $container = new Container;
-        $result = $container->call('ContainerTestCallStub@work', ['foo', 'bar']);
-        $this->assertEquals(['foo', 'bar'], $result);
-
-        $container = new Container;
-        $result = $container->call('ContainerTestCallStub@inject');
-        $this->assertInstanceOf('ContainerConcreteStub', $result[0]);
-        $this->assertEquals('taylor', $result[1]);
-
-        $container = new Container;
-        $result = $container->call('ContainerTestCallStub@inject', ['default' => 'foo']);
-        $this->assertInstanceOf('ContainerConcreteStub', $result[0]);
-        $this->assertEquals('foo', $result[1]);
-
-        $container = new Container;
-        $result = $container->call('ContainerTestCallStub', ['foo', 'bar'], 'work');
-        $this->assertEquals(['foo', 'bar'], $result);
-    }
-
-    public function testCallWithCallableArray()
-    {
-        $container = new Container;
-        $stub = new ContainerTestCallStub();
-        $result = $container->call([$stub, 'work'], ['foo', 'bar']);
-        $this->assertEquals(['foo', 'bar'], $result);
-    }
-
-    public function testCallWithStaticMethodNameString()
-    {
-        $container = new Container;
-        $result = $container->call('ContainerStaticMethodStub::inject');
-        $this->assertInstanceOf('ContainerConcreteStub', $result[0]);
-        $this->assertEquals('taylor', $result[1]);
-    }
-
-    public function testCallWithGlobalMethodName()
-    {
-        $container = new Container;
-        $result = $container->call('containerTestInject');
-        $this->assertInstanceOf('ContainerConcreteStub', $result[0]);
-        $this->assertEquals('taylor', $result[1]);
-    }
-
-    public function testContainerCanInjectDifferentImplementationsDependingOnContext()
-    {
-        $container = new Container;
-
-        $container->bind('IContainerContractStub', 'ContainerImplementationStub');
-
-        $container->when('ContainerTestContextInjectOne')->needs('IContainerContractStub')->give('ContainerImplementationStub');
-        $container->when('ContainerTestContextInjectTwo')->needs('IContainerContractStub')->give('ContainerImplementationStubTwo');
-
-        $one = $container->make('ContainerTestContextInjectOne');
-        $two = $container->make('ContainerTestContextInjectTwo');
-
-        $this->assertInstanceOf('ContainerImplementationStub', $one->impl);
-        $this->assertInstanceOf('ContainerImplementationStubTwo', $two->impl);
-
-        /*
-         * Test With Closures
-         */
-        $container = new Container;
-
-        $container->bind('IContainerContractStub', 'ContainerImplementationStub');
-
-        $container->when('ContainerTestContextInjectOne')->needs('IContainerContractStub')->give('ContainerImplementationStub');
-        $container->when('ContainerTestContextInjectTwo')->needs('IContainerContractStub')->give(function ($container) {
-            return $container->make('ContainerImplementationStubTwo');
-        });
-
-        $one = $container->make('ContainerTestContextInjectOne');
-        $two = $container->make('ContainerTestContextInjectTwo');
-
-        $this->assertInstanceOf('ContainerImplementationStub', $one->impl);
-        $this->assertInstanceOf('ContainerImplementationStubTwo', $two->impl);
-    }
-
-    public function testContextualBindingWorksRegardlessOfLeadingBackslash()
-    {
-        $container = new Container;
-
-        $container->bind('IContainerContractStub', 'ContainerImplementationStub');
-
-        $container->when('\ContainerTestContextInjectOne')->needs('IContainerContractStub')->give('ContainerImplementationStubTwo');
-        $container->when('ContainerTestContextInjectTwo')->needs('\IContainerContractStub')->give('ContainerImplementationStubTwo');
-
-        $this->assertInstanceOf(
-            'ContainerImplementationStubTwo',
-            $container->make('ContainerTestContextInjectOne')->impl
-        );
-
-        $this->assertInstanceOf(
-            'ContainerImplementationStubTwo',
-            $container->make('ContainerTestContextInjectTwo')->impl
-        );
-
-        $this->assertInstanceOf(
-            'ContainerImplementationStubTwo',
-            $container->make('\ContainerTestContextInjectTwo')->impl
-        );
-    }
-
-    public function testContainerTags()
-    {
-        $container = new Container;
-        $container->tag('ContainerImplementationStub', 'foo', 'bar');
-        $container->tag('ContainerImplementationStubTwo', ['foo']);
-
-        $this->assertCount(1, $container->tagged('bar'));
-        $this->assertCount(2, $container->tagged('foo'));
-        $this->assertInstanceOf('ContainerImplementationStub', $container->tagged('foo')[0]);
-        $this->assertInstanceOf('ContainerImplementationStub', $container->tagged('bar')[0]);
-        $this->assertInstanceOf('ContainerImplementationStubTwo', $container->tagged('foo')[1]);
-
-        $container = new Container;
-        $container->tag(['ContainerImplementationStub', 'ContainerImplementationStubTwo'], ['foo']);
-        $this->assertCount(2, $container->tagged('foo'));
-        $this->assertInstanceOf('ContainerImplementationStub', $container->tagged('foo')[0]);
-        $this->assertInstanceOf('ContainerImplementationStubTwo', $container->tagged('foo')[1]);
-
-        $this->assertEmpty($container->tagged('this_tag_does_not_exist'));
-    }
-
-    public function testForgetInstanceForgetsInstance()
-    {
-        $container = new Container;
-        $containerConcreteStub = new ContainerConcreteStub;
-        $container->instance('ContainerConcreteStub', $containerConcreteStub);
-        $this->assertTrue($container->isShared('ContainerConcreteStub'));
-        $container->forgetInstance('ContainerConcreteStub');
-        $this->assertFalse($container->isShared('ContainerConcreteStub'));
-    }
-
-    public function testForgetInstancesForgetsAllInstances()
-    {
-        $container = new Container;
-        $containerConcreteStub1 = new ContainerConcreteStub;
-        $containerConcreteStub2 = new ContainerConcreteStub;
-        $containerConcreteStub3 = new ContainerConcreteStub;
-        $container->instance('Instance1', $containerConcreteStub1);
-        $container->instance('Instance2', $containerConcreteStub2);
-        $container->instance('Instance3', $containerConcreteStub3);
-        $this->assertTrue($container->isShared('Instance1'));
-        $this->assertTrue($container->isShared('Instance2'));
-        $this->assertTrue($container->isShared('Instance3'));
-        $container->forgetInstances();
-        $this->assertFalse($container->isShared('Instance1'));
-        $this->assertFalse($container->isShared('Instance2'));
-        $this->assertFalse($container->isShared('Instance3'));
-    }
-
-    public function testContainerFlushFlushesAllBindingsAliasesAndResolvedInstances()
-    {
-        $container = new Container;
-        $container->bind('ConcreteStub', function () {
-            return new ContainerConcreteStub;
-        }, true);
-        $container->alias('ConcreteStub', 'ContainerConcreteStub');
-        $concreteStubInstance = $container->make('ConcreteStub');
-        $this->assertTrue($container->resolved('ConcreteStub'));
-        $this->assertTrue($container->isAlias('ContainerConcreteStub'));
-        $this->assertArrayHasKey('ConcreteStub', $container->getBindings());
-        $this->assertTrue($container->isShared('ConcreteStub'));
-        $container->flush();
-        $this->assertFalse($container->resolved('ConcreteStub'));
-        $this->assertFalse($container->isAlias('ContainerConcreteStub'));
-        $this->assertEmpty($container->getBindings());
-        $this->assertFalse($container->isShared('ConcreteStub'));
-    }
-
-    public function testResolvedResolvesAliasToBindingNameBeforeChecking()
-    {
-        $container = new Container;
-        $container->bind('ConcreteStub', function () {
-            return new ContainerConcreteStub;
-        }, true);
-        $container->alias('ConcreteStub', 'foo');
-
-        $this->assertFalse($container->resolved('ConcreteStub'));
-        $this->assertFalse($container->resolved('foo'));
-
-        $concreteStubInstance = $container->make('ConcreteStub');
-
-        $this->assertTrue($container->resolved('ConcreteStub'));
-        $this->assertTrue($container->resolved('foo'));
-    }
-
-    public function testContainerCanInjectSimpleVariable()
-    {
-        $container = new Container;
-        $container->when('ContainerInjectVariableStub')->needs('$something')->give(100);
-        $instance = $container->make('ContainerInjectVariableStub');
-        $this->assertEquals(100, $instance->something);
-
-        $container = new Container;
-        $container->when('ContainerInjectVariableStub')->needs('$something')->give(function ($container) {
-            return $container->make('ContainerConcreteStub');
-        });
-        $instance = $container->make('ContainerInjectVariableStub');
-        $this->assertInstanceOf('ContainerConcreteStub', $instance->something);
-    }
+class ContainerContainerTest extends PHPUnit_Framework_TestCase {
+	public function testClosureResolution() {
+		$container = new Container;
+		$container->bind( 'name',
+			function () {
+				return 'Taylor';
+			} );
+		$this->assertEquals( 'Taylor', $container->make( 'name' ) );
+	}
+
+	public function testBindIfDoesntRegisterIfServiceAlreadyRegistered() {
+		$container = new Container;
+		$container->bind( 'name',
+			function () {
+				return 'Taylor';
+			} );
+		$container->bindIf( 'name',
+			function () {
+				return 'Dayle';
+			} );
+
+		$this->assertEquals( 'Taylor', $container->make( 'name' ) );
+	}
+
+	public function testSharedClosureResolution() {
+		$container = new Container;
+		$class     = new stdClass;
+		$container->singleton( 'class',
+			function () use ( $class ) {
+				return $class;
+			} );
+		$this->assertSame( $class, $container->make( 'class' ) );
+	}
+
+	public function testAutoConcreteResolution() {
+		$container = new Container;
+		$this->assertInstanceOf( 'ContainerConcreteStub', $container->make( 'ContainerConcreteStub' ) );
+	}
+
+	public function testSlashesAreHandled() {
+		$container = new Container;
+		$container->bind( '\Foo',
+			function () {
+				return 'hello';
+			} );
+		$this->assertEquals( 'hello', $container->make( 'Foo' ) );
+	}
+
+	public function testParametersCanOverrideDependencies() {
+		$container = new Container;
+		$stub      = new ContainerDependentStub( $mock = $this->getMock( 'IContainerContractStub' ) );
+		$resolved  = $container->make( 'ContainerNestedDependentStub', [ $stub ] );
+		$this->assertInstanceOf( 'ContainerNestedDependentStub', $resolved );
+		$this->assertEquals( $mock, $resolved->inner->impl );
+	}
+
+	public function testSharedConcreteResolution() {
+		$container = new Container;
+		$container->singleton( 'ContainerConcreteStub' );
+
+		$var1 = $container->make( 'ContainerConcreteStub' );
+		$var2 = $container->make( 'ContainerConcreteStub' );
+		$this->assertSame( $var1, $var2 );
+	}
+
+	public function testAbstractToConcreteResolution() {
+		$container = new Container;
+		$container->bind( 'IContainerContractStub', 'ContainerImplementationStub' );
+		$class = $container->make( 'ContainerDependentStub' );
+		$this->assertInstanceOf( 'ContainerImplementationStub', $class->impl );
+	}
+
+	public function testNestedDependencyResolution() {
+		$container = new Container;
+		$container->bind( 'IContainerContractStub', 'ContainerImplementationStub' );
+		$class = $container->make( 'ContainerNestedDependentStub' );
+		$this->assertInstanceOf( 'ContainerDependentStub', $class->inner );
+		$this->assertInstanceOf( 'ContainerImplementationStub', $class->inner->impl );
+	}
+
+	public function testContainerIsPassedToResolvers() {
+		$container = new Container;
+		$container->bind( 'something',
+			function ( $c ) {
+				return $c;
+			} );
+		$c = $container->make( 'something' );
+		$this->assertSame( $c, $container );
+	}
+
+	public function testArrayAccess() {
+		$container              = new Container;
+		$container['something'] = function () {
+			return 'foo';
+		};
+		$this->assertTrue( isset( $container['something'] ) );
+		$this->assertEquals( 'foo', $container['something'] );
+		unset( $container['something'] );
+		$this->assertFalse( isset( $container['something'] ) );
+	}
+
+	public function testAliases() {
+		$container        = new Container;
+		$container['foo'] = 'bar';
+		$container->alias( 'foo', 'baz' );
+		$container->alias( 'baz', 'bat' );
+		$this->assertEquals( 'bar', $container->make( 'foo' ) );
+		$this->assertEquals( 'bar', $container->make( 'baz' ) );
+		$this->assertEquals( 'bar', $container->make( 'bat' ) );
+		$container->bind( [ 'bam' => 'boom' ],
+			function () {
+				return 'pow';
+			} );
+		$this->assertEquals( 'pow', $container->make( 'bam' ) );
+		$this->assertEquals( 'pow', $container->make( 'boom' ) );
+		$container->instance( [ 'zoom' => 'zing' ], 'wow' );
+		$this->assertEquals( 'wow', $container->make( 'zoom' ) );
+		$this->assertEquals( 'wow', $container->make( 'zing' ) );
+	}
+
+	public function testShareMethod() {
+		$container = new Container;
+		$closure   = $container->share( function () {
+			return new stdClass;
+		} );
+		$class1    = $closure( $container );
+		$class2    = $closure( $container );
+		$this->assertSame( $class1, $class2 );
+	}
+
+	public function testBindingsCanBeOverridden() {
+		$container        = new Container;
+		$container['foo'] = 'bar';
+		$foo              = $container['foo'];
+		$container['foo'] = 'baz';
+		$this->assertEquals( 'baz', $container['foo'] );
+	}
+
+	public function testExtendedBindings() {
+		$container        = new Container;
+		$container['foo'] = 'foo';
+		$container->extend( 'foo',
+			function ( $old, $container ) {
+				return $old . 'bar';
+			} );
+
+		$this->assertEquals( 'foobar', $container->make( 'foo' ) );
+
+		$container = new Container;
+
+		$container['foo'] = $container->share( function () {
+			return (object) [ 'name' => 'taylor' ];
+		} );
+		$container->extend( 'foo',
+			function ( $old, $container ) {
+				$old->age = 26;
+
+				return $old;
+			} );
+
+		$result = $container->make( 'foo' );
+
+		$this->assertEquals( 'taylor', $result->name );
+		$this->assertEquals( 26, $result->age );
+		$this->assertSame( $result, $container->make( 'foo' ) );
+	}
+
+	public function testMultipleExtends() {
+		$container        = new Container;
+		$container['foo'] = 'foo';
+		$container->extend( 'foo',
+			function ( $old, $container ) {
+				return $old . 'bar';
+			} );
+		$container->extend( 'foo',
+			function ( $old, $container ) {
+				return $old . 'baz';
+			} );
+
+		$this->assertEquals( 'foobarbaz', $container->make( 'foo' ) );
+	}
+
+	public function testExtendInstancesArePreserved() {
+		$container = new Container;
+		$container->bind( 'foo',
+			function () {
+				$obj      = new StdClass;
+				$obj->foo = 'bar';
+
+				return $obj;
+			} );
+		$obj      = new StdClass;
+		$obj->foo = 'foo';
+		$container->instance( 'foo', $obj );
+		$container->extend( 'foo',
+			function ( $obj, $container ) {
+				$obj->bar = 'baz';
+
+				return $obj;
+			} );
+		$container->extend( 'foo',
+			function ( $obj, $container ) {
+				$obj->baz = 'foo';
+
+				return $obj;
+			} );
+
+		$this->assertEquals( 'foo', $container->make( 'foo' )->foo );
+		$this->assertEquals( 'baz', $container->make( 'foo' )->bar );
+		$this->assertEquals( 'foo', $container->make( 'foo' )->baz );
+	}
+
+	public function testExtendIsLazyInitialized() {
+		$container = new Container;
+		$container->bind( 'ContainerLazyExtendStub' );
+		$container->extend( 'ContainerLazyExtendStub',
+			function ( $obj, $container ) {
+				$obj->init();
+
+				return $obj;
+			} );
+		$this->assertFalse( ContainerLazyExtendStub::$initialized );
+		$container->make( 'ContainerLazyExtendStub' );
+		$this->assertTrue( ContainerLazyExtendStub::$initialized );
+	}
+
+	public function testExtendCanBeCalledBeforeBind() {
+		$container = new Container;
+		$container->extend( 'foo',
+			function ( $old, $container ) {
+				return $old . 'bar';
+			} );
+		$container['foo'] = 'foo';
+
+		$this->assertEquals( 'foobar', $container->make( 'foo' ) );
+	}
+
+	public function testParametersCanBePassedThroughToClosure() {
+		$container = new Container;
+		$container->bind( 'foo',
+			function ( $c, $parameters ) {
+				return $parameters;
+			} );
+
+		$this->assertEquals( [ 1, 2, 3 ], $container->make( 'foo', [ 1, 2, 3 ] ) );
+	}
+
+	public function testResolutionOfDefaultParameters() {
+		$container = new Container;
+		$instance  = $container->make( 'ContainerDefaultValueStub' );
+		$this->assertInstanceOf( 'ContainerConcreteStub', $instance->stub );
+		$this->assertEquals( 'taylor', $instance->default );
+	}
+
+	public function testResolvingCallbacksAreCalledForSpecificAbstracts() {
+		$container = new Container;
+		$container->resolving( 'foo',
+			function ( $object ) {
+				return $object->name = 'taylor';
+			} );
+		$container->bind( 'foo',
+			function () {
+				return new StdClass;
+			} );
+		$instance = $container->make( 'foo' );
+
+		$this->assertEquals( 'taylor', $instance->name );
+	}
+
+	public function testResolvingCallbacksAreCalled() {
+		$container = new Container;
+		$container->resolving( function ( $object ) {
+			return $object->name = 'taylor';
+		} );
+		$container->bind( 'foo',
+			function () {
+				return new StdClass;
+			} );
+		$instance = $container->make( 'foo' );
+
+		$this->assertEquals( 'taylor', $instance->name );
+	}
+
+	public function testResolvingCallbacksAreCalledForType() {
+		$container = new Container;
+		$container->resolving( 'StdClass',
+			function ( $object ) {
+				return $object->name = 'taylor';
+			} );
+		$container->bind( 'foo',
+			function () {
+				return new StdClass;
+			} );
+		$instance = $container->make( 'foo' );
+
+		$this->assertEquals( 'taylor', $instance->name );
+	}
+
+	public function testUnsetRemoveBoundInstances() {
+		$container = new Container;
+		$container->instance( 'object', new StdClass );
+		unset( $container['object'] );
+
+		$this->assertFalse( $container->bound( 'object' ) );
+	}
+
+	public function testBoundInstanceAndAliasCheckViaArrayAccess() {
+		$container = new Container;
+		$container->instance( 'object', new StdClass );
+		$container->alias( 'object', 'alias' );
+
+		$this->assertTrue( isset( $container['object'] ) );
+		$this->assertTrue( isset( $container['alias'] ) );
+	}
+
+	public function testReboundListeners() {
+		unset( $_SERVER['__test.rebind'] );
+
+		$container = new Container;
+		$container->bind( 'foo',
+			function () {
+			} );
+		$container->rebinding( 'foo',
+			function () {
+				$_SERVER['__test.rebind'] = true;
+			} );
+		$container->bind( 'foo',
+			function () {
+			} );
+
+		$this->assertTrue( $_SERVER['__test.rebind'] );
+	}
+
+	public function testReboundListenersOnInstances() {
+		unset( $_SERVER['__test.rebind'] );
+
+		$container = new Container;
+		$container->instance( 'foo',
+			function () {
+			} );
+		$container->rebinding( 'foo',
+			function () {
+				$_SERVER['__test.rebind'] = true;
+			} );
+		$container->instance( 'foo',
+			function () {
+			} );
+
+		$this->assertTrue( $_SERVER['__test.rebind'] );
+	}
+
+	public function testPassingSomePrimitiveParameters() {
+		$container = new Container;
+		$value     = $container->make( 'ContainerMixedPrimitiveStub', [ 'first' => 'taylor', 'last' => 'otwell' ] );
+		$this->assertInstanceOf( 'ContainerMixedPrimitiveStub', $value );
+		$this->assertEquals( 'taylor', $value->first );
+		$this->assertEquals( 'otwell', $value->last );
+		$this->assertInstanceOf( 'ContainerConcreteStub', $value->stub );
+
+		$container = new Container;
+		$value     = $container->make( 'ContainerMixedPrimitiveStub', [ 0 => 'taylor', 2 => 'otwell' ] );
+		$this->assertInstanceOf( 'ContainerMixedPrimitiveStub', $value );
+		$this->assertEquals( 'taylor', $value->first );
+		$this->assertEquals( 'otwell', $value->last );
+		$this->assertInstanceOf( 'ContainerConcreteStub', $value->stub );
+	}
+
+	public function testCreatingBoundConcreteClassPassesParameters() {
+		$container = new Container;
+		$container->bind( 'TestAbstractClass', 'ContainerConstructorParameterLoggingStub' );
+		$parameters = [ 'First', 'Second' ];
+		$instance   = $container->make( 'TestAbstractClass', $parameters );
+		$this->assertEquals( $parameters, $instance->receivedParameters );
+	}
+
+	/**
+	 * @expectedException Illuminate\Contracts\Container\BindingResolutionException
+	 * @expectedExceptionMessage Unresolvable dependency resolving [Parameter #0 [ <required> $first ]] in class ContainerMixedPrimitiveStub
+	 */
+	public function testInternalClassWithDefaultParameters() {
+		$container = new Container;
+		$container->make( 'ContainerMixedPrimitiveStub', [ ] );
+	}
+
+	/**
+	 * @expectedException Illuminate\Contracts\Container\BindingResolutionException
+	 * @expectedExceptionMessage Target [IContainerContractStub] is not instantiable.
+	 */
+	public function testBindingResolutionExceptionMessage() {
+		$container = new Container;
+		$container->make( 'IContainerContractStub', [ ] );
+	}
+
+	/**
+	 * @expectedException Illuminate\Contracts\Container\BindingResolutionException
+	 * @expectedExceptionMessage Target [IContainerContractStub] is not instantiable while building [ContainerTestContextInjectOne].
+	 */
+	public function testBindingResolutionExceptionMessageIncludesBuildStack() {
+		$container = new Container;
+		$container->make( 'ContainerTestContextInjectOne', [ ] );
+	}
+
+	public function testCallWithDependencies() {
+		$container = new Container;
+		$result    = $container->call( function ( StdClass $foo, $bar = [ ] ) {
+			return func_get_args();
+		} );
+
+		$this->assertInstanceOf( 'stdClass', $result[0] );
+		$this->assertEquals( [ ], $result[1] );
+
+		$result = $container->call( function ( StdClass $foo, $bar = [ ] ) {
+			return func_get_args();
+		},
+			[ 'bar' => 'taylor' ] );
+
+		$this->assertInstanceOf( 'stdClass', $result[0] );
+		$this->assertEquals( 'taylor', $result[1] );
+
+		/*
+		 * Wrap a function...
+		 */
+		$result = $container->wrap( function ( StdClass $foo, $bar = [ ] ) {
+			return func_get_args();
+		},
+			[ 'bar' => 'taylor' ] );
+
+		$this->assertInstanceOf( 'Closure', $result );
+		$result = $result();
+
+		$this->assertInstanceOf( 'stdClass', $result[0] );
+		$this->assertEquals( 'taylor', $result[1] );
+	}
+
+	/**
+	 * @expectedException ReflectionException
+	 */
+	public function testCallWithAtSignBasedClassReferencesWithoutMethodThrowsException() {
+		$container = new Container;
+		$result    = $container->call( 'ContainerTestCallStub' );
+	}
+
+	public function testCallWithAtSignBasedClassReferences() {
+		$container = new Container;
+		$result    = $container->call( 'ContainerTestCallStub@work', [ 'foo', 'bar' ] );
+		$this->assertEquals( [ 'foo', 'bar' ], $result );
+
+		$container = new Container;
+		$result    = $container->call( 'ContainerTestCallStub@inject' );
+		$this->assertInstanceOf( 'ContainerConcreteStub', $result[0] );
+		$this->assertEquals( 'taylor', $result[1] );
+
+		$container = new Container;
+		$result    = $container->call( 'ContainerTestCallStub@inject', [ 'default' => 'foo' ] );
+		$this->assertInstanceOf( 'ContainerConcreteStub', $result[0] );
+		$this->assertEquals( 'foo', $result[1] );
+
+		$container = new Container;
+		$result    = $container->call( 'ContainerTestCallStub', [ 'foo', 'bar' ], 'work' );
+		$this->assertEquals( [ 'foo', 'bar' ], $result );
+	}
+
+	public function testCallWithCallableArray() {
+		$container = new Container;
+		$stub      = new ContainerTestCallStub();
+		$result    = $container->call( [ $stub, 'work' ], [ 'foo', 'bar' ] );
+		$this->assertEquals( [ 'foo', 'bar' ], $result );
+	}
+
+	public function testCallWithStaticMethodNameString() {
+		$container = new Container;
+		$result    = $container->call( 'ContainerStaticMethodStub::inject' );
+		$this->assertInstanceOf( 'ContainerConcreteStub', $result[0] );
+		$this->assertEquals( 'taylor', $result[1] );
+	}
+
+	public function testCallWithGlobalMethodName() {
+		$container = new Container;
+		$result    = $container->call( 'containerTestInject' );
+		$this->assertInstanceOf( 'ContainerConcreteStub', $result[0] );
+		$this->assertEquals( 'taylor', $result[1] );
+	}
+
+	public function testContainerCanInjectDifferentImplementationsDependingOnContext() {
+		$container = new Container;
+
+		$container->bind( 'IContainerContractStub', 'ContainerImplementationStub' );
+
+		$container->when( 'ContainerTestContextInjectOne' )->needs( 'IContainerContractStub' )->give( 'ContainerImplementationStub' );
+		$container->when( 'ContainerTestContextInjectTwo' )->needs( 'IContainerContractStub' )->give( 'ContainerImplementationStubTwo' );
+
+		$one = $container->make( 'ContainerTestContextInjectOne' );
+		$two = $container->make( 'ContainerTestContextInjectTwo' );
+
+		$this->assertInstanceOf( 'ContainerImplementationStub', $one->impl );
+		$this->assertInstanceOf( 'ContainerImplementationStubTwo', $two->impl );
+
+		/*
+		 * Test With Closures
+		 */
+		$container = new Container;
+
+		$container->bind( 'IContainerContractStub', 'ContainerImplementationStub' );
+
+		$container->when( 'ContainerTestContextInjectOne' )->needs( 'IContainerContractStub' )->give( 'ContainerImplementationStub' );
+		$container->when( 'ContainerTestContextInjectTwo' )->needs( 'IContainerContractStub' )->give( function ( $container ) {
+			return $container->make( 'ContainerImplementationStubTwo' );
+		} );
+
+		$one = $container->make( 'ContainerTestContextInjectOne' );
+		$two = $container->make( 'ContainerTestContextInjectTwo' );
+
+		$this->assertInstanceOf( 'ContainerImplementationStub', $one->impl );
+		$this->assertInstanceOf( 'ContainerImplementationStubTwo', $two->impl );
+	}
+
+	public function testContextualBindingWorksRegardlessOfLeadingBackslash() {
+		$container = new Container;
+
+		$container->bind( 'IContainerContractStub', 'ContainerImplementationStub' );
+
+		$container->when( '\ContainerTestContextInjectOne' )->needs( 'IContainerContractStub' )->give( 'ContainerImplementationStubTwo' );
+		$container->when( 'ContainerTestContextInjectTwo' )->needs( '\IContainerContractStub' )->give( 'ContainerImplementationStubTwo' );
+
+		$this->assertInstanceOf(
+			'ContainerImplementationStubTwo',
+			$container->make( 'ContainerTestContextInjectOne' )->impl
+		);
+
+		$this->assertInstanceOf(
+			'ContainerImplementationStubTwo',
+			$container->make( 'ContainerTestContextInjectTwo' )->impl
+		);
+
+		$this->assertInstanceOf(
+			'ContainerImplementationStubTwo',
+			$container->make( '\ContainerTestContextInjectTwo' )->impl
+		);
+	}
+
+	public function testContainerTags() {
+		$container = new Container;
+		$container->tag( 'ContainerImplementationStub', 'foo', 'bar' );
+		$container->tag( 'ContainerImplementationStubTwo', [ 'foo' ] );
+
+		$this->assertCount( 1, $container->tagged( 'bar' ) );
+		$this->assertCount( 2, $container->tagged( 'foo' ) );
+		$this->assertInstanceOf( 'ContainerImplementationStub', $container->tagged( 'foo' )[0] );
+		$this->assertInstanceOf( 'ContainerImplementationStub', $container->tagged( 'bar' )[0] );
+		$this->assertInstanceOf( 'ContainerImplementationStubTwo', $container->tagged( 'foo' )[1] );
+
+		$container = new Container;
+		$container->tag( [ 'ContainerImplementationStub', 'ContainerImplementationStubTwo' ], [ 'foo' ] );
+		$this->assertCount( 2, $container->tagged( 'foo' ) );
+		$this->assertInstanceOf( 'ContainerImplementationStub', $container->tagged( 'foo' )[0] );
+		$this->assertInstanceOf( 'ContainerImplementationStubTwo', $container->tagged( 'foo' )[1] );
+
+		$this->assertEmpty( $container->tagged( 'this_tag_does_not_exist' ) );
+	}
+
+	public function testForgetInstanceForgetsInstance() {
+		$container             = new Container;
+		$containerConcreteStub = new ContainerConcreteStub;
+		$container->instance( 'ContainerConcreteStub', $containerConcreteStub );
+		$this->assertTrue( $container->isShared( 'ContainerConcreteStub' ) );
+		$container->forgetInstance( 'ContainerConcreteStub' );
+		$this->assertFalse( $container->isShared( 'ContainerConcreteStub' ) );
+	}
+
+	public function testForgetInstancesForgetsAllInstances() {
+		$container              = new Container;
+		$containerConcreteStub1 = new ContainerConcreteStub;
+		$containerConcreteStub2 = new ContainerConcreteStub;
+		$containerConcreteStub3 = new ContainerConcreteStub;
+		$container->instance( 'Instance1', $containerConcreteStub1 );
+		$container->instance( 'Instance2', $containerConcreteStub2 );
+		$container->instance( 'Instance3', $containerConcreteStub3 );
+		$this->assertTrue( $container->isShared( 'Instance1' ) );
+		$this->assertTrue( $container->isShared( 'Instance2' ) );
+		$this->assertTrue( $container->isShared( 'Instance3' ) );
+		$container->forgetInstances();
+		$this->assertFalse( $container->isShared( 'Instance1' ) );
+		$this->assertFalse( $container->isShared( 'Instance2' ) );
+		$this->assertFalse( $container->isShared( 'Instance3' ) );
+	}
+
+	public function testContainerFlushFlushesAllBindingsAliasesAndResolvedInstances() {
+		$container = new Container;
+		$container->bind( 'ConcreteStub',
+			function () {
+				return new ContainerConcreteStub;
+			},
+			true );
+		$container->alias( 'ConcreteStub', 'ContainerConcreteStub' );
+		$concreteStubInstance = $container->make( 'ConcreteStub' );
+		$this->assertTrue( $container->resolved( 'ConcreteStub' ) );
+		$this->assertTrue( $container->isAlias( 'ContainerConcreteStub' ) );
+		$this->assertArrayHasKey( 'ConcreteStub', $container->getBindings() );
+		$this->assertTrue( $container->isShared( 'ConcreteStub' ) );
+		$container->flush();
+		$this->assertFalse( $container->resolved( 'ConcreteStub' ) );
+		$this->assertFalse( $container->isAlias( 'ContainerConcreteStub' ) );
+		$this->assertEmpty( $container->getBindings() );
+		$this->assertFalse( $container->isShared( 'ConcreteStub' ) );
+	}
+
+	public function testResolvedResolvesAliasToBindingNameBeforeChecking() {
+		$container = new Container;
+		$container->bind( 'ConcreteStub',
+			function () {
+				return new ContainerConcreteStub;
+			},
+			true );
+		$container->alias( 'ConcreteStub', 'foo' );
+
+		$this->assertFalse( $container->resolved( 'ConcreteStub' ) );
+		$this->assertFalse( $container->resolved( 'foo' ) );
+
+		$concreteStubInstance = $container->make( 'ConcreteStub' );
+
+		$this->assertTrue( $container->resolved( 'ConcreteStub' ) );
+		$this->assertTrue( $container->resolved( 'foo' ) );
+	}
+
+	public function testContainerCanInjectSimpleVariable() {
+		$container = new Container;
+		$container->when( 'ContainerInjectVariableStub' )->needs( '$something' )->give( 100 );
+		$instance = $container->make( 'ContainerInjectVariableStub' );
+		$this->assertEquals( 100, $instance->something );
+
+		$container = new Container;
+		$container->when( 'ContainerInjectVariableStub' )->needs( '$something' )->give( function ( $container ) {
+			return $container->make( 'ContainerConcreteStub' );
+		} );
+		$instance = $container->make( 'ContainerInjectVariableStub' );
+		$this->assertInstanceOf( 'ContainerConcreteStub', $instance->something );
+	}
+
+	/**
+	 * @group testCallWithGlobalMethodNameAnnotation
+	 */
+	public function testCallWithGlobalMethodNameAnnotation() {
+		$container = new Container;
+		$result    = $container->call( 'containerTestInjectAnnotation' );
+		$this->assertInstanceOf( 'ContainerConcreteStub', $result[0] );
+		$this->assertEquals( 'taylor', $result[1] );
+	}
 }
 
-class ContainerConcreteStub
-{
+class ContainerConcreteStub {
 }
 
-interface IContainerContractStub
-{
+interface IContainerContractStub {
 }
 
-class ContainerImplementationStub implements IContainerContractStub
-{
-}
-class ContainerImplementationStubTwo implements IContainerContractStub
-{
+class ContainerImplementationStub implements IContainerContractStub {
 }
 
-class ContainerDependentStub
-{
-    public $impl;
-
-    public function __construct(IContainerContractStub $impl)
-    {
-        $this->impl = $impl;
-    }
+class ContainerImplementationStubTwo implements IContainerContractStub {
 }
 
-class ContainerNestedDependentStub
-{
-    public $inner;
+class ContainerDependentStub {
+	public $impl;
 
-    public function __construct(ContainerDependentStub $inner)
-    {
-        $this->inner = $inner;
-    }
+	public function __construct( IContainerContractStub $impl ) {
+		$this->impl = $impl;
+	}
 }
 
-class ContainerDefaultValueStub
-{
-    public $stub;
-    public $default;
+class ContainerNestedDependentStub {
+	public $inner;
 
-    public function __construct(ContainerConcreteStub $stub, $default = 'taylor')
-    {
-        $this->stub = $stub;
-        $this->default = $default;
-    }
+	public function __construct( ContainerDependentStub $inner ) {
+		$this->inner = $inner;
+	}
 }
 
-class ContainerMixedPrimitiveStub
-{
-    public $first;
-    public $last;
-    public $stub;
+class ContainerDefaultValueStub {
+	public $stub;
+	public $default;
 
-    public function __construct($first, ContainerConcreteStub $stub, $last)
-    {
-        $this->stub = $stub;
-        $this->last = $last;
-        $this->first = $first;
-    }
+	public function __construct( ContainerConcreteStub $stub, $default = 'taylor' ) {
+		$this->stub    = $stub;
+		$this->default = $default;
+	}
 }
 
-class ContainerConstructorParameterLoggingStub
-{
-    public $receivedParameters;
+class ContainerMixedPrimitiveStub {
+	public $first;
+	public $last;
+	public $stub;
 
-    public function __construct($first, $second)
-    {
-        $this->receivedParameters = func_get_args();
-    }
+	public function __construct( $first, ContainerConcreteStub $stub, $last ) {
+		$this->stub  = $stub;
+		$this->last  = $last;
+		$this->first = $first;
+	}
 }
 
-class ContainerLazyExtendStub
-{
-    public static $initialized = false;
+class ContainerConstructorParameterLoggingStub {
+	public $receivedParameters;
 
-    public function init()
-    {
-        static::$initialized = true;
-    }
+	public function __construct( $first, $second ) {
+		$this->receivedParameters = func_get_args();
+	}
 }
 
-class ContainerTestCallStub
-{
-    public function work()
-    {
-        return func_get_args();
-    }
+class ContainerLazyExtendStub {
+	public static $initialized = false;
 
-    public function inject(ContainerConcreteStub $stub, $default = 'taylor')
-    {
-        return func_get_args();
-    }
+	public function init() {
+		static::$initialized = true;
+	}
 }
 
-class ContainerTestContextInjectOne
-{
-    public $impl;
+class ContainerTestCallStub {
+	public function work() {
+		return func_get_args();
+	}
 
-    public function __construct(IContainerContractStub $impl)
-    {
-        $this->impl = $impl;
-    }
+	public function inject( ContainerConcreteStub $stub, $default = 'taylor' ) {
+		return func_get_args();
+	}
 }
 
-class ContainerTestContextInjectTwo
-{
-    public $impl;
+class ContainerTestContextInjectOne {
+	public $impl;
 
-    public function __construct(IContainerContractStub $impl)
-    {
-        $this->impl = $impl;
-    }
+	public function __construct( IContainerContractStub $impl ) {
+		$this->impl = $impl;
+	}
 }
 
-class ContainerStaticMethodStub
-{
-    public static function inject(ContainerConcreteStub $stub, $default = 'taylor')
-    {
-        return func_get_args();
-    }
+class ContainerTestContextInjectTwo {
+	public $impl;
+
+	public function __construct( IContainerContractStub $impl ) {
+		$this->impl = $impl;
+	}
 }
 
-class ContainerInjectVariableStub
-{
-    public $something;
-
-    public function __construct(ContainerConcreteStub $concrete, $something)
-    {
-        $this->something = $something;
-    }
+class ContainerStaticMethodStub {
+	public static function inject( ContainerConcreteStub $stub, $default = 'taylor' ) {
+		return func_get_args();
+	}
 }
 
-function containerTestInject(ContainerConcreteStub $stub, $default = 'taylor')
-{
-    return func_get_args();
+class ContainerInjectVariableStub {
+	public $something;
+
+	public function __construct( ContainerConcreteStub $concrete, $something ) {
+		$this->something = $something;
+	}
+}
+
+function containerTestInject( ContainerConcreteStub $stub, $default = 'taylor' ) {
+	return func_get_args();
+}
+
+/**
+ * @param ContainerConcreteStub $stub
+ * @param string                $default
+ *
+ * @return array
+ *
+ * @inject('stub', 'ContainerConcreteStub')
+ */
+function containerTestInjectAnnotation( $stub, $default = 'taylor' ) {
+	return func_get_args();
 }

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -188,12 +188,12 @@ class ContainerContainerTest extends PHPUnit_Framework_TestCase {
 		$container = new Container;
 		$container->bind( 'foo',
 			function () {
-				$obj      = new StdClass;
+				$obj      = new stdClass;
 				$obj->foo = 'bar';
 
 				return $obj;
 			} );
-		$obj      = new StdClass;
+		$obj      = new stdClass;
 		$obj->foo = 'foo';
 		$container->instance( 'foo', $obj );
 		$container->extend( 'foo',
@@ -256,6 +256,19 @@ class ContainerContainerTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals( 'taylor', $instance->default );
 	}
 
+	/**
+	 * @group testResolutionOfDefaultParametersAnnotation
+	 */
+	public function testResolutionOfDefaultParametersAnnotation() {
+		$container = new Container;
+		$instance  = $container->make( 'ContainerDefaultValueStubAnnotation' );
+		var_dump($instance);
+		$this->assertInstanceOf( 'ContainerImplementationStub', $instance->stub1 );
+		$this->assertInstanceOf( 'ContainerImplementationStubTwo', $instance->stub2 );
+		$this->assertInstanceOf( 'ContainerConcreteStub', $instance->stub3 );
+		$this->assertEquals( 'taylor', $instance->default );
+	}
+
 	public function testResolvingCallbacksAreCalledForSpecificAbstracts() {
 		$container = new Container;
 		$container->resolving( 'foo',
@@ -264,7 +277,7 @@ class ContainerContainerTest extends PHPUnit_Framework_TestCase {
 			} );
 		$container->bind( 'foo',
 			function () {
-				return new StdClass;
+				return new stdClass;
 			} );
 		$instance = $container->make( 'foo' );
 
@@ -278,7 +291,7 @@ class ContainerContainerTest extends PHPUnit_Framework_TestCase {
 		} );
 		$container->bind( 'foo',
 			function () {
-				return new StdClass;
+				return new stdClass;
 			} );
 		$instance = $container->make( 'foo' );
 
@@ -287,13 +300,13 @@ class ContainerContainerTest extends PHPUnit_Framework_TestCase {
 
 	public function testResolvingCallbacksAreCalledForType() {
 		$container = new Container;
-		$container->resolving( 'StdClass',
+		$container->resolving( 'stdClass',
 			function ( $object ) {
 				return $object->name = 'taylor';
 			} );
 		$container->bind( 'foo',
 			function () {
-				return new StdClass;
+				return new stdClass;
 			} );
 		$instance = $container->make( 'foo' );
 
@@ -302,7 +315,7 @@ class ContainerContainerTest extends PHPUnit_Framework_TestCase {
 
 	public function testUnsetRemoveBoundInstances() {
 		$container = new Container;
-		$container->instance( 'object', new StdClass );
+		$container->instance( 'object', new stdClass );
 		unset( $container['object'] );
 
 		$this->assertFalse( $container->bound( 'object' ) );
@@ -310,7 +323,7 @@ class ContainerContainerTest extends PHPUnit_Framework_TestCase {
 
 	public function testBoundInstanceAndAliasCheckViaArrayAccess() {
 		$container = new Container;
-		$container->instance( 'object', new StdClass );
+		$container->instance( 'object', new stdClass );
 		$container->alias( 'object', 'alias' );
 
 		$this->assertTrue( isset( $container['object'] ) );
@@ -406,14 +419,14 @@ class ContainerContainerTest extends PHPUnit_Framework_TestCase {
 
 	public function testCallWithDependencies() {
 		$container = new Container;
-		$result    = $container->call( function ( StdClass $foo, $bar = [ ] ) {
+		$result    = $container->call( function ( stdClass $foo, $bar = [ ] ) {
 			return func_get_args();
 		} );
 
 		$this->assertInstanceOf( 'stdClass', $result[0] );
 		$this->assertEquals( [ ], $result[1] );
 
-		$result = $container->call( function ( StdClass $foo, $bar = [ ] ) {
+		$result = $container->call( function ( stdClass $foo, $bar = [ ] ) {
 			return func_get_args();
 		},
 			[ 'bar' => 'taylor' ] );
@@ -424,7 +437,7 @@ class ContainerContainerTest extends PHPUnit_Framework_TestCase {
 		/*
 		 * Wrap a function...
 		 */
-		$result = $container->wrap( function ( StdClass $foo, $bar = [ ] ) {
+		$result = $container->wrap( function ( stdClass $foo, $bar = [ ] ) {
 			return func_get_args();
 		},
 			[ 'bar' => 'taylor' ] );
@@ -713,6 +726,31 @@ class ContainerDefaultValueStub {
 
 	public function __construct( ContainerConcreteStub $stub, $default = 'taylor' ) {
 		$this->stub    = $stub;
+		$this->default = $default;
+	}
+}
+
+class ContainerDefaultValueStubAnnotation {
+	public $stub1;
+	public $stub2;
+	public $stub3;
+	public $default;
+
+	/**
+	 * ContainerDefaultValueStubAnnotation constructor.
+	 *
+	 * @param IContainerContractStub $stub1
+	 * @param                        $stub2
+	 * @param ContainerConcreteStub  $stub3
+	 * @param string                 $default
+	 *
+	 * @inject('stub1', 'ContainerImplementationStub')
+	 * @inject('stub2', 'ContainerImplementationStubTwo')
+	 */
+	public function __construct( IContainerContractStub $stub1, $stub2, ContainerConcreteStub $stub3, $default = 'taylor' ) {
+		$this->stub1   = $stub1;
+		$this->stub2   = $stub2;
+		$this->stub3   = $stub3;
 		$this->default = $default;
 	}
 }


### PR DESCRIPTION
This pull request adds an annotation @inject to the Container of Laravel 5 to use with the type hinting injection.
### Problem :

Laravel Container allow to define service with Full qualified classe name or an arbitary unique name.
`app()->bind(Com\Services\Contracts\MyServiceInterface::class, function($app){
    return new Com\Services\MyService();
});`
or
`app()->bind('my_service_2', function($app){
    return new Com\Services\MyService2();
});`

And when we want to inject service 1 in constructor we do :
`public function __construct(Com\Services\Contracts\MyServiceInterface $service1){ }`

But for service 2 we can't unless we define an alias or another binding with type hinting. 
### Proposed solution :

With the new annotation **@inject('param_name', 'service_name')** we can do :
`
/**@inject('service2', 'my_service_2')
*/
public function __construct(Com\Services\Contracts\MyServiceInterface $service1, $service2){ }`
### Usage :

@inject annotation has to parametters :
- First : The function or constructor parametter name which we want to inject.
- Second : The service name in the container.

Thinks
