### PR TITLE
Adding a test to make sure the session id bug doesn't come back

### DIFF
--- a/tests/Session/SessionStoreTest.php
+++ b/tests/Session/SessionStoreTest.php
@@ -64,9 +64,11 @@ class SessionStoreTest extends PHPUnit_Framework_TestCase
     public function testCantSetInvalidId()
     {
         $session = $this->getSession();
+        $this->assertTrue($session->isValidId($session->getId()));
 
         $session->setId(null);
         $this->assertNotNull($session->getId());
+        $this->assertTrue($session->isValidId($session->getId()));
 
         $session->setId(['a']);
         $this->assertNotSame(['a'], $session->getId());


### PR DESCRIPTION
I've been following the issues from the last couple of days and it surprised me that there was no test to verify that a newly-generated session id is valid according to the `isValidId()` method.

I've made this change on the `5.1` branch because my dev environment is still on an older version of php. Should still work the same in `5.3`. Please let me know if anything needs to be changed
