### PR TITLE
[5.3] Consistent message building for database driver

### DIFF
--- a/src/Illuminate/Notifications/Messages/DatabaseMessage.php
+++ b/src/Illuminate/Notifications/Messages/DatabaseMessage.php
@@ -12,13 +12,15 @@ class DatabaseMessage
     public $data = [];
 
     /**
-     * Create a new database message.
+     * Set the message data.
      *
      * @param  array  $data
-     * @return void
+     * @return $this
      */
-    public function __construct(array $data = [])
+    public function data($data)
     {
         $this->data = $data;
+
+        return $this;
     }
 }

--- a/tests/Notifications/NotificationDatabaseChannelTest.php
+++ b/tests/Notifications/NotificationDatabaseChannelTest.php
@@ -33,6 +33,6 @@ class NotificationDatabaseChannelTestNotification extends Notification
 {
     public function toDatabase($notifiable)
     {
-        return new DatabaseMessage(['invoice_id' => 1]);
+        return (new DatabaseMessage())->data(['invoice_id' => 1]);
     }
 }


### PR DESCRIPTION
Since we have:

```
return (new MailMessage)
         ->subject(........);
```

and

```
return (new NexmoMessage)
        ->from(........);
```

and same for slack, I thought it'd be more convenient to build the Database message like this:

```
return (new DatabaseMessage)
        ->data([........]);
```
