### PR TITLE
[5.3] [WIP] Convert rule objects to array

### DIFF
--- a/src/Illuminate/Validation/Rules/Dimensions.php
+++ b/src/Illuminate/Validation/Rules/Dimensions.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\Validation\Rules;
 
-class Dimensions
+class Dimensions implements Rule
 {
     /**
      * The constraints for the dimensions rule.
@@ -111,6 +111,11 @@ class Dimensions
         $this->constraints['ratio'] = $value;
 
         return $this;
+    }
+
+    public function toArray()
+    {
+        return ['dimensions', $this->constraints];
     }
 
     /**

--- a/src/Illuminate/Validation/Rules/Exists.php
+++ b/src/Illuminate/Validation/Rules/Exists.php
@@ -4,7 +4,7 @@ namespace Illuminate\Validation\Rules;
 
 use Closure;
 
-class Exists
+class Exists implements Rule
 {
     /**
      * The table to run the query against.
@@ -60,7 +60,7 @@ class Exists
             return $this->using($column);
         }
 
-        $this->wheres[] = compact('column', 'value');
+        $this->wheres[$column] = $value;
 
         return $this;
     }
@@ -118,8 +118,8 @@ class Exists
      */
     protected function formatWheres()
     {
-        return collect($this->wheres)->map(function ($where) {
-            return $where['column'].','.$where['value'];
+        return collect($this->wheres)->map(function ($value, $key) {
+            return "$key,$value";
         })->implode(',');
     }
 
@@ -131,6 +131,11 @@ class Exists
     public function queryCallbacks()
     {
         return $this->using ? [$this->using] : [];
+    }
+
+    public function toArray()
+    {
+        return ['exists', [$this->table, $this->column, $this->wheres]];
     }
 
     /**

--- a/src/Illuminate/Validation/Rules/Rule.php
+++ b/src/Illuminate/Validation/Rules/Rule.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Illuminate\Validation\Rules;
+
+interface Rule
+{
+    public function toArray();
+}

--- a/src/Illuminate/Validation/Rules/Unique.php
+++ b/src/Illuminate/Validation/Rules/Unique.php
@@ -4,7 +4,7 @@ namespace Illuminate\Validation\Rules;
 
 use Closure;
 
-class Unique
+class Unique implements Rule
 {
     /**
      * The table to run the query against.
@@ -74,7 +74,7 @@ class Unique
             return $this->using($column);
         }
 
-        $this->wheres[] = compact('column', 'value');
+        $this->wheres[$column] = $value;
 
         return $this;
     }
@@ -147,8 +147,8 @@ class Unique
      */
     protected function formatWheres()
     {
-        return collect($this->wheres)->map(function ($where) {
-            return $where['column'].','.$where['value'];
+        return collect($this->wheres)->map(function ($value, $key) {
+            return "$key,$value";
         })->implode(',');
     }
 
@@ -160,6 +160,17 @@ class Unique
     public function queryCallbacks()
     {
         return $this->using ? [$this->using] : [];
+    }
+
+    public function toArray()
+    {
+        return ['unique', [
+            $this->table,
+            $this->column,
+            $this->ignore ?: 'NULL',
+            $this->idColumn,
+            $this->wheres,
+        ]];
     }
 
     /**

--- a/tests/Validation/ValidationUniqueRuleTest.php
+++ b/tests/Validation/ValidationUniqueRuleTest.php
@@ -8,7 +8,6 @@ class ValidationUniqueRuleTest extends PHPUnit_Framework_TestCase
         $rule->where('foo', 'bar');
         $this->assertEquals('unique:table,NULL,NULL,id,foo,bar', (string) $rule);
 
-
         $rule = new Illuminate\Validation\Rules\Unique('table', 'column');
         $rule->ignore(1, 'id_column');
         $rule->where('foo', 'bar');

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -14,6 +14,21 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         m::close();
     }
 
+    public function testCanExtractRuleAndParametersFromARuleObject()
+    {
+        $rule = m::mock(\Illuminate\Validation\Rules\Rule::class);
+
+        // Why 6 times?
+        $rule->shouldReceive('toArray')->times(6)->andReturn(['max', [120]]);
+
+        $rule->shouldReceive('__toString')->never();
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['age' => 30], ['age' => $rule]);
+
+        $this->assertTrue($v->passes());
+    }
+
     public function testSometimesWorksOnNestedArrays()
     {
         $trans = $this->getIlluminateArrayTranslator();
@@ -1928,6 +1943,20 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $v = new Validator($trans, [], ['x' => 'dimensions:ratio=1']);
         $v->setFiles(['x' => $uploadedFile]);
         $this->assertTrue($v->fails());
+    }
+
+    public function testValidateImageDimensionsObject()
+    {
+        $uploadedFile = new \Symfony\Component\HttpFoundation\File\UploadedFile(__DIR__.'/fixtures/image.gif', '', null, null, null, true);
+
+        $trans = $this->getIlluminateArrayTranslator();
+
+        $v = new Validator($trans, [], [
+            'file' => \Illuminate\Validation\Rule::dimensions(['min_width' => 2, 'min_heigh' => 2]),
+        ]);
+        $v->setFiles(['file' => $uploadedFile]);
+
+        $this->assertTrue($v->passes());
     }
 
     /**


### PR DESCRIPTION
That way there is no need to convert the rule object in a string and then parse the string. In theory it should make the rule parsing faster, but anyway since we already have an object it kind of makes more sense to work with it directly.

This is just a proposal and a work in progress to discuss.

I'm also thinking I should have committed this one  for Laravel 5.4? 
