### PR TITLE
[5.3] Make getAlias() public on container

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -1085,7 +1085,7 @@ class Container implements ArrayAccess, ContainerContract
      * @param  string  $abstract
      * @return string
      */
-    protected function getAlias($abstract)
+    public function getAlias($abstract)
     {
         if (! isset($this->aliases[$abstract])) {
             return $abstract;

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -653,6 +653,13 @@ class ContainerContainerTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($container->resolved('foo'));
     }
 
+    public function testGetAlias()
+    {
+        $container = new Container;
+        $container->alias('ConcreteStub', 'foo');
+        $this->assertEquals($container->getAlias('foo'), 'ConcreteStub');
+    }
+
     public function testContainerCanInjectSimpleVariable()
     {
         $container = new Container;


### PR DESCRIPTION
isAlias() is already exposed, would be nice to expose `getAlias()` too for cases where you want to get the concrete class an alias will be resolved to.

My particular use case is I want to call a static method on the class an alias resolves to.
