### PR TITLE
[5.2] Use chunkById in each method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -421,7 +421,7 @@ class Builder
             $this->orderBy($this->model->getQualifiedKeyName(), 'asc');
         }
 
-        return $this->chunk($count, function ($results) use ($callback) {
+        return $this->chunkById($count, function ($results) use ($callback) {
             foreach ($results as $key => $value) {
                 if ($callback($value, $key) === false) {
                     return false;


### PR DESCRIPTION
It is faster on large tables, so, why not?
