### PR TITLE
[5.3] Extend FormRequest directly

### DIFF
--- a/src/Illuminate/Foundation/Console/stubs/request.stub
+++ b/src/Illuminate/Foundation/Console/stubs/request.stub
@@ -2,9 +2,9 @@
 
 namespace DummyNamespace;
 
-use DummyRootNamespaceHttp\Requests\Request;
+use Illuminate\Foundation\Http\FormRequest;
 
-class DummyClass extends Request
+class DummyClass extends FormRequest
 {
     /**
      * Determine if the user is authorized to make this request.


### PR DESCRIPTION
If [we're removing the base request class](https://github.com/laravel/laravel/pull/3867), we have to extend the framework's `FormRequest` directly.
