### PR TITLE
[5.3] Collection::only() with null returns all

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -196,7 +196,7 @@ class Collection extends BaseCollection implements QueueableCollection
     public function only($keys)
     {
         if (is_null($keys)) {
-            return $this;
+            return new static($this->items);
         }
 
         $dictionary = Arr::only($this->getDictionary(), $keys);

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -195,6 +195,10 @@ class Collection extends BaseCollection implements QueueableCollection
      */
     public function only($keys)
     {
+        if (is_null($keys)) {
+            return $this;
+        }
+
         $dictionary = Arr::only($this->getDictionary(), $keys);
 
         return new static(array_values($dictionary));

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -698,6 +698,10 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      */
     public function only($keys)
     {
+        if (is_null($keys)) {
+            return $this;
+        }
+
         $keys = is_array($keys) ? $keys : func_get_args();
 
         return new static(Arr::only($this->items, $keys));

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -699,7 +699,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     public function only($keys)
     {
         if (is_null($keys)) {
-            return $this;
+            return new static($this->items);
         }
 
         $keys = is_array($keys) ? $keys : func_get_args();

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -233,6 +233,7 @@ class DatabaseEloquentCollectionTest extends PHPUnit_Framework_TestCase
 
         $c = new Collection([$one, $two, $three]);
 
+        $this->assertEquals($c, $c->only(null));
         $this->assertEquals(new Collection([$one]), $c->only(1));
         $this->assertEquals(new Collection([$two, $three]), $c->only([2, 3]));
     }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1338,6 +1338,7 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
     {
         $data = new Collection(['first' => 'Taylor', 'last' => 'Otwell', 'email' => 'taylorotwell@gmail.com']);
 
+        $this->assertEquals($data->all(), $data->only(null)->all());
         $this->assertEquals(['first' => 'Taylor'], $data->only(['first', 'missing'])->all());
         $this->assertEquals(['first' => 'Taylor'], $data->only('first', 'missing')->all());
 


### PR DESCRIPTION
This comes in handy when using scopes or filters that can be reused for a lot of scenarios where you may or may not want to limit the results.

``` php
collect(['one' => 1, 'two' => 2, 'three' => 3])->only(null)->all(); 
// ['one' => 1, 'two' => 2, 'three' => 3]
```

For example, this already currently works for `Collection::take()`, which has come in handy:

``` php
collect(['one' => 1, 'two' => 2, 'three' => 3])->take(null)->all();
// ['one' => 1, 'two' => 2, 'three' => 3]
```
