### PR TITLE
[5.4] Fix Blade @parent issue

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -411,7 +411,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
      */
     protected function compileParent()
     {
-        return "##parent-placeholder##";
+        return '##parent-placeholder##';
     }
 
     /**

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -405,6 +405,16 @@ class BladeCompiler extends Compiler implements CompilerInterface
     }
 
     /**
+     * Replace the @parent directive to a placeholder.
+     *
+     * @return string
+     */
+    protected function compileParent()
+    {
+        return "##parent-placeholder##";
+    }
+
+    /**
      * Compile the each statements into valid PHP.
      *
      * @param  string  $expression

--- a/src/Illuminate/View/Factory.php
+++ b/src/Illuminate/View/Factory.php
@@ -631,7 +631,7 @@ class Factory implements FactoryContract
     protected function extendSection($section, $content)
     {
         if (isset($this->sections[$section])) {
-            $content = str_replace('@parent', $content, $this->sections[$section]);
+            $content = str_replace('##parent-placeholder##', $content, $this->sections[$section]);
         }
 
         $this->sections[$section] = $content;
@@ -655,7 +655,7 @@ class Factory implements FactoryContract
         $sectionContent = str_replace('@@parent', '--parent--holder--', $sectionContent);
 
         return str_replace(
-            '--parent--holder--', '@parent', str_replace('@parent', '', $sectionContent)
+            '--parent--holder--', '@parent', str_replace('##parent-placeholder##', '', $sectionContent)
         );
     }
 

--- a/tests/View/ViewFactoryTest.php
+++ b/tests/View/ViewFactoryTest.php
@@ -245,7 +245,7 @@ class ViewFactoryTest extends PHPUnit_Framework_TestCase
     {
         $factory = $this->getFactory();
         $factory->startSection('foo');
-        echo 'hi @parent';
+        echo 'hi ##parent-placeholder##';
         $factory->stopSection();
         $factory->startSection('foo');
         echo 'there';
@@ -257,10 +257,10 @@ class ViewFactoryTest extends PHPUnit_Framework_TestCase
     {
         $factory = $this->getFactory();
         $factory->startSection('foo');
-        echo 'hello @parent nice to see you @parent';
+        echo 'hello ##parent-placeholder## nice to see you ##parent-placeholder##';
         $factory->stopSection();
         $factory->startSection('foo');
-        echo 'my @parent';
+        echo 'my ##parent-placeholder##';
         $factory->stopSection();
         $factory->startSection('foo');
         echo 'friend';

--- a/tests/View/ViewFlowTest.php
+++ b/tests/View/ViewFlowTest.php
@@ -147,8 +147,16 @@ dad
 child
 @endsection'));
 
+        $files->put($this->tempDir.'/extends-child-child.php', $compiler->compileString('
+@extends("extends-child")
+@section("me")
+@parent
+child-child
+@endsection'));
+
         $factory = $this->prepareCommonFactory();
         $this->assertEquals("yield:\ndad\n\nchild\n", $factory->make('extends-child')->render());
+        $this->assertEquals("yield:\ndad\n\nchild\n\nchild-child\n", $factory->make('extends-child-child')->render());
     }
 
     public function testExtendsWithVariable()
@@ -180,7 +188,26 @@ dad
 
         $factory = $this->prepareCommonFactory();
         $this->assertEquals("yield:\ntitle\n", $factory->make('extends-variable-child-a', ['title' => 'title'])->render());
-        $this->assertEquals("yield:\ndad\n\n", $factory->make('extends-variable-child-b', ['title' => '@parent'])->render());
+        $this->assertEquals("yield:\n@parent\n", $factory->make('extends-variable-child-b', ['title' => '@parent'])->render());
+    }
+
+    public function testExtendsWithVariableAndNoParent()
+    {
+        $files = new Filesystem;
+        $compiler = new BladeCompiler($this->getFiles(), __DIR__);
+
+        $files->put($this->tempDir.'/extends-variable-layout.php', $compiler->compileString('
+yield:
+@yield("me")'));
+
+        $files->put($this->tempDir.'/extends-variable.php', $compiler->compileString('
+@extends("extends-variable-layout")
+@section("me")
+{{ $title }}
+@endsection'));
+
+        $factory = $this->prepareCommonFactory();
+        $this->assertEquals("yield:\n@parent\n", $factory->make('extends-variable', ['title' => '@parent'])->render());
     }
 
     protected function prepareCommonFactory()


### PR DESCRIPTION
This is an attempt to fix https://github.com/laravel/framework/issues/10068, currently if a variable was passed to the view that contains the string `@parent`, Blade tries to compile this string as a `@parent` directive causing appending the parent content into the view if a parent section exists, or if not the `@parent` string will be stripped from the response.

This PR attempts to fix this by replacing the actual `@parent` directive with a different placeholder, the change is breaking because any `@parent` that exists in the blade file will be replaced, so for example this echo `{{ '@parent' }}` won't work.
