### PR TITLE
[5.3] Remove unecessary validation feedback for password confirmation field

### DIFF
--- a/src/Illuminate/Auth/Console/stubs/make/views/auth/register.stub
+++ b/src/Illuminate/Auth/Console/stubs/make/views/auth/register.stub
@@ -52,17 +52,11 @@
                             </div>
                         </div>
 
-                        <div class="form-group{{ $errors->has('password_confirmation') ? ' has-error' : '' }}">
+                        <div class="form-group">
                             <label for="password-confirm" class="col-md-4 control-label">Confirm Password</label>
 
                             <div class="col-md-6">
                                 <input id="password-confirm" type="password" class="form-control" name="password_confirmation" required>
-
-                                @if ($errors->has('password_confirmation'))
-                                    <span class="help-block">
-                                        <strong>{{ $errors->first('password_confirmation') }}</strong>
-                                    </span>
-                                @endif
                             </div>
                         </div>
 


### PR DESCRIPTION
The validation feedback is returned on the password field rather than the password confirmation field.

So the errors bag doesn't get the error from the password_confirmation field.
