### PR TITLE
[5.3] Turn off pretty printing JSON in seeJsonContains again

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -321,7 +321,7 @@ trait MakesHttpRequests
 
         $actual = json_encode(Arr::sortRecursive(
             (array) $this->decodeResponseJson()
-        ), JSON_PRETTY_PRINT);
+        ));
 
         foreach (Arr::sortRecursive($data) as $key => $value) {
             $expected = $this->formatToExpectedJson($key, $value);
@@ -373,7 +373,7 @@ trait MakesHttpRequests
      */
     protected function formatToExpectedJson($key, $value)
     {
-        $expected = json_encode([$key => $value], JSON_PRETTY_PRINT);
+        $expected = json_encode([$key => $value]);
 
         if (Str::startsWith($expected, '{')) {
             $expected = substr($expected, 1);

--- a/tests/Foundation/FoundationMakesHttpRequestsJsonTest.php
+++ b/tests/Foundation/FoundationMakesHttpRequestsJsonTest.php
@@ -24,6 +24,13 @@ class FoundationMakesHttpRequestsJsonTest extends PHPUnit_Framework_TestCase
         $this->seeJson($resource->jsonSerialize());
     }
 
+    public function testSeeJsonDeeplyNestedPart()
+    {
+        $this->response = new Illuminate\Http\Response(new JsonSerializableMixedResourcesStub);
+
+        $this->seeJson(['bar' => ['foo' => 'bar 0', 'bar' => 'foo 0']]);
+    }
+
     public function testSeeJsonStructure()
     {
         $this->response = new Illuminate\Http\Response(new JsonSerializableMixedResourcesStub);


### PR DESCRIPTION
This basically reverts #14779

The pretty printing can introduce an arbitrary amount of whitespace which can break the test. I've added a test case as demonstration.

I thought about pretty printing the JSON just for the error message but decoding everything twice looked like overkill to me. The previously introduced line breaks already improve legibility quite a bit.
