### PR TITLE
[5.3] Fix docblock typo

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -824,7 +824,7 @@ class Grammar extends BaseGrammar
     }
 
     /**
-     * Get the gramar specific operators.
+     * Get the grammar specific operators.
      *
      * @return array
      */


### PR DESCRIPTION
I found a typo in the docblock on line 827 of src/Illuminate/Database/Query/Grammars/Grammar.php.