### PR TITLE
[5.3] Fix hard-coded strings

### DIFF
--- a/src/Illuminate/Notifications/resources/views/email.blade.php
+++ b/src/Illuminate/Notifications/resources/views/email.blade.php
@@ -85,9 +85,9 @@ $style = [
                                         <!-- Greeting -->
                                         <h1 style="{{ $style['header-1'] }}">
                                             @if ($level == 'error')
-                                                Whoops!
+                                                @lang('notifications.whoops')
                                             @else
-                                                Hello!
+                                                @lang('notifications.hello')
                                             @endif
                                         </h1>
 
@@ -136,7 +136,7 @@ $style = [
 
                                         <!-- Salutation -->
                                         <p style="{{ $style['paragraph'] }}">
-                                            Regards,<br>{{ config('app.name') }}
+                                            @lang('notifications.regards'),<br>{{ config('app.name') }}
                                         </p>
 
                                         <!-- Sub Copy -->
@@ -145,8 +145,7 @@ $style = [
                                                 <tr>
                                                     <td style="{{ $fontFamily }}">
                                                         <p style="{{ $style['paragraph-sub'] }}">
-                                                            If you’re having trouble clicking the "{{ $actionText }}" button,
-                                                            copy and paste the URL below into your web browser:
+                                                            @lang('notifications.trouble', ['action' => $actionText])
                                                         </p>
 
                                                         <p style="{{ $style['paragraph-sub'] }}">
@@ -173,7 +172,7 @@ $style = [
                                         <p style="{{ $style['paragraph-sub'] }}">
                                             &copy; {{ date('Y') }}
                                             <a style="{{ $style['anchor'] }}" href="{{ url('/') }}" target="_blank">{{ config('app.name') }}</a>.
-                                            All rights reserved.
+                                            @lang('notifications.rights')
                                         </p>
                                     </td>
                                 </tr>
@@ -186,3 +185,4 @@ $style = [
     </table>
 </body>
 </html>
+


### PR DESCRIPTION
And the `resources/lang/en/notifications.php`

```
<?php

return [
    'hello' => 'Hello!',
    'whoops' => 'Whoops!',
    'regards' => 'Regards',
    'trouble' => 'If you’re having trouble clicking the ":action" button, copy and paste the URL below into your web browser',
    'rights' => 'All rights reserved.',
];
```
