### PR TITLE
[5.3] Defer resolving read PDO of read/write connection until needed

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -970,6 +970,10 @@ class Connection implements ConnectionInterface
             return $this->getPdo();
         }
 
+        if ($this->readPdo instanceof Closure) {
+            return $this->readPdo = call_user_func($this->readPdo);
+        }
+
         return $this->readPdo ?: $this->getPdo();
     }
 

--- a/src/Illuminate/Database/Connectors/ConnectionFactory.php
+++ b/src/Illuminate/Database/Connectors/ConnectionFactory.php
@@ -57,9 +57,7 @@ class ConnectionFactory
      */
     protected function createSingleConnection(array $config)
     {
-        $pdo = function () use ($config) {
-            return $this->createConnector($config)->connect($config);
-        };
+        $pdo = $this->createPdoResolver($config);
 
         return $this->createConnection($config['driver'], $pdo, $config['database'], $config['prefix'], $config);
     }
@@ -81,13 +79,24 @@ class ConnectionFactory
      * Create a new PDO instance for reading.
      *
      * @param  array  $config
-     * @return \PDO
+     * @return \Closure
      */
     protected function createReadPdo(array $config)
     {
-        $readConfig = $this->getReadConfig($config);
+        return $this->createPdoResolver($this->getReadConfig($config));
+    }
 
-        return $this->createConnector($readConfig)->connect($readConfig);
+    /**
+     * Create a new Closure that resolves to a PDO instance.
+     *
+     * @param  array  $config
+     * @return \Closure
+     */
+    protected function createPdoResolver(array $config)
+    {
+        return function () use ($config) {
+            return $this->createConnector($config)->connect($config);
+        };
     }
 
     /**

--- a/tests/Database/DatabaseConnectionFactoryTest.php
+++ b/tests/Database/DatabaseConnectionFactoryTest.php
@@ -43,6 +43,30 @@ class DatabaseConnectionFactoryTest extends PHPUnit_Framework_TestCase
         $this->assertInstanceOf('PDO', $this->db->connection('read_write')->getReadPdo());
     }
 
+    public function testSingleConnectionNotCreatedUntilNeeded()
+    {
+        $connection = $this->db->connection();
+        $pdo = new \ReflectionProperty(get_class($connection), 'pdo');
+        $pdo->setAccessible(true);
+        $readPdo = new \ReflectionProperty(get_class($connection), 'readPdo');
+        $readPdo->setAccessible(true);
+
+        $this->assertNotInstanceOf('PDO', $pdo->getValue($connection));
+        $this->assertNotInstanceOf('PDO', $readPdo->getValue($connection));
+    }
+
+    public function testReadWriteConnectionsNotCreatedUntilNeeded()
+    {
+        $connection = $this->db->connection('read_write');
+        $pdo = new \ReflectionProperty(get_class($connection), 'pdo');
+        $pdo->setAccessible(true);
+        $readPdo = new \ReflectionProperty(get_class($connection), 'readPdo');
+        $readPdo->setAccessible(true);
+
+        $this->assertNotInstanceOf('PDO', $pdo->getValue($connection));
+        $this->assertNotInstanceOf('PDO', $readPdo->getValue($connection));
+    }
+
     /**
      * @expectedException InvalidArgumentException
      */


### PR DESCRIPTION
This PR updates the read/write connection so that resolving the PDO instance for the read connection is also deferred until it is needed.

When using a single connection for both reads and writes, the PDO instance is not resolved until the connection is actually needed.

When using separate read/write connections, the PDO instance for the write connection is not resolved until needed, but the PDO instance for the read connection is resolved immediately.

This leads to a minor inconsistency of how reading from a single connection works when compared to how reading from a read/write connection works. If one switches from using a single connection to using a read/write connection, one may incur an unexpected increase in connections to the read database.

It is also slightly inconsistent when comparing how the read connection works to how the corresponding write connection works. One may expect that if the write connection is going to be deferred, then the read connection should be deferred, as well.

I could not find a stated reason for this difference, so I thought it may be something open for change. If there is a reason for this difference, I would love to learn, and I apologize for the wasted PR. Additionally, please let me know if anything should be changed, or if this should be targeted at 5.2.
