### PR TITLE
[5.2] [Proposal] New model method: hasEverBeenUpdated()

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1428,7 +1428,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 
         return $this->fill($attributes)->save($options);
     }
-    
+
     /**
      * Returns a bool based on if the values for "created at"
      * and "updated at" are different or not.

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1428,6 +1428,21 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 
         return $this->fill($attributes)->save($options);
     }
+    
+    /**
+     * Returns a bool based on if the values for "created at"
+     * and "updated at" are different or not.
+     *
+     * @return bool
+     */
+    public function hasEverBeenUpdated()
+    {
+        if ($this->timestamps) {
+            return $this->{static::UPDATED_AT} != $this->{static::CREATED_AT};
+        }
+
+        return false;
+    }
 
     /**
      * Save the model and all of its relationships.


### PR DESCRIPTION
Personally, I don't like to show the updated_at value on results if it's the same as the created_at date, as this implies (at a glance at least) that the row has had an update at some point when it's actually only been created and never touched since, so instead I compare the timestamps to see if there's a difference before showing the date. This is tedious though, so I've added a method to the Model: hasEverBeenUpdated().

This returns a bool based on if the values for "created at" and "updated at" are different or not. True if it has, false if not (or doesn't have timestamp columns). Not a major feature.

I was going to make it throw if there were no timestamp columns but that felt a little harsh.

Also, not sure on the method name... couldn't think of anything better.
