### PR TITLE
[5.3] Add not_before and not_after rules

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1914,7 +1914,7 @@ class Validator implements ValidatorContract
     }
 
     /**
-     * Run after, before not_after or not_before validation depending on given rule
+     * Run after, before not_after or not_before validation depending on given rule.
      *
      * @param string $attribute
      * @param mixed $value
@@ -1932,7 +1932,7 @@ class Validator implements ValidatorContract
         }
 
         if ($format = $this->getDateFormat($attribute)) {
-            return $this->{'validate' . Str::studly($rule). 'WithFormat'}($format, $value, $parameters);
+            return $this->{'validate'.Str::studly($rule).'WithFormat'}($format, $value, $parameters);
         }
 
         if (! $date = $this->getDateTimestamp($parameters[0])) {
@@ -1943,7 +1943,7 @@ class Validator implements ValidatorContract
         if ($dateTimestamp === false || $date === false) {
             return false;
         }
-        
+
         switch ($rule) {
             case 'after':
                 return $this->getDateTimestamp($value) > $date;
@@ -1954,7 +1954,7 @@ class Validator implements ValidatorContract
             case 'not_after':
                 return $this->getDateTimestamp($value) <= $date;
         }
-        
+
         return false;
     }
 
@@ -2003,9 +2003,9 @@ class Validator implements ValidatorContract
         $before = $this->getDateTimeWithOptionalFormat($format, $before);
 
         $after = $this->getDateTimeWithOptionalFormat($format, $after);
-        
+
         if ($allowEqual) {
-            return ($before && $after) && ($after >= $before); 
+            return ($before && $after) && ($after >= $before);
         }
 
         return ($before && $after) && ($after > $before);

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1841,21 +1841,20 @@ class Validator implements ValidatorContract
      */
     protected function validateBefore($attribute, $value, $parameters)
     {
-        $this->requireParameterCount(1, $parameters, 'before');
+        return $this->runAfterOrBeforeValidation($attribute, $value, $parameters, 'before');
+    }
 
