### PR TITLE
[5.3] Fix matching custom validation messages via exact

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -2123,7 +2123,7 @@ class Validator implements ValidatorContract
         );
 
         foreach ($customMessages as $key => $message) {
-            if (Str::contains($key, ['*']) && Str::is($key, $shortKey)) {
+            if ($shortKey === $key || (Str::contains($key, ['*']) && Str::is($key, $shortKey))) {
                 return $message;
             }
         }

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -391,14 +391,19 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
                 'name.*' => [
                     'required' => 'all are really required!',
                 ],
+                'lang.en' => [
+                    'required' => 'english is required!',
+                ],
             ],
         ]);
-        $v = new Validator($trans, ['name' => ['', '']], []);
+        $v = new Validator($trans, ['name' => ['', ''], 'lang' => ['en' => '']], []);
         $v->each('name', 'required|max:255');
+        $v->each('lang.*', 'required|max:255');
         $this->assertFalse($v->passes());
         $v->messages()->setFormat(':message');
         $this->assertEquals('all are really required!', $v->messages()->first('name.0'));
         $this->assertEquals('all are really required!', $v->messages()->first('name.1'));
+        $this->assertEquals('english is required!', $v->messages()->first('lang.en'));
     }
 
     public function testValidationDotCustomDotAnythingCanBeTranslated()


### PR DESCRIPTION
before this the following would work:

```
'custom' => [
    'names.*' => [
        'required' => 'custom-message',
    ],
],
```

But this wouldn't:

```
'custom' => [
    'names.0' => [
        'required' => 'custom-message',
    ],
],
```

This PR fixes this issue, it used to work before but the PR that caused it to break is the following:
https://github.com/laravel/framework/pull/12680
