### PR TITLE
Call hasFile() method in has() method of Request object.

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -287,6 +287,10 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
      */
     public function has($key)
     {
+        if ($this->hasFile($key)) {
+            return true;
+        }
+        
         $keys = is_array($key) ? $key : func_get_args();
 
         foreach ($keys as $value) {


### PR DESCRIPTION
On a few occasions, I've checked if my file exists by accidentally using the has() method out of habit. It seems more intuitive to use the commonly-used has() method for both files and text fields.
