### PR TITLE
[5.4] Add cache forget command and use it in the event Schedule

### DIFF
--- a/src/Illuminate/Cache/CacheServiceProvider.php
+++ b/src/Illuminate/Cache/CacheServiceProvider.php
@@ -4,6 +4,7 @@ namespace Illuminate\Cache;
 
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Cache\Console\ClearCommand;
+use Illuminate\Cache\Console\ForgetCommand;
 
 class CacheServiceProvider extends ServiceProvider
 {
@@ -48,6 +49,12 @@ class CacheServiceProvider extends ServiceProvider
         });
 
         $this->commands('command.cache.clear');
+
+        $this->app->singleton('command.cache.forget', function ($app) {
+            return new ForgetCommand($app['cache']);
+        });
+
+        $this->commands('command.cache.forget');
     }
 
     /**
@@ -58,7 +65,7 @@ class CacheServiceProvider extends ServiceProvider
     public function provides()
     {
         return [
-            'cache', 'cache.store', 'memcached.connector', 'command.cache.clear',
+            'cache', 'cache.store', 'memcached.connector', 'command.cache.clear', 'command.cache.forget'
         ];
     }
 }

--- a/src/Illuminate/Cache/CacheServiceProvider.php
+++ b/src/Illuminate/Cache/CacheServiceProvider.php
@@ -65,7 +65,7 @@ class CacheServiceProvider extends ServiceProvider
     public function provides()
     {
         return [
-            'cache', 'cache.store', 'memcached.connector', 'command.cache.clear', 'command.cache.forget'
+            'cache', 'cache.store', 'memcached.connector', 'command.cache.clear', 'command.cache.forget',
         ];
     }
 }

--- a/src/Illuminate/Cache/Console/ForgetCommand.php
+++ b/src/Illuminate/Cache/Console/ForgetCommand.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Illuminate\Cache\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Cache\CacheManager;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputArgument;
+
+class ForgetCommand extends Command
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'cache:forget';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Remove an item from the cache';
+
+    /**
+     * The cache manager instance.
+     *
+     * @var \Illuminate\Cache\CacheManager
+     */
+    protected $cache;
+
+    /**
+     * Create a new cache clear command instance.
+     *
+     * @param  \Illuminate\Cache\CacheManager  $cache
+     * @return void
+     */
+    public function __construct(CacheManager $cache)
+    {
+        parent::__construct();
+
+        $this->cache = $cache;
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        $this->cache->store($this->argument('store'))
+                    ->forget($this->argument('key'));
+    }
+
+    /**
+     * Get the console command arguments.
+     *
+     * @return array
+     */
+    protected function getArguments()
+    {
+        return [
+            ['key', InputArgument::REQUIRED, 'The name of the key you would like to clear.'],
+            ['store', InputArgument::OPTIONAL, 'The name of the store you would like to clear.'],
+        ];
+    }
+}

--- a/src/Illuminate/Cache/Console/ForgetCommand.php
+++ b/src/Illuminate/Cache/Console/ForgetCommand.php
@@ -61,8 +61,8 @@ class ForgetCommand extends Command
     protected function getArguments()
     {
         return [
-            ['key', InputArgument::REQUIRED, 'The name of the key you would like to clear.'],
-            ['store', InputArgument::OPTIONAL, 'The name of the store you would like to clear.'],
+            ['key', InputArgument::REQUIRED, 'The name of the key.'],
+            ['store', InputArgument::OPTIONAL, 'The name of the store.'],
         ];
     }
 }

--- a/src/Illuminate/Cache/Console/ForgetCommand.php
+++ b/src/Illuminate/Cache/Console/ForgetCommand.php
@@ -4,7 +4,6 @@ namespace Illuminate\Cache\Console;
 
 use Illuminate\Console\Command;
 use Illuminate\Cache\CacheManager;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputArgument;
 
 class ForgetCommand extends Command

--- a/src/Illuminate/Console/Application.php
+++ b/src/Illuminate/Console/Application.php
@@ -4,9 +4,11 @@ namespace Illuminate\Console;
 
 use Closure;
 use Illuminate\Contracts\Events\Dispatcher;
