### PR TITLE
[5.4] Local driver url() call has no longer fixed prefix

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -287,7 +287,7 @@ class FilesystemAdapter implements FilesystemContract, CloudFilesystemContract
 
             return $adapter->getClient()->getObjectUrl($adapter->getBucket(), $path);
         } elseif ($adapter instanceof LocalAdapter) {
-            $path = '/storage/'.$path;
+            $path = $adapter->getPathPrefix().$path;
 
             return Str::contains($path, '/storage/public') ? Str::replaceFirst('/public', '', $path) : $path;
         } else {

--- a/tests/Filesystem/FilesystemAdapterTest.php
+++ b/tests/Filesystem/FilesystemAdapterTest.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Filesystem\FilesystemAdapter;
+use League\Flysystem\Adapter\Local;
+use League\Flysystem\Filesystem;
+
+class FilesystemAdapterTest extends \PHPUnit_Framework_TestCase
+{
+    private $tempDir;
+
+    public function setUp()
+    {
+        $this->tempDir = __DIR__.'/tmp';
+        mkdir($this->tempDir, 0777);
+    }
+
+    public function testUrl()
+    {
+        $adapter = new FilesystemAdapter(new Filesystem(new Local($this->tempDir)));
+        $actual = $adapter->url('foo.txt');
+        $expected = $this->tempDir.DIRECTORY_SEPARATOR.'foo.txt';
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function tearDown()
+    {
+        rmdir($this->tempDir);
+    }
+}

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -269,6 +269,9 @@ class FilesystemTest extends PHPUnit_Framework_TestCase
 
     public function testIsReadable()
     {
+        if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
+            self::markTestSkipped('You cannot remove read permissions on windows');
+        }
         file_put_contents($this->tempDir.'/foo.txt', 'foo');
         $files = new Filesystem();
         @chmod($this->tempDir.'/foo.txt', 0000);


### PR DESCRIPTION
This fixes #13364. 

While testing I also added condition to skip `\FilesystemTest::testIsReadable()` on Windows. It caused 7 other test to fail with error on first run (and whole `\FilesystemTest` on second run). That is because `chmod(0000)` will set "read-only" flag on Windows. But `chmod(0777)` won't remove it. 
