### PR TITLE
[5.3] [Draft] Introduce Illuminate\Notifications\Message (with breaking changes)

### DIFF
--- a/src/Illuminate/Auth/Notifications/ResetPassword.php
+++ b/src/Illuminate/Auth/Notifications/ResetPassword.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Auth\Notifications;
 
+use Illuminate\Notifications\Message;
 use Illuminate\Notifications\Notification;
 
 class ResetPassword extends Notification
@@ -38,15 +39,16 @@ class ResetPassword extends Notification
     /**
      * Build the notification message.
      *
-     * @return $this
+     * @param  \Illuminate\Notifications\Message  $message
+     * @return \Illuminate\Notifications\Message
      */
-    public function message()
+    public function message(Message $message)
     {
-        return $this->line([
+        return $message->line([
                 'You are receiving this email because we received a password reset request for your account.',
                 'Click the button below to reset your password:',
             ])
-            ->action('Reset Password', url('password/reset', $this->token))
+            ->action('Reset Password', url('password/reset', $this->token).'?email='.urlencode($message->notifiable->email))
             ->line('If you did not request a password reset, no further action is required.');
     }
 }

--- a/src/Illuminate/Foundation/Console/stubs/notification.stub
+++ b/src/Illuminate/Foundation/Console/stubs/notification.stub
@@ -3,6 +3,7 @@
 namespace DummyNamespace;
 
 use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Message;
 use Illuminate\Notifications\Notification;
 use Illuminate\Contracts\Queue\ShouldQueue;
 
@@ -34,12 +35,13 @@ class DummyClass extends Notification
     /**
      * Get the notification message.
      *
-     * @return void
+     * @param  \Illuminate\Notifications\Message  $message
+     * @return \Illuminate\Notifications\Message
      */
-    public function message()
+    public function message(Message $message)
     {
-        $this->line('The introduction to the notification.')
-             ->action('Notification Action', 'https://laravel.com')
-             ->line('Thank you for using our application!');
+        return $message->line('The introduction to the notification.')
+                 ->action('Notification Action', 'https://laravel.com')
+                 ->line('Thank you for using our application!');
     }
 }

