### PR TITLE
[5.4] Tighten migration file name restrictions

### DIFF
--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -367,7 +367,7 @@ class Migrator
         if (! preg_match('/\d{4}_\d{2}_\d{2}_\d{6}_([a-zA-Z]\w*)/', $file, $matches)) {
             throw new \InvalidArgumentException("Invalid migration file name '$file'.");
         }
- 
+
         $class = Str::studly($matches[1]);
 
         return new $class;

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -364,7 +364,7 @@ class Migrator
      */
     public function resolve($file)
     {
-        if (!preg_match('/\d{4}_\d{2}_\d{2}_\d{6}_([a-zA-Z]\w*)/', $file, $matches)) {
+        if (! preg_match('/\d{4}_\d{2}_\d{2}_\d{6}_([a-zA-Z]\w*)/', $file, $matches)) {
             throw new \InvalidArgumentException("Invalid migration file name '$file'.");
         }
  

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -364,7 +364,11 @@ class Migrator
      */
     public function resolve($file)
     {
-        $class = Str::studly(implode('_', array_slice(explode('_', $file), 4)));
+        if (!preg_match('/\d{4}_\d{2}_\d{2}_\d{6}_([a-zA-Z]\w*)/', $file, $matches)) {
+            throw new \InvalidArgumentException("Invalid migration file name '$file'.");
+        }
+ 
+        $class = Str::studly($matches[1]);
 
         return new $class;
     }


### PR DESCRIPTION
Currently, any migration file name is allowed as long as 4 underscores precede the class name. For example, `____create_users_table` is valid. To ensure consistency of the file names and their order across packages, a regex check has been added.

Ref: https://github.com/laravel/internals/issues/220
