### PR TITLE
[5.3] Request object returns empty parameters when we make a POST method, and spoof it as a GET request using X-HTTP-METHOD-OVERRIDE or _method parameter

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -665,7 +665,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
             return $this->json();
         }
 
-        return $this->getMethod() == 'GET' ? $this->query : $this->request;
+        return $this->getRealMethod() == 'GET' ? $this->query : $this->request;
     }
 
     /**


### PR DESCRIPTION
Fix issue where request object fails to return parameters when we make a POST method, and spoof it as a GET request using X-HTTP-METHOD-OVERRIDE or _method parameter
#15348
