### PR TITLE
[5.2] Wrap APP_KEY in quotes when regenerating key

### DIFF
--- a/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
+++ b/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
@@ -53,7 +53,7 @@ class KeyGenerateCommand extends Command
     {
         $originalEnvContent = file_get_contents($this->laravel->environmentFilePath());
 
-        $newEnvContent = preg_replace('/APP_KEY="?([A-Za-z0-9:+=\/]+)"?/', "APP_KEY=\"$key\"", $originalEnvContent);
+        $newEnvContent = preg_replace('/APP_KEY="?[^\'"\s]+"?/', "APP_KEY=\"$key\"", $originalEnvContent);
 
         file_put_contents($this->laravel->environmentFilePath(), $newEnvContent);
     }

--- a/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
+++ b/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
@@ -51,11 +51,11 @@ class KeyGenerateCommand extends Command
      */
     protected function setKeyInEnvironmentFile($key)
     {
-        file_put_contents($this->laravel->environmentFilePath(), str_replace(
-            'APP_KEY='.$this->laravel['config']['app.key'],
-            'APP_KEY='.$key,
-            file_get_contents($this->laravel->environmentFilePath())
-        ));
+        $originalEnvContent = file_get_contents($this->laravel->environmentFilePath());
+
+        $newEnvContent = preg_replace('/APP_KEY="?([A-Za-z0-9:+=\/]+)"?/', "APP_KEY=\"$key\"", $originalEnvContent);
+
+        file_put_contents($this->laravel->environmentFilePath(), $newEnvContent);
     }
 
     /**


### PR DESCRIPTION
If the APP_KEY was wrapped in quotes, it was not regenerating it.
