### PR TITLE
[5.3] Fix serialization mistake on notifications

### DIFF
--- a/src/Illuminate/Notifications/ChannelManager.php
+++ b/src/Illuminate/Notifications/ChannelManager.php
@@ -68,9 +68,9 @@ class ChannelManager extends Manager implements DispatcherContract, FactoryContr
 
             foreach ($channels as $channel) {
                 $notification = clone $original;
-                
+
                 $notification->id = $notificationId;
-            
+
                 if (! $this->shouldSendNotification($notifiable, $notification, $channel)) {
                     continue;
                 }

--- a/src/Illuminate/Notifications/ChannelManager.php
+++ b/src/Illuminate/Notifications/ChannelManager.php
@@ -59,10 +59,7 @@ class ChannelManager extends Manager implements DispatcherContract, FactoryContr
         $original = clone $notification;
 
         foreach ($notifiables as $notifiable) {
-            $notification = clone $original;
-
-            $notification->id = (string) Uuid::uuid4();
-
+            $notificationId = (string) Uuid::uuid4();
             $channels = $notification->via($notifiable);
 
             if (empty($channels)) {
@@ -70,6 +67,10 @@ class ChannelManager extends Manager implements DispatcherContract, FactoryContr
             }
 
             foreach ($channels as $channel) {
+                $notification = clone $original;
+                
+                $notification->id = $notificationId;
+            
                 if (! $this->shouldSendNotification($notifiable, $notification, $channel)) {
                     continue;
                 }


### PR DESCRIPTION
If we will use next notification:

```
<?php

namespace App\Notifications\Users;

use App\User;
use Illuminate\Bus\Queueable;
use Illuminate\Notifications\Notification;

class NewColleague extends Notification
{
    /**
     * @var
     */
    public $colleague;

    /**
     * Create a new notification instance.
     * @param User $colleague
     */
    public function __construct(User $colleague)
    {
        $this->colleague = $colleague;
    }

    /**
     * Get the notification's delivery channels.
     *
     * @param  mixed $notifiable
     * @return array
     */
    public function via($notifiable)
    {
        return [
            'broadcast',
            'database',
        ];
    }

    /**
     * Get the array representation of the notification.
     *
     * @param  mixed $notifiable
     * @return array
     */
    public function toArray($notifiable)
    {
        return [
            'text' => 'We have new colleague, his name is ' . $this->colleague->name,
            'icon' => 'fa fa-user-plus',
            'link' => route('employees.show', [$this->colleague]),
        ];
    }
}
```

It throw an Exception because when It execute toArray for `database`, `$this->colleague` is serialized. I think caused by Broadcast job creating.

If you swap `database` and `broadcast` all will be fine.

This patch fixes this issue
