### PR TITLE
[5.1] Added ability to specify middleware to skip during tests

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -794,6 +794,16 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     }
 
     /**
+     * Get specific middleware to be disabled for the application.
+     *
+     * @return array
+     */
+    public function skipMiddleware()
+    {
+        return $this->bound('middleware.skip') ? $this->make('middleware.skip') : [];
+    }
+
+    /**
      * Determine if the application configuration is cached.
      *
      * @return bool

--- a/src/Illuminate/Foundation/Http/Kernel.php
+++ b/src/Illuminate/Foundation/Http/Kernel.php
@@ -118,7 +118,7 @@ class Kernel implements KernelContract
 
         return (new Pipeline($this->app))
                     ->send($request)
-                    ->through($this->app->shouldSkipMiddleware() ? [] : $this->middleware)
+                    ->through($this->app->shouldSkipMiddleware() ? [] : array_diff($this->middleware, $this->app->skipMiddleware()))
                     ->then($this->dispatchToRouter());
     }
 
@@ -131,9 +131,12 @@ class Kernel implements KernelContract
      */
     public function terminate($request, $response)
     {
-        $middlewares = $this->app->shouldSkipMiddleware() ? [] : array_merge(
-            $this->gatherRouteMiddlewares($request),
-            $this->middleware
+        $middlewares = $this->app->shouldSkipMiddleware() ? [] : array_diff(
+            array_merge(
+                $this->gatherRouteMiddlewares($request),
+                $this->middleware
+            ),
+            $this->app->skipMiddleware()
         );
 
         foreach ($middlewares as $middleware) {

--- a/src/Illuminate/Foundation/Testing/ApplicationTrait.php
+++ b/src/Illuminate/Foundation/Testing/ApplicationTrait.php
@@ -192,6 +192,19 @@ trait ApplicationTrait
     }
 
     /**
+     * Skip middleware for the test.
+     *
+     * @param  array  $middleware
+     * @return $this
+     */
+    public function skipMiddleware(array $middleware = [])
+    {
+        $this->app->instance('middleware.skip', $middleware);
+
+        return $this;
+    }
+
+    /**
      * Set the currently logged in user for the application.
      *
      * @param  \Illuminate\Contracts\Auth\Authenticatable  $user

--- a/src/Illuminate/Routing/ControllerDispatcher.php
+++ b/src/Illuminate/Routing/ControllerDispatcher.php
@@ -98,8 +98,9 @@ class ControllerDispatcher
     {
         $shouldSkipMiddleware = $this->container->bound('middleware.disable') &&
                                 $this->container->make('middleware.disable') === true;
+        $skipMiddleware = $this->container->bound('middleware.skip') ? $this->container->make('middleware.skip') : [];
 
-        $middleware = $shouldSkipMiddleware ? [] : $this->getMiddleware($instance, $method);
+        $middleware = $shouldSkipMiddleware ? [] : array_diff($this->getMiddleware($instance, $method), $skipMiddleware);
 
         // Here we will make a stack onion instance to execute this request in, which gives
         // us the ability to define middlewares on controllers. We will return the given

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -696,8 +696,9 @@ class Router implements RegistrarContract
     {
         $shouldSkipMiddleware = $this->container->bound('middleware.disable') &&
                                 $this->container->make('middleware.disable') === true;
+        $skipMiddleware = $this->container->bound('middleware.skip') ? $this->container->make('middleware.skip') : [];
 
-        $middleware = $shouldSkipMiddleware ? [] : $this->gatherRouteMiddlewares($route);
+        $middleware = $shouldSkipMiddleware ? [] : array_diff($this->gatherRouteMiddlewares($route), $skipMiddleware);
 
         return (new Pipeline($this->container))
                         ->send($request)


### PR DESCRIPTION
In response to the issue of CSRF middleware which rarely works in tests, and because I don't want to entirely disable
_all_ middleware while testing, this is a compromise solution.

From a unit test, you can call `$this->skipMiddleware([])`, and pass a list of middleware to skip. For example:

``` php
$this->skipMiddleware([\App\Http\Middleware\VerifyCsrfToken::class]);
$this->post('foo', ['bar' => 'baz']);
```

The most common use case would be wanting to ensure the  user is authorized to perform an action via middleware.
