### PR TITLE
[5.2] Fix missing middleware parameters when using authorizeResource()

### DIFF
--- a/src/Illuminate/Foundation/Auth/Access/AuthorizesResources.php
+++ b/src/Illuminate/Foundation/Auth/Access/AuthorizesResources.php
@@ -16,10 +16,16 @@ trait AuthorizesResources
     {
         $parameter = $parameter ?: strtolower(class_basename($model));
 
+        $middleware = [];
+
         foreach ($this->resourceAbilityMap() as $method => $ability) {
             $modelName = in_array($method, ['index', 'create', 'store']) ? $model : $parameter;
 
-            $this->middleware("can:{$ability},{$modelName}", $options)->only($method);
+            $middleware["can:{$ability},{$modelName}"][] = $method;
+        }
+
+        foreach ($middleware as $middlewareName => $methods) {
+            $this->middleware($middlewareName, $options)->only($methods);
         }
     }
 

--- a/tests/Auth/AuthorizesResourcesTest.php
+++ b/tests/Auth/AuthorizesResourcesTest.php
@@ -11,49 +11,49 @@ class AuthorizesResourcesTest extends PHPUnit_Framework_TestCase
     {
         $controller = new AuthorizesResourcesController($this->request('index'));
 
-        $this->assertHasMiddleware($controller, 'can:view,App\User');
+        $this->assertHasMiddleware($controller, 'index', 'can:view,App\User');
     }
 
     public function testCreateMethod()
     {
         $controller = new AuthorizesResourcesController($this->request('create'));
 
-        $this->assertHasMiddleware($controller, 'can:create,App\User');
+        $this->assertHasMiddleware($controller, 'create', 'can:create,App\User');
     }
 
     public function testStoreMethod()
     {
         $controller = new AuthorizesResourcesController($this->request('store'));
 
-        $this->assertHasMiddleware($controller, 'can:create,App\User');
+        $this->assertHasMiddleware($controller, 'store', 'can:create,App\User');
     }
 
     public function testShowMethod()
     {
         $controller = new AuthorizesResourcesController($this->request('show'));
 
-        $this->assertHasMiddleware($controller, 'can:view,user');
+        $this->assertHasMiddleware($controller, 'show', 'can:view,user');
     }
 
     public function testEditMethod()
     {
         $controller = new AuthorizesResourcesController($this->request('edit'));
 
-        $this->assertHasMiddleware($controller, 'can:update,user');
+        $this->assertHasMiddleware($controller, 'edit', 'can:update,user');
     }
 
     public function testUpdateMethod()
     {
         $controller = new AuthorizesResourcesController($this->request('update'));
 
-        $this->assertHasMiddleware($controller, 'can:update,user');
+        $this->assertHasMiddleware($controller, 'update', 'can:update,user');
     }
 
     public function testDestroyMethod()
     {
         $controller = new AuthorizesResourcesController($this->request('destroy'));
 
-        $this->assertHasMiddleware($controller, 'can:delete,user');
+        $this->assertHasMiddleware($controller, 'destroy', 'can:delete,user');
     }
 
     /**
@@ -63,10 +63,11 @@ class AuthorizesResourcesTest extends PHPUnit_Framework_TestCase
      * @param  string  $middleware
      * @return void
      */
-    protected function assertHasMiddleware($controller, $middleware)
+    protected function assertHasMiddleware($controller, $method, $middleware)
     {
         $this->assertTrue(
-            in_array($middleware, array_keys($controller->getMiddleware())),
+            in_array($middleware, array_keys($controller->getMiddleware()))
+            && in_array($method, $controller->getMiddleware()[$middleware]['only']),
             "The [{$middleware}] middleware was not registered"
         );
     }

--- a/tests/Auth/AuthorizesResourcesTest.php
+++ b/tests/Auth/AuthorizesResourcesTest.php
@@ -1,7 +1,7 @@
 <?php
 
 use Illuminate\Http\Request;
-use Illuminate\Routing\Route;
+use Illuminate\Routing\Router;
 use Illuminate\Routing\Controller;
 use Illuminate\Foundation\Auth\Access\AuthorizesResources;
 
