### PR TITLE
[5.3] Use relative path instead of absolute

### DIFF
--- a/src/Illuminate/Foundation/Console/StorageLinkCommand.php
+++ b/src/Illuminate/Foundation/Console/StorageLinkCommand.php
@@ -31,7 +31,7 @@ class StorageLinkCommand extends Command
             return $this->error('The "public/storage" directory already exists.');
         }
 
-        $this->laravel->make('files')->link(storage_path('app/public'), public_path('storage'));
+        $this->laravel->make('files')->link('../storage/app/public', public_path('storage'));
 
         $this->info('The [public/storage] directory has been linked.');
     }


### PR DESCRIPTION
Currently, if the symbolic links maps to `/home/vagrant/project/storage/app/public`, homestead will work but finder won't know where it is and the link will be only valid from inside the vm.

If we make it relative, it works from inside the vm and outside on hosts file manager.

The real issue that led me to make this PR is because rental servers often fakes your paths in a chroot jail or something I don't understand too much.
This way when we SSH into the rental server and link it to something like `/user/project/storage/app/public`, it will be fine for our SSH connection but I think what happens it that apache/nginx's user reads from the real path `/home/users/user/project/storage/app/public` and not from the fake resulting in broken urls.

I feel bad by removing the helper but I hope you consider merging it giving the benefits!
