### PR TITLE
[5.3] Updates to configuration loader

### DIFF
--- a/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php
+++ b/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php
@@ -91,7 +91,7 @@ class LoadConfiguration
      */
     protected function getConfigurationNesting(SplFileInfo $file, $configPath)
     {
-        $directory = dirname($file->getRealPath());
+        $directory = $file->getPath();
 
         if ($tree = trim(str_replace($configPath, '', $directory), DIRECTORY_SEPARATOR)) {
             $tree = str_replace(DIRECTORY_SEPARATOR, '.', $tree).'.';


### PR DESCRIPTION
There was an issue when loading configuration file in Linux/Unix. When file is actually a symbolic link, the path gets messed up and none of the configuration provided in the target file is accessible because the path with dot notation contains everything in between the link and the target file.
