### PR TITLE
[5.3] Add pick function to collection

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -716,7 +716,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
-     * Create a collection of all elements pulled by their keys
+     * Create a collection of all elements pulled by their keys.
      * @param  mixed $keys
      * @param  array|null  $defaults
      * @return static

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -716,6 +716,26 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
+     * Create a collection of all elements pulled by their keys
+     * @param  mixed $keys
+     * @param  array|null  $defaults
+     * @return static
+     */
+    public function pick($keys, array $defaults = null)
+    {
+        $chunks = [];
+
+        $keys = $this->getArrayableItems($keys);
+
+        foreach ($keys as $key) {
+            $default = ($defaults && array_key_exists($key, $defaults)) ? $defaults[$key] : null;
+            $chunks[$key] = $this->pull($key, $default);
+        }
+
+        return new static($chunks);
+    }
+
+    /**
      * Pass the collection to the given callback and return the result.
      *
      * @param  callable $callback

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1554,6 +1554,86 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
         $collection = new Collection(new \ArrayObject(['foo' => 1, 'bar' => 2, 'baz' => 3]));
         $this->assertEquals(['foo' => 1, 'bar' => 2, 'baz' => 3], $collection->toArray());
     }
+
+    public function testPickRetrievesItemFromCollectionUsingIndex()
+    {
+        $c = new Collection(['foo', 'bar']);
+
+        $this->assertEquals(['foo'], $c->pick(0)->toArray());
+        $this->assertEquals([1 => 'bar'], $c->all());
+    }
+
+    public function testPickRetrievesItemsFromCollectionUsingIndex()
+    {
+        $c = new Collection(['foo', 'bar']);
+
+        $this->assertEquals(['foo', 'bar'], $c->pick([0, 1])->toArray());
+        $this->assertEquals([], $c->all());
+    }
+
+    public function testPickRetrievesNonexistingItemFromCollection()
+    {
+        $c = new Collection(['foo', 'bar']);
+
+        $this->assertEquals(['foo' => null], $c->pick('foo')->toArray());
+        $this->assertEquals(['foo', 'bar'], $c->all());
+    }
+
+    public function testPickRetrievesNonexistingItemsFromCollection()
+    {
+        $c = new Collection(['foo', 'bar']);
+
+        $this->assertEquals(['foo' => null, 'bar' => null], $c->pick(['foo', 'bar'])->toArray());
+        $this->assertEquals(['foo', 'bar'], $c->all());
+    }
+
+    public function testPickRetrievesNonexistingItemFromCollectionReturnsDefault()
+    {
+        $c = new Collection(['foo', 'bar']);
+
+        $this->assertEquals(['foo' => 1], $c->pick('foo', ['foo' => 1])->toArray());
+        $this->assertEquals(['foo', 'bar'], $c->all());
+    }
+
+    public function testPickRetrievesNonexistingItemsFromCollectionReturnsDefaults()
+    {
+        $c = new Collection(['foo', 'bar']);
+
+        $this->assertEquals(['foo' => 1, 'bar' => null], $c->pick(['foo', 'bar'], ['foo' => 1])->toArray());
+        $this->assertEquals(['foo', 'bar'], $c->all());
+    }
+
+    public function testPickRetrievesItemFromAssociativeCollection()
+    {
+        $c = new Collection(['foo' => 1, 'bar' => 2, 'baz' => 3]);
+
+        $this->assertEquals(['foo' => 1], $c->pick('foo')->toArray());
+        $this->assertEquals(['bar' => 2, 'baz' => 3], $c->all());
+    }
+
+    public function testPickRetrievesItemsFromAssociativeCollection()
+    {
+        $c = new Collection(['foo' => 1, 'bar' => 2, 'baz' => 3]);
+
+        $this->assertEquals(['foo' => 1, 'bar' => 2], $c->pick(['foo', 'bar'])->toArray());
+        $this->assertEquals(['baz' => 3], $c->all());
+    }
+
+    public function testPickRetrievesItemsFromAssociativeCollectionIncludingNonexistingItems()
+    {
+        $c = new Collection(['foo' => 1, 'bar' => 2, 'baz' => 3]);
+
+        $this->assertEquals(['foo' => 1, 'bar' => 2, 'zap' => null], $c->pick(['foo', 'bar', 'zap'])->toArray());
+        $this->assertEquals(['baz' => 3], $c->all());
+    }
+
+    public function testPickRetrievesItemsFromAssociativeCollectionIncludingNonexistingItemsReturnsDefaults()
+    {
+        $c = new Collection(['foo' => 1, 'bar' => 2, 'baz' => 3]);
+
+        $this->assertEquals(['foo' => 1, 'bar' => 2, 'zap' => 4], $c->pick(['foo', 'bar', 'zap'], ['zap' => 4])->toArray());
+        $this->assertEquals(['baz' => 3], $c->all());
+    }
 }
 
 class TestAccessorEloquentTestStub


### PR DESCRIPTION
The PR add a `pick` function to the Collection class which allows pulling elements by their keys, returning a new collection with passed keys.

For example,  we want to `firstOrCreate` a user with attributes `foo`, `bar` and `zap` while  using `baz` as an additional attribute.

``` php
// Request::all or Request::only
$data = [
    'foo' => 1,
    'bar' => 2,
    'baz' => 3,
];

$attributes = collect($data);
```

Traditional way:

``` php
$picked = [
    'foo' => $attributes->pull('foo'),
    'bar' => $attributes->pull('bar'),
    'zap' => $attributes->pull('zap', 'default')
];

User::firstOrCreate($picked, $c->all());
```

With `pick`:

``` php
User::firstOrCreate(
    $attributes->pick(['foo', 'bar', 'zap'], ['zap' => 'default']),
    $attributes->all()
);
```
