### PR TITLE
[5.3] test and fix RedisQueue::size() by using zcard and eval

### DIFF
--- a/src/Illuminate/Queue/LuaScripts.php
+++ b/src/Illuminate/Queue/LuaScripts.php
@@ -56,4 +56,16 @@ end
 return true
 LUA;
     }
+
+    /**
+     * Get the Lua script for computing the size of queue.
+     *
+     * @return string
+     */
+    public static function size()
+    {
+        return <<<'LUA'
+return redis.call('llen', KEYS[1]) + redis.call('zcard', KEYS[1]..':delayed') + redis.call('zcard', KEYS[1]..':reserved')
+LUA;
+    }
 }

--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -66,9 +66,7 @@ class RedisQueue extends Queue implements QueueContract
     {
         $queue = $this->getQueue($queue);
 
-        return $this->getConnection()->llen($queue)
-            + $this->getConnection()->llen($queue.':delayed')
-            + $this->getConnection()->llen($queue.':reserved');
+        return $this->getConnection()->eval(LuaScripts::size(), 1, $queue);
     }
 
     /**

--- a/tests/Queue/RedisQueueIntegrationTest.php
+++ b/tests/Queue/RedisQueueIntegrationTest.php
@@ -263,6 +263,21 @@ class RedisQueueIntegrationTest extends PHPUnit_Framework_TestCase
 
         $this->assertNull($this->queue->pop());
     }
+
+    public function testSize()
+    {
+        $this->assertEquals(0, $this->queue->size());
+        $this->queue->push(new RedisQueueIntegrationTestJob(1));
+        $this->assertEquals(1, $this->queue->size());
+        $this->queue->later(60, new RedisQueueIntegrationTestJob(2));
+        $this->assertEquals(2, $this->queue->size());
+        $this->queue->push(new RedisQueueIntegrationTestJob(3));
+        $this->assertEquals(3, $this->queue->size());
+        $job = $this->queue->pop();
+        $this->assertEquals(3, $this->queue->size());
+        $job->delete();
+        $this->assertEquals(2, $this->queue->size());
+    }
 }
 
 class RedisQueueIntegrationTestJob


### PR DESCRIPTION
Using llen for delayed and reserved queue would throw exception.
eval makes the computations atomic and exact.
