### PR TITLE
[5.3] Fix for migrate:rollback with FETCH_ASSOC enabled (#15081)

### DIFF
--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -204,11 +204,12 @@ class Migrator
             $this->requireFiles($files);
 
             foreach ($migrations as $migration) {
+                $migration = (object) $migration;
                 $rolledBack[] = $files[$migration->migration];
 
                 $this->runDown(
                     $files[$migration->migration],
-                    (object) $migration, Arr::get($options, 'pretend', false)
+                    $migration, Arr::get($options, 'pretend', false)
                 );
             }
         }

--- a/tests/Database/DatabaseMigratorIntegrationTest.php
+++ b/tests/Database/DatabaseMigratorIntegrationTest.php
@@ -70,6 +70,21 @@ class DatabaseMigratorIntegrationTest extends PHPUnit_Framework_TestCase
         $this->assertTrue(str_contains($rolledBack[1], 'users'));
     }
 
+    public function testMigrationsCanBeRolledBackWithFetchAssocEnabled()
+    {
+        $this->db->getConnection()->setFetchMode(\PDO::FETCH_ASSOC);
+
+        $this->migrator->run([__DIR__.'/migrations/one']);
+        $this->assertTrue($this->db->schema()->hasTable('users'));
+        $this->assertTrue($this->db->schema()->hasTable('password_resets'));
+        $rolledBack = $this->migrator->rollback([__DIR__.'/migrations/one']);
+        $this->assertFalse($this->db->schema()->hasTable('users'));
+        $this->assertFalse($this->db->schema()->hasTable('password_resets'));
+
+        $this->assertTrue(str_contains($rolledBack[0], 'password_resets'));
+        $this->assertTrue(str_contains($rolledBack[1], 'users'));
+    }
+
     public function testMigrationsCanBeReset()
     {
         $this->migrator->run([__DIR__.'/migrations/one']);


### PR DESCRIPTION
Move where the object cast happens to fix #15081
