### PR TITLE
[5.3] Better (?) exception message scheme

### DIFF
--- a/src/Illuminate/Auth/AuthManager.php
+++ b/src/Illuminate/Auth/AuthManager.php
@@ -83,7 +83,10 @@ class AuthManager implements FactoryContract
         $config = $this->getConfig($name);
 
         if (is_null($config)) {
-            throw new InvalidArgumentException("Auth guard [{$name}] is not defined.");
+            /** @var Closure $message */
+            $message = require __DIR__.'/Templates/AuthGuardNotDefined.php';
+
+            throw new InvalidArgumentException($message($name));
         }
 
         if (isset($this->customCreators[$config['driver']])) {

--- a/src/Illuminate/Auth/Templates/AuthGuardNotDefined.php
+++ b/src/Illuminate/Auth/Templates/AuthGuardNotDefined.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * Generates a message for when the auth.guards.$name is missing.
+ *
+ * @param string $name
+ *
+ * @return string
+ */
+return function ($name) {
+    return preg_replace("/\n {8}/", "\n", "
+        Auth guard [{$name}] is not defined.
+
+        This is usually caused by a faulty configuration, in config/auth.php. You could try adding something like:
+
+        return [
+            // ...
+            'guards' => [
+                '{$name}' => [
+                    'driver' => 'session',
+                    'provider' => 'users',
+                ],
+            ],
+        ];
+
+        - Need more documentation? Check out: https://laravel.com/docs/5.3/authentication#adding-custom-guards
+        - Having issues with this error? Go to: https://laracasts.com/discuss
+    ");
+};

--- a/tests/Auth/AuthExceptionsTest.php
+++ b/tests/Auth/AuthExceptionsTest.php
@@ -1,0 +1,48 @@
+<?php
+
+use Illuminate\Auth\AuthManager;
+use Illuminate\Contracts\Foundation\Application;
+use Mockery as m;
+use Mockery\MockInterface;
+
+class AuthExceptionsTest extends PHPUnit_Framework_TestCase
+{
+    public function tearDown()
+    {
+        m::close();
+    }
+
+    public function testMissingGuardConfiguration()
+    {
+        /** @var MockInterface|Application $app */
+        $app = m::mock('Illuminate\Foundation\Application');
+
+        $app->shouldReceive('offsetGet')
+            ->with('config')
+            ->andReturn($app);
+
+        $app->shouldReceive('offsetGet')
+            ->once()
+            ->with('auth.guards.missing')
+            ->andReturn(null);
+
+        /** @var MockInterface|AuthManager $auth */
+        $auth = m::mock('Illuminate\Auth\AuthManager', [$app]);
+
+        $throws = false;
+
+        try {
+            $auth->resolve('missing');
+        } catch (InvalidArgumentException $e) {
+            $message = $e->getMessage();
+
+            $this->assertContains('This is usually caused by', $message);
+            $this->assertContains('You could try', $message);
+            $this->assertContains('Need more documentation', $message);
+
+            $throws = true;
+        }
+
+        $this->assertTrue($throws);
+    }
+}


### PR DESCRIPTION
![screen shot 2016-09-06 at 8 10 53 pm](https://cloud.githubusercontent.com/assets/200609/18266300/10e5ef0e-746e-11e6-9840-e26310f95e26.png)

Hello!

Inspired by the new [Jest](https://twitter.com/ben336/status/772906536154894336) error messages, I have been thinking about how PHP frameworks can do exceptions better. This pull request is a guide for discussion to that end. 

I've been [discussing the approach](https://github.com/silverstripe/silverstripe-framework/pull/5953) with the SilverStripe folks, and have arrived at this implementation. The basic structure is:

`throw` → load message closure → return helpful message

The indentation formatting and `require` are a bit cringeworthy at first, but they're here for a good reason. We could use helpers to abstract away some of the cringe, but I wanted to use something as close to plain PHP as possible. Using helpers or even generator classes introduce the risk that the code generating exception messages is throwing exceptions of its own. 

An alternative is to generate the messages inside private methods (don't want to add to the public API), but this would bloat the size of most class files significantly.

This way: exception messages serve as a middle-man between documentation/forums and vague exception messages. It's more to maintain (which I've tried to mitigate by including a discussion link), but I think it could be good to introduce more verbose exception messages.
