### PR TITLE
[5.3] Add custom validation error messages on the ResetPasswordController

### DIFF
--- a/src/Illuminate/Foundation/Auth/ResetsPasswords.php
+++ b/src/Illuminate/Foundation/Auth/ResetsPasswords.php
@@ -35,7 +35,7 @@ trait ResetsPasswords
      */
     public function reset(Request $request)
     {
-        $this->validate($request, $this->rules());
+        $this->validate($request, $this->rules(), $this->validationErrorMessages());
 
         // Here we will attempt to reset the user's password. If it is successful we
         // will update the password on an actual user model and persist it to the
@@ -65,6 +65,16 @@ trait ResetsPasswords
             'token' => 'required', 'email' => 'required|email',
             'password' => 'required|confirmed|min:6',
         ];
+    }
+
+    /**
+     * Get the password reset validation error messages.
+     *
+     * @return array
+     */
+    protected function validationErrorMessages()
+    {
+        return [];
     }
 
     /**


### PR DESCRIPTION
At the moment you can't add custom password messages. This would be usefull when using the validator to add certain requirements to the password. Like instead of min:6|alpha generating 2 different messages we could do the same for both.
