### PR TITLE
[5.3] Replace manual comparator with basic asort

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -947,13 +947,9 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     {
         $items = $this->items;
 
-        $callback ? uasort($items, $callback) : uasort($items, function ($a, $b) {
-            if ($a == $b) {
-                return 0;
-            }
-
-            return ($a < $b) ? -1 : 1;
-        });
+        $callback
+            ? uasort($items, $callback) 
+            : asort($items);
 
         return new static($items);
     }

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -948,7 +948,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
         $items = $this->items;
 
         $callback
-            ? uasort($items, $callback) 
+            ? uasort($items, $callback)
             : asort($items);
 
         return new static($items);


### PR DESCRIPTION
There is no need to explicitly compare here. Allow the engine to do so internally without the need to invoke the callback for each comparison. 
