### PR TITLE
[5.3] Allowing unversioned assets with elixir function

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -385,17 +385,26 @@ if (! function_exists('elixir')) {
      */
     function elixir($file, $buildDirectory = 'build')
     {
-        static $manifest;
+        static $manifest = [];
         static $manifestPath;
 
-        if (is_null($manifest) || $manifestPath !== $buildDirectory) {
-            $manifest = json_decode(file_get_contents(public_path($buildDirectory.'/rev-manifest.json')), true);
+        if (empty($manifest) || $manifestPath !== $buildDirectory) {
+            $path = public_path($buildDirectory.'/rev-manifest.json');
 
-            $manifestPath = $buildDirectory;
+            if (file_exists($path)) {
+                $manifest = json_decode(file_get_contents($path), true);
+                $manifestPath = $buildDirectory;
+            }
         }
 
         if (isset($manifest[$file])) {
             return '/'.trim($buildDirectory.'/'.$manifest[$file], '/');
+        }
+
+        $unversioned = public_path($file);
+
+        if (file_exists($unversioned)) {
+            return '/'.trim($file, '/');
         }
 
         throw new InvalidArgumentException("File {$file} not defined in asset manifest.");

--- a/tests/Foundation/FoundationHelpersTest.php
+++ b/tests/Foundation/FoundationHelpersTest.php
@@ -37,4 +37,19 @@ class FoundationHelpersTest extends PHPUnit_Framework_TestCase
 
         cache(['foo' => 'bar']);
     }
+
+    public function testUnversionedElixir()
+    {
+        $file = 'unversioned.css';
+
+        app()->singleton('path.public', function () {
+            return __DIR__;
+        });
+
+        touch(public_path($file));
+
+        $this->assertEquals('/'.$file, elixir($file));
+
+        unlink(public_path($file));
+    }
 }


### PR DESCRIPTION
Currently, when you have a file `myapp/public/css/app.css`, and use `{{ elixir('css/app.css') }}`, you will get an `InvalidArgumentException`, unless you also have `mix.versioned('css/app.css')`.

This change allows `elixir()` to return paths to existing files, preferring to get them out of the manifest.
