### PR TITLE
[5.2] Fixed issue introduced on reverting previous aggregate functions

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1950,11 +1950,11 @@ class Builder
      * Retrieve the sum of the values of a given column.
      *
      * @param  string  $column
-     * @return mixed
+     * @return float
      */
     public function sum($column)
     {
-        return $this->aggregate(__FUNCTION__, [$column]);
+        return $this->numericAggregate(__FUNCTION__, [$column]);
     }
 
     /**


### PR DESCRIPTION
A change to the query builder sum function introduced on revert #14994 presents an issues where the sum function would return values other than of numeric type. It is my understanding that the sum() function should always return a numeric type, as before it used to perform a simple return 0 if result was false.
