### PR TITLE
[5.3] Refactor inTimeInterval method

### DIFF
--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -639,14 +639,10 @@ class Event
      */
     private function inTimeInterval($startTime, $endTime)
     {
-        $startTime = str_replace(':', '', $startTime);
-
-        $endTime = str_replace(':', '', $endTime);
-
-        return function () use ($startTime, $endTime) {
-            $now = Carbon::now()->format('Hi');
-
-            return $now >= $startTime && $now <= $endTime;
+        return function() use($startTime, $endTime) {
+            $now = Carbon::now()->timestamp;
+            
+            return $now >= strtotime($startTime) && $now <= strtotime($endTime);
         };
     }
 

--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -639,7 +639,7 @@ class Event
      */
     private function inTimeInterval($startTime, $endTime)
     {
-        return function () use ($startTime,$endTime) {
+        return function () use ($startTime, $endTime) {
             $now = Carbon::now()->timestamp;
 
             return $now >= strtotime($startTime) && $now <= strtotime($endTime);

--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -639,7 +639,7 @@ class Event
      */
     private function inTimeInterval($startTime, $endTime)
     {
-        return function() use($startTime, $endTime) {
+        return function () use ($startTime,$endTime) {
             $now = Carbon::now()->timestamp;
             
             return $now >= strtotime($startTime) && $now <= strtotime($endTime);

--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -641,7 +641,7 @@ class Event
     {
         return function () use ($startTime,$endTime) {
             $now = Carbon::now()->timestamp;
-            
+
             return $now >= strtotime($startTime) && $now <= strtotime($endTime);
         };
     }

--- a/tests/Console/ConsoleScheduledEventTest.php
+++ b/tests/Console/ConsoleScheduledEventTest.php
@@ -111,7 +111,7 @@ class ConsoleScheduledEventTest extends PHPUnit_Framework_TestCase
         $app = m::mock('Illuminate\Foundation\Application[isDownForMaintenance,environment]');
         $app->shouldReceive('isDownForMaintenance')->andReturn(false);
         $app->shouldReceive('environment')->andReturn('production');
-        Carbon::setTestNow(Carbon::create(2015, 1, 1, 9, 0, 0));
+        Carbon::setTestNow(Carbon::now()->startOfDay()->addHours(9));
 
         $event = new Event('php foo');
         $this->assertTrue($event->between('8:00', '10:00')->filtersPass($app));


### PR DESCRIPTION
Wasn't really happy with the use of `str_replace` so replaced it with an inline `strtotime()`.

Feels much cleaner and clearer to me what is going on.
