### PR TITLE
[5.3] Allow retreiving values of numeric column in Eloquent

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -352,7 +352,7 @@ class Builder
         $builder = $this->applyScopes();
 
         foreach ($builder->query->cursor() as $record) {
-            yield $this->model->newFromBuilder($record);
+            yield $this->model->newFromBuilder((array) $record);
         }
     }
 

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -507,7 +507,10 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     {
         $model = $this->newInstance([], true);
 
-        $model->setRawAttributes((array) $attributes, true);
+        $model->setRawAttributes(
+            array_combine(array_keys($attributes), $attributes),
+            true
+        );
 
         $model->setConnection($connection ?: $this->getConnectionName());
 
@@ -526,7 +529,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         $instance = (new static)->setConnection($connection);
 
         $items = array_map(function ($item) use ($instance) {
-            return $instance->newFromBuilder($item);
+            return $instance->newFromBuilder((array) $item);
         }, $items);
 
         return $instance->newCollection($items);

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -51,6 +51,7 @@ class DatabaseEloquentIntegrationTest extends PHPUnit_Framework_TestCase
                 $table->increments('id');
                 $table->string('name')->nullable();
                 $table->string('email');
+                $table->integer('200');
                 $table->timestamps();
             });
 
@@ -141,6 +142,15 @@ class DatabaseEloquentIntegrationTest extends PHPUnit_Framework_TestCase
         foreach ($records as $record) {
             $this->assertEquals(1, $record->id);
         }
+    }
+
+    public function testModelWithNumericKey()
+    {
+        EloquentTestUser::create(['id' => 1, 'email' => 'test@mail.com', 200 => 1]);
+
+        $model = EloquentTestUser::find(1);
+        $this->assertInstanceOf('EloquentTestUser', $model);
+        $this->assertEquals(1, $model->{200});
     }
 
     public function testBasicModelCollectionRetrieval()


### PR DESCRIPTION
As reported in https://github.com/laravel/framework/issues/15864

Currently you can't retrieve the value of a numeric column of an eloquent model (e.g. `$user->{200}`), this is because when an object with a numeric key is casted to an array that key won't be accessible:

http://php.net/language.types.array#language.types.array.casting

> If an object is converted to an array, the result is an array whose elements are the object's properties. The keys are the member variable names, with a few notable exceptions: integer properties are unaccessible; ...

So while creating the mode instance from the Builder results we cast the given $row as array`(array) $attributes`, and later in `getAttribute` we use `array_key_exists($key, $this->attributes)` to check for key existence which will always fail for numeric keys.

This PR attempts to fix that PHP limitation by rebuilding the casted array using `array_combine`:

```
array_combine(array_keys($attributes), $attributes)
```

---

I think using numeric keys is not a common practise, but afaik it's not a bad practise.
