### PR TITLE
[5.3] Adding name into built in auth routes

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -292,13 +292,13 @@ class Router implements RegistrarContract
         $this->post('logout', 'Auth\LoginController@logout')->name('logout');
 
         // Registration Routes...
-        $this->get('register', 'Auth\RegisterController@showRegistrationForm');
+        $this->get('register', 'Auth\RegisterController@showRegistrationForm')->name('registration');
         $this->post('register', 'Auth\RegisterController@register');
 
         // Password Reset Routes...
-        $this->get('password/reset', 'Auth\ForgotPasswordController@showLinkRequestForm');
+        $this->get('password/reset', 'Auth\ForgotPasswordController@showLinkRequestForm')->name('resetPassword');
         $this->post('password/email', 'Auth\ForgotPasswordController@sendResetLinkEmail');
-        $this->get('password/reset/{token}', 'Auth\ResetPasswordController@showResetForm');
+        $this->get('password/reset/{token}', 'Auth\ResetPasswordController@showResetForm')->name('resetPasswordForm');
         $this->post('password/reset', 'Auth\ResetPasswordController@reset');
     }
 


### PR DESCRIPTION
Adding some named routes in built in auth routes, because since i just tested L5.3 today, i got little confuse how to make link into built in auth system.
1. registration
2. resetPassword
3. resetPasswordForm
