### PR TITLE
[5.1] Fixed the aggregate method

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1751,7 +1751,11 @@ class Builder
         if (isset($results[0])) {
             $result = array_change_key_case((array) $results[0]);
 
-            if (strpos($result['aggregate'], '.') !== false) {
+            if (is_int($result['aggregate']) || is_float($result['aggregate'])) {
+                return $result['aggregate'];
+            }
+
+            if (strpos((string) $result['aggregate'], '.') !== false) {
                 return (int) $result['aggregate'];
             }
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1751,8 +1751,14 @@ class Builder
         if (isset($results[0])) {
             $result = array_change_key_case((array) $results[0]);
 
-            return $result['aggregate'];
+            if (strpos($result['aggregate'], '.') !== false) {
+                return (int) $result['aggregate'];
+            }
+
+            return (float) $result['aggregate'];
         }
+
+        return 0;
     }
 
     /**


### PR DESCRIPTION
It is marked as only returning integers and floats, but it also can return `null` and `string`. That's not the correct behaviour.
