### PR TITLE
[5.3] Load NotificationServiceProvider eagerly

### DIFF
--- a/src/Illuminate/Notifications/NotificationServiceProvider.php
+++ b/src/Illuminate/Notifications/NotificationServiceProvider.php
@@ -9,13 +9,6 @@ use Illuminate\Contracts\Notifications\Dispatcher as DispatcherContract;
 class NotificationServiceProvider extends ServiceProvider
 {
     /**
-     * Indicates if loading of the provider is deferred.
-     *
-     * @var bool
-     */
-    protected $defer = true;
-
-    /**
      * Boot the application services.
      *
      * @return void
@@ -49,17 +42,5 @@ class NotificationServiceProvider extends ServiceProvider
         $this->app->alias(
             ChannelManager::class, FactoryContract::class
         );
-    }
-
-    /**
-     * Get the services provided by the provider.
-     *
-     * @return array
-     */
-    public function provides()
-    {
-        return [
-            ChannelManager::class, DispatcherContract::class, FactoryContract::class,
-        ];
     }
 }


### PR DESCRIPTION
Since we have this in the `boot()` method of the provider:

``` php
$this->loadViewsFrom(__DIR__.'/resources/views', 'notifications');
```

We have to load it early in the initialisation to register the view namespace, if we defer loading the namespace won't get registered.
