### PR TITLE
[5.3] Allow for orderBy to work with arguments passed in an array.

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1343,12 +1343,20 @@ class Builder
     /**
      * Add an "order by" clause to the query.
      *
-     * @param  string  $column
+     * @param  string|array  $column
      * @param  string  $direction
      * @return $this
      */
     public function orderBy($column, $direction = 'asc')
     {
+        if (is_array($column)) {
+            array_walk($column, function ($direction, $column) {
+                $this->orderBy($column, $direction);
+            });
+
+            return $this;
+        }
+
         $this->{$this->unions ? 'unionOrders' : 'orders'}[] = [
             'column' => $column,
             'direction' => strtolower($direction) == 'asc' ? 'asc' : 'desc',

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -571,6 +571,17 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(['foo'], $builder->getBindings());
     }
 
+    public function testOrderByWhenArgumentsProvidedInArray()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->orderBy(['age' => 'desc']);
+        $this->assertEquals('select * from "users" order by "age" desc', $builder->toSql());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->orderBy(['email' => 'asc', 'age' => 'desc']);
+        $this->assertEquals('select * from "users" order by "email" asc, "age" desc', $builder->toSql());
+    }
+
     public function testHavings()
     {
         $builder = $this->getBuilder();


### PR DESCRIPTION
Regarding https://github.com/laravel/framework/issues/14813 and https://github.com/laravel/framework/pull/14841.

This allows to call

``` php
User::orderBy(['last_name' => 'desc', 'first_name' => 'asc']);
```

instead of 

``` php
User::orderBy('last_name', 'desc');
    ->orderBy('first_name');
```
