### PR TITLE
[5.1] Fix improper use of mb_substr()

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -171,8 +171,8 @@ class UrlGenerator implements UrlGeneratorContract
         $root = $this->getRootUrl($scheme);
 
         if (($queryPosition = strpos($path, '?')) !== false) {
-            $query = mb_substr($path, $queryPosition);
-            $path = mb_substr($path, 0, $queryPosition);
+            $query = substr($path, $queryPosition);
+            $path = substr($path, 0, $queryPosition);
         } else {
             $query = '';
         }


### PR DESCRIPTION
Follow-up to #10894.
Because `strpos($path, '?')` is single-byte, the subsequent `substr()` have to be single-byte as well.
- `url('ééé/ààà?ùùù', 'extra');`
  - `http://example.org/ééé/ààà/extra?ùùù` – expected
  - `http://example.org/ééé/ààà?ùùù/extra` – result
- `url('ééé?ààà?ùùù', 'extra');`
  - `http://example.org/ééé/extra?ààà?ùùù` – expected
  - `http://example.org/ééé?àà/extraà?ùùù` – result

<br>ping @rkgrep :)
