### PR TITLE
[5.3] Make getTokenForRequest public

### DIFF
--- a/src/Illuminate/Auth/TokenGuard.php
+++ b/src/Illuminate/Auth/TokenGuard.php
@@ -78,7 +78,7 @@ class TokenGuard implements Guard
      *
      * @return string
      */
-    protected function getTokenForRequest()
+    public function getTokenForRequest()
     {
         $token = $this->request->input($this->inputKey);
 


### PR DESCRIPTION
When calling Auth::guard('api')->user() and receiving null it is not possible to differentiate between guest access and an invalid token. In the case of an invalid token it would be preferable to ask the user to login again and receive a new token rather than assume they are a guest. By making the getTokenForRequest method public that is now possible.
