### PR TITLE
[5.3] Add the 'single' method

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -664,6 +664,37 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
+     * Return a single item from the collection from a callback.
+     *
+     * @param  callable  $callback
+     * @return mixed
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function single(callable $callback)
+    {
+        $items = $this->items;
+        $resultCount = 0;
+
+        foreach ($items as $value) {
+            if ($callback($value)) {
+                $result = $value;
+                $resultCount += 1;
+            }
+        }
+
+        if ($resultCount === 0) {
+            throw new InvalidArgumentException('This sequence contains no matching element');
+        }
+
+        if ($resultCount > 1) {
+            throw new InvalidArgumentException('This sequence contains more than one matching element');
+        }
+
+        return $result;
+    }
+
+    /**
      * "Paginate" the collection by slicing it into a smaller collection.
      *
      * @param  int  $page

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1421,6 +1421,42 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
         $collection = new Collection([1, 2, 2, 1]);
         $this->assertEquals([1, 2], $collection->mode());
     }
+
+    public function testSingle()
+    {
+        $collection = new Collection(['foo', 'bar', 'baz']);
+
+        $result = $collection->single(function ($item) {
+            return $item === 'bar';
+        });
+        $this->assertEquals('bar', $result);
+    }
+
+    /**
+     * @expectedException        InvalidArgumentException
+     * @expectedExceptionMessage This sequence contains more than one matching element
+     */
+    public function testSingleThrowsAnErrorWhenMoreThanOneMatchingValueIsFound()
+    {
+        $collection = new Collection(['foo', 'foo', 'bar']);
+
+        $result = $collection->single(function ($item) {
+            return $item === 'foo';
+        });
+    }
+
+    /**
+     * @expectedException        InvalidArgumentException
+     * @expectedExceptionMessage This sequence contains no matching element
+     */
+    public function testSingleThrowsAnErrorWhenNoMatcingValueIsFound()
+    {
+        $collection = new Collection(['foo', 'bar']);
+
+        $result = $collection->single(function ($item) {
+            return $item === 'baz';
+        });
+    }
 }
 
 class TestAccessorEloquentTestStub


### PR DESCRIPTION
Similar to C# generic collections single method, you can only return a single element that matches a callback. It'll otherwise throw an exception if more than one is found, or none are found.

Included tests
