### PR TITLE
[5.3] Return unique middlewares after sorting

### DIFF
--- a/src/Illuminate/Routing/SortedMiddleware.php
+++ b/src/Illuminate/Routing/SortedMiddleware.php
@@ -65,7 +65,7 @@ class SortedMiddleware extends Collection
             }
         }
 
-        return $middlewares;
+        return array_values(array_unique($middlewares, SORT_REGULAR));
     }
 
     /**

--- a/tests/Routing/RoutingSortedMiddlewareTest.php
+++ b/tests/Routing/RoutingSortedMiddlewareTest.php
@@ -18,8 +18,7 @@ class RoutingSortedMiddlewareTest extends PHPUnit_Framework_TestCase
             'Something',
             'Something',
             'Second',
-            'Something',
-            'Something',
+            'Otherthing',
             'First:api',
             'Third:foo',
             'First:foo,bar',
@@ -29,15 +28,10 @@ class RoutingSortedMiddlewareTest extends PHPUnit_Framework_TestCase
 
         $expected = [
             'Something',
-            'Something',
-            'Something',
-            'Something',
             'First:api',
             'First:foo,bar',
             'Second',
-            'Something',
-            'Something',
-            'Second',
+            'Otherthing',
             'Third:foo',
             'Third',
         ];


### PR DESCRIPTION
Before the new middleware sorting code https://github.com/laravel/framework/commit/6b69fb81fc7c36e9e129a0ce2e56a824cc907859, the method would produce unique middleware because of this line https://github.com/laravel/framework/commit/6b69fb81fc7c36e9e129a0ce2e56a824cc907859#diff-66c4eb54eb5af7de5e493b416e13991dL749.

This PR makes the method act as before by returning a unique set of middlewares.

Check issue: https://github.com/laravel/framework/issues/16027
