### PR TITLE
[5.3] Avoid call_user_func_array in __call functions

### DIFF
--- a/src/Illuminate/Broadcasting/BroadcastManager.php
+++ b/src/Illuminate/Broadcasting/BroadcastManager.php
@@ -303,6 +303,6 @@ class BroadcastManager implements FactoryContract
      */
     public function __call($method, $parameters)
     {
-        return call_user_func_array([$this->driver(), $method], $parameters);
+        return $this->driver()->$method(...$parameters);
     }
 }

--- a/src/Illuminate/Cache/CacheManager.php
+++ b/src/Illuminate/Cache/CacheManager.php
@@ -298,6 +298,6 @@ class CacheManager implements FactoryContract
      */
     public function __call($method, $parameters)
     {
-        return call_user_func_array([$this->store(), $method], $parameters);
+        return $this->store()->$method(...$parameters);
     }
 }

--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -506,7 +506,7 @@ class Repository implements CacheContract, ArrayAccess
             return $this->macroCall($method, $parameters);
         }
 
-        return call_user_func_array([$this->store, $method], $parameters);
+        return $this->store->$method(...$parameters);
     }
 
     /**

--- a/src/Illuminate/Database/Capsule/Manager.php
+++ b/src/Illuminate/Database/Capsule/Manager.php
@@ -196,6 +196,6 @@ class Manager
      */
     public static function __callStatic($method, $parameters)
     {
-        return call_user_func_array([static::connection(), $method], $parameters);
+        return static::connection()->$method(...$parameters);
     }
 }

--- a/src/Illuminate/Database/DatabaseManager.php
+++ b/src/Illuminate/Database/DatabaseManager.php
@@ -314,6 +314,6 @@ class DatabaseManager implements ConnectionResolverInterface
      */
     public function __call($method, $parameters)
     {
-        return call_user_func_array([$this->connection(), $method], $parameters);
+        return $this->connection()->$method(...$parameters);
     }
 }

--- a/src/Illuminate/Filesystem/FilesystemManager.php
+++ b/src/Illuminate/Filesystem/FilesystemManager.php
@@ -325,6 +325,6 @@ class FilesystemManager implements FactoryContract
      */
     public function __call($method, $parameters)
     {
-        return call_user_func_array([$this->disk(), $method], $parameters);
+        return $this->disk()->$method(...$parameters);
     }
 }

--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -563,7 +563,7 @@ abstract class AbstractPaginator implements Htmlable
      */
     public function __call($method, $parameters)
     {
-        return call_user_func_array([$this->getCollection(), $method], $parameters);
+        return $this->getCollection()->$method(...$parameters);
     }
 
     /**

--- a/src/Illuminate/Queue/Capsule/Manager.php
+++ b/src/Illuminate/Queue/Capsule/Manager.php
@@ -166,7 +166,7 @@ class Manager
      */
     public function __call($method, $parameters)
     {
-        return call_user_func_array([$this->manager, $method], $parameters);
+        return $this->manager->$method(...$parameters);
     }
 
     /**
@@ -178,6 +178,6 @@ class Manager
      */
     public static function __callStatic($method, $parameters)
     {
-        return call_user_func_array([static::connection(), $method], $parameters);
+        return static::connection()->$method(...$parameters);
     }
 }

--- a/src/Illuminate/Queue/QueueManager.php
+++ b/src/Illuminate/Queue/QueueManager.php
@@ -260,8 +260,6 @@ class QueueManager implements FactoryContract, MonitorContract
      */
     public function __call($method, $parameters)
     {
-        $callable = [$this->connection(), $method];
-
-        return call_user_func_array($callable, $parameters);
+        return $this->connection()->$method(...$parameters);
     }
 }

--- a/src/Illuminate/Support/Manager.php
+++ b/src/Illuminate/Support/Manager.php
@@ -134,6 +134,6 @@ abstract class Manager
      */
     public function __call($method, $parameters)
     {
-        return call_user_func_array([$this->driver(), $method], $parameters);
+        return $this->driver()->$method(...$parameters);
     }
 }

--- a/src/Illuminate/Support/ViewErrorBag.php
+++ b/src/Illuminate/Support/ViewErrorBag.php
@@ -79,7 +79,7 @@ class ViewErrorBag implements Countable
      */
     public function __call($method, $parameters)
     {
-        return call_user_func_array([$this->default, $method], $parameters);
+        return $this->default->$method(...$parameters);
     }
 
     /**


### PR DESCRIPTION
This greatly improves the stacktrace, and also increases the performance.
