### PR TITLE
[5.3] Allow to set redirect path after logout

### DIFF
--- a/src/Illuminate/Foundation/Auth/AuthenticatesUsers.php
+++ b/src/Illuminate/Foundation/Auth/AuthenticatesUsers.php
@@ -146,7 +146,7 @@ trait AuthenticatesUsers
 
         $request->session()->regenerate();
 
-        return redirect('/');
+        return redirect(property_exists($this, 'redirectAfterLogout') ? $this->redirectAfterLogout : '/');
     }
 
     /**


### PR DESCRIPTION
Currently <code>logout</code> method redirect to the root path and cannot be changed: https://github.com/laravel/framework/blob/5.3/src/Illuminate/Foundation/Auth/AuthenticatesUsers.php#L149

With this PR we are able to set the redirect path like Laravel 5.2.
