### PR TITLE
[5.2] Optimize Filesystem moveDirectory

### DIFF
--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -401,13 +401,11 @@ class Filesystem
     public function moveDirectory($from, $to, $overwrite = false)
     {
         if ($overwrite && $this->isDirectory($to)) {
-            $this->deleteDirectory($to);
+            if (! $this->deleteDirectory($to)) {
+                return false;
+            }
 
-            $this->copyDirectory($from, $to);
-
-            $this->deleteDirectory($from);
-
-            return true;
+            return @rename($from, $to) === true;
         }
 
         return @rename($from, $to) === true;

--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -404,8 +404,6 @@ class Filesystem
             if (! $this->deleteDirectory($to)) {
                 return false;
             }
-
-            return @rename($from, $to) === true;
         }
 
         return @rename($from, $to) === true;


### PR DESCRIPTION
When move directory with overwrite flag, the first step is deleting the target directory.

In the delete step, we should check the return value, we could go on if it succeed.

After deleting the target directory, we use rename function to move the directory instead of coping and deleting.
