### PR TITLE
[5.3] Remove dot

### DIFF
--- a/src/Illuminate/Console/Application.php
+++ b/src/Illuminate/Console/Application.php
@@ -188,7 +188,7 @@ class Application extends SymfonyApplication implements ApplicationContract
      */
     protected function getEnvironmentOption()
     {
-        $message = 'The environment the command should run under.';
+        $message = 'The environment the command should run under';
 
         return new InputOption('--env', null, InputOption::VALUE_OPTIONAL, $message);
     }


### PR DESCRIPTION
Very minor consistency change, all other default option descriptions don't end with a dot
