### PR TITLE
[5.3] Ability to get message using implicit keys from MessageBag

### DIFF
--- a/src/Illuminate/Support/MessageBag.php
+++ b/src/Illuminate/Support/MessageBag.php
@@ -158,14 +158,16 @@ class MessageBag implements Arrayable, Countable, Jsonable, JsonSerializable, Me
      */
     public function get($key, $format = null)
     {
+        // If the message exists in the container, we will transform it and return
+        // the message. Otherwise, we'll check if the key is implicit & collect
+        // all messages that match the given key and output it as an array.
+        if (array_key_exists($key, $this->messages)) {
+            return $this->transform($this->messages[$key], $this->checkFormat($format), $key);
+        }
+
         $output = [];
 
-        // If the message exists in the container, we will transform it and return
-        // the message. Otherwise, we'll return an empty array since the entire
-        // methods is to return back an array of messages in the first place.
-        if (array_key_exists($key, $this->messages)) {
-            $output = $this->transform($this->messages[$key], $this->checkFormat($format), $key);
-        } elseif (Str::contains($key, '*')) {
+        if (Str::contains($key, '*')) {
             foreach ($this->messages as $messageKey => $messages) {
                 if (Str::is($key, $messageKey)) {
                     $output[$messageKey] = $this->transform($messages, $this->checkFormat($format), $messageKey);

--- a/src/Illuminate/Support/MessageBag.php
+++ b/src/Illuminate/Support/MessageBag.php
@@ -158,14 +158,22 @@ class MessageBag implements Arrayable, Countable, Jsonable, JsonSerializable, Me
      */
     public function get($key, $format = null)
     {
+        $output = [];
+
         // If the message exists in the container, we will transform it and return
         // the message. Otherwise, we'll return an empty array since the entire
         // methods is to return back an array of messages in the first place.
         if (array_key_exists($key, $this->messages)) {
-            return $this->transform($this->messages[$key], $this->checkFormat($format), $key);
+            $output = $this->transform($this->messages[$key], $this->checkFormat($format), $key);
+        } elseif (Str::contains($key, '*')) {
+            foreach ($this->messages as $messageKey => $messages) {
+                if (Str::is($key, $messageKey)) {
+                    $output[$messageKey] = $this->transform($messages, $this->checkFormat($format), $messageKey);
+                }
+            }
         }
 
-        return [];
+        return $output;
     }
 
     /**

--- a/tests/Support/SupportMessageBagTest.php
+++ b/tests/Support/SupportMessageBagTest.php
@@ -55,6 +55,15 @@ class SupportMessageBagTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(['bar', 'baz'], $container->get('foo'));
     }
 
+    public function testGetReturnsArrayOfMessagesByImplicitKey()
+    {
+        $container = new MessageBag;
+        $container->setFormat(':message');
+        $container->add('foo.1', 'bar');
+        $container->add('foo.2', 'baz');
+        $this->assertEquals(['foo.1' => ['bar'], 'foo.2' => ['baz']], $container->get('foo.*'));
+    }
+
     public function testFirstReturnsSingleMessage()
     {
         $container = new MessageBag;


### PR DESCRIPTION
In Array validation the error messages are keyed by the explicit field name, for example: `name.0`, `name.4`, ...

Thus retrieving messages by key requires using the explicit key `$errors->get('name.1')`, however we won't know which member of the array has an error, so it makes sense to be able to get messages using an implicit address `name.*`.

In the normal situation the result of `get()` is an array of messages for that field, eg:

``` php
// $errors->get('name.0');
["name.0 is required."]
```

in case of an array field the result is going to be like this:

``` php
// $errors->get('name.*');
[
  "name.0" => [
    "name.0 is required."
  ],
  "name.4" => [
    "name.4 is required."
  ]
]
```

I'm also thinking of an alternative output that collects messages of all fields in 1 array:

``` php
["name.0 is required.", "name.4 is required."]
```
