### PR TITLE
[5.3] Fix Translator::sortReplacements()

### DIFF
--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -197,7 +197,7 @@ class Translator extends NamespacedItemResolver implements TranslatorInterface
     {
         return (new Collection($replace))->sortBy(function ($value, $key) {
             return mb_strlen($key) * -1;
-        });
+        })->all();
     }
 
     /**


### PR DESCRIPTION
Fix `\Illuminate\Translation\Translator::sortReplacements` as an array is expected.