### PR TITLE
[5.3] Add model methods only and except

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -3077,17 +3077,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     {
         $keys = is_array($keys) ? $keys : func_get_args();
 
-        $result = [];
-
-        foreach ($keys as $key) {
-            $value = $this->getAttribute($key);
-
-            if (! is_null($value)) {
-                $result[$key] = $value;
-            }
-        }
-
-        return $result;
+        return Arr::only($this->attributesToArray(), $keys);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -3067,6 +3067,44 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     }
 
     /**
+     * Get a subset of the attributes.
+     *
+     * @param array $keys
+     *
+     * @return array
+     */
+    public function only($keys = [])
+    {
+        $keys = is_array($keys) ? $keys : func_get_args();
+
+        $result = [];
+
+        foreach ($keys as $key) {
+            $value = $this->getAttribute($key);
+
+            if (! is_null($value)) {
+                $result[$key] = $value;
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * Get all of the attributes except the specified keys.
+     *
+     * @param array $keys
+     *
+     * @return array
+     */
+    public function except($keys = [])
+    {
+        $keys = is_array($keys) ? $keys : func_get_args();
+
+        return Arr::except($this->attributesToArray(), $keys);
+    }
+
+    /**
      * Get a selection of the current attributes on the model.
      *
      * @param array $keys

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -43,6 +43,26 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(['name' => 'taylor'], $model->getAttributes(['name', 'doesntexist']));
     }
 
+    public function testOnly()
+    {
+        $model = new EloquentModelStub(['foo' => '1', 'bar' => 2, 'baz' => 3]);
+
+        $this->assertEquals(['foo' => '1'], $model->only('foo'));
+        $this->assertEquals(['foo' => '1', 'bar' => 2], $model->only('foo', 'bar'));
+        $this->assertEquals(['foo' => '1', 'bar' => 2], $model->only(['foo', 'bar']));
+        $this->assertEquals(['foo' => '1', 'bar' => 2, 'baz' => 3], $model->only(['foo', 'bar', 'baz']));
+    }
+
+    public function testExcept()
+    {
+        $model = new EloquentModelStub(['foo' => '1', 'bar' => 2, 'baz' => 3]);
+
+        $this->assertEquals(['bar' => 2, 'baz' => 3], $model->except('foo'));
+        $this->assertEquals(['baz' => 3], $model->except('foo', 'bar'));
+        $this->assertEquals(['baz' => 3], $model->except(['foo', 'bar']));
+        $this->assertEquals([], $model->except(['foo', 'bar', 'baz']));
+    }
+
     public function testDirtyAttributes()
     {
         $model = new EloquentModelStub(['foo' => '1', 'bar' => 2, 'baz' => 3]);


### PR DESCRIPTION
Feels like `except` might be a bit inefficient because it will load relations even if they are "ignored". Any ideas on how to improve it without replicating `attributesToArray`?
