### PR TITLE
[5.2] Different pagintion presenters for different paginators types

### DIFF
--- a/src/Illuminate/Pagination/LengthAwarePaginator.php
+++ b/src/Illuminate/Pagination/LengthAwarePaginator.php
@@ -29,6 +29,13 @@ class LengthAwarePaginator extends AbstractPaginator implements Arrayable, Array
     protected $lastPage;
 
     /**
+     * The default presenter resolver.
+     *
+     * @var \Closure
+     */
+    protected static $presenterResolver;
+
+    /**
      * Create a new paginator instance.
      *
      * @param  mixed  $items
@@ -127,13 +134,28 @@ class LengthAwarePaginator extends AbstractPaginator implements Arrayable, Array
      */
     public function render(Presenter $presenter = null)
     {
-        if (is_null($presenter) && static::$presenterResolver) {
-            $presenter = call_user_func(static::$presenterResolver, $this);
-        }
-
-        $presenter = $presenter ?: new BootstrapThreePresenter($this);
+        $presenter = $presenter ?: $this->getDefaultPresenter();
 
         return $presenter->render();
+    }
+
+    /**
+     * Get default pagination presenter.
+     *
+     * @return \Illuminate\Contracts\Pagination\Presenter|SimpleBootstrapThreePresenter
+     */
+    protected function getDefaultPresenter()
+    {
+        $presenter = null;
+
+        if (static::$presenterResolver) {
+            $presenter = call_user_func(static::$presenterResolver, $this);
+        }
+        if (is_null($presenter) && AbstractPaginator::$presenterResolver) {
+            $presenter = call_user_func(AbstractPaginator::$presenterResolver, $this);
+        }
+
+        return $presenter ?: new SimpleBootstrapThreePresenter($this);
     }
 
     /**

--- a/src/Illuminate/Pagination/Paginator.php
+++ b/src/Illuminate/Pagination/Paginator.php
@@ -22,6 +22,13 @@ class Paginator extends AbstractPaginator implements Arrayable, ArrayAccess, Cou
     protected $hasMore;
 
     /**
+     * The default presenter resolver.
+     *
+     * @var \Closure
+     */
+    protected static $presenterResolver;
+
+    /**
      * Create a new paginator instance.
      *
      * @param  mixed  $items
@@ -110,13 +117,28 @@ class Paginator extends AbstractPaginator implements Arrayable, ArrayAccess, Cou
      */
     public function render(Presenter $presenter = null)
     {
-        if (is_null($presenter) && static::$presenterResolver) {
-            $presenter = call_user_func(static::$presenterResolver, $this);
-        }
-
-        $presenter = $presenter ?: new SimpleBootstrapThreePresenter($this);
+        $presenter = $presenter ?: $this->getDefaultPresenter();
 
         return $presenter->render();
+    }
+
+    /**
+     * Get default pagination presenter.
+     *
+     * @return \Illuminate\Contracts\Pagination\Presenter|SimpleBootstrapThreePresenter
+     */
+    protected function getDefaultPresenter()
+    {
+        $presenter = null;
+
+        if (static::$presenterResolver) {
+            $presenter = call_user_func(static::$presenterResolver, $this);
+        }
+        if (is_null($presenter) && AbstractPaginator::$presenterResolver) {
+            $presenter = call_user_func(AbstractPaginator::$presenterResolver, $this);
+        }
+
+        return $presenter ?: new SimpleBootstrapThreePresenter($this);
     }
 
     /**

--- a/tests/Pagination/PaginationPaginatorTest.php
+++ b/tests/Pagination/PaginationPaginatorTest.php
@@ -129,6 +129,22 @@ class PaginationPaginatorTest extends PHPUnit_Framework_TestCase
     {
         $p = new LengthAwarePaginator([], 1, 1, 1);
         $presenter = m::mock('StdClass');
+        LengthAwarePaginator::presenter(function () use ($presenter) {
+            return $presenter;
+        });
+        $presenter->shouldReceive('render')->andReturn('presenter');
+
+        $this->assertEquals('presenter', $p->render());
+
+        LengthAwarePaginator::presenter(function () {
+            //
+        });
+    }
+
+    public function testCustomDefaultPresenter()
+    {
+        $p = new LengthAwarePaginator([], 1, 1, 1);
+        $presenter = m::mock('StdClass');
         AbstractPaginator::presenter(function () use ($presenter) {
             return $presenter;
         });
@@ -137,6 +153,35 @@ class PaginationPaginatorTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('presenter', $p->render());
 
         AbstractPaginator::presenter(function () {
+            //
+        });
+    }
+
+    public function testDifferentCustomPresentersForDifferentPaginatorTypes()
+    {
+        $simplePresenter = m::mock('StdClass');
+        $simplePresenter->shouldReceive('render')->andReturn('simple');
+
+        Paginator::presenter(function () use ($simplePresenter) {
+            return $simplePresenter;
+        });
+
+        $presenter = m::mock('StdClass');
+        $presenter->shouldReceive('render')->andReturn('presenter');
+        LengthAwarePaginator::presenter(function () use ($presenter) {
+            return $presenter;
+        });
+
+        $p = new LengthAwarePaginator([], 1, 1, 1);
+        $s = new Paginator([], 1, 1);
+
+        $this->assertEquals('presenter', $p->render());
+        $this->assertEquals('simple', $s->render());
+
+        Paginator::presenter(function () {
+            //
+        });
+        LengthAwarePaginator::presenter(function () {
             //
         });
     }


### PR DESCRIPTION
I whont set pagination presenters in service provider:

``` php
        Paginator::presenter(function ($paginator) {
            return new SimpleBootstrapFourPresenter($paginator);
//            return new SimpleUikitPresenter($paginator);
        });

        LengthAwarePaginator::presenter(function ($paginator) {
            return new BootstrapFourPresenter($paginator);
//            return new UikitPresenter($paginator);
        });
```

And i have error.

I resolve this problem in pull request.
