### PR TITLE
[5.3] Add support for setting mail notification priority

### DIFF
--- a/src/Illuminate/Notifications/Channels/MailChannel.php
+++ b/src/Illuminate/Notifications/Channels/MailChannel.php
@@ -70,6 +70,10 @@ class MailChannel
             foreach ($message->rawAttachments as $attachment) {
                 $m->attachData($attachment['data'], $attachment['name'], $attachment['options']);
             }
+
+            if($message->priority !== null) {
+                $m->setPriority($message->priority);
+            }
         });
     }
 }

--- a/src/Illuminate/Notifications/Messages/MailMessage.php
+++ b/src/Illuminate/Notifications/Messages/MailMessage.php
@@ -50,6 +50,13 @@ class MailMessage extends SimpleMessage
     public $rawAttachments = [];
 
     /**
+     * Priority level of the message.
+     *
+     * @var int
+     */
+    public $priority = null;
+
+    /**
      * Set the view for the mail message.
      *
      * @param  string  $view
@@ -128,5 +135,20 @@ class MailMessage extends SimpleMessage
     public function data()
     {
         return array_merge($this->toArray(), $this->viewData);
+    }
+
+    /**
+     * Set the priority of this message.
+     *
+     * The value is an integer where 1 is the highest priority and 5 is the lowest.
+     *
+     * @param  int  $level
+     * @return $this
+     */
+    public function priority($level)
+    {
+        $this->priority = $level;
+
+        return $this;
     }
 }


### PR DESCRIPTION
Usage:

``` php
class Foo extends Notification
{
    public function toMail($notifiable)
    {
        return (new MailMessage)
            ->priority(1);
    }
}
```

Priority levels like in Swift message: 1 - Highest, 3 - Default, 5 - Lowest.
It would be nice if we would have some constants for this. Not sure if it belongs here or on Swift\Message. What do you think?
