### PR TITLE
[5.3] Improve Eloquent naming consistency

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -725,7 +725,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public function hasOne($related, $foreignKey = null, $localKey = null)
     {
-        $foreignKey = $foreignKey ?: $this->getForeignKey();
+        $foreignKey = $foreignKey ?: $this->getForeignKeyName();
 
         $instance = new $related;
 
@@ -861,7 +861,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public function hasMany($related, $foreignKey = null, $localKey = null)
     {
-        $foreignKey = $foreignKey ?: $this->getForeignKey();
+        $foreignKey = $foreignKey ?: $this->getForeignKeyName();
 
         $instance = new $related;
 
@@ -884,7 +884,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     {
         $through = new $through;
 
-        $firstKey = $firstKey ?: $this->getForeignKey();
+        $firstKey = $firstKey ?: $this->getForeignKeyName();
 
         $secondKey = $secondKey ?: $through->getForeignKey();
 
@@ -941,7 +941,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         // First, we'll need to determine the foreign key and "other key" for the
         // relationship. Once we have determined the keys we'll make the query
         // instances as well as the relationship instances we need for this.
-        $foreignKey = $foreignKey ?: $this->getForeignKey();
+        $foreignKey = $foreignKey ?: $this->getForeignKeyName();
 
         $instance = new $related;
 
@@ -1011,7 +1011,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public function morphedByMany($related, $name, $table = null, $foreignKey = null, $otherKey = null)
     {
-        $foreignKey = $foreignKey ?: $this->getForeignKey();
+        $foreignKey = $foreignKey ?: $this->getForeignKeyName();
 
         // For the inverse of the polymorphic many-to-many relations, we will change
         // the way we determine the foreign and other keys, as it is the opposite
@@ -1740,9 +1740,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public function setCreatedAt($value)
     {
-        $this->{static::CREATED_AT} = $value;
-
-        return $this;
+        return $this->setAttribute($this->getCreatedAtColumn(), $value);
     }
 
     /**
@@ -1753,9 +1751,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public function setUpdatedAt($value)
     {
-        $this->{static::UPDATED_AT} = $value;
-
-        return $this;
+        return $this->setAttribute($this->getUpdatedAtColumn(), $value);
     }
 
     /**
@@ -2066,8 +2062,19 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      * Get the default foreign key name for the model.
      *
      * @return string
+     * @deprecated 5.3
      */
     public function getForeignKey()
+    {
+        return $this->getForeignKeyName();
+    }
+
+    /**
+     * Get the default foreign key name for the model.
+     *
+     * @return string
+     */
+    public function getForeignKeyName()
     {
         return Str::snake(class_basename($this)).'_id';
     }
@@ -2190,11 +2197,23 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      * @param  array  $fillable
      * @return $this
      */
-    public function fillable(array $fillable)
+    public function setFillable(array $fillable)
     {
         $this->fillable = $fillable;
 
         return $this;
+    }
+
+    /**
+     * Set the fillable attributes for the model.
+     *
+     * @param  array  $fillable
+     * @return $this
+     * @deprecated 5.3
+     */
+    public function fillable(array $fillable)
+    {
+        return $this->setFillable($fillable);
     }
 
     /**
@@ -2213,11 +2232,23 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      * @param  array  $guarded
      * @return $this
      */
-    public function guard(array $guarded)
+    public function setGuarded(array $guarded)
     {
         $this->guarded = $guarded;
 
         return $this;
+    }
+
+    /**
+     * Set the guarded attributes for the model.
+     *
+     * @param  array  $guarded
+     * @return $this
+     * @deprecated 5.3
+     */
+    public function guard(array $guarded)
+    {
+        return $this->setGuarded($guarded);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/Pivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Pivot.php
@@ -129,7 +129,7 @@ class Pivot extends Model
      *
      * @return string
      */
-    public function getForeignKey()
+    public function getForeignKeyName()
     {
         return $this->foreignKey;
     }

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -739,7 +739,7 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
     public function testFillable()
     {
         $model = new EloquentModelStub;
-        $model->fillable(['name', 'age']);
+        $model->setFillable(['name', 'age']);
         $model->fill(['name' => 'foo', 'age' => 'bar']);
         $this->assertEquals('foo', $model->name);
         $this->assertEquals('bar', $model->age);
@@ -755,7 +755,7 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
     {
         $model = new EloquentModelStub;
         EloquentModelStub::unguard();
-        $model->guard(['*']);
+        $model->setGuarded(['*']);
         $model->fill(['name' => 'foo', 'age' => 'bar']);
         $this->assertEquals('foo', $model->name);
         $this->assertEquals('bar', $model->age);
@@ -772,7 +772,7 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
     public function testGuarded()
     {
         $model = new EloquentModelStub;
-        $model->guard(['name', 'age']);
+        $model->setGuarded(['name', 'age']);
         $model->fill(['name' => 'foo', 'age' => 'bar', 'foo' => 'bar']);
         $this->assertFalse(isset($model->name));
         $this->assertFalse(isset($model->age));
@@ -782,8 +782,8 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
     public function testFillableOverridesGuarded()
     {
         $model = new EloquentModelStub;
-        $model->guard(['name', 'age']);
-        $model->fillable(['age', 'foo']);
+        $model->setGuarded(['name', 'age']);
+        $model->setFillable(['age', 'foo']);
         $model->fill(['name' => 'foo', 'age' => 'bar', 'foo' => 'bar']);
         $this->assertFalse(isset($model->name));
         $this->assertEquals('bar', $model->age);
@@ -796,14 +796,14 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
     public function testGlobalGuarded()
     {
         $model = new EloquentModelStub;
-        $model->guard(['*']);
+        $model->setGuarded(['*']);
         $model->fill(['name' => 'foo', 'age' => 'bar', 'votes' => 'baz']);
     }
 
     public function testUnguardedRunsCallbackWhileBeingUnguarded()
     {
         $model = Model::unguarded(function () {
-            return (new EloquentModelStub)->guard(['*'])->fill(['name' => 'Taylor']);
+            return (new EloquentModelStub)->setGuarded(['*'])->fill(['name' => 'Taylor']);
         });
         $this->assertEquals('Taylor', $model->name);
         $this->assertFalse(Model::isUnguarded());
@@ -813,7 +813,7 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
     {
         Model::unguard();
         $model = Model::unguarded(function () {
-            return (new EloquentModelStub)->guard(['*'])->fill(['name' => 'Taylor']);
+            return (new EloquentModelStub)->setGuarded(['*'])->fill(['name' => 'Taylor']);
         });
         $this->assertEquals('Taylor', $model->name);
         $this->assertTrue(Model::isUnguarded());

--- a/tests/Database/DatabaseEloquentPivotTest.php
+++ b/tests/Database/DatabaseEloquentPivotTest.php
@@ -82,7 +82,7 @@ class DatabaseEloquentPivotTest extends PHPUnit_Framework_TestCase
         $pivot = new Pivot($parent, ['foo' => 'bar'], 'table');
         $pivot->setPivotKeys('foreign', 'other');
 
-        $this->assertEquals('foreign', $pivot->getForeignKey());
+        $this->assertEquals('foreign', $pivot->getForeignKeyName());
         $this->assertEquals('other', $pivot->getOtherKey());
     }
 


### PR DESCRIPTION
Improves naming of model methods.

`getKey()` - returns key value while `getForeignKey()` returns key name. 
Changed to `getForeignKeyName()` to be consistent with `getKeyName()`.

`setCreatedAt()` and `setUpdatedAt()` now use methods to get column names instead of constants.

`fillable()` renamed to `setFillable()` (same as `setVisible()` and `setHidden()`).
`guard()` renamed to `setGuarded()` - same as above + not to confuse with static `unguard()` method.
