### PR TITLE
[5.4] Fix gatherMiddleware() only unique

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -275,7 +275,7 @@ class Route
      */
     public function gatherMiddleware()
     {
-        return array_unique(array_merge($this->middleware(), $this->controllerMiddleware()));
+        return collect(array_merge($this->middleware(), $this->controllerMiddleware()))->unique();
     }
 
     /**

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -275,7 +275,7 @@ class Route
      */
     public function gatherMiddleware()
     {
-        return collect(array_merge($this->middleware(), $this->controllerMiddleware()))->unique();
+        return array_unique(array_merge($this->middleware(), $this->controllerMiddleware()), SORT_REGULAR);
     }
 
     /**

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -275,7 +275,7 @@ class Route
      */
     public function gatherMiddleware()
     {
-        return array_merge($this->middleware(), $this->controllerMiddleware());
+        return array_unique(array_merge($this->middleware(), $this->controllerMiddleware()));
     }
 
     /**


### PR DESCRIPTION
For example: 

I have a route group with middleware 'auth' and controller with middleware 'auth'. 

Maybe **framework/src/Illuminate/Routing/Route.php gatherMiddleware()** must return only unique values ?

``` php
class MainController extends Controller
{

    public function __construct()
    {
        $this->middleware('auth');
    }
}


Route::group(['middleware' => ['auth']], function () {

    Route::get('/first', 'MainController@index');
}

Route::get('/second', 'MainController@index');
```

**php artisan route:list**

before: 

``` php
| Domain | Method   | URI    | Name  | Action                                      | Middleware |

|        | GET|HEAD | first  |       | App\Http\Controllers\MainController@index   | web,auth,auth
|        | GET|HEAD | second |       | App\Http\Controllers\MainController@index   | web,auth
```

after fix:

``` php
| Domain | Method   | URI    | Name  | Action                                      | Middleware |

|        | GET|HEAD | first  |       | App\Http\Controllers\MainController@index   | web,auth
|        | GET|HEAD | second |       | App\Http\Controllers\MainController@index   | web,auth

```

Would it be more preferable if artisan route:list displayed middleware from route and controller separately?

For example: 

``` php
| Domain | Method   | URI    | Name  | Action                                      | Middleware |

|        | GET|HEAD | first  |       | App\Http\Controllers\MainController@index   | [r]web,auth [c]auth
|        | GET|HEAD | second |       | App\Http\Controllers\MainController@index   | [r]web [c]auth
```
