### PR TITLE
[5.3] Option to schedule tasks using the command class instead of it's signature

### DIFF
--- a/src/Illuminate/Console/Scheduling/Schedule.php
+++ b/src/Illuminate/Console/Scheduling/Schedule.php
@@ -37,7 +37,7 @@ class Schedule
      */
     public function command($command, array $parameters = [])
     {
-        if(class_exists($command)) {
+        if (class_exists($command)) {
             $command = (new $command)->getName();
         }
 

--- a/src/Illuminate/Console/Scheduling/Schedule.php
+++ b/src/Illuminate/Console/Scheduling/Schedule.php
@@ -38,7 +38,7 @@ class Schedule
     public function command($command, array $parameters = [])
     {
         if (class_exists($command)) {
-            $command = (new $command)->getName();
+            $command = app($command)->getName();
         }
 
         $binary = ProcessUtils::escapeArgument((new PhpExecutableFinder)->find(false));

--- a/src/Illuminate/Console/Scheduling/Schedule.php
+++ b/src/Illuminate/Console/Scheduling/Schedule.php
@@ -37,6 +37,10 @@ class Schedule
      */
     public function command($command, array $parameters = [])
     {
+        if(class_exists($command)) {
+            $command = (new $command)->getName();
+        }
+
         $binary = ProcessUtils::escapeArgument((new PhpExecutableFinder)->find(false));
 
         $artisan = defined('ARTISAN_BINARY') ? ProcessUtils::escapeArgument(ARTISAN_BINARY) : 'artisan';

--- a/tests/Console/ConsoleEventSchedulerTest.php
+++ b/tests/Console/ConsoleEventSchedulerTest.php
@@ -61,6 +61,7 @@ class ConsoleEventSchedulerTest extends PHPUnit_Framework_TestCase
     }
 }
 
-class ConsoleCommandStub extends Illuminate\Console\Command {
+class ConsoleCommandStub extends Illuminate\Console\Command
+{
     protected $signature = 'foo:bar';
 }

--- a/tests/Console/ConsoleEventSchedulerTest.php
+++ b/tests/Console/ConsoleEventSchedulerTest.php
@@ -47,4 +47,20 @@ class ConsoleEventSchedulerTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($binary.' artisan queue:listen --tries=3', $events[1]->command);
         $this->assertEquals($binary.' artisan queue:listen --tries=3', $events[2]->command);
     }
+
+    public function testCreateNewArtisanCommandUsingCommandClass()
+    {
+        $escape = '\\' === DIRECTORY_SEPARATOR ? '"' : '\'';
+
+        $schedule = new Schedule;
+        $schedule->command(ConsoleCommandStub::class, ['--force']);
+
+        $events = $schedule->events();
+        $binary = $escape.PHP_BINARY.$escape;
+        $this->assertEquals($binary.' artisan foo:bar --force', $events[0]->command);
+    }
+}
+
+class ConsoleCommandStub extends Illuminate\Console\Command {
+    protected $signature = 'foo:bar';
 }

--- a/tests/Console/ConsoleEventSchedulerTest.php
+++ b/tests/Console/ConsoleEventSchedulerTest.php
@@ -61,7 +61,26 @@ class ConsoleEventSchedulerTest extends PHPUnit_Framework_TestCase
     }
 }
 
+class FooClassStub
+{
+    protected $schedule;
+
+    public function __construct(Schedule $schedule)
+    {
+        $this->schedule = $schedule;
+    }
+}
+
 class ConsoleCommandStub extends Illuminate\Console\Command
 {
     protected $signature = 'foo:bar';
+
+    protected $foo;
+
+    public function __construct(FooClassStub $foo)
+    {
+        parent::__construct();
+
+        $this->foo = $foo;
+    }
 }


### PR DESCRIPTION
To schedule a task:

**Kernel.php**

```
<?php

class Kernel extends ConsoleKernel
{
    /**
     * The Artisan commands provided by your application.
     *
     * @var array
     */
    protected $commands = [
        PayablesCommand::class
    ];

    /**
     * Define the application's command schedule.
     *
     * @param  \Illuminate\Console\Scheduling\Schedule  $schedule
     * @return void
     */
    protected function schedule(Schedule $schedule)
    {
        $schedule->command('payables:update')->dailyAt('23:55');
    }
}
```

This PR adds the ability to do this:

```
<?php

class Kernel extends ConsoleKernel
{
    /**
     * The Artisan commands provided by your application.
     *
     * @var array
     */
    protected $commands = [
        PayablesCommand::class
    ];

    /**
     * Define the application's command schedule.
     *
     * @param  \Illuminate\Console\Scheduling\Schedule  $schedule
     * @return void
     */
    protected function schedule(Schedule $schedule)
    {
        $schedule->command(PayablesCommand::class)->dailyAt('23:55');
    }
}
```
