### PR TITLE
[5.1] Revert: Handle InnoDB Deadlocks By Re-Attempting Transactions

### DIFF
--- a/src/Illuminate/Database/DetectsLostConnections.php
+++ b/src/Illuminate/Database/DetectsLostConnections.php
@@ -26,7 +26,6 @@ trait DetectsLostConnections
             'decryption failed or bad record mac',
             'server closed the connection unexpectedly',
             'SSL connection has been closed unexpectedly',
-            'Deadlock found when trying to get lock',
             'Error writing data to the connection',
             'Resource deadlock avoided',
         ]);


### PR DESCRIPTION
This change attempted to reestablish the database connection when encountering a deadlock; per discussion on the previous thread we should revert this and instead reattempt the transaction.
