### PR TITLE
[5.3] Update TokenGuard.php to look for key in query string items only.

### DIFF
--- a/src/Illuminate/Auth/TokenGuard.php
+++ b/src/Illuminate/Auth/TokenGuard.php
@@ -18,11 +18,11 @@ class TokenGuard implements Guard
     protected $request;
 
     /**
-     * The name of the field on the request containing the API token.
+     * The name of the query string item from the request containing the API token.
      *
      * @var string
      */
-    protected $inputKey;
+    protected $queryKey;
 
     /**
      * The name of the token "column" in persistent storage.
@@ -42,7 +42,7 @@ class TokenGuard implements Guard
     {
         $this->request = $request;
         $this->provider = $provider;
-        $this->inputKey = 'api_token';
+        $this->queryKey = 'api_token';
         $this->storageKey = 'api_token';
     }
 
@@ -80,7 +80,7 @@ class TokenGuard implements Guard
      */
     public function getTokenForRequest()
     {
-        $token = $this->request->input($this->inputKey);
+        $token = $this->request->query($this->queryKey);
 
         if (empty($token)) {
             $token = $this->request->bearerToken();
@@ -101,11 +101,11 @@ class TokenGuard implements Guard
      */
     public function validate(array $credentials = [])
     {
-        if (empty($credentials[$this->inputKey])) {
+        if (empty($credentials[$this->queryKey])) {
             return false;
         }
 
-        $credentials = [$this->storageKey => $credentials[$this->inputKey]];
+        $credentials = [$this->storageKey => $credentials[$this->queryKey]];
 
         if ($this->provider->retrieveByCredentials($credentials)) {
             return true;

--- a/src/Illuminate/Auth/TokenGuard.php
+++ b/src/Illuminate/Auth/TokenGuard.php
@@ -22,7 +22,7 @@ class TokenGuard implements Guard
      *
      * @var string
      */
-    protected $queryKey;
+    protected $inputKey;
 
     /**
      * The name of the token "column" in persistent storage.
@@ -42,7 +42,7 @@ class TokenGuard implements Guard
     {
         $this->request = $request;
         $this->provider = $provider;
-        $this->queryKey = 'api_token';
+        $this->inputKey = 'api_token';
         $this->storageKey = 'api_token';
     }
 
@@ -80,7 +80,7 @@ class TokenGuard implements Guard
      */
     public function getTokenForRequest()
     {
-        $token = $this->request->query($this->queryKey);
+        $token = $this->request->query($this->inputKey);
 
         if (empty($token)) {
             $token = $this->request->bearerToken();
@@ -101,11 +101,11 @@ class TokenGuard implements Guard
      */
     public function validate(array $credentials = [])
     {
-        if (empty($credentials[$this->queryKey])) {
+        if (empty($credentials[$this->inputKey])) {
             return false;
         }
 
-        $credentials = [$this->storageKey => $credentials[$this->queryKey]];
+        $credentials = [$this->storageKey => $credentials[$this->inputKey]];
 
         if ($this->provider->retrieveByCredentials($credentials)) {
             return true;


### PR DESCRIPTION
Because in Larvel's combined input system, the body items take precedence over query string items. If an item appears in the body that uses the same key as the one being used for the API token, then this body item is then assumed to be the token which could lead to authentication errors especially if the key is being set to a more generic custom name with a high risk of conflict, e.g. 'password'. This file has been edited to restrict the API token to being in the query string only by using request->query instead of request->input which I think is the expected behaviour for token authentication.

After checking the query string it still falls back to looking in the headers for a bearer token or basic auth password as it was originally designed.

I also renamed the variable to queryKey to convey it is only relevant to the query string rather than the combined input, however, given 5.3 is already released this would be a breaking change if anyone has already subclassed TokenGuard to rename the token key. Thus it might be better to leave the variable named inputKey.
