### PR TITLE
[5.3] Add casts for pivot tables

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2749,6 +2749,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     public function setCasts(array $casts)
     {
         $this->casts = $casts;
+        
         return $this;
     }
 

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2741,6 +2741,18 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     }
 
     /**
+     * Sets the casts array.
+     *
+     * @param  array  $casts
+     * @return $this
+     */
+    public function setCasts(array $casts)
+    {
+        $this->casts = $casts;
+        return $this;
+    }
+
+    /**
      * Determine whether an attribute should be cast to a native type.
      *
      * @param  string  $key

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2749,7 +2749,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     public function setCasts(array $casts)
     {
         $this->casts = $casts;
-        
+
         return $this;
     }
 

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -1219,6 +1219,32 @@ class BelongsToMany extends Relation
     }
 
     /**
+     * Return an array of casts for the pivot table.
+     *
+     * @return array
+     */
+    public function getPivotCasts()
+    {
+        if (empty($this->parent->getCasts())) {
+            return [];
+        }
+
+        $prefix = Str::snake($this->relationName) . '.pivot.';
+        $prefixLength = strlen($prefix);
+
+        $casts = [];
+
+        foreach ($this->parent->getCasts() as $key => $type) {
+            if (substr($key, 0, $prefixLength) === $prefix) {
+                $key = substr($key, $prefixLength);
+                $casts[ $key ] = $type;
+            }
+        }
+
+        return $casts;
+    }
+
+    /**
      * Create a new query builder for the pivot table.
      *
      * @return \Illuminate\Database\Query\Builder
@@ -1270,7 +1296,10 @@ class BelongsToMany extends Relation
     {
         $pivot = $this->related->newPivot($this->parent, $attributes, $this->table, $exists);
 
-        return $pivot->setPivotKeys($this->foreignKey, $this->otherKey);
+        $pivot->setPivotKeys($this->foreignKey, $this->otherKey)
+              ->setCasts($this->getPivotCasts());
+
+        return $pivot;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -1229,7 +1229,7 @@ class BelongsToMany extends Relation
             return [];
         }
 
-        $prefix = Str::snake($this->relationName) . '.pivot.';
+        $prefix = Str::snake($this->relationName).'.pivot.';
         $prefixLength = strlen($prefix);
 
         $casts = [];
@@ -1237,7 +1237,7 @@ class BelongsToMany extends Relation
         foreach ($this->parent->getCasts() as $key => $type) {
             if (substr($key, 0, $prefixLength) === $prefix) {
                 $key = substr($key, $prefixLength);
-                $casts[ $key ] = $type;
+                $casts[$key] = $type;
             }
         }
 

--- a/src/Illuminate/Database/Eloquent/Relations/MorphToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphToMany.php
@@ -134,7 +134,8 @@ class MorphToMany extends BelongsToMany
 
         $pivot->setPivotKeys($this->foreignKey, $this->otherKey)
               ->setMorphType($this->morphType)
-              ->setMorphClass($this->morphClass);
+              ->setMorphClass($this->morphClass)
+              ->setCasts($this->getPivotCasts());
 
         return $pivot;
     }

--- a/tests/Database/DatabaseEloquentBelongsToManyTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyTest.php
@@ -698,7 +698,7 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase
         $related->shouldReceive('getTable')->andReturn('roles');
         $related->shouldReceive('getKeyName')->andReturn('id');
         $parent->shouldReceive('getCasts')->andReturn([
-            'relation_name.pivot.active' => 'boolean'
+            'relation_name.pivot.active' => 'boolean',
         ]);
         $related->shouldReceive('newPivot')->andReturnUsing(function () {
             $reflector = new ReflectionClass('Illuminate\Database\Eloquent\Relations\Pivot');

--- a/tests/Database/DatabaseEloquentBelongsToManyTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyTest.php
@@ -15,9 +15,9 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase
     public function testModelsAreProperlyHydrated()
     {
         $model1 = new EloquentBelongsToManyModelStub;
-        $model1->fill(['name' => 'taylor', 'pivot_user_id' => 1, 'pivot_role_id' => 2]);
+        $model1->fill(['name' => 'taylor', 'pivot_user_id' => 1, 'pivot_role_id' => 2, 'pivot_active' => 1]);
         $model2 = new EloquentBelongsToManyModelStub;
-        $model2->fill(['name' => 'dayle', 'pivot_user_id' => 3, 'pivot_role_id' => 4]);
+        $model2->fill(['name' => 'dayle', 'pivot_user_id' => 3, 'pivot_role_id' => 4, 'pivot_active' => 0]);
         $models = [$model1, $model2];
 
         $baseBuilder = m::mock('Illuminate\Database\Query\Builder');
@@ -49,6 +49,8 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(4, $results[1]->pivot->role_id);
         $this->assertEquals('foo.connection', $results[1]->pivot->getConnectionName());
         $this->assertEquals('user_role', $results[0]->pivot->getTable());
+        $this->assertTrue($results[0]->pivot->active);
+        $this->assertFalse($results[1]->pivot->active);
         $this->assertTrue($results[0]->pivot->exists);
     }
 
@@ -695,6 +697,9 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase
 
         $related->shouldReceive('getTable')->andReturn('roles');
         $related->shouldReceive('getKeyName')->andReturn('id');
+        $parent->shouldReceive('getCasts')->andReturn([
+            'relation_name.pivot.active' => 'boolean'
+        ]);
         $related->shouldReceive('newPivot')->andReturnUsing(function () {
             $reflector = new ReflectionClass('Illuminate\Database\Eloquent\Relations\Pivot');
 


### PR DESCRIPTION
Currently I miss an Eloquent feature for casting pivot attributes.
I'm currently working on a project where I have a Team model which has many users with different roles (integers). So I implemented that feature and made this PR.

I believe this is a simple and valuable feature and it works with camelCased relationship methods too ;)

I've to admit, that I'm not quite sure if I implemented the tests correctly.
# Simple Usage

Store a pivot attribute to reflect if a team member is active and cast it to boolean

```
<?php

namespace App;

use Illuminate\Database\Eloquent\Model;

class Team extends Model
{
    protected $casts = [
        'users.pivot.active' => 'boolean',
        'users_of_my_team.pivot.active' => 'boolean',
    ];

    public function users()
    {
        return $this->belongsToMany(User::class)->withPivot('active');
    }

    // CamelCased relation methods are also handled
    public function usersOfMyTeam()
    {
        return $this->belongsToMany(User::class)->withPivot('active');
    }
}
```
