### PR TITLE
[5.3] Allow usage of a default error page

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -197,10 +197,14 @@ class Handler implements ExceptionHandlerContract
         $status = $e->getStatusCode();
 
         if (view()->exists("errors.{$status}")) {
-            return response()->view("errors.{$status}", ['exception' => $e], $status, $e->getHeaders());
+            $viewName = "errors.{$status}";
+        } elseif (config('app.debug', false) !== true && view()->exists('errors.default')) {
+            $viewName = 'errors.default';
         } else {
             return $this->convertExceptionToResponse($e);
         }
+
+        return response()->view($viewName, ['exception' => $e], $status, $e->getHeaders());
     }
 
     /**


### PR DESCRIPTION
If a view `errors.default` exists and if the `app.debug` config is not explicitely set to `true`, it can be used as a default error page so that projects can use a "Whoops, looks like something went wrong." page in the layout of their choice.

:octocat: 
