### PR TITLE
[5.3] Remove integer & double from bindings when updating JSON fields

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -169,7 +169,8 @@ class MySqlGrammar extends Grammar
         $index = 0;
 
         foreach ($values as $column => $value) {
-            if ($this->isJsonSelector($column) && is_bool($value)) {
+            if ($this->isJsonSelector($column) &&
+                in_array(gettype($value), ['boolean', 'integer', 'double'])) {
                 unset($bindings[$index]);
             }
 

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1385,10 +1385,17 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase
                         'update `users` set `options` = json_set(`options`, "$.enable", false), `updated_at` = ? where `id` = ?',
                         ['2015-05-26 22:02:06', 0]
                     );
-
         $builder = new Builder($connection, $grammar, $processor);
+        $builder->from('users')->where('id', '=', 0)->update(['options->enable' => false, 'updated_at' => '2015-05-26 22:02:06']);
 
-        $result = $builder->from('users')->where('id', '=', 0)->update(['options->enable' => false, 'updated_at' => '2015-05-26 22:02:06']);
+        $connection->shouldReceive('update')
+            ->once()
+            ->with(
+                'update `users` set `options` = json_set(`options`, "$.size", 45), `updated_at` = ? where `id` = ?',
+                ['2015-05-26 22:02:06', 0]
+            );
+        $builder = new Builder($connection, $grammar, $processor);
+        $builder->from('users')->where('id', '=', 0)->update(['options->size' => 45, 'updated_at' => '2015-05-26 22:02:06']);
     }
 
     public function testMySqlWrappingJsonWithString()


### PR DESCRIPTION
In `JsonExperssion` we remove the binding palceholder and replace it with the actual value (see https://github.com/laravel/framework/blob/6cf003ae02582cf716c10a723ef6bc19690969e7/src/Illuminate/Database/Query/JsonExpression.php#L40), we do the same with booleans as well.

However, we only remove the bool values from the bindings array and not the integer & doubles values. This causes the bindings length to be more than the placeholders given which will lead to faulty query execution.
