### PR TITLE
[5.3] Use asset helper function in app layout stub for auth:make

### DIFF
--- a/src/Illuminate/Auth/Console/stubs/make/views/layouts/app.stub
+++ b/src/Illuminate/Auth/Console/stubs/make/views/layouts/app.stub
@@ -11,7 +11,7 @@
     <title>{{ config('app.name', 'Laravel') }}</title>
 
     <!-- Styles -->
-    <link href="/css/app.css" rel="stylesheet">
+    <link href="{{ asset('css/app.css') }}" rel="stylesheet">
 
     <!-- Scripts -->
     <script>
@@ -82,6 +82,6 @@
     </div>
 
     <!-- Scripts -->
-    <script src="/js/app.js"></script>
+    <script src="{{ asset('js/app.js') }}"></script>
 </body>
 </html>


### PR DESCRIPTION
- Update JS and CSS imports to use asset helper function instead of hardcoded absolute urls
- Makes generated files better conform to recommended conventions of framework
- Makes it easier to switch to using s3 or other providers for assets when using make:auth
