### PR TITLE
[5.3] Removed all HHVM code

### DIFF
--- a/src/Illuminate/Console/Scheduling/Schedule.php
+++ b/src/Illuminate/Console/Scheduling/Schedule.php
@@ -39,15 +39,7 @@ class Schedule
     {
         $binary = ProcessUtils::escapeArgument((new PhpExecutableFinder)->find(false));
 
-        if (defined('HHVM_VERSION')) {
-            $binary .= ' --php';
-        }
-
-        if (defined('ARTISAN_BINARY')) {
-            $artisan = ProcessUtils::escapeArgument(ARTISAN_BINARY);
-        } else {
-            $artisan = 'artisan';
-        }
+        $artisan = defined('ARTISAN_BINARY') ? ProcessUtils::escapeArgument(ARTISAN_BINARY) : 'artisan';
 
         return $this->exec("{$binary} {$artisan} {$command}", $parameters);
     }

--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Foundation\Console;
 
-use Exception;
 use Illuminate\Console\Command;
 use Symfony\Component\Process\ProcessUtils;
 use Symfony\Component\Console\Input\InputOption;

--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -45,15 +45,7 @@ class ServeCommand extends Command
 
         $this->info("Laravel development server started on http://{$host}:{$port}/");
 
-        if (defined('HHVM_VERSION')) {
-            if (version_compare(HHVM_VERSION, '3.8.0') >= 0) {
-                passthru("{$binary} -m server -v Server.Type=proxygen -v Server.SourceRoot={$base}/ -v Server.IP={$host} -v Server.Port={$port} -v Server.DefaultDocument=server.php -v Server.ErrorDocument404=server.php");
-            } else {
-                throw new Exception("HHVM's built-in server requires HHVM >= 3.8.0.");
-            }
-        } else {
-            passthru("{$binary} -S {$host}:{$port} {$base}/server.php");
-        }
+        passthru("{$binary} -S {$host}:{$port} {$base}/server.php");
     }
 
     /**

--- a/src/Illuminate/Queue/Listener.php
+++ b/src/Illuminate/Queue/Listener.php
@@ -72,15 +72,7 @@ class Listener
     {
         $binary = ProcessUtils::escapeArgument((new PhpExecutableFinder)->find(false));
 
-        if (defined('HHVM_VERSION')) {
-            $binary .= ' --php';
-        }
-
-        if (defined('ARTISAN_BINARY')) {
-            $artisan = ProcessUtils::escapeArgument(ARTISAN_BINARY);
-        } else {
-            $artisan = 'artisan';
-        }
+        $artisan = defined('ARTISAN_BINARY') ? ProcessUtils::escapeArgument(ARTISAN_BINARY) : 'artisan';
 
         $command = 'queue:work %s --queue=%s --delay=%s --memory=%s --sleep=%s --tries=%s';
 

--- a/src/Illuminate/Support/Composer.php
+++ b/src/Illuminate/Support/Composer.php
@@ -74,10 +74,6 @@ class Composer
 
         $binary = ProcessUtils::escapeArgument((new PhpExecutableFinder)->find(false));
 
-        if (defined('HHVM_VERSION')) {
-            $binary .= ' --php';
-        }
-
         return "{$binary} composer.phar";
     }
 

--- a/tests/Console/ConsoleEventSchedulerTest.php
+++ b/tests/Console/ConsoleEventSchedulerTest.php
@@ -42,7 +42,7 @@ class ConsoleEventSchedulerTest extends PHPUnit_Framework_TestCase
         $schedule->command('queue:listen', ['--tries' => 3]);
 
         $events = $schedule->events();
-        $binary = $escape.PHP_BINARY.$escape.(defined('HHVM_VERSION') ? ' --php' : '');
+        $binary = $escape.PHP_BINARY.$escape;
         $this->assertEquals($binary.' artisan queue:listen', $events[0]->command);
         $this->assertEquals($binary.' artisan queue:listen --tries=3', $events[1]->command);
         $this->assertEquals($binary.' artisan queue:listen --tries=3', $events[2]->command);

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -312,12 +312,6 @@ class FilesystemTest extends PHPUnit_Framework_TestCase
      */
     public function testSharedGet()
     {
-        if (defined('HHVM_VERSION')) {
-            $this->markTestSkipped('Skip HHVM test due to bug: https://github.com/facebook/hhvm/issues/5657');
-
-            return;
-        }
-
         $content = '';
         for ($i = 0; $i < 1000000; ++$i) {
             $content .= $i;

--- a/tests/Foundation/FoundationComposerTest.php
+++ b/tests/Foundation/FoundationComposerTest.php
@@ -17,7 +17,7 @@ class FoundationComposerTest extends PHPUnit_Framework_TestCase
         $files->shouldReceive('exists')->once()->with(__DIR__.'/composer.phar')->andReturn(true);
         $process = m::mock('stdClass');
         $composer->expects($this->once())->method('getProcess')->will($this->returnValue($process));
-        $process->shouldReceive('setCommandLine')->once()->with($escape.PHP_BINARY.$escape.(defined('HHVM_VERSION') ? ' --php' : '').' composer.phar dump-autoload');
+        $process->shouldReceive('setCommandLine')->once()->with($escape.PHP_BINARY.$escape.' composer.phar dump-autoload');
         $process->shouldReceive('run')->once();
 
         $composer->dumpAutoloads();

--- a/tests/Queue/QueueListenerTest.php
+++ b/tests/Queue/QueueListenerTest.php
@@ -39,6 +39,6 @@ class QueueListenerTest extends PHPUnit_Framework_TestCase
         $this->assertInstanceOf('Symfony\Component\Process\Process', $process);
         $this->assertEquals(__DIR__, $process->getWorkingDirectory());
         $this->assertEquals(3, $process->getTimeout());
-        $this->assertEquals($escape.PHP_BINARY.$escape.(defined('HHVM_VERSION') ? ' --php' : '')." artisan queue:work {$escape}connection{$escape} --queue={$escape}queue{$escape} --delay=1 --memory=2 --sleep=3 --tries=0", $process->getCommandLine());
+        $this->assertEquals($escape.PHP_BINARY.$escape." artisan queue:work {$escape}connection{$escape} --queue={$escape}queue{$escape} --delay=1 --memory=2 --sleep=3 --tries=0", $process->getCommandLine());
     }
 }


### PR DESCRIPTION
Laravel 5.3 is no longer getting tested on HHVM due to HHVM's lack of feature parity beyond PHP 5.5. One such example is arrays as constants.
