### PR TITLE
[5.4] Allow Memcached to cache for more than 30 days

### DIFF
--- a/src/Illuminate/Cache/MemcachedStore.php
+++ b/src/Illuminate/Cache/MemcachedStore.php
@@ -82,7 +82,7 @@ class MemcachedStore extends TaggableStore implements Store
      */
     public function put($key, $value, $minutes)
     {
-        $this->memcached->set($this->prefix.$key, $value, $this->formatExpireTime($minutes));
+        $this->memcached->set($this->prefix.$key, $value, (int) (time() + ($minutes * 60)));
     }
 
     /**
@@ -100,7 +100,7 @@ class MemcachedStore extends TaggableStore implements Store
             $prefixedValues[$this->prefix.$key] = $value;
         }
 
-        $this->memcached->setMulti($prefixedValues, $this->formatExpireTime($minutes));
+        $this->memcached->setMulti($prefixedValues, (int) (time() + ($minutes * 60)));
     }
 
     /**
@@ -113,7 +113,7 @@ class MemcachedStore extends TaggableStore implements Store
      */
     public function add($key, $value, $minutes)
     {
-        return $this->memcached->add($this->prefix.$key, $value, $this->formatExpireTime($minutes));
+        return $this->memcached->add($this->prefix.$key, $value, (int) (time() + ($minutes * 60)));
     }
 
     /**
@@ -202,23 +202,5 @@ class MemcachedStore extends TaggableStore implements Store
     public function setPrefix($prefix)
     {
         $this->prefix = ! empty($prefix) ? $prefix.':' : '';
-    }
-
-    /**
-     * Memcached requires the expiration time to be seconds unless they exceed
-     * 30 days. Then, a unix timestamp is expected. This will return the correct
-     * representation to be used for Memcached.
-     *
-     * @param  int     $minutes
-     * @return int
-     */
-    private function formatExpireTime($minutes)
-    {
-        // 30 days in minutes
-        if ($minutes > 60 * 24 * 30) {
-            return (int) (time() + ($minutes * 60));
-        }
-
-        return (int) ($minutes * 60);
     }
 }

--- a/src/Illuminate/Cache/MemcachedStore.php
+++ b/src/Illuminate/Cache/MemcachedStore.php
@@ -82,7 +82,7 @@ class MemcachedStore extends TaggableStore implements Store
      */
     public function put($key, $value, $minutes)
     {
-        $this->memcached->set($this->prefix.$key, $value, (int) ($minutes > 0 ? time() + ($minutes * 60) : 0));
+        $this->memcached->set($this->prefix.$key, $value, $this->formatExpireTime($minutes));
     }
 
     /**
@@ -100,7 +100,7 @@ class MemcachedStore extends TaggableStore implements Store
             $prefixedValues[$this->prefix.$key] = $value;
         }
 
-        $this->memcached->setMulti($prefixedValues, (int) ($minutes > 0 ? time() + ($minutes * 60) : 0));
+        $this->memcached->setMulti($prefixedValues, $this->formatExpireTime($minutes));
     }
 
     /**
@@ -113,7 +113,7 @@ class MemcachedStore extends TaggableStore implements Store
      */
     public function add($key, $value, $minutes)
     {
-        return $this->memcached->add($this->prefix.$key, $value, (int) ($minutes > 0 ? time() + ($minutes * 60) : 0));
+        return $this->memcached->add($this->prefix.$key, $value, $this->formatExpireTime($minutes));
     }
 
     /**
@@ -202,5 +202,21 @@ class MemcachedStore extends TaggableStore implements Store
     public function setPrefix($prefix)
     {
         $this->prefix = ! empty($prefix) ? $prefix.':' : '';
+    }
+
+    /**
+     * Memcached requires the expiration time to be a unix timestamp if they exceed
+     * 30 days. This will return the correct representation to be used for Memcached.
+     *
+     * @param  int     $minutes
+     * @return int
+     */
+    protected function formatExpireTime($minutes)
+    {
+        if ($minutes == 0) {
+            return 0;
+        }
+
+        return time() + ((int) $minutes * 60);
     }
 }

