### PR TITLE
[5.3] migrate:status can be ran with another connection

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/StatusCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/StatusCommand.php
@@ -49,11 +49,11 @@ class StatusCommand extends BaseCommand
      */
     public function fire()
     {
+        $this->migrator->setConnection($this->option('database'));
+
         if (! $this->migrator->repositoryExists()) {
             return $this->error('No migrations found.');
         }
-
-        $this->migrator->setConnection($this->option('database'));
 
         $ran = $this->migrator->getRepository()->getRan();
 


### PR DESCRIPTION
Bug was, if I tried to run the command with an sqlite connection, and
that I didn't have mysql installed, it didn't work.
