### PR TITLE
[5.3] New object syntax for the rule in

### DIFF
--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -28,6 +28,17 @@ class Rule
     }
 
     /**
+     * Get a in constraint builder instance.
+     *
+     * @param  array  $values
+     * @return \Illuminate\Validation\Rules\In
+     */
+    public static function in(array $values)
+    {
+        return new Rules\In($values);
+    }
+
+    /**
      * Get a unique constraint builder instance.
      *
      * @param  string  $table

--- a/src/Illuminate/Validation/Rules/In.php
+++ b/src/Illuminate/Validation/Rules/In.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Illuminate\Validation\Rules;
+
+class In
+{
+    /**
+     * The accepted values.
+     *
+     * @var array
+     */
+    protected $values;
+
+    /**
+     * Create a new in rule instance.
+     *
+     * @param  array  $values
+     * @return void
+     */
+    public function __construct(array $values)
+    {
+        $this->values = $values;
+    }
+
+    /**
+     * Convert the rule to a validation string.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return 'in:'.implode(',', $this->values);
+    }
+}

--- a/tests/Validation/ValidationInRuleTest.php
+++ b/tests/Validation/ValidationInRuleTest.php
@@ -1,0 +1,18 @@
+<?php
+
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\Rules\In;
+
+class ValidationInRuleTest extends PHPUnit_Framework_TestCase
+{
+    public function testItCorrectlyFormatsAStringVersionOfTheRule()
+    {
+        $rule = new In(['Laravel', 'Framework', 'PHP']);
+
+        $this->assertEquals('in:Laravel,Framework,PHP', (string) $rule);
+
+        $rule = Rule::in([1, 2, 3, 4]);
+
+        $this->assertEquals('in:1,2,3,4', (string) $rule);
+    }
+}


### PR DESCRIPTION
I've found myself doing `'in:'.implode(',', $values)` because I have the `$values` var and it's an array already (located in the config, etc.) and then having to add a similar helper to my project. So I think this rule will be useful as well. 
