### PR TITLE
[5.3] Consider local key for HasManyThrough

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -138,7 +138,7 @@ class HasManyThrough extends Relation
     {
         $table = $this->parent->getTable();
 
-        $this->query->whereIn($table.'.'.$this->firstKey, $this->getKeys($models));
+        $this->query->whereIn($table.'.'.$this->firstKey, $this->getKeys($models, $this->localKey));
     }
 
     /**


### PR DESCRIPTION
Issue: https://github.com/laravel/framework/issues/14743

The relation is currently neglecting the defined local key on eager loading and using the primary key instead.
