### PR TITLE
[5.3] Add --path option support for artisan migrate:rollback/refresh/reset fixes #13631

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/RefreshCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/RefreshCommand.php
@@ -48,11 +48,11 @@ class RefreshCommand extends Command
 
         if ($step > 0) {
             $this->call('migrate:rollback', [
-                '--database' => $database, '--force' => $force, '--step' => $step,
+                '--database' => $database, '--force' => $force, '--path' => $path, '--step' => $step,
             ]);
         } else {
             $this->call('migrate:reset', [
-                '--database' => $database, '--force' => $force,
+                '--database' => $database, '--force' => $force, '--path' => $path,
             ]);
         }
 

--- a/src/Illuminate/Database/Console/Migrations/ResetCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/ResetCommand.php
@@ -88,6 +88,8 @@ class ResetCommand extends BaseCommand
 
             ['force', null, InputOption::VALUE_NONE, 'Force the operation to run when in production.'],
 
+            ['path', null, InputOption::VALUE_OPTIONAL, 'The path of migrations files to be executed.'],
+
             ['pretend', null, InputOption::VALUE_NONE, 'Dump the SQL queries that would be run.'],
         ];
     }

--- a/src/Illuminate/Database/Console/Migrations/RollbackCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/RollbackCommand.php
@@ -81,6 +81,8 @@ class RollbackCommand extends BaseCommand
 
             ['force', null, InputOption::VALUE_NONE, 'Force the operation to run when in production.'],
 
+            ['path', null, InputOption::VALUE_OPTIONAL, 'The path of migrations files to be executed.'],
+
             ['pretend', null, InputOption::VALUE_NONE, 'Dump the SQL queries that would be run.'],
 
             ['step', null, InputOption::VALUE_OPTIONAL, 'The number of migrations to be reverted.'],

--- a/tests/Database/DatabaseMigrationRefreshCommandTest.php
+++ b/tests/Database/DatabaseMigrationRefreshCommandTest.php
@@ -32,7 +32,7 @@ class DatabaseMigrationRefreshCommandTest extends PHPUnit_Framework_TestCase
         $console->shouldReceive('find')->with('migrate:reset')->andReturn($resetCommand);
         $console->shouldReceive('find')->with('migrate')->andReturn($migrateCommand);
 
-        $resetCommand->shouldReceive('run')->with(new InputMatcher("--database --force 'migrate:reset'"), m::any());
+        $resetCommand->shouldReceive('run')->with(new InputMatcher("--database --force --path 'migrate:reset'"), m::any());
         $migrateCommand->shouldReceive('run')->with(new InputMatcher('--database --force --path migrate'), m::any());
 
         $this->runCommand($command);
@@ -54,7 +54,7 @@ class DatabaseMigrationRefreshCommandTest extends PHPUnit_Framework_TestCase
         $console->shouldReceive('find')->with('migrate:rollback')->andReturn($rollbackCommand);
         $console->shouldReceive('find')->with('migrate')->andReturn($migrateCommand);
 
-        $rollbackCommand->shouldReceive('run')->with(new InputMatcher("--database --force --step=2 'migrate:rollback'"), m::any());
+        $rollbackCommand->shouldReceive('run')->with(new InputMatcher("--database --force --path --step=2 'migrate:rollback'"), m::any());
         $migrateCommand->shouldReceive('run')->with(new InputMatcher('--database --force --path migrate'), m::any());
 
         $this->runCommand($command, ['--step' => 2]);


### PR DESCRIPTION
Added the `--path` command option to the RollbackCommand, RefreshCommand and ResetCommand to support rolling back commands that may have been executed with the `--path` option in the MigrateCommand. This is especially needed for multitenant db migrations where tenant database migrations are typically stored in a `tenant` subfolder of the migrations directory.

More background:

I have a multi-tenant app with one main application/security database and separate tenant databases. I keep tenant migrations stored in a `migrations/tenant` subfolder. I have a custom Artisan command (`php artisan migrate:tenant`) which, in turn, calls `php artisan migrate` for each tenant and passes the `--database=tenant` option to specify the tenant database connection and the `--path` option to specify the path to the tenant migrations (i.e. `database/migrations/tenant`). This works fine and executes the migrations against the tenant database(s), but if I try to run `php artisan migrate:rollback --database=tenant`, it tries to rollback the migrations in the main `migrations` folder, not the `migrations/tenant` subfolder. So, the `--path` option is needed on the rollback, refresh and reset commands in order to make this work.
