### PR TITLE
[5.3] Remove the class name from "Any" method calls

### DIFF
--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -373,6 +373,8 @@ class Gate implements GateContract
             // call the policy method with either a class or model name consistently.
             if (isset($arguments[0]) && is_string($arguments[0])) {
                 $ability = $ability.'Any';
+
+                array_shift($arguments);
             }
 
             if (! is_callable([$instance, $ability])) {

--- a/tests/Auth/AuthAccessGateTest.php
+++ b/tests/Auth/AuthAccessGateTest.php
@@ -170,7 +170,7 @@ class GateTest extends PHPUnit_Framework_TestCase
 
         $gate->policy(AccessGateTestDummy::class, AccessGateTestPolicy::class);
 
-        $this->assertTrue($gate->check('create', AccessGateTestDummy::class));
+        $this->assertTrue($gate->check('create', [AccessGateTestDummy::class, true]));
     }
 
     public function test_policies_may_have_before_methods_to_override_checks()
@@ -272,9 +272,9 @@ class AccessGateTestPolicy
 {
     use HandlesAuthorization;
 
-    public function createAny($user)
+    public function createAny($user, $additional)
     {
-        return $user->isAdmin ? $this->allow() : $this->deny('You are not an admin.');
+        return $additional;
     }
 
     public function create($user)


### PR DESCRIPTION
They serve no purpose, and push off the second argument to the third spot.
