### PR TITLE
Adding firstOrCreateWithValues

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -180,6 +180,27 @@ class Builder
     }
 
     /**
+     * Get the first record matching the attributes or create it with the given values.
+     *
+     * @param  array $attributes
+     * @param  array $values
+     * @return \Illuminate\Database\Eloquent\Model
+     */
+    public function firstOrCreateWithValues(array $attributes, array $values)
+    {
+        if (!is_null($instance = $this->where($attributes)->first()))
+        {
+            return $instance;
+        }
+
+        $instance = $this->model->newInstance(array_merge($attributes, $values));
+
+        $instance->save();
+
+        return $instance;
+    }
+
+    /**
      * Create or update a record matching the attributes, and fill it with values.
      *
      * @param  array  $attributes

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -188,8 +188,7 @@ class Builder
      */
     public function firstOrCreateWithValues(array $attributes, array $values)
     {
-        if (!is_null($instance = $this->where($attributes)->first()))
-        {
+        if (! is_null($instance = $this->where($attributes)->first())) {
             return $instance;
         }
 

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -687,6 +687,25 @@ class BelongsToMany extends Relation
     }
 
     /**
+     * Get the first related record matching the attributes or create it with the given values.
+     *
+     * @param  array  $attributes
+     * @param  array  $values
+     * @param  array  $joining
+     * @param  bool   $touch
+     * @return \Illuminate\Database\Eloquent\Model
+     */
+    public function firstOrCreateWithValues(array $attributes, array $values, array $joining = [], $touch = true)
+    {
+        if (is_null($instance = $this->where($attributes)->first()))
+        {
+            $instance = $this->create(array_merge($attributes, $values), $joining, $touch);
+        }
+
+        return $instance;
+    }
+
+    /**
      * Create or update a related record matching the attributes, and fill it with values.
      *
      * @param  array  $attributes

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -697,8 +697,7 @@ class BelongsToMany extends Relation
      */
     public function firstOrCreateWithValues(array $attributes, array $values, array $joining = [], $touch = true)
     {
-        if (is_null($instance = $this->where($attributes)->first()))
-        {
+        if (is_null($instance = $this->where($attributes)->first())) {
             $instance = $this->create(array_merge($attributes, $values), $joining, $touch);
         }
 

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -282,6 +282,23 @@ abstract class HasOneOrMany extends Relation
     }
 
     /**
+     * Get the first related record matching the attributes or create it with the given values.
+     *
+     * @param  array $attributes
+     * @param  array $values
+     * @return \Illuminate\Database\Eloquent\Model
+     */
+    public function firstOrCreateWithValues(array $attributes, array $values)
+    {
+        if (is_null($instance = $this->where($attributes)->first()))
+        {
+            $instance = $this->create(array_merge($attributes, $values));
+        }
+
+        return $instance;
+    }
+
+    /**
      * Create or update a related record matching the attributes, and fill it with values.
      *
      * @param  array  $attributes

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -290,8 +290,7 @@ abstract class HasOneOrMany extends Relation
      */
     public function firstOrCreateWithValues(array $attributes, array $values)
     {
-        if (is_null($instance = $this->where($attributes)->first()))
-        {
+        if (is_null($instance = $this->where($attributes)->first())) {
             $instance = $this->create(array_merge($attributes, $values));
         }
 

--- a/src/Illuminate/Database/Eloquent/Relations/MorphOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphOneOrMany.php
@@ -159,8 +159,7 @@ abstract class MorphOneOrMany extends HasOneOrMany
      */
     public function firstOrCreateWithValues(array $attributes, array $values)
     {
-        if (is_null($instance = $this->where($attributes)->first()))
-        {
+        if (is_null($instance = $this->where($attributes)->first())) {
             $instance = $this->create(array_merge($attributes, $values));
         }
 

--- a/src/Illuminate/Database/Eloquent/Relations/MorphOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphOneOrMany.php
@@ -151,6 +151,23 @@ abstract class MorphOneOrMany extends HasOneOrMany
     }
 
     /**
+     * Get the first related record matching the attributes or create it with the given values.
+     *
+     * @param  array $attributes
+     * @param  array $values
+     * @return \Illuminate\Database\Eloquent\Model
+     */
+    public function firstOrCreateWithValues(array $attributes, array $values)
+    {
+        if (is_null($instance = $this->where($attributes)->first()))
+        {
+            $instance = $this->create(array_merge($attributes, $values));
+        }
+
+        return $instance;
+    }
+
+    /**
      * Create or update a related record matching the attributes, and fill it with values.
      *
      * @param  array  $attributes

--- a/tests/Database/DatabaseEloquentBelongsToManyTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyTest.php
@@ -374,6 +374,26 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase
         $this->assertInstanceOf(StdClass::class, $relation->firstOrCreate(['foo']));
     }
 
+    public function testFirstOrCreateWithValuesMethodFindsFirstModel()
+    {
+        $relation = $this->getMock('Illuminate\Database\Eloquent\Relations\BelongsToMany', ['where', 'create'], $this->getRelationArguments());
+        $relation->expects($this->once())->method('where')->with(['foo'])->will($this->returnValue($relation->getQuery()));
+        $relation->getQuery()->shouldReceive('first')->once()->andReturn($model = m::mock('StdClass'));
+        $relation->expects($this->never())->method('create')->with(array_merge(['foo'],['bar']))->will($this->returnValue(null));
+
+        $this->assertInstanceOf(StdClass::class, $relation->firstOrCreateWithValues(['foo'],['bar']));
+    }
+
+    public function testFirstOrCreateWithValuesMethodReturnsNewModel()
+    {
+        $relation = $this->getMock('Illuminate\Database\Eloquent\Relations\BelongsToMany', ['where', 'create'], $this->getRelationArguments());
+        $relation->expects($this->once())->method('where')->with(['foo'])->will($this->returnValue($relation->getQuery()));
+        $relation->getQuery()->shouldReceive('first')->once()->andReturn(null);
+        $relation->expects($this->once())->method('create')->with(array_merge(['foo'],['bar']))->will($this->returnValue($model = m::mock('StdClass')));
+
+        $this->assertInstanceOf(StdClass::class, $relation->firstOrCreateWithValues(['foo'],['bar']));
+    }
+
     public function testUpdateOrCreateMethodFindsFirstModelAndUpdates()
     {
         $relation = $this->getMock('Illuminate\Database\Eloquent\Relations\BelongsToMany', ['where', 'create'], $this->getRelationArguments());

--- a/tests/Database/DatabaseEloquentBelongsToManyTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyTest.php
@@ -379,9 +379,9 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase
         $relation = $this->getMock('Illuminate\Database\Eloquent\Relations\BelongsToMany', ['where', 'create'], $this->getRelationArguments());
         $relation->expects($this->once())->method('where')->with(['foo'])->will($this->returnValue($relation->getQuery()));
         $relation->getQuery()->shouldReceive('first')->once()->andReturn($model = m::mock('StdClass'));
-        $relation->expects($this->never())->method('create')->with(array_merge(['foo'],['bar']))->will($this->returnValue(null));
+        $relation->expects($this->never())->method('create')->with(array_merge(['foo'], ['bar']))->will($this->returnValue(null));
 
-        $this->assertInstanceOf(StdClass::class, $relation->firstOrCreateWithValues(['foo'],['bar']));
+        $this->assertInstanceOf(StdClass::class, $relation->firstOrCreateWithValues(['foo'], ['bar']));
     }
 
     public function testFirstOrCreateWithValuesMethodReturnsNewModel()
@@ -389,9 +389,9 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase
         $relation = $this->getMock('Illuminate\Database\Eloquent\Relations\BelongsToMany', ['where', 'create'], $this->getRelationArguments());
         $relation->expects($this->once())->method('where')->with(['foo'])->will($this->returnValue($relation->getQuery()));
         $relation->getQuery()->shouldReceive('first')->once()->andReturn(null);
-        $relation->expects($this->once())->method('create')->with(array_merge(['foo'],['bar']))->will($this->returnValue($model = m::mock('StdClass')));
+        $relation->expects($this->once())->method('create')->with(array_merge(['foo'], ['bar']))->will($this->returnValue($model = m::mock('StdClass')));
 
-        $this->assertInstanceOf(StdClass::class, $relation->firstOrCreateWithValues(['foo'],['bar']));
+        $this->assertInstanceOf(StdClass::class, $relation->firstOrCreateWithValues(['foo'], ['bar']));
     }
 
     public function testUpdateOrCreateMethodFindsFirstModelAndUpdates()

--- a/tests/Database/DatabaseEloquentHasManyTest.php
+++ b/tests/Database/DatabaseEloquentHasManyTest.php
@@ -86,6 +86,30 @@ class DatabaseEloquentHasManyTest extends PHPUnit_Framework_TestCase
         $this->assertInstanceOf(StdClass::class, $relation->firstOrCreate(['foo']));
     }
 
+    public function testFirstOrCreateWithValuesMethodFindsFirstModel()
+    {
+        $relation = $this->getRelation();
+        $relation->getQuery()->shouldReceive('where')->once()->with(['foo'])->andReturn($relation->getQuery());
+        $relation->getQuery()->shouldReceive('first')->once()->with()->andReturn($model = m::mock('StdClass'));
+        $relation->getRelated()->shouldReceive('newInstance')->never();
+        $model->shouldReceive('setAttribute')->never();
+        $model->shouldReceive('save')->never();
+
+        $this->assertInstanceOf(StdClass::class, $relation->firstOrCreateWithValues(['foo'],['bar']));
+    }
+
+    public function testFirstOrCreateWithValuesMethodCreatesNewModelWithForeignKeySet()
+    {
+        $relation = $this->getRelation();
+        $relation->getQuery()->shouldReceive('where')->once()->with(['foo'])->andReturn($relation->getQuery());
+        $relation->getQuery()->shouldReceive('first')->once()->with()->andReturn(null);
+        $relation->getRelated()->shouldReceive('newInstance')->once()->with(array_merge(['foo'],['bar']))->andReturn($model = m::mock('StdClass'));
+        $model->shouldReceive('save')->once()->andReturn(true);
+        $model->shouldReceive('setAttribute')->once()->with('foreign_key', 1);
+
+        $this->assertInstanceOf(StdClass::class, $relation->firstOrCreateWithValues(['foo'],['bar']));
+    }
+
     public function testUpdateOrCreateMethodFindsFirstModelAndUpdates()
     {
         $relation = $this->getRelation();

--- a/tests/Database/DatabaseEloquentHasManyTest.php
+++ b/tests/Database/DatabaseEloquentHasManyTest.php
@@ -95,7 +95,7 @@ class DatabaseEloquentHasManyTest extends PHPUnit_Framework_TestCase
         $model->shouldReceive('setAttribute')->never();
         $model->shouldReceive('save')->never();
 
-        $this->assertInstanceOf(StdClass::class, $relation->firstOrCreateWithValues(['foo'],['bar']));
+        $this->assertInstanceOf(StdClass::class, $relation->firstOrCreateWithValues(['foo'], ['bar']));
     }
 
     public function testFirstOrCreateWithValuesMethodCreatesNewModelWithForeignKeySet()
@@ -103,11 +103,11 @@ class DatabaseEloquentHasManyTest extends PHPUnit_Framework_TestCase
         $relation = $this->getRelation();
         $relation->getQuery()->shouldReceive('where')->once()->with(['foo'])->andReturn($relation->getQuery());
         $relation->getQuery()->shouldReceive('first')->once()->with()->andReturn(null);
-        $relation->getRelated()->shouldReceive('newInstance')->once()->with(array_merge(['foo'],['bar']))->andReturn($model = m::mock('StdClass'));
+        $relation->getRelated()->shouldReceive('newInstance')->once()->with(array_merge(['foo'], ['bar']))->andReturn($model = m::mock('StdClass'));
         $model->shouldReceive('save')->once()->andReturn(true);
         $model->shouldReceive('setAttribute')->once()->with('foreign_key', 1);
 
-        $this->assertInstanceOf(StdClass::class, $relation->firstOrCreateWithValues(['foo'],['bar']));
+        $this->assertInstanceOf(StdClass::class, $relation->firstOrCreateWithValues(['foo'], ['bar']));
     }
 
     public function testUpdateOrCreateMethodFindsFirstModelAndUpdates()

--- a/tests/Database/DatabaseEloquentMorphTest.php
+++ b/tests/Database/DatabaseEloquentMorphTest.php
@@ -150,7 +150,7 @@ class DatabaseEloquentMorphTest extends PHPUnit_Framework_TestCase
         $model->shouldReceive('setAttribute')->never();
         $model->shouldReceive('save')->never();
 
-        $this->assertInstanceOf(Model::class, $relation->firstOrCreateWithValues(['foo'],['bar']));
+        $this->assertInstanceOf(Model::class, $relation->firstOrCreateWithValues(['foo'], ['bar']));
     }
 
     public function testFirstOrCreateWithValuesMethodCreatesNewMorphModel()
@@ -158,12 +158,12 @@ class DatabaseEloquentMorphTest extends PHPUnit_Framework_TestCase
         $relation = $this->getOneRelation();
         $relation->getQuery()->shouldReceive('where')->once()->with(['foo'])->andReturn($relation->getQuery());
         $relation->getQuery()->shouldReceive('first')->once()->with()->andReturn(null);
-        $relation->getRelated()->shouldReceive('newInstance')->once()->with(array_merge(['foo'],['bar']))->andReturn($model = m::mock('Illuminate\Database\Eloquent\Model'));
+        $relation->getRelated()->shouldReceive('newInstance')->once()->with(array_merge(['foo'], ['bar']))->andReturn($model = m::mock('Illuminate\Database\Eloquent\Model'));
         $model->shouldReceive('setAttribute')->once()->with('morph_id', 1);
         $model->shouldReceive('setAttribute')->once()->with('morph_type', get_class($relation->getParent()));
         $model->shouldReceive('save')->once()->andReturn(true);
 
-        $this->assertInstanceOf(Model::class, $relation->firstOrCreateWithValues(['foo'],['bar']));
+        $this->assertInstanceOf(Model::class, $relation->firstOrCreateWithValues(['foo'], ['bar']));
     }
 
     public function testUpdateOrCreateMethodFindsFirstModelAndUpdates()


### PR DESCRIPTION
In seeders, it is convenient to have a method that creates a new instance if it doesn't exist yet. The firstOrCreate method is not sufficent because I need to set some values only if the model doesn't exit.
For example, I want to seed my settings table (key, value), and I run the seeds with my CI. Sometimes I extend this seeder when there is something more to set. 
Now I can do this:

```
Setting::firstOrCreateWithValues(['key'=>'foo'], ['value'=>'bar']);
```

Instead of this:

```
$setting= Setting::firstOrNew(['key' => 'foo']);
if (!$setting->exists) {
    $setting->value = 'bar';
}
$setting->save();
```

Since these files are the same in 5.1, 5.2 and 5.3, it can be merged in all of them.
