### PR TITLE
[5.3] [WIP] Add a sanitizer

### DIFF
--- a/src/Illuminate/Validation/Sanitizer.php
+++ b/src/Illuminate/Validation/Sanitizer.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace Illuminate\Validation;
+
+use Illuminate\Container\Container;
+
+class Sanitizer
+{
+    /**
+     * The registered global sanitizers.
+     *
+     * @var array
+     */
+    protected static $sanitizers = [];
+
+    /**
+     * Sanitizer bound to the current instance.
+     *
+     * @var array
+     */
+    protected $instanceSanitizers = [];
+
+    /**
+     * The registered sanitizer aliases.
+     *
+     * @var array
+     */
+    protected static $aliases = [];
+
+    /**
+     * The data we are sanitizing.
+     *
+     * @var array
+     */
+    protected $inputData = [];
+
+    /**
+     * The sanitizing rules to apply to the data.
+     *
+     * @var array
+     */
+    protected $rules = [];
+
+    /**
+     * Sanitizer constructor.
+     *
+     * @param $inputData
+     * @param $rules
+     */
+    public function __construct(array $inputData = [], array $rules = [])
+    {
+        $this->inputData = $inputData;
+        $this->rules = $rules;
+    }
+
+    /**
+     * Sanitize the data.
+     *
+     * @return array
+     */
+    public function sanitize()
+    {
+        $results = [];
+
+        foreach ($this->rules as $inputKey => $rule) {
+            if (! array_key_exists($this->inputData, $inputKey)) {
+                continue;
+            }
+
+            $results[$inputKey] = $this->applySanitizer($rule, $this->inputData[$inputKey]);
+        }
+    }
+
+    /**
+     * Register a new global sanitizer.
+     *
+     * @param $name
+     * @param \Closure $sanitizer
+     */
+    public static function add($name, \Closure $sanitizer)
+    {
+        static::$sanitizers[$name] = $sanitizer;
+    }
+
+    /**
+     * Create a string alias for a sanitizer.
+     *
+     * @param $alias
+     * @param $actual
+     */
+    public static function alias($alias, $actual)
+    {
+        $callable = explode('@', $actual);
+        $callable = array_pad($callable, - (count($callable) - 2), 'sanitize');
+
+        if (! class_exists($callable[0])) {
+            throw new \InvalidArgumentException("Sanitizer class does not exist");
+        }
+
+        if(! method_exists($callable[0], $callable[1])) {
+            throw new \InvalidArgumentException("Sanitizer method {$callable[1]} does not exist");
+        }
+
+        static::$aliases[$alias] = implode('@', $callable);
+    }
+
+    /**
+     * Apply a sanitizer to certain data.
+     *
+     * @param $sanitizer
+     * @param $data
+     * @return mixed
+     */
+    protected function applySanitizer($sanitizer, $data)
+    {
+        if (function_exists($sanitizer) || array_key_exists($sanitizer, static::$sanitizers)) {
+            return $sanitizer($data);
+        }
+
+        if (array_key_exists($sanitizer, static::$aliases)) {
+            $sanitizer = static::$aliases[$sanitizer];
+        }
+
+        return Container::getInstance()->call($sanitizer);
+    }
+}


### PR DESCRIPTION
This PR aims to resolve #14467. I'm opening this PR now already to be able to take in feedback on functionality and usage. I have tried to keep this sanitiser as general purpose as I could. Right now, there is only a `Sanitizer` class but the idea is that the `FormRequest` will also have a more user-friendly access to it by simply return an array of sanitiser rules to apply. The current interface is this:

Register a globally available sanitizer:

```
Sanitizer::register('name', function($name) {
    return trim($name);
});
```

Alias a custom sanitizer class (and optionally method):

```
Sanitizer::alias('string', StringSanitizer::class);

Sanitizer::alias('name', StringSanitizer::class.'@sanitizeName');

class StringSanitizer {
    /**
     * The default sanitizer.
     *
     * @param  string  $string
     * @return string
     */
    public function sanitize($string)
    {
        return trim($string);
    }

    /**
     * A custom sanitizer.
     *
     * @param  string  $name
     * @return string
     */
    public function sanitizeName($name)
    {
        return ucfirst($this->sanitize($name));
    }
}
```

Finally, to use the sanitiser:

```
$data = [
    'first_name' => 'Taylor',
];
$rules = [
    'first_name' => 'name',
];
$sanitizer = new Sanitizer($data, $rules);

$sanitizedData = $sanitizer->sanitize();
```

To-do:
- [ ] Make data sanitization easily accessible through the `FormRequest`

Considered improvements
- Allow applying a sanitizer to _every_ item of the array
  - either through numeric key, or `*` as key
- Allow applying a sanitizer to an array
  - either supply just the array name (or `arrayName.*`, or individual items by dot notation `array.item`

---

**PLEASE NOTE: This PR is a work in progress and created early for input**
