### PR TITLE
[5.3] firstOrCreate and New should use forceFill 

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -234,7 +234,7 @@ class Builder
      */
     public function firstOrNew(array $attributes)
     {
-        $mutatedAttributes = $this->model->newInstance($attributes)->getAttributes();
+        $mutatedAttributes = $this->model->newInstance()->forceFill($attributes)->getAttributes();
 
         if (! is_null($instance = $this->where($mutatedAttributes)->first())) {
             return $instance;
@@ -252,7 +252,7 @@ class Builder
      */
     public function firstOrCreate(array $attributes, array $values = [])
     {
-        $mutatedAttributes = $this->model->newInstance($attributes)->getAttributes();
+        $mutatedAttributes = $this->model->newInstance()->forceFill($attributes)->getAttributes();
 
         if (! is_null($instance = $this->where($mutatedAttributes)->first())) {
             return $instance;


### PR DESCRIPTION
firstOrCreate and firstOrNew would not search for attributes that were not mass assignable. 

See PR [#3902](https://github.com/laravel/laravel/pull/3902#issuecomment-241552319) 
