### PR TITLE
[5.3] Instance ids are passed to the ModelNotFoundException

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -207,7 +207,7 @@ class Builder
             return $result;
         }
 
-        throw (new ModelNotFoundException)->setModel(get_class($this->model));
+        throw (new ModelNotFoundException)->setModel(get_class($this->model), $id);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/ModelNotFoundException.php
+++ b/src/Illuminate/Database/Eloquent/ModelNotFoundException.php
@@ -14,17 +14,17 @@ class ModelNotFoundException extends RuntimeException
     protected $model;
 
     /**
-     * Ids of the affected instances
+     * Ids of the affected instances.
      *
-     * @var integer|array
+     * @var int|array
      */
     protected $instanceIds;
 
     /**
-     * Set the affected Eloquent model and instance ids
+     * Set the affected Eloquent model and instance ids.
      *
-     * @param  string        $model
-     * @param  integer|array $instanceIds
+     * @param  string    $model
+     * @param  int|array $instanceIds
      * @return $this
      */
     public function setModel($model, $instanceIds)
@@ -52,12 +52,12 @@ class ModelNotFoundException extends RuntimeException
     }
 
     /**
-     * Get the affected instance ids
+     * Get the affected instance ids.
      *
-     * @return integer|array
+     * @return int|array
      */
     public function getInstanceIds()
     {
-        return $this->instanceId;
+        return $this->instanceIds;
     }
 }

--- a/src/Illuminate/Database/Eloquent/ModelNotFoundException.php
+++ b/src/Illuminate/Database/Eloquent/ModelNotFoundException.php
@@ -14,16 +14,29 @@ class ModelNotFoundException extends RuntimeException
     protected $model;
 
     /**
+     * Id or array of ids of the affected instances
+     *
+     * @var integer|array
+     */
+    protected $instanceId;
+
+    /**
      * Set the affected Eloquent model.
      *
-     * @param  string   $model
+     * @param  string        $model
+     * @param  integer|array $instanceId
      * @return $this
      */
-    public function setModel($model)
+    public function setModel($model, $instanceId)
     {
-        $this->model = $model;
+        $this->model      = $model;
+        $this->instanceId = $instanceId;
 
-        $this->message = "No query results for model [{$model}].";
+        if (is_array($instanceId)) {
+            $instanceId = sprintf('[%s]', implode($instanceId, ', '));
+        }
+
+        $this->message = "No query results for model [{$model}] with id={$instanceId}.";
 
         return $this;
     }
@@ -36,5 +49,15 @@ class ModelNotFoundException extends RuntimeException
     public function getModel()
     {
         return $this->model;
+    }
+
+    /**
+     * Get the affected instance id or array of ids
+     *
+     * @return integer|array
+     */
+    public function getInstanceId()
+    {
+        return $this->instanceId;
     }
 }

--- a/src/Illuminate/Database/Eloquent/ModelNotFoundException.php
+++ b/src/Illuminate/Database/Eloquent/ModelNotFoundException.php
@@ -29,7 +29,7 @@ class ModelNotFoundException extends RuntimeException
      */
     public function setModel($model, $instanceIds)
     {
-        $this->model       = $model;
+        $this->model = $model;
         $this->instanceIds = $instanceIds;
 
         if (is_array($instanceIds)) {

--- a/src/Illuminate/Database/Eloquent/ModelNotFoundException.php
+++ b/src/Illuminate/Database/Eloquent/ModelNotFoundException.php
@@ -14,29 +14,29 @@ class ModelNotFoundException extends RuntimeException
     protected $model;
 
     /**
-     * Id or array of ids of the affected instances
+     * Ids of the affected instances
      *
      * @var integer|array
      */
-    protected $instanceId;
+    protected $instanceIds;
 
     /**
-     * Set the affected Eloquent model.
+     * Set the affected Eloquent model and instance ids
      *
      * @param  string        $model
-     * @param  integer|array $instanceId
+     * @param  integer|array $instanceIds
      * @return $this
      */
-    public function setModel($model, $instanceId)
+    public function setModel($model, $instanceIds)
     {
-        $this->model      = $model;
-        $this->instanceId = $instanceId;
+        $this->model       = $model;
+        $this->instanceIds = $instanceIds;
 
-        if (is_array($instanceId)) {
-            $instanceId = sprintf('[%s]', implode($instanceId, ', '));
+        if (is_array($instanceIds)) {
+            $instanceIds = sprintf('[%s]', implode($instanceIds, ', '));
         }
 
-        $this->message = "No query results for model [{$model}] with id={$instanceId}.";
+        $this->message = "No query results for model [{$model}] with id={$instanceIds}.";
 
         return $this;
     }
@@ -52,11 +52,11 @@ class ModelNotFoundException extends RuntimeException
     }
 
     /**
-     * Get the affected instance id or array of ids
+     * Get the affected instance ids
      *
      * @return integer|array
      */
-    public function getInstanceId()
+    public function getInstanceIds()
     {
         return $this->instanceId;
     }


### PR DESCRIPTION
In order to have more descriptive exception messages, instance ids are passed to the ModelNotFoundException.
