### PR TITLE
[5.1] Fix typo on docblock

### DIFF
--- a/src/Illuminate/Cache/Console/CacheTableCommand.php
+++ b/src/Illuminate/Cache/Console/CacheTableCommand.php
@@ -35,7 +35,7 @@ class CacheTableCommand extends Command
     protected $composer;
 
     /**
-     * Create a new session table command instance.
+     * Create a new cache table command instance.
      *
      * @param  \Illuminate\Filesystem\Filesystem  $files
      * @param  \Illuminate\Foundation\Composer  $composer


### PR DESCRIPTION
Change a word, "session" to "cache".
