### PR TITLE
[5.3] Implement reset notifier callback usage

### DIFF
--- a/src/Illuminate/Auth/Passwords/PasswordBroker.php
+++ b/src/Illuminate/Auth/Passwords/PasswordBroker.php
@@ -50,9 +50,10 @@ class PasswordBroker implements PasswordBrokerContract
      * Send a password reset link to a user.
      *
      * @param  array  $credentials
+     * @param  \Closure  $notifier
      * @return string
      */
-    public function sendResetLink(array $credentials)
+    public function sendResetLink(array $credentials, Closure $notifier = null)
     {
         // First we will check to see if we found a user at the given credentials and
         // if we did not we will redirect back to this current URI with a piece of
@@ -66,9 +67,13 @@ class PasswordBroker implements PasswordBrokerContract
         // Once we have the reset token, we are ready to send the message out to this
         // user with a link to reset their password. We will then redirect back to
         // the current URI having nothing set in the session to indicate errors.
-        $user->sendPasswordResetNotification(
-            $this->tokens->create($user)
-        );
+        if ($notifier) {
+            call_user_func($notifier, $user, $this->tokens->create($user));
+        } else {
+            $user->sendPasswordResetNotification(
+                $this->tokens->create($user)
+            );
+        }
 
         return static::RESET_LINK_SENT;
     }

--- a/src/Illuminate/Contracts/Auth/PasswordBroker.php
+++ b/src/Illuminate/Contracts/Auth/PasswordBroker.php
@@ -45,9 +45,10 @@ interface PasswordBroker
      * Send a password reset link to a user.
      *
      * @param  array  $credentials
+     * @param  \Closure  $notifier
      * @return string
      */
-    public function sendResetLink(array $credentials);
+    public function sendResetLink(array $credentials, Closure $notifier = null);
 
     /**
      * Reset the password for the given token.


### PR DESCRIPTION
Why [this](https://github.com/laravel/framework/blob/5.3/src/Illuminate/Foundation/Auth/SendsPasswordResetEmails.php#L34) is not used? :)
