### PR TITLE
[5.2] Tests for Arr::get()/has() with exact key containing dot

### DIFF
--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -147,7 +147,7 @@ class SupportArrTest extends PHPUnit_Framework_TestCase
     public function testGet()
     {
         $array = ['products.desk' => ['price' => 100]];
-        $this->assertEquals(['price' => 100], Arr::get($array, ['products.desk']));
+        $this->assertEquals(['price' => 100], Arr::get($array, 'products.desk'));
 
         $array = ['products' => ['desk' => ['price' => 100]]];
         $value = Arr::get($array, 'products.desk');
@@ -214,6 +214,7 @@ class SupportArrTest extends PHPUnit_Framework_TestCase
     public function testHas()
     {
         $array = ['products.desk' => ['price' => 100]];
+        $this->assertTrue(Arr::has($array, 'products.desk'));
         $this->assertTrue(Arr::has($array, ['products.desk']));
         $this->assertFalse(Arr::has($array, ['products.desk', 'missing']));
 

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -146,6 +146,9 @@ class SupportArrTest extends PHPUnit_Framework_TestCase
 
     public function testGet()
     {
+        $array = ['products.desk' => ['price' => 100]];
+        $this->assertEquals(['price' => 100], Arr::get($array, ['products.desk']));
+
         $array = ['products' => ['desk' => ['price' => 100]]];
         $value = Arr::get($array, 'products.desk');
         $this->assertEquals(['price' => 100], $value);
@@ -210,6 +213,10 @@ class SupportArrTest extends PHPUnit_Framework_TestCase
 
     public function testHas()
     {
+        $array = ['products.desk' => ['price' => 100]];
+        $this->assertTrue(Arr::has($array, ['products.desk']));
+        $this->assertFalse(Arr::has($array, ['products.desk', 'missing']));
+
         $array = ['products' => ['desk' => ['price' => 100]]];
         $this->assertTrue(Arr::has($array, 'products.desk'));
         $this->assertTrue(Arr::has($array, 'products.desk.price'));


### PR DESCRIPTION
- Backport of test for `Arr::has()` introduced in 5.3, in #14976. Better be safe.
- Added similar test for `Arr::get()`, which should be merged into 5.3 as well.

ping @themsaid :)
