### PR TITLE
[5.3] Use bootstrappers instead of events

### DIFF
--- a/src/Illuminate/Console/Application.php
+++ b/src/Illuminate/Console/Application.php
@@ -28,6 +28,13 @@ class Application extends SymfonyApplication implements ApplicationContract
     protected $lastOutput;
 
     /**
+     * The console application bootstrappers.
+     *
+     * @var array
+     */
+    protected static $bootstrappers = [];
+
+    /**
      * Create a new Artisan console application.
      *
      * @param  \Illuminate\Contracts\Container\Container  $laravel
@@ -44,6 +51,20 @@ class Application extends SymfonyApplication implements ApplicationContract
         $this->setCatchExceptions(false);
 
         $events->fire(new Events\ArtisanStarting($this));
+
+        $this->bootstrap();
+    }
+
+    /**
+     * Bootstrap the console application.
+     *
+     * @return void
+     */
+    protected function bootstrap()
+    {
+        foreach (static::$bootstrappers as $bootstrapper) {
+            $bootstrapper($this);
+        }
     }
 
     /**
@@ -168,5 +189,16 @@ class Application extends SymfonyApplication implements ApplicationContract
     public function getLaravel()
     {
         return $this->laravel;
+    }
+
+    /**
+     * Register an application starting bootstrapper.
+     *
+     * @param  \Closure  $callback
+     * @return void
+     */
+    public static function starting(\Closure $callback)
+    {
+        static::$bootstrappers[] = $callback;
     }
 }

--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -8,7 +8,6 @@ use Throwable;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Console\Application as Artisan;
-use Illuminate\Console\Events\ArtisanStarting;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Contracts\Console\Kernel as KernelContract;
 use Symfony\Component\Debug\Exception\FatalThrowableError;
@@ -181,8 +180,8 @@ class Kernel implements KernelContract
     {
         $command = new ClosureCommand($signature, $callback);
 
-        $this->app['events']->listen(ArtisanStarting::class, function ($event) use ($command) {
-            $event->artisan->add($command);
+        Artisan::starting(function ($artisan) use ($command) {
+            $artisan->add($command);
         });
 
         return $command;

--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\Support;
 
-use Illuminate\Console\Events\ArtisanStarting;
+use Illuminate\Console\Application as Artisan;
 
 abstract class ServiceProvider
 {
@@ -176,13 +176,8 @@ abstract class ServiceProvider
     {
         $commands = is_array($commands) ? $commands : func_get_args();
 
-        // To register the commands with Artisan, we will grab each of the arguments
-        // passed into the method and listen for Artisan "start" event which will
-        // give us the Artisan console instance which we will give commands to.
-        $events = $this->app['events'];
-
-        $events->listen(ArtisanStarting::class, function ($event) use ($commands) {
-            $event->artisan->resolveCommands($commands);
+        Artisan::starting(function ($artisan) use ($commands) {
+            $artisan->resolveCommands($commands);
         });
     }
 


### PR DESCRIPTION
This PR switches to using a static object to collect console application bootstrappers that needs to run on starting Artisan, this is an attempt to deal with the situation where you use `$this->withoutEvents();` while running tests & try to call a console command which will attempt to listen to the ArtisanStarting event, but since the Dispatcher is mocked no events get fired.
