### PR TITLE
[5.3] Allow wrapping schema changes in a transaction if the database supports it

### DIFF
--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -365,7 +365,7 @@ class Migrator
      * Run a migration, inside a transaction if the database supports it.
      *
      * @param  \Closure  $callback
-     * @retrun void
+     * @return void
      */
     protected function runMigration(Closure $callback)
     {

--- a/src/Illuminate/Database/Schema/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/Grammar.php
@@ -18,6 +18,13 @@ use Doctrine\DBAL\Schema\AbstractSchemaManager as SchemaManager;
 abstract class Grammar extends BaseGrammar
 {
     /**
+     * If this Grammar supports schema changes wrapped in a transaction.
+     *
+     * @var bool
+     */
+    protected $transactions = false;
+
+    /**
      * Compile a rename column command.
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
@@ -455,5 +462,15 @@ abstract class Grammar extends BaseGrammar
     protected function mapFluentValueToDoctrine($option, $value)
     {
         return $option == 'notnull' ? ! $value : $value;
+    }
+
+    /**
+     * Check if this Grammar supports schema changes wrapped in a transaction.
+     *
+     * @return bool
+     */
+    public function supportsSchemaTransactions()
+    {
+        return $this->transactions;
     }
 }

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -8,6 +8,13 @@ use Illuminate\Database\Schema\Blueprint;
 class PostgresGrammar extends Grammar
 {
     /**
+     * If this Grammar supports schema changes wrapped in a transaction.
+     *
+     * @var bool
+     */
+    protected $transactions = true;
+
+    /**
      * The possible column modifiers.
      *
      * @var array


### PR DESCRIPTION
This is mostly to deal with a pet peeve of mine, and a source of endless frustration for newcomers: making an error in a migration file that results in changes being half applied.

This could be an error after a `create table`, in which the table is created, but the migration entry is never added. So you then get a "table exists" error, or a data migration that was only half-applied and was never idempotent. You then need to either call the query builder from tinker and reverse the migration manually, or dive into the database and fix stuff up (again, manually).

Certain databases (SQL Server, PostgreSQL) support wrapping schema changes in a transaction so they can be fully rolled back in the event of an error. I've only included PostgreSQL in here as I don't have a copy of SQL Server so I'm unable to actually test it myself.

I'm also not entirely sure if SQLite fully supports alter table within a transaction. Documentation seems to suggest it, and it _works_ when I try it on another app of mine, but SQLite's somewhat lacking support for alter table means DBAL is needed anyway so I'm not sure if simply wrapping the migration would actually effectively roll back errors.

I'd love feedback/criticism and maybe pointers on how to actually test this, or how to do this in a more elegant way.
