### PR TITLE
[5.3] Arr::sort(): limited use of underlying Collection fixed

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -452,13 +452,13 @@ class Arr
     }
 
     /**
-     * Sort the array using the given callback.
+     * Sort the array using the given callback or "dot" notation.
      *
      * @param  array  $array
-     * @param  callable  $callback
+     * @param  callable|string  $callback
      * @return array
      */
-    public static function sort($array, callable $callback)
+    public static function sort($array, $callback)
     {
         return Collection::make($array)->sortBy($callback)->all();
     }

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -358,20 +358,25 @@ class SupportArrTest extends PHPUnit_Framework_TestCase
 
     public function testSort()
     {
-        $array = [
+        $unsorted = [
             ['name' => 'Desk'],
             ['name' => 'Chair'],
         ];
-
-        $array = array_values(Arr::sort($array, function ($value) {
-            return $value['name'];
-        }));
 
         $expected = [
             ['name' => 'Chair'],
             ['name' => 'Desk'],
         ];
-        $this->assertEquals($expected, $array);
+
+        // sort with closure
+        $sortedWithClosure = array_values(Arr::sort($unsorted, function ($value) {
+            return $value['name'];
+        }));
+        $this->assertEquals($expected, $sortedWithClosure);
+
+        // sort with dot notation
+        $sortedWithDotNotation = array_values(Arr::sort($unsorted, 'name'));
+        $this->assertEquals($expected, $sortedWithDotNotation);
     }
 
     public function testSortRecursive()


### PR DESCRIPTION
Hello,

I'm noticed that  [Arr::sort()](https://github.com/laravel/framework/blob/5.3/src/Illuminate/Support/Arr.php#L461) that based on [Collection::sortBy](https://github.com/laravel/framework/blob/5.3/src/Illuminate/Support/Collection.php#L965) limiting use of `$callback`. In `Collection` it can be as closure as string in dot notation via following mechanics

```
protected function valueRetriever($value)
{
    if ($this->useAsCallable($value)) {
        return $value;
    }

    return function ($item) use ($value) {
        return data_get($item, $value);
    };
}
```

Checkout please.

Thanks,
Alex
