### PR TITLE
[5.3] Remove Requests import from controller stub

### DIFF
--- a/src/Illuminate/Routing/Console/stubs/controller.plain.stub
+++ b/src/Illuminate/Routing/Console/stubs/controller.plain.stub
@@ -4,7 +4,6 @@ namespace DummyNamespace;
 
 use Illuminate\Http\Request;
 
-use DummyRootNamespaceHttp\Requests;
 use DummyRootNamespaceHttp\Controllers\Controller;
 
 class DummyClass extends Controller

--- a/src/Illuminate/Routing/Console/stubs/controller.stub
+++ b/src/Illuminate/Routing/Console/stubs/controller.stub
@@ -4,7 +4,6 @@ namespace DummyNamespace;
 
 use Illuminate\Http\Request;
 
-use DummyRootNamespaceHttp\Requests;
 use DummyRootNamespaceHttp\Controllers\Controller;
 
 class DummyClass extends Controller


### PR DESCRIPTION
In laravel 5.3 Requests folder are removed form initial installation
