### PR TITLE
[5.1] Restore support for using snake case model relationship names 5.*.*

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2629,18 +2629,20 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public function getRelationValue($key)
     {
+        $camelKey = camel_case($key);
+
         // If the key already exists in the relationships array, it just means the
         // relationship has already been loaded, so we'll just return it out of
         // here because there is no need to query within the relations twice.
-        if ($this->relationLoaded($key)) {
-            return $this->relations[$key];
+        if ($this->relationLoaded($camelKey)) {
+            return $this->relations[$camelKey];
         }
 
         // If the "attribute" exists as a method on the model, we will just assume
         // it is a relationship and will load and return results from the query
         // and hydrate the relationship's value on the "relationships" array.
-        if (method_exists($this, $key)) {
-            return $this->getRelationshipFromMethod($key);
+        if (method_exists($this, $camelKey)) {
+            return $this->getRelationshipFromMethod($camelKey);
         }
     }
 


### PR DESCRIPTION
I am currently upgrading a 4.2 project to 5.\* and came across issues wherever we call a camel case relation using snake case. For example, with 4.2 and the abbreviated class definition below...

``` php
class Foo
{
    public function barBaz()
    {
        return $this->belongsToMany(...);
    }
}
```

...we were able to get the results of the relation as follows...

``` php
$results = $foo->bar_baz;
// or
$results = $foo->barBaz;
```

..., but with 5.\* the use of snake case (which we use a lot) no longer works. It always returns `null`.

It seems as though this ability was removed beginning with 5.0, but I didn't see any note of it on the upgrade guidelines page nor anywhere else, so if there isn't a specific reason to lose this functionality, we would really appreciate having it restored.

Thanks
