### PR TITLE
[5.3] Updated method has

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -277,15 +277,15 @@ class Arr
      */
     public static function has($array, $keys)
     {
+        if (! $array) {
+            return false;
+        }
+
         if (is_null($keys)) {
             return false;
         }
 
         $keys = (array) $keys;
-
-        if (! $array) {
-            return false;
-        }
 
         if ($keys === []) {
             return false;


### PR DESCRIPTION
We do not need to allocate memory for `$keys`  if we do not have a collection to check.
