### PR TITLE
[5.2] Move Date Conversion

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2645,6 +2645,13 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     {
         $value = $this->getAttributeFromArray($key);
 
+        // If the attribute is listed as a date, we will convert it to a DateTime
+        // instance on retrieval, which makes it quite convenient to work with
+        // date fields without having to create a mutator for each property.
+        if (in_array($key, $this->getDates()) && ! is_null($value)) {
+            $value = $this->asDateTime($value);
+        }
+
         // If the attribute has a get mutator, we will call that then return what
         // it returns as the value, which is useful for transforming values on
         // retrieval from the model to a form that is more useful for usage.
@@ -2657,13 +2664,6 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         // given with the key in the pair. Dayle made this comment line up.
         if ($this->hasCast($key)) {
             return $this->castAttribute($key, $value);
-        }
-
-        // If the attribute is listed as a date, we will convert it to a DateTime
-        // instance on retrieval, which makes it quite convenient to work with
-        // date fields without having to create a mutator for each property.
-        if (in_array($key, $this->getDates()) && ! is_null($value)) {
-            return $this->asDateTime($value);
         }
 
         return $value;


### PR DESCRIPTION
Moved the date conversion to before the mutateAttribute field to allow an instance of Carbon to be passed down to the mutate method.

Stems from issue in laravel-mongo package jenssegers/laravel-mongodb#902
