### PR TITLE
[5.3] Set has() parameter to null by default

### DIFF
--- a/src/Illuminate/Support/MessageBag.php
+++ b/src/Illuminate/Support/MessageBag.php
@@ -101,7 +101,7 @@ class MessageBag implements Arrayable, Countable, Jsonable, JsonSerializable, Me
      * @param  array|string  $key
      * @return bool
      */
-    public function has($key)
+    public function has($key = null)
     {
         if (is_null($key)) {
             return $this->any();


### PR DESCRIPTION
This will avoid "Missing argument 1 for Illuminate\Support\MessageBag::has()" error when using

``` php
$errors->has()
```

in blade templates.
