### PR TITLE
[5.3] Fix validator messages for implicit attributes with errors

### DIFF
--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -128,6 +128,23 @@ class Translator extends NamespacedItemResolver implements TranslatorInterface
     }
 
     /**
+     * Add translation lines to the given locale.
+     *
+     * @param  array  $lines
+     * @param  string  $locale
+     * @param  string  $namespace
+     * @return void
+     */
+    public function addLines(array $lines, $locale, $namespace = '*')
+    {
+        foreach ($lines as $key => $value) {
+            list($group, $item) = explode('.', $key, 2);
+
+            Arr::set($this->loaded, "$namespace.$group.$locale.$item", $value);
+        }
+    }
+
+    /**
      * Retrieve a language line out the loaded array.
      *
      * @param  string  $namespace

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -2242,12 +2242,10 @@ class Validator implements ValidatorContract
                 return $this->customAttributes[$expectedAttributeName];
             }
 
-            $key = "validation.attributes.{$expectedAttributeName}";
-
             // We allow for the developer to specify language lines for each of the
             // attributes allowing for more displayable counterparts of each of
             // the attributes. This provides the ability for simple formats.
-            if (($line = $this->translator->trans($key)) !== $key) {
+            if ($line = Arr::get($this->translator->get('validation.attributes'), $expectedAttributeName)) {
                 return $line;
             }
         }

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -14,19 +14,19 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
     public function testSometimesWorksOnNestedArrays()
     {
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['foo' => ['bar' => ['baz' => '']]], ['foo.bar.baz' => 'sometimes|required']);
         $this->assertFalse($v->passes());
         $this->assertEquals(['foo.bar.baz' => ['Required' => []]], $v->failed());
 
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['foo' => ['bar' => ['baz' => 'nonEmpty']]], ['foo.bar.baz' => 'sometimes|required']);
         $this->assertTrue($v->passes());
     }
 
     public function testAfterCallbacksAreCalledWithValidatorInstance()
     {
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['foo' => 'bar', 'baz' => 'boom'], ['foo' => 'Same:baz']);
         $v->setContainer(new Illuminate\Container\Container);
         $v->after(function ($validator) {
@@ -45,12 +45,12 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
     public function testSometimesWorksOnArrays()
     {
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['foo' => ['bar', 'baz', 'moo']], ['foo' => 'sometimes|required|between:5,10']);
         $this->assertFalse($v->passes());
         $this->assertNotEmpty($v->failed());
 
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['foo' => ['bar', 'baz', 'moo', 'pew', 'boom']], ['foo' => 'sometimes|required|between:5,10']);
         $this->assertTrue($v->passes());
     }
@@ -60,7 +60,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
      */
     public function testValidateThrowsOnFail()
     {
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['foo' => 'bar'], ['baz' => 'required']);
 
         $v->validate();
@@ -68,7 +68,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
     public function testValidateDoesntThrowOnPass()
     {
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['foo' => 'bar'], ['foo' => 'required']);
 
         $v->validate();
@@ -76,7 +76,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
     public function testHasFailedValidationRules()
     {
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['foo' => 'bar', 'baz' => 'boom'], ['foo' => 'Same:baz']);
         $this->assertFalse($v->passes());
         $this->assertEquals(['foo' => ['Same' => ['baz']]], $v->failed());
@@ -84,7 +84,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
     public function testFailingOnce()
     {
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['foo' => 'bar', 'baz' => 'boom'], ['foo' => 'Bail|Same:baz|In:qux']);
         $this->assertFalse($v->passes());
         $this->assertEquals(['foo' => ['Same' => ['baz']]], $v->failed());
