### PR TITLE
[5.2] Remove as on table alias

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
@@ -109,7 +109,7 @@ class BelongsTo extends Relation
     {
         $query->select($columns);
 
-        $query->from($query->getModel()->getTable().' as '.$hash = $this->getRelationCountHash());
+        $query->from($query->getModel()->getTable().' '.$hash = $this->getRelationCountHash());
 
         $query->getModel()->setTable($hash);
 

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -332,7 +332,7 @@ class BelongsToMany extends Relation
     {
         $query->select($columns);
 
-        $query->from($this->related->getTable().' as '.$hash = $this->getRelationCountHash());
+        $query->from($this->related->getTable().' '.$hash = $this->getRelationCountHash());
 
         $this->related->setTable($hash);
 

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -83,7 +83,7 @@ abstract class HasOneOrMany extends Relation
     {
         $query->select($columns);
 
-        $query->from($query->getModel()->getTable().' as '.$hash = $this->getRelationCountHash());
+        $query->from($query->getModel()->getTable().' '.$hash = $this->getRelationCountHash());
 
         $query->getModel()->setTable($hash);
 

--- a/src/Illuminate/Database/Grammar.php
+++ b/src/Illuminate/Database/Grammar.php
@@ -63,6 +63,14 @@ abstract class Grammar
             }
 
             return $this->wrap($segments[0]).' as '.$this->wrapValue($segments[2]);
+        } elseif (strpos(strtolower($value), ' ') !== false) {
+            $segments = explode(' ', $value);
+
+            if ($prefixAlias) {
+                $segments[1] = $this->tablePrefix.$segments[1];
+            }
+
+            return $this->wrap($segments[0]).' as '.$this->wrapValue($segments[1]);
         }
 
         $wrapped = [];


### PR DESCRIPTION
This PR will:
1. Remove ' as ' on table alias for self relationship. Fixes issue on yajra/laravel-oci8#211.
2.  Allow table aliasing without the optional `as` keyword for SQLITE.

A fix for PR https://github.com/laravel/framework/pull/15776
