### PR TITLE
[5.3] Optimize Arr::first when array is large

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -134,7 +134,13 @@ class Arr
     public static function first($array, callable $callback = null, $default = null)
     {
         if (is_null($callback)) {
-            return empty($array) ? value($default) : reset($array);
+            if (empty($array)) {
+                return value($default);
+            }
+
+            foreach ($array as $item) {
+                return $item;
+            }
         }
 
         foreach ($array as $key => $value) {


### PR DESCRIPTION
Variable in PHP uses copy-on-write (http://php.net/manual/en/internals2.variables.intro.php).

Thus, using reset to get the array first element will take additional time.

The side effect is particularly evident when the array is large.

Benchmark: http://sandbox.onlinephpfunctions.com/code/d16f2e69944643bd49ad3b2beb4d37ad23a2d742
