### PR TITLE
[5.3] Ability to use keyBy on objects castable to string

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -483,7 +483,11 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
         $results = [];
 
         foreach ($this->items as $key => $item) {
-            $results[$keyBy($item, $key)] = $item;
+            $k = $keyBy($item, $key);
+            if (is_object($k))
+                $k = (string) $k;
+
+            $results[$k] = $item;
         }
 
         return new static($results);


### PR DESCRIPTION
Ran into an issue specifically where I couldn't conveniently use keyBy on a collection with a Carbon object.

The proposed change allows one to use keyBy against any object that can be cast to a string without modifying the existing functionality.

To give an example, say we have the following code which is typical if you're using Carbon dates in laravel or lumen on eloquent models..

```
        \Carbon\Carbon::setToStringFormat('Y-m-d');

        $obj = new \stdClass;
        $obj->date = new \Carbon\Carbon('2017-09-01');
        $obj->name = 'hello';
        $test = new \Illuminate\Support\Collection([$obj, $obj]);

       // Illegal offset type Exception called
       dd($test->keyBy('date'));        
```

The expected output that this patch provides

```
object(Illuminate\Support\Collection)#134 (1) {
  ["items":protected]=>
  array(1) {
    ["2017-09-01"]=>
    object(stdClass)#117 (2) {
      ["date"]=>
      object(Carbon\Carbon)#130 (3) {
        ["date"]=>
        string(26) "2017-09-01 00:00:00.000000"
        ["timezone_type"]=>
        int(3)
        ["timezone"]=>
        string(3) "UTC"
      }
      ["name"]=>
      string(5) "hello"
    }
  }
}
```