-        if (! is_string($value) && ! is_numeric($value) && ! $value instanceof DateTimeInterface) {
-            return false;
-        }
-
-        if ($format = $this->getDateFormat($attribute)) {
-            return $this->validateBeforeWithFormat($format, $value, $parameters);
-        }
-
-        if (! $date = $this->getDateTimestamp($parameters[0])) {
-            $date = $this->getDateTimestamp($this->getValue($parameters[0]));
-        }
-
-        return $this->getDateTimestamp($value) < $date;
+    /**
+     * Validate the date is not before a given date.
+     *
+     * @param  string  $attribute
+     * @param  mixed   $value
+     * @param  array   $parameters
+     * @return bool
+     */
+    protected function validateNotBefore($attribute, $value, $parameters)
+    {
+        return $this->runAfterOrBeforeValidation($attribute, $value, $parameters, 'not_before');
     }
 
     /**
@@ -1874,6 +1873,21 @@ class Validator implements ValidatorContract
     }
 
     /**
+     * Validate the date is not before a given date with a given format.
+     *
+     * @param  string  $format
+     * @param  mixed   $value
+     * @param  array   $parameters
+     * @return bool
+     */
+    protected function validateNotBeforeWithFormat($format, $value, $parameters)
+    {
+        $param = $this->getValue($parameters[0]) ?: $parameters[0];
+
+        return $this->checkDateTimeOrder($format, $param, $value, true);
+    }
+
+    /**
      * Validate the date is after a given date.
      *
      * @param  string  $attribute
@@ -1883,21 +1897,65 @@ class Validator implements ValidatorContract
      */
     protected function validateAfter($attribute, $value, $parameters)
     {
-        $this->requireParameterCount(1, $parameters, 'after');
+        return $this->runAfterOrBeforeValidation($attribute, $value, $parameters, 'after');
+    }
+
+    /**
+     * Validate the date is not after a given date.
+     *
+     * @param  string  $attribute
+     * @param  mixed   $value
+     * @param  array   $parameters
+     * @return bool
+     */
+    protected function validateNotAfter($attribute, $value, $parameters)
+    {
+        return $this->runAfterOrBeforeValidation($attribute, $value, $parameters, 'not_after');
+    }
+
+    /**
+     * Run after, before not_after or not_before validation depending on given rule
+     *
+     * @param string $attribute
+     * @param mixed $value
+     * @param array $parameters
+     * @param string $rule
+     *
+     * @return bool
+     */
+    protected function runAfterOrBeforeValidation($attribute, $value, $parameters, $rule)
+    {
+        $this->requireParameterCount(1, $parameters, $rule);
 
         if (! is_string($value) && ! is_numeric($value) && ! $value instanceof DateTimeInterface) {
             return false;
         }
 
         if ($format = $this->getDateFormat($attribute)) {
-            return $this->validateAfterWithFormat($format, $value, $parameters);
+            return $this->{'validate' . Str::studly($rule). 'WithFormat'}($format, $value, $parameters);
         }
 
         if (! $date = $this->getDateTimestamp($parameters[0])) {
             $date = $this->getDateTimestamp($this->getValue($parameters[0]));
         }
 
-        return $this->getDateTimestamp($value) > $date;
+        $dateTimestamp = $this->getDateTimestamp($value);
+        if ($dateTimestamp === false || $date === false) {
+            return false;
+        }
+        
+        switch ($rule) {
+            case 'after':
+                return $this->getDateTimestamp($value) > $date;
+            case 'not_before':
+                return $this->getDateTimestamp($value) >= $date;
+            case 'before':
+                return $this->getDateTimestamp($value) < $date;
+            case 'not_after':
+                return $this->getDateTimestamp($value) <= $date;
+        }
+        
+        return false;
     }
 
     /**
@@ -1916,18 +1974,39 @@ class Validator implements ValidatorContract
     }
 
     /**
+     * Validate the date is not after a given date with a given format.
+     *
+     * @param  string  $format
+     * @param  mixed   $value
+     * @param  array   $parameters
+     * @return bool
+     */
+    protected function validateNotAfterWithFormat($format, $value, $parameters)
+    {
+        $param = $this->getValue($parameters[0]) ?: $parameters[0];
+
+        return $this->checkDateTimeOrder($format, $value, $param, true);
+    }
+
+    /**
      * Given two date/time strings, check that one is after the other.
      *
      * @param  string  $format
      * @param  string  $before
      * @param  string  $after
+     * @param  bool  $allowEqual
+     *
      * @return bool
      */
-    protected function checkDateTimeOrder($format, $before, $after)
+    protected function checkDateTimeOrder($format, $before, $after, $allowEqual = false)
     {
         $before = $this->getDateTimeWithOptionalFormat($format, $before);
 
         $after = $this->getDateTimeWithOptionalFormat($format, $after);
+        
+        if ($allowEqual) {
+            return ($before && $after) && ($after >= $before); 
+        }
 
         return ($before && $after) && ($after > $before);
     }

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -2174,7 +2174,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['x' => new DateTime('2012-01-03')], ['x' => 'Not_After:2012-01-02']);
-        $this->assertFalse($v->passes());        
+        $this->assertFalse($v->passes());
 
         $v = new Validator($trans, ['x' => new DateTime('2012-01-02')], ['x' => 'Not_Before:2012-01-01']);
         $this->assertTrue($v->passes());
@@ -2183,7 +2183,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['x' => new DateTime('2012-01-01')], ['x' => 'Not_Before:2012-01-02']);
-        $this->assertFalse($v->passes());        
+        $this->assertFalse($v->passes());
 
         $v = new Validator($trans, ['start' => new DateTime('2012-01-01'), 'ends' => new Carbon('2013-01-01')], ['start' => 'Not_After:ends', 'ends' => 'Not_Before:start']);
         $this->assertTrue($v->passes());
@@ -2196,7 +2196,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
         $v = new Validator($trans, ['start' => 'today', 'ends' => 'tomorrow'], ['start' => 'Not_After:ends', 'ends' => 'Not_Before:start']);
         $this->assertTrue($v->passes());
