### PR TITLE
Alias sort functions on Collection

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1020,6 +1020,42 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     {
         return $this->sortBy($callback, $options, true);
     }
+    
+    /**
+     * Alias for sort function.
+     *
+     * @param  callable|null  $callback
+     * @return static
+     */
+    public function order(callable $callback = null)
+    {
+        return $this->sort($callback);
+    }
+
+    /**
+     * Alias for sortBy function.
+     *
+     * @param  callable|string  $callback
+     * @param  int   $options
+     * @param  bool  $descending
+     * @return static
+     */
+    public function orderBy($callback, $options = SORT_REGULAR, $descending = false)
+    {
+        return $this->sortBy($callback, $options, $descending);
+    }
+
+    /**
+     * Alias for sortByDesc function.
+     *
+     * @param  callable|string  $callback
+     * @param  int  $options
+     * @return static
+     */
+    public function orderByDesc($callback, $options = SORT_REGULAR)
+    {
+        return $this->sortByDesc($callback, $options);
+    }
 
     /**
      * Splice a portion of the underlying collection array.


### PR DESCRIPTION
On eloquent we use `orderBy` - but on collection classes we use `sortBy`. They both perform largely the same function, yet have different names.

It would be nice to alias the collections to allow `orderBy` etc. This makes the code simpler and easier, since you can use the same syntax across both.

If this is accepted - maybe we could/should add an alias to the Eloquent classes for `sort` (as an alias for order)?

And if this is accepted I'll send a PR for the docs.
