### PR TITLE
[5.2] Fixes input order issue

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -95,7 +95,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
         }
 
         $values = with(isset($key) ? $this->pluck($key) : $this)
-                    ->values()->sort();
+                    ->sort()->values();
 
         $middle = (int) floor($count / 2);
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1310,6 +1310,16 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(1.5, $collection->median('foo'));
     }
 
+    public function testMedianOutOfOrderCollection()
+    {
+        $collection = new Collection([
+            (object) ['foo' => 0],
+            (object) ['foo' => 5],
+            (object) ['foo' => 3],
+        ]);
+        $this->assertEquals(3, $collection->median('foo'));
+    }
+
     public function testMedianOnEmptyCollectionReturnsNull()
     {
         $collection = new Collection();


### PR DESCRIPTION
As the keys previously kept their order, median wouldn't return the correct value if the input was out of order.
