### PR TITLE
[5.3] Setup additional configuration for Slack Client.

### DIFF
--- a/src/Illuminate/Notifications/Channels/SlackWebhookChannel.php
+++ b/src/Illuminate/Notifications/Channels/SlackWebhookChannel.php
@@ -59,12 +59,19 @@ class SlackWebhookChannel
             'channel' => data_get($message, 'channel'),
         ]);
 
-        return [
+        $payload = [
             'json' => array_merge([
                 'text' => $message->content,
                 'attachments' => $this->attachments($message),
             ], $optionalFields),
         ];
+
+        // Add other configuration settings if available.
+        if (! empty($message->options)) {
+            $payload = array_merge($payload, $message->options);
+        }
+
+        return $payload;
     }
 
     /**

--- a/src/Illuminate/Notifications/Messages/SlackMessage.php
+++ b/src/Illuminate/Notifications/Messages/SlackMessage.php
@@ -49,6 +49,13 @@ class SlackMessage
     public $attachments = [];
 
     /**
+     * Additional settings for Slack HTTP Client.
+     *
+     * @var array
+     */
+    public $options = [];
+
+    /**
      * Indicate that the notification gives information about a successful operation.
      *
      * @return $this
@@ -144,5 +151,18 @@ class SlackMessage
             case 'error':
                 return '#F35A00';
         }
+    }
+
+    /**
+     * Setup additional configuration for Slack HTTP Client.
+     *
+     * @param  array  $options
+     * @return $this
+     */
+    public function options($options)
+    {
+        $this->options = $options;
+
+        return $this;
     }
 }


### PR DESCRIPTION
As described in #15837, currently there is no way we can specify additional options for Guzzle like `headers` or `proxy` when using Slack notifications. This PR allows you to specify such settings. 

Whenever you create a notification through `php artisan make:notification` and add `toSlack`method. Then you can specify additional parameters for Guzzle like this:

```
$options = [
    'proxy' => [
        'http'  => 'tcp://localhost:8125',
        'https' => 'tcp://localhost:9124',
    ]
];
return (new SlackMessage)
        ->options($options)
        ->content('Some Tests');   
```
