### PR TITLE
[5.3] Use connection name in determining model equality

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -3043,7 +3043,8 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     public function is(Model $model)
     {
         return $this->getKey() === $model->getKey() &&
-               $this->getTable() === $model->getTable();
+               $this->getTable() === $model->getTable() &&
+               $this->getConnectionName() === $model->getConnectionName();
     }
 
     /**

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1365,11 +1365,20 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
         $this->assertFalse($result);
     }
 
-    public function testIsWIthAnotherModel()
+    public function testIsWIthAnotherTable()
     {
         $firstInstance = new EloquentModelStub(['id' => 1]);
         $secondInstance = new EloquentModelStub(['id' => 1]);
         $secondInstance->setTable('foo');
+        $result = $firstInstance->is($secondInstance);
+        $this->assertFalse($result);
+    }
+
+    public function testIsWithAnotherConnection()
+    {
+        $firstInstance = new EloquentModelStub(['id' => 1]);
+        $secondInstance = new EloquentModelStub(['id' => 1]);
+        $secondInstance->setConnection('foo');
         $result = $firstInstance->is($secondInstance);
         $this->assertFalse($result);
     }

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1365,7 +1365,7 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
         $this->assertFalse($result);
     }
 
-    public function testIsWIthAnotherTable()
+    public function testIsWithAnotherTable()
     {
         $firstInstance = new EloquentModelStub(['id' => 1]);
         $secondInstance = new EloquentModelStub(['id' => 1]);


### PR DESCRIPTION
Following up from some feedback on my previous PR (#14281), I've added a check to ensure the connection name is the same, in addition to the model key and table name.
