### PR TITLE
[5.3] Updates Service Provider class to use resource path over base path

### DIFF
--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -68,7 +68,7 @@ abstract class ServiceProvider
      */
     protected function loadViewsFrom($path, $namespace)
     {
-        if (is_dir($appPath = $this->app->basePath().'/resources/views/vendor/'.$namespace)) {
+        if (is_dir($appPath = $this->app->resourcePath().'/views/vendor/'.$namespace)) {
             $this->app['view']->addNamespace($namespace, $appPath);
         }
 


### PR DESCRIPTION
Minor alteration for service providers to no longer use base path to map view vendor folders
