### PR TITLE
[5.3] Fix database factory error for negative count values

### DIFF
--- a/src/Illuminate/Database/Eloquent/FactoryBuilder.php
+++ b/src/Illuminate/Database/Eloquent/FactoryBuilder.php
@@ -102,7 +102,7 @@ class FactoryBuilder
      */
     public function make(array $attributes = [])
     {
-        if (! $this->amount) {
+        if ($this->amount < 1) {
             return new Collection;
         }
 


### PR DESCRIPTION
Add further checks to issue corrected in #15764. The issue i found was if i provide a negative number to `factory` method like `factor(App\User::class, -1)`, Laravel will create three new records for User. Refer to the screenshot below.

![screenshot from 2016-10-06 10 47 01](https://cloud.githubusercontent.com/assets/839335/19141926/ed0e2cf2-8bb2-11e6-8138-9f68a9326ce4.png)

This PR corrects the issue for providing negative numbers for `factory` method. 
