### PR TITLE
[5.2] Url::to() from http://example.com/index.php

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -176,7 +176,7 @@ class UrlGenerator implements UrlGeneratorContract
         // Once we have the scheme we will compile the "tail" by collapsing the values
         // into a single string delimited by slashes. This just makes it convenient
         // for passing the array of parameters to this URL as a list of segments.
-        $root = $this->getRootUrl($scheme);
+        $root = $this->removeIndex($this->getRootUrl($scheme));
 
         if (($queryPosition = strpos($path, '?')) !== false) {
             $query = mb_substr($path, $queryPosition);

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -42,6 +42,49 @@ class RoutingUrlGeneratorTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('https://www.foo.com/foo/bar', $url->asset('foo/bar', true));
     }
 
+    public function testIndexHandling()
+    {
+        $url = new UrlGenerator(
+            $routes = new RouteCollection,
+            $request = Request::create('http://www.foo.com/index.php', 'GET', [], [], [], [
+                'SCRIPT_FILENAME' => 'index.php',
+                'SCRIPT_NAME' => 'index.php',
+            ])
+        );
+
+        $this->assertEquals('http://www.foo.com/foo/bar', $url->to('foo/bar'));
+        $this->assertEquals('https://www.foo.com/foo/bar', $url->to('foo/bar', [], true));
+        $this->assertEquals('https://www.foo.com/foo/bar/baz/boom', $url->to('foo/bar', ['baz', 'boom'], true));
+        $this->assertEquals('https://www.foo.com/foo/bar/baz?foo=bar', $url->to('foo/bar?foo=bar', ['baz'], true));
+
+        /*
+         * Test HTTPS request URL generation...
+         */
+        $url = new UrlGenerator(
+            $routes = new RouteCollection,
+            $request = Request::create('https://www.foo.com/index.php', 'GET', [], [], [], [
+                'SCRIPT_FILENAME' => 'index.php',
+                'SCRIPT_NAME' => 'index.php',
+            ])
+        );
+
+        $this->assertEquals('https://www.foo.com/foo/bar', $url->to('foo/bar'));
+
+        /*
+         * Test asset URL generation...
+         */
+        $url = new UrlGenerator(
+            $routes = new RouteCollection,
+            $request = Request::create('http://www.foo.com/index.php', 'GET', [], [], [], [
+                'SCRIPT_FILENAME' => 'index.php',
+                'SCRIPT_NAME' => 'index.php',
+            ])
+        );
+
+        $this->assertEquals('http://www.foo.com/foo/bar', $url->asset('foo/bar'));
+        $this->assertEquals('https://www.foo.com/foo/bar', $url->asset('foo/bar', true));
+    }
+
     public function testBasicRouteGeneration()
     {
         $url = new UrlGenerator(


### PR DESCRIPTION
Hello there!

The `Url::to()` behaves differently when running from http://example.com/ and http://example.com/index.php

**http://example.com/**
Url::to('some/page') => http://example.com/some/page

**http://example.com/index.php**
Url::to('some/page') => http://example.com/index.php/some/page

If search crawler visits http://example.com/index.php, it may index a whole bunch of strange links such as http://example.com/index.php/some/page, which mirror real site pages. This is not very well for SEO, not to mention general usability.

One can even confirm this on laravel.com, visit this [link](https://laravel.com/index.php/docs/5.2/homestead), open dropdown with versions and look at the urls you see there, they all will start with "index.php".

I checked the framework [test file for UrlGenerator](https://github.com/laravel/framework/blob/5.2/tests/Routing/RoutingUrlGeneratorTest.php) to understand why tests do not catch that. And that's because a new [artificial Request](https://github.com/laravel/framework/blob/5.2/tests/Routing/RoutingUrlGeneratorTest.php#L15) object is created for tests. That requests' SCRIPT_FILENAME will be empty. On the other hand, the natural Request object created from server globals will have its SCRIPT_FILENAME set to 'index.php'. That's why test works just fine, but reality sucks.

I've created a straightforward solution for the problem, but I'm not sure whether my approach is any good.

By the way, any site owner who want completely handle this problem, should also fix his nginx host by adding rewrite rule such as this one:

```
    location / {
        rewrite ^/(.*?)index\.php[^/] /$1? redirect;
        rewrite ^/(.*?)index\.php(?:/(.*))?$ /$1$2? redirect;
        try_files $uri $uri/ /index.php?$query_string;
    }
```

and also making sure his site has proper "canonical" meta tag.

Here are related links from elsewhere:
https://laracasts.com/discuss/channels/general-discussion/remving-indexphp-completely
http://stackoverflow.com/questions/25105872/remove-redirect-index-php-from-url-to-prevent-duplicate-urls
