### PR TITLE
[5.3] Camel case helper formats uppercase strings wrong

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -56,7 +56,7 @@ class Str
             return static::$camelCache[$value];
         }
 
-        return static::$camelCache[$value] = lcfirst(static::studly(strtolower($value)));
+        return static::$camelCache[$value] = lcfirst(static::studly((ctype_upper(preg_replace("/[-_]/", "", $value))) ? strtolower($value) : $value));
     }
 
     /**

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -56,7 +56,7 @@ class Str
             return static::$camelCache[$value];
         }
 
-        return static::$camelCache[$value] = lcfirst(static::studly($value));
+        return static::$camelCache[$value] = lcfirst(static::studly(strtolower($value)));
     }
 
     /**

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -56,7 +56,7 @@ class Str
             return static::$camelCache[$value];
         }
 
-        return static::$camelCache[$value] = lcfirst(static::studly((ctype_upper(preg_replace("/[-_]/", "", $value))) ? strtolower($value) : $value));
+        return static::$camelCache[$value] = lcfirst(static::studly((ctype_upper(preg_replace('/[-_]/', '', $value))) ? strtolower($value) : $value));
     }
 
     /**

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -195,6 +195,7 @@ class SupportStrTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('laravelPhpFramework', Str::camel('Laravel_php_framework'));
         $this->assertEquals('laravelPhPFramework', Str::camel('Laravel-phP-framework'));
         $this->assertEquals('laravelPhpFramework', Str::camel('Laravel  -_-  php   -_-   framework   '));
+        $this->assertEquals('laravelPhpFramework', Str::camel('LARAVEL_PHP_FRAMEWORK'));
     }
 
     public function testSubstr()


### PR DESCRIPTION
Without the fix

> > > camel_case('LARAVEL_PHP_FRAMEWORK');
> > > => "lARAVELPHPFRAMEWORK"

With the fix

> > > camel_case('LARAVEL_PHP_FRAMEWORK');
> > > => "laravelPhpFramework"
