### PR TITLE
[5.3] fire Authenticated event whenever $guard->setUser() is called

### DIFF
--- a/src/Illuminate/Auth/Events/Authenticated.php
+++ b/src/Illuminate/Auth/Events/Authenticated.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Illuminate\Auth\Events;
+
+use Illuminate\Queue\SerializesModels;
+
+class Authenticated
+{
+    use SerializesModels;
+
+    /**
+     * The authenticated user.
+     *
+     * @var \Illuminate\Contracts\Auth\Authenticatable
+     */
+    public $user;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
+     * @return void
+     */
+    public function __construct($user)
+    {
+        $this->user = $user;
+    }
+}

--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -130,6 +130,9 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
 
         if (! is_null($id)) {
             $user = $this->provider->retrieveById($id);
+            if ($user) {
+                $this->fireAuthenticatedEvent($user);
+            }
         }
 
         // If the user is null, but we decrypt a "recaller" cookie we can attempt to
@@ -472,6 +475,19 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
     }
 
     /**
+     * Fire the authenticated event if the dispatcher is set.
+     *
+     * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
+     * @return void
+     */
+    protected function fireAuthenticatedEvent($user)
+    {
+        if (isset($this->events)) {
+            $this->events->fire(new Events\Authenticated($user));
+        }
+    }
+
+    /**
      * Update the session with the given ID.
      *
      * @param  string  $id
@@ -719,6 +735,8 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
         $this->user = $user;
 
         $this->loggedOut = false;
+
+        $this->fireAuthenticatedEvent($user);
 
         return $this;
     }

--- a/tests/Auth/AuthGuardTest.php
+++ b/tests/Auth/AuthGuardTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Auth\Events\Authenticated;
 use Mockery as m;
 use Illuminate\Auth\Events\Failed;
 use Illuminate\Auth\Events\Attempting;
@@ -107,13 +108,14 @@ class AuthGuardTest extends PHPUnit_Framework_TestCase
         $mock->login($user);
     }
 
-    public function testLoginFiresLoginEvent()
+    public function testLoginFiresLoginAndAuthenticatedEvents()
     {
         list($session, $provider, $request, $cookie) = $this->getMocks();
         $mock = $this->getMockBuilder('Illuminate\Auth\SessionGuard')->setMethods(['getName'])->setConstructorArgs(['default', $provider, $session, $request])->getMock();
         $mock->setDispatcher($events = m::mock('Illuminate\Contracts\Events\Dispatcher'));
         $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');
         $events->shouldReceive('fire')->once()->with(m::type('Illuminate\Auth\Events\Login'));
+        $events->shouldReceive('fire')->once()->with(m::type('Illuminate\Auth\Events\Authenticated'));
         $mock->expects($this->once())->method('getName')->will($this->returnValue('foo'));
         $user->shouldReceive('getAuthIdentifier')->once()->andReturn('bar');
         $mock->getSession()->shouldReceive('set')->with('foo', 'bar')->once();
@@ -137,6 +139,15 @@ class AuthGuardTest extends PHPUnit_Framework_TestCase
         $guard = $this->getGuard()->setUser($user);
 
         $this->assertEquals($user, $guard->authenticate());
+    }
+
+    public function testSetUserFiresAuthenticatedEvent()
+    {
+        $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');
+        $guard = $this->getGuard();
+        $guard->setDispatcher($events = m::mock('Illuminate\Contracts\Events\Dispatcher'));
+        $events->shouldReceive('fire')->once()->with(m::type(Authenticated::class));
+        $guard->setUser($user);
     }
 
     /**

--- a/tests/Auth/AuthGuardTest.php
+++ b/tests/Auth/AuthGuardTest.php
@@ -251,6 +251,7 @@ class AuthGuardTest extends PHPUnit_Framework_TestCase
         $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');
         $user->shouldReceive('setRememberToken')->once();
         $provider->shouldReceive('updateRememberToken')->once();
+        $events->shouldReceive('fire')->once()->with(m::type(Authenticated::class));
         $mock->setUser($user);
         $events->shouldReceive('fire')->once()->with(m::type('Illuminate\Auth\Events\Logout'));
         $mock->logout();


### PR DESCRIPTION
Related to #14834

There needs to be a way to tell when an authenticated user has been set in the request. Currently the Login event only records actual logins via form or when a remember_me token is used to setup a new session. Current session authentications have no events fired at all.

This new `Authenticated` event fires on every request as soon as the user is set in the auth guard allowing you to listen for that event and execute code that depends on the user being authenticated.

I can add the relevant docs if/when this is accepted.
