### PR TITLE
[5.3] Create a resource controller along with the model

### DIFF
--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -42,6 +42,11 @@ class ModelMakeCommand extends GeneratorCommand
 
                 $this->call('make:migration', ['name' => "create_{$table}_table", '--create' => $table]);
             }
+            if ($this->option('controller')) {
+                $controller = Str::camel(class_basename($this->argument('name')));
+
+                $this->call('make:controller', ['name' => "{$controller}Controller", '--resource' => true]);
+            }
         }
     }
 
@@ -75,6 +80,7 @@ class ModelMakeCommand extends GeneratorCommand
     {
         return [
             ['migration', 'm', InputOption::VALUE_NONE, 'Create a new migration file for the model.'],
+            ['controller', 'c', InputOption::VALUE_NONE, 'Create a new resource controller for the model.'],
         ];
     }
 }


### PR DESCRIPTION
it's incredibly common for me to make a resource controller for most of my models, so it'd be nice do it in one line.

while this would be a nicety, I can also see someone arguing that this adds unnecessary complexity, when it's already easy enough to just run the commands one after the other.

curious where you stand on this, because we could just as easily add an option to create a seeder at the same time.
