### PR TITLE
[5.3] Use cc instead of bcc in Notification MailChannel

### DIFF
--- a/src/Illuminate/Notifications/Channels/MailChannel.php
+++ b/src/Illuminate/Notifications/Channels/MailChannel.php
@@ -54,7 +54,7 @@ class MailChannel
             }
 
             if (is_array($recipients)) {
-                $m->bcc($recipients);
+                $m->cc($recipients);
             } else {
                 $m->to($recipients);
             }

--- a/tests/Notifications/NotificationMailChannelTest.php
+++ b/tests/Notifications/NotificationMailChannelTest.php
@@ -110,7 +110,7 @@ class NotificationMailChannelTest extends PHPUnit_Framework_TestCase
 
             $mock->shouldReceive('to')->never();
 
-            $mock->shouldReceive('bcc')->with(['taylor@laravel.com', 'jeffrey@laracasts.com']);
+            $mock->shouldReceive('cc')->with(['taylor@laravel.com', 'jeffrey@laracasts.com']);
 
             $closure($mock);
 


### PR DESCRIPTION
Since this will be breaking, because people already using it as bcc will expect bcc and not cc, i'm going to delete this pull request and make another allowing to set cc
