### PR TITLE
[5.3] Improve Interacts with database testing methods

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
@@ -2,6 +2,9 @@
 
 namespace Illuminate\Foundation\Testing\Concerns;
 
+use PHPUnit_Framework_Constraint_Not as ReverseConstraint;
+use Illuminate\Foundation\Testing\Constraints\HasInDatabase;
+
 trait InteractsWithDatabase
 {
     /**
@@ -10,21 +13,39 @@ trait InteractsWithDatabase
      * @param  string  $table
      * @param  array  $data
      * @param  string  $connection
+     * @param  bool  $reverse
      * @return $this
      */
-    protected function seeInDatabase($table, array $data, $connection = null)
+    protected function seeInDatabase($table, array $data, $connection = null, $reverse = false)
     {
-        $database = $this->app->make('db');
+        $constraint = new HasInDatabase($data, $this->getConnection($connection));
 
-        $connection = $connection ?: $database->getDefaultConnection();
+        if ($reverse) {
+            $constraint = new ReverseConstraint($constraint);
+        }
 
-        $count = $database->connection($connection)->table($table)->where($data)->count();
-
-        $this->assertGreaterThan(0, $count, sprintf(
-            'Unable to find row in database table [%s] that matched attributes [%s].', $table, json_encode($data)
-        ));
+        $this->assertThat($table, $constraint);
 
         return $this;
+    }
+
+    /**
+     * Assert that a given where condition exists in the database and retrieve the results found.
+     *
+     * @param  string  $table
+     * @param  array  $data
+     * @param  string  $connection
+     * @return $this
+     */
+    protected function seeAndGetInDatabase($table, array $data, $connection = null)
+    {
+        $constraint = new HasInDatabase($data, $this->getConnection($connection));
+
+        $this->assertThat($table, $constraint);
+
+        $results = $constraint->getResults();
+
+        return $results->count() == 1 ? $results->first() : $results;
     }
 
     /**
@@ -63,17 +84,7 @@ trait InteractsWithDatabase
      */
     protected function notSeeInDatabase($table, array $data, $connection = null)
     {
-        $database = $this->app->make('db');
-
-        $connection = $connection ?: $database->getDefaultConnection();
-
-        $count = $database->connection($connection)->table($table)->where($data)->count();
-
-        $this->assertEquals(0, $count, sprintf(
-            'Found unexpected records in database table [%s] that matched attributes [%s].', $table, json_encode($data)
-        ));
-
-        return $this;
+        return $this->seeInDatabase($table, $data, $connection, true);
     }
 
     /**
@@ -85,5 +96,20 @@ trait InteractsWithDatabase
     public function seed($class = 'DatabaseSeeder')
     {
         $this->artisan('db:seed', ['--class' => $class]);
+    }
+
+    /**
+     * Get the database connection.
+     *
+     * @param  string|null  $connection
+     * @return \Illuminate\Database\Collection
+     */
+    protected function getConnection($connection = null)
+    {
+        $database = $this->app->make('db');
+
+        $connection = $connection ?: $database->getDefaultConnection();
+
+        return $database->connection($connection);
     }
 }

--- a/src/Illuminate/Foundation/Testing/Constraints/HasInDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Constraints/HasInDatabase.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Illuminate\Foundation\Testing\Constraints;
+
+use PHPUnit_Framework_Constraint;
+use Illuminate\Database\Connection;
+
+class HasInDatabase extends PHPUnit_Framework_Constraint
+{
+    /**
+     * Number of records that will be shown in the console in case of failure.
+     *
+     * @var int
+     */
+    protected $take = 5;
+
+    /**
+     * Database connection.
+     *
+     * @var \Illuminate\Database\Collection
+     */
+    protected $database;
+
+    /**
+     * Data that will be used to narrow the search in the database table.
+     *
+     * @var array
+     */
+    protected $data;
+
+    /**
+     * Name of the queried database table.
+     *
+     * @var string
+     */
+    protected $table;
+
+    /**
+     * Create a new constraint instance.
+     *
+     * @param  array  $data
+     * @param  \Illuminate\Database\Collection  $database
+     */
+    public function __construct(array $data, Connection $database)
+    {
+        $this->data = $data;
+
+        $this->database = $database;
+    }
+
+    /**
+     * Check if the data is found in the given table.
+     *
+     * @param  string  $table
+     * @return bool
+     */
+    public function matches($table)
+    {
+        $this->table = $table;
+
+        return $this->database->table($table)->where($this->data)->count() > 0;
+    }
+
+    /**
+     * Get the database results.
+     *
+     * @return \Illuminate\Database\Collection
+     */
+    public function getResults()
+    {
+        return $this->database->table($this->table)->get();
+    }
+
+    /**
+     * Get the description of the failure.
+     *
+     * @param  string  $table
+     * @return string
+     */
+    public function failureDescription($table)
+    {
+        $results = $this->getResults();
+
+        $description = sprintf(
+            "a row in the table \"%s\" matches the attributes %s.\n\nFound instead: %s",
+            $table, $this->toString(), json_encode($results->take(5))
+        );
+
+        if ($this->take > 5) {
+            $description .= sprintf(' and %s others.', $this->count - $results->count());
+        }
+
+        return $description;
+    }
+
+    /**
+     * Get a string representation of the object.
+     *
+     * @return string
+     */
+    public function toString()
+    {
+        return json_encode($this->data);
+    }
+}


### PR DESCRIPTION
Right now it's a little bit annoying when `seeInDatabase` fails because there is not enough feedback. On the other hand, when it passes sometimes you want to grab the results and right now the only way is to execute a different query. This PR attempts to fix these 2 problems and improve the code as well.

With this upgrade you get more feedback:

```
Failed asserting that a row in the table "users" matches the attributes {"username":"Silence","first_name":"Duilio","last_name":"Palacios"}.

Found instead: [{"id":6,"username":"","first_name":"Duilio","last_name":"Palacios","email":"admin@styde.net","member":0,"remember_token":null,"created_at":"2016-10-09 15:52:54","updated_at":"2016-10-09 15:52:54"}].
```

You can also use `seeAndGetInDatabase` (Couldn't think of a better name)

So instead of this:

```
        $token = $this->seeInDatabase('tokens', [
            'email' => 'admin@styde.net'
        ]);

        $token = Token::where('email', 'admin@styde.net')->first() //or Token::first();
```

You can use:

```
        $token = $this->seeAndGetInDatabase('tokens', [
            'email' => 'admin@styde.net'
        ]);
```

I'd be happy to read some feedback or suggestions for other methods or improvements.
