### PR TITLE
[5.2] Use \Doctrine\DBAL\Driver\PDOConnection if available

### DIFF
--- a/src/Illuminate/Database/Connectors/Connector.php
+++ b/src/Illuminate/Database/Connectors/Connector.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Database\Connectors;
 
 use PDO;
+use Doctrine\DBAL\Driver\PDOConnection;
 use Exception;
 use Illuminate\Support\Arr;
 use Illuminate\Database\DetectsLostConnections;
@@ -52,7 +53,8 @@ class Connector
         $password = Arr::get($config, 'password');
 
         try {
-            $pdo = new PDO($dsn, $username, $password, $options);
+            $pdoClass = $this->getPdoClass();
+            $pdo = new $pdoClass($dsn, $username, $password, $options);
         } catch (Exception $e) {
             $pdo = $this->tryAgainIfCausedByLostConnection(
                 $e, $dsn, $username, $password, $options
@@ -84,6 +86,23 @@ class Connector
     }
 
     /**
+     * Returns the class name for the PDO connection to use.
+     *
+     * If doctrine/dbal is installed it will be `\Doctrine\DBAL\Driver\PDOConnection`,
+     * else `PDO`.
+     *
+     * @return string
+     */
+    protected function getPdoClass()
+    {
+        if (class_exists(PDOConnection::class)) {
+            return PDOConnection::class;
+        }
+
+        return PDO::class;
+    }
+
+    /**
      * Handle a exception that occurred during connect execution.
      *
      * @param  \Exception  $e
@@ -98,7 +117,9 @@ class Connector
     protected function tryAgainIfCausedByLostConnection(Exception $e, $dsn, $username, $password, $options)
     {
         if ($this->causedByLostConnection($e)) {
-            return new PDO($dsn, $username, $password, $options);
+            $pdoClass = $this->getPdoClass();
+
+            return new $pdoClass($dsn, $username, $password, $options);
         }
 
         throw $e;


### PR DESCRIPTION
This fixes #14356.

Short summary of the problem: I wasn't able to change a column of a database table that already had a `json` or `jsonb` column. Doctrine/DBAL threw an exception "Unknown database type json requested ..." although my database supported JSON just fine.

I found that relatively new database types like `json` are only supported by DBAL if it is able to [detect the version](https://github.com/doctrine/dbal/blob/61e1f860a304c3fb6961ecbec36927b5f20b71c6/lib/Doctrine/DBAL/Connection.php#L430-L435) of the database in use. For example only the PostgreSQL92Platform [supports](https://github.com/doctrine/dbal/blob/61e1f860a304c3fb6961ecbec36927b5f20b71c6/lib/Doctrine/DBAL/Platforms/PostgreSQL92Platform.php#L73) `json` but the "default" PostgreSqlPlatform (which is used when no version can be detected) does not.

DBAL uses the [PDOConnection](https://github.com/doctrine/dbal/blob/61e1f860a304c3fb6961ecbec36927b5f20b71c6/lib/Doctrine/DBAL/Driver/PDOConnection.php) class as a wrapper for PDO to determine if it can check the database versions. But the Laravel database connector always used just PDO, so DBAL was never able to check the database versions and things like the `json` type were not supported.

This PR modifies the database connector to use the PDOConnection if Doctrine/DBAL is installed and PDO if it is not.
