### PR TITLE
[5.4] Added values parameter to Builder::firstOrNew

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -230,15 +230,16 @@ class Builder
      * Get the first record matching the attributes or instantiate it.
      *
      * @param  array  $attributes
+     * @param  array  $values
      * @return \Illuminate\Database\Eloquent\Model
      */
-    public function firstOrNew(array $attributes)
+    public function firstOrNew(array $attributes, array $values = [])
     {
         if (! is_null($instance = $this->where($attributes)->first())) {
             return $instance;
         }
 
-        return $this->model->newInstance($attributes);
+        return $this->model->newInstance($attributes + $values);
     }
 
     /**


### PR DESCRIPTION
`firstOrCreate` accepts a `$values` parameter to immediately merge in default values when returning a new model. This PR adds the same functionality to `firstOrNew`.

It provides less value than in the case of `firstOrCreate`, however, it can save you a line of code and it makes sense to have the same signature across the two methods for consistency.

Since this is a signature change, I assume it's breaking and can only be added in 5.4.
