### PR TITLE
[5.3] Allow passing a Closure to View::share() method

### DIFF
--- a/src/Illuminate/View/View.php
+++ b/src/Illuminate/View/View.php
@@ -162,8 +162,7 @@ class View implements ArrayAccess, ViewContract
         foreach ($data as $key => $value) {
             if ($value instanceof Renderable) {
                 $data[$key] = $value->render();
-            }
-            elseif ($value instanceof Closure) {
+            } elseif ($value instanceof Closure) {
                 $data[$key] = call_user_func($value);
             }
         }

--- a/src/Illuminate/View/View.php
+++ b/src/Illuminate/View/View.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\View;
 
+use Closure;
 use Exception;
 use Throwable;
 use ArrayAccess;
@@ -161,6 +162,9 @@ class View implements ArrayAccess, ViewContract
         foreach ($data as $key => $value) {
             if ($value instanceof Renderable) {
                 $data[$key] = $value->render();
+            }
+            elseif ($value instanceof Closure) {
+                $data[$key] = call_user_func($value);
             }
         }
 


### PR DESCRIPTION
This pull request allows you to pass a Closure as the $value parameter to View::share() method.

**Example**

``` php
class AppServiceProvider extends ServiceProvider
{
    public function boot()
    {
        View::share('key', function () {
            // do something
            return 'something else';
        });
    }
    //.....
}
```
