### PR TITLE
[5.3] Implement new password validation rule

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -969,6 +969,31 @@ class Validator implements ValidatorContract
     }
 
     /**
+     * Validate that the current logged in user's password matches the given value.
+     *
+     * @param  string  $attribute
+     * @param  mixed   $value
+     * @param  array   $parameters
+     * @return bool
+     */
+    protected function validatePassword($attribute, $value, $parameters)
+    {
+        $hasher = $this->container->make('hash');
+
+        if ($givenPasswordHash = Arr::first($parameters)) {
+            return $hasher->check($value, $givenPasswordHash);
+        }
+
+        $auth = $this->container->make('auth');
+
+        if ($auth->guest()) {
+            return false;
+        }
+
+        return $hasher->check($value, $auth->user()->getAuthPassword());
+    }
+
+    /**
      * Validate that an attribute has a matching confirmation.
      *
      * @param  string  $attribute

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -771,6 +771,88 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('The value of foo.2 does not exist in bar.*.', $v->messages()->first('foo.2'));
     }
 
+    public function testValidatePassword()
+    {
+        // Fails when user is not logged in.
+        $auth = m::mock(Illuminate\Contracts\Auth\Guard::class);
+        $auth->shouldReceive('guest')->andReturn(true);
+
+        $hasher = m::mock(Illuminate\Contracts\Hashing\Hasher::class);
+
+        $container = m::mock(Illuminate\Container\Container::class);
+        $container->shouldReceive('make')->with('auth')->andReturn($auth);
+        $container->shouldReceive('make')->with('hash')->andReturn($hasher);
+
+        $trans = $this->getRealTranslator();
+        $v = new Validator($trans, ['password' => 'foo'], ['password' => 'password']);
+        $v->setContainer($container);
+        $this->assertFalse($v->passes());
+
+        // Fails when password is incorrect.
+        $user = m::mock(Illuminate\Contracts\Auth\Authenticatable::class);
+        $user->shouldReceive('getAuthPassword');
+
+        $auth = m::mock(Illuminate\Contracts\Auth\Guard::class);
+        $auth->shouldReceive('guest')->andReturn(false);
+        $auth->shouldReceive('user')->andReturn($user);
+
+        $hasher = m::mock(Illuminate\Contracts\Hashing\Hasher::class);
+        $hasher->shouldReceive('check')->andReturn(false);
+
+        $container = m::mock(Illuminate\Container\Container::class);
+        $container->shouldReceive('make')->with('auth')->andReturn($auth);
+        $container->shouldReceive('make')->with('hash')->andReturn($hasher);
+
+        $trans = $this->getRealTranslator();
+        $v = new Validator($trans, ['password' => 'foo'], ['password' => 'password']);
+        $v->setContainer($container);
+        $this->assertFalse($v->passes());
+
+        // Succeeds when password is correct.
+        $user = m::mock(Illuminate\Contracts\Auth\Authenticatable::class);
+        $user->shouldReceive('getAuthPassword');
+
+        $auth = m::mock(Illuminate\Contracts\Auth\Guard::class);
+        $auth->shouldReceive('guest')->andReturn(false);
+        $auth->shouldReceive('user')->andReturn($user);
+
+        $hasher = m::mock(Illuminate\Contracts\Hashing\Hasher::class);
+        $hasher->shouldReceive('check')->andReturn(true);
+
+        $container = m::mock(Illuminate\Container\Container::class);
+        $container->shouldReceive('make')->with('auth')->andReturn($auth);
+        $container->shouldReceive('make')->with('hash')->andReturn($hasher);
+
+        $trans = $this->getRealTranslator();
+        $v = new Validator($trans, ['password' => 'foo'], ['password' => 'password']);
+        $v->setContainer($container);
+        $this->assertTrue($v->passes());
+
+        // Fails for an incorrect given hash.
+        $hasher = m::mock(Illuminate\Contracts\Hashing\Hasher::class);
+        $hasher->shouldReceive('check')->andReturn(false);
+
+        $container = m::mock(Illuminate\Container\Container::class);
+        $container->shouldReceive('make')->with('hash')->andReturn($hasher);
+
+        $trans = $this->getRealTranslator();
+        $v = new Validator($trans, ['password' => 'foo'], ['password' => 'password:incorrecthash']);
+        $v->setContainer($container);
+        $this->assertFalse($v->passes());
+
+        // Succeeds for a correct hash.
+        $hasher = m::mock(Illuminate\Contracts\Hashing\Hasher::class);
+        $hasher->shouldReceive('check')->andReturn(true);
+
+        $container = m::mock(Illuminate\Container\Container::class);
+        $container->shouldReceive('make')->with('hash')->andReturn($hasher);
+
+        $trans = $this->getRealTranslator();
+        $v = new Validator($trans, ['password' => 'foo'], ['password' => 'password:correcthash']);
+        $v->setContainer($container);
+        $this->assertTrue($v->passes());
+    }
+
     public function testValidateConfirmed()
     {
         $trans = $this->getRealTranslator();


### PR DESCRIPTION
Skeleton update: https://github.com/laravel/laravel/pull/3836
Docs update: https://github.com/laravel/docs/pull/2414

This new rule will allow to validate a given value to match the current logged in user's password. This is handy to require a user to fill in his/her password when submitting forms, etc. For example, when changing a password, you can now add an extra field to require the user's current password to be filled in as well.

This allows you to require a user to fill in his/her password on a form, for example, to change their password:

``` php
Validator::make($request->all(), [
    'current_password' => 'required|password',
    'password' => 'required|confirmed',
]);
```

And countless other examples where password validation can be required.

I'm still a bit unsure about the rule name. `password` seems a bit too general but on the other hand, it's pretty easy to use and remember. `current_password` seems a bit too long. `passcheck` is a bit weird. Feel free to suggest other ones.

I was unsure at first if this should be in core since this couples the auth and hasher component with the validation component. But on the other hand, the validation component already requires the contracts component so we can easily test this (see the added test). There's no extra coupling to the hasher and auth component since you'd only invoke them when the rule is being used.

Would love to get some more opinions on this so feel free to comment 😄 
