### PR TITLE
[5.3] Allow passing a closure to assertViewHas for finer control

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -669,6 +669,8 @@ trait MakesHttpRequests
 
         if (is_null($value)) {
             PHPUnit::assertArrayHasKey($key, $this->response->original->getData());
+        } elseif ($value instanceof \Closure) {
+            PHPUnit::assertTrue($value($this->response->original->$key));
         } else {
             PHPUnit::assertEquals($value, $this->response->original->$key);
         }


### PR DESCRIPTION
This PR allows you to pass a closure as the `$value` argument, where the user can return a statement that should evaluate to `true` if the data in the view is what they want.

For example, this assertion would pass as long as the `currentUser` variable passed to the view had a `name` attribute of `"Taylor"`:

``` php
$this->assertViewHas('currentUser', function ($user) {
    return $user['name'] == 'Taylor';
});
```

This makes it much easier to write assertions against view data when it's hard to mimic the entire object you want to inspect. It's almost impossible to do this with Eloquent models currently if you create one in a factory in your test for example, because the object in your test and the object retrieved in your app code will have subtle differences in private attributes that don't actually matter to your test.
