### PR TITLE
[5.3] Custom Paginator and LengthAwarePaginator toArray formats

### DIFF
--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -81,6 +81,13 @@ abstract class AbstractPaginator implements Htmlable
     protected static $viewFactoryResolver;
 
     /**
+     * The toArray resolver callback.
+     *
+     * @var \Closure
+     */
+    protected static $toArrayResolver;
+
+    /**
      * The default pagination view.
      *
      * @var string
@@ -386,6 +393,17 @@ abstract class AbstractPaginator implements Htmlable
     public static function viewFactoryResolver(Closure $resolver)
     {
         static::$viewFactoryResolver = $resolver;
+    }
+
+    /**
+     * Set the toArray resolver callback.
+     *
+     * @param  \Closure $callback
+     * @return void
+     */
+    public static function toArrayResolver(Closure $callback)
+    {
+        static::$toArrayResolver = $callback;
     }
 
     /**

--- a/src/Illuminate/Pagination/LengthAwarePaginator.php
+++ b/src/Illuminate/Pagination/LengthAwarePaginator.php
@@ -150,6 +150,10 @@ class LengthAwarePaginator extends AbstractPaginator implements Arrayable, Array
      */
     public function toArray()
     {
+        if (isset(static::$toArrayResolver)) {
+            return call_user_func(static::$toArrayResolver, $this);
+        }
+
         return [
             'total' => $this->total(),
             'per_page' => $this->perPage(),

--- a/src/Illuminate/Pagination/Paginator.php
+++ b/src/Illuminate/Pagination/Paginator.php
@@ -137,6 +137,10 @@ class Paginator extends AbstractPaginator implements Arrayable, ArrayAccess, Cou
      */
     public function toArray()
     {
+        if (isset(static::$toArrayResolver)) {
+            return call_user_func(static::$toArrayResolver, $this);
+        }
+
         return [
             'per_page' => $this->perPage(),
             'current_page' => $this->currentPage(),

--- a/tests/Pagination/PaginationPaginatorTest.php
+++ b/tests/Pagination/PaginationPaginatorTest.php
@@ -126,4 +126,38 @@ class PaginationPaginatorTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals('http://website.com/test?page=1', $p->previousPageUrl());
     }
+
+    public function testSimplePaginatorUsesCustomToArrayResolver()
+    {
+        Paginator::toArrayResolver(function ($paginator) {
+            return [
+                'count' => $paginator->count(),
+                'data' => $paginator->getCollection()->toArray(),
+            ];
+        });
+
+        $p = new Paginator($array = ['item1', 'item2', 'item3'], 10);
+
+        $this->assertEquals([
+            'count' => 3,
+            'data' => ['item1', 'item2', 'item3'],
+        ], $p->toArray());
+    }
+
+    public function testLengthAwarePaginatorUsesCustomToArrayResolver()
+    {
+        Paginator::toArrayResolver(function ($paginator) {
+            return [
+                'count' => $paginator->count(),
+                'data' => $paginator->getCollection()->toArray(),
+            ];
+        });
+
+        $p = new LengthAwarePaginator($array = ['item1', 'item2', 'item3'], 3, 10);
+
+        $this->assertEquals([
+            'count' => 3,
+            'data' => ['item1', 'item2', 'item3'],
+        ], $p->toArray());
+    }
 }


### PR DESCRIPTION
I've often wanted to be able to change how the JSON representation of my Paginator instances are formatted, without intercepting the response in the controller or middleware.

This change allows you to register a callback with the Paginator and LengthAwarePaginator objects so you can return your own array format.

Example usage in a service provider:

```
class PaginationServiceProvider extends ServiceProvider
{
    /**
     * Register the service provider.
     *
     * @return void
     */
    public function register()
    {
        Paginator::toArrayResolver(function ($paginator) {
            return [
                'count' => $paginator->count(),
                'data' => $paginator->getCollection()->toArray(),
                'custom' => 'property',
            ];
        });
    }
}
```

Of course, if no callback is registered, the default format is used.

Thanks for any feedback!
