### PR TITLE
[5.3] Increase the default redis timeout

### DIFF
--- a/src/Illuminate/Redis/Database.php
+++ b/src/Illuminate/Redis/Database.php
@@ -26,7 +26,7 @@ class Database implements DatabaseContract
     {
         $cluster = Arr::pull($servers, 'cluster');
 
-        $options = (array) Arr::pull($servers, 'options');
+        $options = array_merge(['timeout' => 10.0], (array) Arr::pull($servers, 'options'));
 
         if ($cluster) {
             $this->clients = $this->createAggregateClient($servers, $options);


### PR DESCRIPTION
This increases it from 5 to 10 seconds. Particularly useful when you have a busy server processing a boat load of queue jobs.
