### PR TITLE
[5.2] Provide a method to flush an Event Listener

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1276,6 +1276,24 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
             static::$dispatcher->forget("eloquent.{$event}: ".static::class);
         }
     }
+    
+    /**
+     * Remove a specific event listener for the model.
+     *
+     * @param string $event
+     * @return void
+     */
+    public static function flushEventListener(string $event)
+    {
+        if ( ! isset(static::$dispatcher)) {
+            return;
+        }
+        $instance = new static;
+        if ( ! in_array($event, $instance->getObservableEvents())) {
+            return;
+        }
+        static::$dispatcher->forget("eloquent.{$event}: " . static::class);
+    }
 
     /**
      * Register a model event with the dispatcher.


### PR DESCRIPTION
With this new method, one is able to flush just a specific event listener.
I don't really know if this is useful to the Laravel framework, but since I've had this particular need, it might come in handy for someone.
