### PR TITLE
Fixed Paginator to correctly slice items from collection

### DIFF
--- a/src/Illuminate/Pagination/Paginator.php
+++ b/src/Illuminate/Pagination/Paginator.php
@@ -66,7 +66,7 @@ class Paginator extends AbstractPaginator implements Arrayable, ArrayAccess, Cou
     {
         $this->hasMore = count($this->items) > ($this->perPage);
 
-        $this->items = $this->items->slice(0, $this->perPage);
+        $this->items = $this->items->slice(($this->currentPage - 1) * $this->perPage, $this->perPage);
     }
 
     /**


### PR DESCRIPTION
It was always displaying the same first items because it was always slicing from 0 index
