### PR TITLE
Possibility to ignore pushing null values in a collection

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -756,7 +756,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
 
     /**
      * Push an item onto the end of the collection.
-     * only not null values will be pushed if $nullable is false
+     * only not null values will be pushed if $nullable is false.
      *
      * @param  mixed  $value
      * @param  bool  $nullable
@@ -764,8 +764,8 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      */
     public function push($value, $nullable = true)
     {
-        if (!$nullable) {
-            if (!is_null($value)) {
+        if (! $nullable) {
+            if (! is_null($value)) {
                 $this->offsetSet(null, $value);
             }
         } else {

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -756,13 +756,21 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
 
     /**
      * Push an item onto the end of the collection.
+     * only not null values will be pushed if $nullable is false
      *
      * @param  mixed  $value
+     * @param  bool  $nullable
      * @return $this
      */
-    public function push($value)
+    public function push($value, $nullable = true)
     {
-        $this->offsetSet(null, $value);
+        if (!$nullable) {
+            if (!is_null($value)) {
+                $this->offsetSet(null, $value);
+            }
+        } else {
+            $this->offsetSet(null, $value);
+        }
 
         return $this;
     }


### PR DESCRIPTION
suppose the next example :

```
$collection = collect([1, 2, 3, 4]);
$numbers = [5, 6, null, 7, 8];
foreach($numbers as $number){
    $collection->push($number, false);
}
$collection->all();
```

// [1, 2, 3, 4, 5, 6, 7, 8]
