### PR TITLE
[5.3] Update Validator.php

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -459,11 +459,13 @@ class Validator implements ValidatorContract
 
             foreach ($rules as $rule) {
                 $this->validateAttribute($attribute, $rule);
-
                 if ($this->shouldStopValidating($attribute)) {
                     break;
                 }
             }
+             if ($this->shouldStopValidation($attribute)) {
+                 break;
+             }
         }
 
         // Here we will spin through all of the "after" hooks on this validator and
@@ -770,30 +772,66 @@ class Validator implements ValidatorContract
         return true;
     }
 
-    /**
-     * Check if we should stop further validations on a given attribute.
-     *
-     * @param  string  $attribute
-     * @return bool
-     */
-    protected function shouldStopValidating($attribute)
-    {
-        if ($this->hasRule($attribute, ['Bail'])) {
-            return $this->messages->has($attribute);
-        }
+     /**
+      * Check if we should stop further validations on a given attribute.
+      *
+      * @param  string  $attribute
+      * @return bool
+      */
+     protected function shouldStopValidating($attribute)
+     {
+         return $this->shouldStop($attribute, 'Bail');
+     }
 
-        if (isset($this->failedRules[$attribute]) &&
-            in_array('uploaded', array_keys($this->failedRules[$attribute]))) {
-            return true;
-        }
+     /**
+      * "Break" on first rule fail.
+      *
+      * Always returns true, just lets us put "stop" in rules.
+      *
+      * @return bool
+      */
+     protected function validateStop()
+     {
+         return true;
+     }
 
-        // In case the attribute has any rule that indicates that the field is required
-        // and that rule already failed then we should stop validation at this point
-        // as now there is no point in calling other rules with this field empty.
-        return $this->hasRule($attribute, $this->implicitRules) &&
-               isset($this->failedRules[$attribute]) &&
-               array_intersect(array_keys($this->failedRules[$attribute]), $this->implicitRules);
-    }
+     /**
+      * Check if we should stop further validations after attribute rule fails
+      *
+      * @param  string  $attribute
+      * @return bool
+      */
+     protected function shouldStopValidation($attribute)
+     {
+         return $this->shouldStop($attribute, 'Stop');
+     }
+
+     /**
+      * Stop on error if the specified rule is assigned and attribute has a message.
+      *
+      * @param $attribute
+      * @param $rule
+      * @return bool
+      */
+     protected function shouldStop($attribute, $rule)
+     {
+         if ($this->hasRule($attribute, $rule)) {
+             return $this->messages->has($attribute);
+         }
+
+         if (isset($this->failedRules[$attribute]) &&
+             in_array('uploaded', array_keys($this->failedRules[$attribute]))) {
+             return true;
+         }
+
+         // In case the attribute has any rule that indicates that the field is required
+         // and that rule already failed then we should stop validation at this point
+         // as now there is no point in calling other rules with this field empty.
+         return $this->hasRule($attribute, $this->implicitRules) &&
+         isset($this->failedRules[$attribute]) &&
+         array_intersect(array_keys($this->failedRules[$attribute]), $this->implicitRules);
+     }
+
 
     /**
      * Validate that a required attribute exists.


### PR DESCRIPTION
This change is used when you need that validation stop after the rule of an attribute fails. It's similar to what the ' Bail ' do, but we stopped validation instead of validating the next attribute.

The use is best accomplished when an attribute use another attribute in your rule.

To use this, only use "stop" in attribute rule.
