### PR TITLE
[5.3] Dry up \Illuminate\Translation\Translator::load

### DIFF
--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -261,16 +261,12 @@ class Translator extends NamespacedItemResolver implements TranslatorInterface
      */
     public function load($namespace, $group, $locale)
     {
-        if ($this->isLoaded($namespace, $group, $locale)) {
-            return;
-        }
-
         // The loader is responsible for returning the array of language lines for the
         // given namespace, group, and locale. We'll set the lines in this array of
         // lines that have already been loaded so that we can easily access them.
-        $lines = $this->loader->load($locale, $group, $namespace);
-
-        $this->loaded[$namespace][$group][$locale] = $lines;
+        Arr::add($this->loaded, "$namespace.$group.$locale",
+            $this->loader->load($locale, $group, $namespace)
+        );
     }
 
     /**


### PR DESCRIPTION
Dry up `\Illuminate\Translation\Translator::load`

---

`\Illuminate\Translation\Translator::isLoaded` could then probably be marked as deprecated for `5.4`.