### PR TITLE
[5.3] Decouple date serialization from database format using a new serializedDateFormat property

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -155,6 +155,13 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     protected $dateFormat;
 
     /**
+     * The format of the model's dates when serialized.
+     *
+     * @var string
+     */
+    protected $serializedDateFormat;
+
+    /**
      * The attributes that should be cast to native types.
      *
      * @var array
@@ -2974,7 +2981,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     protected function serializeDate(DateTimeInterface $date)
     {
-        return $date->format($this->getDateFormat());
+        return $date->format($this->getSerializedDateFormat());
     }
 
     /**
@@ -2996,6 +3003,29 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     public function setDateFormat($format)
     {
         $this->dateFormat = $format;
+
+        return $this;
+    }
+
+    /**
+     * Get the format for serialization of dates.
+     *
+     * @return string
+     */
+    protected function getSerializedDateFormat()
+    {
+        return $this->serializedDateFormat ?: $this->getDateFormat();
+    }
+
+    /**
+     * Set the date format used for serialization of dates.
+     *
+     * @param  string  $format
+     * @return $this
+     */
+    public function setSerializedDateFormat($format)
+    {
+        $this->serializedDateFormat = $format;
 
         return $this;
     }


### PR DESCRIPTION
This is the PR to fix issue #11963 by adding a new property `serializedDateFormat`.

Essentially what this does is allow you to output a date in a different format from how it is stored in the database. Normally the `toArray()` code path calls `asDateTime()` which creates a `Carbon` using the `dateFormat`, and then it calls `serializeDate()` which again uses the `dateFormat` to convert it back again, thus an attempt to change the `dateFormat` for `toArray` will exception because it will no longer be able to convert from the database string.

If serializedDateFormat isn't set, it falls back to dateFormat for backwards compatibility.

Now you can do:

```
    public function show($id)
    {
        $model = $this->newModel()->findOrFail($id);
        $model->setSerializedDateFormat('c');
        return $model;
    }
```

And you'll get:

```
{
  "id": "1",
  "created_at": "2016-09-03T13:53:31+00:00",
  "updated_at": "2016-09-03T13:53:31+00:00"
}
```

Whereas previously it would invalid argument exception because 'c' was not the format used by the database. 

Note it is possible to achieve the same thing in a Model subclass and overriding serializeDate, so up to you if you want this as a property or not.
