### PR TITLE
[5.3] Adds X-RateLimit-Reset header to a throttled response

### DIFF
--- a/src/Illuminate/Routing/Middleware/ThrottleRequests.php
+++ b/src/Illuminate/Routing/Middleware/ThrottleRequests.php
@@ -102,6 +102,7 @@ class ThrottleRequests
 
         if (! is_null($retryAfter)) {
             $headers['Retry-After'] = $retryAfter;
+            $headers['X-RateLimit-Reset'] = time() + $retryAfter;
         }
 
         $response->headers->add($headers);


### PR DESCRIPTION
This change will add the **X-RateLimit-Reset** header to get a non relative value for the next request. In an async-environmet **Retry-After** can lead to unnecessary delays in request processing.
Further more it is good practice for responding throttling headers (github, twitter, auth0, ...).
