### PR TITLE
[5.3] Make TaggableStore implement Store contract

### DIFF
--- a/src/Illuminate/Cache/TaggableStore.php
+++ b/src/Illuminate/Cache/TaggableStore.php
@@ -2,7 +2,9 @@
 
 namespace Illuminate\Cache;
 
-abstract class TaggableStore
+use Illuminate\Contracts\Cache\Store;
+
+abstract class TaggableStore implements Store
 {
     /**
      * Begin executing a new tags operation.


### PR DESCRIPTION
Both `TaggedCache` and `TagSet` constuctors are typehinted with `Store` contract. Which means `TaggableStore` must implement it in order to work properly.
https://github.com/rkgrep/framework/blob/c163e00964207092bd627c7fc6fc46eb1c206c8e/src/Illuminate/Cache/TaggableStore.php#L17
