### PR TITLE
[5.3] Make Storage::delete() act like Filesystem::delete()

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -198,15 +198,19 @@ class FilesystemAdapter implements FilesystemContract, CloudFilesystemContract
     {
         $paths = is_array($paths) ? $paths : func_get_args();
 
+        $success = true;
+
         foreach ($paths as $path) {
             try {
-                $this->driver->delete($path);
+                if (! $this->driver->delete($path)) {
+                    $success = false;
+                }
             } catch (FileNotFoundException $e) {
-                //
+                $success = false;
             }
         }
 
-        return true;
+        return $success;
     }
 
     /**


### PR DESCRIPTION
The current implementation will always return true even if one of file(s) weren't deleted unlike the delete method in Filesystem.

Note: This can be considered a breaking change, if so we can just change to master if the change is desirable.
