### PR TITLE
[5.4] Update Request::intersect to use array_intersect_key

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -383,7 +383,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
      */
     public function intersect($keys)
     {
-        return array_filter($this->only(is_array($keys) ? $keys : func_get_args()));
+        return array_intersect_key($this->all(), array_flip($keys));
     }
 
     /**

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -260,8 +260,8 @@ class HttpRequestTest extends PHPUnit_Framework_TestCase
 
     public function testIntersectMethod()
     {
-        $request = Request::create('/', 'GET', ['name' => 'Taylor', 'age' => null]);
-        $this->assertEquals(['name' => 'Taylor'], $request->intersect('name', 'age', 'email'));
+        $request = Request::create('/', 'GET', ['a' => 'a', 'b' => '', 'c' => null, 'd' => false, 'e' => 0, 'f' => 'foo']);
+        $this->assertEquals(['a' => 'a', 'b' => '', 'c' => null, 'd' => false, 'e' => 0], $request->intersect(['a', 'b', 'c', 'd', 'e']));
     }
 
     public function testQueryMethod()


### PR DESCRIPTION
This will prevent filtering null and falsy values when using Request intersect.

given

``` json
{
    "foo": " ",
    "bar": null,
    "baz": false
}
```

Before

``` php
Request::intersect('foo', 'bar', 'baz')
// ["foo" => " "]
```

After

``` php
Request::intersect('foo', 'bar', 'baz')
// ["foo" => " ",  "baz" => false]
```

moved from #15417 
