### PR TITLE
[5.4] Add PhpDoc to improve code insight for migrations

### DIFF
--- a/src/Illuminate/Support/Fluent.php
+++ b/src/Illuminate/Support/Fluent.php
@@ -7,6 +7,17 @@ use JsonSerializable;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Contracts\Support\Arrayable;
 
+/**
+ * @method Fluent first()
+ * @method Fluent after(string $column)
+ * @method Fluent nullable()
+ * @method Fluent default($value)
+ * @method Fluent unsigned()
+ * @method Fluent comment(string $comment)
+ *
+ * @method Fluent unique()
+ * @method Fluent index()
+ */
 class Fluent implements ArrayAccess, Arrayable, Jsonable, JsonSerializable
 {
     /**


### PR DESCRIPTION
I added the needed PhpDoc declarations so that the available fluent column and index modifiers can be surfaced inside an IDE.
