### PR TITLE
[5.3] Make toBase on the base collection actually be useful

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -356,14 +356,4 @@ class Collection extends BaseCollection implements QueueableCollection
     {
         return $this->modelKeys();
     }
-
-    /**
-     * Get a base Support collection instance from this collection.
-     *
-     * @return \Illuminate\Support\Collection
-     */
-    public function toBase()
-    {
-        return new BaseCollection($this->items);
-    }
 }

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1171,13 +1171,11 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Get a base Support collection instance from this collection.
      *
-     * Provided for API compatibility with Eloquent collections.
-     *
      * @return \Illuminate\Support\Collection
      */
     public function toBase()
     {
-        return $this;
+        return is_subclass_of($this, self::class) ? new self($this) : $this;
     }
 
     /**

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -161,18 +161,16 @@ class DatabaseEloquentCollectionTest extends PHPUnit_Framework_TestCase
         $this->assertInstanceOf(Collection::class, $cAfterMap);
     }
 
-    public function testCollectionChangesToBaseCollectionIfMapLosesModels()
+    public function testMappingToNonModelsReturnsABaseCollection()
     {
         $one = m::mock('Illuminate\Database\Eloquent\Model');
         $two = m::mock('Illuminate\Database\Eloquent\Model');
 
-        $c = new Collection([$one, $two]);
-
-        $cAfterMap = $c->map(function ($item) {
-            return [];
+        $c = (new Collection([$one, $two]))->map(function ($item) {
+            return 'not-a-model';
         });
 
-        $this->assertInstanceOf(BaseCollection::class, $cAfterMap);
+        $this->assertEquals(BaseCollection::class, get_class($c));
     }
 
     public function testCollectionDiffsWithGivenCollection()

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -274,12 +274,12 @@ class DatabaseEloquentCollectionTest extends PHPUnit_Framework_TestCase
     {
         $a = new Collection([['foo' => 'bar'], ['foo' => 'baz']]);
         $b = new Collection(['a', 'b', 'c']);
-        $this->assertEquals(get_class($a->pluck('foo')), BaseCollection::class);
-        $this->assertEquals(get_class($a->keys()), BaseCollection::class);
-        $this->assertEquals(get_class($a->collapse()), BaseCollection::class);
-        $this->assertEquals(get_class($a->flatten()), BaseCollection::class);
-        $this->assertEquals(get_class($a->zip(['a', 'b'], ['c', 'd'])), BaseCollection::class);
-        $this->assertEquals(get_class($b->flip()), BaseCollection::class);
+        $this->assertEquals(BaseCollection::class, get_class($a->pluck('foo')));
+        $this->assertEquals(BaseCollection::class, get_class($a->keys()));
+        $this->assertEquals(BaseCollection::class, get_class($a->collapse()));
+        $this->assertEquals(BaseCollection::class, get_class($a->flatten()));
+        $this->assertEquals(BaseCollection::class, get_class($a->zip(['a', 'b'], ['c', 'd'])));
+        $this->assertEquals(BaseCollection::class, get_class($b->flip()));
     }
 
     public function testMakeVisibleRemovesHiddenAndIncludesVisible()


### PR DESCRIPTION
1. The base collection's `toBase` now makes more sense. Before, if a custom extended collection called `toBase` it simply returned that same collection :confused:
2. Now that we have that, we don't need the `toBase` method on the Eloquent collection class anymore.
3. Fixed the test for `map` where it returns non-model values, so that it actually checks that the returned collection is a base collection.
4. The other `toBase` tests were passing the arguments in the wrong order. Fixed.
