### PR TITLE
[5.2] Return a BaseCollection when an Eloquent collection is mapped to no longer hold only models

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -5,6 +5,7 @@ namespace Illuminate\Database\Eloquent;
 use LogicException;
 use Illuminate\Support\Arr;
 use Illuminate\Contracts\Queue\QueueableCollection;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection as BaseCollection;
 
 class Collection extends BaseCollection implements QueueableCollection
@@ -112,6 +113,25 @@ class Collection extends BaseCollection implements QueueableCollection
         }
 
         return new static(array_values($dictionary));
+    }
+
+    /**
+     * Run a map over each of the items.
+     *
+     * @param  callable  $callback
+     * @return static
+     */
+    public function map(callable $callback)
+    {
+        $keys = array_keys($this->items);
+
+        $items = array_map($callback, $this->items, $keys);
+
+        $result = new static(array_combine($keys, $items));
+
+        return $result->contains(function ($_, $item) {
+            return !($item instanceof Model);
+        }) ? $result->toBase() : $result;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -123,11 +123,7 @@ class Collection extends BaseCollection implements QueueableCollection
      */
     public function map(callable $callback)
     {
-        $keys = array_keys($this->items);
-
-        $items = array_map($callback, $this->items, $keys);
-
-        $result = new static(array_combine($keys, $items));
+        $result = parent::map($callback);
 
         return $result->contains(function ($_, $item) {
             return !($item instanceof Model);

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -5,7 +5,6 @@ namespace Illuminate\Database\Eloquent;
 use LogicException;
 use Illuminate\Support\Arr;
 use Illuminate\Contracts\Queue\QueueableCollection;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection as BaseCollection;
 
 class Collection extends BaseCollection implements QueueableCollection

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -126,7 +126,7 @@ class Collection extends BaseCollection implements QueueableCollection
         $result = parent::map($callback);
 
         return $result->contains(function ($_, $item) {
-            return !($item instanceof Model);
+            return ! ($item instanceof Model);
         }) ? $result->toBase() : $result;
     }
 

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1091,6 +1091,16 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
+     * Return self to allow compatibility with Illuminate\Database\Eloquent\Collection.
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    public function toBase()
+    {
+        return $this;
+    }
+
+    /**
      * Get the collection of items as a plain array.
      *
      * @return array

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -178,7 +178,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      * @return static
      */
     public function diff($items)
-    {   
+    {
         return new static(array_diff($this->items, $this->getArrayableItems($items)));
     }
 

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -178,7 +178,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      * @return static
      */
     public function diff($items)
-    {
+    {   
         return new static(array_diff($this->items, $this->getArrayableItems($items)));
     }
 

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -153,7 +153,7 @@ class DatabaseEloquentCollectionTest extends PHPUnit_Framework_TestCase
 
         $c = new Collection([$one, $two]);
 
-        $cAfterMap = $c->map(function($item) {
+        $cAfterMap = $c->map(function ($item) {
             return $item;
         });
 
@@ -168,7 +168,7 @@ class DatabaseEloquentCollectionTest extends PHPUnit_Framework_TestCase
 
         $c = new Collection([$one, $two]);
 
-        $cAfterMap = $c->map(function($item) {
+        $cAfterMap = $c->map(function ($item) {
             return [];
         });
 

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -146,6 +146,35 @@ class DatabaseEloquentCollectionTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(new Collection([$one, $two, $three]), $c1->merge($c2));
     }
 
+    public function testMap()
+    {
+        $one = m::mock('Illuminate\Database\Eloquent\Model');
+        $two = m::mock('Illuminate\Database\Eloquent\Model');
+
+        $c = new Collection([$one, $two]);
+
+        $cAfterMap = $c->map(function($item) {
+            return $item;
+        });
+
+        $this->assertEquals($c->all(), $cAfterMap->all());
+        $this->assertInstanceOf(Collection::class, $cAfterMap);
+    }
+
+    public function testCollectionChangesToBaseCollectionIfMapLosesModels()
+    {
+        $one = m::mock('Illuminate\Database\Eloquent\Model');
+        $two = m::mock('Illuminate\Database\Eloquent\Model');
+
+        $c = new Collection([$one, $two]);
+
+        $cAfterMap = $c->map(function($item) {
+            return [];
+        });
+
+        $this->assertInstanceOf(BaseCollection::class, $cAfterMap);
+    }
+
     public function testCollectionDiffsWithGivenCollection()
     {
         $one = m::mock('Illuminate\Database\Eloquent\Model');

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1390,6 +1390,12 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
         $collection = new Collection([1, 2, 3, 4, 5, 6, 7, 8]);
         $this->assertEquals([3, 4, 5, 6], $collection->slice(-6, -2)->values()->toArray());
     }
+
+    public function testToBase()
+    {
+        $collection = new Collection([1, 2, 3]);
+        $this->assertSame($collection, $collection->toBase());
+    }
 }
 
 class TestAccessorEloquentTestStub


### PR DESCRIPTION
Collections have confusing behavior when you map an instance of Database\Eloquent\Collection to something other than a collection of models. 

Writing code like the following:

```
App\Post::all()->map(function($post) {  
  return ['title' => $post->title];
})->merge($anotherCollection);
```

Will throw a fatal error when getKey is called on what is no longer a model (since the collection is now a collection of arrays)

`PHP Fatal error:  Call to a member function getKey() on a non-object in .../vendor/laravel/framework/src/Illuminate/Database/Eloquent/Collection.php on line 240`

The toBase() function exists on instances of Database\Eloquent\Collection (and would solve this issue), but since the intention of a collection is to be treated just like any other data structure, I think requiring a developer to know so much about the specific implementation and prior use is a flaw.

Edit: Changed the map example to return an array instead of a string to not confuse it with a situation that would be better solved by pluck.

Edit2: I realized that this would be a breaking change for anyone currently calling toBase() after mapping away their models so, to allow this branch to still go into 5.2, I added a toBase() method to Support/Collection that just returns itself.  I think it probably makes more sense to have it be a breaking change in 5.3, but I wanted to present this option as well.
