### PR TITLE
[5.2] Declare missing abstract render method

### DIFF
--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -81,6 +81,13 @@ abstract class AbstractPaginator implements Htmlable
     protected static $presenterResolver;
 
     /**
+     * Render the paginator.
+     *
+     * @return mixed
+     */
+    abstract public function render();
+
+    /**
      * Determine if the given value is a valid page number.
      *
      * @param  int  $page


### PR DESCRIPTION
Declare missing abstract `render` method.
