### PR TITLE
[5.3] Create NotificationFailed event

### DIFF
--- a/src/Illuminate/Notifications/Events/NotificationFailed.php
+++ b/src/Illuminate/Notifications/Events/NotificationFailed.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Illuminate\Notifications\Events;
+
+class NotificationFailed
+{
+    /**
+     * The notifiable entity who received the notification.
+     *
+     * @var mixed
+     */
+    public $notifiable;
+
+    /**
+     * The notification instance.
+     *
+     * @var \Illuminate\Notifications\Notification
+     */
+    public $notification;
+
+    /**
+     * The channel name.
+     *
+     * @var string
+     */
+    public $channel;
+    
+    /**
+     * The data needed to process this failure.
+     *
+     * @var array
+     */
+    public $data = [];
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  mixed  $notifiable
+     * @param  \Illuminate\Notifications\Notification  $notification
+     * @param  string  $channel
+     * @param  array  $data
+     * @return void
+     */
+    public function __construct($notifiable, $notification, $channel, $data = [])
+    {
+        $this->channel = $channel;
+        $this->notifiable = $notifiable;
+        $this->notification = $notification;
+        $this->data = $data;
+    }
+}


### PR DESCRIPTION
In the case of a failure, which shouldn't be retried, it currently is possible to handle this, right?

I propose we add an event for when a Notification fails, eg. for push notifications when a token is invalid. We would like to respond by removing the push token from the user model (or log/notify/do something else).

Throwing an exception would break the flow (eg. when the 1st of 2 notification channels throws an exception).
