### PR TITLE
[5.3] [BUGFIX] Ensure dontReport is array

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -90,7 +90,7 @@ class Handler implements ExceptionHandlerContract
      */
     protected function shouldntReport(Exception $e)
     {
-        $dontReport = array_merge($this->dontReport, [HttpResponseException::class]);
+        $dontReport = array_merge(is_array($this->dontReport) ? $this->dontReport : [], [HttpResponseException::class]);
 
         foreach ($dontReport as $type) {
             if ($e instanceof $type) {


### PR DESCRIPTION
With latest release, initial `laravel new` and `composer install` always fails, because `$this->dontReport` is set to null ! Simple solution is to ensure dontReport is always an array, or just simply convert it to.

Exception:

```
Loading composer repositories with package information
Installing dependencies (including require-dev) from lock file
Nothing to install or update
Generating autoload files
> Illuminate\Foundation\ComposerScripts::postInstall
> php artisan optimize
PHP Fatal error:  Uncaught ErrorException: array_merge(): Argument #1 is not an array in /opt/c/opt/Code/Laravel/vendor/laravel/framework/src/Illuminate/Foundation/Exceptions/Handler.php:93
Stack trace:
#0 [internal function]: Illuminate\Foundation\Bootstrap\HandleExceptions->handleError(2, 'array_merge(): ...', '/opt/c/opt/Code...', 93, Array)
#1 /opt/c/opt/Code/Laravel/vendor/laravel/framework/src/Illuminate/Foundation/Exceptions/Handler.php(93): array_merge(Array)
#2 /opt/c/opt/Code/Laravel/vendor/laravel/framework/src/Illuminate/Foundation/Exceptions/Handler.php(61): Illuminate\Foundation\Exceptions\Handler->shouldntReport(Object(ErrorException))
#3 /opt/c/opt/Code/Laravel/app/Exceptions/Handler.php(35): Illuminate\Foundation\Exceptions\Handler->report(Object(ErrorException))
#4 /opt/c/opt/Code/Laravel/vendor/laravel/framework/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php(79): App\Exceptions\Handler->report(Object(ErrorException))
#5 [internal function]: Illuminate\Foundation\Bootstrap\HandleExcep in /opt/c/opt/Code/Laravel/vendor/laravel/framework/src/Illuminate/Foundation/Exceptions/Handler.php on line 93
PHP Fatal error:  Uncaught ErrorException: array_merge(): Argument #1 is not an array in /opt/c/opt/Code/Laravel/vendor/laravel/framework/src/Illuminate/Foundation/Exceptions/Handler.php:93
Stack trace:
#0 [internal function]: Illuminate\Foundation\Bootstrap\HandleExceptions->handleError(2, 'array_merge(): ...', '/opt/c/opt/Code...', 93, Array)
#1 /opt/c/opt/Code/Laravel/vendor/laravel/framework/src/Illuminate/Foundation/Exceptions/Handler.php(93): array_merge(Array)
#2 /opt/c/opt/Code/Laravel/vendor/laravel/framework/src/Illuminate/Foundation/Exceptions/Handler.php(61): Illuminate\Foundation\Exceptions\Handler->shouldntReport(Object(Symfony\Component\Debug\Exception\FatalErrorException))
#3 /opt/c/opt/Code/Laravel/app/Exceptions/Handler.php(35): Illuminate\Foundation\Exceptions\Handler->report(Object(Symfony\Component\Debug\Exception\FatalErrorException))
#4 /opt/c/opt/Code/Laravel/vendor/laravel/framework/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php(79): App\Exceptions\Handler->report(Object(Symfon in /opt/c/opt/Code/Laravel/vendor/laravel/framework/src/Illuminate/Foundation/Exceptions/Handler.php on line 93
```
