### PR TITLE
[5.3] Prevent calling Model.php methods when calling them as attributes

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2601,7 +2601,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         }
 
         if (method_exists(self::class, $key)) {
-            return null;
+            return;
         }
 
         return $this->getRelationValue($key);

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2600,6 +2600,10 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
             return $this->getAttributeValue($key);
         }
 
+        if (method_exists(self::class, $key)) {
+            return null;
+        }
+
         return $this->getRelationValue($key);
     }
 

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1376,6 +1376,17 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
         $this->assertTrue(isset($model->some_relation));
     }
 
+    public function testNonExistingAttributeWithInternalMethodNameDoesntCallMethod()
+    {
+        $model = m::mock('EloquentModelStub[delete]');
+        $model->shouldNotReceive('delete');
+        $this->assertNull($model->delete);
+
+        $model = m::mock('EloquentModelStub[delete]');
+        $model->delete = 123;
+        $this->assertEquals(123, $model->delete);
+    }
+
     public function testIntKeyTypePreserved()
     {
         $model = $this->getMockBuilder('EloquentModelStub')->setMethods(['newQueryWithoutScopes', 'updateTimestamps', 'refresh'])->getMock();

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1378,8 +1378,18 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
 
     public function testNonExistingAttributeWithInternalMethodNameDoesntCallMethod()
     {
-        $model = m::mock('EloquentModelStub[delete]');
+        $model = m::mock('EloquentModelStub[delete,getRelationValue]');
+        $model->name = 'Spark';
         $model->shouldNotReceive('delete');
+        $model->shouldReceive('getRelationValue')->once()->with('belongsToStub')->andReturn('relation');
+
+        // Can return a normal relation
+        $this->assertEquals('relation', $model->belongsToStub);
+
+        // Can return a normal attribute
+        $this->assertEquals('Spark', $model->name);
+
+        // Returns null for a Model.php method name
         $this->assertNull($model->delete);
 
         $model = m::mock('EloquentModelStub[delete]');


### PR DESCRIPTION
When `$user->delete` is called, Eloquent will try to get an attribute with name `delete`, if not found it'll assume it's a name of a relation and try to call the method `delete` which will throw an exception `Relationship method must return an object of type ...` however the `delete()` method will be executed.

This PR checks if the attribute has the name of a method existing in `Model.php` it returns null and doesn't assume it's a relationship.
