### PR TITLE
[5.3] Introduce ServiceProvider::$migrate property to publishing migration by extending a service provider.

### DIFF
--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -21,6 +21,13 @@ abstract class ServiceProvider
     protected $defer = false;
 
     /**
+     * Indicates if migration should be executed (default as `true`) or published.
+     *
+     * @var bool
+     */
+    protected $migrate = true;
+
+    /**
      * The paths that should be published.
      *
      * @var array
@@ -95,11 +102,32 @@ abstract class ServiceProvider
      */
     protected function loadMigrationsFrom($paths)
     {
+        if ($this->migrate !== true) {
+            return $this->publishMigrationsFrom($paths);
+        }
+
         $this->app->afterResolving('migrator', function ($migrator) use ($paths) {
             foreach ((array) $paths as $path) {
                 $migrator->path($path);
             }
         });
+    }
+
+    /**
+     * Publish a database migration path.
+     *
+     * @param  array|string  $paths
+     * @return void
+     */
+    protected function publishMigrationsFrom($paths)
+    {
+        $migrations = [];
+
+        foreach ((array) $paths as $path) {
+            $migrations[$path] = database_path('migrations');
+        }
+
+        $this->publishes($migrations, 'migrations');
     }
 
     /**


### PR DESCRIPTION
By default all packages' Service Provider should be able to load custom migration paths, however the developer of each application should be able to override this by extending the original service provider. As example, for `PassportServiceProvider` you could actually something such as:

``` php
<?php

namespace App\Providers;

class PassportServiceProvider extends \Laravel\Passport\PassportServiceProvider
{
    protected $migrate = false;
}
```

Signed-off-by: crynobone crynobone@gmail.com
