### PR TITLE
[5.2] Remove duplicate interface implementation

### DIFF
--- a/src/Illuminate/Bus/Dispatcher.php
+++ b/src/Illuminate/Bus/Dispatcher.php
@@ -9,9 +9,8 @@ use Illuminate\Contracts\Queue\Queue;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Bus\QueueingDispatcher;
-use Illuminate\Contracts\Bus\Dispatcher as DispatcherContract;
 
-class Dispatcher implements DispatcherContract, QueueingDispatcher
+class Dispatcher implements QueueingDispatcher
 {
     /**
      * The container implementation.


### PR DESCRIPTION
Because the interface `QueueingDispatcher`   inherits from the interface `Illuminate\Contracts\Bus\Dispatcher`, there is no need to implement the interface `Illuminate\Contracts\Bus\Dispatcher` again.
