### PR TITLE
[5.3] Fix foreach blade compiler

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -624,7 +624,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
     {
         $empty = '$__empty_'.++$this->forelseCounter;
 
-        preg_match('/\( *(.*) +as *([^\)]*)/s', $expression, $matches);
+        preg_match('/\( *(.*) +as *([^\)]*)/is', $expression, $matches);
 
         $iteratee = trim($matches[1]);
 

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -579,7 +579,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
      */
     protected function compileForeach($expression)
     {
-        preg_match('/\( *(.*) +as *([^\)]*)/s', $expression, $matches);
+        preg_match('/\( *(.*) +as *([^\)]*)/is', $expression, $matches);
 
         $iteratee = trim($matches[1]);
 

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -579,7 +579,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
      */
     protected function compileForeach($expression)
     {
-        preg_match('/\( *(.*) +as *([^\)]*)/i', $expression, $matches);
+        preg_match('/\( *(.*) +as *([^\)]*)/s', $expression, $matches);
 
         $iteratee = trim($matches[1]);
 
@@ -624,7 +624,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
     {
         $empty = '$__empty_'.++$this->forelseCounter;
 
-        preg_match('/\( *(.*) +as *([^\)]*)/', $expression, $matches);
+        preg_match('/\( *(.*) +as *([^\)]*)/s', $expression, $matches);
 
         $iteratee = trim($matches[1]);
 

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -528,6 +528,22 @@ empty
         $this->assertEquals($expected, $compiler->compileString($string));
     }
 
+    public function testForelseStatementsAreCompiledWithUppercaseSyntax()
+    {
+        $compiler = new BladeCompiler($this->getFiles(), __DIR__);
+        $string = '@forelse ($this->getUsers() AS $user)
+breeze
+@empty
+empty
+@endforelse';
+        $expected = '<?php $__empty_1 = true; $__currentLoopData = $this->getUsers(); $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $user): $__env->incrementLoopIndices(); $loop = $__env->getFirstLoop(); $__empty_1 = false; ?>
+breeze
+<?php endforeach; $__env->popLoop(); $loop = $__env->getFirstLoop(); if ($__empty_1): ?>
+empty
+<?php endif; ?>';
+        $this->assertEquals($expected, $compiler->compileString($string));
+    }
+
     public function testForelseStatementsAreCompiledWithMultipleLine()
     {
         $compiler = new BladeCompiler($this->getFiles(), __DIR__);

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -451,6 +451,24 @@ test
         $this->assertEquals($expected, $compiler->compileString($string));
     }
 
+    public function testForeachStatementsAreCompileWithMultipleLine()
+    {
+        $compiler = new BladeCompiler($this->getFiles(), __DIR__);
+        $string = '@foreach ([
+foo,
+bar,
+] as $label)
+test
+@endforeach';
+        $expected = '<?php $__currentLoopData = [
+foo,
+bar,
+]; $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $label): $__env->incrementLoopIndices(); $loop = $__env->getFirstLoop(); ?>
+test
+<?php endforeach; $__env->popLoop(); $loop = $__env->getFirstLoop(); ?>';
+        $this->assertEquals($expected, $compiler->compileString($string));
+    }
+
     public function testNestedForeachStatementsAreCompiled()
     {
         $compiler = new BladeCompiler($this->getFiles(), __DIR__);

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -528,6 +528,28 @@ empty
         $this->assertEquals($expected, $compiler->compileString($string));
     }
 
+    public function testForelseStatementsAreCompiledWithMultipleLine()
+    {
+        $compiler = new BladeCompiler($this->getFiles(), __DIR__);
+        $string = '@forelse ([
+foo,
+bar,
+] as $label)
+breeze
+@empty
+empty
+@endforelse';
+        $expected = '<?php $__empty_1 = true; $__currentLoopData = [
+foo,
+bar,
+]; $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $label): $__env->incrementLoopIndices(); $loop = $__env->getFirstLoop(); $__empty_1 = false; ?>
+breeze
+<?php endforeach; $__env->popLoop(); $loop = $__env->getFirstLoop(); if ($__empty_1): ?>
+empty
+<?php endif; ?>';
+        $this->assertEquals($expected, $compiler->compileString($string));
+    }
+
     public function testNestedForelseStatementsAreCompiled()
     {
         $compiler = new BladeCompiler($this->getFiles(), __DIR__);


### PR DESCRIPTION
 New line in `@foreach` and `@forelse` should be allowed:

``` php
@foreach([
    'foo'
] as $var)

@endforeach
```

And this feature is also supported before 5.3

I removed amiss `i` regex modifier and added `s` modifier.
