### PR TITLE
[5.3] Add missing ClosureCommand::$callback property

### DIFF
--- a/src/Illuminate/Foundation/Console/ClosureCommand.php
+++ b/src/Illuminate/Foundation/Console/ClosureCommand.php
@@ -11,6 +11,13 @@ use Symfony\Component\Console\Output\OutputInterface;
 class ClosureCommand extends Command
 {
     /**
+     * The callback.
+     *
+     * @var \Closure
+     */
+    protected $callback;
+
+    /**
      * Create a new command instance.
      *
      * @param  string  $signature


### PR DESCRIPTION
Add missing `\Illuminate\Foundation\Console\ClosureCommand::$callback` property
