### PR TITLE
[5.3] ARGV for Lua scripts

### DIFF
--- a/src/Illuminate/Queue/LuaScripts.php
+++ b/src/Illuminate/Queue/LuaScripts.php
@@ -18,7 +18,7 @@ if(job ~= false) then
     reserved = cjson.decode(job)
     reserved['attempts'] = reserved['attempts'] + 1
     reserved = cjson.encode(reserved)
-    redis.call('zadd', KEYS[2], KEYS[3], reserved)
+    redis.call('zadd', KEYS[2], ARGV[1], reserved)
 end
 return {job, reserved}
 LUA;
@@ -32,8 +32,8 @@ LUA;
     public static function release()
     {
         return <<<'LUA'
-redis.call('zrem', KEYS[2], KEYS[3])
-redis.call('zadd', KEYS[1], KEYS[4], KEYS[3])
+redis.call('zrem', KEYS[2], ARGV[1])
+redis.call('zadd', KEYS[1], ARGV[2], ARGV[1])
 return true
 LUA;
     }
@@ -46,7 +46,7 @@ LUA;
     public static function migrateExpiredJobs()
     {
         return <<<'LUA'
-local val = redis.call('zrangebyscore', KEYS[1], '-inf', KEYS[3])
+local val = redis.call('zrangebyscore', KEYS[1], '-inf', ARGV[1])
 if(next(val) ~= nil) then
     redis.call('zremrangebyrank', KEYS[1], 0, #val - 1)
     for i = 1, #val, 100 do
@@ -65,7 +65,7 @@ LUA;
     public static function size()
     {
         return <<<'LUA'
-return redis.call('llen', KEYS[1]) + redis.call('zcard', KEYS[1]..':delayed') + redis.call('zcard', KEYS[1]..':reserved')
+return redis.call('llen', KEYS[1]) + redis.call('zcard', KEYS[2]) + redis.call('zcard', KEYS[3])
 LUA;
     }
 }

--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -66,7 +66,7 @@ class RedisQueue extends Queue implements QueueContract
     {
         $queue = $this->getQueue($queue);
 
-        return $this->getConnection()->eval(LuaScripts::size(), 1, $queue);
+        return $this->getConnection()->eval(LuaScripts::size(), 3, $queue, $queue.':delayed', $queue.':reserved');
     }
 
     /**
@@ -136,7 +136,7 @@ class RedisQueue extends Queue implements QueueContract
         }
 
         list($job, $reserved) = $this->getConnection()->eval(
-            LuaScripts::pop(), 3, $queue, $queue.':reserved', $this->getTime() + $this->expire
+            LuaScripts::pop(), 2, $queue, $queue.':reserved', $this->getTime() + $this->expire
         );
 
         if ($reserved) {
@@ -169,7 +169,7 @@ class RedisQueue extends Queue implements QueueContract
         $queue = $this->getQueue($queue);
 
         $this->getConnection()->eval(
-            LuaScripts::release(), 4, $queue.':delayed', $queue.':reserved',
+            LuaScripts::release(), 2, $queue.':delayed', $queue.':reserved',
             $job, $this->getTime() + $delay
         );
     }
@@ -184,7 +184,7 @@ class RedisQueue extends Queue implements QueueContract
     public function migrateExpiredJobs($from, $to)
     {
         $this->getConnection()->eval(
-            LuaScripts::migrateExpiredJobs(), 3, $from, $to, $this->getTime()
+            LuaScripts::migrateExpiredJobs(), 2, $from, $to, $this->getTime()
         );
     }
 


### PR DESCRIPTION
According to [Redis documentations](http://redis.io/commands/EVAL), this commit makes things compatible with Redis Clusters.
- The LuaScripts::size() should not dynamically generate key names.
- For LuaScripts::pop,release, and migrateExpiredJobs(), there is no reason to pass non-key arguments as KEYS - unnecessary overhead I think.

Note: I have not tested Redis clusters yet. Sorry about that.
