### PR TITLE
[5.3] Add SSL options for Postgres DSN

### DIFF
--- a/src/Illuminate/Database/Connectors/PostgresConnector.php
+++ b/src/Illuminate/Database/Connectors/PostgresConnector.php
@@ -97,6 +97,18 @@ class PostgresConnector extends Connector implements ConnectorInterface
             $dsn .= ";sslmode={$sslmode}";
         }
 
+        if (isset($config['sslcert'])) {
+            $dsn .= ";sslcert={$sslcert}";
+        }
+        
+        if (isset($config['sslkey'])) {
+            $dsn .= ";sslkey={$sslkey}";
+        }
+
+        if (isset($config['sslrootcert'])) {
+            $dsn .= ";sslrootcert={$sslrootcert}";
+        }
+
         return $dsn;
     }
 

--- a/src/Illuminate/Database/Connectors/PostgresConnector.php
+++ b/src/Illuminate/Database/Connectors/PostgresConnector.php
@@ -100,7 +100,7 @@ class PostgresConnector extends Connector implements ConnectorInterface
         if (isset($config['sslcert'])) {
             $dsn .= ";sslcert={$sslcert}";
         }
-        
+
         if (isset($config['sslkey'])) {
             $dsn .= ";sslkey={$sslkey}";
         }


### PR DESCRIPTION
There is already the SSLMODE option available, but if you set it to verify-full, you would need to also set the sslrootcert with the full path of the server certificate. This way, the client will be able to check the certificate of the server and be sure it's connecting to the right one.

This patch is only adding the different SSL option available for a postgres connection has stated here: https://www.postgresql.org/docs/9.5/static/libpq-connect.html
