### PR TITLE
[5.2] Add withoutTrashed method to SoftDeletingScope

### DIFF
--- a/src/Illuminate/Database/Eloquent/SoftDeletingScope.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletingScope.php
@@ -9,7 +9,7 @@ class SoftDeletingScope implements Scope
      *
      * @var array
      */
-    protected $extensions = ['ForceDelete', 'Restore', 'WithTrashed', 'OnlyTrashed'];
+    protected $extensions = ['ForceDelete', 'Restore', 'WithTrashed', 'OnlyTrashed', 'WithoutTrashed'];
 
     /**
      * Apply the scope to a given Eloquent query builder.
@@ -112,6 +112,25 @@ class SoftDeletingScope implements Scope
             $model = $builder->getModel();
 
             $builder->withoutGlobalScope($this)->whereNotNull(
+                $model->getQualifiedDeletedAtColumn()
+            );
+
+            return $builder;
+        });
+    }
+
+    /**
+     * Add the without-trashed extension to the builder.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder  $builder
+     * @return void
+     */
+    protected function addWithoutTrashed(Builder $builder)
+    {
+        $builder->macro('withoutTrashed', function (Builder $builder) {
+            $model = $builder->getModel();
+            
+            $builder->withoutGlobalScope($this)->whereNull(
                 $model->getQualifiedDeletedAtColumn()
             );
 

--- a/src/Illuminate/Database/Eloquent/SoftDeletingScope.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletingScope.php
@@ -129,7 +129,7 @@ class SoftDeletingScope implements Scope
     {
         $builder->macro('withoutTrashed', function (Builder $builder) {
             $model = $builder->getModel();
-            
+
             $builder->withoutGlobalScope($this)->whereNull(
                 $model->getQualifiedDeletedAtColumn()
             );

--- a/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
@@ -204,7 +204,7 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends PHPUnit_Framework_TestC
         $users = SoftDeletesTestUser::withTrashed()->withoutTrashed()->get();
 
         $this->assertCount(1, $users);
-        $this->assertEquals(2, $users->first()->id);        
+        $this->assertEquals(2, $users->first()->id);
     }
 
     public function testFirstOrNew()

--- a/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
@@ -192,6 +192,21 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends PHPUnit_Framework_TestC
         $this->assertEquals(1, $users->first()->id);
     }
 
+    public function testOnlyWithoutTrashedOnlyReturnsTrashedRecords()
+    {
+        $this->createUsers();
+
+        $users = SoftDeletesTestUser::withoutTrashed()->get();
+
+        $this->assertCount(1, $users);
+        $this->assertEquals(2, $users->first()->id);
+
+        $users = SoftDeletesTestUser::withTrashed()->withoutTrashed()->get();
+
+        $this->assertCount(1, $users);
+        $this->assertEquals(2, $users->first()->id);        
+    }
+
     public function testFirstOrNew()
     {
         $this->createUsers();

--- a/tests/Database/DatabaseSoftDeletingScopeTest.php
+++ b/tests/Database/DatabaseSoftDeletingScopeTest.php
@@ -84,4 +84,24 @@ class DatabaseSoftDeletingScopeTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals($givenBuilder, $result);
     }
+
+    public function testWithoutTrashedExtension()
+    {
+        $builder = m::mock('Illuminate\Database\Eloquent\Builder');
+        $builder->shouldDeferMissing();
+        $model = m::mock('Illuminate\Database\Eloquent\Model');
+        $model->shouldDeferMissing();
+        $scope = m::mock('Illuminate\Database\Eloquent\SoftDeletingScope[remove]');
+        $scope->extend($builder);
+        $callback = $builder->getMacro('withoutTrashed');
+        $givenBuilder = m::mock('Illuminate\Database\Eloquent\Builder');
+        $givenBuilder->shouldReceive('getQuery')->andReturn($query = m::mock('stdClass'));
+        $givenBuilder->shouldReceive('getModel')->andReturn($model);
+        $givenBuilder->shouldReceive('withoutGlobalScope')->with($scope)->andReturn($givenBuilder);
+        $model->shouldReceive('getQualifiedDeletedAtColumn')->andReturn('table.deleted_at');
+        $givenBuilder->shouldReceive('whereNull')->once()->with('table.deleted_at');
+        $result = $callback($givenBuilder);
+
+        $this->assertEquals($givenBuilder, $result);
+    }
 }


### PR DESCRIPTION
Sometimes it's useful to exclude trashed records when `withTrashed` scope has been already applied.

Let's assume we have some complex list and data returned depends on user role. By default we allow to display all the users also trashed data, but for user with role `Client` we won't to allow this. So we can either to repeat `withTrashed` for all roles except `Client` or we can just use `withTrashed` globally and then for user with role `Client` use `->whereNull('deleted_at')`. It would be better to use `withoutTrashed` proposed here than manually adding such condition to query. 
