### PR TITLE
[5.4] Allow the first validation error to be found on wildcard lookups

### DIFF
--- a/src/Illuminate/Support/MessageBag.php
+++ b/src/Illuminate/Support/MessageBag.php
@@ -146,7 +146,7 @@ class MessageBag implements Arrayable, Countable, Jsonable, JsonSerializable, Me
     {
         $messages = is_null($key) ? $this->all($format) : $this->get($key, $format);
 
-        return count($messages) > 0 ? $messages[0] : '';
+        return head(array_flatten($messages)) ?: '';
     }
 
     /**

--- a/tests/Support/SupportMessageBagTest.php
+++ b/tests/Support/SupportMessageBagTest.php
@@ -188,4 +188,13 @@ class SupportMessageBagTest extends PHPUnit_Framework_TestCase
         $messageBag = new MessageBag(['country' => 'Azerbaijan', 'capital' => 'Baku']);
         $this->assertEquals(['country' => ['Azerbaijan'], 'capital' => ['Baku']], $messageBag->getMessages());
     }
+
+    public function testFirstFindsMessageForWildcardKey()
+    {
+        $container = new MessageBag;
+        $container->setFormat(':message');
+        $container->add('foo.bar', 'baz');
+        $messages = $container->getMessages();
+        $this->assertEquals('baz', $container->first('foo.*'));
+    }
 }


### PR DESCRIPTION
With validation rules like

```
'photos.image' => 'required|image',
'photos.caption' => 'required|min:20',
```

If an image and no caption are provided and we ask the messagebag if `photos.*` has any errors 

```
$errors->has('photos.*');
```

an `\ErrorException` occurs:

```
Undefined offset: 0
```

because the structure of the errors array in this situation is like

```
[
    'photos.caption' => [
        'The photos.caption field is required'
    ]
]
```

This PR flattens and filters empty validation messages regardless of depth, returning the first non-empty message if present.
