### PR TITLE
[5.3] Remove uninstantiable seeder class

### DIFF
--- a/src/Illuminate/Database/SeedServiceProvider.php
+++ b/src/Illuminate/Database/SeedServiceProvider.php
@@ -21,10 +21,6 @@ class SeedServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->app->singleton('seeder', function () {
-            return new Seeder;
-        });
-
         $this->registerSeedCommand();
 
         $this->commands('command.seed');


### PR DESCRIPTION
The Seeder class became abstract in this commit https://github.com/laravel/framework/commit/65f69f0ebf1622ae5e0ffb23d8e1ac1e178b03fa, thus cannot be instantiated.
