### PR TITLE
[5.2] Adds clearer method and stub names

### DIFF
--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1338,7 +1338,7 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
         $this->assertTrue(isset($model->some_relation));
     }
 
-    public function testIntIdTypePreserved()
+    public function testIntKeyTypePreserved()
     {
         $model = $this->getMock('EloquentModelStub', ['newQueryWithoutScopes', 'updateTimestamps', 'refresh']);
         $query = m::mock('Illuminate\Database\Eloquent\Builder');
@@ -1349,9 +1349,9 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(1, $model->id);
     }
 
-    public function testStringIdTypePreserved()
+    public function testStringKeyTypePreserved()
     {
-        $model = $this->getMock('EloquentIdTypeModelStub', ['newQueryWithoutScopes', 'updateTimestamps', 'refresh']);
+        $model = $this->getMock('EloquentKeyTypeModelStub', ['newQueryWithoutScopes', 'updateTimestamps', 'refresh']);
         $query = m::mock('Illuminate\Database\Eloquent\Builder');
         $query->shouldReceive('insertGetId')->once()->with([], 'id')->andReturn('string id');
         $model->expects($this->once())->method('newQueryWithoutScopes')->will($this->returnValue($query));
@@ -1504,7 +1504,7 @@ class EloquentModelSaveStub extends Model
     }
 }
 
-class EloquentIdTypeModelStub extends EloquentModelStub
+class EloquentKeyTypeModelStub extends EloquentModelStub
 {
     protected $keyType = 'string';
 }


### PR DESCRIPTION
A `$keyType` attribute was introduced onto the model class to fix an issue with `getCasts` for non integer primary keys. The tests and stub are still named for the original property name `$idType`. This is an extremely minor change with no functional impact - just thought I'd put it out there since I was digging into this code anyway.
