### PR TITLE
[5.3] Allow to check if a model is force deleting.

### DIFF
--- a/src/Illuminate/Database/Eloquent/SoftDeletes.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletes.php
@@ -104,6 +104,16 @@ trait SoftDeletes
     }
 
     /**
+     * Determine if the model is currently force deleting.
+     *
+     * @return bool
+     */
+    public function isForceDeleting()
+    {
+        return $this->forceDeleting;
+    }
+
+    /**
      * Register a restoring model event with the dispatcher.
      *
      * @param  \Closure|string  $callback


### PR DESCRIPTION
Sometimes when force deleting a model, more actions is needed to be done. As of now, the only way (that I found) is to check the **protected** variable `$forceDeleting`.

If these actions take place inside e.g. an Observer for Eloquent events, this variable is not accessible. So I think an accessor for it, is needed.
