### PR TITLE
[5.3] Resources helper relies on Application defined resources path

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -277,6 +277,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     {
         $this->instance('path', $this->path());
         $this->instance('path.base', $this->basePath());
+        $this->instance('path.resources', $this->resourcesPath());
         $this->instance('path.lang', $this->langPath());
         $this->instance('path.config', $this->configPath());
         $this->instance('path.public', $this->publicPath());
@@ -351,13 +352,23 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     }
 
     /**
+     * Get the path to the resources folder.
+     *
+     * @return string
+     */
+    public function resourcesPath()
+    {
+        return $this->basePath.DIRECTORY_SEPARATOR.'resources';
+    }
+
+    /**
      * Get the path to the language files.
      *
      * @return string
      */
     public function langPath()
     {
-        return $this->basePath.DIRECTORY_SEPARATOR.'resources'.DIRECTORY_SEPARATOR.'lang';
+        return $this->resourcesPath().DIRECTORY_SEPARATOR.'lang';
     }
 
     /**

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -653,7 +653,7 @@ if (! function_exists('resource_path')) {
      */
     function resource_path($path = '')
     {
-        return app()->basePath().DIRECTORY_SEPARATOR.'resources'.($path ? DIRECTORY_SEPARATOR.$path : $path);
+        return app()->resourcePath().($path ? DIRECTORY_SEPARATOR.$path : $path);
     }
 }
 


### PR DESCRIPTION
I and I'm sure a few others use different paths for where they store their resources in their Laravel projects, as the resources_path function has been added recently it would be nice if it relied on the Application instance rather than being hard coded.

With more service providers (Pagination, Spark, Passport) publishing assets and views it would be preferable if the application's configuration could define where these get installed as currently it always ends up in resources. This would also be of benefit for backwards compatibility should things change in the future.
