### PR TITLE
[5.3] $column parameter can be a Closure

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -757,7 +757,7 @@ class Builder
     /**
      * Add a basic where clause to the query.
      *
-     * @param  string  $column
+     * @param  string|\Closure  $column
      * @param  string  $operator
      * @param  mixed   $value
      * @param  string  $boolean


### PR DESCRIPTION
In `Builder::where()`, the first parameter `$column` can be a closure.
