### PR TITLE
Update str_plural() to add intval($count)

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -713,7 +713,7 @@ if (! function_exists('str_plural')) {
      */
     function str_plural($value, $count = 2)
     {
-        return Str::plural($value, $count);
+        return Str::plural($value, intval($count));
     }
 }
 


### PR DESCRIPTION
A lot of the time when you use `str_plural()` you get the $count value from a form request which returns the number as a string and therefore this helper won't work as expected. This small change should make sure the $count is in integer format.
