### PR TITLE
[5.4] Add make:view Artisan command

### DIFF
--- a/src/Illuminate/Foundation/Console/ViewMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ViewMakeCommand.php
@@ -77,7 +77,7 @@ class ViewMakeCommand extends GeneratorCommand
      */
     protected function getPath($name)
     {
-        return resource_path('/views/' . $name . '.blade.php');
+        return resource_path('/views/'.$name.'.blade.php');
     }
 
     /**
@@ -125,7 +125,7 @@ class ViewMakeCommand extends GeneratorCommand
         $stub = str_replace(
             'DummySection', $sectionName, $stub
         );
-        if ($class != 'false'){
+        if ($class != 'false') {
             $divStart = "<div class='{$class}'>".PHP_EOL;
             $divEnd = PHP_EOL.'</div>';
         } else {

--- a/src/Illuminate/Foundation/Console/ViewMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ViewMakeCommand.php
@@ -42,7 +42,7 @@ class ViewMakeCommand extends GeneratorCommand
      */
     protected function alreadyExists($rawName)
     {
-        return file_exists($rawName);
+        return file_exists($this->getPath($this->parseName($rawName)));
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/ViewMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ViewMakeCommand.php
@@ -1,0 +1,180 @@
+<?php
+/**
+ * Copyright (c) 2016 S-IMK GmbH
+ * Letzte Dateiänderung: 23.08.16 14:37 (kaemmerling)
+ */
+
+namespace Illuminate\Foundation\Console;
+
+use Illuminate\Console\GeneratorCommand;
+use Illuminate\Support\Str;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+
+class ViewMakeCommand extends GeneratorCommand
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'make:view';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create a new view';
+
+    /**
+     * The type of class being generated.
+     *
+     * @var string
+     */
+    protected $type = 'View';
+
+    /**
+     * Determine if the class already exists.
+     *
+     * @param  string $rawName
+     * @return bool
+     */
+    protected function alreadyExists($rawName)
+    {
+        return file_exists($rawName);
+    }
+
+    /**
+     * Parse the name and format according to the root namespace.
+     *
+     * @param  string $name
+     * @return string
+     */
+    protected function parseName($name)
+    {
+
+        if (Str::contains($name, '\\')) {
+            $name = str_replace('\\', '/', $name);
+        }
+        if (Str::contains($name, '.')) {
+            $name = str_replace('.', '/', $name);
+        }
+
+        return $name;
+    }
+
+    /**
+     * Get the stub file for the generator.
+     *
+     * @return string
+     */
+    protected function getStub()
+    {
+        return __DIR__ . '/stubs/view.stub';
+    }
+
+    /**
+     * Get the destination class path.
+     *
+     * @param  string $name
+     * @return string
+     */
+    protected function getPath($name)
+    {
+        return resource_path('/views/' . $name . '.blade.php');
+    }
+
+    /**
+     * Build the class with the given name.
+     *
+     * @param  string $name
+     * @return string
+     */
+    protected function buildClass($name)
+    {
+        $stub = $this->files->get($this->getStub());
+        $parent = $this->option('parent');
+        $section = $this->option('section');
+        $stacks = $this->option('stacks');
+        $this->replaceParentView($stub, $parent)->replaceSection($stub, $section)->insertStacks($stub,$stacks);
+        return $stub;
+    }
+
+    /**
+     * Replace the Parent View Name for the given stub.
+     *
+     * @param  string $stub
+     * @param  string $parentViewName
+     * @return $this
+     */
+    protected function replaceParentView(&$stub, $parentViewName)
+    {
+        $stub = str_replace(
+            'DummyParentView', $parentViewName, $stub
+        );
+        return $this;
+    }
+
+    /**
+     * Replace the Section Name for the given stub.
+     *
+     * @param  string $stub
+     * @param  string $sectionName
+     * @return $this
+     */
+    protected function replaceSection(&$stub, $sectionName)
+    {
+        $stub = str_replace(
+            'DummySection', $sectionName, $stub
+        );
+        return $this;
+    }
+
+    /**
+     * Inserts the Stacks at the end of the stub.
+     *
+     * @param  string $stub
+     * @param  string $sectionName
+     * @return $this
+     */
+    protected function insertStacks(&$stub, array $stacks = [])
+    {
+        if(!empty($stacks)){
+            $stub_stack = PHP_EOL.'@stack(\'DummyStack\')'.PHP_EOL.PHP_EOL.'@endstack';
+
+            foreach ($stacks as $stack){
+                $stub = str_replace('DummyStack',$stack, ($stub.$stub_stack));
+            }
+        }
+        return $this;
+    }
+
+    /**
+     * Get the console command arguments.
+     *
+     * @return array
+     */
+    protected function getArguments()
+    {
+        return [
+            ['name', InputArgument::REQUIRED, 'The name of the view'],
+        ];
+    }
+
+    /**
+     * Get the console command options.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [
+            ['parent', null, InputOption::VALUE_REQUIRED, 'The parent view that would be extended.', 'layouts.app'],
+
+            ['section', null, InputOption::VALUE_REQUIRED, 'The section where your content is placed', 'content'],
+
+            ['stacks', null, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'Prepares your stacks in the view'],
+        ];
+    }
+}

--- a/src/Illuminate/Foundation/Console/ViewMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ViewMakeCommand.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Copyright (c) 2016 S-IMK GmbH
- * Letzte Dateiänderung: 23.08.16 14:37 (kaemmerling)
- */
-
 namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\GeneratorCommand;

--- a/src/Illuminate/Foundation/Console/ViewMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ViewMakeCommand.php
@@ -48,7 +48,6 @@ class ViewMakeCommand extends GeneratorCommand
      */
     protected function parseName($name)
     {
-
         if (Str::contains($name, '\\')) {
             $name = str_replace('\\', '/', $name);
         }
@@ -110,7 +109,7 @@ class ViewMakeCommand extends GeneratorCommand
         $stub = str_replace(
             'DummyParentView', $parentViewName, $stub
         );
-        
+
         return $this;
     }
 

--- a/src/Illuminate/Foundation/Console/ViewMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ViewMakeCommand.php
@@ -66,7 +66,7 @@ class ViewMakeCommand extends GeneratorCommand
      */
     protected function getStub()
     {
-        return __DIR__ . '/stubs/view.stub';
+        return __DIR__.'/stubs/view.stub';
     }
 
     /**
@@ -93,7 +93,7 @@ class ViewMakeCommand extends GeneratorCommand
         $section = $this->option('section');
         $class = $this->option('class');
         $stacks = $this->option('stacks');
-        $this->replaceParentView($stub, $parent)->replaceSection($stub, $section,$class)->insertStacks($stub,$stacks);
+        $this->replaceParentView($stub, $parent)->replaceSection($stub, $section, $class)->insertStacks($stub, $stacks);
         return $stub;
     }
 
@@ -120,14 +120,14 @@ class ViewMakeCommand extends GeneratorCommand
      * @param  string $class
      * @return $this
      */
-    protected function replaceSection(&$stub, $sectionName,$class)
+    protected function replaceSection(&$stub, $sectionName, $class)
     {
         $stub = str_replace(
             'DummySection', $sectionName, $stub
         );
-        if($class != 'false'){
+        if ($class != 'false'){
             $divStart = "<div class='{$class}'>".PHP_EOL;
-            $divEnd = PHP_EOL."</div>";
+            $divEnd = PHP_EOL.'</div>';
         } else {
             $divStart = null;
             $divEnd = null;
@@ -150,11 +150,11 @@ class ViewMakeCommand extends GeneratorCommand
      */
     protected function insertStacks(&$stub, array $stacks = [])
     {
-        if(!empty($stacks)){
+        if (! empty($stacks)) {
             $stub_stack = PHP_EOL.'@stack(\'DummyStack\')'.PHP_EOL.PHP_EOL.'@endstack';
 
-            foreach ($stacks as $stack){
-                $stub = str_replace('DummyStack',$stack, ($stub.$stub_stack));
+            foreach ($stacks as $stack) {
+                $stub = str_replace('DummyStack', $stack, ($stub.$stub_stack));
             }
         }
         return $this;
@@ -184,7 +184,7 @@ class ViewMakeCommand extends GeneratorCommand
 
             ['section', null, InputOption::VALUE_REQUIRED, 'The section where your content is placed', 'content'],
 
-            ['class', null, InputOption::VALUE_OPTIONAL, 'Defines the default bootstrap class that wrapps your content. [false for disable]','container'],
+            ['class', null, InputOption::VALUE_OPTIONAL, 'Defines the default bootstrap class that wrapps your content. [false for disable]', 'container'],
 
             ['stacks', null, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'Creates stackes'],
         ];

--- a/src/Illuminate/Foundation/Console/ViewMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ViewMakeCommand.php
@@ -96,8 +96,9 @@ class ViewMakeCommand extends GeneratorCommand
         $stub = $this->files->get($this->getStub());
         $parent = $this->option('parent');
         $section = $this->option('section');
+        $class = $this->option('class');
         $stacks = $this->option('stacks');
-        $this->replaceParentView($stub, $parent)->replaceSection($stub, $section)->insertStacks($stub,$stacks);
+        $this->replaceParentView($stub, $parent)->replaceSection($stub, $section,$class)->insertStacks($stub,$stacks);
         return $stub;
     }
 
@@ -121,12 +122,26 @@ class ViewMakeCommand extends GeneratorCommand
      *
      * @param  string $stub
      * @param  string $sectionName
+     * @param  string $class
      * @return $this
      */
-    protected function replaceSection(&$stub, $sectionName)
+    protected function replaceSection(&$stub, $sectionName,$class)
     {
         $stub = str_replace(
             'DummySection', $sectionName, $stub
+        );
+        if($class != 'false'){
+            $divStart = "<div class='{$class}'>".PHP_EOL;
+            $divEnd = PHP_EOL."</div>";
+        } else {
+            $divStart = null;
+            $divEnd = null;
+        }
+        $stub = str_replace(
+            '<DumyDiv>', $divStart, $stub
+        );
+        $stub = str_replace(
+            '</DumyDiv>', $divEnd, $stub
         );
         return $this;
     }
@@ -174,7 +189,9 @@ class ViewMakeCommand extends GeneratorCommand
 
             ['section', null, InputOption::VALUE_REQUIRED, 'The section where your content is placed', 'content'],
 
-            ['stacks', null, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'Prepares your stacks in the view'],
+            ['class', null, InputOption::VALUE_OPTIONAL, 'Defines the default bootstrap class that wrapps your content. [false for disable]','container'],
+
+            ['stacks', null, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'Creates stackes'],
         ];
     }
 }

--- a/src/Illuminate/Foundation/Console/ViewMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ViewMakeCommand.php
@@ -94,6 +94,7 @@ class ViewMakeCommand extends GeneratorCommand
         $class = $this->option('class');
         $stacks = $this->option('stacks');
         $this->replaceParentView($stub, $parent)->replaceSection($stub, $section, $class)->insertStacks($stub, $stacks);
+
         return $stub;
     }
 
@@ -109,6 +110,7 @@ class ViewMakeCommand extends GeneratorCommand
         $stub = str_replace(
             'DummyParentView', $parentViewName, $stub
         );
+        
         return $this;
     }
 
