### PR TITLE
[5.2] Inaccurate Chinese character length problem

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -140,7 +140,7 @@ class Str
      */
     public static function length($value)
     {
-        return mb_strlen($value);
+        return mb_strlen($value, 'UTF-8');
     }
 
     /**


### PR DESCRIPTION
mb_strlen second parameter to add utf-8 support Chinese string length calculations.