@@ -9,84 +9,73 @@ class AuthorizesResourcesTest extends PHPUnit_Framework_TestCase
 {
     public function testIndexMethod()
     {
-        $controller = new AuthorizesResourcesController($this->request('index'));
+        $controller = new AuthorizesResourcesController();
 
         $this->assertHasMiddleware($controller, 'index', 'can:view,App\User');
     }
 
     public function testCreateMethod()
     {
-        $controller = new AuthorizesResourcesController($this->request('create'));
+        $controller = new AuthorizesResourcesController();
 
         $this->assertHasMiddleware($controller, 'create', 'can:create,App\User');
     }
 
     public function testStoreMethod()
     {
-        $controller = new AuthorizesResourcesController($this->request('store'));
+        $controller = new AuthorizesResourcesController();
 
         $this->assertHasMiddleware($controller, 'store', 'can:create,App\User');
     }
 
     public function testShowMethod()
     {
-        $controller = new AuthorizesResourcesController($this->request('show'));
+        $controller = new AuthorizesResourcesController();
 
         $this->assertHasMiddleware($controller, 'show', 'can:view,user');
     }
 
     public function testEditMethod()
     {
-        $controller = new AuthorizesResourcesController($this->request('edit'));
+        $controller = new AuthorizesResourcesController();
 
         $this->assertHasMiddleware($controller, 'edit', 'can:update,user');
     }
 
     public function testUpdateMethod()
     {
-        $controller = new AuthorizesResourcesController($this->request('update'));
+        $controller = new AuthorizesResourcesController();
 
         $this->assertHasMiddleware($controller, 'update', 'can:update,user');
     }
 
     public function testDestroyMethod()
     {
-        $controller = new AuthorizesResourcesController($this->request('destroy'));
+        $controller = new AuthorizesResourcesController();
 
         $this->assertHasMiddleware($controller, 'destroy', 'can:delete,user');
     }
 
     /**
-     * Assert that the given middleware has been registered on the given controller.
+     * Assert that the given middleware has been registered on the given controller for the given method.
      *
      * @param  \Illuminate\Routing\Controller  $controller
+     * @param  string  $method
      * @param  string  $middleware
      * @return void
      */
     protected function assertHasMiddleware($controller, $method, $middleware)
     {
-        $this->assertTrue(
-            in_array($middleware, array_keys($controller->getMiddleware()))
-            && in_array($method, $controller->getMiddleware()[$middleware]['only']),
-            "The [{$middleware}] middleware was not registered"
+        $router = new Router(new Illuminate\Events\Dispatcher);
+
+        $router->middleware('can', 'AuthorizesResourcesMiddleware');
+        $router->get($method)->uses('AuthorizesResourcesController@'.$method);
+
+        $this->assertEquals(
+            'caught '.$middleware,
+            $router->dispatch(Request::create($method, 'GET'))->getContent(),
+            "The [{$middleware}] middleware was not registered for method [{$method}]"
         );
-    }
-
-    /**
-     * Get a request object, with the route pointing to the given method on the controller.
-     *
-     * @param  string  $method
-     * @return \Illuminate\Http\Request
-     */
-    protected function request($method)
-    {
-        return Request::create('foo', 'GET')->setRouteResolver(function () use ($method) {
-            $action = ['uses' => 'AuthorizesResourcesController@'.$method];
-
-            $action['controller'] = $action['uses'];
-
-            return new Route('GET', 'foo', $action);
-        });
     }
 }
 
@@ -94,8 +83,51 @@ class AuthorizesResourcesController extends Controller
 {
     use AuthorizesResources;
 
-    public function __construct(Request $request)
+    public function __construct()
     {
-        $this->authorizeResource('App\User', 'user', [], $request);
+        $this->authorizeResource('App\User', 'user');
+    }
+
+    public function index()
+    {
+        //
+    }
+
+    public function create()
+    {
+        //
+    }
+
+    public function store()
+    {
+        //
+    }
+
+    public function show()
+    {
+        //
+    }
+
+    public function edit()
+    {
+        //
+    }
+
+    public function update()
+    {
+        //
+    }
+
+    public function destroy()
+    {
+        //
+    }
+}
+
+class AuthorizesResourcesMiddleware
+{
+    public function handle($request, Closure $next, $method, $parameter)
+    {
+        return "caught can:{$method},{$parameter}";
     }
 }


### PR DESCRIPTION
This fixes an issue with the `authorizeResource` method in the `AuthorizesResources` trait. Previously, the middleware would not be properly applied to some of the controller's methods.

As an example, say you have a `PostsController` class that uses `authorizeResource` as follows:

``` php
class PostsController extends Controller
{
   function __construct()
   {
        $this->authorizeResource(\App\Post::class);
   }
}
```

Let's say this controller is registered as a resource:

``` php
Route::singularResourceParameters();
Route::resource('posts', 'PostsController');
```

Running `php artisan route:list` will reveal that the controller's `create` and `edit` methods do not have the proper middleware applied:

```
+--------+-----------+-------------------+---------------+----------------------------------------------+-------------------------+
| Domain | Method    | URI               | Name          | Action                                       | Middleware              |
+--------+-----------+-------------------+---------------+----------------------------------------------+-------------------------+
|        | GET|HEAD  | /                 |               | Closure                                      | web                     |
|        | POST      | posts             | posts.store   | App\Http\Controllers\PostsController@store   | web,can:create,App\Post |
|        | GET|HEAD  | posts             | posts.index   | App\Http\Controllers\PostsController@index   | web,can:view,App\Post   |
|        | GET|HEAD  | posts/create      | posts.create  | App\Http\Controllers\PostsController@create  | web                     |
|        | DELETE    | posts/{post}      | posts.destroy | App\Http\Controllers\PostsController@destroy | web,can:delete,post     |
|        | PUT|PATCH | posts/{post}      | posts.update  | App\Http\Controllers\PostsController@update  | web,can:update,post     |
|        | GET|HEAD  | posts/{post}      | posts.show    | App\Http\Controllers\PostsController@show    | web,can:view,post       |
|        | GET|HEAD  | posts/{post}/edit | posts.edit    | App\Http\Controllers\PostsController@edit    | web                     |
+--------+-----------+-------------------+---------------+----------------------------------------------+-------------------------+
```

This happens because `authorizeResource` repeatedly calls `$this->middleware()` ([here](https://github.com/laravel/framework/blob/ef392e1d11a4df6e1eedf720d37eb22f61e59543/src/Illuminate/Foundation/Auth/Access/AuthorizesResources.php#L22)), which replaces the entry in the middleware each time it is called ([here](https://github.com/laravel/framework/blob/ef392e1d11a4df6e1eedf720d37eb22f61e59543/src/Illuminate/Routing/Controller.php#L34)).

This was missed by the unit tests for this method because the tests only verified the presence of middleware by name -- the tests didn't make sure the middleware was actually being applied to the correct methods.

After applying this fix, the routing table will appear as follows:

```
+--------+-----------+-------------------+---------------+----------------------------------------------+-------------------------+
| Domain | Method    | URI               | Name          | Action                                       | Middleware              |
+--------+-----------+-------------------+---------------+----------------------------------------------+-------------------------+
|        | GET|HEAD  | /                 |               | Closure                                      | web                     |
|        | POST      | posts             | posts.store   | App\Http\Controllers\PostsController@store   | web,can:create,App\Post |
|        | GET|HEAD  | posts             | posts.index   | App\Http\Controllers\PostsController@index   | web,can:view,App\Post   |
|        | GET|HEAD  | posts/create      | posts.create  | App\Http\Controllers\PostsController@create  | web,can:create,App\Post |
|        | DELETE    | posts/{post}      | posts.destroy | App\Http\Controllers\PostsController@destroy | web,can:delete,post     |
|        | PUT|PATCH | posts/{post}      | posts.update  | App\Http\Controllers\PostsController@update  | web,can:update,post     |
|        | GET|HEAD  | posts/{post}      | posts.show    | App\Http\Controllers\PostsController@show    | web,can:view,post       |
|        | GET|HEAD  | posts/{post}/edit | posts.edit    | App\Http\Controllers\PostsController@edit    | web,can:update,post     |
+--------+-----------+-------------------+---------------+----------------------------------------------+-------------------------+
```

The same issue appears in Laravel 5.3, but I am guessing the middleware names applied in this method might be changing since the default Policy stub for resources includes methods like `viewAny` in addition to `view`.
