### PR TITLE
[5.4] Initial concept for update scheduler escaping

### DIFF
--- a/src/Illuminate/Console/Scheduling/Schedule.php
+++ b/src/Illuminate/Console/Scheduling/Schedule.php
@@ -77,10 +77,10 @@ class Schedule
     {
         return collect($parameters)->map(function ($value, $key) {
             if (is_array($value)) {
-                $value = collect($value)->map(function($value) {
+                $value = collect($value)->map(function ($value) {
                     return ProcessUtils::escapeArgument($value);
                 })->implode(' ');
-            } elseif (!is_numeric($value) && !preg_match('/^(-.$|--.*)/i', $value)) {
+            } elseif (! is_numeric($value) && ! preg_match('/^(-.$|--.*)/i', $value)) {
                 $value = ProcessUtils::escapeArgument($value);
             }
 

--- a/src/Illuminate/Console/Scheduling/Schedule.php
+++ b/src/Illuminate/Console/Scheduling/Schedule.php
@@ -76,7 +76,15 @@ class Schedule
     protected function compileParameters(array $parameters)
     {
         return collect($parameters)->map(function ($value, $key) {
-            return is_numeric($key) ? $value : $key.'='.(is_numeric($value) ? $value : ProcessUtils::escapeArgument($value));
+            if (is_array($value)) {
+                $value = collect($value)->map(function($value) {
+                    return ProcessUtils::escapeArgument($value);
+                })->implode(' ');
+            } elseif (!is_numeric($value) && !preg_match('/^(-.$|--.*)/i', $value)) {
+                $value = ProcessUtils::escapeArgument($value);
+            }
+
+            return is_numeric($key) ? $value : "{$key}={$value}";
         })->implode(' ');
     }
 

--- a/tests/Console/ConsoleEventSchedulerTest.php
+++ b/tests/Console/ConsoleEventSchedulerTest.php
@@ -22,6 +22,8 @@ class ConsoleEventSchedulerTest extends PHPUnit_Framework_TestCase
         $schedule->exec('path/to/command', ['--foo' => 'bar']);
         $schedule->exec('path/to/command', ['-f', '--foo' => 'bar']);
         $schedule->exec('path/to/command', ['--title' => 'A "real" test']);
+        $schedule->exec('path/to/command', [['one', 'two']]);
+        $schedule->exec('path/to/command', ['-1 minute']);
 
         $events = $schedule->events();
         $this->assertEquals('path/to/command', $events[0]->command);
@@ -30,6 +32,8 @@ class ConsoleEventSchedulerTest extends PHPUnit_Framework_TestCase
         $this->assertEquals("path/to/command --foo={$escape}bar{$escape}", $events[3]->command);
         $this->assertEquals("path/to/command -f --foo={$escape}bar{$escape}", $events[4]->command);
         $this->assertEquals("path/to/command --title={$escape}A {$escapeReal}real{$escapeReal} test{$escape}", $events[5]->command);
+        $this->assertEquals("path/to/command {$escape}one{$escape} {$escape}two{$escape}", $events[6]->command);
+        $this->assertEquals("path/to/command {$escape}-1 minute{$escape}", $events[7]->command);
     }
 
     public function testCommandCreatesNewArtisanCommand()


### PR DESCRIPTION
Addresses #15996 by adding the following logic:
- If a parameter value is an array, escape each item and return a space-delimited list (implements [input arrays](https://laravel.com/docs/5.3/artisan#input-arrays))
- If a parameter `is_numeric` or if a parameter looks like an option (i.e. `-a` or `--append`), then leave it as-is
- Otherwise, escape all arguments

This means that:
- `$schedule->command('my:command', ['-10 minutes']);` results in `php artisan my:command '-10 minutes'`
- `$schedule->command('my:command', ['-a', '-w']);` results in `php artisan my:command -a -w`
- `$schedule->command('my:command', [['one', 'two', 'three']]);` results in `php artisan my:command 'one' 'two' 'three'`
