### PR TITLE
[5.3] Add mailer() helper

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -533,6 +533,18 @@ if (! function_exists('logger')) {
     }
 }
 
+if (! function_exists('mailer')) {
+    /**
+     * Get the Mailer instance.
+     *
+     * @return \Illuminate\Contracts\Mail\Mailer|null
+     */
+    function mailer()
+    {
+        return app('mailer');
+    }
+}
+
 if (! function_exists('method_field')) {
     /**
      * Generate a form field to spoof the HTTP verb used by forms.


### PR DESCRIPTION
Instead of `Mail::` facade, it would be nice if we could use Mailer like this

``` php
mailer()->to('mul14@example.com')->send(new Mailable);
```

So, we don't need to import facade everytime we need to use Mailer.
