### PR TITLE
[5.2] Prevent make:migration from creating duplicate classes

### DIFF
--- a/src/Illuminate/Database/Migrations/MigrationCreator.php
+++ b/src/Illuminate/Database/Migrations/MigrationCreator.php
@@ -41,9 +41,16 @@ class MigrationCreator
      * @param  string  $table
      * @param  bool    $create
      * @return string
+     * @throws \Exception 
      */
     public function create($name, $path, $table = null, $create = false)
     {
+        // Prevent creating a duplicate class name.
+        $className = $this->getClassName($name);
+        if (class_exists($className)) {
+            throw new \Exception("$className already exists");
+        }
+
         $path = $this->getPath($name, $path);
 
         // First we will get the stub file for the migration, which serves as a type

--- a/tests/Database/DatabaseMigrationCreatorTest.php
+++ b/tests/Database/DatabaseMigrationCreatorTest.php
@@ -47,6 +47,21 @@ class DatabaseMigrationCreatorTest extends PHPUnit_Framework_TestCase
         $creator->create('create_bar', 'foo', 'baz', true);
     }
 
+    public function testTableUpdateMigrationWontCreateDuplicateClass()
+    {
+        $creator = $this->getCreator();
+        eval("class UpdateBar{}");
+
+        try {
+            $creator->create('update_bar', 'foo');
+        } catch(\Exception $e) {
+            $this->assertEquals($e->getMessage(), "UpdateBar already exists");
+            return;
+        }
+
+        $this->fail();
+    }
+
     protected function getCreator()
     {
         $files = m::mock('Illuminate\Filesystem\Filesystem');


### PR DESCRIPTION
I recently ran into some headaches because two migrations created with the `artisan make:migration` command had the same class names. This small change causes `make:migration` to throw an exception if the class it would create already exists.
