### PR TITLE
[5.3] Refactor away from call_user_func[_array] in stack sensitive areas

### DIFF
--- a/src/Illuminate/Pipeline/Pipeline.php
+++ b/src/Illuminate/Pipeline/Pipeline.php
@@ -116,7 +116,7 @@ class Pipeline implements PipelineContract
                     // If the pipe is an instance of a Closure, we will just call it directly but
                     // otherwise we'll resolve the pipes out of the container and call it with
                     // the appropriate method and arguments, returning the results back out.
-                    return call_user_func($pipe, $passable, $stack);
+                    return $pipe($passable, $stack);
                 } elseif (! is_object($pipe)) {
                     list($name, $parameters) = $this->parsePipeString($pipe);
 
@@ -133,14 +133,7 @@ class Pipeline implements PipelineContract
                     $parameters = [$passable, $stack];
                 }
 
-                switch (count($parameters)) {
-                    case 0: return $pipe->{$this->method}();
-                    case 1: return $pipe->{$this->method}($parameters[0]);
-                    case 2: return $pipe->{$this->method}($parameters[0], $parameters[1]);
-                    case 3: return $pipe->{$this->method}($parameters[0], $parameters[1], $parameters[2]);
-                    case 4: return $pipe->{$this->method}($parameters[0], $parameters[1], $parameters[2], $parameters[3]);
-                    default: return call_user_func_array([$pipe, $this->method], $parameters);
-                }
+                return $pipe->{$this->method}(...$parameters);
             };
         };
     }
@@ -154,7 +147,7 @@ class Pipeline implements PipelineContract
     protected function getInitialSlice(Closure $destination)
     {
         return function ($passable) use ($destination) {
-            return call_user_func($destination, $passable);
+            return $destination($passable);
         };
     }
 

--- a/src/Illuminate/Pipeline/Pipeline.php
+++ b/src/Illuminate/Pipeline/Pipeline.php
@@ -98,8 +98,8 @@ class Pipeline implements PipelineContract
         $firstSlice = $this->getInitialSlice($destination);
 
         $pipes = array_reverse($this->pipes);
-
         $callable = array_reduce($pipes, $this->getSlice(), $firstSlice);
+
         return $callable($this->passable);
     }
 

--- a/src/Illuminate/Pipeline/Pipeline.php
+++ b/src/Illuminate/Pipeline/Pipeline.php
@@ -99,9 +99,8 @@ class Pipeline implements PipelineContract
 
         $pipes = array_reverse($this->pipes);
 
-        return call_user_func(
-            array_reduce($pipes, $this->getSlice(), $firstSlice), $this->passable
-        );
+        $callable = array_reduce($pipes, $this->getSlice(), $firstSlice);
+        return $callable($this->passable);
     }
 
     /**
@@ -134,7 +133,14 @@ class Pipeline implements PipelineContract
                     $parameters = [$passable, $stack];
                 }
 
-                return call_user_func_array([$pipe, $this->method], $parameters);
+                switch (count($parameters)) {
+                    case 0: return $pipe->{$this->method}();
+                    case 1: return $pipe->{$this->method}($parameters[0]);
+                    case 2: return $pipe->{$this->method}($parameters[0], $parameters[1]);
+                    case 3: return $pipe->{$this->method}($parameters[0], $parameters[1], $parameters[2]);
+                    case 4: return $pipe->{$this->method}($parameters[0], $parameters[1], $parameters[2], $parameters[3]);
+                    default: return call_user_func_array([$pipe, $this->method], $parameters);
+                }
             };
         };
     }

--- a/src/Illuminate/Routing/Pipeline.php
+++ b/src/Illuminate/Routing/Pipeline.php
@@ -29,6 +29,7 @@ class Pipeline extends BasePipeline
                 try {
                     $slice = parent::getSlice();
                     $callable = $slice($stack, $pipe);
+
                     return $callable($passable);
                 } catch (Exception $e) {
                     return $this->handleException($passable, $e);

--- a/src/Illuminate/Routing/Pipeline.php
+++ b/src/Illuminate/Routing/Pipeline.php
@@ -28,8 +28,8 @@ class Pipeline extends BasePipeline
             return function ($passable) use ($stack, $pipe) {
                 try {
                     $slice = parent::getSlice();
-
-                    return call_user_func($slice($stack, $pipe), $passable);
+                    $callable = $slice($stack, $pipe);
+                    return $callable($passable);
                 } catch (Exception $e) {
                     return $this->handleException($passable, $e);
                 } catch (Throwable $e) {
@@ -49,7 +49,7 @@ class Pipeline extends BasePipeline
     {
         return function ($passable) use ($destination) {
             try {
-                return call_user_func($destination, $passable);
+                return $destination($passable);
             } catch (Exception $e) {
                 return $this->handleException($passable, $e);
             } catch (Throwable $e) {

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -171,7 +171,16 @@ class Route
             $this->parametersWithoutNulls(), new ReflectionFunction($this->action['uses'])
         );
 
-        return call_user_func_array($this->action['uses'], $parameters);
+        $callable = $this->action['uses'];
+        $parameters = array_values($parameters);
+        switch (count($parameters)) {
+            case 0: return $callable();
+            case 1: return $callable($parameters[0]);
+            case 2: return $callable($parameters[0], $parameters[1]);
+            case 3: return $callable($parameters[0], $parameters[1], $parameters[2]);
+            case 4: return $callable($parameters[0], $parameters[1], $parameters[2], $parameters[3]);
+            default: return call_user_func_array($callable, $parameters);
+        }
     }
 
     /**

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -172,6 +172,7 @@ class Route
         );
 
         $callable = $this->action['uses'];
+
         return $callable(...array_values($parameters));
     }
 

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -172,15 +172,7 @@ class Route
         );
 
         $callable = $this->action['uses'];
-        $parameters = array_values($parameters);
-        switch (count($parameters)) {
-            case 0: return $callable();
-            case 1: return $callable($parameters[0]);
-            case 2: return $callable($parameters[0], $parameters[1]);
-            case 3: return $callable($parameters[0], $parameters[1], $parameters[2]);
-            case 4: return $callable($parameters[0], $parameters[1], $parameters[2], $parameters[3]);
-            default: return call_user_func_array($callable, $parameters);
-        }
+        return $callable(...array_values($parameters));
     }
 
     /**


### PR DESCRIPTION
Instead of calling a function (`call_user_func` & `call_user_func_array`), call the target callable directly.  This has the benefit of tightening up the stack trace making it easier to read through. At current, introducing a middleware to the pipeline requires 5 function calls to dispatch and unravel the remaining pipelined middlewares.  This patch reduces the number of function calls required to 3 per middleware.  This could potentially have the side-effect of being a micro-optimization, but that is not the intent.

As an example, throw an exception from the Hello World controller.  At this point in the default dispatch cycle, the controller is 55 frames deep.  After this change, we've reduced the stack from 55 to 36 frames.  Essentially, every new Middleware that is introduced before the RouteServiceProvider/dispatcher will require 5 function calls currently, and only 3 after. Images attached...

Before:
![framework-stacktrace-small](https://cloud.githubusercontent.com/assets/76674/17459069/8b4a6c0c-5bf0-11e6-866f-cecd4844a733.jpg)

After:
![framework-stacktrace-after-small](https://cloud.githubusercontent.com/assets/76674/17459072/9f2446bc-5bf0-11e6-8bee-0f1e586b3ac2.jpg)
