### PR TITLE
[5.4] roll back to a given transaction level (savepoint)

### DIFF
--- a/tests/Database/DatabaseConnectionTest.php
+++ b/tests/Database/DatabaseConnectionTest.php
@@ -160,8 +160,19 @@ class DatabaseConnectionTest extends PHPUnit_Framework_TestCase
         $pdo = $this->createMock('DatabaseConnectionTestMockPDO');
         $connection = $this->getMockConnection(['getName'], $pdo);
         $connection->expects($this->any())->method('getName')->will($this->returnValue('name'));
+        $connection->beginTransaction();
         $connection->setEventDispatcher($events = m::mock('Illuminate\Contracts\Events\Dispatcher'));
         $events->shouldReceive('fire')->once()->with(m::type('Illuminate\Database\Events\TransactionRolledBack'));
+        $connection->rollBack();
+    }
+
+    public function testRedundantRollBackFiresNoEvent()
+    {
+        $pdo = $this->createMock('DatabaseConnectionTestMockPDO');
+        $connection = $this->getMockConnection(['getName'], $pdo);
+        $connection->expects($this->any())->method('getName')->will($this->returnValue('name'));
+        $connection->setEventDispatcher($events = m::mock('Illuminate\Contracts\Events\Dispatcher'));
+        $events->shouldNotReceive('fire');
         $connection->rollBack();
     }
 


### PR DESCRIPTION
- DB::rollBack(0) rolls back the outer most transaction.
- DB::rollBack(1) rollback to savepoint `trans2`
- DB::rollBack(2) rollback to savepoint `trans3`
- ...
- Redundant calls to DB::rollBack(), e.g. when not in a transaction, don't fire 'rollingBack' event anymore.
