### PR TITLE
[5.2] Add preserveKeys option to collection slice() function

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -862,11 +862,12 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      *
      * @param  int   $offset
      * @param  int   $length
+     * @param  bool   $preserveKeys
      * @return static
      */
-    public function slice($offset, $length = null)
+    public function slice($offset, $length = null, $preserveKeys = true)
     {
-        return new static(array_slice($this->items, $offset, $length, true));
+        return new static(array_slice($this->items, $offset, $length, $preserveKeys));
     }
 
     /**


### PR DESCRIPTION
Now collect([1,2,3,4,5])->slice(2,3) will return collection with assoc array in it.

```
[
     2 => 2,
     3 => 3,
     4 => 4,
]
```

In some cases we don't need this. (for example if we want compare 2 collections from DB with limit()->offset() and from $collection->slice()
So after this change we can do $collection->slice(2,3, false) and get collection without keys

```
[
     2,
     3,
     4,
]
```

If someone abuse this feature before, i place default param as "true" for saving old behavior by default.
