### PR TITLE
use get_class in NotificationFake@notificationsFor as in sendNow

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
@@ -93,8 +93,8 @@ class NotificationFake implements NotificationFactory
      */
     protected function notificationsFor($notifiable, $notification)
     {
-        if (isset($this->notifications[get_class($notifiable)][$notifiable->getKey()][$notification])) {
-            return $this->notifications[get_class($notifiable)][$notifiable->getKey()][$notification];
+        if (isset($this->notifications[get_class($notifiable)][$notifiable->getKey()][get_class($notification)])) {
+            return $this->notifications[get_class($notifiable)][$notifiable->getKey()][get_class($notification)];
         }
 
         return [];

--- a/tests/Support/Testing/NotificationFakeTest.php
+++ b/tests/Support/Testing/NotificationFakeTest.php
@@ -1,0 +1,60 @@
+<?php
+
+use Illuminate\Support\Collection;
+use Illuminate\Support\Testing\Fakes\NotificationFake;
+use Illuminate\Notifications\Notifiable;
+use Illuminate\Notifications\Notification;
+
+class NotificationFakeTest extends PHPUnit_Framework_TestCase
+{
+
+	public function setup()
+	{
+		$this->notification = new NotificationFake();
+	}
+
+	public function tearDown()
+    {
+        Mockery::close();
+    }
+
+	public function testNotificationsCanBeSentToASingleNotifiable()
+    {
+		$notifiable = static::mockNotifiable();
+		$notification = static::mockNotification();
+
+		$this->notification->send( $notifiable, $notification );
+        $this->notification->assertSentTo( $notifiable, $notification );
+    }
+
+	public function testNotificationsCanBeSentToAnArray()
+    {
+        $notifiable1 = static::mockNotifiable();
+        $notifiable2 = static::mockNotifiable();
+		$notification = static::mockNotification();
+
+		$this->notification->send( [ $notifiable1, $notifiable2 ], $notification );
+
+		$this->notification->assertSentTo( $notifiable1, $notification );
+        $this->notification->assertSentTo( $notifiable2, $notification );
+    }
+
+
+
+	private static function mockNotifiable()
+	{
+		$observable = Mockery::mock();
+		$observable->shouldReceive('getKey')
+			->andReturn( rand(1,999) );
+		return $observable;
+	}
+
+	private static function mockNotification()
+	{
+		$notification = Mockery::mock(Notification::class);
+		$notification->shouldReceive('via')
+			->andReturn([]);
+		return $notification;
+	}
+
+}


### PR DESCRIPTION
Use `get_class` in `NotificationFake@notificationsFor` as is done in `NotificationFake@sendNow`. Required to allow passing mocks to `notificationsFor`.  Required for https://github.com/laravel/framework/pull/15484.

(Splits https://github.com/laravel/framework/pull/15463 into 2 pull requests as requested)
