### PR TITLE
[5.3] Prefers View contract name() method

### DIFF
--- a/src/Illuminate/View/Factory.php
+++ b/src/Illuminate/View/Factory.php
@@ -516,7 +516,7 @@ class Factory implements FactoryContract
      */
     public function callComposer(ViewContract $view)
     {
-        $this->events->fire('composing: '.$view->getName(), [$view]);
+        $this->events->fire('composing: '.$view->name(), [$view]);
     }
 
     /**
@@ -527,7 +527,7 @@ class Factory implements FactoryContract
      */
     public function callCreator(ViewContract $view)
     {
-        $this->events->fire('creating: '.$view->getName(), [$view]);
+        $this->events->fire('creating: '.$view->name(), [$view]);
     }
 
     /**

--- a/tests/View/ViewFactoryTest.php
+++ b/tests/View/ViewFactoryTest.php
@@ -209,7 +209,7 @@ class ViewFactoryTest extends PHPUnit_Framework_TestCase
     {
         $factory = $this->getFactory();
         $view = m::mock('Illuminate\View\View');
-        $view->shouldReceive('getName')->once()->andReturn('name');
+        $view->shouldReceive('name')->once()->andReturn('name');
         $factory->getDispatcher()->shouldReceive('fire')->once()->with('composing: name', [$view]);
 
         $factory->callComposer($view);


### PR DESCRIPTION
As `getName()` is just an alias of `name()` and only `name()` is in `\Illuminate\Contracts\View\View` interface.
