### PR TITLE
[5.3] Add redirect helper to router

### DIFF
--- a/src/Illuminate/Foundation/Http/RedirectController.php
+++ b/src/Illuminate/Foundation/Http/RedirectController.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Illuminate\Foundation\Http;
+
+use Illuminate\Http\RedirectResponse;
+
+class RedirectController
+{
+    /**
+     * Handle a redirect.
+     *
+     * @param  string  $destination
+     * @param  int  $status
+     * @return \Illuminate\Http\RedirectResponse
+     */
+    public function handle($destination, $status)
+    {
+        return new RedirectResponse($destination, $status);
+    }
+
+    /**
+     * Extract the redirect data from the route and call the handler.
+     *
+     * @param  string  $method
+     * @param  array  $parameters
+     * @param  \Illuminate\Routing\Route $route
+     * @return \Illuminate\Http\RedirectResponse
+     */
+    public function callAction($method, $parameters, $route)
+    {
+        return $this->handle($route->getData('destination'), $route->getData('status'));
+    }
+}

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -80,7 +80,7 @@ class Route
 
     /**
      * Additional data to set on the route.
-     * 
+     *
      * @var array
      */
     protected $data = [];

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -79,6 +79,13 @@ class Route
     protected $parameterNames;
 
     /**
+     * Additional data to set on the route.
+     * 
+     * @var array
+     */
+    protected $data = [];
+
+    /**
      * The compiled version of the route.
      *
      * @var \Symfony\Component\Routing\CompiledRoute
@@ -470,6 +477,46 @@ class Route
         return array_map(function ($m) {
             return trim($m, '?');
         }, $matches[1]);
+    }
+
+    /**
+     * Get a given key from the data.
+     *
+     * @param  string  $key
+     * @param  mixed|null  $default
+     * @return mixed
+     */
+    public function getData($key, $default = null)
+    {
+        return Arr::get($this->data(), $key, $default);
+    }
+
+    /**
+     * Pass data to the route.
+     *
+     * @param  string|array  $key
+     * @param  mixed  $value
+     * @return $this
+     */
+    public function setData($key, $value = null)
+    {
+        $key = is_array($key) ? $key : [$key => $value];
+
+        foreach ($key as $k => $v) {
+            $this->data[$k] = $v;
+        }
+
+        return $this;
+    }
+
+    /**
+     * Get the additional data for the route.
+     *
+     * @return array
+     */
+    public function data()
+    {
+        return $this->data;
     }
 
     /**

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -7,7 +7,6 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
-use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Collection;
 use Illuminate\Container\Container;
 use Illuminate\Database\Eloquent\Model;
@@ -279,20 +278,21 @@ class Router implements RegistrarContract
 
         $registrar->register($name, $controller, $options);
     }
-    
+
     /**
      * Register a new redirect route with the router.
      *
-     * @param  string  $from
-     * @param  string  $to
+     * @param  string  $url
+     * @param  string  $destination
      * @param  int  $status
      * @return \Illuminate\Routing\Route
      */
-    public function redirect($from, $to, $status = 301)
+    public function redirect($url, $destination, $status = 301)
     {
-        return $this->get($from, function () use ($to, $status) {
-            return new RedirectResponse($to, $status);
-        });
+        return $this->any($url, '\Illuminate\Foundation\Http\RedirectController@handle')->withData([
+            'destination' => $destination,
+            'status' => $status,
+        ]);
     }
 
     /**

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Collection;
 use Illuminate\Container\Container;
 use Illuminate\Database\Eloquent\Model;
@@ -277,6 +278,21 @@ class Router implements RegistrarContract
         }
 
         $registrar->register($name, $controller, $options);
+    }
+    
+    /**
+     * Register a new redirect route with the router.
+     *
+     * @param  string  $from
+     * @param  string  $to
+     * @param  int  $status
+     * @return \Illuminate\Routing\Route
+     */
+    public function redirect($from, $to, $status = 301)
+    {
+        return $this->get($from, function () use ($to, $status) {
+            return new RedirectResponse($to, $status);
+        });
     }
 
     /**


### PR DESCRIPTION
As proposed on [this internals thread](https://github.com/laravel/internals/issues/172), this PR adds a redirect helper to the Router for those occasions when you want to redirect from an old route to a new route.

Route caching still works because the redirection is handled by an internal controller.
