### PR TITLE
[5.3] Dump the passed variables and continue the script.

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -486,6 +486,21 @@ if (! function_exists('data_set')) {
     }
 }
 
+if (! function_exists('dc')) {
+    /**
+     * Dump the passed variables and continue the script.
+     *
+     * @param  mixed
+     * @return void
+     */
+    function dc()
+    {
+        array_map(function ($x) {
+            (new Dumper)->dump($x);
+        }, func_get_args());
+    }
+}
+
 if (! function_exists('dd')) {
     /**
      * Dump the passed variables and end the script.
@@ -495,9 +510,7 @@ if (! function_exists('dd')) {
      */
     function dd()
     {
-        array_map(function ($x) {
-            (new Dumper)->dump($x);
-        }, func_get_args());
+        dc(...func_get_args());
 
         die(1);
     }


### PR DESCRIPTION
The `dd()` function is very useful. Dump the given variables it's very simple::

``` php
dd('expression');
```

![2016-09-30_23h06_10](https://cloud.githubusercontent.com/assets/1490347/19011078/821abc3e-8762-11e6-86a2-7e5f8ade8fb9.png)

But in some use cases we need to dump the variables and continue to the next expression.
In this case we use the `dump()` function. The difference here is that it displays the other style

``` php
$items= ['StartSession', 'EndSession'];

foreach($items as $item){
    dump($item);
}
```

![2016-09-30_23h02_24](https://cloud.githubusercontent.com/assets/1490347/19011050/fc38082e-8761-11e6-98af-815ac903c9d8.png)

This pull request add the `dc()` function (dump and continue). It will keep laravel style and syntax similar to `dd()` function.

``` php
$items= ['StartSession', 'EndSession'];

foreach($items as $item){
    dc($item);
}
```

![2016-09-30_23h04_43](https://cloud.githubusercontent.com/assets/1490347/19011068/4c2306f4-8762-11e6-902e-7ddf3e3e0d9c.png)
