### PR TITLE
[5.3] Use getPdo() to ensure we get  actual PDO instance not a closure

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -603,7 +603,7 @@ class Connection implements ConnectionInterface
     {
         if ($this->transactions == 0) {
             try {
-                $this->pdo->beginTransaction();
+                $this->getPdo()->beginTransaction();
             } catch (Exception $e) {
                 if ($this->causedByLostConnection($e)) {
                     $this->reconnect();
@@ -613,7 +613,7 @@ class Connection implements ConnectionInterface
                 }
             }
         } elseif ($this->transactions >= 1 && $this->queryGrammar->supportsSavepoints()) {
-            $this->pdo->exec(
+            $this->getPdo()->exec(
                 $this->queryGrammar->compileSavepoint('trans'.($this->transactions + 1))
             );
         }


### PR DESCRIPTION
In this commit https://github.com/laravel/framework/commit/7a0832bb44057f1060c96c2e01652aae7c583323#diff-b31f91220886998b9ea2bb850342e47cR606

we replaced using `getPdo()` with calling the class parameter directly, however when we create the connection we pass a closure that shall be used to resolve the PDO, when we use `getPdo()` we resolve this closure into an actual PDO instance if it wasn't resolved already thus we ensure a PDO instance is passed.

Currently DB transactions aren't working https://github.com/laravel/framework/issues/15927
