### PR TITLE
[5.3] Only bind int with PDO::PARAM_INT

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -407,7 +407,7 @@ class Connection implements ConnectionInterface
         foreach ($bindings as $key => $value) {
             $statement->bindValue(
                 is_string($key) ? $key : $key + 1, $value,
-                ! is_string($value) && is_numeric($value) ? PDO::PARAM_INT : PDO::PARAM_STR
+                is_int($value) ? PDO::PARAM_INT : PDO::PARAM_STR
             );
         }
     }


### PR DESCRIPTION
If for example a float is bound with `PDO::PARAM_INT`, SQLite (haven't tested with any other DBMS) will discard the decimal part (`0.5` will become `0.0` in the DB). This totally broke my application.

Related to #14786.

Side note: Should we use `PDO::PARAM_BOOL` here, too?
