### PR TITLE
[5.4] RedisStore::add()

### DIFF
--- a/src/Illuminate/Cache/RedisStore.php
+++ b/src/Illuminate/Cache/RedisStore.php
@@ -135,6 +135,7 @@ redis.call('setex', KEYS[1], ARGV[2], ARGV[1])
 return true
 LUA;
         $value = $this->serialize($value);
+
         return (bool) $this->connection()->eval($lua, 1, $this->prefix.$key, $value, (int) max(1, $minutes * 60));
     }
 

--- a/src/Illuminate/Cache/RedisStore.php
+++ b/src/Illuminate/Cache/RedisStore.php
@@ -127,12 +127,11 @@ class RedisStore extends TaggableStore implements Store
     public function add($key, $value, $minutes)
     {
         $lua = <<<'LUA'
-local v = redis.call('get', KEYS[1])
-if (v) then
-return false
+if (redis.call('exists', KEYS[1]) > 0) then
+return 0
 end
 redis.call('setex', KEYS[1], ARGV[2], ARGV[1])
-return true
+return 1
 LUA;
         $value = $this->serialize($value);
 

--- a/src/Illuminate/Cache/RedisStore.php
+++ b/src/Illuminate/Cache/RedisStore.php
@@ -126,13 +126,8 @@ class RedisStore extends TaggableStore implements Store
      */
     public function add($key, $value, $minutes)
     {
-        $lua = <<<'LUA'
-if (redis.call('exists', KEYS[1]) > 0) then
-return 0
-end
-redis.call('setex', KEYS[1], ARGV[2], ARGV[1])
-return 1
-LUA;
+        $lua = "return redis.call('exists',KEYS[1])<1 and redis.call('setex',KEYS[1],ARGV[2],ARGV[1])";
+
         $value = $this->serialize($value);
 
         return (bool) $this->connection()->eval($lua, 1, $this->prefix.$key, $value, (int) max(1, $minutes * 60));

--- a/tests/Cache/CacheRepositoryTest.php
+++ b/tests/Cache/CacheRepositoryTest.php
@@ -125,6 +125,14 @@ class CacheRepositoryTest extends PHPUnit_Framework_TestCase
         $this->assertFalse($result);
     }
 
+    public function testCacheAddCallsRedisStoreAdd()
+    {
+        $store = m::mock(Illuminate\Cache\RedisStore::class);
+        $store->shouldReceive('add')->once()->with('k', 'v', 60)->andReturn(true);
+        $repository = new Illuminate\Cache\Repository($store);
+        $this->assertTrue($repository->add('k', 'v', 60));
+    }
+
     public function testRegisterMacroWithNonStaticCall()
     {
         $repo = $this->getRepository();

--- a/tests/Cache/RedisCacheIntegrationTest.php
+++ b/tests/Cache/RedisCacheIntegrationTest.php
@@ -48,7 +48,7 @@ class RedisCacheTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * Breaking change
+     * Breaking change.
      */
     public function testRedisCacheAddFalse()
     {
@@ -59,7 +59,7 @@ class RedisCacheTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * Breaking change
+     * Breaking change.
      */
     public function testRedisCacheAddNull()
     {

--- a/tests/Cache/RedisCacheIntegrationTest.php
+++ b/tests/Cache/RedisCacheIntegrationTest.php
@@ -1,0 +1,71 @@
+<?php
+
+use Illuminate\Cache\RedisStore;
+use Illuminate\Cache\Repository;
+use Illuminate\Redis\PredisDatabase;
+use Mockery as m;
+
+class RedisCacheTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var PredisDatabase
+     */
+    private $redis;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $host = getenv('REDIS_HOST') ?: '127.0.0.1';
+        $port = getenv('REDIS_PORT') ?: 6379;
+
+        $this->redis = new PredisDatabase([
+            'cluster' => false,
+            'default' => [
+                'host' => $host,
+                'port' => $port,
+                'database' => 5,
+                'timeout' => 0.5,
+            ],
+        ]);
+
+        $this->redis->connection()->flushdb();
+    }
+
+    public function tearDown()
+    {
+        parent::tearDown();
+        m::close();
+        $this->redis->connection()->flushdb();
+    }
+
+    public function testRedisCacheAddTwice()
+    {
+        $store = new RedisStore($this->redis);
+        $repository = new Repository($store);
+        $this->assertTrue($repository->add('k', 'v', 60));
+        $this->assertFalse($repository->add('k', 'v', 60));
+    }
+
+    /**
+     * Breaking change
+     */
+    public function testRedisCacheAddFalse()
+    {
+        $store = new RedisStore($this->redis);
+        $repository = new Repository($store);
+        $repository->forever('k', false);
+        $this->assertFalse($repository->add('k', 'v', 60));
+    }
+
+    /**
+     * Breaking change
+     */
+    public function testRedisCacheAddNull()
+    {
+        $store = new RedisStore($this->redis);
+        $repository = new Repository($store);
+        $repository->forever('k', null);
+        $this->assertFalse($repository->add('k', 'v', 60));
+    }
+}


### PR DESCRIPTION
Isolate concurrent calls to Cache::add() when Redis driver is used, just like Memcached.
