### PR TITLE
[5.1] bcc mail issue (mailgun) (#10650)

### DIFF
--- a/src/Illuminate/Mail/Transport/MailgunTransport.php
+++ b/src/Illuminate/Mail/Transport/MailgunTransport.php
@@ -60,18 +60,18 @@ class MailgunTransport extends Transport
 
         $options = ['auth' => ['api', $this->key]];
 
-        $to = $this->getTo($message);
-
-        $message->setBcc([]);
-
         if (version_compare(ClientInterface::VERSION, '6') === 1) {
             $options['multipart'] = [
-                ['name' => 'to', 'contents' => $to],
+                ['name' => 'to', 'contents' => $this->getTo($message)],
+                ['name' => 'cc', 'contents' => $this->getCc($message)],
+                ['name' => 'bcc', 'contents' => $this->getBcc($message)],
                 ['name' => 'message', 'contents' => $message->toString(), 'filename' => 'message.mime'],
             ];
         } else {
             $options['body'] = [
-                'to' => $to,
+                'to'      => $this->getTo($message),
+                'cc'      => $this->getCc($message),
+                'bcc'     => $this->getBcc($message),
                 'message' => new PostFile('message', $message->toString()),
             ];
         }
@@ -83,15 +83,44 @@ class MailgunTransport extends Transport
      * Get the "to" payload field for the API request.
      *
      * @param  \Swift_Mime_Message  $message
-     * @return array
+     * @return string
      */
     protected function getTo(Swift_Mime_Message $message)
     {
-        $formatted = [];
+        return $this->formatAddress($message->getTo());
+    }
 
-        $contacts = array_merge(
-            (array) $message->getTo(), (array) $message->getCc(), (array) $message->getBcc()
-        );
+    /**
+     * Get the "cc" payload field for the API request.
+     *
+     * @param  \Swift_Mime_Message  $message
+     * @return string
+     */
+    protected function getCc(Swift_Mime_Message $message)
+    {
+        return $this->formatAddress($message->getCc());
+    }
+
+    /**
+     * Get the "bcc" payload field for the API request.
+     *
+     * @param  \Swift_Mime_Message  $message
+     * @return string
+     */
+    protected function getBcc(Swift_Mime_Message $message)
+    {
+        return $this->formatAddress($message->getBcc());
+    }
+
+    /**
+     * Get Comma-Separated Address (with name, if available) for the API request.
+     *
+     * @param  array $contacts
+     * @return string
+     */
+    protected function formatAddress($contacts)
+    {
+        $formatted = [];
 
         foreach ($contacts as $address => $display) {
             $formatted[] = $display ? $display." <$address>" : $address;


### PR DESCRIPTION
MailGun Adapter was sending CC, BCC as part of email body (in `to` field), 
So BCC address was visible on email clients (#10650; verified on gmail.com, outlook.com). If more than one bcc addresses are provided, all addresses was visible to all `To`, `cc` and `bcc` recipients of email. 

From message body

```
From: No Reply <abc.xyz@jklcom>
To: abc@zzz.ooo, def@yyy.ooo, ghi@xxx.com
Bcc: user one <user.one@www.com>, user two
 <user.two@vvv.com>
```

As per MailGun's [documentation](https://documentation.mailgun.com/api-sending.html#sending), `cc` and `bcc` are two different fields for API request. This fix gets the `cc`, `bcc` addresses from `Swift_Mime_Message`, and add them separately to the request. This is further handled by MailGun, that mail got delivered to Recipient by this header

```
Delivered-To: ashwanixxxxxxxxxx@gmail.com
```

Other BCC addresses are not part of email body.
