### PR TITLE
[5.3] Commands can now implement ShouldFake interface so they are not run on local environment

### DIFF
--- a/src/Illuminate/Contracts/Bus/ShouldFake.php
+++ b/src/Illuminate/Contracts/Bus/ShouldFake.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Illuminate\Contracts\Bus;
+
+interface ShouldFake
+{
+    public function fake();
+}


### PR DESCRIPTION
for some specific kind of jobs that interact with 3rd party APIs it is sometimes good not to have them actually execute the job. for example there are some services that don't provide you a `developer` plan and getting an api key is always a matter of being a subscriber of the service. or they provide you an api for trail period and then you have to upgrade. as a developer working on a client requested feature you don't necessarily want to be a subscriber of that service. for things of that nature you may want to be able to easily trigger the jobs being executed when on local environment.

I thought it'd be nice to be able to have some commands simply to implement `ShouldFake` interface which would resolve commands `fake` method and stop further execution
