### PR TITLE
[5.3] allow return full word in str_limit

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -149,15 +149,30 @@ class Str
      * @param  string  $value
      * @param  int     $limit
      * @param  string  $end
+     * @param  bool    $fullWord
      * @return string
      */
-    public static function limit($value, $limit = 100, $end = '...')
+    public static function limit($value, $limit = 100, $end = '...', $fullWord = false)
     {
         if (mb_strwidth($value, 'UTF-8') <= $limit) {
             return $value;
         }
 
-        return rtrim(mb_strimwidth($value, 0, $limit, '', 'UTF-8')).$end;
+        $sentence = rtrim(mb_strimwidth($value, 0, $limit, '', 'UTF-8'));
+
+        if (! $fullWord) {
+            return $sentence.$end;
+        }
+        $newLimit = mb_strpos($value, ' ', $limit + 1);
+        if ($newLimit !== false) {
+            $sentence = rtrim(mb_strimwidth($value, 0, $newLimit, '', 'UTF-8'));
+        }
+        $limit = mb_strrpos($sentence, ' ');
+        if ($limit !== false && $newLimit !== false) {
+            $sentence = rtrim(mb_strimwidth($sentence, 0, $limit, '', 'UTF-8'));
+        }
+
+        return $sentence.$end;
     }
 
     /**

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -683,11 +683,12 @@ if (! function_exists('str_limit')) {
      * @param  string  $value
      * @param  int     $limit
      * @param  string  $end
+     * @param  bool    $fullWord
      * @return string
      */
-    function str_limit($value, $limit = 100, $end = '...')
+    function str_limit($value, $limit = 100, $end = '...', $fullWord = false)
     {
-        return Str::limit($value, $limit, $end);
+        return Str::limit($value, $limit, $end, $fullWord);
     }
 }
 

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -274,6 +274,8 @@ class SupportHelpersTest extends PHPUnit_Framework_TestCase
         $string = 'The PHP framework for web artisans.';
         $this->assertEquals('The PHP...', Str::limit($string, 7));
         $this->assertEquals('The PHP', Str::limit($string, 7, ''));
+        $this->assertEquals('The PHP f', Str::limit($string, 9, ''));
+        $this->assertEquals('The PHP', Str::limit($string, 9, '', true));
         $this->assertEquals('The PHP framework for web artisans.', Str::limit($string, 100));
 
         $nonAsciiString = '这是一段中文';


### PR DESCRIPTION
$string='The PHP framework for web artisans.';

str_limit($string, 10, ''); //Result: The PHP fr
str_limit($string, 10, '', true); //Reuslt: The PHP
