### PR TITLE
[5.1] beginTransaction(): Reconnect if connection is lost

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -498,25 +498,29 @@ class Connection implements ConnectionInterface
      * Start a new database transaction.
      *
      * @return void
-     * @throws Exception
+     *
+     * @throws \Exception
      */
     public function beginTransaction()
     {
-        ++$this->transactions;
-
-        if ($this->transactions == 1) {
+        if ($this->transactions == 0) {
             try {
-                $this->pdo->beginTransaction();
+                $this->getPdo()->beginTransaction();
             } catch (Exception $e) {
-                --$this->transactions;
-
-                throw $e;
+                if ($this->causedByLostConnection($e)) {
+                    $this->reconnect();
+                    $this->getPdo()->beginTransaction();
+                } else {
+                    throw $e;
+                }
             }
-        } elseif ($this->transactions > 1 && $this->queryGrammar->supportsSavepoints()) {
+        } elseif ($this->transactions >= 1 && $this->queryGrammar->supportsSavepoints()) {
             $this->pdo->exec(
-                $this->queryGrammar->compileSavepoint('trans'.$this->transactions)
+                $this->queryGrammar->compileSavepoint('trans'.($this->transactions + 1))
             );
         }
+
+        ++$this->transactions;
 
         $this->fireConnectionEvent('beganTransaction');
     }
@@ -866,6 +870,8 @@ class Connection implements ConnectionInterface
      *
      * @param  \PDO|null  $pdo
      * @return $this
+     *
+     * @throws \RuntimeException
      */
     public function setPdo($pdo)
     {

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -505,11 +505,11 @@ class Connection implements ConnectionInterface
     {
         if ($this->transactions == 0) {
             try {
-                $this->getPdo()->beginTransaction();
+                $this->pdo->beginTransaction();
             } catch (Exception $e) {
                 if ($this->causedByLostConnection($e)) {
                     $this->reconnect();
-                    $this->getPdo()->beginTransaction();
+                    $this->pdo->beginTransaction();
                 } else {
                     throw $e;
                 }

--- a/tests/Database/DatabaseConnectionTest.php
+++ b/tests/Database/DatabaseConnectionTest.php
@@ -111,14 +111,14 @@ class DatabaseConnectionTest extends PHPUnit_Framework_TestCase
         $this->assertTrue(is_numeric($log[0]['time']));
     }
 
-    public function testTransactionsDecrementedOnTransactionException()
+    public function testTransactionLevelNotIncrementedOnTransactionException()
     {
         $pdo = $this->getMock('DatabaseConnectionTestMockPDO');
-        $pdo->expects($this->once())->method('beginTransaction')->will($this->throwException(new ErrorException('MySQL server has gone away')));
+        $pdo->expects($this->once())->method('beginTransaction')->will($this->throwException(new Exception));
         $connection = $this->getMockConnection([], $pdo);
         try {
             $connection->beginTransaction();
-        } catch (ErrorException $e) {
+        } catch (Exception $e) {
             $this->assertEquals(0, $connection->transactionLevel());
         }
     }

--- a/tests/Database/DatabaseConnectionTest.php
+++ b/tests/Database/DatabaseConnectionTest.php
@@ -123,6 +123,36 @@ class DatabaseConnectionTest extends PHPUnit_Framework_TestCase
         }
     }
 
+    public function testBeginTransactionMethodRetriesOnFailure()
+    {
+        $pdo = $this->getMock('DatabaseConnectionTestMockPDO');
+        $pdo->expects($this->exactly(2))->method('beginTransaction');
+        $pdo->expects($this->at(0))->method('beginTransaction')->will($this->throwException(new ErrorException('server has gone away')));
+        $connection = $this->getMockConnection(['reconnect'], $pdo);
+        $connection->expects($this->once())->method('reconnect');
+        $connection->beginTransaction();
+        $this->assertEquals(1, $connection->transactionLevel());
+    }
+
+    public function testBeginTransactionMethodNeverRetriesIfWithinTransaction()
+    {
+        $pdo = $this->getMock('DatabaseConnectionTestMockPDO');
+        $pdo->expects($this->once())->method('beginTransaction');
+        $pdo->expects($this->once())->method('exec')->will($this->throwException(new Exception));
+        $connection = $this->getMockConnection([], $pdo);
+        $queryGrammar = $this->getMock('Illuminate\Database\Query\Grammars\Grammar');
+        $queryGrammar->expects($this->once())->method('supportsSavepoints')->will($this->returnValue(true));
+        $connection->setQueryGrammar($queryGrammar);
+        $connection->expects($this->never())->method('reconnect');
+        $connection->beginTransaction();
+        $this->assertEquals(1, $connection->transactionLevel());
+        try {
+            $connection->beginTransaction();
+        } catch (Exception $e) {
+            $this->assertEquals(1, $connection->transactionLevel());
+        }
+    }
+
     /**
      * @expectedException RuntimeException
      */


### PR DESCRIPTION
I couldn't figure out how to get PHPUnit to do what I wanted in order to write a test for this. There doesn't seem to be a way to do 

```
$pdo->expects($this->once())->method('beginTransaction')->will($this->throwException(new ErrorException('MySQL server has gone away')));
```

for the first run of `$this->getPdo()->beginTransaction()` but then expect a second run of `$this->getPdo()->beginTransaction()` to run successfully.

Let me know if you have any suggestions on how to test this.

This PR should, at least partly, fix issue #15179.
