### PR TITLE
[5.3] Fix JSON contains check

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -383,7 +383,7 @@ trait MakesHttpRequests
             $expected = substr($expected, 0, -1);
         }
 
-        return $expected;
+        return trim($expected);
     }
 
     /**


### PR DESCRIPTION
Actual:

```
{\n
    "status": "success",\n
    "user": null,\n
    "version": "v0"\n
}
```

Expected:

```
\n
    "status": "success"\n
```

Currently test fails because of trailing line-ending characters.
