### PR TITLE
[5.3] Make afterApplicationCreated() callback registration public

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -154,7 +154,7 @@ abstract class TestCase extends PHPUnit_Framework_TestCase
      * @param  callable  $callback
      * @return void
      */
-    protected function afterApplicationCreated(callable $callback)
+    public function afterApplicationCreated(callable $callback)
     {
         $this->afterApplicationCreatedCallbacks[] = $callback;
 


### PR DESCRIPTION
Rational: when using e.g. [PHPUnit Listener](https://phpunit.de/manual/current/en/extending-phpunit.html#extending-phpunit.PHPUnit_Framework_TestListener) we receive the test class before a certain test has run.

This allows further inspection or adding additional stuff.

Unfortunately it doesn't allow registering additional after application callbacks from e.g. `\PHPUnit_Framework_TestListener::startTest` because the method `\Illuminate\Foundation\Testing\TestCase::afterApplicationCreated` isn't public => this PR changes this.

A concrete example what I'm doing: for every test in my Listener I'm registering a callback which in-depth analyzes the SQL statements performed. But I can only hook into `DB::listen` once the application is "started", as such I need to do this in the mentioned callbacks. But currently it's not directly possible to the visibility.

It's possible to workaround this but my understanding is that `TestCase` should be open in this regard to be more flexible, like in this scenario I described.
