### PR TITLE
[5.4] Allow dependency injection on seeders `run` method.

### DIFF
--- a/src/Illuminate/Database/Console/Seeds/SeedCommand.php
+++ b/src/Illuminate/Database/Console/Seeds/SeedCommand.php
@@ -60,7 +60,7 @@ class SeedCommand extends Command
         $this->resolver->setDefaultConnection($this->getDatabase());
 
         Model::unguarded(function () {
-            $this->getSeeder()->run();
+            $this->getSeeder()->__invoke();
         });
     }
 

--- a/src/Illuminate/Database/Seeder.php
+++ b/src/Illuminate/Database/Seeder.php
@@ -22,13 +22,6 @@ abstract class Seeder
     protected $command;
 
     /**
-     * Run the database seeds.
-     *
-     * @return void
-     */
-    abstract public function run();
-
-    /**
      * Seed the given connection from the given path.
      *
      * @param  string  $class
@@ -36,7 +29,7 @@ abstract class Seeder
      */
     public function call($class)
     {
-        $this->resolve($class)->run();
+        $this->resolve($class)->__invoke();
 
         if (isset($this->command)) {
             $this->command->getOutput()->writeln("<info>Seeded:</info> $class");
@@ -90,5 +83,25 @@ abstract class Seeder
         $this->command = $command;
 
         return $this;
+    }
+
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function __invoke()
+    {
+        if (method_exists($this, 'run')) {
+            if (isset($this->container)) {
+                return $this->container->call([$this, 'run']);
+            }
+
+            return $this->run();
+        }
+
+        throw new \InvalidArgumentException('Method [run] missing from '.get_class($this));
     }
 }

--- a/tests/Database/SeedCommandTest.php
+++ b/tests/Database/SeedCommandTest.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Container\Container;
+use Illuminate\Database\ConnectionResolverInterface;
+use Illuminate\Database\Console\Seeds\SeedCommand;
+use Illuminate\Database\Seeder;
+
+class SeedCommandTest extends PHPUnit_Framework_TestCase
+{
+    public function testFire()
+    {
+        $seeder = Mockery::mock(Seeder::class);
+        $seeder->shouldReceive('setContainer')->once()->andReturnSelf();
+        $seeder->shouldReceive('setCommand')->once()->andReturnSelf();
+        $seeder->shouldReceive('__invoke')->once();
+
+        $resolver = Mockery::mock(ConnectionResolverInterface::class);
+        $resolver->shouldReceive('setDefaultConnection')->once()->with('sqlite');
+
+        $container = Mockery::mock(Container::class);
+        $container->shouldReceive('call');
+        $container->shouldReceive('environment')->once()->andReturn('testing');
+        $container->shouldReceive('make')->with('DatabaseSeeder')->andReturn($seeder);
+
+        $command = new SeedCommand($resolver);
+        $command->setLaravel($container);
+
+        // call run to set up IO, then fire manually.
+        $command->run(new Symfony\Component\Console\Input\ArrayInput(['--force' => true, '--database' => 'sqlite']), new Symfony\Component\Console\Output\NullOutput);
+        $command->fire();
+
+        $container->shouldHaveReceived('call')->with([$command, 'fire']);
+    }
+
+    protected function tearDown()
+    {
+        Mockery::close();
+    }
+}


### PR DESCRIPTION
This makes `Seeder` classes look a lot more like how `Command` classes work: instead of using an abstract method with no parameters, implement a method that delegates the call to the DI container.

Should be 99.9% backwards compatible. Added a `SeedCommandTest` to be sure.
Also, used the `__invoke` magic method but never really _invoked_ any seeder, so that could be changed as well.
