### PR TITLE
[5.3] Update Model save() to return true on non-error

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1462,7 +1462,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         // clause to only update this model. Otherwise, we'll just insert them.
         if ($this->exists) {
             $saved = $this->isDirty() ?
-                        $this->performUpdate($query) : false;
+                        $this->performUpdate($query) : true;
         }
 
         // If the model is brand new, we'll insert it into our database and set the


### PR DESCRIPTION
In 5.3, the Model `save()` method is updated to return false when no attributes have changed.

This breaks all of my project repository classes, which use the following code:

``` php
if ( ! $user->save() ) {
    throw new StorageException;
}
```

If the Eloquent class is extended or an Eloquent event listener is used, `save()` correctly returns false, which will halt my repository with an exception.

Saving without changing anything on the model is fine, so I don't think `false` is an appropriate return value from this method.

Commit 34b86ebd2990e4908209a27bcf1eff4693d8acda fixed this same issue 5.2

Thanks :)

David.
