### PR TITLE
[5.1] Updated symfony/css-selector version.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "psy/psysh": "0.7.*",
         "swiftmailer/swiftmailer": "~5.1",
         "symfony/console": "2.7.*",
-        "symfony/css-selector": "2.7.*",
+        "symfony/css-selector": "2.7.*|2.8.*",
         "symfony/debug": "2.7.*",
         "symfony/dom-crawler": "2.7.*",
         "symfony/finder": "2.7.*",


### PR DESCRIPTION
Facebook instant article sdk requires syfmony/css-selector 2.8.x version and cannot use this package. Also CssSelectorConverter class has added to css-selector at 2.8 version which may use in different projects.
