### PR TITLE
[5.3] Controller closure middleware

### DIFF
--- a/src/Illuminate/Routing/Controller.php
+++ b/src/Illuminate/Routing/Controller.php
@@ -17,14 +17,17 @@ abstract class Controller
     /**
      * Register middleware on the controller.
      *
-     * @param  array|string  $middleware
+     * @param  array|string|\Closure  $middlewares
      * @param  array   $options
      * @return \Illuminate\Routing\ControllerMiddlewareOptions
      */
-    public function middleware($middleware, array $options = [])
+    public function middleware($middlewares, array $options = [])
     {
-        foreach ((array) $middleware as $middlewareName) {
-            $this->middleware[$middlewareName] = &$options;
+        foreach ((array) $middlewares as $middleware) {
+            $this->middleware[] = [
+                'middleware' => $middleware,
+                'options' => &$options,
+            ];
         }
 
         return new ControllerMiddlewareOptions($options);

--- a/src/Illuminate/Routing/ControllerDispatcher.php
+++ b/src/Illuminate/Routing/ControllerDispatcher.php
@@ -60,9 +60,9 @@ class ControllerDispatcher
             return [];
         }
 
-        return collect($controller->getMiddleware())->reject(function ($options, $name) use ($method) {
-            return static::methodExcludedByOptions($method, $options);
-        })->keys()->all();
+        return collect($controller->getMiddleware())->reject(function ($data) use ($method) {
+            return static::methodExcludedByOptions($method, $data['options']);
+        })->pluck('middleware')->all();
     }
 
     /**

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -669,16 +669,18 @@ class Router implements RegistrarContract
     {
         $map = $this->middleware;
 
-        // If the middleware is the name of a middleware group, we will return the array
-        // of middlewares that belong to the group. This allows developers to group a
-        // set of middleware under single keys that can be conveniently referenced.
-        if (isset($this->middlewareGroups[$name])) {
-            return $this->parseMiddlewareGroup($name);
         // When the middleware is simply a Closure, we will return this Closure instance
         // directly so that Closures can be registered as middleware inline, which is
         // convenient on occasions when the developers are experimenting with them.
+        if ($name instanceof Closure) {
+            return $name;
         } elseif (isset($map[$name]) && $map[$name] instanceof Closure) {
             return $map[$name];
+        // If the middleware is the name of a middleware group, we will return the array
+        // of middlewares that belong to the group. This allows developers to group a
+        // set of middleware under single keys that can be conveniently referenced.
+        } elseif (isset($this->middlewareGroups[$name])) {
+            return $this->parseMiddlewareGroup($name);
         // Finally, when the middleware is simply a string mapped to a class name the
         // middleware name will get parsed into the full class name and parameters
         // which may be run using the Pipeline which accepts this string format.

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -4,6 +4,7 @@ use Illuminate\Http\Request;
 use Illuminate\Routing\Route;
 use Illuminate\Routing\Router;
 use Illuminate\Events\Dispatcher;
+use Illuminate\Routing\Controller;
 use Illuminate\Container\Container;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Auth\Middleware\Authorize;
@@ -1129,7 +1130,7 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase
     }
 }
 
-class RouteTestControllerStub extends Illuminate\Routing\Controller
+class RouteTestControllerStub extends Controller
 {
     public function __construct()
     {
@@ -1145,7 +1146,7 @@ class RouteTestControllerStub extends Illuminate\Routing\Controller
     }
 }
 
-class RouteTestControllerMiddlewareGroupStub extends Illuminate\Routing\Controller
+class RouteTestControllerMiddlewareGroupStub extends Controller
 {
     public function __construct()
     {
@@ -1158,7 +1159,7 @@ class RouteTestControllerMiddlewareGroupStub extends Illuminate\Routing\Controll
     }
 }
 
-class RouteTestControllerWithParameterStub extends Illuminate\Routing\Controller
+class RouteTestControllerWithParameterStub extends Controller
 {
     public function returnParameter($bar = '')
     {

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -148,6 +148,18 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase
     public function testClosureMiddleware()
     {
         $router = $this->getRouter();
+        $middleware = function ($request, $next) {
+            return 'caught';
+        };
+        $router->get('foo/bar', ['middleware' => $middleware, function () {
+            return 'hello';
+        }]);
+        $this->assertEquals('caught', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
+    }
+
+    public function testDefinedClosureMiddleware()
+    {
+        $router = $this->getRouter();
         $router->get('foo/bar', ['middleware' => 'foo', function () {
             return 'hello';
         }]);


### PR DESCRIPTION
This will allow registering a closure middleware in the controller's constructor, so that any auth/session stuff can be called and set as properties on the controller:

``` php
public function __construct()
{
    $this->middleware(function ($request, $next) {
        $this->user = $request->user();

        return $next($request);
    });
}
```

**Notes**:
1. To allow middleware closures, I had to rework the router's `sortMiddleware` method to not use collections, since `contains` and `search` do something else (invoke it) when passed a closure. That method looks a little nasty now :confused: 
2. There's a small change which I'm not sure would be considered breaking: the `middleware` property on the controller is now stored in a different format. I don't think this is meant to be tinkered with directly, but who knows?
