### PR TITLE
[5.3] Fix sending empty input fields as null inputs when running tests

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithPages.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithPages.php
@@ -693,6 +693,10 @@ trait InteractsWithPages
     {
         $files = $form->getFiles();
 
+        $files = array_filter($files, function ($name) use ($uploads) {
+            return isset($uploads[$name]);
+        }, ARRAY_FILTER_USE_KEY);
+
         $names = array_keys($files);
 
         $files = array_map(function (array $file, $name) use ($uploads) {


### PR DESCRIPTION
Added a filter to get only the file inputs called with `this->attach(input, value)`

> Note: This only happens when running tests.

If you are submitting a form that has input file fields and don't attach any file on those inputs
**it will send those as normal inputs with a value of null** causing a validation exception if any of
those fields have a validation rule of any kind (except required, that will be obvious).

I think there is no use in sending empty file fields as normal inputs with a value of null.

This happens because on how validation of null fields are handled now in 5.3.

If you don't expect those fields to be nullable, you'll have to add the 'nullable' validation rule to
make your test pass.

This filter prevents sending empty input file fields as normal inputs with a null value.

File inputs in an html form...

```
// within an html form in a view
<input type="file" name="front_photo">
<input type="file" name="back_photo">
<input type="file" name="left_photo">
<input type="file" name="right_photo">
<input type="submit" value="submit">
```

Test submitting the form...

```
// within a test class method...
$this->attach('path-to-file.ext', 'front_photo');

$this->press('submit');
```

Inspecting the input within the controller with `dd($request->all())`...

```
// without the filter i get:
[
    back_photo => null
    left_photo => null
    right_photo => null
]

// with the filter i get:
[]
```
