### PR TITLE
[5.2] Add strictContains method to collection

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -156,7 +156,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      * @param  mixed  $value
      * @return bool
      */
-    public function contains($key, $value = null, $strict = false)
+    public function contains($key, $value = null)
     {
         if (func_num_args() == 2) {
             return $this->contains(function ($k, $item) use ($key, $value) {

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -156,7 +156,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      * @param  mixed  $value
      * @return bool
      */
-    public function contains($key, $value = null)
+    public function contains($key, $value = null, $strict = false)
     {
         if (func_num_args() == 2) {
             return $this->contains(function ($k, $item) use ($key, $value) {
@@ -169,6 +169,28 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
         }
 
         return in_array($key, $this->items);
+    }
+
+    /**
+     * Determine if an item exists in the collection (strict way).
+     *
+     * @param  mixed  $key
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function strictContains($key, $value = null)
+    {
+        if (func_num_args() == 2) {
+            return $this->contains(function ($k, $item) use ($key, $value) {
+                return data_get($item, $key) === $value;
+            });
+        }
+
+        if ($this->useAsCallable($key)) {
+            return ! is_null($this->first($key));
+        }
+
+        return in_array($key, $this->items, true);
     }
 
     /**

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -995,6 +995,36 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
         $this->assertFalse($c->contains('foo'));
     }
 
+    public function testStrictContains()
+    {
+        $c = new Collection([1, 3, 5]);
+
+        $this->assertTrue($c->strictContains(1));
+        $this->assertFalse($c->strictContains('01'));
+
+        $this->assertTrue($c->strictContains(function ($value) {
+            return $value < 5;
+        }));
+        $this->assertFalse($c->strictContains(function ($value) {
+            return $value > 5;
+        }));
+
+        $c = new Collection([['v' => 1], ['v' => 3], ['v' => 5]]);
+
+        $this->assertTrue($c->strictContains('v', 1));
+        $this->assertFalse($c->strictContains('v', '01'));
+        $this->assertFalse($c->strictContains('v', 2));
+
+        $c = new Collection(['date', '01', 'class', (object) ['foo' => 50]]);
+
+        $this->assertTrue($c->strictContains('date'));
+        $this->assertTrue($c->strictContains('class'));
+        $this->assertTrue($c->strictContains('01'));
+        $this->assertFalse($c->strictContains(1));
+        $this->assertTrue($c->contains(1));
+        $this->assertFalse($c->strictContains('foo'));
+    }
+
     public function testGettingSumFromCollection()
     {
         $c = new Collection([(object) ['foo' => 50], (object) ['foo' => 50]]);


### PR DESCRIPTION
There is missing strict comparison using contains method. I think it's not possible to add `$strict` parameter to `contains` method so I've added proposal to extra method to achieve that.
