### PR TITLE
[5.3] Catch dns_get_record possible warnings in validateActiveUrl

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1655,7 +1655,11 @@ class Validator implements ValidatorContract
         }
 
         if ($url = parse_url($value, PHP_URL_HOST)) {
-            return count(dns_get_record($url, DNS_A | DNS_AAAA)) > 0;
+            try {
+                return count(dns_get_record($url, DNS_A | DNS_AAAA)) > 0;
+            } catch (Exception $e) {
+                return false;
+            }
         }
 
         return false;


### PR DESCRIPTION
In some cases dns_get_record can throw warnings
- An unexpected server failure occurred.
- A temporary server error occurred.
- DNS Query failed
