### PR TITLE
[5.3] Fix empty session

### DIFF
--- a/src/Illuminate/Session/FileSessionHandler.php
+++ b/src/Illuminate/Session/FileSessionHandler.php
@@ -68,7 +68,7 @@ class FileSessionHandler implements SessionHandlerInterface
     {
         if ($this->files->exists($path = $this->path.'/'.$sessionId)) {
             if (filemtime($path) >= Carbon::now()->subMinutes($this->minutes)->getTimestamp()) {
-                return $this->files->get($path);
+                return $this->files->get($path, true);
             }
         }
 


### PR DESCRIPTION
Fix session being empty when the file is being read and/or written by multiple instance of apache simultaneously. This append to me when assets (javascript / css) are being loaded dynamically using php. Multiples assets in the same request cause the sessions to be corrupted.
