### PR TITLE
Revert "[5.3] Fix: flatten should always ignore keys"

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -172,15 +172,25 @@ class Arr
      */
     public static function flatten($array, $depth = INF)
     {
-        return array_reduce($array, function ($result, $item) use ($depth) {
+        $result = [];
+
+        foreach ($array as $item) {
             $item = $item instanceof Collection ? $item->all() : $item;
 
-            if ($depth === 1 || ! is_array($item)) {
-                return array_merge($result, array_values((array) $item));
+            if (is_array($item)) {
+                if ($depth === 1) {
+                    $result = array_merge($result, $item);
+                    continue;
+                }
+
+                $result = array_merge($result, static::flatten($item, $depth - 1));
+                continue;
             }
 
-            return array_merge($result, static::flatten($item, $depth - 1));
-        }, []);
+            $result[] = $item;
+        }
+
+        return $result;
     }
 
     /**

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -404,17 +404,6 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(['#foo', '#bar', ['#baz'], '#zap'], $c->flatten(2)->all());
     }
 
-    public function testFlattenIgnoresKeys()
-    {
-        // No depth ignores keys
-        $c = new Collection(['#foo', ['key' => '#bar'], ['key' => '#baz'], 'key' => '#zap']);
-        $this->assertEquals(['#foo', '#bar', '#baz', '#zap'], $c->flatten()->all());
-
-        // Depth of 1 ignores keys
-        $c = new Collection(['#foo', ['key' => '#bar'], ['key' => '#baz'], 'key' => '#zap']);
-        $this->assertEquals(['#foo', '#bar', '#baz', '#zap'], $c->flatten(1)->all());
-    }
-
     public function testMergeNull()
     {
         $c = new Collection(['name' => 'Hello']);


### PR DESCRIPTION
Reverts laravel/framework#14318
