### PR TITLE
[5.3] Allow to pass multiple arguments to Authorize

### DIFF
--- a/src/Illuminate/Auth/Middleware/Authorize.php
+++ b/src/Illuminate/Auth/Middleware/Authorize.php
@@ -41,17 +41,17 @@ class Authorize
      * @param  \Illuminate\Http\Request  $request
      * @param  \Closure  $next
      * @param  string  $ability
-     * @param  string|null  $model
+     * @param  array|null  $models
      * @return mixed
      *
      * @throws \Illuminate\Auth\Access\AuthenticationException
      * @throws \Illuminate\Auth\Access\AuthorizationException
      */
-    public function handle($request, Closure $next, $ability, $model = null)
+    public function handle($request, Closure $next, $ability, ...$models)
     {
         $this->auth->authenticate();
 
-        $this->gate->authorize($ability, $this->getGateArguments($request, $model));
+        $this->gate->authorize($ability, $this->getGateArguments($request, $models));
 
         return $next($request);
     }
@@ -60,12 +60,21 @@ class Authorize
      * Get the arguments parameter for the gate.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @param  string|null  $model
+     * @param  array|null  $models
      * @return array|string|\Illuminate\Database\Eloquent\Model
      */
-    protected function getGateArguments($request, $model)
+    protected function getGateArguments($request, $models)
     {
-        return is_null($model) ? [] : $this->getModel($request, $model);
+        if (is_null($models)) {
+            return [];
+        }
+
+        $gate_args = [];
+        foreach ($models as $model) {
+            $gate_args[] = $this->getModel($request, $model);
+        }
+
+        return $gate_args;
     }
 
     /**


### PR DESCRIPTION
This issue was closed because it needed to go into 5.3. So a new pull request with the same functionality:
https://github.com/laravel/framework/pull/14168

I have a situation where I have a policy where user X is allowed to do an action on user Y only if user X has a specific role and user Y has a relation to user X. So for this policy I need both objects.

My url is: user/{user}/disconnect/{professional}

So I have this for a route (I'm using laravel collective annotations):

```
    /**
     * @Get("{user}/disconnect/{professional}", as="users.disconnectProfessional")
     * @Middleware("can:disconnect-professional,user,professional")
     */
```

As far as I've tried it's not possible to do this with the current Authorize middleware. Therefore my patch.
