### PR TITLE
[5.3] Fix lower case model names in policy classes

### DIFF
--- a/src/Illuminate/Foundation/Console/PolicyMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/PolicyMakeCommand.php
@@ -65,9 +65,9 @@ class PolicyMakeCommand extends GeneratorCommand
 
         $stub = str_replace('DummyModel', $model, $stub);
 
-        $stub = str_replace('dummyModelName', Str::lower($model), $stub);
+        $stub = str_replace('dummyModelName', Str::camel($model), $stub);
 
-        return str_replace('dummyPluralModelName', Str::plural(Str::lower($model)), $stub);
+        return str_replace('dummyPluralModelName', Str::plural(Str::camel($model)), $stub);
     }
 
     /**


### PR DESCRIPTION
Fixes the model name variables (from lower case to camel case) when generating a policy class based on a model.
