### PR TITLE
[5.3] Added resolveName to the job contract

### DIFF
--- a/src/Illuminate/Contracts/Queue/Job.php
+++ b/src/Illuminate/Contracts/Queue/Job.php
@@ -55,6 +55,13 @@ interface Job
     public function getName();
 
     /**
+     * Get the resolved name of the queued job class.
+     *
+     * @return string
+     */
+    public function resolveName();
+
+    /**
      * Call the failed method on the job instance.
      *
      * @param  \Throwable  $e


### PR DESCRIPTION
I was listening for the `Illuminate\Queue\Events\JobProcessing` event, and I was accessing the `job` property on it which is an instance of `Illuminate\Contracts\Queue\Job`, but I want to get the resolved name (in order to set the error context on my bugsnag logs), but the method `resolveName` is not available on the contract. I think it should be, since that method is pretty useful.
## 

TLDR: plz add this method to the contract. :P
