### PR TITLE
[5.3] Subjective improvement to window.Laravel.csrfToken stub

### DIFF
--- a/src/Illuminate/Auth/Console/stubs/make/views/layouts/app.stub
+++ b/src/Illuminate/Auth/Console/stubs/make/views/layouts/app.stub
@@ -15,9 +15,7 @@
 
     <!-- Scripts -->
     <script>
-        window.Laravel = <?php echo json_encode([
-            'csrfToken' => csrf_token(),
-        ]); ?>
+        window.Laravel = {!! json_encode(['csrfToken' => csrf_token()]) !!};
     </script>
 </head>
 <body>


### PR DESCRIPTION
Subjective improvement to window.Laravel.csrfToken stub in auth scaffolding.  I don't see reason to use standard `<?php echo` `?>` tags when we have beautiful blade braces ;)

@taylorotwell I happened to notice the new auth scaffolding stubs it out, but not everyone will use this new auth scaffolding (especially in an established project where they upgraded to 5.3 with auth already in place).  Could it be mentioned in the new [5.3 csrf docs](https://laravel.com/docs/5.3/csrf) about how to set this?  It's obvious to me that `bootstrap.js` expects me to set `window.Laravel`, but a new user might not understand how to use that vue-resource interceptor you've suggested in `bootstrap.js`.
