### PR TITLE
[5.3] Hide empty paginators

### DIFF
--- a/src/Illuminate/Pagination/resources/views/bootstrap-4.blade.php
+++ b/src/Illuminate/Pagination/resources/views/bootstrap-4.blade.php
@@ -1,34 +1,36 @@
-<ul class="pagination">
-    <!-- Previous Page Link -->
-    @if ($paginator->onFirstPage())
-        <li class="page-item disabled"><span class="page-link">&laquo;</span></li>
-    @else
-        <li class="page-item"><a class="page-link" href="{{ $paginator->previousPageUrl() }}" rel="prev">&laquo;</a></li>
-    @endif
-
-    <!-- Pagination Elements -->
-    @foreach ($elements as $element)
-        <!-- "Three Dots" Separator -->
-        @if (is_string($element))
-            <li class="page-item disabled"><span class="page-link">{{ $element }}</span></li>
+@if (!$paginator->onFirstPage() || $paginator->hasMorePages())
+    <ul class="pagination">
+        <!-- Previous Page Link -->
+        @if ($paginator->onFirstPage())
+            <li class="page-item disabled"><span class="page-link">&laquo;</span></li>
+        @else
+            <li class="page-item"><a class="page-link" href="{{ $paginator->previousPageUrl() }}" rel="prev">&laquo;</a></li>
         @endif
 
-        <!-- Array Of Links -->
-        @if (is_array($element))
-            @foreach ($element as $page => $url)
-                @if ($page == $paginator->currentPage())
-                    <li class="page-item active"><span class="page-link">{{ $page }}</span></li>
-                @else
-                    <li class="page-item"><a class="page-link" href="{{ $url }}">{{ $page }}</a></li>
-                @endif
-            @endforeach
-        @endif
-    @endforeach
+        <!-- Pagination Elements -->
+        @foreach ($elements as $element)
+            <!-- "Three Dots" Separator -->
+            @if (is_string($element))
+                <li class="page-item disabled"><span class="page-link">{{ $element }}</span></li>
+            @endif
 
-    <!-- Next Page Link -->
-    @if ($paginator->hasMorePages())
-        <li class="page-item"><a class="page-link" href="{{ $paginator->nextPageUrl() }}" rel="next">&raquo;</a></li>
-    @else
-        <li class="page-item disabled"><span class="page-link">&raquo;</span></li>
-    @endif
-</ul>
+            <!-- Array Of Links -->
+            @if (is_array($element))
+                @foreach ($element as $page => $url)
+                    @if ($page == $paginator->currentPage())
+                        <li class="page-item active"><span class="page-link">{{ $page }}</span></li>
+                    @else
+                        <li class="page-item"><a class="page-link" href="{{ $url }}">{{ $page }}</a></li>
+                    @endif
+                @endforeach
+            @endif
+        @endforeach
+
+        <!-- Next Page Link -->
+        @if ($paginator->hasMorePages())
+            <li class="page-item"><a class="page-link" href="{{ $paginator->nextPageUrl() }}" rel="next">&raquo;</a></li>
+        @else
+            <li class="page-item disabled"><span class="page-link">&raquo;</span></li>
+        @endif
+    </ul>
+@endif

--- a/src/Illuminate/Pagination/resources/views/default.blade.php
+++ b/src/Illuminate/Pagination/resources/views/default.blade.php
@@ -1,34 +1,36 @@
-<ul class="pagination">
-    <!-- Previous Page Link -->
-    @if ($paginator->onFirstPage())
-        <li class="disabled"><span>&laquo;</span></li>
-    @else
-        <li><a href="{{ $paginator->previousPageUrl() }}" rel="prev">&laquo;</a></li>
-    @endif
-
-    <!-- Pagination Elements -->
-    @foreach ($elements as $element)
-        <!-- "Three Dots" Separator -->
-        @if (is_string($element))
-            <li class="disabled"><span>{{ $element }}</span></li>
+@if (!$paginator->onFirstPage() || $paginator->hasMorePages())
+    <ul class="pagination">
+        <!-- Previous Page Link -->
+        @if ($paginator->onFirstPage())
+            <li class="disabled"><span>&laquo;</span></li>
+        @else
+            <li><a href="{{ $paginator->previousPageUrl() }}" rel="prev">&laquo;</a></li>
         @endif
 
-        <!-- Array Of Links -->
-        @if (is_array($element))
-            @foreach ($element as $page => $url)
-                @if ($page == $paginator->currentPage())
-                    <li class="active"><span>{{ $page }}</span></li>
-                @else
-                    <li><a href="{{ $url }}">{{ $page }}</a></li>
-                @endif
-            @endforeach
-        @endif
-    @endforeach
+        <!-- Pagination Elements -->
+        @foreach ($elements as $element)
+            <!-- "Three Dots" Separator -->
+            @if (is_string($element))
+                <li class="disabled"><span>{{ $element }}</span></li>
+            @endif
 