@@ -118,7 +118,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
     public function testValidateEmptyStringsAlwaysPasses()
     {
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
 
         $v = new Validator($trans, ['x' => ''], ['x' => 'size:10|array|integer|min:5']);
         $this->assertTrue($v->passes());
@@ -126,7 +126,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
     public function testEmptyExistingAttributesAreValidated()
     {
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
 
         $v = new Validator($trans, ['x' => ''], ['x' => 'array']);
         $this->assertTrue($v->passes());
@@ -149,7 +149,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
     public function testNullable()
     {
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
 
         $v = new Validator($trans, [
             'x' => null, 'y' => null, 'z' => null, 'a' => null, 'b' => null,
@@ -173,18 +173,19 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
     public function testProperLanguageLineIsSet()
     {
-        $trans = $this->getRealTranslator();
-        $trans->addResource('array', ['validation.required' => 'required!'], 'en', 'messages');
+        $trans = $this->getIlluminateArrayTranslator();
+        $trans->addLines(['validation.required' => 'required!'], 'en');
         $v = new Validator($trans, ['name' => ''], ['name' => 'Required']);
         $this->assertFalse($v->passes());
         $v->messages()->setFormat(':message');
+
         $this->assertEquals('required!', $v->messages()->first('name'));
     }
 
     public function testCustomReplacersAreCalled()
     {
-        $trans = $this->getRealTranslator();
-        $trans->addResource('array', ['validation.required' => 'foo bar'], 'en', 'messages');
+        $trans = $this->getIlluminateArrayTranslator();
+        $trans->addLines(['validation.required' => 'foo bar'], 'en');
         $v = new Validator($trans, ['name' => ''], ['name' => 'Required']);
         $v->addReplacer('required', function ($message, $attribute, $rule, $parameters) {
             return str_replace('bar', 'taylor', $message);
@@ -196,8 +197,8 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
     public function testClassBasedCustomReplacers()
     {
-        $trans = $this->getRealTranslator();
-        $trans->addResource('array', ['validation.foo' => 'foo!'], 'en', 'messages');
+        $trans = $this->getIlluminateArrayTranslator();
+        $trans->addLines(['validation.foo' => 'foo!'], 'en');
         $v = new Validator($trans, [], ['name' => 'required']);
         $v->setContainer($container = m::mock('Illuminate\Container\Container'));
         $v->addReplacer('required', 'Foo@bar');
@@ -210,23 +211,23 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
     public function testAttributeNamesAreReplaced()
     {
-        $trans = $this->getRealTranslator();
-        $trans->addResource('array', ['validation.required' => ':attribute is required!'], 'en', 'messages');
+        $trans = $this->getIlluminateArrayTranslator();
+        $trans->addLines(['validation.required' => ':attribute is required!'], 'en');
         $v = new Validator($trans, ['name' => ''], ['name' => 'Required']);
         $this->assertFalse($v->passes());
         $v->messages()->setFormat(':message');
         $this->assertEquals('name is required!', $v->messages()->first('name'));
 
-        $trans = $this->getRealTranslator();
-        $trans->addResource('array', ['validation.required' => ':attribute is required!', 'validation.attributes.name' => 'Name'], 'en', 'messages');
+        $trans = $this->getIlluminateArrayTranslator();
+        $trans->addLines(['validation.required' => ':attribute is required!', 'validation.attributes.name' => 'Name'], 'en');
         $v = new Validator($trans, ['name' => ''], ['name' => 'Required']);
         $this->assertFalse($v->passes());
         $v->messages()->setFormat(':message');
         $this->assertEquals('Name is required!', $v->messages()->first('name'));
 
         //set customAttributes by setter
-        $trans = $this->getRealTranslator();
-        $trans->addResource('array', ['validation.required' => ':attribute is required!'], 'en', 'messages');
+        $trans = $this->getIlluminateArrayTranslator();
+        $trans->addLines(['validation.required' => ':attribute is required!'], 'en');
         $customAttributes = ['name' => 'Name'];
         $v = new Validator($trans, ['name' => ''], ['name' => 'Required']);
         $v->addCustomAttributes($customAttributes);
@@ -234,23 +235,23 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $v->messages()->setFormat(':message');
         $this->assertEquals('Name is required!', $v->messages()->first('name'));
 
-        $trans = $this->getRealTranslator();
-        $trans->addResource('array', ['validation.required' => ':attribute is required!'], 'en', 'messages');
+        $trans = $this->getIlluminateArrayTranslator();
+        $trans->addLines(['validation.required' => ':attribute is required!'], 'en');
         $v = new Validator($trans, ['name' => ''], ['name' => 'Required']);
         $v->setAttributeNames(['name' => 'Name']);
         $this->assertFalse($v->passes());
         $v->messages()->setFormat(':message');
         $this->assertEquals('Name is required!', $v->messages()->first('name'));
 
-        $trans = $this->getRealTranslator();
-        $trans->addResource('array', ['validation.required' => ':Attribute is required!'], 'en', 'messages');
+        $trans = $this->getIlluminateArrayTranslator();
+        $trans->addLines(['validation.required' => ':Attribute is required!'], 'en');
         $v = new Validator($trans, ['name' => ''], ['name' => 'Required']);
         $this->assertFalse($v->passes());
         $v->messages()->setFormat(':message');
         $this->assertEquals('Name is required!', $v->messages()->first('name'));
 
-        $trans = $this->getRealTranslator();
-        $trans->addResource('array', ['validation.required' => ':ATTRIBUTE is required!'], 'en', 'messages');
+        $trans = $this->getIlluminateArrayTranslator();
+        $trans->addLines(['validation.required' => ':ATTRIBUTE is required!'], 'en');
         $v = new Validator($trans, ['name' => ''], ['name' => 'Required']);
         $this->assertFalse($v->passes());
         $v->messages()->setFormat(':message');
@@ -259,25 +260,25 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
     public function testAttributeNamesAreReplacedInArrays()
     {
-        $trans = $this->getRealTranslator();
-        $trans->addResource('array', ['validation.required' => ':attribute is required!'], 'en', 'messages');
+        $trans = $this->getIlluminateArrayTranslator();
+        $trans->addLines(['validation.required' => ':attribute is required!'], 'en');
         $v = new Validator($trans, ['users' => [['country_code' => 'US'], ['country_code' => null]]], ['users.*.country_code' => 'Required']);
         $this->assertFalse($v->passes());
         $v->messages()->setFormat(':message');
         $this->assertEquals('users.1.country_code is required!', $v->messages()->first('users.1.country_code'));
 
-        $trans = $this->getRealTranslator();
-        $trans->addResource('array', [
+        $trans = $this->getIlluminateArrayTranslator();
+        $trans->addLines([
             'validation.string' => ':attribute must be a string!',
             'validation.attributes.name.*' => 'Any name',
-        ], 'en', 'messages');
+        ], 'en');
         $v = new Validator($trans, ['name' => ['Jon', 2]], ['name.*' => 'string']);
         $this->assertFalse($v->passes());
         $v->messages()->setFormat(':message');
         $this->assertEquals('Any name must be a string!', $v->messages()->first('name.1'));
 
-        $trans = $this->getRealTranslator();
-        $trans->addResource('array', ['validation.string' => ':attribute must be a string!'], 'en', 'messages');
+        $trans = $this->getIlluminateArrayTranslator();
+        $trans->addLines(['validation.string' => ':attribute must be a string!'], 'en');
         $v = new Validator($trans, ['name' => ['Jon', 2]], ['name.*' => 'string']);
         $v->setAttributeNames(['name.*' => 'Any name']);
         $this->assertFalse($v->passes());
@@ -290,37 +291,52 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $v->messages()->setFormat(':message');
         $this->assertEquals('Any name must be a string!', $v->messages()->first('users.1.name'));
 
-        $trans->addResource('array', ['validation.required' => ':attribute is required!'], 'en', 'messages');
+        $trans->addLines(['validation.required' => ':attribute is required!'], 'en');
         $v = new Validator($trans, ['title' => ['nl' => '', 'en' => 'Hello']], ['title.*' => 'required'], [], ['title.nl' => 'Titel', 'title.en' => 'Title']);
         $this->assertFalse($v->passes());
         $v->messages()->setFormat(':message');
         $this->assertEquals('Titel is required!', $v->messages()->first('title.nl'));
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $trans->addLines(['validation.required' => ':attribute is required!'], 'en');
+        $trans->addLines(['validation.attributes' => ['names.*' => 'names']], 'en');
+        $v = new Validator($trans, ['names' => [null, 'name']], ['names.*' => 'Required']);
+        $v->messages()->setFormat(':message');
+        $this->assertEquals('names is required!', $v->messages()->first('names.0'));
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $trans->addLines(['validation.required' => ':attribute is required!'], 'en');
+        $trans->addLines(['validation.attributes' => ['names.*' => 'names']], 'en');
+        $trans->addLines(['validation.attributes' => ['names.0' => 'First name']], 'en');
+        $v = new Validator($trans, ['names' => [null, 'name']], ['names.*' => 'Required']);
+        $v->messages()->setFormat(':message');
+        $this->assertEquals('First name is required!', $v->messages()->first('names.0'));
     }
 
     public function testDisplayableValuesAreReplaced()
     {
         //required_if:foo,bar
-        $trans = $this->getRealTranslator();
-        $trans->addResource('array', ['validation.required_if' => 'The :attribute field is required when :other is :value.'], 'en', 'messages');
-        $trans->addResource('array', ['validation.values.color.1' => 'red'], 'en', 'messages');
+        $trans = $this->getIlluminateArrayTranslator();
+        $trans->addLines(['validation.required_if' => 'The :attribute field is required when :other is :value.'], 'en');
+        $trans->addLines(['validation.values.color.1' => 'red'], 'en');
         $v = new Validator($trans, ['color' => '1', 'bar' => ''], ['bar' => 'RequiredIf:color,1']);
         $this->assertFalse($v->passes());
         $v->messages()->setFormat(':message');
         $this->assertEquals('The bar field is required when color is red.', $v->messages()->first('bar'));
 
         //in:foo,bar,...
-        $trans = $this->getRealTranslator();
-        $trans->addResource('array', ['validation.in' => ':attribute must be included in :values.'], 'en', 'messages');
-        $trans->addResource('array', ['validation.values.type.5' => 'Short'], 'en', 'messages');
-        $trans->addResource('array', ['validation.values.type.300' => 'Long'], 'en', 'messages');
+        $trans = $this->getIlluminateArrayTranslator();
+        $trans->addLines(['validation.in' => ':attribute must be included in :values.'], 'en');
+        $trans->addLines(['validation.values.type.5' => 'Short'], 'en');
+        $trans->addLines(['validation.values.type.300' => 'Long'], 'en');
         $v = new Validator($trans, ['type' => '4'], ['type' => 'in:5,300']);
         $this->assertFalse($v->passes());
         $v->messages()->setFormat(':message');
         $this->assertEquals('type must be included in Short, Long.', $v->messages()->first('type'));
 
         // test addCustomValues
-        $trans = $this->getRealTranslator();
-        $trans->addResource('array', ['validation.in' => ':attribute must be included in :values.'], 'en', 'messages');
+        $trans = $this->getIlluminateArrayTranslator();
+        $trans->addLines(['validation.in' => ':attribute must be included in :values.'], 'en');
         $customValues = [
             'type' => [
                 '5' => 'Short',
@@ -334,8 +350,8 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('type must be included in Short, Long.', $v->messages()->first('type'));
 
         // set custom values by setter
-        $trans = $this->getRealTranslator();
-        $trans->addResource('array', ['validation.in' => ':attribute must be included in :values.'], 'en', 'messages');
+        $trans = $this->getIlluminateArrayTranslator();
+        $trans->addLines(['validation.in' => ':attribute must be included in :values.'], 'en');
         $customValues = [
             'type' => [
                 '5' => 'Short',
@@ -408,13 +424,13 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
     public function testInlineValidationMessagesAreRespected()
     {
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['name' => ''], ['name' => 'Required'], ['name.required' => 'require it please!']);
         $this->assertFalse($v->passes());
         $v->messages()->setFormat(':message');
         $this->assertEquals('require it please!', $v->messages()->first('name'));
 
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['name' => ''], ['name' => 'Required'], ['required' => 'require it please!']);
         $this->assertFalse($v->passes());
         $v->messages()->setFormat(':message');
@@ -423,7 +439,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
     public function testInlineValidationMessagesAreRespectedWithAsterisks()
     {
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['name' => ['', '']], [], ['name.*.required' => 'all must be required!']);
         $v->each('name', 'required|max:255');
         $this->assertFalse($v->passes());
@@ -434,7 +450,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
     public function testIfRulesAreSuccessfullyAdded()
     {
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, [], ['foo' => 'Required']);
         // foo has required rule
         $this->assertTrue($v->hasRule('foo', 'Required'));
@@ -446,7 +462,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
     public function testValidateArray()
     {
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
 
         $v = new Validator($trans, ['foo' => [1, 2, 3]], ['foo' => 'Array']);
         $this->assertTrue($v->passes());
@@ -457,7 +473,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
     public function testValidateFilled()
     {
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, [], ['name' => 'filled']);
         $this->assertTrue($v->passes());
 
@@ -476,7 +492,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
     public function testValidationStopsAtFailedPresenceCheck()
     {
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
 
         $v = new Validator($trans, ['name' => null], ['name' => 'Required|string']);
         $v->passes();
@@ -497,7 +513,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
     public function testValidatePresent()
     {
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, [], ['name' => 'present']);
         $this->assertFalse($v->passes());
 
@@ -519,7 +535,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
     public function testValidateRequired()
     {
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, [], ['name' => 'Required']);
         $this->assertFalse($v->passes());
 
@@ -540,7 +556,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
     public function testValidateRequiredWith()
     {
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['first' => 'Taylor'], ['last' => 'required_with:first']);
         $this->assertFalse($v->passes());
 
@@ -573,7 +589,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
     public function testRequiredWithAll()
     {
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['first' => 'foo'], ['last' => 'required_with_all:first,foo']);
         $this->assertTrue($v->passes());
 
@@ -583,7 +599,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
     public function testValidateRequiredWithout()
     {
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['first' => 'Taylor'], ['last' => 'required_without:first']);
         $this->assertTrue($v->passes());
 
@@ -637,7 +653,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
     public function testRequiredWithoutMultiple()
     {
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
 
         $rules = [
             'f1' => 'required_without:f2,f3',
@@ -672,7 +688,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
     public function testRequiredWithoutAll()
     {
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
 
         $rules = [
             'f1' => 'required_without_all:f2,f3',
@@ -707,33 +723,33 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
     public function testRequiredIf()
     {
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['first' => 'taylor'], ['last' => 'required_if:first,taylor']);
         $this->assertTrue($v->fails());
 
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['first' => 'taylor', 'last' => 'otwell'], ['last' => 'required_if:first,taylor']);
         $this->assertTrue($v->passes());
 
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['first' => 'taylor', 'last' => 'otwell'], ['last' => 'required_if:first,taylor,dayle']);
         $this->assertTrue($v->passes());
 
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['first' => 'dayle', 'last' => 'rees'], ['last' => 'required_if:first,taylor,dayle']);
         $this->assertTrue($v->passes());
 
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['foo' => true], ['bar' => 'required_if:foo,false']);
         $this->assertTrue($v->passes());
 
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['foo' => true], ['bar' => 'required_if:foo,true']);
         $this->assertTrue($v->fails());
 
         // error message when passed multiple values (required_if:foo,bar,baz)
-        $trans = $this->getRealTranslator();
-        $trans->addResource('array', ['validation.required_if' => 'The :attribute field is required when :other is :value.'], 'en', 'messages');
+        $trans = $this->getIlluminateArrayTranslator();
+        $trans->addLines(['validation.required_if' => 'The :attribute field is required when :other is :value.'], 'en');
         $v = new Validator($trans, ['first' => 'dayle', 'last' => ''], ['last' => 'RequiredIf:first,taylor,dayle']);
         $this->assertFalse($v->passes());
         $this->assertEquals('The last field is required when first is dayle.', $v->messages()->first('last'));
@@ -741,29 +757,29 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
     public function testRequiredUnless()
     {
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['first' => 'sven'], ['last' => 'required_unless:first,taylor']);
         $this->assertTrue($v->fails());
 
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['first' => 'taylor'], ['last' => 'required_unless:first,taylor']);
         $this->assertTrue($v->passes());
 
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['first' => 'sven', 'last' => 'wittevrongel'], ['last' => 'required_unless:first,taylor']);
         $this->assertTrue($v->passes());
 
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['first' => 'taylor'], ['last' => 'required_unless:first,taylor,sven']);
         $this->assertTrue($v->passes());
 
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['first' => 'sven'], ['last' => 'required_unless:first,taylor,sven']);
         $this->assertTrue($v->passes());
 
         // error message when passed multiple values (required_unless:foo,bar,baz)
-        $trans = $this->getRealTranslator();
-        $trans->addResource('array', ['validation.required_unless' => 'The :attribute field is required unless :other is in :values.'], 'en', 'messages');
+        $trans = $this->getIlluminateArrayTranslator();
+        $trans->addLines(['validation.required_unless' => 'The :attribute field is required unless :other is in :values.'], 'en');
         $v = new Validator($trans, ['first' => 'dayle', 'last' => ''], ['last' => 'RequiredUnless:first,taylor,sven']);
         $this->assertFalse($v->passes());
         $this->assertEquals('The last field is required unless first is in taylor, sven.', $v->messages()->first('last'));
@@ -771,7 +787,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
     public function testFailedFileUploads()
     {
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
 
         // If file is not successfully uploaded validation should fail with a
         // 'uploaded' error message instead of the original rule.
@@ -811,30 +827,30 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
     public function testValidateInArray()
     {
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['foo' => [1, 2, 3], 'bar' => [1, 2]], ['foo.*' => 'in_array:bar.*']);
         $this->assertFalse($v->passes());
 
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['foo' => [1, 2], 'bar' => [1, 2, 3]], ['foo.*' => 'in_array:bar.*']);
         $this->assertTrue($v->passes());
 
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['foo' => [['bar_id' => 5], ['bar_id' => 2]], 'bar' => [['id' => 1, ['id' => 2]]]], ['foo.*.bar_id' => 'in_array:bar.*.id']);
         $this->assertFalse($v->passes());
 
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['foo' => [['bar_id' => 1], ['bar_id' => 2]], 'bar' => [['id' => 1, ['id' => 2]]]], ['foo.*.bar_id' => 'in_array:bar.*.id']);
         $this->assertTrue($v->passes());
 
-        $trans->addResource('array', ['validation.in_array' => 'The value of :attribute does not exist in :other.'], 'en', 'messages');
+        $trans->addLines(['validation.in_array' => 'The value of :attribute does not exist in :other.'], 'en');
         $v = new Validator($trans, ['foo' => [1, 2, 3], 'bar' => [1, 2]], ['foo.*' => 'in_array:bar.*']);
         $this->assertEquals('The value of foo.2 does not exist in bar.*.', $v->messages()->first('foo.2'));
     }
 
     public function testValidateConfirmed()
     {
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['password' => 'foo'], ['password' => 'Confirmed']);
         $this->assertFalse($v->passes());
 
@@ -850,7 +866,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
     public function testValidateSame()
     {
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['foo' => 'bar', 'baz' => 'boom'], ['foo' => 'Same:baz']);
         $this->assertFalse($v->passes());
 
@@ -866,7 +882,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
     public function testValidateDifferent()
     {
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['foo' => 'bar', 'baz' => 'boom'], ['foo' => 'Different:baz']);
         $this->assertTrue($v->passes());
 
@@ -882,7 +898,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
     public function testValidateAccepted()
     {
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['foo' => 'no'], ['foo' => 'Accepted']);
         $this->assertFalse($v->passes());
 
@@ -922,33 +938,33 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
     public function testValidateString()
     {
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['x' => 'aslsdlks'], ['x' => 'string']);
         $this->assertTrue($v->passes());
 
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['x' => ['blah' => 'test']], ['x' => 'string']);
         $this->assertFalse($v->passes());
     }
 
     public function testValidateJson()
     {
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['foo' => 'aslksd'], ['foo' => 'json']);
         $this->assertFalse($v->passes());
 
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['foo' => '[]'], ['foo' => 'json']);
         $this->assertTrue($v->passes());
 
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['foo' => '{"name":"John","age":"34"}'], ['foo' => 'json']);
         $this->assertTrue($v->passes());
     }
 
     public function testValidateBoolean()
     {
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['foo' => 'no'], ['foo' => 'Boolean']);
         $this->assertFalse($v->passes());
 
@@ -985,7 +1001,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
     public function testValidateBool()
     {
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['foo' => 'no'], ['foo' => 'Bool']);
         $this->assertFalse($v->passes());
 
@@ -1022,7 +1038,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
     public function testValidateNumeric()
     {
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['foo' => 'asdad'], ['foo' => 'Numeric']);
         $this->assertFalse($v->passes());
 
@@ -1038,7 +1054,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
     public function testValidateInteger()
     {
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['foo' => 'asdad'], ['foo' => 'Integer']);
         $this->assertFalse($v->passes());
 
@@ -1054,7 +1070,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
     public function testValidateInt()
     {
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['foo' => 'asdad'], ['foo' => 'Int']);
         $this->assertFalse($v->passes());
 
@@ -1070,7 +1086,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
     public function testValidateDigits()
     {
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['foo' => '12345'], ['foo' => 'Digits:5']);
         $this->assertTrue($v->passes());
 
@@ -1083,7 +1099,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $v = new Validator($trans, ['foo' => '2e7'], ['foo' => 'Digits:3']);
         $this->assertTrue($v->fails());
 
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['foo' => '12345'], ['foo' => 'digits_between:1,6']);
         $this->assertTrue($v->passes());
 
@@ -1099,7 +1115,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
     public function testValidateSize()
     {
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['foo' => 'asdad'], ['foo' => 'Size:3']);
         $this->assertFalse($v->passes());
 
@@ -1133,7 +1149,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
     public function testValidateBetween()
     {
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['foo' => 'asdad'], ['foo' => 'Between:3,4']);
         $this->assertFalse($v->passes());
 
@@ -1173,7 +1189,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
     public function testValidateMin()
     {
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['foo' => '3'], ['foo' => 'Min:3']);
         $this->assertFalse($v->passes());
 
@@ -1207,7 +1223,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
     public function testValidateMax()
     {
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['foo' => 'aslksd'], ['foo' => 'Max:3']);
         $this->assertFalse($v->passes());
 
@@ -1249,8 +1265,8 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
     public function testProperMessagesAreReturnedForSizes()
     {
-        $trans = $this->getRealTranslator();
-        $trans->addResource('array', ['validation.min.numeric' => 'numeric', 'validation.size.string' => 'string', 'validation.max.file' => 'file'], 'en', 'messages');
+        $trans = $this->getIlluminateArrayTranslator();
+        $trans->addLines(['validation.min.numeric' => 'numeric', 'validation.size.string' => 'string', 'validation.max.file' => 'file'], 'en');
         $v = new Validator($trans, ['name' => '3'], ['name' => 'Numeric|Min:5']);
         $this->assertFalse($v->passes());
         $v->messages()->setFormat(':message');
@@ -1272,11 +1288,11 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
     public function testValidateIn()
     {
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['name' => 'foo'], ['name' => 'In:bar,baz']);
         $this->assertFalse($v->passes());
 
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['name' => 0], ['name' => 'In:bar,baz']);
         $this->assertFalse($v->passes());
 
@@ -1298,7 +1314,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
     public function testValidateNotIn()
     {
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['name' => 'foo'], ['name' => 'NotIn:bar,baz']);
         $this->assertTrue($v->passes());
 
@@ -1308,7 +1324,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
     public function testValidateDistinct()
     {
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
 
         $v = new Validator($trans, ['foo' => ['foo', 'foo']], ['foo.*' => 'distinct']);
         $this->assertFalse($v->passes());
@@ -1349,7 +1365,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
     public function testValidateUnique()
     {
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['email' => 'foo'], ['email' => 'Unique:users']);
         $mock = m::mock('Illuminate\Validation\PresenceVerifierInterface');
         $mock->shouldReceive('setConnection')->once()->with(null);
@@ -1398,7 +1414,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
      */
     public function testValidateUniqueAndExistsSendsCorrectFieldNameToDBWithArrays()
     {
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, [['email' => 'foo', 'type' => 'bar']], ['*.email' => 'unique:users', '*.type' => 'exists:user_types']);
         $mock = m::mock('Illuminate\Validation\PresenceVerifierInterface');
         $mock->shouldReceive('setConnection')->twice()->with(null);
@@ -1410,7 +1426,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
     public function testValidationExists()
     {
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['email' => 'foo'], ['email' => 'Exists:users']);
         $mock = m::mock('Illuminate\Validation\PresenceVerifierInterface');
         $mock->shouldReceive('setConnection')->once()->with(null);
@@ -1418,7 +1434,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $v->setPresenceVerifier($mock);
         $this->assertTrue($v->passes());
 
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['email' => 'foo'], ['email' => 'Exists:users,email,account_id,1,name,taylor']);
         $mock = m::mock('Illuminate\Validation\PresenceVerifierInterface');
         $mock->shouldReceive('setConnection')->once()->with(null);
@@ -1450,14 +1466,14 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
     public function testValidationExistsIsNotCalledUnnecessarily()
     {
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['id' => 'foo'], ['id' => 'Integer|Exists:users,id']);
         $mock = m::mock('Illuminate\Validation\PresenceVerifierInterface');
         $mock->shouldReceive('getCount')->never();
         $v->setPresenceVerifier($mock);
         $this->assertFalse($v->passes());
 
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['id' => '1'], ['id' => 'Integer|Exists:users,id']);
         $mock = m::mock('Illuminate\Validation\PresenceVerifierInterface');
         $mock->shouldReceive('setConnection')->once()->with(null);
@@ -1468,7 +1484,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
     public function testValidateIp()
     {
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['ip' => 'aslsdlks'], ['ip' => 'Ip']);
         $this->assertFalse($v->passes());
 
@@ -1478,7 +1494,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
     public function testValidateEmail()
     {
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['x' => 'aslsdlks'], ['x' => 'Email']);
         $this->assertFalse($v->passes());
 
@@ -1491,7 +1507,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
      */
     public function testValidateUrlWithValidUrls($validUrl)
     {
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['x' => $validUrl], ['x' => 'Url']);
         $this->assertTrue($v->passes());
     }
