### PR TITLE
[5.5] Add a simple transformer

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -12,6 +12,7 @@ use DateTimeInterface;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
+use Illuminate\Support\Fluent;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Support\Arrayable;
@@ -2466,6 +2467,17 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         $this->incrementing = $value;
 
         return $this;
+    }
+
+    /**
+     * Transform each attribute in the model using a callback.
+     *
+     * @param  callable  $callback
+     * @return \Illuminate\Support\Fluent
+     */
+    public function transform(callable $callback)
+    {
+        return new Fluent($callback($this));
     }
 
     /**

--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -499,6 +499,19 @@ abstract class AbstractPaginator implements Htmlable
     }
 
     /**
+     * Transform each item in the collection using a callback.
+     *
+     * @param  callable  $callback
+     * @return $this
+     */
+    public function transform(callable $callback)
+    {
+        $this->items = $this->items->transform($callback);
+
+        return $this;
+    }
+
+    /**
      * Determine if the given item exists.
      *
      * @param  mixed  $key

--- a/src/Illuminate/Support/Fluent.php
+++ b/src/Illuminate/Support/Fluent.php
@@ -56,6 +56,19 @@ class Fluent implements ArrayAccess, Arrayable, Jsonable, JsonSerializable
     }
 
     /**
+     * Transform each item in the attributes using a callback.
+     *
+     * @param  callable  $callback
+     * @return $this
+     */
+    public function transform(callable $callback)
+    {
+        $this->attributes = $callback($this);
+
+        return $this;
+    }
+
+    /**
      * Convert the Fluent instance to an array.
      *
      * @return array

--- a/tests/Support/SupportFluentTest.php
+++ b/tests/Support/SupportFluentTest.php
@@ -79,6 +79,20 @@ class SupportFluentTest extends PHPUnit_Framework_TestCase
         $this->assertFalse(isset($fluent->name));
     }
 
+    public function testTransformingAttributes()
+    {
+        $array = ['name' => 'Taylor', 'age' => 25];
+        $fluent = new Fluent($array);
+
+        $fluent->transform(function ($item) {
+            return [
+                'realname' => $item->name,
+            ];
+        });
+
+        $this->assertEquals(['realname' => 'Taylor'], $fluent->toArray());
+    }
+
     public function testToArrayReturnsAttribute()
     {
         $array = ['name' => 'Taylor', 'age' => 25];


### PR DESCRIPTION
Moved from #14339 since 5.3 is almost ready for release.

---

Would be useful to support simple transformer without requiring full-blown thephpleague/fractal. The idea is to provide basic transformer so we can have standard output when transforming single
model or a collection.

This is essentially useful for API response development since whenever we add new fields to say a Model, our API would then automatically has access to this information. It would be nice to have an explicit transformer to format the output.

Got this idea based on #14333

Signed-off-by: crynobone crynobone@gmail.com
