### PR TITLE
[5.3] Add greeting option to SimpleMessage notification

### DIFF
--- a/src/Illuminate/Notifications/Messages/SimpleMessage.php
+++ b/src/Illuminate/Notifications/Messages/SimpleMessage.php
@@ -21,6 +21,14 @@ class SimpleMessage
     public $subject;
 
     /**
+     * Greeting at the beginning of the notification.
+     * If null, a greeting depending on the level will be displayed.
+     *
+     * @var string|null
+     */
+    public $greeting = null;
+
+    /**
      * The "intro" lines of the notification.
      *
      * @var array
@@ -99,6 +107,19 @@ class SimpleMessage
     }
 
     /**
+     * Set the greeting of the notification.
+     *
+     * @param  string  $greeting
+     * @return $this
+     */
+    public function greeting($greeting)
+    {
+        $this->greeting = $greeting;
+
+        return $this;
+    }
+
+    /**
      * Add a line of text to the notification.
      *
      * @param  \Illuminate\Notifications\Action|string  $line
@@ -168,6 +189,7 @@ class SimpleMessage
         return [
             'level' => $this->level,
             'subject' => $this->subject,
+            'greeting' => $this->greeting,
             'introLines' => $this->introLines,
             'outroLines' => $this->outroLines,
             'actionText' => $this->actionText,

--- a/src/Illuminate/Notifications/Messages/SimpleMessage.php
+++ b/src/Illuminate/Notifications/Messages/SimpleMessage.php
@@ -22,6 +22,7 @@ class SimpleMessage
 
     /**
      * Greeting at the beginning of the notification.
+     * 
      * If null, a greeting depending on the level will be displayed.
      *
      * @var string|null

--- a/src/Illuminate/Notifications/Messages/SimpleMessage.php
+++ b/src/Illuminate/Notifications/Messages/SimpleMessage.php
@@ -22,7 +22,6 @@ class SimpleMessage
 
     /**
      * Greeting at the beginning of the notification.
-     * 
      * If null, a greeting depending on the level will be displayed.
      *
      * @var string|null

--- a/src/Illuminate/Notifications/resources/views/email-plain.blade.php
+++ b/src/Illuminate/Notifications/resources/views/email-plain.blade.php
@@ -1,5 +1,5 @@
 <?php
-if ( $greeting !== null ) {
+if ($greeting !== null) {
     echo e($greeting);
 } else {
     echo $level == 'error' ? 'Whoops!' : 'Hello!';

--- a/src/Illuminate/Notifications/resources/views/email-plain.blade.php
+++ b/src/Illuminate/Notifications/resources/views/email-plain.blade.php
@@ -1,8 +1,8 @@
 <?php
 if( $greeting !== null ) {
-	echo e($greeting);
+    echo e($greeting);
 } else {
-	echo $level == 'error' ? 'Whoops!' : 'Hello!';
+    echo $level == 'error' ? 'Whoops!' : 'Hello!';
 }
 
 ?>

--- a/src/Illuminate/Notifications/resources/views/email-plain.blade.php
+++ b/src/Illuminate/Notifications/resources/views/email-plain.blade.php
@@ -1,5 +1,5 @@
 <?php
-if( $greeting !== null ) {
+if ( $greeting !== null ) {
     echo e($greeting);
 } else {
     echo $level == 'error' ? 'Whoops!' : 'Hello!';

--- a/src/Illuminate/Notifications/resources/views/email-plain.blade.php
+++ b/src/Illuminate/Notifications/resources/views/email-plain.blade.php
@@ -1,4 +1,4 @@
-{{ $level == 'error' ? 'Whoops!' : 'Hello!' }}
+{{ ( $greeting !== null ) ? $greeting : ($level == 'error' ? 'Whoops!' : 'Hello!') }}
 
 <?php
 

--- a/src/Illuminate/Notifications/resources/views/email-plain.blade.php
+++ b/src/Illuminate/Notifications/resources/views/email-plain.blade.php
@@ -1,4 +1,11 @@
-{{ ( $greeting !== null ) ? $greeting : ($level == 'error' ? 'Whoops!' : 'Hello!') }}
+<?php
+if( $greeting !== null ) {
+	echo e($greeting);
+} else {
+	echo $level == 'error' ? 'Whoops!' : 'Hello!';
+}
+
+?>
 
 <?php
 

--- a/src/Illuminate/Notifications/resources/views/email.blade.php
+++ b/src/Illuminate/Notifications/resources/views/email.blade.php
@@ -84,10 +84,14 @@ $style = [
                                     <td style="{{ $fontFamily }} {{ $style['email-body_cell'] }}">
                                         <!-- Greeting -->
                                         <h1 style="{{ $style['header-1'] }}">
-                                            @if ($level == 'error')
-                                                Whoops!
+                                            @if ($greeting !== null)
+                                                {{ $greeting }}
                                             @else
-                                                Hello!
+                                                @if ($level == 'error')
+                                                    Whoops!
+                                                @else
+                                                    Hello!
+                                                @endif
                                             @endif
                                         </h1>
 


### PR DESCRIPTION
By default 'Hello!' or 'Whoops!' is displayed as greeting.

You can override this with the `greeting()` method:

``` php
public function toMail($notifiable)
{
    return (new MailMessage)
                ->greeting("Hi {$notifiable->name},")
                ->line('The introduction to the notification.')
                ->action('Notification Action', 'https://laravel.com')
                ->line('Thank you for using our application!');
}
```
