### PR TITLE
Add the exists_not rule

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1491,6 +1491,20 @@ class Validator implements ValidatorContract
             $connection, $table, $column, $value, $parameters
         ) >= $expected;
     }
+    
+    /**
+     * Validate the existence of an attribute value in a database table and return false 
+     * if the record exists.
+     *
+     * @param  string  $attribute
+     * @param  mixed   $value
+     * @param  array   $parameters
+     * @return bool
+     */
+    public function validateExistsNot($attribute, $value, $parameters)
+    {
+        return !$this->validateExists($attribute, $value, $parameters);
+    }
 
     /**
      * Get the number of records that exist in storage.

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1491,9 +1491,9 @@ class Validator implements ValidatorContract
             $connection, $table, $column, $value, $parameters
         ) >= $expected;
     }
-    
+
     /**
-     * Validate the existence of an attribute value in a database table and return false 
+     * Validate the existence of an attribute value in a database table and return false.
      * if the record exists.
      *
      * @param  string  $attribute
@@ -1503,7 +1503,7 @@ class Validator implements ValidatorContract
      */
     public function validateExistsNot($attribute, $value, $parameters)
     {
-        return !$this->validateExists($attribute, $value, $parameters);
+        return ! $this->validateExists($attribute, $value, $parameters);
     }
 
     /**


### PR DESCRIPTION
I've had a case where the validation should fail if a specific record exists in the database. There was no such function that will do the opposite of `exists` so I've added `exists_not`.

```
[
    'user_id' => 'exists_not:user_checks,user_id',
]
```

The above example will let the validator fail if the table `user_checks` has a column `user_id` with the current user id in it.
