### PR TITLE
[5.3] base64_encode serialized objects before passing them to json_encode

### DIFF
--- a/src/Illuminate/Queue/CallQueuedHandler.php
+++ b/src/Illuminate/Queue/CallQueuedHandler.php
@@ -35,7 +35,7 @@ class CallQueuedHandler
     public function call(Job $job, array $data)
     {
         $command = $this->setJobInstanceIfNecessary(
-            $job, unserialize($data['command'])
+            $job, array_key_exists('command64', $data) ? unserialize($data['command64']) : unserialize($data['command'])
         );
 
         $handler = $this->dispatcher->getCommandHandler($command) ?: null;
@@ -78,7 +78,7 @@ class CallQueuedHandler
      */
     public function failed(array $data, $e)
     {
-        $command = unserialize($data['command']);
+        $command = array_key_exists('command64', $data) ? unserialize($data['command64']) : unserialize($data['command']);
 
         if (method_exists($command, 'failed')) {
             $command->failed($e);

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -83,15 +83,11 @@ abstract class Queue
                 'job' => 'Illuminate\Queue\CallQueuedHandler@call',
                 'data' => [
                     'commandName' => get_class($job),
-                    'command' => serialize(clone $job),
+                    'command64' => base64_encode(serialize(clone $job)),
                 ],
             ]);
         } else {
             $payload = json_encode($this->createPlainPayload($job, $data));
-        }
-
-        if (JSON_ERROR_NONE !== json_last_error()) {
-            throw new InvalidArgumentException('Unable to create payload: '.json_last_error_msg());
         }
 
         return $payload;


### PR DESCRIPTION
In `Queue::createPayload()`, it is unsafe to `json_encode(['command' => serialize(clone $job)])`. Instead of throwing exception when json_encode is failed, we can do `json_encode(['command64' => base_64(serialize(clone $job))])`.

Related PR: #15284

@taylorotwell @themsaid Do you consider it as a breaking change? I tried to handle old jobs already in the queue by changing the array key from 'command' to 'command64', and handling both keys in `CallQueuedHandler`.
