### PR TITLE
[5.3] Allow control over the short property on slack attachment fields.

### DIFF
--- a/src/Illuminate/Notifications/Channels/SlackWebhookChannel.php
+++ b/src/Illuminate/Notifications/Channels/SlackWebhookChannel.php
@@ -95,6 +95,9 @@ class SlackWebhookChannel
     protected function fields(SlackAttachment $attachment)
     {
         return collect($attachment->fields)->map(function ($value, $key) {
+            if (is_array($value)) {
+                return $value;
+            }
             return ['title' => $key, 'value' => $value, 'short' => true];
         })->values()->all();
     }

--- a/src/Illuminate/Notifications/Channels/SlackWebhookChannel.php
+++ b/src/Illuminate/Notifications/Channels/SlackWebhookChannel.php
@@ -98,6 +98,7 @@ class SlackWebhookChannel
             if (is_array($value)) {
                 return $value;
             }
+
             return ['title' => $key, 'value' => $value, 'short' => true];
         })->values()->all();
     }


### PR DESCRIPTION
In order to give access to the **short** setting on a Slack attachment field, _optionally_ allow an array to be passed in.  This provides a way to set short to false when we need it.

Example configuration could then be:

```
->fields([
    'ID'     => 99, 
    [
        'title' => 'Description',
        'value' => $description,
        'short' => false,
    ],
]);
```

As opposed to:

```
->fields([
    'ID' => 99, 
    'Description' => $description,
]);
```

This ensures that **description** will be nicely rendered on it’s own line in Slack.  Without this, Slack will render it in 50% width even when it is not necessary (mobile = always, desktop = if next to another field) which does not look nice.
