### PR TITLE
[5.3] Fix support for multi-schema search_path in Postgres

### DIFF
--- a/src/Illuminate/Database/Schema/PostgresBuilder.php
+++ b/src/Illuminate/Database/Schema/PostgresBuilder.php
@@ -16,6 +16,10 @@ class PostgresBuilder extends Builder
 
         $schema = $this->connection->getConfig('schema');
 
+        if (is_array($schema)) {
+            $schema = head($schema);
+        }
+
         $table = $this->connection->getTablePrefix().$table;
 
         return count($this->connection->select($sql, [$schema, $table])) > 0;


### PR DESCRIPTION
Following my bug report from #8639, the [PostgresConnector](src/Illuminate/Database/Connectors/PostgresConnector.php) class was modified to support a multi-schema `search_path` if the connection's `schema` configuration value is an array, e.g. 

``` php
'connections' => [
    'postgres' => [
        // ... other options here ...
        'schema' => ['app', 'public'],
    ],
],
```

That fix does correctly set the `search_path` to the specified one but using an array instead of a string for the schema now produces an error in artisan migrations. 

Running `php artisan migrate` now trows the following:

> [Illuminate\Database\QueryException]
> Array to string conversion (SQL: select \* from information_schema.tables where table_schema = app and table_name = migrations)

The fix submitted with this pull request addresses this issue by using the first schema specified in the `schema` configuration array as the default schema for artisan migrations.

Users are still able to override this default schema if needed by specifying the schema in the `migrations` configuration options:

``` php
 'migrations' => 'public.migrations',
```

or by specifying a schema in the actual migration script:

``` php
public function up()
{
    Schema::create('public.users', function (Blueprint $table) {
        // ... migration ....
    }
}
```
