### PR TITLE
[5.3] Use studly case for controller names

### DIFF
--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -44,7 +44,7 @@ class ModelMakeCommand extends GeneratorCommand
             }
 
             if ($this->option('controller')) {
-                $controller = Str::camel(class_basename($this->argument('name')));
+                $controller = Str::studly(class_basename($this->argument('name')));
 
                 $this->call('make:controller', ['name' => "{$controller}Controller", '--resource' => true]);
             }


### PR DESCRIPTION
At the moment all controllers that will be generated with `php artisan make:model Post --controller` have lower-case first letters because camel-case is used, this should fix this.

``` php
// Current
$controller = Str::camel(class_basename($this->argument('name')));
// postController

// New
$controller = Str::studly(class_basename($this->argument('name')));
// PostController
```
