### PR TITLE
[5.2] support dot notation in Request::exists()

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -271,7 +271,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
         $input = $this->all();
 
         foreach ($keys as $value) {
-            if (! array_key_exists($value, $input)) {
+            if (! Arr::has($input, $value)) {
                 return false;
             }
         }

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -198,6 +198,10 @@ class HttpRequestTest extends PHPUnit_Framework_TestCase
         $request = Request::create('/', 'GET', ['foo' => '', 'bar' => null]);
         $this->assertTrue($request->exists('foo'));
         $this->assertTrue($request->exists('bar'));
+
+        $request = Request::create('/', 'GET', ['foo' => ['bar' => null, 'baz' => '']]);
+        $this->assertTrue($request->exists('foo.bar'));
+        $this->assertTrue($request->exists('foo.baz'));
     }
 
     public function testHasMethod()
@@ -214,6 +218,9 @@ class HttpRequestTest extends PHPUnit_Framework_TestCase
         //test arrays within query string
         $request = Request::create('/', 'GET', ['foo' => ['bar', 'baz']]);
         $this->assertTrue($request->has('foo'));
+
+        $request = Request::create('/', 'GET', ['foo' => ['bar' => 'baz']]);
+        $this->assertTrue($request->has('foo.bar'));
     }
 
     public function testInputMethod()


### PR DESCRIPTION
`Request::has()` supports dot notation already while `Request::exists()` does not. This PR adds dot notation support to `exists()`.

https://github.com/laravel/framework/issues/14643
