### PR TITLE
[5.3] Validate Resource's controller name

### DIFF
--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -74,6 +74,11 @@ class ResourceRegistrar
 
             return;
         }
+        
+        // Validate controller name doesn't have any @ for methods
+        if(Str::contains($controller,'@')) {
+            throw new \InvalidArgumentException("doesn't expect @ in resource [ $controller ]");
+        } 
 
         // We need to extract the base resource from the resource name. Nested resources
         // are supported in the framework, but we need to know what name to use for a


### PR DESCRIPTION
Hi , the problem here is when i register a route resource like

``` php
Route::resource('/users', 'UsersController@index');
```

the routes will generated as 
- App\Http\Controllers\UsersController@index@index
- App\Http\Controllers\UsersController@index@store
- App\Http\Controllers\UsersController@index@create
- App\Http\Controllers\UsersController@index@destroy
- App\Http\Controllers\UsersController@index@update
- App\Http\Controllers\UsersController@index@show
- App\Http\Controllers\UsersController@index@edit

and it will all redirect to index method  so it will be good if we validate the controller name itself by validating the controller name doesn't have '@' .
