### PR TITLE
[5.3] Testing jobs dispatched now

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MocksApplicationServices.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MocksApplicationServices.php
@@ -313,7 +313,7 @@ trait MocksApplicationServices
     {
         $mock = Mockery::mock('Illuminate\Contracts\Bus\Dispatcher');
 
-        $mock->shouldReceive('dispatch')->andReturnUsing(function ($dispatched) {
+        $mock->shouldReceive('dispatch', 'dispatchNow')->andReturnUsing(function ($dispatched) {
             $this->dispatchedJobs[] = $dispatched;
         });
 


### PR DESCRIPTION
I use jobs that are dispatched now quite extensively as they do things I don't want to wait for in the queue. Adding dispatchNow to `shouldReceive()` will allow this without having to write a method that `expectsJobsNow`.
