### PR TITLE
[5.3] Added support for notifications MailChannel using messages that implements Mailable contract

### DIFF
--- a/src/Illuminate/Notifications/Channels/MailChannel.php
+++ b/src/Illuminate/Notifications/Channels/MailChannel.php
@@ -4,6 +4,7 @@ namespace Illuminate\Notifications\Channels;
 
 use Illuminate\Support\Str;
 use Illuminate\Contracts\Mail\Mailer;
+use Illuminate\Contracts\Mail\Mailable;
 use Illuminate\Notifications\Notification;
 
 class MailChannel
@@ -40,6 +41,11 @@ class MailChannel
         }
 
         $message = $notification->toMail($notifiable);
+
+        if ($message instanceof Mailable) {
+            $message->send($this->mailer);
+            return;
+        }
 
         $this->mailer->send($message->view, $message->data(), function ($m) use ($notifiable, $notification, $message) {
             $recipients = empty($message->to) ? $notifiable->routeNotificationFor('mail') : $message->to;

--- a/src/Illuminate/Notifications/Channels/MailChannel.php
+++ b/src/Illuminate/Notifications/Channels/MailChannel.php
@@ -44,6 +44,7 @@ class MailChannel
 
         if ($message instanceof Mailable) {
             $message->send($this->mailer);
+
             return;
         }
 

--- a/tests/Notifications/NotificationMailChannelTest.php
+++ b/tests/Notifications/NotificationMailChannelTest.php
@@ -210,6 +210,20 @@ class NotificationMailChannelTest extends PHPUnit_Framework_TestCase
 
         $channel->send($notifiable, $notification);
     }
+
+    public function testMessageWithMailableContract()
+    {
+        $notification = new NotificationMailChannelTestNotificationWithMailableContract;
+        $notifiable = new NotificationMailChannelTestNotifiable;
+
+        $channel = new Illuminate\Notifications\Channels\MailChannel(
+            $mailer = Mockery::mock(Illuminate\Contracts\Mail\Mailer::class)
+        );
+
+        $mailer->shouldReceive('send')->once();
+
+        $channel->send($notifiable, $notification);
+    }
 }
 
 class NotificationMailChannelTestNotifiable
@@ -270,5 +284,25 @@ class NotificationMailChannelTestNotificationWithToAddress extends Notification
     {
         return (new MailMessage)
             ->to('jeffrey@laracasts.com');
+    }
+}
+
+class NotificationMailChannelTestNotificationWithMailableContract extends Notification
+{
+    public function toMail($notifiable)
+    {
+        $mock = Mockery::mock(Illuminate\Contracts\Mail\Mailable::class);
+
+        $mock->shouldReceive('send')->once()->with(Mockery::on(function($mailer) {
+            if (! ($mailer instanceof \Illuminate\Contracts\Mail\Mailer)) {
+                return false;
+            }
+
+            $mailer->send('notifications::email-plain');
+
+            return true;
+        }));
+
+        return $mock;
     }
 }

--- a/tests/Notifications/NotificationMailChannelTest.php
+++ b/tests/Notifications/NotificationMailChannelTest.php
@@ -294,7 +294,7 @@ class NotificationMailChannelTestNotificationWithMailableContract extends Notifi
         $mock = Mockery::mock(Illuminate\Contracts\Mail\Mailable::class);
 
         $mock->shouldReceive('send')->once()->with(Mockery::on(function ($mailer) {
-            if (! ($mailer instanceof \Illuminate\Contracts\Mail\Mailer)) {
+            if (! $mailer instanceof Illuminate\Contracts\Mail\Mailer) {
                 return false;
             }
 

--- a/tests/Notifications/NotificationMailChannelTest.php
+++ b/tests/Notifications/NotificationMailChannelTest.php
@@ -293,7 +293,7 @@ class NotificationMailChannelTestNotificationWithMailableContract extends Notifi
     {
         $mock = Mockery::mock(Illuminate\Contracts\Mail\Mailable::class);
 
-        $mock->shouldReceive('send')->once()->with(Mockery::on(function($mailer) {
+        $mock->shouldReceive('send')->once()->with(Mockery::on(function ($mailer) {
             if (! ($mailer instanceof \Illuminate\Contracts\Mail\Mailer)) {
                 return false;
             }


### PR DESCRIPTION
``` php
...

public function toMail($notifiable)
{
      return (new \App\Mail\OrderShipped($this->order))->to($notifiable->routeNotificationFor('mail'));
}
...
```
