### PR TITLE
[5.4] Add remember helper

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -608,6 +608,23 @@ if (! function_exists('redirect')) {
     }
 }
 
+if (! function_exists('remember')) {
+    /**
+     * Get an item from the cache, or store the default value.
+     *
+     * @param $key
+     * @param Closure $callback
+     * @param null $minutes
+     * @return mixed
+     */
+    function remember($key, Closure $callback, $minutes = null)
+    {
+        $minutes = $minutes ?: config('cache.default_minutes', 1);
+
+        return cache()->remember($key, $minutes, $callback);
+    }
+}
+
 if (! function_exists('request')) {
     /**
      * Get an instance of the current request or an input item from the request.


### PR DESCRIPTION
It makes `cache()->remember()` more readable, simpler to use and would give us the ability to use a default `$minutes` to most of our cached stuff by simpy:

```
remember('users', function() {
    return DB::table('users')->get();
});
```

// In app/cache.php, it will need something like

```
'remember_default_minutes' => env('CACHE_REMEMBER_DEFAULT_MINUTES', 1),
```
