### PR TITLE
[5.3] Add an `any` method to the Arr class

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -38,6 +38,28 @@ class Arr
     }
 
     /**
+     * Check if any item or items exist in an array using "dot" notation.
+     *
+     * @param  \ArrayAccess|array  $array
+     * @param  string|array  $keys
+     * @return bool
+     */
+    public static function any($array, $keys)
+    {
+        if (! static::accessible($array)) {
+            return false;
+        }
+
+        foreach ((array) $keys as $key) {
+            if(static::has($array, $key)){
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * Collapse an array of arrays into a single array.
      *
      * @param  array  $array

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -24,6 +24,38 @@ class SupportArrTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(['name' => 'Desk', 'price' => 100], $array);
     }
 
+    public function testAny()
+    {
+        $array = ['products.desk' => ['price' => 100]];
+        $this->assertTrue(Arr::any($array, 'products.desk'));
+
+        $array = ['products' => ['desk' => ['price' => 100], 'foo' => ['price' => 100]]];
+        $this->assertTrue(Arr::any($array, ['products.foo', 'products.desk']));
+        $this->assertTrue(Arr::any($array, ['products.desk.price', 'products.desk.count']));
+        $this->assertFalse(Arr::any($array, ['products.baz', 'products.desk.count']));
+
+        $array = ['foo' => null, 'bar' => ['baz' => null]];
+        $this->assertTrue(Arr::any($array, ['foo', 'desk']));
+        $this->assertTrue(Arr::any($array, ['foo.foo', 'bar.baz']));
+
+        $array = new ArrayObject(['foo' => 10, 'bar' => new ArrayObject(['baz' => 10])]);
+        $this->assertTrue(Arr::any($array, ['foo.foo', 'baz.bar', 'bar']));
+        $this->assertTrue(Arr::any($array, ['bar', 'baz']));
+
+        $array = ['foo', 'bar'];
+        $this->assertFalse(Arr::any($array, null));
+
+        $this->assertFalse(Arr::any(null, ['foo', 'baz']));
+        $this->assertFalse(Arr::any(false, ['foo', 'bar.foo']));
+        $this->assertFalse(Arr::any(true, ['foo', 'bar', 'baz']));
+
+        $this->assertFalse(Arr::any(null, null));
+        $this->assertFalse(Arr::any([], null));
+
+        $this->assertFalse(Arr::any([], [null, true]));
+        $this->assertFalse(Arr::any(null, [null, false]));
+    }
+
     public function testCollapse()
     {
         $data = [['foo', 'bar'], ['baz']];


### PR DESCRIPTION
Allows check if any item or items exist in an array using "dot" notation.

``` php
if (Arr::any($array, $keys)) {
    //
}
```
