### PR TITLE
[5.3] Use ... operator in stead of func_get_args()

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -152,7 +152,7 @@ class Grammar extends BaseGrammar
             // Cross joins generate a cartesian product between this first table and a joined
             // table. In case the user didn't specify any "on" clauses on the join we will
             // append this SQL and jump right back into the next iteration of this loop.
-            if ($type === 'cross' &&  ! $join->clauses) {
+            if ($type === 'cross' && ! $join->clauses) {
                 $sql[] = "cross join $table";
 
                 continue;

--- a/src/Illuminate/Foundation/Validation/ValidatesRequests.php
+++ b/src/Illuminate/Foundation/Validation/ValidatesRequests.php
@@ -7,6 +7,7 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Routing\UrlGenerator;
 use Illuminate\Contracts\Validation\Factory;
 use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Validation\ValidationException;
 
 trait ValidatesRequests
 {
@@ -81,7 +82,7 @@ trait ValidatesRequests
      * @param  \Illuminate\Contracts\Validation\Validator  $validator
      * @return void
      *
-     * @throws \Illuminate\Foundation\Validation\ValidationException
+     * @throws \Illuminate\Validation\ValidationException
      */
     protected function throwValidationException(Request $request, $validator)
     {

--- a/src/Illuminate/Foundation/Validation/ValidatesRequests.php
+++ b/src/Illuminate/Foundation/Validation/ValidatesRequests.php
@@ -7,7 +7,6 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Routing\UrlGenerator;
 use Illuminate\Contracts\Validation\Factory;
 use Illuminate\Contracts\Validation\Validator;
-use Illuminate\Validation\ValidationException;
 
 trait ValidatesRequests
 {
@@ -82,7 +81,7 @@ trait ValidatesRequests
      * @param  \Illuminate\Contracts\Validation\Validator  $validator
      * @return void
      *
-     * @throws \Illuminate\Validation\ValidationException
+     * @throws \Illuminate\Foundation\Validation\ValidationException
      */
     protected function throwValidationException(Request $request, $validator)
     {

--- a/src/Illuminate/Routing/ControllerMiddlewareOptions.php
+++ b/src/Illuminate/Routing/ControllerMiddlewareOptions.php
@@ -25,12 +25,12 @@ class ControllerMiddlewareOptions
     /**
      * Set the controller methods the middleware should apply to.
      *
-     * @param  array|string|dynamic  $methods
+     * @param  array  $methods
      * @return $this
      */
-    public function only($methods)
+    public function only(...$methods)
     {
-        $this->options['only'] = is_array($methods) ? $methods : func_get_args();
+        $this->options['only'] = $methods;
 
         return $this;
     }
@@ -38,12 +38,12 @@ class ControllerMiddlewareOptions
     /**
      * Set the controller methods the middleware should exclude.
      *
-     * @param  array|string|dynamic  $methods
+     * @param  array  $methods
      * @return $this
      */
-    public function except($methods)
+    public function except(...$methods)
     {
-        $this->options['except'] = is_array($methods) ? $methods : func_get_args();
+        $this->options['except'] = $methods;
 
         return $this;
     }


### PR DESCRIPTION
Use the (cleaner) ... operator for the variadic functions in stead of using func_get_args(). Usable in PHP 5.6 and above. See http://php.net/manual/en/functions.arguments.php#functions.variable-arg-list.
