### PR TITLE
[5.3] Change server variables when bootstrapping the app request from artisan.

### DIFF
--- a/src/Illuminate/Foundation/Bootstrap/SetRequestForConsole.php
+++ b/src/Illuminate/Foundation/Bootstrap/SetRequestForConsole.php
@@ -16,7 +16,11 @@ class SetRequestForConsole
     public function bootstrap(Application $app)
     {
         $url = $app->make('config')->get('app.url', 'http://localhost');
-
+        $urlParts = parse_url($url);
+        if (isset($urlParts['path']) && mb_strlen($urlParts['path']) > 1) {
+            $_SERVER['SCRIPT_NAME'] = $urlParts['path'].DIRECTORY_SEPARATOR.'index.php';
+            $_SERVER['SCRIPT_FILENAME'] = getenv('PWD').DIRECTORY_SEPARATOR.$urlParts['path'].DIRECTORY_SEPARATOR.'index.php';
+        }
         $app->instance('request', Request::create($url, 'GET', [], [], [], $_SERVER));
     }
 }


### PR DESCRIPTION
This change fixes #14139 .

I am not sure where would tests for this belong. Should they go on `tests/Routing/RoutingUrlGeneratorTest.php` or on `tests\Console\ConsoleApplicationTest.php`? I think the former is better but I'd like to have somebody else opinion.
