### PR TITLE
[5.3] Use intersect instead of only in the request helper

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -600,7 +600,7 @@ if (! function_exists('request')) {
         }
 
         if (is_array($key)) {
-            return app('request')->only($key);
+            return app('request')->intersect($key);
         } else {
             return app('request')->input($key, $default);
         }


### PR DESCRIPTION
`request()->only()` is a little weird, in that it returns `null` for missing values:

``` php
// $_POST === ['a' => 1, 'c' => 3];

request()->only('a', 'b'); // ['a' => 1, 'b' => null]
```

This is quite weird, as `array_only` skips missing values completely. I guess it's too late to change `Request@only` now, so a while ago [the `intersect` method was added](https://github.com/laravel/framework/pull/13167), which mimics `array_only`:

``` php
// $_POST === ['a' => 1, 'c' => 3];

request()->intersect('a', 'b'); // ['a' => 1]
```

This is the behavior you'd want most of the time. Imagine you're sticking stuff into the database:

``` php
$post->update(request(['title', 'body', 'date']));
```

If the user hasn't provided one of those properties, you definitely do _not_ want to set those to `null`!
