### PR TITLE
[5.2] Make custom validation rules to be dependent rules

### DIFF
--- a/src/Illuminate/Validation/Factory.php
+++ b/src/Illuminate/Validation/Factory.php
@@ -47,7 +47,7 @@ class Factory implements FactoryContract
 
     /**
      * All of the custom validator rules to be depedent.
-     * 
+     *
      * @var array
      */
     protected $dependentRules = [];
@@ -206,7 +206,7 @@ class Factory implements FactoryContract
 
     /**
      * Add a custom rule as dependent rule.
-     * 
+     *
      * @param string $rule
      */
     protected function addDependentRule($rule)

--- a/src/Illuminate/Validation/Factory.php
+++ b/src/Illuminate/Validation/Factory.php
@@ -46,6 +46,13 @@ class Factory implements FactoryContract
     protected $implicitExtensions = [];
 
     /**
+     * All of the custom validator rules to be depedent.
+     * 
+     * @var array
+     */
+    protected $dependentRules = [];
+
+    /**
      * All of the custom validator message replacers.
      *
      * @var array
@@ -128,6 +135,8 @@ class Factory implements FactoryContract
 
         $validator->addImplicitExtensions($implicit);
 
+        $validator->addDependentRules($this->dependentRules);
+
         $validator->addReplacers($this->replacers);
 
         $validator->setFallbackMessages($this->fallbackMessages);
@@ -157,11 +166,16 @@ class Factory implements FactoryContract
      * @param  string  $rule
      * @param  \Closure|string  $extension
      * @param  string  $message
+     * @param bool $isDependentRule
      * @return void
      */
-    public function extend($rule, $extension, $message = null)
+    public function extend($rule, $extension, $message = null, $isDependentRule = false)
     {
         $this->extensions[$rule] = $extension;
+
+        if ($isDependentRule) {
+            $this->addDependentRule($rule);
+        }
 
         if ($message) {
             $this->fallbackMessages[Str::snake($rule)] = $message;
@@ -174,15 +188,30 @@ class Factory implements FactoryContract
      * @param  string   $rule
      * @param  \Closure|string  $extension
      * @param  string  $message
+     * @param bool $isDependentRule
      * @return void
      */
-    public function extendImplicit($rule, $extension, $message = null)
+    public function extendImplicit($rule, $extension, $message = null, $isDependentRule = false)
     {
         $this->implicitExtensions[$rule] = $extension;
+
+        if ($isDependentRule) {
+            $this->addDependentRule($rule);
+        }
 
         if ($message) {
             $this->fallbackMessages[Str::snake($rule)] = $message;
         }
+    }
+
+    /**
+     * Add a custom rule as dependent rule.
+     * 
+     * @param string $rule
+     */
+    protected function addDependentRule($rule)
+    {
+        $this->dependentRules[] = $rule;
     }
 
     /**

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -2833,6 +2833,18 @@ class Validator implements ValidatorContract
     }
 
     /**
+     * Set a custom validator extension as a dependent rule.
+     * 
+     * @param array $rules
+     */
+    public function addDependentRules(array $rules)
+    {
+        foreach ($rules as $rule) {
+            $this->dependentRules[] = Str::studly($rule);
+        }
+    }
+
+    /**
      * Get the array of custom validator message replacers.
      *
      * @return array

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -2834,7 +2834,7 @@ class Validator implements ValidatorContract
 
     /**
      * Set a custom validator extension as a dependent rule.
-     * 
+     *
      * @param array $rules
      */
     public function addDependentRules(array $rules)


### PR DESCRIPTION
This little contribution allows custom validation rules to be dependent on other fields.

This will allow to create a rule like this:

First Field should be Greater than Second Field:

```
'things.*.first_field' => 'greater:things.*.second_field'
```

This means that the \* in the parameter of the rule (the other field) will be resolved as keys.

Right now there is no way to tell to the validator that a custom extension should be dependent, so it will not resolve the keys from the dependent field.

Letting the validator resolve this keys, will make a breeze to do this kind of custom validator:

```
Validator::extend('greater', function($attribute, $value, $parameters, $validator) {
    $other = Arr::get($validator->getData(), $parameters[0]);

    return $value >= $other;
}, null, true);

Validator::extendImplicit('greater', function($attribute, $value, $parameters, $validator) {
    $other = Arr::get($validator->getData(), $parameters[0]);

    return $value >= $other;
}, null, true);

// The last parameter on the extend and extendImplicit method tells that this is a dependent rule.
// By default is false to get the normal behavior.
```

Now we can create implicit and explicit custom validation rules that can be dependent on other field.
