### PR TITLE
[5.3] Add $when parameter in binding

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -839,7 +839,19 @@ class Router implements RegistrarContract
      */
     protected function performBinding($key, $value, $route)
     {
-        return call_user_func($this->binders[$key], $value, $route);
+        $routes = array_filter($this->binders[$key], function($key) use($route) {
+            return preg_match('#' . str_replace('/', '\/', $key) . '#', $route->getUri());
+        }, ARRAY_FILTER_USE_KEY);
+        if (count($routes) > 1) {
+            $routes = array_filter($routes, function($key) {
+                return $key != '.*';
+            }, ARRAY_FILTER_USE_KEY);
+        }
+        $binder = array_first($routes);
+        if (is_null($binder)) {
+            return $value;
+        }
+        return call_user_func($binder, $value, $route);
     }
 
     /**
@@ -933,11 +945,12 @@ class Router implements RegistrarContract
      * @param  string  $key
      * @param  string  $class
      * @param  \Closure|null  $callback
+     * @param  string|null  $when
      * @return void
      *
      * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
      */
-    public function model($key, $class, Closure $callback = null)
+    public function model($key, $class, Closure $callback = null, $when = null)
     {
         $this->bind($key, function ($value) use ($class, $callback) {
             if (is_null($value)) {
@@ -961,7 +974,7 @@ class Router implements RegistrarContract
             }
 
             throw (new ModelNotFoundException)->setModel($class);
-        });
+        }, $when);
     }
 
     /**
@@ -969,15 +982,19 @@ class Router implements RegistrarContract
      *
      * @param  string  $key
      * @param  string|callable  $binder
+     * @param  string  $when
      * @return void
      */
-    public function bind($key, $binder)
+    public function bind($key, $binder, $when = null)
     {
         if (is_string($binder)) {
             $binder = $this->createClassBinding($binder);
         }
-
-        $this->binders[str_replace('-', '_', $key)] = $binder;
+        $key = str_replace('-', '_', $key);
+        if (!isset($this->binders[$key])) {
+            $this->binders[$key] = [];
+        }
+        $this->binders[$key][is_null($when) ? '.*' : $when] = $binder;
     }
 
     /**

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -582,6 +582,30 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('TAYLOR', $router->dispatch(Request::create('foo/taylor', 'GET'))->getContent());
     }
 
+    public function testRouteBindingWithWhen()
+    {
+        $router = $this->getRouter();
+        $router->get('foo/{bar}', ['middleware' => SubstituteBindings::class, 'uses' => function ($name) {
+            return $name;
+        }]);
+        $router->bind('bar', function ($value) {
+            return strtoupper($value);
+        }, 'foo/.*');
+        $this->assertEquals('TAYLOR', $router->dispatch(Request::create('foo/taylor', 'GET'))->getContent());
+    }
+
+    public function testRouteBindingWithWhenOtherWhen()
+    {
+        $router = $this->getRouter();
+        $router->get('foo/{bar}', ['middleware' => SubstituteBindings::class, 'uses' => function ($name) {
+            return $name;
+        }]);
+        $router->bind('bar', function ($value) {
+            return strtoupper($value);
+        }, 'blah/.*');
+        $this->assertEquals('taylor', $router->dispatch(Request::create('foo/taylor', 'GET'))->getContent());
+    }
+
     public function testRouteClassBinding()
     {
         $router = $this->getRouter();
@@ -590,6 +614,26 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase
         }]);
         $router->bind('bar', 'RouteBindingStub');
         $this->assertEquals('TAYLOR', $router->dispatch(Request::create('foo/taylor', 'GET'))->getContent());
+    }
+
+    public function testRouteClassBindingWithWhen()
+    {
+        $router = $this->getRouter();
+        $router->get('foo/{bar}', ['middleware' => SubstituteBindings::class, 'uses' => function ($name) {
+            return $name;
+        }]);
+        $router->bind('bar', 'RouteBindingStub', 'foo/.*');
+        $this->assertEquals('TAYLOR', $router->dispatch(Request::create('foo/taylor', 'GET'))->getContent());
+    }
+
+    public function testRouteClassBindingWithWhenOtherWhen()
+    {
+        $router = $this->getRouter();
+        $router->get('foo/{bar}', ['middleware' => SubstituteBindings::class, 'uses' => function ($name) {
+            return $name;
+        }]);
+        $router->bind('bar', 'RouteBindingStub', 'blah/.*');
+        $this->assertEquals('taylor', $router->dispatch(Request::create('foo/taylor', 'GET'))->getContent());
     }
 
     public function testRouteClassMethodBinding()


### PR DESCRIPTION
Sometimes, you have clashes with name binding. 
If you have the following code

``` php
Router::get('/news/{category}', ...);
Router::get('/faqs/{category}', ...);
```

You will not be able to bind `category` to load your news category or your faq category.

This PR adds a third parameter to `Router::bind` and `Router::model`. This `$when` parameter allows you to add a regex which will match your route. 
You will be able to specify the regex matching your route

``` php
Router::bind('category', function($value) {return ...}, 'news/.*');
Router::model('category', Faq\Category::class, 'faqs/.*');
```

The PR includes test coverage.
