### PR TITLE
[5.2] Fixed race condition between DatabaseMigration and DatabaseTransaction

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -94,12 +94,12 @@ abstract class TestCase extends PHPUnit_Framework_TestCase
     {
         $uses = array_flip(class_uses_recursive(static::class));
 
-        if (isset($uses[DatabaseTransactions::class])) {
-            $this->beginDatabaseTransaction();
-        }
-
         if (isset($uses[DatabaseMigrations::class])) {
             $this->runDatabaseMigrations();
+        }
+
+        if (isset($uses[DatabaseTransactions::class])) {
+            $this->beginDatabaseTransaction();
         }
 
         if (isset($uses[WithoutMiddleware::class])) {


### PR DESCRIPTION
Hey Taylor, 
the sequence of databaseMigration and databaseTransaction in tests, which uses both traits, has been changed since laravel 5.2.7. It was also the reason for this issue: https://github.com/laravel/framework/issues/12161

Here you can see the different behavior:

| <= 5.2.6 | >= 5.2.7 |
| --- | --- |
| migration | transaction start |
| transaction start | migration |
| testing... | testing... |
| migration rollback | transaction end |
| transaction end | migration rollback |

Regards
Henrik
