### PR TITLE
[5.3] Add database notification relation readNotifications()

### DIFF
--- a/src/Illuminate/Notifications/HasDatabaseNotifications.php
+++ b/src/Illuminate/Notifications/HasDatabaseNotifications.php
@@ -22,4 +22,14 @@ trait HasDatabaseNotifications
                             ->whereNull('read_at')
                             ->orderBy('created_at', 'desc');
     }
+
+    /**
+     * Get the entity's read notifications.
+     */
+    public function readNotifications()
+    {
+        return $this->morphMany(DatabaseNotification::class, 'notifiable')
+                            ->whereNotNull('read_at')
+                            ->orderBy('created_at', 'desc');
+    }
 }


### PR DESCRIPTION
This comes in handy in situations like :
- When deleting read notifications.
- A screen where the user can view all of his notifications with a filter for showing read or unread notifications.
