### PR TITLE
[5.2] Fix pokemon plural form

### DIFF
--- a/src/Illuminate/Support/Pluralizer.php
+++ b/src/Illuminate/Support/Pluralizer.php
@@ -32,6 +32,7 @@ class Pluralizer
         'nutrition',
         'offspring',
         'plankton',
+        'pokemon',
         'police',
         'rice',
         'series',


### PR DESCRIPTION
As with the words deer and sheep, the singular and plural forms of the word "Pokémon" do not differ, nor does each individual species name; in short, it is grammatically correct to say both "one Pokémon" and "many Pokémon"
