### PR TITLE
[5.3] fire new Registered event when user registers

### DIFF
--- a/src/Illuminate/Auth/Events/Registered.php
+++ b/src/Illuminate/Auth/Events/Registered.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Illuminate\Auth\Events;
+
+use Illuminate\Queue\SerializesModels;
+
+class Registered
+{
+    use SerializesModels;
+
+    /**
+     * The authenticated user.
+     *
+     * @var \Illuminate\Contracts\Auth\Authenticatable
+     */
+    public $user;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
+     * @return void
+     */
+    public function __construct($user)
+    {
+        $this->user = $user;
+    }
+}

--- a/src/Illuminate/Foundation/Auth/RegistersUsers.php
+++ b/src/Illuminate/Foundation/Auth/RegistersUsers.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Foundation\Auth;
 
+use Illuminate\Auth\Events\Registered;
+use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 
@@ -29,9 +31,24 @@ trait RegistersUsers
     {
         $this->validator($request->all())->validate();
 
-        $this->guard()->login($this->create($request->all()));
+        $user = $this->create($request->all());
+
+        $this->fireRegisteredEvent($user);
+
+        $this->guard()->login($user);
 
         return redirect($this->redirectPath());
+    }
+
+    /**
+     * Fire an event when a user registers.
+     *
+     * @param \Illuminate\Contracts\Auth\Authenticatable $authenticatable
+     * @return void
+     */
+    protected function fireRegisteredEvent(Authenticatable $authenticatable)
+    {
+        event(new Registered($authenticatable));
     }
 
     /**

--- a/src/Illuminate/Foundation/Auth/RegistersUsers.php
+++ b/src/Illuminate/Foundation/Auth/RegistersUsers.php
@@ -2,10 +2,10 @@
 
 namespace Illuminate\Foundation\Auth;
 
-use Illuminate\Auth\Events\Registered;
-use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Auth\Events\Registered;
+use Illuminate\Contracts\Auth\Authenticatable;
 
 trait RegistersUsers
 {


### PR DESCRIPTION
As proposed in laravel/internals#197 this PR adds a new event, `Illuminate\Auth\Events\Registered`, which fires when registering a user via the `RegistersUsers` trait.
