### PR TITLE
[5.2] Moved up collectGarbage call to run it even when the response throws an exception

### DIFF
--- a/src/Illuminate/Session/Middleware/StartSession.php
+++ b/src/Illuminate/Session/Middleware/StartSession.php
@@ -57,6 +57,8 @@ class StartSession
             $session = $this->startSession($request);
 
             $request->setSession($session);
+
+            $this->collectGarbage($session);
         }
 
         $response = $next($request);
@@ -66,8 +68,6 @@ class StartSession
         // add the session identifier cookie to the application response headers now.
         if ($this->sessionConfigured()) {
             $this->storeCurrentUrl($request, $session);
-
-            $this->collectGarbage($session);
 
             $this->addCookieToResponse($response, $session);
         }


### PR DESCRIPTION
Lately, we've been seeing a type of attack where the attacker tries to make as much sessions as possible, which can cause a server to run out of disk space. Because the requests are empty POST's, they throw a TokenMismatchException. When this happens on a website that doesn't see much traffic, the garbage collector is rarely run, so the old session files are rarely deleted.

To fix this, I've moved the collectGarbage call to above the point where any exception might be thrown.
