### PR TITLE
[5.3] Micro optimizations in query builder

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -296,7 +296,7 @@ class Connection implements ConnectionInterface
     {
         $records = $this->select($query, $bindings);
 
-        return count($records) > 0 ? reset($records) : null;
+        return ! empty($records) ? reset($records) : null;
     }
 
     /**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -768,7 +768,7 @@ class Builder
      */
     public function addNestedWhereQuery($query, $boolean = 'and')
     {
-        if (count($query->wheres)) {
+        if (! empty($query->wheres)) {
             $type = 'Nested';
 
             $this->wheres[] = compact('type', 'query', 'boolean');
@@ -1603,7 +1603,7 @@ class Builder
     {
         $result = (array) $this->first([$column]);
 
-        return count($result) > 0 ? reset($result) : null;
+        return ! empty($result) ? reset($result) : null;
     }
 
     /**

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -164,11 +164,11 @@ class Grammar extends BaseGrammar
      */
     protected function compileWheres(Builder $query)
     {
-        $sql = [];
-
-        if (is_null($query->wheres)) {
+        if (empty($query->wheres)) {
             return '';
         }
+
+        $sql = [];
 
         // Each type of where clauses has its own compiler function which is responsible
         // for actually creating the where clauses SQL. This helps keep the code nice
@@ -179,18 +179,15 @@ class Grammar extends BaseGrammar
             $sql[] = $where['boolean'].' '.$this->$method($query, $where);
         }
 
-        // If we actually have some where clauses, we will strip off the first boolean
+        // As we actually have some where clauses, we will strip off the first boolean
         // operator, which is added by the query builders for convenience so we can
         // avoid checking for the first clauses in each of the compilers methods.
-        if (count($sql) > 0) {
-            $sql = implode(' ', $sql);
 
-            $conjunction = $query instanceof JoinClause ? 'on' : 'where';
+        $sql = implode(' ', $sql);
 
-            return $conjunction.' '.$this->removeLeadingBoolean($sql);
-        }
+        $conjunction = $query instanceof JoinClause ? 'on' : 'where';
 
-        return '';
+        return $conjunction.' '.$this->removeLeadingBoolean($sql);
     }
 
     /**


### PR DESCRIPTION
`empty()` is a better pick than `count()`.

Refs #16188 (merged to master, will conflict)