### PR TITLE
[5.3] Added between and unlessBetween to Scheduler

### DIFF
--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -728,7 +728,7 @@ class Event
      * @param  string  $endTime
      * @return $this
      */
-    public function exceptBetween($startTime, $endTime)
+    public function unlessBetween($startTime, $endTime)
     {
         return $this->skip($this->inTimeInterval($startTime, $endTime));
     }

--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -710,6 +710,49 @@ class Event
     }
 
     /**
+     * Schedule the event to run between start and end time.
+     *
+     * @param  string  $startTime
+     * @param  string  $endTime
+     * @return $this
+     */
+    public function between($startTime, $endTime)
+    {
+        return $this->when($this->inTimeInterval($startTime, $endTime));
+    }
+
+    /**
+     * Schedule the event to not run between start and end time.
+     *
+     * @param  string  $startTime
+     * @param  string  $endTime
+     * @return $this
+     */
+    public function exceptBetween($startTime, $endTime)
+    {
+        return $this->skip($this->inTimeInterval($startTime, $endTime));
+    }
+
+    /**
+     * Schedule the event to run between start and end time.
+     *
+     * @param  string  $startTime
+     * @param  string  $endTime
+     * @return \Closure
+     */
+    private function inTimeInterval($startTime, $endTime)
+    {
+        $startTime = str_replace(":", "", $startTime);
+        $endTime = str_replace(":", "", $endTime);
+
+        return function() use($startTime, $endTime) {
+            $now = Carbon::now()->format('Hi');
+
+            return $now >= $startTime && $now <= $endTime;
+        };
+    }
+
+    /**
      * Send the output of the command to a given location.
      *
      * @param  string  $location

--- a/tests/Console/ConsoleScheduledEventTest.php
+++ b/tests/Console/ConsoleScheduledEventTest.php
@@ -118,7 +118,7 @@ class ConsoleScheduledEventTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($event->between("9:00", "9:00")->filtersPass($app));
         $this->assertFalse($event->between("10:00", "11:00")->filtersPass($app));
 
-        $this->assertFalse($event->exceptBetween("8:00", "10:00")->filtersPass($app));
-        $this->assertTrue($event->exceptBetween("10:00", "11:00")->isDue($app));
+        $this->assertFalse($event->unlessBetween("8:00", "10:00")->filtersPass($app));
+        $this->assertTrue($event->unlessBetween("10:00", "11:00")->isDue($app));
     }
 }


### PR DESCRIPTION
This allows you to run commands only between certain times of the day or exclude certain times of day. 

The current solution makes use of the `when` method and is showed below.

![image](https://cloud.githubusercontent.com/assets/1517011/18182710/b349b6d4-7056-11e6-97e7-fc5c070eef10.png)

with the new `between` method, you could substitute the entire `when` with `between("8:00", "17:00")`.

the `unlessBetween` function handles instances where you want a job to be excluded from running for certain periods of time.

Tests written and passing ✅
