### PR TITLE
[5.3] Add error message on invalid foreach/forelse

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -4,6 +4,7 @@ namespace Illuminate\View\Compilers;
 
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
+use RuntimeException;
 
 class BladeCompiler extends Compiler implements CompilerInterface
 {
@@ -576,10 +577,13 @@ class BladeCompiler extends Compiler implements CompilerInterface
      *
      * @param  string  $expression
      * @return string
+     * @throws RuntimeException if the $expression doesn't match a valid foreach expression.
      */
     protected function compileForeach($expression)
     {
-        preg_match('/\( *(.*) +as *([^\)]*)/i', $expression, $matches);
+        if (! preg_match('/\( *(.*) +as *([^\)]*)/i', $expression, $matches)) {
+            throw new RuntimeException("Invalid `foreach` expression: ${expression}");
+        }
 
         $iteratee = trim($matches[1]);
 
@@ -619,12 +623,15 @@ class BladeCompiler extends Compiler implements CompilerInterface
      *
      * @param  string  $expression
      * @return string
+     * @throws RuntimeException if the $expression doesn't match a valid foreach expression.
      */
     protected function compileForelse($expression)
     {
         $empty = '$__empty_'.++$this->forelseCounter;
 
-        preg_match('/\( *(.*) +as *([^\)]*)/', $expression, $matches);
+        if (! preg_match('/\( *(.*) +as *([^\)]*)/', $expression, $matches)) {
+            throw new RuntimeException("Invalid `forelse` expression: ${expression}");
+        }
 
         $iteratee = trim($matches[1]);
 

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -814,4 +814,28 @@ test';
             ['(((', ')))'],
         ];
     }
+
+    /**
+     * @expectedException \RuntimeException
+     */
+    public function testInvalidForeachRaisesException()
+    {
+        $compiler = new BladeCompiler($this->getFiles(), __DIR__);
+        $string = '@foreach($foos => $foo)
+test
+@endforeach';
+        $compiler->compileString($string);
+    }
+
+    /**
+     * @expectedException \RuntimeException
+     */
+    public function testInvalidForelseRaisesException()
+    {
+        $compiler = new BladeCompiler($this->getFiles(), __DIR__);
+        $string = '@forelse($foos => $foo)
+test
+@endforelse';
+        $compiler->compileString($string);
+    }
 }


### PR DESCRIPTION
This kind of code (typo in the `endforeach`)

``` php
@foreach($messages as $m):
  {{ $m }}
@foreach
```

Produces this exception

> ErrorException in BladeCompiler.php line 584: Undefined offset: 1

It feels confusing. I would be looking for an array in my code when it's the compiler that tries to access an empty `preg_match()` `$matches`.

Would you recommend a better exception? It doesn't seem that we've got any information about the file neither the line we're in while compile the blade, right?
