### PR TITLE
[5.4] Create tracing on Eloquent Models

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\Database\Eloquent;
 
-use Auth;
+use Illuminate\Support\Facades\Auth;
 use Closure;
 use DateTime;
 use Exception;

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Database\Eloquent;
 
+use Auth;
 use Closure;
 use DateTime;
 use Exception;
@@ -83,6 +84,13 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      * @var bool
      */
     public $timestamps = true;
+
+    /**
+     * Indicates if the model should have tracing enabled.
+     *
+     * @var bool
+     */
+    public $tracings = true;
 
     /**
      * The model's attributes.
@@ -265,6 +273,20 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      * @var string
      */
     const UPDATED_AT = 'updated_at';
+
+    /**
+     * The name of the "created by" column.
+     *
+     * @var string
+     */
+    const CREATED_BY = 'created_by';
+
+    /**
+     * The name of the "updated by" column.
+     *
+     * @var string
+     */
+    const UPDATED_BY = 'updated_by';
 
     /**
      * Create a new Eloquent model instance.
@@ -1533,6 +1555,11 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
             $this->updateTimestamps();
         }
 
+        // Next, if tracings are enabled, update the author and last editor of the model.
+        if ($this->tracings) {
+            $this->updateTracings();
+        }
+
         // Once we have run the update operation, we will fire the "updated" event for
         // this model instance. This will allow developers to hook into these after
         // models are updated, giving them a chance to do any special processing.
@@ -1564,6 +1591,11 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         // convenience. After, we will just continue saving these model instances.
         if ($this->timestamps) {
             $this->updateTimestamps();
+        }
+
+        // Next, if tracings are enabled, update the author and last editor of the model.
+        if ($this->tracings) {
+            $this->updateTracings();
         }
 
         // If the model has an incrementing key, we can use the "insertGetId" method on
@@ -1692,7 +1724,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     }
 
     /**
-     * Update the model's update timestamp.
+     * Update the model's update timestamp and tracings.
      *
      * @return bool
      */
@@ -1703,6 +1735,8 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         }
 
         $this->updateTimestamps();
+
+        $this->updateTracings();
 
         return $this->save();
     }
@@ -1789,6 +1823,70 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     public function freshTimestampString()
     {
         return $this->fromDateTime($this->freshTimestamp());
+    }
+
+    /**
+     * Update the author and last editor tracings.
+     *
+     * @return void
+     */
+    protected function updateTracings()
+    {
+        if (Auth::check()) {
+            if (! $this->isDirty(static::UPDATED_BY)) {
+                $this->setUpdatedBy(Auth::id());
+            }
+
+            if (! $this->exists && ! $this->isDirty(static::CREATED_BY)) {
+                $this->setCreatedBy(Auth::id());
+            }
+        }
+    }
+
+    /**
+     * Set the value of the "created by" attribute.
+     *
+     * @param  mixed  $value
+     * @return $this
+     */
+    public function setCreatedBy($value)
+    {
+        $this->{static::CREATED_BY} = $value;
+
+        return $this;
+    }
+
+    /**
+     * Set the value of the "updated by" attribute.
+     *
+     * @param  mixed  $value
+     * @return $this
+     */
+    public function setUpdatedBy($value)
+    {
+        $this->{static::UPDATED_BY} = $value;
+
+        return $this;
+    }
+
+    /**
+     * Get the name of the "created by" column.
+     *
+     * @return string
+     */
+    public function getCreatedByColumn()
+    {
+        return static::CREATED_BY;
+    }
+
+    /**
+     * Get the name of the "updated by" column.
+     *
+     * @return string
+     */
+    public function getUpdatedByColumn()
+    {
+        return static::UPDATED_BY;
     }
 
     /**
@@ -1995,6 +2093,16 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     public function usesTimestamps()
     {
         return $this->timestamps;
+    }
+
+    /**
+     * Determine if the model uses tracings.
+     *
+     * @return bool
+     */
+    public function usesTracings()
+    {
+        return $this->tracings;
     }
 
     /**
@@ -3035,6 +3143,8 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
             $this->getKeyName(),
             $this->getCreatedAtColumn(),
             $this->getUpdatedAtColumn(),
+            $this->getCreatedByColumn(),
+            $this->getUpdatedByColumn(),
         ];
 
         $except = $except ? array_unique(array_merge($except, $defaults)) : $defaults;

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -307,6 +307,16 @@ class Blueprint
     }
 
     /**
+     * Indicate that the tracing columns should be dropped.
+     *
+     * @return void
+     */
+    public function dropTracings()
+    {
+        $this->dropColumn('created_by', 'updated_by');
+    }
+
+    /**
      * Indicate that the soft delete column should be dropped.
      *
      * @return void
@@ -809,6 +819,18 @@ class Blueprint
         $this->timestampTz('created_at')->nullable();
 
         $this->timestampTz('updated_at')->nullable();
+    }
+
+    /**
+     * Add nullable creation and update trancing columns to the table.
+     *
+     * @return void
+     */
+    public function tracings()
+    {
+        $this->unsignedInteger('created_by')->nullable();
+
+        $this->unsignedInteger('updated_by')->nullable();
     }
 
     /**


### PR DESCRIPTION
Similar to what Laravel has currently with timestamps ('created_at' /
'updated_at') on models, I propose the creation of a (very) basic user
action tracing system through 'created_by' (for the author) and
'updated_by' (for the last editor) attributes on models.

I've had this need on a project I'm working on, and thought that maybe
it could be useful to someone else.

TODO: add methods on Model class to retrieve the author instance and
last editor instance. I have to dig a bit on this as the user provider
depends on the provider that is configured. Just wanted to check
with you if this is valid or not before I do that.
