### PR TITLE
[5.3] Consider IP option as well for throttle key

### DIFF
--- a/src/Illuminate/Foundation/Auth/ThrottlesLogins.php
+++ b/src/Illuminate/Foundation/Auth/ThrottlesLogins.php
@@ -83,7 +83,7 @@ trait ThrottlesLogins
      */
     protected function throttleKey(Request $request)
     {
-        if(Config::get('auth.throttle_key') == 'ip') {
+        if (Config::get('auth.throttle_key') == 'ip') {
             return $request->ip();
         } else {
             return Str::lower($request->input($this->username())).'|'.$request->ip();

--- a/src/Illuminate/Foundation/Auth/ThrottlesLogins.php
+++ b/src/Illuminate/Foundation/Auth/ThrottlesLogins.php
@@ -83,7 +83,11 @@ trait ThrottlesLogins
      */
     protected function throttleKey(Request $request)
     {
-        return Str::lower($request->input($this->username())).'|'.$request->ip();
+        if(Config::get('auth.throttle_key') == 'ip') {
+            return $request->ip();
+        } else {
+            return Str::lower($request->input($this->username())).'|'.$request->ip();
+        }
     }
 
     /**


### PR DESCRIPTION
Just wondering in situations where someone had a list of emails and passwords they would iterate over that list against a site. The throttle would never kick in since each attempt is with a different email.

For example Yahoo list of emails and passwords (if decrypted), now someone is using those to see if these users used the same password on other sites. 

By adding this to `config/auth.php`

```
    /*
    |--------------------------------------------------------------------------
    | Throttle Key
    |--------------------------------------------------------------------------
    |
    | You may choose to block ip address from failed attempts
    | of a combination of IP and Username
    |
    | Supported: "ip", "username|ip"
    |
    */
    'throttle_key' => 'ip'
```

And the above code the site admin could easily switch this out.

The odd part is if an office of staff are using the application and x number of people in the office try to log in and have issues then the 6th user might get hit by this throttle.
