### PR TITLE
Add common replacement feature

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -2219,6 +2219,15 @@ class Validator implements ValidatorContract
             $message = $this->$replacer($message, $attribute, $rule, $parameters);
         }
 
+        $matches = [];
+
+        preg_match_all('/:(\w+)[^\w]?/', $message, $matches);
+
+        foreach ($matches[1] as $match)
+        {
+            $message = str_replace(":{$match}", $this->getAttribute($match), $message);
+        }
+        
         return $message;
     }
 

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -2223,8 +2223,7 @@ class Validator implements ValidatorContract
 
         preg_match_all('/:(\w+)[^\w]?/', $message, $matches);
 
-        foreach ($matches[1] as $match)
-        {
+        foreach ($matches[1] as $match) {
             $message = str_replace(":{$match}", $this->getAttribute($match), $message);
         }
         


### PR DESCRIPTION
No we can use custom attributes in all messages with errors.

Sometimes i want to pass in custom attribute's messages smth like "field_code" => "The field with name `Code`" and want it can be accessed in any messages with error.
