### PR TITLE
[5.3] $request is not defined

### DIFF
--- a/src/Illuminate/Foundation/Auth/ResetsPasswords.php
+++ b/src/Illuminate/Foundation/Auth/ResetsPasswords.php
@@ -108,7 +108,7 @@ trait ResetsPasswords
     protected function sendResetFailedResponse($response)
     {
         return redirect()->back()
-                    ->withInput($request->only('email'))
+                    ->withInput(\Request::only('email'))
                     ->withErrors(['email' => trans($response)]);
     }
 


### PR DESCRIPTION
Inside `sendResetFailedResponse($response)` function `$response` is not defined! Workaround is using static \Request Facade.
