### PR TITLE
[5.3] remove enableHttpMethodParameterOverride() from Request::capture()

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -52,8 +52,6 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
      */
     public static function capture()
     {
-        static::enableHttpMethodParameterOverride();
-
         return static::createFromBase(SymfonyRequest::createFromGlobals());
     }
 


### PR DESCRIPTION
It's already added into `Http\Kernel::handle()` https://github.com/laravel/framework/commit/2a7fdfcf894467a0b195decce32e54f688e2d974#diff-798238c3e70c741fc1bb04056a2d617f so I don't think we need to call it here anymore.
