### PR TITLE
[5.3] Prevent N notifications getting sent out when using the Notification facade

### DIFF
--- a/src/Illuminate/Notifications/ChannelManager.php
+++ b/src/Illuminate/Notifications/ChannelManager.php
@@ -114,7 +114,7 @@ class ChannelManager extends Manager implements DispatcherContract, FactoryContr
         foreach ($notifiables as $notifiable) {
             foreach ($notification->via($notifiable) as $channel) {
                 $bus->dispatch(
-                    (new SendQueuedNotifications($notifiables, $notification, [$channel]))
+                    (new SendQueuedNotifications([$notifiable], $notification, [$channel]))
                             ->onConnection($notification->connection)
                             ->onQueue($notification->queue)
                             ->delay($notification->delay)


### PR DESCRIPTION
Each Notification would get sent N times to the same Notifiable for each Notifiable there is. This fix prevents the behavior.
