### PR TITLE
add missing 'use Collection' in NotificationFake + use get_class when retrieving notifications

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Support\Testing\Fakes;
 
+use Illuminate\Support\Collection;
 use Ramsey\Uuid\Uuid;
 use PHPUnit_Framework_Assert as PHPUnit;
 use Illuminate\Contracts\Notifications\Factory as NotificationFactory;
@@ -93,8 +94,8 @@ class NotificationFake implements NotificationFactory
      */
     protected function notificationsFor($notifiable, $notification)
     {
-        if (isset($this->notifications[get_class($notifiable)][$notifiable->getKey()][$notification])) {
-            return $this->notifications[get_class($notifiable)][$notifiable->getKey()][$notification];
+        if (isset($this->notifications[get_class($notifiable)][$notifiable->getKey()][get_class($notification)])) {
+            return $this->notifications[get_class($notifiable)][$notifiable->getKey()][get_class($notification)];
         }
 
         return [];

--- a/tests/Support/Testing/NotificationFakeTest.php
+++ b/tests/Support/Testing/NotificationFakeTest.php
@@ -1,0 +1,72 @@
+<?php
+
+use Illuminate\Support\Collection;
+use Illuminate\Support\Testing\Fakes\NotificationFake;
+use Illuminate\Notifications\Notifiable;
+use Illuminate\Notifications\Notification;
+
+class NotificationFakeTest extends PHPUnit_Framework_TestCase
+{
+
+	public function setup()
+	{
+		$this->notification = new NotificationFake();
+	}
+
+	public function tearDown()
+    {
+        Mockery::close();
+    }
+
+	public function testNotificationsCanBeSentToASingleNotifiable()
+    {
+		$notifiable = static::mockNotifiable();
+		$notification = static::mockNotification();
+
+		$this->notification->send( $notifiable, $notification );
+        $this->notification->assertSentTo( $notifiable, $notification );
+    }
+
+	public function testNotificationsCanBeSentToAnArray()
+    {
+        $notifiable1 = static::mockNotifiable();
+        $notifiable2 = static::mockNotifiable();
+		$notification = static::mockNotification();
+
+		$this->notification->send( [ $notifiable1, $notifiable2 ], $notification );
+
+		$this->notification->assertSentTo( $notifiable1, $notification );
+        $this->notification->assertSentTo( $notifiable2, $notification );
+    }
+
+    public function testNotificationsCanBeSentToACollection()
+    {
+        $notifiable1 = static::mockNotifiable();
+        $notifiable2 = static::mockNotifiable();
+		$notification = static::mockNotification();
+
+		$this->notification->send( new Collection([ $notifiable1, $notifiable2 ]), $notification );
+
+		$this->notification->assertSentTo( $notifiable1, $notification );
+        $this->notification->assertSentTo( $notifiable2, $notification );
+    }
+
+
+
+	private static function mockNotifiable()
+	{
+		$observable = Mockery::mock();
+		$observable->shouldReceive('getKey')
+			->andReturn( rand(1,999) );
+		return $observable;
+	}
+
+	private static function mockNotification()
+	{
+		$notification = Mockery::mock(Notification::class);
+		$notification->shouldReceive('via')
+			->andReturn([]);
+		return $notification;
+	}
+
+}


### PR DESCRIPTION
- adds missing `use Illuminate\Support\Collection` in `NotificationFake` that meant the instanceOf check that was meant to allow passing in collections to `Notification::send()` always failed when using the fake
- use `getClass` when retrieving sent notifications in `NotificationFake`, as is done in the `sendNow` method
