### PR TITLE
[5.3] Fix case of: If a comment contains a single '

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -777,7 +777,7 @@ class MySqlGrammar extends Grammar
     protected function modifyComment(Blueprint $blueprint, Fluent $column)
     {
         if (! is_null($column->comment)) {
-            return " comment '".$column->comment."'";
+            return ' comment '.parent::wrapValue($column->comment);
         }
     }
 


### PR DESCRIPTION
My comments had a single ' and were causing migrate failures. Fixed by using Grammar.php's wrapValue.
