### PR TITLE
[4.2] handleViewException in PHP7

### DIFF
--- a/src/Illuminate/View/Engines/CompilerEngine.php
+++ b/src/Illuminate/View/Engines/CompilerEngine.php
@@ -1,6 +1,7 @@
 <?php namespace Illuminate\View\Engines;
 
 use Illuminate\View\Compilers\CompilerInterface;
+use Symfony\Component\Debug\Exception\FatalThrowableError;
 
 class CompilerEngine extends PhpEngine {
 
@@ -71,6 +72,10 @@ class CompilerEngine extends PhpEngine {
 	 */
 	protected function handleViewException($e, $obLevel)
 	{
+		if (! $e instanceof \Exception) {
+			$e = new FatalThrowableError($e);
+		}
+
 		$e = new \ErrorException($this->getMessage($e), 0, 1, $e->getFile(), $e->getLine(), $e);
 
 		parent::handleViewException($e, $obLevel);


### PR DESCRIPTION
This PR fixes that issue: https://github.com/laravel/framework/issues/16123

Exceptions thrown from blade files are currently not being handled correctly for PHP7.
