### PR TITLE
[5.3] Removed unnecessary variable

### DIFF
--- a/src/Illuminate/Foundation/Auth/AuthenticatesUsers.php
+++ b/src/Illuminate/Foundation/Auth/AuthenticatesUsers.php
@@ -33,7 +33,7 @@ trait AuthenticatesUsers
         // If the class is using the ThrottlesLogins trait, we can automatically throttle
         // the login attempts for this application. We'll key this by the username and
         // the IP address of the client making these requests into this application.
-        if ($lockedOut = $this->hasTooManyLoginAttempts($request)) {
+        if ($this->hasTooManyLoginAttempts($request)) {
             $this->fireLockoutEvent($request);
 
             return $this->sendLockoutResponse($request);
@@ -48,9 +48,7 @@ trait AuthenticatesUsers
         // If the login attempt was unsuccessful we will increment the number of attempts
         // to login and redirect the user back to the login form. Of course, when this
         // user surpasses their maximum number of attempts they will get locked out.
-        if (! $lockedOut) {
-            $this->incrementLoginAttempts($request);
-        }
+        $this->incrementLoginAttempts($request);
 
         return $this->sendFailedLoginResponse($request);
     }


### PR DESCRIPTION
There is no need to use that variable so we can just remove it to make that code easier to read.
