### PR TITLE
[5.3] Decode URI before dividing into segments

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -167,7 +167,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
      */
     public function segments()
     {
-        $segments = explode('/', $this->path());
+        $segments = explode('/', $this->decodedPath());
 
         return array_values(array_filter($segments, function ($v) {
             return $v != '';
@@ -182,7 +182,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
     public function is()
     {
         foreach (func_get_args() as $pattern) {
-            if (Str::is($pattern, urldecode($this->path()))) {
+            if (Str::is($pattern, $this->decodedPath())) {
                 return true;
             }
         }


### PR DESCRIPTION
For a URL like `http://domain.com/رحاب`

`Request::segment(1)` returns `%D8%B1%D8%AD%D8%A7%D8%A8`

This PR decodes the URI before dividing into segments.
