### PR TITLE
[5.3] Fire BelongsToMany relation events for attach/detach/sync/toggle

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1243,6 +1243,110 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     }
 
     /**
+     * Register a relation attaching model event with the dispatcher.
+     *
+     * @param  string  $relation
+     * @param  \Closure|string  $callback
+     * @param  int  $priority
+     * @return void
+     */
+    public static function attaching($relation, $callback, $priority = 0)
+    {
+        static::registerModelEvent("attaching.{$relation}", $callback, $priority);
+    }
+
+    /**
+     * Register a relation attached model event with the dispatcher.
+     *
+     * @param  string  $relation
+     * @param  \Closure|string  $callback
+     * @param  int  $priority
+     * @return void
+     */
+    public static function attached($relation, $callback, $priority = 0)
+    {
+        static::registerModelEvent("attached.{$relation}", $callback, $priority);
+    }
+
+    /**
+     * Register a relation detaching model event with the dispatcher.
+     *
+     * @param  string  $relation
+     * @param  \Closure|string  $callback
+     * @param  int  $priority
+     * @return void
+     */
+    public static function detaching($relation, $callback, $priority = 0)
+    {
+        static::registerModelEvent("detaching.{$relation}", $callback, $priority);
+    }
+
+    /**
+     * Register a relation detached model event with the dispatcher.
+     *
+     * @param  string  $relation
+     * @param  \Closure|string  $callback
+     * @param  int  $priority
+     * @return void
+     */
+    public static function detached($relation, $callback, $priority = 0)
+    {
+        static::registerModelEvent("detached.{$relation}", $callback, $priority);
+    }
+
+    /**
+     * Register a relation syncing model event with the dispatcher.
+     *
+     * @param  string  $relation
+     * @param  \Closure|string  $callback
+     * @param  int  $priority
+     * @return void
+     */
+    public static function syncing($relation, $callback, $priority = 0)
+    {
+        static::registerModelEvent("syncing.{$relation}", $callback, $priority);
+    }
+
+    /**
+     * Register a relation synced model event with the dispatcher.
+     *
+     * @param  string  $relation
+     * @param  \Closure|string  $callback
+     * @param  int  $priority
+     * @return void
+     */
+    public static function synced($relation, $callback, $priority = 0)
+    {
+        static::registerModelEvent("synced.{$relation}", $callback, $priority);
+    }
+
+    /**
+     * Register a relation toggling model event with the dispatcher.
+     *
+     * @param  string  $relation
+     * @param  \Closure|string  $callback
+     * @param  int  $priority
+     * @return void
+     */
+    public static function toggling($relation, $callback, $priority = 0)
+    {
+        static::registerModelEvent("toggling.{$relation}", $callback, $priority);
+    }
+
+    /**
+     * Register a relation toggled model event with the dispatcher.
+     *
+     * @param  string  $relation
+     * @param  \Closure|string  $callback
+     * @param  int  $priority
+     * @return void
+     */
+    public static function toggled($relation, $callback, $priority = 0)
+    {
+        static::registerModelEvent("toggled.{$relation}", $callback, $priority);
+    }
+
+    /**
      * Remove all of the event listeners for the model.
      *
      * @return void

--- a/tests/Database/DatabaseEloquentBelongsToManyTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyTest.php
@@ -138,13 +138,12 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase
 
     public function testAttachInsertsPivotTableRecord()
     {
-        $relation = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\BelongsToMany')->setMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
-        $query = m::mock('stdClass');
-        $query->shouldReceive('from')->once()->with('user_role')->andReturn($query);
-        $query->shouldReceive('insert')->once()->with([['user_id' => 1, 'role_id' => 2, 'foo' => 'bar']])->andReturn(true);
-        $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock('StdClass'));
-        $mockQueryBuilder->shouldReceive('newQuery')->once()->andReturn($query);
-        $relation->expects($this->once())->method('touchIfTouching');
+        $relation = $this->getRelation();
+        $relation->getParent()->shouldReceive('touches')->andReturn(false);
+        $relation->getRelated()->shouldReceive('touches')->andReturn(false);
+
+        $query = $this->getNewStatement($relation);
+        $query->shouldReceive('insert')->once()->with([['user_id' => 1, 'role_id' => 2, 'foo' => 'bar']]);
 
         $relation->attach(2, ['foo' => 'bar']);
     }
@@ -609,53 +608,159 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase
         $relation->touchIfTouching();
     }
 
-    public function testSyncMethodConvertsCollectionToArrayOfKeys()
+    public function testSyncMethodAcceptsCollectionOfModels()
     {
-        $relation = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\BelongsToMany')->setMethods(['attach', 'detach', 'touchIfTouching', 'formatRecordsList'])->setConstructorArgs($this->getRelationArguments())->getMock();
-        $query = m::mock('stdClass');
-        $query->shouldReceive('from')->once()->with('user_role')->andReturn($query);
-        $query->shouldReceive('where')->once()->with('user_id', 1)->andReturn($query);
-        $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock('StdClass'));
-        $mockQueryBuilder->shouldReceive('newQuery')->once()->andReturn($query);
-        $query->shouldReceive('pluck')->once()->with('role_id')->andReturn(new BaseCollection([1, 2, 3]));
+        $relation = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\BelongsToMany')->setMethods(['attach', 'detach', 'touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
+        $query = $this->getNewQuery($relation);
+        $query->shouldReceive('pluck')->once()->with('role_id')->andReturn(new BaseCollection());
 
         $collection = new Collection([
             m::mock(['getKey' => 1]),
             m::mock(['getKey' => 2]),
-            m::mock(['getKey' => 3]),
         ]);
-        $relation->expects($this->once())->method('formatRecordsList')->with([1, 2, 3])->will($this->returnValue([1 => [], 2 => [], 3 => []]));
-        $relation->sync($collection);
+        $this->assertEquals(['attached' => [1, 2], 'detached' => [], 'updated' => []], $relation->sync($collection));
     }
 
     public function testWherePivotParamsUsedForNewQueries()
     {
-        $relation = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\BelongsToMany')->setMethods(['attach', 'detach', 'touchIfTouching', 'formatRecordsList'])->setConstructorArgs($this->getRelationArguments())->getMock();
-
-        // we expect to call $relation->wherePivot()
-        $relation->getQuery()->shouldReceive('where')->once()->andReturn($relation);
-
-        // Our sync() call will produce a new query
-        $mockQueryBuilder = m::mock('stdClass');
-        $query = m::mock('stdClass');
-        $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder);
-        $mockQueryBuilder->shouldReceive('newQuery')->once()->andReturn($query);
-
-        // BelongsToMany::newPivotStatement() sets this
-        $query->shouldReceive('from')->once()->with('user_role')->andReturn($query);
-
-        // BelongsToMany::newPivotQuery() sets this
-        $query->shouldReceive('where')->once()->with('user_id', 1)->andReturn($query);
+        $relation = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\BelongsToMany')->setMethods(['attach', 'detach', 'touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
+        $relation->getQuery()->shouldReceive('where')->once()->with('user_role.foo', '=', 'bar', 'and')->andReturnSelf();
+        $currentQuery = $this->getNewQuery($relation);
+        $currentQuery->shouldReceive('pluck')->andReturn(new BaseCollection([1, 2, 3]));
 
         // This is our test! The wherePivot() params also need to be called
-        $query->shouldReceive('where')->once()->with('foo', '=', 'bar')->andReturn($query);
+        $currentQuery->shouldReceive('where')->once()->with('foo', '=', 'bar')->andReturnSelf();
 
-        // This is so $relation->sync() works
-        $query->shouldReceive('pluck')->once()->with('role_id')->andReturn(new BaseCollection([1, 2, 3]));
-        $relation->expects($this->once())->method('formatRecordsList')->with([1, 2, 3])->will($this->returnValue([1 => [], 2 => [], 3 => []]));
+        $relation->wherePivot('foo', '=', 'bar')->sync([1, 2, 3]);
+    }
 
-        $relation = $relation->wherePivot('foo', '=', 'bar'); // these params are to be stored
-        $relation->sync([1, 2, 3]); // triggers the whole process above
+    public function testAttachingFiresEvents()
+    {
+        $query = $this->getNewStatement($relation = $this->getRelation());
+        $query->shouldReceive('insert')->once()->andReturn(1);
+
+        $relation->getRelated()->shouldReceive('touches')->andReturn(false);
+        list($parent, $events) = $this->getEventsParent($relation);
+
+        $events->shouldReceive('until')->once()->with('eloquent.attaching.relation_name: '.get_class($parent), [$parent, new BaseCollection([['user_id' => 1, 'role_id' => 5, 'pivot_column' => 'extra_data']])])->andReturn(true);
+        $events->shouldReceive('fire')->once()->with('eloquent.attached.relation_name: '.get_class($parent), [$parent, new BaseCollection([['user_id' => 1, 'role_id' => 5, 'pivot_column' => 'extra_data']])])->andReturn(true);
+
+        $relation->attach(5, ['pivot_column' => 'extra_data']);
+    }
+
+    public function testDetachingFiresEvents()
+    {
+        $query = $this->getNewQuery($relation = $this->getRelation());
+        $query->shouldReceive('whereIn')->once()->with('role_id', [5]);
+        $query->shouldReceive('delete')->once()->andReturn(1);
+
+        $relation->getRelated()->shouldReceive('touches')->andReturn(false);
+        list($parent, $events) = $this->getEventsParent($relation);
+
+        $events->shouldReceive('until')->once()->with('eloquent.detaching.relation_name: '.get_class($parent), [$parent, new BaseCollection(5)])->andReturn(true);
+        $events->shouldReceive('fire')->once()->with('eloquent.detached.relation_name: '.get_class($parent), [$parent, new BaseCollection(5)])->andReturn(true);
+
+        $relation->detach(5);
+    }
+
+    public function testSyncingFiresEvents()
+    {
+        $current = $this->getNewQuery($relation = $this->getRelation());
+        $current->shouldReceive('pluck')->with('role_id')->andReturn(new BaseCollection(5));
+
+        $queryForId = $this->getNewQuery($relation);
+        $queryForId->shouldReceive('where')->with('role_id', 5)->andReturnSelf();
+        $queryForId->shouldReceive('update')->once()->with(['pivot_column' => 'extra_data'])->andReturn(1);
+
+        $relation->getRelated()->shouldReceive('touches')->andReturn(false);
+        list($parent, $events) = $this->getEventsParent($relation);
+
+        $events->shouldReceive('until')->once()->with('eloquent.syncing.relation_name: '.get_class($parent), [$parent, new BaseCollection([5 => ['pivot_column' => 'extra_data']])])->andReturn(true);
+        $events->shouldReceive('fire')->once()->with('eloquent.synced.relation_name: '.get_class($parent), [$parent, new BaseCollection(['attached' => [], 'detached' => [], 'updated' => [5]])])->andReturn(true);
+
+        $relation->sync([5 => ['pivot_column' => 'extra_data']]);
+    }
+
+    public function testTogglingFiresEvents()
+    {
+        $current = $this->getNewQuery($relation = $this->getRelation());
+        $current->shouldReceive('pluck')->with('role_id')->andReturn(new BaseCollection(4));
+
+        $detaching = $this->getNewQuery($relation);
+        $detaching->shouldReceive('whereIn')->once()->with('role_id', [4]);
+        $detaching->shouldReceive('delete')->once()->andReturn(1);
+
+        $attaching = $this->getNewStatement($relation);
+        $attaching->shouldReceive('insert')->once()->andReturn(1);
+
+        $relation->getRelated()->shouldReceive('touches')->andReturn(false);
+        list($parent, $events) = $this->getEventsParent($relation);
+
+        $events->shouldReceive('until')->once()->with('eloquent.toggling.relation_name: '.get_class($parent), [$parent, new BaseCollection([4 => [], 5 => ['pivot_column' => 'extra_data']])])->andReturn(true);
+        $events->shouldReceive('until')->once()->with('eloquent.detaching.relation_name: '.get_class($parent), [$parent, new BaseCollection(4)])->andReturn(true);
+        $events->shouldReceive('fire')->once()->with('eloquent.detached.relation_name: '.get_class($parent), [$parent, new BaseCollection(4)])->andReturn(true);
+        $events->shouldReceive('until')->once()->with('eloquent.attaching.relation_name: '.get_class($parent), [$parent, new BaseCollection([['user_id' => 1, 'role_id' => 5, 'pivot_column' => 'extra_data']])])->andReturn(true);
+        $events->shouldReceive('fire')->once()->with('eloquent.attached.relation_name: '.get_class($parent), [$parent, new BaseCollection([['user_id' => 1, 'role_id' => 5, 'pivot_column' => 'extra_data']])])->andReturn(true);
+        $events->shouldReceive('fire')->once()->with('eloquent.toggled.relation_name: '.get_class($parent), [$parent, new BaseCollection(['attached' => [5], 'detached' => [4]])])->andReturn(true);
+
+        $relation->toggle([4, 5 => ['pivot_column' => 'extra_data']]);
+    }
+
+    public function testSyncingFiresAllEvents()
+    {
+        $relation = $this->getRelation();
+        $relation->getRelated()->shouldReceive('touches')->andReturn(false);
+        $syncData = [
+            5 => ['pivot_column' => 'extra_updated'],
+            6 => ['pivot_column' => 'extra_attached'],
+        ];
+
+        $current = $this->getNewQuery($relation);
+        $current->shouldReceive('pluck')->with('role_id')->andReturn(new BaseCollection([4, 5]));
+
+        $detaching = $this->getNewQuery($relation);
+        $detaching->shouldReceive('whereIn')->once()->with('role_id', [4]);
+        $detaching->shouldReceive('delete')->once()->andReturn(1);
+
+        $updating = $this->getNewQuery($relation);
+        $updating->shouldReceive('where')->with('role_id', 5)->andReturnSelf();
+        $updating->shouldReceive('update')->once()->with(['pivot_column' => 'extra_updated'])->andReturn(1);
+
+        $attaching = $this->getNewStatement($relation);
+        $attaching->shouldReceive('insert')->once()->andReturn(1);
+
+        list($parent, $events) = $this->getEventsParent($relation);
+
+        $events->shouldReceive('until')->once()->with('eloquent.syncing.relation_name: '.get_class($parent), [$parent, new BaseCollection($syncData)])->andReturn(true);
+        $events->shouldReceive('until')->once()->with('eloquent.detaching.relation_name: '.get_class($parent), [$parent, new BaseCollection(4)])->andReturn(true);
+        $events->shouldReceive('fire')->once()->with('eloquent.detached.relation_name: '.get_class($parent), [$parent, new BaseCollection(4)])->andReturn(true);
+        $events->shouldReceive('until')->once()->with('eloquent.attaching.relation_name: '.get_class($parent), [$parent, new BaseCollection([['user_id' => 1, 'role_id' => 6, 'pivot_column' => 'extra_attached']])])->andReturn(true);
+        $events->shouldReceive('fire')->once()->with('eloquent.attached.relation_name: '.get_class($parent), [$parent, new BaseCollection([['user_id' => 1, 'role_id' => 6, 'pivot_column' => 'extra_attached']])])->andReturn(true);
+        $events->shouldReceive('fire')->once()->with('eloquent.synced.relation_name: '.get_class($parent), [$parent, new BaseCollection(['attached' => [6], 'detached' => [4], 'updated' => [5]])])->andReturn(true);
+
+        $relation->sync($syncData);
+    }
+
+    public function getEventsParent($relation)
+    {
+        $parent = $relation->getParent();
+        $parent->shouldReceive('touches')->andReturn(false);
+        $parent->shouldReceive('getEventDispatcher')->andReturn($events = m::mock('Illuminate\Contracts\Events\Dispatcher'));
+        return [$parent, $events];
+    }
+
+    public function getNewStatement($relation)
+    {
+        $relationQuery = $relation->getQuery();
+        $relationQuery->shouldReceive('getQuery->newQuery->from')->once()->andReturn($newPivotStatement = m::mock('Illuminate\Database\Query\Builder'));
+        return $newPivotStatement;
+    }
+
+    public function getNewQuery($relation)
+    {
+        $statement = $this->getNewStatement($relation);
+        $statement->shouldReceive('where')->once()->with('user_id', 1)->andReturnSelf();
+        return $statement;
     }
 
     public function getRelation()
@@ -671,6 +776,7 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase
         $parent->shouldReceive('getKey')->andReturn(1);
         $parent->shouldReceive('getCreatedAtColumn')->andReturn('created_at');
         $parent->shouldReceive('getUpdatedAtColumn')->andReturn('updated_at');
+        $parent->shouldReceive('getEventDispatcher')->byDefault();
 
         $builder = m::mock('Illuminate\Database\Eloquent\Builder');
         $related = m::mock('Illuminate\Database\Eloquent\Model');

--- a/tests/Database/DatabaseEloquentBelongsToManyTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyTest.php
@@ -746,6 +746,7 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase
         $parent = $relation->getParent();
         $parent->shouldReceive('touches')->andReturn(false);
         $parent->shouldReceive('getEventDispatcher')->andReturn($events = m::mock('Illuminate\Contracts\Events\Dispatcher'));
+
         return [$parent, $events];
     }
 
@@ -753,6 +754,7 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase
     {
         $relationQuery = $relation->getQuery();
         $relationQuery->shouldReceive('getQuery->newQuery->from')->once()->andReturn($newPivotStatement = m::mock('Illuminate\Database\Query\Builder'));
+
         return $newPivotStatement;
     }
 
@@ -760,6 +762,7 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase
     {
         $statement = $this->getNewStatement($relation);
         $statement->shouldReceive('where')->once()->with('user_id', 1)->andReturnSelf();
+
         return $statement;
     }
 

--- a/tests/Database/DatabaseEloquentMorphToManyTest.php
+++ b/tests/Database/DatabaseEloquentMorphToManyTest.php
@@ -82,6 +82,7 @@ class DatabaseEloquentMorphToManyTest extends PHPUnit_Framework_TestCase
         $parent->shouldReceive('getCreatedAtColumn')->andReturn('created_at');
         $parent->shouldReceive('getUpdatedAtColumn')->andReturn('updated_at');
         $parent->shouldReceive('getMorphClass')->andReturn(get_class($parent));
+        $parent->shouldReceive('getEventDispatcher')->byDefault();
 
         $builder = m::mock('Illuminate\Database\Eloquent\Builder');
         $related = m::mock('Illuminate\Database\Eloquent\Model');


### PR DESCRIPTION
BelongsToMany relations is the only missing part in the **events** system in eloquent.

It has been requested for a long time and has many applications, eg. 
#10435 #10545 #10770 #4022 #2303 #1703 #8452

_This **PR is BC** however it also brings change in the public interface, that is all the methods (`attach/detach/sync/toggle`) get additional `false` return value in case `*ing` event halts the execution. As is it doesn't break BC however there might be edge case:_

_1. one relies on `array` return value from `sync` or `toggle`_
_2. then adds `syncing/toggling` event handler that can halt execution in some circumstances_
_3. the return value under those circumstances is no longer `array` but `false`_

---
- It introduces 8 new events:

``` php
eloquent.attaching.[RELATION]: Parent\Model
eloquent.attached.[RELATION]: Parent\Model
eloquent.detaching._RELATION_: Parent\Model
eloquent.detached._RELATION_: Parent\Model
eloquent.syncing._RELATION_: Parent\Model
eloquent.synced._RELATION_: Parent\Model
eloquent.toggling._RELATION_: Parent\Model
eloquent.toggled._RELATION_: Parent\Model
```
- and appropriate methods on the `Model` to register these events (due to different nature, they have additional parameter - relation name), eg:

``` php
// Model::attaching($relation, function ($parent, Support\Collection $pivotData) { ... })
User::attaching('roles', function ($user, $pivotData) {
    // payload contains parent of the relation AND pivot data being inserted to the table
    $pivotData == Collection([
        ['user_id' => $user->id, 'role_id' => ATTACHED_ID, 'some_pivot_field' => 'some pivot value'],
        ...
    ]);
})

// manually
$dispatcher->listen('eloquent.attaching.roles: App\User', function ($user, $pivotData) { ... })
```

Since the `$pivotData` payload may vary depending on the event, here's complete list of its content:
- `attaching` - like in the example above - Collection with **raw data to be inserted** to the pivot table
- `attached` - same as above
- `detaching` - Collection of **ids** being detached OR empty Collection
- `detaching` - Collection of detached **ids** OR empty Collection
- `syncing` - Collection of **id => [ ..pivot data.. ]** entries to be inserted/updated
- `synced` - Collection of **changes** made (the same as return value of `sync` only wrapped in Collection)
- `toggling` - Collection of **id => [ ..pivot data.. ]** entries to be inserted/updated
- `toggled` - Collection of **changes** made (the same as return value of `sync` only wrapped in Collection)

and an example of all events being fired when `syncing`:

``` php
>>> $user->roles()->sync([1, 2 => ['extra' => 'provided pivot value']])

user 1 syncing roles: {"1":[],"2":{"extra":"provided pivot value"}}
user 1 detaching roles: ["6"]
user 1 detached roles: ["6"]
user 1 attaching roles: [{"user_id":1,"role_id":1}]
user 1 attached roles: [{"user_id":1,"role_id":1,}]
user 1 attaching roles: [{"user_id":1,"role_id":2,"extra":"provided pivot value"}]
user 1 attached roles: [{"user_id":1,"role_id":2,"extra":"provided pivot value"}]
user 1 synced roles: {"attached":[1,2],"detached":[6],"updated":[]}
```

---

All of the `*ing` events are, just like existing ones, capable of **halting** the action if your listener returns `false`:

``` php
// Bill can't be an admin:
User::attaching('roles', function ($user, $pivotData) use ($adminRole) {
   if ($user->name == 'Bill'
      && $pivotData->contains(function ($record) use ($adminRole) {
           return $record['role_id'] == $adminRole->id;
      })
   ) {
       return false;
   }
})
```

You can also adjust pivot data in the callback, just like you'd do with exiting events:

``` php
// We need UUID for the pivot records (well... yeah):
User::attaching('roles', function ($user, $pivotData) {
   foreach ($pivotData as $key => $record) {
      $record['uuid'] = data_get($record, 'uuid', Uuid::generate()); // generate if not provided already
      $pivodData->put($key, $record);
   } 
})


>>> $user->roles()->attach(5)
>>> $user->roles()->find(5)
Role {
  'name' => 'editor',
  ...
  'pivot' => Pivot {
    'user_id' => 1,
    'role_id' => 5,
    'uuid' => 'a-nice-auto-generated-uuid'
  }
}
```
### Notes on the commits:
1. the code in `BelongsToMany` has been a bit refactored in order to use `Collection` where events require that
2. new tests added + some brittle tests refactored
