### PR TITLE
[5.4] Model binding in broadcasting channel definitions

### DIFF
--- a/tests/Broadcasting/BroadcasterTest.php
+++ b/tests/Broadcasting/BroadcasterTest.php
@@ -1,0 +1,102 @@
+<?php
+
+use Mockery as m;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Broadcasting\Broadcasters\Broadcaster;
+
+class BroadcasterTest extends PHPUnit_Framework_TestCase
+{
+    public function tearDown()
+    {
+        m::close();
+    }
+
+    public function testExtractingParametersWhileCheckingForUserAccess()
+    {
+        $broadcaster = new FakeBroadcaster();
+
+        $callback = function ($user, BroadcasterTestEloquentModelStub $model, $nonModel) {
+        };
+        $parameters = $broadcaster->extractAuthParameters('asd.{model}.{nonModel}', 'asd.1.something', $callback);
+        $this->assertEquals(['model.1.instance', 'something'], $parameters);
+
+        $callback = function ($user, BroadcasterTestEloquentModelStub $model, BroadcasterTestEloquentModelStub $model2, $something) {
+        };
+        $parameters = $broadcaster->extractAuthParameters('asd.{model}.{model}.{nonModel}', 'asd.1.uid.something', $callback);
+        $this->assertEquals(['model.1.instance', 'model.uid.instance', 'something'], $parameters);
+
+        $callback = function ($user) {
+        };
+        $parameters = $broadcaster->extractAuthParameters('asd', 'asd', $callback);
+        $this->assertEquals([], $parameters);
+
+        $callback = function ($user, $something) {
+        };
+        $parameters = $broadcaster->extractAuthParameters('asd', 'asd', $callback);
+        $this->assertEquals([null], $parameters);
+
+        $callback = function ($user, BroadcasterTestEloquentModelNotFoundStub $model) {
+        };
+        $parameters = $broadcaster->extractAuthParameters('asd.{model}', 'asd.1', $callback);
+        $this->assertEquals([null], $parameters);
+    }
+}
+
+class FakeBroadcaster extends Broadcaster
+{
+    public function auth($request)
+    {
+    }
+
+    public function validAuthenticationResponse($request, $result)
+    {
+    }
+
+    public function broadcast(array $channels, $event, array $payload = [])
+    {
+    }
+
+    public function extractAuthParameters($pattern, $channel, $callback)
+    {
+        return parent::extractAuthParameters($pattern, $channel, $callback);
+    }
+}
+
+class BroadcasterTestEloquentModelStub extends Model
+{
+    public function getRouteKeyName()
+    {
+        return 'id';
+    }
+
+    public function where($key, $value)
+    {
+        $this->value = $value;
+
+        return $this;
+    }
+
+    public function first()
+    {
+        return "model.{$this->value}.instance";
+    }
+}
+
+class BroadcasterTestEloquentModelNotFoundStub extends Model
+{
+    public function getRouteKeyName()
+    {
+        return 'id';
+    }
+
+    public function where($key, $value)
+    {
+        $this->value = $value;
+
+        return $this;
+    }
+
+    public function first()
+    {
+    }
+}


### PR DESCRIPTION
This PR allows model binding on channel authorization:

```
Broadcast::channel('order.{order}', function ($user, App\Order $order) {
    return $user->id === $order->user_id;
});
```

You can still pass normal values:

```
Broadcast::channel('order.{order}, function ($user, $orderId) {
    return $user->id === Order::findOrNew($orderId)->user_id;
});
```

If model wasn't found its value will be null:

```
Broadcast::channel('order.{order}', function ($user, App\Order $order) {
    // $order will be null in case we couldn't find the model
});
```

Unlike models, the key names here can be anything:

```
Broadcast::channel('order.{order_reference_number}', function ($user, App\Order $order) {
    return $user->id === $order->user_id;
});
```

Note that we use `Model::getRouteKeyName` to get the key name instead of having a separate method for the broadcaster.
