### PR TITLE
[5.3] Crontab add runAsynBackground to run all the tasks concurrently(#15720)

### DIFF
--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -71,6 +71,34 @@ class Event
     public $runInBackground = false;
 
     /**
+     * Indicates if the command should run in asyn and will check the status.
+     *
+     * @var bool
+     */
+    public $runAsynBackground = false;
+
+    /**
+     * The lengthest seconds of the command can run. (-1 indicates no limits)
+     * 
+     * @var int
+     */
+    public $mostRunTime = -1;
+
+    /**
+     * The expiredTime the command can run. (-1 indicates no limits)
+     * 
+     * @var int
+     */
+    public $expiredTime = -1;
+
+    /**
+     * The email to alarm when command run in exception
+     * 
+     * @var int
+     */
+    public $alarmEmail = "";
+
+    /**
      * The array of filter callbacks.
      *
      * @var array
@@ -149,10 +177,17 @@ class Event
      */
     public function run(Container $container)
     {
+        // We can use runCommandAsynBackground instead of runCommandInForeground
         if (! $this->runInBackground) {
             $this->runCommandInForeground($container);
+        } elseif ($this->runAsynBackground) {
+            $this->runCommandAsynBackground($container);
         } else {
             $this->runCommandInBackground();
+        }
+
+        if (0 < $this->mostRunTime) {
+            $this->expiredTime = time() + $this->mostRunTime;
         }
     }
 
@@ -166,11 +201,56 @@ class Event
     {
         $this->callBeforeCallbacks($container);
 
+        $timeout = (0 < $this->mostRunTime) ? $this->mostRunTime : 60;
         (new Process(
-            trim($this->buildCommand(), '& '), base_path(), null, null, null
+            trim($this->buildCommand(), '& '), base_path(), null, null, $timeout
         ))->run();
+        $this->callAfterCallbacks($container);
+    }
+
+
+    /**
+     * Run the command in the background.
+     *
+     * @param  \Illuminate\Contracts\Container\Container  $container
+     * @return void
+     */
+    protected function runCommandAsynBackground(Container $container)
+    {
+        $this->callBeforeCallbacks($container);
+
+        $timeout = (0 < $this->mostRunTime) ? $this->mostRunTime : 60;
+        (new Process(
+            $this->buildCommand(), base_path(), null, null, $timeout
+        ))->run();
+    }
+
+    /**
+     * Run the command in the background.
+     *
+     * @param  \Illuminate\Contracts\Container\Container  $container
+     * @return bool
+     */
+    public function tryCleanUp(Container $container)
+    {
+        if (!$this->runAsynBackground) {
+            return true;
+        }
+
+        // timeout alarm 
+        if (0 < $this->expiredTime && time() >= $this->expiredTime) {
+            // alert
+            $this->alarmTimeout($container);
+            return true;
+        }
+
+        // is running
+        if (file_exists($this->mutexPath())) {
+            return false;
+        }
 
         $this->callAfterCallbacks($container);
+        return true;
     }
 
     /**
@@ -180,8 +260,9 @@ class Event
      */
     protected function runCommandInBackground()
     {
+        $timeout = (0 < $this->mostRunTime) ? $this->mostRunTime : 60;
         (new Process(
-            $this->buildCommand(), base_path(), null, null, null
+            $this->buildCommand(), base_path(), null, null, $timeout
         ))->run();
     }
 
@@ -222,7 +303,7 @@ class Event
 
         $redirect = $this->shouldAppendOutput ? ' >> ' : ' > ';
 
-        if ($this->withoutOverlapping) {
+        if ($this->withoutOverlapping || $this->runAsynBackground) {
             if (windows_os()) {
                 $command = '(echo \'\' > "'.$this->mutexPath().'" & '.$this->command.' & del "'.$this->mutexPath().'")'.$redirect.$output.' 2>&1 &';
             } else {
@@ -659,6 +740,31 @@ class Event
     }
 
     /**
+     * State that the command should run in background and will check status.
+     *
+     * @return $this
+     */
+    public function runAsynBackground()
+    {
+        $this->runAsynBackground = true;
+        $this->runInBackground = true;
+
+        return $this;
+    }
+
+    /**
+     * State the lengthest seconds of the command can run. (-1 indicates no limits)
+     * 
+     * @var int
+     */
+    public function mostRunTime($seconds = -1)
+    {
+        $this->mostRunTime = $seconds;
+
+        return $this;
+    }
+
+    /**
      * Set the timezone the date should be evaluated on.
      *
      * @param  \DateTimeZone|string  $timezone
@@ -809,6 +915,19 @@ class Event
     public function emailWrittenOutputTo($addresses)
     {
         return $this->emailOutputTo($addresses, true);
+    }
+
+    /**
+     * E-mail to developers if it run in exception.
+     *
+     * @param  array|mixed  $addresses
+     * @return $this
+     *
+     * @throws \LogicException
+     */
+    public function failEmailTo($addresses)
+    {
+        return $this->alarmEmail = $addresses;
     }
 
     /**
@@ -975,5 +1094,27 @@ class Event
     public function getExpression()
     {
         return $this->expression;
+    }
+
+    /**
+     * alerm where the command run too long
+     */
+    private function alarmTimeout(Container $container)
+    {
+        $addresses = $this->alarmEmail;
+
+        if (empty($addresses)) {
+            return;
+        }
+
+        $container->call(function(Mailer $mailer) use ($addresses) {
+            $mailer->raw("run timeout", function ($m) use ($addresses) {
+                $m->subject($this->getEmailSubject());
+
+                foreach ($addresses as $address) {
+                    $m->to($address);
+                }
+            });
+        });
     }
 }

--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -78,25 +78,25 @@ class Event
     public $runAsynBackground = false;
 
     /**
-     * The lengthest seconds of the command can run. (-1 indicates no limits)
-     * 
+     * The lengthest seconds of the command can run. (-1 indicates no limits).
+     *
      * @var int
      */
     public $mostRunTime = -1;
 
     /**
-     * The expiredTime the command can run. (-1 indicates no limits)
+     * The expiredTime the command can run. (-1 indicates no limits).
      * 
      * @var int
      */
     public $expiredTime = -1;
 
     /**
-     * The email to alarm when command run in exception
+     * The email to alarm when command run in exception.
      * 
      * @var int
      */
-    public $alarmEmail = "";
+    public $alarmEmail = '';
 
     /**
      * The array of filter callbacks.
@@ -233,11 +233,11 @@ class Event
      */
     public function tryCleanUp(Container $container)
     {
-        if (!$this->runAsynBackground) {
+        if (! $this->runAsynBackground) {
             return true;
         }
 
-        // timeout alarm 
+        // timeout alarm
         if (0 < $this->expiredTime && time() >= $this->expiredTime) {
             // alert
             $this->alarmTimeout($container);
@@ -753,9 +753,10 @@ class Event
     }
 
     /**
-     * State the lengthest seconds of the command can run. (-1 indicates no limits)
+     * State the lengthest seconds of the command can run. (-1 indicates no limits).
      * 
      * @var int
+     * @return $this
      */
     public function mostRunTime($seconds = -1)
     {
@@ -1097,7 +1098,10 @@ class Event
     }
 
     /**
-     * alerm where the command run too long
+     * alerm where the command run too long.
+     *
+     * @param  \Illuminate\Contracts\Container\Container  $container
+     * @return void
      */
     private function alarmTimeout(Container $container)
     {
@@ -1107,8 +1111,8 @@ class Event
             return;
         }
 
-        $container->call(function(Mailer $mailer) use ($addresses) {
-            $mailer->raw("run timeout", function ($m) use ($addresses) {
+        $container->call(function (Mailer $mailer) use ($addresses) {
+            $mailer->raw('run timeout', function ($m) use ($addresses) {
                 $m->subject($this->getEmailSubject());
 
                 foreach ($addresses as $address) {

--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -86,14 +86,14 @@ class Event
 
     /**
      * The expiredTime the command can run. (-1 indicates no limits).
-     * 
+     *
      * @var int
      */
     public $expiredTime = -1;
 
     /**
      * The email to alarm when command run in exception.
-     * 
+     *
      * @var int
      */
     public $alarmEmail = '';
@@ -208,7 +208,6 @@ class Event
         $this->callAfterCallbacks($container);
     }
 
-
     /**
      * Run the command in the background.
      *
@@ -226,7 +225,7 @@ class Event
     }
 
     /**
-     * Run the command in the background.
+     * try clean up finished command.
      *
      * @param  \Illuminate\Contracts\Container\Container  $container
      * @return bool
@@ -241,6 +240,7 @@ class Event
         if (0 < $this->expiredTime && time() >= $this->expiredTime) {
             // alert
             $this->alarmTimeout($container);
+
             return true;
         }
 
@@ -250,6 +250,7 @@ class Event
         }
 
         $this->callAfterCallbacks($container);
+
         return true;
     }
 
@@ -754,7 +755,7 @@ class Event
 
     /**
      * State the lengthest seconds of the command can run. (-1 indicates no limits).
-     * 
+     *
      * @var int
      * @return $this
      */

--- a/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
@@ -66,5 +66,18 @@ class ScheduleRunCommand extends Command
         if (count($events) === 0 || $eventsRan === 0) {
             $this->info('No scheduled commands are ready to run.');
         }
+
+        // the last to cleanUp all the commands
+        $finished = false;
+        while (!$finished) {
+            $finished = true;
+            foreach ($events as $event) {
+                $status = $event->tryCleanUp($this->laravel);
+                if ($finished) {
+                    $finished = $status;
+                }
+            }
+            sleep(1);
+        }
     }
 }

--- a/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
@@ -69,7 +69,7 @@ class ScheduleRunCommand extends Command
 
         // the last to cleanUp all the commands
         $finished = false;
-        while (!$finished) {
+        while (! $finished) {
             $finished = true;
             foreach ($events as $event) {
                 $status = $event->tryCleanUp($this->laravel);


### PR DESCRIPTION
## Reasons

When I use the laravel's crontabs I found some shortcomings. 

> in v5.1

```
public function run(Container $container) {
    if (count($this->afterCallbacks) > 0) {
        // will call wait and all command run serially
        $this->runCommandInForeground($container);
    } else {
        $this->runCommandInBackground();
    }
}


protected function runCommandInBackground() {
    chdir(base_path());
    exec($this->buildCommand());
}
```

> > When the commands have some afterCallbacks I must run them serially.
> > 
> > If some commands run in background, I can't get any feedback.
> 
> in v5.3

```
public function run(Container $container) {
    if (! $this->runInBackground) {
        $this->runCommandInForeground($container);
    } else {
        $this->runCommandInBackground();
    }
}

protected function runCommandInForeground(Container $container) {
    $this->callBeforeCallbacks($container);

    (new Process(trim($this->buildCommand(), '& '), base_path(), null, null, null))->run();

    $this->callAfterCallbacks($container);
}


protected function runCommandInBackground() {
    (new Process($this->buildCommand(), base_path(), null, null, null))->run();
}
```

> > Just change the to use "Process" instead of "exec" by runInBackground flag.
> > 
> > The same as the above problems.
## Add concurrence

> Just like v5.3, I add runAsynBackground flag

```
public function run(Container $container) {
    // We can use runCommandAsynBackground instead of runCommandInForeground
    if (! $this->runInBackground) {
        $this->runCommandInForeground($container);
    } elseif ($this->runAsynBackground) {
        $this->runCommandAsynBackground($container);
    }
    ...
}

protected function runCommandAsynBackground(Container $container) {
    $this->callBeforeCallbacks($container);

    (new Process($this->buildCommand(), base_path(), null, null, $timeout))->run();
}
```

> Add CleanUp function to do afterCallbacks

```
// lluminate\Console\Scheduling\ScheduleRunCommand 
public function fire() {
    $events = $this->schedule->dueEvents($this->laravel);
    ...
    foreach ($events as $event) {
        ...
        $event->run($this->laravel);
    }
    ...

    // the last to cleanUp all the commands
    $finished = false;
    while (!$finished) {
        $finished = true;
        foreach ($events as $event) {
            $status = $event->cleanUp($this->laravel);
            if ($finished) {
                $finished = $status;
            }
        }

        sleep(1);
    }
}
```

```
public function tryCleanUp(Container $container) {
    if (!$this->runAsynBackground) {
        return true;
    }

    // is run
    if (file_exists($this->mutexPath())) {
        return false;
    }

    $this->callAfterCallbacks($container);
    return true;
}
```
## Example as

```
 $schedule->command('laravel:test')->runAsynBackground()->cron('* * * * * *')->failEmailTo("uppinggoer@gmail.com");
```
## Others

> add timeout 
> 
> add alarm email

```
public function tryCleanUp(Container $container) {
    ...

    // timeout alarm 
    if (0 < $this->expiredTime && time() >= $this->expiredTime) {
        // alert email
        $this->alarmTimeout($container);
        return true;
    }
}
```

> examples

```
$schedule->command('laravel:test')->runAsynBackground()->mostRunTime(3)->cron('* * * * * *')->failEmailTo("aaa@qq.com");
```
## Future

> alarm email will notify command's unexpected exit code
