### PR TITLE
[5.3] Default $callback in whereHas

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -870,10 +870,10 @@ class Builder
     /**
      * Add a relationship count / exists condition to the query with where clauses.
      *
-     * @param  string    $relation
+     * @param  string  $relation
      * @param  \Closure|null  $callback
-     * @param  string    $operator
-     * @param  int       $count
+     * @param  string  $operator
+     * @param  int     $count
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
     public function whereHas($relation, Closure $callback = null, $operator = '>=', $count = 1)

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -871,12 +871,12 @@ class Builder
      * Add a relationship count / exists condition to the query with where clauses.
      *
      * @param  string    $relation
-     * @param  \Closure  $callback
+     * @param  \Closure|null  $callback
      * @param  string    $operator
      * @param  int       $count
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
-    public function whereHas($relation, Closure $callback, $operator = '>=', $count = 1)
+    public function whereHas($relation, Closure $callback = null, $operator = '>=', $count = 1)
     {
         return $this->has($relation, $operator, $count, 'and', $callback);
     }


### PR DESCRIPTION
This was annoying me in the Eloquent Builder's 'whereHas', and 'has' has a default $callback too.
