### PR TITLE
[5.3] Pagination count: Use the first column instead of * if distinct

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1702,6 +1702,10 @@ class Builder
      */
     public function getCountForPagination($columns = ['*'])
     {
+        if ($this->distinct && $columns == ['*'] && $column = Arr::first($this->columns)) {
+            $columns = [$column];
+        }
+
         $this->backupFieldsForCount();
 
         $this->aggregate = ['function' => 'count', 'columns' => $this->clearSelectAliases($columns)];

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -708,6 +708,48 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase
         $this->assertEquals([4], $builder->getBindings());
     }
 
+    public function testGetCountForPaginationWithDistinctWhileColumnsSelected()
+    {
+        $builder = $this->getBuilder();
+        $builder->from('users')->select('users.id')->distinct();
+
+        $builder->getConnection()->shouldReceive('select')->once()->with('select count(distinct "users"."id") as aggregate from "users"', [], true)->andReturn([['aggregate' => 1]]);
+        $builder->getProcessor()->shouldReceive('processSelect')->once()->andReturnUsing(function ($builder, $results) {
+            return $results;
+        });
+
+        $count = $builder->getCountForPagination();
+        $this->assertEquals(1, $count);
+    }
+
+    public function testGetCountForPaginationWithDistinctWithNoColumnsSelected()
+    {
+        $builder = $this->getBuilder();
+        $builder->from('users')->distinct();
+
+        $builder->getConnection()->shouldReceive('select')->once()->with('select count(*) as aggregate from "users"', [], true)->andReturn([['aggregate' => 1]]);
+        $builder->getProcessor()->shouldReceive('processSelect')->once()->andReturnUsing(function ($builder, $results) {
+            return $results;
+        });
+
+        $count = $builder->getCountForPagination();
+        $this->assertEquals(1, $count);
+    }
+
+    public function testGetCountForPaginationWithoutDistinct()
+    {
+        $builder = $this->getBuilder();
+        $builder->from('users')->select('one', 'two');
+
+        $builder->getConnection()->shouldReceive('select')->once()->with('select count(*) as aggregate from "users"', [], true)->andReturn([['aggregate' => 1]]);
+        $builder->getProcessor()->shouldReceive('processSelect')->once()->andReturnUsing(function ($builder, $results) {
+            return $results;
+        });
+
+        $count = $builder->getCountForPagination();
+        $this->assertEquals(1, $count);
+    }
+
     public function testGetCountForPaginationWithColumnAliases()
     {
         $builder = $this->getBuilder();


### PR DESCRIPTION
When you use:

```
->select('users.id')->distinct()->paginate()
```

The count query neglects the `distinct` flag:

```
select count(*) as aggregate from ...
```

Which causes the count to be wrong, this PR fixes that issue by including the first selected column in the aggregate function if distinct was used:

```
select count(distinct `users`.`id`) as aggregate from ...
```