-    }    
+    }
 
     public function testBeforeAndAfterWithFormat()
     {
@@ -2212,7 +2212,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['x' => '31/12/2012'], ['x' => 'date_format:d/m/Y|before:31/12/2012']);
-        $this->assertFalse($v->passes());        
+        $this->assertFalse($v->passes());
 
         $v = new Validator($trans, ['x' => '31/12/2012'], ['x' => 'after:31/12/2000']);
         $this->assertTrue($v->fails());
@@ -2224,7 +2224,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['x' => '31/12/2000'], ['x' => 'date_format:d/m/Y|before:31/12/2000']);
-        $this->assertFalse($v->passes());        
+        $this->assertFalse($v->passes());
 
         $v = new Validator($trans, ['start' => '31/12/2012', 'ends' => '31/12/2013'], ['start' => 'after:01/01/2000', 'ends' => 'after:start']);
         $this->assertTrue($v->fails());
@@ -2283,7 +2283,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['x' => '31/12/2012'], ['x' => 'date_format:d/m/Y|not_after:30/12/2012']);
-        $this->assertTrue($v->fails());        
+        $this->assertTrue($v->fails());
 
         $v = new Validator($trans, ['x' => '31/12/2012'], ['x' => 'not_before:31/12/2000']);
         $this->assertTrue($v->fails());
@@ -2298,7 +2298,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['x' => '31/12/2000'], ['x' => 'date_format:d/m/Y|not_after:30/12/2000']);
-        $this->assertTrue($v->fails());        
+        $this->assertTrue($v->fails());
 
         $v = new Validator($trans, ['start' => '31/12/2012', 'ends' => '31/12/2013'], ['start' => 'not_before:01/01/2000', 'ends' => 'not_before:start']);
         $this->assertTrue($v->fails());
@@ -2328,7 +2328,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['start' => '31/12/2012', 'ends' => '30/12/2012'], ['start' => 'date_format:d/m/Y|not_after:ends']);
-        $this->assertTrue($v->fails());        
+        $this->assertTrue($v->fails());
 
         $v = new Validator($trans, ['start' => 'invalid', 'ends' => 'invalid'], ['start' => 'date_format:d/m/Y|not_after:ends', 'ends' => 'date_format:d/m/Y|not_before:start']);
         $this->assertTrue($v->fails());

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -2093,6 +2093,24 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $v = new Validator($trans, ['x' => new DateTime('2000-01-01')], ['x' => 'Before:2012-01-01']);
         $this->assertTrue($v->passes());
 
+        $v = new Validator($trans, ['x' => new DateTime('2012-01-01')], ['x' => 'Before:2012-01-01']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['x' => new DateTime('2012-01-01')], ['x' => 'Before:2012-01-02']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => new DateTime('2012-01-03')], ['x' => 'Before:2012-01-02']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['x' => new DateTime('2012-01-02')], ['x' => 'After:2012-01-01']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => new DateTime('2012-01-02')], ['x' => 'After:2012-01-02']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['x' => new DateTime('2012-01-01')], ['x' => 'After:2012-01-02']);
+        $this->assertFalse($v->passes());
+
         $v = new Validator($trans, ['start' => new DateTime('2012-01-01'), 'ends' => new Carbon('2013-01-01')], ['start' => 'Before:ends', 'ends' => 'After:start']);
         $this->assertTrue($v->passes());
 
@@ -2105,6 +2123,80 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $v = new Validator($trans, ['start' => 'today', 'ends' => 'tomorrow'], ['start' => 'Before:ends', 'ends' => 'After:start']);
         $this->assertTrue($v->passes());
     }
