### PR TITLE
Update DatabaseMigrations.php

### DIFF
--- a/src/Illuminate/Foundation/Testing/DatabaseMigrations.php
+++ b/src/Illuminate/Foundation/Testing/DatabaseMigrations.php
@@ -11,6 +11,12 @@ trait DatabaseMigrations
      */
     public function runDatabaseMigrations()
     {
+        // dropping all tables before migrating
+        foreach(\DB::select('SHOW TABLES') as $table) {
+            $table_array = get_object_vars($table);
+            \Schema::drop($table_array[key($table_array)]);
+        }
+        
         $this->artisan('migrate');
 
         $this->beforeApplicationDestroyed(function () {


### PR DESCRIPTION
Dropping all tables before migrating might be usefull in case of unexpected shutdowns during tests when the database is not cleared, which makes tests impossible to rerun unless the database has been cleared manually.
