### PR TITLE
[5.4] Add make:view Artisan command

### DIFF
--- a/src/Illuminate/Foundation/Console/ViewMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ViewMakeCommand.php
@@ -1,0 +1,195 @@
+<?php
+namespace Illuminate\Foundation\Console;
+
+use Illuminate\Console\GeneratorCommand;
+use Illuminate\Support\Str;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+
+class ViewMakeCommand extends GeneratorCommand
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'make:view';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create a new view';
+
+    /**
+     * The type of class being generated.
+     *
+     * @var string
+     */
+    protected $type = 'View';
+
+    /**
+     * Determine if the class already exists.
+     *
+     * @param  string $rawName
+     * @return bool
+     */
+    protected function alreadyExists($rawName)
+    {
+        return file_exists($this->getPath($this->parseName($rawName)));
+    }
+
+    /**
+     * Parse the name and format according to the root namespace.
+     *
+     * @param  string $name
+     * @return string
+     */
+    protected function parseName($name)
+    {
+        if (Str::contains($name, '\\')) {
+            $name = str_replace('\\', '/', $name);
+        }
+        if (Str::contains($name, '.')) {
+            $name = str_replace('.', '/', $name);
+        }
+
+        return $name;
+    }
+
+    /**
+     * Get the stub file for the generator.
+     *
+     * @return string
+     */
+    protected function getStub()
+    {
+        return __DIR__.'/stubs/view.stub';
+    }
+
+    /**
+     * Get the destination class path.
+     *
+     * @param  string $name
+     * @return string
+     */
+    protected function getPath($name)
+    {
+        return resource_path('/views/'.$name.'.blade.php');
+    }
+
+    /**
+     * Build the class with the given name.
+     *
+     * @param  string $name
+     * @return string
+     */
+    protected function buildClass($name)
+    {
+        $stub = $this->files->get($this->getStub());
+        $parent = $this->option('parent');
+        $section = $this->option('section');
+        $class = $this->option('class');
+        $stacks = $this->option('stacks');
+        $this->replaceParentView($stub, $parent)->replaceSection($stub, $section, $class)->insertStacks($stub, $stacks);
+
+        return $stub;
+    }
+
+    /**
+     * Replace the Parent View Name for the given stub.
+     *
+     * @param  string $stub
+     * @param  string $parentViewName
+     * @return $this
+     */
+    protected function replaceParentView(&$stub, $parentViewName)
+    {
+        $stub = str_replace(
+            'DummyParentView', $parentViewName, $stub
+        );
+
+        return $this;
+    }
+
+    /**
+     * Replace the Section Name for the given stub.
+     *
+     * @param  string $stub
+     * @param  string $sectionName
+     * @param  string $class
+     * @return $this
+     */
+    protected function replaceSection(&$stub, $sectionName, $class)
+    {
+        $stub = str_replace(
+            'DummySection', $sectionName, $stub
+        );
+        if ($class != 'false') {
+            $divStart = "<div class='{$class}'>".PHP_EOL;
+            $divEnd = PHP_EOL.'</div>';
+        } else {
+            $divStart = null;
+            $divEnd = null;
+        }
+        $stub = str_replace(
+            '<DumyDiv>', $divStart, $stub
+        );
+        $stub = str_replace(
+            '</DumyDiv>', $divEnd, $stub
+        );
+
+        return $this;
+    }
+
+    /**
+     * Inserts the Stacks at the end of the stub.
+     *
+     * @param  string $stub
+     * @param  string $sectionName
+     * @return $this
+     */
+    protected function insertStacks(&$stub, array $stacks = [])
+    {
+        if (! empty($stacks)) {
+            $stub_stack = PHP_EOL.'@stack(\'DummyStack\')'.PHP_EOL.PHP_EOL.'@endstack';
+
+            foreach ($stacks as $stack) {
+                $stub = str_replace('DummyStack', $stack, ($stub.$stub_stack));
+            }
+        }
+
+        return $this;
+    }
+
+    /**
+     * Get the console command arguments.
+     *
+     * @return array
+     */
+    protected function getArguments()
+    {
+        return [
+            ['name', InputArgument::REQUIRED, 'The name of the view'],
+        ];
+    }
+
+    /**
+     * Get the console command options.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [
+            ['parent', null, InputOption::VALUE_REQUIRED, 'The parent view that would be extended.', 'layouts.app'],
+
+            ['section', null, InputOption::VALUE_REQUIRED, 'The section where your content is placed', 'content'],
+
+            ['class', null, InputOption::VALUE_OPTIONAL, 'Defines the default bootstrap class that wrapps your content. [false for disable]', 'container'],
+
+            ['stacks', null, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'Creates stackes'],
+        ];
+    }
+}

--- a/src/Illuminate/Foundation/Console/stubs/view.stub
+++ b/src/Illuminate/Foundation/Console/stubs/view.stub
@@ -1,0 +1,5 @@
+@extends('DummyParentView')
+
+@section('DummySection')
+<DumyDiv></DumyDiv>
+@endsection

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -1,7 +1,7 @@
 <?php
-
 namespace Illuminate\Foundation\Providers;
 
+use Illuminate\Foundation\Console\ViewMakeCommand;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Queue\Console\TableCommand;
 use Illuminate\Auth\Console\MakeAuthCommand;
@@ -105,6 +105,7 @@ class ArtisanServiceProvider extends ServiceProvider
         'Serve' => 'command.serve',
         'TestMake' => 'command.test.make',
         'VendorPublish' => 'command.vendor.publish',
+        'ViewMake' => 'command.view.make',
     ];
 
     /**
@@ -601,6 +602,18 @@ class ArtisanServiceProvider extends ServiceProvider
     {
         $this->app->singleton('command.notification.table', function ($app) {
             return new NotificationTableCommand($app['files'], $app['composer']);
+        });
+    }
+
+    /**
+     * Register the command.
+     *
+     * @return void
+     */
+    protected function registerViewMakeCommand()
+    {
+        $this->app->singleton('command.view.make', function ($app) {
+            return new ViewMakeCommand($app['files']);
         });
     }
 


### PR DESCRIPTION
Adds the ability to create Views from Artisan.

`php artisan make:view {NameOfView}` 

**Create Folder(s) and View:**

`php artisan make:view folder.to.thisView` creates an thisView.blade.php in the  _`view folder`_`/folder/to/` and create the folder _`view folder`_`/folder/to/` if it doesn't exists.

**Options:**
Of course, combinations of options are possible.

`php artisan make:view TestView` creates an TestView.blade.php in the _`view folder`_
Content:

```
@extends('layouts.app')

@section('content')
<div class='container'>

</div>
@endsection
```

`php artisan make:view TestView --parent=OtherParentLayout` creates an TestView.blade.php in the _`view folder`_
Content:

```
@extends('OtherParentLayout')

@section('content')
<div class='container'>

</div>
@endsection
```

`php artisan make:view TestView --section=OtherSection` creates an TestView.blade.php in the _`view folder`_

```
@extends('layouts.app')

@section('OtherSection')
<div class='container'>

</div>
@endsection
```

`php artisan make:view TestView --class=OtherClass` creates an TestView.blade.php in the _`view folder`_

```
@extends('layouts.app')

@section('content')
<div class='OtherClass'>

</div>
@endsection
```

`php artisan make:view TestView --class=false` creates an TestView.blade.php in the _`view folder`_

```
@extends('layouts.app')

@section('content')

@endsection
```
