### PR TITLE
[5.2] Fix for Eloquent function makeHidden() when used with a string. 

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2150,7 +2150,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     {
         $this->visible = array_diff($this->visible, (array) $attributes);
 
-        $this->hidden = array_unique(array_merge($this->hidden, $attributes));
+        $this->hidden = array_unique(array_merge($this->hidden, (array) $attributes));
 
         return $this;
     }

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -719,8 +719,15 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
 
     public function testMakeHidden()
     {
-        $model = new EloquentModelStub(['name' => 'foo', 'age' => 'bar', 'id' => 'baz']);
+        $model = new EloquentModelStub(['name' => 'foo', 'age' => 'bar', 'address' => 'foobar', 'id' => 'baz']);
         $array = $model->toArray();
+        $this->assertArrayHasKey('name', $array);
+        $this->assertArrayHasKey('age', $array);
+        $this->assertArrayHasKey('address', $array);
+        $this->assertArrayHasKey('id', $array);
+
+        $array = $model->makeHidden('address')->toArray();
+        $this->assertArrayNotHasKey('address', $array);
         $this->assertArrayHasKey('name', $array);
         $this->assertArrayHasKey('age', $array);
         $this->assertArrayHasKey('id', $array);
@@ -728,6 +735,7 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
         $array = $model->makeHidden(['name', 'age'])->toArray();
         $this->assertArrayNotHasKey('name', $array);
         $this->assertArrayNotHasKey('age', $array);
+        $this->assertArrayNotHasKey('address', $array);
         $this->assertArrayHasKey('id', $array);
     }
 


### PR DESCRIPTION
According to the docs (phpDocs and laravel-docs) makeHidden function can be used with a string (for only one attribute) but 45d6abfe makes it fail because array_merge() expects both parameters to be arrays. 

This bug is also present on master.
