### PR TITLE
[5.3] Added username, icon and channel options for Slack Notifications

### DIFF
--- a/src/Illuminate/Notifications/Channels/SlackWebhookChannel.php
+++ b/src/Illuminate/Notifications/Channels/SlackWebhookChannel.php
@@ -42,12 +42,31 @@ class SlackWebhookChannel
 
         $message = $notification->toSlack($notifiable);
 
-        $this->http->post($url, [
+        $this->http->post($url, $this->buildJsonPayload($message));
+    }
+
+    /**
+     * Build up a JSON payload for the Slack webhook.
+     *
+     * @param  \Illuminate\Notifications\Messages\SlackMessage  $message
+     * @return array
+     */
+    protected function buildJsonPayload(SlackMessage $message)
+    {
+        $optionalFields = collect([
+            'username' => null, 'icon_emoji' => null, 'channel' => null,
+        ])->map(function ($value, $key) use ($message) {
+            return $message->{$key};
+        })->reject(function ($item) {
+            return is_null($item);
+        })->all();
+
+        return [
             'json' => [
                 'text' => $message->content,
                 'attachments' => $this->attachments($message),
-            ],
-        ]);
+            ] + $optionalFields,
+        ];
     }
 
     /**

--- a/src/Illuminate/Notifications/Messages/SlackMessage.php
+++ b/src/Illuminate/Notifications/Messages/SlackMessage.php
@@ -14,6 +14,27 @@ class SlackMessage
     public $level = 'info';
 
     /**
+     * Webhook username.
+     *
+     * @var string|null
+     */
+    public $username;
+
+    /**
+     * Webhook icon emoji.
+     *
+     * @var string|null
+     */
+    public $icon_emoji;
+
+    /**
+     * Channel override.
+     *
+     * @var string|null
+     */
+    public $channel;
+
+    /**
      * The text content of the message.
      *
      * @var string
@@ -47,6 +68,37 @@ class SlackMessage
     public function error()
     {
         $this->level = 'error';
+
+        return $this;
+    }
+
+    /**
+     * Set a custom username and emoji icon for the Slack message.
+     *
+     * @param  string       $username
+     * @param  string|null  $icon
+     * @return $this
+     */
+    public function as($username, $icon = null)
+    {
+        $this->username = $username;
+
+        if (! is_null($icon)) {
+            $this->icon_emoji = $icon;
+        }
+
+        return $this;
+    }
+
+    /**
+     * Set which channel the Slack message should be posted in.
+     *
+     * @param  string $channel
+     * @return $this
+     */
+    public function in($channel)
+    {
+        $this->channel = $channel;
 
         return $this;
     }

--- a/src/Illuminate/Notifications/Messages/SlackMessage.php
+++ b/src/Illuminate/Notifications/Messages/SlackMessage.php
@@ -79,7 +79,7 @@ class SlackMessage
      * @param  string|null  $icon
      * @return $this
      */
-    public function as($username, $icon = null)
+    public function from($username, $icon = null)
     {
         $this->username = $username;
 
@@ -96,7 +96,7 @@ class SlackMessage
      * @param  string $channel
      * @return $this
      */
-    public function in($channel)
+    public function to($channel)
     {
         $this->channel = $channel;
 

--- a/tests/Notifications/NotificationSlackChannelTest.php
+++ b/tests/Notifications/NotificationSlackChannelTest.php
@@ -98,8 +98,8 @@ class NotificationSlackChannelTestNotification extends Notification
     public function toSlack($notifiable)
     {
         return (new SlackMessage)
-                    ->as('Ghostbot', ':ghost:')
-                    ->in('#ghost-talk')
+                    ->from('Ghostbot', ':ghost:')
+                    ->to('#ghost-talk')
                     ->content('Content')
                     ->attachment(function ($attachment) {
                         $attachment->title('Laravel', 'https://laravel.com')


### PR DESCRIPTION
This PR allows you to set a custom username, icon (emoji) and channel override for incoming webhooks in Slack.

This is a [totally supported](https://api.slack.com/incoming-webhooks) feature in Slack, so why not take advantage of it?

``` php
<?php

class FooNotification extends Notification
{
    public function toSlack($notifiable)
    {
        return (new SlackMessage)
                    ->from('Ghostbot', ':ghost:')
                    ->to('#testytest') // `@username` is also supported
                    ->content('This is a message from a ghost posted in #testytest!');
    }
}
```

.. will give you this:

![image](https://cloud.githubusercontent.com/assets/4445087/17831809/f53dc2b8-66f3-11e6-8f50-7196ea013119.png)

As the new methods are optional, this PR is not a breaking change.

Thoughts?
## 

_Edit: Renamed methods_ 
