### PR TITLE
add array_map_with_keys and array_collapse_with_keys helper functions

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -57,7 +57,7 @@ if (! function_exists('array_collapse')) {
     }
 }
 
-if (!function_exists('array_collapse_with_keys')) {
+if (! function_exists('array_collapse_with_keys')) {
     /**
      * Collapse an array of arrays into a single array, avoids using array_merge to preserve the keys.
      *
@@ -208,7 +208,7 @@ if (! function_exists('array_last')) {
     }
 }
 
-if (!function_exists('array_map_with_keys')) {
+if (! function_exists('array_map_with_keys')) {
     /**
      * Run an associative map over each of the items, preserving keys.
      *
@@ -218,7 +218,8 @@ if (!function_exists('array_map_with_keys')) {
      * @param $array
      * @return array
      */
-    function array_map_with_keys($callback, $array) {
+    function array_map_with_keys($callback, $array)
+    {
         $mapped = array_map($callback, $array);
 
         return array_collapse_with_keys($mapped);

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -57,6 +57,29 @@ if (! function_exists('array_collapse')) {
     }
 }
 
+if (!function_exists('array_collapse_with_keys')) {
+    /**
+     * Collapse an array of arrays into a single array, avoids using array_merge to preserve the keys.
+     *
+     * @param $parent
+     * @return array
+     */
+    function array_collapse_with_keys($parent)
+    {
+        $result = [];
+
+        foreach ($parent as $child) {
+            if (is_array($child)) {
+                foreach ($child as $key => $value) {
+                    $result[$key] = $value;
+                }
+            }
+        }
+
+        return $result;
+    }
+}
+
 if (! function_exists('array_divide')) {
     /**
      * Divide an array into two arrays. One with keys and the other with values.
@@ -182,6 +205,23 @@ if (! function_exists('array_last')) {
     function array_last($array, callable $callback = null, $default = null)
     {
         return Arr::last($array, $callback, $default);
+    }
+}
+
+if (!function_exists('array_map_with_keys')) {
+    /**
+     * Run an associative map over each of the items, preserving keys.
+     *
+     * The callback should return an associative array with a single key/value pair.
+     *
+     * @param $callback
+     * @param $array
+     * @return array
+     */
+    function array_map_with_keys($callback, $array) {
+        $mapped = array_map($callback, $array);
+
+        return array_collapse_with_keys($mapped);
     }
 }
 

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -163,7 +163,7 @@ class SupportHelpersTest extends PHPUnit_Framework_TestCase
                 'name' => 'Jane',
                 'department' => 'Marketing',
                 'email' => 'jane@example.com',
-            ]
+            ],
         ];
 
         $mapped = array_map_with_keys(

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -149,6 +149,37 @@ class SupportHelpersTest extends PHPUnit_Framework_TestCase
         }));
     }
 
+    public function testArrayMapWithKeys()
+    {
+        $array = [
+            [
+                'id' => 5,
+                'name' => 'John',
+                'department' => 'Sales',
+                'email' => 'john@example.com'
+            ],
+            [
+                'id' => 7,
+                'name' => 'Jane',
+                'department' => 'Marketing',
+                'email' => 'jane@example.com'
+            ]
+        ];
+
+        $mapped = array_map_with_keys(
+            function ($item) {
+                    return [$item['id'] => $item['name']];
+            }, $array);
+
+        $expected = [
+            5 => 'John',
+            7 => 'Jane',
+        ];
+
+        $this->assertEquals($mapped, $expected);
+    }
+
+
     public function testArrayPluck()
     {
         $data = [

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -156,19 +156,19 @@ class SupportHelpersTest extends PHPUnit_Framework_TestCase
                 'id' => 5,
                 'name' => 'John',
                 'department' => 'Sales',
-                'email' => 'john@example.com'
+                'email' => 'john@example.com',
             ],
             [
                 'id' => 7,
                 'name' => 'Jane',
                 'department' => 'Marketing',
-                'email' => 'jane@example.com'
+                'email' => 'jane@example.com',
             ]
         ];
 
         $mapped = array_map_with_keys(
             function ($item) {
-                    return [$item['id'] => $item['name']];
+                return [$item['id'] => $item['name']];
             }, $array);
 
         $expected = [
@@ -178,7 +178,6 @@ class SupportHelpersTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals($mapped, $expected);
     }
-
 
     public function testArrayPluck()
     {


### PR DESCRIPTION
array_map_with_keys useful when syncing many to many relationships while pushing extra fields onto the pivot table
created array_collapse_with_keys since array_collapse uses array_merge and doesn't preserve numeric keys
