### PR TITLE
[5.3] Add MailEvents for listening sent and not sent

### DIFF
--- a/src/Illuminate/Mail/Events/MessageNotSent.php
+++ b/src/Illuminate/Mail/Events/MessageNotSent.php
@@ -19,9 +19,9 @@ class MessageNotSent
     public $transport;
 
     /**
-     * The throwed Exception
+     * The throwed \Exception or \Throwable
      *
-     * @var \Exception
+     * @var \Exception|\Throwable
      */
     public $exception;
 
@@ -29,7 +29,7 @@ class MessageNotSent
      * Create a new event instance.
      *
      * @param  \Swift_Message  $message
-     * @param  \Exception  $exception
+     * @param  \Exception|\Throwable  $exception
      * @param  string  $transport
      * @return void
      */

--- a/src/Illuminate/Mail/Events/MessageNotSent.php
+++ b/src/Illuminate/Mail/Events/MessageNotSent.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Illuminate\Mail\Events;
+
+class MessageNotSent
+{
+    /**
+     * The Swift message instance.
+     *
+     * @var \Swift_Message
+     */
+    public $message;
+
+    /**
+     * The Swift transport
+     *
+     * @var string
+     */
+    public $transport;
+
+    /**
+     * The throwed Exception
+     *
+     * @var \Exception
+     */
+    public $exception;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  \Swift_Message  $message
+     * @param  \Exception  $exception
+     * @param  string  $transport
+     * @return void
+     */
+    public function __construct($message, $exception, $transport)
+    {
+        $this->message = $message;
+        $this->transport = $transport;
+        $this->exception = $exception;
+    }
+}

--- a/src/Illuminate/Mail/Events/MessageNotSent.php
+++ b/src/Illuminate/Mail/Events/MessageNotSent.php
@@ -14,18 +14,18 @@ class MessageNotSent
     public $message;
 
     /**
-     * The Swift transport.
-     *
-     * @var string
-     */
-    public $transport;
-
-    /**
      * The exception thrown.
      *
      * @var \Throwable
      */
     public $exception;
+
+    /**
+     * The Swift transport.
+     *
+     * @var string
+     */
+    public $transport;
 
     /**
      * Create a new event instance.

--- a/src/Illuminate/Mail/Events/MessageNotSent.php
+++ b/src/Illuminate/Mail/Events/MessageNotSent.php
@@ -2,12 +2,14 @@
 
 namespace Illuminate\Mail\Events;
 
+use Swift_Message;
+
 class MessageNotSent
 {
     /**
      * The Swift message instance.
      *
-     * @var \Swift_Message
+     * @var Swift_Message
      */
     public $message;
 
@@ -28,12 +30,12 @@ class MessageNotSent
     /**
      * Create a new event instance.
      *
-     * @param  \Swift_Message  $message
+     * @param  Swift_Message  $message
      * @param  \Throwable  $exception
      * @param  string  $transport
      * @return void
      */
