### PR TITLE
[5.3] Support listening on event interfaces

### DIFF
--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -295,21 +295,28 @@ class Dispatcher implements DispatcherContract
      * Sort the listeners for a given event by priority.
      *
      * @param  string  $eventName
-     * @return array
+     * @return void
      */
     protected function sortListeners($eventName)
     {
-        $this->sorted[$eventName] = [];
-
         // If listeners exist for the given event, we will sort them by the priority
         // so that we can call them in the correct order. We will cache off these
         // sorted event listeners so we do not have to re-sort on every events.
-        if (isset($this->listeners[$eventName])) {
-            krsort($this->listeners[$eventName]);
+        $listeners = isset($this->listeners[$eventName]) ? $this->listeners[$eventName] : [];
 
-            $this->sorted[$eventName] = call_user_func_array(
-                'array_merge', $this->listeners[$eventName]
-            );
+        if (class_exists($eventName, false)) {
+            foreach (class_implements($eventName) as $interface) {
+                if (isset($this->listeners[$interface])) {
+                    $listeners = array_merge_recursive($listeners, $this->listeners[$interface]);
+                }
+            }
+        }
+
+        if ($listeners) {
+            krsort($listeners);
+            $this->sorted[$eventName] = call_user_func_array('array_merge', $listeners);
+        } else {
+            $this->sorted[$eventName] = [];
         }
     }
 

--- a/tests/Events/EventsDispatcherTest.php
+++ b/tests/Events/EventsDispatcherTest.php
@@ -180,6 +180,46 @@ class EventsDispatcherTest extends PHPUnit_Framework_TestCase
         $d->listen('some.event', 'TestDispatcherQueuedHandlerCustomQueue@someMethod');
         $d->fire('some.event', ['foo', 'bar']);
     }
+
+    public function testClassesWork()
+    {
+        unset($_SERVER['__event.test']);
+        $d = new Dispatcher;
+        $d->listen('ExampleEvent', function () {
+            $_SERVER['__event.test'] = 'baz';
+        });
+        $d->fire(new ExampleEvent);
+
+        $this->assertSame('baz', $_SERVER['__event.test']);
+    }
+
+    public function testInterfacesWork()
+    {
+        unset($_SERVER['__event.test']);
+        $d = new Dispatcher;
+        $d->listen('SomeEventInterface', function () {
+            $_SERVER['__event.test'] = 'bar';
+        });
+        $d->fire(new AnotherEvent);
+
+        $this->assertSame('bar', $_SERVER['__event.test']);
+    }
+
+    public function testBothClassesAndInterfacesWork()
+    {
+        unset($_SERVER['__event.test']);
+        $d = new Dispatcher;
+        $d->listen('AnotherEvent', function () {
+            $_SERVER['__event.test1'] = 'fooo';
+        });
+        $d->listen('SomeEventInterface', function () {
+            $_SERVER['__event.test2'] = 'baar';
+        });
+        $d->fire(new AnotherEvent);
+
+        $this->assertSame('fooo', $_SERVER['__event.test1']);
+        $this->assertSame('baar', $_SERVER['__event.test2']);
+    }
 }
 
 class TestDispatcherQueuedHandler implements Illuminate\Contracts\Queue\ShouldQueue
@@ -199,4 +239,19 @@ class TestDispatcherQueuedHandlerCustomQueue implements Illuminate\Contracts\Que
     {
         $queue->push($handler, $payload);
     }
+}
+
+class ExampleEvent
+{
+    //
+}
+
+interface SomeEventInterface
+{
+    //
+}
+
+class AnotherEvent implements SomeEventInterface
+{
+    //
 }


### PR DESCRIPTION
Being able to listen on events would be a massive time saver. For example, StyleCI has 22 events that extend an interface called `AnalysisEventInterface`, and it would be really cool to be able to just register one event listener on that interface instead of registering it 22 times for each class.
