### PR TITLE
[5.4] Apply policies on subtypes of the configured class

### DIFF
--- a/tests/Auth/AuthAccessGateTest.php
+++ b/tests/Auth/AuthAccessGateTest.php
@@ -155,6 +155,15 @@ class GateTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($gate->check('update', new AccessGateTestSubDummy));
     }
 
+    public function test_policy_classes_handle_checks_for_interfaces()
+    {
+        $gate = $this->getBasicGate();
+
+        $gate->policy(AccessGateTestDummyInterface::class, AccessGateTestPolicy::class);
+
+        $this->assertTrue($gate->check('update', new AccessGateTestSubDummy));
+    }
+
     public function test_policy_converts_dash_to_camel()
     {
         $gate = $this->getBasicGate();
@@ -272,7 +281,12 @@ class AccessGateTestClass
     }
 }
 
-class AccessGateTestDummy
+interface AccessGateTestDummyInterface
+{
+    //
+}
+
+class AccessGateTestDummy implements AccessGateTestDummyInterface
 {
     //
 }

--- a/tests/Auth/AuthAccessGateTest.php
+++ b/tests/Auth/AuthAccessGateTest.php
@@ -146,6 +146,15 @@ class GateTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($gate->check('update', new AccessGateTestDummy));
     }
 
+    public function test_policy_classes_handle_checks_for_all_subtypes()
+    {
+        $gate = $this->getBasicGate();
+
+        $gate->policy(AccessGateTestDummy::class, AccessGateTestPolicy::class);
+
+        $this->assertTrue($gate->check('update', new AccessGateTestSubDummy));
+    }
+
     public function test_policy_converts_dash_to_camel()
     {
         $gate = $this->getBasicGate();
@@ -264,6 +273,11 @@ class AccessGateTestClass
 }
 
 class AccessGateTestDummy
+{
+    //
+}
+
+class AccessGateTestSubDummy extends AccessGateTestDummy
 {
     //
 }


### PR DESCRIPTION
This gives the `Gate` the ability to find the first `Policy` for a given class / object, where this object is either the configured class, extends from it **or implements the configured interface**.
# Example usage

``` php
interface Foo {}
class Bar implements Foo {}
class Baz extends Bar {}

// Previous behavior
Gate::policy(SomePolicy::class, Bar::class);
Gate::check('update', new Bar); // This works, as the policy is bound to Bar::class
Gate::check('update', new Baz); // But not this one!

// Now I can...
Gate::check('update', Baz::class); // as it IS a Bar.

Gate::policy(SomePolicy::class, Foo::class);
Gate::check('update', Bar::class); // It IS a Foo
Gate::check('update', Baz::class); // It IS also a Foo
```
# Backwards compatibility breaks:
- The public method `getPolicyFor($class)` used to throw `InvalidArgumentException` when no policy was found. **Now it returns either a `Policy` or null**. This **was not being used anywhere else** inside the framework, and the `Gate` would never reach the exception itself, as **the argument was always validated beforehand**. 
- The protected method `firstArgumentCorrespondsToPolicy($arguments)` **is gone**, as it duplicated most of the work done in `getPolicyFor($class)`. Now the `Gate` will attempt to get the Policy, and if null is returned, will continue trying as before.
- The protected method `resolvePolicyCallback(...)` now **receives the Policy instead of fetching it**.

Pointing at 5.4 because of all this BC breaks. Let me know if you want me to try other approaches to this, or if it's something you don't plan to support.

Cheers!
