### PR TITLE
[5.3] Replace htmlentities with htmlspecialchars.

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -501,7 +501,7 @@ if (! function_exists('dd')) {
 
 if (! function_exists('e')) {
     /**
-     * Escape HTML entities in a string.
+     * Escape HTML special characters in a string.
      *
      * @param  \Illuminate\Contracts\Support\Htmlable|string  $value
      * @return string
@@ -512,7 +512,7 @@ if (! function_exists('e')) {
             return $value->toHtml();
         }
 
-        return htmlentities($value, ENT_QUOTES, 'UTF-8', false);
+        return htmlspecialchars($value, ENT_QUOTES, 'UTF-8', false);
     }
 }
 


### PR DESCRIPTION
As a non-english speaker, I would like to keep my strings non escaped.

For the record:
- [Twig](https://github.com/twigphp/Twig/blob/c535bc0b56aa93ead7a75b6841f28645153b0539/doc/filters/escape.rst) uses `htmlspecialchars`
- [Smarty](https://github.com/smarty-php/smarty/blob/ff6a8521bb588187eefa2695c3959fe101d22c18/libs/plugins/modifier.escape.php) uses `htmlspecialchars` in most cases.

(was #15158 and #15154)
