### PR TITLE
[5.3] Add whereBits to the query builder

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1080,7 +1080,9 @@ class Builder
 
         $type = 'Bits';
 
-        $this->wheres[] = compact('type', 'column', 'bits', 'bitwise', 'compare', 'compareValue', 'boolean');
+        $this->wheres[] = compact('type', 'column', 'bitwise', 'compare', 'boolean');
+
+        $this->addBinding([$bits, $compareValue], 'where');
 
         return $this;
     }

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1052,6 +1052,55 @@ class Builder
     }
 
     /**
+     * Add a "where bits" statement to the query.
+     *
+     * @param  string  $column
+     * @param  string  $bitwise
+     * @param  int  $bits
+     * @param  string  $compare
+     * @param  int  $compareValue
+     * @param  string  $boolean
+     * @return \Illuminate\Database\Query\Builder|static
+     */
+    public function whereBits($column, $bitwise = '&', $bits = 0, $compare = '=', $compareValue = null, $boolean = 'and')
+    {
+        // Shorthand if we want a simple comparison, much like `where(...)`
+        if (func_num_args() == 2) {
+            $bits = $bitwise;
+            $bitwise = '&';
+        }
+
+        if (! in_array($bitwise, $this->operators) || ! in_array($compare, $this->operators)) {
+            throw new InvalidArgumentException('Illegal operators');
+        }
+
+        if (is_null($compareValue)) {
+            $compareValue = $bits;
+        }
+
+        $type = 'Bits';
+
+        $this->wheres[] = compact('type', 'column', 'bits', 'bitwise', 'compare', 'compareValue', 'boolean');
+
+        return $this;
+    }
+
+    /**
+     * Add an "or where bits" statement to the query.
+     *
+     * @param  string  $column
+     * @param  string  $bitwise
+     * @param  int  $bits
+     * @param  string  $compare
+     * @param  int  $compareValue
+     * @return \Illuminate\Database\Query\Builder|static
+     */
+    public function orWhereBits($column, $bitwise = '&', $bits = 0, $compare = '=', $compareValue = null)
+    {
+        return $this->whereBits($column, $bitwise, $bits, $compare, $compareValue, 'or');
+    }
+
+    /**
      * Add a "where date" statement to the query.
      *
      * @param  string  $column

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -386,10 +386,7 @@ class Grammar extends BaseGrammar
      */
     protected function whereBits(Builder $query, $where)
     {
-        $maskBits = 'b\''.decbin($where['bits']).'\'';
-        $valueBits = 'b\''.decbin($where['compareValue']).'\'';
-
-        return $this->wrap($where['column'])." {$where['bitwise']} {$maskBits} {$where['compare']} {$valueBits}";
+        return $this->wrap($where['column'])." {$where['bitwise']} ? {$where['compare']} ?";
     }
 
     /**

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -378,6 +378,21 @@ class Grammar extends BaseGrammar
     }
 
     /**
+     * Compile a "where bits" clause.
+     *
+     * @param  Builder  $query
+     * @param  array  $where
+     * @return string
+     */
+    protected function whereBits(Builder $query, $where)
+    {
+        $maskBits = 'b\''.decbin($where['bits']).'\'';
+        $valueBits = 'b\''.decbin($where['compareValue']).'\'';
+
+        return $this->wrap($where['column'])." {$where['bitwise']} {$maskBits} {$where['compare']} {$valueBits}";
+    }
+
+    /**
      * Compile a "where date" clause.
      *
      * @param  \Illuminate\Database\Query\Builder  $query

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -552,6 +552,23 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase
         $this->assertEquals([0 => 1], $builder->getBindings());
     }
 
+    public function testWhereBits()
+    {
+        $FLAG_CAN_READ = 0b01;
+        $FLAG_CAN_WRITE = 0b10;
+        $FLAG_CAN_DO_SOMETHING = 0b1;
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereBits('flags', $FLAG_CAN_READ | $FLAG_CAN_WRITE);
+        $this->assertEquals('select * from "users" where "flags" & b\'11\' = b\'11\'', $builder->toSql());
+        $this->assertEquals([], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('role', '=', 'admin')->orWhereBits('flags', '|', $FLAG_CAN_DO_SOMETHING, '>', 2);
+        $this->assertEquals('select * from "users" where "role" = ? or "flags" | b\'1\' > b\'10\'', $builder->toSql());
+        $this->assertEquals([0 => 'admin'], $builder->getBindings());
+    }
+
     public function testGroupBys()
     {
         $builder = $this->getBuilder();

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -560,13 +560,13 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereBits('flags', $FLAG_CAN_READ | $FLAG_CAN_WRITE);
-        $this->assertEquals('select * from "users" where "flags" & b\'11\' = b\'11\'', $builder->toSql());
-        $this->assertEquals([], $builder->getBindings());
+        $this->assertEquals('select * from "users" where "flags" & ? = ?', $builder->toSql());
+        $this->assertEquals([0 => 3, 1 => 3], $builder->getBindings());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where('role', '=', 'admin')->orWhereBits('flags', '|', $FLAG_CAN_DO_SOMETHING, '>', 2);
-        $this->assertEquals('select * from "users" where "role" = ? or "flags" | b\'1\' > b\'10\'', $builder->toSql());
-        $this->assertEquals([0 => 'admin'], $builder->getBindings());
+        $this->assertEquals('select * from "users" where "role" = ? or "flags" | ? > ?', $builder->toSql());
+        $this->assertEquals([0 => 'admin', 1 => 1, 2 => 2], $builder->getBindings());
     }
 
     public function testGroupBys()


### PR DESCRIPTION
When using integer fields as flag fields this is helpful when querying.

**Signature:**

``` php
whereBits($column, $bitwise = '&', $bits = 0, $compare = '=', $compareValue = null)
// which will roughly translate to SQL:
//     "where $column & $bits $compare $compareValue"
// e.g.
//     "select * from users where `flags` | ? > ?" with bindings like [0 => $bits, 1 => $compareValue]
```

When the number of arguments is 2, it will be assumed that the second argument is the `$bits` argument. `$compareValue`, if ommitted will be assumed to have the same value as `$bits`.

**Example:**

``` php
define('CAN_DO_SOMETHING', 0b0001); // 1
define('CAN_READ',         0b0010); // 2
define('CAN_WRITE',        0b0100); // 4
define('CAN_ADMIN',        0b1000); // 8

$admin = CAN_READ | CAN_WRITE | CAN_ADMIN; // 0b1110 or 14

// Will get all users that can read, write and administer
\DB::table('users')->whereBits('flags', $admin)->get();
// SQL: "select * from users where flags & ? = ?" with bindings [0 => 14, 1 => 14]
```
