### PR TITLE
[5.1] Fix jobs that cause indefinite looping if queue driver goes away

### DIFF
--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -146,17 +146,27 @@ class Worker
      */
     public function pop($connectionName, $queue = null, $delay = 0, $sleep = 3, $maxTries = 0)
     {
-        $connection = $this->manager->connection($connectionName);
+        try {
+            $connection = $this->manager->connection($connectionName);
 
-        $job = $this->getNextJob($connection, $queue);
+            $job = $this->getNextJob($connection, $queue);
 
-        // If we're able to pull a job off of the stack, we will process it and
-        // then immediately return back out. If there is no job on the queue
-        // we will "sleep" the worker for the specified number of seconds.
-        if (! is_null($job)) {
-            return $this->process(
-                $this->manager->getName($connectionName), $job, $maxTries, $delay
-            );
+            // If we're able to pull a job off of the stack, we will process it and
+            // then immediately return back out. If there is no job on the queue
+            // we will "sleep" the worker for the specified number of seconds.
+            if (! is_null($job)) {
+                return $this->process(
+                    $this->manager->getName($connectionName), $job, $maxTries, $delay
+                );
+            }
+        } catch (Exception $e) {
+            if ($this->exceptions) {
+                $this->exceptions->report($e);
+            }
+        } catch (Throwable $e) {
+            if ($this->exceptions) {
+                $this->exceptions->report(new FatalThrowableError($e));
+            }
         }
 
         $this->sleep($sleep);


### PR DESCRIPTION
In instances where your queue driver goes away (network connectivity,
database locks, jobs table doesn’t exist, etc), exceptions are
generated but never caught by the `pop` method.

As a result, `sleep` is never called and these exceptions are spewed to
`laravel.log` until either somebody notices, the driver returns, or the
log file fills the disk entirely/you tank your <remote bug tracking
service> quota for the month.
