### PR TITLE
[5.3] The option function only takes one argument

### DIFF
--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -105,7 +105,7 @@ class WorkCommand extends Command
      */
     protected function gatherWorkerOptions()
     {
-        $timeout = $this->option('timeout', 60);
+        $timeout = $this->option('timeout');
 
         if ($timeout && ! function_exists('pcntl_fork')) {
             throw new RuntimeException('The pcntl extension is required in order to specify job timeouts.');


### PR DESCRIPTION
The default is already determined from the getOptions function.
