### PR TITLE
[5.2] Support column aliases in chunkById

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1783,11 +1783,14 @@ class Builder
      * @param  int  $count
      * @param  callable  $callback
      * @param  string  $column
+     * @param  string  $alias  Alias of the ID column if there are multiple columns with the same name. The alias must be defined in a select statement.
      * @return bool
      */
-    public function chunkById($count, callable $callback, $column = 'id')
+    public function chunkById($count, callable $callback, $column = 'id', $alias = null)
     {
         $lastId = null;
+
+        $alias = is_null($alias) ? $column : $alias;
 
         $results = $this->forPageAfterId($count, 0, $column)->get();
 
@@ -1796,7 +1799,7 @@ class Builder
                 return false;
             }
 
-            $lastId = last($results)->{$column};
+            $lastId = last($results)->{$alias};
 
             $results = $this->forPageAfterId($count, $lastId, $column)->get();
         }

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1667,6 +1667,19 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase
         }, 'someIdField');
     }
 
+    public function testChunkPaginatesUsingIdWithAlias()
+    {
+        $builder = $this->getMockQueryBuilder();
+        $builder->shouldReceive('forPageAfterId')->once()->with(2, 0, 'table.id')->andReturn($builder);
+        $builder->shouldReceive('forPageAfterId')->once()->with(2, 10, 'table.id')->andReturn($builder);
+        $builder->shouldReceive('get')->times(2)->andReturn(
+            [(object) ['table_id' => 1], (object) ['table_id' => 10]],
+            []
+        );
+        $builder->chunkById(2, function ($results) {
+        }, 'table.id', 'table_id');
+    }
+
     public function testPaginate()
     {
         $perPage = 16;


### PR DESCRIPTION
This is a follow-up on #14499 where `chunkById` should be fixed to support more complex queries. The following query currently does not work:

``` php
// both the annotations and images tables have an id column
DB::table('annotations')
   ->join('images', 'annotations.image_id', '=', 'images.id')
   ->where(/* something with images */)
   ->chunkById(500, $handleChunk, 'annotations.id');
```

With this PR it can be done like this:

``` php
DB::table('annotations')
   ->join('images', 'annotations.image_id', '=', 'images.id')
   ->where(/* something with images */)
   ->select('annotations.id as annotations_id', /* ... */)
   ->chunkById(500, $handleChunk, 'annotations.id', 'annotations_id');
```
