### PR TITLE
[5.2] Add count helpers to InteractsWithDatabase trait

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
@@ -168,7 +168,6 @@ trait InteractsWithDatabase
         return $this;
     }
 
-
     /**
      * Returns the count for a given where condition in the database.
      *

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
@@ -14,11 +14,7 @@ trait InteractsWithDatabase
      */
     protected function seeInDatabase($table, array $data, $connection = null)
     {
-        $database = $this->app->make('db');
-
-        $connection = $connection ?: $database->getDefaultConnection();
-
-        $count = $database->connection($connection)->table($table)->where($data)->count();
+        $count = $this->getCountForTableAndAttributes($table, $data, $connection);
 
         $this->assertGreaterThan(0, $count, sprintf(
             'Unable to find row in database table [%s] that matched attributes [%s].', $table, json_encode($data)
@@ -63,11 +59,7 @@ trait InteractsWithDatabase
      */
     protected function notSeeInDatabase($table, array $data, $connection = null)
     {
-        $database = $this->app->make('db');
-
-        $connection = $connection ?: $database->getDefaultConnection();
-
-        $count = $database->connection($connection)->table($table)->where($data)->count();
+        $count = $this->getCountForTableAndAttributes($table, $data, $connection);
 
         $this->assertEquals(0, $count, sprintf(
             'Found unexpected records in database table [%s] that matched attributes [%s].', $table, json_encode($data)
@@ -87,11 +79,7 @@ trait InteractsWithDatabase
      */
     protected function countInDatabase($table, $expectedCount, array $data = [], $connection = null)
     {
-        $database = $this->app->make('db');
-
-        $connection = $connection ?: $database->getDefaultConnection();
-
-        $count = $database->connection($connection)->table($table)->where($data)->count();
+        $count = $this->getCountForTableAndAttributes($table, $data, $connection);
 
         $this->assertCount($expectedCount, $count, sprintf(
             'Expected count does not match the amount of rows in database table [%s] that matched attributes [%s].', $table, json_encode($data)
@@ -111,11 +99,7 @@ trait InteractsWithDatabase
      */
     protected function greaterCountInDatabase($table, $expectedCount, array $data = [], $connection = null)
     {
-        $database = $this->app->make('db');
-
-        $connection = $connection ?: $database->getDefaultConnection();
-
-        $count = $database->connection($connection)->table($table)->where($data)->count();
+        $count = $this->getCountForTableAndAttributes($table, $data, $connection);
 
         $this->assertGreaterThan($expectedCount, $count, sprintf(
             'Expected count is lower or equal than the amount of rows in database table [%s] that matched attributes [%s].', $table, json_encode($data)
@@ -135,11 +119,7 @@ trait InteractsWithDatabase
      */
     protected function greaterOrEqualCountInDatabase($table, $expectedCount, array $data = [], $connection = null)
     {
-        $database = $this->app->make('db');
-
-        $connection = $connection ?: $database->getDefaultConnection();
-
-        $count = $database->connection($connection)->table($table)->where($data)->count();
+        $count = $this->getCountForTableAndAttributes($table, $data, $connection);
 
         $this->assertGreaterThanOrEqual($expectedCount, $count, sprintf(
             'Expected count is lower than the amount of rows in database table [%s] that matched attributes [%s].', $table, json_encode($data)
@@ -159,11 +139,7 @@ trait InteractsWithDatabase
      */
     protected function lowerCountInDatabase($table, $expectedCount, array $data = [], $connection = null)
     {
-        $database = $this->app->make('db');
-
-        $connection = $connection ?: $database->getDefaultConnection();
-
-        $count = $database->connection($connection)->table($table)->where($data)->count();
+        $count = $this->getCountForTableAndAttributes($table, $data, $connection);
 
         $this->assertLessThan($expectedCount, $count, sprintf(
             'Expected count is greater or equal than the amount of rows in database table [%s] that matched attributes [%s].', $table, json_encode($data)
@@ -183,17 +159,31 @@ trait InteractsWithDatabase
      */
     protected function lowerOrEqualCountInDatabase($table, $expectedCount, array $data = [], $connection = null)
     {
-        $database = $this->app->make('db');
-
-        $connection = $connection ?: $database->getDefaultConnection();
-
-        $count = $database->connection($connection)->table($table)->where($data)->count();
+        $count = $this->getCountForTableAndAttributes($table, $data, $connection);
 
         $this->assertLessThanOrEqual($expectedCount, $count, sprintf(
             'Expected count is greater than the amount of rows in database table [%s] that matched attributes [%s].', $table, json_encode($data)
         ));
 
         return $this;
+    }
+
+
+    /**
+     * Returns the count for a given where condition in the database.
+     *
+     * @param  string  $table
+     * @param  array  $data
+     * @param  string  $connection
+     * @return int
+     */
+    private function getCountForTableAndAttributes($table, array $data = [], $connection = null)
+    {
+        $database = $this->app->make('db');
+
+        $connection = $connection ?: $database->getDefaultConnection();
+
+        return $database->connection($connection)->table($table)->where($data)->count();
     }
 
     /**

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
@@ -77,6 +77,126 @@ trait InteractsWithDatabase
     }
 
     /**
+     * Assert that a given count matches the amount of rows in the database for a given where condition.
+     *
+     * @param  string  $table
+     * @param  int  $expectedCount
+     * @param  array  $data
+     * @param  string  $connection
+     * @return $this
+     */
+    protected function countInDatabase($table, $expectedCount, array $data = [], $connection = null)
+    {
+        $database = $this->app->make('db');
+
+        $connection = $connection ?: $database->getDefaultConnection();
+
+        $count = $database->connection($connection)->table($table)->where($data)->count();
+
+        $this->assertCount($expectedCount, $count, sprintf(
+            'Expected count does not match the amount of rows in database table [%s] that matched attributes [%s].', $table, json_encode($data)
+        ));
+
+        return $this;
+    }
+
+    /**
+     * Assert that a given count is greater than the amount of rows in the database for a given where condition.
+     *
+     * @param  string  $table
+     * @param  int  $expectedCount
+     * @param  array  $data
+     * @param  string  $connection
+     * @return $this
+     */
+    protected function greaterCountInDatabase($table, $expectedCount, array $data = [], $connection = null)
+    {
+        $database = $this->app->make('db');
+
+        $connection = $connection ?: $database->getDefaultConnection();
+
+        $count = $database->connection($connection)->table($table)->where($data)->count();
+
+        $this->assertGreaterThan($expectedCount, $count, sprintf(
+            'Expected count is lower or equal than the amount of rows in database table [%s] that matched attributes [%s].', $table, json_encode($data)
+        ));
+
+        return $this;
+    }
+
+    /**
+     * Assert that a given count is greater or equal than the amount of rows in the database for a given where condition.
+     *
+     * @param  string  $table
+     * @param  int  $expectedCount
+     * @param  array  $data
+     * @param  string  $connection
+     * @return $this
+     */
+    protected function greaterOrEqualCountInDatabase($table, $expectedCount, array $data = [], $connection = null)
+    {
+        $database = $this->app->make('db');
+
+        $connection = $connection ?: $database->getDefaultConnection();
+
+        $count = $database->connection($connection)->table($table)->where($data)->count();
+
+        $this->assertGreaterThanOrEqual($expectedCount, $count, sprintf(
+            'Expected count is lower than the amount of rows in database table [%s] that matched attributes [%s].', $table, json_encode($data)
+        ));
+
+        return $this;
+    }
+
+    /**
+     * Assert that a given count is lower than the amount of rows in the database for a given where condition.
+     *
+     * @param  string  $table
+     * @param  int  $expectedCount
+     * @param  array  $data
+     * @param  string  $connection
+     * @return $this
+     */
+    protected function lowerCountInDatabase($table, $expectedCount, array $data = [], $connection = null)
+    {
+        $database = $this->app->make('db');
+
+        $connection = $connection ?: $database->getDefaultConnection();
+
+        $count = $database->connection($connection)->table($table)->where($data)->count();
+
+        $this->assertLessThan($expectedCount, $count, sprintf(
+            'Expected count is greater or equal than the amount of rows in database table [%s] that matched attributes [%s].', $table, json_encode($data)
+        ));
+
+        return $this;
+    }
+
+    /**
+     * Assert that a given count is lower or equal than the amount of rows in the database for a given where condition.
+     *
+     * @param  string  $table
+     * @param  int  $expectedCount
+     * @param  array  $data
+     * @param  string  $connection
+     * @return $this
+     */
+    protected function lowerOrEqualCountInDatabase($table, $expectedCount, array $data = [], $connection = null)
+    {
+        $database = $this->app->make('db');
+
+        $connection = $connection ?: $database->getDefaultConnection();
+
+        $count = $database->connection($connection)->table($table)->where($data)->count();
+
+        $this->assertLessThanOrEqual($expectedCount, $count, sprintf(
+            'Expected count is greater than the amount of rows in database table [%s] that matched attributes [%s].', $table, json_encode($data)
+        ));
+
+        return $this;
+    }
+
+    /**
      * Seed a given database connection.
      *
      * @param  string  $class


### PR DESCRIPTION
This PR adds some extra helper methods to the `InteractsWithDatabase` trait. I'm already adding the `countInDatabase` method to my own projects so I thought it would be helpful for others as well.

Also has a commit that cleans up some shared logic.

Again: I think this is a pretty small feature so that why I sent it to the 5.2 branch but if you want this sent to 5.3, let me know.
