### PR TITLE
[5.3] Allow more flexible migration file names.

### DIFF
--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -364,7 +364,7 @@ class Migrator
      */
     public function resolve($file)
     {
-        preg_match('/_(_*[a-fA-F].*)/', $file, $matches);
+        preg_match('/_(_*[a-zA-Z].*)/', $file, $matches);
         $class = Str::studly($matches[1]);
 
         return new $class;

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -364,7 +364,8 @@ class Migrator
      */
     public function resolve($file)
     {
-        $class = Str::studly(implode('_', array_slice(explode('_', $file), 4)));
+        preg_match('/_(_*[a-fA-F].*)/', $file, $matches);
+        $class = Str::studly($matches[1]);
 
         return new $class;
     }


### PR DESCRIPTION
Migration file names have to be prefixed with this format: `2016_06_01_205951_`. This change allows them to be prefixed with any number of non-alpha characters, such as `123_`, making it easier to create migrations by hand. Compatibility with class names starting with one or more underscores is preserved.
