### PR TITLE
[5.3] Add like method on Collections

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -375,6 +375,77 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
+     * Filter items where the given key's content is like the value.
+     *
+     * @param  string  $key
+     * @param  mixed  $value
+     * @return static
+     */
+    public function like($key, $value = null)
+    {
+        return $this->filter($this->callbackForLike($key, 'like', $value));
+    }
+
+    /**
+     * Filter items where the given key's content is like the value while considering case.
+     *
+     * @param  string  $key
+     * @param  mixed  $value
+     * @return static
+     */
+    public function likeCaseSensitive($key, $value = null)
+    {
+        return $this->filter($this->callbackForLike($key, 'likecs', $value));
+    }
+
+    /**
+     * Filter items where the given key's content is not like the value.
+     *
+     * @param  string  $key
+     * @param  mixed  $value
+     * @return static
+     */
+    public function notLike($key, $value = null)
+    {
+        return $this->filter($this->callbackForLike($key, 'notlike', $value));
+    }
+
+    /**
+     * Filter items where the given key's content is not like the value while considering case.
+     *
+     * @param  string  $key
+     * @param  mixed  $value
+     * @return static
+     */
+    public function notLikeCaseSensitive($key, $value = null)
+    {
+        return $this->filter($this->callbackForLike($key, 'notlikecs', $value));
+    }
+
+    /**
+     * Get an like checker callback.
+     *
+     * @param  string $key
+     * @param string $comparison
+     * @param  mixed $value
+     * @return \Closure
+     */
+    protected function callbackForLike($key, $comparison, $value)
+    {
+        return $callback = function ($item) use ($key, $comparison, $value) {
+            $retrieved = data_get($item, $key);
+
+            switch ($comparison) {
+                default:
+                case 'like': return mb_stripos($retrieved, $value) !== false;
+                case 'notlike': return mb_stripos($retrieved, $value) === false;
+                case 'likecs': return mb_strpos($retrieved, $value) !== false;
+                case 'notlikecs': return mb_strpos($retrieved, $value) === false;
+            }
+        };
+    }
+
+    /**
      * Get the first item from the collection.
      *
      * @param  callable|null  $callback

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -357,6 +357,126 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
         $this->assertEquals([['v' => 1], ['v' => 3]], $c->whereInStrict('v', [1, 3])->values()->all());
     }
 
+    public function testLike()
+    {
+        $c = new Collection([['v' => 'Taylor'], ['v' => 'Jeffrey'], ['v' => 'Eric'], ['v' => 'Amo'], ['v' => 'Jack']]);
+
+        $this->assertEquals(
+            [['v' => 'Taylor']],
+            $c->like('v', 'Tay')->values()->all()
+        );
+
+        $this->assertEquals(
+            [['v' => 'Jeffrey']],
+            $c->like('v', 'ff')->values()->all()
+        );
+
+        $this->assertEquals(
+            [['v' => 'Amo']],
+            $c->like('v', 'Amo')->values()->all()
+        );
+
+        $this->assertEquals(
+            [['v' => 'Taylor'], ['v' => 'Amo'], ['v' => 'Jack']],
+            $c->like('v', 'a')->values()->all()
+        );
+    }
+
+    public function testNotLike()
+    {
+        $c = new Collection([['v' => 'Taylor'], ['v' => 'Jeffrey'], ['v' => 'Eric'], ['v' => 'Amo'], ['v' => 'Jack']]);
+
+        $this->assertEquals(
+            [['v' => 'Jeffrey'], ['v' => 'Eric'], ['v' => 'Amo'], ['v' => 'Jack']],
+            $c->notLike('v', 'Tay')->values()->all()
+        );
+
+        $this->assertEquals(
+            [['v' => 'Taylor'], ['v' => 'Eric'], ['v' => 'Amo'], ['v' => 'Jack']],
+            $c->notLike('v', 'ff')->values()->all()
+        );
+
+        $this->assertEquals(
+            [['v' => 'Taylor'], ['v' => 'Jeffrey'], ['v' => 'Eric'], ['v' => 'Jack']],
+            $c->notLike('v', 'Amo')->values()->all()
+        );
+
+        $this->assertEquals(
+            [['v' => 'Jeffrey'], ['v' => 'Eric']],
+            $c->notLike('v', 'a')->values()->all()
+        );
+    }
+
+    public function testLikeCaseSensitive()
+    {
+        $c = new Collection([['v' => 'Taylor'], ['v' => 'Jeffrey'], ['v' => 'Eric'], ['v' => 'Amo'], ['v' => 'Jack']]);
+
+        $this->assertEquals(
+            [['v' => 'Taylor']],
+            $c->likeCaseSensitive('v', 'Tay')->values()->all()
+        );
+
+        $this->assertEquals(
+            [],
+            $c->likeCaseSensitive('v', 'tay')->values()->all()
+        );
+
+        $this->assertEquals(
+            [['v' => 'Jeffrey']],
+            $c->likeCaseSensitive('v', 'ff')->values()->all()
+        );
+
+        $this->assertEquals(
+            [],
+            $c->likeCaseSensitive('v', 'FF')->values()->all()
+        );
+
+        $this->assertEquals(
+            [['v' => 'Amo']],
+            $c->likeCaseSensitive('v', 'Amo')->values()->all()
+        );
+
+        $this->assertEquals(
+            [],
+            $c->likeCaseSensitive('v', 'amo')->values()->all()
+        );
+
+        $this->assertEquals(
+            [['v' => 'Taylor'], ['v' => 'Jack']],
+            $c->likeCaseSensitive('v', 'a')->values()->all()
+        );
+    }
+
+    public function testNotLikeCaseSensitive()
+    {
+        $c = new Collection([['v' => 'Taylor'], ['v' => 'Jeffrey'], ['v' => 'Eric'], ['v' => 'Amo'], ['v' => 'Jack']]);
+
+        $this->assertEquals(
+            [['v' => 'Taylor'], ['v' => 'Jeffrey'], ['v' => 'Eric'], ['v' => 'Amo'], ['v' => 'Jack']],
+            $c->notLikeCaseSensitive('v', 'tay')->values()->all()
+        );
+
+        $this->assertEquals(
+            [['v' => 'Jeffrey'], ['v' => 'Eric'], ['v' => 'Amo'], ['v' => 'Jack']],
+            $c->notLikeCaseSensitive('v', 'Tay')->values()->all()
+        );
+
+        $this->assertEquals(
+            [['v' => 'Jeffrey'], ['v' => 'Eric'], ['v' => 'Amo'], ['v' => 'Jack']],
+            $c->notLikeCaseSensitive('v', 'T')->values()->all()
+        );
+
+        $this->assertEquals(
+            [['v' => 'Taylor'], ['v' => 'Jeffrey'], ['v' => 'Eric'], ['v' => 'Amo'], ['v' => 'Jack']],
+            $c->notLikeCaseSensitive('v', 'amo')->values()->all()
+        );
+
+        $this->assertEquals(
+            [['v' => 'Jeffrey'], ['v' => 'Eric'], ['v' => 'Amo']],
+            $c->notLikeCaseSensitive('v', 'a')->values()->all()
+        );
+    }
+
     public function testValues()
     {
         $c = new Collection([['id' => 1, 'name' => 'Hello'], ['id' => 2, 'name' => 'World']]);


### PR DESCRIPTION
I often find that I need to filter my collections very loosely, where a value partially matches my filter. For example, from the collection below I'd like to be able to retrieve all of the users who name begins with the letter 'T'. 

This feature implements that functionality.

``` php
    $users = new Collection([
        ['name' => 'Taylor'],
        ['name' => 'Jeffrey'],
        ['name' => 'Eric'],
        ['name' => 'Amo'],
        ['name' => 'Jack']
    ]);

   $beginningWithT = $users->like('name', 't')->values()->all();
```

Methods that this feature provides:
- like()
- notLike()
- likeCaseSensitive()
- notLikeCaseSensitive()

The `like` methods make case-insensitive comparisons by default, and in some cases this isn't desired. Rather than having to pass boolean values to `like()` and `notLike()`, which would be really messy and horrible to read I implemented the case-insensitive version, too.

I'm not really happy with the naming of those methods, so if you have any suggestions I'd be happy to refactor.

Additionally, I appreciate this could also have been implemented as a macro but I think there's definite value to adding this to the class itself as a convenience.

Code is backwards compatible with other 5.x versions (4.x not checked).
