### PR TITLE
[5.3] [Proposal] Validation of existence of relational entries

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1538,7 +1538,7 @@ class Validator implements ValidatorContract
 
         return $attribute;
     }
-    
+
     /**
      * Validate the existence of a relation to its model.
      *
@@ -1553,13 +1553,13 @@ class Validator implements ValidatorContract
 
         $relations = $this->getRelations($parameters);
 
-        if(is_array($value)) {
-            return !$this->checkMultiRelationsExists(
+        if (is_array($value)) {
+            return ! $this->checkMultiRelationsExists(
                 $value, $attribute, $parameters[0], $relations
             );
         }
 
-        return !$this->checkSingleRelationExists(
+        return ! $this->checkSingleRelationExists(
             $value, $attribute, $parameters[0], $relations
         );
     }
@@ -1578,7 +1578,7 @@ class Validator implements ValidatorContract
 
         $relations = $this->getRelations($parameters);
 
-        if(is_array($value)) {
+        if (is_array($value)) {
             return $this->checkMultiRelationsExists(
                 $value, $attribute, $parameters[0], $relations
             );
@@ -1590,7 +1590,7 @@ class Validator implements ValidatorContract
     }
 
     /**
-     * Get Relations for validation
+     * Get Relations for validation.
      *
      * @param  array $parameters
      *
@@ -1604,7 +1604,7 @@ class Validator implements ValidatorContract
     }
 
     /**
-     * This will be used when the value is an array
+     * This will be used when the value is an array.
      *
      * @param  array  $value
      * @param  string $attribute
@@ -1620,8 +1620,8 @@ class Validator implements ValidatorContract
         // This will check if the relations specified for the model exists
         // If in case any of the relations given doesn't exist, false will
         // be returned
-        foreach($collection as $model) {
-            if(!$this->checkIfRelationExists($model, $relations)) {
+        foreach ($collection as $model) {
+            if (! $this->checkIfRelationExists($model, $relations)) {
                 return false;
             }
         }
@@ -1630,7 +1630,7 @@ class Validator implements ValidatorContract
     }
 
     /**
-     * This will be used when only single value is present
+     * This will be used when only single value is present.
      *
      * @param  int|string|array   $value
      * @param  string             $attribute
@@ -1642,13 +1642,15 @@ class Validator implements ValidatorContract
     {
         $model = (new $model)->where(explode('.', $attribute)[0], $value)->first();
 
-        if(!$model) throw new ModelNotFoundException;
+        if (! $model) {
+            throw new ModelNotFoundException;
+        }
 
         return $this->checkIfRelationExists($model, $relations);
     }
 
     /**
-     * Check if the relation exists for that model
+     * Check if the relation exists for that model.
      *
      * @param  Model $model
      * @param  string $relations
@@ -1662,11 +1664,13 @@ class Validator implements ValidatorContract
 
             $relationSet = explode('.', $relationSet);
 
-            foreach($relationSet as $relation) {
+            foreach ($relationSet as $relation) {
                 $builder = $builder->$relation();
             }
 
-            if(!$builder->count()) return false;
+            if (! $builder->count()) {
+                return false;
+            }
         }
 
         return true;
@@ -2778,7 +2782,7 @@ class Validator implements ValidatorContract
 
         return str_replace(':values', implode(' / ', $parameters), $message);
     }
-    
+
     /**
      * Get all attributes.
      *

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -19,6 +19,7 @@ use Illuminate\Contracts\Container\Container;
 use Symfony\Component\HttpFoundation\File\File;
 use Symfony\Component\Translation\TranslatorInterface;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Contracts\Validation\Validator as ValidatorContract;
 
 class Validator implements ValidatorContract
@@ -1537,6 +1538,139 @@ class Validator implements ValidatorContract
 
         return $attribute;
     }
+    
+    /**
+     * Validate the existence of a relation to its model.
+     *
+     * @param  string  $attribute
+     * @param  mixed   $value
+     * @param  array   $parameters
+     * @return bool
+     */
+    protected function validateRelationExists($attribute, $value, $parameters)
+    {
+        $this->requireParameterCount(2, $parameters, 'relation_exists');
+
+        $relations = $this->getRelations($parameters);
+
+        if(is_array($value)) {
+            return !$this->checkMultiRelationsExists(
+                $value, $attribute, $parameters[0], $relations
+            );
+        }
+
+        return !$this->checkSingleRelationExists(
+            $value, $attribute, $parameters[0], $relations
+        );
+    }
+
+    /**
+     * Validate the non existence of a relation to its model.
+     *
+     * @param  string  $attribute
+     * @param  mixed   $value
+     * @param  array   $parameters
+     * @return bool
+     */
+    protected function validateRelationNotExists($attribute, $value, $parameters)
+    {
+        $this->requireParameterCount(2, $parameters, 'relation_not_exists');
+
+        $relations = $this->getRelations($parameters);
+
+        if(is_array($value)) {
+            return $this->checkMultiRelationsExists(
+                $value, $attribute, $parameters[0], $relations
+            );
+        }
+
+        return $this->checkSingleRelationExists(
+            $value, $attribute, $parameters[0], $relations
+        );
+    }
+
+    /**
+     * Get Relations for validation
+     *
+     * @param  array $parameters
+     *
+     * @return array
+     */
+    protected function getRelations($parameters)
+    {
+        unset($parameters[0]);
+
+        return $parameters;
+    }
+
+    /**
+     * This will be used when the value is an array
+     *
+     * @param  array  $value
+     * @param  string $attribute
+     * @param  Model  $model
+     * @param  string $relations
+     * @return bool
+     */
+    protected function checkMultiRelationsExists($value, $attribute, $model, $relations)
+    {
+        //This gives us the collection of models to run validation in
+        $collection = (new $model)->whereIn(explode('.', $attribute)[0], $value)->get();
+
+        // This will check if the relations specified for the model exists
+        // If in case any of the relations given doesn't exist, false will
+        // be returned
+        foreach($collection as $model) {
+            if(!$this->checkIfRelationExists($model, $relations)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * This will be used when only single value is present
+     *
+     * @param  int|string|array   $value
+     * @param  string             $attribute
+     * @param  Model              $model
+     * @param  string $relations
+     * @return bool
+     */
+    protected function checkSingleRelationExists($value, $attribute, $model, $relations)
+    {
+        $model = (new $model)->where(explode('.', $attribute)[0], $value)->first();
+
+        if(!$model) throw new ModelNotFoundException;
+
+        return $this->checkIfRelationExists($model, $relations);
+    }
+
+    /**
+     * Check if the relation exists for that model
+     *
+     * @param  Model $model
+     * @param  string $relations
+     * @return bool
+     */
+    protected function checkIfRelationExists($model, $relations)
+    {
+        foreach ($relations as $relationSet) {
+            //After this, we will be using the model as builder for queries
+            $builder = $model;
+
+            $relationSet = explode('.', $relationSet);
+
+            foreach($relationSet as $relation) {
+                $builder = $builder->$relation();
+            }
+
+            if(!$builder->count()) return false;
+        }
+
+        return true;
+    }
 
     /**
      * Validate that an attribute is a valid IP.
@@ -2609,6 +2743,42 @@ class Validator implements ValidatorContract
         return $this->replaceBefore($message, $attribute, $rule, $parameters);
     }
 
+    /**
+     * Replace all place-holders for the relation_exists rule.
+     *
+     * @param  string  $message
+     * @param  string  $attribute
+     * @param  string  $rule
+     * @param  array   $parameters
+     * @return string
+     */
+    protected function replaceRelationExists($message, $attribute, $rule, $parameters)
+    {
+        $parameters = $this->getAttributeList($parameters);
+
+        unset($parameters[0]);
+
+        return str_replace(':values', implode(' / ', $parameters), $message);
+    }
+
+    /**
+     * Replace all place-holders for the relation_not_exists rule.
+     *
+     * @param  string  $message
+     * @param  string  $attribute
+     * @param  string  $rule
+     * @param  array   $parameters
+     * @return string
+     */
+    protected function replaceRelationNotExists($message, $attribute, $rule, $parameters)
+    {
+        $parameters = $this->getAttributeList($parameters);
+
+        unset($parameters[0]);
+
+        return str_replace(':values', implode(' / ', $parameters), $message);
+    }
+    
     /**
      * Get all attributes.
      *


### PR DESCRIPTION
Hello all,

My name is Prateek and like many people out there... I love Laravel too 😄 

## Why the pull request?

While coding for a project, I came across an issue where validating the existence of relational entries is really important. A common example of this case is, 

### Example 1
- Let us say we have a *User* **A** and two *Languages* **E** and **F** stored in the database. A common relation between the **Language** model and **User** model is that of `belongsToMany()`. So, a user can have many languages and a language can belong to many users... Now, when we try to delete *language* **E** , we will also have to check if that language is being used anywhere or by any user as well... If yes, then the deletion of the language is not possible, but in the other case it is. 

Here the case to for validation to be handled is that of `relation_not_exists`

### Example 2
- Let us say a *User* **A** is placing an order on an online E-commerce website made on Laravel. Now, the **User** model has a relation to say **Address** model. In this case, a **User** can have many address and an **Address** belong to only 1 User... Therefore, the relation here is of `hasMany()` and `belongsTo()`. So, let us just say, the user can not place an order until there are entries in his/her addresses table. 

Here the case to for validation to be handled is that of `relation_exists`

To skip through the mess up of everyone writing such logic in their class functions, they can simply add this in the validator and an error will be thrown for either cases...

## How It Works

We simply add this to our validation rules - 

So, for **example 1** - 

```php
$rules = [
  'id' => 'relation_not_exists:App\Language,users'
];
```
Here, the `$attribute` passed in the Validation function gives us **id** and `$value` passed as input gives us **the id of language** - say **'1'**. Now the function will find an entry in the Language table with `id = 1` and then count the no of `users` belonging to it and *return false* `if(count > 0)` and *true* otherwise

For **example 2** - 
```php
$rules = [
  'id' => 'relation_exists:App\User,addresses'
```
Here, the `$attribute` passed in the Validation function gives us **id** and `$value` passed as input gives us **the id of user** - say **'1'**. Now the function will find an entry in the User table with `id = 1` and then count the no of `addresses` belonging to it and *return true* `if (count > 0)` and false otherwise. 

## Validation Messages

Since I was not able to decide how/what message should exactly be shown, I am writing a dummy message which can be simply added to `resources->lang->validation.php` as the main attributes.

```php
'relation_not_exists'  => 'This :attribute already has entries corresponding to its relations (:values)',
'relation_exists'      => 'This :attribute must already have entries for :values. relations',
```

I hope I was able to make my points clear and was able to give suitable examples to common problems faced by users. If this validation rule is added, a lot of logic/extra code can be removed from our services/repository functions and cleaner coding patterns will be followed 👍 