### PR TITLE
[5.1] Do not allow empty cache paths

### DIFF
--- a/src/Illuminate/View/Compilers/Compiler.php
+++ b/src/Illuminate/View/Compilers/Compiler.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\View\Compilers;
 
+use InvalidArgumentException;
 use Illuminate\Filesystem\Filesystem;
 
 abstract class Compiler
@@ -26,9 +27,15 @@ abstract class Compiler
      * @param  \Illuminate\Filesystem\Filesystem  $files
      * @param  string  $cachePath
      * @return void
+     *
+     * @throws \InvalidArgumentException
      */
     public function __construct(Filesystem $files, $cachePath)
     {
+        if (! $cachePath) {
+            throw new InvalidArgumentException('The cache path must be non-empty.');
+        }
+
         $this->files = $files;
         $this->cachePath = $cachePath;
     }
@@ -57,7 +64,7 @@ abstract class Compiler
         // If the compiled file doesn't exist we will indicate that the view is expired
         // so that it can be re-compiled. Else, we will verify the last modification
         // of the views is less than the modification times of the compiled views.
-        if (! $this->cachePath || ! $this->files->exists($compiled)) {
+        if (! $this->files->exists($compiled)) {
             return true;
         }
 

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -17,11 +17,12 @@ class ViewBladeCompilerTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($compiler->isExpired('foo'));
     }
 
-    public function testIsExpiredReturnsTrueIfCachePathIsNull()
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testCannotConstructWithBadCachePath()
     {
-        $compiler = new BladeCompiler($files = $this->getFiles(), null);
-        $files->shouldReceive('exists')->never();
-        $this->assertTrue($compiler->isExpired('foo'));
+        new BladeCompiler($this->getFiles(), null);
     }
 
     public function testIsExpiredReturnsTrueWhenModificationTimesWarrant()
@@ -73,14 +74,6 @@ class ViewBladeCompilerTest extends PHPUnit_Framework_TestCase
         // trigger compilation with null $path
         $compiler->compile();
         $this->assertEquals('foo', $compiler->getPath());
-    }
-
-    public function testCompileDoesntStoreFilesWhenCachePathIsNull()
-    {
-        $compiler = new BladeCompiler($files = $this->getFiles(), null);
-        $files->shouldReceive('get')->once()->with('foo')->andReturn('Hello World');
-        $files->shouldReceive('put')->never();
-        $compiler->compile('foo');
     }
 
     public function testEchosAreCompiled()


### PR DESCRIPTION
Replaces #14277. Closes #14271.
