### PR TITLE
[5.3] Make new validation Rule class macroable

### DIFF
--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -2,8 +2,12 @@
 
 namespace Illuminate\Validation;
 
+use Illuminate\Support\Traits\Macroable;
+
 class Rule
 {
+    use Macroable;
+
     /**
      * Get a dimensions constraint builder instance.
      *

--- a/tests/Validation/ValidationRuleTest.php
+++ b/tests/Validation/ValidationRuleTest.php
@@ -1,0 +1,16 @@
+<?php
+
+use Illuminate\Validation\Rule;
+
+class ValidationRuleTest extends PHPUnit_Framework_TestCase
+{
+    public function testMacroable()
+    {
+        // phone macro : validate a phone number
+        Rule::macro('phone', function () {
+            return 'regex:/^([0-9\s\-\+\(\)]*)$/';
+        });
+        $c = Rule::phone();
+        $this->assertSame('regex:/^([0-9\s\-\+\(\)]*)$/', $c);
+    }
+}


### PR DESCRIPTION
Allows for developers to use their own classes (or simple functions, like I did for the test) to use the fluent Rule syntax for validation.
