### PR TITLE
[5.3] Remove the condition from updateOrInsert since it's added already

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2172,7 +2172,7 @@ class Builder
             return $this->insert(array_merge($attributes, $values));
         }
 
-        return (bool) $this->where($attributes)->take(1)->update($values);
+        return (bool) $this->take(1)->update($values);
     }
 
     /**

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1286,7 +1286,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase
             m::mock('Illuminate\Database\Query\Processors\Processor'),
         ]);
 
-        $builder->shouldReceive('where')->twice()->with(['email' => 'foo'])->andReturn(m::self());
+        $builder->shouldReceive('where')->once()->with(['email' => 'foo'])->andReturn(m::self());
         $builder->shouldReceive('exists')->once()->andReturn(true);
         $builder->shouldReceive('take')->andReturnSelf();
         $builder->shouldReceive('update')->once()->with(['name' => 'bar'])->andReturn(1);


### PR DESCRIPTION
```
public function updateOrInsert(array $attributes, array $values = [])
{
    if (! $this->where($attributes)->exists()) {
        return $this->insert(array_merge($attributes, $values));
    }

    return (bool) $this->where($attributes)->take(1)->update($values);
}
```

Calling `$this->where($attributes)->exists()` adds the conditions already, adding another `where()` while making an update results a query like this:

```
update `users` set `name` = ? where (`name` = ?) and (`name` = ?) limit 1
```
