### PR TITLE
[5.4] Fix a SQLite compileInsert error when `$values` argument is empty

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
@@ -39,6 +39,10 @@ class SQLiteGrammar extends Grammar
         // grammar insert builder because no special syntax is needed for the single
         // row inserts in SQLite. However, if there are multiples, we'll continue.
         if (count($values) == 1) {
+            if (empty($values[0])) {
+                return "insert into $table (rowid) values (null)";
+            }
+
             return parent::compileInsert($query, reset($values));
         }
 


### PR DESCRIPTION
I have a model which is only composer by a primary autoincrement key. Then when I try to insert in my SQLite database I get an error.

``` php
//For the schema
class CreateTable extends Migration
{
    /**
     * Run the migrations.
     *
     * @return void
     */
    public function up()
    {
        Schema::create('table', function(Blueprint $table) {
            $table->increments('id');
        });
    }
}

//For the model
class Table extends Model
{
    /**
     * Indicates if the model should be timestamped.
     *
     * @var bool
     */
    public $timestamps = false;

    /**
     * The table associated with the model.
     *
     * @var string
     */
    protected $table = 'table';
}

//Reproduce error by inserting that model in the database
$model = new Table();
$model->save();
```

This is because SQLite can’t handle an “empty” insert statement : `insert into “table” () values ()`

I retrieve a “General error” form the driver :
`SQLSTATE[HY000]: General error: 1 near ")": syntax error (SQL: insert into “table” () values ())`

When there is no values to insert, we must tell to SQLite to increment the [ROWID](https://sqlite.org/autoinc.html) which is the unique row identifier. The primary key is an alias for this specific column so we don’t need to take care of a column name.
