### PR TITLE
[5.2] Enhance @each/renderEach to allow additional data to be passed along with the primary object being looped

### DIFF
--- a/src/Illuminate/View/Factory.php
+++ b/src/Illuminate/View/Factory.php
@@ -274,7 +274,14 @@ class Factory implements FactoryContract
             foreach ($data as $key => $value) {
                 $data = ['key' => $key, $iterator => $value];
 
-                $result .= $this->make($view, $data)->render();
+                // Passing the view as an array in the format of key = the view file,
+                // value = array of parameters, it'll render the view with the additional
+                // blade parameters, rather than the pure $data object
+                if (is_array($view)) {
+                    $result .= $this->make(key($view), array_merge($view[key($view)], $data))->render();
+                } else {
+                    $result .= $this->make($view, $data)->render();
+                }
             }
         }
 

--- a/src/Illuminate/View/Factory.php
+++ b/src/Illuminate/View/Factory.php
@@ -257,10 +257,10 @@ class Factory implements FactoryContract
     /**
      * Get the rendered contents of a partial from a loop.
      *
-     * @param  string  $view
-     * @param  array   $data
-     * @param  string  $iterator
-     * @param  string  $empty
+     * @param  sting|array  $view
+     * @param  array        $data
+     * @param  string       $iterator
+     * @param  string       $empty
      * @return string
      */
     public function renderEach($view, $data, $iterator, $empty = 'raw|')


### PR DESCRIPTION
I had an issue where I'd like to have passed additional data to the view file when performing an @each loop, but didn't want to push that data into the object I was passing the loop. Normally you can pass a view this array of data, but the @each way of including is limited to what can be passed in the normal fashion.

I've worked out a simple (and backwards compatible way) of doing this:

If you'd like to pass additional data, when calling your @each you'd structure it like this:

``` php
@each(['my-view-file' => ['foo' => 'bar']], $mainObject, 'mainObject')
```

Instead of the view file being a string, it'd be the key in an array. The value of that array key would be your array of parameters. Leaving the view file as a pure string would keep the functionality the same as it always has been, keeping the system backward compatible.
