### PR TITLE
[5.3] Only filter null values on Request::intersect

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -383,7 +383,11 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
      */
     public function intersect($keys)
     {
-        return array_filter($this->only(is_array($keys) ? $keys : func_get_args()));
+        $keys = is_array($keys) ? $keys : func_get_args();
+
+        return array_filter($this->only($keys), function ($value) {
+            return ! is_null($value);
+        });
     }
 
     /**

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -260,8 +260,8 @@ class HttpRequestTest extends PHPUnit_Framework_TestCase
 
     public function testIntersectMethod()
     {
-        $request = Request::create('/', 'GET', ['name' => 'Taylor', 'age' => null]);
-        $this->assertEquals(['name' => 'Taylor'], $request->intersect('name', 'age', 'email'));
+        $request = Request::create('/', 'GET', ['name' => 'Taylor', 'age' => null, 'approved' => false]);
+        $this->assertEquals(['name' => 'Taylor', 'approved' => false], $request->intersect('name', 'age', 'email', 'approved'));
     }
 
     public function testQueryMethod()

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -264,7 +264,7 @@ class HttpRequestTest extends PHPUnit_Framework_TestCase
             'name' => 'Taylor',
             'age' => null,
             'approved' => false,
-            'bio' => ''
+            'bio' => '',
         ]);
         $this->assertEquals(
             ['name' => 'Taylor', 'approved' => false, 'bio' => ''],

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -260,8 +260,16 @@ class HttpRequestTest extends PHPUnit_Framework_TestCase
 
     public function testIntersectMethod()
     {
-        $request = Request::create('/', 'GET', ['name' => 'Taylor', 'age' => null, 'approved' => false]);
-        $this->assertEquals(['name' => 'Taylor', 'approved' => false], $request->intersect('name', 'age', 'email', 'approved'));
+        $request = Request::create('/', 'GET', [
+            'name' => 'Taylor',
+            'age' => null,
+            'approved' => false,
+            'bio' => ''
+        ]);
+        $this->assertEquals([
+            'name' => 'Taylor', 'approved' => false, 'bio' => ''
+            ], $request->intersect('name', 'age', 'email', 'approved', 'bio')
+        );
     }
 
     public function testQueryMethod()

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -266,9 +266,9 @@ class HttpRequestTest extends PHPUnit_Framework_TestCase
             'approved' => false,
             'bio' => ''
         ]);
-        $this->assertEquals([
-            'name' => 'Taylor', 'approved' => false, 'bio' => ''
-            ], $request->intersect('name', 'age', 'email', 'approved', 'bio')
+        $this->assertEquals(
+            ['name' => 'Taylor', 'approved' => false, 'bio' => ''],
+            $request->intersect('name', 'age', 'email', 'approved', 'bio')
         );
     }
 


### PR DESCRIPTION
This will prevent filtering out falsy and instead only filter `null` values.

given

``` json
{
    "foo": " ",
    "bar": null,
    "baz": false
}
```

Before

``` php
Request::intersect('foo', 'bar', 'baz')
// ["foo" => " "]
```

After

``` php
Request::intersect('foo', 'bar', 'baz')
// ["foo" => " ",  "baz" => false]
```
