### PR TITLE
[5.3] Strips protocol from defined Route Group Domains

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -820,7 +820,7 @@ class Route
      */
     public function domain()
     {
-        return isset($this->action['domain']) ? $this->action['domain'] : null;
+        return isset($this->action['domain']) ? str_replace(['http://', 'https://'], '', $this->action['domain']) : null;
     }
 
     /**

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -292,6 +292,35 @@ class RoutingUrlGeneratorTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('http://sub.taylor.com:8080/foo/bar/otwell', $url->route('bar', ['taylor', 'otwell']));
     }
 
+    public function testRoutesWithDomainsStripsProtocols()
+    {
+        /*
+         * http:// Route
+         */
+        $url = new UrlGenerator(
+            $routes = new RouteCollection,
+            $request = Request::create('http://www.foo.com/')
+        );
+
+        $route = new Route(['GET'], 'foo/bar', ['as' => 'foo', 'domain' => 'http://sub.foo.com']);
+        $routes->add($route);
+
+        $this->assertEquals('http://sub.foo.com/foo/bar', $url->route('foo'));
+
+        /*
+         * https:// Route
+         */
+        $url = new UrlGenerator(
+            $routes = new RouteCollection,
+            $request = Request::create('https://www.foo.com/')
+        );
+
+        $route = new Route(['GET'], 'foo/bar', ['as' => 'foo', 'domain' => 'https://sub.foo.com']);
+        $routes->add($route);
+
+        $this->assertEquals('https://sub.foo.com/foo/bar', $url->route('foo'));
+    }
+
     public function testHttpsRoutesWithDomains()
     {
         $url = new UrlGenerator(


### PR DESCRIPTION
So that APP_URL can be used in routes with a domain defined:

``` php
        Route::group([
            'domain' => config('app.url'),
            'middleware' => 'web',
        ], function ($router) {
            require base_path('routes/web.php');
        });
```
