### PR TITLE
[5.2] Fix pagination issue in the latest release

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -482,14 +482,15 @@ class Builder
      */
     public function paginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null)
     {
+        $page = $page ?: Paginator::resolveCurrentPage($pageName);
+
+        $perPage = $perPage ?: $this->model->getPerPage();
+
         $query = $this->toBase();
 
         $total = $query->getCountForPagination();
 
-        $results = $total ? $this->forPage(
-            $page = $page ?: Paginator::resolveCurrentPage($pageName),
-            $perPage = $perPage ?: $this->model->getPerPage()
-        )->get($columns) : [];
+        $results = $total ? $this->forPage($page, $perPage)->get($columns) : [];
 
         return new LengthAwarePaginator($results, $total, $perPage, $page, [
             'path' => Paginator::resolveCurrentPath(),


### PR DESCRIPTION
Addressed in https://github.com/laravel/framework/issues/14387

The issue was caused by this change: https://github.com/laravel/framework/pull/14188/files

if `$total` is evaluated as `false`, `$perPage = $perPage ?: $this->model->getPerPage()` will never be executed leaving `$perPage` equal to null if it wasn't provided in the method call.

So calling `->paginate()` without any arguments, if no results found `$perPage` will be equal to null causing a Division By Zero error in LengthAwarePaginator
