### PR TITLE
[5.3] whereNot function in Collection

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -228,6 +228,22 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
+     * Filter items that don't match the given key value pair.
+     *
+     * @param  string  $key
+     * @param  mixed  $value
+     * @param  bool  $strict
+     * @return static
+     */
+    public function whereNot($key, $value, $strict = true)
+    {
+        return $this->filter(function ($item) use ($key, $value, $strict) {
+            return $strict ? data_get($item, $key) !== $value
+                           : data_get($item, $key) != $value;
+        });
+    }
+
+    /**
      * Filter items by the given key value pair using loose comparison.
      *
      * @param  string  $key


### PR DESCRIPTION
Adds a `whereNot` function to the Collection, which is essentially the inverse of `where`. Not extremely necessary, but can be useful sometimes.
