### PR TITLE
[5.3] Allow for splitting commands and handlers on jobs.

### DIFF
--- a/tests/Bus/BusDispatcherTest.php
+++ b/tests/Bus/BusDispatcherTest.php
@@ -61,6 +61,21 @@ class BusDispatcherTest extends PHPUnit_Framework_TestCase
 
         $dispatcher->dispatch(new BusDispatcherBasicCommand);
     }
+    
+    public function testDispatcherCanDispatchStandAloneHandler()
+    {
+        $container = new Container;
+        $mock = m::mock('Illuminate\Contracts\Queue\Queue');
+        $dispatcher = new Dispatcher($container, function () use ($mock) {
+            return $mock;
+        });
+        
+        $dispatcher->map(StandAloneCommand::class, StandAloneHandler::class);
+
+        $response = $dispatcher->dispatch(new StandAloneCommand);
+
+        $this->assertEquals('stone-alone-handler', $response);
+    }
 }
 
 class BusInjectionStub
@@ -94,4 +109,17 @@ class BusDispatcherTestSpecificQueueAndDelayCommand implements Illuminate\Contra
 {
     public $queue = 'foo';
     public $delay = 10;
+}
+
+class StandAloneCommand
+{
+    
+}
+
+class StandAloneHandler
+{
+    public function handle()
+    {
+        return 'stone-alone-handler';
+    }
 }

--- a/tests/Bus/BusDispatcherTest.php
+++ b/tests/Bus/BusDispatcherTest.php
@@ -61,7 +61,7 @@ class BusDispatcherTest extends PHPUnit_Framework_TestCase
 
         $dispatcher->dispatch(new BusDispatcherBasicCommand);
     }
-    
+
     public function testDispatcherCanDispatchStandAloneHandler()
     {
         $container = new Container;
@@ -69,7 +69,7 @@ class BusDispatcherTest extends PHPUnit_Framework_TestCase
         $dispatcher = new Dispatcher($container, function () use ($mock) {
             return $mock;
         });
-        
+
         $dispatcher->map(StandAloneCommand::class, StandAloneHandler::class);
 
         $response = $dispatcher->dispatch(new StandAloneCommand);
@@ -113,7 +113,7 @@ class BusDispatcherTestSpecificQueueAndDelayCommand implements Illuminate\Contra
 
 class StandAloneCommand
 {
-    
+
 }
 
 class StandAloneHandler

--- a/tests/Bus/BusDispatcherTest.php
+++ b/tests/Bus/BusDispatcherTest.php
@@ -74,7 +74,7 @@ class BusDispatcherTest extends PHPUnit_Framework_TestCase
 
         $response = $dispatcher->dispatch(new StandAloneCommand);
 
-        $this->assertEquals('stone-alone-handler', $response);
+        $this->assertInstanceOf(StandAloneCommand::class, $response);
     }
 }
 
@@ -118,8 +118,8 @@ class StandAloneCommand
 
 class StandAloneHandler
 {
-    public function handle()
+    public function handle(StandAloneCommand $command)
     {
-        return 'stone-alone-handler';
+        return $command;
     }
 }

--- a/tests/Bus/BusDispatcherTest.php
+++ b/tests/Bus/BusDispatcherTest.php
@@ -113,7 +113,6 @@ class BusDispatcherTestSpecificQueueAndDelayCommand implements Illuminate\Contra
 
 class StandAloneCommand
 {
-
 }
 
 class StandAloneHandler


### PR DESCRIPTION
This pull request allows for commands and handlers (whether in a queue, or command bus) to be separate as an alternative to self-handling jobs.

I have explained the purpose of this fix (and discussed it in detail) with Taylor, but I'll explain it here for the benefit of those reviewing.

Having the separation between commands and handlers makes the most sense in 'multi-app' environments that use a single queue consumer project. Consider the following:

```
APP1     APP2      APP3

    all fire queued jobs to:

          APP4
  (running queue:listen)
```

Consider the following job:

``` php
<?php

use Some\Other\Package\FooService;

class DoSomething
{
    protected $someId;

    public function __construct($someId)
    {
        $this->someId = $id;
    }

    public function handle(FooService $foo)
    {
        // Do something with foo service.
    }
}
```

Apps 1-3 might wish to fire this job, but to do so they will need to import the package for `FooService` using composer, even though it's never used from those projects.

By separating the command and handler (splitting into two classes, one a value object, the other with a handle method) and allowing the user to map commands to handlers we can fire the jobs from APP1-3 without the FooService requirement.

Mapping commands looks like the following:

``` php
Bus::map(CommandClassHere::class, HandlerClassHere::class);
```

Firing jobs should use the 'command':

``` php
$this->dispatch(CommandClassHere::class)
```

Stand alone handlers should inject their dependencies through the constructor, where existing self-handling jobs will inject their dependencies through the handle method.

This change should be backwards compatible and still allow for self-handling jobs to function as before.

Thanks for reading!
