### PR TITLE
[5.4] Added `Container::factory()` method to the Container contract

### DIFF
--- a/src/Illuminate/Contracts/Container/Container.php
+++ b/src/Illuminate/Contracts/Container/Container.php
@@ -98,6 +98,15 @@ interface Container
     public function when($concrete);
 
     /**
+     * Get a closure to resolve the given type from the container.
+     *
+     * @param  string  $abstract
+     * @param  array  $defaults
+     * @return \Closure
+     */
+    public function factory($abstract, array $defaults = []);
+
+    /**
      * Resolve the given type from the container.
      *
      * @param  string  $abstract


### PR DESCRIPTION
As discussed with @GrahamCampbell in #15414 and #15415, this BC change could be introduced in 5.4.
