### PR TITLE
[5.3] Replace only the first instance of the app namespace in Generators

### DIFF
--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -87,7 +87,7 @@ abstract class GeneratorCommand extends Command
      */
     protected function getPath($name)
     {
-        $name = str_replace($this->laravel->getNamespace(), '', $name);
+        $name = str_replace_first($this->laravel->getNamespace(), '', $name);
 
         return $this->laravel['path'].'/'.str_replace('\\', '/', $name).'.php';
     }


### PR DESCRIPTION
Currently doing this `php artisan make:controller App\Http\Controllers\App\AppController` creates the controller in `app\Http\Controllers\AppController`, this PR fixes this by replacing only the first instance of the app namespace instead of all instances.
