### PR TITLE
[5.4] Update Blueprint.php to allow for utf8mb4 charset string or char index

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -449,7 +449,7 @@ class Blueprint
      * @param  int  $length
      * @return \Illuminate\Support\Fluent
      */
-    public function char($column, $length = 255)
+    public function char($column, $length = 191)
     {
         return $this->addColumn('char', $column, compact('length'));
     }
@@ -461,7 +461,7 @@ class Blueprint
      * @param  int  $length
      * @return \Illuminate\Support\Fluent
      */
-    public function string($column, $length = 255)
+    public function string($column, $length = 191)
     {
         return $this->addColumn('string', $column, compact('length'));
     }


### PR DESCRIPTION
For discussion. When using charset 'utf8mb4' on MySql you will get this error running migrations for any key or index set to string or char:
Syntax error or access violation: 1071 Specified key was too long; max key length is 767 bytes
Example database config contains:
            'charset' => 'utf8mb4',
            'collation' => 'utf8mb4_unicode_ci',

Reasons: The InnoDB storage engine has a maximum index length of 767 bytes, so will reserve worst case scenario of 4 bytes per character 'utf8mb4' charset. That leaves us with 191 chars, while utf8, using 3 bytes, lets you index a maximum of 255 characters.

Warning: If you change charsets, you will first have to check that column values do not exceed the new limit.

The workaround is if you are using 'utf8mb4', set the column length in the migration.
Ex: $table->string('email', 191)->index();
