### PR TITLE
[5.3] Reset artisan application after running migrations in tests

### DIFF
--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -269,6 +269,17 @@ class Kernel implements KernelContract
     }
 
     /**
+     * Set the Artisan application instance.
+     *
+     * @param  \Illuminate\Console\Application $value
+     * @return void
+     */
+    public function setArtisan($value)
+    {
+        $this->artisan = $value;
+    }
+
+    /**
      * Get the Artisan application instance.
      *
      * @return \Illuminate\Console\Application

--- a/src/Illuminate/Foundation/Testing/DatabaseMigrations.php
+++ b/src/Illuminate/Foundation/Testing/DatabaseMigrations.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\Foundation\Testing;
 
-use Illuminate\Foundation\Console\Kernel;
+use Illuminate\Contracts\Console\Kernel;
 
 trait DatabaseMigrations
 {

--- a/src/Illuminate/Foundation/Testing/DatabaseMigrations.php
+++ b/src/Illuminate/Foundation/Testing/DatabaseMigrations.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Foundation\Testing;
 
+use Illuminate\Foundation\Console\Kernel;
+
 trait DatabaseMigrations
 {
     /**
@@ -12,6 +14,8 @@ trait DatabaseMigrations
     public function runDatabaseMigrations()
     {
         $this->artisan('migrate');
+
+        $this->app[Kernel::class]->setArtisan(null);
 
         $this->beforeApplicationDestroyed(function () {
             $this->artisan('migrate:rollback');


### PR DESCRIPTION
When you use the DatabaseMigrations trait in tests, a call to $this->artisan('migrate') is made for every test, this call creates an instance of Illuminate\Console\Application and resolves all commands.

Inside any test if you try to swap any console command dependency using $this->app->bind() and then call the command via $this->artisan('command') the old concrete implementation will be called instead of the swapped dummy one.

This PR fixes that by resetting the artisan application instance so that it gets rebuilt inside the actual tests allowing the swapping of bindings.
