### PR TITLE
[5.2] Extract \Illuminate\Support\Collection::pipe to a trait

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -9,13 +9,14 @@ use CachingIterator;
 use JsonSerializable;
 use IteratorAggregate;
 use InvalidArgumentException;
+use Illuminate\Support\Traits\Pipable;
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Contracts\Support\Arrayable;
 
 class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate, Jsonable, JsonSerializable
 {
-    use Macroable;
+    use Macroable, Pipable;
 
     /**
      * The items contained in the collection.
@@ -661,17 +662,6 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     public function forPage($page, $perPage)
     {
         return $this->slice(($page - 1) * $perPage, $perPage);
-    }
-
-    /**
-     * Pass the collection to the given callback and return the result.
-     *
-     * @param  callable $callback
-     * @return mixed
-     */
-    public function pipe(callable $callback)
-    {
-        return $callback($this);
     }
 
     /**

--- a/src/Illuminate/Support/Traits/Pipable.php
+++ b/src/Illuminate/Support/Traits/Pipable.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Illuminate\Support\Traits;
+
+trait Pipable
+{
+    /**
+     * Pass the instance to the given callback and return the result.
+     *
+     * @param  callable $callback
+     * @return mixed
+     */
+    public function pipe(callable $callback)
+    {
+        return $callback($this);
+    }
+}


### PR DESCRIPTION
This allows any class within a Laravel project to use the `pipe` function.

---

Related: #13899 / https://github.com/laravel/internals/issues/112
