### PR TITLE
[5.3] let the worker sleep 1 second more when app is down for maintenance

### DIFF
--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -90,8 +90,13 @@ class Worker
      */
     protected function daemonShouldRun()
     {
-        return $this->manager->isDownForMaintenance()
-            ? false : $this->events->until('illuminate.queue.looping') !== false;
+        if ($this->manager->isDownForMaintenance() || $this->events->until('illuminate.queue.looping') === false) {
+            $this->sleep(1);
+
+            return false;
+        }
+
+        return true;
     }
 
     /**


### PR DESCRIPTION
If the queue driver, like sqs, supports long polling, it is better to set `--sleep=0` when running `queue:work` console command. But if it is done so, the CPU will reach 100% when application is down by `artisan app:down`.

If you find this PR valid, please decide if it is backward compatible or not, and if it should be applied to earlier versions as well.

Thanks.
