### PR TITLE
Helpful comments and removed void returns

### DIFF
--- a/src/Illuminate/Notifications/ChannelManager.php
+++ b/src/Illuminate/Notifications/ChannelManager.php
@@ -32,7 +32,7 @@ class ChannelManager extends Manager implements DispatcherContract, FactoryContr
     public function send($notifiables, $notification)
     {
         if ($notification instanceof ShouldQueue) {
-            $this->queueNotification($notifiables, $notification);
+            return $this->queueNotification($notifiables, $notification);
         }
 
         $this->sendNow($notifiables, $notification);

--- a/src/Illuminate/Notifications/ChannelManager.php
+++ b/src/Illuminate/Notifications/ChannelManager.php
@@ -32,10 +32,10 @@ class ChannelManager extends Manager implements DispatcherContract, FactoryContr
     public function send($notifiables, $notification)
     {
         if ($notification instanceof ShouldQueue) {
-            return $this->queueNotification($notifiables, $notification);
+            $this->queueNotification($notifiables, $notification);
         }
 
-        return $this->sendNow($notifiables, $notification);
+        $this->sendNow($notifiables, $notification);
     }
 
     /**

--- a/src/Illuminate/Notifications/RoutesNotifications.php
+++ b/src/Illuminate/Notifications/RoutesNotifications.php
@@ -20,6 +20,8 @@ trait RoutesNotifications
 
     /**
      * Get the notification routing information for the given driver.
+     * In case of an empty return value, the notification will
+     * not be sent.
      *
      * @param  string  $driver
      * @return mixed


### PR DESCRIPTION
Hey dudes, I was working on your notifications and I noticed notifications weren't sending if the "email" value of a user was empty. It took me a while to figure out since I was expecting an error. 

After a little more thought it was obvious why you wouldn't want to throw an error there, it's not "eloquent" ^^ and will be a pain when dealing with large collections. So I added a little comment above the method that mentions this. That little snippet might clear up future confusion for other developers. 

Also as a bonus, I removed some un-needed returns. 

Peace <3