--- a/src/Illuminate/Cache/MemcachedStore.php
+++ b/src/Illuminate/Cache/MemcachedStore.php
@@ -82,7 +82,7 @@ class MemcachedStore extends TaggableStore implements Store
      */
     public function put($key, $value, $minutes)
     {
-        $this->memcached->set($this->prefix.$key, $value, (int) ($minutes * 60));
+        $this->memcached->set($this->prefix.$key, $value, $this->formatExpireTime($minutes));
     }
 
     /**
@@ -100,7 +100,7 @@ class MemcachedStore extends TaggableStore implements Store
             $prefixedValues[$this->prefix.$key] = $value;
         }
 
-        $this->memcached->setMulti($prefixedValues, (int) ($minutes * 60));
+        $this->memcached->setMulti($prefixedValues, $this->formatExpireTime($minutes));
     }
 
     /**
@@ -113,7 +113,7 @@ class MemcachedStore extends TaggableStore implements Store
      */
     public function add($key, $value, $minutes)
     {
-        return $this->memcached->add($this->prefix.$key, $value, (int) ($minutes * 60));
+        return $this->memcached->add($this->prefix.$key, $value, $this->formatExpireTime($minutes));
     }
 
     /**
@@ -202,5 +202,23 @@ class MemcachedStore extends TaggableStore implements Store
     public function setPrefix($prefix)
     {
         $this->prefix = ! empty($prefix) ? $prefix.':' : '';
+    }
+
+    /**
+     * Memcached requires the expiration time to be seconds unless they exceed
+     * 30 days. Then, a unix timestamp is expected. This will return the correct
+     * representation to be used for Memcached.
+     *
+     * @param  int     $minutes
+     * @return int
+     */
+    private function formatExpireTime($minutes)
+    {
+        // 30 days in minutes
+        if ($minutes > 60 * 24 * 30) {
+            return (int) (time() + ($minutes * 60));
+        }
+
+        return (int) ($minutes * 60);
     }
 }

--- a/src/Illuminate/Cache/MemcachedStore.php
+++ b/src/Illuminate/Cache/MemcachedStore.php
@@ -82,7 +82,7 @@ class MemcachedStore extends TaggableStore implements Store
      */
     public function put($key, $value, $minutes)
     {
-        $this->memcached->set($this->prefix.$key, $value, (int) (time() + ($minutes * 60)));
+        $this->memcached->set($this->prefix.$key, $value, (int) ($minutes > 0 ? time() + ($minutes * 60) : 0));
     }
 
     /**
@@ -100,7 +100,7 @@ class MemcachedStore extends TaggableStore implements Store
             $prefixedValues[$this->prefix.$key] = $value;
         }
 
-        $this->memcached->setMulti($prefixedValues, (int) (time() + ($minutes * 60)));
+        $this->memcached->setMulti($prefixedValues, (int) ($minutes > 0 ? time() + ($minutes * 60) : 0));
     }
 
     /**
@@ -113,7 +113,7 @@ class MemcachedStore extends TaggableStore implements Store
      */
     public function add($key, $value, $minutes)
     {
-        return $this->memcached->add($this->prefix.$key, $value, (int) (time() + ($minutes * 60)));
+        return $this->memcached->add($this->prefix.$key, $value, (int) ($minutes > 0 ? time() + ($minutes * 60) : 0));
     }
 
     /**

--- a/tests/Cache/CacheMemcachedStoreTest.php
+++ b/tests/Cache/CacheMemcachedStoreTest.php
@@ -50,7 +50,13 @@ class CacheMemcachedStoreTest extends PHPUnit_Framework_TestCase
         }
 
         $memcache = $this->getMockBuilder('Memcached')->setMethods(['set'])->getMock();
-        $memcache->expects($this->once())->method('set')->with($this->equalTo('foo'), $this->equalTo('bar'), $this->equalTo(60));
+
+        // Since the expire time is relative to the current unix time, a second could've passed between
+        // the defined expectation and the actual put-call. Thus, either of these calls is valid.
+        $memcache->expects($this->once())->method('set')->withConsecutive(
+            [$this->equalTo('foo'), $this->equalTo('bar'), $this->equalTo(time() + 60)],
+            [$this->equalTo('foo'), $this->equalTo('bar'), $this->equalTo(time() + 61)]
+        );
         $store = new Illuminate\Cache\MemcachedStore($memcache);
         $store->put('foo', 'bar', 1);
     }


### PR DESCRIPTION
This pull request will allow Memcached to cache entries for more than
30 days. Every expiration time in Memcached will be converted to
seconds, [unless they exceed 30 days](http://php.net/manual/en/memcache.set.php). Then, instead of seconds, a
unix timestamp is expected.

If not adjusted, this will most likely result in an immediate
expiration of the entry stored. An example would be:
1. The user stores an entry for 40 days, supplying 57600 minutes.
2. The minutes will get converted to 3456000 seconds.
3. Since the timespan exceeds 30 days, Memcached now expects a
   unix timestamp.
4. The unix timestamp would be "1970-02-10 00:00:00", meaning the
   entry stored is already expired upon store.

To avoid this, every value greater than 30 days, will automatically
be converted to the correct unix timestamp.

This pull request will break programs that already are aware of that
behaviour and used a workaround for it. However, this will make
sure that the Memcached implementation is compatible to the other
caching providers and will avoid unexpected behaviour.
