### PR TITLE
[5.3] Skip tests if Predis\Client not installed

### DIFF
--- a/tests/Queue/RedisQueueIntegrationTest.php
+++ b/tests/Queue/RedisQueueIntegrationTest.php
@@ -27,6 +27,12 @@ class RedisQueueIntegrationTest extends PHPUnit_Framework_TestCase
     {
         parent::setUp();
 
+        if (!class_exists('Predis\Client')) {
+            $this->markTestSkipped("Class 'Predis\\Client' not found");
+
+            return;
+        }
+        
         $host = getenv('REDIS_HOST') ?: '127.0.0.1';
         $port = getenv('REDIS_PORT') ?: 6379;
 

--- a/tests/Redis/RedisConnectionTest.php
+++ b/tests/Redis/RedisConnectionTest.php
@@ -23,6 +23,12 @@ class RedisConnectionTest extends PHPUnit_Framework_TestCase
 
     protected function getRedis($cluster = false)
     {
+        if (!class_exists('Predis\Client')) {
+            $this->markTestSkipped("Class 'Predis\\Client' not found");
+
+            return;
+        }
+        
         $servers = [
             'cluster' => $cluster,
             'default' => [


### PR DESCRIPTION
I have a lot of errors in tests if predis is not installed. Can I skip these tests ?
