### PR TITLE
[5.3] Migrations command refactoring

### DIFF
--- a/src/Illuminate/Cache/Console/CacheTableCommand.php
+++ b/src/Illuminate/Cache/Console/CacheTableCommand.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\Cache\Console;
 
-use Illuminate\Database\Console\MigrationCreatorCommand;
+use Illuminate\Console\MigrationCreatorCommand;
 
 class CacheTableCommand extends MigrationCreatorCommand
 {

--- a/src/Illuminate/Cache/Console/CacheTableCommand.php
+++ b/src/Illuminate/Cache/Console/CacheTableCommand.php
@@ -2,11 +2,9 @@
 
 namespace Illuminate\Cache\Console;
 
-use Illuminate\Console\Command;
-use Illuminate\Support\Composer;
-use Illuminate\Filesystem\Filesystem;
+use Illuminate\Database\Console\MigrationCreatorCommand;
 
-class CacheTableCommand extends Command
+class CacheTableCommand extends MigrationCreatorCommand
 {
     /**
      * The console command name.
@@ -23,59 +21,18 @@ class CacheTableCommand extends Command
     protected $description = 'Create a migration for the cache database table';
 
     /**
-     * The filesystem instance.
-     *
-     * @var \Illuminate\Filesystem\Filesystem
-     */
-    protected $files;
-
-    /**
-     * @var \Illuminate\Support\Composer
-     */
-    protected $composer;
-
-    /**
-     * Create a new session table command instance.
-     *
-     * @param  \Illuminate\Filesystem\Filesystem  $files
-     * @param  \Illuminate\Support\Composer  $composer
-     * @return void
-     */
-    public function __construct(Filesystem $files, Composer $composer)
-    {
-        parent::__construct();
-
-        $this->files = $files;
-        $this->composer = $composer;
-    }
-
-    /**
-     * Execute the console command.
-     *
-     * @return void
-     */
-    public function fire()
-    {
-        $fullPath = $this->createBaseMigration();
-
-        $this->files->put($fullPath, $this->files->get(__DIR__.'/stubs/cache.stub'));
-
-        $this->info('Migration created successfully!');
-
-        $this->composer->dumpAutoloads();
-    }
-
-    /**
-     * Create a base migration file for the table.
-     *
      * @return string
      */
-    protected function createBaseMigration()
+    public function migrationTableName()
     {
-        $name = 'create_cache_table';
+        return $this->laravel['config']->get('cache.stores.database.table', 'cache');
+    }
 
-        $path = $this->laravel->databasePath().'/migrations';
-
-        return $this->laravel['migration.creator']->create($name, $path);
+    /**
+     * @return string
+     */
+    public function migrationStubPath()
+    {
+        return __DIR__.'/stubs/cache.stub';
     }
 }

--- a/src/Illuminate/Cache/Console/stubs/cache.stub
+++ b/src/Illuminate/Cache/Console/stubs/cache.stub
@@ -3,7 +3,7 @@
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
 
-class CreateCacheTable extends Migration
+class Create{{tableClassName}}Table extends Migration
 {
     /**
      * Run the migrations.
@@ -12,7 +12,7 @@ class CreateCacheTable extends Migration
      */
     public function up()
     {
-        Schema::create('cache', function (Blueprint $table) {
+        Schema::create('{{table}}', function (Blueprint $table) {
             $table->string('key')->unique();
             $table->text('value');
             $table->integer('expiration');
@@ -26,6 +26,6 @@ class CreateCacheTable extends Migration
      */
     public function down()
     {
-        Schema::drop('cache');
+        Schema::drop('{{table}}');
     }
 }

--- a/src/Illuminate/Console/MigrationCreatorCommand.php
+++ b/src/Illuminate/Console/MigrationCreatorCommand.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Illuminate\Database\Console;
+namespace Illuminate\Console;
 
 use Illuminate\Support\Str;
 use Illuminate\Console\Command;

--- a/src/Illuminate/Console/MigrationCreatorCommand.php
+++ b/src/Illuminate/Console/MigrationCreatorCommand.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Console;
 
 use Illuminate\Support\Str;
-use Illuminate\Console\Command;
 use Illuminate\Support\Composer;
 use Illuminate\Filesystem\Filesystem;
 

--- a/src/Illuminate/Database/Console/MigrationCreatorCommand.php
+++ b/src/Illuminate/Database/Console/MigrationCreatorCommand.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Illuminate\Database\Console;
+
+use Illuminate\Support\Str;
+use Illuminate\Console\Command;
+use Illuminate\Support\Composer;
+use Illuminate\Filesystem\Filesystem;
+
+abstract class MigrationCreatorCommand extends Command
+{
+    /**
+     * The filesystem instance.
+     *
+     * @var \Illuminate\Filesystem\Filesystem
+     */
+    protected $files;
+
+    /**
+     * @var \Illuminate\Support\Composer
+     */
+    protected $composer;
+
+    /**
+     * Create a new table command instance.
+     *
+     * @param  \Illuminate\Filesystem\Filesystem  $files
+     * @param  \Illuminate\Support\Composer  $composer
+     * @return void
+     */
+    public function __construct(Filesystem $files, Composer $composer)
+    {
+        parent::__construct();
+
+        $this->files = $files;
+        $this->composer = $composer;
+    }
+
+    /**
+     * The table to migrate.
+     *
+     * @return string
+     */
+    abstract public function migrationTableName();
+
+    /**
+     * The location where is the migration file.
+     *
+     * @return string
+     */
+    abstract public function migrationStubPath();
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function fire()
+    {
+        $table = $this->migrationTableName();
+        $tableClassName = Str::studly($table);
+
+        $fullPath = $this->createBaseMigration($table);
+        $stub = str_replace(
+            ['{{table}}', '{{tableClassName}}'],
+            [$table, $tableClassName],
+            $this->files->get(
+                $this->migrationStubPath()
+            )
+        );
+
+        $this->files->put($fullPath, $stub);
+
+        $this->info('Migration created successfully!');
+
+        $this->composer->dumpAutoloads();
+    }
+
+    /**
+     * Create a base migration file for the table.
+     *
+     * @param  string  $table
+     * @return string
+     */
+    protected function createBaseMigration($table)
+    {
+        $name = 'create_'.$table.'_table';
+
+        $path = $this->laravel->databasePath().'/migrations';
+
+        return $this->laravel['migration.creator']->create($name, $path);
+    }
+}

--- a/src/Illuminate/Queue/Console/FailedTableCommand.php
+++ b/src/Illuminate/Queue/Console/FailedTableCommand.php
@@ -2,12 +2,9 @@
 
 namespace Illuminate\Queue\Console;
 
-use Illuminate\Support\Str;
-use Illuminate\Console\Command;
-use Illuminate\Support\Composer;
-use Illuminate\Filesystem\Filesystem;
+use Illuminate\Database\Console\MigrationCreatorCommand;
 
-class FailedTableCommand extends Command
+class FailedTableCommand extends MigrationCreatorCommand
 {
     /**
      * The console command name.
@@ -24,68 +21,18 @@ class FailedTableCommand extends Command
     protected $description = 'Create a migration for the failed queue jobs database table';
 
     /**
-     * The filesystem instance.
-     *
-     * @var \Illuminate\Filesystem\Filesystem
-     */
-    protected $files;
-
-    /**
-     * @var \Illuminate\Support\Composer
-     */
-    protected $composer;
-
-    /**
-     * Create a new failed queue jobs table command instance.
-     *
-     * @param  \Illuminate\Filesystem\Filesystem  $files
-     * @param  \Illuminate\Support\Composer    $composer
-     * @return void
-     */
-    public function __construct(Filesystem $files, Composer $composer)
-    {
-        parent::__construct();
-
-        $this->files = $files;
-        $this->composer = $composer;
-    }
-
-    /**
-     * Execute the console command.
-     *
-     * @return void
-     */
-    public function fire()
-    {
-        $table = $this->laravel['config']['queue.failed.table'];
-
-        $tableClassName = Str::studly($table);
-
-        $fullPath = $this->createBaseMigration($table);
-
-        $stub = str_replace(
-            ['{{table}}', '{{tableClassName}}'], [$table, $tableClassName], $this->files->get(__DIR__.'/stubs/failed_jobs.stub')
-        );
-
-        $this->files->put($fullPath, $stub);
-
-        $this->info('Migration created successfully!');
-
-        $this->composer->dumpAutoloads();
-    }
-
-    /**
-     * Create a base migration file for the table.
-     *
-     * @param  string  $table
      * @return string
      */
-    protected function createBaseMigration($table = 'failed_jobs')
+    public function migrationTableName()
     {
-        $name = 'create_'.$table.'_table';
+        return $this->laravel['config']->get('queue.failed.table', 'failed_jobs');
+    }
 
-        $path = $this->laravel->databasePath().'/migrations';
-
-        return $this->laravel['migration.creator']->create($name, $path);
+    /**
+     * @return string
+     */
+    public function migrationStubPath()
+    {
+        return __DIR__.'/stubs/failed_jobs.stub';
     }
 }

--- a/src/Illuminate/Queue/Console/FailedTableCommand.php
+++ b/src/Illuminate/Queue/Console/FailedTableCommand.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\Queue\Console;
 
-use Illuminate\Database\Console\MigrationCreatorCommand;
+use Illuminate\Console\MigrationCreatorCommand;
 
 class FailedTableCommand extends MigrationCreatorCommand
 {

--- a/src/Illuminate/Queue/Console/TableCommand.php
+++ b/src/Illuminate/Queue/Console/TableCommand.php
@@ -2,12 +2,9 @@
 
 namespace Illuminate\Queue\Console;
 
-use Illuminate\Support\Str;
-use Illuminate\Console\Command;
-use Illuminate\Support\Composer;
-use Illuminate\Filesystem\Filesystem;
+use Illuminate\Database\Console\MigrationCreatorCommand;
 
-class TableCommand extends Command
+class TableCommand extends MigrationCreatorCommand
 {
     /**
      * The console command name.
@@ -24,68 +21,18 @@ class TableCommand extends Command
     protected $description = 'Create a migration for the queue jobs database table';
 
     /**
-     * The filesystem instance.
-     *
-     * @var \Illuminate\Filesystem\Filesystem
-     */
-    protected $files;
-
-    /**
-     * @var \Illuminate\Support\Composer
-     */
-    protected $composer;
-
-    /**
-     * Create a new queue job table command instance.
-     *
-     * @param  \Illuminate\Filesystem\Filesystem  $files
-     * @param  \Illuminate\Support\Composer    $composer
-     * @return void
-     */
-    public function __construct(Filesystem $files, Composer $composer)
-    {
-        parent::__construct();
-
-        $this->files = $files;
-        $this->composer = $composer;
-    }
-
-    /**
-     * Execute the console command.
-     *
-     * @return void
-     */
-    public function fire()
-    {
-        $table = $this->laravel['config']['queue.connections.database.table'];
-
-        $tableClassName = Str::studly($table);
-
-        $fullPath = $this->createBaseMigration($table);
-
-        $stub = str_replace(
-            ['{{table}}', '{{tableClassName}}'], [$table, $tableClassName], $this->files->get(__DIR__.'/stubs/jobs.stub')
-        );
-
-        $this->files->put($fullPath, $stub);
-
-        $this->info('Migration created successfully!');
-
-        $this->composer->dumpAutoloads();
-    }
-
-    /**
-     * Create a base migration file for the table.
-     *
-     * @param  string  $table
      * @return string
      */
-    protected function createBaseMigration($table = 'jobs')
+    public function migrationTableName()
     {
-        $name = 'create_'.$table.'_table';
+        return $this->laravel['config']->get('queue.connections.database.table', 'jobs');
+    }
 
-        $path = $this->laravel->databasePath().'/migrations';
-
-        return $this->laravel['migration.creator']->create($name, $path);
+    /**
+     * @return string
+     */
+    public function migrationStubPath()
+    {
+        return __DIR__.'/stubs/jobs.stub';
     }
 }

--- a/src/Illuminate/Queue/Console/TableCommand.php
+++ b/src/Illuminate/Queue/Console/TableCommand.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\Queue\Console;
 
-use Illuminate\Database\Console\MigrationCreatorCommand;
+use Illuminate\Console\MigrationCreatorCommand;
 
 class TableCommand extends MigrationCreatorCommand
 {

--- a/src/Illuminate/Session/Console/SessionTableCommand.php
+++ b/src/Illuminate/Session/Console/SessionTableCommand.php
@@ -2,11 +2,9 @@
 
 namespace Illuminate\Session\Console;
 
-use Illuminate\Console\Command;
-use Illuminate\Support\Composer;
-use Illuminate\Filesystem\Filesystem;
+use Illuminate\Database\Console\MigrationCreatorCommand;
 
-class SessionTableCommand extends Command
+class SessionTableCommand extends MigrationCreatorCommand
 {
     /**
      * The console command name.
@@ -23,59 +21,18 @@ class SessionTableCommand extends Command
     protected $description = 'Create a migration for the session database table';
 
     /**
-     * The filesystem instance.
-     *
-     * @var \Illuminate\Filesystem\Filesystem
-     */
-    protected $files;
-
-    /**
-     * @var \Illuminate\Support\Composer
-     */
-    protected $composer;
-
-    /**
-     * Create a new session table command instance.
-     *
-     * @param  \Illuminate\Filesystem\Filesystem  $files
-     * @param  \Illuminate\Support\Composer  $composer
-     * @return void
-     */
-    public function __construct(Filesystem $files, Composer $composer)
-    {
-        parent::__construct();
-
-        $this->files = $files;
-        $this->composer = $composer;
-    }
-
-    /**
-     * Execute the console command.
-     *
-     * @return void
-     */
-    public function fire()
-    {
-        $fullPath = $this->createBaseMigration();
-
-        $this->files->put($fullPath, $this->files->get(__DIR__.'/stubs/database.stub'));
-
-        $this->info('Migration created successfully!');
-
-        $this->composer->dumpAutoloads();
-    }
-
-    /**
-     * Create a base migration file for the session.
-     *
      * @return string
      */
-    protected function createBaseMigration()
+    public function migrationTableName()
     {
-        $name = 'create_sessions_table';
+        return $this->laravel['config']->get('session.table', 'sessions');
+    }
 
-        $path = $this->laravel->databasePath().'/migrations';
-
-        return $this->laravel['migration.creator']->create($name, $path);
+    /**
+     * @return string
+     */
+    public function migrationStubPath()
+    {
+        return __DIR__.'/stubs/database.stub';
     }
 }

--- a/src/Illuminate/Session/Console/SessionTableCommand.php
+++ b/src/Illuminate/Session/Console/SessionTableCommand.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\Session\Console;
 
-use Illuminate\Database\Console\MigrationCreatorCommand;
+use Illuminate\Console\MigrationCreatorCommand;
 
 class SessionTableCommand extends MigrationCreatorCommand
 {

--- a/src/Illuminate/Session/Console/stubs/database.stub
+++ b/src/Illuminate/Session/Console/stubs/database.stub
@@ -3,7 +3,7 @@
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
 
-class CreateSessionsTable extends Migration
+class Create{{tableClassName}}Table extends Migration
 {
     /**
      * Run the migrations.
@@ -12,7 +12,7 @@ class CreateSessionsTable extends Migration
      */
     public function up()
     {
-        Schema::create('sessions', function (Blueprint $table) {
+        Schema::create('{{table}}', function (Blueprint $table) {
             $table->string('id')->unique();
             $table->integer('user_id')->nullable();
             $table->string('ip_address', 45)->nullable();
@@ -29,6 +29,6 @@ class CreateSessionsTable extends Migration
      */
     public function down()
     {
-        Schema::drop('sessions');
+        Schema::drop('{{table}}');
     }
 }

--- a/tests/Cache/CacheTableCommandTest.php
+++ b/tests/Cache/CacheTableCommandTest.php
@@ -2,6 +2,7 @@
 
 use Mockery as m;
 use Illuminate\Foundation\Application;
+use Illuminate\Config\Repository as Config;
 use Illuminate\Cache\Console\CacheTableCommand;
 
 class CacheTableCommandTest extends PHPUnit_Framework_TestCase
@@ -20,11 +21,15 @@ class CacheTableCommandTest extends PHPUnit_Framework_TestCase
         $creator = m::mock('Illuminate\Database\Migrations\MigrationCreator')->shouldIgnoreMissing();
 
         $app = new Application();
+        $app->singleton('config', function () {
+            return $this->createConfig();
+        });
+
         $app->useDatabasePath(__DIR__);
         $app['migration.creator'] = $creator;
         $command->setLaravel($app);
         $path = __DIR__.'/migrations';
-        $creator->shouldReceive('create')->once()->with('create_cache_table', $path)->andReturn($path);
+        $creator->shouldReceive('create')->once()->with('create_cache_test_table', $path)->andReturn($path);
         $files->shouldReceive('get')->once()->andReturn('foo');
         $files->shouldReceive('put')->once()->with($path, 'foo');
         $composer->shouldReceive('dumpAutoloads')->once();
@@ -35,6 +40,22 @@ class CacheTableCommandTest extends PHPUnit_Framework_TestCase
     protected function runCommand($command, $input = [])
     {
         return $command->run(new Symfony\Component\Console\Input\ArrayInput($input), new Symfony\Component\Console\Output\NullOutput);
+    }
+
+    /**
+     * Create a new config repository instance.
+     *
+     * @return \Illuminate\Config\Repository
+     */
+    protected function createConfig()
+    {
+        return new Config([
+            'cache' => [
+                'stores' => [
+                    'database' => ['table' => 'cache_test'],
+                ],
+            ],
+        ]);
     }
 }
 

--- a/tests/Queue/QueueTableCommandTest.php
+++ b/tests/Queue/QueueTableCommandTest.php
@@ -1,0 +1,102 @@
+<?php
+
+use Mockery as m;
+use Illuminate\Foundation\Application;
+use Illuminate\Queue\Console\TableCommand;
+use Illuminate\Config\Repository as Config;
+use Illuminate\Queue\Console\FailedTableCommand;
+
+class QueueTableCommandTest extends PHPUnit_Framework_TestCase
+{
+    public function tearDown()
+    {
+        m::close();
+    }
+
+    public function setUp()
+    {
+        $this->app = new Application();
+        $this->app->singleton('config', function () {
+            return $this->createConfig();
+        });
+
+        $this->app->useDatabasePath(__DIR__);
+
+        $this->creator = m::mock('Illuminate\Database\Migrations\MigrationCreator')->shouldIgnoreMissing();
+        $this->app['migration.creator'] = $this->creator;
+    }
+
+    public function testCreateMakesMigration()
+    {
+        $command = new QueueTableCommandTestStub(
+            $files = m::mock('Illuminate\Filesystem\Filesystem'),
+            $composer = m::mock('Illuminate\Support\Composer')
+        );
+
+        $command->setLaravel($this->app);
+        $path = __DIR__.'/migrations';
+        $this->creator->shouldReceive('create')->once()->with('create_jobs_test_table', $path)->andReturn($path);
+        $files->shouldReceive('get')->once()->andReturn('foo');
+        $files->shouldReceive('put')->once()->with($path, 'foo');
+        $composer->shouldReceive('dumpAutoloads')->once();
+
+        $this->runCommand($command);
+    }
+
+    public function testCreateMakesFailedMigration()
+    {
+        $command = new QueueFailedTableCommandTestStub(
+            $files = m::mock('Illuminate\Filesystem\Filesystem'),
+            $composer = m::mock('Illuminate\Support\Composer')
+        );
+
+        $command->setLaravel($this->app);
+        $path = __DIR__.'/migrations';
+        $this->creator->shouldReceive('create')->once()->with('create_failed_test_table', $path)->andReturn($path);
+        $files->shouldReceive('get')->once()->andReturn('foo');
+        $files->shouldReceive('put')->once()->with($path, 'foo');
+        $composer->shouldReceive('dumpAutoloads')->once();
+
+        $this->runCommand($command);
+    }
+
+    protected function runCommand($command, $input = [])
+    {
+        return $command->run(new Symfony\Component\Console\Input\ArrayInput($input), new Symfony\Component\Console\Output\NullOutput);
+    }
+
+    /**
+     * Create a new config repository instance.
+     *
+     * @return \Illuminate\Config\Repository
+     */
+    protected function createConfig()
+    {
+        return new Config([
+            'queue' => [
+                'connections' => [
+                    'database' => ['table' => 'jobs_test'],
+                ],
+                'failed' => [
+                    'table' => 'failed_test'
+                ]
+            ],
+        ]);
+    }
+}
+
+class QueueTableCommandTestStub extends TableCommand
+{
+    public function call($command, array $arguments = [])
+    {
+        //
+    }
+}
+
+class QueueFailedTableCommandTestStub extends FailedTableCommand
+{
+    public function call($command, array $arguments = [])
+    {
+        //
+    }
+}

--- a/tests/Queue/QueueTableCommandTest.php
+++ b/tests/Queue/QueueTableCommandTest.php
@@ -78,8 +78,8 @@ class QueueTableCommandTest extends PHPUnit_Framework_TestCase
                     'database' => ['table' => 'jobs_test'],
                 ],
                 'failed' => [
-                    'table' => 'failed_test'
-                ]
+                    'table' => 'failed_test',
+                ],
             ],
         ]);
     }

--- a/tests/Session/SessionTableCommandTest.php
+++ b/tests/Session/SessionTableCommandTest.php
@@ -1,8 +1,9 @@
 <?php
 
-use Illuminate\Session\Console\SessionTableCommand;
-use Illuminate\Foundation\Application;
 use Mockery as m;
+use Illuminate\Foundation\Application;
+use Illuminate\Config\Repository as Config;
+use Illuminate\Session\Console\SessionTableCommand;
 
 class SessionTableCommandTest extends PHPUnit_Framework_TestCase
 {
@@ -20,11 +21,15 @@ class SessionTableCommandTest extends PHPUnit_Framework_TestCase
         $creator = m::mock('Illuminate\Database\Migrations\MigrationCreator')->shouldIgnoreMissing();
 
         $app = new Application();
+        $app->singleton('config', function () {
+            return $this->createConfig();
+        });
+
         $app->useDatabasePath(__DIR__);
         $app['migration.creator'] = $creator;
         $command->setLaravel($app);
         $path = __DIR__.'/migrations';
-        $creator->shouldReceive('create')->once()->with('create_sessions_table', $path)->andReturn($path);
+        $creator->shouldReceive('create')->once()->with('create_sessions_test_table', $path)->andReturn($path);
         $files->shouldReceive('get')->once()->andReturn('foo');
         $files->shouldReceive('put')->once()->with($path, 'foo');
         $composer->shouldReceive('dumpAutoloads')->once();
@@ -35,6 +40,20 @@ class SessionTableCommandTest extends PHPUnit_Framework_TestCase
     protected function runCommand($command, $input = [])
     {
         return $command->run(new Symfony\Component\Console\Input\ArrayInput($input), new Symfony\Component\Console\Output\NullOutput);
+    }
+
+    /**
+     * Create a new config repository instance.
+     *
+     * @return \Illuminate\Config\Repository
+     */
+    protected function createConfig()
+    {
+        return new Config([
+            'session' => [
+                'table' => 'sessions_test',
+            ],
+        ]);
     }
 }
 


### PR DESCRIPTION
Add new abstract command class `MigrationCreatorCommand`
Add tests for creating queue tables

Example for new migration:

``` php
use Illuminate\Database\Console\MigrationCreatorCommand;

class CacheTableCommand extends MigrationCreatorCommand
{
    /**
     * The console command name.
     *
     * @var string
     */
    protected $name = 'cache:table';

    /**
     * The console command description.
     *
     * @var string
     */
    protected $description = '...';

    /**
     * @return string
     */
    public function migrationTableName()
    {
        return 'cache';
    }

    /**
     * @return string
     */
    public function migrationStubPath()
    {
        return __DIR__.'/stubs/cache.stub';
    }
}
```

**stub**

```
<?php

use Illuminate\Database\Schema\Blueprint;
use Illuminate\Database\Migrations\Migration;

class Create{{tableClassName}}Table extends Migration
{
    /**
     * Run the migrations.
     *
     * @return void
     */
    public function up()
    {
        Schema::create('{{table}}', function (Blueprint $table) {
            ...
        });
    }

    /**
     * Reverse the migrations.
     *
     * @return void
     */
    public function down()
    {
        Schema::drop('{{table}}');
    }
}

```
