### PR TITLE
[5.3] Make mapToAssoc return a collection

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -600,15 +600,16 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
-     * Run map over each items and return an associative array.
+     * Run an associative map over each of the items.
      *
-     * @param callable $callback
+     * The callback should return an associative array with a single key/value pair.
      *
-     * @return array
+     * @param  callable  $callback
+     * @return static
      */
     public function mapToAssoc(callable $callback)
     {
-        return $this->flatMap($callback)->all();
+        return $this->flatMap($callback);
     }
 
     /**

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -907,7 +907,7 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
         });
         $this->assertEquals(
             ['Blastoise' => 'Water', 'Charmander' => 'Fire', 'Dragonair' => 'Dragon'],
-            $data
+            $data->all()
         );
     }
 


### PR DESCRIPTION
BTW @adamwathan, wouldn't `mapAssoc`/`associativeMap`/`mapWithKeys` be better names?

The point is not to "create" an associative collection. The original collection may have also been associative.

The point of this method is that we're running an associative map, instead of a plain map.
