### PR TITLE
Backport JSON encoding exception handling to 4.2

### DIFF
--- a/src/Illuminate/Http/JsonResponse.php
+++ b/src/Illuminate/Http/JsonResponse.php
@@ -1,6 +1,7 @@
 <?php namespace Illuminate\Http;
 
 use Illuminate\Support\Contracts\JsonableInterface;
+use InvalidArgumentException;
 
 class JsonResponse extends \Symfony\Component\HttpFoundation\JsonResponse {
 
@@ -48,6 +49,14 @@ class JsonResponse extends \Symfony\Component\HttpFoundation\JsonResponse {
 		$this->data = $data instanceof JsonableInterface
 								   ? $data->toJson($this->jsonOptions)
 								   : json_encode($data, $this->jsonOptions);
+
+        if (JSON_ERROR_NONE !== json_last_error()) {
+            if (function_exists('json_last_error_msg')) {
+                throw new InvalidArgumentException(json_last_error_msg());
+            } else {
+                throw new InvalidArgumentException('A JSON encoding error occurred', json_last_error());
+            }
+        }
 
 		return $this->update();
 	}


### PR DESCRIPTION
On the 4.2 branch, calling `Response::json($x)` where `json_encode($x)` fails (e.g., where $x is an invalid UTF-8 character string) produces the following:

```
local.ERROR: exception 'UnexpectedValueException' with message 'The Response content must be a string or object implementing __toString(), "boolean" given.' in /www/gateway/vendor/symfony/http-foundation/Symfony/Component/HttpFoundation/Response.php:403
Stack trace:
#0 /www/gateway/vendor/symfony/http-foundation/Symfony/Component/HttpFoundation/JsonResponse.php(173): Symfony\Component\HttpFoundation\Response->setContent(false)
#1 /www/gateway/vendor/laravel/framework/src/Illuminate/Http/JsonResponse.php(52): Symfony\Component\HttpFoundation\JsonResponse->update()
#2 /www/gateway/vendor/symfony/http-foundation/Symfony/Component/HttpFoundation/JsonResponse.php(49): Illuminate\Http\JsonResponse->setData(Array)
#3 /www/gateway/vendor/laravel/framework/src/Illuminate/Http/JsonResponse.php(28): Symfony\Component\HttpFoundation\JsonResponse->__construct(Array, 200, Array)
```

Based on this alone, it's not clear that `json_encode()` failing is the cause of the error. The [Symfony JsonResponse class from which this is derived handles this](https://github.com/symfony/http-foundation/blob/6a5b4e01eeb168cea372c6a7eac023b80b31e846/JsonResponse.php#L113), but the `setData` method is overridden in the Laravel implementation. The [5.2 branch also looks for an error on json_encode() and  emits a more useful exception](https://github.com/laravel/framework/blob/249c948ce62dd9543e23cb2d7158f5edb651bf67/src/Illuminate/Http/JsonResponse.php#L45), so I'm backporting that logic here. Since `json_last_error_msg()` was added in PHP 5.5.0 and Laravel 4.2 supports PHP 5.4.0, I have to additionally check that this function exists.
