### PR TITLE
[5.4] Support ArrayAccess way to set relations values

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2858,10 +2858,10 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         }
 
         // Support ArrayAccess set relations value
-        if (isset($this->relations[$key])){
-        	$this->relations[$key] = $value;
+        if (isset($this->relations[$key])) {
+            $this->relations[$key] = $value;
         }else{
-        	$this->attributes[$key] = $value;
+            $this->attributes[$key] = $value;
         }
 
         return $this;

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2860,7 +2860,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         // Support ArrayAccess set relations value
         if (isset($this->relations[$key])) {
             $this->relations[$key] = $value;
-        }else{
+        } else {
             $this->attributes[$key] = $value;
         }
 

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2857,7 +2857,12 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
             $value = $this->asJson($value);
         }
 
-        $this->attributes[$key] = $value;
+        // Support ArrayAccess set relations value
+        if (isset($this->relations[$key])){
+        	$this->relations[$key] = $value;
+        }else{
+        	$this->attributes[$key] = $value;
+        }
 
         return $this;
     }


### PR DESCRIPTION
Example: 
model have relation A, and relation A have relation B. use: 
`$model->with('A', 'A.B')->find(1);`
we get a model object have relations[A], and relations[A] have relations[B]. if we want relations[B] only have id column:
`$model['relationA']['relationB'] = $model['relationA']['relationB']->pluck('id');`
