### PR TITLE
[5.3] Allow for numeric validation ratios when validating image uploads.

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1640,7 +1640,7 @@ class Validator implements ValidatorContract
         }
 
         if (isset($parameters['ratio'])) {
-            list($numerator, $denominator) = array_pad(sscanf($parameters['ratio'], '%d/%d'), 2, 1);
+            list($numerator, $denominator) = array_replace([1, 1], array_filter(sscanf($parameters['ratio'], '%f/%d')));
 
             return $numerator / $denominator == $width / $height;
         }

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1801,7 +1801,15 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $v->setFiles(['x' => $uploadedFile]);
         $this->assertTrue($v->passes());
 
+        $v = new Validator($trans, [], ['x' => 'dimensions:ratio=1.5']);
+        $v->setFiles(['x' => $uploadedFile]);
+        $this->assertTrue($v->passes());
+
         $v = new Validator($trans, [], ['x' => 'dimensions:ratio=1/1']);
+        $v->setFiles(['x' => $uploadedFile]);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, [], ['x' => 'dimensions:ratio=1']);
         $v->setFiles(['x' => $uploadedFile]);
         $this->assertTrue($v->fails());
     }


### PR DESCRIPTION
I was writing up a post on the image validation  and at first tried to pass `1.5` in to `ratio`, only to find that it's intended to be something like `3/2`. I figured I would propose the possibility to do either, to see if there's a specific/intentional reason it's currently only `3/2` (and there totally may be; just curious).

---

Image validation ratios can now be the current format (`3/2`) or a float (`1.5`).

---

(duplicated from https://github.com/laravel/framework/pull/14478, but moved to 5.3 in this PR)
