### PR TITLE
[5.3] Passing the attributes received by factory::raw() through

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factory.php
@@ -165,7 +165,7 @@ class Factory implements ArrayAccess
      */
     public function raw($class, array $attributes = [], $name = 'default')
     {
-        $raw = call_user_func($this->definitions[$class][$name], $this->faker);
+        $raw = call_user_func($this->definitions[$class][$name], $this->faker, $attributes);
 
         return array_merge($raw, $attributes);
     }


### PR DESCRIPTION
When using the model factory and evaluating the attributes in the definition, extending a version via raw() was not passing the attributes through.  I.e, when I have a model factory that checks to see if a foreign key is set and if not it creates an entry for it, extending it and calling 'raw' did not work because the $attributes were not being passed via the raw() function.

```
$factory->define(App\foo::class, function(Faker\Generator $faker, $attributes) use($factory) {
    if(empty($attributes['wollaby_id'])) {
        $walloby = factory(App\wollaby::class)->create();
    } else {
        $wollaby = new App\wollaby;
    }
    return [
            'wolloby_id'=>$wolloby->id,
        ];
});

$factory->defineAs(App\foo::class, 'with-widget', function(Faker\Generator $faker) use($factory) {
    return $factory->raw(App\foo::class,[
            'widget'=>true,
        ]);
}
```
