### PR TITLE
[5.3] allow passing object instance to class_uses_recursive

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -334,11 +334,15 @@ if (! function_exists('class_uses_recursive')) {
     /**
      * Returns all traits used by a class, its subclasses and trait of their traits.
      *
-     * @param  string  $class
+     * @param  object|string  $class
      * @return array
      */
     function class_uses_recursive($class)
     {
+        if (is_object($class)) {
+            $class = get_class($class);
+        }
+
         $results = [];
 
         foreach (array_merge([$class => $class], class_parents($class)) as $class) {

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -661,6 +661,15 @@ class SupportHelpersTest extends PHPUnit_Framework_TestCase
         class_uses_recursive('SupportTestClassTwo'));
     }
 
+    public function testClassUsesRecursiveAcceptsObject()
+    {
+        $this->assertEquals([
+            'SupportTestTraitOne' => 'SupportTestTraitOne',
+            'SupportTestTraitTwo' => 'SupportTestTraitTwo',
+        ],
+        class_uses_recursive(new SupportTestClassTwo));
+    }
+
     public function testArrayAdd()
     {
         $this->assertEquals(['surname' => 'Mövsümov'], array_add([], 'surname', 'Mövsümov'));


### PR DESCRIPTION
This PR makes `class_uses_recursive` more useful and compatible with `class_uses` native function:

![screenshot from 2016-09-02 12 05 27](https://cloud.githubusercontent.com/assets/6928818/18192325/cb473306-7105-11e6-933e-5b20231a44ab.png)

As you can see in the screenshot, when you try to feed it with an object, rather than class name, you get pretty annoying and useless error message. 

This PR gets rid of that:

``` php
>>> class_uses_recursive('App\User')
=> [
     "Illuminate\Notifications\Notifiable" => "Illuminate\Notifications\Notifiable",
     "Illuminate\Notifications\HasDatabaseNotifications" => "Illuminate\Notifications\HasDatabaseNotifications",
     "Illuminate\Notifications\RoutesNotifications" => "Illuminate\Notifications\RoutesNotifications",
     "Illuminate\Auth\Authenticatable" => "Illuminate\Auth\Authenticatable",
     "Illuminate\Foundation\Auth\Access\Authorizable" => "Illuminate\Foundation\Auth\Access\Authorizable",
     "Illuminate\Auth\Passwords\CanResetPassword" => "Illuminate\Auth\Passwords\CanResetPassword",
   ]
>>> class_uses_recursive(new App\User)
=> [
     "Illuminate\Notifications\Notifiable" => "Illuminate\Notifications\Notifiable",
     "Illuminate\Notifications\HasDatabaseNotifications" => "Illuminate\Notifications\HasDatabaseNotifications",
     "Illuminate\Notifications\RoutesNotifications" => "Illuminate\Notifications\RoutesNotifications",
     "Illuminate\Auth\Authenticatable" => "Illuminate\Auth\Authenticatable",
     "Illuminate\Foundation\Auth\Access\Authorizable" => "Illuminate\Foundation\Auth\Access\Authorizable",
     "Illuminate\Auth\Passwords\CanResetPassword" => "Illuminate\Auth\Passwords\CanResetPassword",
   ]
>>> 

```
