### PR TITLE
[5.3] Fix export-ignore for phpunit.xml

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,6 +8,6 @@
 .nitpick.json export-ignore
 .php_cs export-ignore
 .travis.yml export-ignore
-phpunit.xml export-ignore
+phpunit.xml.dist export-ignore
 CHANGELOG.md export-ignore
 CONTRIBUTING.md export-ignore


### PR DESCRIPTION
Export phpunit.xml.dist instead of phpunit.xml.
