### PR TITLE
[5.3] Allow array of strings/arrays, optional name attr

### DIFF
--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -374,9 +374,9 @@ class Mailable implements MailableContract
 
         if ($address instanceof Collection || is_array($address)) {
             foreach ($address as $user) {
-                if (is_array($user)){
+                if (is_array($user)) {
                     $user = (object) $user;
-                }elseif (is_string($user)) {
+                } elseif (is_string($user)) {
                     $user = (object) ['email' => $user];
                 }
                 $this->{$property}($user->email, isset($user->name) ? $user->name : null);

--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -374,7 +374,12 @@ class Mailable implements MailableContract
 
         if ($address instanceof Collection || is_array($address)) {
             foreach ($address as $user) {
-                $this->{$property}($user->email, $user->name);
+                if (is_array($user)){
+                    $user = (object) $user;
+                }elseif (is_string($user)) {
+                    $user = (object) ['email' => $user];
+                }
+                $this->{$property}($user->email, isset($user->name) ? $user->name : null);
             }
         } else {
             $this->{$property}[] = compact('address', 'name');


### PR DESCRIPTION
This works in 5.3:
Mail::to('name1@example.com')->send(new OrderShipped($order));

And this works too:
$user1 = User::find(1);
$user2 = User::find(2);
Mail::to([$user1, $user2])->send(new OrderShipped($order));

However this does not work in 5.3:
Mail::to(['name1@example.com','name2@example.com'])->send(new
OrderShipped($order));

And this does not work in 5.3 too:
$user1 = User::find(1)->toArray();
$user2 = User::find(2)->toArray();
Mail::to([$user1, $user2])->send(new OrderShipped($order));

This commmit implements all cases plus it allows to not to have 'name'
attribute in User model (User models often have first_name and
last_name).
