### PR TITLE
[5.3] Ability to set from address in mail notifications

### DIFF
--- a/src/Illuminate/Notifications/Channels/MailChannel.php
+++ b/src/Illuminate/Notifications/Channels/MailChannel.php
@@ -50,6 +50,10 @@ class MailChannel
                 $m->to($recipients);
             }
 
+            if (! empty($message->from)) {
+                $m->from($message->from[0], isset($message->from[1]) ? $message->from[1] : null);
+            }
+
             $m->subject($message->subject ?: Str::title(
                 Str::snake(class_basename($notification), ' ')
             ));

--- a/src/Illuminate/Notifications/Messages/MailMessage.php
+++ b/src/Illuminate/Notifications/Messages/MailMessage.php
@@ -12,6 +12,13 @@ class MailMessage extends SimpleMessage
     public $view = 'notifications::email';
 
     /**
+     * The from address for the message.
+     *
+     * @var array
+     */
+    public $from = [];
+
+    /**
      * The view data for the message.
      *
      * @var array
@@ -43,6 +50,19 @@ class MailMessage extends SimpleMessage
     {
         $this->view = $view;
         $this->viewData = $data;
+
+        return $this;
+    }
+
+    /**
+     * Set the from address for the mail message.
+     *
+     * @param  string  $address
+     * @return $this
+     */
+    public function from($address, $name = null)
+    {
+        $this->from = [$address, $name];
 
         return $this;
     }

--- a/tests/Notifications/NotificationMailChannelTest.php
+++ b/tests/Notifications/NotificationMailChannelTest.php
@@ -26,6 +26,149 @@ class NotificationMailChannelTest extends PHPUnit_Framework_TestCase
 
         $channel->send($notifiable, $notification);
     }
