### PR TITLE
[5.3] Add a simple transformer.

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2389,7 +2389,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public function transform(callable $callback)
     {
-        return (new Fluent($this->toArray()))->transform($callback);
+        return new Fluent($callback($this));
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -13,6 +13,7 @@ use DateTimeInterface;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
+use Illuminate\Support\Fluent;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Support\Arrayable;
@@ -22,11 +23,11 @@ use Illuminate\Database\Eloquent\Relations\Pivot;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
-use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Eloquent\Relations\MorphOne;
+use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Collection as BaseCollection;
-use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Database\Query\Builder as QueryBuilder;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
@@ -2378,6 +2379,17 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         $this->incrementing = $value;
 
         return $this;
+    }
+
+    /**
+     * Transform each attribute in the model using a callback.
+     *
+     * @param  callable  $callback
+     * @return \Illuminate\Support\Fluent
+     */
+    public function transform(callable $callback)
+    {
+        return (new Fluent($this->toArray()))->transform($callback);
     }
 
     /**

--- a/src/Illuminate/Support/Fluent.php
+++ b/src/Illuminate/Support/Fluent.php
@@ -56,6 +56,19 @@ class Fluent implements ArrayAccess, Arrayable, Jsonable, JsonSerializable
     }
 
     /**
+     * Transform each item in the attributes using a callback.
+     *
+     * @param  callable  $callback
+     * @return $this
+     */
+    public function transform(callable $callback)
+    {
+        $this->attributes = $callback($this);
+
+        return $this;
+    }
+
+    /**
      * Convert the Fluent instance to an array.
      *
      * @return array

--- a/tests/Support/SupportFluentTest.php
+++ b/tests/Support/SupportFluentTest.php
@@ -79,6 +79,20 @@ class SupportFluentTest extends PHPUnit_Framework_TestCase
         $this->assertFalse(isset($fluent->name));
     }
 
+    public function testTransformingAttributes()
+    {
+        $array = ['name' => 'Taylor', 'age' => 25];
+        $fluent = new Fluent($array);
+
+        $fluent->transform(function ($item) {
+            return [
+                'realname' => $item->name,
+            ];
+        });
+
+        $this->assertEquals(['realname' => 'Taylor'], $fluent->toArray());
+    }
+
     public function testToArrayReturnsAttribute()
     {
         $array = ['name' => 'Taylor', 'age' => 25];


### PR DESCRIPTION
Would be useful to support simple transformer without requiring full-blown `thephpleague/fractal`. The idea is to provide basic transformer so we can have standard output when transforming single
model or a collection.

This is essentially useful for API response development since whenever we add new fields to say a Model, our API would then automatically has access to this information. It would be nice to have an explicit transformer to format the output.

Got this idea based on #14333
