### PR TITLE
[5.4] Normalizes abstract when extract it from an array.

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -185,6 +185,7 @@ class Container implements ArrayAccess, ContainerContract
         // alias with the container so that it can be used as a shortcut for it.
         if (is_array($abstract)) {
             list($abstract, $alias) = $this->extractAlias($abstract);
+            $abstract = $this->normalize($abstract);
 
             $this->alias($abstract, $alias);
         }
@@ -331,6 +332,7 @@ class Container implements ArrayAccess, ContainerContract
         // will be registered with the container so we can resolve it out later.
         if (is_array($abstract)) {
             list($abstract, $alias) = $this->extractAlias($abstract);
+            $abstract = $this->normalize($abstract);
 
             $this->alias($abstract, $alias);
         }


### PR DESCRIPTION
When an abstract is coming from an array, container missing fix it.
