### PR TITLE
[5.3] Catch errors when handling a failed job

### DIFF
--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Queue;
 
 use Exception;
-use RuntimeException;
 use Throwable;
 use Illuminate\Contracts\Queue\Job;
 use Illuminate\Contracts\Events\Dispatcher;
@@ -309,7 +308,8 @@ class Worker
             $job->delete();
 
             $job->failed($e);
-        } catch (Exception $e) {}
+        } catch (Exception $e) {
+        }
 
         $this->raiseFailedJobEvent($connectionName, $job, $e);
 

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -234,7 +234,7 @@ class Worker
             $this->raiseExceptionOccurredJobEvent(
                 $connectionName, $job, $e
             );
-        } catch(Exception $exception) {
+        } catch (Exception $exception) {
             $this->raiseFailedJobEvent($connectionName, $job, $exception);
         } finally {
             if (! $job->isDeleted()) {

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -235,11 +235,6 @@ class Worker
             $this->raiseExceptionOccurredJobEvent(
                 $connectionName, $job, $e
             );
-<<<<<<< HEAD
-=======
-        } catch (Exception $exception) {
-            $this->raiseFailedJobEvent($connectionName, $job, $exception);
->>>>>>> origin/fix-queue-failed-job-event
         } finally {
             if (! $job->isDeleted()) {
                 $job->release($options->delay);

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -308,10 +308,9 @@ class Worker
             $job->delete();
 
             $job->failed($e);
-        } catch (Exception $exception) {
+        } finally {
+            $this->raiseFailedJobEvent($connectionName, $job, $e);
         }
-
-        $this->raiseFailedJobEvent($connectionName, $job, $e);
     }
 
     /**

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -307,7 +307,7 @@ class Worker
             $job->delete();
 
             $job->failed($e);
-        } catch(Exception $exception) {
+        } catch (Exception $exception) {
             $e = new RuntimeException($exception->getMessage(), $exception->getCode(), $e);
         }
 

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -309,7 +309,6 @@ class Worker
 
             $job->failed($e);
         } catch (Exception $e) {
-            
         }
 
         $this->raiseFailedJobEvent($connectionName, $job, $e);

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -234,6 +234,8 @@ class Worker
             $this->raiseExceptionOccurredJobEvent(
                 $connectionName, $job, $e
             );
+        } catch(Exception $exception) {
+            $this->raiseFailedJobEvent($connectionName, $job, $exception);
         } finally {
             if (! $job->isDeleted()) {
                 $job->release($options->delay);

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -264,6 +264,8 @@ class Worker
         );
 
         $this->failJob($connectionName, $job, $e);
+
+        throw $e;
     }
 
     /**
@@ -292,8 +294,6 @@ class Worker
      * @param  \Illuminate\Contracts\Queue\Job  $job
      * @param  \Exception  $e
      * @return void
-     *
-     * @throws \Exception
      */
     protected function failJob($connectionName, $job, $e)
     {
@@ -308,12 +308,10 @@ class Worker
             $job->delete();
 
             $job->failed($e);
-        } catch (Exception $e) {
+        } catch (Exception $exception) {
         }
 
         $this->raiseFailedJobEvent($connectionName, $job, $e);
-
-        throw $e;
     }
 
     /**

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -309,6 +309,7 @@ class Worker
 
             $job->failed($e);
         } catch (Exception $e) {
+            
         }
 
         $this->raiseFailedJobEvent($connectionName, $job, $e);

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -293,6 +293,8 @@ class Worker
      * @param  \Illuminate\Contracts\Queue\Job  $job
      * @param  \Exception  $e
      * @return void
+     *
+     * @throws \Exception
      */
     protected function failJob($connectionName, $job, $e)
     {
@@ -307,9 +309,7 @@ class Worker
             $job->delete();
 
             $job->failed($e);
-        } catch (Exception $exception) {
-            $e = new RuntimeException($exception->getMessage(), $exception->getCode(), $e);
-        }
+        } catch (Exception $e) {}
 
         $this->raiseFailedJobEvent($connectionName, $job, $e);
 


### PR DESCRIPTION
More explanation in my comment on this [issue](https://github.com/laravel/framework/issues/15192#issuecomment-257585432)

TLDR;
If there is any problems with the payload of a job then the failed job event will not fire and the job is lost.