### PR TITLE
[5.3] Added a `removeGlobalScope` method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -399,6 +399,21 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     }
 
     /**
+     * Unregister a global scope on the model.
+     *
+     * @param  \Illuminate\Database\Eloquent\Scope|string  $scope
+     * @return \Illuminate\Database\Eloquent\Scope|\Closure|null
+     */
+    public static function removeGlobalScope($scope)
+    {
+        if (! is_string($scope)) {
+            $scope = get_class($scope);
+        }
+
+        return Arr::forget(static::$globalScopes, static::class.'.'.$scope);
+    }
+
+    /**
      * Register an observer with the Model.
      *
      * @param  object|string  $class

--- a/tests/Database/DatabaseEloquentGlobalScopesTest.php
+++ b/tests/Database/DatabaseEloquentGlobalScopesTest.php
@@ -25,6 +25,18 @@ class DatabaseEloquentGlobalScopesTest extends PHPUnit_Framework_TestCase
         $this->assertEquals([], $query->getBindings());
     }
 
+    public function testGlobalScopeCanBeTotallyRemoved()
+    {
+        $model = new EloquentGlobalScopesTestModel();
+        $model::removeGlobalScope(ActiveScope::class);
+        $query = $model->newQuery();
+        $this->assertEquals('select * from "table"', $query->toSql());
+        $this->assertEquals([], $query->getBindings());
+
+        // Re-add the global scope for the next tests
+        $model::addGlobalScope(new ActiveScope);
+    }
+
     public function testClosureGlobalScopeIsApplied()
     {
         $model = new EloquentClosureGlobalScopesTestModel();


### PR DESCRIPTION
I'm in a situation where a package is doing queries on one of my models which has a global scope. I'd like to disable the scope in this instance, but currently there isn't any way for me to do so (I need access to the query builder objects for `withoutGlobalScope`).

Being able to fully remove the global scope solves the issue (I'd rather do it differently, but don't seem to have a choice in this case).

Not sure about the tests, I had to re-add it at the end since the cases depend on the same static property.
