### PR TITLE
[5.3] Add later() method to MailableMailer as per docs

### DIFF
--- a/src/Illuminate/Mail/MailableMailer.php
+++ b/src/Illuminate/Mail/MailableMailer.php
@@ -128,6 +128,22 @@ class MailableMailer
     }
 
     /**
+     * Deliver the queued message after the given delay.
+     *
+     * @param  \DateTime|int  $delay
+     * @param  Mailable  $mailable
+     * @return mixed
+     */
+    public function later($delay, Mailable $mailable)
+    {
+        $mailable = $mailable->to($this->to)
+                 ->cc($this->cc)
+                 ->bcc($this->bcc);
+
+        return $this->mailer->later($delay, $mailable);
+    }
+
+    /**
      * Populate the mailable with the addresses.
      *
      * @param  Mailable  $mailable


### PR DESCRIPTION
The example in the docs regarding delaying email https://laravel.com/docs/5.3/mail#queueing-mail has a call to a `later()` method which doesn't exist anymore, it was removed in this PR (https://github.com/laravel/framework/pull/14757)

This PR brings it back, if not merged then we need to update the docs.
