### PR TITLE
[5.3] Provide access to model collection from Eloquent Builder before pagination

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -177,7 +177,7 @@ class Builder
     public function findMany($ids, $columns = ['*'])
     {
         if (empty($ids)) {
-            return $this->model->newCollection();
+            return $this->collect($this->model->newCollection());
         }
 
         $this->query->whereIn($this->model->getQualifiedKeyName(), $ids);
@@ -323,7 +323,35 @@ class Builder
             $models = $builder->eagerLoadRelations($models);
         }
 
-        return $builder->getModel()->newCollection($models);
+        return $this->collect($builder->getModel()->newCollection($models));
+    }
+
+    /**
+     * Return collection passed through an optional callback.
+     *
+     * @param  \Illuminate\Database\Eloquent\Collection $collection
+     * @return \Illuminate\Database\Eloquent\Collection
+     */
+    public function collect($collection)
+    {
+        if (isset($this->onCollect)) {
+           return call_user_func($this->onCollect, $collection);
+       }
+
+        return $collection;
+    }
+
+     /**
+     * Register a callback on new collections.
+     *
+     * @param  \Closure  $callback
+     * @return $this
+     */
+    public function onCollect(Closure $callback)
+    {
+        $this->onCollect = $callback;
+
+        return $this;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -335,13 +335,13 @@ class Builder
     public function collect($collection)
     {
         if (isset($this->onCollect)) {
-           return call_user_func($this->onCollect, $collection);
-       }
+            return call_user_func($this->onCollect, $collection);
+        }
 
         return $collection;
     }
 
-     /**
+    /**
      * Register a callback on new collections.
      *
      * @param  \Closure  $callback


### PR DESCRIPTION
Added methods that allow adding a callback to underlying collection before pagination and other collection methods in Eloquent Builder.
## Use Case

There have been times where I've needed to append specific attributes to models, but not with `$appends` which always includes the attribute. For example, on a route used to search for new users to follow, it would be beneficial to return an attribute that displays if the returned users are following the authenticated user. This kind of attribute requires a user to be logged in and has a specific use case so I would rather control when and how it's used as opposed to adding to `$appends`.

The problem is that I haven't found a way to modify collections before paginating. In order to modify the models of a collection, there would need to be a way to access the collection before pagination occurs.

**What I've tried so far**

``` php
$users = new App\User; 

return $users->append(['is_following'])->paginate(); // Attribute is not added to each model.

return $users->paginate()->append(['is_following']); // Method doesn't exist.
```

Only works when using `first()` since this method returns a model.

``` php
$users = new App\User; 

return $users->first()->append(['is_following']); // Works.
```
## Proposal

``` php
$users = new App\User; 

$users = $users->onCollect(function($collection) {
        return $collection->each(function($user) {
            $user->append(['is_following']);
        });
    });

return $users->paginate(); // Attribute is added to each model.
```

There may already be a way to do this so please let me know if there is.
