### PR TITLE
[5.3] Option to clean file cache dirs during forget()

### DIFF
--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -172,7 +172,10 @@ class FileStore implements Store
     {
         $file = $this->path($key);
 
-        if ($this->files->exists($file)) {
+        if (config('cache.stores.file.gc_dirs')) {
+            $topmost_directory = dirname(dirname($file));
+            return $this->files->deleteDirectory($topmost_directory);
+        } else if ($this->files->exists($file)) {
             return $this->files->delete($file);
         }
 

--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -175,7 +175,7 @@ class FileStore implements Store
         if (config('cache.stores.file.gc_dirs')) {
             $topmost_directory = dirname(dirname($file));
             return $this->files->deleteDirectory($topmost_directory);
-        } else if ($this->files->exists($file)) {
+        } elseif ($this->files->exists($file)) {
             return $this->files->delete($file);
         }
 


### PR DESCRIPTION
Default behaviour is unchanged. But if the config option cache.stores.file.gc_dirs is present and true, forget() now removes the two parent cache directories in addition to the cache file.
