### PR TITLE
[5.3] Fire an event while running a console command

### DIFF
--- a/src/Illuminate/Console/Events/CommandRunning.php
+++ b/src/Illuminate/Console/Events/CommandRunning.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Illuminate\Console\Events;
+
+use Symfony\Component\Console\Input\InputInterface;
+
+class CommandRunning
+{
+    /**
+     * The command name.
+     *
+     * @var string
+     */
+    public $command;
+
+    /**
+     * The console input.
+     *
+     * @var string
+     */
+    public $input;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  string $command
+     * @param \Symfony\Component\Console\Input\InputInterface $input
+     * @return void
+     */
+    public function __construct($command, InputInterface $input)
+    {
+        $this->command = $command;
+        $this->input = $input;
+    }
+}

--- a/src/Illuminate/Console/Events/CommandRunning.php
+++ b/src/Illuminate/Console/Events/CommandRunning.php
@@ -16,7 +16,7 @@ class CommandRunning
     /**
      * The console input.
      *
-     * @var string
+     * @var \Symfony\Component\Console\Input\InputInterface
      */
     public $input;
 


### PR DESCRIPTION
This PR fires a `CommandRunning` event before executing a console command.

As reported in https://github.com/laravel/framework/issues/15610, laravel doesn't set Symfony's dispatcher while running console commands which causes Symfony's own console events not to fire.

Laravel already fires a `ArtisanStarting` command on Artisan start, but it doesn't contain information about the command running or the inputs given, this new event will get fired before running every console command allowing tasks like logging, sending notifications, etc...
