### PR TITLE
[5.3] Fix line breaks in plain text email

### DIFF
--- a/src/Illuminate/Notifications/resources/views/email-plain.blade.php
+++ b/src/Illuminate/Notifications/resources/views/email-plain.blade.php
@@ -1,22 +1,22 @@
 <?php
-if ($greeting !== null) {
-    echo e($greeting);
+
+if (! empty($greeting)) {
+    echo $greeting, "\n\n";
 } else {
-    echo $level == 'error' ? 'Whoops!' : 'Hello!';
+    echo $level == 'error' ? 'Whoops!' : 'Hello!', "\n\n";
 }
 
 if (! empty($introLines)) {
-    echo implode("\r\n", $introLines), "\r\n\r\n";
+    echo implode("\n", $introLines), "\n\n";
 }
 
 if (isset($actionText)) {
-    echo "{$actionText}: {$actionUrl}\r\n\r\n";
+    echo "{$actionText}: {$actionUrl}\n\n";
 }
 
 if (! empty($outroLines)) {
-    echo implode("\r\n", $outroLines), "\r\n\r\n";
+    echo implode("\n", $outroLines), "\n\n";
 }
-?>
 
-Regards,
-{{ config('app.name') }}
+echo 'Regards,', "\n";
+echo config('app.name'), "\n";

--- a/src/Illuminate/Notifications/resources/views/email-plain.blade.php
+++ b/src/Illuminate/Notifications/resources/views/email-plain.blade.php
@@ -11,7 +11,7 @@ if (! empty($introLines)) {
 }
 
 if (isset($actionText)) {
-    echo "{$actionText}: {$actionUrl}\n\n";
+    echo "{$actionText}: {$actionUrl}", "\n\n";
 }
 
 if (! empty($outroLines)) {


### PR DESCRIPTION
https://github.com/laravel/framework/pull/15108 broke the new-lines in the plain text email for notifications.

This PR fixes those line breaks.

For future PRs the importance of new-lines in plain text emails has been highlighted by only using echo statements in `email-plain.blade.php`.

CRLFs have been replaced by LFs, because SwiftMailer canonicalizes them anyhow. 
