### PR TITLE
[5.4] Model::toJson() silently fails on error

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2396,10 +2396,18 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      *
      * @param  int  $options
      * @return string
+     *
+     * @throws \InvalidArgumentException
      */
     public function toJson($options = 0)
     {
-        return json_encode($this->jsonSerialize(), $options);
+        $json = json_encode($this->jsonSerialize(), $options);
+
+        if (JSON_ERROR_NONE !== json_last_error()) {
+            throw new InvalidArgumentException(json_last_error_msg());
+        }
+
+        return $json;
     }
 
     /**


### PR DESCRIPTION
I had not UTF-8 chars into a legacy database and this method was silently failing.
I think it's a good impovement to throw an InvalidArgumentException
