### PR TITLE
[5.4] Add ability to set custom view names in auth based controllers

### DIFF
--- a/src/Illuminate/Foundation/Auth/AuthenticatesUsers.php
+++ b/src/Illuminate/Foundation/Auth/AuthenticatesUsers.php
@@ -11,13 +11,23 @@ trait AuthenticatesUsers
     use RedirectsUsers, ThrottlesLogins;
 
     /**
+     * Get the login form view name to be used by the controller.
+     *
+     * @return string
+     */
+    public function loginFormViewName()
+    {
+        return property_exists($this, 'loginFormViewName') ? $this->loginFormViewName : 'auth.login';
+    }
+
+    /**
      * Show the application's login form.
      *
      * @return \Illuminate\Http\Response
      */
     public function showLoginForm()
     {
-        return view('auth.login');
+        return view($this->loginFormViewName());
     }
 
     /**

--- a/src/Illuminate/Foundation/Auth/RegistersUsers.php
+++ b/src/Illuminate/Foundation/Auth/RegistersUsers.php
@@ -10,13 +10,23 @@ trait RegistersUsers
     use RedirectsUsers;
 
     /**
+     * Get the registration form view name to be used by the controller.
+     *
+     * @return string
+     */
+    public function registrationFormViewName()
+    {
+        return property_exists($this, 'registrationFormViewName') ? $this->registrationFormViewName : 'auth.register';
+    }
+
+    /**
      * Show the application registration form.
      *
      * @return \Illuminate\Http\Response
      */
     public function showRegistrationForm()
     {
-        return view('auth.register');
+        return view($this->registrationFormViewName());
     }
 
     /**

--- a/src/Illuminate/Foundation/Auth/SendsPasswordResetEmails.php
+++ b/src/Illuminate/Foundation/Auth/SendsPasswordResetEmails.php
@@ -8,13 +8,23 @@ use Illuminate\Support\Facades\Password;
 trait SendsPasswordResetEmails
 {
     /**
+     * Get the link request form view name to be used by the controller.
+     *
+     * @return string
+     */
+    public function linkRequestFormViewName()
+    {
+        return property_exists($this, 'linkRequestFormViewName') ? $this->linkRequestFormViewName : 'auth.passwords.email';
+    }
+
+    /**
      * Display the form to request a password reset link.
      *
      * @return \Illuminate\Http\Response
      */
     public function showLinkRequestForm()
     {
-        return view('auth.passwords.email');
+        return view($this->linkRequestFormViewName());
     }
 
     /**


### PR DESCRIPTION
When using custom guards, user may want to use a different form view than the default.
We check for existing properties and use it if available and if not revert back to default.
We can set custom view names for:
1) login form
2) register form
3) send password reset email form
