### PR TITLE
[5.1] Add test for current page validation

### DIFF
--- a/tests/Pagination/PaginationLengthAwarePaginatorTest.php
+++ b/tests/Pagination/PaginationLengthAwarePaginatorTest.php
@@ -1,0 +1,59 @@
+<?php
+
+use Mockery as m;
+use Illuminate\Pagination\UrlWindow;
+use Illuminate\Pagination\AbstractPaginator;
+use Illuminate\Pagination\LengthAwarePaginator;
+use Illuminate\Pagination\Paginator as Paginator;
+use Illuminate\Pagination\BootstrapThreePresenter as BootstrapPresenter;
+
+class PaginationLengthAwarePaginatorTest extends PHPUnit_Framework_TestCase
+{
+    protected $allItems;
+    protected $visibleSliceOfItems;
+    protected $perPage;
+    protected $totalNumberOfItems;
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->allItems = ['item1','item2','item3', 'item4', 'item5', 'item6'];
+        // The currently visible items. We're at the end of the pagination.
+        $this->visibleSliceOfItems = ['item4', 'item5', 'item6'];
+        // Items to show per page
+        $this->perPage = count($this->visibleSliceOfItems);
+        // The total number of items – 6 in our case
+        $this->totalNumberOfItems = count($this->allItems);
+    }
+
+    public function tearDown()
+    {
+        m::close();
+    }
+
+    public function testPaginatorReturnsCurrentPageCorrectly()
+    {
+        $currentPage = 2;
+        $paginator = new LengthAwarePaginator(
+            $this->visibleSliceOfItems,
+            $this->totalNumberOfItems,
+            $this->perPage,
+            $currentPage
+        );
+        $this->assertEquals($currentPage, $paginator->currentPage());
+    }
+
+    public function testPaginatorDoesNotExceedBoundariesEvenIfAskedToDoSo()
+    {
+        // exceeds boundary of pagination
+        $currentPage = 3;
+        $expectedLastPage = 2;
+        $paginator = new LengthAwarePaginator(
+            $this->visibleSliceOfItems,
+            $this->totalNumberOfItems,
+            $this->perPage,
+            $currentPage
+        );
+        $this->assertEquals($expectedLastPage, $paginator->currentPage());
+    }
+}


### PR DESCRIPTION
I'm using laravel/framework 5.3 in my current project.

I think I discovered a pagination bug that was introduced somewhere between version 5.1 and the current version 5.3. While I was searching the cause of the bug, I added this test and based it on branch 5.1. I noticed that 5.1 performed just as expected, while 5.3 wasn't (I added the test to 5.3 locally as well).

I wanted to share the test in the first place and ask why the changes were made. I would gladly fix the bug as well, if you considered that helpful.

In 5.1, `LengthAwarePaginator::currentPage()` returned either the requested current page or the last page, if the current page exceeded the boundaries. Example: you requested `$currentPage==5` but the pagination only had 4 pages. Then `LengthAwarePaginator::currentPage()` returned 4.

In 5.3, when doing the same, the `LengthAwarePaginator::currentPage()` returns 5. It doesn't take the boundaries into account anymore.

So this test succeeds on 5.1 while it fails on 5.3.

**Please tell me if this is by intent and whether you'd want me to fix the bug or not.**
