### PR TITLE
[5.3] Fix Action class reference

### DIFF
--- a/src/Illuminate/Notifications/Messages/SimpleMessage.php
+++ b/src/Illuminate/Notifications/Messages/SimpleMessage.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Notifications\Messages;
 
+use Illuminate\Notifications\Action;
+
 class SimpleMessage
 {
     /**


### PR DESCRIPTION
The `use` of `Action` is missing.
