### PR TITLE
[5.2] add new parameter to relations functions to either force the connection or not

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -738,6 +738,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         $foreignKey = $foreignKey ?: $this->getForeignKey();
 
         $instance = new $related;
+        $instance->setConnection($this->connection);
 
         $localKey = $localKey ?: $this->getKeyName();
 
@@ -757,6 +758,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     public function morphOne($related, $name, $type = null, $id = null, $localKey = null)
     {
         $instance = new $related;
+        $instance->setConnection($this->connection);
 
         list($type, $id) = $this->getMorphs($name, $type, $id);
 
@@ -795,6 +797,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         }
 
         $instance = new $related;
+        $instance->setConnection($this->connection);
 
         // Once we have the foreign key names, we'll just create a new Eloquent query
         // for the related models and returns the relationship instance which will
@@ -843,6 +846,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
             $class = $this->getActualClassNameForMorph($class);
 
             $instance = new $class;
+            $instance->setConnection($this->connection);
 
             return new MorphTo(
                 $instance->newQuery(), $this, $id, $instance->getKeyName(), $type, $name
@@ -874,6 +878,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         $foreignKey = $foreignKey ?: $this->getForeignKey();
 
         $instance = new $related;
+        $instance->setConnection($this->connection);
 
         $localKey = $localKey ?: $this->getKeyName();
 
@@ -900,7 +905,9 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 
         $localKey = $localKey ?: $this->getKeyName();
 
-        return new HasManyThrough((new $related)->newQuery(), $this, $through, $firstKey, $secondKey, $localKey);
+        $instance = (new $related)->setConnection($this->connection);
+
+        return new HasManyThrough($instance->newQuery(), $this, $through, $firstKey, $secondKey, $localKey);
     }
 
     /**
@@ -916,6 +923,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     public function morphMany($related, $name, $type = null, $id = null, $localKey = null)
     {
         $instance = new $related;
+        $instance->setConnection($this->connection);
 
         // Here we will gather up the morph type and ID for the relationship so that we
         // can properly query the intermediate table of a relation. Finally, we will
@@ -954,6 +962,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         $foreignKey = $foreignKey ?: $this->getForeignKey();
 
         $instance = new $related;
+        $instance->setConnection($this->connection);
 
         $otherKey = $otherKey ?: $instance->getForeignKey();
 
@@ -993,6 +1002,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         $foreignKey = $foreignKey ?: $name.'_id';
 
         $instance = new $related;
+        $instance->setConnection($this->connection);
 
         $otherKey = $otherKey ?: $instance->getForeignKey();
 

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -731,7 +731,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      * @param  string  $related
      * @param  string  $foreignKey
      * @param  string  $localKey
-     * @param  bool  $forceConnection     
+     * @param  bool  $forceConnection
      * @return \Illuminate\Database\Eloquent\Relations\HasOne
      */
     public function hasOne($related, $foreignKey = null, $localKey = null, $forceConnection = false)
@@ -740,9 +740,10 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 
         $instance = new $related;
         
-        if($forceConnection)
+        if ($forceConnection) {
             $instance->setConnection($this->connection);
-
+        }
+        
         $localKey = $localKey ?: $this->getKeyName();
 
         return new HasOne($instance->newQuery(), $this, $instance->getTable().'.'.$foreignKey, $localKey);
@@ -756,15 +757,16 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      * @param  string  $type
      * @param  string  $id
      * @param  string  $localKey
