### PR TITLE
[5.3] Create environment file & generate app key upon composer install & update

### DIFF
--- a/src/Illuminate/Foundation/ComposerScripts.php
+++ b/src/Illuminate/Foundation/ComposerScripts.php
@@ -41,6 +41,17 @@ class ComposerScripts
     {
         $laravel = new Application(getcwd());
 
+        // Create environment file if it doesn't exists.
+        if (! file_exists($laravel->environmentFilePath())) {
+            exec("php -r \"copy('".$laravel->environmentFilePath().".example',
+             '".$laravel->environmentFilePath().');"');
+        }
+
+        // Create app key.
+        if (empty(env('APP_KEY'))) {
+            exec('php artisan key:generate');
+        }
+
         if (file_exists($compiledPath = $laravel->getCachedCompilePath())) {
             @unlink($compiledPath);
         }


### PR DESCRIPTION
Currently whenever we clone [Laravel](https://github.com/laravel/laravel) application from any versioning system and run `composer install`. All the dependencies are installed, but no `.env` file is created & no application key is generated.

This PR fixes that issue. It automatically create `env` file & generate application key when the commands `composer install` or `composer update` are run. 
