### PR TITLE
[5.3] Validator explodeRules param type in docblock

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -268,10 +268,10 @@ class Validator implements ValidatorContract
     /**
      * Explode the rules into an array of rules.
      *
-     * @param  string|array  $rules
+     * @param  array  $rules
      * @return array
      */
-    protected function explodeRules($rules)
+    protected function explodeRules(array $rules)
     {
         foreach ($rules as $key => $rule) {
             if (Str::contains($key, '*')) {


### PR DESCRIPTION
If string will be bypassed somehow an exception will be raised:

> Invalid argument supplied for foreach()
