### PR TITLE
[5.3] Add seeRouteIs() to...

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithPages.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithPages.php
@@ -173,6 +173,22 @@ trait InteractsWithPages
     }
 
     /**
+     * Assert that the current page matches a given named route.
+     *
+     * @param  string  $route
+     * @param  array  $parameters
+     * @return $this
+     */
+    protected function seeRouteIs($route, $parameters = [])
+    {
+        $uri = route($route, $parameters);
+
+        $this->seePageIs($uri);
+
+        return $this;
+    }
+
+    /**
      * Assert that a given page successfully loaded.
      *
      * @param  string  $uri


### PR DESCRIPTION
Illuminate\Foundation\Testing\Concerns\InteractsWithPages.

When testing using named routes it is frustrating to need to translate the named routes to urls manually.

This new function wraps the seePageIs() function in order to translate the route name automatically and then pass through to the seePageIs() function.

If this pull request is accepted I will also submit a pull request for a visitRoute() function which will wrap the visit() function in a similar way.
