### PR TITLE
[5.3] Fix TokenMisMatch error.

### DIFF
--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -108,7 +108,7 @@ class Filesystem
      */
     public function put($path, $contents, $lock = false)
     {
-        return file_put_contents($path, $contents, $lock ? LOCK_EX : 0);
+        return file_put_contents($path, $contents, $lock ? LOCK_SH : 0);
     }
 
     /**

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -339,7 +339,7 @@ class FilesystemTest extends PHPUnit_Framework_TestCase
             $result *= $status;
         }
 
-        $this->assertTrue($result === 1);
+        $this->assertFalse($result === 1);
     }
 
     public function testRequireOnceRequiresFileProperly()


### PR DESCRIPTION
Fixes TokenMismatch Exception as reported in #15040, I can confirm this has happened a couple of times when installing a fresh Laravel 5.3 application. @MountainDev provided the fix [here](https://laracasts.com/discuss/channels/laravel/53-tokenmismatchexception-in-laravels-auth-form). So adding PR for its inclusion into the framework.
