### PR TITLE
[5.3] Notifications id column type

### DIFF
--- a/src/Illuminate/Notifications/Console/stubs/notifications.stub
+++ b/src/Illuminate/Notifications/Console/stubs/notifications.stub
@@ -13,7 +13,7 @@ class CreateNotificationsTable extends Migration
     public function up()
     {
         Schema::create('notifications', function (Blueprint $table) {
-            $table->string('id')->primary();
+            $table->uuid('id')->primary();
             $table->string('type');
             $table->morphs('notifiable');
             $table->text('data');


### PR DESCRIPTION
Because notifications `id` column using UUID as primary key and it's length is always fixed wouldn't it be better to use `CHAR(36)` type instead of `VARCHAR(255)`?

_Updated. Using `UUID` type now._
