### PR TITLE
[5.4] Allow passing relative view path to @include

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -4,8 +4,8 @@ namespace Illuminate\View\Compilers;
 
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
-use Illuminate\View\Factory as ViewFactory;
 use Illuminate\View\ViewFinderInterface;
+use Illuminate\View\Factory as ViewFactory;
 
 class BladeCompiler extends Compiler implements CompilerInterface
 {

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -995,7 +995,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
      */
     public function stripQuotes($expression)
     {
-        foreach (['\'', '""'] as $quote) {
+        foreach (["'", '"'] as $quote) {
             if (Str::startsWith($expression, $quote)) {
                 $expression = substr($expression, 1, - 1);
             }

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -997,7 +997,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
     {
         foreach (["'", '"'] as $quote) {
             if (Str::startsWith($expression, $quote)) {
-                $expression = substr($expression, 1, - 1);
+                $expression = substr($expression, 1, -1);
             }
         }
 

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -997,7 +997,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
     public function stripQuotes($expression)
     {
         if (Str::startsWith($expression, ["'", '"'])) {
-            $expression = substr($expression, 1, - 1);
+            $expression = substr($expression, 1, -1);
         }
 
         return $expression;

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -5,6 +5,7 @@ namespace Illuminate\View\Compilers;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\View\Factory as ViewFactory;
+use Illuminate\View\ViewFinderInterface;
 
 class BladeCompiler extends Compiler implements CompilerInterface
 {
@@ -995,10 +996,8 @@ class BladeCompiler extends Compiler implements CompilerInterface
      */
     public function stripQuotes($expression)
     {
-        foreach (["'", '"'] as $quote) {
-            if (Str::startsWith($expression, $quote)) {
-                $expression = substr($expression, 1, -1);
-            }
+        if (Str::startsWith($expression, ["'", '"'])) {
+            $expression = substr($expression, 1, - 1);
         }
 
         return $expression;
@@ -1163,13 +1162,15 @@ class BladeCompiler extends Compiler implements CompilerInterface
      */
     private function viewBase()
     {
+        $namespaceDelimiter = ViewFinderInterface::HINT_PATH_DELIMITER;
+
         $parts = explode('.', $this->view);
 
         array_pop($parts);
 
-        if (Str::contains($this->view, '::')) {
+        if (Str::contains($this->view, $namespaceDelimiter)) {
             return empty($parts)
-                   ? strtok($this->view, '::').'::' : implode('.', $parts).'.';
+                   ? strtok($this->view, $namespaceDelimiter).$namespaceDelimiter : implode('.', $parts).'.';
         }
 
         return count($parts) > 1 ? implode('.', $parts).'.' : head($parts);
@@ -1183,8 +1184,10 @@ class BladeCompiler extends Compiler implements CompilerInterface
      */
     public function getViewNameFromExpression($expression)
     {
-        if ($this->view && Str::startsWith($stripped = $this->stripQuotes($expression), '>')) {
-            return "'".$this->viewBase().ltrim($stripped, '>')."'";
+        $relativePathDelimiter = ViewFinderInterface::RELATIVE_PATH_DELIMITER;
+
+        if ($this->view && Str::startsWith($stripped = $this->stripQuotes($expression), $relativePathDelimiter)) {
+            return "'".$this->viewBase().ltrim($stripped, $relativePathDelimiter)."'";
         }
 
         return $expression;

--- a/src/Illuminate/View/Compilers/CompilerInterface.php
+++ b/src/Illuminate/View/Compilers/CompilerInterface.php
@@ -24,7 +24,8 @@ interface CompilerInterface
      * Compile the view at the given path.
      *
      * @param  string  $path
+     * @param  string  $view
      * @return void
      */
-    public function compile($path);
+    public function compile($path, $view = null);
 }

--- a/src/Illuminate/View/Engines/CompilerEngine.php
+++ b/src/Illuminate/View/Engines/CompilerEngine.php
@@ -38,9 +38,10 @@ class CompilerEngine extends PhpEngine
      *
      * @param  string  $path
      * @param  array   $data
+     * @param  string  $view
      * @return string
      */
-    public function get($path, array $data = [])
+    public function get($path, array $data = [], $view = null)
     {
         $this->lastCompiled[] = $path;
 
@@ -48,7 +49,7 @@ class CompilerEngine extends PhpEngine
         // it was last compiled, we will re-compile the views so we can evaluate a
         // fresh copy of the view. We'll pass the compiler the path of the view.
         if ($this->compiler->isExpired($path)) {
-            $this->compiler->compile($path);
+            $this->compiler->compile($path, $view);
         }
 
         $compiled = $this->compiler->getCompiledPath($path);

--- a/src/Illuminate/View/Engines/EngineInterface.php
+++ b/src/Illuminate/View/Engines/EngineInterface.php
@@ -9,7 +9,8 @@ interface EngineInterface
      *
      * @param  string  $path
      * @param  array   $data
+     * @param  string  $view
      * @return string
      */
-    public function get($path, array $data = []);
+    public function get($path, array $data = [], $view = null);
 }

--- a/src/Illuminate/View/Engines/PhpEngine.php
+++ b/src/Illuminate/View/Engines/PhpEngine.php
@@ -13,9 +13,10 @@ class PhpEngine implements EngineInterface
      *
      * @param  string  $path
      * @param  array   $data
+     * @param  string  $view
      * @return string
      */
-    public function get($path, array $data = [])
+    public function get($path, array $data = [], $view = null)
     {
         return $this->evaluatePath($path, $data);
     }

--- a/src/Illuminate/View/View.php
+++ b/src/Illuminate/View/View.php
@@ -146,7 +146,7 @@ class View implements ArrayAccess, ViewContract
      */
     protected function getContents()
     {
-        return $this->engine->get($this->path, $this->gatherData());
+        return $this->engine->get($this->path, $this->gatherData(), $this->view);
     }
 
     /**

--- a/src/Illuminate/View/ViewFinderInterface.php
+++ b/src/Illuminate/View/ViewFinderInterface.php
@@ -12,6 +12,13 @@ interface ViewFinderInterface
     const HINT_PATH_DELIMITER = '::';
 
     /**
+     * Relative path delimiter value.
+     *
+     * @var string
+     */
+    const RELATIVE_PATH_DELIMITER = ':';
+
+    /**
      * Get the fully qualified location of the view.
      *
      * @param  string  $view

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -710,7 +710,10 @@ empty
         $this->assertEquals("'bar'", $compiler->getViewNameFromExpression("'>bar'"));
 
         $compiler->setView('hadi.badi.zabadi');
-        $this->assertEquals("'hadi.badi.nadi'", $compiler->getViewNameFromExpression(">nadi"));
+        $this->assertEquals("'hadi.badi.nadi'", $compiler->getViewNameFromExpression("'>nadi'"));
+
+        $compiler->setView('hadi.badi.zabadi');
+        $this->assertEquals("'hadi.badi.nadi'", $compiler->getViewNameFromExpression('">nadi"'));
 
         $compiler->setView('foo.bar');
         $this->assertEquals("'foo.bar.baz'", $compiler->getViewNameFromExpression("'foo.bar.baz'"));

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\View\ViewFinderInterface;
 use Mockery as m;
 use Illuminate\View\Compilers\BladeCompiler;
 
@@ -700,20 +701,22 @@ empty
     {
         $compiler = new BladeCompiler($this->getFiles(), __DIR__);
 
+        $delimiter = ViewFinderInterface::RELATIVE_PATH_DELIMITER;
+
         $compiler->setView(null);
         $this->assertEquals("'bar'", $compiler->getViewNameFromExpression("'bar'"));
 
         $compiler->setView(null);
-        $this->assertEquals("'>bar'", $compiler->getViewNameFromExpression("'>bar'"));
+        $this->assertEquals("'{$delimiter}bar'", $compiler->getViewNameFromExpression("'{$delimiter}bar'"));
 
         $compiler->setView('foo');
-        $this->assertEquals("'bar'", $compiler->getViewNameFromExpression("'>bar'"));
+        $this->assertEquals("'bar'", $compiler->getViewNameFromExpression("'{$delimiter}bar'"));
 
         $compiler->setView('hadi.badi.zabadi');
-        $this->assertEquals("'hadi.badi.nadi'", $compiler->getViewNameFromExpression("'>nadi'"));
+        $this->assertEquals("'hadi.badi.nadi'", $compiler->getViewNameFromExpression("'{$delimiter}nadi'"));
 
         $compiler->setView('hadi.badi.zabadi');
-        $this->assertEquals("'hadi.badi.nadi'", $compiler->getViewNameFromExpression('">nadi"'));
+        $this->assertEquals("'hadi.badi.nadi'", $compiler->getViewNameFromExpression('"'.$delimiter.'nadi"'));
 
         $compiler->setView('foo.bar');
         $this->assertEquals("'foo.bar.baz'", $compiler->getViewNameFromExpression("'foo.bar.baz'"));
@@ -722,10 +725,10 @@ empty
         $this->assertEquals('foo(bar)', $compiler->getViewNameFromExpression('foo(bar)'));
 
         $compiler->setView('namespace::foo');
-        $this->assertEquals("'namespace::baz'", $compiler->getViewNameFromExpression("'>baz'"));
+        $this->assertEquals("'namespace::baz'", $compiler->getViewNameFromExpression("'{$delimiter}baz'"));
 
         $compiler->setView('namespace::foo.bar');
-        $this->assertEquals("'namespace::foo.baz'", $compiler->getViewNameFromExpression("'>baz'"));
+        $this->assertEquals("'namespace::foo.baz'", $compiler->getViewNameFromExpression("'{$delimiter}baz'"));
     }
 
     public function testShowEachAreCompiled()

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -719,7 +719,7 @@ empty
         $this->assertEquals("'foo.bar.baz'", $compiler->getViewNameFromExpression("'foo.bar.baz'"));
 
         $compiler->setView('foo.baz');
-        $this->assertEquals("foo(bar)", $compiler->getViewNameFromExpression("foo(bar)"));
+        $this->assertEquals('foo(bar)', $compiler->getViewNameFromExpression('foo(bar)'));
 
         $compiler->setView('namespace::foo');
         $this->assertEquals("'namespace::baz'", $compiler->getViewNameFromExpression("'>baz'"));

--- a/tests/View/ViewCompilerEngineTest.php
+++ b/tests/View/ViewCompilerEngineTest.php
@@ -15,7 +15,7 @@ class ViewCompilerEngineTest extends PHPUnit_Framework_TestCase
         $engine = $this->getEngine();
         $engine->getCompiler()->shouldReceive('getCompiledPath')->with(__DIR__.'/fixtures/foo.php')->andReturn(__DIR__.'/fixtures/basic.php');
         $engine->getCompiler()->shouldReceive('isExpired')->once()->with(__DIR__.'/fixtures/foo.php')->andReturn(true);
-        $engine->getCompiler()->shouldReceive('compile')->once()->with(__DIR__.'/fixtures/foo.php');
+        $engine->getCompiler()->shouldReceive('compile')->once()->with(__DIR__.'/fixtures/foo.php', null);
         $results = $engine->get(__DIR__.'/fixtures/foo.php');
 
         $this->assertEquals('Hello World

--- a/tests/View/ViewTest.php
+++ b/tests/View/ViewTest.php
@@ -28,7 +28,7 @@ class ViewTest extends PHPUnit_Framework_TestCase
         $view->getFactory()->shouldReceive('incrementRender')->once()->ordered();
         $view->getFactory()->shouldReceive('callComposer')->once()->ordered()->with($view);
         $view->getFactory()->shouldReceive('getShared')->once()->andReturn(['shared' => 'foo']);
-        $view->getEngine()->shouldReceive('get')->once()->with('path', ['foo' => 'bar', 'shared' => 'foo'])->andReturn('contents');
+        $view->getEngine()->shouldReceive('get')->once()->with('path', ['foo' => 'bar', 'shared' => 'foo'], 'view')->andReturn('contents');
         $view->getFactory()->shouldReceive('decrementRender')->once()->ordered();
         $view->getFactory()->shouldReceive('flushSectionsIfDoneRendering')->once();
 
@@ -84,7 +84,7 @@ class ViewTest extends PHPUnit_Framework_TestCase
         $view->getFactory()->shouldReceive('incrementRender')->twice();
         $view->getFactory()->shouldReceive('callComposer')->twice()->with($view);
         $view->getFactory()->shouldReceive('getShared')->twice()->andReturn(['shared' => 'foo']);
-        $view->getEngine()->shouldReceive('get')->twice()->with('path', ['foo' => 'bar', 'shared' => 'foo'])->andReturn('contents');
+        $view->getEngine()->shouldReceive('get')->twice()->with('path', ['foo' => 'bar', 'shared' => 'foo'], 'view')->andReturn('contents');
         $view->getFactory()->shouldReceive('decrementRender')->twice();
         $view->getFactory()->shouldReceive('flushSectionsIfDoneRendering')->twice();
 


### PR DESCRIPTION
In reference to https://github.com/laravel/internals/issues/183

This PR allows the following:

```
// In view blog/posts/post.blade.php

@include('>sidebar')
```

This is equivalent to:

```
@include('blog.posts.sidebar')
```

**Edit:**
The delimiter was changed to `:`, a class constant is now used to set the delimiter for easy change.