### PR TITLE
[5.3] Add given guards to AuthenticationException

### DIFF
--- a/src/Illuminate/Auth/AuthenticationException.php
+++ b/src/Illuminate/Auth/AuthenticationException.php
@@ -7,7 +7,7 @@ use Exception;
 class AuthenticationException extends Exception
 {
     /**
-     * Array of the given guards
+     * Array of the given guards.
      *
      * @var array
      */
@@ -24,7 +24,7 @@ class AuthenticationException extends Exception
     }
 
     /**
-     * Set the given guards
+     * Set the given guards.
      *
      * @param array $guards
      * @return $this
@@ -37,7 +37,7 @@ class AuthenticationException extends Exception
     }
 
     /**
-     * Get the given guards
+     * Get the given guards.
      *
      * @return array
      */

--- a/src/Illuminate/Auth/AuthenticationException.php
+++ b/src/Illuminate/Auth/AuthenticationException.php
@@ -7,6 +7,13 @@ use Exception;
 class AuthenticationException extends Exception
 {
     /**
+     * Array of the given guards
+     *
+     * @var array
+     */
+    protected $guards;
+
+    /**
      * Create a new authentication exception.
      *
      * @param string  $message
@@ -14,5 +21,28 @@ class AuthenticationException extends Exception
     public function __construct($message = 'Unauthenticated.')
     {
         parent::__construct($message);
+    }
+
+    /**
+     * Set the given guards
+     *
+     * @param array $guards
+     * @return $this
+     */
+    public function setGuards(array $guards)
+    {
+        $this->guards = $guards;
+
+        return $this;
+    }
+
+    /**
+     * Get the given guards
+     *
+     * @return array
+     */
+    public function getGuards()
+    {
+        return $this->guards;
     }
 }

--- a/src/Illuminate/Auth/Middleware/Authenticate.php
+++ b/src/Illuminate/Auth/Middleware/Authenticate.php
@@ -63,6 +63,6 @@ class Authenticate
             }
         }
 
-        throw new AuthenticationException;
+        throw (new AuthenticationException)->setGuards($guards);
     }
 }

--- a/tests/Auth/AuthenticateMiddlewareTest.php
+++ b/tests/Auth/AuthenticateMiddlewareTest.php
@@ -46,8 +46,10 @@ class AuthenticateMiddlewareTest extends PHPUnit_Framework_TestCase
             $this->authenticate('default');
         } catch (AuthenticationException $e) {
             $this->assertContains('default', $e->getGuards());
+
             return;
         }
+
         return $this->fail();
     }
 
@@ -94,8 +96,10 @@ class AuthenticateMiddlewareTest extends PHPUnit_Framework_TestCase
             $this->authenticate(...$expectedGuards);
         } catch (AuthenticationException $e) {
             $this->assertEquals($expectedGuards, $e->getGuards());
+
             return;
         }
+
         return $this->fail();
     }
 

--- a/tests/Auth/AuthenticateMiddlewareTest.php
+++ b/tests/Auth/AuthenticateMiddlewareTest.php
@@ -38,6 +38,19 @@ class AuthenticateMiddlewareTest extends PHPUnit_Framework_TestCase
         $this->authenticate();
     }
 
+    public function testDefaultUnauthenticatedThrowsWithGuards()
+    {
+        try {
+            $this->registerAuthDriver('default', false);
+
+            $this->authenticate('default');
+        } catch (AuthenticationException $e) {
+            $this->assertContains('default', $e->getGuards());
+            return;
+        }
+        return $this->fail();
+    }
+
     public function testDefaultAuthenticatedKeepsDefaultDriver()
     {
         $driver = $this->registerAuthDriver('default', true);
@@ -67,6 +80,23 @@ class AuthenticateMiddlewareTest extends PHPUnit_Framework_TestCase
         $this->registerAuthDriver('secondary', false);
 
         $this->authenticate('default', 'secondary');
+    }
+
+    public function testMultipleDriversUnauthenticatedThrowsWithGuards()
+    {
+        $expectedGuards = ['default', 'secondary'];
+
+        try {
+            $this->registerAuthDriver('default', false);
+
+            $this->registerAuthDriver('secondary', false);
+
+            $this->authenticate(...$expectedGuards);
+        } catch (AuthenticationException $e) {
+            $this->assertEquals($expectedGuards, $e->getGuards());
+            return;
+        }
+        return $this->fail();
     }
 
     public function testMultipleDriversAuthenticatedUdatesDefault()


### PR DESCRIPTION
This is the default handler for `AuthenticationException` in `laravel/laravel`

``` php
    protected function unauthenticated($request, AuthenticationException $exception)
    {
        if ($request->expectsJson()) {
            return response()->json(['error' => 'Unauthenticated.'], 401);
        }

        return redirect()->guest('login');
    }
```

Currently, there is no way to determine which guards are given when the exception is thrown. The PR add a setter / getter of guards to AuthenticationException.