-    <!-- Next Page Link -->
-    @if ($paginator->hasMorePages())
-        <li><a href="{{ $paginator->nextPageUrl() }}" rel="next">&raquo;</a></li>
-    @else
-        <li class="disabled"><span>&raquo;</span></li>
-    @endif
-</ul>
+            <!-- Array Of Links -->
+            @if (is_array($element))
+                @foreach ($element as $page => $url)
+                    @if ($page == $paginator->currentPage())
+                        <li class="active"><span>{{ $page }}</span></li>
+                    @else
+                        <li><a href="{{ $url }}">{{ $page }}</a></li>
+                    @endif
+                @endforeach
+            @endif
+        @endforeach
+
+        <!-- Next Page Link -->
+        @if ($paginator->hasMorePages())
+            <li><a href="{{ $paginator->nextPageUrl() }}" rel="next">&raquo;</a></li>
+        @else
+            <li class="disabled"><span>&raquo;</span></li>
+        @endif
+    </ul>
+@endif

--- a/src/Illuminate/Pagination/resources/views/simple-bootstrap-4.blade.php
+++ b/src/Illuminate/Pagination/resources/views/simple-bootstrap-4.blade.php
@@ -1,15 +1,17 @@
-<ul class="pagination">
-    <!-- Previous Page Link -->
-    @if ($paginator->onFirstPage())
-        <li class="page-item disabled"><span class="page-link">&laquo;</span></li>
-    @else
-        <li class="page-item"><a class="page-link" href="{{ $paginator->previousPageUrl() }}" rel="prev">&laquo;</a></li>
-    @endif
+@if (!$paginator->onFirstPage() || $paginator->hasMorePages())
+    <ul class="pagination">
+        <!-- Previous Page Link -->
+        @if ($paginator->onFirstPage())
+            <li class="page-item disabled"><span class="page-link">&laquo;</span></li>
+        @else
+            <li class="page-item"><a class="page-link" href="{{ $paginator->previousPageUrl() }}" rel="prev">&laquo;</a></li>
+        @endif
 
-    <!-- Next Page Link -->
-    @if ($paginator->hasMorePages())
-        <li class="page-item"><a class="page-link" href="{{ $paginator->nextPageUrl() }}" rel="next">&raquo;</a></li>
-    @else
-        <li class="page-item disabled"><span class="page-link">&raquo;</span></li>
-    @endif
-</ul>
+        <!-- Next Page Link -->
+        @if ($paginator->hasMorePages())
+            <li class="page-item"><a class="page-link" href="{{ $paginator->nextPageUrl() }}" rel="next">&raquo;</a></li>
+        @else
+            <li class="page-item disabled"><span class="page-link">&raquo;</span></li>
+        @endif
+    </ul>
+@endif

--- a/src/Illuminate/Pagination/resources/views/simple-default.blade.php
+++ b/src/Illuminate/Pagination/resources/views/simple-default.blade.php
@@ -1,15 +1,17 @@
-<ul class="pagination">
-    <!-- Previous Page Link -->
-    @if ($paginator->onFirstPage())
-        <li class="disabled"><span>&laquo;</span></li>
-    @else
-        <li><a href="{{ $paginator->previousPageUrl() }}" rel="prev">&laquo;</a></li>
-    @endif
+@if (!$paginator->onFirstPage() || $paginator->hasMorePages())
+    <ul class="pagination">
+        <!-- Previous Page Link -->
+        @if ($paginator->onFirstPage())
+            <li class="disabled"><span>&laquo;</span></li>
+        @else
+            <li><a href="{{ $paginator->previousPageUrl() }}" rel="prev">&laquo;</a></li>
+        @endif
 
-    <!-- Next Page Link -->
-    @if ($paginator->hasMorePages())
-        <li><a href="{{ $paginator->nextPageUrl() }}" rel="next">&raquo;</a></li>
-    @else
-        <li class="disabled"><span>&raquo;</span></li>
-    @endif
-</ul>
+        <!-- Next Page Link -->
+        @if ($paginator->hasMorePages())
+            <li><a href="{{ $paginator->nextPageUrl() }}" rel="next">&raquo;</a></li>
+        @else
+            <li class="disabled"><span>&raquo;</span></li>
+        @endif
+    </ul>
+@endif


### PR DESCRIPTION
Fixes #15124 correctly. It should now have the same behavior as 5.2.

Also, see #15125 for further discussion.
