### PR TITLE
[5.3] Make json attributes fillable if Model field is fillable

### DIFF
--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -788,6 +788,21 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('bar', $model->age);
     }
 
+    public function testFillableJSONColumns()
+    {
+        $model = new EloquentModelStub;
+        $model->fillable(['options', 'meta-data']);
+        $model->fill(['options->name' => 'foo']);
+        $model->fill(['meta-data->name' => 'foo']);
+        $this->assertEquals(
+            [
+                'options->name' => 'foo',
+                'meta-data->name' => 'foo',
+            ],
+            $model->getAttributes()
+        );
+    }
+
     public function testForceFillMethodFillsGuardedAttributes()
     {
         $model = (new EloquentModelSaveStub)->forceFill(['id' => 21]);


### PR DESCRIPTION
Having the following Model:

``` php
class User extends Model
{
    protected $fillable = ['options'];
}
```

If you try to fill the model using a JSON path it won't work:

``` php
$user->update(['options->newsletter' => true]);
```

That's because `options->newsletter` is not defined in the $fillable array, so you have to add all your JSON attributes in order for it to work.

This PR will allow filling a JSON attribute if the Model field is fillable.

More details about this issue: https://github.com/laravel/framework/issues/15433
