### PR TITLE
[5.3] Collection: Failing test for flatten(1) which works for flatten()

### DIFF
--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -404,6 +404,21 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(['#foo', '#bar', ['#baz'], '#zap'], $c->flatten(2)->all());
     }
 
+    public function testFlattenWithDepthAndKeys()
+    {
+        // No depth flattens recursively
+        $c = new Collection(['#foo', ['key' => '#bar'], ['key' => '#baz'], 'key' => '#zap']);
+        $this->assertEquals(['#foo', '#bar', '#baz', '#zap'], $c->flatten()->all());
+
+        // With a depth of 1 it suddenly cares about keys
+        $c = new Collection(['#foo', ['key' => '#bar'], ['key' => '#baz'], 'key' => '#zap']);
+        $this->assertEquals(['#foo', '#bar', '#baz', '#zap'], $c->flatten(1)->all());
+
+        // Without keys
+        $c = new Collection(['#foo', ['#bar'], ['#baz'], 'key' => '#zap']);
+        $this->assertEquals(['#foo', '#bar', '#baz', '#zap'], $c->flatten(1)->all());
+    }
+
     public function testMergeNull()
     {
         $c = new Collection(['name' => 'Hello']);


### PR DESCRIPTION
When using `$collection->flatten(1)` array keys somehow mess with the result, whereas the same set does work as expected if no depth is supplied.
