### PR TITLE
[5.3] Return new exception

### DIFF
--- a/src/Illuminate/Database/Eloquent/RelationNotFoundException.php
+++ b/src/Illuminate/Database/Eloquent/RelationNotFoundException.php
@@ -17,6 +17,6 @@ class RelationNotFoundException extends RuntimeException
     {
         $class = get_class($model);
 
-        throw new static("Call to undefined relationship [{$relation}] on model [{$class}].");
+        return new static("Call to undefined relationship [{$relation}] on model [{$class}].");
     }
 }


### PR DESCRIPTION
A named constructor shouldn't throw an exception. The caller should throw it, and [it does](https://github.com/laravel/framework/blob/5.3/src/Illuminate/Database/Eloquent/Builder.php#L684).
