### PR TITLE
[5.3] Allow notifications to be dynamically enabled/disabled

### DIFF
--- a/src/Illuminate/Notifications/Notification.php
+++ b/src/Illuminate/Notifications/Notification.php
@@ -99,6 +99,16 @@ class Notification
     }
 
     /**
+     * Specify if the notification is enabled and can be sent.
+     *
+     * @return bool
+     */
+    public function enabled()
+    {
+        return true;
+    }
+
+    /**
      * Indicate that the notification gives information about a successful operation.
      *
      * @return $this

--- a/src/Illuminate/Notifications/RoutesNotifications.php
+++ b/src/Illuminate/Notifications/RoutesNotifications.php
@@ -10,12 +10,14 @@ trait RoutesNotifications
     /**
      * Send the given notification.
      *
-     * @param  mixed  $instance
+     * @param  Notification  $instance
      * @return void
      */
-    public function notify($instance)
+    public function notify(Notification $instance)
     {
-        app(Dispatcher::class)->send([$this], $instance);
+        if ($instance->enabled($this)) {
+            app(Dispatcher::class)->send([$this], $instance);
+        }
     }
 
     /**

--- a/tests/Notifications/NotificationRoutesNotificationsTest.php
+++ b/tests/Notifications/NotificationRoutesNotificationsTest.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Notifications\Dispatcher;
+use Illuminate\Notifications\Notification;
 
 class NotificationRoutesNotificationsTest extends PHPUnit_Framework_TestCase
 {
@@ -16,8 +17,21 @@ class NotificationRoutesNotificationsTest extends PHPUnit_Framework_TestCase
         $factory = Mockery::mock(Dispatcher::class);
         $container->instance(Dispatcher::class, $factory);
         $notifiable = new RoutesNotificationsTestInstance;
-        $instance = new StdClass;
+        $instance = new Notification();
         $factory->shouldReceive('send')->with([$notifiable], $instance);
+        Container::setInstance($container);
+
+        $notifiable->notify($instance);
+    }
+
+    public function testNotificationCanBeDisabled()
+    {
+        $container = new Container;
+        $factory = Mockery::mock(Dispatcher::class);
+        $container->instance(Dispatcher::class, $factory);
+        $notifiable = new RoutesNotificationsTestInstance;
+        $instance = new DisabledNotification;
+        $factory->shouldNotReceive('send')->with([$notifiable], $instance);
         Container::setInstance($container);
 
         $notifiable->notify($instance);
@@ -42,5 +56,13 @@ class RoutesNotificationsTestInstance
     public function routeNotificationForFoo()
     {
         return 'bar';
+    }
+}
+
+class DisabledNotification extends Notification
+{
+    public function enabled()
+    {
+        return false;
     }
 }


### PR DESCRIPTION
This PR allows the Notification class to handle the enabled/disabled state of a single notification.

This allows us to write the logic, if a "Notifiable" model should receive the notification into the Notification class itself, instead of having to spread these logic checks throughout our application.

It's similar to the `authorize` method on FormRequests, but for notifications.

For example:

```
class FriendshipRequestNotification extends Notification
{

    public function __construct(User $user){
        $this->user = $user;
    }

    public function enabled(){
        return $this->user->notifications_enabled;
    }

}
```
