### PR TITLE
[5.3] Fix StartSession middleware for test cases

### DIFF
--- a/src/Illuminate/Session/Middleware/StartSession.php
+++ b/src/Illuminate/Session/Middleware/StartSession.php
@@ -6,6 +6,7 @@ use Closure;
 use Carbon\Carbon;
 use Illuminate\Support\Arr;
 use Illuminate\Http\Request;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Session\SessionManager;
 use Illuminate\Session\SessionInterface;
 use Symfony\Component\HttpFoundation\Cookie;
@@ -86,6 +87,9 @@ class StartSession
     {
         if ($this->sessionHandled && $this->sessionConfigured() && ! $this->usingCookieSessions()) {
             $this->manager->driver()->save();
+            if ($response instanceof RedirectResponse) {
+                $this->manager->driver()->reflash();
+            }
         }
     }
 


### PR DESCRIPTION
Fix StartSession middleware to get it working with assertSessionHasErrors() on test cases
[https://github.com/laravel/framework/issues/15305](https://github.com/laravel/framework/issues/15305)
