### PR TITLE
[5.3] Remove forking and pcntl requirements while still supporting timeouts.

### DIFF
--- a/src/Illuminate/Queue/Console/DaemonCommand.php
+++ b/src/Illuminate/Queue/Console/DaemonCommand.php
@@ -3,14 +3,12 @@
 namespace Illuminate\Queue\Console;
 
 use Carbon\Carbon;
-use RuntimeException;
 use Illuminate\Queue\Worker;
 use Illuminate\Console\Command;
 use Illuminate\Queue\WorkerOptions;
 use Illuminate\Contracts\Queue\Job;
 use Illuminate\Queue\Events\JobFailed;
 use Illuminate\Queue\Events\JobProcessed;
-use Illuminate\Queue\Events\JobProcessing;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputArgument;
 

--- a/src/Illuminate/Queue/Console/DaemonCommand.php
+++ b/src/Illuminate/Queue/Console/DaemonCommand.php
@@ -1,0 +1,215 @@
+<?php
+
+namespace Illuminate\Queue\Console;
+
+use Carbon\Carbon;
+use RuntimeException;
+use Illuminate\Queue\Worker;
+use Illuminate\Console\Command;
+use Illuminate\Queue\WorkerOptions;
+use Illuminate\Contracts\Queue\Job;
+use Illuminate\Queue\Events\JobFailed;
+use Illuminate\Queue\Events\JobProcessed;
+use Illuminate\Queue\Events\JobProcessing;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputArgument;
+
+class DaemonCommand extends Command
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'queue:daemon';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Daemon worker process that should not be called directly (use queue:work)';
+
+    /**
+     * The queue worker instance.
+     *
+     * @var \Illuminate\Queue\Worker
+     */
+    protected $worker;
+
+    /**
+     * Create a new queue listen command.
+     *
+     * @param  \Illuminate\Queue\Worker  $worker
+     * @return void
+     */
+    public function __construct(Worker $worker)
+    {
+        parent::__construct();
+
+        $this->worker = $worker;
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function fire()
+    {
+        if ($this->downForMaintenance() && $this->option('once')) {
+            return $this->worker->sleep($this->option('sleep'));
+        }
+
+        // We'll listen to the processed and failed events so we can write information
+        // to the console as jobs are processed, which will let the developer watch
+        // which jobs are coming through a queue and be informed on its progress.
+        $this->listenForEvents();
+
+        $connection = $this->argument('connection')
+                        ?: $this->laravel['config']['queue.default'];
+
+        // We need to get the right queue for the connection which is set in the queue
+        // configuration file for the application. We will pull it based on the set
+        // connection being run for the queue operation currently being executed.
+        $queue = $this->option('queue') ?: $this->laravel['config']->get(
+            "queue.connections.{$connection}.queue", 'default'
+        );
+
+        $response = $this->runWorker(
+            $connection, $queue
+        );
+    }
+
+    /**
+     * Run the worker instance.
+     *
+     * @param  string  $connection
+     * @param  string  $queue
+     * @return array
+     */
+    protected function runWorker($connection, $queue)
+    {
+        $this->worker->setCache($this->laravel['cache']->driver());
+
+        return $this->worker->{$this->option('once') ? 'runNextJob' : 'daemon'}(
+            $connection, $queue, $this->gatherWorkerOptions()
+        );
+    }
+
+    /**
+     * Gather all of the queue worker options as a single object.
+     *
+     * @return \Illuminate\Queue\WorkerOptions
+     */
+    protected function gatherWorkerOptions()
+    {
+        return new WorkerOptions(
+            $this->option('delay'), $this->option('memory'),
+            $this->option('timeout'), $this->option('sleep'),
+            $this->option('tries')
+        );
+    }
+
+    /**
+     * Listen for the queue events in order to update the console output.
+     *
+     * @return void
+     */
+    protected function listenForEvents()
+    {
+        $this->laravel['events']->listen('illuminate.queue.looping', function () {
+            $this->output->writeln('.');
+        });
+
+        $this->laravel['events']->listen(JobProcessed::class, function ($event) {
+            $this->writeOutput($event->job, false);
+        });
+
+        $this->laravel['events']->listen(JobFailed::class, function ($event) {
+            $this->writeOutput($event->job, true);
+
+            $this->logFailedJob($event);
+        });
+    }
+
+    /**
+     * Write the status output for the queue worker.
+     *
+     * @param  \Illuminate\Contracts\Queue\Job  $job
+     * @param  bool  $failed
+     * @return void
+     */
+    protected function writeOutput(Job $job, $failed)
+    {
+        if ($failed) {
+            $this->output->writeln('<error>['.Carbon::now()->format('Y-m-d H:i:s').'] Failed:</error> '.$job->resolveName());
+        } else {
+            $this->output->writeln('<info>['.Carbon::now()->format('Y-m-d H:i:s').'] Processed:</info> '.$job->resolveName());
+        }
+    }
+
+    /**
+     * Store a failed job event.
+     *
+     * @param  JobFailed  $event
+     * @return void
+     */
+    protected function logFailedJob(JobFailed $event)
+    {
+        $this->laravel['queue.failer']->log(
+            $event->connectionName, $event->job->getQueue(),
+            $event->job->getRawBody(), $event->exception
+        );
+    }
+
+    /**
+     * Determine if the worker should run in maintenance mode.
+     *
+     * @return bool
+     */
+    protected function downForMaintenance()
+    {
+        return $this->option('force') ? false : $this->laravel->isDownForMaintenance();
+    }
+
+    /**
+     * Get the console command arguments.
+     *
+     * @return array
+     */
+    protected function getArguments()
+    {
+        return [
+            ['connection', InputArgument::OPTIONAL, 'The name of connection', null],
+        ];
+    }
+
+    /**
+     * Get the console command options.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [
+            ['queue', null, InputOption::VALUE_OPTIONAL, 'The queue to listen on'],
+
+            ['daemon', null, InputOption::VALUE_NONE, 'Run the worker in daemon mode (Deprecated)'],
+
+            ['once', null, InputOption::VALUE_NONE, 'Only process the next job on the queue'],
+
+            ['delay', null, InputOption::VALUE_OPTIONAL, 'Amount of time to delay failed jobs', 0],
+
+            ['force', null, InputOption::VALUE_NONE, 'Force the worker to run even in maintenance mode'],
+
+            ['memory', null, InputOption::VALUE_OPTIONAL, 'The memory limit in megabytes', 128],
+
+            ['sleep', null, InputOption::VALUE_OPTIONAL, 'Number of seconds to sleep when no job is available', 3],
+
+            ['timeout', null, InputOption::VALUE_OPTIONAL, 'The number of seconds a child process can run', 60],
+
+            ['tries', null, InputOption::VALUE_OPTIONAL, 'Number of times to attempt a job before logging it failed', 0],
+        ];
+    }
+}

--- a/src/Illuminate/Queue/Console/ListenCommand.php
+++ b/src/Illuminate/Queue/Console/ListenCommand.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Queue\Console;
 
-use RuntimeException;
 use Illuminate\Queue\Listener;
 use Illuminate\Console\Command;
 use Symfony\Component\Console\Input\InputOption;
@@ -48,8 +47,6 @@ class ListenCommand extends Command
      * Execute the console command.
      *
      * @return void
-     *
-     * @throws \RuntimeException
      */
     public function fire()
     {
@@ -65,10 +62,6 @@ class ListenCommand extends Command
         $connection = $this->input->getArgument('connection');
 
         $timeout = $this->input->getOption('timeout');
-
-        if ($timeout && ! function_exists('pcntl_fork')) {
-            throw new RuntimeException('Timeouts not supported without the pcntl_fork extension.');
-        }
 
         // We need to get the right queue for the connection which is set in the queue
         // configuration file for the application. We will pull it based on the set

--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -3,13 +3,8 @@
 namespace Illuminate\Queue\Console;
 
 use Carbon\Carbon;
-use RuntimeException;
-use Illuminate\Queue\Worker;
 use Illuminate\Console\Command;
-use Illuminate\Queue\WorkerOptions;
-use Illuminate\Contracts\Queue\Job;
-use Illuminate\Queue\Events\JobFailed;
-use Illuminate\Queue\Events\JobProcessed;
+use Symfony\Component\Process\Process;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputArgument;
 
@@ -27,27 +22,7 @@ class WorkCommand extends Command
      *
      * @var string
      */
-    protected $description = 'Process the next job on a queue';
-
-    /**
-     * The queue worker instance.
-     *
-     * @var \Illuminate\Queue\Worker
-     */
-    protected $worker;
-
-    /**
-     * Create a new queue listen command.
-     *
-     * @param  \Illuminate\Queue\Worker  $worker
-     * @return void
-     */
-    public function __construct(Worker $worker)
-    {
-        parent::__construct();
-
-        $this->worker = $worker;
-    }
+    protected $description = 'Start processing jobs from the queue';
 
     /**
      * Execute the console command.
@@ -56,136 +31,27 @@ class WorkCommand extends Command
      */
     public function fire()
     {
-        if ($this->downForMaintenance() && $this->option('once')) {
-            return $this->worker->sleep($this->option('sleep'));
-        }
+        $process = $this->newProxyProcess();
 
-        // We'll listen to the processed and failed events so we can write information
-        // to the console as jobs are processed, which will let the developer watch
-        // which jobs are coming through a queue and be informed on its progress.
-        $this->listenForEvents();
-
-        $connection = $this->argument('connection')
-                        ?: $this->laravel['config']['queue.default'];
-
-        // We need to get the right queue for the connection which is set in the queue
-        // configuration file for the application. We will pull it based on the set
-        // connection being run for the queue operation currently being executed.
-        $queue = $this->option('queue') ?: $this->laravel['config']->get(
-            "queue.connections.{$connection}.queue", 'default'
-        );
-
-        $response = $this->runWorker(
-            $connection, $queue
-        );
+        exit($process->run(function ($type, $line) {
+            if (trim($line) !== '.') {
+                $this->output->write($line);
+            }
+        }));
     }
 
     /**
-     * Run the worker instance.
+     * Get a new proxy process to the daemon command.
      *
-     * @param  string  $connection
-     * @param  string  $queue
-     * @return array
+     * @return Process
      */
-    protected function runWorker($connection, $queue)
+    protected function newProxyProcess()
     {
-        $this->worker->setCache($this->laravel['cache']->driver());
+        $_SERVER['argv'][1] = 'queue:daemon';
 
-        $method = $this->option('once') ? 'runNextJob' : 'daemon';
-
-        return $this->worker->{$method}(
-            $connection, $queue, $this->gatherWorkerOptions()
-        );
-    }
-
-    /**
-     * Gather all of the queue worker options as a single object.
-     *
-     * @return \Illuminate\Queue\WorkerOptions
-     */
-    protected function gatherWorkerOptions()
-    {
-        $timeout = $this->option('timeout');
-
-        if ($timeout && ! function_exists('pcntl_fork')) {
-            throw new RuntimeException('The pcntl extension is required in order to specify job timeouts.');
-        }
-
-        return new WorkerOptions(
-            $this->option('delay'), $this->option('memory'),
-            $timeout, $this->option('sleep'),
-            $this->option('tries')
-        );
-    }
-
-    /**
-     * Listen for the queue events in order to update the console output.
-     *
-     * @return void
-     */
-    protected function listenForEvents()
-    {
-        $this->laravel['events']->listen(JobProcessed::class, function ($event) {
-            $this->writeOutput($event->job, false);
-        });
-
-        $this->laravel['events']->listen(JobFailed::class, function ($event) {
-            $this->writeOutput($event->job, true);
-
-            $this->logFailedJob($event);
-        });
-    }
-
-    /**
-     * Write the status output for the queue worker.
-     *
-     * @param  \Illuminate\Contracts\Queue\Job  $job
-     * @param  bool  $failed
-     * @return void
-     */
-    protected function writeOutput(Job $job, $failed)
-    {
-        if ($failed) {
-            $this->output->writeln('<error>['.Carbon::now()->format('Y-m-d H:i:s').'] Failed:</error> '.$job->resolveName());
-        } else {
-            $this->output->writeln('<info>['.Carbon::now()->format('Y-m-d H:i:s').'] Processed:</info> '.$job->resolveName());
-        }
-    }
-
-    /**
-     * Store a failed job event.
-     *
-     * @param  JobFailed  $event
-     * @return void
-     */
-    protected function logFailedJob(JobFailed $event)
-    {
-        $this->laravel['queue.failer']->log(
-            $event->connectionName, $event->job->getQueue(),
-            $event->job->getRawBody(), $event->exception
-        );
-    }
-
-    /**
-     * Determine if the worker should run in maintenance mode.
-     *
-     * @return bool
-     */
-    protected function downForMaintenance()
-    {
-        return $this->option('force') ? false : $this->laravel->isDownForMaintenance();
-    }
-
-    /**
-     * Get the console command arguments.
-     *
-     * @return array
-     */
-    protected function getArguments()
-    {
-        return [
-            ['connection', InputArgument::OPTIONAL, 'The name of connection', null],
-        ];
+        return (new Process(PHP_BINARY.' '.implode(' ', $_SERVER['argv']), getcwd()))
+                    ->setTimeout(null)
+                    ->setIdleTimeout($this->option('timeout') + $this->option('sleep'));
     }
 
     /**

--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -2,11 +2,9 @@
 
 namespace Illuminate\Queue\Console;
 
-use Carbon\Carbon;
 use Illuminate\Console\Command;
 use Symfony\Component\Process\Process;
 use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Input\InputArgument;
 
 class WorkCommand extends Command
 {

--- a/src/Illuminate/Queue/QueueServiceProvider.php
+++ b/src/Illuminate/Queue/QueueServiceProvider.php
@@ -4,6 +4,7 @@ namespace Illuminate\Queue;
 
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Queue\Console\WorkCommand;
+use Illuminate\Queue\Console\DaemonCommand;
 use Illuminate\Queue\Console\ListenCommand;
 use Illuminate\Queue\Console\RestartCommand;
 use Illuminate\Queue\Connectors\SqsConnector;
@@ -89,11 +90,15 @@ class QueueServiceProvider extends ServiceProvider
      */
     protected function registerWorkCommand()
     {
-        $this->app->singleton('command.queue.work', function ($app) {
-            return new WorkCommand($app['queue.worker']);
+        $this->app->singleton('command.queue.work', function () {
+            return new WorkCommand;
         });
 
-        $this->commands('command.queue.work');
+        $this->app->singleton('command.queue.daemon', function ($app) {
+            return new DaemonCommand($app['queue.worker']);
+        });
+
+        $this->commands('command.queue.work', 'command.queue.daemon');
     }
 
     /**

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -71,7 +71,7 @@ class Worker
 
         while (true) {
             if ($this->daemonShouldRun()) {
-                $this->runNextJobForDaemon($connectionName, $queue, $options);
+                $this->runNextJob($connectionName, $queue, $options);
             } else {
                 $this->sleep($options->sleep);
             }
@@ -101,30 +101,6 @@ class Worker
         }
 
         return true;
-    }
-
-    /**
-     * Run the next job for the daemon worker.
-     *
-     * @param  string  $connectionName
-     * @param  string  $queue
-     * @param  \Illuminate\Queue\WorkerOptions  $options
-     * @return void
-     */
-    protected function runNextJobForDaemon($connectionName, $queue, WorkerOptions $options)
-    {
-        return $this->runNextJob($connectionName, $queue, $options);
-
-        // Removing forking for now because it doesn't work with SQS...
-        if (! $options->timeout) {
-            $this->runNextJob($connectionName, $queue, $options);
-        } elseif ($processId = pcntl_fork()) {
-            $this->waitForChildProcess($processId, $options->timeout);
-        } else {
-            $this->runNextJob($connectionName, $queue, $options);
-
-            exit;
-        }
     }
 
     /**


### PR DESCRIPTION
This is done by proxying into a new command using Symfony Process and utilizing the `setIdleTimeout` on the proxy process.

AWS SDK does not function correctly in a forked process due to problems with curl in PHP.
