### PR TITLE
[5.3] Add '-r' option shortcut to 'make:controller' artisan command.

### DIFF
--- a/src/Illuminate/Routing/Console/ControllerMakeCommand.php
+++ b/src/Illuminate/Routing/Console/ControllerMakeCommand.php
@@ -61,7 +61,7 @@ class ControllerMakeCommand extends GeneratorCommand
     protected function getOptions()
     {
         return [
-            ['resource', null, InputOption::VALUE_NONE, 'Generate a resource controller class.'],
+            ['resource', 'r', InputOption::VALUE_NONE, 'Generate a resource controller class.'],
         ];
     }
 


### PR DESCRIPTION
This PR allows developers the option to use the `-r` shortcut for `--resource` option, when creating a resource controller via `make:controller` artisan command.

ex.
`php artisan make:controller PostController -r`
