### PR TITLE
[5.3] Check attempts before firing queue job.

### DIFF
--- a/src/Illuminate/Queue/AttemptsExceededException.php
+++ b/src/Illuminate/Queue/AttemptsExceededException.php
@@ -1,0 +1,12 @@
+<?php
+
+
+namespace Illuminate\Queue;
+
+
+use RuntimeException;
+
+class AttemptsExceededException extends RuntimeException
+{
+    //
+}

--- a/src/Illuminate/Queue/AttemptsExceededException.php
+++ b/src/Illuminate/Queue/AttemptsExceededException.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace Illuminate\Queue;
-
 
 use RuntimeException;
 

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -269,7 +269,7 @@ class Worker
         }
 
         $e = new AttemptsExceededException(
-            "Queue job has already been attempted more than maxTries, it may have previously timed out");
+            'Queue job has already been attempted more than maxTries, it may have previously timed out');
 
         $this->failJob($connectionName, $job, $e);
 

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -254,8 +254,9 @@ class Worker
     }
 
     /**
-     * Mark the given job as failed if it has exceeded the maximum allowed attempts. This will likely be because
-     * the job previously exceeded a timeout.
+     * Mark the given job as failed if it has exceeded the maximum allowed attempts.
+     *
+     * This will likely be because the job previously exceeded a timeout.
      *
      * @param  string  $connectionName
      * @param  \Illuminate\Contracts\Queue\Job  $job
@@ -269,7 +270,8 @@ class Worker
         }
 
         $e = new AttemptsExceededException(
-            'Queue job has already been attempted more than maxTries, it may have previously timed out');
+            'Queue job has already been attempted more than maxTries, it may have previously timed out'
+        );
 
         $this->failJob($connectionName, $job, $e);
 

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -91,7 +91,6 @@ class QueueWorkerTest extends PHPUnit_Framework_TestCase
         $e = new RuntimeException;
 
         $job = new WorkerFakeJob(function ($job) use ($e) {
-
             // In normal use this would be incremented by being popped off the queue
             $job->attempts++;
 


### PR DESCRIPTION
Check jobs before working to see if they have already been received too many times.

Resolves an issue with the `--timeout` feature where jobs the repeatedly timed out would never be marked as `failed`, as the worker process would be killed before
it could reach the failing logic.

To maintain compatibility there are now two checks against the number of attempts a job has had, one before working the job and one in the case of an job raising an exception.

see laravel/framework#15317 for more details.
