### PR TITLE
[5.4] Add model only and except methods

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -3067,6 +3067,34 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     }
 
     /**
+     * Get a subset of the attributes.
+     *
+     * @param array $keys
+     *
+     * @return array
+     */
+    public function only($keys = [])
+    {
+        $keys = is_array($keys) ? $keys : func_get_args();
+
+        return Arr::only($this->attributesToArray(), $keys);
+    }
+
+    /**
+     * Get all of the attributes except the specified keys.
+     *
+     * @param array $keys
+     *
+     * @return array
+     */
+    public function except($keys = [])
+    {
+        $keys = is_array($keys) ? $keys : func_get_args();
+
+        return Arr::except($this->attributesToArray(), $keys);
+    }
+
+    /**
      * Get all of the current attributes on the model.
      *
      * @return array

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -3077,7 +3077,17 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     {
         $keys = is_array($keys) ? $keys : func_get_args();
 
-        return Arr::only($this->attributesToArray(), $keys);
+        $result = [];
+
+        foreach ($keys as $key) {
+            $value = $this->getAttribute($key);
+
+            if (! is_null($value)) {
+                $result[$key] = $value;
+            }
+        }
+
+        return $result;
     }
 
     /**

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -31,6 +31,26 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(json_encode(['name' => 'taylor']), $attributes['list_items']);
     }
 
+    public function testOnly()
+    {
+        $model = new EloquentModelStub(['foo' => '1', 'bar' => 2, 'baz' => 3]);
+
+        $this->assertEquals(['foo' => '1'], $model->only('foo'));
+        $this->assertEquals(['foo' => '1', 'bar' => 2], $model->only('foo', 'bar'));
+        $this->assertEquals(['foo' => '1', 'bar' => 2], $model->only(['foo', 'bar']));
+        $this->assertEquals(['foo' => '1', 'bar' => 2, 'baz' => 3], $model->only(['foo', 'bar', 'baz']));
+    }
+
+    public function testExcept()
+    {
+        $model = new EloquentModelStub(['foo' => '1', 'bar' => 2, 'baz' => 3]);
+
+        $this->assertEquals(['bar' => 2, 'baz' => 3], $model->except('foo'));
+        $this->assertEquals(['baz' => 3], $model->except('foo', 'bar'));
+        $this->assertEquals(['baz' => 3], $model->except(['foo', 'bar']));
+        $this->assertEquals([], $model->except(['foo', 'bar', 'baz']));
+    }
+
     public function testDirtyAttributes()
     {
         $model = new EloquentModelStub(['foo' => '1', 'bar' => 2, 'baz' => 3]);


### PR DESCRIPTION
Any suggestions on how to avoid making the `except` method load in every relation, even when not requested? Would rather use the existing functionality if it exists instead of creating a new method.
