### PR TITLE
Add common replacement feature

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -2219,6 +2219,14 @@ class Validator implements ValidatorContract
             $message = $this->$replacer($message, $attribute, $rule, $parameters);
         }
 
+        $matches = [];
+
+        preg_match_all('/:(\w+)[^\w]?/', $message, $matches);
+
+        foreach ($matches[1] as $match) {
+            $message = str_replace(":{$match}", $this->getAttribute($match), $message);
+        }
+
         return $message;
     }
 


### PR DESCRIPTION
Now we can use custom attributes in all messages with errors.

Sometimes i want to pass in custom attribute's messages like "custom_license" => "Common license" and want it can be accessed in any messages with errors.

Example:

```
app('validator')->make(
        [
            'id' => 10,
            'title' => [
                'en' => 'Field of object'
            ],
            'key' => 'string',
            'class_model' => '\App\Vendor\SomeVendor\Eloquent\ObjectField'
            'class_controller' => '\App\Vendor\SomeVendor\Controller\ObjectFieldController'
        ], 
        [
            'title.*' => ['required'],
            'class_model' => ['required'],
        ],
        [
            'required' => 'Field ":attribute" required by license :custom_license'
        ],
        [
            'custom_license' => "Common license"
        ]
    );
```