-    public function __construct($message, $exception, $transport)
+    public function __construct(Swift_Message $message, $exception, $transport)
     {
         $this->message = $message;
         $this->transport = $transport;

--- a/src/Illuminate/Mail/Events/MessageNotSent.php
+++ b/src/Illuminate/Mail/Events/MessageNotSent.php
@@ -19,9 +19,9 @@ class MessageNotSent
     public $transport;
 
     /**
-     * The throwed \Exception or \Throwable.
+     * The exception thrown.
      *
-     * @var \Exception|\Throwable
+     * @var \Throwable
      */
     public $exception;
 
@@ -29,7 +29,7 @@ class MessageNotSent
      * Create a new event instance.
      *
      * @param  \Swift_Message  $message
-     * @param  \Exception|\Throwable  $exception
+     * @param  \Throwable  $exception
      * @param  string  $transport
      * @return void
      */

--- a/src/Illuminate/Mail/Events/MessageNotSent.php
+++ b/src/Illuminate/Mail/Events/MessageNotSent.php
@@ -9,7 +9,7 @@ class MessageNotSent
     /**
      * The Swift message instance.
      *
-     * @var Swift_Message
+     * @var \Swift_Message
      */
     public $message;
 
@@ -30,7 +30,7 @@ class MessageNotSent
     /**
      * Create a new event instance.
      *
-     * @param  Swift_Message  $message
+     * @param  \Swift_Message  $message
      * @param  \Throwable  $exception
      * @param  string  $transport
      * @return void

--- a/src/Illuminate/Mail/Events/MessageNotSent.php
+++ b/src/Illuminate/Mail/Events/MessageNotSent.php
@@ -12,14 +12,14 @@ class MessageNotSent
     public $message;
 
     /**
-     * The Swift transport
+     * The Swift transport.
      *
      * @var string
      */
     public $transport;
 
     /**
-     * The throwed \Exception or \Throwable
+     * The throwed \Exception or \Throwable.
      *
      * @var \Exception|\Throwable
      */

--- a/src/Illuminate/Mail/Events/MessageSent.php
+++ b/src/Illuminate/Mail/Events/MessageSent.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Illuminate\Mail\Events;
+
+class MessageSent
+{
+    /**
+     * The Swift message instance.
+     *
+     * @var \Swift_Message
+     */
+    public $message;
+
+    /**
+     * The Swift transport
+     *
+     * @var string
+     */
+    public $transport;
+
+    /**
+     * The Swift send result - format depends on the transport.
+     *
+     * @var array
+     */
+    public $result;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  \Swift_Message  $message
+     * @param  array  $result
+     * @param  string  $transport
+     * @return void
+     */
+    public function __construct($message, $result, $transport)
+    {
+        $this->message = $message;
+        $this->transport = $transport;
+        $this->result = $result;
+    }
+}

--- a/src/Illuminate/Mail/Events/MessageSent.php
+++ b/src/Illuminate/Mail/Events/MessageSent.php
@@ -12,7 +12,7 @@ class MessageSent
     public $message;
 
     /**
-     * The Swift transport
+     * The Swift transport.
      *
      * @var string
      */

--- a/src/Illuminate/Mail/Events/MessageSent.php
+++ b/src/Illuminate/Mail/Events/MessageSent.php
@@ -9,7 +9,7 @@ class MessageSent
     /**
      * The Swift message instance.
      *
-     * @var Swift_Message
+     * @var \Swift_Message
      */
     public $message;
 
@@ -30,7 +30,7 @@ class MessageSent
     /**
      * Create a new event instance.
      *
-     * @param  Swift_Message  $message
+     * @param  \Swift_Message  $message
      * @param  array  $result
      * @param  string  $transport
      * @return void

--- a/src/Illuminate/Mail/Events/MessageSent.php
+++ b/src/Illuminate/Mail/Events/MessageSent.php
@@ -14,18 +14,18 @@ class MessageSent
     public $message;
 
     /**
-     * The Swift transport.
-     *
-     * @var string
-     */
-    public $transport;
-
-    /**
      * The Swift send result - format depends on the transport.
      *
      * @var array
      */
     public $result;
+
+    /**
+     * The Swift transport.
+     *
+     * @var string
+     */
+    public $transport;
 
     /**
      * Create a new event instance.

--- a/src/Illuminate/Mail/Events/MessageSent.php
+++ b/src/Illuminate/Mail/Events/MessageSent.php
@@ -2,12 +2,14 @@
 
 namespace Illuminate\Mail\Events;
 
+use Swift_Message;
+
 class MessageSent
 {
     /**
      * The Swift message instance.
      *
-     * @var \Swift_Message
+     * @var Swift_Message
      */
     public $message;
 
@@ -28,12 +30,12 @@ class MessageSent
     /**
      * Create a new event instance.
      *
-     * @param  \Swift_Message  $message
+     * @param  Swift_Message  $message
      * @param  array  $result
      * @param  string  $transport
      * @return void
      */
-    public function __construct($message, $result, $transport)
+    public function __construct(Swift_Message $message, $result, $transport)
     {
         $this->message = $message;
         $this->transport = $transport;

--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -386,7 +386,7 @@ class Mailer implements MailerContract, MailQueueContract
         try {
             $result = $this->swift->send($message, $this->failedRecipients);
             if ($this->events) {
-                $this->events->fire(new Events\MessageSent($message, $result));
+                $this->events->fire(new Events\MessageSent($message, $result, get_class($this->swift->getTransport())));
             }
 
             return $result;

--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -392,6 +392,11 @@ class Mailer implements MailerContract, MailQueueContract
                 $this->events->fire(new Events\MessageNotSent($message, $e, get_class($this->swift->getTransport())));
             }
             throw $e;
+        } catch (\Throwable $e) {
+            if ($this->events) {
+                $this->events->fire(new Events\MessageNotSent($message, $e, get_class($this->swift->getTransport())));
+            }
+            throw $e;
         } finally {
             $this->swift->getTransport()->stop();
         }

--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -386,6 +386,7 @@ class Mailer implements MailerContract, MailQueueContract
             if ($this->events) {
                 $this->events->fire(new Events\MessageSent($message, $result));
             }
+
             return $result;
         } catch (\Exception $e) {
             if ($this->events) {

--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -3,6 +3,8 @@
 namespace Illuminate\Mail;
 
 use Closure;
+use Exception;
+use Throwable;
 use Swift_Mailer;
 use Swift_Message;
 use Illuminate\Support\Arr;
@@ -388,12 +390,12 @@ class Mailer implements MailerContract, MailQueueContract
             }
 
             return $result;
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             if ($this->events) {
                 $this->events->fire(new Events\MessageNotSent($message, $e, get_class($this->swift->getTransport())));
             }
             throw $e;
-        } catch (\Throwable $e) {
+        } catch (Throwable $e) {
             if ($this->events) {
                 $this->events->fire(new Events\MessageNotSent($message, $e, get_class($this->swift->getTransport())));
             }


### PR DESCRIPTION
I add two more MailEvents for notify **AFTER** an Email is sent or not.

The main reason ist, that I want a secured MailLog in the database and to know if a email is sent or not and it's not enought to now that the email was planed to send.

The second benefit is the result of the transport, cause Amazon SES return a MessageID for identifying the message in their system which I need to match the bounces I get per a JSON Post and to monitor the [ses sending activity](http://docs.aws.amazon.com/ses/latest/DeveloperGuide/monitor-sending-activity.html)

The `MailingNotSent` event is only the missing part to make the MailEventSystem complete.

Any suggestions?
