### PR TITLE
[5.3] Minor change to create/update migration stubs

### DIFF
--- a/src/Illuminate/Database/Migrations/stubs/create.stub
+++ b/src/Illuminate/Database/Migrations/stubs/create.stub
@@ -7,13 +7,20 @@ use Illuminate\Database\Migrations\Migration;
 class DummyClass extends Migration
 {
     /**
+     * The table associated with the migration.
+     *
+     * @var string
+     */
+    protected $table = 'DummyTable';
+
+    /**
      * Run the migrations.
      *
      * @return void
      */
     public function up()
     {
-        Schema::create('DummyTable', function (Blueprint $table) {
+        Schema::create($this->table, function (Blueprint $table) {
             $table->increments('id');
             $table->timestamps();
         });
@@ -26,6 +33,6 @@ class DummyClass extends Migration
      */
     public function down()
     {
-        Schema::dropIfExists('DummyTable');
+        Schema::dropIfExists($this->table);
     }
 }

--- a/src/Illuminate/Database/Migrations/stubs/update.stub
+++ b/src/Illuminate/Database/Migrations/stubs/update.stub
@@ -7,13 +7,20 @@ use Illuminate\Database\Migrations\Migration;
 class DummyClass extends Migration
 {
     /**
+     * The table associated with the migration.
+     *
+     * @var string
+     */
+    protected $table = 'DummyTable';
+
+    /**
      * Run the migrations.
      *
      * @return void
      */
     public function up()
     {
-        Schema::table('DummyTable', function (Blueprint $table) {
+        Schema::table($this->table, function (Blueprint $table) {
             //
         });
     }
@@ -25,7 +32,7 @@ class DummyClass extends Migration
      */
     public function down()
     {
-        Schema::table('DummyTable', function (Blueprint $table) {
+        Schema::table($this->table, function (Blueprint $table) {
             //
         });
     }


### PR DESCRIPTION
This minor change to the create and update migration stubs puts the table name in one place.
