### PR TITLE
Fix bug on request->has()

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -242,7 +242,7 @@ class Request extends SymfonyRequest implements ArrayAccess
      */
     public function has($key)
     {
-        $keys = is_array($key) ? $key : func_get_args();
+        $keys = is_array($key) ? func_get_args() : $key;
 
         foreach ($keys as $value) {
             if ($this->isEmptyString($value)) {


### PR DESCRIPTION
Inversion of terms in ternary operator within method has()

Method was failing to match multiple keys passed by means of an array. However, it would appear to be working properly if argument were a string or an array with a single key. 

**Reason**: the ternary operator has its terms inverted. func_get_args() should be the result of the condition is_array($keys)
