### PR TITLE
[5.3] Return early when chunk size is less than zero

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -955,6 +955,12 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      */
     public function chunk($size)
     {
+        if ($size < 0) {
+            throw new InvalidArgumentException(
+                'Size parameter expected to be greater than 0'
+            );
+        }
+
         if ($size == 0) {
             return new static;
         }

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -928,6 +928,10 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      */
     public function chunk($size)
     {
+        if ($size == 0) {
+            return $this;
+        }
+
         $chunks = [];
 
         foreach (array_chunk($this->items, $size, true) as $chunk) {

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -956,7 +956,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     public function chunk($size)
     {
         if ($size == 0) {
-            return $this;
+            return new static;
         }
 
         $chunks = [];

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -955,6 +955,10 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      */
     public function chunk($size)
     {
+        if ($size == 0) {
+            return $this;
+        }
+
         $chunks = [];
 
         foreach (array_chunk($this->items, $size, true) as $chunk) {

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -682,6 +682,14 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
         $this->assertEquals([9 => 10], $data[3]->toArray());
     }
 
+    public function testChunkWhenGivenZeroAsSize()
+    {
+        $data = new Collection([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+        $chunkedData = $data->chunk(0);
+
+        $this->assertEquals($data, $chunkedData);
+    }
+
     public function testEvery()
     {
         $data = new Collection([

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -665,6 +665,14 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
         $this->assertEquals([9 => 10], $data[3]->toArray());
     }
 
+    public function testChunkWhenGivenZeroAsSize()
+    {
+        $data = new Collection([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+        $chunkedData = $data->chunk(0);
+
+        $this->assertEquals($data, $chunkedData);
+    }
+
     public function testEvery()
     {
         $data = new Collection([

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -692,6 +692,17 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
         );
     }
 
+    public function testChunkWhenGivenLessThanZero()
+    {
+        $collection = new Collection([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->assertEquals(
+            [],
+            $collection->chunk(-1)->toArray()
+        );
+    }
+
     public function testEvery()
     {
         $data = new Collection([

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -684,10 +684,12 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
 
     public function testChunkWhenGivenZeroAsSize()
     {
-        $data = new Collection([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
-        $chunkedData = $data->chunk(0);
+        $collection = new Collection([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
 
-        $this->assertEquals($data, $chunkedData);
+        $this->assertEquals(
+            [],
+            $collection->chunk(0)->toArray()
+        );
     }
 
     public function testEvery()


### PR DESCRIPTION
I found that this PR might be relevant after working on spatie/laravel-collection-macros#13, and figured it might be relevant for the core. It is very much an edge-case.

### The problem
Many use `chunk()` as a way to split their collection into parts, so that it's easier to create columns of content. But if the `$size` is dynamically calculated, it may occur that the result of the calculation is 0.
If `array_chunk()` is given a value less than 1, it will throw an error. This will, from my point of view, generate a lot of unnecessary empty checks in peoples views.

### The solution
If the `chunk()` method would return early if the given chunk size was == 0, 