### PR TITLE
[5.3] Allow append to be called on Eloquent Collection

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -353,7 +353,7 @@ class Collection extends BaseCollection implements QueueableCollection
     }
 
     /**
-     * Apply append to all models within the collection
+     * Apply append to all models within the collection.
      *
      * @param  array|string  $attributes
      * @return BaseCollection
@@ -365,7 +365,6 @@ class Collection extends BaseCollection implements QueueableCollection
         }
 
         return $this->each(function ($item) use ($attributes) {
-
             if ($item instanceof Model) {
                 call_user_func_array([$item, 'append'], $attributes);
             }

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -355,7 +355,7 @@ class Collection extends BaseCollection implements QueueableCollection
     /**
      * Apply append to all models within the collection
      *
-     * @param $attributes
+     * @param  array|string  $attributes
      * @return BaseCollection
      */
     public function append($attributes)

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -353,6 +353,26 @@ class Collection extends BaseCollection implements QueueableCollection
     }
 
     /**
+     * Apply append to all models within the collection
+     *
+     * @param $attributes
+     * @return BaseCollection
+     */
+    public function append($attributes)
+    {
+        if (is_string($attributes)) {
+            $attributes = func_get_args();
+        }
+
+        return $this->each(function ($item) use ($attributes) {
+
+            if ($item instanceof Model) {
+                call_user_func_array([$item, 'append'], $attributes);
+            }
+        });
+    }
+
+    /**
      * Get the identifiers for all of the entities.
      *
      * @return array

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -306,6 +306,20 @@ class DatabaseEloquentCollectionTest extends PHPUnit_Framework_TestCase
         $c = new Collection([new TestEloquentCollectionModel, (object) ['id' => 'something']]);
         $c->getQueueableClass();
     }
+    
+    public function testAppendIsCalledOnEachModelInTheCollection()
+    {
+        $mockModel1 = m::mock('Illuminate\Database\Eloquent\Model');
+        $mockModel1->shouldReceive('append')->with('attribute');
+        $mockModel2 = m::mock('Illuminate\Database\Eloquent\Model');
+        $mockModel2->shouldReceive('append')->with('attribute');
+        $mockModel3 = m::mock('Illuminate\Database\Eloquent\Model');
+        $mockModel3->shouldReceive('append')->with('attribute');
+
+        $c = new Collection([$mockModel1, $mockModel2, $mockModel3]);
+
+        $c->append('attribute');
+    }
 }
 
 class TestEloquentCollectionModel extends Illuminate\Database\Eloquent\Model

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -306,7 +306,7 @@ class DatabaseEloquentCollectionTest extends PHPUnit_Framework_TestCase
         $c = new Collection([new TestEloquentCollectionModel, (object) ['id' => 'something']]);
         $c->getQueueableClass();
     }
-    
+
     public function testAppendIsCalledOnEachModelInTheCollection()
     {
         $mockModel1 = m::mock('Illuminate\Database\Eloquent\Model');


### PR DESCRIPTION
Rather than having to iterate over the collection to use `append()`, allow it to be called directly on the collection and have it be applied to its containing models e.g.

```
$users = App\User::all()->map(function ($item) {

    return $item->append('someValue');
});
```
becomes:
```
$users = App\User::all()->append('someValue');
```