@@ -1501,7 +1517,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
      */
     public function testValidateUrlWithInvalidUrls($invalidUrl)
     {
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['x' => $invalidUrl], ['x' => 'Url']);
         $this->assertFalse($v->passes());
     }
@@ -1766,7 +1782,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
     public function testValidateActiveUrl()
     {
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['x' => 'aslsdlks'], ['x' => 'active_url']);
         $this->assertFalse($v->passes());
 
@@ -1785,7 +1801,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
     public function testValidateImage()
     {
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
         $uploadedFile = [__FILE__, '', null, null, null, true];
 
         $file = $this->getMockBuilder('Symfony\Component\HttpFoundation\File\UploadedFile')->setMethods(['guessExtension'])->setConstructorArgs($uploadedFile)->getMock();
@@ -1825,7 +1841,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
     {
         // Knowing that demo image.gif has width = 3 and height = 2
         $uploadedFile = new \Symfony\Component\HttpFoundation\File\UploadedFile(__DIR__.'/fixtures/image.gif', '', null, null, null, true);
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
 
         $v = new Validator($trans, ['x' => 'file'], ['x' => 'dimensions']);
         $this->assertTrue($v->fails());
@@ -1892,7 +1908,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
      */
     public function testValidateMimetypes()
     {
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
         $uploadedFile = [__FILE__, '', null, null, null, true];
 
         $file = $this->getMockBuilder('Symfony\Component\HttpFoundation\File\UploadedFile')->setMethods(['guessExtension'])->setConstructorArgs($uploadedFile)->getMock();
@@ -1904,7 +1920,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
     public function testValidateMime()
     {
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
         $uploadedFile = [__FILE__, '', null, null, null, true];
 
         $file = $this->getMockBuilder('Symfony\Component\HttpFoundation\File\UploadedFile')->setMethods(['guessExtension'])->setConstructorArgs($uploadedFile)->getMock();
@@ -1926,7 +1942,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
      */
     public function testValidateFile()
     {
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
         $file = new Symfony\Component\HttpFoundation\File\UploadedFile(__FILE__, '', null, null, null, true);
 
         $v = new Validator($trans, ['x' => '1'], ['x' => 'file']);
@@ -1939,7 +1955,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
     public function testEmptyRulesSkipped()
     {
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['x' => 'aslsdlks'], ['x' => ['alpha', [], '']]);
         $this->assertTrue($v->passes());
 
@@ -1949,18 +1965,18 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
     public function testAlternativeFormat()
     {
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['x' => 'aslsdlks'], ['x' => ['alpha', ['min', 3], ['max', 10]]]);
         $this->assertTrue($v->passes());
     }
 
     public function testValidateAlpha()
     {
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['x' => 'aslsdlks'], ['x' => 'Alpha']);
         $this->assertTrue($v->passes());
 
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['x' => 'aslsdlks
 1
 1'], ['x' => 'Alpha']);
@@ -2002,7 +2018,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
     public function testValidateAlphaNum()
     {
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['x' => 'asls13dlks'], ['x' => 'AlphaNum']);
         $this->assertTrue($v->passes());
 
@@ -2021,7 +2037,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
     public function testValidateAlphaDash()
     {
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['x' => 'asls1-_3dlks'], ['x' => 'AlphaDash']);
         $this->assertTrue($v->passes());
 
@@ -2037,7 +2053,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
     public function testValidateTimezone()
     {
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['foo' => 'India'], ['foo' => 'Timezone']);
         $this->assertFalse($v->passes());
 
@@ -2056,7 +2072,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
     public function testValidateRegex()
     {
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['x' => 'asdasdf'], ['x' => 'Regex:/^([a-z])+$/i']);
         $this->assertTrue($v->passes());
 
@@ -2076,7 +2092,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
     public function testValidateDateAndFormat()
     {
         date_default_timezone_set('UTC');
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['x' => '2000-01-01'], ['x' => 'date']);
         $this->assertTrue($v->passes());
 
@@ -2114,7 +2130,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
     public function testBeforeAndAfter()
     {
         date_default_timezone_set('UTC');
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['x' => '2000-01-01'], ['x' => 'Before:2012-01-01']);
         $this->assertTrue($v->passes());
 
@@ -2170,7 +2186,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
     public function testBeforeAndAfterWithFormat()
     {
         date_default_timezone_set('UTC');
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['x' => '31/12/2000'], ['x' => 'before:31/02/2012']);
         $this->assertTrue($v->fails());
 
@@ -2231,35 +2247,35 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
     public function testSometimesAddingRules()
     {
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['x' => 'foo'], ['x' => 'Required']);
         $v->sometimes('x', 'Confirmed', function ($i) {
             return $i->x == 'foo';
         });
         $this->assertEquals(['x' => ['Required', 'Confirmed']], $v->getRules());
 
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['x' => 'foo'], ['x' => 'Required']);
         $v->sometimes('x', 'Confirmed', function ($i) {
             return $i->x == 'bar';
         });
         $this->assertEquals(['x' => ['Required']], $v->getRules());
 
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['x' => 'foo'], ['x' => 'Required']);
         $v->sometimes('x', 'Foo|Bar', function ($i) {
             return $i->x == 'foo';
         });
         $this->assertEquals(['x' => ['Required', 'Foo', 'Bar']], $v->getRules());
 
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['x' => 'foo'], ['x' => 'Required']);
         $v->sometimes('x', ['Foo', 'Bar:Baz'], function ($i) {
             return $i->x == 'foo';
         });
         $this->assertEquals(['x' => ['Required', 'Foo', 'Bar:Baz']], $v->getRules());
 
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['foo' => [['name' => 'first', 'title' => null]]], []);
         $v->sometimes('foo.*.name', 'Required|String', function ($i) {
             return $i['foo'][0]['title'] === null;
@@ -2269,8 +2285,8 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
     public function testCustomValidators()
     {
-        $trans = $this->getRealTranslator();
-        $trans->addResource('array', ['validation.foo' => 'foo!'], 'en', 'messages');
+        $trans = $this->getIlluminateArrayTranslator();
+        $trans->addLines(['validation.foo' => 'foo!'], 'en');
         $v = new Validator($trans, ['name' => 'taylor'], ['name' => 'foo']);
         $v->addExtension('foo', function () {
             return false;
@@ -2279,8 +2295,8 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $v->messages()->setFormat(':message');
         $this->assertEquals('foo!', $v->messages()->first('name'));
 
-        $trans = $this->getRealTranslator();
-        $trans->addResource('array', ['validation.foo_bar' => 'foo!'], 'en', 'messages');
+        $trans = $this->getIlluminateArrayTranslator();
+        $trans->addLines(['validation.foo_bar' => 'foo!'], 'en');
         $v = new Validator($trans, ['name' => 'taylor'], ['name' => 'foo_bar']);
         $v->addExtension('FooBar', function () {
             return false;
@@ -2289,7 +2305,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $v->messages()->setFormat(':message');
         $this->assertEquals('foo!', $v->messages()->first('name'));
 
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['name' => 'taylor'], ['name' => 'foo_bar']);
         $v->addExtension('FooBar', function () {
             return false;
@@ -2299,7 +2315,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $v->messages()->setFormat(':message');
         $this->assertEquals('foo!', $v->messages()->first('name'));
 
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['name' => 'taylor'], ['name' => 'foo_bar']);
         $v->addExtensions(['FooBar' => function () {
             return false;
@@ -2312,8 +2328,8 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
     public function testClassBasedCustomValidators()
     {
-        $trans = $this->getRealTranslator();
-        $trans->addResource('array', ['validation.foo' => 'foo!'], 'en', 'messages');
+        $trans = $this->getIlluminateArrayTranslator();
+        $trans->addLines(['validation.foo' => 'foo!'], 'en');
         $v = new Validator($trans, ['name' => 'taylor'], ['name' => 'foo']);
         $v->setContainer($container = m::mock('Illuminate\Container\Container'));
         $v->addExtension('foo', 'Foo@bar');
@@ -2326,8 +2342,8 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
     public function testClassBasedCustomValidatorsUsingConventionalMethod()
     {
-        $trans = $this->getRealTranslator();
-        $trans->addResource('array', ['validation.foo' => 'foo!'], 'en', 'messages');
+        $trans = $this->getIlluminateArrayTranslator();
+        $trans->addLines(['validation.foo' => 'foo!'], 'en');
         $v = new Validator($trans, ['name' => 'taylor'], ['name' => 'foo']);
         $v->setContainer($container = m::mock('Illuminate\Container\Container'));
         $v->addExtension('foo', 'Foo');
@@ -2340,7 +2356,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
     public function testCustomImplicitValidators()
     {
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, [], ['implicit_rule' => 'foo']);
         $v->addImplicitExtension('implicit_rule', function () {
             return true;
@@ -2360,7 +2376,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
     public function testValidateImplicitEachWithAsterisks()
     {
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
         $data = ['foo' => [5, 10, 15]];
 
         // pipe rules fails
@@ -2428,7 +2444,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
     public function testSometimesFailOnEmptyArrayInImplicitRules()
     {
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
 
         $data = ['names' => [['second' => []]]];
         $v = new Validator($trans, $data, ['names.*.second' => 'sometimes|required']);
@@ -2437,7 +2453,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
     public function testValidateImplicitEachWithAsterisksForRequiredNonExistingKey()
     {
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
 
         $data = ['companies' => ['spark']];
         $v = new Validator($trans, $data, ['companies.*.name' => 'required']);
@@ -2508,7 +2524,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
     public function testParsingArrayKeysWithDot()
     {
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
 
         $v = new Validator($trans, ['foo' => ['bar' => ''], 'foo.bar' => 'valid'], ['foo.bar' => 'required']);
         $this->assertTrue($v->fails());
@@ -2525,7 +2541,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
     public function testImplicitEachWithAsterisksWithArrayValues()
     {
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
 
         $v = new Validator($trans, ['foo' => [1, 2, 3]], ['foo' => 'size:4']);
         $this->assertFalse($v->passes());
@@ -2557,7 +2573,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
     public function testValidateNestedArrayWithCommonParentChildKey()
     {
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
 
         $data = [
             'products' => [
@@ -2581,7 +2597,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
     public function testValidateNestedArrayWithNonNumericKeys()
     {
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
 
         $data = [
             'item_amounts' => [
@@ -2595,7 +2611,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
     public function testValidateImplicitEachWithAsterisksConfirmed()
     {
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
 
         // confirmed passes
         $v = new Validator($trans, ['foo' => [
@@ -2640,7 +2656,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
     public function testValidateImplicitEachWithAsterisksDifferent()
     {
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
 
         // different passes
         $v = new Validator($trans, ['foo' => [
@@ -2681,7 +2697,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
     public function testValidateImplicitEachWithAsterisksSame()
     {
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
 
         // same passes
         $v = new Validator($trans, ['foo' => [
@@ -2722,7 +2738,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
     public function testValidateImplicitEachWithAsterisksRequired()
     {
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
 
         // required passes
         $v = new Validator($trans, ['foo' => [
@@ -2761,7 +2777,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
     public function testValidateImplicitEachWithAsterisksRequiredIf()
     {
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
 
         // required_if passes
         $v = new Validator($trans, ['foo' => [
@@ -2800,7 +2816,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
     public function testValidateImplicitEachWithAsterisksRequiredUnless()
     {
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
 
         // required_unless passes
         $v = new Validator($trans, ['foo' => [
@@ -2839,7 +2855,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
     public function testValidateImplicitEachWithAsterisksRequiredWith()
     {
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
 
         // required_with passes
         $v = new Validator($trans, ['foo' => [
@@ -2884,7 +2900,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
     public function testValidateImplicitEachWithAsterisksRequiredWithAll()
     {
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
 
         // required_with_all passes
         $v = new Validator($trans, ['foo' => [
@@ -2923,7 +2939,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
     public function testValidateImplicitEachWithAsterisksRequiredWithout()
     {
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
 
         // required_without passes
         $v = new Validator($trans, ['foo' => [
@@ -2962,7 +2978,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
     public function testValidateImplicitEachWithAsterisksRequiredWithoutAll()
     {
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
 
         // required_without_all passes
         $v = new Validator($trans, ['foo' => [
@@ -3003,7 +3019,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
     public function testValidateImplicitEachWithAsterisksBeforeAndAfter()
     {
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
 
         $v = new Validator($trans, ['foo' => [
             ['start' => '2016-04-19', 'end' => '2017-04-19'],
@@ -3028,7 +3044,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
     public function testValidateEachWithNonIndexedArray()
     {
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
         $data = ['foobar' => [
             ['key' => 'foo', 'value' => 5],
             ['key' => 'foo', 'value' => 10],
@@ -3046,7 +3062,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
     public function testValidateEachWithNonArrayWithArrayRule()
     {
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['foo' => 'string'], ['foo' => 'Array']);
         $v->each('foo', ['min:7|max:13']);
         $this->assertFalse($v->passes());
@@ -3054,7 +3070,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
     public function testValidateEachWithNonArrayWithoutArrayRule()
     {
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['foo' => 'string'], ['foo' => 'numeric']);
         $v->each('foo', ['min:7|max:13']);
         $this->assertFalse($v->passes());
@@ -3062,7 +3078,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
     public function testGetLeadingExplicitAttributePath()
     {
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, [], []);
 
         $method = new ReflectionMethod(Validator::class, 'getLeadingExplicitAttributePath');
@@ -3079,7 +3095,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
     {
         $method = new ReflectionMethod(Validator::class, 'extractDataFromPath');
         $method->setAccessible(true);
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
 
         $v = new Validator($trans, [['email' => 'mail'], ['email' => 'mail2']], []);
         $this->assertEquals([['email' => 'mail'], ['email' => 'mail2']], $method->invoke($v, null));
@@ -3097,12 +3113,12 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
     public function testUsingSettersWithImplicitRules()
     {
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['foo' => ['a', 'b', 'c']], ['foo.*' => 'string']);
         $v->setData(['foo' => ['a', 'b', 'c', 4]]);
         $this->assertFalse($v->passes());
 
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['foo' => ['a', 'b', 'c']], ['foo.*' => 'string']);
         $v->setRules(['foo.*' => 'integer']);
         $this->assertFalse($v->passes());
@@ -3110,7 +3126,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
     public function testInvalidMethod()
     {
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
 
         $v = new Validator($trans,
             [
@@ -3142,7 +3158,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
     public function testValidMethod()
     {
-        $trans = $this->getRealTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
 
         $v = new Validator($trans,
             [
@@ -3181,14 +3197,6 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
     protected function getTranslator()
     {
         return m::mock('Symfony\Component\Translation\TranslatorInterface');
-    }
-
-    protected function getRealTranslator()
-    {
-        $trans = new Symfony\Component\Translation\Translator('en', new Symfony\Component\Translation\MessageSelector);
-        $trans->addLoader('array', new Symfony\Component\Translation\Loader\ArrayLoader);
-
-        return $trans;
     }
 
     public function getIlluminateArrayTranslator()


### PR DESCRIPTION
In the validations language file you can set a custom attribute name for implicit attributes:

```
'attributes' => [
    'image.*' => 'Images'
],
```

This would replace the attribute name for all image errors with `Images` and will produce messages like "Images is required" instead of "image.0 is required".

You can also have this:

```
'attributes' => [
    'image.1' => 'Images'
],
```

Which will replace only `image.1` with "Images" keeping the rest of the messages to be displayed as is.

The problem is that the validator uses `$this->trans('validations.attributes.image.1')` which expects a format like this:

```
'attributes' => [
    'image' => ['1' => 'Images']
],
```

Internally `trans()` uses `Arr:get()` which searches for the key using the dot format.

However, `Arr:get()` checks for the exact key first before assuming it's in dot format so calling `Arr::get($attributes, 'image.1')` will check for exact key `image.1` before checking for `['image'][1]`, for this Instead of calling `$this->trans('validations.attributes.image.1')` I collect all attributes translations using `$this->trans->get('validation.attributes')` and then use array get to get the keys.

That's the main purpose of the PR, however in the Validator test we use Symfony's translator instead of Laravel's translator because it contains an `AddResource` method we use in tests, but passing Symfony's translator while we use `Translator::get()` method, which only exists in Laravel's, throws an exception.

So in this PR I added an `addLines()` method to Laravel's translator and converted the tests to use Laravel's translator and this method instead of Symfony's.
