### PR TITLE
[5.3] Add support for Collection's `contains` to look in single-dimension arrays for a key/value pair

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -161,7 +161,11 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     {
         if (func_num_args() == 2) {
             return $this->contains(function ($item) use ($key, $value) {
-                return data_get($item, $key) == $value;
+                if (is_array($item)) {
+                    return data_get($item, $key) == $value;
+                }
+
+                return data_get($this->items, $key) == $value;
             });
         }
 
@@ -183,7 +187,11 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     {
         if (func_num_args() == 2) {
             return $this->contains(function ($item) use ($key, $value) {
-                return data_get($item, $key) === $value;
+                if (is_array($item)) {
+                    return data_get($item, $key) === $value;
+                }
+
+                return data_get($this->items, $key) === $value;
             });
         }
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1096,6 +1096,11 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
             return $value > 5;
         }));
 
+        $c = new Collection(['v' => 1, 'a' => 3, 'l' => 5]);
+
+        $this->assertTrue($c->contains('v', 1));
+        $this->assertFalse($c->contains('a', 7));
+
         $c = new Collection([['v' => 1], ['v' => 3], ['v' => 5]]);
 
         $this->assertTrue($c->contains('v', 1));
@@ -1121,6 +1126,13 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
         $this->assertFalse($c->containsStrict(function ($value) {
             return $value > 5;
         }));
+
+        $c = new Collection(['v' => 1, 'a' => 3, 'l' => '05']);
+
+        $this->assertTrue($c->containsStrict('v', 1));
+        $this->assertFalse($c->containsStrict('a', 7));
+        $this->assertFalse($c->containsStrict('l', 5));
+        $this->assertTrue($c->containsStrict('l', '05'));
 
         $c = new Collection([['v' => 1], ['v' => 3], ['v' => '04'], ['v' => 5]]);
 


### PR DESCRIPTION
This is a shortcut for something like the following:

``` php
$key = 'key';
$value = 'value';
$collection->contains(function ($v, $k) use ($key, $value) {
    return ($k === $key) && ($v == $value);
});
```

Instead you can do:

``` php
$collection->contains('key', 'value');
```

Also applies to `containsStrict`.
