### PR TITLE
[5.3] Keep files in the  $data array after hydration

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -255,7 +255,6 @@ class Validator implements ValidatorContract
             // we use to conveniently separate out these files from other data.
             if ($value instanceof File) {
                 $this->files[$newKey] = $value;
-
             } elseif (is_array($value) && ! empty($value) &&
                       empty($this->hydrateFiles($value, $newKey))) {
             }

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -256,10 +256,8 @@ class Validator implements ValidatorContract
             if ($value instanceof File) {
                 $this->files[$newKey] = $value;
 
-                unset($data[$key]);
             } elseif (is_array($value) && ! empty($value) &&
                       empty($this->hydrateFiles($value, $newKey))) {
-                unset($data[$key]);
             }
         }
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -564,7 +564,9 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $foo = new File(__FILE__, false);
         $v = new Validator($trans, ['name' => [$file, $foo]], ['name.0' => 'Required', 'name.1' => 'Required']);
         $this->assertTrue($v->passes());
-        $this->assertEmpty($v->getData());
+
+        $v = new Validator($trans, ['files' => [$file, $foo]], ['files' => 'Required']);
+        $this->assertTrue($v->passes());
     }
 
     public function testValidateRequiredWith()
@@ -3227,7 +3229,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $file = new File(__FILE__, false);
         $v = new Validator($trans, ['file' => $file, 'text' => 'text'], ['text' => 'Required']);
         $this->assertEquals(['file' => $file], $v->getFiles());
-        $this->assertEquals(['text' => 'text'], $v->getData());
+        $this->assertEquals(['text' => 'text', 'file' => $file], $v->getData());
     }
 
     public function testArrayOfFilesHydration()
@@ -3237,7 +3239,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $file2 = new File(__FILE__, false);
         $v = new Validator($trans, ['file' => [$file, $file2], 'text' => 'text'], ['text' => 'Required']);
         $this->assertEquals(['file.0' => $file, 'file.1' => $file2], $v->getFiles());
-        $this->assertEquals(['text' => 'text'], $v->getData());
+        $this->assertEquals(['text' => 'text', 'file' => [$file, $file2]], $v->getData());
     }
 
     public function testMultipleFileUploads()


### PR DESCRIPTION
Let's say we have this validator instance:

```
    $file = new File(__FILE__, false);
    $v = new Validator($trans, ['files' => [$file]], ['files' => 'Required']);
```

When `hydrateFiles()` is called `$validator->data` will be empty, and `$validator->files` will look like:

```
['files.1' => /** File Instance **/];
```

So when the required rule runs, it expects a `files` key to be present, but that key was removed during hydration so the rule will fail although there are files present in the Validator instance.

This PR prevents removing the files from `$validator->data` which will make such rule pass.

In 5.4 we removed the hydration step entirely.
