### PR TITLE
[5.3] Added database slave failover

### DIFF
--- a/src/Illuminate/Database/Connectors/ConnectionFactory.php
+++ b/src/Illuminate/Database/Connectors/ConnectionFactory.php
@@ -120,13 +120,16 @@ class ConnectionFactory
                 shuffle($hosts);
             }
 
+            $lastHost = end($hosts);
             foreach ($hosts as $host) {
                 $config['host'] = $host;
 
                 try {
                     return $this->createConnector($config)->connect($config);
                 } catch (PDOException $e) {
-                	//
+	                if ($host !== $lastHost) {
+	                    $this->container->make('Illuminate\Contracts\Debug\ExceptionHandler')->report($e);
+                    }
                 }
             }
 

--- a/src/Illuminate/Database/Connectors/ConnectionFactory.php
+++ b/src/Illuminate/Database/Connectors/ConnectionFactory.php
@@ -10,6 +10,7 @@ use Illuminate\Database\SQLiteConnection;
 use Illuminate\Database\PostgresConnection;
 use Illuminate\Database\SqlServerConnection;
 use Illuminate\Contracts\Container\Container;
+use PDOException;
 
 class ConnectionFactory
 {
@@ -99,9 +100,8 @@ class ConnectionFactory
         if (array_key_exists('host', $config)) {
             return $this->createPdoResolverWithHosts($config);
         }
-        else{
-            return $this->createPdoResolverWithoutHosts($config);
-        }
+
+        return $this->createPdoResolverWithoutHosts($config);
     }
 
     /**
@@ -110,27 +110,27 @@ class ConnectionFactory
      * @param  array  $config
      * @return \Closure
      */
