### PR TITLE
[5.4] Return a Database Collection from HasOneOrMany::createMany

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -329,10 +329,10 @@ abstract class HasOneOrMany extends Relation
     }
 
     /**
-     * Create an array of new instances of the related model.
+     * Create a Collection of new instances of the related model.
      *
      * @param  array  $records
-     * @return array
+     * @return \Illuminate\Database\Eloquent\Collection
      */
     public function createMany(array $records)
     {

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -336,10 +336,10 @@ abstract class HasOneOrMany extends Relation
      */
     public function createMany(array $records)
     {
-        $instances = [];
+        $instances = $this->related->newCollection();
 
         foreach ($records as $record) {
-            $instances[] = $this->create($record);
+            $instances->push($this->create($record));
         }
 
         return $instances;

--- a/tests/Database/DatabaseEloquentHasManyTest.php
+++ b/tests/Database/DatabaseEloquentHasManyTest.php
@@ -14,10 +14,7 @@ class DatabaseEloquentHasManyTest extends PHPUnit_Framework_TestCase
     public function testCreateMethodProperlyCreatesNewModel()
     {
         $relation = $this->getRelation();
-        $created = $this->getMockBuilder('Illuminate\Database\Eloquent\Model')->setMethods(['save', /*'getKey',*/ 'setAttribute'])->getMock();
-        $created->expects($this->once())->method('save')->will($this->returnValue(true));
-        $relation->getRelated()->shouldReceive('newInstance')->once()->with(['name' => 'taylor'])->andReturn($created);
-        $created->expects($this->once())->method('setAttribute')->with('foreign_key', 1);
+        $created = $this->expectCreatedModel($relation, ['name' => 'taylor']);
 
         $this->assertEquals($created, $relation->create(['name' => 'taylor']));
     }
@@ -56,10 +53,9 @@ class DatabaseEloquentHasManyTest extends PHPUnit_Framework_TestCase
         $relation = $this->getRelation();
         $relation->getQuery()->shouldReceive('where')->once()->with(['foo'])->andReturn($relation->getQuery());
         $relation->getQuery()->shouldReceive('first')->once()->with()->andReturn(null);
-        $relation->getRelated()->shouldReceive('newInstance')->once()->with(['foo'])->andReturn($model = m::mock('StdClass'));
-        $model->shouldReceive('setAttribute')->once()->with('foreign_key', 1);
+        $model = $this->expectNewModel($relation, ['foo']);
 
-        $this->assertInstanceOf(StdClass::class, $relation->firstOrNew(['foo']));
+        $this->assertEquals($model, $relation->firstOrNew(['foo']));
     }
 
     public function testFirstOrCreateMethodFindsFirstModel()
@@ -79,11 +75,9 @@ class DatabaseEloquentHasManyTest extends PHPUnit_Framework_TestCase
         $relation = $this->getRelation();
         $relation->getQuery()->shouldReceive('where')->once()->with(['foo'])->andReturn($relation->getQuery());
         $relation->getQuery()->shouldReceive('first')->once()->with()->andReturn(null);
-        $relation->getRelated()->shouldReceive('newInstance')->once()->with(['foo'])->andReturn($model = m::mock('StdClass'));
-        $model->shouldReceive('save')->once()->andReturn(true);
-        $model->shouldReceive('setAttribute')->once()->with('foreign_key', 1);
+        $model = $this->expectCreatedModel($relation, ['foo']);
 
-        $this->assertInstanceOf(StdClass::class, $relation->firstOrCreate(['foo']));
+        $this->assertEquals($model, $relation->firstOrCreate(['foo']));
     }
 
     public function testUpdateOrCreateMethodFindsFirstModelAndUpdates()
@@ -187,8 +181,8 @@ class DatabaseEloquentHasManyTest extends PHPUnit_Framework_TestCase
         $relation = $this->getRelation();
         $relation->getRelated()->shouldReceive('newCollection')->once()->andReturn(new Collection);
 
-        $taylor = $this->expectNewlyCreatedModel($relation, ['name' => 'taylor']);
-        $colin = $this->expectNewlyCreatedModel($relation, ['name' => 'colin']);
+        $taylor = $this->expectCreatedModel($relation, ['name' => 'taylor']);
+        $colin = $this->expectCreatedModel($relation, ['name' => 'colin']);
 
         $instances = $relation->createMany($records);
         $this->assertInstanceOf(Collection::class, $instances);
@@ -211,12 +205,19 @@ class DatabaseEloquentHasManyTest extends PHPUnit_Framework_TestCase
         return new HasMany($builder, $parent, 'table.foreign_key', 'id');
     }
 
-    protected function expectNewlyCreatedModel($relation, $attributes)
+    protected function expectNewModel($relation, $attributes = null)
     {
         $model = $this->getMockBuilder('Illuminate\Database\Eloquent\Model')->setMethods(['setAttribute', 'save'])->getMock();
+        $relation->getRelated()->shouldReceive('newInstance')->with($attributes)->andReturn($model);
         $model->expects($this->once())->method('setAttribute')->with('foreign_key', 1);
+
+        return $model;
+    }
+
+    protected function expectCreatedModel($relation, $attributes)
+    {
+        $model = $this->expectNewModel($relation, $attributes);
         $model->expects($this->once())->method('save');
-        $relation->getRelated()->shouldReceive('newInstance')->once()->with($attributes)->andReturn($model);
 
         return $model;
     }

--- a/tests/Database/DatabaseEloquentHasManyTest.php
+++ b/tests/Database/DatabaseEloquentHasManyTest.php
@@ -175,7 +175,7 @@ class DatabaseEloquentHasManyTest extends PHPUnit_Framework_TestCase
     {
         $records = [
             'taylor' => ['name' => 'taylor'],
-            'colin' => ['name' => 'colin']
+            'colin' => ['name' => 'colin'],
         ];
 
         $relation = $this->getRelation();


### PR DESCRIPTION
While there is enough information available to return something more useful, `Illuminate\Database\Eloquent\Relation\HasOneOrMany::createMany` returns an `array`. It should return an instance of `Illuminate\Database\Eloquent\Collection` based on the `$related` model.

Fixes #15943 
