### PR TITLE
[4.2] Expand on PHP7 compatiblity with __isset() fix from 5.3 branch

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -3077,8 +3077,7 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	 */
 	public function __isset($key)
 	{
-		return ((isset($this->attributes[$key]) || isset($this->relations[$key])) ||
-				($this->hasGetMutator($key) && ! is_null($this->getAttributeValue($key))));
+		return ! is_null($this->getAttribute($key));
 	}
 
 	/**


### PR DESCRIPTION
I was unable to cherry-pick the commit since so much has changed from 4 -> 5, so I applied the fix manually. 

Reference commit: https://github.com/laravel/framework/commit/8fb89c61c24af905b0b9db4d645d68a2c4a133b9
Conversation: https://github.com/laravel/framework/pull/13509#issuecomment-256683363
