### PR TITLE
[5.3] Fix issue where PDO::prepare() returning false results in fatal error

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -331,6 +331,9 @@ class Connection implements ConnectionInterface
             // of the database result set. Each element in the array will be a single
             // row from the database table, and will either be an array or objects.
             $statement = $this->getPdoForSelect($useReadPdo)->prepare($query);
+            if ($statement === false) {
+                throw new QueryException($query, $bindings, new Exception());
+            }
 
             $me->bindValues($statement, $me->prepareBindings($bindings));
 
@@ -367,6 +370,9 @@ class Connection implements ConnectionInterface
             }
 
             $statement = $this->getPdoForSelect($useReadPdo)->prepare($query);
+            if ($statement === false) {
+                throw new QueryException($query, $bindings, new Exception());
+            }
 
             $fetchMode = $me->getFetchMode();
             $fetchArgument = $me->getFetchArgument();
@@ -474,6 +480,9 @@ class Connection implements ConnectionInterface
             }
 
             $statement = $this->getPdo()->prepare($query);
+            if ($statement === false) {
+                throw new QueryException($query, $bindings, new Exception());
+            }
 
             $this->bindValues($statement, $me->prepareBindings($bindings));
 
@@ -499,6 +508,9 @@ class Connection implements ConnectionInterface
             // by the statement and return that back to the developer. We'll first need
             // to execute the statement and then we'll use PDO to fetch the affected.
             $statement = $me->getPdo()->prepare($query);
+            if ($statement === false) {
+                throw new QueryException($query, $bindings, new Exception());
+            }
 
             $this->bindValues($statement, $me->prepareBindings($bindings));
 

--- a/tests/Database/DatabaseConnectionTest.php
+++ b/tests/Database/DatabaseConnectionTest.php
@@ -55,6 +55,18 @@ class DatabaseConnectionTest extends PHPUnit_Framework_TestCase
         $this->assertTrue(is_numeric($log[0]['time']));
     }
 
+    /**
+     * @expectedException \Illuminate\Database\QueryException
+     */
+    public function testSelectThrowsQueryExceptionWhenPrepareIsFalse()
+    {
+        $pdo = $this->getMockBuilder('DatabaseConnectionTestMockPDO')->setMethods(['prepare'])->getMock();
+        $pdo->expects($this->once())->method('prepare')->with('foo')->will($this->returnValue(false));
+        $mock = $this->getMockConnection();
+        $mock->setReadPdo($pdo);
+        $mock->select('foo', ['foo' => 'bar']);
+    }
+
     public function testInsertCallsTheStatementMethod()
     {
         $connection = $this->getMockConnection(['statement']);
@@ -96,6 +108,17 @@ class DatabaseConnectionTest extends PHPUnit_Framework_TestCase
         $this->assertTrue(is_numeric($log[0]['time']));
     }
 
+    /**
+     * @expectedException \Illuminate\Database\QueryException
+     */
+    public function testStatementThrowsQueryExceptionWhenPrepareIsFalse()
+    {
+        $pdo = $this->getMockBuilder('DatabaseConnectionTestMockPDO')->setMethods(['prepare'])->getMock();
+        $pdo->expects($this->once())->method('prepare')->with('foo')->will($this->returnValue(false));
+        $mock = $this->getMockConnection([], $pdo);
+        $mock->statement('foo', ['foo' => 'bar']);
+    }
+
     public function testAffectingStatementProperlyCallsPDO()
     {
         $pdo = $this->getMockBuilder('DatabaseConnectionTestMockPDO')->setMethods(['prepare'])->getMock();
@@ -112,6 +135,17 @@ class DatabaseConnectionTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('foo', $log[0]['query']);
         $this->assertEquals(['foo' => 'bar'], $log[0]['bindings']);
         $this->assertTrue(is_numeric($log[0]['time']));
+    }
+
+    /**
+     * @expectedException \Illuminate\Database\QueryException
+     */
+    public function testAffectingStatementThrowsQueryExceptionWhenPrepareIsFalse()
+    {
+        $pdo = $this->getMockBuilder('DatabaseConnectionTestMockPDO')->setMethods(['prepare'])->getMock();
+        $pdo->expects($this->once())->method('prepare')->with('foo')->will($this->returnValue(false));
+        $mock = $this->getMockConnection([], $pdo);
+        $mock->affectingStatement('foo', ['foo' => 'bar']);
     }
 
     public function testTransactionLevelNotIncrementedOnTransactionException()


### PR DESCRIPTION
PDO::prepare is able to return false: http://php.net/manual/en/pdo.prepare.php#refsect1-pdo.prepare-returnvalues

Here is the failure I've seen occur most often: https://github.com/php/php-src/blob/0b7ecd6f10e8cc0835dece9e295b5ecdff477587/ext/mysqlnd/mysqlnd_wireprotocol.c#L2033-L2035

Unfortunately it is impossible to detect this failure (since no `PDOException` is thrown). Laravel continues to execute code despite this failure, and then attempts to run `$statement->execute()` when `$statement` is `false` which results in a fatal error.

This change detects `prepare` failures and throws a `QueryException`. There doesn't seem to be much precedent in `Connection` for throwing plain exceptions, hence why I'm throwing `QueryException` with a raw `Exception` as the 3rd argument. If there are any better ideas on what exception to throw, please let me know.
