### PR TITLE
[5.3] Fire notification events on channel level & fire event before sending

### DIFF
--- a/src/Illuminate/Notifications/Events/NotificationSending.php
+++ b/src/Illuminate/Notifications/Events/NotificationSending.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\Notifications\Events;
 
-class NotificationSent
+class NotificationSending
 {
     /**
      * The notifiable entity who received the notification.

--- a/tests/Notifications/NotificationChannelManagerTest.php
+++ b/tests/Notifications/NotificationChannelManagerTest.php
@@ -20,10 +20,27 @@ class NotificationChannelManagerTest extends PHPUnit_Framework_TestCase
         Container::setInstance($container);
         $manager = Mockery::mock(ChannelManager::class.'[driver]', [$container]);
         $manager->shouldReceive('driver')->andReturn($driver = Mockery::mock());
+        $events->shouldReceive('until')->with(Mockery::type(Illuminate\Notifications\Events\NotificationSending::class))->andReturn(true);
         $driver->shouldReceive('send')->once();
         $events->shouldReceive('fire')->with(Mockery::type(Illuminate\Notifications\Events\NotificationSent::class));
 
         $manager->send([new NotificationChannelManagerTestNotifiable], new NotificationChannelManagerTestNotification);
+    }
+
+    public function testNotificationNotSentOnHalt()
+    {
+        $container = new Container;
+        $container->instance('config', ['app.name' => 'Name', 'app.logo' => 'Logo']);
+        $container->instance('events', $events = Mockery::mock());
+        Container::setInstance($container);
+        $manager = Mockery::mock(ChannelManager::class.'[driver]', [$container]);
+        $events->shouldReceive('until')->once()->with(Mockery::type(Illuminate\Notifications\Events\NotificationSending::class))->andReturn(false);
+        $events->shouldReceive('until')->with(Mockery::type(Illuminate\Notifications\Events\NotificationSending::class))->andReturn(true);
+        $manager->shouldReceive('driver')->once()->andReturn($driver = Mockery::mock());
+        $driver->shouldReceive('send')->once();
+        $events->shouldReceive('fire')->with(Mockery::type(Illuminate\Notifications\Events\NotificationSent::class));
+
+        $manager->send([new NotificationChannelManagerTestNotifiable], new NotificationChannelManagerTestNotificationWithTwoChannels);
     }
 
     public function testNotificationCanBeQueued()
@@ -49,6 +66,19 @@ class NotificationChannelManagerTestNotification extends Notification
     public function via()
     {
         return ['test'];
+    }
+
+    public function message()
+    {
+        return $this->line('test')->action('Text', 'url');
+    }
+}
+
+class NotificationChannelManagerTestNotificationWithTwoChannels extends Notification
+{
+    public function via()
+    {
+        return ['test', 'test2'];
     }
 
     public function message()


### PR DESCRIPTION
This proposal includes the following:
1. Firing a "haltable" event `SendingNotification` before sending.
2. Firing both `SendingNotification` and `NotificationSent` per channel attempt.
3. Adding a `channel` parameter to the events constructors.

Scenario that inspired the changes:

While sending to tenant members, the `SendingNotification` event can be used to skip sending if the tenant is blocked from sending on the `sms` channel for example or out of credit for only `sms`, but the notifier may proceed to send on the `mail` channel.

Moving the `NotificationSent` to the `$channels` loop will allow for example decrementing the credit for the tenant for every `sms` sent so that later we can email him "Low credit, please recharge." or stop him from sending like the scenario stated earlier.
