### PR TITLE
[5.3] Add "base64:" prefix support to env() helper (laravel/internals#266)

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -426,7 +426,7 @@ if (! function_exists('encrypt')) {
 
 if (! function_exists('env')) {
     /**
-     * Gets the value of an environment variable. Supports boolean, empty and null.
+     * Gets the value of an environment variable. Supports boolean, empty, null and base64 prefix.
      *
      * @param  string  $key
      * @param  mixed   $default
@@ -455,13 +455,17 @@ if (! function_exists('env')) {
                 return;
         }
 
+        if (Str::startsWith($value, 'base64:')) {
+            return base64_decode(substr($value, 7));
+        }
+
         if (strlen($value) > 1 && Str::startsWith($value, '"') && Str::endsWith($value, '"')) {
             return substr($value, 1, -1);
         }
 
         return $value;
     }
-}
+}   
 
 if (! function_exists('event')) {
     /**


### PR DESCRIPTION
This allows you to prefix any field in the `.env` file with `base64:`. `env()` will return the decoded results. 
