### PR TITLE
[5.3] Swaps Drop for DropIfExists

### DIFF
--- a/src/Illuminate/Database/Migrations/stubs/create.stub
+++ b/src/Illuminate/Database/Migrations/stubs/create.stub
@@ -26,6 +26,6 @@ class DummyClass extends Migration
      */
     public function down()
     {
-        Schema::drop('DummyTable');
+        Schema::dropIfExists('DummyTable');
     }
 }


### PR DESCRIPTION
During development I find myself migrating up and down frequently. If an error pops up that causes the migration to fail, it often requires manual db manipulation to get the migration flow running again. DropIfExists has helped in these situations.

Signed-off-by: Jesse Schutt jesse.schutt@zaengle.com
