### PR TITLE
[5.2] Fix validator digits between

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1132,7 +1132,7 @@ class Validator implements ValidatorContract
     {
         $this->requireParameterCount(2, $parameters, 'digits_between');
 
-        if(! $this->validateNumeric($attribute, $value)){
+        if (! $this->validateNumeric($attribute, $value)){
             return false;
         }
 

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1132,7 +1132,7 @@ class Validator implements ValidatorContract
     {
         $this->requireParameterCount(2, $parameters, 'digits_between');
 
-        if(!$this->validateNumeric($attribute, $value)){
+        if(! $this->validateNumeric($attribute, $value)){
             return false;
         }
 

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1132,10 +1132,13 @@ class Validator implements ValidatorContract
     {
         $this->requireParameterCount(2, $parameters, 'digits_between');
 
+        if(!$this->validateNumeric($attribute, $value)){
+            return false;
+        }
+
         $length = strlen((string) $value);
 
-        return $this->validateNumeric($attribute, $value)
-          && $length >= $parameters[0] && $length <= $parameters[1];
+        return $length >= $parameters[0] && $length <= $parameters[1];
     }
 
     /**

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -939,6 +939,9 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
         $v = new Validator($trans, ['foo' => '123'], ['foo' => 'digits_between:4,5']);
         $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => ['123']], ['foo' => 'digits_between:4,5']);
+        $this->assertFalse($v->passes());
     }
 
     public function testValidateSize()


### PR DESCRIPTION
The digits_between validation rule would checked for numeric value before find length, otherwise if array is passed throw ErrorException with message "Array to string conversion".

in 5.3 should compare with [#14650](https://github.com/laravel/framework/pull/14650)
