### PR TITLE
Fixed bug css, js about auth views (css, js not loaded)

### DIFF
--- a/src/Illuminate/Auth/Console/stubs/make/views/layouts/app.stub
+++ b/src/Illuminate/Auth/Console/stubs/make/views/layouts/app.stub
@@ -11,7 +11,7 @@
     <title>{{ config('app.name', 'Laravel') }}</title>
 
     <!-- Styles -->
-    <link href="/css/app.css" rel="stylesheet">
+    <link href="css/app.css" rel="stylesheet">
 
     <!-- Scripts -->
     <script>
@@ -80,6 +80,6 @@
     @yield('content')
 
     <!-- Scripts -->
-    <script src="/js/app.js"></script>
+    <script src="js/app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
When you start the command
`php artisan make:auth`

We have all our files related to authentication. the problem is that If we use the routes managed by the command, files css/app.css and js/app.js are not loaded.

**Exemple** : your-website.com/public/register
![register](https://cloud.githubusercontent.com/assets/6777193/19021836/650878d4-88ca-11e6-9efa-2f231345d392.png)

The problem only comes from '**/**' before each name folder. If we remove it, we have our views with their css and js.
![capture d ecran 2016-10-02 a 18 05 05](https://cloud.githubusercontent.com/assets/6777193/19021862/ce05a96a-88ca-11e6-884f-f48f0e8a72d3.png)
