### PR TITLE
[5.4] Fix docblock.

### DIFF
--- a/src/Illuminate/Session/Middleware/StartSession.php
+++ b/src/Illuminate/Session/Middleware/StartSession.php
@@ -199,7 +199,7 @@ class StartSession
     /**
      * Get the cookie lifetime in seconds.
      *
-     * @return int
+     * @return \DateTimeInterface
      */
     protected function getCookieExpirationDate()
     {


### PR DESCRIPTION
Targeting `5.4` as this is a breaking change for classes extending `\Illuminate\Session\Middleware\StartSession::getCookieExpirationDate`

---

Related to https://github.com/laravel/framework/pull/15617
