### PR TITLE
[5.3] Take alternative filename for composer.json from environment

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -1140,7 +1140,8 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
             return $this->namespace;
         }
 
-        $composer = json_decode(file_get_contents(base_path('composer.json')), true);
+        $composer_filename = env('COMPOSER', 'composer.json');
+        $composer = json_decode(file_get_contents(base_path($composer_filename)), true);
 
         foreach ((array) data_get($composer, 'autoload.psr-4') as $namespace => $path) {
             foreach ((array) $path as $pathChoice) {

--- a/src/Illuminate/Foundation/Console/AppNameCommand.php
+++ b/src/Illuminate/Foundation/Console/AppNameCommand.php
@@ -258,7 +258,9 @@ class AppNameCommand extends Command
      */
     protected function getComposerPath()
     {
-        return $this->laravel->basePath().'/composer.json';
+        $composer_filename = env('COMPOSER', 'composer.json');
+
+        return $this->laravel->basePath().'/'.$composer_filename;
     }
 
     /**


### PR DESCRIPTION
This edit grabs the alternative filename for composer.json from the COMPOSER environment variable, as specified by [Composer](https://getcomposer.org/doc/03-cli.md#composer)

Issue for this here: https://github.com/laravel/internals/issues/243
