### PR TITLE
Update Pivot.php

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Pivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Pivot.php
@@ -15,6 +15,10 @@ class Pivot extends Model
     protected $parent;
 
     /**
+    * Whether to use timestamps
+    */
+    public $timestamps;
+    /**
      * The name of the foreign key column.
      *
      * @var string


### PR DESCRIPTION
When pivot table is serialised, it looks for timestamps property for whether to include created_at and updated_at fields. Since it's not there, it fails with 'Undefined property'
