### PR TITLE
[5.2] Allow collections to be created from objects that implement Traversable

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -4,6 +4,7 @@ namespace Illuminate\Support;
 
 use Countable;
 use ArrayAccess;
+use Traversable;
 use ArrayIterator;
 use CachingIterator;
 use JsonSerializable;
@@ -1241,6 +1242,8 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
             return json_decode($items->toJson(), true);
         } elseif ($items instanceof JsonSerializable) {
             return $items->jsonSerialize();
+        } elseif ($items instanceof Traversable) {
+            return iterator_to_array($items);
         }
 
         return (array) $items;

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1393,14 +1393,14 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
 
     public function testCollectonFromTraversable()
     {
-        $collection = new Collection(new \ArrayObject([1 , 2, 3]));
-        $this->assertEquals([1 , 2, 3], $collection->toArray());
+        $collection = new Collection(new \ArrayObject([1, 2, 3]));
+        $this->assertEquals([1, 2, 3], $collection->toArray());
     }
 
     public function testCollectonFromTraversableWithKeys()
     {
-        $collection = new Collection(new \ArrayObject(['foo' => 1 , 'bar' => 2, 'baz' => 3]));
-        $this->assertEquals(['foo' => 1 , 'bar' => 2, 'baz' => 3], $collection->toArray());
+        $collection = new Collection(new \ArrayObject(['foo' => 1, 'bar' => 2, 'baz' => 3]));
+        $this->assertEquals(['foo' => 1, 'bar' => 2, 'baz' => 3], $collection->toArray());
     }
 }
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1390,6 +1390,18 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
         $collection = new Collection([1, 2, 3, 4, 5, 6, 7, 8]);
         $this->assertEquals([3, 4, 5, 6], $collection->slice(-6, -2)->values()->toArray());
     }
+
+    public function testCollectonFromTraversable()
+    {
+        $collection = new Collection(new \ArrayObject([1 , 2, 3]));
+        $this->assertEquals([1 , 2, 3], $collection->toArray());
+    }
+
+    public function testCollectonFromTraversableWithKeys()
+    {
+        $collection = new Collection(new \ArrayObject(['foo' => 1 , 'bar' => 2, 'baz' => 3]));
+        $this->assertEquals(['foo' => 1 , 'bar' => 2, 'baz' => 3], $collection->toArray());
+    }
 }
 
 class TestAccessorEloquentTestStub


### PR DESCRIPTION
As the title suggests. I'm making use of the Collection code via [tightenco/collect](/tightenco/collect), and I had a use case where my data was contained within an object that implements Iterator. 
