### PR TITLE
[5.3] Alias Mailer as MailerContract

### DIFF
--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -7,7 +7,7 @@ use ReflectionProperty;
 use Illuminate\Support\Str;
 use Illuminate\Support\Collection;
 use Illuminate\Container\Container;
-use Illuminate\Contracts\Mail\Mailer;
+use Illuminate\Contracts\Mail\Mailer as MailerContract;
 use Illuminate\Contracts\Queue\Factory as Queue;
 use Illuminate\Contracts\Mail\Mailable as MailableContract;
 
@@ -100,10 +100,10 @@ class Mailable implements MailableContract
     /**
      * Send the message using the given mailer.
      *
-     * @param  Mailer  $mailer
+     * @param  MailerContract  $mailer
      * @return void
      */
-    public function send(Mailer $mailer)
+    public function send(MailerContract $mailer)
     {
         Container::getInstance()->call([$this, 'build']);
 


### PR DESCRIPTION
I was testing out the new Mailable functionality and encountered a bug. It appears as though the `Mailable#send` method is trying to get an instance of `Mailable`, I don't quite understand why, but it looks to be the culprit for the exception I am seeing.

> Cannot use Illuminate\Contracts\Mail\Mailer as Mailer because the name is already in use in /vendor/laravel/framework/src/Illuminate/Mail/Mailable.php on line 10

To fix this, I aliased the `Mailer` dependency as `MailerContract`; which follows Laravel's convention for aliasing interface dependencies. After making the change, I never get the exception.
## Reproducing the bug

For reference, the code I wrote to test the Mailable functionality has been provided below.

``` php
class EmailConfirmationController extends Controller
{
    public function resend(Request $request)
    {
        Mail::send(new EmailConfirmation($request->user()));

        return redirect('/email/confirmations/sent');
    }
}
```

``` php
class EmailConfirmation extends Mailable
{
    use Queueable, SerializesModels;

    /**
     * The user we are sending the email to.
     *
     * @var \App\User
     */
    public $user;

    /**
     * Create a new email confirmation.
     *
     * @param \App\User $user
     */
    public function __construct(User $user)
    {
        $this->user = $user;
    }

    /**
     * Build the message.
     *
     * @return $this
     */
    public function build()
    {
        return $this->view('emails.email_confirmation')
            ->to($this->user->email, $this->user->name)
            ->subject('Email confirmation');
    }
}
```
