### PR TITLE
[5.3] Add test to proove issue with numeric aggregation

### DIFF
--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -4,11 +4,47 @@ use Mockery as m;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Collection as BaseCollection;
+use Illuminate\Database\Capsule\Manager as DB;
 
 class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase
 {
+    public function setUp()
+    {
+        $db = new DB;
+
+        $db->addConnection([
+            'driver'    => 'sqlite',
+            'database'  => ':memory:',
+        ]);
+
+        $db->bootEloquent();
+        $db->setAsGlobal();
+
+        $this->createSchema();
+    }
+
+    /**
+     * Setup the database schema.
+     *
+     * @return void
+     */
+    public function createSchema()
+    {
+        $this->schema()->create('users', function ($table) {
+            $table->increments('id');
+            $table->string('email')->unique();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Tear down the database schema.
+     *
+     * @return void
+     */
     public function tearDown()
     {
+        $this->schema()->drop('users');
         m::close();
     }
 
@@ -511,6 +547,15 @@ class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(['foo' => $builder], $builder->delete());
     }
 
+    public function testAggregatedValuesOfDatetimeField()
+    {
+        EloquentBuilderTestUser::create(['id' => 1, 'email' => 'test1@test.test', 'created_at' => '2016-08-10 09:21:00']);
+        EloquentBuilderTestUser::create(['id' => 2, 'email' => 'test2@test.test', 'created_at' => '2016-08-01 12:00:00']);
+
+        $this->assertEquals('2016-08-10 09:21:00', EloquentBuilderTestUser::max('created_at'));
+        $this->assertEquals('2016-08-01 12:00:00', EloquentBuilderTestUser::min('created_at'));
+    }
+
     public function testWithCount()
     {
         $model = new EloquentBuilderTestModelParentStub;
@@ -724,6 +769,26 @@ class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase
 
         return $query;
     }
+
+    /**
+     * Get a database connection instance.
+     *
+     * @return Illuminate\Database\Connection
+     */
+    protected function connection()
+    {
+        return Illuminate\Database\Eloquent\Model::getConnectionResolver()->connection();
+    }
+
+    /**
+     * Get a schema builder instance.
+     *
+     * @return Illuminate\Database\Schema\Builder
+     */
+    protected function schema()
+    {
+        return $this->connection()->getSchemaBuilder();
+    }
 }
 
 class EloquentBuilderTestScopeStub extends Illuminate\Database\Eloquent\Model
@@ -843,4 +908,11 @@ class EloquentBuilderTestModelSelfRelatedStub extends Illuminate\Database\Eloque
     {
         return $this->hasMany('EloquentBuilderTestModelFarRelatedStub', 'foreign_key', 'id', 'bar');
     }
+}
+
+class EloquentBuilderTestUser extends Illuminate\Database\Eloquent\Model
+{
+    protected $table = 'users';
+    protected $guarded = [];
+    public $timestamps = false;
 }

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -4,13 +4,12 @@ use Mockery as m;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Collection as BaseCollection;
-use Illuminate\Database\Capsule\Manager as DB;
 
 class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase
 {
     public function setUp()
     {
-        $db = new DB;
+        $db = new Illuminate\Database\Capsule\Manager;
 
         $db->addConnection([
             'driver'    => 'sqlite',


### PR DESCRIPTION
I dont know if this is the place to place the test.

I am having issues with min() and max() on the eloquent builder is expected to be a float or int.

I have a scenario, where I am interrested in seeing the highest and lowest datetime in the database.

The problem seems to have been implemented in following pull request:
https://github.com/laravel/framework/pull/14793
