### PR TITLE
[5.3] Notifiable property of each dispatchedNotifications array item contains a single Eloquent model

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MocksApplicationServices.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MocksApplicationServices.php
@@ -401,13 +401,13 @@ trait MocksApplicationServices
 
         $this->beforeApplicationDestroyed(function () use ($notifiable, $notification) {
             foreach ($this->dispatchedNotifications as $dispatched) {
-                foreach ($dispatched['notifiable'] as $notified) {
-                    if (($notified === $notifiable ||
-                         $notified->getKey() == $notifiable->getKey()) &&
-                        get_class($dispatched['instance']) === $notification
-                    ) {
-                        return $this;
-                    }
+                $notified = $dispatched['notifiable'];
+
+                if (($notified === $notifiable ||
+                     $notified->getKey() == $notifiable->getKey()) &&
+                    get_class($dispatched['instance']) === $notification
+                ) {
+                    return $this;
                 }
             }
 


### PR DESCRIPTION
Since version `5.3.15` (up to and including `5.3.18`) using `expectsNotification()` throws an error `Error: Call to a member function getKey() on boolean`. It works as expected on `5.3.14`

It appears `$dispatched['notifiable']` (from the `$this->dispatchedNotifications` array) returns a single Eloquent model, rather than an array.
### Steps To Reproduce bug on `5.3.18`:

```
class ExampleTest extends TestCase
{
    public function test_notifications()
    {
        $user = factory(App\User::class)->create();
        $this->expectsNotification($user, 'App\Notifications\SomeNotification');
        $user->notify(new App\Notifications\SomeNotification);
    }
}
```
