### PR TITLE
[5.3] Add an ObserverServiceProvider

### DIFF
--- a/src/Illuminate/Foundation/Support/Providers/ObserverServiceProvider.php
+++ b/src/Illuminate/Foundation/Support/Providers/ObserverServiceProvider.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Illuminate\Foundation\Support\Providers;
+
+use Illuminate\Support\ServiceProvider;
+
+class ObserverServiceProvider extends ServiceProvider
+{
+    /**
+     * The observer mappings for the application.
+     *
+     * @var array
+     */
+    protected $observers = [];
+
+    /**
+     * Register the application's observers.
+     *
+     * @return void
+     */
+    public function registerObservers()
+    {
+        foreach ($this->observers as $key => $value) {
+            $key::observe($value);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function register()
+    {
+        //
+    }
+}


### PR DESCRIPTION
**What does it do?**
Adds an `ObserverServiceProvider` for registering model observers.

**More info**
Instead of having to bind the observer to the model inside the `AppServiceProvider`, dedicate a Service Provider for doing so. It uses the same syntax as the `PolicyServiceProvider`.
From the docs: [Eloquent Events](https://laravel.com/docs/5.3/eloquent#events).

**Example:**

``` php
<?php

namespace App\Providers;

use App\Role;
use App\Observers\RoleObserver;
use Illuminate\Foundation\Support\Providers\ObserverServiceProvider as ServiceProvider;

class ObserverServiceProvider extends ServiceProvider
{
    /**
    * The observer mappings for the application.
    *
    * @var array
    */
    protected $observers = [
        User::class => UserObserver::class,
    ];

    /**
     * Bootstrap any application services.
     *
     * @return void
     */
    public function boot()
    {
        $this->registerObservers();
    }
}
```
