### PR TITLE
[5.3] Add optional fallback to @includeIf statement

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -889,8 +889,13 @@ class BladeCompiler extends Compiler implements CompilerInterface
         $expression = $this->stripParentheses($expression);
 
         if (preg_match('/(.+),\s*(.+)/', $expression, $matches)) {
-            return "<?php if (\$__env->exists({$matches[1]})) echo \$__env->make({$matches[1]}, array_except(get_defined_vars(), array('__data', '__path')))->render(); ".
-                "else echo \$__env->make({$matches[2]}, array_except(get_defined_vars(), array('__data', '__path')))->render(); ?>";
+            return "<?php
+                if (\$__env->exists({$matches[1]})) {
+                    echo \$__env->make({$matches[1]}, array_except(get_defined_vars(), array('__data', '__path')))->render();
+                } { else {
+                    echo \$__env->make({$matches[2]}, array_except(get_defined_vars(), array('__data', '__path')))->render();
+                }
+            ?>";
         }
 
         return "<?php if (\$__env->exists($expression)) echo \$__env->make($expression, array_except(get_defined_vars(), array('__data', '__path')))->render(); ?>";

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -888,6 +888,11 @@ class BladeCompiler extends Compiler implements CompilerInterface
     {
         $expression = $this->stripParentheses($expression);
 
+        if (preg_match('/(.+),\s*(.+)/', $expression, $matches)) {
+            return "<?php if (\$__env->exists({$matches[1]})) echo \$__env->make({$matches[1]}, array_except(get_defined_vars(), array('__data', '__path')))->render(); ".
+                "else echo \$__env->make({$matches[2]}, array_except(get_defined_vars(), array('__data', '__path')))->render(); ?>";
+        }
+
         return "<?php if (\$__env->exists($expression)) echo \$__env->make($expression, array_except(get_defined_vars(), array('__data', '__path')))->render(); ?>";
     }
 

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -622,8 +622,20 @@ empty
         $compiler = new BladeCompiler($this->getFiles(), __DIR__);
         $this->assertEquals('<?php if ($__env->exists(\'foo\')) echo $__env->make(\'foo\', array_except(get_defined_vars(), array(\'__data\', \'__path\')))->render(); ?>', $compiler->compileString('@includeIf(\'foo\')'));
         $this->assertEquals('<?php if ($__env->exists(name(foo))) echo $__env->make(name(foo), array_except(get_defined_vars(), array(\'__data\', \'__path\')))->render(); ?>', $compiler->compileString('@includeIf(name(foo))'));
-        $this->assertEquals('<?php if ($__env->exists(\'foo\')) echo $__env->make(\'foo\', array_except(get_defined_vars(), array(\'__data\', \'__path\')))->render(); else echo $__env->make(\'bar\', array_except(get_defined_vars(), array(\'__data\', \'__path\')))->render(); ?>', $compiler->compileString('@includeIf(\'foo\', \'bar\')'));
-        $this->assertEquals('<?php if ($__env->exists(name(foo))) echo $__env->make(name(foo), array_except(get_defined_vars(), array(\'__data\', \'__path\')))->render(); else echo $__env->make(name(bar), array_except(get_defined_vars(), array(\'__data\', \'__path\')))->render(); ?>', $compiler->compileString('@includeIf(name(foo), name(bar))'));
+        $this->assertEquals('<?php
+                if ($__env->exists(\'foo\')) {
+                    echo $__env->make(\'foo\', array_except(get_defined_vars(), array(\'__data\', \'__path\')))->render();
+                } { else {
+                    echo $__env->make(\'bar\', array_except(get_defined_vars(), array(\'__data\', \'__path\')))->render();
+                }
+            ?>', $compiler->compileString('@includeIf(\'foo\', \'bar\')'));
+        $this->assertEquals('<?php
+                if ($__env->exists(name(foo))) {
+                    echo $__env->make(name(foo), array_except(get_defined_vars(), array(\'__data\', \'__path\')))->render();
+                } { else {
+                    echo $__env->make(name(bar), array_except(get_defined_vars(), array(\'__data\', \'__path\')))->render();
+                }
+            ?>', $compiler->compileString('@includeIf(name(foo), name(bar))'));
     }
 
     public function testShowEachAreCompiled()

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -622,6 +622,8 @@ empty
         $compiler = new BladeCompiler($this->getFiles(), __DIR__);
         $this->assertEquals('<?php if ($__env->exists(\'foo\')) echo $__env->make(\'foo\', array_except(get_defined_vars(), array(\'__data\', \'__path\')))->render(); ?>', $compiler->compileString('@includeIf(\'foo\')'));
         $this->assertEquals('<?php if ($__env->exists(name(foo))) echo $__env->make(name(foo), array_except(get_defined_vars(), array(\'__data\', \'__path\')))->render(); ?>', $compiler->compileString('@includeIf(name(foo))'));
+        $this->assertEquals('<?php if ($__env->exists(\'foo\')) echo $__env->make(\'foo\', array_except(get_defined_vars(), array(\'__data\', \'__path\')))->render(); else echo $__env->make(\'bar\', array_except(get_defined_vars(), array(\'__data\', \'__path\')))->render(); ?>', $compiler->compileString('@includeIf(\'foo\', \'bar\')'));
+        $this->assertEquals('<?php if ($__env->exists(name(foo))) echo $__env->make(name(foo), array_except(get_defined_vars(), array(\'__data\', \'__path\')))->render(); else echo $__env->make(name(bar), array_except(get_defined_vars(), array(\'__data\', \'__path\')))->render(); ?>', $compiler->compileString('@includeIf(name(foo), name(bar))'));
     }
 
     public function testShowEachAreCompiled()


### PR DESCRIPTION
Adds an optional fallback parameter for when a view doesn't exist.

Example & Use case:

``` blade
@foreach ($section in $sections)
    @includeIf('part.' . $section->type . '.header', 'part.header')
@endforeach
```
