### PR TITLE
[5.3] Remove getRouteKeyName() from UrlRoutable interface

### DIFF
--- a/src/Illuminate/Contracts/Routing/UrlRoutable.php
+++ b/src/Illuminate/Contracts/Routing/UrlRoutable.php
@@ -10,11 +10,4 @@ interface UrlRoutable
      * @return mixed
      */
     public function getRouteKey();
-
-    /**
-     * Get the route key for the model.
-     *
-     * @return string
-     */
-    public function getRouteKeyName();
 }


### PR DESCRIPTION
It does not make much sense to have this `getRouteKeyName()` method on the `UrlRoutable` interface. It is convenient to have this method on the Eloquent's `Model` class to be able to specify a route key attribute, but it does not belong to the `UrlRoutable` interface.

I stumbled on this when I wanted to make a non-Eloquent class UrlRoutable. My current implementation returns the desired string from `getRouteKey()` and `getRouteKeyName() {}` is just empty. I am forced to add this method because of the interface. This is of course not ideal.

Note that the only usage of `getRouteKeyName()` is in Eloquent's `Model::getRouteKey()`, so this removal does not break things.
