### PR TITLE
[5.3] Add '.' by default for 'as' on route

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -875,7 +875,7 @@ class Route
      */
     public function name($name)
     {
-        $this->action['as'] = isset($this->action['as']) ? trim($this->action['as'],'.').'.'.$name : $name;
+        $this->action['as'] = isset($this->action['as']) ? trim($this->action['as'], '.').'.'.$name : $name;
 
         return $this;
     }

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -875,7 +875,7 @@ class Route
      */
     public function name($name)
     {
-        $this->action['as'] = isset($this->action['as']) ? $this->action['as'].$name : $name;
+        $this->action['as'] = isset($this->action['as']) ? trim($this->action['as'],'.').'.'.$name : $name;
 
         return $this;
     }


### PR DESCRIPTION
Related issue:

laravel/internals#181 and #15058

This change adds '.' by default when creating the name of a route so instead of using it like this:

``` php
Route::group([
    'as' => 'admin.', // the trailing dot makes me think this is unintended
    'prefix' => 'admin'
], function () {
    Route::resource('users', 'UserController');
});
```

You can now use it like this:

``` php
Route::group([
    'as' => 'admin',
    'prefix' => 'admin'
], function () {
    Route::resource('users', 'UserController');
});
```

Since prefix is not appending a name to the route name anymore people are using the 'as' to achieve this.

Added a trim function so if you are using the old version with an . at the final of the 'as' parameter it will remove it not breaking existing code base.