+use Symfony\Component\Process\ProcessUtils;
 use Illuminate\Contracts\Container\Container;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Process\PhpExecutableFinder;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Application as SymfonyApplication;
 use Symfony\Component\Console\Command\Command as SymfonyCommand;
@@ -201,5 +203,25 @@ class Application extends SymfonyApplication implements ApplicationContract
     public function getLaravel()
     {
         return $this->laravel;
+    }
+
+    /**
+     * The PHP executable.
+     *
+     * @return string
+     */
+    public static function phpBinary()
+    {
+        return ProcessUtils::escapeArgument((new PhpExecutableFinder)->find(false));
+    }
+
+    /**
+     * The Artisan executable.
+     *
+     * @return string
+     */
+    public static function artisanBinary()
+    {
+        return defined('ARTISAN_BINARY') ? ProcessUtils::escapeArgument(ARTISAN_BINARY) : 'artisan';
     }
 }

--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -238,7 +238,7 @@ class Event
         $redirect = $this->shouldAppendOutput ? ' >> ' : ' > ';
 
         if ($this->withoutOverlapping) {
-            $cacheForgetCommand = sprintf("%s %s %s", Application::phpBinary(), Application::artisanBinary(), 'cache:forget');
+            $cacheForgetCommand = sprintf('%s %s %s', Application::phpBinary(), Application::artisanBinary(), 'cache:forget');
 
             if (windows_os()) {
                 $command = '('.$this->command.' & '.$cacheForgetCommand.' "'.$this->mutexName().'")'.$redirect.$output.' 2>&1 &';

--- a/src/Illuminate/Console/Scheduling/Schedule.php
+++ b/src/Illuminate/Console/Scheduling/Schedule.php
@@ -62,7 +62,7 @@ class Schedule
         }
 
         return $this->exec(
-            sprintf("%s %s %s", Application::phpBinary(), Application::artisanBinary(), $command),
+            sprintf('%s %s %s', Application::phpBinary(), Application::artisanBinary(), $command),
             $parameters
         );
     }

--- a/tests/Console/ConsoleScheduledEventTest.php
+++ b/tests/Console/ConsoleScheduledEventTest.php
@@ -32,7 +32,7 @@ class ConsoleScheduledEventTest extends PHPUnit_Framework_TestCase
         $app->shouldReceive('isDownForMaintenance')->andReturn(false);
         $app->shouldReceive('environment')->andReturn('production');
 
-        $event = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php foo', 'cache:forget');
+        $event = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php foo');
         $this->assertEquals('* * * * * *', $event->getExpression());
         $this->assertTrue($event->isDue($app));
         $this->assertTrue($event->skip(function () {
@@ -42,49 +42,49 @@ class ConsoleScheduledEventTest extends PHPUnit_Framework_TestCase
             return true;
         })->filtersPass($app));
 
-        $event = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php foo', 'cache:forget');
+        $event = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php foo');
         $this->assertEquals('* * * * * *', $event->getExpression());
         $this->assertFalse($event->environments('local')->isDue($app));
 
-        $event = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php foo', 'cache:forget');
+        $event = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php foo');
         $this->assertEquals('* * * * * *', $event->getExpression());
         $this->assertFalse($event->when(function () {
             return false;
         })->filtersPass($app));
 
-        $event = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php foo', 'cache:forget');
+        $event = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php foo');
         $this->assertEquals('*/5 * * * * *', $event->everyFiveMinutes()->getExpression());
 
-        $event = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php foo', 'cache:forget');
+        $event = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php foo');
         $this->assertEquals('0 0 * * * *', $event->daily()->getExpression());
 
-        $event = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php foo', 'cache:forget');
+        $event = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php foo');
         $this->assertEquals('0 3,15 * * * *', $event->twiceDaily(3, 15)->getExpression());
 
-        $event = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php foo', 'cache:forget');
+        $event = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php foo');
         $this->assertEquals('*/5 * * * 3 *', $event->everyFiveMinutes()->wednesdays()->getExpression());
 
