### PR TITLE
[5.3] Naming auth routes

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -287,19 +287,19 @@ class Router implements RegistrarContract
     public function auth()
     {
         // Authentication Routes...
-        $this->get('login', 'Auth\LoginController@showLoginForm')->name('login');
-        $this->post('login', 'Auth\LoginController@login');
-        $this->post('logout', 'Auth\LoginController@logout');
+        $this->get('login', 'Auth\LoginController@showLoginForm')->name('auth.login');
+        $this->post('login', 'Auth\LoginController@login')->name('auth.login');
+        $this->post('logout', 'Auth\LoginController@logout')->name('auth.logout');
 
         // Registration Routes...
-        $this->get('register', 'Auth\RegisterController@showRegistrationForm');
-        $this->post('register', 'Auth\RegisterController@register');
+        $this->get('register', 'Auth\RegisterController@showRegistrationForm')->name('auth.register');
+        $this->post('register', 'Auth\RegisterController@register')->name('auth.register');
 
         // Password Reset Routes...
-        $this->get('password/reset', 'Auth\ForgotPasswordController@showLinkRequestForm');
-        $this->post('password/email', 'Auth\ForgotPasswordController@sendResetLinkEmail');
-        $this->get('password/reset/{token}', 'Auth\ResetPasswordController@showResetForm');
-        $this->post('password/reset', 'Auth\ResetPasswordController@reset');
+        $this->get('password/reset', 'Auth\ForgotPasswordController@showLinkRequestForm')->name('auth.password.forgot');
+        $this->post('password/email', 'Auth\ForgotPasswordController@sendResetLinkEmail')->name('auth.password.forgot');
+        $this->get('password/reset/{token}', 'Auth\ResetPasswordController@showResetForm')->name('auth.password.reset');
+        $this->post('password/reset', 'Auth\ResetPasswordController@reset')->name('auth.password.reset');
     }
 
     /**


### PR DESCRIPTION
I think there wouldn't be any conflict between identical route names for two HTTP methods but if you think it is not a good way that two methods have the same route name, then I have one another idea.

For example, here we have the same name for these methods:

``` php
public function auth()
{
    // Authentication Routes...
    $this->get('login', 'Auth\LoginController@showLoginForm')->name('auth.login');
    $this->post('login', 'Auth\LoginController@login')->name('auth.login');
    ...
    ...
}
```

So we can change the rotue name of first method like this:

``` php
$this->get('login', 'Auth\LoginController@showLoginForm')->name('auth.login.form');
```

And so on for other mehtod's route name.
