### PR TITLE
[5.2] named routes v5.2

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -367,9 +367,9 @@ class Router implements RegistrarContract
     public function auth()
     {
         // Authentication Routes...
-        $this->get('login', 'Auth\AuthController@showLoginForm');
+        $this->get('login', 'Auth\AuthController@showLoginForm')->name('login');
         $this->post('login', 'Auth\AuthController@login');
-        $this->get('logout', 'Auth\AuthController@logout');
+        $this->get('logout', 'Auth\AuthController@logout')->name('logout');
 
         // Registration Routes...
         $this->get('register', 'Auth\AuthController@showRegistrationForm');


### PR DESCRIPTION
I know that in version 5.3 logout-route changed to post but it still make sense to have named authorization routes in Laravel 5.2