+
+    public function testNotBeforeAndNotAfter()
+    {
+        date_default_timezone_set('UTC');
+        $trans = $this->getRealTranslator();
+        $v = new Validator($trans, ['x' => '2000-01-01'], ['x' => 'Not_After:2012-01-01']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => ['2000-01-01']], ['x' => 'Not_After:2012-01-01']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['x' => new Carbon('2000-01-01')], ['x' => 'Not_After:2012-01-01']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => [new Carbon('2000-01-01')]], ['x' => 'Not_After:2012-01-01']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['x' => '2012-01-01'], ['x' => 'Not_Before:2000-01-01']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => ['2012-01-01']], ['x' => 'Not_Before:2000-01-01']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['x' => new Carbon('2012-01-01')], ['x' => 'Not_Before:2000-01-01']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => [new Carbon('2012-01-01')]], ['x' => 'Not_Before:2000-01-01']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['start' => '2012-01-01', 'ends' => '2013-01-01'], ['start' => 'Not_Before:2000-01-01', 'ends' => 'Not_Before:start']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['start' => '2012-01-01', 'ends' => '2000-01-01'], ['start' => 'Not_Before:2000-01-01', 'ends' => 'Not_Before:start']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['start' => '2012-01-01', 'ends' => '2013-01-01'], ['start' => 'Not_After:ends', 'ends' => 'Not_Before:start']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['start' => '2012-01-01', 'ends' => '2000-01-01'], ['start' => 'Not_After:ends', 'ends' => 'Not_Before:start']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['x' => new DateTime('2000-01-01')], ['x' => 'Not_After:2012-01-01']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => new DateTime('2012-01-01')], ['x' => 'Not_After:2012-01-01']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => new DateTime('2012-01-01')], ['x' => 'Not_After:2012-01-02']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => new DateTime('2012-01-03')], ['x' => 'Not_After:2012-01-02']);
+        $this->assertFalse($v->passes());        
+
+        $v = new Validator($trans, ['x' => new DateTime('2012-01-02')], ['x' => 'Not_Before:2012-01-01']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => new DateTime('2012-01-02')], ['x' => 'Not_Before:2012-01-02']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => new DateTime('2012-01-01')], ['x' => 'Not_Before:2012-01-02']);
+        $this->assertFalse($v->passes());        
+
+        $v = new Validator($trans, ['start' => new DateTime('2012-01-01'), 'ends' => new Carbon('2013-01-01')], ['start' => 'Not_After:ends', 'ends' => 'Not_Before:start']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['start' => '2012-01-01', 'ends' => new DateTime('2013-01-01')], ['start' => 'Not_After:ends', 'ends' => 'Not_Before:start']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['start' => new DateTime('2012-01-01'), 'ends' => new DateTime('2000-01-01')], ['start' => 'Not_Before:2000-01-01', 'ends' => 'Not_Before:start']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['start' => 'today', 'ends' => 'tomorrow'], ['start' => 'Not_After:ends', 'ends' => 'Not_Before:start']);
+        $this->assertTrue($v->passes());
+    }    
 
     public function testBeforeAndAfterWithFormat()
     {
@@ -2119,6 +2211,9 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $v = new Validator($trans, ['x' => '31/12/2000'], ['x' => 'date_format:d/m/Y|before:31/12/2012']);
         $this->assertTrue($v->passes());
 
+        $v = new Validator($trans, ['x' => '31/12/2012'], ['x' => 'date_format:d/m/Y|before:31/12/2012']);
+        $this->assertFalse($v->passes());        
+
         $v = new Validator($trans, ['x' => '31/12/2012'], ['x' => 'after:31/12/2000']);
         $this->assertTrue($v->fails());
 
@@ -2127,6 +2222,9 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
         $v = new Validator($trans, ['x' => '31/12/2012'], ['x' => 'date_format:d/m/Y|after:31/12/2000']);
         $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => '31/12/2000'], ['x' => 'date_format:d/m/Y|before:31/12/2000']);
+        $this->assertFalse($v->passes());        
 
         $v = new Validator($trans, ['start' => '31/12/2012', 'ends' => '31/12/2013'], ['start' => 'after:01/01/2000', 'ends' => 'after:start']);
         $this->assertTrue($v->fails());
