### PR TITLE
[5.3] Fix migrate:refresh bug with invalid step

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/RefreshCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/RefreshCommand.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Database\Console\Migrations;
 
-use Illuminate\Support\Arr;
 use Illuminate\Console\Command;
 use Illuminate\Console\ConfirmableTrait;
 use Symfony\Component\Console\Input\InputOption;
@@ -45,9 +44,7 @@ class RefreshCommand extends Command
         // If the "step" option is specified it means we only want to rollback a small
         // number of migrations before migrating again. For example, the user might
         // only rollback and remigrate the latest four migrations instead of all.
-        $step = Arr::get(
-            $this->getOptions(), $this->input->getOption('step'), 0
-        );
+        $step = $this->input->getOption('step') ?: 0;
 
         if ($step > 0) {
             $this->call('migrate:rollback', [

--- a/tests/Database/DatabaseMigrationRefreshCommandTest.php
+++ b/tests/Database/DatabaseMigrationRefreshCommandTest.php
@@ -1,0 +1,99 @@
+<?php
+
+use Mockery as m;
+use Illuminate\Foundation\Application;
+use Illuminate\Database\Migrations\Migrator;
+use Illuminate\Database\Console\Migrations\ResetCommand;
+use Illuminate\Database\Console\Migrations\MigrateCommand;
+use Illuminate\Database\Console\Migrations\RefreshCommand;
+use Illuminate\Database\Console\Migrations\RollbackCommand;
+use Symfony\Component\Console\Application as ConsoleApplication;
+
+class DatabaseMigrationRefreshCommandTest extends PHPUnit_Framework_TestCase
+{
+    public function tearDown()
+    {
+        m::close();
+    }
+
+    public function testRefreshCommandCallsCommandsWithProperArguments()
+    {
+        $command = new RefreshCommand($migrator = m::mock(Migrator::class));
+
+        $app = new ApplicationDatabaseRefreshStub(['path.database' => __DIR__]);
+        $console = m::mock(ConsoleApplication::class)->makePartial();
+        $console->__construct();
+        $command->setLaravel($app);
+        $command->setApplication($console);
+
+        $resetCommand = m::mock(ResetCommand::class);
+        $migrateCommand = m::mock(MigrateCommand::class);
+
+        $console->shouldReceive('find')->with('migrate:reset')->andReturn($resetCommand);
+        $console->shouldReceive('find')->with('migrate')->andReturn($migrateCommand);
+
+        $resetCommand->shouldReceive('run')->with(new InputMatcher("--database --force 'migrate:reset'"), m::any());
+        $migrateCommand->shouldReceive('run')->with(new InputMatcher('--database --force --path migrate'), m::any());
+
+        $this->runCommand($command);
+    }
+
+    public function testRefreshCommandCallsCommandsWithStep()
+    {
+        $command = new RefreshCommand($migrator = m::mock(Migrator::class));
+
+        $app = new ApplicationDatabaseRefreshStub(['path.database' => __DIR__]);
+        $console = m::mock(ConsoleApplication::class)->makePartial();
+        $console->__construct();
+        $command->setLaravel($app);
+        $command->setApplication($console);
+
+        $rollbackCommand = m::mock(RollbackCommand::class);
+        $migrateCommand = m::mock(MigrateCommand::class);
+
+        $console->shouldReceive('find')->with('migrate:rollback')->andReturn($rollbackCommand);
+        $console->shouldReceive('find')->with('migrate')->andReturn($migrateCommand);
+
+        $rollbackCommand->shouldReceive('run')->with(new InputMatcher("--database --force --step=2 'migrate:rollback'"), m::any());
+        $migrateCommand->shouldReceive('run')->with(new InputMatcher('--database --force --path migrate'), m::any());
+
+        $this->runCommand($command, ['--step' => 2]);
+    }
+
+    protected function runCommand($command, $input = [])
+    {
+        return $command->run(new Symfony\Component\Console\Input\ArrayInput($input), new Symfony\Component\Console\Output\NullOutput);
+    }
+}
+
+class InputMatcher extends m\Matcher\MatcherAbstract
+{
+    /**
+     * @param \Symfony\Component\Console\Input\ArrayInput  $actual
+     * @return bool
+     */
+    public function match(&$actual)
+    {
+        return (string) $actual == $this->_expected;
+    }
+
+    public function __toString()
+    {
+        return '';
+    }
+}
+
+class ApplicationDatabaseRefreshStub extends Application
+{
+    public function __construct(array $data = [])
+    {
+        foreach ($data as $abstract => $instance) {
+            $this->instance($abstract, $instance);
+        }
+    }
+
+    public function environment()
+    {
+        return 'development';
+    }
+}


### PR DESCRIPTION
If step was undefined, `Arr::get` returned full array and caused rollback to make only one step.
