### PR TITLE
[5.3] Validate digits only for digits & digits_between validation rules

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1149,7 +1149,7 @@ class Validator implements ValidatorContract
     {
         $this->requireParameterCount(1, $parameters, 'digits');
 
-        return $this->validateNumeric($attribute, $value)
+        return ! preg_match('/[^0-9]/', $value)
             && strlen((string) $value) == $parameters[0];
     }
 
@@ -1167,7 +1167,7 @@ class Validator implements ValidatorContract
 
         $length = strlen((string) $value);
 
-        return $this->validateNumeric($attribute, $value)
+        return ! preg_match('/[^0-9]/', $value)
           && $length >= $parameters[0] && $length <= $parameters[1];
     }
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1016,6 +1016,12 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $v = new Validator($trans, ['foo' => '123'], ['foo' => 'Digits:200']);
         $this->assertFalse($v->passes());
 
+        $v = new Validator($trans, ['foo' => '+2.37'], ['foo' => 'Digits:5']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['foo' => '2e7'], ['foo' => 'Digits:3']);
+        $this->assertTrue($v->fails());
+
         $trans = $this->getRealTranslator();
         $v = new Validator($trans, ['foo' => '12345'], ['foo' => 'digits_between:1,6']);
         $this->assertTrue($v->passes());
@@ -1024,6 +1030,9 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $this->assertFalse($v->passes());
 
         $v = new Validator($trans, ['foo' => '123'], ['foo' => 'digits_between:4,5']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => '+12.3'], ['foo' => 'digits_between:1,6']);
         $this->assertFalse($v->passes());
     }
 


### PR DESCRIPTION
As addressed here: https://github.com/laravel/framework/issues/14647

The digits and digits_between validation rules would pass the values like `+2.37` & `2e7` since it uses `is_numeric` to validate the value.
