### PR TITLE
[5.4] Throw ModelNotFoundException when model bind not found

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -16,7 +16,7 @@ use Psr\Http\Message\ResponseInterface as PsrResponseInterface;
 use Symfony\Bridge\PsrHttpMessage\Factory\HttpFoundationFactory;
 use Illuminate\Contracts\Routing\Registrar as RegistrarContract;
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
-use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 
 class Router implements RegistrarContract
 {
@@ -927,7 +927,7 @@ class Router implements RegistrarContract
      * @param  \Closure|null  $callback
      * @return void
      *
-     * @throws \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
+     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
      */
     public function model($key, $class, Closure $callback = null)
     {
@@ -952,7 +952,7 @@ class Router implements RegistrarContract
                 return call_user_func($callback, $value);
             }
 
-            throw new NotFoundHttpException;
+            throw (new ModelNotFoundException)->setModel($class);
         });
     }
 


### PR DESCRIPTION
This is a PR for [Issue #13455](https://github.com/laravel/framework/issues/13455) to bring consistency to model bind not found and findOrFail.

The NotFoundHttpException was changed to a ModelNotFoundException and has the model set, the exact same as in Eloquent/Builder findOrFail.

Although the [Exceptions/Handler.php](https://github.com/laravel/framework/blob/master/src/Illuminate/Foundation/Exceptions/Handler.php) converts this back to a NotFoundHttpException in the prepareException method anyway (so thus should have same behaviour for projects using the default handling), by throwing a ModelNotFoundException in the first instance has the added benefit that a custom Handler subclass can render both cases of a model binding not found and a findOrFail in the same way. Furthermore, by having an exception that has the model name set on it, exception handling can be even more improved for binding failures, e.g. by default there is now the message "No query results for model [App\ModeClass]." instead of no message. This message is exactly the same as the exception from findOrFail since it is created inside the ModelNotFoundException itself.

Before this fix, developers had to workaround this issue by providing a closure to return the correct exception on all their route models via a closure, although in the example given in this forum post, the developer didn't set the model on the exception:
https://laracasts.com/discuss/channels/general-discussion/throw-modelnotfoundexception-using-route-model-binding
