### PR TITLE
[5.3] Allow to disable form fields validation when value is set during tests

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithPages.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithPages.php
@@ -560,11 +560,13 @@ trait InteractsWithPages
      * Submit a form using the button with the given text value.
      *
      * @param  string  $buttonText
+     * @param  bool  $disableValidation
+     *
      * @return $this
      */
-    protected function press($buttonText)
+    protected function press($buttonText, $disableValidation = false)
     {
-        return $this->submitForm($buttonText, $this->inputs, $this->uploads);
+        return $this->submitForm($buttonText, $this->inputs, $this->uploads, $disableValidation);
     }
 
     /**
@@ -573,11 +575,13 @@ trait InteractsWithPages
      * @param  string  $buttonText
      * @param  array  $inputs
      * @param  array  $uploads
+     * @param  bool  $disableValidation
+     *
      * @return $this
      */
-    protected function submitForm($buttonText, $inputs = [], $uploads = [])
+    protected function submitForm($buttonText, $inputs = [], $uploads = [], $disableValidation = false)
     {
-        $this->makeRequestUsingForm($this->fillForm($buttonText, $inputs), $uploads);
+        $this->makeRequestUsingForm($this->fillForm($buttonText, $inputs, $disableValidation), $uploads);
 
         return $this;
     }
@@ -587,9 +591,11 @@ trait InteractsWithPages
      *
      * @param  string  $buttonText
      * @param  array  $inputs
+     * @param  bool  $disableValidation
+     *
      * @return \Symfony\Component\DomCrawler\Form
      */
-    protected function fillForm($buttonText, $inputs = [])
+    protected function fillForm($buttonText, $inputs = [], $disableValidation = false)
     {
         if (! is_string($buttonText)) {
             $inputs = $buttonText;
@@ -597,7 +603,13 @@ trait InteractsWithPages
             $buttonText = null;
         }
 
-        return $this->getForm($buttonText)->setValues($inputs);
+        $form =  $this->getForm($buttonText);
+
+        if ($disableValidation) {
+            $form = $form->disableValidation();
+        }
+
+        return $form->setValues($inputs);
     }
 
     /**

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithPages.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithPages.php
@@ -603,7 +603,7 @@ trait InteractsWithPages
             $buttonText = null;
         }
 
-        $form =  $this->getForm($buttonText);
+        $form = $this->getForm($buttonText);
 
         if ($disableValidation) {
             $form = $form->disableValidation();


### PR DESCRIPTION
During writing tests when using for example Select2 select it's impossible to set value because at the moment as we get for example:

> Input "invoice_id" cannot take "207" as a value (possible values: )

This is because Symfony's **Symfony\Component\DomCrawler\Field\ChoiceFormField** when trying to set value verifies whether option could be set and if not, it will throw exception. The workaround is to use **disableValidation** method from this class which can be set also using the same method in **Symfony\Component\DomCrawler\Form** class and this is done in this PR
