### PR TITLE
[5.3] Optimize Str::random() by just using strlen() and substr()

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -224,12 +224,12 @@ class Str
     {
         $string = '';
 
-        while (($len = static::length($string)) < $length) {
+        while (($len = strlen($string)) < $length) {
             $size = $length - $len;
 
             $bytes = random_bytes($size);
 
-            $string .= static::substr(str_replace(['/', '+', '='], '', base64_encode($bytes)), 0, $size);
+            $string .= substr(str_replace(['/', '+', '='], '', base64_encode($bytes)), 0, $size);
         }
 
         return $string;
@@ -253,7 +253,7 @@ class Str
 
         $pool = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
 
-        return static::substr(str_shuffle(str_repeat($pool, $length)), 0, $length);
+        return substr(str_shuffle(str_repeat($pool, $length)), 0, $length);
     }
 
     /**


### PR DESCRIPTION
Figures, for only 10,000 iterations:
- before: 963 ms
- after: 887 ms

So, `Str::random()` is quite slow, this PR brings a speedup of about 8% which I think is worth it.

The `substr()` being applied on a base64 output, the change is safe and straightforward.
