### PR TITLE
[5.2] Added wherelike method to query builder

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1001,6 +1001,38 @@ class Builder
     }
 
     /**
+     * Add a "where like" clause to the query.
+     *
+     * @param string $column
+     * @param string $operator
+     * @param string $value
+     * @return $this
+     */
+    public function whereLike($column, $operator, $value = null)
+    {
+        if (func_num_args() === 2) {
+            list($value, $operator) = [$operator, 'like'];
+        }
+
+        if ($this->valueHasWildcard($value)) {
+            return $this->where($column, $operator, $value);
+        }
+
+        return $this->where($column, $operator, '%' . $value . '%');
+    }
+
+    /**
+     * Check to see if a query value has a wildcard.
+     *
+     * @param string $value
+     * @return bool
+     */
+    protected function valueHasWildcard($value)
+    {
+        return false != strpos($value, '%');
+    }
+
+    /**
      * Add a "where null" clause to the query.
      *
      * @param  string  $column

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -143,6 +143,27 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase
         $this->assertEquals([0 => 1], $builder->getBindings());
     }
 
+    public function testWhereLike()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereLike('name', 'test');
+        
+        $this->assertEquals('select * from "users" where "name" like ?', $builder->toSql());
+        $this->assertEquals([0 => '%test%'], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereLike('name', 'test%');
+        
+        $this->assertEquals('select * from "users" where "name" like ?', $builder->toSql());
+        $this->assertEquals([0 => 'test%'], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereLike('name', 'not like', 'test');
+        
+        $this->assertEquals('select * from "users" where "name" not like ?', $builder->toSql());
+        $this->assertEquals([0 => '%test%'], $builder->getBindings());
+    }
+
     public function testMySqlWrappingProtectsQuotationMarks()
     {
         $builder = $this->getMySqlBuilder();


### PR DESCRIPTION
Any chance of getting something like this merged? 

I know doing something like `where('name', 'like', '%jordan%')` isn't bad at all, but I think writing something like `whereLike('name', 'jordan')` is a bit cleaner, which would result in `where name like '%jordan%'`.

Also if its something you think is a good addition I can add it to Eloquent's builder as well!
