### PR TITLE
[5.3] Fix in Arr::has to check for exact key first

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -288,6 +288,10 @@ class Arr
         foreach ($keys as $key) {
             $subKeyArray = $array;
 
+            if (static::exists($array, $key)) {
+                continue;
+            }
+
             foreach (explode('.', $key) as $segment) {
                 if (static::accessible($subKeyArray) && static::exists($subKeyArray, $segment)) {
                     $subKeyArray = $subKeyArray[$segment];

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -221,6 +221,10 @@ class SupportArrTest extends PHPUnit_Framework_TestCase
 
     public function testHas()
     {
+        $array = ['products.desk' => ['price' => 100]];
+        $this->assertTrue(Arr::has($array, ['products.desk']));
+        $this->assertFalse(Arr::has($array, ['products.desk', 'missing']));
+
         $array = ['products' => ['desk' => ['price' => 100]]];
         $this->assertTrue(Arr::has($array, 'products.desk'));
         $this->assertTrue(Arr::has($array, 'products.desk.price'));


### PR DESCRIPTION
The change was presented here:
https://github.com/laravel/framework/pull/14789

Before the above change using `Arr::has(['first.name' => 'Jon'], 'first.name')` would return true as the method was checking for the exact key first before assuming it's a dot notation.

The PR purpose doesn't indicate removing this behaviour, so I assume this needs a fix.