-        $event = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php foo', 'cache:forget');
+        $event = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php foo');
         $this->assertEquals('0 * * * * *', $event->everyFiveMinutes()->hourly()->getExpression());
 
-        $event = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php foo', 'cache:forget');
+        $event = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php foo');
         $this->assertEquals('0 15 4 * * *', $event->monthlyOn(4, '15:00')->getExpression());
 
-        $event = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php foo', 'cache:forget');
+        $event = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php foo');
         $this->assertEquals('0 0 * * 1-5 *', $event->weekdays()->daily()->getExpression());
 
-        $event = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php foo', 'cache:forget');
+        $event = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php foo');
         $this->assertEquals('0 * * * 1-5 *', $event->weekdays()->hourly()->getExpression());
 
         // chained rules should be commutative
-        $eventA = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php foo', 'cache:forget');
-        $eventB = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php foo', 'cache:forget');
+        $eventA = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php foo');
+        $eventB = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php foo');
         $this->assertEquals(
             $eventA->daily()->hourly()->getExpression(),
             $eventB->hourly()->daily()->getExpression());
 
-        $eventA = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php foo', 'cache:forget');
-        $eventB = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php foo', 'cache:forget');
+        $eventA = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php foo');
+        $eventB = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php foo');
         $this->assertEquals(
             $eventA->weekdays()->hourly()->getExpression(),
             $eventB->hourly()->weekdays()->getExpression());
@@ -97,11 +97,11 @@ class ConsoleScheduledEventTest extends PHPUnit_Framework_TestCase
         $app->shouldReceive('environment')->andReturn('production');
         Carbon::setTestNow(Carbon::create(2015, 1, 1, 0, 0, 0));
 
-        $event = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php foo', 'cache:forget');
+        $event = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php foo');
         $this->assertEquals('* * * * 4 *', $event->thursdays()->getExpression());
         $this->assertTrue($event->isDue($app));
 
-        $event = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php foo', 'cache:forget');
+        $event = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php foo');
         $this->assertEquals('0 19 * * 3 *', $event->wednesdays()->at('19:00')->timezone('EST')->getExpression());
         $this->assertTrue($event->isDue($app));
     }
@@ -113,7 +113,7 @@ class ConsoleScheduledEventTest extends PHPUnit_Framework_TestCase
         $app->shouldReceive('environment')->andReturn('production');
         Carbon::setTestNow(Carbon::now()->startOfDay()->addHours(9));
 
-        $event = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php foo', 'cache:forget');
+        $event = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php foo');
         $this->assertTrue($event->between('8:00', '10:00')->filtersPass($app));
         $this->assertTrue($event->between('9:00', '9:00')->filtersPass($app));
         $this->assertFalse($event->between('10:00', '11:00')->filtersPass($app));

--- a/tests/Console/ConsoleScheduledEventTest.php
+++ b/tests/Console/ConsoleScheduledEventTest.php
@@ -32,7 +32,7 @@ class ConsoleScheduledEventTest extends PHPUnit_Framework_TestCase
         $app->shouldReceive('isDownForMaintenance')->andReturn(false);
         $app->shouldReceive('environment')->andReturn('production');
 
-        $event = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php foo');
+        $event = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php foo', 'cache:forget');
         $this->assertEquals('* * * * * *', $event->getExpression());
         $this->assertTrue($event->isDue($app));
         $this->assertTrue($event->skip(function () {
@@ -42,49 +42,49 @@ class ConsoleScheduledEventTest extends PHPUnit_Framework_TestCase
             return true;
         })->filtersPass($app));
 
-        $event = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php foo');
+        $event = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php foo', 'cache:forget');
         $this->assertEquals('* * * * * *', $event->getExpression());
         $this->assertFalse($event->environments('local')->isDue($app));
 
-        $event = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php foo');
+        $event = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php foo', 'cache:forget');
         $this->assertEquals('* * * * * *', $event->getExpression());
         $this->assertFalse($event->when(function () {
             return false;
         })->filtersPass($app));
 
