### PR TITLE
[5.3] Add soft deletes timestamp with timezone to database blueprint

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -317,6 +317,16 @@ class Blueprint
     }
 
     /**
+     * Indicate that the soft delete column should be dropped.
+     *
+     * @return void
+     */
+    public function dropSoftDeletesTz()
+    {
+        $this->dropSoftDeletes();
+    }
+
+    /**
      * Indicate that the remember token column should be dropped.
      *
      * @return void
@@ -819,6 +829,16 @@ class Blueprint
     public function softDeletes()
     {
         return $this->timestamp('deleted_at')->nullable();
+    }
+
+    /**
+     * Add a "deleted at" timestampTz for the table.
+     *
+     * @return \Illuminate\Support\Fluent
+     */
+    public function softDeletesTz()
+    {
+        return $this->timestampTz('deleted_at')->nullable();
     }
 
     /**


### PR DESCRIPTION
Adds consistency when working with `softDeletes()` and timestamps with timezones.
- Creates methods `softDeletesTz()` and `dropSoftDeletesTz()` to database migration blueprint.
- Utilizes existing `timestampTz()` methods for testing purposes.

If there are some tests that anyone feels should be written for this, please advise. Due to the nature of utilizing the `timestampTz()` method, I felt it wasn't needed.
