### PR TITLE
[5.3] Add ability to pass an array to Notification Fakes

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
@@ -58,12 +58,12 @@ class NotificationFake implements NotificationFactory
      */
     public function sent($notifiable, $notification, $callback = null)
     {
-        if (!is_array($notifiable ) && !($notifiable instanceof \IteratorAggregate)) {
+        if (! is_array($notifiable) && ! ($notifiable instanceof \IteratorAggregate)) {
             $notifiable = [$notifiable];
         }
 
-        return collect($notifiable)->flatMap(function($notifiableItem) use ($notification, $callback) {
-            if (!$this->hasSent($notifiableItem, $notification)) {
+        return collect($notifiable)->flatMap(function ($notifiableItem) use ($notification, $callback) {
+            if (! $this->hasSent($notifiableItem, $notification)) {
                 return collect();
             }
 

--- a/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
@@ -27,7 +27,11 @@ class NotificationFake implements NotificationFactory
     public function assertSentTo($notifiable, $notification, $callback = null)
     {
         PHPUnit::assertTrue(
-            $this->sent($notifiable, $notification, $callback)->count() > 0,
+            $this->sent($notifiable, $notification, $callback)->filter(
+                function ($notifications) {
+                    return $notifications->isEmpty();
+                }
+            )->count() === 0,
             "The expected [{$notification}] notification was not sent."
         );
     }
@@ -43,7 +47,11 @@ class NotificationFake implements NotificationFactory
     public function assertNotSentTo($notifiable, $notification, $callback = null)
     {
         PHPUnit::assertTrue(
-            $this->sent($notifiable, $notification, $callback)->count() === 0,
+            $this->sent($notifiable, $notification, $callback)->filter(
+                function ($notifications) {
+                    return ! $notifications->isEmpty();
+                }
+            )->count() === 0,
             "The unexpected [{$notification}] notification was sent."
         );
     }
@@ -62,7 +70,7 @@ class NotificationFake implements NotificationFactory
             $notifiable = [$notifiable];
         }
 
-        return collect($notifiable)->flatMap(function ($notifiableItem) use ($notification, $callback) {
+        return collect($notifiable)->map(function ($notifiableItem) use ($notification, $callback) {
             if (! $this->hasSent($notifiableItem, $notification)) {
                 return collect();
             }
@@ -80,7 +88,7 @@ class NotificationFake implements NotificationFactory
     }
 
     /**
-     * Determine if there are more notifications left to inspect.
+     * Determine if there are morae notifications left to inspect.
      *
      * @param  mixed  $notifiable
      * @param  string  $notification


### PR DESCRIPTION
In documentation in [Notification Fakes](https://laravel.com/docs/5.3/mocking#notification-fakes) section wrote:

```
// Assert a notification was sent to the given users...
Notification::assertSentTo(
    [$user], OrderShipped::class
);
```

But when passing array to first argument it throws an Exception:

```
BadMethodCallException: Method getKey does not exist.
```

This PR adds support to pass an array as argument

If you would like to merge it please add #hacktoberfest tag
