### PR TITLE
[5.4] Allow numeric ratio values for validation

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1640,11 +1640,9 @@ class Validator implements ValidatorContract
         }
 
         if (isset($parameters['ratio'])) {
-            $ratioParam = array_filter(sscanf($parameters['ratio'], '%d/%d'));
+            list($numerator, $denominator) = array_replace([1, 1], array_filter(sscanf($parameters['ratio'], '%f/%d')));
 
-            $ratio = count($ratioParam) > 1 ? $ratioParam[0] / $ratioParam[1] : floatval($parameters['ratio']);
-
-            return bccomp($ratio, $width / $height, 8) === 0;
+            return $numerator / $denominator == $width / $height;
         }
 
         return true;

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1640,9 +1640,11 @@ class Validator implements ValidatorContract
         }
 
         if (isset($parameters['ratio'])) {
-            list($numerator, $denominator) = array_pad(sscanf($parameters['ratio'], '%d/%d'), 2, 1);
+            $ratioParam = array_filter(sscanf($parameters['ratio'], '%d/%d'));
 
-            return $numerator / $denominator == $width / $height;
+            $ratio = count($ratioParam) > 1 ? $ratioParam[0] / $ratioParam[1] : floatval($parameters['ratio']);
+
+            return bccomp($ratio, $width / $height, 8) === 0;
         }
 
         return true;

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1801,7 +1801,15 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $v->setFiles(['x' => $uploadedFile]);
         $this->assertTrue($v->passes());
 
+        $v = new Validator($trans, [], ['x' => 'dimensions:ratio=1.5']);
+        $v->setFiles(['x' => $uploadedFile]);
+        $this->assertTrue($v->passes());
+
         $v = new Validator($trans, [], ['x' => 'dimensions:ratio=1/1']);
+        $v->setFiles(['x' => $uploadedFile]);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, [], ['x' => 'dimensions:ratio=1']);
         $v->setFiles(['x' => $uploadedFile]);
         $this->assertTrue($v->fails());
     }


### PR DESCRIPTION
I was writing up a post on the image validation  and at first tried to pass `1.5` in to `ratio`, only to find that it's intended to be something like `3/2`. I figured I would propose the possibility to do either, to see if there's a specific/intentional reason it's currently only `3/2` (and there totally may be; just curious).

---

Image validation ratios can now be the current format (`3/2`) or a float (`1.5`).

Checks up to 8 digits, which is a weirdly arbitrary number, so I could use some help on whether there's a precedent elsewhere on these sort of float precision issues.

This is the cleanest way I could figure out how to do it, but would love input if anyone has a cleaner proposal.
