### PR TITLE
[5.3] Added illuminate/notifications to composer replaced packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -59,6 +59,7 @@
         "illuminate/http": "self.version",
         "illuminate/log": "self.version",
         "illuminate/mail": "self.version",
+        "illuminate/notifications": "self.version",
         "illuminate/pagination": "self.version",
         "illuminate/pipeline": "self.version",
         "illuminate/queue": "self.version",


### PR DESCRIPTION
The package `illuminate/notifications` was missing from composer.json replace packages. 
