### PR TITLE
[5.3] Database notifications collection with ‘mark as read’ method

### DIFF
--- a/src/Illuminate/Notifications/DatabaseNotification.php
+++ b/src/Illuminate/Notifications/DatabaseNotification.php
@@ -54,4 +54,15 @@ class DatabaseNotification extends Model
     {
         $this->forceFill(['read' => true])->save();
     }
+
+    /**
+     * Create a new database notification collection instance.
+     *
+     * @param  array  $models
+     * @return \Illuminate\Notifications\DatabaseNotificationCollection
+     */
+    public function newCollection(array $models = [])
+    {
+        return new DatabaseNotificationCollection($models);
+    }
 }

--- a/src/Illuminate/Notifications/DatabaseNotificationCollection.php
+++ b/src/Illuminate/Notifications/DatabaseNotificationCollection.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Illuminate\Notifications;
+
+use Illuminate\Database\Eloquent\Collection;
+
+class DatabaseNotificationCollection extends Collection
+{
+    /**
+     * Mark all notification as read.
+     *
+     * @return void
+     */
+    public function markAsRead()
+    {
+        $this->each(function ($notification) {
+            $notification->markAsRead();
+        });
+    }
+}


### PR DESCRIPTION
Saw in the [Laracast’s “Notifications: Database” lesson](https://laracasts.com/series/whats-new-in-laravel-5-3/episodes/10), Jeffrey loops over notifications to mark them as read. Therefore, thought it would be handy if given a collection of notifications you could dismiss them all, i.e.

``` php
$notifications = Auth::user()->unreadNotifications;
$notifications->markAsRead();
```
