### PR TITLE
[5.3] Add concatenate method to Support/Collection

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -652,6 +652,20 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
+     * Concatenate the collection and the given items.
+     *
+     * @param  mixed  $items
+     * @return static
+     */
+    public function concatenate($items)
+    {
+        return new static(array_merge(
+            array_values($this->items),
+            array_values($this->getArrayableItems($items))
+        ));
+    }
+
+    /**
      * Create a collection by using this collection for keys and another for its values.
      *
      * @param  mixed  $values

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -146,6 +146,43 @@ class DatabaseEloquentCollectionTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(new Collection([$one, $two, $three]), $c1->merge($c2));
     }
 
+    public function testCollectionConcatenateDoesNotRemoveDuplicates()
+    {
+        $one = m::mock('Illuminate\Database\Eloquent\Model');
+        $one->shouldReceive('getKey')->andReturn(1);
+
+        $two = m::mock('Illuminate\Database\Eloquent\Model');
+        $two->shouldReceive('getKey')->andReturn(2);
+
+        $three = m::mock('Illuminate\Database\Eloquent\Model');
+        $three->shouldReceive('getKey')->andReturn(3);
+
+        $c1 = new Collection([$one, $two]);
+        $c2 = new Collection([$two, $three]);
+
+        $this->assertEquals(new Collection([$one, $two, $two, $three]), $c1->concatenate($c2));
+    }
+
+    public function testCollectionConcatenateWorksLikeMergeWhenNoDuplicatesArePresent()
+    {
+        $one = m::mock('Illuminate\Database\Eloquent\Model');
+        $one->shouldReceive('getKey')->andReturn(1);
+
+        $two = m::mock('Illuminate\Database\Eloquent\Model');
+        $two->shouldReceive('getKey')->andReturn(2);
+
+        $three = m::mock('Illuminate\Database\Eloquent\Model');
+        $three->shouldReceive('getKey')->andReturn(3);
+
+        $four = m::mock('Illuminate\Database\Eloquent\Model');
+        $four->shouldReceive('getKey')->andReturn(4);
+
+        $c1 = new Collection([$one, $two]);
+        $c2 = new Collection([$three, $four]);
+
+        $this->assertEquals(new Collection([$one, $two, $three, $four]), $c1->concatenate($c2));
+    }
+
     public function testMap()
     {
         $one = m::mock('Illuminate\Database\Eloquent\Model');

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -443,6 +443,67 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(['name' => 'World', 'id' => 1], $c->merge(new Collection(['name' => 'World', 'id' => 1]))->all());
     }
 
+    public function testConcatenateNull()
+    {
+        $c = new Collection(['name' => 'Hello']);
+
+        $this->assertEquals(['Hello'], $c->concatenate(null)->all());
+    }
+
+    public function testConcatenateArrayWithDifferentKeys()
+    {
+        $first = new Collection(['name' => 'Hello']);
+        $second = ['id' => 1];
+
+        $this->assertEquals(['Hello', 1], $first->concatenate($second)->all());
+    }
+
+    public function testConcatenateArrayWithRepeatingKeys()
+    {
+        $first = new Collection(['name' => 'Hello', 'id' => 1]);
+        $second = ['name' => 'World', 'id' => 2];
+
+        $this->assertEquals(['Hello', 1, 'World', 2], $first->concatenate($second)->all());
+    }
+
+    public function testConcatenateCollectionWithDifferentKeys()
+    {
+        $first = new Collection(['name' => 'Hello']);
+        $second = new Collection(['id' => 1]);
+
+        $this->assertEquals(['Hello', 1], $first->concatenate($second)->all());
+    }
+
+    public function testConcatenateCollectionWithRepeatingKeys()
+    {
+        $first = new Collection(['name' => 'Hello', 'id' => 1]);
+        $second = new Collection(['name' => 'World', 'id' => 2]);
+
+        $this->assertEquals(['Hello', 1, 'World', 2], $first->concatenate($second)->all());
+    }
+
+    public function testConcatenateNonAssociativeCollectionWorksLikeMerge()
+    {
+        $first = new Collection(['first', 'second']);
+        $second = new Collection(['third', 'fourth']);
+
+        $expected = $first->merge($second);
+        $actual = $first->concatenate($second);
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function testConcatenateNonAssociativeArrayWorksLikeMerge()
+    {
+        $first = new Collection(['first', 'second']);
+        $second = ['third', 'fourth'];
+
+        $expected = $first->merge($second);
+        $actual = $first->concatenate($second);
+
+        $this->assertEquals($expected, $actual);
+    }
+
     public function testUnionNull()
     {
         $c = new Collection(['name' => 'Hello']);


### PR DESCRIPTION
As described here: https://github.com/laravel/framework/issues/15182

Another option would be to iterate over provided items and add them one by one but that has proven to be 30% slower.
