### PR TITLE
[5.2] Add Blade count directive

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -708,6 +708,17 @@ class BladeCompiler extends Compiler implements CompilerInterface
     }
 
     /**
+     * Compile the count statements into valid PHP.
+     *
+     * @param  string  $expression
+     * @return string
+     */
+    protected function compileCount($expression)
+    {
+        return "<?php echo count{$expression}; ?>";
+    }
+
+    /**
      * Compile the while statements into valid PHP.
      *
      * @param  string  $expression

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -328,6 +328,12 @@ breeze
         $this->assertEquals($expected, $compiler->compileString($string));
     }
 
+    public function testCountStatementsAreCompiled()
+    {
+        $compiler = new BladeCompiler($this->getFiles(), __DIR__);
+        $this->assertEquals('<?php echo count($countable); ?>', $compiler->compileString('@count($countable)'));
+    }
+
     public function testWhileStatementsAreCompiled()
     {
         $compiler = new BladeCompiler($this->getFiles(), __DIR__);


### PR DESCRIPTION
Docs update: https://github.com/laravel/docs/pull/2415

This commit implements a new Blade "count" directive which will echo the count result for a countable. I actually thought this was already in here so was pretty weird to see it not being in here.

Sent this to 5.2 because I thought this was a minor feature. If you want me to sent this to 5.3 let me know.
