### PR TITLE
[5.1] Backport HHVM type error fix

### DIFF
--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -128,7 +128,7 @@ abstract class AbstractPaginator
         }
 
         return $this->path.'?'
-                        .http_build_query($parameters, null, '&')
+                        .http_build_query($parameters, '', '&')
                         .$this->buildFragment();
     }
 


### PR DESCRIPTION
This backports https://github.com/laravel/framework/pull/13758.

Avoids the following error:

```
TypeError: Argument 2 passed to http_build_query() must be an instance of string, null given
```
