### PR TITLE
[5.3] Send multipart email notification

### DIFF
--- a/src/Illuminate/Notifications/Messages/MailMessage.php
+++ b/src/Illuminate/Notifications/Messages/MailMessage.php
@@ -9,7 +9,10 @@ class MailMessage extends SimpleMessage
      *
      * @var string
      */
-    public $view = 'notifications::email';
+    public $view = [
+        'notifications::email',
+        'notifications::email-plain',
+    ];
 
     /**
      * The view data for the message.

--- a/src/Illuminate/Notifications/resources/views/email-plain.blade.php
+++ b/src/Illuminate/Notifications/resources/views/email-plain.blade.php
@@ -1,0 +1,19 @@
+{{ $level == 'error' ? 'Whoops!' : 'Hello!' }}
+
+<?php
+
+if (! empty($introLines)) {
+    echo implode("\r\n", $introLines), "\r\n\r\n";
+}
+
+if (isset($actionText)) {
+    echo "{$actionText}: {$actionUrl}\r\n\r\n";
+}
+
+if (! empty($outroLines)) {
+    echo implode("\r\n", $outroLines), "\r\n\r\n";
+}
+
+?>
+Regards,
+{{ config('app.name') }}

--- a/tests/Notifications/NotificationMailChannelTest.php
+++ b/tests/Notifications/NotificationMailChannelTest.php
@@ -22,9 +22,9 @@ class NotificationMailChannelTest extends PHPUnit_Framework_TestCase
             $mailer = Mockery::mock(Illuminate\Contracts\Mail\Mailer::class)
         );
 
-        $view = ['notifications::email', 'notifications::email-plain'];
+        $views = ['notifications::email', 'notifications::email-plain'];
 
-        $mailer->shouldReceive('send')->with($view, $data, Mockery::type('Closure'));
+        $mailer->shouldReceive('send')->with($views, $data, Mockery::type('Closure'));
 
         $channel->send($notifiable, $notification);
     }
@@ -41,7 +41,9 @@ class NotificationMailChannelTest extends PHPUnit_Framework_TestCase
             $mailer = Mockery::mock(Illuminate\Contracts\Mail\Mailer::class)
         );
 
-        $mailer->shouldReceive('send')->with('notifications::email', $data, Mockery::on(function ($closure) {
+        $views = ['notifications::email', 'notifications::email-plain'];
+
+        $mailer->shouldReceive('send')->with($views, $data, Mockery::on(function ($closure) {
             $mock = Mockery::mock('Illuminate\Mailer\Message');
 
             $mock->shouldReceive('subject')->once()->with('test subject');
@@ -70,7 +72,9 @@ class NotificationMailChannelTest extends PHPUnit_Framework_TestCase
             $mailer = Mockery::mock(Illuminate\Contracts\Mail\Mailer::class)
         );
 
-        $mailer->shouldReceive('send')->with('notifications::email', $data, Mockery::on(function ($closure) {
+        $views = ['notifications::email', 'notifications::email-plain'];
+
+        $mailer->shouldReceive('send')->with($views, $data, Mockery::on(function ($closure) {
             $mock = Mockery::mock('Illuminate\Mailer\Message');
 
             $mock->shouldReceive('subject')->once()->with('Notification Mail Channel Test Notification No Subject');
@@ -97,7 +101,9 @@ class NotificationMailChannelTest extends PHPUnit_Framework_TestCase
             $mailer = Mockery::mock(Illuminate\Contracts\Mail\Mailer::class)
         );
 
-        $mailer->shouldReceive('send')->with('notifications::email', $data, Mockery::on(function ($closure) {
+        $views = ['notifications::email', 'notifications::email-plain'];
+
+        $mailer->shouldReceive('send')->with($views, $data, Mockery::on(function ($closure) {
             $mock = Mockery::mock('Illuminate\Mailer\Message');
 
             $mock->shouldReceive('subject')->once();
@@ -126,7 +132,9 @@ class NotificationMailChannelTest extends PHPUnit_Framework_TestCase
             $mailer = Mockery::mock(Illuminate\Contracts\Mail\Mailer::class)
         );
 
-        $mailer->shouldReceive('send')->with('notifications::email', $data, Mockery::on(function ($closure) {
+        $views = ['notifications::email', 'notifications::email-plain'];
+
+        $mailer->shouldReceive('send')->with($views, $data, Mockery::on(function ($closure) {
             $mock = Mockery::mock('Illuminate\Mailer\Message');
 
             $mock->shouldReceive('subject')->once();
@@ -155,7 +163,9 @@ class NotificationMailChannelTest extends PHPUnit_Framework_TestCase
             $mailer = Mockery::mock(Illuminate\Contracts\Mail\Mailer::class)
         );
 
-        $mailer->shouldReceive('send')->with('notifications::email', $data, Mockery::on(function ($closure) {
+        $views = ['notifications::email', 'notifications::email-plain'];
+
+        $mailer->shouldReceive('send')->with($views, $data, Mockery::on(function ($closure) {
             $mock = Mockery::mock('Illuminate\Mailer\Message');
 
             $mock->shouldReceive('subject')->once();

--- a/tests/Notifications/NotificationMailChannelTest.php
+++ b/tests/Notifications/NotificationMailChannelTest.php
@@ -22,7 +22,9 @@ class NotificationMailChannelTest extends PHPUnit_Framework_TestCase
             $mailer = Mockery::mock(Illuminate\Contracts\Mail\Mailer::class)
         );
 
-        $mailer->shouldReceive('send')->with('notifications::email', $data, Mockery::type('Closure'));
+        $view = ['notifications::email', 'notifications::email-plain'];
+
+        $mailer->shouldReceive('send')->with($view, $data, Mockery::type('Closure'));
 
         $channel->send($notifiable, $notification);
     }


### PR DESCRIPTION
It would be nice if Laravel would send a plain text alternative alongside the HTML email notifications out of the box. Reasons for that are:
- Improves the spam score
- Some email clients/apps still can’t handle HTML
- Some people prefer viewing emails as plain text

Since calling `php artisan vendor:publish` is necessary anyhow to add the new plain text template file, I also went ahead and changed the `resource` directory structure from:

```
notifications/email.blade.php
```

To:

```
notifications/email/html.blade.php
notifications/email/text.blade.php
```

If that's too much of a breaking change, we could do this:

```
notifications/email.blade.php
notifications/email-plain.blade.php
```

Feedback appreciated 😀
