### PR TITLE
[5.3] Mock correct method on NotificationDispatcher

### DIFF
--- a/src/Illuminate/Contracts/Notifications/Dispatcher.php
+++ b/src/Illuminate/Contracts/Notifications/Dispatcher.php
@@ -4,13 +4,21 @@ namespace Illuminate\Contracts\Notifications;
 
 interface Dispatcher
 {
-    // *
-    //  * Dispatch the given notification instance to the given notifiable.
-    //  *
-    //  * @param  mixed  $notifiable
-    //  * @param  mixed  $instance
-    //  * @param  array  $channels
-    //  * @return void
+    /**
+     * Send the given notification to the given notifiable entities.
+     *
+     * @param  \Illuminate\Support\Collection|array|mixed  $notifiables
+     * @param  mixed  $notification
+     * @return void
+     */
+    public function send($notifiables, $notification);
 
-    // public function dispatch($notifiable, $instance, array $channels = []);
+    /**
+     * Send the given notification immediately.
+     *
+     * @param  \Illuminate\Support\Collection|array|mixed  $notifiables
+     * @param  mixed  $notification
+     * @return void
+     */
+    public function sendNow($notifiables, $notification);
 }

--- a/src/Illuminate/Foundation/Testing/Concerns/MocksApplicationServices.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MocksApplicationServices.php
@@ -379,7 +379,7 @@ trait MocksApplicationServices
     {
         $mock = Mockery::mock(NotificationDispatcher::class);
 
-        $mock->shouldReceive('dispatch')->andReturnUsing(function ($notifiable, $instance, $channels = []) {
+        $mock->shouldReceive('send')->andReturnUsing(function ($notifiable, $instance, $channels = []) {
             $this->dispatchedNotifications[] = compact(
                 'notifiable', 'instance', 'channels'
             );
@@ -403,10 +403,13 @@ trait MocksApplicationServices
 
         $this->beforeApplicationDestroyed(function () use ($notifiable, $notification) {
             foreach ($this->dispatchedNotifications as $dispatched) {
-                if (($dispatched['notifiable'] === $notifiable ||
-                    $dispatched['notifiable']->getKey() == $notifiable->getKey()) &&
-                    get_class($dispatched['instance']) === $notification) {
-                    return $this;
+                foreach($dispatched['notifiable'] as $notified) {
+                    if (($notified === $notifiable ||
+                         $notified->getKey() == $notifiable->getKey()) &&
+                        get_class($dispatched['instance']) === $notification
+                    ) {
+                        return $this;
+                    }
                 }
             }
 


### PR DESCRIPTION
- withoutNotifications mocks a method never called on ChannelManager
- dispatched notification is to an array of notifiables
