### PR TITLE
[5.3] dont rollback to savepoints on deadlock

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -576,6 +576,14 @@ class Connection implements ConnectionInterface
             // up in the database. Then we'll re-throw the exception so it can
             // be handled how the developer sees fit for their applications.
             catch (Exception $e) {
+                // On deadlock, if this is a nested transaction, we cannot retry.
+                // the outer most transaction is rolled back by the server
+                // so we shouldn't rollback to save points.
+                if ($this->causedByDeadlock($e) && $this->transactions > 1) {
+                    --$this->transactions;
+                    throw $e;
+                }
+
                 $this->rollBack();
 
                 if ($this->causedByDeadlock($e) && $a < $attempts) {


### PR DESCRIPTION
This fix only applies to calls to DB::transaction() inside another transaction. e.g.:

``` php
\DB::transaction(function(){
    ...
    //directly or indirectly call another transaction:
    \DB::transaction(function() {
        ...
        //dead lock!
        ...
    }, 2);//attempt twice
}, 2);//attempt twice
```

Deadlock in the inner transaction() function means the DBMS has rolled back the outer transaction as well. So the inner transaction function should not attempt again. It only should decrement `Connection::transactions` before throwing exception, so that the outer transaction() function attempts again.

Here is a quote from [MySQL Reference Manual](http://dev.mysql.com/doc/refman/5.7/en/innodb-error-handling.html):

>  A transaction deadlock causes InnoDB to roll back the entire transaction. Retry the whole transaction when this happens.
