### PR TITLE
[5.3] Make sure the correct return type is used

### DIFF
--- a/src/Illuminate/Auth/Access/Response.php
+++ b/src/Illuminate/Auth/Access/Response.php
@@ -34,7 +34,7 @@ class Response
     /**
      * Get the string representation of the message.
      *
-     * @return string
+     * @return string|nulls
      */
     public function __toString()
     {

--- a/src/Illuminate/Auth/Access/Response.php
+++ b/src/Illuminate/Auth/Access/Response.php
@@ -34,7 +34,7 @@ class Response
     /**
      * Get the string representation of the message.
      *
-     * @return string|nulls
+     * @return string|null
      */
     public function __toString()
     {


### PR DESCRIPTION
The `__toString` method might return `null` since the `message` function might return `null`.

I think we can do two things here. Update the docs or update the code and check for `null`
