### PR TITLE
[5.3] Fire / check queue looping event before running daemon

### DIFF
--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -90,7 +90,8 @@ class Worker
      */
     protected function daemonShouldRun()
     {
-        return ! $this->manager->isDownForMaintenance();
+        return $this->manager->isDownForMaintenance()
+            ? false : $this->events->until('illuminate.queue.looping') !== false;
     }
 
     /**


### PR DESCRIPTION
After upgrading to Laravel 5.3, I've noticed the queue looping event (`illuminate.queue.looping`) no longer fires.  It looks like the queue worker never fires the event.  See `daemonShouldRun()` in [5.2](https://github.com/laravel/framework/blob/v5.2.45/src/Illuminate/Queue/Worker.php#L131) vs [5.3](https://github.com/laravel/framework/blob/v5.3.6/src/Illuminate/Queue/Worker.php#L93).

This PR reverts to the 5.2 functionality. I'm not sure if this would be considered a breaking change as the deamon will stop if a listener returns `false` to the `illuminate.queue.looping` event.  This is the functionality in 5.2 and users / packages may expect 5.3 to behave the same way.  On the other hand, if this is considered a breaking change, perhaps we can just fire the `illuminate.queue.looping` event without it having an effect on whether or not the daemon will run.

The looping event listener is presented in contracts / classes such as [Illuminate\Contracts\Queue\Monitor](https://github.com/laravel/framework/blob/v5.3.6/src/Illuminate/Contracts/Queue/Monitor.php#L13) and [Illuminate\Queue\QueueManager](https://github.com/laravel/framework/blob/v5.3.6/src/Illuminate/Queue/QueueManager.php#L83), therefore I assume this issue of it not being fired at all should be fixed.
