### PR TITLE
[5.3] Split messages by all possible EOLs

### DIFF
--- a/src/Illuminate/Notifications/Messages/SimpleMessage.php
+++ b/src/Illuminate/Notifications/Messages/SimpleMessage.php
@@ -160,7 +160,7 @@ class SimpleMessage
             return implode(' ', array_map('trim', $line));
         }
 
-        return trim(implode(' ', array_map('trim', explode(PHP_EOL, $line))));
+        return trim(implode(' ', array_map('trim', preg_split('/\n|\r\n?/', $line))));
     }
 
     /**


### PR DESCRIPTION
Fixes `testMessageFormatsMultiLineText()` on Windows.

Would also fix a CRLF encoded file on an Unix server.
