### PR TITLE
[5.3] All Whitespace Validation Rule

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -819,7 +819,7 @@ class Validator implements ValidatorContract
 
         return true;
     }
-    
+
     /**
      * Validate that the given attribute does not contain all whitespaces if it is present.
      *

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -163,7 +163,7 @@ class Validator implements ValidatorContract
      */
     protected $implicitRules = [
         'Required', 'Filled', 'RequiredWith', 'RequiredWithAll', 'RequiredWithout', 'RequiredWithoutAll',
-        'RequiredIf', 'RequiredUnless', 'Accepted', 'Present',
+        'RequiredIf', 'RequiredUnless', 'Accepted', 'Present', 'AllWhitespace',
     ];
 
     /**
@@ -815,6 +815,22 @@ class Validator implements ValidatorContract
     {
         if (Arr::has(array_merge($this->data, $this->files), $attribute)) {
             return $this->validateRequired($attribute, $value);
+        }
+
+        return true;
+    }
+    
+    /**
+     * Validate that the given attribute does not contain all whitespaces if it is present.
+     *
+     * @param  string  $attribute
+     * @param  mixed   $value
+     * @return bool
+     */
+    protected function validateAllWhitespace($attribute, $value)
+    {
+        if (ctype_space($value)) {
+            return false;
         }
 
         return true;

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -516,7 +516,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $v = new Validator($trans, ['foo' => [['id' => 1], ['id' => null]]], ['foo.*.id' => 'present']);
         $this->assertTrue($v->passes());
     }
-    
+
     public function testValidateAllWhitespace()
     {
         $trans = $this->getRealTranslator();
@@ -528,7 +528,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
         $v = new Validator($trans, ['name' => 'foo'], ['name' => 'all_whitespace']);
         $this->assertTrue($v->passes());
-        
+
         $v = new Validator($trans, ['name' => ' '], ['name' => 'all_whitespace']);
         $this->assertFalse($v->passes());
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -516,6 +516,34 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $v = new Validator($trans, ['foo' => [['id' => 1], ['id' => null]]], ['foo.*.id' => 'present']);
         $this->assertTrue($v->passes());
     }
+    
+    public function testValidateAllWhitespace()
+    {
+        $trans = $this->getRealTranslator();
+        $v = new Validator($trans, [], ['name' => 'all_whitespace']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['name' => ''], ['name' => 'all_whitespace']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['name' => 'foo'], ['name' => 'all_whitespace']);
+        $this->assertTrue($v->passes());
+        
+        $v = new Validator($trans, ['name' => ' '], ['name' => 'all_whitespace']);
+        $this->assertFalse($v->passes());
+
+        $file = new File('', false);
+        $v = new Validator($trans, ['name' => $file], ['name' => 'all_whitespace']);
+        $this->assertTrue($v->passes());
+        
+        $file = new File(' ', false);
+        $v = new Validator($trans, ['name' => $file], ['name' => 'all_whitespace']);
+        $this->assertFalse($v->passes());
+
+        $file = new File(__FILE__, false);
+        $v = new Validator($trans, ['name' => $file], ['name' => 'all_whitespace']);
+        $this->assertTrue($v->passes());
+    }
 
     public function testValidateRequired()
     {

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -535,10 +535,6 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $file = new File('', false);
         $v = new Validator($trans, ['name' => $file], ['name' => 'all_whitespace']);
         $this->assertTrue($v->passes());
-        
-        $file = new File(' ', false);
-        $v = new Validator($trans, ['name' => $file], ['name' => 'all_whitespace']);
-        $this->assertFalse($v->passes());
 
         $file = new File(__FILE__, false);
         $v = new Validator($trans, ['name' => $file], ['name' => 'all_whitespace']);


### PR DESCRIPTION
Currently if an input containing all whitespace is validated, and an implicit rule such as required is not applied, the input will simply be ignored, and no sort of error message created. The all_whitespace rule would throw an error stating that the field cannot contain all whitespace.

[See question here for more details](http://stackoverflow.com/questions/39258434/whitespace-not-caught-by-laravel-validation).
