### PR TITLE
Modify the dependence on the Events

### DIFF
--- a/src/Illuminate/Console/Application.php
+++ b/src/Illuminate/Console/Application.php
@@ -35,15 +35,16 @@ class Application extends SymfonyApplication implements ApplicationContract
      * @param  string  $version
      * @return void
      */
-    public function __construct(Container $laravel, Dispatcher $events, $version)
+    public function __construct(Container $laravel, Dispatcher $events = null, $version)
     {
         parent::__construct('Laravel Framework', $version);
 
         $this->laravel = $laravel;
         $this->setAutoExit(false);
         $this->setCatchExceptions(false);
-
-        $events->fire(new Events\ArtisanStarting($this));
+        if($events){
+            $events->fire(new Events\ArtisanStarting($this));
+        }
     }
 
     /**


### PR DESCRIPTION
If $event must dependence Event\Dispatcher,  I can't use the Console module independent. 
So,I think $event should have default value is null. 
For example https://github.com/laravel/framework/blob/5.2/src/Illuminate/Queue/Worker.php construct