@@ -2165,6 +2263,86 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['x' => date('Y-m-d')], ['x' => 'after:tomorrow|before:yesterday']);
+        $this->assertTrue($v->fails());
+    }
+
+    public function testNotBeforeAndNotAfterWithFormat()
+    {
+        date_default_timezone_set('UTC');
+        $trans = $this->getRealTranslator();
+        $v = new Validator($trans, ['x' => '31/12/2000'], ['x' => 'not_after:31/02/2012']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['x' => ['31/12/2000']], ['x' => 'not_after:31/02/2012']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['x' => '31/12/2000'], ['x' => 'date_format:d/m/Y|not_after:31/12/2012']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => '31/12/2012'], ['x' => 'date_format:d/m/Y|not_after:31/12/2012']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => '31/12/2012'], ['x' => 'date_format:d/m/Y|not_after:30/12/2012']);
+        $this->assertTrue($v->fails());        
+
+        $v = new Validator($trans, ['x' => '31/12/2012'], ['x' => 'not_before:31/12/2000']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['x' => ['31/12/2012']], ['x' => 'not_before:31/12/2000']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['x' => '31/12/2012'], ['x' => 'date_format:d/m/Y|not_before:31/12/2000']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => '31/12/2000'], ['x' => 'date_format:d/m/Y|not_after:31/12/2000']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => '31/12/2000'], ['x' => 'date_format:d/m/Y|not_after:30/12/2000']);
+        $this->assertTrue($v->fails());        
+
+        $v = new Validator($trans, ['start' => '31/12/2012', 'ends' => '31/12/2013'], ['start' => 'not_before:01/01/2000', 'ends' => 'not_before:start']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['start' => '31/12/2012', 'ends' => '31/12/2013'], ['start' => 'date_format:d/m/Y|not_before:31/12/2000', 'ends' => 'date_format:d/m/Y|not_before:start']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['start' => '31/12/2012', 'ends' => '31/12/2000'], ['start' => 'not_before:31/12/2000', 'ends' => 'not_before:start']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['start' => '31/12/2012', 'ends' => '31/12/2000'], ['start' => 'date_format:d/m/Y|not_before:31/12/2000', 'ends' => 'date_format:d/m/Y|not_before:start']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['start' => '31/12/2012', 'ends' => '31/12/2013'], ['start' => 'not_after:ends', 'ends' => 'not_before:start']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['start' => '31/12/2012', 'ends' => '31/12/2013'], ['start' => 'date_format:d/m/Y|not_after:ends', 'ends' => 'date_format:d/m/Y|not_before:start']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['start' => '31/12/2012', 'ends' => '31/12/2000'], ['start' => 'not_after:ends', 'ends' => 'not_before:start']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['start' => '31/12/2012', 'ends' => '31/12/2000'], ['start' => 'date_format:d/m/Y|not_after:ends', 'ends' => 'date_format:d/m/Y|not_before:start']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['start' => '31/12/2012', 'ends' => '31/12/2012'], ['start' => 'date_format:d/m/Y|not_after:ends']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['start' => '31/12/2012', 'ends' => '30/12/2012'], ['start' => 'date_format:d/m/Y|not_after:ends']);
+        $this->assertTrue($v->fails());        
+
+        $v = new Validator($trans, ['start' => 'invalid', 'ends' => 'invalid'], ['start' => 'date_format:d/m/Y|not_after:ends', 'ends' => 'date_format:d/m/Y|not_before:start']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['x' => date('d/m/Y')], ['x' => 'date_format:d/m/Y|not_before:yesterday|not_after:tomorrow']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => date('d/m/Y')], ['x' => 'date_format:d/m/Y|not_before:tomorrow|not_after:yesterday']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['x' => date('Y-m-d')], ['x' => 'not_before:yesterday|not_after:tomorrow']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => date('Y-m-d')], ['x' => 'not_before:tomorrow|not_after:yesterday']);
         $this->assertTrue($v->fails());
     }
 


### PR DESCRIPTION
Added to 2 date rules that I always miss:

**not_before** - same date or after
**not_after** - same date or before

A bit of code has been refactored, so if approved someone more experienced should probably also look at this to make sure nothing won't be broken
