### PR TITLE
[5.3] Only mark read_at if not already set

### DIFF
--- a/src/Illuminate/Notifications/DatabaseNotification.php
+++ b/src/Illuminate/Notifications/DatabaseNotification.php
@@ -52,7 +52,9 @@ class DatabaseNotification extends Model
      */
     public function markAsRead()
     {
-        $this->forceFill(['read_at' => $this->freshTimestamp()])->save();
+        if (is_null($this->read_at)) {
+            $this->forceFill(['read_at' => $this->freshTimestamp()])->save();
+        }
     }
 
     /**


### PR DESCRIPTION
Just a thought, curious what others have to say about this one.

To prevent a notification from being marked read repeatedly, perhaps it should only be marked as read the first time. Any additional calls to `markAsRead` will do nothing. 
