### PR TITLE
[5.3] Add Eloquent is() method for model comparison

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -3038,6 +3038,17 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     }
 
     /**
+     * Determine if the model matches the model passed in.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @return bool
+     */
+    public function is(Model $model)
+    {
+        return $this->getKey() === $model->getKey() && $this->getTable() === $model->getTable();
+    }
+
+    /**
      * Get all of the current attributes on the model.
      *
      * @return array

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1349,6 +1349,31 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
         $this->assertSame($scopes, $model->scopesCalled);
     }
 
+    public function testIsWithTheSameModelInstance()
+    {
+        $firstInstance = new EloquentModelStub(['id' => 1]);
+        $secondInstance = new EloquentModelStub(['id' => 1]);
+        $result = $firstInstance->is($secondInstance);
+        $this->assertTrue($result);
+    }
+
+    public function testIsWithAnotherModelInstance()
+    {
+        $firstInstance = new EloquentModelStub(['id' => 1]);
+        $secondInstance = new EloquentModelStub(['id' => 2]);
+        $result = $firstInstance->is($secondInstance);
+        $this->assertFalse($result);
+    }
+
+    public function testIsWIthAnotherModel()
+    {
+        $firstInstance = new EloquentModelStub(['id' => 1]);
+        $secondInstance = new EloquentModelStub(['id' => 1]);
+        $secondInstance->setTable('foo');
+        $result = $firstInstance->is($secondInstance);
+        $this->assertFalse($result);
+    }
+
     protected function addMockConnection($model)
     {
         $model->setConnectionResolver($resolver = m::mock('Illuminate\Database\ConnectionResolverInterface'));


### PR DESCRIPTION
This adds a helper method to compare two Eloquent models. I've found it useful for checking whether two Eloquent models reference the same row or not. I think it reads a little cleaner when performing certain logic.

```
if (auth()->user()->is($post->user)) {
    //
}

// Versus:

if (auth()->id() === $post->user_id) {
    //
}
```

Or any other scenario where where you need to compare two models.
