### PR TITLE
[5.3] Fixing error when .env does not exist

### DIFF
--- a/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
+++ b/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
@@ -52,14 +52,13 @@ class KeyGenerateCommand extends Command
     protected function setKeyInEnvironmentFile($key)
     {
         if (file_exists($this->laravel->environmentFilePath())) {
-
             file_put_contents($this->laravel->environmentFilePath(), str_replace(
                 'APP_KEY='.$this->laravel['config']['app.key'],
                 'APP_KEY='.$key,
                 file_get_contents($this->laravel->environmentFilePath())
             ));
         } else {
-            $this->error("Environment file is missing.");
+            $this->error('Environment file is missing.');
             exit();
         }
     }

--- a/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
+++ b/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
@@ -54,7 +54,7 @@ class KeyGenerateCommand extends Command
         file_put_contents($this->laravel->environmentFilePath(), str_replace(
             'APP_KEY='.$this->laravel['config']['app.key'],
             'APP_KEY='.$key,
-            file_get_contents($this->laravel->environmentFilePath())
+            @file_get_contents($this->laravel->environmentFilePath())
         ));
     }
 

--- a/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
+++ b/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
@@ -51,11 +51,17 @@ class KeyGenerateCommand extends Command
      */
     protected function setKeyInEnvironmentFile($key)
     {
-        file_put_contents($this->laravel->environmentFilePath(), str_replace(
-            'APP_KEY='.$this->laravel['config']['app.key'],
-            'APP_KEY='.$key,
-            @file_get_contents($this->laravel->environmentFilePath())
-        ));
+        if (file_exists($this->laravel->environmentFilePath())) {
+
+            file_put_contents($this->laravel->environmentFilePath(), str_replace(
+                'APP_KEY='.$this->laravel['config']['app.key'],
+                'APP_KEY='.$key,
+                file_get_contents($this->laravel->environmentFilePath())
+            ));
+        } else {
+            $this->error("Environment file is missing.");
+            exit();
+        }
     }
 
     /**


### PR DESCRIPTION
file_get_contents( /path/to/.env ) failed to open stream: No such file or directory..
