### PR TITLE
[5.3][Proposal] Add ability to get a collection with a specific record on head.

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -726,6 +726,28 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
+     * Get the collection with a specific record on head.
+     * 
+     * @param mixed $key
+     * 
+     * @return mixed
+     */ 
+    public function onHead($key)
+    {
+        if (!$this->offsetExists($key)) {
+            return;
+        }
+
+        $carry = $this->items[$key];
+
+        $this->offsetUnset($key);
+
+        array_unshift($this->items, $carry);
+
+        return $this;
+    }
+
+    /**
      * Pass the collection to the given callback and return the result.
      *
      * @param  callable $callback

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -729,12 +729,11 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      * Get the collection with a specific record on head.
      * 
      * @param mixed $key
-     * 
      * @return mixed
      */ 
     public function onHead($key)
     {
-        if (!$this->offsetExists($key)) {
+        if (! $this->offsetExists($key)) {
             return;
         }
 


### PR DESCRIPTION
Sometimes all what we need  is a specific record on head of a collection. 
## Example:

Let's say we want a collection of all **products** with a specific record on head which belongs to **Command**.

``` php
$command = \App\Command::findOrFail($id);

$products  = \App\Product::all()->pluck('name','id')->onHead($command->product_id);

return view('command.example',compact('command','products'));
```

So `onHead($key)` will return all the collection with specific record on head so we could use it in blade (select,grid,etc) reducing a lot of operations.
## This is better:

``` html
<div class="form-group">
    <label>Product Select</label>
    <select name = 'product_id' class = "form-control">
        @foreach($products as $key => $value)
        <option value="{{$key}}">{{$value}}</option>
        @endforeach
    </select>
</div>
```
## Than:

``` html
<div class="form-group">
    <label>Product Select</label>
    <select name = 'product_id' class = "form-control">
        <option value="{{$command->product_id}}">{{$command->product->name}}</option>
        @foreach($products->except($command->product_id) as $key => $value)
        <option value="{{$key}}">{{$value}}</option>
        @endforeach
    </select>
</div>
```

keeps our code clean :smile: 
