### PR TITLE
[5.4] Slice accepts 3rd argument to optionally not preserve keys

### DIFF
--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1421,6 +1421,18 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
         $collection = new Collection([1, 2, 2, 1]);
         $this->assertEquals([1, 2], $collection->mode());
     }
+
+    public function testSlice()
+    {
+        $collection = new Collection([1, 2, 3, 4]);
+        $this->assertEquals([3, 4], $collection->slice(2)->values()->toArray());
+    }
+
+    public function testSliceWithLength()
+    {
+        $collection = new Collection([1, 2, 3, 4]);
+        $this->assertEquals([2, 3], $collection->slice(1, 2)->values()->toArray());
+    }
 }
 
 class TestAccessorEloquentTestStub


### PR DESCRIPTION
Issue raised here https://github.com/laravel/docs/issues/2428

The documentation for [`Collection::slice`](https://laravel.com/docs/master/collections#method-slice) currently states the following:

> The returned slice will have new, numerically indexed keys. If you wish to preserve the original keys, pass true as the third argument to the method.

Not only is this false in that the current behavior preserves keys by default, but slice doesn't even support a 3rd argument.

This change introduces the third argument and keeps the current behavior unchanged.

There is a separate pull request to update the documentation to correct this discrepancy: https://github.com/laravel/docs/pull/2437

If it would be preferred to not preserve keys by default, let me know and I can update the default argument and documentation accordingly.
