### PR TITLE
[Proposal] Update NotFoundHttpException that is thrown to include method and path info

### DIFF
--- a/src/Illuminate/Routing/RouteCollection.php
+++ b/src/Illuminate/Routing/RouteCollection.php
@@ -158,7 +158,7 @@ class RouteCollection implements Countable, IteratorAggregate
             return $this->getRouteForMethods($request, $others);
         }
 
-        throw new NotFoundHttpException;
+		throw new NotFoundHttpException("Could not find route for method '" . $request->getMethod() . "' and path '" . $request->path() . "'");
     }
 
     /**


### PR DESCRIPTION
Currently, when NotFoundHttpException is thrown, it includes no information about the request that could not be handled which is a problem if you are seeing it in the logs.  This addresses that.
