### PR TITLE
[5.3] Support for suffix in routes and route groups

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -127,6 +127,10 @@ class Route
         if (isset($this->action['prefix'])) {
             $this->prefix($this->action['prefix']);
         }
+
+        if (isset($this->action['suffix'])) {
+            $this->suffix($this->action['suffix']);
+        }
     }
 
     /**
@@ -744,6 +748,21 @@ class Route
     }
 
     /**
+     * Add a suffix to the route URI.
+     *
+     * @param  string  $suffix
+     * @return $this
+     */
+    public function suffix($suffix)
+    {
+        $uri = rtrim($this->uri).ltrim($suffix);
+
+        $this->uri = trim($uri);
+
+        return $this;
+    }
+
+    /**
      * Get the URI associated with the route.
      *
      * @return string
@@ -855,6 +874,16 @@ class Route
     public function getPrefix()
     {
         return isset($this->action['prefix']) ? $this->action['prefix'] : null;
+    }
+
+    /**
+     * Get the suffix of the route instance.
+     *
+     * @return string
+     */
+    public function getSuffix()
+    {
+        return isset($this->action['suffix']) ? $this->action['suffix'] : null;
     }
 
     /**

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -360,6 +360,8 @@ class Router implements RegistrarContract
 
         $new['prefix'] = static::formatGroupPrefix($new, $old);
 
+        $new['suffix'] = static::formatGroupSuffix($new, $old);
+
         if (isset($new['domain'])) {
             unset($old['domain']);
         }
@@ -373,7 +375,7 @@ class Router implements RegistrarContract
             $new['as'] = $old['as'].(isset($new['as']) ? $new['as'] : '');
         }
 
-        return array_merge_recursive(Arr::except($old, ['namespace', 'prefix', 'where', 'as']), $new);
+        return array_merge_recursive(Arr::except($old, ['namespace', 'prefix', 'suffix', 'where', 'as']), $new);
     }
 
     /**
@@ -413,6 +415,24 @@ class Router implements RegistrarContract
     }
 
     /**
+     * Format the suffix for the new group attributes.
+     *
+     * @param  array  $new
+     * @param  array  $old
+     * @return string|null
+     */
+    protected static function formatGroupSuffix($new, $old)
+    {
+        $oldSuffix = isset($old['suffix']) ? $old['suffix'] : null;
+
+        if (isset($new['suffix'])) {
+            return trim($new['suffix']).trim($oldSuffix);
+        }
+
+        return $oldSuffix;
+    }
+
+    /**
      * Get the prefix from the last group on the stack.
      *
      * @return string
@@ -423,6 +443,22 @@ class Router implements RegistrarContract
             $last = end($this->groupStack);
 
             return isset($last['prefix']) ? $last['prefix'] : '';
+        }
+
+        return '';
+    }
+
+    /**
+     * Get the suffix from the last group on the stack.
+     *
+     * @return string
+     */
+    public function getLastGroupSuffix()
+    {
+        if (! empty($this->groupStack)) {
+            $last = end($this->groupStack);
+
+            return isset($last['suffix']) ? $last['suffix'] : '';
         }
 
         return '';
@@ -459,7 +495,7 @@ class Router implements RegistrarContract
         }
 
         $route = $this->newRoute(
-            $methods, $this->prefix($uri), $action
+            $methods, $this->prefix($this->suffix($uri)), $action
         );
 
         // If we have groups that need to be merged, we will merge them now after this
@@ -498,6 +534,17 @@ class Router implements RegistrarContract
     protected function prefix($uri)
     {
         return trim(trim($this->getLastGroupPrefix(), '/').'/'.trim($uri, '/'), '/') ?: '/';
+    }
+
+    /**
+     * Suffix the given URI with the last suffix.
+     *
+     * @param  string  $uri
+     * @return string
+     */
+    protected function suffix($uri)
+    {
+        return trim($uri).trim($this->getLastGroupSuffix());
     }
 
     /**


### PR DESCRIPTION
# Intention

Have a URL that normally displays a HTML page, but when adding a suffix gives that same content in another form.
# Usecase

Present rendered HTML of a set of eloquent model instances in the un-suffixed case, and present the the same elements represented in a machine readable format (e.g. JSON or XML) by using an appropriate file extension on the end of the URL.
# Example:

This is a common approach of providing open/linked data. BBC programmes/IPlayer sites does this. Find any programme URL, or IPlayer video:
- http://www.bbc.co.uk/programmes/b07w52tp
- http://www.bbc.co.uk/iplayer/episode/b07wwd9d/the-doctor-who-gave-up-drugs-episode-2

Add .json to the end of the URL get's that content in a machine readable form:
- http://www.bbc.co.uk/programmes/b07w52tp.json
- http://www.bbc.co.uk/iplayer/episode/b07wwd9d/the-doctor-who-gave-up-drugs-episode-2.json
# Existing Alternatives
## Prefix

Using the BBC example this would be:
http://www.bbc.co.uk/programmes/b07w52tp => http://www.bbc.co.uk/json/programmes/b07w52tp
This is not intuitive and fairly difficult for a machine to process (e.g. at what level in the URL does the 'json' path segment appear?).
## Subdomain

Using the BBC example this would be:
http://www.bbc.co.uk/programmes/b07w52tp => http://json.bbc.co.uk/programmes/b07w52tp
Similar argument to the prefix approach, although easier to process. It does, however, add a requirement for the site to support as many subdomains as data formats, which is heavy handed/requires additional overhead (e.g. more SSL certificates for HTTPS connections).
# Usage of submitted code

Suffix usage with Route

``` php
Route::get('data', ['suffix' => '.json', function (Request $request) {
    return App\User::latest()->all();
}]);
```

Suffix usage with Route::Group

``` php
Route::group([
    'suffix' => '.json',
    ], function ($router) {

    Route::get('data', function() {
        dd("DATA.JSON");
    });

    Route::group([
        'suffix' => '.test',
        ], function ($router) {

        Route::get('data', function() {
            dd("DATA.TEST.JSON");
        });
    });
});
```
# Backwards compatibility

As far as we can see from our own products this new feature does not have a negative impact on existing code.
