### PR TITLE
Support listening on abstract classes

### DIFF
--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -306,9 +306,11 @@ class Dispatcher implements DispatcherContract
                             ? $this->listeners[$eventName] : [];
 
         if (class_exists($eventName, false)) {
-            foreach (class_implements($eventName) as $interface) {
-                if (isset($this->listeners[$interface])) {
-                    $listeners = array_merge_recursive($listeners, $this->listeners[$interface]);
+            $abstractTypes = array_merge(class_implements($eventName), class_parents($eventName));
+
+            foreach ($abstractTypes as $abstractType) {
+                if (isset($this->listeners[$abstractType])) {
+                    $listeners = array_merge_recursive($listeners, $this->listeners[$abstractType]);
                 }
             }
         }

--- a/tests/Events/EventsDispatcherTest.php
+++ b/tests/Events/EventsDispatcherTest.php
@@ -207,7 +207,7 @@ class EventsDispatcherTest extends PHPUnit_Framework_TestCase
 
     public function testBothClassesAndInterfacesWork()
     {
-        unset($_SERVER['__event.test']);
+        unset($_SERVER['__event.test1'], $_SERVER['__event.test2']);
         $d = new Dispatcher;
         $d->listen('AnotherEvent', function () {
             $_SERVER['__event.test1'] = 'fooo';

--- a/tests/Events/EventsDispatcherTest.php
+++ b/tests/Events/EventsDispatcherTest.php
@@ -220,6 +220,34 @@ class EventsDispatcherTest extends PHPUnit_Framework_TestCase
         $this->assertSame('fooo', $_SERVER['__event.test1']);
         $this->assertSame('baar', $_SERVER['__event.test2']);
     }
+
+    public function testAbstractClassesWork()
+    {
+        unset($_SERVER['__event.test']);
+        $d = new Dispatcher;
+        $d->listen('SomeAbstractClass', function () {
+            $_SERVER['__event.test'] = 'bar';
+        });
+        $d->fire(new ExampleConcreteEvent);
+
+        $this->assertSame('bar', $_SERVER['__event.test']);
+    }
+
+    public function testBothClassesAndAbstractClassesWork()
+    {
+        unset($_SERVER['__event.test1'], $_SERVER['__event.test2']);
+        $d = new Dispatcher;
+        $d->listen('ExampleConcreteEvent', function () {
+            $_SERVER['__event.test1'] = 'fooo';
+        });
+        $d->listen('SomeAbstractClass', function () {
+            $_SERVER['__event.test2'] = 'baar';
+        });
+        $d->fire(new ExampleConcreteEvent);
+
+        $this->assertSame('fooo', $_SERVER['__event.test1']);
+        $this->assertSame('baar', $_SERVER['__event.test2']);
+    }
 }
 
 class TestDispatcherQueuedHandler implements Illuminate\Contracts\Queue\ShouldQueue
@@ -252,6 +280,16 @@ interface SomeEventInterface
 }
 
 class AnotherEvent implements SomeEventInterface
+{
+    //
+}
+
+abstract class SomeAbstractClass
+{
+    //
+}
+
+class ExampleConcreteEvent extends SomeAbstractClass
 {
     //
 }


### PR DESCRIPTION
Event Dispatcher supports listening on abstract classes in addition to concrete classes and interfaces.
