### PR TITLE
[5.3] Sets visibility VendorPublishCommand::publishTag() to protected

### DIFF
--- a/src/Illuminate/Foundation/Console/VendorPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/VendorPublishCommand.php
@@ -69,7 +69,7 @@ class VendorPublishCommand extends Command
      * @param  string  $tag
      * @return mixed
      */
-    private function publishTag($tag)
+    protected function publishTag($tag)
     {
         $paths = ServiceProvider::pathsToPublish(
             $this->option('provider'), $tag


### PR DESCRIPTION
Visibility was set to private. Setting it to protected (like all other non public methods in VendorPublishCommand and every other command) makes it possible to override the fire() method when subclassing VendorPublishCommand.
