### PR TITLE
[5.3] Allow to force a value on a select field

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithPages.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithPages.php
@@ -51,7 +51,7 @@ trait InteractsWithPages
     protected $uploads = [];
 
     /**
-     * Disabled validation fields array
+     * Disabled validation fields array.
      *
      * @var array
      */
@@ -656,11 +656,11 @@ trait InteractsWithPages
      */
     private function disableValidationOn($form)
     {
-        if (!is_array($this->disabledValidationFields)) {
+        if (! is_array($this->disabledValidationFields)) {
             return;
         }
 
-        foreach($this->disabledValidationFields as $field)
+        foreach ($this->disabledValidationFields as $field)
         {
             $form->get($field)->disableValidation();
         }

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithPages.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithPages.php
@@ -660,8 +660,7 @@ trait InteractsWithPages
             return;
         }
 
-        foreach ($this->disabledValidationFields as $field)
-        {
+        foreach ($this->disabledValidationFields as $field) {
             $form->get($field)->disableValidation();
         }
 

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithPages.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithPages.php
@@ -51,6 +51,13 @@ trait InteractsWithPages
     protected $uploads = [];
 
     /**
+     * Disabled validation fields array
+     *
+     * @var array
+     */
+    protected $disabledValidationFields = [];
+
+    /**
      * Visit the given URI with a GET request.
      *
      * @param  string  $uri
@@ -543,6 +550,20 @@ trait InteractsWithPages
     }
 
     /**
+     * Select an option from a drop-down filled with Ajax.
+     *
+     * @param  string  $option
+     * @param  string  $element
+     * @return $this
+     */
+    protected function forceSelect($option, $element)
+    {
+        $this->disabledValidationFields[] = $element;
+
+        return $this->storeInput($element, $option);
+    }
+
+    /**
      * Attach a file to a form field on the page.
      *
      * @param  string  $absolutePath
@@ -597,7 +618,11 @@ trait InteractsWithPages
             $buttonText = null;
         }
 
-        return $this->getForm($buttonText)->setValues($inputs);
+        $form = $this->getForm($buttonText);
+
+        $this->disableValidationOn($form);
+
+        return $form->setValues($inputs);
     }
 
     /**
@@ -621,6 +646,26 @@ trait InteractsWithPages
                 "Could not find a form that has submit button [{$buttonText}]."
             );
         }
+    }
+
+    /**
+     * Disables validation for selected fields on the form.
+     *
+     * @param \Symfony\Component\DomCrawler\Form  $form
+     * @return void
+     */
+    private function disableValidationOn($form)
+    {
+        if (!is_array($this->disabledValidationFields)) {
+            return;
+        }
+
+        foreach($this->disabledValidationFields as $field)
+        {
+            $form->get($field)->disableValidation();
+        }
+
+        $this->disabledValidationFields = [];
     }
 
     /**


### PR DESCRIPTION
Hi,
I often use ajax filled select fields (ajax loaded cities list, ...). If I want to test a form containing this kind of fields I can't just use : 

``` php
$this->select('Paris', 'home_town');
```

The options of a select field ajax filled are not seen by symfony's dom crawler, so when it tries to validate it, an Exception is thrown : 

```
InvalidArgumentException: Input "home_town" cannot take "Paris" as a value (possible values: ).
```

The idea is to use the [disableValidation](http://symfony.com/doc/current/components/dom_crawler.html#selecting-invalid-choice-values) method on those fields in order to force a value.

Thanks.

Xavier
