### PR TITLE
[5.2] Validate presence of APP_KEY key

### DIFF
--- a/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
+++ b/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
@@ -32,6 +32,11 @@ class KeyGenerateCommand extends Command
         if ($this->option('show')) {
             return $this->line('<comment>'.$key.'</comment>');
         }
+        
+        // We verify the APP_KEY key exists in the environment file.
+        if (!preg_match("/APP_KEY=/", file_get_contents($this->laravel->environmentFilePath()))) {
+            return $this->line('<error>'.'Missing or invalid APP_KEY in environment file'.'</error>');
+        }
 
         // Next, we will replace the application key in the environment file so it is
         // automatically setup for this developer. This key gets generated using a


### PR DESCRIPTION
If the environment file does not have a valid APP_KEY entry, the generated key is _not_ saved, but the command still returns : 

`
Application key [base64:kFi4GlZASPjDXjP7ujztxMWJT+LpspJTHFNhGZT6Juk=] set successfully.
`

This can lead to confusion because the key was actually _not_ set.

This PR validates the presence of a valid APP_KEY key and displays  an error message if it's missing or invalid.
