### PR TITLE
[5.2] Fix #14468 by fixing another issue with PR #14188

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -490,7 +490,7 @@ class Builder
 
         $total = $query->getCountForPagination();
 
-        $results = $total ? $this->forPage($page, $perPage)->get($columns) : [];
+        $results = $total ? $this->forPage($page, $perPage)->get($columns) : new Collection();
 
         return new LengthAwarePaginator($results, $total, $perPage, $page, [
             'path' => Paginator::resolveCurrentPath(),


### PR DESCRIPTION
As addressed here: https://github.com/laravel/framework/issues/14468

The change merged in PR https://github.com/laravel/framework/pull/14188 causes the results inside the Paginator to be an empty array if no results while it'll be an Eloquent Collection otherwise.

Inside the `LengthAwarePaginator` the empty array will be converted to an empty Base Collection while it's expected to be an Eloquent Collection instead.

This results a `Method Not Found` exception when you try to use any of the methods that exist in Eloquent\Collection but doesn't exist in Base Collection in the case of no results found.
