### PR TITLE
[5.3] Allow to hook into the validator instance from the FormRequest

### DIFF
--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -79,16 +79,16 @@ class FormRequest extends Request implements ValidatesWhenResolved
         if (method_exists($this, 'validator')) {
             $validator = $this->container->call([$this, 'validator'], compact('factory'));
         } else {
-	        $validator = $factory->make(
-	            $this->validationData(), $this->container->call([$this, 'rules']), $this->messages(), $this->attributes()
-	        );
+            $validator = $factory->make(
+                $this->validationData(), $this->container->call([$this, 'rules']), $this->messages(), $this->attributes()
+            );
         }
 
         if (method_exists($this, 'validatorHooks')) {
-        	$this->validatorHooks($validator);
+            $this->validatorHooks($validator);
         }
 
-       	return $validator;
+        return $validator;
     }
 
     /**

--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -77,12 +77,18 @@ class FormRequest extends Request implements ValidatesWhenResolved
         $factory = $this->container->make(ValidationFactory::class);
 
         if (method_exists($this, 'validator')) {
-            return $this->container->call([$this, 'validator'], compact('factory'));
+            $validator = $this->container->call([$this, 'validator'], compact('factory'));
+        } else {
+	        $validator = $factory->make(
+	            $this->validationData(), $this->container->call([$this, 'rules']), $this->messages(), $this->attributes()
+	        );
         }
 
-        return $factory->make(
-            $this->validationData(), $this->container->call([$this, 'rules']), $this->messages(), $this->attributes()
-        );
+        if (method_exists($this, 'validatorHooks')) {
+        	$this->validatorHooks($validator);
+        }
+
+       	return $validator;
     }
 
     /**


### PR DESCRIPTION
Before this PR, when i need to add an After Validation Hook in a FormRequest class i must define a validator() method

``` php
public function validator(Factory $factory)
{
    $validator = $factory->make($this->all(), $this->rules(), $this->messages(), $this->attributes());

    $validator->after(function($v) {
        if( true ) {
            $v->errors()->add('field', 'Something is wrong with this field!');
        }
    });

    return $validator;
}
```

The down side is that i need to define how the validator instance is created.

This PR will allow to easily add After Validation Hook to the validator instance without the need to define how the validator instance is made.

``` php
class CommentStoreRequest extends FormRequest
{
    protected function validatorHooks($validator)
    {
        $validator->after(function($v) {
            if( true ) {
                $v->errors()->add('field', 'Something is wrong with this field!');
            }
        });
    }
}
```
