### PR TITLE
[5.3] Use getter instead of accessing the protected property directly.

### DIFF
--- a/src/Illuminate/Database/Query/JoinClause.php
+++ b/src/Illuminate/Database/Query/JoinClause.php
@@ -42,7 +42,7 @@ class JoinClause extends Builder
         $this->parentQuery = $parentQuery;
 
         parent::__construct(
-            $parentQuery->connection, $parentQuery->grammar, $parentQuery->processor
+            $parentQuery->getConnection(), $parentQuery->getGrammar(), $parentQuery->getProcessor()
         );
     }
 


### PR DESCRIPTION
Use getter instead of accessing the protected property directly to avoid having error like below:

```
PHP Fatal error:  Uncaught Error: Cannot access protected property
```