@@ -138,6 +140,7 @@ class ViewMakeCommand extends GeneratorCommand
         $stub = str_replace(
             '</DumyDiv>', $divEnd, $stub
         );
+
         return $this;
     }
 
@@ -157,6 +160,7 @@ class ViewMakeCommand extends GeneratorCommand
                 $stub = str_replace('DummyStack', $stack, ($stub.$stub_stack));
             }
         }
+
         return $this;
     }
 

--- a/src/Illuminate/Foundation/Console/stubs/view.stub
+++ b/src/Illuminate/Foundation/Console/stubs/view.stub
@@ -1,5 +1,5 @@
 @extends('DummyParentView')
 
 @section('DummySection')
-
+<DumyDiv></DumyDiv>
 @endsection

--- a/src/Illuminate/Foundation/Console/stubs/view.stub
+++ b/src/Illuminate/Foundation/Console/stubs/view.stub
@@ -1,0 +1,5 @@
+@extends('DummyParentView')
+
+@section('DummySection')
+
+@endsection

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Foundation\Providers;
 
+use Illuminate\Foundation\Console\ViewMakeCommand;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Queue\Console\TableCommand;
 use Illuminate\Auth\Console\MakeAuthCommand;
@@ -105,6 +106,7 @@ class ArtisanServiceProvider extends ServiceProvider
         'Serve' => 'command.serve',
         'TestMake' => 'command.test.make',
         'VendorPublish' => 'command.vendor.publish',
