### PR TITLE
[5.3] TokenGuard fix for when invalid token supplied and no user retrieved

### DIFF
--- a/src/Illuminate/Auth/TokenGuard.php
+++ b/src/Illuminate/Auth/TokenGuard.php
@@ -68,6 +68,10 @@ class TokenGuard implements Guard
             $user = $this->provider->retrieveByCredentials(
                 [$this->storageKey => $token]
             );
+            
+            if (is_null($user)) {
+                throw new AuthenticationException;
+            }
         }
 
         return $this->user = $user;


### PR DESCRIPTION
With non-guarded api routes sometimes we want to allow guest access but also access the user if a token was supplied. For example when allowing guest and user posts to a service. When calling Auth::guard('api')->user() it is not possible to differentiate between guest access and an invalid token. The provided fix will throw an authentication exception in this particular case, this allows the user to recognise their token is invalid and fix that issue (e.g. by logging in again and retrieving a new token) rather than the site assuming they are a guest. Thanks!
