### PR TITLE
[5.4] Add an extra testing function seeRouteIs

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithPages.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithPages.php
@@ -173,6 +173,22 @@ trait InteractsWithPages
     }
 
     /**
+     * Assert that the current page matches a given named route.
+     *
+     * @param  string  $route
+     * @param  array  $parameters
+     * @return $this
+     */
+    protected function seeRouteIs($route, $parameters = [])
+    {
+        $uri = route($route, $parameters);
+
+        $this->seePageIs($uri);
+
+        return $this;
+    }
+
+    /**
      * Assert that a given page successfully loaded.
      *
      * @param  string  $uri


### PR DESCRIPTION
Add an extra testing function seeRouteIs() to allow easier testing when using named routes.

The new function wraps the existing seePageIs() function.
