### PR TITLE
[5.3] Allow passing a where condition directly to Builder::when()

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -731,16 +731,20 @@ class Builder
     /**
      * Apply the callback's query changes if the given "value" is true.
      *
-     * @param  bool  $value
-     * @param  \Closure  $callback
-     * @return $this
+     * @param  bool  $condition
+     * @param  \Closure|string  $callback
+     * @param  string  $operator
+     * @param  string  $value
+     * @return \Illuminate\Database\Query\Builder
      */
-    public function when($value, $callback)
+    public function when($condition, $callback, $operator = null, $value = null)
     {
         $builder = $this;
 
-        if ($value) {
-            $builder = call_user_func($callback, $builder);
+        if ($condition) {
+            $builder = is_callable($callback)
+                ? call_user_func($callback, $builder)
+                : $this->where($callback, $operator, $value);
         }
 
         return $builder;

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -457,16 +457,20 @@ class Builder
     /**
      * Apply the callback's query changes if the given "value" is true.
      *
-     * @param  bool  $value
-     * @param  \Closure  $callback
+     * @param  bool  $condition
+     * @param  \Closure|string  $callback
+     * @param  string  $operator
+     * @param  string  $value
      * @return \Illuminate\Database\Query\Builder
      */
-    public function when($value, $callback)
+    public function when($condition, $callback, $operator = null, $value = null)
     {
         $builder = $this;
 
-        if ($value) {
-            $builder = call_user_func($callback, $builder);
+        if ($condition) {
+            $builder = is_callable($callback)
+                ? call_user_func($callback, $builder)
+                : $this->where($callback, $operator, $value);
         }
 
         return $builder;

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -133,6 +133,10 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->when(false, $callback)->where('email', 'foo');
         $this->assertEquals('select * from "users" where "email" = ?', $builder->toSql());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->when(true, 'age', '>', 30)->where('email', 'foo');
+        $this->assertEquals('select * from "users" where "age" > ? and "email" = ?', $builder->toSql());
     }
 
     public function testBasicWheres()


### PR DESCRIPTION
Besides being able to do this:

``` php
User::when($currentCompany, function($q) use ($currentCompany){
    return $q->where('company_id', '=', $currentCompany->id);
})->get();
```

We can do that:

``` php
User::when($currentCompany, 'company_id', '=', $currentCompany->id)->get();
```
