### PR TITLE
[5.3] Added ability to better control middleware during tests

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -822,10 +822,20 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
      *
      * @return bool
      */
-    public function shouldSkipMiddleware()
+    public function shouldDisableMiddleware()
     {
         return $this->bound('middleware.disable') &&
                $this->make('middleware.disable') === true;
+    }
+
+    /**
+     * Determine which middleware, if any, has been disabled for the application.
+     *
+     * @return array
+     */
+    public function shouldSkipMiddleware()
+    {
+        return $this->bound('middleware.skip') ? $this->make('middleware.skip') : [];
     }
 
     /**

--- a/src/Illuminate/Foundation/Http/Kernel.php
+++ b/src/Illuminate/Foundation/Http/Kernel.php
@@ -145,7 +145,7 @@ class Kernel implements KernelContract
 
         return (new Pipeline($this->app))
                     ->send($request)
-                    ->through($this->app->shouldSkipMiddleware() ? [] : $this->middleware)
+                    ->through($this->app->shouldDisableMiddleware() ? [] : array_values(array_diff($this->middleware, $this->app->shouldSkipMiddleware())))
                     ->then($this->dispatchToRouter());
     }
 
@@ -158,10 +158,13 @@ class Kernel implements KernelContract
      */
     public function terminate($request, $response)
     {
-        $middlewares = $this->app->shouldSkipMiddleware() ? [] : array_merge(
-            $this->gatherRouteMiddleware($request),
-            $this->middleware
-        );
+        $middlewares = $this->app->shouldDisableMiddleware() ? [] : array_keys(array_diff(
+            array_merge(
+                $this->gatherRouteMiddleware($request),
+                $this->middleware
+            ),
+            $this->app->shouldSkipMiddleware()
+        ));
 
         foreach ($middlewares as $middleware) {
             if (! is_string($middleware)) {

--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -50,6 +50,37 @@ trait MakesHttpRequests
     }
 
     /**
+     * Re-enable middleware for the test, even if disabled by the WithoutMiddleware trait.
+     *
+     * @return $this
+     */
+    public function withMiddleware()
+    {
+        $this->app->instance('middleware.disable', false);
+
+        return $this;
+    }
+
+    /**
+     * Disable specific middleware for the test.
+     *
+     * @param  array  $middleware
+     * @return $this
+     */
+    public function skipMiddleware(array $middleware = [])
+    {
+        $middleware = collect($middleware)->map(
+            function ($name) {
+                return (array) $this->app['router']->resolveMiddlewareClassName($name);
+            }
+        )->flatten()->toArray();
+
+        $this->app->instance('middleware.skip', $middleware);
+
+        return $this;
+    }
+
+    /**
      * Visit the given URI with a JSON request.
      *
      * @param  string  $method

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -629,10 +629,12 @@ class Router implements RegistrarContract
      */
     protected function runRouteWithinStack(Route $route, Request $request)
     {
-        $shouldSkipMiddleware = $this->container->bound('middleware.disable') &&
-                                $this->container->make('middleware.disable') === true;
+        $shouldDisableMiddleware = $this->container->bound('middleware.disable') &&
+                                   $this->container->make('middleware.disable') === true;
 
-        $middleware = $shouldSkipMiddleware ? [] : $this->gatherRouteMiddleware($route);
+        $shouldSkipMiddleware = $this->container->bound('middleware.skip') ? $this->container->make('middleware.skip') : [];
+
+        $middleware = $shouldDisableMiddleware ? [] : array_values(array_diff($this->gatherRouteMiddleware($route), $shouldSkipMiddleware));
 
         return (new Pipeline($this->container))
                         ->send($request)


### PR DESCRIPTION
From a unit test, you can call `$this->skipMiddleware([])`, and pass a list of middleware to skip. For example:

``` php
$this->skipMiddleware(['App\Http\Middleware\VerifyCsrfToken', 'auth']);
$this->post('foo', ['bar' => 'baz']);
```

This middleware will be resolved to actual middleware.

You can also selectively _re-enable_ middleware for a test when using the `WithoutMiddleware` trait.

This can be done by calling `$this->withMiddleware()`

Not that I also changed `shouldSkipMiddleware()` to `shouldDisableMiddleware()`, and added a new definition of `shouldSkipMiddleware()` with the middleware to skip.
