### PR TITLE
[5.3] Add ability to disable touching of related model when toggling relation

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -801,9 +801,10 @@ class BelongsToMany extends Relation
      * Each existing model is detached, and non existing ones are attached.
      *
      * @param  mixed  $ids
+     * @param  bool   $touch
      * @return array
      */
-    public function toggle($ids)
+    public function toggle($ids, $touch = true)
     {
         $changes = [
             'attached' => [], 'detached' => [],
@@ -849,7 +850,7 @@ class BelongsToMany extends Relation
             $changes['attached'] = array_keys($attach);
         }
 
-        if (count($changes['attached']) || count($changes['detached'])) {
+        if ($touch && (count($changes['attached']) || count($changes['detached']))) {
             $this->touchIfTouching();
         }
 


### PR DESCRIPTION
Currently when toggling a relation on a model, the related model gets automatically touched. However, in a lot of cases this may not be desirable. Per example in the case of a user being able to like articles, you wouldn't want to change the article's update date whenever an user likes it.

This PR adds a second facultative argument to `toggle` allowing to change that. This is a minor non-breaking change so I targeted 5.3.
