### PR TITLE
[5.3] Check for valid JSON in Request

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -12,6 +12,7 @@ use Illuminate\Support\Traits\Macroable;
 use Illuminate\Contracts\Support\Arrayable;
 use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 
 class Request extends SymfonyRequest implements Arrayable, ArrayAccess
 {
@@ -647,6 +648,10 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
     {
         if (! isset($this->json)) {
             $this->json = new ParameterBag((array) json_decode($this->getContent(), true));
+            
+            if (JSON_ERROR_NONE !== json_last_error()) {
+                throw new BadRequestHttpException('JSON '.json_last_error_msg());
+            }
         }
 
         if (is_null($key)) {
@@ -855,8 +860,6 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
         );
 
         $request->content = $content;
-
-        $request->request = $request->getInputSource();
 
         return $request;
     }


### PR DESCRIPTION
Fix for long standing issue #5022 

To make this possible in createFromBase this was removed:

`$request->request = $request->getInputSource();`

To me it looked redundant because the request was already set in the parent Symfony Request, and in this class getInputSource is always called to access the request anyway. However please check I haven't missed something.

With this removed, JSON parsing is now delayed until it is needed which may be more efficient and also allows an exception to be thrown on invalid JSON. The exception is now handled correctly since at the time $request->json() is accessed, the request will have been finished being created which is why this was not possible before.
