### PR TITLE
Added name attribute to DatabaseNotification model

### DIFF
--- a/src/Illuminate/Notifications/DatabaseNotification.php
+++ b/src/Illuminate/Notifications/DatabaseNotification.php
@@ -67,4 +67,9 @@ class DatabaseNotification extends Model
     {
         return new DatabaseNotificationCollection($models);
     }
+    
+    public function getNameAttribute()
+    {
+        return snake_case(class_basename($this->type));
+    }
 }

--- a/src/Illuminate/Notifications/DatabaseNotification.php
+++ b/src/Illuminate/Notifications/DatabaseNotification.php
@@ -68,6 +68,11 @@ class DatabaseNotification extends Model
         return new DatabaseNotificationCollection($models);
     }
     
+    /**
+     * Get the name attribute of the instance.
+     *
+     * @return string
+     */
     public function getNameAttribute()
     {
         return snake_case(class_basename($this->type));


### PR DESCRIPTION
Proposal: Adding a name attribute to DatabaseNotification model, so you don't have to retrieve it in your view each time you just want to know the type instead of the full namespace, which is just a little cleaner I think.
