### PR TITLE
[5.3] toBase should always return a new instance

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1236,7 +1236,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      */
     public function toBase()
     {
-        return is_subclass_of($this, self::class) ? new self($this) : $this;
+        return new self($this);
     }
 
     /**


### PR DESCRIPTION
If `toBase` is used on a child collection, a new collection is returned.

For consistency, I think it makes sense to always return a new collection instance.
