### PR TITLE
[5.2] Fix for deprecated ValidationException

### DIFF
--- a/src/Illuminate/Foundation/Validation/ValidatesRequests.php
+++ b/src/Illuminate/Foundation/Validation/ValidatesRequests.php
@@ -7,6 +7,7 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Routing\UrlGenerator;
 use Illuminate\Contracts\Validation\Factory;
 use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Validation\ValidationException;
 
 trait ValidatesRequests
 {
@@ -81,7 +82,7 @@ trait ValidatesRequests
      * @param  \Illuminate\Contracts\Validation\Validator  $validator
      * @return void
      *
-     * @throws \Illuminate\Foundation\Validation\ValidationException
+     * @throws \Illuminate\Validation\ValidationException
      */
     protected function throwValidationException(Request $request, $validator)
     {


### PR DESCRIPTION
In the throwValidationException function in the Illuminate\Foundation\Validation\ValidatesRequests class the ValidationException thrown is a referral to a deprecated class.
