### PR TITLE
[5.2] Fix seeIsSelected for <option> tags without value attribute

### DIFF
--- a/src/Illuminate/Foundation/Testing/Constraints/IsSelected.php
+++ b/src/Illuminate/Foundation/Testing/Constraints/IsSelected.php
@@ -60,15 +60,28 @@ class IsSelected extends FormFieldConstraint
             if ($option->nodeName === 'optgroup') {
                 foreach ($option->childNodes as $child) {
                     if ($child->hasAttribute('selected')) {
-                        $selected[] = $child->getAttribute('value');
+                        $selected[] = $this->getOptionValue($child);
                     }
                 }
             } elseif ($option->hasAttribute('selected')) {
-                $selected[] = $option->getAttribute('value');
+                $selected[] = $this->getOptionValue($option);
             }
         }
 
         return $selected;
+    }
+
+    /**
+     * Get the selected value from an option element.
+     *
+     * @return string
+     */
+    protected function getOptionValue(\DOMElement $option)
+    {
+        if($option->hasAttribute('value')){
+            return $option->getAttribute('value');
+        }
+        return $option->textContent;
     }
 
     /**

--- a/src/Illuminate/Foundation/Testing/Constraints/IsSelected.php
+++ b/src/Illuminate/Foundation/Testing/Constraints/IsSelected.php
@@ -74,6 +74,7 @@ class IsSelected extends FormFieldConstraint
     /**
      * Get the selected value from an option element.
      *
+     * @param \DOMElement $option
      * @return string
      */
     protected function getOptionValue(\DOMElement $option)

--- a/src/Illuminate/Foundation/Testing/Constraints/IsSelected.php
+++ b/src/Illuminate/Foundation/Testing/Constraints/IsSelected.php
@@ -75,7 +75,7 @@ class IsSelected extends FormFieldConstraint
     /**
      * Get the selected value from an option element.
      *
-     * @param DOMElement $option
+     * @param \DOMElement $option
      * @return string
      */
     protected function getOptionValue(DOMElement $option)
@@ -83,6 +83,7 @@ class IsSelected extends FormFieldConstraint
         if ($option->hasAttribute('value')) {
             return $option->getAttribute('value');
         }
+        
         return $option->textContent;
     }
 

--- a/src/Illuminate/Foundation/Testing/Constraints/IsSelected.php
+++ b/src/Illuminate/Foundation/Testing/Constraints/IsSelected.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Foundation\Testing\Constraints;
 
+use DOMElement;
 use Symfony\Component\DomCrawler\Crawler;
 
 class IsSelected extends FormFieldConstraint
@@ -74,12 +75,12 @@ class IsSelected extends FormFieldConstraint
     /**
      * Get the selected value from an option element.
      *
-     * @param \DOMElement $option
+     * @param DOMElement $option
      * @return string
      */
-    protected function getOptionValue(\DOMElement $option)
+    protected function getOptionValue(DOMElement $option)
     {
-        if($option->hasAttribute('value')){
+        if ($option->hasAttribute('value')) {
             return $option->getAttribute('value');
         }
         return $option->textContent;

--- a/tests/Foundation/FoundationInteractsWithPagesTest.php
+++ b/tests/Foundation/FoundationInteractsWithPagesTest.php
@@ -215,6 +215,28 @@ class FoundationInteractsWithPagesTest extends PHPUnit_Framework_TestCase
         $this->dontSeeIsSelected('availability', 'partial_time');
     }
 
+    protected function getSelectHtmlWithoutValueAttribute()
+    {
+        return
+            '<select name="size">
+              <option>S</option>
+              <option selected>M</option>
+              <option>L</option>
+          </select>';
+    }
+
+    public function testSeeOptionWithoutValueIsSelected()
+    {
+        $this->setCrawler($this->getSelectHtmlWithoutValueAttribute());
+        $this->seeIsSelected('size', 'M');
+    }
+
+    public function testDontSeeOptionWithoutValueIsSelected()
+    {
+        $this->setCrawler($this->getSelectHtmlWithoutValueAttribute());
+        $this->dontSeeIsSelected('size', 'S');
+    }
+
     protected function getEmptySelectHtml()
     {
         return


### PR DESCRIPTION
This PR adds support for `<option>` tags without a `value="…"` attribute to the `seeIsSelected` testing helper.

c.f. MDN: https://developer.mozilla.org/en/docs/Web/HTML/Element/option

> The content of this attribute represents the value to be submitted with the form, should this option be selected. **If this attribute is omitted, the value is taken from the text content of the option element**.
