### PR TITLE
[5.3] Swap Drop for DropIfExists in all stubs

### DIFF
--- a/src/Illuminate/Cache/Console/stubs/cache.stub
+++ b/src/Illuminate/Cache/Console/stubs/cache.stub
@@ -27,6 +27,6 @@ class CreateCacheTable extends Migration
      */
     public function down()
     {
-        Schema::drop('cache');
+        Schema::dropIfExists('cache');
     }
 }

--- a/src/Illuminate/Notifications/Console/stubs/notifications.stub
+++ b/src/Illuminate/Notifications/Console/stubs/notifications.stub
@@ -29,6 +29,6 @@ class CreateNotificationsTable extends Migration
      */
     public function down()
     {
-        Schema::drop('notifications');
+        Schema::dropIfExists('notifications');
     }
 }

--- a/src/Illuminate/Queue/Console/stubs/failed_jobs.stub
+++ b/src/Illuminate/Queue/Console/stubs/failed_jobs.stub
@@ -30,6 +30,6 @@ class Create{{tableClassName}}Table extends Migration
      */
     public function down()
     {
-        Schema::drop('{{table}}');
+        Schema::dropIfExists('{{table}}');
     }
 }

--- a/src/Illuminate/Queue/Console/stubs/jobs.stub
+++ b/src/Illuminate/Queue/Console/stubs/jobs.stub
@@ -32,6 +32,6 @@ class Create{{tableClassName}}Table extends Migration
      */
     public function down()
     {
-        Schema::drop('{{table}}');
+        Schema::dropIfExists('{{table}}');
     }
 }

--- a/src/Illuminate/Session/Console/stubs/database.stub
+++ b/src/Illuminate/Session/Console/stubs/database.stub
@@ -30,6 +30,6 @@ class CreateSessionsTable extends Migration
      */
     public function down()
     {
-        Schema::drop('sessions');
+        Schema::dropIfExists('sessions');
     }
 }

--- a/tests/Database/migrations/one/2016_01_01_000000_create_users_table.php
+++ b/tests/Database/migrations/one/2016_01_01_000000_create_users_table.php
@@ -30,6 +30,6 @@ class CreateUsersTable extends Migration
      */
     public function down()
     {
-        Schema::drop('users');
+        Schema::dropIfExists('users');
     }
 }

--- a/tests/Database/migrations/one/2016_01_01_100000_create_password_resets_table.php
+++ b/tests/Database/migrations/one/2016_01_01_100000_create_password_resets_table.php
@@ -27,6 +27,6 @@ class CreatePasswordResetsTable extends Migration
      */
     public function down()
     {
-        Schema::drop('password_resets');
+        Schema::dropIfExists('password_resets');
     }
 }

--- a/tests/Database/migrations/two/2016_01_01_200000_create_flights_table.php
+++ b/tests/Database/migrations/two/2016_01_01_200000_create_flights_table.php
@@ -25,6 +25,6 @@ class CreateFlightsTable extends Migration
      */
     public function down()
     {
-        Schema::drop('flights');
+        Schema::dropIfExists('flights');
     }
 }


### PR DESCRIPTION
PR #15113 swapped `Schema::drop` call with `Schema::dropIfExists` for the create stub. This creates a inconsistency between the `php artisan make:*` commands.

This PR changes all `drop` calls with `dropIfExists` to be consistent.

First Laravel PR, woohoo!
