### PR TITLE
[5.4] Preserve original keys in Arr::pluck()

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -345,14 +345,14 @@ class Arr
 
         list($value, $key) = static::explodePluckParameters($value, $key);
 
-        foreach ($array as $item) {
+        foreach ($array as $origKey => $item) {
             $itemValue = data_get($item, $value);
 
-            // If the key is "null", we will just append the value to the array and keep
-            // looping. Otherwise we will key the array using the value of the key we
-            // received from the developer. Then we'll return the final array form.
+            // If the key is "null", we will preserve the key from the original array.
+            // Otherwise we will key the array using the value of the key we received
+            // from the developer.
             if (is_null($key)) {
-                $results[] = $itemValue;
+                $results[$origKey] = $itemValue;
             } else {
                 $itemKey = data_get($item, $key);
 

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -169,21 +169,32 @@ class SupportHelpersTest extends PHPUnit_Framework_TestCase
         ];
 
         $this->assertEquals([
-            0 => [
+            'post-1' => [
                 'tags' => [
                     '#foo', '#bar',
                 ],
             ],
-            1 => [
+            'post-2' => [
                 'tags' => [
                     '#baz',
                 ],
             ],
         ], array_pluck($data, 'comments'));
 
-        $this->assertEquals([['#foo', '#bar'], ['#baz']], array_pluck($data, 'comments.tags'));
-        $this->assertEquals([null, null], array_pluck($data, 'foo'));
-        $this->assertEquals([null, null], array_pluck($data, 'foo.bar'));
+        $this->assertEquals([
+            'post-1' => ['#foo', '#bar'],
+            'post-2' => ['#baz'],
+        ], array_pluck($data, 'comments.tags'));
+
+        $this->assertEquals([
+            'post-1' => null,
+            'post-2' => null,
+        ], array_pluck($data, 'foo'));
+
+        $this->assertEquals([
+            'post-1' => null,
+            'post-2' => null,
+        ], array_pluck($data, 'foo.bar'));
     }
 
     public function testArrayPrepend()


### PR DESCRIPTION
There is no way to preserve keys when using `Arr::pluck($arr, $value, $key=null)`, or `$collection->pluck($value, $key=null)`.

If the `$key` argument is not given, it returns a plain array with numeric keys, which, frankly, is quite useless -- if the user doesn't specify a key, we might just as well keep the original keys, which I at least would expect from the function. You can always run array_values() or `->values()` on it if numeric keys is what you'd like.

It also helps consistency, other methods such as `->filter()` preserves keys.

The tests would have to be changed (different expected results), if this is agreed to be merged.

If you don't like changing this for backwards compatibility, I'd suggest adding a `kpluck()` method, or another argument, since this feature is really important in my opinion.
