### PR TITLE
[5.4] Add support for PhpRedis

### DIFF
--- a/src/Illuminate/Cache/RedisStore.php
+++ b/src/Illuminate/Cache/RedisStore.php
@@ -3,14 +3,14 @@
 namespace Illuminate\Cache;
 
 use Illuminate\Contracts\Cache\Store;
-use Illuminate\Contracts\Redis\Database as Redis;
+use Illuminate\Contracts\Redis\Database;
 
 class RedisStore extends TaggableStore implements Store
 {
     /**
      * The Redis database connection.
      *
-     * @var \Illuminate\Redis\Database
+     * @var \Illuminate\Contracts\Redis\Database
      */
     protected $redis;
 
@@ -31,12 +31,12 @@ class RedisStore extends TaggableStore implements Store
     /**
      * Create a new Redis store.
      *
-     * @param  \Illuminate\Redis\Database  $redis
+     * @param  \Illuminate\Contracts\Redis\Database  $redis
      * @param  string  $prefix
      * @param  string  $connection
      * @return void
      */
-    public function __construct(Redis $redis, $prefix = '', $connection = 'default')
+    public function __construct(Database $redis, $prefix = '', $connection = 'default')
     {
         $this->redis = $redis;
         $this->setPrefix($prefix);
@@ -51,7 +51,9 @@ class RedisStore extends TaggableStore implements Store
      */
     public function get($key)
     {
-        if (! is_null($value = $this->connection()->get($this->prefix.$key))) {
+        $value = $this->connection()->get($this->prefix.$key);
+
+        if (! is_null($value) && $value !== false) {
             return is_numeric($value) ? $value : unserialize($value);
         }
     }
@@ -208,7 +210,7 @@ class RedisStore extends TaggableStore implements Store
     /**
      * Get the Redis database instance.
      *
-     * @return \Illuminate\Redis\Database
+     * @return \Illuminate\Contracts\Redis\Database
      */
     public function getRedis()
     {

--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -110,7 +110,9 @@ class Repository implements CacheContract, ArrayAccess
      */
     public function has($key)
     {
-        return ! is_null($this->get($key));
+        $value = $this->get($key);
+
+        return ! is_null($value) && $value !== false;
     }
 
     /**
@@ -128,7 +130,7 @@ class Repository implements CacheContract, ArrayAccess
 
         $value = $this->store->get($this->itemKey($key));
 
-        if (is_null($value)) {
+        if (is_null($value) || $value === false) {
             $this->fireCacheEvent('missed', [$key]);
 
             $value = value($default);
@@ -158,7 +160,7 @@ class Repository implements CacheContract, ArrayAccess
         $values = $this->store->many($normalizedKeys);
 
         foreach ($values as $key => &$value) {
-            if (is_null($value)) {
+            if (is_null($value) || $value === false) {
                 $this->fireCacheEvent('missed', [$key]);
 
                 $value = isset($keys[$key]) ? value($keys[$key]) : null;
@@ -249,7 +251,9 @@ class Repository implements CacheContract, ArrayAccess
             return $this->store->add($this->itemKey($key), $value, $minutes);
         }
 
-        if (is_null($this->get($key))) {
+        $exists = $this->get($key);
+
+        if (is_null($exists) || $exists === false) {
             $this->put($key, $value, $minutes);
 
             return true;
@@ -306,10 +310,12 @@ class Repository implements CacheContract, ArrayAccess
      */
     public function remember($key, $minutes, Closure $callback)
     {
+        $value = $this->get($key);
+
         // If the item exists in the cache we will just return this immediately
         // otherwise we will execute the given Closure and cache the result
         // of that execution for the given number of minutes in storage.
-        if (! is_null($value = $this->get($key))) {
+        if (! is_null($value) && $value !== false) {
             return $value;
         }
 
@@ -339,10 +345,12 @@ class Repository implements CacheContract, ArrayAccess
      */
     public function rememberForever($key, Closure $callback)
     {
+        $value = $this->get($key);
+
         // If the item exists in the cache we will just return this immediately
         // otherwise we will execute the given Closure and cache the result
         // of that execution for the given number of minutes. It's easy.
-        if (! is_null($value = $this->get($key))) {
+        if (! is_null($value) && $value !== false) {
             return $value;
         }
 

--- a/src/Illuminate/Queue/Connectors/RedisConnector.php
+++ b/src/Illuminate/Queue/Connectors/RedisConnector.php
@@ -3,15 +3,15 @@
 namespace Illuminate\Queue\Connectors;
 
 use Illuminate\Support\Arr;
-use Illuminate\Redis\Database;
 use Illuminate\Queue\RedisQueue;
+use Illuminate\Contracts\Redis\Database;
 
 class RedisConnector implements ConnectorInterface
 {
     /**
      * The Redis database instance.
      *
-     * @var \Illuminate\Redis\Database
+     * @var \Illuminate\Contracts\Redis\Database
      */
     protected $redis;
 
@@ -25,7 +25,7 @@ class RedisConnector implements ConnectorInterface
     /**
      * Create a new Redis queue connector instance.
      *
-     * @param  \Illuminate\Redis\Database  $redis
+     * @param  \Illuminate\Contracts\Redis\Database  $redis
      * @param  string|null  $connection
      * @return void
      */

--- a/src/Illuminate/Queue/Jobs/RedisJob.php
+++ b/src/Illuminate/Queue/Jobs/RedisJob.php
@@ -114,7 +114,7 @@ class RedisJob extends Job implements JobContract
     /**
      * Get the underlying queue driver instance.
      *
-     * @return \Illuminate\Redis\Database
+     * @return \Illuminate\Contracts\Redis\Database
      */
     public function getRedisQueue()
     {

--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -4,8 +4,8 @@ namespace Illuminate\Queue;
 
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
-use Illuminate\Redis\Database;
 use Illuminate\Queue\Jobs\RedisJob;
+use Illuminate\Contracts\Redis\Database;
 use Illuminate\Contracts\Queue\Queue as QueueContract;
 
 class RedisQueue extends Queue implements QueueContract
@@ -13,7 +13,7 @@ class RedisQueue extends Queue implements QueueContract
     /**
      * The Redis database instance.
      *
-     * @var \Illuminate\Redis\Database
+     * @var \Illuminate\Contracts\Redis\Database
      */
     protected $redis;
 
@@ -41,7 +41,7 @@ class RedisQueue extends Queue implements QueueContract
     /**
      * Create a new Redis queue instance.
      *
-     * @param  \Illuminate\Redis\Database  $redis
+     * @param  \Illuminate\Contracts\Redis\Database  $redis
      * @param  string  $default
      * @param  string  $connection
      * @param  int  $expire
@@ -239,7 +239,7 @@ class RedisQueue extends Queue implements QueueContract
     /**
      * Get the underlying Redis instance.
      *
-     * @return \Illuminate\Redis\Database
+     * @return \Illuminate\Contracts\Redis\Database
      */
     public function getRedis()
     {

--- a/src/Illuminate/Redis/Database.php
+++ b/src/Illuminate/Redis/Database.php
@@ -2,69 +2,11 @@
 
 namespace Illuminate\Redis;
 
-use Closure;
-use Predis\Client;
 use Illuminate\Support\Arr;
 use Illuminate\Contracts\Redis\Database as DatabaseContract;
 
-class Database implements DatabaseContract
+abstract class Database implements DatabaseContract
 {
-    /**
-     * The host address of the database.
-     *
-     * @var array
-     */
-    protected $clients;
-
-    /**
-     * Create a new Redis connection instance.
-     *
-     * @param  array  $servers
-     * @return void
-     */
-    public function __construct(array $servers = [])
-    {
-        $cluster = Arr::pull($servers, 'cluster');
-
-        $options = array_merge(['timeout' => 10.0], (array) Arr::pull($servers, 'options'));
-
-        if ($cluster) {
-            $this->clients = $this->createAggregateClient($servers, $options);
-        } else {
-            $this->clients = $this->createSingleClients($servers, $options);
-        }
-    }
-
-    /**
-     * Create a new aggregate client supporting sharding.
-     *
-     * @param  array  $servers
-     * @param  array  $options
-     * @return array
-     */
-    protected function createAggregateClient(array $servers, array $options = [])
-    {
-        return ['default' => new Client(array_values($servers), $options)];
-    }
-
-    /**
-     * Create an array of single connection clients.
-     *
-     * @param  array  $servers
-     * @param  array  $options
-     * @return array
-     */
-    protected function createSingleClients(array $servers, array $options = [])
-    {
-        $clients = [];
-
-        foreach ($servers as $key => $server) {
-            $clients[$key] = new Client($server, $options);
-        }
-
-        return $clients;
-    }
-
     /**
      * Get a specific Redis connection instance.
      *
@@ -86,43 +28,6 @@ class Database implements DatabaseContract
     public function command($method, array $parameters = [])
     {
         return call_user_func_array([$this->clients['default'], $method], $parameters);
-    }
-
-    /**
-     * Subscribe to a set of given channels for messages.
-     *
-     * @param  array|string  $channels
-     * @param  \Closure  $callback
-     * @param  string  $connection
-     * @param  string  $method
-     * @return void
-     */
-    public function subscribe($channels, Closure $callback, $connection = null, $method = 'subscribe')
-    {
-        $loop = $this->connection($connection)->pubSubLoop();
-
-        call_user_func_array([$loop, $method], (array) $channels);
-
-        foreach ($loop as $message) {
-            if ($message->kind === 'message' || $message->kind === 'pmessage') {
-                call_user_func($callback, $message->payload, $message->channel);
-            }
-        }
-
-        unset($loop);
-    }
-
-    /**
-     * Subscribe to a set of given channels with wildcards.
-     *
-     * @param  array|string  $channels
-     * @param  \Closure  $callback
-     * @param  string  $connection
-     * @return void
-     */
-    public function psubscribe($channels, Closure $callback, $connection = null)
-    {
-        return $this->subscribe($channels, $callback, $connection, __FUNCTION__);
     }
 
     /**

--- a/src/Illuminate/Redis/PhpRedisDatabase.php
+++ b/src/Illuminate/Redis/PhpRedisDatabase.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace Illuminate\Redis;
+
+use Redis;
+use Closure;
+use RedisCluster;
+use Illuminate\Support\Arr;
+
+class PhpRedisDatabase extends Database
+{
+    /**
+     * The host address of the database.
+     *
+     * @var array
+     */
+    protected $clients;
+
+    /**
+     * Create a new Redis connection instance.
+     *
+     * @param  array  $servers
+     * @return void
+     */
+    public function __construct(array $servers = [])
+    {
+        $cluster = Arr::pull($servers, 'cluster');
+
+        $options = (array) Arr::pull($servers, 'options');
+
+        if ($cluster) {
+            $this->clients = $this->createAggregateClient($servers, $options);
+        } else {
+            $this->clients = $this->createSingleClients($servers, $options);
+        }
+    }
+
+    /**
+     * Create a new aggregate client supporting sharding.
+     *
+     * @param  array  $servers
+     * @param  array  $options
+     * @return array
+     */
+    protected function createAggregateClient(array $servers, array $options = [])
+    {
+        $servers = array_map([$this, 'buildClusterSeed'], $servers);
+
+        $timeout = empty($options['timeout']) ? 0 : $options['timeout'];
+        $readTimeout = empty($options['read_write_timeout']) ? 0 : $options['read_write_timeout'];
+        $persistent = isset($options['persistent']) && $options['persistent'];
+
+        return ['default' => new RedisCluster(
+            null, array_values($servers), $timeout, $readTimeout, $persistent
+        )];
+    }
+
+    /**
+     * Create an array of single connection clients.
+     *
+     * @param  array  $servers
+     * @param  array  $options
+     * @return array
+     */
+    protected function createSingleClients(array $servers, array $options = [])
+    {
+        $clients = [];
+
+        foreach ($servers as $key => $server) {
+            $client = new Redis;
+
+            $timeout = empty($server['timeout']) ? 0 : $server['timeout'];
+
+            if (isset($server['persistent']) && $server['persistent']) {
+                $client->pconnect($server['host'], $server['port'], $timeout);
+            } else {
+                $client->connect($server['host'], $server['port'], $timeout);
+            }
+
+            if (! empty($server['prefix'])) {
+                $client->setOption(Redis::OPT_PREFIX, $server['prefix']);
+            }
+
+            if (! empty($server['read_write_timeout'])) {
+                $client->setOption(Redis::OPT_READ_TIMEOUT, $server['read_write_timeout']);
+            }
+
+            if (! empty($server['password'])) {
+                $client->auth($server['password']);
+            }
+
+            if (! empty($server['database'])) {
+                $client->select($server['database']);
+            }
+
+            $clients[$key] = $client;
+        }
+
+        return $clients;
+    }
+
+    /**
+     * Build a single cluster seed string from array.
+     *
+     * @param  array  $server
+     * @return string
+     */
+    protected function buildClusterSeed(array $server)
+    {
+        $parameters = [];
+
+        if (! empty($server['database'])) {
+            $parameters['database'] = $server['database'];
+        }
+
+        if (! empty($server['password'])) {
+            $parameters['auth'] = $server['password'];
+        }
+
+        if (! empty($server['prefix'])) {
+            $parameters['prefix'] = $server['prefix'];
+        }
+
+        if (! empty($server['timeout'])) {
+            $parameters['timeout'] = $server['timeout'];
+        }
+
+        if (! empty($server['read_write_timeout'])) {
+            $parameters['read_timeout'] = $server['read_write_timeout'];
+        }
+
+        return $server['host'].':'.$server['port'].'?'.http_build_query($parameters);
+    }
+
+    /**
+     * Subscribe to a set of given channels for messages.
+     *
+     * @param  array|string  $channels
+     * @param  \Closure  $callback
+     * @param  string  $connection
+     * @param  string  $method
+     * @return void
+     */
+    public function subscribe($channels, Closure $callback, $connection = null, $method = 'subscribe')
+    {
+        call_user_func_array([$this->connection($connection), $method], (array) $channels, $callback);
+    }
+
+    /**
+     * Subscribe to a set of given channels with wildcards.
+     *
+     * @param  array|string  $channels
+     * @param  \Closure  $callback
+     * @param  string  $connection
+     * @return void
+     */
+    public function psubscribe($channels, Closure $callback, $connection = null)
+    {
+        $this->psubscribe($channels, $callback, $connection, __FUNCTION__);
+    }
+}

--- a/src/Illuminate/Redis/PredisDatabase.php
+++ b/src/Illuminate/Redis/PredisDatabase.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Illuminate\Redis;
+
+use Closure;
+use Predis\Client;
+use Illuminate\Support\Arr;
+
+class PredisDatabase extends Database
+{
+    /**
+     * The host address of the database.
+     *
+     * @var array
+     */
+    protected $clients;
+
+    /**
+     * Create a new Redis connection instance.
+     *
+     * @param  array  $servers
+     * @return void
+     */
+    public function __construct(array $servers = [])
+    {
+        $cluster = Arr::pull($servers, 'cluster');
+
+        $options = array_merge(['timeout' => 10.0], (array) Arr::pull($servers, 'options'));
+
+        if ($cluster) {
+            $this->clients = $this->createAggregateClient($servers, $options);
+        } else {
+            $this->clients = $this->createSingleClients($servers, $options);
+        }
+    }
+
+    /**
+     * Create a new aggregate client supporting sharding.
+     *
+     * @param  array  $servers
+     * @param  array  $options
+     * @return array
+     */
+    protected function createAggregateClient(array $servers, array $options = [])
+    {
+        return ['default' => new Client(array_values($servers), $options)];
+    }
+
+    /**
+     * Create an array of single connection clients.
+     *
+     * @param  array  $servers
+     * @param  array  $options
+     * @return array
+     */
+    protected function createSingleClients(array $servers, array $options = [])
+    {
+        $clients = [];
+
+        foreach ($servers as $key => $server) {
+            $clients[$key] = new Client($server, $options);
+        }
+
+        return $clients;
+    }
+
+    /**
+     * Subscribe to a set of given channels for messages.
+     *
+     * @param  array|string  $channels
+     * @param  \Closure  $callback
+     * @param  string  $connection
+     * @param  string  $method
+     * @return void
+     */
+    public function subscribe($channels, Closure $callback, $connection = null, $method = 'subscribe')
+    {
+        $loop = $this->connection($connection)->pubSubLoop();
+
+        call_user_func_array([$loop, $method], (array) $channels);
+
+        foreach ($loop as $message) {
+            if ($message->kind === 'message' || $message->kind === 'pmessage') {
+                call_user_func($callback, $message->payload, $message->channel);
+            }
+        }
+
+        unset($loop);
+    }
+
+    /**
+     * Subscribe to a set of given channels with wildcards.
+     *
+     * @param  array|string  $channels
+     * @param  \Closure  $callback
+     * @param  string  $connection
+     * @return void
+     */
+    public function psubscribe($channels, Closure $callback, $connection = null)
+    {
+        $this->subscribe($channels, $callback, $connection, __FUNCTION__);
+    }
+}

--- a/src/Illuminate/Redis/RedisServiceProvider.php
+++ b/src/Illuminate/Redis/RedisServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Redis;
 
+use Illuminate\Support\Arr;
 use Illuminate\Support\ServiceProvider;
 
 class RedisServiceProvider extends ServiceProvider
@@ -21,7 +22,14 @@ class RedisServiceProvider extends ServiceProvider
     public function register()
     {
         $this->app->singleton('redis', function ($app) {
-            return new Database($app['config']['database.redis']);
+            $servers = $app['config']['database.redis'];
+            $client = Arr::pull($servers, 'client');
+
+            if ($client === 'phpredis') {
+                return new PhpRedisDatabase($servers);
+            }
+
+            return new PredisDatabase($servers);
         });
     }
 

--- a/src/Illuminate/Support/Facades/Redis.php
+++ b/src/Illuminate/Support/Facades/Redis.php
@@ -4,6 +4,9 @@ namespace Illuminate\Support\Facades;
 
 /**
  * @see \Illuminate\Redis\Database
+ * @see \Illuminate\Redis\PredisDatabase
+ * @see \Illuminate\Redis\PhpRedisDatabase
+ * @see \Illuminate\Contracts\Redis\Database
  */
 class Redis extends Facade
 {

--- a/tests/Cache/CacheRedisStoreTest.php
+++ b/tests/Cache/CacheRedisStoreTest.php
@@ -131,6 +131,6 @@ class CacheRedisStoreTest extends PHPUnit_Framework_TestCase
 
     protected function getRedis()
     {
-        return new Illuminate\Cache\RedisStore(m::mock('Illuminate\Redis\Database'), 'prefix');
+        return new Illuminate\Cache\RedisStore(m::mock('Illuminate\Redis\PredisDatabase'), 'prefix');
     }
 }

--- a/tests/Queue/QueueRedisQueueTest.php
+++ b/tests/Queue/QueueRedisQueueTest.php
@@ -11,7 +11,7 @@ class QueueRedisQueueTest extends PHPUnit_Framework_TestCase
 
     public function testPushProperlyPushesJobOntoRedis()
     {
-        $queue = $this->getMockBuilder('Illuminate\Queue\RedisQueue')->setMethods(['getRandomId'])->setConstructorArgs([$redis = m::mock('Illuminate\Redis\Database'), 'default'])->getMock();
+        $queue = $this->getMockBuilder('Illuminate\Queue\RedisQueue')->setMethods(['getRandomId'])->setConstructorArgs([$redis = m::mock('Illuminate\Redis\PredisDatabase'), 'default'])->getMock();
         $queue->expects($this->once())->method('getRandomId')->will($this->returnValue('foo'));
         $redis->shouldReceive('connection')->once()->andReturn($redis);
         $redis->shouldReceive('rpush')->once()->with('queues:default', json_encode(['job' => 'foo', 'data' => ['data'], 'id' => 'foo', 'attempts' => 1]));
@@ -22,7 +22,7 @@ class QueueRedisQueueTest extends PHPUnit_Framework_TestCase
 
     public function testDelayedPushProperlyPushesJobOntoRedis()
     {
-        $queue = $this->getMockBuilder('Illuminate\Queue\RedisQueue')->setMethods(['getSeconds', 'getTime', 'getRandomId'])->setConstructorArgs([$redis = m::mock('Illuminate\Redis\Database'), 'default'])->getMock();
+        $queue = $this->getMockBuilder('Illuminate\Queue\RedisQueue')->setMethods(['getSeconds', 'getTime', 'getRandomId'])->setConstructorArgs([$redis = m::mock('Illuminate\Redis\PredisDatabase'), 'default'])->getMock();
         $queue->expects($this->once())->method('getRandomId')->will($this->returnValue('foo'));
         $queue->expects($this->once())->method('getSeconds')->with(1)->will($this->returnValue(1));
         $queue->expects($this->once())->method('getTime')->will($this->returnValue(1));
@@ -41,7 +41,7 @@ class QueueRedisQueueTest extends PHPUnit_Framework_TestCase
     public function testDelayedPushWithDateTimeProperlyPushesJobOntoRedis()
     {
         $date = Carbon\Carbon::now();
-        $queue = $this->getMockBuilder('Illuminate\Queue\RedisQueue')->setMethods(['getSeconds', 'getTime', 'getRandomId'])->setConstructorArgs([$redis = m::mock('Illuminate\Redis\Database'), 'default'])->getMock();
+        $queue = $this->getMockBuilder('Illuminate\Queue\RedisQueue')->setMethods(['getSeconds', 'getTime', 'getRandomId'])->setConstructorArgs([$redis = m::mock('Illuminate\Redis\PredisDatabase'), 'default'])->getMock();
         $queue->expects($this->once())->method('getRandomId')->will($this->returnValue('foo'));
         $queue->expects($this->once())->method('getSeconds')->with($date)->will($this->returnValue(1));
         $queue->expects($this->once())->method('getTime')->will($this->returnValue(1));

--- a/tests/Queue/RedisQueueIntegrationTest.php
+++ b/tests/Queue/RedisQueueIntegrationTest.php
@@ -1,10 +1,10 @@
 <?php
 
 use Mockery as m;
-use Illuminate\Redis\Database;
 use Illuminate\Queue\RedisQueue;
 use Illuminate\Container\Container;
 use Illuminate\Queue\Jobs\RedisJob;
+use Illuminate\Redis\PredisDatabase;
 
 class RedisQueueIntegrationTest extends PHPUnit_Framework_TestCase
 {
@@ -36,7 +36,7 @@ class RedisQueueIntegrationTest extends PHPUnit_Framework_TestCase
             return;
         }
 
-        $this->redis = new Database([
+        $this->redis = new PredisDatabase([
             'cluster' => false,
             'default' => [
                 'host' => $host,

--- a/tests/Redis/RedisConnectionTest.php
+++ b/tests/Redis/RedisConnectionTest.php
@@ -35,6 +35,6 @@ class RedisConnectionTest extends PHPUnit_Framework_TestCase
             ],
         ];
 
-        return new Illuminate\Redis\Database($servers);
+        return new Illuminate\Redis\PredisDatabase($servers);
     }
 }


### PR DESCRIPTION
I messed up the branch and didn't know how to recover. This is the original PR: https://github.com/laravel/framework/pull/14850

Followup from https://github.com/laravel/docs/pull/2500 to add [PhpRedis](https://github.com/phpredis/phpredis) support to Laravel, because it's [significatly](http://alekseykorzun.com/post/53283070010/benchmarking-memcached-and-redis-clients) [faster](http://dev.af83.com/2011/01/01/which-php-library-to-use-with-redis-the-benchmark.html) than Predis.

This is a proof of concept. Feedback/suggestions are greatly appreciated.
- `Illuminate\Redis\Database` is now an abstract class.
- `PredisDatabase` and `PhpRedisDatabase` were introduced, extending `Illuminate\Redis\Database`
- Laravel uses `Illuminate\Contracts\Redis\Database` instead of  `Illuminate\Redis\Database` in most places.
- `Illuminate/Cache/RedisStore` and `Illuminate/Cache/Repository` now check key existence using `null` or `false`.
- Laravel will use Predis as default unless the config value `database.redis.client` is set to `phpredis`.
- Predis connection parameters are mapped to the slightly different `Redis` and `RedisCluster` parameters.
- I've pointed the core alias for `redis` to the abstract `Illuminate\Redis\Database` class. I'm not sure if that's correct, or if we need a Redis Database Manager or similar.

To test/use this:
- Rename (or uncomment) `Redis` facade in `config/app.php`.
- Add `'client' => 'phpredis',` to `redis` array in `config/database.php`.
