### PR TITLE
[5.3] Let cookie expiration date return an integer.

### DIFF
--- a/src/Illuminate/Session/Middleware/StartSession.php
+++ b/src/Illuminate/Session/Middleware/StartSession.php
@@ -205,7 +205,7 @@ class StartSession
     {
         $config = $this->manager->getSessionConfig();
 
-        return $config['expire_on_close'] ? 0 : Carbon::now()->addMinutes($config['lifetime']);
+        return $config['expire_on_close'] ? 0 : Carbon::now()->addMinutes($config['lifetime'])->getTimestamp();
     }
 
     /**


### PR DESCRIPTION
Let cookie expiration date return an integer and stick to the expected return type.
