### PR TITLE
[5.3] Add a doesntExpectNotification() method for tests

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MocksApplicationServices.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MocksApplicationServices.php
@@ -418,4 +418,44 @@ trait MocksApplicationServices
 
         return $this;
     }
+
+    /**
+     * Specify a list of notifications that should not be dispatched for the given operation.
+     *
+     * These notifications will be mocked, so that handlers will not actually be executed.
+     *
+     * @param  array|string  $notifications
+     * @return $this
+     */
+    protected function doesntExpectNotification($notifications)
+    {
+        $notifications = is_array($notifications) ? $notifications : func_get_args();
+
+        $this->withoutNotifications();
+
+        $this->beforeApplicationDestroyed(function () use ($notifications) {
+            if ($dispatched = $this->getDispatchedNotifications($notifications)) {
+                throw new Exception(
+                    'These unexpected notifications were dispatched: ['.implode(', ', $dispatched).']'
+                );
+            }
+        });
+
+        return $this;
+    }
+
+    /**
+     * Filter the given notifications against the dispatched notifications.
+     *
+     * @param  array  $notifications
+     * @return array
+     */
+    protected function getDispatchedNotifications(array $notifications)
+    {
+        return $this->getDispatched($notifications,
+            collect($this->dispatchedNotifications)->map(function($notification) {
+                return $notification["instance"];
+            })->all()
+        );
+    }
 }

--- a/src/Illuminate/Foundation/Testing/Concerns/MocksApplicationServices.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MocksApplicationServices.php
@@ -453,7 +453,7 @@ trait MocksApplicationServices
     protected function getDispatchedNotifications(array $notifications)
     {
         return $this->getDispatched($notifications,
-            collect($this->dispatchedNotifications)->map(function($notification) {
+            collect($this->dispatchedNotifications)->map(function ($notification) {
                 return $notification['instance'];
             })->all()
         );

--- a/src/Illuminate/Foundation/Testing/Concerns/MocksApplicationServices.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MocksApplicationServices.php
@@ -454,7 +454,7 @@ trait MocksApplicationServices
     {
         return $this->getDispatched($notifications,
             collect($this->dispatchedNotifications)->map(function($notification) {
-                return $notification["instance"];
+                return $notification['instance'];
             })->all()
         );
     }


### PR DESCRIPTION
There was no way, in a test, to assert that a certain `Notification` was created, like we have for `Job`, `ModelEvent` or `Event`. This PR is a proposal to fix this.
