### PR TITLE
[5.4] Cron rules should be commutative

### DIFF
--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -341,7 +341,7 @@ class Event
      */
     public function hourly()
     {
-        return $this->cron('0 * * * * *');
+        return $this->spliceIntoPosition(1, 0);
     }
 
     /**
@@ -351,7 +351,8 @@ class Event
      */
     public function daily()
     {
-        return $this->cron('0 0 * * * *');
+        return $this->spliceIntoPosition(1, 0)
+                    ->spliceIntoPosition(2, 0);
     }
 
     /**
@@ -481,7 +482,9 @@ class Event
      */
     public function weekly()
     {
-        return $this->cron('0 0 * * 0 *');
+        return $this->spliceIntoPosition(1, 0)
+                    ->spliceIntoPosition(2, 0)
+                    ->spliceIntoPosition(5, 0);
     }
 
     /**
@@ -505,7 +508,9 @@ class Event
      */
     public function monthly()
     {
-        return $this->cron('0 0 1 * * *');
+        return $this->spliceIntoPosition(1, 0)
+                    ->spliceIntoPosition(2, 0)
+                    ->spliceIntoPosition(3, 1);
     }
 
     /**
@@ -529,7 +534,10 @@ class Event
      */
     public function quarterly()
     {
-        return $this->cron('0 0 1 */3 *');
+        return $this->spliceIntoPosition(1, 0)
+                    ->spliceIntoPosition(2, 0)
+                    ->spliceIntoPosition(3, 1)
+                    ->spliceIntoPosition(4, '*/3');
     }
 
     /**
@@ -539,7 +547,10 @@ class Event
      */
     public function yearly()
     {
-        return $this->cron('0 0 1 1 * *');
+        return $this->spliceIntoPosition(1, 0)
+                    ->spliceIntoPosition(2, 0)
+                    ->spliceIntoPosition(3, 1)
+                    ->spliceIntoPosition(4, 1);
     }
 
     /**
@@ -549,7 +560,7 @@ class Event
      */
     public function everyMinute()
     {
-        return $this->cron('* * * * * *');
+        return $this->spliceIntoPosition(1, '*');
     }
 
     /**
@@ -559,7 +570,7 @@ class Event
      */
     public function everyFiveMinutes()
     {
-        return $this->cron('*/5 * * * * *');
+        return $this->spliceIntoPosition(1, '*/5');
     }
 
     /**
@@ -569,7 +580,7 @@ class Event
      */
     public function everyTenMinutes()
     {
-        return $this->cron('*/10 * * * * *');
+        return $this->spliceIntoPosition(1, '*/10');
     }
 
     /**
@@ -579,7 +590,7 @@ class Event
      */
     public function everyThirtyMinutes()
     {
-        return $this->cron('0,30 * * * * *');
+        return $this->spliceIntoPosition(1, '0,30');
     }
 
     /**

--- a/tests/Console/ConsoleScheduledEventTest.php
+++ b/tests/Console/ConsoleScheduledEventTest.php
@@ -69,6 +69,25 @@ class ConsoleScheduledEventTest extends PHPUnit_Framework_TestCase
 
         $event = new Event('php foo');
         $this->assertEquals('0 15 4 * * *', $event->monthlyOn(4, '15:00')->getExpression());
+
+        $event = new Event('php foo');
+        $this->assertEquals('0 0 * * 1-5 *', $event->weekdays()->daily()->getExpression());
+
+        $event = new Event('php foo');
+        $this->assertEquals('0 * * * 1-5 *', $event->weekdays()->hourly()->getExpression());
+
+        // chained rules should be commutative
+        $eventA = new Event('php foo');
+        $eventB = new Event('php foo');
+        $this->assertEquals(
+            $eventA->daily()->hourly()->getExpression(),
+            $eventB->hourly()->daily()->getExpression());
+
+        $eventA = new Event('php foo');
+        $eventB = new Event('php foo');
+        $this->assertEquals(
+            $eventA->weekdays()->hourly()->getExpression(),
+            $eventB->hourly()->weekdays()->getExpression());
     }
 
     public function testEventIsDueCheck()


### PR DESCRIPTION
This change addresses https://github.com/laravel/docs/issues/2395

```
    $command->hourly()->weekdays()->getExpression(); // 0 * * * 1-5 *
    $command->weekdays()->hourly()->getExpression(); // 0 * * * * *
```

The standard cron rules `hourly`, `daily`, `weekly`, `monthly`, `quarterly`, `yearly`, `everyMinute`, `everyFiveMinutes`, `everyTenMinutes`, and `everyThirtyMinutes` will completely overwrite the current expression instead of changing what the user would logically think should be replaced. This forces the user to start with one of those before adding modifiers like `monday`, `tuesday`, `twiceDaily`, `weekdays`, `monthlyOn`, `weeklyOn`, etc

The expression is already starts out defaulted to \* \* \* \* \* \* so using splicing nets more expected results.

All existing tests pass and I added a few to ensure the specified issues are covered.

I'm not in love with chaining multiple  `spliceIntoPosition`s and it would be really simple to permit that function to allow arrays similar to `str_replace` or other core php functions. The only reason I didn't was because it made the resulting code less simple to read.

I'm happy to port this change to 5.2 as well, if another pull request is required.
