### PR TITLE
[5.3] Granular notification queue jobs

### DIFF
--- a/src/Illuminate/Notifications/SendQueuedNotifications.php
+++ b/src/Illuminate/Notifications/SendQueuedNotifications.php
@@ -25,14 +25,23 @@ class SendQueuedNotifications implements ShouldQueue
     protected $notification;
 
     /**
+     * All of the channels to send the notification too.
+     *
+     * @var array
+     */
+    protected $channels = null;
+
+    /**
      * Create a new job instance.
      *
      * @param  \Illuminate\Support\Collection  $notifiables
      * @param  \Illuminate\Notifications\Notification  $notification
+     * @param  array  $channels
      * @return void
      */
-    public function __construct($notifiables, $notification)
+    public function __construct($notifiables, $notification, array $channels = null)
     {
+        $this->channels = $channels;
         $this->notifiables = $notifiables;
         $this->notification = $notification;
     }
@@ -45,6 +54,6 @@ class SendQueuedNotifications implements ShouldQueue
      */
     public function handle(ChannelManager $manager)
     {
-        $manager->sendNow($this->notifiables, $this->notification);
+        $manager->sendNow($this->notifiables, $this->notification, $this->channels);
     }
 }

--- a/tests/Notifications/NotificationSendQueuedNotificationTest.php
+++ b/tests/Notifications/NotificationSendQueuedNotificationTest.php
@@ -13,7 +13,7 @@ class NotificationSendQueuedNotificationTest extends PHPUnit_Framework_TestCase
     {
         $job = new SendQueuedNotifications('notifiables', 'notification');
         $manager = Mockery::mock('Illuminate\Notifications\ChannelManager');
-        $manager->shouldReceive('sendNow')->once()->with('notifiables', 'notification');
+        $manager->shouldReceive('sendNow')->once()->with('notifiables', 'notification', null);
         $job->handle($manager);
     }
 }


### PR DESCRIPTION
This tweaks notification queued job to queue a job for each notifiable
/ channel combination. The reason for this is with the prior setup of
using a single job, if one channel fails to send and the job retries
all channels you could deliver duplicate/N number of notifications on a
given channel, possibly costing you money if the channel charges money
per notification.
