### PR TITLE
[5.3] Resolve issues with multi-value select elements

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithPages.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithPages.php
@@ -635,6 +635,7 @@ trait InteractsWithPages
         $this->assertFilterProducesResults($element);
 
         $element = str_replace('#', '', $element);
+        $element = str_replace('[]', '', $element);
 
         $this->inputs[$element] = $text;
 


### PR DESCRIPTION
This PR implements @spikerok's suggestion from https://github.com/laravel/framework/issues/10514#issuecomment-187711052 to strip [] out of element names. 

I've been running with this for a week or so and everything looks OK.

---

Closes #10514.
