### PR TITLE
Added Doc Blocks to Fluent class

### DIFF
--- a/src/Illuminate/Support/Fluent.php
+++ b/src/Illuminate/Support/Fluent.php
@@ -8,8 +8,7 @@ use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Contracts\Support\Arrayable;
 
 /**
- * Class Fluent
- * @package Illuminate\Support
+ * Class Fluent.
  *
  * @see https://laravel.com/docs/master/migrations
  *

--- a/src/Illuminate/Support/Fluent.php
+++ b/src/Illuminate/Support/Fluent.php
@@ -7,6 +7,21 @@ use JsonSerializable;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Contracts\Support\Arrayable;
 
+/**
+ * Class Fluent
+ * @package Illuminate\Support
+ *
+ * @see https://laravel.com/docs/master/migrations
+ *
+ * @method Fluent unsigned()
+ * @method Fluent nullable()
+ * @method Fluent unique()
+ * @method Fluent default(mixed $value)
+ * @method Fluent references(string $key)
+ * @method Fluent on(string $table)
+ * @method Fluent onDelete(string $action)
+ * @method Fluent onUpdate(string $action)
+ */
 class Fluent implements ArrayAccess, Arrayable, Jsonable, JsonSerializable
 {
     /**


### PR DESCRIPTION
Cause some methods in `Illuminate\Support\Fluent` class called via magic methods, there are IDE's code inspection warnings, and also no way to autocomplete these items.

<img width="458" alt="2016-07-28 15 30 37" src="https://cloud.githubusercontent.com/assets/724423/17212684/bd6d9b48-54e1-11e6-8d09-502c11036abe.png">

Doc blocks will fixing it.
