### PR TITLE
[5.3] Fix calling closure based commands from code

### DIFF
--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -210,6 +210,12 @@ class Kernel implements KernelContract
     {
         $this->bootstrap();
 
+        if (! $this->commandsLoaded) {
+            $this->commands();
+
+            $this->commandsLoaded = true;
+        }
+
         return $this->getArtisan()->call($command, $parameters);
     }
 


### PR DESCRIPTION
We do it by registering those commands when we call the `call()` method.
