### PR TITLE
[5.4] Check for api token in request headers

### DIFF
--- a/src/Illuminate/Auth/TokenGuard.php
+++ b/src/Illuminate/Auth/TokenGuard.php
@@ -25,6 +25,13 @@ class TokenGuard implements Guard
     protected $inputKey;
 
     /**
+     * The name of the field in the request headers containing the API token.
+     *
+     * @var string
+     */
+    protected $headerKey;
+
+    /**
      * The name of the token "column" in persistent storage.
      *
      * @var string
@@ -43,6 +50,7 @@ class TokenGuard implements Guard
         $this->request = $request;
         $this->provider = $provider;
         $this->inputKey = 'api_token';
+        $this->headerKey = 'api-token';
         $this->storageKey = 'api_token';
     }
 
@@ -88,6 +96,10 @@ class TokenGuard implements Guard
 
         if (empty($token)) {
             $token = $this->request->getPassword();
+        }
+
+        if (empty($token)) {
+            $token = $this->request->header($this->headerKey, '');
         }
 
         return $token;


### PR DESCRIPTION
Look for the api token in request headers. If you want to use header token without framing it to look like OAuth's Bearer token.