-    protected function createPdoResolverWithHosts(array $config){
+    protected function createPdoResolverWithHosts(array $config)
+    {
         return function () use ($config) {
-            if (!is_array($config['host'])) {
+            if (! is_array($config['host'])) {
                 $hosts = [$config['host']];
             } else {
                 $hosts = $config['host'];
                 shuffle($hosts);
             }
 
-            foreach($hosts as $host){
+            foreach ($hosts as $host) {
                 $config['host'] = $host;
 
-                try{
+                try {
                     return $this->createConnector($config)->connect($config);
-                }
-                catch(\PDOException $e){
+                } catch(PDOException $e) {
                 }
             }
 
             if (empty($hosts)) {
-                throw new InvalidArgumentException("Database hosts array cannot be empty");
+                throw new InvalidArgumentException('Database hosts array cannot be empty');
             }
 
             throw $e;
@@ -138,14 +138,15 @@ class ConnectionFactory
     }
 
     /**
-     * Create a new Closure that resolves to a PDO instance where there is no configured host
+     * Create a new Closure that resolves to a PDO instance where there is no configured host.
      *
      * @param  array  $config
      * @return \Closure
      */
-    protected function createPdoResolverWithoutHosts(array $config){
+    protected function createPdoResolverWithoutHosts(array $config)
+    {
         return function () use ($config) {
-                return $this->createConnector($config)->connect($config);
+            return $this->createConnector($config)->connect($config);
         };
     }
 

--- a/src/Illuminate/Database/Connectors/ConnectionFactory.php
+++ b/src/Illuminate/Database/Connectors/ConnectionFactory.php
@@ -96,10 +96,54 @@ class ConnectionFactory
      */
     protected function createPdoResolver(array $config)
     {
-        return function () use ($config) {
-            return $this->createConnector($config)->connect($config);
-        };
+	    if (array_key_exists('host', $config)) {
+	    	return $this->createPdoResolverWithHosts($config);
+	    }
+	    else{
+		    return $this->createPdoResolverWithoutHosts($config);
+	    }
     }
+
+	/**
+	 * Create a new Closure that resolves to a PDO instance with a specific host or an array of hosts.
+	 *
+	 * @param  array  $config
+	 * @return \Closure
+	 */
+    protected function createPdoResolverWithHosts(array $config){
+	    return function () use ($config) {
+		    if (!is_array($config['host'])) {
+			    $hosts = [$config['host']];
+		    } else {
+			    $hosts = $config['host'];
+			    shuffle($hosts);
+		    }
+
+		    foreach($hosts as $host){
+			    $config['host'] = $host;
+
+			    try{
+				    return $this->createConnector($config)->connect($config);
+			    }
+			    catch(\PDOException $e){
+			    }
+		    }
+
+		    throw $e;
+	    };
+    }
+
+	/**
+	 * Create a new Closure that resolves to a PDO instance where there is no configured host
+	 *
+	 * @param  array  $config
+	 * @return \Closure
+	 */
+	protected function createPdoResolverWithoutHosts(array $config){
+		return function () use ($config) {
+				return $this->createConnector($config)->connect($config);
+		};
+	}
 
     /**
      * Get the read configuration for a read / write connection.
@@ -110,12 +154,6 @@ class ConnectionFactory
     protected function getReadConfig(array $config)
     {
         $readConfig = $this->getReadWriteConfig($config, 'read');
-
-        if (isset($readConfig['host']) && is_array($readConfig['host'])) {
-            $readConfig['host'] = count($readConfig['host']) > 1
-                ? $readConfig['host'][array_rand($readConfig['host'])]
-                : $readConfig['host'][0];
-        }
 
         return $this->mergeReadWriteConfig($config, $readConfig);
     }

--- a/src/Illuminate/Database/Connectors/ConnectionFactory.php
+++ b/src/Illuminate/Database/Connectors/ConnectionFactory.php
@@ -96,54 +96,58 @@ class ConnectionFactory
      */
     protected function createPdoResolver(array $config)
     {
-	    if (array_key_exists('host', $config)) {
-	    	return $this->createPdoResolverWithHosts($config);
-	    }
-	    else{
-		    return $this->createPdoResolverWithoutHosts($config);
-	    }
+        if (array_key_exists('host', $config)) {
+            return $this->createPdoResolverWithHosts($config);
+        }
+        else{
+            return $this->createPdoResolverWithoutHosts($config);
+        }
     }
 
-	/**
-	 * Create a new Closure that resolves to a PDO instance with a specific host or an array of hosts.
-	 *
-	 * @param  array  $config
-	 * @return \Closure
-	 */
+    /**
+     * Create a new Closure that resolves to a PDO instance with a specific host or an array of hosts.
+     *
+     * @param  array  $config
+     * @return \Closure
+     */
     protected function createPdoResolverWithHosts(array $config){
-	    return function () use ($config) {
-		    if (!is_array($config['host'])) {
-			    $hosts = [$config['host']];
-		    } else {
-			    $hosts = $config['host'];
-			    shuffle($hosts);
-		    }
+        return function () use ($config) {
+            if (!is_array($config['host'])) {
+                $hosts = [$config['host']];
+            } else {
+                $hosts = $config['host'];
+                shuffle($hosts);
+            }
 
-		    foreach($hosts as $host){
-			    $config['host'] = $host;
+            foreach($hosts as $host){
+                $config['host'] = $host;
 
-			    try{
-				    return $this->createConnector($config)->connect($config);
-			    }
-			    catch(\PDOException $e){
-			    }
-		    }
+                try{
+                    return $this->createConnector($config)->connect($config);
+                }
+                catch(\PDOException $e){
+                }
+            }
 
-		    throw $e;
-	    };
+            if (empty($hosts)) {
+                throw new InvalidArgumentException("Database hosts array cannot be empty");
+            }
+
+            throw $e;
+        };
     }
 
-	/**
-	 * Create a new Closure that resolves to a PDO instance where there is no configured host
-	 *
-	 * @param  array  $config
-	 * @return \Closure
-	 */
-	protected function createPdoResolverWithoutHosts(array $config){
-		return function () use ($config) {
-				return $this->createConnector($config)->connect($config);
-		};
-	}
+    /**
+     * Create a new Closure that resolves to a PDO instance where there is no configured host
+     *
+     * @param  array  $config
+     * @return \Closure
+     */
+    protected function createPdoResolverWithoutHosts(array $config){
+        return function () use ($config) {
+                return $this->createConnector($config)->connect($config);
+        };
+    }
 
     /**
      * Get the read configuration for a read / write connection.

--- a/src/Illuminate/Database/Connectors/ConnectionFactory.php
+++ b/src/Illuminate/Database/Connectors/ConnectionFactory.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Database\Connectors;
 
 use PDO;
+use PDOException;
 use Illuminate\Support\Arr;
 use InvalidArgumentException;
 use Illuminate\Database\MySqlConnection;
@@ -10,7 +11,6 @@ use Illuminate\Database\SQLiteConnection;
 use Illuminate\Database\PostgresConnection;
 use Illuminate\Database\SqlServerConnection;
 use Illuminate\Contracts\Container\Container;
-use PDOException;
 
 class ConnectionFactory
 {
@@ -125,7 +125,8 @@ class ConnectionFactory
 
                 try {
                     return $this->createConnector($config)->connect($config);
-                } catch(PDOException $e) {
+                } catch (PDOException $e) {
+                	//
                 }
             }
 


### PR DESCRIPTION
If we have more than one database slave (read hosts) and our application fails to connect to one of them, we want our application to try the next one instead of simply failing. 

This commit will try hosts in a random order until one works or until they have all failed.
