### PR TITLE
Remove forced env in unit tests

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -86,8 +86,6 @@ abstract class TestCase extends PHPUnit_Framework_TestCase
      */
     protected function refreshApplication()
     {
-        putenv('APP_ENV=testing');
-
         $this->app = $this->createApplication();
     }
 


### PR DESCRIPTION
In unit tests, this line made every change of the APP_ENV variable in the .env or phpunit.xml or even the command line irrelevant.
This change just removes that line and makes the APP_ENV variable mutable.
