### PR TITLE
[5.3] Added `Container::getFactory()` method

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -1238,4 +1238,21 @@ class Container implements ArrayAccess, ContainerContract
     {
         $this[$key] = $value;
     }
+
+    /**
+     * Get a closure to resolve the given type from the container.
+     * The given closure will have an optional [array $parameters] parameter
+     * to merge with the default parameters given when the factory was made.
+     *
+     * @param  string $abstract
+     * @param  array  $defaults
+     *
+     * @return \Closure
+     */
+    public function getFactory($abstract, array $defaults = [])
+    {
+        return function (array $params = []) use ($abstract, $defaults) {
+            return $this->make($abstract, $params + $defaults);
+        };
+    }
 }

--- a/src/Illuminate/Contracts/Container/Container.php
+++ b/src/Illuminate/Contracts/Container/Container.php
@@ -141,4 +141,16 @@ interface Container
      * @return void
      */
     public function afterResolving($abstract, Closure $callback = null);
+
+    /**
+     * Get a closure to resolve the given type from the container.
+     * The given closure will have an optional [array $parameters] parameter
+     * to merge with the default parameters given when the factory was made.
+     *
+     * @param  string $abstract
+     * @param  array  $defaults
+     *
+     * @return \Closure
+     */
+    public function getFactory($abstract, array $defaults = []);
 }

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -667,6 +667,50 @@ class ContainerContainerTest extends PHPUnit_Framework_TestCase
         $instance = $container->make('ContainerInjectVariableStub');
         $this->assertInstanceOf('ContainerConcreteStub', $instance->something);
     }
+
+    public function testContainerGetFactory()
+    {
+        $container = new Container;
+        $container->bind('name', function () {
+            return 'Taylor';
+        });
+    
+        $factory = $container->getFactory('name');
+        $this->assertEquals($container->make('name'), $factory());
+    }
+
+    public function testContainerGetFactoryWithDefaultParams()
+    {
+        $container = new Container;
+        $container->bind('foo', function ($c, $parameters) {
+            return $parameters;
+        });
+    
+        $factory = $container->getFactory('foo', [1, 2, 3]);
+        $this->assertEquals([1, 2, 3], $factory());
+    }
+
+    public function testContainerGetFactoryWithOverridenParams()
+    {
+        $container = new Container;
+        $container->bind('foo', function ($c, $parameters) {
+            return $parameters;
+        });
+    
+        $factory = $container->getFactory('foo', [1, 2, 3]);
+        $this->assertEquals([4, 2, 3], $factory([4]));
+    }
+
+    public function testContainerGetFactoryWithOverridenNamedParams()
+    {
+        $container = new Container;
+        $container->bind('foo', function ($c, $parameters) {
+            return $parameters;
+        });
+    
+        $factory = $container->getFactory('foo', ['bar' => 1, 'baz' => 2]);
+        $this->assertEquals(['bar' => 1, 'baz' => 3], $factory(['baz' => 3]));
+    }
 }
 
 class ContainerConcreteStub


### PR DESCRIPTION
This would allow `Closure` factories to be easily made at entry point level, without having to inject `Container` where only a single factory method is required.
