### PR TITLE
[5.3] Fix PHPDoc blocks for responses

### DIFF
--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -156,7 +156,7 @@ class FormRequest extends Request implements ValidatesWhenResolved
     /**
      * Get the response for a forbidden operation.
      *
-     * @return \Illuminate\Http\Response
+     * @return  \Symfony\Component\HttpFoundation\Response
      */
     public function forbiddenResponse()
     {

--- a/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
+++ b/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
@@ -125,8 +125,8 @@ class VerifyCsrfToken
      * Add the CSRF token to the response cookies.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @param  \Illuminate\Http\Response  $response
-     * @return \Illuminate\Http\Response
+     * @param  \Symfony\Component\HttpFoundation\Response  $response
+     * @return \Symfony\Component\HttpFoundation\Response
      */
     protected function addCookieToResponse($request, $response)
     {

--- a/src/Illuminate/Foundation/Validation/ValidatesRequests.php
+++ b/src/Illuminate/Foundation/Validation/ValidatesRequests.php
@@ -96,7 +96,7 @@ trait ValidatesRequests
      *
      * @param  \Illuminate\Http\Request  $request
      * @param  array  $errors
-     * @return \Illuminate\Http\Response
+     * @return \Symfony\Component\HttpFoundation\Response
      */
     protected function buildFailedValidationResponse(Request $request, array $errors)
     {

--- a/src/Illuminate/Http/Middleware/FrameGuard.php
+++ b/src/Illuminate/Http/Middleware/FrameGuard.php
@@ -11,7 +11,7 @@ class FrameGuard
      *
      * @param  \Illuminate\Http\Request  $request
      * @param  \Closure  $next
-     * @return \Illuminate\Http\Response
+     * @return \Symfony\Component\HttpFoundation\Response
      */
     public function handle($request, Closure $next)
     {

--- a/src/Illuminate/Http/ResponseTrait.php
+++ b/src/Illuminate/Http/ResponseTrait.php
@@ -30,13 +30,13 @@ trait ResponseTrait
      * Set a header on the Response.
      *
      * @param  string  $key
-     * @param  string  $value
+     * @param  array|string  $values
      * @param  bool    $replace
      * @return $this
      */
-    public function header($key, $value, $replace = true)
+    public function header($key, $values, $replace = true)
     {
-        $this->headers->set($key, $value, $replace);
+        $this->headers->set($key, $values, $replace);
 
         return $this;
     }
@@ -87,7 +87,7 @@ trait ResponseTrait
     /**
      * Throws the response in a HttpResponseException instance.
      *
-     * @throws Illuminate\Http\Exception\HttpResponseException;
+     * @throws \Illuminate\Http\Exception\HttpResponseException;
      */
     public function throwResponse()
     {

--- a/src/Illuminate/Routing/Middleware/ThrottleRequests.php
+++ b/src/Illuminate/Routing/Middleware/ThrottleRequests.php
@@ -69,7 +69,7 @@ class ThrottleRequests
      *
      * @param  string  $key
      * @param  int  $maxAttempts
-     * @return \Illuminate\Http\Response
+     * @return \Symfony\Component\HttpFoundation\Response
      */
     protected function buildResponse($key, $maxAttempts)
     {
@@ -91,7 +91,7 @@ class ThrottleRequests
      * @param  int  $maxAttempts
      * @param  int  $remainingAttempts
      * @param  int|null  $retryAfter
-     * @return \Illuminate\Http\Response
+     * @return \Symfony\Component\HttpFoundation\Response
      */
     protected function addHeaders(Response $response, $maxAttempts, $remainingAttempts, $retryAfter = null)
     {

--- a/src/Illuminate/Validation/ValidationException.php
+++ b/src/Illuminate/Validation/ValidationException.php
@@ -16,7 +16,7 @@ class ValidationException extends Exception
     /**
      * The recommended response to send to the client.
      *
-     * @var \Illuminate\Http\Response|null
+     * @var \Symfony\Component\HttpFoundation\Response|null
      */
     public $response;
 
@@ -24,7 +24,7 @@ class ValidationException extends Exception
      * Create a new exception instance.
      *
      * @param  \Illuminate\Contracts\Validation\Validator  $validator
-     * @param  \Illuminate\Http\Response  $response
+     * @param  \Symfony\Component\HttpFoundation\Response  $response
      * @return void
      */
     public function __construct($validator, $response = null)


### PR DESCRIPTION
Use Symfony response where Illuminate response is not needed and 2 minor fixes
