### PR TITLE
[5.1] Handle deadlocks by (optionally) re-attempting transactions

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -20,7 +20,7 @@ use Illuminate\Database\Query\Grammars\Grammar as QueryGrammar;
 
 class Connection implements ConnectionInterface
 {
-    use DetectsLostConnections;
+    use DetectsLostConnections, DetectsDeadlocks;
 
     /**
      * The active PDO connection.
@@ -461,37 +461,44 @@ class Connection implements ConnectionInterface
      * Execute a Closure within a transaction.
      *
      * @param  \Closure  $callback
+     * @param  int       $attempts
      * @return mixed
      *
      * @throws \Throwable
      */
-    public function transaction(Closure $callback)
+    public function transaction(Closure $callback, $attempts = 1)
     {
-        $this->beginTransaction();
+        for ($a = 1; $a <= $attempts; $a++) {
+            $this->beginTransaction();
 
-        // We'll simply execute the given callback within a try / catch block
-        // and if we catch any exception we can rollback the transaction
-        // so that none of the changes are persisted to the database.
-        try {
-            $result = $callback($this);
+            // We'll simply execute the given callback within a try / catch block
+            // and if we catch any exception we can rollback the transaction
+            // so that none of the changes are persisted to the database.
+            try {
+                $result = $callback($this);
 
-            $this->commit();
+                $this->commit();
+            }
+
+            // If we catch an exception, we will roll back so nothing gets messed
+            // up in the database. Then we'll re-throw the exception so it can
+            // be handled how the developer sees fit for their applications.
+            catch (Exception $e) {
+                $this->rollBack();
+
+                if ($this->causedByDeadlock($e) && $a < $attempts) {
+                    continue;
+                }
+
+                throw $e;
+            } catch (Throwable $e) {
+                $this->rollBack();
+
+                throw $e;
+            }
+
+            return $result;
         }
-
-        // If we catch an exception, we will roll back so nothing gets messed
-        // up in the database. Then we'll re-throw the exception so it can
-        // be handled how the developer sees fit for their applications.
-        catch (Exception $e) {
-            $this->rollBack();
-
-            throw $e;
-        } catch (Throwable $e) {
-            $this->rollBack();
-
-            throw $e;
-        }
-
-        return $result;
     }
 
     /**

--- a/src/Illuminate/Database/ConnectionInterface.php
+++ b/src/Illuminate/Database/ConnectionInterface.php
@@ -105,11 +105,12 @@ interface ConnectionInterface
      * Execute a Closure within a transaction.
      *
      * @param  \Closure  $callback
+     * @param  int       $attempts
      * @return mixed
      *
      * @throws \Throwable
      */
-    public function transaction(Closure $callback);
+    public function transaction(Closure $callback, $attempts = 0);
 
     /**
      * Start a new database transaction.

--- a/src/Illuminate/Database/DetectsDeadlocks.php
+++ b/src/Illuminate/Database/DetectsDeadlocks.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Illuminate\Database;
+
+use Exception;
+use Illuminate\Support\Str;
+
+trait DetectsDeadlocks
+{
+    /**
+     * Determine if the given exception was caused by a deadlock.
+     *
+     * @param  \Exception  $e
+     * @return bool
+     */
+    protected function causedByDeadlock(Exception $e)
+    {
+        $message = $e->getMessage();
+
+        return Str::contains($message, [
+            'Deadlock found when trying to get lock',
+            'deadlock detected',
+            'The database file is locked',
+            'A table in the database is locked',
+            'has been chosen as the deadlock victim',
+        ]);
+    }
+}

--- a/src/Illuminate/Database/DetectsLostConnections.php
+++ b/src/Illuminate/Database/DetectsLostConnections.php
@@ -26,7 +26,6 @@ trait DetectsLostConnections
             'decryption failed or bad record mac',
             'server closed the connection unexpectedly',
             'SSL connection has been closed unexpectedly',
-            'Deadlock found when trying to get lock',
             'Error writing data to the connection',
             'Resource deadlock avoided',
         ]);

--- a/tests/Database/DatabaseConnectionTest.php
+++ b/tests/Database/DatabaseConnectionTest.php
@@ -174,6 +174,21 @@ class DatabaseConnectionTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($mock, $result);
     }
 
+    /**
+     * @expectedException \Illuminate\Database\QueryException
+     */
+    public function testTransactionMethodRetriesOnDeadlock()
+    {
+        $pdo = $this->getMock('DatabaseConnectionTestMockPDO', ['beginTransaction', 'commit', 'rollBack']);
+        $mock = $this->getMockConnection([], $pdo);
+        $pdo->expects($this->exactly(3))->method('beginTransaction');
+        $pdo->expects($this->exactly(3))->method('rollBack');
+        $pdo->expects($this->never())->method('commit');
+        $mock->transaction(function () {
+            throw new \Illuminate\Database\QueryException('', [], new \Exception('Deadlock found when trying to get lock'));
+        }, 3);
+    }
+
     public function testTransactionMethodRollsbackAndThrows()
     {
         $pdo = $this->getMock('DatabaseConnectionTestMockPDO', ['beginTransaction', 'commit', 'rollBack']);


### PR DESCRIPTION
This PR reverts #12151 as per the discussion on that thread -- the previous fix attempts to reestablish the database connection upon encountering a deadlock, rather than reattempting the transaction.

Instead, we can provide an additional, optional parameter on the `transaction` method allowing the developer to specify the number of attempts that should be made to complete the transaction. This is a basic implementation of the [solution suggested by @mhayes14](https://github.com/laravel/framework/issues/5380#issuecomment-51717786).
