### PR TITLE
Sleep the correct number of seconds in retry()

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -630,7 +630,7 @@ if (! function_exists('retry')) {
             $times--;
 
             if ($sleep) {
-                usleep($sleep * 1000);
+                usleep($sleep * 1000000);
             }
 
             goto beginning;


### PR DESCRIPTION
`usleep()` is in microseconds which is 1000000 seconds. I assumed the`$sleep` parameter was meant to be seconds. If it is supposed to be milliseconds then the original code is correct but may be useful to add something to the docblock to know if it is seconds or milliseconds.
