### PR TITLE
[5.3] Add SendGrid mail transport

### DIFF
--- a/src/Illuminate/Mail/Transport/SendGridTransport.php
+++ b/src/Illuminate/Mail/Transport/SendGridTransport.php
@@ -1,0 +1,221 @@
+<?php
+
+namespace Illuminate\Mail\Transport;
+
+use Swift_Attachment;
+use Swift_Image;
+use Swift_Mime_Message;
+use GuzzleHttp\ClientInterface;
+
+class SendGridTransport extends Transport
+{
+	/**
+     * Guzzle client instance.
+     *
+     * @var \GuzzleHttp\ClientInterface
+     */
+    protected $client;
+
+    /**
+     * The SendGrid API key.
+     *
+     * @var string
+     */
+    protected $key;
+
+    /**
+     * Create a new SendGrid transport instance.
+     *
+     * @param  \GuzzleHttp\ClientInterface  $client
+     * @param  string  $key
+     */
+    public function __construct(ClientInterface $client, $key)
+    {
+        $this->client = $client;
+        $this->key    = $key;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function send(Swift_Mime_Message $message, &$failedRecipients = null)
+    {
+        $this->beforeSendPerformed($message);
+
+        $this->client->post($this->getUrl(), $this->getOptions($message));
+
+        return $this->numberOfRecipients($message);
+    }
+
+    /**
+     * Get the options array.
+     *
+     * @param  Swift_Mime_Message  $message
+     * @return array
+     */
+    protected function getOptions(Swift_Mime_Message $message)
+    {
+        $options = [
+            'headers' => [
+                'Authorization' => 'Bearer ' . $this->key,
+                'Content-Type'  => 'application/json',
+            ],
+            'json' => [
+                'personalizations' => [
+                    [
+                        'to'  => $this->getTo($message),
+                        'cc'  => $this->getCc($message),
+                        'bcc' => $this->getBcc($message),
+                        'subject' => $message->getSubject(),
+                    ],
+                ],
+                'from'        => $this->getFrom($message),
+                'reply_to'    => $this->getReplyTo($message),
+                'content'     => $this->getContent($message),
+                'attachments' => $this->getAttachments($message),
+            ],
+        ];
+
+        $options = array_filter_recursive($options);
+
+        return $options;
+    }
+
+    /**
+     * Get the "to" payload field for the API request.
+     *
+     * @param  \Swift_Mime_Message $message
+     * @return array
+     */
+    protected function getTo(Swift_Mime_Message $message)
+    {
+        $to = [];
+
+        foreach ((array) $message->getTo() as $email => $name) {
+            $to[] = ['email' => $email, 'name' => $name];
+        }
+
+        return $to;
+    }
+
+    /**
+     * Get the "cc" payload field for the API request.
+     *
+     * @param  Swift_Mime_Message  $message
+     * @return array
+     */
+    protected function getCc(Swift_Mime_Message $message)
+    {
+        $cc = [];
+
+        foreach ((array) $message->getCc() as $email => $name) {
+            $cc[] = ['email' => $email, 'name' => $name];
+        }
+
+        return $cc;
+    }
+
+    /**
+     * Get the "bcc" payload field for the API request.
+     *
+     * @param  Swift_Mime_Message  $message
+     * @return array
+     */
+    protected function getBcc(Swift_Mime_Message $message)
+    {
+        $bcc = [];
+
+        foreach ((array) $message->getBcc() as $email => $name) {
+            $bcc[] = ['email' => $email, 'name' => $name];
+        }
+
+        return $bcc;
+    }
+
+    /**
+     * Get the "from" payload field for the API request.
+     *
+     * @param  Swift_Mime_Message  $message
+     * @return array
+     */
+    protected function getFrom(Swift_Mime_Message $message)
+    {
+        $from = $message->getFrom();
+
+        if ($from) {
+            return ['email' => key($from)];
+        }
+
+        return [];
+    }
+
+    /**
+     * Get the "reply_to" payload field for the API request.
+     *
+     * @param  Swift_Mime_Message  $message
+     * @return array
+     */
+    protected function getReplyTo(Swift_Mime_Message $message)
+    {
+        $replyTo = $message->getReplyTo();
+
+        if ($replyTo) {
+            return ['email' => key($replyTo)];
+        }
+
+        return [];
+    }
+
+    /**
+     * Get the email content.
+     *
+     * @param  Swift_Mime_Message  $message
+     * @return array
+     */
+    protected function getContent(Swift_Mime_Message $message)
+    {
+        $content = [
+            [
+                'type'  => 'text/html',
+                'value' => $message->getBody(),
+            ],
+        ];
+
+        return $content;
+    }
+
+    /**
+     * Get the email attachments.
+     *
+     * @param  Swift_Mime_Message  $message
+     * @return array
+     */
+    protected function getAttachments(Swift_Mime_Message $message)
+    {
+        $attachments = [];
+
+        foreach ($message->getChildren() as $attachment) {
+            if ($attachment instanceof Swift_Attachment || $attachment instanceof Swift_Image) {
+                $attachments[] = [
+                    'content'     => base64_encode($attachment->getBody()),
+                    'type'        => $attachment->getContentType(),
+                    'filename'    => $attachment->getFilename(),
+                    'disposition' => $attachment->getDisposition(),
+                    'content_id'  => $attachment->getId(),
+                ];
+            }
+        }
+
+        return $attachments;
+    }
+
+    /**
+     * Get the API URL.
+     *
+     * @return string
+     */
+    protected function getUrl()
+    {
+        return 'https://api.sendgrid.com/v3/mail/send';
+    }
+}

--- a/src/Illuminate/Mail/TransportManager.php
+++ b/src/Illuminate/Mail/TransportManager.php
@@ -12,6 +12,7 @@ use Illuminate\Mail\Transport\LogTransport;
 use Illuminate\Mail\Transport\SesTransport;
 use Illuminate\Mail\Transport\MailgunTransport;
 use Illuminate\Mail\Transport\MandrillTransport;
+use Illuminate\Mail\Transport\SendGridTransport;
 use Illuminate\Mail\Transport\SparkPostTransport;
 use Swift_SendmailTransport as SendmailTransport;
 
@@ -121,6 +122,16 @@ class TransportManager extends Manager
 
         return new MandrillTransport(
             $this->getHttpClient($config), $config['secret']
+        );
+    }
+
+    protected function createSendGridDriver()
+    {
+        $config = $this->app['config']->get('services.sendgrid', []);
+
+        return new SendGridTransport(
+            $this->getHttpClient($config),
+            $config['key']
         );
     }
 

