### PR TITLE
Upgrade guzzlehttp/guzzle suggested version.

### DIFF
--- a/src/Illuminate/Console/composer.json
+++ b/src/Illuminate/Console/composer.json
@@ -31,7 +31,7 @@
         }
     },
     "suggest": {
-        "guzzlehttp/guzzle": "Required to use the ping methods on schedules (~5.3|~6.0).",
+        "guzzlehttp/guzzle": "Required to use the ping methods on schedules (~5.3|~6.2.1).",
         "mtdowling/cron-expression": "Required to use scheduling component (~1.0).",
         "symfony/process": "Required to use scheduling component (3.1.*)."
     },

--- a/src/Illuminate/Mail/composer.json
+++ b/src/Illuminate/Mail/composer.json
@@ -33,7 +33,7 @@
     },
     "suggest": {
         "aws/aws-sdk-php": "Required to use the SES mail driver (~3.0).",
-        "guzzlehttp/guzzle": "Required to use the Mailgun and Mandrill mail drivers (~5.3|~6.0).",
+        "guzzlehttp/guzzle": "Required to use the Mailgun and Mandrill mail drivers (~5.3|~6.2.1).",
         "jeremeamia/superclosure": "Required to be able to serialize closures (~2.0)."
     },
     "minimum-stability": "dev"


### PR DESCRIPTION
Version `6.2.1` fix HTTP_PROXY security vulnerability : CVE-2016-5385

---

See : https://github.com/guzzle/guzzle/releases/tag/6.2.1
