### PR TITLE
[5.3] add $default parameter to query builder when() method

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -459,14 +459,17 @@ class Builder
      *
      * @param  bool  $value
      * @param  \Closure  $callback
+     * @param  \Closure  $default
      * @return \Illuminate\Database\Query\Builder
      */
-    public function when($value, $callback)
+    public function when($value, $callback, $default = null)
     {
         $builder = $this;
 
         if ($value) {
             $builder = call_user_func($callback, $builder);
+        } elseif ($default) {
+            $builder = call_user_func($default, $builder);
         }
 
         return $builder;

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -134,13 +134,13 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase
         $builder->select('*')->from('users')->when(false, $callback)->where('email', 'foo');
         $this->assertEquals('select * from "users" where "email" = ?', $builder->toSql());
     }
-    
+
     public function testWhenCallbackWithDefault()
     {
         $callback = function ($query) {
             return $query->where('id', '=', 1);
         };
-        
+
         $default = function ($query) {
             return $query->where('id', '=', 2);
         };

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -134,6 +134,27 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase
         $builder->select('*')->from('users')->when(false, $callback)->where('email', 'foo');
         $this->assertEquals('select * from "users" where "email" = ?', $builder->toSql());
     }
+    
+    public function testWhenCallbackWithDefault()
+    {
+        $callback = function ($query) {
+            return $query->where('id', '=', 1);
+        };
+        
+        $default = function ($query) {
+            return $query->where('id', '=', 2);
+        };
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->when(true, $callback, $default)->where('email', 'foo');
+        $this->assertEquals('select * from "users" where "id" = ? and "email" = ?', $builder->toSql());
+        $this->assertEquals([0 => 1], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->when(false, $callback, $default)->where('email', 'foo');
+        $this->assertEquals('select * from "users" where "id" = ? and "email" = ?', $builder->toSql());
+        $this->assertEquals([0 => 2], $builder->getBindings());
+    }
 
     public function testBasicWheres()
     {

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -148,12 +148,12 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->when(true, $callback, $default)->where('email', 'foo');
         $this->assertEquals('select * from "users" where "id" = ? and "email" = ?', $builder->toSql());
-        $this->assertEquals([1 => 1], $builder->getBindings());
+        $this->assertEquals([0 => 1, 1 => 'foo'], $builder->getBindings());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->when(false, $callback, $default)->where('email', 'foo');
         $this->assertEquals('select * from "users" where "id" = ? and "email" = ?', $builder->toSql());
-        $this->assertEquals([1 => 2], $builder->getBindings());
+        $this->assertEquals([0 => 2, 1 => 'foo'], $builder->getBindings());
     }
 
     public function testBasicWheres()

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -148,12 +148,12 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->when(true, $callback, $default)->where('email', 'foo');
         $this->assertEquals('select * from "users" where "id" = ? and "email" = ?', $builder->toSql());
-        $this->assertEquals([0 => 1], $builder->getBindings());
+        $this->assertEquals([1 => 1], $builder->getBindings());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->when(false, $callback, $default)->where('email', 'foo');
         $this->assertEquals('select * from "users" where "id" = ? and "email" = ?', $builder->toSql());
-        $this->assertEquals([0 => 2], $builder->getBindings());
+        $this->assertEquals([1 => 2], $builder->getBindings());
     }
 
     public function testBasicWheres()


### PR DESCRIPTION
Trying this again (old PRS #15422 #15421)
## 

This allows you to specify a default closure to run if the `when()` $value attribute is false.

I recently found myself creating a sorting / filtering system with defaults that the user could change. Without this you would have to do all kinds of wackiness to clear the previous where() clause on $value being true.

Here is an example of this in action

``` php

Time::when($request->has('type'), function ($query) use ($request) {
    return $query->where('type', $request->input('type'));
}, function ($query) {
    return $query->where('type', 1);
})
->get();


```
