### PR TITLE
[5.2] Allow transform a collection within Paginator

### DIFF
--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -289,6 +289,19 @@ abstract class AbstractPaginator implements Htmlable
     {
         return ! ($this->currentPage() == 1 && ! $this->hasMorePages());
     }
+    
+    /**
+     * Transform each item in the collection using a callback.
+     *
+     * @param  callable  $callback
+     * @return $this
+     */
+    public function transform(callable $callback)
+    {
+        $this->items = $this->items->transform($callback);
+
+        return $this;
+    }
 
     /**
      * Resolve the current request path or return the default value.


### PR DESCRIPTION
Not sure if it's the best way .. But the idea is allow transform a collection within a paging.

``` php
//Currently
$paginator = $taskModel
    ->orderBy($column, $direction)
    ->paginate($limit);

$tasksTransformed = $paginator->getCollection()->transform(function(Task $task)
{
    return [
       'id' => $task->id,
       'name' => $task->name,
       'username' => $task->user->name,
    ];
});

return new LengthAwarePaginator($tasksTransformed, $paginator->total(), $paginator->perPage(), $paginator->currentPage());
```

``` php
//Proposal
return $taskModel
    ->orderBy($column, $direction)
    ->paginate($limit)
    ->transform(function(Task $task)
    {
        return [
            'id' => $task->id,
            'name' => $task->name,
            'username' => $task->user->name,
        ];
    });
```
