### PR TITLE
[5.3] Add date-specific test to getDirty() so new representations of the same dates are not marked as dirty

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -3218,9 +3218,9 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         $original = $this->original[$key];
 
         if ((is_null($current) && ! is_null($original)) ||
-            (is_null($original) && ! is_null($current))) {
-                return false;
-            }
+                    (is_null($original) && ! is_null($current))) {
+            return false;
+        }
 
         $current = new Carbon($current);
         $original = new Carbon($original);

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -3213,9 +3213,17 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
             return false;
         }
 
-        $current = new Carbon($this->attributes[$key]);
+        $current = $this->attributes[$key];
 
-        $original = new Carbon($this->original[$key]);
+        $original = $this->original[$key];
+
+        if ((is_null($current) && ! is_null($original)) ||
+            (is_null($original) && ! is_null($current))) {
+                return false;
+            }
+
+        $current = new Carbon($current);
+        $original = new Carbon($original);
 
         return $current->eq($original);
     }

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -3177,7 +3177,8 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
             if (! array_key_exists($key, $this->original)) {
                 $dirty[$key] = $value;
             } elseif ($value !== $this->original[$key] &&
-                                 ! $this->originalIsNumericallyEquivalent($key)) {
+                                 ! $this->originalIsNumericallyEquivalent($key) &&
+                                 ! $this->originalIsSameDateAndTime($key)) {
                 $dirty[$key] = $value;
             }
         }
@@ -3198,6 +3199,25 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         $original = $this->original[$key];
 
         return is_numeric($current) && is_numeric($original) && strcmp((string) $current, (string) $original) === 0;
+    }
+
+    /**
+     * Determine if the new and old values for a given key are equivalent dates.
+     *
+     * @param  string  $key
+     * @return bool
+     */
+    protected function originalIsSameDateAndTime($key)
+    {
+        if (! in_array($key, $this->dates)) {
+            return false;
+        }
+
+        $current = new Carbon($this->attributes[$key]);
+
+        $original = new Carbon($this->original[$key]);
+
+        return $current->eq($original);
     }
 
     /**


### PR DESCRIPTION
This should resolve issue #15060, "[5.3 and below] getDirty() does not handle date columns right".

Adds a new function `originalIsSameDateAndTime` that performs a similar task to `originalIsNumericallyEquivalent`, except for members of the model's `dates` array. A call to this function is added as a check in `getDirty()` before deciding to add the current key-value pair to the `$dirty` array.

The result is that a new string representations of the original date value will not be deemed dirty.
