### PR TITLE
[5.3] Add split method to collection class

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -921,6 +921,23 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
+     * Split a collection into a certain number of groups.
+     *
+     * @param int $numberOfGroups
+     * @return static
+     */
+     public function split($numberOfGroups)
+     {
+        if ($this->isEmpty()) {
+           return $this;
+        }
+
+        $groupSize = ceil($this->count() / $numberOfGroups);
+
+        return $this->chunk($groupSize);
+     }
+
+    /**
      * Chunk the underlying collection array.
      *
      * @param  int   $size

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -923,7 +923,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Split a collection into a certain number of groups.
      *
-     * @param int $numberOfGroups
+     * @param  int $numberOfGroups
      * @return static
      */
      public function split($numberOfGroups)

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -923,7 +923,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Split a collection into a certain number of groups.
      *
-     * @param  int    $numberOfGroups
+     * @param  int  $numberOfGroups
      * @return static
      */
     public function split($numberOfGroups)

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -929,7 +929,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     public function split($numberOfGroups)
     {
         if ($this->isEmpty()) {
-            return $this;
+            return new static;
         }
 
         $groupSize = ceil($this->count() / $numberOfGroups);

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -920,21 +920,21 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
         return new static(array_slice($this->items, $offset, $length, true));
     }
 
-    /**
-     * Split a collection into a certain number of groups.
-     *
-     * @param  int $numberOfGroups
-     * @return static
-     */
+     /**
+      * Split a collection into a certain number of groups.
+      *
+      * @param  int $numberOfGroups
+      * @return static
+      */
      public function split($numberOfGroups)
      {
-        if ($this->isEmpty()) {
-           return $this;
-        }
+         if ($this->isEmpty()) {
+             return $this;
+         }
 
-        $groupSize = ceil($this->count() / $numberOfGroups);
+         $groupSize = ceil($this->count() / $numberOfGroups);
 
-        return $this->chunk($groupSize);
+         return $this->chunk($groupSize);
      }
 
     /**

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -920,22 +920,22 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
         return new static(array_slice($this->items, $offset, $length, true));
     }
 
-     /**
-      * Split a collection into a certain number of groups.
-      *
-      * @param  int $numberOfGroups
-      * @return static
-      */
-     public function split($numberOfGroups)
-     {
-         if ($this->isEmpty()) {
-             return $this;
-         }
+    /**
+     * Split a collection into a certain number of groups.
+     *
+     * @param  int    $numberOfGroups
+     * @return static
+     */
+    public function split($numberOfGroups)
+    {
+        if ($this->isEmpty()) {
+            return $this;
+        }
 
-         $groupSize = ceil($this->count() / $numberOfGroups);
+        $groupSize = ceil($this->count() / $numberOfGroups);
 
-         return $this->chunk($groupSize);
-     }
+        return $this->chunk($groupSize);
+    }
 
     /**
      * Chunk the underlying collection array.

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1579,7 +1579,7 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
         );
     }
 
-    public function  testSplitCollectionWithCountLessThenDivisor()
+    public function testSplitCollectionWithCountLessThenDivisor()
     {
         $collection = new Collection(['a']);
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1557,7 +1557,7 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
 
     public function testSplitCollectionWithADivisableCount()
     {
-        $collection = Collection::make(['a', 'b', 'c', 'd']);
+        $collection = new Collection(['a', 'b', 'c', 'd']);
 
         $this->assertEquals(
             [['a', 'b'], ['c', 'd']],

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1554,6 +1554,54 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
         $collection = new Collection(new \ArrayObject(['foo' => 1, 'bar' => 2, 'baz' => 3]));
         $this->assertEquals(['foo' => 1, 'bar' => 2, 'baz' => 3], $collection->toArray());
     }
+
+    public function testSplitCollectionWithADivisableCount()
+    {
+        $collection = Collection::make(['a', 'b', 'c', 'd']);
+
+        $this->assertEquals(
+            [['a', 'b'], ['c', 'd']],
+            $collection->split(2)->map(function (Collection $chunk) {
+                return $chunk->values()->toArray();
+            })->toArray()
+        );
+    }
+
+    public function testSplitCollectionWithAnUndivisableCount()
+    {
+        $collection = new Collection(['a', 'b', 'c']);
+
+        $this->assertEquals(
+            [['a', 'b'], ['c']],
+            $collection->split(2)->map(function (Collection $chunk) {
+                return $chunk->values()->toArray();
+            })->toArray()
+        );
+    }
+
+    public function  testSplitCollectionWithCountLessThenDivisor()
+    {
+        $collection = new Collection(['a']);
+
+        $this->assertEquals(
+            [['a']],
+            $collection->split(2)->map(function (Collection $chunk) {
+                return $chunk->values()->toArray();
+            })->toArray()
+        );
+    }
+
+    public function testSplitEmptyCollection()
+    {
+        $collection = new Collection();
+
+        $this->assertEquals(
+            [],
+            $collection->split(2)->map(function (Collection $chunk) {
+                return $chunk->values()->toArray();
+            })->toArray()
+        );
+    }
 }
 
 class TestAccessorEloquentTestStub


### PR DESCRIPTION
This PR adds a `split` method to `Illuminate\Support\Collection` that splits a collection into the given number of groups.

``` php
$collection = collect(['a', 'b', 'c', 'd'])->split(2);

$collection->count(); // returns 2

$collection->first(); // returns a collection with 'a' and 'b';
$collection->last(); // returns a collection with 'c' and 'd';
```
