### PR TITLE
[5.3] Add possibility of not displaying any greeting

### DIFF
--- a/src/Illuminate/Notifications/resources/views/email-plain.blade.php
+++ b/src/Illuminate/Notifications/resources/views/email-plain.blade.php
@@ -1,6 +1,6 @@
 <?php
 
-if (! empty($greeting)) {
+if (! is_null($greeting)) {
     echo $greeting, "\n\n";
 } else {
     echo $level == 'error' ? 'Whoops!' : 'Hello!', "\n\n";

--- a/src/Illuminate/Notifications/resources/views/email.blade.php
+++ b/src/Illuminate/Notifications/resources/views/email.blade.php
@@ -83,17 +83,19 @@ $style = [
                                 <tr>
                                     <td style="{{ $fontFamily }} {{ $style['email-body_cell'] }}">
                                         <!-- Greeting -->
-                                        <h1 style="{{ $style['header-1'] }}">
-                                            @if (! empty($greeting))
-                                                {{ $greeting }}
-                                            @else
-                                                @if ($level == 'error')
-                                                    Whoops!
+                                        @if (! empty($greeting) || is_null($greeting))
+                                            <h1 style="{{ $style['header-1'] }}">
+                                                @if (! is_null($greeting))
+                                                    {{ $greeting }}
                                                 @else
-                                                    Hello!
+                                                    @if ($level == 'error')
+                                                        Whoops!
+                                                    @else
+                                                        Hello!
+                                                    @endif
                                                 @endif
-                                            @endif
-                                        </h1>
+                                            </h1>
+                                        @endif
 
                                         <!-- Intro -->
                                         @foreach ($introLines as $line)


### PR DESCRIPTION
if greeting is set to `false` or `''` nothing should be displayed. However now in these cases it defaults to hello/oops. This pr aims to fix this. 

Reverting https://github.com/laravel/framework/commit/7299d016862c5163570c9c7aa86a95fc26234521  (https://github.com/laravel/framework/pull/15127)

and reverting change of is_null to empty in https://github.com/laravel/framework/commit/2df848545b19cb70d0ce6a4d2a9560c7d1244cdd
