### PR TITLE
[5.3] Dedicated method for password validation rules.

### DIFF
--- a/src/Illuminate/Foundation/Auth/ResetsPasswords.php
+++ b/src/Illuminate/Foundation/Auth/ResetsPasswords.php
@@ -35,10 +35,7 @@ trait ResetsPasswords
      */
     public function reset(Request $request)
     {
-        $this->validate($request, [
-            'token' => 'required', 'email' => 'required|email',
-            'password' => 'required|confirmed|min:6',
-        ]);
+        $this->validate($request, $this->getResetValidationRules());
 
         // Here we will attempt to reset the user's password. If it is successful we
         // will update the password on an actual user model and persist it to the
@@ -55,6 +52,19 @@ trait ResetsPasswords
         return $response == Password::PASSWORD_RESET
                     ? $this->sendResetResponse($response)
                     : $this->sendResetFailedResponse($request, $response);
+    }
+
+    /**
+     * Get the password reset validation rules.
+     *
+     * @return array
+     */
+    protected function getResetValidationRules()
+    {
+        return [
+            'token' => 'required', 'email' => 'required|email',
+            'password' => 'required|confirmed|min:6',
+        ];
     }
 
     /**


### PR DESCRIPTION
Puts password validation rules in a dedicated method so they can be overridden in the ResetPasswordsController in the application without needing to override the entire reset method.  Ensures the framework response logic in the resets method isn’t being unnecessarily overridden in an application controller.