+        'ViewMake' => 'command.view.make',
     ];
 
     /**
@@ -603,7 +605,17 @@ class ArtisanServiceProvider extends ServiceProvider
             return new NotificationTableCommand($app['files'], $app['composer']);
         });
     }
-
+    /**
+     * Register the command.
+     *
+     * @return void
+     */
+    protected function registerViewMakeCommand()
+    {
+        $this->app->singleton('command.view.make', function ($app) {
+            return new ViewMakeCommand($app['files']);
+        });
+    }
     /**
      * Get the services provided by the provider.
      *

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Copyright (c) 2016 S-IMK GmbH
- * Letzte Dateiänderung: 23.08.16 14:40 (kaemmerling)
- */
-
 namespace Illuminate\Foundation\Providers;
 
 use Illuminate\Foundation\Console\ViewMakeCommand;

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * Copyright (c) 2016 S-IMK GmbH
+ * Letzte Dateiänderung: 23.08.16 14:40 (kaemmerling)
+ */
 
 namespace Illuminate\Foundation\Providers;
 
@@ -605,6 +609,7 @@ class ArtisanServiceProvider extends ServiceProvider
             return new NotificationTableCommand($app['files'], $app['composer']);
         });
     }
+
     /**
      * Register the command.
      *
@@ -616,6 +621,7 @@ class ArtisanServiceProvider extends ServiceProvider
             return new ViewMakeCommand($app['files']);
         });
     }
+
     /**
      * Get the services provided by the provider.
      *


### PR DESCRIPTION
Adds the ability to create Views from Artisan.

`php artisan make:view {NameOfView}` 

**Create Folder(s) and View:**

`php artisan make:view folder.to.thisView` creates an thisView.blade.php in the  _`view folder`_`/folder/to/` and create the folder _`view folder`_`/folder/to/` if it doesn't exists.

**Options:**
Of course, combinations of options are possible.

`php artisan make:view TestView` creates an TestView.blade.php in the _`view folder`_
Content:

```
@extends('layouts.app')

@section('content')
<div class='container'>

</div>
@endsection
```

`php artisan make:view TestView --parent=OtherParentLayout` creates an TestView.blade.php in the _`view folder`_
Content:

```
@extends('OtherParentLayout')

@section('content')
<div class='container'>

</div>
@endsection
```

`php artisan make:view TestView --section=OtherSection` creates an TestView.blade.php in the _`view folder`_

```
@extends('layouts.app')

@section('OtherSection')
<div class='container'>

</div>
@endsection
```

`php artisan make:view TestView --class=OtherClass` creates an TestView.blade.php in the _`view folder`_

```
@extends('layouts.app')

@section('content')
<div class='OtherClass'>

</div>
@endsection
```

`php artisan make:view TestView --class=false` creates an TestView.blade.php in the _`view folder`_

```
@extends('layouts.app')

@section('content')

@endsection
```
