### PR TITLE
[5.3] Use valid case for stdClass class

### DIFF
--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -574,7 +574,7 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
 
     public function testCollapse()
     {
-        $data = new Collection([[$object1 = new StdClass], [$object2 = new StdClass]]);
+        $data = new Collection([[$object1 = new stdClass], [$object2 = new stdClass]]);
         $this->assertEquals([$object1, $object2], $data->collapse()->all());
     }
 


### PR DESCRIPTION
Although classes are not case sensitive they should be rather used in same case as they are. There are many more such cases also in `src` (not only `tests`) but at the moment I've fixed this in single file
