### PR TITLE
[5.3] Adding two new method next() and previous() to Collection

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -589,7 +589,8 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
 
         if ($previous->count() === 2) {
             return $previous->last();
-        } elseif ($loop) {
+        }
+        if ($loop) {
             return $this->last();
         }
 
@@ -612,7 +613,8 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
 
         if ($next->count() === 2) {
             return $next->last();
-        } elseif ($loop) {
+        }
+        if ($loop) {
             return $this->first();
         }
 

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -587,7 +587,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
 
         $previous = $reversedCollection->slice($current, 2);
 
-        if ($previous->count() == 2) {
+        if ($previous->count() === 2) {
             return $previous->last();
         } elseif ($loop) {
             return $this->last();
@@ -610,7 +610,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
 
         $next = $this->slice($current, 2);
 
-        if ($next->count() == 2) {
+        if ($next->count() === 2) {
             return $next->last();
         } elseif ($loop) {
             return $this->first();

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -585,18 +585,18 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
         $current = $reversedCollection->search($currentItem, true);
         $current = $reversedCollection->keys()->search($current, true);
 
-        $previous = $reversedCollection->slice($current, 2);	  	        
+        $previous = $reversedCollection->slice($current, 2);
 
         if ($previous->count() == 2) {
             return $previous->last();
         } elseif ($loop) {
             return $this->last();
-        }		              
+        }
 
         return false;
     }
 
-     /**
+    /**
      * Get the next item from the collection.
      *
      * @param  mixed  $currentItem
@@ -606,7 +606,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     public function next($currentItem, $loop = false)
     {
         $current = $this->search($currentItem, true);
-        $current = $this->keys()->search($current, true);	
+        $current = $this->keys()->search($current, true);
 
         $next = $this->slice($current, 2);
 
@@ -614,7 +614,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
             return $next->last();
         } elseif ($loop) {
             return $this->first();
-        }		              
+        }
 
         return false;
     }

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -571,8 +571,8 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     {
         return Arr::last($this->items, $callback, $default);
     }
-    
-     /**
+
+    /**
      * Get the previous item from the collection.
      *
      * @param  mixed  $currentItem
@@ -582,20 +582,21 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     public function previous($currentItem, $loop = false)
     {
         $reversedCollection = $this->reverse();
-		$current = $reversedCollection->search($currentItem, true);			
-		$current = $reversedCollection->keys()->search($current, true);	
+        $current = $reversedCollection->search($currentItem, true);
+        $current = $reversedCollection->keys()->search($current, true);
 
         $previous = $reversedCollection->slice($current, 2);	  	        
 
-		if($previous->count() == 2)
-			return $previous->last();
-		else if($loop)
-			return $this->last();			              
+        if ($previous->count() == 2) {
+            return $previous->last();
+        } elseif ($loop) {
+            return $this->last();
+        }		              
 
         return false;
     }
-    
-    /**
+
+     /**
      * Get the next item from the collection.
      *
      * @param  mixed  $currentItem
@@ -605,14 +606,15 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     public function next($currentItem, $loop = false)
     {
         $current = $this->search($currentItem, true);
-		$current = $this->keys()->search($current, true);	
+        $current = $this->keys()->search($current, true);	
 
-        $next = $this->slice($current, 2);	
+        $next = $this->slice($current, 2);
 
-		if($next->count() == 2)
-			return $next->last();
-		else if($loop)
-			return $this->first();			              
+        if ($next->count() == 2) {
+            return $next->last();
+        } elseif ($loop) {
+            return $this->first();
+        }		              
 
         return false;
     }

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -571,6 +571,51 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     {
         return Arr::last($this->items, $callback, $default);
     }
+    
+     /**
+     * Get the previous item from the collection.
+     *
+     * @param  mixed  $currentItem
+     * @param  bool|false  $loop
+     * @return mixed
+     */
+    public function previous($currentItem, $loop = false)
+    {
+        $reversedCollection = $this->reverse();
+		$current = $reversedCollection->search($currentItem, true);			
+		$current = $reversedCollection->keys()->search($current, true);	
+
+        $previous = $reversedCollection->slice($current, 2);	  	        
+
+		if($previous->count() == 2)
+			return $previous->last();
+		else if($loop)
+			return $this->last();			              
+
+        return false;
+    }
+    
+    /**
+     * Get the next item from the collection.
+     *
+     * @param  mixed  $currentItem
+     * @param  bool|false  $loop
+     * @return mixed
+     */
+    public function next($currentItem, $loop = false)
+    {
+        $current = $this->search($currentItem, true);
+		$current = $this->keys()->search($current, true);	
+
+        $next = $this->slice($current, 2);	
+
+		if($next->count() == 2)
+			return $next->last();
+		else if($loop)
+			return $this->first();			              
+
+        return false;
+    }
 
     /**
      * Get the values of a given key.

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -48,29 +48,31 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
         $result = $data->last(null, 'default');
         $this->assertEquals('default', $result);
     }
-    
-    public function testPrevious() {
-        $data = new Collection(["a" => 2,3,4,5]);
-        
+
+    public function testPrevious()
+    {
+        $data = new Collection(['a' => 2, 3, 4, 5]);
+
         $result = $data->previous(2);
         $this->assertEquals(false, $result);
-        
+
         $result = $data->previous(2, true);
         $this->assertEquals(5, $result);
-        
+
         $result = $data->previous(5);
         $this->assertEquals(4, $result);
     }
-    
-    public function testNext() {
-        $data = new Collection(["a" => 2,3,4,5]);
-        
+
+    public function testNext()
+    {
+        $data = new Collection(['a' => 2, 3, 4, 5]);
+
         $result = $data->next(5);
         $this->assertEquals(false, $result);
-        
+
         $result = $data->next(5, true);
         $this->assertEquals(2, $result);
-        
+
         $result = $data->next(2);
         $this->assertEquals(3, $result);
     }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -48,6 +48,32 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
         $result = $data->last(null, 'default');
         $this->assertEquals('default', $result);
     }
+    
+    public function testPrevious() {
+        $data = new Collection(["a" => 2,3,4,5]);
+        
+        $result = $data->previous(2);
+        $this->assertEquals(false, $result);
+        
+        $result = $data->previous(2, true);
+        $this->assertEquals(5, $result);
+        
+        $result = $data->previous(5);
+        $this->assertEquals(4, $result);
+    }
+    
+    public function testNext() {
+        $data = new Collection(["a" => 2,3,4,5]);
+        
+        $result = $data->next(5);
+        $this->assertEquals(false, $result);
+        
+        $result = $data->next(5, true);
+        $this->assertEquals(2, $result);
+        
+        $result = $data->next(2);
+        $this->assertEquals(3, $result);
+    }
 
     public function testPopReturnsAndRemovesLastItemInCollection()
     {


### PR DESCRIPTION
Not sure if this will be useful for anyone else.

Added two methods to  the Collection class, next() and previous().

This works with any sort of order and keys, as far as i could test, however i guess that we could come up with a better idea for the previous method.

Also this is useful when you want to loop the next and previous links.
