### PR TITLE
[5.2] Support composite column names like 'table.id' in chunkById

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1763,13 +1763,14 @@ class Builder
         $lastId = null;
 
         $results = $this->forPageAfterId($count, 0, $column)->get();
+        $columnSuffix = last(explode('.', $column));
 
         while (! empty($results)) {
             if (call_user_func($callback, $results) === false) {
                 return false;
             }
 
-            $lastId = last($results)->{$column};
+            $lastId = last($results)->{$columnSuffix};
 
             $results = $this->forPageAfterId($count, $lastId, $column)->get();
         }

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1659,6 +1659,22 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase
         }, 'someIdField');
     }
 
+    public function testChunkPaginatesUsingIdWithCompositeColumnName()
+    {
+        $builder = $this->getMockQueryBuilder();
+
+        $builder->shouldReceive('forPageAfterId')->once()->with(2, 0, 'table.id')->andReturn($builder);
+        $builder->shouldReceive('forPageAfterId')->once()->with(2, 10, 'table.id')->andReturn($builder);
+
+        $builder->shouldReceive('get')->times(2)->andReturn(
+            [(object) ['id' => 1], (object) ['id' => 10]],
+            []
+        );
+
+        $builder->chunkById(2, function ($results) {
+        }, 'table.id');
+    }
+
     public function testPaginate()
     {
         $perPage = 16;


### PR DESCRIPTION
Example use case that didn't work before:

``` php
// both the annotations and images tables have an id column
DB::table('annotations')
   ->join('images', 'annotations.image_id', '=', 'images.id')
   ->where(/* something with images */)
   ->chunkById(500, $handleChunk, 'annotations.id');
```

As a workaround I used an alias for the ambiguous column:

``` php
DB::table('annotations')
   ->join('images', 'annotations.image_id', '=', 'images.id')
   ->where(/* something with images */)
   ->select('annotations.id as annotations_id', /* ... */)
   ->chunkById(500, $handleChunk, 'annotations_id');
```

But PostgreSQL for example doesn't allow the use of an alias in a `where` statement like it is built by `chunkById`.
