### PR TITLE
Update helpers.php

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -517,6 +517,20 @@ if (! function_exists('policy')) {
     }
 }
 
+if (! function_exists('public_storage')) {
+    /**
+     * Generate an asset path for the application, prefixed by storage/.
+     *
+     * @param  string  $path
+     * @param  bool    $secure
+     * @return string
+     */
+    function public_storage($path, $secure = null)
+    {
+        return app('url')->asset('storage'.DIRECTORY_SEPARATOR.$path, $secure);
+    }
+}
+
 if (! function_exists('public_path')) {
     /**
      * Get the path to the public folder.


### PR DESCRIPTION
By default laravel symlinks `public/storage` to `storage/app/public`. This means when trying to retrieve files from `public/storage` using the `asset()` helper you need to prefix your paths with `storage/`. The PR adds a public `public_storage()` which returns the the same as the `asset()` but automatically prefixed with `storage/`. This works well with 5.3 news `->store()` method for easy file uploads.
