### PR TITLE
[5.3] Optimize content generation in testSharedGet()

### DIFF
--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -327,10 +327,7 @@ class FilesystemTest extends PHPUnit_Framework_TestCase
             $this->markTestSkipped('Skipping since the pcntl extension is not available');
         }
 
-        $content = '';
-        for ($i = 0; $i < 1000000; ++$i) {
-            $content .= $i;
-        }
+        $content = str_repeat('123456', 1000000);
         $result = 1;
 
         for ($i = 1; $i <= 20; ++$i) {


### PR DESCRIPTION
- length of previous string: 5888890 bytes (5.62 MB)
- length of new string: 6000000 bytes (5.72 MB)

Benchmark:

``` php
$nb = 10;

$t1 = microtime(true);
for ($x = $nb; $x--; ) {

    $content = '';
    for ($i = 0; $i < 1000000; ++$i) {
        $content .= $i;
    }

}
$t2 = microtime(true);
for ($x = $nb; $x--; ) {

    $content = str_repeat('123456', 1000000);

}
$t3 = microtime(true);

echo $t2 - $t1;
echo PHP_SAPI == 'cli' ? "\n" : '<br>';
echo $t3 - $t2;
```

Results on PHP 5.6, for 10 iterations (yes, only 10):
- Before: 3.904000043869 seconds (that means 390 ms for _one_ iteration!)
- After: 0.065000057220459 seconds

About 60 times faster.
