### PR TITLE
[5.3] Optimize Arr methods

### DIFF
--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -100,6 +100,10 @@ class SupportArrTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(200, $last);
 
         $this->assertEquals(300, Arr::last($array));
+
+        $array = [100, '#bar' => 200, 'baz' => 300];
+
+        $this->assertEquals(300, Arr::last($array));
     }
 
     public function testFlatten()


### PR DESCRIPTION
- Arr::exists

Using isset to optimize the process, only if the value is null will use array_key_exists to determine the given key exists.
- Arr::last

Same as #15213, prevent array copy.
- Arr::forget, Arr::set

Use foreach to prevent multiple array_shift.
