### PR TITLE
[5.3] Add collection drop functionality

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1322,4 +1322,19 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
 
         return (array) $items;
     }
+
+    /**
+     * Drop the first or last {$limit} items.
+     *
+     * @param  int  $limit
+     * @return static
+     */
+    public function drop($limit)
+    {
+        if ($limit < 0) {
+            return $this->slice(0, $limit);
+        }
+
+        return $this->slice($limit);
+    }
 }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1554,6 +1554,20 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
         $collection = new Collection(new \ArrayObject(['foo' => 1, 'bar' => 2, 'baz' => 3]));
         $this->assertEquals(['foo' => 1, 'bar' => 2, 'baz' => 3], $collection->toArray());
     }
+
+    public function testDrop()
+    {
+        $data = new Collection(['taylor', 'dayle', 'shawn']);
+        $data = $data->drop(2);
+        $this->assertEquals([2 => 'shawn'], $data->all());
+    }
+
+    public function testDropLast()
+    {
+        $data = new Collection(['taylor', 'dayle', 'shawn']);
+        $data = $data->drop(-2);
+        $this->assertEquals(['taylor'], $data->all());
+    }
 }
 
 class TestAccessorEloquentTestStub


### PR DESCRIPTION
Create the inverse of take method. The drop method returns a new collection without the specified number of items.
