### PR TITLE
[5.3] Changed startsWith and endsWith to use substr (non mbstring)

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -86,8 +86,8 @@ class Str
      */
     public static function endsWith($haystack, $needles)
     {
-        foreach ( (array) $needles as $needle ) {
-            if ( (string) $needle === substr( $haystack, - strlen( $needle ) ) ) {
+        foreach ((array) $needles as $needle) {
+            if ((string) $needle === substr($haystack, - strlen($needle)))  {
                 return true;
             }
         }
@@ -402,8 +402,8 @@ class Str
      */
     public static function startsWith($haystack, $needles)
     {
-        foreach ( (array) $needles as $needle ) {
-            if ( $needle != '' && substr( $haystack, 0, strlen( $needle ) ) === $needle ) {
+        foreach ((array) $needles as $needle) {
+            if ($needle != '' && substr($haystack, 0, strlen($needle)) === $needle) {
                 return true;
             }
         }

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -86,8 +86,8 @@ class Str
      */
     public static function endsWith($haystack, $needles)
     {
-        foreach ((array) $needles as $needle) {
-            if ((string) $needle === static::substr($haystack, -static::length($needle))) {
+        foreach ( (array) $needles as $needle ) {
+            if ( (string) $needle === substr( $haystack, - strlen( $needle ) ) ) {
                 return true;
             }
         }
@@ -402,8 +402,8 @@ class Str
      */
     public static function startsWith($haystack, $needles)
     {
-        foreach ((array) $needles as $needle) {
-            if ($needle != '' && mb_strpos($haystack, $needle) === 0) {
+        foreach ( (array) $needles as $needle ) {
+            if ( $needle != '' && substr( $haystack, 0, strlen( $needle ) ) === $needle ) {
                 return true;
             }
         }


### PR DESCRIPTION
This is OK here because it doesn't

matter whether it's multi-byte unicode chars or not, just that the same number of bytes match at
the start or the end.

The performance of the existing methods becomes increasingly slow with larger strings due to
 mbstring functions.

See https://gist.github.com/Perturbatio/adfe10304f65fb7bdd1adda0435c2f93 for a test.

Running this on my machine using an extreme example of 4.5MB text@10K iterations returns:

> startsWith against validMatch
> Finished in 130.06023406982 seconds, 10000 matches found
> 
> startsWith against invalidMatch
> Finished in 141.01113009453 seconds, 0 matches found
> 
> startsWithAlt against validMatch
> Finished in 0.0055170059204102 seconds, 10000 matches found
> 
> startsWithAlt against invalidMatch
> Finished in 0.0040779113769531 seconds, 0 matches found
> 
> endsWith against validMatch
> Finished in 221.22829198837 seconds, 10000 matches found
> 
> endsWith against invalidMatch
> Finished in 221.26664710045 seconds, 0 matches found
> 
> endsWithAlt against validMatch
> Finished in 0.0044331550598145 seconds, 10000 matches found
> 
> endsWithAlt against invalidMatch
> Finished in 0.0062880516052246 seconds, 0 matches found
