### PR TITLE
[5.3] An ability containing dots should be transformed to camelcase method …

### DIFF
--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -364,6 +364,10 @@ class Gate implements GateContract
                 }
             }
 
+            if (strpos($ability, '.') !== false) {
+                $ability = str_replace('.', '-', $ability);
+            }
+
             if (strpos($ability, '-') !== false) {
                 $ability = Str::camel($ability);
             }

--- a/tests/Auth/AuthAccessGateTest.php
+++ b/tests/Auth/AuthAccessGateTest.php
@@ -155,6 +155,15 @@ class GateTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($gate->check('update-dash', new AccessGateTestDummy));
     }
 
+    public function test_policy_converts_dots_to_camel()
+    {
+        $gate = $this->getBasicGate();
+
+        $gate->policy(AccessGateTestDummy::class, AccessGateTestPolicy::class);
+
+        $this->assertTrue($gate->check('update.dot', new AccessGateTestDummy));
+    }
+
     public function test_policy_default_to_false_if_method_does_not_exist()
     {
         $gate = $this->getBasicGate();
@@ -293,6 +302,11 @@ class AccessGateTestPolicy
     }
 
     public function updateDash($user, AccessGateTestDummy $dummy)
+    {
+        return $user instanceof StdClass;
+    }
+
+    public function updateDot($user, AccessGateTestDummy $dummy)
     {
         return $user instanceof StdClass;
     }


### PR DESCRIPTION
When i name the abilities i tend yo use this convention "moduleName.permission" for example

article.create
article.edit

When it comes to using a policy class with the Article model i should have something like this

``` php
<?php

class ArticlePolicy
{
    public function articleCreate(User $user)
    {
        # code...
    }

    public function articleEdit(User $user, Article $article)
    {
        # code...
    }       
}
```

The current state of the repository instead return these method names

article.create
article.edit

Which are not valid php method names
