### PR TITLE
[5.1] Error on alias loop in container

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -1082,13 +1082,21 @@ class Container implements ArrayAccess, ContainerContract
     /**
      * Get the alias for an abstract if available.
      *
-     * @param  string  $abstract
+     * @param  string $abstract
+     *
      * @return string
+     * @throws \LogicException
      */
     public function getAlias($abstract)
     {
         if (! isset($this->aliases[$abstract])) {
             return $abstract;
+        }
+
+        if ($this->aliases[$abstract] === $abstract) {
+            throw new \LogicException(
+                "Container alias loop: {$abstract} is aliased to {$abstract}."
+            );
         }
 
         return $this->getAlias($this->aliases[$abstract]);


### PR DESCRIPTION
This is to save others some debugging time if they've made the same slip up I did by inadvertently aliasing  something to itself in the container. Currently this leads to a loop and hitting the function nesting limit, which wasn't immediately obvious to me from the logs I was seeing.
