### PR TITLE
Update Pivot.php

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Pivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Pivot.php
@@ -29,6 +29,11 @@ class Pivot extends Model
     protected $otherKey;
 
     /**
+    * Timestamps for pivot table
+    */
+    protected $timestamps = false;
+    
+    /**
      * The attributes that aren't mass assignable.
      *
      * @var array


### PR DESCRIPTION
When pivot table is serialised, it looks for timestamps property for whether to include created_at and updated_at fields. Since it's not there, it fails with 'Undefined property'
