### PR TITLE
[5.3] Update Conatainer::build() implementation

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -775,8 +775,8 @@ class Container implements ArrayAccess, ContainerContract
             return new $concrete;
         }
 
-        // if parameters is empty, reslove the dependency for constructor's parameters,
-        // otherwise pass parameters to constructor.
+        // If parameters is empty, reslove the dependency for constructor's
+        // parameters, otherwise pass parameters to constructor.
         if (empty($parameters)) {
             $reflectedParameters = $constructor->getParameters();
             $instances = $this->getDependencies($reflectedParameters);

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -801,10 +801,9 @@ class Container implements ArrayAccess, ContainerContract
      * Resolve all of the dependencies from the ReflectionParameters.
      *
      * @param  array  $parameters
-     * @param  array  $primitives
      * @return array
      */
-    protected function getDependencies(array $parameters, array $primitives = [])
+    protected function getDependencies(array $parameters)
     {
         $dependencies = [];
 
@@ -814,9 +813,7 @@ class Container implements ArrayAccess, ContainerContract
             // If the class is null, it means the dependency is a string or some other
             // primitive type which we can not resolve since it is not a class and
             // we will just bomb out with an error since we have no-where to go.
-            if (array_key_exists($parameter->name, $primitives)) {
-                $dependencies[] = $primitives[$parameter->name];
-            } elseif (is_null($dependency)) {
+            if (is_null($dependency)) {
                 $dependencies[] = $this->resolveNonClass($parameter);
             } else {
                 $dependencies[] = $this->resolveClass($parameter);

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -371,14 +371,20 @@ class ContainerContainerTest extends PHPUnit_Framework_TestCase
     public function testPassingSomePrimitiveParameters()
     {
         $container = new Container;
-        $value = $container->make('ContainerMixedPrimitiveStub', ['first' => 'taylor', 'last' => 'otwell']);
+        $stub = $container->make('ContainerConcreteStub');
+        $parameters = ['taylor', $stub, 'otwell'];
+        $value = $container->make('ContainerMixedPrimitiveStub', $parameters);
+
         $this->assertInstanceOf('ContainerMixedPrimitiveStub', $value);
         $this->assertEquals('taylor', $value->first);
         $this->assertEquals('otwell', $value->last);
         $this->assertInstanceOf('ContainerConcreteStub', $value->stub);
 
         $container = new Container;
-        $value = $container->make('ContainerMixedPrimitiveStub', [0 => 'taylor', 2 => 'otwell']);
+        $stub = $container->make('ContainerConcreteStub');
+        $parameters = ['taylor', $stub, 'otwell'];
+        $value = $container->make('ContainerMixedPrimitiveStub', $parameters);
+
         $this->assertInstanceOf('ContainerMixedPrimitiveStub', $value);
         $this->assertEquals('taylor', $value->first);
         $this->assertEquals('otwell', $value->last);


### PR DESCRIPTION
The current Container::build() support parameters like below:

``` php
$value = $container->build('ContainerMixedPrimitiveStub', ['first' => 'taylor', 'last' => 'otwell']);
```

It seem weird to only pass the first and the third parameter to a function,  and let the second to be the default value; also this way will lead to some unusual case, for example,  if you change the parameter's name of a concrete's consturctor, you need to change the name of  build method.

So maybe it's better to follow PHP convention, if we need to pass parameter to the constructor, pass all of it manually and sequentially, not just some, in a jumping sequence. Below is the code that finish above task in this way:

``` php
$stub = $container->build('ContainerConcreteStub');
$parameters = ['taylor', $stub, 'otwell'];
$value = $container->build('ContainerMixedPrimitiveStub', $parameters);
```

Please consider it.

Thanks!
