### PR TITLE
[5.1] Flysystem disable_asserts config

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemManager.php
+++ b/src/Illuminate/Filesystem/FilesystemManager.php
@@ -239,7 +239,7 @@ class FilesystemManager implements FactoryContract
      */
     protected function createFlysystem(AdapterInterface $adapter, array $config)
     {
-        $config = Arr::only($config, ['visibility']);
+        $config = Arr::only($config, ['visibility', 'disable_asserts']);
 
         return new Flysystem($adapter, count($config) > 0 ? $config : null);
     }


### PR DESCRIPTION
Flysystem introduced a feature in 1.0.26 that allows you to increase performance by disabling asserts.

http://flysystem.thephpleague.com/performance/

This PR simply lets you set that config value.
