### PR TITLE
[5.3] Use Carbon instead of time()

### DIFF
--- a/src/Illuminate/Cache/DatabaseStore.php
+++ b/src/Illuminate/Cache/DatabaseStore.php
@@ -4,6 +4,7 @@ namespace Illuminate\Cache;
 
 use Closure;
 use Exception;
+use Carbon\Carbon;
 use Illuminate\Contracts\Cache\Store;
 use Illuminate\Database\ConnectionInterface;
 use Illuminate\Contracts\Encryption\Encrypter as EncrypterContract;
@@ -77,7 +78,7 @@ class DatabaseStore implements Store
                 $cache = (object) $cache;
             }
 
-            if (time() >= $cache->expiration) {
+            if (Carbon::now()->timestamp >= $cache->expiration) {
                 $this->forget($key);
 
                 return;
@@ -186,7 +187,7 @@ class DatabaseStore implements Store
      */
     protected function getTime()
     {
-        return time();
+        return Carbon::now()->timestamp;
     }
 
     /**

--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Cache;
 
 use Exception;
+use Carbon\Carbon;
 use Illuminate\Support\Arr;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Contracts\Cache\Store;
@@ -73,7 +74,7 @@ class FileStore implements Store
         // If the current time is greater than expiration timestamps we will delete
         // the file and return null. This helps clean up the old files and keeps
         // this directory much cleaner for us as old files aren't hanging out.
-        if (time() >= $expire) {
+        if (Carbon::now()->timestamp >= $expire) {
             $this->forget($key);
 
             return ['data' => null, 'time' => null];
@@ -84,7 +85,7 @@ class FileStore implements Store
         // Next, we'll extract the number of minutes that are remaining for a cache
         // so that we can properly retain the time for things like the increment
         // operation that may be performed on the cache.
-        $time = ($expire - time()) / 60;
+        $time = ($expire - Carbon::now()->timestamp) / 60;
 
         return compact('data', 'time');
     }
@@ -213,7 +214,7 @@ class FileStore implements Store
      */
     protected function expiration($minutes)
     {
-        $time = time() + (int) ($minutes * 60);
+        $time = Carbon::now()->timestamp + (int) ($minutes * 60);
 
         if ($minutes === 0 || $time > 9999999999) {
             return 9999999999;

--- a/src/Illuminate/Cache/RateLimiter.php
+++ b/src/Illuminate/Cache/RateLimiter.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Cache;
 
+use Carbon\Carbon;
 use Illuminate\Contracts\Cache\Repository as Cache;
 
 class RateLimiter
@@ -39,7 +40,7 @@ class RateLimiter
         }
 
         if ($this->attempts($key) > $maxAttempts) {
-            $this->cache->add($key.':lockout', time() + ($decayMinutes * 60), $decayMinutes);
+            $this->cache->add($key.':lockout', Carbon::now()->timestamp + ($decayMinutes * 60), $decayMinutes);
 
             $this->resetAttempts($key);
 
@@ -120,6 +121,6 @@ class RateLimiter
      */
     public function availableIn($key)
     {
-        return $this->cache->get($key.':lockout') - time();
+        return $this->cache->get($key.':lockout') - Carbon::now()->timestamp;
     }
 }

--- a/src/Illuminate/Cookie/CookieJar.php
+++ b/src/Illuminate/Cookie/CookieJar.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Cookie;
 
+use Carbon\Carbon;
 use Illuminate\Support\Arr;
 use Symfony\Component\HttpFoundation\Cookie;
 use Illuminate\Contracts\Cookie\QueueingFactory as JarContract;
@@ -52,7 +53,7 @@ class CookieJar implements JarContract
     {
         list($path, $domain, $secure) = $this->getPathAndDomain($path, $domain, $secure);
 
-        $time = ($minutes == 0) ? 0 : time() + ($minutes * 60);
+        $time = ($minutes == 0) ? 0 : Carbon::now()->timestamp + ($minutes * 60);
 
         return new Cookie($name, $value, $time, $path, $domain, $secure, $httpOnly);
     }

--- a/src/Illuminate/Foundation/Console/DownCommand.php
+++ b/src/Illuminate/Foundation/Console/DownCommand.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Foundation\Console;
 
+use Carbon\Carbon;
 use Illuminate\Console\Command;
 
 class DownCommand extends Command
@@ -44,7 +45,7 @@ class DownCommand extends Command
     protected function getDownFilePayload()
     {
         return [
-            'time' => time(),
+            'time' => Carbon::now()->timestamp,
             'message' => $this->option('message'),
             'retry' => $this->getRetryTime(),
         ];

--- a/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
+++ b/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Foundation\Http\Middleware;
 
 use Closure;
+use Carbon\Carbon;
 use Illuminate\Foundation\Application;
 use Symfony\Component\HttpFoundation\Cookie;
 use Illuminate\Contracts\Encryption\Encrypter;
@@ -134,7 +135,7 @@ class VerifyCsrfToken
 
         $response->headers->setCookie(
             new Cookie(
-                'XSRF-TOKEN', $request->session()->token(), time() + 60 * $config['lifetime'],
+                'XSRF-TOKEN', $request->session()->token(), Carbon::now()->timestamp + 60 * $config['lifetime'],
                 $config['path'], $config['domain'], $config['secure'], false
             )
         );

--- a/src/Illuminate/Queue/Console/RestartCommand.php
+++ b/src/Illuminate/Queue/Console/RestartCommand.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Queue\Console;
 
+use Carbon\Carbon;
 use Illuminate\Console\Command;
 
 class RestartCommand extends Command
@@ -27,7 +28,7 @@ class RestartCommand extends Command
      */
     public function fire()
     {
-        $this->laravel['cache']->forever('illuminate:queue:restart', time());
+        $this->laravel['cache']->forever('illuminate:queue:restart', Carbon::now()->timestamp);
 
         $this->info('Broadcasting queue restart signal.');
     }

--- a/src/Illuminate/Queue/Jobs/Job.php
+++ b/src/Illuminate/Queue/Jobs/Job.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Queue\Jobs;
 
 use DateTime;
+use Carbon\Carbon;
 use Illuminate\Support\Arr;
 
 abstract class Job
@@ -188,7 +189,7 @@ abstract class Job
      */
     protected function getTime()
     {
-        return time();
+        return Carbon::now()->timestamp;
     }
 
     /**

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Queue;
 
 use DateTime;
+use Carbon\Carbon;
 use Illuminate\Support\Arr;
 use InvalidArgumentException;
 use Illuminate\Container\Container;
@@ -153,7 +154,7 @@ abstract class Queue
      */
     protected function getTime()
     {
-        return time();
+        return Carbon::now()->timestamp;
     }
 
     /**

--- a/src/Illuminate/Routing/Middleware/ThrottleRequests.php
+++ b/src/Illuminate/Routing/Middleware/ThrottleRequests.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Routing\Middleware;
 
 use Closure;
+use Carbon\Carbon;
 use Illuminate\Cache\RateLimiter;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -102,7 +103,7 @@ class ThrottleRequests
 
         if (! is_null($retryAfter)) {
             $headers['Retry-After'] = $retryAfter;
-            $headers['X-RateLimit-Reset'] = time() + $retryAfter;
+            $headers['X-RateLimit-Reset'] = Carbon::now()->timestamp + $retryAfter;
         }
 
         $response->headers->add($headers);

--- a/src/Illuminate/Session/CookieSessionHandler.php
+++ b/src/Illuminate/Session/CookieSessionHandler.php
@@ -60,7 +60,7 @@ class CookieSessionHandler implements SessionHandlerInterface
         $value = $this->request->cookies->get($sessionId) ?: '';
 
         if (! is_null($decoded = json_decode($value, true)) && is_array($decoded)) {
-            if (isset($decoded['expires']) && time() <= $decoded['expires']) {
+            if (isset($decoded['expires']) && Carbon::now()->timestamp <= $decoded['expires']) {
                 return $decoded['data'];
             }
         }

--- a/src/Illuminate/Session/DatabaseSessionHandler.php
+++ b/src/Illuminate/Session/DatabaseSessionHandler.php
@@ -130,7 +130,7 @@ class DatabaseSessionHandler implements SessionHandlerInterface, ExistenceAwareI
      */
     protected function getDefaultPayload($data)
     {
-        $payload = ['payload' => base64_encode($data), 'last_activity' => time()];
+        $payload = ['payload' => base64_encode($data), 'last_activity' => Carbon::now()->timestamp];
 
         if (! $container = $this->container) {
             return $payload;
@@ -164,7 +164,7 @@ class DatabaseSessionHandler implements SessionHandlerInterface, ExistenceAwareI
      */
     public function gc($lifetime)
     {
-        $this->getQuery()->where('last_activity', '<=', time() - $lifetime)->delete();
+        $this->getQuery()->where('last_activity', '<=', Carbon::now()->timestamp - $lifetime)->delete();
     }
 
     /**


### PR DESCRIPTION
As mentioned in this issue: https://github.com/laravel/framework/issues/14253

Carbon library has a very useful and easy to use feature to travel in time inside tests:

```
$knownDate = Carbon::create(2001, 5, 21, 12);
Carbon::setTestNow($knownDate);    
```

Since Carbon is a current dependency in laravel, this PR replaces all calls to php's built in `time()` function and uses Carbon instead, allowing tests to "Time Travel".
