### PR TITLE
[5.3] Keep the Composer Cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,10 @@ matrix:
 
 sudo: false
 
+cache:
+  directories:
+    - $HOME/.composer/cache
+
 services:
   - memcached
   - redis-server


### PR DESCRIPTION
Composer's cache is very reliable. This also speeds up the overall build times +40% to +60%.
