### PR TITLE
[5.4] Possibility to use where for where in clause

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -192,6 +192,7 @@ class Builder
     protected $operators = [
         '=', '<', '>', '<=', '>=', '<>', '!=',
         'like', 'like binary', 'not like', 'between', 'ilike',
+        'in', 'not in',
         '&', '|', '^', '<<', '>>',
         'rlike', 'regexp', 'not regexp',
         '~', '~*', '!~', '!~*', 'similar to',
@@ -490,6 +491,12 @@ class Builder
             return $this->addArrayOfWheres($column, $boolean);
         }
 
+        // If the operator is an array, we will assume it is an array of possible values
+        // for column and can perform whereIn query.
+        if (is_array($operator)) {
+            return $this->whereIn($column, $operator, $boolean);
+        }
+
         // Here we will make some assumptions about the operator. If only 2 values are
         // passed to the method, we will assume that the operator is an equals sign
         // and keep going. Otherwise, we'll require the operator to be passed in.
@@ -526,10 +533,7 @@ class Builder
             return $this->whereNull($column, $boolean, $operator != '=');
         }
 
-        // Now that we are working with just a simple query we can put the elements
-        // in our array and add the query binding to our array of bindings that
-        // will be bound to each SQL statements when it is finally executed.
-        $type = 'Basic';
+        $type = $this->determineWhereType($operator, $value);
 
         if (Str::contains($column, '->') && is_bool($value)) {
             $value = new Expression($value ? 'true' : 'false');
@@ -537,8 +541,13 @@ class Builder
 
         $this->wheres[] = compact('type', 'column', 'operator', 'value', 'boolean');
 
-        if (! $value instanceof Expression) {
+        // Now that we are working with just a simple query we can put the elements
+        // in our array and depending on the type of value add the query binding or bindings to our array of bindings
+        // that will be bound to each SQL statements when it is finally executed.
+        if (! $value instanceof Expression && ! is_array($value)) {
             $this->addBinding($value, 'where');
+        } elseif (is_array($value)) {
+            $this->addBindings($value, 'where');
         }
 
         return $this;
@@ -907,13 +916,9 @@ class Builder
             $values = $values->toArray();
         }
 
-        $this->wheres[] = compact('type', 'column', 'values', 'boolean');
+        $this->wheres[] = array_merge(compact('type', 'column', 'boolean'), ['value' => $values]);
 
-        foreach ($values as $value) {
-            if (! $value instanceof Expression) {
-                $this->addBinding($value, 'where');
-            }
-        }
+        $this->addBindings($values, 'where');
 
         return $this;
     }
@@ -1180,6 +1185,28 @@ class Builder
         $this->addBinding($value, 'where');
 
         return $this;
