### PR TITLE
[5.2] Turn on pretty printing of JSON when test is unable to find fragment

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -321,7 +321,7 @@ trait MakesHttpRequests
 
         $actual = json_encode(Arr::sortRecursive(
             (array) $this->decodeResponseJson()
-        ));
+        ), JSON_PRETTY_PRINT);
 
         foreach (Arr::sortRecursive($data) as $key => $value) {
             $expected = $this->formatToExpectedJson($key, $value);
@@ -373,7 +373,7 @@ trait MakesHttpRequests
      */
     protected function formatToExpectedJson($key, $value)
     {
-        $expected = json_encode([$key => $value]);
+        $expected = json_encode([$key => $value], JSON_PRETTY_PRINT);
 
         if (Str::startsWith($expected, '{')) {
             $expected = substr($expected, 1);

--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -328,7 +328,7 @@ trait MakesHttpRequests
 
             $this->{$method}(
                 Str::contains($actual, $expected),
-                ($negate ? 'Found unexpected' : 'Unable to find')." JSON fragment [{$expected}] within [{$actual}]."
+                ($negate ? 'Found unexpected' : 'Unable to find')." JSON fragment\n[{$expected}]\nwithin\n[{$actual}]."
             );
         }
 


### PR DESCRIPTION
When comparing larger JSON fragments it can be difficult to spot where the error is. Hopefully pretty printing the output it will make it easier for people.
