### PR TITLE
[5.3] Eloquent Model fill multiple columns with a value

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -470,6 +470,19 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     }
 
     /**
+     * Fill the columns defined by keys with the value.
+     *
+     * @param array $keys
+     * @param null  $val
+     *
+     * @return \Illuminate\Database\Eloquent\Model
+     */
+    public function massFill(array $keys, $val = null)
+    {
+        return $this->fill(array_fill_keys($keys, $val));
+    }
+
+    /**
      * Get the fillable attributes of a given array.
      *
      * @param  array  $attributes

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -473,7 +473,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      * Fill the columns defined by keys with the value.
      *
      * @param array $keys
-     * @param null  $val
+     * @param mixed  $val
      *
      * @return \Illuminate\Database\Eloquent\Model
      */

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -751,6 +751,16 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(21, $model->id);
     }
 
+    public function testMassFill()
+    {
+        $model = new EloquentModelStub;
+        $keys = ['name', 'age'];
+        $model->fillable($keys);
+        $model->massFill($keys, 'Yoo');
+        $this->assertEquals('Yoo', $model->name);
+        $this->assertEquals('Yoo', $model->age);
+    }
+
     public function testUnguardAllowsAnythingToBeSet()
     {
         $model = new EloquentModelStub;


### PR DESCRIPTION
e.g: when I have to clear some data from a Model I have to do this:

``` php
$model->fill([
    'key1' => null,
    'key2' => null,
]);
```

Would be better if I could do something like this:

``` php
$model->massFill(['key1', 'key2'], null);
```

Thank you.
