### PR TITLE
[5.3] Change visibility of Illuminate\Routing\Route::getController() to public

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -195,7 +195,7 @@ class Route
      *
      * @return mixed
      */
-    protected function getController()
+    public function getController()
     {
         list($class) = explode('@', $this->action['uses']);
 


### PR DESCRIPTION
My use case is the following :

When Customizing The Resolution Logic of route model binding i can do something like this :

``` php
Route::bind('data_set', function ($value) {
    $route = Route::getCurrentRoute();

    // If the request is coming from an admin controller
    if( $route->getController() instanceof AdminBaseController )
    {
        return 'Custom logic for model binding resolution in the admin area of the website';
    }

    // If the request is coming from api controller
    if( $route->getController() instanceof ApiBaseController )
    {
        return 'Custom logic for model binding resolution in the api';
    }

    //For any other request find or fail
    return DataSet::findOrFail($value);
});
```
