### PR TITLE
[5.3] Using cached controller can lead to race conditions with middleware

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -199,11 +199,7 @@ class Route
     {
         list($class) = explode('@', $this->action['uses']);
 
-        if (! $this->controller) {
-            $this->controller = $this->container->make($class);
-        }
-
-        return $this->controller;
+        return $this->controller = $this->container->make($class);
     }
 
     /**


### PR DESCRIPTION
Just ran into an issue with a recent change in 5.3 in which `Illuminate\Routing\Route::getController()` now caches it's result.

Basically if you are running auth middleware via a group parameter in your routes file

``` php

$router->group(['prefix' => 'projects', 'middleware' => ['auth']], function($router) {
    // Controller setups here
});

```

and you use the `__construct()` method in your controller to bootstrap things that require auth in your controller

``` php

public function __construct()
{
    parent::__construct();

    // this checks the currently logged in user
    $this->participant = $this->project->currentParticipant();
}
```

What you will see is that the Routing class will call `gatherMiddleware()` which will in turn call `controllerMiddleware()`. That `controllerMiddleware()` inits the controller class (to do reflection for any other middleware calls) before any route specified middleware is fired (the auth in this case) and caches the result.

So when the example above happens, `$this->participant` is `null` because the auth middleware hasn't fired yet, logging the user in for that request.

By removing the cache of `$this->controller` it allows the controller to be re-built after all the middleware is initiated and clears this bug up.

It looks like the bug was unintentionally introduced in #14097 by @JosephSilber ... Joseph can you take a look at it and see if removing the cache causes any issues?
