### PR TITLE
[5.4] Fix detach behaviour (BelongsToMany.php)

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -1172,7 +1172,7 @@ class BelongsToMany extends Relation
             if (count($ids) == 0) {
                 return 0;
             }
-            
+
             $query->whereIn($this->otherKey, (array) $ids);
         }
 
@@ -1189,7 +1189,6 @@ class BelongsToMany extends Relation
         // We'll then return the numbers of affected rows.
         return $results;
     }
-
 
     /**
      * If we're touching the parent model, touch.

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -1168,7 +1168,9 @@ class BelongsToMany extends Relation
         // given all of the association ties will be broken.
 
         if ($ids !== NULL) {
-            if(count($ids) == 0) return 0;
+            if(count($ids) == 0) {
+                return 0;
+            }
             $query->whereIn($this->otherKey, (array) $ids);
         }
 

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -1150,7 +1150,7 @@ class BelongsToMany extends Relation
      * @param  bool  $touch
      * @return int
      */
-    public function detach($ids = [], $touch = true)
+    public function detach($ids = null, $touch = true)
     {
         if ($ids instanceof Model) {
             $ids = $ids->getKey();
@@ -1162,26 +1162,30 @@ class BelongsToMany extends Relation
 
         $query = $this->newPivotQuery();
 
-        // If associated IDs were passed to the method we will only delete those
-        // associations, otherwise all of the association ties will be broken.
-        // We'll return the numbers of affected rows when we do the deletes.
-        $ids = (array) $ids;
+        // If any argument is passed for IDs we will only delete those
+        // associations, if it's an empty collection or array, code
+        // will not continue and return zero. If no argument is
+        // given all of the association ties will be broken.
 
-        if (count($ids) > 0) {
-            $query->whereIn($this->otherKey, $ids);
+        if ($ids !== NULL) {
+            if(count($ids) == 0) return 0;
+            $query->whereIn($this->otherKey, (array) $ids);
         }
 
         // Once we have all of the conditions set on the statement, we are ready
         // to run the delete on the pivot table. Then, if the touch parameter
         // is true, we will go ahead and touch all related models to sync.
+
         $results = $query->delete();
 
         if ($touch) {
             $this->touchIfTouching();
         }
 
+        // We'll then return the numbers of affected rows.
         return $results;
     }
+
 
     /**
      * If we're touching the parent model, touch.

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -1148,7 +1148,6 @@ class BelongsToMany extends Relation
      *
      * @param  mixed  $ids
      * @param  bool  $touch
-     *
      * @return int
      */
     public function detach($ids = null, $touch = true)
@@ -1167,7 +1166,6 @@ class BelongsToMany extends Relation
         // associations, if it's an empty collection or array, code
         // will not continue and return zero. If no argument is
         // given all of the association ties will be broken.
-
         if ($ids !== null) {
             if (count($ids) == 0) {
                 return 0;
@@ -1179,7 +1177,6 @@ class BelongsToMany extends Relation
         // Once we have all of the conditions set on the statement, we are ready
         // to run the delete on the pivot table. Then, if the touch parameter
         // is true, we will go ahead and touch all related models to sync.
-
         $results = $query->delete();
 
         if ($touch) {

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -1148,6 +1148,7 @@ class BelongsToMany extends Relation
      *
      * @param  mixed  $ids
      * @param  bool  $touch
+     *
      * @return int
      */
     public function detach($ids = null, $touch = true)
@@ -1167,8 +1168,8 @@ class BelongsToMany extends Relation
         // will not continue and return zero. If no argument is
         // given all of the association ties will be broken.
 
-        if ($ids !== NULL) {
-            if(count($ids) == 0) {
+        if ($ids !== null) {
+            if (count($ids) == 0) {
                 return 0;
             }
             

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -1171,6 +1171,7 @@ class BelongsToMany extends Relation
             if(count($ids) == 0) {
                 return 0;
             }
+            
             $query->whereIn($this->otherKey, (array) $ids);
         }
 


### PR DESCRIPTION
Change behaviour of detach.

Actual behaviour is: If it receives an empty array or collection it will erase all associations.

Example:

`$houses = App\Houses::where("windows",3)->get();`//returns empty collection
`$investor->houses()->detach($houses);`//detaches all houses from $investor

The code above will detach all houses if $houses returns empty.

New behaviour: if it does not receive arguments, all associations are removed. If there is an argument and it is empty, no associations will be broken.

`$houses = App\Houses::where("windows",3)->get();` //returns empty collection
`$investor->houses()->detach($houses);` //detaches nothing

Code modification checks if any $id argument was given and if it's empty, returns zero, to indicate nothing was detached.
