### PR TITLE
[5.2] Amend keyBy() method w/ callback for duplicates

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -437,7 +437,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
         foreach ($this->items as $key => $item) {
             $key = $keyBy($item, $key);
 
-            if(array_key_exists($key, $results) && ! is_null($results[$key]) && ! is_null($callback)) {
+            if (array_key_exists($key, $results) && ! is_null($results[$key]) && ! is_null($callback)) {
                 $item = $callback($results[$key], $item);
             }
 

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -425,16 +425,23 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      * Key an associative array by a field or using a callback.
      *
      * @param  callable|string  $keyBy
+     * @param  callable  $callback
      * @return static
      */
-    public function keyBy($keyBy)
+    public function keyBy($keyBy, callable $callback = null)
     {
         $keyBy = $this->valueRetriever($keyBy);
 
         $results = [];
 
         foreach ($this->items as $key => $item) {
-            $results[$keyBy($item, $key)] = $item;
+            $key = $keyBy($item, $key);
+
+            if(array_key_exists($key, $results) && ! is_null($results[$key]) && ! is_null($callback)) {
+                $item = $callback($results[$key], $item);
+            }
+
+            $results[$key] = $item;
         }
 
         return new static($results);


### PR DESCRIPTION
I raised the issue in detail here: https://github.com/laravel/internals/issues/152

I suggest this change so that the user has an opportunity to resolve the duplicate key with a callback.
