### PR TITLE
[5.3] json_decodes Pusher message from validAuthentiactoinResponse

### DIFF
--- a/src/Illuminate/Broadcasting/Broadcasters/PusherBroadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/PusherBroadcaster.php
@@ -56,11 +56,11 @@ class PusherBroadcaster extends Broadcaster
     public function validAuthenticationResponse($request, $result)
     {
         if (Str::startsWith($request->channel_name, 'private')) {
-            return $this->decodedPusherRepsone(
+            return $this->decodedPusherResponse(
                 $this->pusher->socket_auth($request->channel_name, $request->socket_id)
             );
         } else {
-            return $this->decodedPusherRepsone(
+            return $this->decodedPusherResponse(
                 $this->pusher->presence_auth(
                     $request->channel_name, $request->socket_id, $request->user()->id, $result)
             );
@@ -98,7 +98,7 @@ class PusherBroadcaster extends Broadcaster
      * @param  mixed  $response
      * @return array
      */
-    public function decodedPusherRepsone($response)
+    public function decodedPusherResponse($response)
     {
         return json_decode($response, true);
     }

--- a/src/Illuminate/Broadcasting/Broadcasters/PusherBroadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/PusherBroadcaster.php
@@ -94,6 +94,7 @@ class PusherBroadcaster extends Broadcaster
 
     /**
      * Decoded PusherResponse.
+     *
      * @param  mixed  $response
      * @return array
      */

--- a/src/Illuminate/Broadcasting/Broadcasters/PusherBroadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/PusherBroadcaster.php
@@ -56,10 +56,13 @@ class PusherBroadcaster extends Broadcaster
     public function validAuthenticationResponse($request, $result)
     {
         if (Str::startsWith($request->channel_name, 'private')) {
-            return $this->pusher->socket_auth($request->channel_name, $request->socket_id);
+            return $this->decodedPusherRepsone(
+                $this->pusher->socket_auth($request->channel_name, $request->socket_id)
+            );
         } else {
-            return $this->pusher->presence_auth(
-                $request->channel_name, $request->socket_id, $request->user()->id, $result
+            return $this->decodedPusherRepsone(
+                $this->pusher->presence_auth(
+                    $request->channel_name, $request->socket_id, $request->user()->id, $result)
             );
         }
     }
@@ -87,5 +90,15 @@ class PusherBroadcaster extends Broadcaster
     public function getPusher()
     {
         return $this->pusher;
+    }
+
+    /**
+     * Decoded PusherResponse.
+     * @param  mixed  $response
+     * @return array
+     */
+    public function decodedPusherRepsone($response)
+    {
+        return json_decode($response, true);
     }
 }


### PR DESCRIPTION
Addresses the (probably misplaced) issue https://github.com/laravel/echo/issues/34.

Pusher by default encodes it's response as a string

``` PHP
    /**
     * Creates a socket signature.
     *
     * @param string $socket_id
     * @param string $custom_data
     *
     * @return string
     */
    public function socket_auth($channel, $socket_id, $custom_data = null)
    {
        $this->validate_channel($channel);
        $this->validate_socket_id($socket_id);

        if ($custom_data) {
            $signature = hash_hmac('sha256', $socket_id.':'.$channel.':'.$custom_data, $this->settings['secret'], false);
        } else {
            $signature = hash_hmac('sha256', $socket_id.':'.$channel, $this->settings['secret'], false);
        }

        $signature = array('auth' => $this->settings['auth_key'].':'.$signature);
        // add the custom data if it has been supplied
        if ($custom_data) {
            $signature['channel_data'] = $custom_data;
        }

        return json_encode($signature);
    }
```

Which in situations as described in the open issue, led to an incorrect response.
