### PR TITLE
[5.3] Correction of v5.3.8 release notes

### DIFF
--- a/CHANGELOG-5.3.md
+++ b/CHANGELOG-5.3.md
@@ -19,7 +19,6 @@
 - Added username, icon and channel options for Slack Notifications ([#14910](https://github.com/laravel/framework/pull/14910))
 
 ### Changed
-- Updated `symfony/css-selector` version ([#15344](https://github.com/laravel/framework/pull/15344))
 - Renamed methods in `NotificationFake` ([69b08f6](https://github.com/laravel/framework/commit/69b08f66fbe70b4df8332a8f2a7557a49fd8c693))
 - Minor code improvements ([#15369](https://github.com/laravel/framework/pull/15369))
 


### PR DESCRIPTION
There was no update of symfony/css-selector in Laravel 5.3. The update was made in v5.1.
