### PR TITLE
Update AuthorizesRequests.php

### DIFF
--- a/src/Illuminate/Foundation/Auth/Access/AuthorizesRequests.php
+++ b/src/Illuminate/Foundation/Auth/Access/AuthorizesRequests.php
@@ -86,7 +86,7 @@ trait AuthorizesRequests
         $middleware = [];
 
         foreach ($this->resourceAbilityMap() as $method => $ability) {
-            $modelName = in_array($method, ['index', 'create', 'store']) ? $model : $parameter;
+            $modelName = in_array($method, ['index', 'create', 'store']) ? get_class($model) : $parameter;
 
             $middleware["can:{$ability},{$modelName}"][] = $method;
         }


### PR DESCRIPTION
Use get_class() to get the full class name where implicit model binding is not utilized.
