### PR TITLE
[5.2] Improve Filesystem sharedGet performance

### DIFF
--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -51,14 +51,16 @@ class Filesystem
     {
         $contents = '';
 
-        $handle = fopen($path, 'r');
+        $handle = fopen($path, 'rb');
 
         if ($handle) {
             try {
                 if (flock($handle, LOCK_SH)) {
-                    while (! feof($handle)) {
-                        $contents .= fread($handle, 1048576);
-                    }
+                    clearstatcache(true, $path);
+
+                    $contents = fread($handle, $this->size($path) ?: 1);
+
+                    flock($handle, LOCK_UN);
                 }
             } finally {
                 fclose($handle);


### PR DESCRIPTION
1. Add "b" mode parameter to fopen according to [php manual](http://php.net/manual/en/function.fread.php#example-2648).
2. Read entire file instead of block to enhance performance.
3. Release lock after file read.
