### PR TITLE
[5.3] fixed: test childFoo, original dont have last paramenter

### DIFF
--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -830,7 +830,7 @@ class EloquentBuilderTestModelSelfRelatedStub extends Illuminate\Database\Eloque
 
     public function childFoo()
     {
-        return $this->hasOne('EloquentBuilderTestModelSelfRelatedStub', 'parent_id', 'id', 'child');
+        return $this->hasOne('EloquentBuilderTestModelSelfRelatedStub', 'parent_id', 'id');
     }
 
     public function childFoos()


### PR DESCRIPTION
paramenter 'child' dont exists
