### PR TITLE
[5.3] Adjusting notification template for non-style browsers

### DIFF
--- a/src/Illuminate/Notifications/resources/views/email.blade.php
+++ b/src/Illuminate/Notifications/resources/views/email.blade.php
@@ -1,206 +1,13 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html>
 
 <head>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 
     <style type="text/css" rel="stylesheet" media="all">
-        /* Base ------------------------------ */
+        /* Media Queries ------------------------------ */
 
-        *:not(br):not(tr):not(html) {
-            font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif;
-            -webkit-box-sizing: border-box;
-            box-sizing: border-box;
-        }
-        body {
-            width: 100% !important;
-            height: 100%;
-            margin: 0;
-            line-height: 1.4;
-            background-color: #F2F4F6;
-            color: #74787E;
-            -webkit-text-size-adjust: none;
-        }
-        a {
-            color: #3869D4;
-        }
-
-        /* Layout ------------------------------ */
-
-        .email-wrapper {
-            width: 100%;
-            margin: 0;
-            padding: 0;
-            background-color: #F2F4F6;
-        }
-        .email-content {
-            width: 100%;
-            margin: 0;
-            padding: 0;
-        }
-
-        /* Masthead ----------------------- */
-
-        .email-masthead {
-            padding: 25px 0;
-            text-align: center;
-        }
-        .email-masthead_logo {
-            max-width: 400px;
-            border: 0;
-        }
-        .email-masthead_name {
-            font-size: 16px;
-            font-weight: bold;
-            color: #2F3133;
-            text-decoration: none;
-            text-shadow: 0 1px 0 white;
-        }
-        .email-logo {
-            max-height: 50px;
-        }
-
-        /* Body ------------------------------ */
-
-        .email-body {
-            width: 100%;
-            margin: 0;
-            padding: 0;
-            border-top: 1px solid #EDEFF2;
-            border-bottom: 1px solid #EDEFF2;
-            background-color: #FFF;
-        }
-        .email-body_inner {
-            width: 570px;
-            margin: 0 auto;
-            padding: 0;
-        }
-        .email-footer {
-            width: 570px;
-            margin: 0 auto;
-            padding: 0;
-            text-align: center;
-        }
-        .email-footer p {
-            color: #AEAEAE;
-        }
-        .body-action {
-            width: 100%;
-            margin: 30px auto;
-            padding: 0;
-            text-align: center;
-        }
-        .body-sub {
-            margin-top: 25px;
-            padding-top: 25px;
-            border-top: 1px solid #EDEFF2;
-        }
-        .content-cell {
-            padding: 35px;
-        }
-        .align-right {
-            text-align: right;
-        }
-
-        /* Type ------------------------------ */
-
-        h1 {
-            margin-top: 0;
-            color: #2F3133;
-            font-size: 19px;
-            font-weight: bold;
-            text-align: left;
-        }
-        h2 {
-            margin-top: 0;
-            color: #2F3133;
-            font-size: 16px;
-            font-weight: bold;
-            text-align: left;
-        }
-        h3 {
-            margin-top: 0;
-            color: #2F3133;
-            font-size: 14px;
-            font-weight: bold;
-            text-align: left;
-        }
-        p {
-            margin-top: 0;
-            color: #74787E;
-            font-size: 16px;
-            line-height: 1.5em;
-        }
-        p.sub {
-            font-size: 12px;
-        }
-        p.center {
-            text-align: center;
-        }
-
-        /* Data table ------------------------------ */
-
-        .data-wrapper {
-            width: 100%;
-            margin: 0;
-            padding: 35px 0;
-        }
-        .data-table {
-            width: 100%;
-            margin: 0;
-        }
-        .data-table th {
-            text-align: left;
-            padding: 0px 5px;
-            padding-bottom: 8px;
-            border-bottom: 1px solid #EDEFF2;
-        }
-        .data-table th p {
-            margin: 0;
-            color: #9BA2AB;
-            font-size: 12px;
-        }
-        .data-table td {
-            padding: 10px 5px;
-            color: #74787E;
-            font-size: 15px;
-            line-height: 18px;
-        }
-
-        /* Buttons ------------------------------ */
-
-        .button {
-            display: inline-block;
-            width: 200px;
-            background-color: #3869D4;
-            border-radius: 3px;
-            color: #ffffff;
-            font-size: 15px;
-            line-height: 45px;
-            text-align: center;
-            text-decoration: none;
-            -webkit-text-size-adjust: none;
-            mso-hide: all;
-        }
-        .button--green {
-            background-color: #22BC66;
-        }
-        .button--red {
-            background-color: #dc4d2f;
-        }
-        .button--blue {
-            background-color: #3869D4;
-        }
-
-        /*Media Queries ------------------------------ */
-
-        @media only screen and (max-width: 600px) {
-            .email-body_inner,
-            .email-footer {
-                width: 100% !important;
-            }
-        }
         @media only screen and (max-width: 500px) {
             .button {
                 width: 100% !important;
@@ -209,15 +16,59 @@
     </style>
 </head>
 
-<body>
-    <table class="email-wrapper" width="100%" cellpadding="0" cellspacing="0">
+@php($style = [
+
+    /* Layout ------------------------------ */
+
+    'body' => 'margin: 0; padding: 0; width: 100%; background-color: #F2F4F6;',
+    'email-wrapper' => 'width: 100%; margin: 0; padding: 0; background-color: #F2F4F6;',
+
+    /* Masthead ----------------------- */
+
+    'email-masthead' => 'padding: 25px 0; text-align: center;',
+    'email-masthead_name' => 'font-size: 16px; font-weight: bold; color: #2F3133; text-decoration: none; text-shadow: 0 1px 0 white;',
+
+    'email-body' => 'width: 100%; margin: 0; padding: 0; border-top: 1px solid #EDEFF2; border-bottom: 1px solid #EDEFF2; background-color: #FFF;',
+    'email-body_inner' => 'width: auto; max-width: 570px; margin: 0 auto; padding: 0;',
+    'email-body_cell' => 'padding: 35px;',
+
+    'email-footer' => 'width: auto; max-width: 570px; margin: 0 auto; padding: 0; text-align: center;',
+    'email-footer_cell' => 'color: #AEAEAE; padding: 35px; text-align: center;',
+
+    /* Body ------------------------------ */
+
+    'body_action' => 'width: 100%; margin: 30px auto; padding: 0; text-align: center;',
+    'body_sub' => 'margin-top: 25px; padding-top: 25px; border-top: 1px solid #EDEFF2;',
+
+    /* Type ------------------------------ */
+
+    'header-1' => 'margin-top: 0; color: #2F3133; font-size: 19px; font-weight: bold; text-align: left;',
+    'paragraph' => 'margin-top: 0; color: #74787E; font-size: 16px; line-height: 1.5em;',
+    'paragraph-sub' => 'margin-top: 0; color: #74787E; font-size: 12px; line-height: 1.5em;',
+    'paragraph-center' => 'text-align: center;',
+    'anchor' => 'color: #3869D4;',
+
+    /* Buttons ------------------------------ */
+
+    'button' => 'display: block; display: inline-block; width: 200px; min-height: 20px; padding: 10px;
+        background-color: #3869D4; border-radius: 3px; color: #ffffff; font-size: 15px; line-height: 25px;
+        text-align: center; text-decoration: none; -webkit-text-size-adjust: none;',
+    'button--green' => 'background-color: #22BC66;',
+    'button--red' => 'background-color: #dc4d2f;',
+    'button--blue' => 'background-color: #3869D4;',
+])
+
+@php($fontFaimly = 'font-family: Arial, \'Helvetica Neue\', Helvetica, sans-serif;')
+
+<body style="{{ $style['body'] }}">
+    <table width="100%" cellpadding="0" cellspacing="0">
         <tr>
-            <td align="center">
-                <table class="email-content" width="100%" cellpadding="0" cellspacing="0">
+            <td style="{{ $style['email-wrapper'] }}" align="center">
+                <table width="100%" cellpadding="0" cellspacing="0">
                     <!-- Logo -->
                     <tr>
-                        <td class="email-masthead">
-                            <a class="email-masthead_name" href="{{ url('/') }}" target="_blank">
+                        <td style="{{ $style['email-masthead'] }}">
+                            <a style="{{ $fontFaimly }} {{ $style['email-masthead_name'] }}" href="{{ url('/') }}" target="_blank">
                                 {{ config('app.name') }}
                             </a>
                         </td>
@@ -225,12 +76,12 @@
 
                     <!-- Email Body -->
                     <tr>
-                        <td class="email-body" width="100%">
-                            <table class="email-body_inner" align="center" width="570" cellpadding="0" cellspacing="0">
+                        <td style="{{ $style['email-body'] }}" width="100%">
+                            <table style="{{ $style['email-body_inner'] }}" align="center" width="570" cellpadding="0" cellspacing="0">
                                 <tr>
-                                    <td class="content-cell">
+                                    <td style="{{ $fontFaimly }} {{ $style['email-body_cell'] }}">
                                         <!-- Greeting -->
-                                        <h1>
+                                        <h1 style="{{ $style['header-1'] }}">
                                             @if ($level == 'error')
                                                 Whoops!
                                             @else
@@ -240,34 +91,35 @@
 
                                         <!-- Intro -->
                                         @foreach ($introLines as $line)
-                                            <p>
+                                            <p style="{{ $style['paragraph'] }}">
                                                 {{ $line }}
                                             </p>
                                         @endforeach
 
                                         <!-- Action Button -->
                                         @if (isset($actionText))
-                                            <table class="body-action" align="center" width="100%" cellpadding="0" cellspacing="0">
+                                            <table style="{{ $style['body_action'] }}" align="center" width="100%" cellpadding="0" cellspacing="0">
                                                 <tr>
                                                     <td align="center">
-                                                        <div>
-                                                            <?php
-                                                                switch ($level) {
-                                                                    case 'success':
-                                                                        $actionColor = 'green';
-                                                                        break;
-                                                                    case 'error':
-                                                                        $actionColor = 'red';
-                                                                        break;
-                                                                    default:
-                                                                        $actionColor = 'blue';
-                                                                }
-                                                            ?>
+                                                        <?php
+                                                            switch ($level) {
+                                                                case 'success':
+                                                                    $actionColor = 'button--green';
+                                                                    break;
+                                                                case 'error':
+                                                                    $actionColor = 'button--red';
+                                                                    break;
+                                                                default:
+                                                                    $actionColor = 'button--blue';
+                                                            }
+                                                        ?>
 
-                                                            <a href="{{ $actionUrl }}" class="button button--{{ $actionColor }}" target="_blank">
-                                                                {{ $actionText }}
-                                                            </a>
-                                                        </div>
+                                                        <a href="{{ $actionUrl }}"
+                                                            style="{{ $fontFaimly }} {{ $style['button'] }} {{ $style[$actionColor] }}"
+                                                            class="button"
+                                                            target="_blank">
+                                                            {{ $actionText }}
+                                                        </a>
                                                     </td>
                                                 </tr>
                                             </table>
@@ -275,28 +127,28 @@
 
                                         <!-- Outro -->
                                         @foreach ($outroLines as $line)
-                                            <p>
+                                            <p style="{{ $style['paragraph'] }}">
                                                 {{ $line }}
                                             </p>
                                         @endforeach
 
                                         <!-- Salutation -->
-                                        <p>
+                                        <p style="{{ $style['paragraph'] }}">
                                             Regards,<br>{{ config('app.name') }}
                                         </p>
 
                                         <!-- Sub Copy -->
                                         @if (isset($actionText))
-                                            <table class="body-sub">
+                                            <table style="{{ $style['body_sub'] }}">
                                                 <tr>
-                                                    <td>
-                                                        <p class="sub">
+                                                    <td style="{{ $fontFaimly }}">
+                                                        <p style="{{ $style['paragraph-sub'] }}">
                                                             If you’re having trouble clicking the "{{ $actionText }}" button,
                                                             copy and paste the URL below into your web browser:
                                                         </p>
 
-                                                        <p class="sub">
-                                                            <a href="{{ $actionUrl }}" target="_blank">
+                                                        <p style="{{ $style['paragraph-sub'] }}">
+                                                            <a style="{{ $style['anchor'] }}" href="{{ $actionUrl }}" target="_blank">
                                                                 {{ $actionUrl }}
                                                             </a>
                                                         </p>
@@ -313,12 +165,12 @@
                     <!-- Footer -->
                     <tr>
                         <td>
-                            <table class="email-footer" align="center" width="570" cellpadding="0" cellspacing="0">
+                            <table style="{{ $style['email-footer'] }}" align="center" width="570" cellpadding="0" cellspacing="0">
                                 <tr>
-                                    <td class="content-cell">
-                                        <p class="sub center">
+                                    <td style="{{ $fontFaimly }} {{ $style['email-footer_cell'] }}">
+                                        <p style="{{ $style['paragraph-sub'] }}">
                                             &copy; {{ date('Y') }}
-                                            <a href="{{ url('/') }}" target="_blank">{{ config('app.name') }}</a>.
+                                            <a style="{{ $style['anchor'] }}" href="{{ url('/') }}" target="_blank">{{ config('app.name') }}</a>.
                                             All rights reserved.
                                         </p>
                                     </td>


### PR DESCRIPTION
I moved classes from style tag to inline styles.

The default notification template looked like this:
## GMail:

![gmail](https://cloud.githubusercontent.com/assets/5076084/17632070/d4805168-60c6-11e6-90ea-c4058fb7cdc7.png)
## Yahoo:

![yahoo](https://cloud.githubusercontent.com/assets/5076084/17632067/d462abcc-60c6-11e6-8d4d-885f7fe0f21b.png)
## Windows 10 Mail:

![windows10-mail](https://cloud.githubusercontent.com/assets/5076084/17632072/d486b2c4-60c6-11e6-8878-79dd9a07a300.png)
## OSX Mail:

![osx-mail](https://cloud.githubusercontent.com/assets/5076084/17632068/d47b8818-60c6-11e6-93ec-484982805ccc.png)
## iPhone Inbox:

![iphone4s-inbox](https://cloud.githubusercontent.com/assets/5076084/17632069/d47bb89c-60c6-11e6-81a1-d016ec4f5bf7.PNG)
# New template looks like this:
## GMail:

![gmail](https://cloud.githubusercontent.com/assets/5076084/17632209/72c8a7b2-60c7-11e6-8b2e-b03a1e6ee0e0.png)
## OSX Mail:

![osx-mail](https://cloud.githubusercontent.com/assets/5076084/17632213/72eec4d8-60c7-11e6-8d92-d64836815e85.png)
## Windows 10 Mail:

![windows10-mail](https://cloud.githubusercontent.com/assets/5076084/17632210/72ec5ef0-60c7-11e6-91e0-5d16fffd5cb7.png)
## Yahoo:

![yahoo](https://cloud.githubusercontent.com/assets/5076084/17632212/72ee79ba-60c7-11e6-89cd-6fc0fcdd20bc.png)
## Mailtrap

![mailtrap](https://cloud.githubusercontent.com/assets/5076084/17632211/72ee1bf0-60c7-11e6-9030-5f5a3bd2cd54.png)
## iPhone Inbox:

![iphone4s-inbox](https://cloud.githubusercontent.com/assets/5076084/17632214/72ef6118-60c7-11e6-90c9-fed6806545ee.PNG)