+
+    public function testMessageWithSubject()
+    {
+        $notification = new NotificationMailChannelTestNotification;
+        $notifiable = new NotificationMailChannelTestNotifiable;
+
+        $message = $notification->toMail($notifiable);
+        $data = $message->toArray();
+
+        $channel = new Illuminate\Notifications\Channels\MailChannel(
+            $mailer = Mockery::mock(Illuminate\Contracts\Mail\Mailer::class)
+        );
+
+        $mailer->shouldReceive('send')->with('notifications::email', $data, Mockery::on(function ($closure) {
+            $mock = Mockery::mock('Illuminate\Mailer\Message');
+
+            $mock->shouldReceive('subject')->once()->with('test subject');
+
+            $mock->shouldReceive('to')->once()->with('taylor@laravel.com');
+
+            $mock->shouldReceive('from')->never();
+
+            $closure($mock);
+
+            return true;
+        }));
+
+        $channel->send($notifiable, $notification);
+    }
+
+    public function testMessageWithoutSubjectAutogeneratesSubjectFromClassName()
+    {
+        $notification = new NotificationMailChannelTestNotificationNoSubject;
+        $notifiable = new NotificationMailChannelTestNotifiable;
+
+        $message = $notification->toMail($notifiable);
+        $data = $message->toArray();
+
+        $channel = new Illuminate\Notifications\Channels\MailChannel(
+            $mailer = Mockery::mock(Illuminate\Contracts\Mail\Mailer::class)
+        );
+
+        $mailer->shouldReceive('send')->with('notifications::email', $data, Mockery::on(function ($closure) {
+            $mock = Mockery::mock('Illuminate\Mailer\Message');
+
+            $mock->shouldReceive('subject')->once()->with('Notification Mail Channel Test Notification No Subject');
+
+            $mock->shouldReceive('to')->once()->with('taylor@laravel.com');
+
+            $closure($mock);
+
+            return true;
+        }));
+
+        $channel->send($notifiable, $notification);
+    }
+
+    public function testMessageWithMultipleSenders()
+    {
+        $notification = new NotificationMailChannelTestNotification;
+        $notifiable = new NotificationMailChannelTestNotifiableMultipleEmails;
+
+        $message = $notification->toMail($notifiable);
+        $data = $message->toArray();
+
+        $channel = new Illuminate\Notifications\Channels\MailChannel(
+            $mailer = Mockery::mock(Illuminate\Contracts\Mail\Mailer::class)
+        );
+
+        $mailer->shouldReceive('send')->with('notifications::email', $data, Mockery::on(function ($closure) {
+            $mock = Mockery::mock('Illuminate\Mailer\Message');
+
+            $mock->shouldReceive('subject')->once();
+
+            $mock->shouldReceive('to')->never();
+
+            $mock->shouldReceive('bcc')->with(['taylor@laravel.com', 'jeffrey@laracasts.com']);
+
+            $closure($mock);
+
+            return true;
+        }));
+
+        $channel->send($notifiable, $notification);
+    }
+
+    public function testMessageWithFromAddress()
+    {
+        $notification = new NotificationMailChannelTestNotificationWithFromAddress;
+        $notifiable = new NotificationMailChannelTestNotifiable;
+
+        $message = $notification->toMail($notifiable);
+        $data = $message->toArray();
+
+        $channel = new Illuminate\Notifications\Channels\MailChannel(
+            $mailer = Mockery::mock(Illuminate\Contracts\Mail\Mailer::class)
+        );
+
+        $mailer->shouldReceive('send')->with('notifications::email', $data, Mockery::on(function ($closure) {
+            $mock = Mockery::mock('Illuminate\Mailer\Message');
+
+            $mock->shouldReceive('subject')->once();
+
+            $mock->shouldReceive('to')->once();
+
+            $mock->shouldReceive('from')->with('test@mail.com', 'Test Man');
+
+            $closure($mock);
+
+            return true;
+        }));
+
+        $channel->send($notifiable, $notification);
+    }
+
+    public function testMessageWithFromAddressAndNoName()
+    {
+        $notification = new NotificationMailChannelTestNotificationWithFromAddressNoName;
+        $notifiable = new NotificationMailChannelTestNotifiable;
+
+        $message = $notification->toMail($notifiable);
+        $data = $message->toArray();
+
+        $channel = new Illuminate\Notifications\Channels\MailChannel(
+            $mailer = Mockery::mock(Illuminate\Contracts\Mail\Mailer::class)
+        );
+
+        $mailer->shouldReceive('send')->with('notifications::email', $data, Mockery::on(function ($closure) {
+            $mock = Mockery::mock('Illuminate\Mailer\Message');
+
+            $mock->shouldReceive('subject')->once();
+
+            $mock->shouldReceive('to')->once();
+
+            $mock->shouldReceive('from')->with('test@mail.com', null);
+
+            $closure($mock);
+
+            return true;
+        }));
+
+        $channel->send($notifiable, $notification);
+    }
 }
 
 class NotificationMailChannelTestNotifiable
@@ -35,10 +178,47 @@ class NotificationMailChannelTestNotifiable
     public $email = 'taylor@laravel.com';
 }
 
+class NotificationMailChannelTestNotifiableMultipleEmails
+{
+    use Illuminate\Notifications\Notifiable;
+
+    public function routeNotificationForMail()
+    {
+        return ['taylor@laravel.com', 'jeffrey@laracasts.com'];
+    }
+}
+
 class NotificationMailChannelTestNotification extends Notification
 {
     public function toMail($notifiable)
     {
+        return (new MailMessage)
+            ->subject('test subject');
+    }
+}
+
+class NotificationMailChannelTestNotificationNoSubject extends Notification
+{
+    public function toMail($notifiable)
+    {
         return new MailMessage;
+    }
+}
+
+class NotificationMailChannelTestNotificationWithFromAddress extends Notification
+{
+    public function toMail($notifiable)
+    {
+        return (new MailMessage)
+            ->from('test@mail.com', 'Test Man');
+    }
+}
+
+class NotificationMailChannelTestNotificationWithFromAddressNoName extends Notification
+{
+    public function toMail($notifiable)
+    {
+        return (new MailMessage)
+            ->from('test@mail.com');
     }
 }


### PR DESCRIPTION
This PR adds the ability to set a from address while sending mail notification messages.

``` php
public function toMail($notifiable)
{
    return (new MailMessage)
        ->from('john@mail.com', 'John Doe');
}
```

I also added more tests to the Mail Channel.
