### PR TITLE
[5.3] Make the logout action a POST request

### DIFF
--- a/src/Illuminate/Auth/Console/stubs/make/views/layouts/app.stub
+++ b/src/Illuminate/Auth/Console/stubs/make/views/layouts/app.stub
@@ -52,7 +52,14 @@
                             </a>
 
                             <ul class="dropdown-menu" role="menu">
-                                <li><a href="{{ url('/logout') }}">Logout</a></li>
+                                <li>
+                                    <form action="{{ url('/logout') }}" method="POST">
+                                        {!! csrf_field() !!}
+                                        <button type="submit" class="btn btn-link">
+                                            Logout
+                                        </button>
+                                    </form>
+                                </li>
                             </ul>
                         </li>
                     @endif

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -289,7 +289,7 @@ class Router implements RegistrarContract
         // Authentication Routes...
         $this->get('login', 'Auth\LoginController@showLoginForm');
         $this->post('login', 'Auth\LoginController@login');
-        $this->get('logout', 'Auth\LoginController@logout');
+        $this->post('logout', 'Auth\LoginController@logout');
 
         // Registration Routes...
         $this->get('register', 'Auth\RegisterController@showRegistrationForm');


### PR DESCRIPTION
Instead of a GET request. In this way we can use the CSRF token and avoid other websites calling /logout on ours, which can be annoying or cause bigger problems.