--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -124,6 +124,26 @@ class Arr
     }
 
     /**
+     * Recursively filter an array.
+     *
+     * @param  array  $array
+     * @param  callable|null  $callback
+     * @return array
+     */
+    public static function filterRecursive($array, callable $callback = null)
+    {
+        $array = is_null($callback) ? array_filter($array) : array_filter($array, $callback);
+
+        foreach ($array as &$value) {
+            if (is_array($value)) {
+                $value = forward_static_call(['self', __FUNCTION__], $value, $callback);
+            }
+        }
+
+        return $array;
+    }
+
+    /**
      * Return the first element in an array passing a given truth test.
      *
      * @param  array  $array

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -98,6 +98,19 @@ if (! function_exists('array_except')) {
     }
 }
 
+if (! function_exists('array_filter_recursive')) {
+    /**
+     * Recursively filter an array.
+     *
+     * @param  array  $array
+     * @param  callable|null  $callback
+     * @return array
+     */
+    function array_filter_recursive(array $array, callable $callback = null) {
+        return Arr::filterRecursive($array, $callback);
+    }
+}
+
 if (! function_exists('array_first')) {
     /**
      * Return the first element in an array passing a given truth test.

--- a/tests/Mail/MailSendGridTransportTest.php
+++ b/tests/Mail/MailSendGridTransportTest.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Mail\TransportManager;
+use Illuminate\Support\Collection;
+
+class MailSendGridTransportTest extends PHPUnit_Framework_TestCase
+{
+    public function testGetTransport()
+    {
+        $app = [
+            'config' => new Collection([
+                'services.sendgrid' => [
+                    'key' => 'foo',
+                ],
+            ]),
+        ];
+
+        $manager   = new TransportManager($app);
+        $transport = $manager->driver('sendgrid');
+
+        $key = $this->readAttribute($transport, 'key');
+
+        $this->assertEquals('foo', $key);
+    }
+}

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -73,6 +73,37 @@ class SupportArrTest extends PHPUnit_Framework_TestCase
         $this->assertFalse(Arr::exists(new Collection(['a' => null]), 'b'));
     }
 
+    public function testFilterRecursive()
+    {
+        $array = [
+            'foo' => [
+                'bar' => [
+                    'baz' => ['a', 'b', 'c'],
+                    'foo' => [
+                        'bar' => [],
+                        'baz' => '',
+                    ],
+                ],
+                'foo' => [],
+                'baz' => [true, false],
+            ],
+        ];
+
+        $expected = [
+            'foo' => [
+                'bar' => [
+                    'baz' => ['a', 'b', 'c'],
+                    'foo' => [],
+                ],
+                'baz' => [true],
+            ],
+        ];
+
+        $array = Arr::filterRecursive($array);
+
+        $this->assertEquals($expected, $array);
+    }
+
     public function testFirst()
     {
         $array = [100, 200, 300];


### PR DESCRIPTION
These commits add support for the SendGrid Web API.

The helper array_filter_recursive was added because the API doesn't accept empty attributes.
So it is necessary for removing empty entries from the options array.
