### PR TITLE
[5.3] Directly use getTimestamp() 

### DIFF
--- a/src/Illuminate/Cache/DatabaseStore.php
+++ b/src/Illuminate/Cache/DatabaseStore.php
@@ -78,7 +78,7 @@ class DatabaseStore implements Store
                 $cache = (object) $cache;
             }
 
-            if (Carbon::now()->timestamp >= $cache->expiration) {
+            if (Carbon::now()->getTimestamp() >= $cache->expiration) {
                 $this->forget($key);
 
                 return;
@@ -187,7 +187,7 @@ class DatabaseStore implements Store
      */
     protected function getTime()
     {
-        return Carbon::now()->timestamp;
+        return Carbon::now()->getTimestamp();
     }
 
     /**

--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -74,7 +74,7 @@ class FileStore implements Store
         // If the current time is greater than expiration timestamps we will delete
         // the file and return null. This helps clean up the old files and keeps
         // this directory much cleaner for us as old files aren't hanging out.
-        if (Carbon::now()->timestamp >= $expire) {
+        if (Carbon::now()->getTimestamp() >= $expire) {
             $this->forget($key);
 
             return ['data' => null, 'time' => null];
@@ -85,7 +85,7 @@ class FileStore implements Store
         // Next, we'll extract the number of minutes that are remaining for a cache
         // so that we can properly retain the time for things like the increment
         // operation that may be performed on the cache.
-        $time = ($expire - Carbon::now()->timestamp) / 60;
+        $time = ($expire - Carbon::now()->getTimestamp()) / 60;
 
         return compact('data', 'time');
     }
@@ -214,7 +214,7 @@ class FileStore implements Store
      */
     protected function expiration($minutes)
     {
-        $time = Carbon::now()->timestamp + (int) ($minutes * 60);
+        $time = Carbon::now()->getTimestamp() + (int) ($minutes * 60);
 
         if ($minutes === 0 || $time > 9999999999) {
             return 9999999999;

--- a/src/Illuminate/Cache/MemcachedStore.php
+++ b/src/Illuminate/Cache/MemcachedStore.php
@@ -182,7 +182,7 @@ class MemcachedStore extends TaggableStore implements Store
      */
     protected function toTimestamp($minutes)
     {
-        return $minutes > 0 ? Carbon::now()->addMinutes($minutes)->timestamp : 0;
+        return $minutes > 0 ? Carbon::now()->addMinutes($minutes)->getTimestamp() : 0;
     }
 
     /**

--- a/src/Illuminate/Cache/RateLimiter.php
+++ b/src/Illuminate/Cache/RateLimiter.php
@@ -40,7 +40,7 @@ class RateLimiter
         }
 
         if ($this->attempts($key) > $maxAttempts) {
-            $this->cache->add($key.':lockout', Carbon::now()->timestamp + ($decayMinutes * 60), $decayMinutes);
+            $this->cache->add($key.':lockout', Carbon::now()->getTimestamp() + ($decayMinutes * 60), $decayMinutes);
 
             $this->resetAttempts($key);
 
@@ -121,6 +121,6 @@ class RateLimiter
      */
     public function availableIn($key)
     {
-        return $this->cache->get($key.':lockout') - Carbon::now()->timestamp;
+        return $this->cache->get($key.':lockout') - Carbon::now()->getTimestamp();
     }
 }

--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -640,7 +640,7 @@ class Event
     private function inTimeInterval($startTime, $endTime)
     {
         return function () use ($startTime, $endTime) {
-            $now = Carbon::now()->timestamp;
+            $now = Carbon::now()->getTimestamp();
 
             return $now >= strtotime($startTime) && $now <= strtotime($endTime);
         };

--- a/src/Illuminate/Cookie/CookieJar.php
+++ b/src/Illuminate/Cookie/CookieJar.php
@@ -53,7 +53,7 @@ class CookieJar implements JarContract
     {
         list($path, $domain, $secure) = $this->getPathAndDomain($path, $domain, $secure);
 
-        $time = ($minutes == 0) ? 0 : Carbon::now()->timestamp + ($minutes * 60);
+        $time = ($minutes == 0) ? 0 : Carbon::now()->getTimestamp() + ($minutes * 60);
 
         return new Cookie($name, $value, $time, $path, $domain, $secure, $httpOnly);
     }

--- a/src/Illuminate/Foundation/Console/DownCommand.php
+++ b/src/Illuminate/Foundation/Console/DownCommand.php
@@ -45,7 +45,7 @@ class DownCommand extends Command
     protected function getDownFilePayload()
     {
         return [
-            'time' => Carbon::now()->timestamp,
+            'time' => Carbon::now()->getTimestamp(),
             'message' => $this->option('message'),
             'retry' => $this->getRetryTime(),
         ];

--- a/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
+++ b/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
@@ -135,7 +135,7 @@ class VerifyCsrfToken
 
         $response->headers->setCookie(
             new Cookie(
-                'XSRF-TOKEN', $request->session()->token(), Carbon::now()->timestamp + 60 * $config['lifetime'],
+                'XSRF-TOKEN', $request->session()->token(), Carbon::now()->getTimestamp() + 60 * $config['lifetime'],
                 $config['path'], $config['domain'], $config['secure'], false
             )
         );

--- a/src/Illuminate/Queue/Console/RestartCommand.php
+++ b/src/Illuminate/Queue/Console/RestartCommand.php
@@ -28,7 +28,7 @@ class RestartCommand extends Command
      */
     public function fire()
     {
-        $this->laravel['cache']->forever('illuminate:queue:restart', Carbon::now()->timestamp);
+        $this->laravel['cache']->forever('illuminate:queue:restart', Carbon::now()->getTimestamp());
 
         $this->info('Broadcasting queue restart signal.');
     }

--- a/src/Illuminate/Queue/Jobs/Job.php
+++ b/src/Illuminate/Queue/Jobs/Job.php
@@ -189,7 +189,7 @@ abstract class Job
      */
     protected function getTime()
     {
-        return Carbon::now()->timestamp;
+        return Carbon::now()->getTimestamp();
     }
 
     /**

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -154,7 +154,7 @@ abstract class Queue
      */
     protected function getTime()
     {
-        return Carbon::now()->timestamp;
+        return Carbon::now()->getTimestamp();
     }
 
     /**

--- a/src/Illuminate/Routing/Middleware/ThrottleRequests.php
+++ b/src/Illuminate/Routing/Middleware/ThrottleRequests.php
@@ -103,7 +103,7 @@ class ThrottleRequests
 
         if (! is_null($retryAfter)) {
             $headers['Retry-After'] = $retryAfter;
-            $headers['X-RateLimit-Reset'] = Carbon::now()->timestamp + $retryAfter;
+            $headers['X-RateLimit-Reset'] = Carbon::now()->getTimestamp() + $retryAfter;
         }
 
         $response->headers->add($headers);

--- a/src/Illuminate/Session/CookieSessionHandler.php
+++ b/src/Illuminate/Session/CookieSessionHandler.php
@@ -60,7 +60,7 @@ class CookieSessionHandler implements SessionHandlerInterface
         $value = $this->request->cookies->get($sessionId) ?: '';
 
         if (! is_null($decoded = json_decode($value, true)) && is_array($decoded)) {
-            if (isset($decoded['expires']) && Carbon::now()->timestamp <= $decoded['expires']) {
+            if (isset($decoded['expires']) && Carbon::now()->getTimestamp() <= $decoded['expires']) {
                 return $decoded['data'];
             }
         }

--- a/src/Illuminate/Session/DatabaseSessionHandler.php
+++ b/src/Illuminate/Session/DatabaseSessionHandler.php
@@ -130,7 +130,7 @@ class DatabaseSessionHandler implements SessionHandlerInterface, ExistenceAwareI
      */
     protected function getDefaultPayload($data)
     {
-        $payload = ['payload' => base64_encode($data), 'last_activity' => Carbon::now()->timestamp];
+        $payload = ['payload' => base64_encode($data), 'last_activity' => Carbon::now()->getTimestamp()];
 
         if (! $container = $this->container) {
             return $payload;
@@ -164,7 +164,7 @@ class DatabaseSessionHandler implements SessionHandlerInterface, ExistenceAwareI
      */
     public function gc($lifetime)
     {
-        $this->getQuery()->where('last_activity', '<=', Carbon::now()->timestamp - $lifetime)->delete();
+        $this->getQuery()->where('last_activity', '<=', Carbon::now()->getTimestamp() - $lifetime)->delete();
     }
 
     /**


### PR DESCRIPTION
Each time we access `\Carbon\Carbon::$timestamp`, we are in fact calling the magic `\Carbon\Carbon::__get` function:  https://github.com/briannesbitt/Carbon/blob/master/src/Carbon/Carbon.php#L607-L660

This PR gets rid of this useless intermediary call.

---

Related to #15544 / Ping @themsaid 
