### PR TITLE
[5.3] Allow numeric keys in morphMap

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -306,7 +306,8 @@ abstract class Relation
         $map = static::buildMorphMapFromModels($map);
 
         if (is_array($map)) {
-            static::$morphMap = $merge ? array_merge(static::$morphMap, $map) : $map;
+            static::$morphMap = $merge && static::$morphMap
+                            ? array_merge(static::$morphMap, $map) : $map;
         }
 
         return static::$morphMap;

--- a/tests/Database/DatabaseEloquentRelationTest.php
+++ b/tests/Database/DatabaseEloquentRelationTest.php
@@ -53,6 +53,17 @@ class DatabaseEloquentRelationTest extends PHPUnit_Framework_TestCase
         Relation::morphMap([], false);
     }
 
+    public function testSettingMorphMapWithNumericKeys()
+    {
+        Relation::morphMap([1 => 'App\User']);
+
+        $this->assertEquals([
+            1 => 'App\User',
+        ], Relation::morphMap());
+
+        Relation::morphMap([], false);
+    }
+
     /**
      * Testing to ensure loop does not occur during relational queries in global scopes.
      *


### PR DESCRIPTION
This gives the ability to save numeric keys in the database and then map it with the class names.

```
Relation::morphMap([
    1 => 'App\Post',
    2 => 'App\Audio'
]);
```

Check https://github.com/laravel/framework/issues/12845 for reference.
