### PR TITLE
[5.3] change to loosey comparison to allow queue to run without --tries

### DIFF
--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -266,7 +266,7 @@ class Worker
      */
     protected function markJobAsFailedIfAlreadyExceedsMaxAttempts($connectionName, $job, $maxTries)
     {
-        if ($maxTries === 0 || $job->attempts() <= $maxTries) {
+        if ($maxTries == 0 || $job->attempts() <= $maxTries) {
             return;
         }
 


### PR DESCRIPTION
Fixes the issue where running `php artisan queue:listen` marks jobs failed unless `--tries=1`

The issue is referenced in #15319
