### PR TITLE
[5.3]  Improve Conatainer::build() implementation

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -775,8 +775,8 @@ class Container implements ArrayAccess, ContainerContract
             return new $concrete;
         }
 
-        // if parameters is empty, reslove the dependency for constructor's parameters,
-        // otherwise pass parameters to constructor.
+        // If parameters is empty, reslove the dependency for constructor's
+        // parameters, otherwise pass parameters to constructor.
         if (empty($parameters)) {
             $reflectedParameters = $constructor->getParameters();
             $instances = $this->getDependencies($reflectedParameters);

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -801,10 +801,9 @@ class Container implements ArrayAccess, ContainerContract
      * Resolve all of the dependencies from the ReflectionParameters.
      *
      * @param  array  $parameters
-     * @param  array  $primitives
      * @return array
      */
-    protected function getDependencies(array $parameters, array $primitives = [])
+    protected function getDependencies(array $parameters)
     {
         $dependencies = [];
 
@@ -814,9 +813,7 @@ class Container implements ArrayAccess, ContainerContract
             // If the class is null, it means the dependency is a string or some other
             // primitive type which we can not resolve since it is not a class and
             // we will just bomb out with an error since we have no-where to go.
-            if (array_key_exists($parameter->name, $primitives)) {
-                $dependencies[] = $primitives[$parameter->name];
-            } elseif (is_null($dependency)) {
+            if (is_null($dependency)) {
                 $dependencies[] = $this->resolveNonClass($parameter);
             } else {
                 $dependencies[] = $this->resolveClass($parameter);

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -371,14 +371,20 @@ class ContainerContainerTest extends PHPUnit_Framework_TestCase
     public function testPassingSomePrimitiveParameters()
     {
         $container = new Container;
-        $value = $container->make('ContainerMixedPrimitiveStub', ['first' => 'taylor', 'last' => 'otwell']);
+        $stub = $container->make('ContainerConcreteStub');
+        $parameters = ['taylor', $stub, 'otwell'];
+        $value = $container->make('ContainerMixedPrimitiveStub', $parameters);
+
         $this->assertInstanceOf('ContainerMixedPrimitiveStub', $value);
         $this->assertEquals('taylor', $value->first);
         $this->assertEquals('otwell', $value->last);
         $this->assertInstanceOf('ContainerConcreteStub', $value->stub);
 
         $container = new Container;
-        $value = $container->make('ContainerMixedPrimitiveStub', [0 => 'taylor', 2 => 'otwell']);
+        $stub = $container->make('ContainerConcreteStub');
+        $parameters = ['taylor', $stub, 'otwell'];
+        $value = $container->make('ContainerMixedPrimitiveStub', $parameters);
+
         $this->assertInstanceOf('ContainerMixedPrimitiveStub', $value);
         $this->assertEquals('taylor', $value->first);
         $this->assertEquals('otwell', $value->last);


### PR DESCRIPTION
I think that the second parameter of Container::build()'s purpose is try to pass value to the concrete's constructor without resolve the dependency. The parameters should be numeric-indexed array, and pass it to constructor in sequence.

But the current implementation use Container::keyParametersByArgument() convert alphanumeric-indexed parameters to alpha-indexed parameters, and use the parameters' key to map the construct parameter's name. I am not sure if it is used by some special case, please consider it.

Thanks.
