### PR TITLE
[5.3] Added fix for QueryBuilder::insert to handle missing properties in values array

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2088,10 +2088,16 @@ class Builder
             return true;
         }
 
+        $allKeys = [];
+
         // Since every insert gets treated like a batch insert, we will make sure the
         // bindings are structured in a way that is convenient for building these
         // inserts statements by verifying the elements are actually an array.
+        //
+        // We do this by finding all keys that are used in all records present in the input array
+        // and then iterating through each key when creating bindings
         if (! is_array(reset($values))) {
+            $allKeys = array_keys($values);
             $values = [$values];
         }
 
@@ -2099,20 +2105,32 @@ class Builder
         // bindings are structured in a way that is convenient for building these
         // inserts statements by verifying the elements are actually an array.
         else {
-            foreach ($values as $key => $value) {
-                ksort($value);
-                $values[$key] = $value;
-            }
+            $allKeys = array_unique(
+                array_reduce(
+                    array_map('array_keys', $values),
+                    'array_merge', []
+                )
+            );
         }
+
+        ksort($allKeys);
 
         // We'll treat every insert like a batch insert so we can easily insert each
         // of the records into the database consistently. This will make it much
         // easier on the grammars to just handle one type of record insertion.
         $bindings = [];
 
-        foreach ($values as $record) {
-            foreach ($record as $value) {
-                $bindings[] = $value;
+        foreach ($values as $index => $record) {
+            foreach($allKeys as $key) {
+                if(isset($record[$key])) {
+                    $bindings[] = $record[$key];
+                } else {
+                    $bindings[] = null;
+
+                    // add null to existing values array to ensure placeholders are entered correctly
+                    $record[$key] = null;
+                    $values[$index] = $record;
+                }
             }
         }
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2121,8 +2121,8 @@ class Builder
         $bindings = [];
 
         foreach ($values as $index => $record) {
-            foreach($allKeys as $key) {
-                if(isset($record[$key])) {
+            foreach ($allKeys as $key) {
+                if (isset($record[$key])) {
                     $bindings[] = $record[$key];
                 } else {
                     $bindings[] = null;

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1173,6 +1173,22 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($result);
     }
 
+    public function testSQLiteMultipleInsertsWithSomeRecordKeysMissing()
+    {
+        $builder = $this->getSQLiteBuilder();
+        $builder->getConnection()->shouldReceive('insert')->once()->with('insert into "users" ("email", "name") select ? as "email", ? as "name" union all select ? as "email", ? as "name"', ['foo', 'taylor', null, 'dayle'])->andReturn(true);
+        $result = $builder->from('users')->insert([['email' => 'foo', 'name' => 'taylor'], ['name' => 'dayle']]);
+        $this->assertTrue($result);
+    }
+
+    public function testMultipleInsertsWithSomeRecordKeysMissing()
+    {
+        $builder = $this->getBuilder();
+        $builder->getConnection()->shouldReceive('insert')->once()->with('insert into "users" ("email", "name") values (?, ?), (?, ?)', ['foo', 'taylor', null, 'dayle'])->andReturn(true);
+        $result = $builder->from('users')->insert([['email' => 'foo', 'name' => 'taylor'], ['name' => 'dayle']]);
+        $this->assertTrue($result);
+    }
+
     public function testInsertGetIdMethod()
     {
         $builder = $this->getBuilder();


### PR DESCRIPTION
Currently, if you call the insert() method and pass in multiple records, where one or more records are missing keys, the query builder does not correctly create placeholders, nor bind the correct values. You can end up with shifted values i.e. the values for key A might end up being placed in key B in the query.

This fix allows you to enter i.e. [
 [ k1 => v1, k2 => v2 ],
 [ k2 => v3 ]
], and the query will correctly insert the second record with k2 == v3 assuming the schema constraints allow it, adding a placeholder for k1 and binding NULL in the prepared statement.

I feel like this is a better end user API than requiring the user to pass in property => null for any missing but optional properties in the input array.

Have added two test conditions (one for SQLite and one for standard insert grammar) to handle this case.
