### PR TITLE
[5.3] Improved PolicyMakeCommand to work better with namespaces

### DIFF
--- a/src/Illuminate/Foundation/Console/PolicyMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/PolicyMakeCommand.php
@@ -66,7 +66,7 @@ class PolicyMakeCommand extends GeneratorCommand
 
     /**
      * Separate the namespaced model into
-     * the namespace and the model name
+     * the namespace and the model name.
      *
      * @param  string  $model
      * @return array

--- a/src/Illuminate/Foundation/Console/PolicyMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/PolicyMakeCommand.php
@@ -53,11 +53,17 @@ class PolicyMakeCommand extends GeneratorCommand
      */
     protected function replaceModel($stub, $model)
     {
-        list($model, $namespace) = $this->getModelAndNamespace($model);
+        list($model, $modelNamespace) = $this->getModelAndNamespace($model);
 
-        $stub = str_replace('DummyModelNamespace', $namespace, $stub);
+        list($user,  $userNamespace)  = $this->getUserAndNamespace();
+
+        $stub = str_replace('DummyModelNamespace', $modelNamespace, $stub);
+
+        $stub = str_replace('DummyUserNamespace', $userNamespace, $stub);
 
         $stub = str_replace('DummyModel', $model, $stub);
+
+        $stub = str_replace('DummyUser', $user, $stub);
 
         $stub = str_replace('dummyModelName', Str::camel($model), $stub);
 
@@ -73,7 +79,7 @@ class PolicyMakeCommand extends GeneratorCommand
      */
     protected function getModelAndNamespace($model)
     {
-        $model = str_replace('/', '\\', $model);
+        $model     = str_replace('/', '\\', $model);
 
         $modelName = class_basename(trim($model, '\\'));
 
@@ -84,6 +90,23 @@ class PolicyMakeCommand extends GeneratorCommand
         $namespace = $namespace ?: $this->laravel->getNamespace();
 
         return [$modelName, $namespace];
+    }
+
+    /**
+     * Get the default user and its namespace.
+     *
+     * @param  string  $default
+     * @return array
+     */
+    protected function getUserAndNamespace($default = 'App\\User')
+    {
+        $config   = $this->laravel->make('config');
+
+        $guard    = $config->get('auth.defaults.guard');
+        $provider = $config->get("auth.guards.$guard.provider");
+        $model    = $config->get("auth.providers.$provider.model", $default);
+
+        return $this->getModelAndNamespace($model);
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/PolicyMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/PolicyMakeCommand.php
@@ -53,21 +53,37 @@ class PolicyMakeCommand extends GeneratorCommand
      */
     protected function replaceModel($stub, $model)
     {
-        $model = str_replace('/', '\\', $model);
+        list($model, $namespace) = $this->getModelAndNamespace($model);
 
-        if (Str::startsWith($model, '\\')) {
-            $stub = str_replace('NamespacedDummyModel', trim($model, '\\'), $stub);
-        } else {
-            $stub = str_replace('NamespacedDummyModel', $this->laravel->getNamespace().$model, $stub);
-        }
-
-        $model = class_basename(trim($model, '\\'));
+        $stub = str_replace('DummyModelNamespace', $namespace, $stub);
 
         $stub = str_replace('DummyModel', $model, $stub);
 
         $stub = str_replace('dummyModelName', Str::camel($model), $stub);
 
         return str_replace('dummyPluralModelName', Str::plural(Str::camel($model)), $stub);
+    }
+
+    /**
+     * Separate the namespaced model into
+     * the namespace and the model name
+     *
+     * @param  string  $model
+     * @return array
+     */
+    protected function getModelAndNamespace($model)
+    {
+        $model = str_replace('/', '\\', $model);
+
+        $modelName = class_basename(trim($model, '\\'));
+
+        $namespace = substr($model, 0, -strlen($modelName));
+
+        $namespace = ltrim($namespace, '\\');
+
+        $namespace = $namespace ?: $this->laravel->getNamespace();
+
+        return [$modelName, $namespace];
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/stubs/policy.stub
+++ b/src/Illuminate/Foundation/Console/stubs/policy.stub
@@ -13,8 +13,8 @@ class DummyClass
     /**
      * Determine whether the user can view the dummyModelName.
      *
-     * @param  \DummyModelNamespaceUser  $user
-     * @param  \DummyModelNamespaceDummyModel  $dummyModelName
+     * @param  DummyModelNamespaceUser  $user
+     * @param  DummyModelNamespaceDummyModel  $dummyModelName
      * @return mixed
      */
     public function view(User $user, DummyModel $dummyModelName)
@@ -25,7 +25,7 @@ class DummyClass
     /**
      * Determine whether the user can create dummyPluralModelName.
      *
-     * @param  \DummyModelNamespaceUser  $user
+     * @param  DummyModelNamespaceUser  $user
      * @return mixed
      */
     public function create(User $user)
@@ -36,8 +36,8 @@ class DummyClass
     /**
      * Determine whether the user can update the dummyModelName.
      *
-     * @param  \DummyModelNamespaceUser  $user
-     * @param  \DummyModelNamespaceDummyModel  $dummyModelName
+     * @param  DummyModelNamespaceUser  $user
+     * @param  DummyModelNamespaceDummyModel  $dummyModelName
      * @return mixed
      */
     public function update(User $user, DummyModel $dummyModelName)
@@ -48,8 +48,8 @@ class DummyClass
     /**
      * Determine whether the user can delete the dummyModelName.
      *
-     * @param  \DummyModelNamespaceUser  $user
-     * @param  \DummyModelNamespaceDummyModel  $dummyModelName
+     * @param  DummyModelNamespaceUser  $user
+     * @param  DummyModelNamespaceDummyModel  $dummyModelName
      * @return mixed
      */
     public function delete(User $user, DummyModel $dummyModelName)

--- a/src/Illuminate/Foundation/Console/stubs/policy.stub
+++ b/src/Illuminate/Foundation/Console/stubs/policy.stub
@@ -2,8 +2,8 @@
 
 namespace DummyNamespace;
 
-use DummyRootNamespaceUser;
-use NamespacedDummyModel;
+use DummyModelNamespaceUser;
+use DummyModelNamespaceDummyModel;
 use Illuminate\Auth\Access\HandlesAuthorization;
 
 class DummyClass
@@ -13,8 +13,8 @@ class DummyClass
     /**
      * Determine whether the user can view the dummyModelName.
      *
-     * @param  DummyRootNamespaceUser  $user
-     * @param  DummyRootNamespaceDummyModel  $dummyModelName
+     * @param  \DummyModelNamespaceUser  $user
+     * @param  \DummyModelNamespaceDummyModel  $dummyModelName
      * @return mixed
      */
     public function view(User $user, DummyModel $dummyModelName)
@@ -25,7 +25,7 @@ class DummyClass
     /**
      * Determine whether the user can create dummyPluralModelName.
      *
-     * @param  DummyRootNamespaceUser  $user
+     * @param  \DummyModelNamespaceUser  $user
      * @return mixed
      */
     public function create(User $user)
@@ -36,8 +36,8 @@ class DummyClass
     /**
      * Determine whether the user can update the dummyModelName.
      *
-     * @param  DummyRootNamespaceUser  $user
-     * @param  DummyRootNamespaceDummyModel  $dummyModelName
+     * @param  \DummyModelNamespaceUser  $user
+     * @param  \DummyModelNamespaceDummyModel  $dummyModelName
      * @return mixed
      */
     public function update(User $user, DummyModel $dummyModelName)
@@ -48,8 +48,8 @@ class DummyClass
     /**
      * Determine whether the user can delete the dummyModelName.
      *
-     * @param  DummyRootNamespaceUser  $user
-     * @param  DummyRootNamespaceDummyModel  $dummyModelName
+     * @param  \DummyModelNamespaceUser  $user
+     * @param  \DummyModelNamespaceDummyModel  $dummyModelName
      * @return mixed
      */
     public function delete(User $user, DummyModel $dummyModelName)

--- a/src/Illuminate/Foundation/Console/stubs/policy.stub
+++ b/src/Illuminate/Foundation/Console/stubs/policy.stub
@@ -2,7 +2,7 @@
 
 namespace DummyNamespace;
 
-use DummyModelNamespaceUser;
+use DummyUserNamespaceDummyUser;
 use DummyModelNamespaceDummyModel;
 use Illuminate\Auth\Access\HandlesAuthorization;
 
@@ -13,8 +13,8 @@ class DummyClass
     /**
      * Determine whether the user can view the dummyModelName.
      *
-     * @param  DummyModelNamespaceUser  $user
-     * @param  DummyModelNamespaceDummyModel  $dummyModelName
+     * @param  \DummyUserNamespaceDummyUser  $user
+     * @param  \DummyModelNamespaceDummyModel  $dummyModelName
      * @return mixed
      */
     public function view(User $user, DummyModel $dummyModelName)
@@ -25,7 +25,7 @@ class DummyClass
     /**
      * Determine whether the user can create dummyPluralModelName.
      *
-     * @param  DummyModelNamespaceUser  $user
+     * @param  \DummyUserNamespaceDummyUser  $user
      * @return mixed
      */
     public function create(User $user)
@@ -36,8 +36,8 @@ class DummyClass
     /**
      * Determine whether the user can update the dummyModelName.
      *
-     * @param  DummyModelNamespaceUser  $user
-     * @param  DummyModelNamespaceDummyModel  $dummyModelName
+     * @param  \DummyUserNamespaceDummyUser  $user
+     * @param  \DummyModelNamespaceDummyModel  $dummyModelName
      * @return mixed
      */
     public function update(User $user, DummyModel $dummyModelName)
@@ -48,8 +48,8 @@ class DummyClass
     /**
      * Determine whether the user can delete the dummyModelName.
      *
-     * @param  DummyModelNamespaceUser  $user
-     * @param  DummyModelNamespaceDummyModel  $dummyModelName
+     * @param  \DummyUserNamespaceDummyUser  $user
+     * @param  \DummyModelNamespaceDummyModel  $dummyModelName
      * @return mixed
      */
     public function delete(User $user, DummyModel $dummyModelName)


### PR DESCRIPTION
Now the doc-blocks use absolute namespaces instead of relative
namespaces which was an error. And the User model is now assumed to be
in the same namespace as the other model (the policy’s subject), which
I think is the most likely.
