### PR TITLE
[5.3] Allows to customize broadcast channel name for broadcasting notification channel

### DIFF
--- a/src/Illuminate/Notifications/Events/BroadcastNotificationCreated.php
+++ b/src/Illuminate/Notifications/Events/BroadcastNotificationCreated.php
@@ -77,6 +77,10 @@ class BroadcastNotificationCreated implements ShouldBroadcast
      */
     protected function channelName()
     {
+        if (method_exists($this->notifiable, 'broadcastNotificationChannelName')) {
+            return $this->notifiable->broadcastNotificationChannelName($this->notification);
+        }
+
         $class = str_replace('\\', '.', get_class($this->notifiable));
 
         return $class.'.'.$this->notifiable->getKey();


### PR DESCRIPTION
Allows to customize broadcast channel name for broadcasting notification channel.

To set channel name, place this method in your notifiable class:

``` php
    public function broadcastNotificationChannelName($notification)
    {
        return 'notifications.'.$this->id;
    }
```

I've made this PR because I wanted to get rid of long channel name like `App.Models.Users.User.*`, and hide class structures from an end user. It would be also great if anyone would like to encrypt user id using something like HashIds:

``` php
    public function broadcastNotificationChannelName($notification)
    {
        return 'App.User.' . Hashids::encrypt($this->id);
    }
```
