### PR TITLE
[5.3] Fail-safing Queue's Predis/Redis Unit Tests & Move to phpunit.xml.dist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ composer.lock
 .php_cs.cache
 .DS_Store
 Thumbs.db
+/phpunit.xml

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -26,4 +26,10 @@
             </exclude>
         </whitelist>
     </filter>
+    <php>
+      <!--
+      <env name="REDIS_HOST" value="127.0.0.1" />
+      <env name="REDIS_PORT" value="6379" />
+      -->
+    </php>
 </phpunit>

--- a/tests/Queue/RedisQueueIntegrationTest.php
+++ b/tests/Queue/RedisQueueIntegrationTest.php
@@ -21,11 +21,18 @@ class RedisQueueIntegrationTest extends PHPUnit_Framework_TestCase
     public function setUp()
     {
         parent::setUp();
+        
+        $host = getenv('REDIS_HOST');
+        $port = getenv('REDIS_PORT');
+        if (!$host) {
+            $this->markTestSkipped('Set environment variable REDIS_HOST & REDIS_PORT to enable ' . __CLASS__);
+            return;
+        }
         $this->redis = new Database([
             'cluster' => false,
             'default' => [
-                'host' => '127.0.0.1',
-                'port' => 6379,
+                'host' => $host,
+                'port' => $port,
                 'database' => 5,
             ],
         ]);
@@ -39,7 +46,10 @@ class RedisQueueIntegrationTest extends PHPUnit_Framework_TestCase
     {
         parent::tearDown();
         m::close();
-        $this->redis->connection()->flushdb();
+        if ($this->redis) {
+            $this->redis->connection()->flushdb();            
+        }
+
     }
 
     public function testExpiredJobsArePopped()

--- a/tests/Queue/RedisQueueIntegrationTest.php
+++ b/tests/Queue/RedisQueueIntegrationTest.php
@@ -9,6 +9,11 @@ use Illuminate\Queue\Jobs\RedisJob;
 class RedisQueueIntegrationTest extends PHPUnit_Framework_TestCase
 {
     /**
+     * @var bool
+     */
+    private static $connectionFailedOnceWithDefaultsSkip = false;
+
+    /**
      * @var Database
      */
     private $redis;
@@ -21,22 +26,34 @@ class RedisQueueIntegrationTest extends PHPUnit_Framework_TestCase
     public function setUp()
     {
         parent::setUp();
-        
-        $host = getenv('REDIS_HOST');
-        $port = getenv('REDIS_PORT');
-        if (!$host) {
-            $this->markTestSkipped('Set environment variable REDIS_HOST & REDIS_PORT to enable ' . __CLASS__);
+
+        $host = getenv('REDIS_HOST') ?: '127.0.0.1';
+        $port = getenv('REDIS_PORT') ?: 6379;
+
+        if (static::$connectionFailedOnceWithDefaultsSkip) {
+            $this->markTestSkipped('Trying default host/port failed, please set environment variable REDIS_HOST & REDIS_PORT to enable ' . __CLASS__);
             return;
         }
+
         $this->redis = new Database([
             'cluster' => false,
             'default' => [
                 'host' => $host,
                 'port' => $port,
                 'database' => 5,
+                'timeout' => 0.5
             ],
         ]);
-        $this->redis->connection()->flushdb();
+
+        try {
+            $this->redis->connection()->flushdb();
+        } catch (\Exception $e) {
+            if ($host === '127.0.0.1' && $port === 6379 && getenv('REDIS_HOST') === false) {
+                $this->markTestSkipped('Trying default host/port failed, please set environment variable REDIS_HOST & REDIS_PORT to enable ' . __CLASS__);
+                static::$connectionFailedOnceWithDefaultsSkip = true;
+                return;
+            }
+        }
 
         $this->queue = new RedisQueue($this->redis);
         $this->queue->setContainer(m::mock(Container::class));

--- a/tests/Queue/RedisQueueIntegrationTest.php
+++ b/tests/Queue/RedisQueueIntegrationTest.php
@@ -31,7 +31,8 @@ class RedisQueueIntegrationTest extends PHPUnit_Framework_TestCase
         $port = getenv('REDIS_PORT') ?: 6379;
 
         if (static::$connectionFailedOnceWithDefaultsSkip) {
-            $this->markTestSkipped('Trying default host/port failed, please set environment variable REDIS_HOST & REDIS_PORT to enable ' . __CLASS__);
+            $this->markTestSkipped('Trying default host/port failed, please set environment variable REDIS_HOST & REDIS_PORT to enable '.__CLASS__);
+
             return;
         }
 
@@ -41,7 +42,7 @@ class RedisQueueIntegrationTest extends PHPUnit_Framework_TestCase
                 'host' => $host,
                 'port' => $port,
                 'database' => 5,
-                'timeout' => 0.5
+                'timeout' => 0.5,
             ],
         ]);
 
@@ -49,8 +50,9 @@ class RedisQueueIntegrationTest extends PHPUnit_Framework_TestCase
             $this->redis->connection()->flushdb();
         } catch (\Exception $e) {
             if ($host === '127.0.0.1' && $port === 6379 && getenv('REDIS_HOST') === false) {
-                $this->markTestSkipped('Trying default host/port failed, please set environment variable REDIS_HOST & REDIS_PORT to enable ' . __CLASS__);
+                $this->markTestSkipped('Trying default host/port failed, please set environment variable REDIS_HOST & REDIS_PORT to enable '.__CLASS__);
                 static::$connectionFailedOnceWithDefaultsSkip = true;
+
                 return;
             }
         }
@@ -64,9 +66,8 @@ class RedisQueueIntegrationTest extends PHPUnit_Framework_TestCase
         parent::tearDown();
         m::close();
         if ($this->redis) {
-            $this->redis->connection()->flushdb();            
+            $this->redis->connection()->flushdb();
         }
-
     }
 
     public function testExpiredJobsArePopped()


### PR DESCRIPTION
First, if there is anything in this PR that goes against project philosophy, I won't feel bad if you close it without further consideration.  That said:

It would be nice if out-the-box the framework's unit tests passed without errors, instead using test skipping with an appropriate skip message.  Test skips are currently used for Cache Memcached tests when Memcache is not currently available, so I think it might be appropriate to do the same thing for Predis/Redis.  It would also be nice to use the phpunit supported methodology for allowing developers to have custom configurations (project commits phpunit.xml.dist, and ignores phpunit.xml which is used locally).

This PR:
- moves phpunit.xml -> phpunit.xml.dist (fully phpunit supported)
- adds Redis environment variables to phpunit.xml.dist which are commented out by default
- adds a one-time connection check to the Queue Redis integration check when default values are used (remainder of connection attempts will be skipped
- adds a 0.5 timeout to Predis client (tests should be fast-ish)
