### PR TITLE
[5.3] Deprecate quickRandom

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -240,11 +240,17 @@ class Str
      *
      * Should not be considered sufficient for cryptography, etc.
      *
+     * @deprecated since version 5.3. Use the "random" method directly.
+     *
      * @param  int  $length
      * @return string
      */
     public static function quickRandom($length = 16)
     {
+        if (PHP_MAJOR_VERSION > 5) {
+            return static::random($length);
+        }
+
         $pool = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
 
         return static::substr(str_shuffle(str_repeat($pool, $length)), 0, $length);


### PR DESCRIPTION
On PHP 7, the random function has the same performance, if not slightly better on some systems than quickRandom, so quick random is not really so quick. For this reason, we should deprecate it, and for people running PHP 7, actually make it use the full random function under the hood.
