### PR TITLE
[5.3] Allow the Notifiable to specify the "Key" it should use to broadcast

### DIFF
--- a/src/Illuminate/Notifications/Events/BroadcastNotificationCreated.php
+++ b/src/Illuminate/Notifications/Events/BroadcastNotificationCreated.php
@@ -79,8 +79,8 @@ class BroadcastNotificationCreated implements ShouldBroadcast
     {
         $class = str_replace('\\', '.', get_class($this->notifiable));
 
-        if (method_exists($this->notification, 'getKey')) {
-            $key = $this->notification->getKey($this->notifiable);
+        if (method_exists($this->notifiable, 'getNotificationKey')) {
+            $key = $this->notifiable->getNotificationKey();
         } else {
             $key = $this->notifiable->getKey();
         }

--- a/src/Illuminate/Notifications/Events/BroadcastNotificationCreated.php
+++ b/src/Illuminate/Notifications/Events/BroadcastNotificationCreated.php
@@ -79,6 +79,12 @@ class BroadcastNotificationCreated implements ShouldBroadcast
     {
         $class = str_replace('\\', '.', get_class($this->notifiable));
 
-        return $class.'.'.$this->notifiable->getKey();
+        if (method_exists($this->notification, 'getKey')) {
+            $key = $this->notification->getKey($this->notifiable);
+        } else {
+            $key = $this->notifiable->getKey();
+        }
+
+        return $class.'.'.$key;
     }
 }


### PR DESCRIPTION
I don't like to expose the User.id in my public JavaScript files.
I use Hashid's to hash the user id but then i came across the issue that my Notifiable object could not specify the key it should use to broadcast. This change allows the Notifiable specify a different key or else it just uses the getKey method on the Notifiable object.
