### PR TITLE
[5.3] Add \DateTime to possible types for delay function in Queueable interface

### DIFF
--- a/src/Illuminate/Bus/Queueable.php
+++ b/src/Illuminate/Bus/Queueable.php
@@ -54,7 +54,7 @@ trait Queueable
     /**
      * Set the desired delay for the job.
      *
-     * @param  int|null  $delay
+     * @param  \DateTime|int|null  $delay
      * @return $this
      */
     public function delay($delay)


### PR DESCRIPTION
In examples on the Laravel website, it demonstrates passing a DateTime Carbon object into the delay() function on queueable jobs. While it functions correctly currently, my IDE tells me it's not a correct type (as the docblock only specifies int and null). This fixes the IDE arguing with a correct call.

Note that the actual definition of the variable inside of the class specifies the correct possible types, but the function itself does not.
