### PR TITLE
[5.3] Implement Sometimes rule builder

### DIFF
--- a/src/Illuminate/Contracts/Validation/Rule.php
+++ b/src/Illuminate/Contracts/Validation/Rule.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Illuminate\Contracts\Validation;
+
+interface Rule
+{
+    /**
+     * Apply rule to validator.
+     *
+     * @param  \Illuminate\Contracts\Validation\Validator  $validator
+     * @param  string  $field
+     */
+    public function apply(Validator $validator, $field);
+}

--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -64,4 +64,16 @@ class Rule
     {
         return new Rules\Unique($table, $column);
     }
+
+    /**
+     * Get a sometimes rule builder instance.
+     *
+     * @param  callable  $callback
+     * @param  string|array  $rules
+     * @return void
+     */
+    public static function sometimes($rules, callable $callback)
+    {
+        return new Rules\Sometimes($rules, $callback);
+    }
 }

--- a/src/Illuminate/Validation/Rules/Sometimes.php
+++ b/src/Illuminate/Validation/Rules/Sometimes.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Illuminate\Validation\Rules;
+
+use Illuminate\Contracts\Validation\Rule;
+use Illuminate\Contracts\Validation\Validator;
+
+class Sometimes implements Rule
+{
+    /**
+     * Fields to apply validation.
+     *
+     * @var array|string
+     */
+    protected $rules;
+
+    /**
+     * Callbacks to determine rule.
+     *
+     * @var array
+     */
+    protected $callbacks = [];
+
+    /**
+     * Create a new sometimes rule instance.
+     *
+     * @param  array|callable  $callbacks
+     * @param  string|array  $rules
+     * @return void
+     */
+    public function __construct($rules, $callbacks)
+    {
+        $this->rules = $rules;
+
+        if (is_callable($callbacks)) {
+            $callbacks = [$callbacks];
+        }
+
+        $this->callbacks = $callbacks;
+    }
+
+    /**
+     * @param  callable  $callback
+     */
+    public function when(callable $callback)
+    {
+        $this->callbacks[] = $callback;
+    }
+
+    /**
+     * Apply rule to validator.
+     *
+     * @param  \Illuminate\Contracts\Validation\Validator  $validator
+     * @param  string  $field
+     */
+    public function apply(Validator $validator, $field)
+    {
+        $validator->sometimes($field, $this->rules, function () {
+            foreach ($this->callbacks as $callback) {
+                if (! call_user_func($callback, func_get_args())) {
+                    return false;
+                }
+            }
+
+            return true;
+        });
+    }
+}

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -7,6 +7,7 @@ use DateTime;
 use Countable;
 use Exception;
 use DateTimeZone;
+use Illuminate\Contracts\Validation\Rule;
 use RuntimeException;
 use DateTimeInterface;
 use Illuminate\Support\Arr;
@@ -236,6 +237,10 @@ class Validator implements ValidatorContract
     protected function explodeRules(array $rules)
     {
         foreach ($rules as $key => $rule) {
+            if ($rule instanceof Rule) {
+                $rule->apply($this, $key);
+            }
+
             if (Str::contains($key, '*')) {
                 $this->each($key, [$rule]);
 

--- a/tests/Validation/ValidationSometimesRuleTest.php
+++ b/tests/Validation/ValidationSometimesRuleTest.php
@@ -1,0 +1,25 @@
+<?php
+
+use Mockery as m;
+
+class ValidationSometimesRuleTest extends PHPUnit_Framework_TestCase
+{
+    public function testSometimesRuleCorrectlyApplied()
+    {
+        $rule = new Illuminate\Validation\Rules\Sometimes('required', 'ValidationSometimesRuleTestRule');
+
+        $validator = m::mock(Illuminate\Validation\Validator::class.'[sometimes]', [
+            m::mock(Symfony\Component\Translation\TranslatorInterface::class),
+            [],
+            ['field' => 'test'],
+        ])->makePartial();
+
+        $rule->apply($validator, 'field');
+        $validator->shouldHaveReceived('sometimes')->once();
+    }
+}
+
+function ValidationSometimesRuleTestRule()
+{
+    return true;
+}

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -3119,6 +3119,15 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $this->assertFalse($v->passes());
     }
 
+    public function testUsingRuleContract()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $rule = m::mock(Illuminate\Contracts\Validation\Rule::class.'[apply]');
+        $v = new Validator($trans, ['foo' => 'a'], []);
+        $rule->shouldReceive('apply')->once()->with($v, 'foo');
+        $v->setRules(['foo' => $rule]);
+    }
+
     public function testInvalidMethod()
     {
         $trans = $this->getIlluminateArrayTranslator();


### PR DESCRIPTION
Allows to pass callbacks for `sometimes` rule in the ruleset without need to construct validator first.

``` php

public function store(Request $request)
{
    $this->validate($request, [
        'field' => Rule::sometimes('filled|date')->when(function ($input) {
             return $input->otherfield >= 100500;
        });
    ]);
}
```
