### PR TITLE
[5.3] Keep array keys only if array is Associative

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1008,8 +1008,16 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
         // Once we have sorted all of the keys in the array, we will loop through them
         // and grab the corresponding model so we can set the underlying items list
         // to the sorted version. Then we'll just return the collection instance.
-        foreach (array_keys($results) as $key) {
-            $results[$key] = $this->items[$key];
+        $resultKeys = array_keys($results);
+        if (Arr::isAssoc($this->items)) {
+            foreach ($resultKeys as $key) {
+                $results[$key] = $this->items[$key];
+            }
+        } else {
+            $results = [];
+            foreach ($resultKeys as $key) {
+                $results[] = $this->items[$key];
+            }
         }
 
         return new static($results);

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -634,6 +634,26 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
         $this->assertEquals([['name' => 'dayle'], ['name' => 'taylor']], array_values($data->all()));
     }
 
+    public function testSortByReturnsAssoc()
+    {
+        $data = new Collection(['a' => 'taylor', 'b' => 'dayle']);
+        $data = $data->sortBy(function ($x) {
+            return $x;
+        });
+
+        $this->assertEquals(['b' => 'dayle', 'a' => 'taylor'], $data->all());
+    }
+
+    public function testSortByReturnsSequential()
+    {
+        $data = new Collection(['taylor', 'dayle']);
+        $data = $data->sortBy(function ($x) {
+            return $x;
+        });
+
+        $this->assertEquals(['dayle', 'taylor'], $data->all());
+    }
+
     public function testReverse()
     {
         $data = new Collection(['zaeed', 'alan']);


### PR DESCRIPTION
When you have a sequential array, and you sort it using sortBy, you would expect to get a sequential array back. This is especially an issue when you try to cast it to Json, and you get an object instead of an array. This commit checks if an array is Associative, and if not, discards the keys creating a new sequential array instead.
