### PR TITLE
[5.3] Mailables should respect ShouldQueue

### DIFF
--- a/src/Illuminate/Foundation/Console/stubs/mail.stub
+++ b/src/Illuminate/Foundation/Console/stubs/mail.stub
@@ -5,8 +5,9 @@ namespace DummyNamespace;
 use Illuminate\Bus\Queueable;
 use Illuminate\Mail\Mailable;
 use Illuminate\Queue\SerializesModels;
+use Illuminate\Contracts\Queue\ShouldQueue;
 
-class DummyClass extends Mailable
+class DummyClass extends Mailable implements ShouldQueue
 {
     use Queueable, SerializesModels;
 

--- a/src/Illuminate/Mail/MailableMailer.php
+++ b/src/Illuminate/Mail/MailableMailer.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Mail;
 
+use Illuminate\Contracts\Queue\ShouldQueue;
+
 class MailableMailer
 {
     /**
@@ -90,41 +92,49 @@ class MailableMailer
      */
     public function send(Mailable $mailable)
     {
-        $mailable = $mailable->to($this->to)
-                 ->cc($this->cc)
-                 ->bcc($this->bcc);
+        if ($mailable instanceof ShouldQueue) {
+            return $this->queue($this->fill($mailable));
+        }
 
-        return $this->mailer->send($mailable);
+        return $this->mailer->send($this->fill($mailable));
     }
 
     /**
-     * Queue a mailable message for sending.
+     * Send a mailable message immediately.
      *
      * @param  Mailable  $mailable
      * @return mixed
      */
-    public function queue(Mailable $mailable)
+    public function sendNow(Mailable $mailable)
     {
-        $mailable = $mailable->to($this->to)
-                 ->cc($this->cc)
-                 ->bcc($this->bcc);
+        return $this->mailer->send($this->fill($mailable));
+    }
+
+    /**
+     * Populate the mailable with the addresses.
+     *
+     * @param  Mailable  $mailable
+     * @return Mailable
+     */
+    protected function fill(Mailable $mailable)
+    {
+        return $mailable->to($this->to)
+                        ->cc($this->cc)
+                        ->bcc($this->bcc);
+    }
+
+    /**
+     * Push the given mailable onto the queue.
+     *
+     * @param  Mailable  $mailable
+     * @return mixed
+     */
+    protected function queue(Mailable $mailable)
+    {
+        if (isset($mailable->delay)) {
+            return $this->mailer->later($mailable->delay, $mailable);
+        }
 
         return $this->mailer->queue($mailable);
-    }
-
-    /**
-     * Deliver the queued message after the given delay.
-     *
-     * @param  \DateTime|int  $delay
-     * @param  Mailable  $mailable
-     * @return mixed
-     */
-    public function later($delay, Mailable $mailable)
-    {
-        $mailable = $mailable->to($this->to)
-                 ->cc($this->cc)
-                 ->bcc($this->bcc);
-
-        return $this->mailer->later($delay, $mailable);
     }
 }


### PR DESCRIPTION
After this change, mailables will work similar to job dispatches:
- When calling `send`, if the mailable implements `ShouldQueue` (which the stub now has by default), it'll automatically be queued.
- You can call `sendNow` to force the email to be sent immediately.
- To add a delay, call `delay` on the mailable:
  
  ``` php
  $message = (new ServerProvisioned($server))->delay(60);
  
  Mail::to($server->user->email)->send($message);
  ```
