### PR TITLE
[5.3] If an indexed array is passed into sortBy, return an indexed array

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -976,7 +976,9 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
             $results[$key] = $this->items[$key];
         }
 
-        return new static($results);
+        $instance = new static($results);
+
+        return Arr::isAssoc($this->items) ? $instance : $instance->values();
     }
 
     /**

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -626,6 +626,22 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(['taylor', 'dayle'], array_values($data->all()));
     }
 
+    public function testSortByOnAssoc()
+    {
+        $data = new Collection(['first' => ['order' => 2], 'second' => ['order' => 1]]);
+        $data = $data->sortBy('order');
+
+        $this->assertEquals(['second' => ['order' => 1], 'first' => ['order' => 2]], $data->toArray());
+    }
+
+    public function testSortByOnIndexed()
+    {
+        $data = new Collection([['order' => 2], ['order' => 1]]);
+        $data = $data->sortBy('order');
+
+        $this->assertEquals([['order' => 1], ['order' => 2]], $data->toArray());
+    }
+
     public function testSortByString()
     {
         $data = new Collection([['name' => 'taylor'], ['name' => 'dayle']]);


### PR DESCRIPTION
I've submit this PR before, against 5.2, but I believe it is safer in and belongs in 5.3. I've experienced this issue within my laravel codebase, and found some people running into this issue online. The issue is with php indexed arrays and sorting `Illuminate\Support\Collection` objects. When an indexed array is used to create a collection and then sorted, the keys of the indexed array are maintained, and then used as keys in the newly sorted array sometimes returning an associative array. This can cause the returned collection object to be in an unexpected state and has some inconsistent return/serialization results based on the sortBy. Below is an example:

``` php
$collection = new \Illuminate\Support\Collection([
    ['order' => 1],
    ['order' => 2],
    ['order' => 3]
]);
/**
 *  It is already sorted by order ascending, so after serialization you'd 
 *  get what you would expect, an array exactly as you passed it in.
 */
$collection->sortBy('order')->toJSON();
=> [{"order":1},{"order":2},{"order":3}]

/**
 *  Sorting it by order descending will now reorder the array, and 
 *  after serialization one might expect to receive an array of the
 *  objects, this time in reverse order. Instead you receive an object 
 *  with numeric keys (the keys coming from their location in the original array)
 */
$collection->sortByDesc('order')->toJSON();
=> {"2":{"order":3},"1":{"order":2},"0":{"order":1}}
```

I believe this inconsistency to be a bug, and this PR will resolve it. 
