### PR TITLE
[5.3] Pass array of order by columns to orderBy

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1349,6 +1349,12 @@ class Builder
      */
     public function orderBy($column, $direction = 'asc')
     {
+        // If the column is an array, we will assume it is an array of key-value
+        // pairs and we can add them each as a order by clause.
+        if (is_array($column)) {
+            return $this->addArrayOfOrderBy($column, $direction);
+        }
+
         $this->{$this->unions ? 'unionOrders' : 'orders'}[] = [
             'column' => $column,
             'direction' => strtolower($direction) == 'asc' ? 'asc' : 'desc',
@@ -1406,6 +1412,29 @@ class Builder
         $this->{$property}[] = compact('type', 'sql');
 
         $this->addBinding($bindings, 'order');
+
+        return $this;
+    }
+
+    /**
+     * Add array of "order by" clauses to the query.
+     *
+     * @param  array  $column
+     * @param  string  $direction
+     * @param  string  $method
+     * @return $this
+     */
+    protected function addArrayOfOrderBy($column, $direction, $method = 'orderBy')
+    {
+        foreach ($column as $key => $value) {
+            // If key is an integer, then value must be the column name.
+            if (is_numeric($key)) {
+                $key = $value;
+                $value = $direction;
+            }
+
+            $this->$method($key, $value);
+        }
 
         return $this;
     }

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -571,6 +571,18 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(['foo'], $builder->getBindings());
     }
 
+    public function testorderBysWithArrays()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->orderBy(['email' => 'asc', 'age' => 'desc']);
+        $this->assertEquals('select * from "users" order by "email" asc, "age" desc', $builder->toSql());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->orderBy(['email'])->orderByRaw('"age" ? desc', ['foo']);
+        $this->assertEquals('select * from "users" order by "email" asc, "age" ? desc', $builder->toSql());
+        $this->assertEquals(['foo'], $builder->getBindings());
+    }
+
     public function testHavings()
     {
         $builder = $this->getBuilder();


### PR DESCRIPTION
Adds support to pass an array of order by columns to the `orderBy` function as stated #14813. 
