### PR TITLE
Removed bmp mime from image validation rule

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1552,7 +1552,7 @@ class Validator implements ValidatorContract
      */
     protected function validateImage($attribute, $value)
     {
-        return $this->validateMimes($attribute, $value, ['jpeg', 'png', 'gif', 'bmp', 'svg']);
+        return $this->validateMimes($attribute, $value, ['jpeg', 'png', 'gif', 'svg']);
     }
 
     /**

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1647,18 +1647,13 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($v->passes());
 
         $file4 = $this->getMock('Symfony\Component\HttpFoundation\File\UploadedFile', ['guessExtension'], $uploadedFile);
-        $file4->expects($this->any())->method('guessExtension')->will($this->returnValue('bmp'));
+        $file4->expects($this->any())->method('guessExtension')->will($this->returnValue('png'));
         $v->setFiles(['x' => $file4]);
         $this->assertTrue($v->passes());
 
         $file5 = $this->getMock('Symfony\Component\HttpFoundation\File\UploadedFile', ['guessExtension'], $uploadedFile);
-        $file5->expects($this->any())->method('guessExtension')->will($this->returnValue('png'));
+        $file5->expects($this->any())->method('guessExtension')->will($this->returnValue('svg'));
         $v->setFiles(['x' => $file5]);
-        $this->assertTrue($v->passes());
-
-        $file6 = $this->getMock('Symfony\Component\HttpFoundation\File\UploadedFile', ['guessExtension'], $uploadedFile);
-        $file6->expects($this->any())->method('guessExtension')->will($this->returnValue('svg'));
-        $v->setFiles(['x' => $file6]);
         $this->assertTrue($v->passes());
     }
 


### PR DESCRIPTION
I love the convenience of using the `image` validation rule built-in to Laravel's Validator, but a couple of times recently different apps of mine have crashed because users uploaded Bitmap images and libraries like [Intervention](http://image.intervention.io/) don't play nicely with bmp files. I try to display that image (user avatar) on various pages, so it makes the website unusable for many users until I fix.

I know I can use the `mime` rule to manually set the extensions, which I've done to fix the issue, but I wonder since bmp images aren't web-friendly, have zero compression and aren't well supported, I suggest removing them from the default `image` validation rule to help others.

PS. How do you even make a bmp image these days?