-     * @param  bool  $forceConnection     
+     * @param  bool  $forceConnection
      * @return \Illuminate\Database\Eloquent\Relations\MorphOne
      */
     public function morphOne($related, $name, $type = null, $id = null, $localKey = null, $forceConnection = false)
     {
         $instance = new $related;
 
-        if($forceConnection)
+        if ($forceConnection) {
             $instance->setConnection($this->connection);
+        }
 
         list($type, $id) = $this->getMorphs($name, $type, $id);
 
@@ -782,7 +784,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      * @param  string  $foreignKey
      * @param  string  $otherKey
      * @param  string  $relation
-     * @param  bool  $forceConnection     
+     * @param  bool  $forceConnection
      * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
     public function belongsTo($related, $foreignKey = null, $otherKey = null, $relation = null, $forceConnection = false)
@@ -805,8 +807,9 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 
         $instance = new $related;
 
-        if($forceConnection)
+        if ($forceConnection) {
             $instance->setConnection($this->connection);
+        }
 
         // Once we have the foreign key names, we'll just create a new Eloquent query
         // for the related models and returns the relationship instance which will
@@ -824,7 +827,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      * @param  string  $name
      * @param  string  $type
      * @param  string  $id
-     * @param  bool  $forceConnection     
+     * @param  bool  $forceConnection
      * @return \Illuminate\Database\Eloquent\Relations\MorphTo
      */
     public function morphTo($name = null, $type = null, $id = null, $forceConnection = false)
@@ -857,8 +860,9 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 
             $instance = new $class;
         
-            if($forceConnection)
+            if ($forceConnection) {
                 $instance->setConnection($this->connection);
+            }
 
             return new MorphTo(
                 $instance->newQuery(), $this, $id, $instance->getKeyName(), $type, $name
@@ -883,7 +887,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      * @param  string  $related
      * @param  string  $foreignKey
      * @param  string  $localKey
-     * @param  bool  $forceConnection     
+     * @param  bool  $forceConnection
      * @return \Illuminate\Database\Eloquent\Relations\HasMany
      */
     public function hasMany($related, $foreignKey = null, $localKey = null, $forceConnection = false)
@@ -892,8 +896,9 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 
         $instance = new $related;
     
-        if($forceConnection)
+        if ($forceConnection) {
             $instance->setConnection($this->connection);
+        }
 
         $localKey = $localKey ?: $this->getKeyName();
 
@@ -908,7 +913,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      * @param  string|null  $firstKey
      * @param  string|null  $secondKey
      * @param  string|null  $localKey
-     * @param  bool  $forceConnection     
+     * @param  bool  $forceConnection
      * @return \Illuminate\Database\Eloquent\Relations\HasManyThrough
      */
     public function hasManyThrough($related, $through, $firstKey = null, $secondKey = null, $localKey = null, $forceConnection = false)
@@ -923,8 +928,9 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 
         $instance = (new $related);
         
-        if($forceConnection)
+        if ($forceConnection) {
             $instance->setConnection($this->connection);
+        }
 
 
         return new HasManyThrough($instance->newQuery(), $this, $through, $firstKey, $secondKey, $localKey);
@@ -938,15 +944,16 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      * @param  string  $type
      * @param  string  $id
      * @param  string  $localKey
-     * @param  bool  $forceConnection     
+     * @param  bool  $forceConnection
      * @return \Illuminate\Database\Eloquent\Relations\MorphMany
      */
     public function morphMany($related, $name, $type = null, $id = null, $localKey = null, $forceConnection = false)
     {
         $instance = new $related;
 
-        if($forceConnection)
+        if ($forceConnection) {
             $instance->setConnection($this->connection);
+        }
 
         // Here we will gather up the morph type and ID for the relationship so that we
         // can properly query the intermediate table of a relation. Finally, we will
@@ -968,7 +975,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      * @param  string  $foreignKey
      * @param  string  $otherKey
      * @param  string  $relation
-     * @param  bool  $forceConnection     
+     * @param  bool  $forceConnection
      * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
      */
     public function belongsToMany($related, $table = null, $foreignKey = null, $otherKey = null, $relation = null, $forceConnection = false)
@@ -987,8 +994,9 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 
         $instance = new $related;
 
-        if($forceConnection)
+        if ($forceConnection) {
             $instance->setConnection($this->connection);
+        }
 
         $otherKey = $otherKey ?: $instance->getForeignKey();
 
@@ -1016,7 +1024,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      * @param  string  $foreignKey
      * @param  string  $otherKey
      * @param  bool  $inverse
-     * @param  bool  $forceConnection     
+     * @param  bool  $forceConnection
      * @return \Illuminate\Database\Eloquent\Relations\MorphToMany
      */
     public function morphToMany($related, $name, $table = null, $foreignKey = null, $otherKey = null, $inverse = false, $forceConnection = false)
@@ -1030,8 +1038,9 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 
         $instance = new $related;
 
-        if($forceConnection)
+        if ($forceConnection) {
             $instance->setConnection($this->connection);
+        }
 
         $otherKey = $otherKey ?: $instance->getForeignKey();
 
@@ -1056,7 +1065,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      * @param  string  $table
      * @param  string  $foreignKey
      * @param  string  $otherKey
-     * @param  bool  $forceConnection   
+     * @param  bool  $forceConnection
      * @return \Illuminate\Database\Eloquent\Relations\MorphToMany
      */
     public function morphedByMany($related, $name, $table = null, $foreignKey = null, $otherKey = null, $forceConnection = false)

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -731,14 +731,17 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      * @param  string  $related
      * @param  string  $foreignKey
      * @param  string  $localKey
+     * @param  bool  $forceConnection     
      * @return \Illuminate\Database\Eloquent\Relations\HasOne
      */
-    public function hasOne($related, $foreignKey = null, $localKey = null)
+    public function hasOne($related, $foreignKey = null, $localKey = null, $forceConnection = false)
     {
         $foreignKey = $foreignKey ?: $this->getForeignKey();
 
         $instance = new $related;
-        $instance->setConnection($this->connection);
+        
+        if($forceConnection)
+            $instance->setConnection($this->connection);
 
         $localKey = $localKey ?: $this->getKeyName();
 
@@ -753,12 +756,15 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      * @param  string  $type
      * @param  string  $id
      * @param  string  $localKey
+     * @param  bool  $forceConnection     
      * @return \Illuminate\Database\Eloquent\Relations\MorphOne
      */
-    public function morphOne($related, $name, $type = null, $id = null, $localKey = null)
+    public function morphOne($related, $name, $type = null, $id = null, $localKey = null, $forceConnection = false)
     {
         $instance = new $related;
-        $instance->setConnection($this->connection);
+
+        if($forceConnection)
+            $instance->setConnection($this->connection);
 
         list($type, $id) = $this->getMorphs($name, $type, $id);
 
@@ -776,9 +782,10 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      * @param  string  $foreignKey
      * @param  string  $otherKey
      * @param  string  $relation
+     * @param  bool  $forceConnection     
      * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
-    public function belongsTo($related, $foreignKey = null, $otherKey = null, $relation = null)
+    public function belongsTo($related, $foreignKey = null, $otherKey = null, $relation = null, $forceConnection = false)
     {
         // If no relation name was given, we will use this debug backtrace to extract
         // the calling method's name and use that as the relationship name as most
@@ -797,7 +804,9 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         }
 
         $instance = new $related;
-        $instance->setConnection($this->connection);
+
+        if($forceConnection)
+            $instance->setConnection($this->connection);
 
         // Once we have the foreign key names, we'll just create a new Eloquent query
         // for the related models and returns the relationship instance which will
@@ -815,9 +824,10 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      * @param  string  $name
      * @param  string  $type
      * @param  string  $id
+     * @param  bool  $forceConnection     
      * @return \Illuminate\Database\Eloquent\Relations\MorphTo
      */
-    public function morphTo($name = null, $type = null, $id = null)
+    public function morphTo($name = null, $type = null, $id = null, $forceConnection = false)
     {
         // If no name is provided, we will use the backtrace to get the function name
         // since that is most likely the name of the polymorphic interface. We can
@@ -846,7 +856,9 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
             $class = $this->getActualClassNameForMorph($class);
 
             $instance = new $class;
-            $instance->setConnection($this->connection);
+        
+            if($forceConnection)
+                $instance->setConnection($this->connection);
 
             return new MorphTo(
                 $instance->newQuery(), $this, $id, $instance->getKeyName(), $type, $name
@@ -871,14 +883,17 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      * @param  string  $related
      * @param  string  $foreignKey
      * @param  string  $localKey
+     * @param  bool  $forceConnection     
      * @return \Illuminate\Database\Eloquent\Relations\HasMany
      */
-    public function hasMany($related, $foreignKey = null, $localKey = null)
+    public function hasMany($related, $foreignKey = null, $localKey = null, $forceConnection = false)
     {
         $foreignKey = $foreignKey ?: $this->getForeignKey();
 
         $instance = new $related;
-        $instance->setConnection($this->connection);
+    
+        if($forceConnection)
+            $instance->setConnection($this->connection);
 
         $localKey = $localKey ?: $this->getKeyName();
 
@@ -893,9 +908,10 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      * @param  string|null  $firstKey
      * @param  string|null  $secondKey
      * @param  string|null  $localKey
+     * @param  bool  $forceConnection     
      * @return \Illuminate\Database\Eloquent\Relations\HasManyThrough
      */
-    public function hasManyThrough($related, $through, $firstKey = null, $secondKey = null, $localKey = null)
+    public function hasManyThrough($related, $through, $firstKey = null, $secondKey = null, $localKey = null, $forceConnection = false)
     {
         $through = new $through;
 
@@ -905,7 +921,11 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 
         $localKey = $localKey ?: $this->getKeyName();
 
-        $instance = (new $related)->setConnection($this->connection);
+        $instance = (new $related);
+        
+        if($forceConnection)
+            $instance->setConnection($this->connection);
+
 
         return new HasManyThrough($instance->newQuery(), $this, $through, $firstKey, $secondKey, $localKey);
     }
@@ -918,12 +938,15 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      * @param  string  $type
      * @param  string  $id
      * @param  string  $localKey
+     * @param  bool  $forceConnection     
      * @return \Illuminate\Database\Eloquent\Relations\MorphMany
      */
-    public function morphMany($related, $name, $type = null, $id = null, $localKey = null)
+    public function morphMany($related, $name, $type = null, $id = null, $localKey = null, $forceConnection = false)
     {
         $instance = new $related;
-        $instance->setConnection($this->connection);
+
+        if($forceConnection)
+            $instance->setConnection($this->connection);
 
         // Here we will gather up the morph type and ID for the relationship so that we
         // can properly query the intermediate table of a relation. Finally, we will
@@ -945,9 +968,10 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      * @param  string  $foreignKey
      * @param  string  $otherKey
      * @param  string  $relation
+     * @param  bool  $forceConnection     
      * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
      */
-    public function belongsToMany($related, $table = null, $foreignKey = null, $otherKey = null, $relation = null)
+    public function belongsToMany($related, $table = null, $foreignKey = null, $otherKey = null, $relation = null, $forceConnection = false)
     {
         // If no relationship name was passed, we will pull backtraces to get the
         // name of the calling function. We will use that function name as the
@@ -962,7 +986,9 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         $foreignKey = $foreignKey ?: $this->getForeignKey();
 
         $instance = new $related;
-        $instance->setConnection($this->connection);
+
+        if($forceConnection)
+            $instance->setConnection($this->connection);
 
         $otherKey = $otherKey ?: $instance->getForeignKey();
 
@@ -990,9 +1016,10 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      * @param  string  $foreignKey
      * @param  string  $otherKey
      * @param  bool  $inverse
+     * @param  bool  $forceConnection     
      * @return \Illuminate\Database\Eloquent\Relations\MorphToMany
      */
-    public function morphToMany($related, $name, $table = null, $foreignKey = null, $otherKey = null, $inverse = false)
+    public function morphToMany($related, $name, $table = null, $foreignKey = null, $otherKey = null, $inverse = false, $forceConnection = false)
     {
         $caller = $this->getBelongsToManyCaller();
 
@@ -1002,7 +1029,9 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         $foreignKey = $foreignKey ?: $name.'_id';
 
         $instance = new $related;
-        $instance->setConnection($this->connection);
+
+        if($forceConnection)
+            $instance->setConnection($this->connection);
 
         $otherKey = $otherKey ?: $instance->getForeignKey();
 
@@ -1027,9 +1056,10 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      * @param  string  $table
      * @param  string  $foreignKey
      * @param  string  $otherKey
+     * @param  bool  $forceConnection   
      * @return \Illuminate\Database\Eloquent\Relations\MorphToMany
      */
-    public function morphedByMany($related, $name, $table = null, $foreignKey = null, $otherKey = null)
+    public function morphedByMany($related, $name, $table = null, $foreignKey = null, $otherKey = null, $forceConnection = false)
     {
         $foreignKey = $foreignKey ?: $this->getForeignKey();
 
@@ -1038,7 +1068,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         // of the morph-to-many method since we're figuring out these inverses.
         $otherKey = $otherKey ?: $name.'_id';
 
-        return $this->morphToMany($related, $name, $table, $foreignKey, $otherKey, true);
+        return $this->morphToMany($related, $name, $table, $foreignKey, $otherKey, true, $forceConnection);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -739,11 +739,11 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         $foreignKey = $foreignKey ?: $this->getForeignKey();
 
         $instance = new $related;
-        
+
         if ($forceConnection) {
             $instance->setConnection($this->connection);
         }
-        
+
         $localKey = $localKey ?: $this->getKeyName();
 
         return new HasOne($instance->newQuery(), $this, $instance->getTable().'.'.$foreignKey, $localKey);
@@ -859,7 +859,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
             $class = $this->getActualClassNameForMorph($class);
 
             $instance = new $class;
-        
+
             if ($forceConnection) {
                 $instance->setConnection($this->connection);
             }
@@ -895,7 +895,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         $foreignKey = $foreignKey ?: $this->getForeignKey();
 
         $instance = new $related;
-    
+
         if ($forceConnection) {
             $instance->setConnection($this->connection);
         }
@@ -927,7 +927,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         $localKey = $localKey ?: $this->getKeyName();
 
         $instance = (new $related);
-        
+
         if ($forceConnection) {
             $instance->setConnection($this->connection);
         }


### PR DESCRIPTION
Based on the problem I faced yesterday that the connection was not the same on both of the relations part, and based on @themsaid idea that the model may not be on the same database connection, I changed the code so that they will have the ability to either force the use of the same database connection in the relations or not.

So passing `true` as the last parameter to any relations function will force the use of the initiator connection, other wise the child will depend on his own connection.
