### PR TITLE
[5.3] Suggestion: add abstract methods up and down to migrations

### DIFF
--- a/src/Illuminate/Database/Migrations/Migration.php
+++ b/src/Illuminate/Database/Migrations/Migration.php
@@ -20,4 +20,14 @@ abstract class Migration
     {
         return $this->connection;
     }
+
+    /**
+     * Modify the table.
+     */
+    abstract public function up();
+
+    /**
+     * Rollback changes.
+     */
+    abstract public function down();
 }


### PR DESCRIPTION
This will prevent deployment rollback failure if somebody remove `down` method from his migration. 
For example when migration is altering table this may occurs. Now following exception is thrown.

```
[Symfony\Component\Debug\Exception\FatalThrowableError]
Call to undefined method MigrationClassName::down()
```
