### PR TITLE
[5.1] Don't let relations override user-defined keys

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2411,7 +2411,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     {
         $attributes = $this->attributesToArray();
 
-        return array_merge($attributes, $this->relationsToArray());
+        return array_merge($this->relationsToArray(), $attributes);
     }
 
     /**

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -562,11 +562,13 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
         $model->name = 'foo';
         $model->age = null;
         $model->password = 'password1';
+        $model->override = false;
         $model->setHidden(['password']);
         $model->setRelation('names', new Illuminate\Database\Eloquent\Collection([
             new EloquentModelStub(['bar' => 'baz']), new EloquentModelStub(['bam' => 'boom']),
         ]));
         $model->setRelation('partner', new EloquentModelStub(['name' => 'abby']));
+        $model->setRelation('override', null);
         $model->setRelation('group', null);
         $model->setRelation('multi', new Illuminate\Database\Eloquent\Collection);
         $array = $model->toArray();
@@ -577,6 +579,7 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('boom', $array['names'][1]['bam']);
         $this->assertEquals('abby', $array['partner']['name']);
         $this->assertNull($array['group']);
+        $this->assertFalse($array['override']);
         $this->assertEquals([], $array['multi']);
         $this->assertFalse(isset($array['password']));
 


### PR DESCRIPTION
I think this Behat scenario expresses it clearest:

```
Given that App\Customer has a relationship method `fields`
And that I manually set $customer->fields on an instance
When I call $customer->toJson
Then I expect to see the fields I added
```

What actually happens now is that because the model does `return array_merge($attributes, $this->relationsToArray());`, the arrayed relations will override any keys set manually by the user.

To clarify

```
$fields = [];

$customer->fields = $fields

$this->assertEquals($fields, $customer->fields);
$this->assertEquals($fields, $customer->toArray['fields']);
```

In the above, given there's a relationship method `fields()`, the first assert would succeed, but the second would fail, so there's an inconsistency in the returned result.
