### PR TITLE
[5.3] Add guards to AuthenticationException in Authenticate middleware

### DIFF
--- a/src/Illuminate/Auth/AuthenticationException.php
+++ b/src/Illuminate/Auth/AuthenticationException.php
@@ -3,16 +3,26 @@
 namespace Illuminate\Auth;
 
 use Exception;
+use Illuminate\Support\Collection;
 
 class AuthenticationException extends Exception
 {
+    protected $guards = [];
+
     /**
      * Create a new authentication exception.
      *
-     * @param string  $message
+     * @param string|array $guards
+     * @param string $message
      */
-    public function __construct($message = 'Unauthenticated.')
+    public function __construct($guards = [], $message = 'Unauthenticated.')
     {
+        $this->guards = $guards;
         parent::__construct($message);
+    }
+
+    public function guards()
+    {
+        return new Collection($this->guards);
     }
 }

--- a/src/Illuminate/Auth/Middleware/Authenticate.php
+++ b/src/Illuminate/Auth/Middleware/Authenticate.php
@@ -63,6 +63,6 @@ class Authenticate
             }
         }
 
-        throw new AuthenticationException;
+        throw new AuthenticationException($guards);
     }
 }

--- a/tests/Auth/AuthenticateMiddlewareTest.php
+++ b/tests/Auth/AuthenticateMiddlewareTest.php
@@ -88,8 +88,7 @@ class AuthenticateMiddlewareTest extends PHPUnit_Framework_TestCase
 
         try {
             $this->authenticate('default');
-        }
-        catch(AuthenticationException $e) {
+        } catch(AuthenticationException $e) {
             $this->assertSame($e->guards()->first(), 'default');
 
             throw $e;

--- a/tests/Auth/AuthenticateMiddlewareTest.php
+++ b/tests/Auth/AuthenticateMiddlewareTest.php
@@ -69,7 +69,7 @@ class AuthenticateMiddlewareTest extends PHPUnit_Framework_TestCase
         $this->authenticate('default', 'secondary');
     }
 
-    public function testMultipleDriversAuthenticatedUdatesDefault()
+    public function testMultipleDriversAuthenticatedUpdatesDefault()
     {
         $this->registerAuthDriver('default', false);
 
@@ -78,6 +78,22 @@ class AuthenticateMiddlewareTest extends PHPUnit_Framework_TestCase
         $this->authenticate('default', 'secondary');
 
         $this->assertSame($secondary, $this->auth->guard());
+    }
+
+    public function testUnauthenticatedExceptionContainsGuard()
+    {
+        $this->setExpectedException(AuthenticationException::class);
+
+        $this->registerAuthDriver('default', false);
+
+        try {
+            $this->authenticate('default');
+        }
+        catch(AuthenticationException $e) {
+            $this->assertSame($e->guards()->first(), 'default');
+
+            throw $e;
+        }
     }
 
     /**


### PR DESCRIPTION
Add guards to AuthenticationException in Authenticate middleware. Gives ability to check which guard was used with the unsuccessful auth attempt so we can act accordingly in Handler::unauthenticated().

I notice the AuthenticationException is also thrown in the Illuminate\Auth\GuardHelpers trait, which in-turn is used by some of the guard classes. I couldn't see an easy way to send through the guard(s).
