### PR TITLE
[5.3] Update BladeCompiler.php to change protected function stripParentheses to public

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -930,7 +930,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
      * @param  string  $expression
      * @return string
      */
-    protected function stripParentheses($expression)
+    public function stripParentheses($expression)
     {
         if (Str::startsWith($expression, '(')) {
             $expression = substr($expression, 1, -1);


### PR DESCRIPTION
Function stripParentheses very helpfull in blade extensions

``` php
Blade::directive('example', function($expression) {
    $expression = Blade::stripParentheses($expression); // protected
    return "<?php echo example($expression); ?>";
});

@example('foo', 'bar')
```
