### PR TITLE
[5.2] Allow Validator extensions to be dependent

### DIFF
--- a/src/Illuminate/Validation/Factory.php
+++ b/src/Illuminate/Validation/Factory.php
@@ -60,6 +60,13 @@ class Factory implements FactoryContract
     protected $fallbackMessages = [];
 
     /**
+     * All of the custom rules that are dependent on other fields.
+     *
+     * @var array
+     */
+    protected $dependentRules = [];
+
+    /**
      * The Validator resolver instance.
      *
      * @var Closure
@@ -131,6 +138,8 @@ class Factory implements FactoryContract
         $validator->addReplacers($this->replacers);
 
         $validator->setFallbackMessages($this->fallbackMessages);
+
+        $validator->addDependentRules($this->dependentRules);
     }
 
     /**
@@ -157,14 +166,19 @@ class Factory implements FactoryContract
      * @param  string  $rule
      * @param  \Closure|string  $extension
      * @param  string  $message
+     * @param  bool    $dependent
      * @return void
      */
-    public function extend($rule, $extension, $message = null)
+    public function extend($rule, $extension, $message = null, $dependent = false)
     {
         $this->extensions[$rule] = $extension;
 
         if ($message) {
             $this->fallbackMessages[Str::snake($rule)] = $message;
+        }
+
+        if ($dependent) {
+            $this->dependentRules[] = Str::studly($rule);
         }
     }
 
@@ -174,14 +188,19 @@ class Factory implements FactoryContract
      * @param  string   $rule
      * @param  \Closure|string  $extension
      * @param  string  $message
+     * @param  bool    $dependent
      * @return void
      */
-    public function extendImplicit($rule, $extension, $message = null)
+    public function extendImplicit($rule, $extension, $message = null, $dependent = false)
     {
         $this->implicitExtensions[$rule] = $extension;
 
         if ($message) {
             $this->fallbackMessages[Str::snake($rule)] = $message;
+        }
+
+        if ($dependent) {
+            $this->dependentRules[] = Str::studly($rule);
         }
     }
 

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -3105,6 +3105,32 @@ class Validator implements ValidatorContract
     }
 
     /**
+     * Get the dependent rules for the validator.
+     *
+     * @return array
+     */
+    public function getDependentRules()
+    {
+        return $this->dependentRules;
+    }
+
+    /**
+     * Register an array of custom dependent rules.
+     *
+     * @param  array  $dependentRules
+     * @return void
+     */
+    public function addDependentRules(array $dependentRules)
+    {
+        // Ensure integrity of core validators.
+        $dependentRules = array_filter($dependentRules, function ($rule) {
+            return ! method_exists($this, "validate{$rule}");
+        });
+
+        $this->dependentRules = array_merge($this->dependentRules, $dependentRules);
+    }
+
+    /**
      * Get the failed validation rules.
      *
      * @return array

--- a/tests/Validation/ValidationFactoryTest.php
+++ b/tests/Validation/ValidationFactoryTest.php
@@ -43,6 +43,17 @@ class ValidationFactoryTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(['foo' => $noop1, 'implicit' => $noop2], $validator->getExtensions());
         $this->assertEquals(['foo' => 'foo!', 'implicit' => 'implicit!'], $validator->getFallbackMessages());
         $this->assertEquals($presence, $validator->getPresenceVerifier());
+
+        $presence = m::mock('Illuminate\Validation\PresenceVerifierInterface');
+        $factory->extend('foo', $noop1, 'foo!', true);
+        $factory->extendImplicit('implicit', $noop2, 'implicit!', true);
+        $factory->setPresenceVerifier($presence);
+        $validator = $factory->make([], []);
+        $this->assertEquals(['foo' => $noop1, 'implicit' => $noop2], $validator->getExtensions());
+        $this->assertEquals(['foo' => 'foo!', 'implicit' => 'implicit!'], $validator->getFallbackMessages());
+        $this->assertEquals($presence, $validator->getPresenceVerifier());
+        $this->assertContains('Foo', $validator->getDependentRules());
+        $this->assertContains('Implicit', $validator->getDependentRules());
     }
 
     public function testCustomResolverIsCalled()


### PR DESCRIPTION
This PR allows third-party validators using `Validator::extend()` to be registered as being dependent on other fields so that parameters containing asterisks can be parsed correctly. At the moment there's no clean way to accomplish this.

If this is not implemented in the right way, please consider this PR as a feature request.

https://github.com/Propaganistas/Laravel-Phone/issues/34

(I created the PR against 5.2 but this can be committed to 5.3 without conflicts)
