### PR TITLE
[5.3] Remove old failed() implementation from InteractsWithQueue.

### DIFF
--- a/src/Illuminate/Queue/InteractsWithQueue.php
+++ b/src/Illuminate/Queue/InteractsWithQueue.php
@@ -36,18 +36,6 @@ trait InteractsWithQueue
     }
 
     /**
-     * Fail the job from the queue.
-     *
-     * @return void
-     */
-    public function failed()
-    {
-        if ($this->job) {
-            return $this->job->failed();
-        }
-    }
-
-    /**
      * Release the job back into the queue.
      *
      * @param  int   $delay


### PR DESCRIPTION
I believe the `failed()` method in `InteractsWithQueue` should be removed.  After a conversation with @crynobone, it's original intention and lack of exception parameter seems to conflict with [the new failed() method implementation in 5.3](https://laravel.com/docs/5.3/queues#dealing-with-failed-jobs).

This came about because of [this thread](https://github.com/laravel/framework/issues/15192#issuecomment-248268642), and though it doesn't solve the original issue, this PR would remove some confusion around the new `failed()` functionality in 5.3.

---

![screen shot 2016-09-20 at 8 49 34 am](https://cloud.githubusercontent.com/assets/5187394/18670726/4246ac90-7f0f-11e6-8903-b4978f4d9155.png)
![screen shot 2016-09-20 at 8 49 43 am](https://cloud.githubusercontent.com/assets/5187394/18670728/4333679c-7f0f-11e6-9b46-3fb997a68fd6.png)
