### PR TITLE
DI for explicit route model binding

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -831,7 +831,7 @@ class Router implements RegistrarContract
      */
     protected function performBinding($key, $value, $route)
     {
-        return call_user_func($this->binders[$key], $value, $route);
+        return $this->container->call($this->binders[$key], [$value, $route]);
     }
 
     /**


### PR DESCRIPTION
Add support magic of DI-Container for explicit route model binding.

``` php
$router->bind('some', function(MyCustomServiceClass $service, $value)
{
    return $service->findSomeThingByValue($value);
});
```
