### PR TITLE
[5.2] Request object returns empty parameters when we make a POST method, and spoof it as a GET request using X-HTTP-METHOD-OVERRIDE or _method parameter

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -665,7 +665,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
             return $this->json();
         }
 
-        return $this->getMethod() == 'GET' ? $this->query : $this->request;
+        return $this->getRealMethod() == 'GET' ? $this->query : $this->request;
     }
 
     /**


### PR DESCRIPTION
Same issue, fixed on 5.3, but not on 5.2 yet.

Reference Issue #15348
Reference Commit: https://github.com/laravel/framework/commit/b63b52e056ad0d79827c98bf691e4cc959015c2e
