### PR TITLE
[5.3] Broadcaster channel only looks for the toArray method.

### DIFF
--- a/src/Illuminate/Notifications/Channels/BroadcastChannel.php
+++ b/src/Illuminate/Notifications/Channels/BroadcastChannel.php
@@ -52,6 +52,10 @@ class BroadcastChannel
      */
     protected function getData($notifiable, Notification $notification)
     {
+        if (method_exists($notification, 'toBroadcast')) {
+            return $notification->toBroadcast($notifiable);
+        }
+
         if (method_exists($notification, 'toArray')) {
             return $notification->toArray($notifiable);
         }


### PR DESCRIPTION
The broadcasting notification got the data from the toArray method, but the documentation said that if we need to send different data to the database and the broadcast channel, we can use the toBroadcast method, so i see on the BroadcasterChannel doesn't look for the method toBroadcast, and i put it first because i think this one should have priority over the toArray.

Let me know your thoguhts
