### PR TITLE
[5.3] Access collection items as its properties

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1118,6 +1118,17 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
+     * Dynamically retrieve items on the collection.
+     *
+     * @param  string  $key
+     * @return mixed
+     */
+    public function __get($key)
+    {
+        return $this->get($key);
+    }
+
+    /**
      * Determine if an item exists at an offset.
      *
      * @param  mixed  $key


### PR DESCRIPTION
``` php
$collection = collect([
  'id'   => 23,
  'name' => 'Amrit'
  'age'  => 23
]);

// with this pr you can access items key as collection properties

$collection->id // 23
$collection->name // Amrit

```
