### PR TITLE
[5.3] Add 'html' cast

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -13,6 +13,7 @@ use DateTimeInterface;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
+use Illuminate\Support\HtmlString;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Support\Arrayable;
@@ -2834,6 +2835,8 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
                 return $this->asDateTime($value);
             case 'timestamp':
                 return $this->asTimeStamp($value);
+            case 'html':
+                return $this->asHtml($value);
             default:
                 return $value;
         }
@@ -3021,6 +3024,17 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     public function fromJson($value, $asObject = false)
     {
         return json_decode($value, ! $asObject);
+    }
+
+    /**
+     * Return the given value as HTML-safe object.
+     *
+     * @param  mixed  $value
+     * @return \Illuminate\Support\HtmlString
+     */
+    protected function asHtml($value)
+    {
+        return new HtmlString($value);
     }
 
     /**

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1223,6 +1223,7 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
         $model->dateAttribute = '1969-07-20';
         $model->datetimeAttribute = '1969-07-20 22:56:00';
         $model->timestampAttribute = '1969-07-20 22:56:00';
+        $model->htmlAttribute = '<p>test</p>';
 
         $this->assertInternalType('int', $model->intAttribute);
         $this->assertInternalType('float', $model->floatAttribute);
@@ -1243,6 +1244,7 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('1969-07-20', $model->dateAttribute->toDateString());
         $this->assertEquals('1969-07-20 22:56:00', $model->datetimeAttribute->toDateTimeString());
         $this->assertEquals(-14173440, $model->timestampAttribute);
+        $this->assertInstanceOf('Illuminate\Support\HtmlString', $model->htmlAttribute);
 
         $arr = $model->toArray();
         $this->assertInternalType('int', $arr['intAttribute']);
@@ -1693,6 +1695,7 @@ class EloquentModelCastingStub extends Model
         'dateAttribute' => 'date',
         'datetimeAttribute' => 'datetime',
         'timestampAttribute' => 'timestamp',
+        'htmlAttribute' => 'html',
     ];
 
     public function jsonAttributeValue()


### PR DESCRIPTION
This PR adds a 'html' cast to eloquent models so you can mark certain attributes as HTML-safe.

Useful for simplifying blade templating so you can always use `{{ }}` without worrying about marking attributes as html-safe.
