### PR TITLE
[5.3] Made DatabaseManager always respect type of connection

### DIFF
--- a/src/Illuminate/Database/DatabaseManager.php
+++ b/src/Illuminate/Database/DatabaseManager.php
@@ -72,6 +72,13 @@ class DatabaseManager implements ConnectionResolverInterface
             $this->connections[$name] = $this->prepare($connection);
         }
 
+        // If the connection already exists, we must take the type of the connection
+        // into consideration, otherwise we will never be able to switch the type 
+        // of any already existing connection. This will affect future queries.
+        else {
+            $this->setPdoForType($this->connections[$name], $type);
+        }
+
         return $this->connections[$name];
     }
 


### PR DESCRIPTION
In the `DatabaseManager connection()` method, the name and type is parsed from the `$name` argument. However, if the connection already exists in `$this->connections`, the type is ignored entirely.

This makes it impossible to e.g. write `DB::connection('mysql::write')->select(...)` and expect the select to be made against the write connection.

Note that changing the type of the connection with the already existing `setPdoForType` method kills the other type of connection; e.g. if we do `DB::connection('mysql::write')`, then queries to the read connection will always go to the write connection henceforth. As far as I can see, this has always been the case, however.

This pull request simply always calls the `setPdoForType()` method on the given connection.
