### PR TITLE
[5.3] Changed visibility back to public

### DIFF
--- a/src/Illuminate/Mail/MailableMailer.php
+++ b/src/Illuminate/Mail/MailableMailer.php
@@ -129,7 +129,7 @@ class MailableMailer
      * @param  Mailable  $mailable
      * @return mixed
      */
-    protected function queue(Mailable $mailable)
+    public function queue(Mailable $mailable)
     {
         if (isset($mailable->delay)) {
             return $this->mailer->later($mailable->delay, $mailable);


### PR DESCRIPTION
This code now fails after the commit fa9cdbfd4a480d6d8d38658fc4ec029703ccb777:  `Mail::to($this)->queue(new ResetPassword($this, $token));` with fatal error `Call to protected method Illuminate\Mail\MailableMailer::queue() from context` `App\Models\User`. (I have a method to send password reset in the User model).
