### PR TITLE
[5.1] Check trashed when restoring soft-deleted models

### DIFF
--- a/src/Illuminate/Database/Eloquent/SoftDeletes.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletes.php
@@ -72,7 +72,7 @@ trait SoftDeletes
     {
         // If the model is not soft-deleted, we will not proceed with restore operation
         // as there is no point in doing so.
-        if($this->trashed() === false) {
+        if ($this->trashed() === false) {
             return false;
         }
 

--- a/src/Illuminate/Database/Eloquent/SoftDeletes.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletes.php
@@ -70,6 +70,12 @@ trait SoftDeletes
      */
     public function restore()
     {
+        // If the model is not soft-deleted, we will not proceed with restore operation
+        // as there is no point in doing so.
+        if($this->trashed() === false) {
+            return false;
+        }
+
         // If the restoring event does not return false, we will proceed with this
         // restore operation. Otherwise, we bail out so the developer will stop
         // the restore totally. We will clear the deleted timestamp and save.

--- a/tests/Database/DatabaseSoftDeletingTraitTest.php
+++ b/tests/Database/DatabaseSoftDeletingTraitTest.php
@@ -29,6 +29,21 @@ class DatabaseSoftDeletingTraitTest extends PHPUnit_Framework_TestCase
         $model->shouldReceive('fireModelEvent')->with('restoring')->andReturn(true);
         $model->shouldReceive('save')->once();
         $model->shouldReceive('fireModelEvent')->with('restored', false)->andReturn(true);
+        $model->deleted_at = new \DateTime;
+
+        $model->restore();
+
+        $this->assertNull($model->deleted_at);
+    }
+
+    public function testRestoreNotSoftDeleted()
+    {
+        $model = m::mock('DatabaseSoftDeletingTraitStub');
+        $model->shouldDeferMissing();
+        $model->shouldReceive('fireModelEvent')->with('restoring')->never();
+        $model->shouldReceive('save')->never();
+        $model->shouldReceive('fireModelEvent')->with('restored', false)->never();
+        $model->deleted_at = null;
 
         $model->restore();
 


### PR DESCRIPTION
This just seems to make sense - if a model is not soft-deleted,
( when trashed returns false), don't try to restore it.
