### PR TITLE
Implement the two methods see description why

### DIFF
--- a/src/Illuminate/Broadcasting/Broadcasters/NullBroadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/NullBroadcaster.php
@@ -11,4 +11,15 @@ class NullBroadcaster extends Broadcaster
     {
         //
     }
+    
+       public function check($request)
+    {
+        // 
+    }
+
+    public function validAuthenticationResponse($request, $result)
+    {
+        // 
+    }
+    
 }


### PR DESCRIPTION
Hi, 

I was working with the 5.3 development version when I continously got an error logging after doing composer update over this class. I included the error notification at the end of this file change so can you see what it is. I tried by implementing it myself locally and after adding these 2 methods to the NullBroadcaster I got no errors anymore. So unless there is a better way this fixes it.

" [2016-08-09 23:16:04] local.ERROR: Symfony\Component\Debug\Exception\FatalErrorException:
Class Illuminate\Broadcasting\Broadcasters\NullBroadcaster contains 2 abstract methods
and must therefore be declared abstract or implement the remaining methods
(Illuminate\Contracts\Broadcasting\Broadcaster::check,
Illuminate\Contracts\Broadcasting\Broadcaster::validAuthenticationResponse)
in C:\laragonversion202\www\laravelcms\vendor\laravel\framework\src\Illuminate\Broadcasting\Broadcasters\NullBroadcaster.php:5
Stack trace:
#0 {main}  "
