### PR TITLE
[5.3] Allow boot() method on controllers

### DIFF
--- a/src/Illuminate/Routing/ControllerDispatcher.php
+++ b/src/Illuminate/Routing/ControllerDispatcher.php
@@ -39,6 +39,10 @@ class ControllerDispatcher
         $parameters = $this->resolveClassMethodDependencies(
             $route->parametersWithoutNulls(), $controller, $method
         );
+        
+        if (method_exists($controller, 'boot')) {
+            $controller->boot();
+        }
 
         if (method_exists($controller, 'callAction')) {
             return $controller->callAction($method, $parameters);

--- a/src/Illuminate/Routing/ControllerDispatcher.php
+++ b/src/Illuminate/Routing/ControllerDispatcher.php
@@ -39,7 +39,7 @@ class ControllerDispatcher
         $parameters = $this->resolveClassMethodDependencies(
             $route->parametersWithoutNulls(), $controller, $method
         );
-        
+
         if (method_exists($controller, 'boot')) {
             $controller->boot();
         }


### PR DESCRIPTION
This is related to #14824 where not all the middleware executes before a controller is initiated which can lead to issues with auth, session, etc.

Adding a `boot()` method allows us to have BaseControllers that interact with "middlewarey" things without having to duplicate code / calls in each controller action.
