### PR TITLE
[5.3] Add remember helper to session store

### DIFF
--- a/src/Illuminate/Session/Store.php
+++ b/src/Illuminate/Session/Store.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Session;
 
+use Closure;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use SessionHandlerInterface;
@@ -747,5 +748,25 @@ class Store implements SessionInterface
         if ($this->handlerNeedsRequest()) {
             $this->handler->setRequest($request);
         }
+    }
+
+    /**
+     * Get an item from the sessuib, or store the default value.
+     *
+     * @param  string $key
+     * @param  \Closure $callback
+     * @return mixed
+     */
+    public function remember($key, Closure $callback)
+    {
+        // If the item exists in the session we will just return this immediately
+        // otherwise we will execute the given Closure and store the result
+        if (!is_null($value = $this->get($key))) {
+            return $value;
+        }
+
+        $this->put($key, $value = $callback());
+
+        return $value;
     }
 }

--- a/tests/Session/SessionStoreTest.php
+++ b/tests/Session/SessionStoreTest.php
@@ -345,6 +345,17 @@ class SessionStoreTest extends PHPUnit_Framework_TestCase
         $this->assertFalse($session->exists(['foo', 'baz', 'bogus']));
     }
 
+    public function testRememberMethodCallsPutAndReturnsDefault()
+    {
+        $session = $this->getSession();
+        $session->getHandler()->shouldReceive('get')->andReturn(null);
+        $result = $session->remember('foo', function () {
+            return 'bar';
+        });
+        $this->assertEquals('bar', $session->get('foo'));
+        $this->assertEquals('bar', $result);
+    }
+
     public function getSession()
     {
         $reflection = new ReflectionClass('Illuminate\Session\Store');


### PR DESCRIPTION
Add remember helper to session store like the remember helper on the cache

``` php
$orders = session()->remember('orders', function () {
    return Api::getOrders();
});
```
