### PR TITLE
[5.3] Add support for testing eloquent model events

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MocksApplicationServices.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MocksApplicationServices.php
@@ -142,14 +142,15 @@ trait MocksApplicationServices
      *
      * These events will be mocked, so that handlers will not actually be executed.
      *
+     * @param  string  $model
      * @param  array|string  $events
      * @return $this
      *
      * @throws \Exception
      */
-    public function expectsModelEvents($events)
+    public function expectsModelEvents($model, $events)
     {
-        $events = is_array($events) ? $events : func_get_args();
+        $events = $this->formatModelEvents($model, $events);
 
         $this->withoutModelEvents();
 
@@ -171,12 +172,15 @@ trait MocksApplicationServices
      *
      * These events will be mocked, so that handlers will not actually be executed.
      *
+     * @param  string  $model
      * @param  array|string  $events
      * @return $this
+     *
+     * @throws \Exception
      */
-    public function doesntExpectModelEvents($events)
+    public function doesntExpectModelEvents($model, $events)
     {
-        $events = is_array($events) ? $events : func_get_args();
+        $events = $this->formatModelEvents($model, $events);
 
         $this->withoutModelEvents();
 
@@ -189,6 +193,24 @@ trait MocksApplicationServices
         });
 
         return $this;
+    }
+
+    /**
+     * Turn a model and a list of events into the format used by eloquent
+     *
+     * @param  string  $model
+     * @param  array|string  $events
+     * @return string[]
+     *
+     * @throws \Exception
+     */
+    private function formatModelEvents($model, $events)
+    {
+        $events = (array) $events;
+
+        return array_map(function ($event) use ($model) {
+            return "eloquent.{$event}: {$model}";
+        }, (array) $events);
     }
 
     /**

--- a/src/Illuminate/Foundation/Testing/Concerns/MocksApplicationServices.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MocksApplicationServices.php
@@ -196,7 +196,7 @@ trait MocksApplicationServices
     }
 
     /**
-     * Turn a model and a list of events into the format used by eloquent
+     * Convert a model and a list of events into the format used by eloquent.
      *
      * @param  string  $model
      * @param  array|string  $events

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -4,6 +4,7 @@ namespace Illuminate\Foundation\Testing;
 
 use Mockery;
 use PHPUnit_Framework_TestCase;
+use Illuminate\Database\Eloquent\Model;
 
 abstract class TestCase extends PHPUnit_Framework_TestCase
 {
@@ -83,6 +84,7 @@ abstract class TestCase extends PHPUnit_Framework_TestCase
         putenv('APP_ENV=testing');
 
         $this->app = $this->createApplication();
+        Model::setEventDispatcher($this->app['events']);
     }
 
     /**

--- a/tests/Foundation/FoundationExpectsModelEventsTest.php
+++ b/tests/Foundation/FoundationExpectsModelEventsTest.php
@@ -100,7 +100,7 @@ class FoundationExpectsModelEventsTest extends TestCase
     /** @test */
     public function expects_model_events_can_take_a_string_as_the_event_name()
     {
-        $this->expectsModelEvents(EloquentTestModel::class, "booting");
+        $this->expectsModelEvents(EloquentTestModel::class, 'booting');
 
         EloquentTestModel::create(['field' => 1]);
     }
@@ -138,7 +138,7 @@ class FoundationExpectsModelEventsTest extends TestCase
     /** @test */
     public function doesnt_expect_model_events_can_take_a_string_as_the_event_name()
     {
-        $this->doesntExpectModelEvents(EloquentTestModel::class, "deleting");
+        $this->doesntExpectModelEvents(EloquentTestModel::class, 'deleting');
 
         EloquentTestModel::create(['field' => 1]);
     }

