### PR TITLE
[5.3] Use Macroable trait in Message Builder

### DIFF
--- a/src/Illuminate/Notifications/MessageBuilder.php
+++ b/src/Illuminate/Notifications/MessageBuilder.php
@@ -2,8 +2,12 @@
 
 namespace Illuminate\Notifications;
 
+use Illuminate\Support\Traits\Macroable;
+
 class MessageBuilder
 {
+    use Macroable;
+
     /**
      * All of the message elements.
      *


### PR DESCRIPTION
Allows to add additional features to notifications without rewriting native classes.
