### PR TITLE
[5.3] Show Generated Filename

### DIFF
--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -63,7 +63,9 @@ abstract class GeneratorCommand extends Command
 
         $this->files->put($path, $this->buildClass($name));
 
-        $this->info($this->type.' created successfully.');
+        $file = pathinfo($this->getPath($name), PATHINFO_FILENAME);
+
+        $this->line("<info>Created {$this->type}:</info> $file");
     }
 
     /**

--- a/src/Illuminate/Database/SqlServerConnection.php
+++ b/src/Illuminate/Database/SqlServerConnection.php
@@ -16,41 +16,44 @@ class SqlServerConnection extends Connection
      * Execute a Closure within a transaction.
      *
      * @param  \Closure  $callback
+     * @param  int  $attempts
      * @return mixed
      *
      * @throws \Exception|\Throwable
      */
-    public function transaction(Closure $callback)
+    public function transaction(Closure $callback, $attempts = 1)
     {
-        if ($this->getDriverName() == 'sqlsrv') {
-            return parent::transaction($callback);
+        for ($a = 1; $a <= $attempts; $a++) {
+            if ($this->getDriverName() == 'sqlsrv') {
+                return parent::transaction($callback);
+            }
+
+            $this->getPdo()->exec('BEGIN TRAN');
+
+            // We'll simply execute the given callback within a try / catch block
+            // and if we catch any exception we can rollback the transaction
+            // so that none of the changes are persisted to the database.
+            try {
+                $result = $callback($this);
+
+                $this->getPdo()->exec('COMMIT TRAN');
+            }
+
+            // If we catch an exception, we will roll back so nothing gets messed
+            // up in the database. Then we'll re-throw the exception so it can
+            // be handled how the developer sees fit for their applications.
+            catch (Exception $e) {
+                $this->getPdo()->exec('ROLLBACK TRAN');
+
+                throw $e;
+            } catch (Throwable $e) {
+                $this->getPdo()->exec('ROLLBACK TRAN');
+
+                throw $e;
+            }
+
+            return $result;
         }
-
-        $this->getPdo()->exec('BEGIN TRAN');
-
-        // We'll simply execute the given callback within a try / catch block
-        // and if we catch any exception we can rollback the transaction
-        // so that none of the changes are persisted to the database.
-        try {
-            $result = $callback($this);
-
-            $this->getPdo()->exec('COMMIT TRAN');
-        }
-
-        // If we catch an exception, we will roll back so nothing gets messed
-        // up in the database. Then we'll re-throw the exception so it can
-        // be handled how the developer sees fit for their applications.
-        catch (Exception $e) {
-            $this->getPdo()->exec('ROLLBACK TRAN');
-
-            throw $e;
-        } catch (Throwable $e) {
-            $this->getPdo()->exec('ROLLBACK TRAN');
-
-            throw $e;
-        }
-
-        return $result;
     }
 
     /**


### PR DESCRIPTION
I always found it a bit strange that the migration generator command has a different output to other generators. I quite like it that the filename gets outputted to the console when you create a migration, so I created this PR do the the same thing when you use a generator command.

The first line is the original output and the rest are the new outputs after this change was implemented:

<img width="909" alt="screen shot 2016-08-23 at 16 26 33" src="https://cloud.githubusercontent.com/assets/754498/17895799/87755a22-694e-11e6-9acc-2646833252bf.png">
