### PR TITLE
[5.3] Allow the Notifiable to specify the channel it should broadcast…

### DIFF
--- a/src/Illuminate/Notifications/Events/BroadcastNotificationCreated.php
+++ b/src/Illuminate/Notifications/Events/BroadcastNotificationCreated.php
@@ -76,7 +76,7 @@ class BroadcastNotificationCreated implements ShouldBroadcast
      * @return string
      */
     protected function channelName()
-    {       
+    {
         if (method_exists($this->notifiable, 'getNotificationChannel')) {
             return $this->notifiable->getNotificationChannel();
         } else {

--- a/src/Illuminate/Notifications/Events/BroadcastNotificationCreated.php
+++ b/src/Illuminate/Notifications/Events/BroadcastNotificationCreated.php
@@ -76,9 +76,11 @@ class BroadcastNotificationCreated implements ShouldBroadcast
      * @return string
      */
     protected function channelName()
-    {
-        $class = str_replace('\\', '.', get_class($this->notifiable));
-
-        return $class.'.'.$this->notifiable->getKey();
+    {       
+        if (method_exists($this->notifiable, 'getNotificationChannel')) {
+            return $this->notifiable->getNotificationChannel();
+        } else {
+            return str_replace('\\', '.', get_class($this->notifiable)).'.'.$this->notifiable->getKey();
+        }
     }
 }

--- a/src/Illuminate/Notifications/Events/BroadcastNotificationCreated.php
+++ b/src/Illuminate/Notifications/Events/BroadcastNotificationCreated.php
@@ -79,8 +79,8 @@ class BroadcastNotificationCreated implements ShouldBroadcast
     {
         if (method_exists($this->notifiable, 'getNotificationChannel')) {
             return $this->notifiable->getNotificationChannel();
-        } else {
-            return str_replace('\\', '.', get_class($this->notifiable)).'.'.$this->notifiable->getKey();
-        }
+        } 
+        
+        return str_replace('\\', '.', get_class($this->notifiable)).'.'.$this->notifiable->getKey();       
     }
 }

--- a/src/Illuminate/Notifications/Events/BroadcastNotificationCreated.php
+++ b/src/Illuminate/Notifications/Events/BroadcastNotificationCreated.php
@@ -79,8 +79,8 @@ class BroadcastNotificationCreated implements ShouldBroadcast
     {
         if (method_exists($this->notifiable, 'getNotificationChannel')) {
             return $this->notifiable->getNotificationChannel();
-        }
+        } 
         
-        return str_replace('\\', '.', get_class($this->notifiable)).'.'.$this->notifiable->getKey();       
+        return str_replace('\\', '.', get_class($this->notifiable)).'.'.$this->notifiable->getKey();    
     }
 }

--- a/src/Illuminate/Notifications/Events/BroadcastNotificationCreated.php
+++ b/src/Illuminate/Notifications/Events/BroadcastNotificationCreated.php
@@ -79,8 +79,8 @@ class BroadcastNotificationCreated implements ShouldBroadcast
     {
         if (method_exists($this->notifiable, 'getNotificationChannel')) {
             return $this->notifiable->getNotificationChannel();
-        } 
-        
-        return str_replace('\\', '.', get_class($this->notifiable)).'.'.$this->notifiable->getKey();    
+        } else {
+            return str_replace('\\', '.', get_class($this->notifiable)).'.'.$this->notifiable->getKey();
+        }
     }
 }

--- a/src/Illuminate/Notifications/Events/BroadcastNotificationCreated.php
+++ b/src/Illuminate/Notifications/Events/BroadcastNotificationCreated.php
@@ -79,7 +79,7 @@ class BroadcastNotificationCreated implements ShouldBroadcast
     {
         if (method_exists($this->notifiable, 'getNotificationChannel')) {
             return $this->notifiable->getNotificationChannel();
-        } 
+        }
         
         return str_replace('\\', '.', get_class($this->notifiable)).'.'.$this->notifiable->getKey();       
     }


### PR DESCRIPTION
I don't like to expose the User.id in my public JavaScript files.
I use Hashid's to hash the user id but then i came across the issue that my Notifiable object could not specify a custom channel it should use to broadcast on. This change allows the Notifiable specify a custom channel.

This is a re-submit of [#15593](https://github.com/laravel/framework/pull/15593#issuecomment-249891223)
