### PR TITLE
[5.2] Update Str::plural() to use intval()

### DIFF
--- a/src/Illuminate/Support/Pluralizer.php
+++ b/src/Illuminate/Support/Pluralizer.php
@@ -50,7 +50,7 @@ class Pluralizer
      */
     public static function plural($value, $count = 2)
     {
-        if (intval($count) === 1 || static::uncountable($value)) {
+        if ((int) $count === 1 || static::uncountable($value)) {
             return $value;
         }
 

--- a/src/Illuminate/Support/Pluralizer.php
+++ b/src/Illuminate/Support/Pluralizer.php
@@ -50,7 +50,7 @@ class Pluralizer
      */
     public static function plural($value, $count = 2)
     {
-        if ($count === 1 || static::uncountable($value)) {
+        if (intval($count) === 1 || static::uncountable($value)) {
             return $value;
         }
 


### PR DESCRIPTION
A lot of the time when you use str_plural() you get the $count value from a form request which returns the number as a string and therefore this won't work as expected. This small change should make sure the $count is in integer format.

Many thanks to @barryvdh for suggesting to do this change deeper in the code.
