### PR TITLE
[5.2] Add deferred botted callbacks to be fired after booting all deferred providers

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -63,6 +63,13 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     protected $bootedCallbacks = [];
 
     /**
+     * The array of deferred booted callbacks.
+     *
+     * @var array
+     */
+    protected $deferredBootedCallbacks = [];
+
+    /**
      * The array of terminating callbacks.
      *
      * @var array
@@ -628,6 +635,8 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
         }
 
         $this->deferredServices = [];
+
+        $this->fireAppCallbacks($this->deferredBootedCallbacks);
     }
 
     /**
@@ -782,6 +791,17 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
         if ($this->isBooted()) {
             $this->fireAppCallbacks([$callback]);
         }
+    }
+
+    /**
+     * Register a new "deferredBooted" listener.
+     *
+     * @param  mixed  $callback
+     * @return void
+     */
+    public function deferredBooted($callback)
+    {
+        $this->deferredBootedCallbacks[] = $callback;
     }
 
     /**


### PR DESCRIPTION
I believe at the moment there is no clean way to run an action on resolved service when it's in deferred provider because you cannot verify if this service has been already resolved or not - using `isDeferredService('migrator')` for example will return always `true`..

I've proposed it to 5.2 (it might be useful for someone) but I can show you sample usage for 5.3 version:

```
$this->app->deferredBooted(function($app) {
    if (!$this->app->isDeferredService('migrator')) {
        $somePaths = [];
        // ... <- here you set migrations paths
        // now you set custom migrations paths without a problem
        $this->loadMigrationsFrom($paths);
    }
}); 
```

I believe without it, in this case you either will be resolving migrator also when not running in console or you would need to create custom `ConsoleSupportProvider` where you extend functionality of original providers but those 2 solutions wouldn't be as elegant enough as above one.
