### PR TITLE
[5.3] Improve RoutesNotification routeNotificationFor

### DIFF
--- a/src/Illuminate/Notifications/Channels/DatabaseChannel.php
+++ b/src/Illuminate/Notifications/Channels/DatabaseChannel.php
@@ -16,7 +16,9 @@ class DatabaseChannel
      */
     public function send($notifiable, Notification $notification)
     {
-        $notifiable->routeNotificationFor('database')->create([
+        $notifiable->routeNotificationFor('database', function($object) {
+            return $object->notifications();
+        })->create([
             'id' => $notification->id,
             'type' => get_class($notification),
             'data' => $this->getData($notifiable, $notification),

--- a/src/Illuminate/Notifications/Channels/MailChannel.php
+++ b/src/Illuminate/Notifications/Channels/MailChannel.php
@@ -35,14 +35,14 @@ class MailChannel
      */
     public function send($notifiable, Notification $notification)
     {
-        if (! $notifiable->routeNotificationFor('mail')) {
+        if (! $notifiable->routeNotificationFor('mail', 'email')) {
             return;
         }
 
         $message = $notification->toMail($notifiable);
 
         $this->mailer->send($message->view, $message->toArray(), function ($m) use ($notifiable, $notification, $message) {
-            $m->to($notifiable->routeNotificationFor('mail'));
+            $m->to($notifiable->routeNotificationFor('mail', 'email'));
 
             $m->subject($message->subject ?: Str::title(
                 Str::snake(class_basename($notification), ' ')

--- a/src/Illuminate/Notifications/Channels/NexmoSmsChannel.php
+++ b/src/Illuminate/Notifications/Channels/NexmoSmsChannel.php
@@ -44,7 +44,7 @@ class NexmoSmsChannel
      */
     public function send($notifiable, Notification $notification)
     {
-        if (! $to = $notifiable->routeNotificationFor('nexmo')) {
+        if (! $to = $notifiable->routeNotificationFor('nexmo', 'phone_number')) {
             return;
         }
 

--- a/src/Illuminate/Notifications/RoutesNotifications.php
+++ b/src/Illuminate/Notifications/RoutesNotifications.php
@@ -22,21 +22,21 @@ trait RoutesNotifications
      * Get the notification routing information for the given driver.
      *
      * @param  string  $driver
+     * @param  string|\Closure|null  $attribute
      * @return mixed
      */
-    public function routeNotificationFor($driver)
+    public function routeNotificationFor($driver, $attribute = null)
     {
         if (method_exists($this, $method = 'routeNotificationFor'.Str::studly($driver))) {
             return $this->{$method}();
         }
 
-        switch ($driver) {
-            case 'database':
-                return $this->notifications();
-            case 'mail':
-                return $this->email;
-            case 'nexmo':
-                return $this->phone_number;
+        if (is_string($attribute)) {
+            return $this->$attribute;
+        }
+
+        if ($attribute instanceof \Closure) {
+            return $attribute($this);
         }
     }
 }

--- a/tests/Notifications/NotificationRoutesNotificationsTest.php
+++ b/tests/Notifications/NotificationRoutesNotificationsTest.php
@@ -27,8 +27,8 @@ class NotificationRoutesNotificationsTest extends PHPUnit_Framework_TestCase
     {
         $instance = new RoutesNotificationsTestInstance;
         $this->assertEquals('bar', $instance->routeNotificationFor('foo'));
-        $this->assertEquals('taylor@laravel.com', $instance->routeNotificationFor('mail'));
-        $this->assertEquals('5555555555', $instance->routeNotificationFor('nexmo'));
+        $this->assertEquals('taylor@laravel.com', $instance->routeNotificationFor('mail', 'email'));
+        $this->assertEquals('5555555555', $instance->routeNotificationFor('nexmo', 'phone_number'));
     }
 }
 


### PR DESCRIPTION
Added a new `$attribute` optional parameter to `routeNotificationFor` method:
- If `$attribute` is a string, it will check for that attribute name in the notifiable object.
- If `$attribute` is a Closure, it will call it passing the notifiable as a parameter and returning the result.

In that way, the channel is the responsible of setting the default parameter to check for in the notifiable, and it allows custom channels to use the same "default attribute" functionality.
