### PR TITLE
[5.3] fix multifile uploads when empty

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -864,7 +864,28 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
      */
     public function duplicate(array $query = null, array $request = null, array $attributes = null, array $cookies = null, array $files = null, array $server = null)
     {
-        return parent::duplicate($query, $request, $attributes, $cookies, array_filter((array) $files), $server);
+        return parent::duplicate($query, $request, $attributes, $cookies, $this->filterFiles($files), $server);
+    }
+
+    /**
+     * Filter the given request files.
+     *
+     * @param  array  $files
+     * @return mixed
+     */
+    private function filterFiles($files)
+    {
+        foreach ($files as $key => $file) {
+            if (is_array($file)) {
+                $files[$key] = $this->filterFiles($files[$key]);
+            }
+
+            if (is_null($files[$key]) || empty($files[$key])) {
+                unset($files[$key]);
+            }
+        }
+
+        return $files;
     }
 
     /**

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -873,7 +873,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
      * @param  array  $files
      * @return mixed
      */
-    private function filterFiles($files)
+    protected function filterFiles($files)
     {
         foreach ($files as $key => $file) {
             if (is_array($file)) {

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -880,7 +880,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
                 $files[$key] = $this->filterFiles($files[$key]);
             }
 
-            if (is_null($files[$key]) || empty($files[$key])) {
+            if (! $files[$key]) {
                 unset($files[$key]);
             }
         }

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -454,6 +454,25 @@ class HttpRequestTest extends PHPUnit_Framework_TestCase
         $request = Request::createFromBase($baseRequest);
     }
 
+    public function testMultipleFileUploadWithEmptyValue()
+    {
+        $invalidFiles = [
+            'file' => [
+                'name' => [''],
+                'type' => [''],
+                'tmp_name' => [''],
+                'error' => [4],
+                'size' => [0],
+            ],
+        ];
+
+        $baseRequest = SymfonyRequest::create('/?boom=breeze', 'GET', ['foo' => ['bar' => 'baz']], [], $invalidFiles);
+
+        $request = Request::createFromBase($baseRequest);
+
+        $this->assertEmpty($request->files->all());
+    }
+
     public function testOldMethodCallsSession()
     {
         $request = Request::create('/', 'GET');


### PR DESCRIPTION
When you have a field like this:

```
<input type="file" name="files[]" multiple>
```

And you submit without providing any value, Symfony's `files->all()` will have the following value:

```
['files' => [null]]
```

Same issue was noticed with single file uploads reported here https://github.com/laravel/framework/issues/6189, and fixed here https://github.com/laravel/framework/pull/6256

This issue was causing problems with the validator, like here for example: https://github.com/laravel/framework/issues/15044#issuecomment-244364706
