### PR TITLE
[5.3] Fix aggregate method sum() to always return numeric

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1984,7 +1984,9 @@ class Builder
      */
     public function sum($column)
     {
-        return $this->aggregate(__FUNCTION__, [$column]);
+        $result = $this->aggregate(__FUNCTION__, [$column]);
+
+        return $result ?: 0;
     }
 
     /**


### PR DESCRIPTION
Changed here: https://github.com/laravel/framework/pull/14793
Reverted here: https://github.com/laravel/framework/pull/14994

However while reverting the `sum()` method didn't actually get back to the original form, in the current state it may return null in case there are no records.

This PR insures the return value is always numeric.
