### PR TITLE
allow date format to be set in app.config

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2989,7 +2989,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     protected function getDateFormat()
     {
-        return $this->dateFormat ?: $this->getConnection()->getQueryGrammar()->getDateFormat();
+        return ($this->dateFormat ?: config('app.dateFormat')) ?: $this->getConnection()->getQueryGrammar()->getDateFormat();
     }
 
     /**


### PR DESCRIPTION
Adding the date format to the `app.config` file will allow modification of packages like Laravel Passport that extend the Eloquent model, without modifying the actual Model class. Errors have come up mostly when using SqlSrv with dblib, whereby the query grammar is gives `Y-m-d H:i:s.000` while the required is `Y-m-d H:i:s`.

![image](https://cloud.githubusercontent.com/assets/2639600/18625602/52a4a144-7e58-11e6-85a7-e63591175b2e.png)
