### PR TITLE
[5.3] Fixes undefined index "aggregate" when you try to use paginator with fetchMode set to Entity

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1716,7 +1716,7 @@ class Builder
         $item = $results[0];
 
         if (is_object($item)) {
-            return $item->aggregate;
+            return (int) $item->aggregate;
         }
     
         return (int) array_change_key_case((array) $item)['aggregate'];

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1709,7 +1709,17 @@ class Builder
             return count($results);
         }
 
-        return isset($results[0]) ? (int) array_change_key_case((array) $results[0])['aggregate'] : 0;
+        if (! isset($results[0])) {
+            return 0;
+        }
+
+        $item = $results[0];
+
+        if (is_object($item)) {
+            return $item->aggregate;
+        }
+    
+        return (int) array_change_key_case((array) $item)['aggregate'];
     }
 
     /**


### PR DESCRIPTION
`Notice: Undefined index: aggregate in /home/rafael/Projects/veridu/idos/api/vendor/illuminate/database/Query/Builder.php on line 1654`

The above Notice is thrown when you try to use Builder's pagination with PDO fetchMode set to an entity (like Eloquent), because of its magic methods `__set` and `__get`.
