### PR TITLE
[5.4] Fixed broken dependency between sf/debug and sf/console

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "ramsey/uuid": "~3.0",
         "swiftmailer/swiftmailer": "~5.1",
         "symfony/console": "3.2.*",
-        "symfony/debug": "3.2.*",
+        "symfony/debug": "~2.7|3.2.*",
         "symfony/finder": "3.2.*",
         "symfony/http-foundation": "3.2.*",
         "symfony/http-kernel": "3.2.*",


### PR DESCRIPTION
Due to [this commit in symfony/console](https://github.com/symfony/console/commit/94234c0b81c39c832e907b65d7af1621be43d6ec#diff-b5d0ee8c97c7abd7e3fa29b9a27d1780), pointing at `symfony/debug:3.2.*` is not compatible with `symfony/console:3.2.*`.

This fixes the compatibility. Will probably have to revert once sf straightens their deps.
