### PR TITLE
[5.3] QueueContract should come from Queue not Factory at Mailer

### DIFF
--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -11,7 +11,7 @@ use Illuminate\Contracts\View\Factory;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Mail\Mailer as MailerContract;
-use Illuminate\Contracts\Queue\Factory as QueueContract;
+use Illuminate\Contracts\Queue\Queue as QueueContract;
 use Illuminate\Contracts\Mail\Mailable as MailableContract;
 use Illuminate\Contracts\Mail\MailQueue as MailQueueContract;
 

--- a/tests/Mail/MailMailerTest.php
+++ b/tests/Mail/MailMailerTest.php
@@ -77,8 +77,8 @@ class MailMailerTest extends PHPUnit_Framework_TestCase
     {
         list($view, $swift) = $this->getMocks();
         $mailer = new Illuminate\Mail\Mailer($view, $swift);
-        $mailer->setQueue($queue = m::mock('Illuminate\Contracts\Queue\Factory'));
-        $queue->shouldReceive('pushOn')->once()->with(null, m::type('Illuminate\Mail\Jobs\HandleQueuedMessage'));
+        $mailer->setQueue($queue = m::mock('Illuminate\Contracts\Queue\Queue'));
+        $queue->shouldReceive('pushOn')->once()->with(null, m:F:type('Illuminate\Mail\Jobs\HandleQueuedMessage'));
 
         $mailer->queue('foo', [1], 'callable');
     }
@@ -87,7 +87,7 @@ class MailMailerTest extends PHPUnit_Framework_TestCase
     {
         list($view, $swift) = $this->getMocks();
         $mailer = new Illuminate\Mail\Mailer($view, $swift);
-        $mailer->setQueue($queue = m::mock('Illuminate\Contracts\Queue\Factory'));
+        $mailer->setQueue($queue = m::mock('Illuminate\Contracts\Queue\Queue'));
         $queue->shouldReceive('pushOn')->once()->with('queue', m::type('Illuminate\Mail\Jobs\HandleQueuedMessage'));
 
         $mailer->queueOn('queue', 'foo', [1], 'callable');

--- a/tests/Mail/MailMailerTest.php
+++ b/tests/Mail/MailMailerTest.php
@@ -78,7 +78,7 @@ class MailMailerTest extends PHPUnit_Framework_TestCase
         list($view, $swift) = $this->getMocks();
         $mailer = new Illuminate\Mail\Mailer($view, $swift);
         $mailer->setQueue($queue = m::mock('Illuminate\Contracts\Queue\Queue'));
-        $queue->shouldReceive('pushOn')->once()->with(null, m:F:type('Illuminate\Mail\Jobs\HandleQueuedMessage'));
+        $queue->shouldReceive('pushOn')->once()->with(null, m::type('Illuminate\Mail\Jobs\HandleQueuedMessage'));
 
         $mailer->queue('foo', [1], 'callable');
     }
@@ -97,7 +97,7 @@ class MailMailerTest extends PHPUnit_Framework_TestCase
     {
         list($view, $swift) = $this->getMocks();
         $mailer = new Illuminate\Mail\Mailer($view, $swift);
-        $mailer->setQueue($queue = m::mock('Illuminate\Contracts\Queue\Factory'));
+        $mailer->setQueue($queue = m::mock('Illuminate\Contracts\Queue\Queue'));
         $queue->shouldReceive('laterOn')->once()->with(null, 10, m::type('Illuminate\Mail\Jobs\HandleQueuedMessage'));
 
         $mailer->later(10, 'foo', [1], 'callable');
@@ -107,7 +107,7 @@ class MailMailerTest extends PHPUnit_Framework_TestCase
     {
         list($view, $swift) = $this->getMocks();
         $mailer = new Illuminate\Mail\Mailer($view, $swift);
-        $mailer->setQueue($queue = m::mock('Illuminate\Contracts\Queue\Factory'));
+        $mailer->setQueue($queue = m::mock('Illuminate\Contracts\Queue\Queue'));
         $queue->shouldReceive('laterOn')->once()->with('queue', 10, m::type('Illuminate\Mail\Jobs\HandleQueuedMessage'));
 
         $mailer->laterOn('queue', 10, 'foo', [1], 'callable');


### PR DESCRIPTION
QueueContract should come from Illuminate\Contracts\Queue\Queue not Illuminate\Contracts\Queue\Factory at Mailer. This makes setQueue fail with a RedisQueue as RedisQueue implements  Illuminate\Contracts\Queue\Queue
