### PR TITLE
[5.4] Remove the morphclass

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -183,13 +183,6 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     protected $with = [];
 
     /**
-     * The class name to be used in polymorphic relations.
-     *
-     * @var string
-     */
-    protected $morphClass;
-
-    /**
      * Indicates if the model exists.
      *
      * @var bool
@@ -2036,7 +2029,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
             return array_search($class, $morphMap, true);
         }
 
-        return $this->morphClass ?: $class;
+        return $class;
     }
 
     /**


### PR DESCRIPTION
Shame we didn't manage to get #14477 merged (although I would really still prefer it, see my last comment in that thread). This is the exact same PR, but for 5.4
### Upgrade notes

The `protected $morphClass` on the `Model` has been removed in favour of `Relation::morphMap()`. If you were previously relying on the `$morphClass` for your polymorphic relations, you should now move this into the `morphMap`. This is done with the syntax

``` php
Relation::morphMap([
    'YourCustomMorphClass' => YourModel::class,
]);
```

So if previously you had

``` php
class User extends Model
{
    // ...
    protected $morphClass = 'Mod::Auth::User'
    // ...
}
```

You would instead have this in a service provider.

``` php
Relation::morphMap([
    'Mod::Auth::User' => User::class,
]);
```
