### PR TITLE
[5.2] Image orientation validation rule

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1898,6 +1898,43 @@ class Validator implements ValidatorContract
     }
 
     /**
+     * Validate that an image is a valid orientation.
+     *
+     * @param  string  $attribute
+     * @param  mixed   $value
+     * @param  array   $parameters
+     * @return bool
+     *
+     * @throws \InvalidArgumentException
+     */
+    protected function validateOrientation($attribute, $value, $parameters)
+    {
+        if (! $this->isAValidFileInstance($value) || ! $sizeDetails = getimagesize($value->getRealPath())) {
+            return false;
+        }
+
+        if (empty($parameters)) {
+            throw new InvalidArgumentException('Validation rule orientation requires 1 parameter.');
+        }
+
+        list($width, $height) = $sizeDetails;
+
+        switch ($orientation = strtolower($parameters[0])) {
+            case 'landscape':
+                return $width > $height;
+
+            case 'portrait':
+                return $width < $height;
+
+            case 'square':
+                return $width === $height;
+
+            default:
+                throw new InvalidArgumentException("Invalid orientation [$orientation]");
+        }
+    }
+
+    /**
      * Get the date format for an attribute if it has one.
      *
      * @param  string  $attribute
@@ -2506,6 +2543,20 @@ class Validator implements ValidatorContract
     protected function replaceAfter($message, $attribute, $rule, $parameters)
     {
         return $this->replaceBefore($message, $attribute, $rule, $parameters);
+    }
+
+    /**
+     * Replace all place-holders for the orientation rule.
+     *
+     * @param  string  $message
+     * @param  string  $attribute
+     * @param  string  $rule
+     * @param  array   $parameters
+     * @return string
+     */
+    protected function replaceOrientation($message, $attribute, $rule, $parameters)
+    {
+        return str_replace(':orientation', $parameters[0], $message);
     }
 
     /**

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1913,9 +1913,7 @@ class Validator implements ValidatorContract
             return false;
         }
 
-        if (empty($parameters)) {
-            throw new InvalidArgumentException('Validation rule orientation requires 1 parameter.');
-        }
+        $this->requireParameterCount(1, $parameters, 'orientation');
 
         list($width, $height) = $sizeDetails;
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1667,8 +1667,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
     public function testValidateImageDimensions()
     {
-        // Knowing that demo image.gif has width = 3 and height = 2
-        $uploadedFile = new \Symfony\Component\HttpFoundation\File\UploadedFile(__DIR__.'/fixtures/image.gif', '', null, null, null, true);
+        $uploadedFile = $this->getTestImage();
         $trans = $this->getRealTranslator();
 
         $v = new Validator($trans, ['x' => 'file'], ['x' => 'dimensions']);
@@ -2930,6 +2929,27 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $this->assertFalse($v->passes());
     }
 
+    public function testValidateImageOrientation()
+    {
+        $uploadedFile = $this->getTestImage();
+        $trans = $this->getRealTranslator();
+
+        $v = new Validator($trans, ['x' => 'file'], ['x' => 'orientation']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, [], ['x' => 'orientation:portrait']);
+        $v->setFiles(['x' => $uploadedFile]);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, [], ['x' => 'orientation:landscape']);
+        $v->setFiles(['x' => $uploadedFile]);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, [], ['x' => 'orientation:square']);
+        $v->setFiles(['x' => $uploadedFile]);
+        $this->assertTrue($v->fails());
+    }
+
     protected function getTranslator()
     {
         return m::mock('Symfony\Component\Translation\TranslatorInterface');
@@ -2941,6 +2961,11 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $trans->addLoader('array', new Symfony\Component\Translation\Loader\ArrayLoader);
 
         return $trans;
+    }
+
+    protected function getTestImage()
+    {
+        return new \Symfony\Component\HttpFoundation\File\UploadedFile(__DIR__.'/fixtures/image.gif', '', null, null, null, true);
     }
 
     public function getIlluminateArrayTranslator()

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -2934,9 +2934,6 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $uploadedFile = $this->getTestImage();
         $trans = $this->getRealTranslator();
 
-        $v = new Validator($trans, ['x' => 'file'], ['x' => 'orientation']);
-        $this->assertTrue($v->fails());
-
         $v = new Validator($trans, [], ['x' => 'orientation:portrait']);
         $v->setFiles(['x' => $uploadedFile]);
         $this->assertTrue($v->fails());


### PR DESCRIPTION
The `dimensions` validation rule is great for exact dimensions and ratios, but I needed a validation rule to check an image’s orientation. Submitting it for inclusion in the framework!
