### PR TITLE
[5.3] Revert Eloquent builder changes on firstOr* functions to fix bug

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -234,9 +234,7 @@ class Builder
      */
     public function firstOrNew(array $attributes)
     {
-        $mutatedAttributes = $this->model->newInstance()->forceFill($attributes)->getAttributes();
-
-        if (! is_null($instance = $this->where($mutatedAttributes)->first())) {
+        if (! is_null($instance = $this->where($attributes)->first())) {
             return $instance;
         }
 
@@ -252,9 +250,7 @@ class Builder
      */
     public function firstOrCreate(array $attributes, array $values = [])
     {
-        $mutatedAttributes = $this->model->newInstance()->forceFill($attributes)->getAttributes();
-
-        if (! is_null($instance = $this->where($mutatedAttributes)->first())) {
+        if (! is_null($instance = $this->where($attributes)->first())) {
             return $instance;
         }
 


### PR DESCRIPTION
This reverts the changes made in PR #14656 & Issue #14649, which broke the firstOr\* functions in certain scenarios. They started returning either a new instance if the DB was empty or the first row if anything existed depending on what your mutators did. This is fine, but it's a breaking change that should be applied and documented appropriately.
