### PR TITLE
[5.3] Add Possibility to TokenAuth via header and not via GET param

### DIFF
--- a/src/Illuminate/Auth/TokenGuard.php
+++ b/src/Illuminate/Auth/TokenGuard.php
@@ -80,7 +80,7 @@ class TokenGuard implements Guard
      */
     protected function getTokenForRequest()
     {
-        $token = $this->request->input($this->inputKey);
+        $token = $this->request->hasHeader($this->inputKey) ? $this->request->header($this->inputKey): $this->request->input($this->inputKey);
 
         if (empty($token)) {
             $token = $this->request->bearerToken();

--- a/src/Illuminate/Auth/TokenGuard.php
+++ b/src/Illuminate/Auth/TokenGuard.php
@@ -80,7 +80,7 @@ class TokenGuard implements Guard
      */
     protected function getTokenForRequest()
     {
-        $token = $this->request->hasHeader($this->inputKey) ? $this->request->header($this->inputKey): $this->request->input($this->inputKey);
+        $token = $this->request->hasHeader($this->inputKey) ? $this->request->header($this->inputKey) : $this->request->input($this->inputKey);
 
         if (empty($token)) {
             $token = $this->request->bearerToken();


### PR DESCRIPTION
This PR makes it possible to Auth via Token with HTTP Header (api_token) instead of GET Parameter. The HTTP Header has an higher priority as the GET Parameter.

I think it is much cleaner to hide Auth Things for normal users when you do an HTTP Request
