### PR TITLE
[5.3] Add and additional "fallback" parameter for back() helper

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -157,11 +157,12 @@ if (! function_exists('back')) {
      *
      * @param  int    $status
      * @param  array  $headers
+     * @param  mixed  $fallback
      * @return \Illuminate\Http\RedirectResponse
      */
-    function back($status = 302, $headers = [])
+    function back($status = 302, $headers = [], $fallback = false)
     {
-        return app('redirect')->back($status, $headers);
+        return app('redirect')->back($status, $headers, $fallback);
     }
 }
 

--- a/src/Illuminate/Routing/Redirector.php
+++ b/src/Illuminate/Routing/Redirector.php
@@ -48,11 +48,12 @@ class Redirector
      *
      * @param  int    $status
      * @param  array  $headers
+     * @param  mixed  $fallback
      * @return \Illuminate\Http\RedirectResponse
      */
-    public function back($status = 302, $headers = [])
+    public function back($status = 302, $headers = [], $fallback = false)
     {
-        $back = $this->generator->previous();
+        $back = $this->generator->previous($fallback);
 
         return $this->createRedirect($back, $status, $headers);
     }

--- a/tests/Routing/RoutingRedirectorTest.php
+++ b/tests/Routing/RoutingRedirectorTest.php
@@ -106,6 +106,22 @@ class RoutingRedirectorTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('http://foo.com/bar', $response->getTargetUrl());
     }
 
+    public function testBackRedirectToFallback()
+    {
+        $this->headers->shouldReceive('has')->with('referer')->andReturn(false);
+        $this->url->shouldReceive('previous')->with('http://foo.com/fallback')->andReturn('http://foo.com/fallback');
+        $response = $this->redirect->back(302, [], 'http://foo.com/fallback');
+        $this->assertEquals('http://foo.com/fallback', $response->getTargetUrl());
+    }
+
+    public function testBackRedirectToIndex()
+    {
+        $this->headers->shouldReceive('has')->with('referer')->andReturn(false);
+        $this->url->shouldReceive('previous')->with(false)->andReturn('/');
+        $response = $this->redirect->back();
+        $this->assertEquals('/', $response->getTargetUrl());
+    }
+
     public function testAwayDoesntValidateTheUrl()
     {
         $response = $this->redirect->away('bar');


### PR DESCRIPTION
Hello, good night.

As the back() helper function relies on Redirector->back() and then UrlGenerator->previous(), it should be useful to allow to pass a fallback url to back() in case we're not able to determine the previous location.

Added and additional test too.

Hope it helps.
