### PR TITLE
[5.3] JSON response for private and presence channels auth method

### DIFF
--- a/src/Illuminate/Broadcasting/Broadcasters/PusherBroadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/PusherBroadcaster.php
@@ -37,7 +37,7 @@ class PusherBroadcaster extends Broadcaster
     public function auth($request)
     {
         if (Str::startsWith($request->channel_name, ['private-', 'presence-']) &&
-            !$request->user()
+            ! $request->user()
         ) {
             throw new HttpException(403);
         }
@@ -63,8 +63,7 @@ class PusherBroadcaster extends Broadcaster
             return new JsonResponse(
                 $this->pusher->presence_auth(
                     $request->channel_name, $request->socket_id, $request->user()->id, $result
-                )
-                , 200, [], true);
+                ), 200, [], true);
         }
     }
 

--- a/src/Illuminate/Broadcasting/Broadcasters/PusherBroadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/PusherBroadcaster.php
@@ -5,6 +5,7 @@ namespace Illuminate\Broadcasting\Broadcasters;
 use Pusher;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
+use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 
 class PusherBroadcaster extends Broadcaster
@@ -19,7 +20,7 @@ class PusherBroadcaster extends Broadcaster
     /**
      * Create a new broadcaster instance.
      *
-     * @param  \Pusher  $pusher
+     * @param  \Pusher $pusher
      * @return void
      */
     public function __construct(Pusher $pusher)
@@ -30,13 +31,14 @@ class PusherBroadcaster extends Broadcaster
     /**
      * Authenticate the incoming request for a given channel.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  \Illuminate\Http\Request $request
      * @return mixed
      */
     public function auth($request)
     {
         if (Str::startsWith($request->channel_name, ['private-', 'presence-']) &&
-            ! $request->user()) {
+            !$request->user()
+        ) {
             throw new HttpException(403);
         }
 
@@ -48,27 +50,30 @@ class PusherBroadcaster extends Broadcaster
     /**
      * Return the valid authentication response.
      *
-     * @param  \Illuminate\Http\Request  $request
-     * @param  mixed  $result
+     * @param  \Illuminate\Http\Request $request
+     * @param  mixed $result
      * @return mixed
      */
     public function validAuthenticationResponse($request, $result)
     {
         if (Str::startsWith($request->channel_name, 'private')) {
-            return $this->pusher->socket_auth($request->channel_name, $request->socket_id);
+            return new JsonResponse($this->pusher->socket_auth($request->channel_name, $request->socket_id), 200, [],
+                true);
         } else {
-            return $this->pusher->presence_auth(
-                $request->channel_name, $request->socket_id, $request->user()->id, $result
-            );
+            return new JsonResponse(
+                $this->pusher->presence_auth(
+                    $request->channel_name, $request->socket_id, $request->user()->id, $result
+                )
+                , 200, [], true);
         }
     }
 
     /**
      * Broadcast the given event.
      *
-     * @param  array  $channels
-     * @param  string  $event
-     * @param  array  $payload
+     * @param  array $channels
+     * @param  string $event
+     * @param  array $payload
      * @return void
      */
     public function broadcast(array $channels, $event, array $payload = [])

--- a/src/Illuminate/Broadcasting/Broadcasters/RedisBroadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/RedisBroadcaster.php
@@ -5,6 +5,7 @@ namespace Illuminate\Broadcasting\Broadcasters;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Contracts\Redis\Database as RedisDatabase;
+use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 
 class RedisBroadcaster extends Broadcaster
@@ -64,10 +65,10 @@ class RedisBroadcaster extends Broadcaster
     public function validAuthenticationResponse($request, $result)
     {
         if (is_bool($result)) {
-            return json_encode($result);
+            return new JsonResponse($result);
         }
 
-        return json_encode(['channel_data' => [
+        return new JsonResponse(['channel_data' => [
             'user_id' => $request->user()->getKey(),
             'user_info' => $result,
         ]]);


### PR DESCRIPTION
Now PusherBroadcaster and RedisBroadcaster return header: **Content-type: text/html**
I use debugbar and spend many time while debug subscriptions to private channel with Pusher. Error with subscription was caused by panel that added to response when **Content-type: text/html**

![image](https://cloud.githubusercontent.com/assets/2044754/18139057/24591542-6fc9-11e6-856e-27709906128a.png)

After this fix response header will be set correctly to `application/json`
![image](https://cloud.githubusercontent.com/assets/2044754/18139093/564ea788-6fc9-11e6-9d3a-18471a243114.png)

And debugbar don't add panel and all works perfect.
