### PR TITLE
[5.2] Added an alias for orderBy method

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1325,6 +1325,18 @@ class Builder
     }
 
     /**
+     * Add an "order by" clause to the query.
+     *
+     * @param  string  $column
+     * @param  string  $direction
+     * @return $this
+     */
+    public function sortBy($column, $direction = 'asc')
+    {
+        return $this->orderBy($column, $direction);
+    }
+
+    /**
      * Add an "order by" clause for a timestamp to the query.
      *
      * @param  string  $column


### PR DESCRIPTION
### Issue

I find it difficult to remember to use an `orderBy` method and instead I always try to use a non-existent `sortBy` method. This PR solves this issue by adding an alias for developers' convenience.
### Changes:

Added a `sortBy` method that is an alias for `orderBy` method.
