### PR TITLE
[5.4] fix Call to undefined method resourcePath()

### DIFF
--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -68,7 +68,7 @@ abstract class ServiceProvider
      */
     protected function loadViewsFrom($path, $namespace)
     {
-        if (is_dir($appPath = $this->app->resourcePath().'/views/vendor/'.$namespace)) {
+        if (is_dir($appPath = $this->app->basePath().'/resources/views/vendor/'.$namespace)) {
             $this->app['view']->addNamespace($namespace, $appPath);
         }
 


### PR DESCRIPTION
lumen 5.3 app doesn't have `resourcePath` method, use `basePath` instead

> [2016-10-02 15:14:43] lumen.ERROR: Symfony\Component\Debug\Exception\FatalThrowableError: Call to undefined method Laravel\Lumen\Application::resourcePath() in /var/www/proj1/vendor/laravel/framework/src/Illuminate/Support/ServiceProvider.php:71
> Stack trace:
> # 0 /var/www/proj1/vendor/laravel/framework/src/Illuminate/Pagination/PaginationServiceProvider.php(16): Illuminate\Support\ServiceProvider->loadViewsFrom('/var/www/proj1-...', 'pagination')
> # 1 [internal function]: Illuminate\Pagination\PaginationServiceProvider->boot()
> # 2 /var/www/proj1/vendor/laravel/framework/src/Illuminate/Container/Container.php(508): call_user_func_array(Array, Array)
> # 3 /var/www/proj1/vendor/laravel/lumen-framework/src/Application.php(177): Illuminate\Container\Container->call(Array)
> # 4 /var/www/proj1/vendor/laravel/lumen-framework/src/Application.php(563): Laravel\Lumen\Application->register(Object(Illuminate\Pagination\PaginationServiceProvider))
> # 5 /var/www/proj1/vendor/laravel/lumen-framework/src/Application.php(315): Laravel\Lumen\Application->loadComponent('database', Array, 'db')
> # 6 /var/www/proj1/vendor/laravel/framework/src/Illuminate/Container/Container.php(746): Laravel\Lumen\Application->Laravel\Lumen{closure}(Object(Laravel\Lumen\Application), Array)
> # 7 /var/www/proj1/vendor/laravel/framework/src/Illuminate/Container/Container.php(644): Illuminate\Container\Container->build(Object(Closure), Array)
> # 8 /var/www/proj1/vendor/laravel/lumen-framework/src/Application.php(211): Illuminate\Container\Container->make('db', Array)
> # 9 /var/www/proj1/vendor/laravel/lumen-framework/src/Application.php(674): Laravel\Lumen\Application->make('db')
> # 10 /var/www/proj1/bootstrap/app.php(41): Laravel\Lumen\Application->withEloquent()
> # 11 /var/www/proj1/public/index.php(14): require('/var/www/proj1-...')
> # 12 {main}
