### PR TITLE
[5.3] Hash password in User model

### DIFF
--- a/src/Illuminate/Foundation/Auth/ResetsPasswords.php
+++ b/src/Illuminate/Foundation/Auth/ResetsPasswords.php
@@ -80,7 +80,7 @@ trait ResetsPasswords
     protected function resetPassword($user, $password)
     {
         $user->forceFill([
-            'password' => bcrypt($password),
+            'password' => $password,
             'remember_token' => Str::random(60),
         ])->save();
 

--- a/src/Illuminate/Foundation/Auth/User.php
+++ b/src/Illuminate/Foundation/Auth/User.php
@@ -16,4 +16,14 @@ class User extends Model implements
     CanResetPasswordContract
 {
     use Authenticatable, Authorizable, CanResetPassword;
+
+    /**
+     * Set Bcrypt hashed password
+     *
+     * @param  string $value
+     */
+    public function setPasswordAttribute($value)
+    {
+        $this->attributes['password'] = bcrypt($value);
+    }
 }

--- a/src/Illuminate/Foundation/Auth/User.php
+++ b/src/Illuminate/Foundation/Auth/User.php
@@ -18,7 +18,7 @@ class User extends Model implements
     use Authenticatable, Authorizable, CanResetPassword;
 
     /**
-     * Set Bcrypt hashed password
+     * Set Bcrypt hashed password.
      *
      * @param  string $value
      */


### PR DESCRIPTION
I think the better instead of using `bcrypt` in many places is adding mutator to default `User` model and in case of any change,  it would be easier to change it to anything else if someone wants to customize. This would need to go of course with app changes https://github.com/laravel/laravel/pull/3879

If approved, it should be probably added also to documentation and upgrade guide to 5.3
