### PR TITLE
[5.3] Add missing interface methods in Registrar contract.

### DIFF
--- a/src/Illuminate/Contracts/Routing/Registrar.php
+++ b/src/Illuminate/Contracts/Routing/Registrar.php
@@ -88,4 +88,20 @@ interface Registrar
      * @return void
      */
     public function group(array $attributes, Closure $callback);
+
+    /**
+     * Substitute the route bindings onto the route.
+     *
+     * @param  \Illuminate\Routing\Route  $route
+     * @return \Illuminate\Routing\Route
+     */
+    public function substituteBindings($route);
+
+    /**
+     * Substitute the implicit Eloquent model bindings for the route.
+     *
+     * @param  \Illuminate\Routing\Route  $route
+     * @return void
+     */
+    public function substituteImplicitBindings($route);
 }


### PR DESCRIPTION
Add missing interface methods in `\Illuminate\Contracts\Routing\Registrar`
See `\Illuminate\Routing\Middleware\SubstituteBindings::handle`
