### PR TITLE
[5.3] A notification can be broadcasted to custom channels

### DIFF
--- a/src/Illuminate/Notifications/Events/BroadcastNotificationCreated.php
+++ b/src/Illuminate/Notifications/Events/BroadcastNotificationCreated.php
@@ -54,6 +54,12 @@ class BroadcastNotificationCreated implements ShouldBroadcast
      */
     public function broadcastOn()
     {
+        $channels = $this->notification->broadcastOn();
+
+        if (!empty($channels)) {
+            return $channels;
+        }
+
         return [new PrivateChannel($this->channelName())];
     }
 

--- a/src/Illuminate/Notifications/Events/BroadcastNotificationCreated.php
+++ b/src/Illuminate/Notifications/Events/BroadcastNotificationCreated.php
@@ -56,7 +56,7 @@ class BroadcastNotificationCreated implements ShouldBroadcast
     {
         $channels = $this->notification->broadcastOn();
 
-        if (!empty($channels)) {
+        if (! empty($channels)) {
             return $channels;
         }
 

--- a/tests/Notifications/NotificationBroadcastChannelTest.php
+++ b/tests/Notifications/NotificationBroadcastChannelTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Notifications\Notification;
+use Illuminate\Broadcasting\PrivateChannel;
 use Illuminate\Notifications\Channels\BroadcastChannel;
 
 class NotificationBroadcastChannelTest extends PHPUnit_Framework_TestCase
@@ -21,6 +22,21 @@ class NotificationBroadcastChannelTest extends PHPUnit_Framework_TestCase
         $channel = new BroadcastChannel($events);
         $channel->send($notifiable, $notification);
     }
+
+    public function testNotificationIsBroadcastedOnCustomChannels()
+    {
+        $notification = new CustomChannelsTestNotification;
+        $notification->id = 1;
+        $notifiable = Mockery::mock();
+
+        $event = new Illuminate\Notifications\Events\BroadcastNotificationCreated(
+            $notifiable, $notification, $notification->toArray($notifiable)
+        );
+
+        $channels = $event->broadcastOn();
+
+        $this->assertEquals(new PrivateChannel('custom-channel'), $channels[0]);
+    }
 }
 
 class NotificationBroadcastChannelTestNotification extends Notification
@@ -28,5 +44,18 @@ class NotificationBroadcastChannelTestNotification extends Notification
     public function toArray($notifiable)
     {
         return ['invoice_id' => 1];
+    }
+}
+
+class CustomChannelsTestNotification extends Notification
+{
+    public function toArray($notifiable)
+    {
+        return ['invoice_id' => 1];
+    }
+
+    public function broadcastOn()
+    {
+        return [new PrivateChannel('custom-channel')];
     }
 }


### PR DESCRIPTION
This PR will allow to specify the channels to broadcast to, upon overriding the broadcastOn() on a notification.

``` php
class ProductPurchased extends Notification implements ShouldQueue
{
    public function broadcastOn()
    {
        return [
            new PrivateChannel('sales'),
            new PrivateChannel('accountant'),
            new PrivateChannel('admin')
        ];
    }
}
```
