### PR TITLE
[5.3] ServiceProvider::loadMigrationsFrom() should only use migrator when it has been resolved.

### DIFF
--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -95,9 +95,11 @@ abstract class ServiceProvider
      */
     protected function loadMigrationsFrom($paths)
     {
-        foreach ((array) $paths as $path) {
-            $this->app['migrator']->path($path);
-        }
+        $this->app->afterResolving('migrator', function ($migrator) use ($paths) {
+            foreach ((array) $paths as $path) {
+                $migrator->path($path);
+            }
+        });
     }
 
     /**


### PR DESCRIPTION
As suggested under #14452

Signed-off-by: crynobone crynobone@gmail.com
