### PR TITLE
[5.3] Add Arr::random() method

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -497,4 +497,15 @@ class Arr
     {
         return array_filter($array, $callback, ARRAY_FILTER_USE_BOTH);
     }
+
+    /**
+     * Fetch a random array element.
+     *
+     * @param  array
+     * @return mixed
+     */
+    public static function random($array)
+    {
+        return $array[array_rand($array)];
+    }
 }


### PR DESCRIPTION
I tried to find if this had been proposed before, but got lost in a mess of issues/PRs around randomising database results. This is just syntactical sugar for fetching a random array element, as I have to look up how to do it again every time I need it.

I'm not sure if you'll agree on the utility of having it there, but thought it couldn't hurt to throw it out there.
