### PR TITLE
[5.3] Mailer setQueue should expect QueueContract

### DIFF
--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -11,7 +11,7 @@ use Illuminate\Contracts\View\Factory;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Mail\Mailer as MailerContract;
-use Illuminate\Contracts\Queue\Factory as QueueContract;
+use Illuminate\Contracts\Queue\Queue as QueueContract;
 use Illuminate\Contracts\Mail\Mailable as MailableContract;
 use Illuminate\Contracts\Mail\MailQueue as MailQueueContract;
 


### PR DESCRIPTION
QueueContract comes from use Illuminate\Contracts\Queue\Factory instead of Illuminate\Contracts\Queue\Queue. Thant makes setQueue from mailer fail if we make setQueue(RedisQueue) for example, as RedisQueue implements Illuminate\Contracts\Queue\Queue.
