### PR TITLE
[5.4] Allow query data to be passed into "get" request method.

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -100,6 +100,7 @@ trait MakesHttpRequests
      * Visit the given URI with a GET request.
      *
      * @param  string  $uri
+     * @param  array  $data
      * @param  array  $headers
      * @return $this
      */

--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -103,11 +103,11 @@ trait MakesHttpRequests
      * @param  array  $headers
      * @return $this
      */
-    public function get($uri, array $headers = [])
+    public function get($uri, array $data = [], array $headers = [])
     {
         $server = $this->transformHeadersToServerVars($headers);
 
-        $this->call('GET', $uri, [], [], [], $server);
+        $this->call('GET', $uri, $data, [], [], $server);
 
         return $this;
     }


### PR DESCRIPTION
I found myself doing this often:

``` php
$this->get('/api/item?' . http_build_query($data));
```

I would rather do this (like you do in a post request)

``` php
$this->get('/api/item', $data);
```
