### PR TITLE
[5.3][WIP] Adding support for Twitter notifications

### DIFF
--- a/src/Illuminate/Notifications/ChannelManager.php
+++ b/src/Illuminate/Notifications/ChannelManager.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Notifications;
 
+use Codebird as TwitterClient;
 use InvalidArgumentException;
 use Illuminate\Support\Manager;
 use Nexmo\Client as NexmoClient;
@@ -144,6 +145,23 @@ class ChannelManager extends Manager implements DispatcherContract, FactoryContr
     protected function createSlackDriver()
     {
         return new Channels\SlackWebhookChannel(new HttpClient);
+    }
+
+    /**
+     * Create an instance of the Twitter driver.
+     *
+     * @return \Illuminate\Notifications\Channels\TwitterChannel
+     */
+    protected function createTwitterDriver()
+    {
+        $codebird = new TwitterClient;
+
+        $codebird->setToken(
+            $this->app['config']['services.twitter.token'],
+            $this->app['config']['services.twitter.secret']
+        );
+
+        return new Channels\TwitterChannel($codebird);
     }
 
     /**

--- a/src/Illuminate/Notifications/Channels/TwitterChannel.php
+++ b/src/Illuminate/Notifications/Channels/TwitterChannel.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Illuminate\Notifications\Channels;
+
+use Codebird;
+use Illuminate\Notifications\Notification;
+
+class TwitterChannel
+{
+    /**
+     * The Twitter client instance.
+     *
+     * @var \Codebird
+     */
+    protected $twitter;
+
+    /**
+     * Create a new Twitter channel instance.
+     *
+     * @param  \Codebird  $twitter
+     * @return void
+     */
+    public function __construct(Codebird $twitter)
+    {
+        $this->twitter = $twitter;
+    }
+
+    /**
+     * Send the given notification.
+     *
+     * @param  \Illuminate\Support\Collection  $notifiables
+     * @param  \Illuminate\Notifications\Channels\Notification  $notification
+     * @return void
+     */
+    public function send($notifiables, Notification $notification)
+    {
+        foreach ($notifiables as $notifiable) {
+            if (! $url = $notifiable->routeNotificationFor('twitter')) {
+                continue;
+            }
+
+            $this->twitter->statuses_update([
+                'status' => $this->format($notification),
+            ]);
+        }
+    }
+
+    /**
+     * Format the given notification.
+     *
+     * @param  \Illuminate\Notifications\Channels\Notification  $notification
+     * @return string
+     */
+    protected function format(Notification $notification)
+    {
+        $message = trim(implode(PHP_EOL.PHP_EOL, $notification->introLines));
+
+        if ($notification->actionText) {
+            $message .= ' <'.$notification->actionUrl.'|'.$notification->actionText.'> ';
+        }
+
+        $message .= trim(implode(PHP_EOL.PHP_EOL, $notification->outroLines));
+
+        return trim($message);
+    }
+}

--- a/src/Illuminate/Notifications/composer.json
+++ b/src/Illuminate/Notifications/composer.json
@@ -32,7 +32,8 @@
     "suggest": {
         "guzzlehttp/guzzle": "Required to use the Slack transport.",
         "illuminate/database": "Required to use the database transport (5.3.*).",
-        "nexmo/client": "Required to use the Nexmo transport."
+        "nexmo/client": "Required to use the Nexmo transport.",
+        "jublonet/codebird-php": "Required to use the Twitter transport."
     },
     "minimum-stability": "dev"
 }

--- a/tests/Notifications/NotificationTwitterChannelTest.php
+++ b/tests/Notifications/NotificationTwitterChannelTest.php
@@ -1,0 +1,44 @@
+<?php
+
+use Illuminate\Notifications\Notification;
+
+class NotificationTwitterChannelTest extends PHPUnit_Framework_TestCase
+{
+    public function tearDown()
+    {
+        Mockery::close();
+    }
+
+    public function testTweetIsSentViaTwitter()
+    {
+        $notification = new Notification;
+        $notifiables = collect([
+            $notifiable = new NotificationTwitterChannelTestNotifiable,
+        ]);
+
+        $notification->introLines = ['line 1'];
+        $notification->actionText = 'Text';
+        $notification->actionUrl = 'url';
+        $notification->outroLines = ['line 2'];
+
+        $channel = new Illuminate\Notifications\Channels\TwitterChannel(
+            $twitter = Mockery::mock(Codebird::class)
+        );
+
+        $twitter->shouldReceive('statuses_update')->with([
+            'status' => 'line1<url|Text>line2',
+        ]);
+
+        $channel->send($notifiables, $notification);
+    }
+}
+
+class NotificationTwitterChannelTestNotifiable
+{
+    use Illuminate\Notifications\Notifiable;
+
+    public function routeNotificationForTwitter()
+    {
+        return 'twitter';
+    }
+}


### PR DESCRIPTION
So it turns out that there doesn't seem to be any decent PHP Twitter packages... Codebird isn't great itself, so I'm happy to change this if someone has any any better suggestions?

Tests fail because of Mockery:

```
1) NotificationTwitterChannelTest::testTweetIsSentViaTwitter
Mockery\Exception\NoMatchingExpectationException: No matching handler found for Mockery_2__Codebird::statuses_update(array('status'=>'line1<url|Text>line2',)). Either the method was unexpected or its arguments matched no expected argument list for this method
```

I'll fix this when I get a bit more time.

Finally, I still need to trim the tweet down nicely and end it with `[...]` or something? @taylorotwell and I discussed this and we weren't sure on the best way of handling truncating tweets.