-        $event = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php foo');
+        $event = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php foo', 'cache:forget');
         $this->assertEquals('*/5 * * * * *', $event->everyFiveMinutes()->getExpression());
 
-        $event = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php foo');
+        $event = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php foo', 'cache:forget');
         $this->assertEquals('0 0 * * * *', $event->daily()->getExpression());
 
-        $event = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php foo');
+        $event = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php foo', 'cache:forget');
         $this->assertEquals('0 3,15 * * * *', $event->twiceDaily(3, 15)->getExpression());
 
-        $event = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php foo');
+        $event = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php foo', 'cache:forget');
         $this->assertEquals('*/5 * * * 3 *', $event->everyFiveMinutes()->wednesdays()->getExpression());
 
-        $event = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php foo');
+        $event = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php foo', 'cache:forget');
         $this->assertEquals('0 * * * * *', $event->everyFiveMinutes()->hourly()->getExpression());
 
-        $event = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php foo');
+        $event = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php foo', 'cache:forget');
         $this->assertEquals('0 15 4 * * *', $event->monthlyOn(4, '15:00')->getExpression());
 
-        $event = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php foo');
+        $event = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php foo', 'cache:forget');
         $this->assertEquals('0 0 * * 1-5 *', $event->weekdays()->daily()->getExpression());
 
-        $event = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php foo');
+        $event = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php foo', 'cache:forget');
         $this->assertEquals('0 * * * 1-5 *', $event->weekdays()->hourly()->getExpression());
 
         // chained rules should be commutative
-        $eventA = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php foo');
-        $eventB = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php foo');
+        $eventA = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php foo', 'cache:forget');
+        $eventB = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php foo', 'cache:forget');
         $this->assertEquals(
             $eventA->daily()->hourly()->getExpression(),
             $eventB->hourly()->daily()->getExpression());
 
-        $eventA = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php foo');
-        $eventB = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php foo');
+        $eventA = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php foo', 'cache:forget');
+        $eventB = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php foo', 'cache:forget');
         $this->assertEquals(
             $eventA->weekdays()->hourly()->getExpression(),
             $eventB->hourly()->weekdays()->getExpression());
@@ -97,11 +97,11 @@ class ConsoleScheduledEventTest extends PHPUnit_Framework_TestCase
         $app->shouldReceive('environment')->andReturn('production');
         Carbon::setTestNow(Carbon::create(2015, 1, 1, 0, 0, 0));
 
-        $event = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php foo');
+        $event = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php foo', 'cache:forget');
         $this->assertEquals('* * * * 4 *', $event->thursdays()->getExpression());
         $this->assertTrue($event->isDue($app));
 
-        $event = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php foo');
+        $event = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php foo', 'cache:forget');
         $this->assertEquals('0 19 * * 3 *', $event->wednesdays()->at('19:00')->timezone('EST')->getExpression());
         $this->assertTrue($event->isDue($app));
     }
@@ -113,7 +113,7 @@ class ConsoleScheduledEventTest extends PHPUnit_Framework_TestCase
         $app->shouldReceive('environment')->andReturn('production');
         Carbon::setTestNow(Carbon::now()->startOfDay()->addHours(9));
 
-        $event = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php foo');
+        $event = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php foo', 'cache:forget');
         $this->assertTrue($event->between('8:00', '10:00')->filtersPass($app));
         $this->assertTrue($event->between('9:00', '9:00')->filtersPass($app));
         $this->assertFalse($event->between('10:00', '11:00')->filtersPass($app));

