### PR TITLE
[5.3] Fix #15892 by using the default schema grammar if not set.

### DIFF
--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Database\Migrations;
 
-use Closure;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Support\Collection;

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -374,11 +374,28 @@ class Migrator
             $migration->$method();
         };
 
-        $grammar = $connection->getSchemaGrammar();
+        $grammar = $this->getSchemaGrammar($connection);
 
         $grammar->supportsSchemaTransactions()
                     ? $connection->transaction($callback)
                     : $callback();
+    }
+
+    /**
+     * Get the schema grammar out of a migration connection.
+     *
+     * @param  \Illuminate\Database\Connection  $connection
+     * @return \Illuminate\Database\Schema\Grammars\Grammar
+     */
+    protected function getSchemaGrammar($connection)
+    {
+        if (is_null($grammar = $connection->getSchemaGrammar())) {
+            $connection->useDefaultSchemaGrammar();
+
+            $grammar = $connection->getSchemaGrammar();
+        }
+
+        return $grammar;
     }
 
     /**

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -159,7 +159,7 @@ class Migrator
             return $this->pretendToRun($migration, 'up');
         }
 
-        $this->migrate($migration, 'up');
+        $this->runMigration($migration, 'up');
 
         // Once we have run a migrations class, we will log that it was run in this
         // repository so that we don't try to run it next time we do a migration


### PR DESCRIPTION
I broke rolling back migrations in #15780; this fixes that break.

When rolling back a migration, there is no set Schema grammar.

I also ensured that we use the migration's connection (`protected $connection = 'foo';`) whenever we wrap migrations in a transaction, in case it has been overridden.
