### PR TITLE
[5.3] Bind numeric string with PDO::PARAM_STR

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -407,7 +407,7 @@ class Connection implements ConnectionInterface
         foreach ($bindings as $key => $value) {
             $statement->bindValue(
                 is_string($key) ? $key : $key + 1, $value,
-                filter_var($value, FILTER_VALIDATE_FLOAT) !== false ? PDO::PARAM_INT : PDO::PARAM_STR
+                ! is_string($value) && is_numeric($value) ? PDO::PARAM_INT : PDO::PARAM_STR
             );
         }
     }


### PR DESCRIPTION
This pull request fixes a problem with SQLite caused by #13066 and #13233.

In #13066 and #13233, numeric strings are bound with PDO::PARAM_INT. 
That caused a problem with SQLite. For example, if I create `products` table with `code` column which has string type and try to set numeric value starting with padding zeros, zeros will be discarded.

```
$product = new Product();
$product->code = '0012';
$product->save();

$product = Product::first();
echo $product->code  //=> '12'
```

It can be fixed by specifying PDO::PARAM_STR when a string is bound.