--- a/tests/Foundation/FoundationExpectsModelEventsTest.php
+++ b/tests/Foundation/FoundationExpectsModelEventsTest.php
@@ -1,0 +1,139 @@
+<?php
+
+use Illuminate\Events\Dispatcher;
+use Mockery\MockInterface as Mock;
+use Illuminate\Foundation\Application;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Testing\TestCase;
+use Illuminate\Database\Capsule\Manager as DB;
+use Illuminate\Database\Eloquent\Model as Eloquent;
+
+class FoundationExpectsModelEventsTest extends TestCase
+{
+    public function createApplication()
+    {
+        $app = new Application;
+
+        $db = new DB;
+
+        $db->addConnection([
+            'driver'    => 'sqlite',
+            'database'  => ':memory:',
+        ]);
+
+        $db->bootEloquent();
+        $db->setAsGlobal();
+
+        $this->createSchema();
+
+        return $app;
+    }
+
+    /** @test */
+    public function a_mock_replaces_the_event_dispatcher_when_calling_expects_model_events()
+    {
+        $this->assertInstanceOf(Dispatcher::class, Model::getEventDispatcher());
+
+        $this->assertNotInstanceOf(Mock::class, Model::getEventDispatcher());
+
+        $this->expectsModelEvents([]);
+
+        $this->assertNotInstanceOf(Dispatcher::class, Model::getEventDispatcher());
+        $this->assertInstanceOf(Mock::class, Model::getEventDispatcher());
+    }
+
+    /** @test */
+    public function a_mock_does_not_carry_over_between_tests()
+    {
+        $this->assertInstanceOf(Dispatcher::class, Model::getEventDispatcher());
+
+        $this->assertNotInstanceOf(Mock::class, Model::getEventDispatcher());
+    }
+
+    /** @test */
+    public function fired_events_can_be_checked_for()
+    {
+        $this->expectsModelEvents([
+            'eloquent.booting: EloquentTestModel',
+            'eloquent.booted: EloquentTestModel',
+
+            'eloquent.creating: EloquentTestModel',
+            'eloquent.created: EloquentTestModel',
+
+            'eloquent.saving: EloquentTestModel',
+            'eloquent.saved: EloquentTestModel',
+
+            'eloquent.updating: EloquentTestModel',
+            'eloquent.updated: EloquentTestModel',
+
+            'eloquent.deleting: EloquentTestModel',
+            'eloquent.deleted: EloquentTestModel',
+        ]);
+
+        $model = EloquentTestModel::create(['field' => 1]);
+        $model->field = 2;
+        $model->save();
+        $model->delete();
+    }
+
+    /** @test */
+    public function observers_do_not_fire_when_mocking_events()
+    {
+        $this->expectsModelEvents([
+            'eloquent.saving: EloquentTestModel',
+            'eloquent.saved: EloquentTestModel',
+        ]);
+
+        EloquentTestModel::observe(new EloquentTestModelFailingObserver);
+
+        EloquentTestModel::create(['field' => 1]);
+    }
+
+    protected function createSchema()
+    {
+        $this->schema('default')->create('test', function ($table) {
+            $table->increments('id');
+            $table->string('field');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Get a database connection instance.
+     *
+     * @return Connection
+     */
+    protected function connection($connection = 'default')
+    {
+        return Eloquent::getConnectionResolver()->connection($connection);
+    }
+
+    /**
+     * Get a schema builder instance.
+     *
+     * @return Schema\Builder
+     */
+    protected function schema($connection = 'default')
+    {
+        return $this->connection($connection)->getSchemaBuilder();
+    }
+}
+
+class EloquentTestModel extends Eloquent
+{
+    protected $guarded = [];
+    protected $table = 'test';
+}
+
+class EloquentTestModelFailingObserver
+{
+    public function saving()
+    {
+        PHPUnit_Framework_Assert::fail('The [saving] method should not be called on '.static::class);
+    }
+
+    public function saved()
+    {
+        PHPUnit_Framework_Assert::fail('The [saved] method should not be called on '.static::class);
+    }
+}


### PR DESCRIPTION
Take 2. I've added a separate method for mocking model events so it shouldn't completely break code using observers (sorry!).

Notes:
- Observers are explicitly setup to not fire. This is tested for.
- I copied the eloquent setup from the integration tests. Perhaps this code could be moved to a trait? Though, a little duplication here isn't a terribly big deal.
- I'm not 100% pleased with how I had to write the test but I couldn't think of another way to do it. Specifically I extended `Illuminate\Foundation\Testing\TestCase` to treat it as an integration test to be sure it worked within the context of using that class.
