### PR TITLE
[5.2] fix #14367 by removing double URL decoding

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -373,9 +373,7 @@ class Route
     public function parameters()
     {
         if (isset($this->parameters)) {
-            return array_map(function ($value) {
-                return is_string($value) ? rawurldecode($value) : $value;
-            }, $this->parameters);
+            return $this->parameters;
         }
 
         throw new LogicException('Route is not bound.');

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -94,6 +94,12 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase
         $this->assertFalse($router->is('bar'));
 
         $router = $this->getRouter();
+        $route = $router->get('foo/{file}', function ($file) {
+            return $file;
+        });
+        $this->assertEquals('oxygen%20', $router->dispatch(Request::create('http://test.com/foo/oxygen%2520', 'GET'))->getContent());
+
+        $router = $this->getRouter();
         $router->patch('foo/bar', ['as' => 'foo', function () {
             return 'bar';
         }]);


### PR DESCRIPTION
URL Parameters were decoded twice:

One time at binding the path parameters to create the parameters list via `$request->decodedPath()`:
https://github.com/laravel/framework/blob/5.2/src/Illuminate/Routing/Route.php#L472

Another time in the `parameters()` method used to get the final parameters of a route:
https://github.com/laravel/framework/blob/5.2/src/Illuminate/Routing/Route.php#L377

Issue adressing the effect of double decoding:
https://github.com/laravel/framework/issues/14367
