### PR TITLE
[5.2] Checks if is an accessible array

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -301,7 +301,7 @@ class Arr
      */
     public static function has($array, $key)
     {
-        if (! $array) {
+        if (! static::accessible($array)) {
             return false;
         }
 

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -238,6 +238,7 @@ class SupportArrTest extends PHPUnit_Framework_TestCase
 
         $this->assertFalse(Arr::has(null, 'foo'));
         $this->assertFalse(Arr::has(false, 'foo'));
+        $this->assertFalse(Arr::has(true, 'foo'));
 
         $this->assertFalse(Arr::has(null, null));
         $this->assertFalse(Arr::has([], null));


### PR DESCRIPTION
This ensures that the input is an accessible array.

The method returned an exception when my entry resulted in true:

``` php
Arr::has(true, 'something')
```
