### PR TITLE
[5.3] An option with shortcut "q" already exists.

### DIFF
--- a/src/Illuminate/Foundation/Console/ListenerMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ListenerMakeCommand.php
@@ -116,7 +116,7 @@ class ListenerMakeCommand extends GeneratorCommand
         return [
             ['event', 'e', InputOption::VALUE_REQUIRED, 'The event class being listened for.'],
 
-            ['queued', 'q', InputOption::VALUE_NONE, 'Indicates the event listener should be queued.'],
+            ['queued', null, InputOption::VALUE_NONE, 'Indicates the event listener should be queued.'],
         ];
     }
 }


### PR DESCRIPTION
`php artisan make:listener` will result error:

```
[Symfony\Component\Console\Exception\LogicException]  
An option with shortcut "q" already exists.           
```
