### PR TITLE
[5.3] Notification UUID set prior to queuing to ensure it is consistent.

### DIFF
--- a/src/Illuminate/Notifications/ChannelManager.php
+++ b/src/Illuminate/Notifications/ChannelManager.php
@@ -36,6 +36,8 @@ class ChannelManager extends Manager implements DispatcherContract, FactoryContr
     {
         $notifiables = $this->formatNotifiables($notifiables);
 
+        $notification->id = (string) Uuid::uuid4();
+
         if ($notification instanceof ShouldQueue) {
             return $this->queueNotification($notifiables, $notification);
         }
@@ -106,8 +108,6 @@ class ChannelManager extends Manager implements DispatcherContract, FactoryContr
         $notifiables = $this->formatNotifiables($notifiables);
 
         $bus = $this->app->make(Bus::class);
-
-        $notification->id = (string) Uuid::uuid4();
 
         foreach ($notifiables as $notifiable) {
             foreach ($notification->via($notifiable) as $channel) {

--- a/src/Illuminate/Notifications/ChannelManager.php
+++ b/src/Illuminate/Notifications/ChannelManager.php
@@ -57,8 +57,6 @@ class ChannelManager extends Manager implements DispatcherContract, FactoryContr
         $original = clone $notification;
 
         foreach ($notifiables as $notifiable) {
-            $notificationId = (string) Uuid::uuid4();
-
             $channels = $channels ?: $notification->via($notifiable);
 
             if (empty($channels)) {
@@ -67,8 +65,6 @@ class ChannelManager extends Manager implements DispatcherContract, FactoryContr
 
             foreach ($channels as $channel) {
                 $notification = clone $original;
-
-                $notification->id = $notificationId;
 
                 if (! $this->shouldSendNotification($notifiable, $notification, $channel)) {
                     continue;
@@ -110,6 +106,8 @@ class ChannelManager extends Manager implements DispatcherContract, FactoryContr
         $notifiables = $this->formatNotifiables($notifiables);
 
         $bus = $this->app->make(Bus::class);
+
+        $notification->id = (string) Uuid::uuid4();
 
         foreach ($notifiables as $notifiable) {
             foreach ($notification->via($notifiable) as $channel) {


### PR DESCRIPTION
When a notification implements ShouldQueue, different queued jobs are created for each channel, and as the UUID is set in the execution of each job it will be different for each channel (despite relating to the same notification).  Without ShouldQueue implemented, the UUID is set once and therefore the same throughout all channel executions.

This commit changes that to set the UUID on the notification once prior to queuing, and then accessing that id when executing the jobs on each channel.

This means we can always rely on $this->id returning the same value within the toMail, toDatabase, etc methods even when a notification is queued, keeping it consistent with how it works if not queued.

**Example Use Case**
I need to know that an email received, and a DatabaseNotification record were generated by the same Notification.  This way the email URL can link them back to the database version of the notification in my application:

```
->action(_('Login'), url('/notifications/' . $this->id))
```

I could then mark it as read before moving them on to the actual content I want them to see.  Without this, a user can click on a mail notification to link into my app, but there is no association with the DatabaseNotification I can use to mark it as read - so they’ll see the same notification in an unread state in the application despite having viewed the content.

I think this is potentially a broad use case, but even if not hopefully it is appealing to have $this->id return the same value in each channel method on the Notification regardless of whether it was queued or executed live. Thanks for the consideration! :)
