### PR TITLE
[5.3] Allow Eloquent has one relations to return a default new model

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/HasOne.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOne.php
@@ -2,10 +2,30 @@
 
 namespace Illuminate\Database\Eloquent\Relations;
 
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Collection;
 
 class HasOne extends HasOneOrMany
 {
+    /**
+     * Determine whether getResults should return a default new model instance or not.
+     *
+     * @var bool
+     */
+    protected $withDefault = false;
+
+    /**
+     * Return a new model instance in case the relationship does not exist.
+     *
+     * @return $this
+     */
+    public function withDefault()
+    {
+        $this->withDefault = true;
+
+        return $this;
+    }
+
     /**
      * Get the results of the relationship.
      *
@@ -13,7 +33,7 @@ class HasOne extends HasOneOrMany
      */
     public function getResults()
     {
-        return $this->query->first();
+        return $this->query->first() ?: $this->getDefaultFor($this->parent);
     }
 
     /**
@@ -26,7 +46,7 @@ class HasOne extends HasOneOrMany
     public function initRelation(array $models, $relation)
     {
         foreach ($models as $model) {
-            $model->setRelation($relation, null);
+            $model->setRelation($relation, $this->getDefaultFor($model));
         }
 
         return $models;
@@ -35,7 +55,7 @@ class HasOne extends HasOneOrMany
     /**
      * Match the eagerly loaded results to their parents.
      *
-     * @param  array   $models
+     * @param  array  $models
      * @param  \Illuminate\Database\Eloquent\Collection  $results
      * @param  string  $relation
      * @return array
@@ -43,5 +63,20 @@ class HasOne extends HasOneOrMany
     public function match(array $models, Collection $results, $relation)
     {
         return $this->matchOne($models, $results, $relation);
+    }
+
+    /**
+     * Get the default value for this relation.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @return \Illuminate\Database\Eloquent\Model|null
+     */
+    protected function getDefaultFor(Model $model)
+    {
+        if ($this->withDefault) {
+            return $this->related->newInstance()->setAttribute(
+                $this->getPlainForeignKey(), $model->getAttribute($this->localKey)
+            );
+        }
     }
 }

--- a/tests/Database/DatabaseEloquentHasOneTest.php
+++ b/tests/Database/DatabaseEloquentHasOneTest.php
@@ -6,9 +6,30 @@ use Illuminate\Database\Eloquent\Relations\HasOne;
 
 class DatabaseEloquentHasOneTest extends PHPUnit_Framework_TestCase
 {
+    protected $builder;
+
+    protected $related;
+
+    protected $parent;
+
     public function tearDown()
     {
         m::close();
+    }
+
+    public function testHasOneWithDefault()
+    {
+        $relation = $this->getRelation()->withDefault();
+
+        $this->builder->shouldReceive('first')->once()->andReturnNull();
+
+        $newModel = m::mock('Illuminate\Database\Eloquent\Model');
+
+        $newModel->shouldReceive('setAttribute')->once()->with('foreign_key', 1)->andReturn($newModel);
+
+        $this->related->shouldReceive('newInstance')->once()->andReturn($newModel);
+
+        $this->assertInstanceOf('Illuminate\Database\Eloquent\Model', $relation->getResults());
     }
 
     public function testSaveMethodSetsForeignKeyOnModel()
@@ -113,18 +134,18 @@ class DatabaseEloquentHasOneTest extends PHPUnit_Framework_TestCase
 
     protected function getRelation()
     {
-        $builder = m::mock('Illuminate\Database\Eloquent\Builder');
-        $builder->shouldReceive('whereNotNull')->with('table.foreign_key');
-        $builder->shouldReceive('where')->with('table.foreign_key', '=', 1);
-        $related = m::mock('Illuminate\Database\Eloquent\Model');
-        $builder->shouldReceive('getModel')->andReturn($related);
-        $parent = m::mock('Illuminate\Database\Eloquent\Model');
-        $parent->shouldReceive('getAttribute')->with('id')->andReturn(1);
-        $parent->shouldReceive('getCreatedAtColumn')->andReturn('created_at');
-        $parent->shouldReceive('getUpdatedAtColumn')->andReturn('updated_at');
-        $parent->shouldReceive('newQueryWithoutScopes')->andReturn($builder);
+        $this->builder = m::mock('Illuminate\Database\Eloquent\Builder');
+        $this->builder->shouldReceive('whereNotNull')->with('table.foreign_key');
+        $this->builder->shouldReceive('where')->with('table.foreign_key', '=', 1);
+        $this->related = m::mock('Illuminate\Database\Eloquent\Model');
+        $this->builder->shouldReceive('getModel')->andReturn($this->related);
+        $this->parent = m::mock('Illuminate\Database\Eloquent\Model');
+        $this->parent->shouldReceive('getAttribute')->with('id')->andReturn(1);
+        $this->parent->shouldReceive('getCreatedAtColumn')->andReturn('created_at');
+        $this->parent->shouldReceive('getUpdatedAtColumn')->andReturn('updated_at');
+        $this->parent->shouldReceive('newQueryWithoutScopes')->andReturn($this->builder);
 
-        return new HasOne($builder, $parent, 'table.foreign_key', 'id');
+        return new HasOne($this->builder, $this->parent, 'table.foreign_key', 'id');
     }
 }
 


### PR DESCRIPTION
So I've been dealing with this problem: I have a user and I need to get its profile, but the user does not have one, so something like this throws an exception:

`$thi->profile->twitter` (Trying to use a property on a non-object whatever whatever...)

So I came with this idea:

```
    public function profile()
    {
        return $this->hasOne(UserProfile::class)->withDefault();
    }
```

Now when the result is not found, Eloquent creates one new model instance for me and I can continue with my life... 

This is just a proposal / proof of concept. 