### PR TITLE
[5.3] Add primary key to migrations table

### DIFF
--- a/src/Illuminate/Database/Migrations/DatabaseMigrationRepository.php
+++ b/src/Illuminate/Database/Migrations/DatabaseMigrationRepository.php
@@ -136,6 +136,8 @@ class DatabaseMigrationRepository implements MigrationRepositoryInterface
             // The migrations table is responsible for keeping track of which of the
             // migrations have actually run for the application. We'll create the
             // table to hold the migration file's path as well as the batch ID.
+            $table->increments('id');
+
             $table->string('migration');
 
             $table->integer('batch');


### PR DESCRIPTION
I recently upgraded my XtraDB cluster and encountered errors when running any migrations. By default now XtraDB cluster ships with strict mode on which requires an **explicit** primary key for all tables.
### Background

XtraDB is a performance-enhanced fork of the InnoDB storage engine. It is the primary engine for both MariaDB and Percona. It is a drop-in replacement.
### The Problem

The latest XtraDB cluster (and I assume Galera cluster) hard fail because they now ship with strict mode on. Every table needs an **explicit** primary key defined. This means out of the box laravel doesn't work with XtraDB cluster/Galera cluster. At the moment this only affects the latest cluster versions but there is talk in the community of rolling this out further to non-clustered versions.
### All InnoDB tables have primary keys

All InnoDB tables actually have primary keys. If the user does not explicitly define a primary key then a hidden 6-byte PK is created. Since most Laravel users are probably on MySQL and the default storage engine is InnoDB, this means we already have a primary key anyway, it's just very inefficient (as tests prove). Further, I don't believe that adding a primary key would affect any of the other db engines supported by Laravel (Postgres, SQLite, SQL Server).
### How to fix and why

We should explicitly state the primary key. This ensures Laravel will work out of the box on clustered setups **and** improves efficiency for all MySQL users as we are no longer using the inefficient hidden PK. In other words, on the majority of setups the PK is there anyway, let's just explicitly define it. This will also help for future proofing if later on explicit primary keys are required in the non-clustered versions. Think back to what a pain NO_ZERO_DATE was.