--- a/tests/Console/Scheduling/EventTest.php
+++ b/tests/Console/Scheduling/EventTest.php
@@ -14,7 +14,7 @@ class EventTest extends PHPUnit_Framework_TestCase
     {
         $quote = (DIRECTORY_SEPARATOR == '\\') ? '"' : "'";
 
-        $event = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php -i');
+        $event = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php -i', 'cache:forget');
 
         $defaultOutput = (DIRECTORY_SEPARATOR == '\\') ? 'NUL' : '/dev/null';
         $this->assertSame("php -i > {$quote}{$defaultOutput}{$quote} 2>&1 &", $event->buildCommand());
@@ -24,12 +24,12 @@ class EventTest extends PHPUnit_Framework_TestCase
     {
         $quote = (DIRECTORY_SEPARATOR == '\\') ? '"' : "'";
 
-        $event = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php -i');
+        $event = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php -i', 'cache:forget');
 
         $event->sendOutputTo('/dev/null');
         $this->assertSame("php -i > {$quote}/dev/null{$quote} 2>&1 &", $event->buildCommand());
 
-        $event = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php -i');
+        $event = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php -i', 'cache:forget');
 
         $event->sendOutputTo('/my folder/foo.log');
         $this->assertSame("php -i > {$quote}/my folder/foo.log{$quote} 2>&1 &", $event->buildCommand());
@@ -39,7 +39,7 @@ class EventTest extends PHPUnit_Framework_TestCase
     {
         $quote = (DIRECTORY_SEPARATOR == '\\') ? '"' : "'";
 
-        $event = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php -i');
+        $event = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php -i', 'cache:forget');
 
         $event->appendOutputTo('/dev/null');
         $this->assertSame("php -i >> {$quote}/dev/null{$quote} 2>&1 &", $event->buildCommand());
@@ -50,7 +50,7 @@ class EventTest extends PHPUnit_Framework_TestCase
      */
     public function testEmailOutputToThrowsExceptionIfOutputFileWasNotSpecified()
     {
-        $event = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php -i');
+        $event = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php -i', 'cache:forget');
         $event->emailOutputTo('foo@example.com');
 
         $event->buildCommand();

--- a/tests/Console/Scheduling/EventTest.php
+++ b/tests/Console/Scheduling/EventTest.php
@@ -14,7 +14,7 @@ class EventTest extends PHPUnit_Framework_TestCase
     {
         $quote = (DIRECTORY_SEPARATOR == '\\') ? '"' : "'";
 
-        $event = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php -i', 'cache:forget');
+        $event = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php -i');
 
         $defaultOutput = (DIRECTORY_SEPARATOR == '\\') ? 'NUL' : '/dev/null';
         $this->assertSame("php -i > {$quote}{$defaultOutput}{$quote} 2>&1 &", $event->buildCommand());
@@ -24,12 +24,12 @@ class EventTest extends PHPUnit_Framework_TestCase
     {
         $quote = (DIRECTORY_SEPARATOR == '\\') ? '"' : "'";
 
-        $event = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php -i', 'cache:forget');
+        $event = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php -i');
 
         $event->sendOutputTo('/dev/null');
         $this->assertSame("php -i > {$quote}/dev/null{$quote} 2>&1 &", $event->buildCommand());
 
-        $event = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php -i', 'cache:forget');
+        $event = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php -i');
 
         $event->sendOutputTo('/my folder/foo.log');
         $this->assertSame("php -i > {$quote}/my folder/foo.log{$quote} 2>&1 &", $event->buildCommand());
@@ -39,7 +39,7 @@ class EventTest extends PHPUnit_Framework_TestCase
     {
         $quote = (DIRECTORY_SEPARATOR == '\\') ? '"' : "'";
 
-        $event = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php -i', 'cache:forget');
+        $event = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php -i');
 
         $event->appendOutputTo('/dev/null');
         $this->assertSame("php -i >> {$quote}/dev/null{$quote} 2>&1 &", $event->buildCommand());
@@ -50,7 +50,7 @@ class EventTest extends PHPUnit_Framework_TestCase
      */
     public function testEmailOutputToThrowsExceptionIfOutputFileWasNotSpecified()
     {
-        $event = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php -i', 'cache:forget');
+        $event = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php -i');
         $event->emailOutputTo('foo@example.com');
 
         $event->buildCommand();


### PR DESCRIPTION
Instead of forgetting the cache key directly after running the command (which can be run in the background), we use a `cache:forget` console command that'll run after our command runs, this ensure the cache is cleared after the command actually finished running.