### PR TITLE
[5.3] Add method Builder::lastInsertId()

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2143,6 +2143,17 @@ class Builder
     }
 
     /**
+     * Get the ID of the last inserted row.
+     *
+     * @param  string  $sequence
+     * @return int
+     */
+    public function lastInsertId($sequence = null)
+    {
+        return $this->processor->processLastInsertId($this, $sequence);
+    }
+
+    /**
      * Update a record in the database.
      *
      * @param  array  $values

--- a/src/Illuminate/Database/Query/Processors/PostgresProcessor.php
+++ b/src/Illuminate/Database/Query/Processors/PostgresProcessor.php
@@ -27,6 +27,25 @@ class PostgresProcessor extends Processor
     }
 
     /**
+     * Process a "last insert ID" query.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  string  $sequence
+     * @return int
+     */
+    public function processLastInsertId(Builder $query, $sequence = null)
+    {
+        $table = $query->from;
+        $sequence = $sequence ?: 'id';
+
+        $sequenceName = "{$table}_{$sequence}_seq";
+
+        $id = $query->getConnection()->getPdo()->lastInsertId($sequenceName);
+
+        return is_numeric($id) ? (int) $id : $id;
+    }
+
+    /**
      * Process the results of a column listing query.
      *
      * @param  array  $results

--- a/src/Illuminate/Database/Query/Processors/Processor.php
+++ b/src/Illuminate/Database/Query/Processors/Processor.php
@@ -19,7 +19,7 @@ class Processor
     }
 
     /**
-     * Process an  "insert get ID" query.
+     * Process an "insert get ID" query.
      *
      * @param  \Illuminate\Database\Query\Builder  $query
      * @param  string  $sql

--- a/src/Illuminate/Database/Query/Processors/Processor.php
+++ b/src/Illuminate/Database/Query/Processors/Processor.php
@@ -31,6 +31,18 @@ class Processor
     {
         $query->getConnection()->insert($sql, $values);
 
+        return $this->processLastInsertId($query, $sequence);
+    }
+
+    /**
+     * Process a "last insert ID" query.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  string  $sequence
+     * @return int
+     */
+    public function processLastInsertId(Builder $query, $sequence = null)
+    {
         $id = $query->getConnection()->getPdo()->lastInsertId($sequence);
 
         return is_numeric($id) ? (int) $id : $id;

--- a/src/Illuminate/Database/Query/Processors/SqlServerProcessor.php
+++ b/src/Illuminate/Database/Query/Processors/SqlServerProcessor.php
@@ -9,22 +9,6 @@ use Illuminate\Database\Query\Builder;
 class SqlServerProcessor extends Processor
 {
     /**
-     * Process an "insert get ID" query.
-     *
-     * @param  \Illuminate\Database\Query\Builder  $query
-     * @param  string  $sql
-     * @param  array   $values
-     * @param  string  $sequence
-     * @return int
-     */
-    public function processInsertGetId(Builder $query, $sql, $values, $sequence = null)
-    {
-        $query->getConnection()->insert($sql, $values);
-
-        return $this->processLastInsertId($query, $sequence);
-    }
-
-    /**
      * Process a "last insert ID" query.
      *
      * @param  \Illuminate\Database\Query\Builder  $query

--- a/src/Illuminate/Database/Query/Processors/SqlServerProcessor.php
+++ b/src/Illuminate/Database/Query/Processors/SqlServerProcessor.php
@@ -33,7 +33,7 @@ class SqlServerProcessor extends Processor
     }
 
     /**
-     * Process an "insert get ID" query for ODBC.
+     * Process a "last insert ID" query for ODBC.
      *
      * @param  \Illuminate\Database\Connection  $connection
      * @return int

--- a/src/Illuminate/Database/Query/Processors/SqlServerProcessor.php
+++ b/src/Illuminate/Database/Query/Processors/SqlServerProcessor.php
@@ -19,9 +19,21 @@ class SqlServerProcessor extends Processor
      */
     public function processInsertGetId(Builder $query, $sql, $values, $sequence = null)
     {
-        $connection = $query->getConnection();
+        $query->getConnection()->insert($sql, $values);
 
-        $connection->insert($sql, $values);
+        return $this->processLastInsertId($query, $sequence);
+    }
+
+    /**
+     * Process a "last insert ID" query.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  string  $sequence
+     * @return int
+     */
+    public function processLastInsertId(Builder $query, $sequence = null)
+    {
+        $connection = $query->getConnection();
 
         if ($connection->getConfig('odbc') === true) {
             $id = $this->processInsertGetIdForOdbc($connection);

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1176,6 +1176,11 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase
     public function testInsertGetIdMethod()
     {
         $builder = $this->getBuilder();
+        $builder->getProcessor()->shouldReceive('processInsertGetId')->once()->with($builder, 'insert into "users" ("email") values (?)', ['foo'], null)->andReturn(1);
+        $result = $builder->from('users')->insertGetId(['email' => 'foo']);
+        $this->assertEquals(1, $result);
+
+        $builder = $this->getBuilder();
         $builder->getProcessor()->shouldReceive('processInsertGetId')->once()->with($builder, 'insert into "users" ("email") values (?)', ['foo'], 'id')->andReturn(1);
         $result = $builder->from('users')->insertGetId(['email' => 'foo'], 'id');
         $this->assertEquals(1, $result);

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1194,6 +1194,19 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(1, $result);
     }
 
+    public function testLastInsertIdMethod()
+    {
+        $builder = $this->getBuilder();
+        $builder->getProcessor()->shouldReceive('processLastInsertId')->once()->with($builder, null)->andReturn(1);
+        $result = $builder->lastInsertId();
+        $this->assertEquals(1, $result);
+
+        $builder = $this->getBuilder();
+        $builder->getProcessor()->shouldReceive('processLastInsertId')->once()->with($builder, 'id')->andReturn(1);
+        $result = $builder->lastInsertId('id');
+        $this->assertEquals(1, $result);
+    }
+
     public function testInsertMethodRespectsRawBindings()
     {
         $builder = $this->getBuilder();


### PR DESCRIPTION
Use case:

``` php
$query->insert($bulk);

// before (long, not DB-agnostic)
$idFirst = $query->getConnection()->getPdo()->lastInsertId();
// after (zonda)
$idFirst = $query->lastInsertId();

$idLast = $idFirst + count($bulk) - 1;
```

PostgreSQL is a bit tricky, see http://stackoverflow.com/questions/2944297/postgresql-function-for-last-inserted-id#2944481. Current `processInsertGetId()` uses option 3, my added `processLastInsertId()` uses option 1.
