### PR TITLE
[5.3] Add missing import at RedisBroadcaster

### DIFF
--- a/src/Illuminate/Broadcasting/Broadcasters/RedisBroadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/RedisBroadcaster.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Broadcasting\Broadcasters;
 
 use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
 use Illuminate\Contracts\Redis\Database as RedisDatabase;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 


### PR DESCRIPTION
Illuminate\Support\Str is used by the auth method of RedisBroadcaster but is not imported.