--- a/src/Illuminate/Notifications/ChannelManager.php
+++ b/src/Illuminate/Notifications/ChannelManager.php
@@ -46,8 +46,6 @@ class ChannelManager extends Manager implements DispatcherContract, FactoryContr
      */
     public function sendNow($notifiables, $notification)
     {
-        $notification->message();
-
         if (! $notification->application) {
             $notification->application(
                 $this->app['config']['app.name'],
@@ -56,6 +54,7 @@ class ChannelManager extends Manager implements DispatcherContract, FactoryContr
         }
 
         foreach ($notifiables as $notifiable) {
+            $message = new Message($notifiable, $notification);
             $channels = $notification->via($notifiable);
 
             if (empty($channels)) {
@@ -63,11 +62,11 @@ class ChannelManager extends Manager implements DispatcherContract, FactoryContr
             }
 
             $this->app->make('events')->fire(
-                new Events\NotificationSent($notifiable, $notification)
+                new Events\NotificationSent($notifiable, $message)
             );
 
             foreach ($channels as $channel) {
-                $this->driver($channel)->send(collect([$notifiable]), $notification);
+                $this->driver($channel)->send(collect([$notifiable]), $message);
             }
         }
     }

--- a/src/Illuminate/Notifications/Channels/BroadcastChannel.php
+++ b/src/Illuminate/Notifications/Channels/BroadcastChannel.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Notifications\Channels;
 
+use Illuminate\Notifications\Message;
 use Illuminate\Notifications\Notification;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Notifications\Events\DatabaseNotificationCreated;
@@ -30,16 +31,16 @@ class BroadcastChannel extends DatabaseChannel
      * Send the given notification.
      *
      * @param  \Illuminate\Support\Collection  $notifiables
-     * @param  \Illuminate\Notifications\Notification  $notification
+     * @param  \Illuminate\Notifications\Message  $message
      * @return void
      */
-    public function send($notifiables, Notification $notification)
+    public function send($notifiables, Message $message)
     {
         foreach ($notifiables as $notifiable) {
-            $databaseNotification = $this->createNotification($notifiable, $notification);
+            $databaseNotification = $this->createNotification($notifiable, $message);
 
             $this->events->fire(new DatabaseNotificationCreated(
-                $notifiable, $notification, $databaseNotification
+                $notifiable, $message, $databaseNotification
             ));
         }
     }

--- a/src/Illuminate/Notifications/Channels/DatabaseChannel.php
+++ b/src/Illuminate/Notifications/Channels/DatabaseChannel.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\Notifications\Channels;
 
-use Illuminate\Notifications\Notification;
+use Illuminate\Notifications\Message;
 
 class DatabaseChannel
 {
@@ -10,13 +10,13 @@ class DatabaseChannel
      * Send the given notification.
      *
      * @param  \Illuminate\Support\Collection  $notifiables
-     * @param  \Illuminate\Notifications\Notification  $notification
+     * @param  \Illuminate\Notifications\Message  $message
      * @return void
      */
-    public function send($notifiables, Notification $notification)
+    public function send($notifiables, Message $message)
     {
         foreach ($notifiables as $notifiable) {
-            $this->createNotification($notifiable, $notification);
+            $this->createNotification($notifiable, $message);
         }
     }
 
@@ -24,18 +24,18 @@ class DatabaseChannel
      * Create a database notification record for the notifiable.
      *
      * @param  mixed  $notifiable
-     * @param  \Illuminate\Notifications\Notification  $notification
+     * @param  \Illuminate\Notifications\Message  $message
      * @return \Illuminate\Notifications\DatabaseNotification
      */
-    protected function createNotification($notifiable, Notification $notification)
+    protected function createNotification($notifiable, Message $message)
     {
         return $notifiable->routeNotificationFor('database')->create([
-            'type' => get_class($notification),
-            'level' => $notification->level,
-            'intro' => $notification->introLines,
-            'outro' => $notification->outroLines,
-            'action_text' => $notification->actionText,
-            'action_url' => $notification->actionUrl,
+            'type' => get_class($message->notification),
+            'level' => $message->notification->level,
+            'intro' => $message->introLines,
+            'outro' => $message->outroLines,
+            'action_text' => $message->actionText,
+            'action_url' => $message->actionUrl,
             'read' => false,
         ]);
     }

--- a/src/Illuminate/Notifications/Channels/MailChannel.php
+++ b/src/Illuminate/Notifications/Channels/MailChannel.php
@@ -5,7 +5,7 @@ namespace Illuminate\Notifications\Channels;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Contracts\Mail\Mailer;
-use Illuminate\Notifications\Notification;
+use Illuminate\Notifications\Message;
 
 class MailChannel
 {
@@ -31,12 +31,12 @@ class MailChannel
      * Send the given notification.
      *
      * @param  \Illuminate\Support\Collection  $notifiables
-     * @param  \Illuminate\Notifications\Notification  $notification
+     * @param  \Illuminate\Notifications\Message  $message
      * @return void
      */
-    public function send($notifiables, Notification $notification)
+    public function send($notifiables, Message $message)
     {
-        $data = $this->prepareNotificationData($notification);
+        $data = $this->prepareNotificationData($message);
 
         $emails = $notifiables->map(function ($n) {
             return $n->routeNotificationFor('mail');
@@ -46,14 +46,14 @@ class MailChannel
             return;
         }
 
-        $view = data_get($notification, 'options.view', 'notifications::email');
+        $view = data_get($message, 'options.view', 'notifications::email');
 
-        $this->mailer->send($view, $data, function ($m) use ($notifiables, $notification, $emails) {
+        $this->mailer->send($view, $data, function ($m) use ($notifiables, $message, $emails) {
             count($notifiables) === 1
                         ? $m->to($emails) : $m->bcc($emails);
 
-            $m->subject($notification->subject ?: Str::title(
-                Str::snake(class_basename($notification), ' ')
+            $m->subject($message->subject ?: Str::title(
+                Str::snake(class_basename($message->notification), ' ')
             ));
         });
     }
@@ -61,12 +61,12 @@ class MailChannel
     /**
      * Prepare the data from the given notification.
      *
-     * @param  \Illuminate\Notifications\Notification  $notification
+     * @param  \Illuminate\Notifications\Message  $message
      * @return array
      */
-    protected function prepareNotificationData($notification)
+    protected function prepareNotificationData(Message $message)
     {
-        $data = $notification->toArray();
+        $data = $message->toArray();
 
         return Arr::set($data, 'actionColor', $this->actionColorForLevel($data['level']));
     }

--- a/src/Illuminate/Notifications/Channels/NexmoSmsChannel.php
+++ b/src/Illuminate/Notifications/Channels/NexmoSmsChannel.php
@@ -4,7 +4,7 @@ namespace Illuminate\Notifications\Channels;
 
 use Illuminate\Support\Arr;
 use Nexmo\Client as NexmoClient;
-use Illuminate\Notifications\Notification;
+use Illuminate\Notifications\Message;
 
 class NexmoSmsChannel
 {
@@ -39,10 +39,10 @@ class NexmoSmsChannel
      * Send the given notification.
      *
      * @param  \Illuminate\Support\Collection  $notifiables
-     * @param  \Illuminate\Notifications\Notification  $notification
+     * @param  \Illuminate\Notifications\Message  $message
      * @return void
      */
-    public function send($notifiables, Notification $notification)
+    public function send($notifiables, Message $message)
     {
         foreach ($notifiables as $notifiable) {
             if (! $to = $notifiable->routeNotificationFor('nexmo')) {
@@ -52,7 +52,7 @@ class NexmoSmsChannel
             $this->nexmo->message()->send([
                 'from' => $this->from,
                 'to' => $to,
-                'text' => $this->formatNotification($notification),
+                'text' => $this->formatNotification($message),
             ]);
         }
     }
@@ -60,15 +60,15 @@ class NexmoSmsChannel
     /**
      * Format the given notification to a single string.
      *
-     * @param  \Illuminate\Notifications\Notification  $notification
+     * @param  \Illuminate\Notifications\Message  $message
      * @return string
      */
-    protected function formatNotification(Notification $notification)
+    protected function formatNotification(Message $message)
     {
-        $data = $notification->toArray();
+        $data = $message->toArray();
 
-        $actionText = $notification->actionText
-                    ? $notification->actionText.': ' : '';
+        $actionText = $message->actionText
+                    ? $message->actionText.': ' : '';
 
         return trim(implode(PHP_EOL.PHP_EOL, array_filter([
             implode(' ', Arr::get($data, 'introLines', [])),

--- a/src/Illuminate/Notifications/Channels/SlackWebhookChannel.php
+++ b/src/Illuminate/Notifications/Channels/SlackWebhookChannel.php
@@ -3,7 +3,7 @@
 namespace Illuminate\Notifications\Channels;
 
 use GuzzleHttp\Client as HttpClient;
-use Illuminate\Notifications\Notification;
+use Illuminate\Notifications\Message;
 
 class SlackWebhookChannel
 {
@@ -29,10 +29,10 @@ class SlackWebhookChannel
      * Send the given notification.
      *
      * @param  \Illuminate\Support\Collection  $notifiables
-     * @param  \Illuminate\Notifications\Notification  $notification
+     * @param  \Illuminate\Notifications\Message  $message
      * @return void
      */
-    public function send($notifiables, Notification $notification)
+    public function send($notifiables, Message $message)
     {
         foreach ($notifiables as $notifiable) {
             if (! $url = $notifiable->routeNotificationFor('slack')) {
@@ -43,10 +43,10 @@ class SlackWebhookChannel
                 'json' => [
                     'attachments' => [
                         array_filter([
-                            'color' => $this->color($notification),
-                            'title' => $notification->subject,
-                            'title_link' => $notification->actionUrl ?: null,
-                            'text' => $this->format($notification),
+                            'color' => $this->color($message),
+                            'title' => $message->subject,
+                            'title_link' => $message->actionUrl ?: null,
+                            'text' => $this->format($message),
                         ]),
                     ],
                 ],
@@ -57,31 +57,31 @@ class SlackWebhookChannel
     /**
      * Format the given notification.
      *
-     * @param  \Illuminate\Notifications\Notification  $notification
+     * @param  \Illuminate\Notifications\Message  $message
      * @return string
      */
-    protected function format(Notification $notification)
+    protected function format(Message $message)
     {
-        $message = trim(implode(PHP_EOL.PHP_EOL, $notification->introLines));
+        $text = trim(implode(PHP_EOL.PHP_EOL, $message->introLines));
 
-        if ($notification->actionText) {
-            $message .= PHP_EOL.PHP_EOL.'<'.$notification->actionUrl.'|'.$notification->actionText.'>';
+        if ($message->actionText) {
+            $text .= PHP_EOL.PHP_EOL.'<'.$message->actionUrl.'|'.$message->actionText.'>';
         }
 
-        $message .= PHP_EOL.PHP_EOL.trim(implode(PHP_EOL.PHP_EOL, $notification->outroLines));
+        $text .= PHP_EOL.PHP_EOL.trim(implode(PHP_EOL.PHP_EOL, $message->outroLines));
 
-        return trim($message);
+        return trim($text);
     }
 
     /**
      * Get the color that should be applied to the notification.
      *
-     * @param  \Illuminate\Notifications\Notification  $notification
+     * @param  \Illuminate\Notifications\Message  $message
      * @return string|null
      */
-    protected function color(Notification $notification)
+    protected function color(Message $message)
     {
-        switch ($notification->level) {
+        switch ($message->notification->level) {
             case 'success':
                 return 'good';
             case 'error':

--- a/src/Illuminate/Notifications/Events/DatabaseNotificationCreated.php
+++ b/src/Illuminate/Notifications/Events/DatabaseNotificationCreated.php
@@ -20,11 +20,11 @@ class DatabaseNotificationCreated implements ShouldBroadcast
     public $notifiable;
 
     /**
-     * The notification instance.
+     * The notification message instance.
      *
-     * @var \Illuminate\Notifications\Notification
+     * @var \Illuminate\Notifications\Message
      */
-    public $notification;
+    public $message;
 
     /**
      * The database notification instance.
@@ -37,14 +37,14 @@ class DatabaseNotificationCreated implements ShouldBroadcast
      * Create a new event instance.
      *
      * @param  mixed  $notifiable
-     * @param  \Illuminate\Notifications\Notification  $notification
+     * @param  \Illuminate\Notifications\Message  $message
      * @param  \Illuminate\Notifications\DatabaseNotification  $databaseNotification
      * @return void
      */
-    public function __construct($notifiable, $notification, $databaseNotification)
+    public function __construct($notifiable, $message, $databaseNotification)
     {
         $this->notifiable = $notifiable;
-        $this->notification = $notification;
+        $this->message = $message;
         $this->databaseNotification = $databaseNotification;
     }
 

--- a/src/Illuminate/Notifications/Events/NotificationSent.php
+++ b/src/Illuminate/Notifications/Events/NotificationSent.php
@@ -14,22 +14,22 @@ class NotificationSent
     public $notifiable;
 
     /**
-     * The notification instance.
+     * The notification message instance.
      *
-     * @var \Illuminate\Notifications\Notification
+     * @var \Illuminate\Notifications\Message
      */
-    public $notification;
+    public $message;
 
     /**
      * Create a new event instance.
      *
      * @param  mixed  $notifiable
-     * @param  \Illuminate\Notifications\Notification  $notification
+     * @param  \Illuminate\Notifications\Message  $message
      * @return void
      */
-    public function __construct($notifiable, $notification)
+    public function __construct($notifiable, $message)
     {
         $this->notifiable = $notifiable;
-        $this->notification = $notification;
+        $this->message = $message;
     }
 }

--- a/src/Illuminate/Notifications/Message.php
+++ b/src/Illuminate/Notifications/Message.php
@@ -1,0 +1,225 @@
+<?php
+
+namespace Illuminate\Notifications;
+
+class Message
+{
+    /**
+     * The entity that should receive the notification.
+     *
+     * @var mixed
+     */
+    public $notifiable;
+
+    /**
+     * The notification instance.
+     *
+     * @var \Illuminate\Notifications\Notification
+     */
+    public $notification;
+
+    /**
+     * The "level" of the notification (info, success, error).
+     *
+     * @var string
+     */
+    public $level = 'info';
+
+    /**
+     * The subject of the notification.
+     *
+     * @var string
+     */
+    public $subject;
+
+    /**
+     * The "intro" lines of the notification.
+     *
+     * @var array
+     */
+    public $introLines = [];
+
+    /**
+     * The "outro" lines of the notification.
+     *
+     * @var array
+     */
+    public $outroLines = [];
+
+    /**
+     * The text / label for the action.
+     *
+     * @var string
+     */
+    public $actionText;
+
+    /**
+     * The action URL.
+     *
+     * @var string
+     */
+    public $actionUrl;
+
+    /**
+     * The notification's options.
+     *
+     * @var array
+     */
+    public $options = [];
+
+    /**
+     * Construct a new notification message.
+     *
+     * @param  mixed  $notifiable
+     * @param  \Illuminate\Notifications\Notification  $notification
+     * @return void
+     */
+    public function __construct($notifiable, Notification $notification)
+    {
+        $this->notifiable = $notifiable;
+        $this->notification = $notification;
+
+        if (method_exists($notification, 'message')) {
+            $this->notification->message($this);
+        }
+    }
+
+    /**
+     * Indicate that the notification gives information about a successful operation.
+     *
+     * @return $this
+     */
+    public function success()
+    {
+        return $this->level('success');
+    }
+
+    /**
+     * Indicate that the notification gives information about an error.
+     *
+     * @return $this
+     */
+    public function error()
+    {
+        return $this->level('error');
+    }
+
+    /**
+     * Set the "level" of the notification (success, error, etc.).
+     *
+     * @param  string  $level
+     * @return $this
+     */
+    public function level($level)
+    {
+        $this->notification->level = $level;
+
+        return $this;
+    }
+
+    /**
+     * Set the subject of the notification.
+     *
+     * @param  string  $subject
+     * @return $this
+     */
+    public function subject($subject)
+    {
+        $this->subject = $subject;
+
+        return $this;
+    }
+
+    /**
+     * Add a line of text to the notification.
+     *
+     * @param  \Illuminate\Notifications\Action|string  $line
+     * @return $this
+     */
+    public function line($line)
+    {
+        return $this->with($line);
+    }
+
+    /**
+     * Add a line of text to the notification.
+     *
+     * @param  \Illuminate\Notifications\Action|string|array  $line
+     * @return $this
+     */
+    public function with($line)
+    {
+        if ($line instanceof Action) {
+            $this->action($line->text, $line->url);
+        } elseif (! $this->actionText) {
+            $this->introLines[] = $this->formatLine($line);
+        } else {
+            $this->outroLines[] = $this->formatLine($line);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Format the given line of text.
+     *
+     * @param  string|array  $line
+     * @return string
+     */
+    protected function formatLine($line)
+    {
+        if (is_array($line)) {
+            return implode(' ', array_map('trim', $line));
+        }
+
+        return trim(implode(' ', array_map('trim', explode(PHP_EOL, $line))));
+    }
+
+    /**
+     * Set the notification's options.
+     *
+     * @param  array  $options
+     * @return $this
+     */
+    public function options(array $options)
+    {
+        $this->options = $options;
+
+        return $this;
+    }
+
+    /**
+     * Configure the "call to action" button.
+     *
+     * @param  string  $text
+     * @param  string  $url
+     * @return $this
+     */
+    public function action($text, $url)
+    {
+        $this->actionText = $text;
+        $this->actionUrl = $url;
+
+        return $this;
+    }
+
+    /**
+     * Get the instance as an array.
+     *
+     * @return array
+     */
+    public function toArray()
+    {
+        return [
+            'notifiable' => $this->notifiable,
+            'application' => $this->notification->application,
+            'logoUrl' => $this->notification->logoUrl,
+            'level' => $this->notification->level,
+            'subject' => $this->subject,
+            'introLines' => $this->introLines,
+            'outroLines' => $this->outroLines,
+            'actionText' => $this->actionText,
+            'actionUrl' => $this->actionUrl,
+        ];
+    }
+}

--- a/src/Illuminate/Notifications/Notification.php
+++ b/src/Illuminate/Notifications/Notification.php
@@ -30,48 +30,6 @@ class Notification
     public $level = 'info';
 
     /**
-     * The subject of the notification.
-     *
-     * @var string
-     */
-    public $subject;
-
-    /**
-     * The "intro" lines of the notification.
-     *
-     * @var array
-     */
-    public $introLines = [];
-
-    /**
-     * The "outro" lines of the notification.
-     *
-     * @var array
-     */
-    public $outroLines = [];
-
-    /**
-     * The text / label for the action.
-     *
-     * @var string
-     */
-    public $actionText;
-
-    /**
-     * The action URL.
-     *
-     * @var string
-     */
-    public $actionUrl;
-
-    /**
-     * The notification's options.
-     *
-     * @var array
-     */
-    public $options = [];
-
-    /**
      * Specify the name of the application sending the notification.
      *
      * @param  string  $application
@@ -93,9 +51,7 @@ class Notification
      */
     public function success()
     {
-        $this->level = 'success';
-
-        return $this;
+        return $this->level('success');
     }
 
     /**
@@ -105,9 +61,7 @@ class Notification
      */
     public function error()
     {
-        $this->level = 'error';
-
-        return $this;
+        return $this->level('error');
     }
 
     /**
@@ -121,110 +75,5 @@ class Notification
         $this->level = $level;
 
         return $this;
-    }
-
-    /**
-     * Set the subject of the notification.
-     *
-     * @param  string  $subject
-     * @return $this
-     */
-    public function subject($subject)
-    {
-        $this->subject = $subject;
-
-        return $this;
-    }
-
-    /**
-     * Add a line of text to the notification.
-     *
-     * @param  \Illuminate\Notifications\Action|string  $line
-     * @return $this
-     */
-    public function line($line)
-    {
-        return $this->with($line);
-    }
-
-    /**
-     * Add a line of text to the notification.
-     *
-     * @param  \Illuminate\Notifications\Action|string|array  $line
-     * @return $this
-     */
-    public function with($line)
-    {
-        if ($line instanceof Action) {
-            $this->action($line->text, $line->url);
-        } elseif (! $this->actionText) {
-            $this->introLines[] = $this->formatLine($line);
-        } else {
-            $this->outroLines[] = $this->formatLine($line);
-        }
-
-        return $this;
-    }
-
-    /**
-     * Format the given line of text.
-     *
-     * @param  string|array  $line
-     * @return string
-     */
-    protected function formatLine($line)
-    {
-        if (is_array($line)) {
-            return implode(' ', array_map('trim', $line));
-        }
-
-        return trim(implode(' ', array_map('trim', explode(PHP_EOL, $line))));
-    }
-
-    /**
-     * Set the notification's options.
-     *
-     * @param  array  $options
-     * @return $this
-     */
-    public function options(array $options)
-    {
-        $this->options = $options;
-
-        return $this;
-    }
-
-    /**
-     * Configure the "call to action" button.
-     *
-     * @param  string  $text
-     * @param  string  $url
-     * @return $this
-     */
-    public function action($text, $url)
-    {
-        $this->actionText = $text;
-        $this->actionUrl = $url;
-
-        return $this;
-    }
-
-    /**
-     * Get the instance as an array.
-     *
-     * @return array
-     */
-    public function toArray()
-    {
-        return [
-            'application' => $this->application,
-            'logoUrl' => $this->logoUrl,
-            'level' => $this->level,
-            'subject' => $this->subject,
-            'introLines' => $this->introLines,
-            'outroLines' => $this->outroLines,
-            'actionText' => $this->actionText,
-            'actionUrl' => $this->actionUrl,
-        ];
     }
 }

--- a/tests/Notifications/NotificationBroadcastChannelTest.php
+++ b/tests/Notifications/NotificationBroadcastChannelTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Notifications\Message;
 use Illuminate\Notifications\Notification;
 use Illuminate\Notifications\Channels\BroadcastChannel;
 
@@ -12,11 +13,11 @@ class NotificationBroadcastChannelTest extends PHPUnit_Framework_TestCase
 
     public function testBroadcastChannelCreatesDatabaseRecordWithProperData()
     {
-        $notification = new Notification;
         $notifiables = collect([$notifiable = Mockery::mock()]);
+        $message = new Message($notifiable, new Notification);
 
         $notifiable->shouldReceive('routeNotificationFor->create')->with([
-            'type' => get_class($notification),
+            'type' => get_class($message->notification),
             'level' => 'info',
             'intro' => [],
             'outro' => [],
@@ -29,6 +30,6 @@ class NotificationBroadcastChannelTest extends PHPUnit_Framework_TestCase
         $events->shouldReceive('fire')->once()->with('Illuminate\Notifications\Events\DatabaseNotificationCreated');
 
         $channel = new BroadcastChannel($events);
-        $channel->send($notifiables, $notification);
+        $channel->send($notifiables, $message);
     }
 }

--- a/tests/Notifications/NotificationChannelManagerTest.php
+++ b/tests/Notifications/NotificationChannelManagerTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Container\Container;
+use Illuminate\Notifications\Message;
 use Illuminate\Notifications\Notification;
 use Illuminate\Notifications\ChannelManager;
 use Illuminate\Contracts\Bus\Dispatcher as Bus;
@@ -20,12 +21,12 @@ class NotificationChannelManagerTest extends PHPUnit_Framework_TestCase
         Container::setInstance($container);
         $manager = Mockery::mock(ChannelManager::class.'[driver]', [$container]);
         $manager->shouldReceive('driver')->andReturn($driver = Mockery::mock());
-        $driver->shouldReceive('send')->andReturnUsing(function ($notifiables, $notification) {
-            $this->assertEquals('Name', $notification->application);
-            $this->assertEquals('Logo', $notification->logoUrl);
-            $this->assertEquals('test', $notification->introLines[0]);
-            $this->assertEquals('Text', $notification->actionText);
-            $this->assertEquals('url', $notification->actionUrl);
+        $driver->shouldReceive('send')->andReturnUsing(function ($notifiables, $message) {
+            $this->assertEquals('Name', $message->notification->application);
+            $this->assertEquals('Logo', $message->notification->logoUrl);
+            $this->assertEquals('test', $message->introLines[0]);
+            $this->assertEquals('Text', $message->actionText);
+            $this->assertEquals('url', $message->actionUrl);
         });
         $events->shouldReceive('fire')->with(Mockery::type(Illuminate\Notifications\Events\NotificationSent::class));
 
@@ -57,9 +58,9 @@ class NotificationChannelManagerTestNotification extends Notification
         return ['test'];
     }
 
-    public function message()
+    public function message(Message $message)
     {
-        return $this->line('test')->action('Text', 'url');
+        return $message->line('test')->action('Text', 'url');
     }
 }
 
@@ -72,8 +73,8 @@ class NotificationChannelManagerTestQueuedNotification extends Notification impl
         return ['test'];
     }
 
-    public function message()
+    public function message(Message $message)
     {
-        return $this->line('test')->action('Text', 'url');
+        return $message->line('test')->action('Text', 'url');
     }
 }

--- a/tests/Notifications/NotificationDatabaseChannelTest.php
+++ b/tests/Notifications/NotificationDatabaseChannelTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Notifications\Message;
 use Illuminate\Notifications\Notification;
 use Illuminate\Notifications\Channels\DatabaseChannel;
 
@@ -12,8 +13,8 @@ class NotificationDatabaseChannelTest extends PHPUnit_Framework_TestCase
 
     public function testDatabaseChannelCreatesDatabaseRecordWithProperData()
     {
-        $notification = new Notification;
         $notifiables = collect([$notifiable = Mockery::mock()]);
+        $message = new Message($notifiable, new Notification);
 
         $notifiable->shouldReceive('routeNotificationFor->create')->with([
             'type' => get_class($notification),
@@ -26,6 +27,6 @@ class NotificationDatabaseChannelTest extends PHPUnit_Framework_TestCase
         ]);
 
         $channel = new DatabaseChannel;
-        $channel->send($notifiables, $notification);
+        $channel->send($notifiables, $message);
     }
 }

--- a/tests/Notifications/NotificationDatabaseChannelTest.php
+++ b/tests/Notifications/NotificationDatabaseChannelTest.php
@@ -17,7 +17,7 @@ class NotificationDatabaseChannelTest extends PHPUnit_Framework_TestCase
         $message = new Message($notifiable, new Notification);
 
         $notifiable->shouldReceive('routeNotificationFor->create')->with([
-            'type' => get_class($notification),
+            'type' => get_class($message->notification),
             'level' => 'info',
             'intro' => [],
             'outro' => [],

--- a/tests/Notifications/NotificationMailChannelTest.php
+++ b/tests/Notifications/NotificationMailChannelTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Notifications\Message;
 use Illuminate\Notifications\Notification;
 
 class NotificationMailChannelTest extends PHPUnit_Framework_TestCase
@@ -11,12 +12,12 @@ class NotificationMailChannelTest extends PHPUnit_Framework_TestCase
 
     public function testMailIsSentByChannel()
     {
-        $notification = new Notification;
         $notifiables = collect([
             $notifiable = new NotificationMailChannelTestNotifiable,
         ]);
+        $message = new Message($notifiable, new Notification);
 
-        $array = $notification->toArray();
+        $array = $message->toArray();
         $array['actionColor'] = 'blue';
 
         $channel = new Illuminate\Notifications\Channels\MailChannel(
@@ -25,7 +26,7 @@ class NotificationMailChannelTest extends PHPUnit_Framework_TestCase
 
         $mailer->shouldReceive('send')->with('notifications::email', $array, Mockery::type('Closure'));
 
-        $channel->send($notifiables, $notification);
+        $channel->send($notifiables, $message);
     }
 }
 

--- a/tests/Notifications/NotificationNexmoChannelTest.php
+++ b/tests/Notifications/NotificationNexmoChannelTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Notifications\Message;
 use Illuminate\Notifications\Notification;
 
 class NotificationNexmoChannelTest extends PHPUnit_Framework_TestCase
@@ -11,15 +12,15 @@ class NotificationNexmoChannelTest extends PHPUnit_Framework_TestCase
 
     public function testSmsIsSentViaNexmo()
     {
-        $notification = new Notification;
         $notifiables = collect([
             $notifiable = new NotificationNexmoChannelTestNotifiable,
         ]);
+        $message = new Message($notifiable, new Notification);
 
-        $notification->introLines = ['line 1'];
-        $notification->actionText = 'Text';
-        $notification->actionUrl = 'url';
-        $notification->outroLines = ['line 2'];
+        $message->introLines = ['line 1'];
+        $message->actionText = 'Text';
+        $message->actionUrl = 'url';
+        $message->outroLines = ['line 2'];
 
         $channel = new Illuminate\Notifications\Channels\NexmoSmsChannel(
             $nexmo = Mockery::mock(Nexmo\Client::class), '4444444444'
@@ -35,7 +36,7 @@ Text: url
 line 2',
         ]);
 
-        $channel->send($notifiables, $notification);
+        $channel->send($notifiables, $message);
     }
 }
 

--- a/tests/Notifications/NotificationNotificationTest.php
+++ b/tests/Notifications/NotificationNotificationTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Notifications\Message;
 use Illuminate\Notifications\Notification;
 
 class NotificationNotificationTest extends PHPUnit_Framework_TestCase
@@ -16,21 +17,21 @@ class NotificationNotificationTest extends PHPUnit_Framework_TestCase
 
     public function testChannelNotificationFormatsMultiLineText()
     {
-        $notification = new Notification([]);
-        $notification->with('
+        $message = new Message(null, new Notification([]));
+        $message->with('
             This is a
             single line of text.
         ');
 
-        $this->assertEquals('This is a single line of text.', $notification->introLines[0]);
+        $this->assertEquals('This is a single line of text.', $message->introLines[0]);
 
-        $notification = new Notification([]);
-        $notification->with([
+        $message = new Message(null, new Notification([]));
+        $message->with([
             'This is a',
             'single line of text.',
         ]);
 
-        $this->assertEquals('This is a single line of text.', $notification->introLines[0]);
+        $this->assertEquals('This is a single line of text.', $message->introLines[0]);
     }
 }
 

--- a/tests/Notifications/NotificationSlackChannelTest.php
+++ b/tests/Notifications/NotificationSlackChannelTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Notifications\Message;
 use Illuminate\Notifications\Notification;
 
 class NotificationSlackChannelTest extends PHPUnit_Framework_TestCase
@@ -11,17 +12,17 @@ class NotificationSlackChannelTest extends PHPUnit_Framework_TestCase
 
     public function testCorrectPayloadIsSentToSlack()
     {
-        $notification = new Notification;
         $notifiables = collect([
             $notifiable = new NotificationSlackChannelTestNotifiable,
         ]);
+        $message = new Message($notifiable, new Notification);
 
-        $notification->subject = 'Subject';
-        $notification->level = 'success';
-        $notification->introLines = ['line 1'];
-        $notification->actionText = 'Text';
-        $notification->actionUrl = 'url';
-        $notification->outroLines = ['line 2'];
+        $message->subject = 'Subject';
+        $message->success();
+        $message->introLines = ['line 1'];
+        $message->actionText = 'Text';
+        $message->actionUrl = 'url';
+        $message->outroLines = ['line 2'];
 
         $channel = new Illuminate\Notifications\Channels\SlackWebhookChannel(
             $http = Mockery::mock('GuzzleHttp\Client')
@@ -44,7 +45,7 @@ line 2',
             ],
         ]);
 
-        $channel->send($notifiables, $notification);
+        $channel->send($notifiables, $message);
     }
 }
 


### PR DESCRIPTION
This would allow user to customize message for each notifiable.

The main idea with this is to allow user to customise message send to each users (`notifiables`). Without this we can only send generic message for every users. This also clean-up some of the old unusable code from the last notifications refactors.

Signed-off-by: crynobone crynobone@gmail.com
