### PR TITLE
[5.3] Support custom recipient(s) with MailMessage

### DIFF
--- a/src/Illuminate/Notifications/Channels/MailChannel.php
+++ b/src/Illuminate/Notifications/Channels/MailChannel.php
@@ -42,7 +42,7 @@ class MailChannel
         $message = $notification->toMail($notifiable);
 
         $this->mailer->send($message->view, $message->data(), function ($m) use ($notifiable, $notification, $message) {
-            $recipients = $notifiable->routeNotificationFor('mail');
+            $recipients = empty($message->to) ? $notifiable->routeNotificationFor('mail') : $message->to;
 
             if (! empty($message->from)) {
                 $m->from($message->from[0], isset($message->from[1]) ? $message->from[1] : null);

--- a/src/Illuminate/Notifications/Messages/MailMessage.php
+++ b/src/Illuminate/Notifications/Messages/MailMessage.php
@@ -29,6 +29,13 @@ class MailMessage extends SimpleMessage
     public $from = [];
 
     /**
+     * The recipient information for the message.
+     *
+     * @var array
+     */
+    public $to = [];
+
+    /**
      * The attachments for the message.
      *
      * @var array
@@ -67,6 +74,19 @@ class MailMessage extends SimpleMessage
     public function from($address, $name = null)
     {
         $this->from = [$address, $name];
+
+        return $this;
+    }
+
+    /**
+     * Set the recipient address for the mail message.
+     *
+     * @param  string|array  $address
+     * @return $this
+     */
+    public function to($address)
+    {
+        $this->to = $address;
 
         return $this;
     }

--- a/tests/Notifications/NotificationMailChannelTest.php
+++ b/tests/Notifications/NotificationMailChannelTest.php
@@ -181,6 +181,35 @@ class NotificationMailChannelTest extends PHPUnit_Framework_TestCase
 
         $channel->send($notifiable, $notification);
     }
+
+    public function testMessageWithToAddress()
+    {
+        $notification = new NotificationMailChannelTestNotificationWithToAddress;
+        $notifiable = new NotificationMailChannelTestNotifiable;
+
+        $message = $notification->toMail($notifiable);
+        $data = $message->toArray();
+
+        $channel = new Illuminate\Notifications\Channels\MailChannel(
+            $mailer = Mockery::mock(Illuminate\Contracts\Mail\Mailer::class)
+        );
+
+        $views = ['notifications::email', 'notifications::email-plain'];
+
+        $mailer->shouldReceive('send')->with($views, $data, Mockery::on(function ($closure) {
+            $mock = Mockery::mock('Illuminate\Mailer\Message');
+
+            $mock->shouldReceive('subject')->once();
+
+            $mock->shouldReceive('to')->once()->with('jeffrey@laracasts.com');
+
+            $closure($mock);
+
+            return true;
+        }));
+
+        $channel->send($notifiable, $notification);
+    }
 }
 
 class NotificationMailChannelTestNotifiable
@@ -232,5 +261,14 @@ class NotificationMailChannelTestNotificationWithFromAddressNoName extends Notif
     {
         return (new MailMessage)
             ->from('test@mail.com');
+    }
+}
+
+class NotificationMailChannelTestNotificationWithToAddress extends Notification
+{
+    public function toMail($notifiable)
+    {
+        return (new MailMessage)
+            ->to('jeffrey@laracasts.com');
     }
 }


### PR DESCRIPTION
This comes in handy when sending "email address confirmation" requests.
