### PR TITLE
[5.3] Fix undefined variable: request

### DIFF
--- a/src/Illuminate/Foundation/Auth/ResetsPasswords.php
+++ b/src/Illuminate/Foundation/Auth/ResetsPasswords.php
@@ -54,7 +54,7 @@ trait ResetsPasswords
         // redirect them back to where they came from with their error message.
         return $response == Password::PASSWORD_RESET
                     ? $this->sendResetResponse($response)
-                    : $this->sendResetFailedResponse($response);
+                    : $this->sendResetFailedResponse($request, $response);
     }
 
     /**
@@ -102,10 +102,11 @@ trait ResetsPasswords
     /**
      * Get the response for a failed password reset.
      *
+     * @param  \Illuminate\Http\Request
      * @param  string  $response
      * @return \Illuminate\Http\Response
      */
-    protected function sendResetFailedResponse($response)
+    protected function sendResetFailedResponse(Request $request, $response)
     {
         return redirect()->back()
                     ->withInput($request->only('email'))


### PR DESCRIPTION
Injected `Illuminate\Http\Request` in `sendResetFailedResponse()` method.
