### PR TITLE
[5.2] Fix missing makeHidden method in Model.php

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2141,6 +2141,23 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     }
 
     /**
+     * Make the given, typically visible, attributes hidden.
+     *
+     * @param  array|string  $attributes
+     * @return $this
+     */
+    public function makeHidden($attributes)
+    {
+        $this->visible = array_diff($this->visible, (array) $attributes);
+
+        if (! empty($this->hidden)) {
+            $this->addHidden($attributes);
+        }
+
+        return $this;
+    }
+
+    /**
      * Make the given, typically hidden, attributes visible.
      *
      * @param  array|string  $attributes


### PR DESCRIPTION
The documentation references this method but it doesn't seem to exist (https://laravel.com/docs/5.2/eloquent-serialization#hiding-attributes-from-json) 
Tested and implemented this in my current project.
I hope this is useful and i am not missing something. 
If i am please let me know :)
