### PR TITLE
[5.2] Use getArrayableItems for Collection::only()

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -647,8 +647,8 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      */
     public function only($keys)
     {
-        $keys = is_array($keys) ? $keys : func_get_args();
-
+        $keys = func_num_args() > 1 ? func_get_args() : $this->getArrayableItems($keys);
+        
         return new static(Arr::only($this->items, $keys));
     }
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1191,9 +1191,11 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals(['first' => 'Taylor'], $data->only(['first', 'missing'])->all());
         $this->assertEquals(['first' => 'Taylor'], $data->only('first', 'missing')->all());
+        $this->assertEquals(['first' => 'Taylor'], $data->only(new Collection(['first', 'missing']))->all());
 
         $this->assertEquals(['first' => 'Taylor', 'email' => 'taylorotwell@gmail.com'], $data->only(['first', 'email'])->all());
         $this->assertEquals(['first' => 'Taylor', 'email' => 'taylorotwell@gmail.com'], $data->only('first', 'email')->all());
+        $this->assertEquals(['first' => 'Taylor', 'email' => 'taylorotwell@gmail.com'], $data->only(new Collection(['first', 'email']))->all());
     }
 
     public function testGettingAvgItemsFromCollection()


### PR DESCRIPTION
This tripped me up a few times as I expected I could pass a collection to `only()`. It's a minor improvement for a bit more consistency, happy to refactor if not up to project standards.
