### PR TITLE
[5.3] Handle validating failed file uploads

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -150,6 +150,13 @@ class Validator implements ValidatorContract
     protected $sizeRules = ['Size', 'Between', 'Min', 'Max'];
 
     /**
+     * The validation rules that work with files.
+     *
+     * @var array
+     */
+    protected $fileRules = ['File', 'Image', 'Mimes', 'Mimetypes', 'Min', 'Max', 'Size', 'Between', 'Dimensions'];
+
+    /**
      * The numeric related validation rules.
      *
      * @var array
@@ -518,6 +525,15 @@ class Validator implements ValidatorContract
         // that the attribute is required, rules are not run for missing values.
         $value = $this->getValue($attribute);
 
+        if (
+            $value instanceof UploadedFile &&
+            ! $value->isValid() &&
+            $this->hasRule($attribute, array_merge($this->fileRules, $this->implicitRules))
+        ) {
+            return $this->addFailure($attribute, 'file_uploaded', []);
+        }
+
+
         $validatable = $this->isValidatable($rule, $attribute, $value);
 
         $method = "validate{$rule}";
@@ -760,6 +776,10 @@ class Validator implements ValidatorContract
     {
         if ($this->hasRule($attribute, ['Bail'])) {
             return $this->messages->has($attribute);
+        }
+
+        if (isset($this->failedRules[$attribute]) && in_array('file_uploaded', array_keys($this->failedRules[$attribute]))) {
+            return true;
         }
 
         // In case the attribute has any rule that indicates that the field is required

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -769,6 +769,46 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('The last field is required unless first is in taylor, sven.', $v->messages()->first('last'));
     }
 
+    public function testFailedFileUploads()
+    {
+        $trans = $this->getRealTranslator();
+
+        // If file is not successfully uploaded validation should fail with a
+        // 'file_uploaded' error message instead of the original rule.
+        $file = m::mock('Symfony\Component\HttpFoundation\File\UploadedFile');
+        $file->shouldReceive('isValid')->andReturn(false);
+        $file->shouldNotReceive('getSize');
+        $v = new Validator($trans, [], ['photo' => 'Max:10']);
+        $v->setFiles(['photo' => $file]);
+        $this->assertTrue($v->fails());
+        $this->assertEquals(['validation.file_uploaded'], $v->errors()->get('photo'));
+
+        // Even "required" will not run if the file failed to upload.
+        $file = m::mock('Symfony\Component\HttpFoundation\File\UploadedFile');
+        $file->shouldReceive('isValid')->once()->andReturn(false);
+        $v = new Validator($trans, [], ['photo' => 'required']);
+        $v->setFiles(['photo' => $file]);
+        $this->assertTrue($v->fails());
+        $this->assertEquals(['validation.file_uploaded'], $v->errors()->get('photo'));
+
+        // It should only fail with that rule if a validation rule implies it's
+        // a file. Otherwise it should fail with the regular rule.
+        $file = m::mock('Symfony\Component\HttpFoundation\File\UploadedFile');
+        $file->shouldReceive('isValid')->andReturn(false);
+        $v = new Validator($trans, [], ['photo' => 'string']);
+        $v->setFiles(['photo' => $file]);
+        $this->assertTrue($v->fails());
+        $this->assertEquals(['validation.string'], $v->errors()->get('photo'));
+
+        // Validation shouldn't continue if a file failed to upload.
+        $file = m::mock('Symfony\Component\HttpFoundation\File\UploadedFile');
+        $file->shouldReceive('isValid')->once()->andReturn(false);
+        $v = new Validator($trans, [], ['photo' => 'file|mimes:pdf|min:10']);
+        $v->setFiles(['photo' => $file]);
+        $this->assertTrue($v->fails());
+        $this->assertEquals(['validation.file_uploaded'], $v->errors()->get('photo'));
+    }
+
     public function testValidateInArray()
     {
         $trans = $this->getRealTranslator();
@@ -1187,7 +1227,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $this->assertFalse($v->passes());
 
         $file = $this->getMockBuilder('Symfony\Component\HttpFoundation\File\UploadedFile')->setMethods(['isValid', 'getSize'])->setConstructorArgs([__FILE__, basename(__FILE__)])->getMock();
-        $file->expects($this->at(0))->method('isValid')->will($this->returnValue(true));
+        $file->expects($this->any())->method('isValid')->will($this->returnValue(true));
         $file->expects($this->at(1))->method('getSize')->will($this->returnValue(3072));
         $v = new Validator($trans, [], ['photo' => 'Max:10']);
         $v->setFiles(['photo' => $file]);


### PR DESCRIPTION
This PR is an attempt to deal with these issues: https://github.com/laravel/framework/issues/8203, https://github.com/laravel/framework/issues/4467, https://github.com/laravel/framework/issues/4226 and many other duplicates.

The problem:
When uploading files greater than `upload_max_filesize` all validation rules related to file validation fails due to the file being invalid. Also a required validation rule will return false so the user will get "The file is required" even though he did attach a file to the form.

The suggested solution:
While validating each rule we check if the value is a file that failed to upload `isValid()===false` and that a rule that imply the field is required or is a file was being used. If that's the case we cause the validation to fail with a message `file_uploaded`, this message will have a translation line in the language files and the output will be `The image uploading failed.`.

This behaviour will indicate a generic upload failure instead of showing a validation error that's not related to the actual problem.
