### PR TITLE
[5.3] Let setData handles data transformation

### DIFF
--- a/src/Illuminate/Routing/ResponseFactory.php
+++ b/src/Illuminate/Routing/ResponseFactory.php
@@ -2,12 +2,10 @@
 
 namespace Illuminate\Routing;
 
-use JsonSerializable;
 use Illuminate\Support\Str;
 use Illuminate\Http\Response;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Traits\Macroable;
-use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\View\Factory as ViewFactory;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
@@ -74,7 +72,7 @@ class ResponseFactory implements FactoryContract
     /**
      * Return a new JSON response from the application.
      *
-     * @param  string|array  $data
+     * @param  mixed  $data
      * @param  int  $status
      * @param  array  $headers
      * @param  int  $options
@@ -82,10 +80,6 @@ class ResponseFactory implements FactoryContract
      */
     public function json($data = [], $status = 200, array $headers = [], $options = 0)
     {
-        if ($data instanceof Arrayable && ! $data instanceof JsonSerializable) {
-            $data = $data->toArray();
-        }
-
         return new JsonResponse($data, $status, $headers, $options);
     }
 
@@ -93,7 +87,7 @@ class ResponseFactory implements FactoryContract
      * Return a new JSONP response from the application.
      *
      * @param  string  $callback
-     * @param  string|array  $data
+     * @param  mixed  $data
      * @param  int  $status
      * @param  array  $headers
      * @param  int  $options


### PR DESCRIPTION
It does not make any sense to restrict the type of data at the instantiation, but not when setting data with `\Illuminate\Http\JsonResponse::setData`.

At the very end, `setData` is used, so no need to transform data and pass an array.

---

Hesitating on which branch to target tho
