### PR TITLE
[5.3] Add mime and mimetype validation rule objects

### DIFF
--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -60,4 +60,16 @@ class Rule
     {
         return new Rules\Unique($table, $column);
     }
+
+    /**
+     * Get a mime constraint builder instance.
+     *
+     * @param $mimes
+     *
+     * @return \Illuminate\Validation\Rules\Mimes
+     */
+    public static function mime(array $mimes = [])
+    {
+        return new Rules\Mimes($mimes);
+    }
 }

--- a/src/Illuminate/Validation/Rules/Mimes.php
+++ b/src/Illuminate/Validation/Rules/Mimes.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Illuminate\Validation\Rules;
+
+class Mimes
+{
+    /**
+     * The mimes and mimetypes.
+     *
+     * @var array
+     */
+    protected $mimes = [];
+
+    /**
+     * Create a new mime rule instance.
+     *
+     * @param array $mimes
+     */
+    public function __construct(array $mimes)
+    {
+        $this->mimes = $mimes;
+    }
+
+    /**
+     * Set a mimetype.
+     *
+     * @param string|array $value
+     *
+     * @return $this
+     */
+    public function type($value)
+    {
+        if (is_array($value)) {
+            foreach ($value as $type) {
+                $this->mimes['types'][] = $type;
+            }
+        } else {
+            $this->mimes['types'][] = $value;
+        }
+
+        return $this;
+    }
+
+    /**
+     * Set a mime.
+     *
+     * @param string|array $value
+     *
+     * @return $this
+     */
+    public function rule($value)
+    {
+        if (is_array($value)) {
+            foreach ($value as $rule) {
+                $this->mimes['rules'][] = $rule;
+            }
+        } else {
+            $this->mimes['rules'][] = $value;
+        }
+
+        return $this;
+    }
+
+    /**
+     * Convert the rule to a validation string.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        if (isset($this->mimes['types'])) {
+            return 'mimetypes:'.implode(',', $this->mimes['types']);
+        }
+
+        if (isset($this->mimes['rules'])) {
+            return 'mimes:'.implode(',', $this->mimes['rules']);
+        }
+    }
+}

--- a/tests/Validation/ValidationMimesRuleTest.php
+++ b/tests/Validation/ValidationMimesRuleTest.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\Rules\Mimes;
+
+class ValidationMimesRuleTest extends PHPUnit_Framework_TestCase
+{
+    public function testItCorrectlyFormatsAStringVersionOfTheRule()
+    {
+        $type = new Mimes(['types' => ['video/avi']]);
+        $this->assertEquals('mimetypes:video/avi', (string) $type);
+
+        $rule = new Mimes(['rules' => ['png']]);
+        $this->assertEquals('mimes:png', (string) $rule);
+
+        $type = Rule::mime()->type('video/avi');
+        $this->assertEquals('mimetypes:video/avi', (string) $type);
+
+        $rule = Rule::mime()->rule('png');
+        $this->assertEquals('mimes:png', (string) $rule);
+
+        $multipleTypes = Rule::mime()->type(['video/avi','video/mpeg']);
+        $this->assertEquals('mimetypes:video/avi,video/mpeg', (string) $multipleTypes);
+
+        $multipleRules = Rule::mime()->rule(['gif','png']);
+        $this->assertEquals('mimes:gif,png', (string) $multipleRules);
+    }
+}


### PR DESCRIPTION
I thought this might be a nice addition to the object style of validation.
Optionally I could add functions for the different mimetypes, turning this:

``` php
Rule::mime()->type('image/png');
```

into this:

``` php
Rule::mime()->image('png');
```
