### PR TITLE
[5.2] Revert "[5.2] Wrap APP_KEY in quotes when regenerating key"

### DIFF
--- a/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
+++ b/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
@@ -51,11 +51,11 @@ class KeyGenerateCommand extends Command
      */
     protected function setKeyInEnvironmentFile($key)
     {
-        $originalEnvContent = file_get_contents($this->laravel->environmentFilePath());
-
-        $newEnvContent = preg_replace('/APP_KEY="?[^\'"\s]+"?/', "APP_KEY=\"$key\"", $originalEnvContent);
-
-        file_put_contents($this->laravel->environmentFilePath(), $newEnvContent);
+        file_put_contents($this->laravel->environmentFilePath(), str_replace(
+            'APP_KEY='.$this->laravel['config']['app.key'],
+            'APP_KEY='.$key,
+            file_get_contents($this->laravel->environmentFilePath())
+        ));
     }
 
     /**


### PR DESCRIPTION
Reverts laravel/framework#14862

This was reverted in the 5.3 branch: https://github.com/laravel/framework/commit/64b2015f3156ad67fbd4b006efc3b629ec41b989
