### PR TITLE
[5.3] Flash messages are now displayed on login page when REFERER is not sent

### DIFF
--- a/src/Illuminate/Routing/Redirector.php
+++ b/src/Illuminate/Routing/Redirector.php
@@ -215,5 +215,9 @@ class Redirector
     public function setSession(SessionStore $session)
     {
         $this->session = $session;
+
+        $this->generator->setSessionResolver(function () {
+            return $this->session;
+        });
     }
 }

--- a/tests/Routing/RoutingRedirectorTest.php
+++ b/tests/Routing/RoutingRedirectorTest.php
@@ -25,6 +25,7 @@ class RoutingRedirectorTest extends PHPUnit_Framework_TestCase
         $this->url->shouldReceive('to')->with('login', [], null)->andReturn('http://foo.com/login');
         $this->url->shouldReceive('to')->with('http://foo.com/bar', [], null)->andReturn('http://foo.com/bar');
         $this->url->shouldReceive('to')->with('/', [], null)->andReturn('http://foo.com/');
+        $this->url->shouldReceive('setSessionResolver')->with(m::type('callable'));
 
         $this->session = m::mock('Illuminate\Session\Store');
 


### PR DESCRIPTION
This is a fix for a bug I found while writing test for a project. If the client doesn't send a `REFERER` header when posting data on a login form, the client is not redirected properly and the flash messages (containing the errors) are lost in the process. 

The bug occur in the following circumstances:
- You have a route redirecting from `/` to `/login`
- The client post his (wrong) credentials on the `/login` page without the  `REFERER` header
- Laravel return `/` when executing `redirect()->back()` because the referer is missing and the session cannot be accessed (session is always `null`)
- The client tries to access `/` but is redirected to `/login`, losing the flash messages (flash messages are flushed once the request is completed)
- The client access `/login` with no error messages displayed

Here's relevant code snippets mentioned in the flow above:
- https://github.com/laravel/framework/blob/5.3/src/Illuminate/Foundation/Auth/AuthenticatesUsers.php#L118
- https://github.com/laravel/framework/blob/5.3/src/Illuminate/Routing/Redirector.php#L55
- https://github.com/laravel/framework/blob/5.3/src/Illuminate/Routing/UrlGenerator.php#L136

The bug affect 5.2 and 5.3 and exists since this commit: https://github.com/laravel/framework/commit/4326dc07d8d96161fdc18d0d5859928c395819ad

The fix I propose is relatively simple. It gives UrlGenerator access to the session, so it is able to access `$session->previousUrl()` when the referer is missing. The session is set from Redirector when `setSession($session)` is called.