+    }
+
+    /**
+     * Intuitive approximation based on operator and value type.
+     *
+     * @param string $operator
+     * @param mixed $value
+     * @return string
+     */
+    protected function determineWhereType($operator, $value)
+    {
+        $operator = strtolower($operator);
+
+        if (in_array($operator, ['in', '=']) && is_array($value)) {
+            return 'In';
+        }
+
+        if (in_array($operator, ['not in', '!=']) && is_array($value)) {
+            return 'NotIn';
+        }
+
+        return 'Basic';
     }
 
     /**
@@ -2351,6 +2378,24 @@ class Builder
             $this->bindings[$type] = array_values(array_merge($this->bindings[$type], $value));
         } else {
             $this->bindings[$type][] = $value;
+        }
+
+        return $this;
+    }
+
+    /**
+     * Add an array of bindings to the query.
+     *
+     * @param array $values
+     * @param string $type
+     * @return $this
+     */
+    public function addBindings(array $values, $type = 'where')
+    {
+        foreach ($values as $value) {
+            if (! $value instanceof Expression) {
+                $this->addBinding($value, $type);
+            }
         }
 
         return $this;

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -298,11 +298,11 @@ class Grammar extends BaseGrammar
      */
     protected function whereIn(Builder $query, $where)
     {
-        if (empty($where['values'])) {
+        if (empty($where['value'])) {
             return '0 = 1';
         }
 
-        $values = $this->parameterize($where['values']);
+        $values = $this->parameterize($where['value']);
 
         return $this->wrap($where['column']).' in ('.$values.')';
     }
@@ -316,11 +316,11 @@ class Grammar extends BaseGrammar
      */
     protected function whereNotIn(Builder $query, $where)
     {
-        if (empty($where['values'])) {
+        if (empty($where['value'])) {
             return '1 = 1';
         }
 
-        $values = $this->parameterize($where['values']);
+        $values = $this->parameterize($where['value']);
 
         return $this->wrap($where['column']).' not in ('.$values.')';
     }

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -329,6 +329,36 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase
         $builder->select('*')->from('users')->where('id', '=', 1)->orWhereIn('id', [1, 2, 3]);
         $this->assertEquals('select * from "users" where "id" = ? or "id" in (?, ?, ?)', $builder->toSql());
         $this->assertEquals([0 => 1, 1 => 1, 2 => 2, 3 => 3], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('id', [1, 2, 3]);
+        $this->assertEquals('select * from "users" where "id" in (?, ?, ?)', $builder->toSql());
+        $this->assertEquals([0 => 1, 1 => 2, 2 => 3], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('id', '=', 2)->where('id', [1, 2, 3]);
+        $this->assertEquals('select * from "users" where "id" = ? and "id" in (?, ?, ?)', $builder->toSql());
+        $this->assertEquals([0 => 2, 1 => 1, 2 => 2, 3 => 3], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('id', 'in', [1, 2, 3]);
+        $this->assertEquals('select * from "users" where "id" in (?, ?, ?)', $builder->toSql());
+        $this->assertEquals([0 => 1, 1 => 2, 2 => 3], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('id', '=', 1)->where('id', 'in', [1, 2, 3]);
+        $this->assertEquals('select * from "users" where "id" = ? and "id" in (?, ?, ?)', $builder->toSql());
+        $this->assertEquals([0 => 1, 1 => 1, 2 => 2, 3 => 3], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('id', '=', [1, 2, 3]);
+        $this->assertEquals('select * from "users" where "id" in (?, ?, ?)', $builder->toSql());
+        $this->assertEquals([0 => 1, 1 => 2, 2 => 3], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('id', '=', 3)->where('id', '=', [1, 2, 3]);
+        $this->assertEquals('select * from "users" where "id" = ? and "id" in (?, ?, ?)', $builder->toSql());
+        $this->assertEquals([0 => 3, 1 => 1, 2 => 2, 3 => 3], $builder->getBindings());
     }
 
     public function testBasicWhereNotIns()
@@ -342,6 +372,26 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase
         $builder->select('*')->from('users')->where('id', '=', 1)->orWhereNotIn('id', [1, 2, 3]);
         $this->assertEquals('select * from "users" where "id" = ? or "id" not in (?, ?, ?)', $builder->toSql());
         $this->assertEquals([0 => 1, 1 => 1, 2 => 2, 3 => 3], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('id', '!=', [1, 2, 3]);
+        $this->assertEquals('select * from "users" where "id" not in (?, ?, ?)', $builder->toSql());
+        $this->assertEquals([0 => 1, 1 => 2, 2 => 3], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('id', '!=', [1, 2, 3])->orWhereNotIn('id', [1, 2, 3]);
+        $this->assertEquals('select * from "users" where "id" not in (?, ?, ?) or "id" not in (?, ?, ?)', $builder->toSql());
+        $this->assertEquals([0 => 1, 1 => 2, 2 => 3, 3 => 1, 4 => 2, 5 => 3], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('id', 'not in', [1, 2, 3]);
+        $this->assertEquals('select * from "users" where "id" not in (?, ?, ?)', $builder->toSql());
+        $this->assertEquals([0 => 1, 1 => 2, 2 => 3], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('id', '=', 3)->where('id', 'not in', [1, 2, 3]);
+        $this->assertEquals('select * from "users" where "id" = ? and "id" not in (?, ?, ?)', $builder->toSql());
+        $this->assertEquals([0 => 3, 1 => 1, 2 => 2, 3 => 3], $builder->getBindings());
     }
 
     public function testRawWhereIns()


### PR DESCRIPTION
I didn't get a reply in #15219 and decide to pr again. Close so close)

``` php
$builder->where('id', [1,2,3]);
$builder->where('id', 'in', [1,2,3]);
$builder->where('id', '=', [1,2,3]);
```

will produce: `select * from table where "id" in (?, ?, ?)`

``` php
$builder->where('id', '!=', [1,2,3]);
$builder->where('id', 'not in', [1,2,3]);
```

will produce: `select * from table where "id" not in (?, ?, ?)`
