### PR TITLE
[5.4] Add common replacement feature

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -2219,6 +2219,14 @@ class Validator implements ValidatorContract
             $message = $this->$replacer($message, $attribute, $rule, $parameters);
         }
 
+        $matches = [];
+
+        preg_match_all('/:(\w+)[^\w]?/', $message, $matches);
+
+        foreach ($matches[1] as $match) {
+            $message = str_replace(":{$match}", $this->getAttribute($match), $message);
+        }
+
         return $message;
     }
 


### PR DESCRIPTION
No we can use custom attributes in all messages with errors.

Sometimes i want to pass in custom attribute's messages like "field_code" => "The field with name `Code`" and want it can be accessed in any messages with errors.
