### PR TITLE
[5.3] Create seeders when creating Models or Migrations

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
@@ -4,6 +4,7 @@ namespace Illuminate\Database\Console\Migrations;
 
 use Illuminate\Support\Composer;
 use Illuminate\Database\Migrations\MigrationCreator;
+use Illuminate\Support\Str;
 
 class MigrateMakeCommand extends BaseCommand
 {
@@ -15,7 +16,8 @@ class MigrateMakeCommand extends BaseCommand
     protected $signature = 'make:migration {name : The name of the migration.}
         {--create= : The table to be created.}
         {--table= : The table to migrate.}
-        {--path= : The location where the migration file should be created.}';
+        {--path= : The location where the migration file should be created.}
+        {--s|seeder : Create a Seeder class for the table}';
 
     /**
      * The console command description.
@@ -69,6 +71,8 @@ class MigrateMakeCommand extends BaseCommand
 
         $create = $this->input->getOption('create') ?: false;
 
+        $seeder = $this->input->getOption('seeder') ?: false;
+
         if (! $table && is_string($create)) {
             $table = $create;
 
@@ -76,9 +80,14 @@ class MigrateMakeCommand extends BaseCommand
         }
 
         // Now we are ready to write the migration out to disk. Once we've written
-        // the migration out, we will dump-autoload for the entire framework to
-        // make sure that the migrations are registered by the class loaders.
+        // the migration out, we will make a Seeder (if requested) and then
+        // dump-autoload for the entire framework to make sure that the
+        // migrations are registered by the class loaders.
         $this->writeMigration($name, $table, $create);
+
+        if ($seeder && $table) {
+            $this->makeSeeder($table);
+        }
 
         $this->composer->dumpAutoloads();
     }
@@ -112,5 +121,16 @@ class MigrateMakeCommand extends BaseCommand
         }
 
         return parent::getMigrationPath();
+    }
+
+    /**
+     * Create Seeder using the table name for the Seeder name
+     *
+     * @param $table
+     */
+    protected function makeSeeder($table)
+    {
+        $seeder = Str::plural(Str::studly(class_basename($table)));
+        $this->call('make:seeder', ['name' => "{$seeder}Seeder"]);
     }
 }

--- a/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
@@ -2,9 +2,9 @@
 
 namespace Illuminate\Database\Console\Migrations;
 
+use Illuminate\Support\Str;
 use Illuminate\Support\Composer;
 use Illuminate\Database\Migrations\MigrationCreator;
-use Illuminate\Support\Str;
 
 class MigrateMakeCommand extends BaseCommand
 {
@@ -124,7 +124,7 @@ class MigrateMakeCommand extends BaseCommand
     }
 
     /**
-     * Create Seeder using the table name for the Seeder name
+     * Create Seeder using the table name for the Seeder name.
      *
      * @param $table
      */

--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -49,6 +49,12 @@ class ModelMakeCommand extends GeneratorCommand
             ]);
         }
 
+        if ($this->option('seeder')) {
+            $seeder = Str::plural(Str::studly(class_basename($this->argument('name'))));
+
+            $this->call('make:seeder', ['name' => "{$seeder}Seeder"]);
+        }
+
         if ($this->option('controller')) {
             $controller = Str::studly(class_basename($this->argument('name')));
 
@@ -89,6 +95,8 @@ class ModelMakeCommand extends GeneratorCommand
     {
         return [
             ['migration', 'm', InputOption::VALUE_NONE, 'Create a new migration file for the model.'],
+
+            ['seeder', 's', InputOption::VALUE_NONE, 'Create a new Seeder class for the model.'],
 
             ['controller', 'c', InputOption::VALUE_NONE, 'Create a new controller for the model.'],
 


### PR DESCRIPTION
Add `--seeder` to `artisan make:migration` or `artisan make:model` to create a matching Seeder. This was discussed in [laravel/internals Issue 13](https://github.com/laravel/internals/issues/13). A matching PR for laravel/docs will be following.
