### PR TITLE
[5.3] Add relationship tools

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -3188,7 +3188,6 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
                     break;
                 }
             }
-
         }
 
         return $pass;

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2739,8 +2739,13 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         $parent_reflection = $reflection->getParentClass();
 
         // Get names of all methods on the current (child) and parent classes.
-        $reflection_list = array_map(function($v) {return $v->name;}, $reflection->getMethods());
-        $parent_reflection_list = array_map(function($v) {return $v->name;}, $parent_reflection->getMethods());
+        $reflection_list = array_map(function($v) {
+            return $v->name;
+        }, $reflection->getMethods());
+
+        $parent_reflection_list = array_map(function($v) {
+            return $v->name;
+        }, $parent_reflection->getMethods());
 
         // Remove the parent method names from the child method names.
         $methods = array_diff($reflection_list, $parent_reflection_list);
@@ -2753,14 +2758,16 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         // Check each method to see if it is a relation.
         foreach ($methods as $method) {
             // Do not call this method. Avoid self-recursive loop.
-            if ($method == $this_func_name) continue;
+            if ($method == $this_func_name) {
+                continue;
+            }
 
             try {
                 $result = $model->$method();
                 if ($result instanceof Relation) {
                     // Record the method.
                     $relations_map[$method] = [
-                        'class' => get_class($result->getRelated())
+                        'class' => get_class($result->getRelated()),
                     ];
                 }
             } catch (\Exception $e) {
@@ -3168,7 +3175,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
             // Ensure results are in a collection.
             $collection = new BaseCollection();
 
-            if ($result instanceof Model) {
+            if ($result instanceof self) {
                 $collection->push($result);
             } elseif ($result instanceof BaseCollection) {
                 $collection = $result;

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -676,7 +676,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public function load($relations = null)
     {
-        if (null == $relations) {
+        if (null === $relations) {
             $relations = array_keys($this->getRelationsMap());
         } elseif (is_string($relations)) {
             $relations = func_get_args();

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2739,11 +2739,11 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         $parent_reflection = $reflection->getParentClass();
 
         // Get names of all methods on the current (child) and parent classes.
-        $reflection_list = array_map(function($v) {
+        $reflection_list = array_map(function ($v) {
             return $v->name;
         }, $reflection->getMethods());
 
-        $parent_reflection_list = array_map(function($v) {
+        $parent_reflection_list = array_map(function ($v) {
             return $v->name;
         }, $parent_reflection->getMethods());
 

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -677,7 +677,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     public function load($relations = null)
     {
         if (null == $relations) {
-            $relations = array_keys($this->getrelationsMap());
+            $relations = array_keys($this->getRelationsMap());
         } elseif (is_string($relations)) {
             $relations = func_get_args();
         }
@@ -696,7 +696,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public static function withAll()
     {
-        $relations = array_keys((new static)->getrelationsMap());
+        $relations = array_keys((new static)->getRelationsMap());
         return static::with($relations);
     }
 

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Database\Eloquent;
 
+use ReflectionClass;
 use Closure;
 use DateTime;
 use Exception;
@@ -104,6 +105,13 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      * @var array
      */
     protected $relations = [];
+
+    /**
+     * The name and class of the relationships for the model.
+     *
+     * @var array|null
+     */
+    protected $relationsMap = null;
 
     /**
      * The attributes that should be hidden for arrays.
@@ -663,12 +671,14 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     /**
      * Eager load relations on the model.
      *
-     * @param  array|string  $relations
+     * @param  array|string|null  $relations
      * @return $this
      */
-    public function load($relations)
+    public function load($relations = null)
     {
-        if (is_string($relations)) {
+        if (null == $relations) {
+            $relations = array_keys($this->getrelationsMap());
+        } elseif (is_string($relations)) {
             $relations = func_get_args();
         }
 
@@ -677,6 +687,17 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         $query->eagerLoadRelations([$this]);
 
         return $this;
+    }
+
+    /**
+     * Begin querying a model with eager loading for all relationships.
+     *
+     * @return \Illuminate\Database\Eloquent\Builder|static
+     */
+    public static function withAll()
+    {
+        $relations = array_keys((new static)->getrelationsMap());
+        return static::with($relations);
     }
 
     /**
@@ -2681,6 +2702,78 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     }
 
     /**
+     * Return the key:value pairs for relationships and related model classes.
+     *
+     * @return array
+     */
+    public function getRelationsMap()
+    {
+        // Lazy load once since model relations are not dynamic.
+        if (null === $this->relationsMap) {
+            $this->setRelationsMap();
+        }
+
+        return $this->relationsMap;
+    }
+
+    /**
+     * Set the key:value pairs for relationships and related model classes.
+     *
+     * @param  array  $map
+     * @return array
+     */
+    public function setRelationsMap(array $map = null)
+    {
+        if ($map) {
+            // Set to provided relations map.
+            $this->relationsMap = $map;
+            return $this;
+        }
+
+        $this_func_name = __FUNCTION__;
+
+        // Currently instantiated Model.
+        $reflection = new ReflectionClass(new static);
+
+        // Model parent class, \Illuminate\Database\Eloquent\Model.
+        $parent_reflection = $reflection->getParentClass();
+
+        // Get names of all methods on the current (child) and parent classes.
+        $reflection_list = array_map(function($v) {return $v->name;}, $reflection->getMethods());
+        $parent_reflection_list = array_map(function($v) {return $v->name;}, $parent_reflection->getMethods());
+
+        // Remove the parent method names from the child method names.
+        $methods = array_diff($reflection_list, $parent_reflection_list);
+
+        // New model instance.
+        $model = new static;
+
+        $relations_map = [];
+
+        // Check each method to see if it is a relation.
+        foreach ($methods as $method) {
+            // Do not call this method. Avoid self-recursive loop.
+            if ($method == $this_func_name) continue;
+
+            try {
+                $result = $model->$method();
+                if ($result instanceof Relation) {
+                    // Record the method.
+                    $relations_map[$method] = [
+                        'class' => get_class($result->getRelated())
+                    ];
+                }
+            } catch (\Exception $e) {
+                continue;
+            }
+        }
+
+        $this->relationsMap = $relations_map;
+
+        return $this;
+    }
+
+    /**
      * Determine if a get mutator exists for an attribute.
      *
      * @param  string  $key
@@ -3045,6 +3138,53 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         return $this->getKey() === $model->getKey() &&
                $this->getTable() === $model->getTable() &&
                $this->getConnectionName() === $model->getConnectionName();
+    }
+
+    /**
+     * Determine if two models are related.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @return bool
+     */
+    public function is_related(Model $model)
+    {
+        // Fully qualified class name of the model.
+        $class_name = get_class($model);
+
+        // Assume the models are not related.
+        $pass = false;
+
+        // Check each known relation.
+        foreach ($this->getRelationsMap() as $name => $relation) {
+
+            // Check for exact class name match.
+            if ($relation['class'] !== $class_name) {
+                continue;
+            }
+
+            // Get the relation results.
+            $result = $this->$name()->get();
+
+            // Ensure results are in a collection.
+            $collection = new BaseCollection();
+
+            if ($result instanceof Model) {
+                $collection->push($result);
+            } elseif ($result instanceof BaseCollection) {
+                $collection = $result;
+            }
+
+            // Compare if the models point to the same record.
+            foreach ($collection as $related) {
+                if ($related->is($model)) {
+                    $pass = true;
+                    break;
+                }
+            }
+
+        }
+
+        return $pass;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -697,6 +697,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     public static function withAll()
     {
         $relations = array_keys((new static)->getRelationsMap());
+
         return static::with($relations);
     }
 
@@ -2727,6 +2728,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         if ($map) {
             // Set to provided relations map.
             $this->relationsMap = $map;
+
             return $this;
         }
 


### PR DESCRIPTION
**Description**
- Get relations names and classes dynamically
- Query with all relations or load all relations any time
- Determine if other model is related

**Functionality**

``` php
// Begin querying a model with eager loading for all relationships.
Model::withAll();

// Eager load relations on the model.
$model->load();

// Returns array e.g. [ 'relationName' => [ 'class' => 'App\Models\ModelName' ] ]
$model->getRelationsMap();

// Scan the model methods. Set the array returned by getRelationsMap().
$model->setRelationsMap();
```

**Use Case**
- While working on a JSON API I wanted to programmatically build [resource object relationships](http://jsonapi.org/format/#document-resource-object-relationships) for entities. The method names of a model's relationships was a good place to start.
- While working with nested resources I wanted to control that the nested resource was related to the parent resource.
