### PR TITLE
[5.3] Fix: flatten should always ignore keys

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -172,25 +172,15 @@ class Arr
      */
     public static function flatten($array, $depth = INF)
     {
-        $result = [];
-
-        foreach ($array as $item) {
+        return array_reduce($array, function ($result, $item) use ($depth) {
             $item = $item instanceof Collection ? $item->all() : $item;
 
-            if (is_array($item)) {
-                if ($depth === 1) {
-                    $result = array_merge($result, $item);
-                    continue;
-                }
-
-                $result = array_merge($result, static::flatten($item, $depth - 1));
-                continue;
+            if ($depth === 1 || ! is_array($item)) {
+                return array_merge($result, (array) $item);
             }
 
-            $result[] = $item;
-        }
-
-        return $result;
+            return array_merge($result, static::flatten($item, $depth - 1));
+        }, []);
     }
 
     /**

--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -176,7 +176,7 @@ class Arr
             $item = $item instanceof Collection ? $item->all() : $item;
 
             if ($depth === 1 || ! is_array($item)) {
-                return array_merge($result, (array) $item);
+                return array_merge($result, array_values((array) $item));
             }
 
             return array_merge($result, static::flatten($item, $depth - 1));

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -404,6 +404,21 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(['#foo', '#bar', ['#baz'], '#zap'], $c->flatten(2)->all());
     }
 
+    public function testFlattenWithDepthAndKeys()
+    {
+        // No depth flattens recursively
+        $c = new Collection(['#foo', ['key' => '#bar'], ['key' => '#baz'], 'key' => '#zap']);
+        $this->assertEquals(['#foo', '#bar', '#baz', '#zap'], $c->flatten()->all());
+
+        // With a depth of 1 it suddenly cares about keys
+        $c = new Collection(['#foo', ['key' => '#bar'], ['key' => '#baz'], 'key' => '#zap']);
+        $this->assertEquals(['#foo', '#bar', '#baz', '#zap'], $c->flatten(1)->all());
+
+        // Without keys
+        $c = new Collection(['#foo', ['#bar'], ['#baz'], 'key' => '#zap']);
+        $this->assertEquals(['#foo', '#bar', '#baz', '#zap'], $c->flatten(1)->all());
+    }
+
     public function testMergeNull()
     {
         $c = new Collection(['name' => 'Hello']);

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -404,18 +404,14 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(['#foo', '#bar', ['#baz'], '#zap'], $c->flatten(2)->all());
     }
 
-    public function testFlattenWithDepthAndKeys()
+    public function testFlattenIgnoresKeys()
     {
-        // No depth flattens recursively
+        // No depth ignores keys
         $c = new Collection(['#foo', ['key' => '#bar'], ['key' => '#baz'], 'key' => '#zap']);
         $this->assertEquals(['#foo', '#bar', '#baz', '#zap'], $c->flatten()->all());
 
-        // With a depth of 1 it suddenly cares about keys
+        // Depth of 1 ignores keys
         $c = new Collection(['#foo', ['key' => '#bar'], ['key' => '#baz'], 'key' => '#zap']);
-        $this->assertEquals(['#foo', '#bar', '#baz', '#zap'], $c->flatten(1)->all());
-
-        // Without keys
-        $c = new Collection(['#foo', ['#bar'], ['#baz'], 'key' => '#zap']);
         $this->assertEquals(['#foo', '#bar', '#baz', '#zap'], $c->flatten(1)->all());
     }
 


### PR DESCRIPTION
I've included @LostKobrakai's test from #14304, so merging this (without squashing) will automatically close that too.
