### PR TITLE
[5.3] Only reverse the wording of the failure description

### DIFF
--- a/src/Illuminate/Foundation/Testing/Constraints/HasInElement.php
+++ b/src/Illuminate/Foundation/Testing/Constraints/HasInElement.php
@@ -65,4 +65,14 @@ class HasInElement extends PageConstraint
     {
         return sprintf('[%s] contains %s', $this->element, $this->text);
     }
+
+    /**
+     * Returns the reversed description of the failure.
+     *
+     * @return string
+     */
+    protected function getReverseFailureDescription()
+    {
+        return sprintf('[%s] does not contain %s', $this->element, $this->text);
+    }
 }

--- a/src/Illuminate/Foundation/Testing/Constraints/HasLink.php
+++ b/src/Illuminate/Foundation/Testing/Constraints/HasLink.php
@@ -89,7 +89,23 @@ class HasLink extends PageConstraint
      */
     public function getFailureDescription()
     {
-        $description = "a link with the text [{$this->text}]";
+        $description = "has a link with the text [{$this->text}]";
+
+        if ($this->url) {
+            $description .= " and the URL [{$this->url}]";
+        }
+
+        return $description;
+    }
+
+    /**
+     * Returns the reversed description of the failure.
+     *
+     * @return string
+     */
+    protected function getReverseFailureDescription()
+    {
+        $description = "does not have a link with the text [{$this->text}]";
 
         if ($this->url) {
             $description .= " and the URL [{$this->url}]";

--- a/src/Illuminate/Foundation/Testing/Constraints/HasValue.php
+++ b/src/Illuminate/Foundation/Testing/Constraints/HasValue.php
@@ -58,4 +58,17 @@ class HasValue extends FormFieldConstraint
             $this->selector, $this->value
         );
     }
+
+    /**
+     * Returns the reversed description of the failure.
+     *
+     * @return string
+     */
+    protected function getReverseFailureDescription()
+    {
+        return sprintf(
+            'the field [%s] does not contain the expected value [%s]',
+            $this->selector, $this->value
+        );
+    }
 }

--- a/src/Illuminate/Foundation/Testing/Constraints/IsChecked.php
+++ b/src/Illuminate/Foundation/Testing/Constraints/IsChecked.php
@@ -47,4 +47,14 @@ class IsChecked extends FormFieldConstraint
     {
         return "the checkbox [{$this->selector}] is checked";
     }
+
+    /**
+     * Returns the reversed description of the failure.
+     *
+     * @return string
+     */
+    protected function getReverseFailureDescription()
+    {
+        return "the checkbox [{$this->selector}] is not checked";
+    }
 }

--- a/src/Illuminate/Foundation/Testing/Constraints/IsSelected.php
+++ b/src/Illuminate/Foundation/Testing/Constraints/IsSelected.php
@@ -98,4 +98,17 @@ class IsSelected extends FormFieldConstraint
             $this->selector, $this->value
         );
     }
+
+    /**
+     * Returns the reversed description of the failure.
+     *
+     * @return string
+     */
+    protected function getReverseFailureDescription()
+    {
+        return sprintf(
+            'the element [%s] does not have the selected value [%s]',
+            $this->selector, $this->value
+        );
+    }
 }

--- a/src/Illuminate/Foundation/Testing/Constraints/PageConstraint.php
+++ b/src/Illuminate/Foundation/Testing/Constraints/PageConstraint.php
@@ -101,6 +101,16 @@ abstract class PageConstraint extends PHPUnit_Framework_Constraint
     }
 
     /**
+     * Returns the reversed description of the failure.
+     *
+     * @return string
+     */
+    protected function getReverseFailureDescription()
+    {
+        return 'the page does not contain '.$this->toString();
+    }
+
+    /**
      * Get a string representation of the object.
      *
      * Placeholder method to avoid forcing definition of this method.

--- a/src/Illuminate/Foundation/Testing/Constraints/ReversePageConstraint.php
+++ b/src/Illuminate/Foundation/Testing/Constraints/ReversePageConstraint.php
@@ -42,11 +42,7 @@ class ReversePageConstraint extends PageConstraint
      */
     protected function getFailureDescription()
     {
-        return str_replace(
-            ['contains', 'is', 'has'],
-            ['does not contain', 'is not', 'does not have'],
-            $this->pageConstraint->getFailureDescription()
-        );
+        return $this->pageConstraint->getReverseFailureDescription();
     }
 
     /**


### PR DESCRIPTION
This adjusts the testing page constraints so they can provide a correctly-worded reversed description. Previously the `ReversePageConstraint` would just do a string replace over the entire failure description which would also impact content the test was looking for (see #14174 for more information).
