### PR TITLE
[5.3] Cache: fix file store extending cache expiration time

### DIFF
--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -83,8 +83,8 @@ class FileStore implements Store
 
         // Next, we'll extract the number of minutes that are remaining for a cache
         // so that we can properly retain the time for things like the increment
-        // operation that may be performed on the cache. We'll round this out.
-        $time = ceil(($expire - time()) / 60);
+        // operation that may be performed on the cache.
+        $time = ($expire - time()) / 60;
 
         return compact('data', 'time');
     }
@@ -132,7 +132,7 @@ class FileStore implements Store
 
         $int = ((int) $raw['data']) + $value;
 
-        $this->put($key, $int, (int) $raw['time']);
+        $this->put($key, $int, $raw['time']);
 
         return $int;
     }
@@ -213,7 +213,7 @@ class FileStore implements Store
      */
     protected function expiration($minutes)
     {
-        $time = time() + ($minutes * 60);
+        $time = time() + (int) ($minutes * 60);
 
         if ($minutes === 0 || $time > 9999999999) {
             return 9999999999;

--- a/tests/Cache/CacheFileStoreTest.php
+++ b/tests/Cache/CacheFileStoreTest.php
@@ -79,6 +79,20 @@ class CacheFileStoreTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('Hello World', $store->get('foo'));
     }
 
+    public function testIncrementDoesNotExtendCacheLife()
+    {
+        $files = $this->mockFilesystem();
+        $expiration = time() + 59;
+        $initialValue = $expiration.serialize(1);
+        $valueAfterIncrement = $expiration.serialize(2);
+        $store = new FileStore($files, __DIR__);
+        $files->expects($this->once())->method('get')->will($this->returnValue($initialValue));
+        $hash = sha1('foo');
+        $cache_dir = substr($hash, 0, 2).'/'.substr($hash, 2, 2);
+        $files->expects($this->once())->method('put')->with($this->equalTo(__DIR__.'/'.$cache_dir.'/'.$hash), $this->equalTo($valueAfterIncrement));
+        $store->increment('foo');
+    }
+
     public function testRemoveDeletesFileDoesntExist()
     {
         $files = $this->mockFilesystem();


### PR DESCRIPTION
Problem: When incrementing a cached value which expires in less than a minute, the expiration time is extended to a full minute. This mainly causes problems when using API rate limiter with `file` cache driver, see #15152.

Solution: don't round up the remaining number of minutes when retrieving cache payload, cast calculated seconds to `int` in `expiration()` instead.

Other cache drivers don't seem to have this problem.
