### PR TITLE
[5.3] Create an abstract HTTP channel

### DIFF
--- a/src/Illuminate/Notifications/Channels/HttpChannel.php
+++ b/src/Illuminate/Notifications/Channels/HttpChannel.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Illuminate\Notifications\Channels;
+
+use GuzzleHttp\Client as HttpClient;
+use Illuminate\Notifications\Notification;
+
+abstract class HttpChannel
+{
+    /**
+     * The HTTP client instance.
+     *
+     * @var \GuzzleHttp\Client
+     */
+    protected $http;
+
+    /**
+     * Create a new Slack channel instance.
+     *
+     * @param  \GuzzleHttp\Client  $http
+     * @return void
+     */
+    public function __construct(HttpClient $http)
+    {
+        $this->http = $http;
+    }
+
+    /**
+     * Send the given notification.
+     *
+     * @param  mixed  $notifiable
+     * @param  \Illuminate\Notifications\Notification  $notification
+     * @return void
+     */
+    abstract public function send($notifiable, Notification $notification);
+}

--- a/src/Illuminate/Notifications/Channels/SlackWebhookChannel.php
+++ b/src/Illuminate/Notifications/Channels/SlackWebhookChannel.php
@@ -2,31 +2,12 @@
 
 namespace Illuminate\Notifications\Channels;
 
-use GuzzleHttp\Client as HttpClient;
 use Illuminate\Notifications\Notification;
 use Illuminate\Notifications\Messages\SlackMessage;
 use Illuminate\Notifications\Messages\SlackAttachment;
 
-class SlackWebhookChannel
+class SlackWebhookChannel extends HttpChannel
 {
-    /**
-     * The HTTP client instance.
-     *
-     * @var \GuzzleHttp\Client
-     */
-    protected $http;
-
-    /**
-     * Create a new Slack channel instance.
-     *
-     * @param  \GuzzleHttp\Client  $http
-     * @return void
-     */
-    public function __construct(HttpClient $http)
-    {
-        $this->http = $http;
-    }
-
     /**
      * Send the given notification.
      *


### PR DESCRIPTION
Extract Slack HTTP to an abstract HTTP channel.
This allows to implement other HTTP-related driver (which are many)
