### PR TITLE
Eager load a relationship with a condition

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -673,6 +673,25 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     }
 
     /**
+     * Eager load relations on the model with a condition.
+     *
+     * @param  string  $relation
+     * @param  string  $column
+     * @param  string  $operator
+     * @param  mixed   $value
+     * @param  string  $boolean
+     * @return $this
+     */
+    public function loadWhere($relation, $column, $operator = null, $value = null, $boolean = 'and')
+    {
+        return $this->load([
+            $relation => function ($query) use ($column, $operator, $value, $boolean) {
+                return call_user_func([$query, 'where'], $column, $operator, $value, $boolean);
+            },
+        ]);
+    }
+
+    /**
      * Begin querying a model with eager loading.
      *
      * @param  array|string  $relations
@@ -687,6 +706,25 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         $instance = new static;
 
         return $instance->newQuery()->with($relations);
+    }
+
+    /**
+     * Begin querying a model with eager loading with a condition.
+     *
+     * @param  string  $relation
+     * @param  string  $column
+     * @param  string  $operator
+     * @param  mixed   $value
+     * @param  string  $boolean
+     * @return $this
+     */
+    public static function withWhere($relation, $column, $operator = null, $value = null, $boolean = 'and')
+    {
+        return static::with([
+            $relation => function ($query) use ($column, $operator, $value, $boolean) {
+                return call_user_func([$query, 'where'], $column, $operator, $value, $boolean);
+            },
+        ]);
     }
 
     /**

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -578,6 +578,13 @@ class DatabaseEloquentIntegrationTest extends PHPUnit_Framework_TestCase
 
         $post = EloquentTestPost::with('user')->where('name', 'First Post')->get();
         $this->assertEquals('taylorotwell@gmail.com', $post->first()->user->email);
+
+        $user->friends()->create(['email' => 'abigailotwell@gmail.com']);
+        $user->friends()->create(['email' => 'matt@cantseethecode.com']);
+
+        $taylor = EloquentTestUser::withWhere('friends', 'email', 'matt@cantseethecode.com')->first();
+        $this->assertEquals(1, $taylor->friends->count());
+        $this->assertEquals(1, $user->loadWhere('friends', ['email' => 'abigailotwell@gmail.com'])->friends->count());
     }
 
     public function testBasicNestedSelfReferencingHasManyEagerLoading()


### PR DESCRIPTION
I often find myself adding simple conditions to my eager loading relations with some code that looks something like this:

``` php
Model::with([
    'related' => function ($query) {
        return $query->where('email', 'like', '%@example.com');
    }
])->get();
```

I propose adding 2 functions to wrap this functionality up into 2 easy to use methods like so:

``` php
Model::withWhere('related', 'email', 'like', '%@example.com');
$model->loadWhere('related', 'email', 'like', '%@example.com');
```

I'm open to any thoughts or suggestions. There maybe other useful functions that could be created; `loadOrderedBy` for example. 

This would be a minor features with fully backwards compatible. 

https://github.com/laravel/internals/issues/211
