### PR TITLE
[5.3] Deal with null $files in request

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -870,11 +870,15 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
     /**
      * Filter the given array of files, removing any empty values.
      *
-     * @param  array  $files
+     * @param  mixed  $files
      * @return mixed
      */
     protected function filterFiles($files)
     {
+        if (! $files) {
+            return null;
+        }
+
         foreach ($files as $key => $file) {
             if (is_array($file)) {
                 $files[$key] = $this->filterFiles($files[$key]);

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -876,7 +876,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
     protected function filterFiles($files)
     {
         if (! $files) {
-            return null;
+            return;
         }
 
         foreach ($files as $key => $file) {


### PR DESCRIPTION
In Request::duplicate:

```
public function duplicate(array $query = null, array $request = null, array $attributes = null, array $cookies = null, array $files = null, array $server = null)
{
    return parent::duplicate($query, $request, $attributes, $cookies, $this->filterFiles($files), $server);
}
```

Since files can be `null` we should skip the loop in that case to avoid `Invalid argument supplied for foreach()`
