### PR TITLE
[5.3] Parameter acceptable values

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -582,7 +582,7 @@ class Builder
     /**
      * Add an "or where" clause to the query.
      *
-     * @param  string  $column
+     * @param  string|\Closure  $column
      * @param  string  $operator
      * @param  mixed   $value
      * @return \Illuminate\Database\Query\Builder|static


### PR DESCRIPTION
orWhere() accepts Closure as first parameter. Example - https://laravel.com/docs/5.3/queries#parameter-grouping
