### PR TITLE
[5.3] Remove unused method

### DIFF
--- a/src/Illuminate/Foundation/Auth/SendsPasswordResetEmails.php
+++ b/src/Illuminate/Foundation/Auth/SendsPasswordResetEmails.php
@@ -31,7 +31,7 @@ trait SendsPasswordResetEmails
         // to send the link, we will examine the response then see the message we
         // need to show to the user. Finally, we'll send out a proper response.
         $response = $this->broker()->sendResetLink(
-            $request->only('email'), $this->resetNotifier()
+            $request->only('email')
         );
 
         if ($response === Password::RESET_LINK_SENT) {
@@ -44,16 +44,6 @@ trait SendsPasswordResetEmails
         return back()->withErrors(
             ['email' => trans($response)]
         );
-    }
-
-    /**
-     * Get the Closure which is used to build the password reset notification.
-     *
-     * @return \Closure
-     */
-    protected function resetNotifier()
-    {
-        //
     }
 
     /**


### PR DESCRIPTION
The second argument is removed from `PasswordBroker@sendResetLink` in this commit https://github.com/laravel/framework/commit/3d74a120ec88b1cb6e43729636902ecb54b59950#diff-cf92d664ce927bbc7cec4713bb5b612b

This PR removes unused method from the `SendsPasswordResetEmails` trait.
