### PR TITLE
[5.2] Adding onlyIfPresent method

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -373,7 +373,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
         $input = $this->all();
 
         foreach ($keys as $key) {
-            if($this->has($key)) {
+            if ($this->has($key)) {
                 Arr::set($results, $key, data_get($input, $key));
             }
         }

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -359,6 +359,29 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
     }
 
     /**
+     * Get a subset of the items from the input data, if present.
+     *
+     * @param  array|mixed  $keys
+     * @return array
+     */
+    public function onlyIfPresent($keys)
+    {
+        $keys = is_array($keys) ? $keys : func_get_args();
+
+        $results = [];
+
+        $input = $this->all();
+
+        foreach ($keys as $key) {
+            if($this->has($key)) {
+                Arr::set($results, $key, data_get($input, $key));
+            }
+        }
+
+        return $results;
+    }
+
+    /**
      * Get all of the input except for a specified array of items.
      *
      * @param  array|mixed  $keys

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -238,6 +238,13 @@ class HttpRequestTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(['developer' => ['name' => 'Taylor'], 'test' => null], $request->only('developer.name', 'test'));
     }
 
+    public function testOnlyIfPresentMethod()
+    {
+        $request = Request::create('/', 'GET', ['name' => 'Taylor', 'age' => 25]);
+        $this->assertEquals(['age' => 25], $request->onlyIfPresent('age', 'gender'));
+        $this->assertEquals(['name' => 'Taylor', 'age' => 25], $request->onlyIfPresent('name', 'age', 'gender'));
+    }
+
     public function testExceptMethod()
     {
         $request = Request::create('/', 'GET', ['name' => 'Taylor', 'age' => 25]);


### PR DESCRIPTION
My specific use case:

I have an API endpoint that allows the user to post 'start', 'end', 'description', and 'status' fields. All of these are "fillable" on the model.

Given `$model->fill($request->only('start', 'end', 'description', 'status'))`, if the user only provides 'status' (as my UI does), 'start', 'end', and 'description' are returned with null values from the `only()` method. `onlyIfPresent()` first checks if the request `has($key)` before setting it on the `$results` array.
