### PR TITLE
[5.3] Changing the name of the method mapToAssoc() to mapWithKeys()

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -8,7 +8,7 @@ use Traversable;
 use ArrayIterator;
 use CachingIterator;
 use JsonSerializable;
-use IteratorAggregate;m
+use IteratorAggregate;
 use InvalidArgumentException;
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\Contracts\Support\Jsonable;

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -600,9 +600,9 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
-     * Run an associative map over each of the items.
-     *
      * Map a collection persisting any changes made to keys.
+     *
+     * The callback should return an associative array with a single key/value pair.
      *
      * @param  callable  $callback
      * @return static

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -8,7 +8,7 @@ use Traversable;
 use ArrayIterator;
 use CachingIterator;
 use JsonSerializable;
-use IteratorAggregate;
+use IteratorAggregate;m
 use InvalidArgumentException;
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\Contracts\Support\Jsonable;
@@ -602,12 +602,12 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Run an associative map over each of the items.
      *
-     * The callback should return an associative array with a single key/value pair.
+     * Map a collection persisting any changes made to keys.
      *
      * @param  callable  $callback
      * @return static
      */
-    public function mapToAssoc(callable $callback)
+    public function mapWithKeys(callable $callback)
     {
         return $this->flatMap($callback);
     }

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -600,7 +600,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
-     * Map a collection persisting any changes made to keys.
+     * Run an associative map over each of the items.
      *
      * The callback should return an associative array with a single key/value pair.
      *

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -895,14 +895,14 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(['programming', 'basketball', 'music', 'powerlifting'], $data->all());
     }
 
-    public function testMapToAssoc()
+    public function testMapWithKeys()
     {
         $data = new Collection([
             ['name' => 'Blastoise', 'type' => 'Water', 'idx' => 9],
             ['name' => 'Charmander', 'type' => 'Fire', 'idx' => 4],
             ['name' => 'Dragonair', 'type' => 'Dragon', 'idx' => 148],
         ]);
-        $data = $data->mapToAssoc(function ($pokemon) {
+        $data = $data->mapWithKeys(function ($pokemon) {
             return [$pokemon['name'] => $pokemon['type']];
         });
         $this->assertEquals(


### PR DESCRIPTION
This was suggested in #14795 by @JosephSilber and @adamwathan and is a better definition of this method.

Also changed the test accordingly.
