### PR TITLE
[5.3] Fix fatal error on file uploads

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -880,7 +880,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
                 $files[$key] = $this->filterFiles($files[$key]);
             }
 
-            if (! $files[$key]) {
+            if (empty($files[$key])) {
                 unset($files[$key]);
             }
         }


### PR DESCRIPTION
This PR fixes the code from #15250 which broke file uploads in Laravel 5.3.7.

```
Catchable fatal error: Object of class Symfony\Component\HttpFoundation\File\UploadedFile could not be converted to boolean in vendor\laravel\framework\src\Illuminate\Http\Request.php on line 883
```

You can't convert `SplFileInfo`, and therefore Symfony's `UploadedFile`, to a boolean. See: http://stackoverflow.com/questions/17488674/why-cant-splfileinfo-be-converted-to-boolean

Edit: I should add that it looks like this has been fixed at some point after PHP 5.6.4, but as 5.6.4 is the minimum version required for Laravel 5.3 I think this PR is still needed.
