### PR TITLE
[5.3] Throw exception on invalid foreach/forelse

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\View\Compilers;
 
+use RuntimeException;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 
@@ -576,10 +577,14 @@ class BladeCompiler extends Compiler implements CompilerInterface
      *
      * @param  string  $expression
      * @return string
+     *
+     * @throws \RuntimeException
      */
     protected function compileForeach($expression)
     {
-        preg_match('/\( *(.*) +as *([^\)]*)/i', $expression, $matches);
+        if (! preg_match('/\( *(.*) +as *([^\)]*)/i', $expression, $matches)) {
+            throw new RuntimeException("Invalid 'foreach' expression: ${expression}");
+        }
 
         $iteratee = trim($matches[1]);
 
@@ -619,12 +624,16 @@ class BladeCompiler extends Compiler implements CompilerInterface
      *
      * @param  string  $expression
      * @return string
+     *
+     * @throws \RuntimeException
      */
     protected function compileForelse($expression)
     {
         $empty = '$__empty_'.++$this->forelseCounter;
 
-        preg_match('/\( *(.*) +as *([^\)]*)/', $expression, $matches);
+        if (! preg_match('/\( *(.*) +as *([^\)]*)/', $expression, $matches)) {
+            throw new RuntimeException("Invalid 'forelse' expression: ${expression}");
+        }
 
         $iteratee = trim($matches[1]);
 

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -814,4 +814,30 @@ test';
             ['(((', ')))'],
         ];
     }
+
+    /**
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage Invalid 'foreach' expression: ($messages => $m)
+     */
+    public function testInvalidForeachRaisesException()
+    {
+        $compiler = new BladeCompiler($this->getFiles(), __DIR__);
+        $string = '@foreach ($messages => $m)
+test
+@endforeach';
+        $compiler->compileString($string);
+    }
+
+    /**
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage Invalid 'forelse' expression: ($messages => $m)
+     */
+    public function testInvalidForelseRaisesException()
+    {
+        $compiler = new BladeCompiler($this->getFiles(), __DIR__);
+        $string = '@forelse ($messages => $m)
+test
+@endforelse';
+        $compiler->compileString($string);
+    }
 }


### PR DESCRIPTION
The current code throws an `ErrorException` saying `Undefined offset: 1` which can be
quite confusing for newcomers.
This modification offers an alternative error message that aims at better helping the developer fixing their code.

However, It does **not**:
- add any validations (the `preg_match` expressions are unchanged)
- change the compiled template
- break more often (or less often) than the actual code

Google search for [`laravel undefined offset`](https://encrypted.google.com/search?hl=en&q=laravel%20undefined%20offset)
Previous discussion : #15226

Thanks for giving it a second look,

Cheers,
