### PR TITLE
[5.3] Hide developer hints in html

### DIFF
--- a/src/Illuminate/Pagination/resources/views/bootstrap-4.blade.php
+++ b/src/Illuminate/Pagination/resources/views/bootstrap-4.blade.php
@@ -1,20 +1,20 @@
 @if ($paginator->hasPages())
     <ul class="pagination">
-        <!-- Previous Page Link -->
+        {{-- Previous Page Link --}}
         @if ($paginator->onFirstPage())
             <li class="page-item disabled"><span class="page-link">&laquo;</span></li>
         @else
             <li class="page-item"><a class="page-link" href="{{ $paginator->previousPageUrl() }}" rel="prev">&laquo;</a></li>
         @endif
 
-        <!-- Pagination Elements -->
+        {{-- Pagination Elements --}}
         @foreach ($elements as $element)
-            <!-- "Three Dots" Separator -->
+            {{-- "Three Dots" Separator --}}
             @if (is_string($element))
                 <li class="page-item disabled"><span class="page-link">{{ $element }}</span></li>
             @endif
 
-            <!-- Array Of Links -->
+            {{-- Array Of Links --}}
             @if (is_array($element))
                 @foreach ($element as $page => $url)
                     @if ($page == $paginator->currentPage())
@@ -26,7 +26,7 @@
             @endif
         @endforeach
 
-        <!-- Next Page Link -->
+        {{-- Next Page Link --}}
         @if ($paginator->hasMorePages())
             <li class="page-item"><a class="page-link" href="{{ $paginator->nextPageUrl() }}" rel="next">&raquo;</a></li>
         @else

--- a/src/Illuminate/Pagination/resources/views/default.blade.php
+++ b/src/Illuminate/Pagination/resources/views/default.blade.php
@@ -1,20 +1,20 @@
 @if ($paginator->hasPages())
     <ul class="pagination">
-        <!-- Previous Page Link -->
+        {{-- Previous Page Link --}}
         @if ($paginator->onFirstPage())
             <li class="disabled"><span>&laquo;</span></li>
         @else
             <li><a href="{{ $paginator->previousPageUrl() }}" rel="prev">&laquo;</a></li>
         @endif
 
-        <!-- Pagination Elements -->
+        {{-- Pagination Elements --}}
         @foreach ($elements as $element)
-            <!-- "Three Dots" Separator -->
+            {{-- "Three Dots" Separator --}}
             @if (is_string($element))
                 <li class="disabled"><span>{{ $element }}</span></li>
             @endif
 
-            <!-- Array Of Links -->
+            {{-- Array Of Links --}}
             @if (is_array($element))
                 @foreach ($element as $page => $url)
                     @if ($page == $paginator->currentPage())
@@ -26,7 +26,7 @@
             @endif
         @endforeach
 
-        <!-- Next Page Link -->
+        {{-- Next Page Link --}}
         @if ($paginator->hasMorePages())
             <li><a href="{{ $paginator->nextPageUrl() }}" rel="next">&raquo;</a></li>
         @else

--- a/src/Illuminate/Pagination/resources/views/simple-bootstrap-4.blade.php
+++ b/src/Illuminate/Pagination/resources/views/simple-bootstrap-4.blade.php
@@ -1,13 +1,13 @@
 @if ($paginator->hasPages())
     <ul class="pagination">
-        <!-- Previous Page Link -->
+        {{-- Previous Page Link --}}
         @if ($paginator->onFirstPage())
             <li class="page-item disabled"><span class="page-link">&laquo;</span></li>
         @else
             <li class="page-item"><a class="page-link" href="{{ $paginator->previousPageUrl() }}" rel="prev">&laquo;</a></li>
         @endif
 
-        <!-- Next Page Link -->
+        {{-- Next Page Link --}}
         @if ($paginator->hasMorePages())
             <li class="page-item"><a class="page-link" href="{{ $paginator->nextPageUrl() }}" rel="next">&raquo;</a></li>
         @else

--- a/src/Illuminate/Pagination/resources/views/simple-default.blade.php
+++ b/src/Illuminate/Pagination/resources/views/simple-default.blade.php
@@ -1,13 +1,13 @@
 @if ($paginator->hasPages())
     <ul class="pagination">
-        <!-- Previous Page Link -->
+        {{-- Previous Page Link --}}
         @if ($paginator->onFirstPage())
             <li class="disabled"><span>&laquo;</span></li>
         @else
             <li><a href="{{ $paginator->previousPageUrl() }}" rel="prev">&laquo;</a></li>
         @endif
 
-        <!-- Next Page Link -->
+        {{-- Next Page Link --}}
         @if ($paginator->hasMorePages())
             <li><a href="{{ $paginator->nextPageUrl() }}" rel="next">&raquo;</a></li>
         @else


### PR DESCRIPTION
Turn html comments into blade comments so that the resulting html is cleaner.
