### PR TITLE
[5.4] SQLServerGrammar: added collation support

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -12,7 +12,7 @@ class SqlServerGrammar extends Grammar
      *
      * @var array
      */
-    protected $modifiers = ['Increment', 'Nullable', 'Default'];
+    protected $modifiers = ['Increment', 'Collate', 'Nullable', 'Default'];
 
     /**
      * The columns available as serials.
@@ -596,6 +596,20 @@ class SqlServerGrammar extends Grammar
         return $column->nullable ? ' null' : ' not null';
     }
 
+     /**
+     * Get the SQL for a collation column modifier.
+     *
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @param  \Illuminate\Support\Fluent  $column
+     * @return string|null
+     */
+    protected function modifyCollate(Blueprint $blueprint, Fluent $column)
+    {
+        if (! is_null($column->collation)) {
+            return ' collate '.$column->collation;
+        }
+    }
+    
     /**
      * Get the SQL for a default column modifier.
      *


### PR DESCRIPTION
You can define collation in table creation:

```php
Schema::create('table_name', function (Blueprint $table) {
    $table->string('field_name')->collation('Latin1_General_CS_AS');
});
```

This is same implementation as MySQL grammar.

If any maintainer like this feature, I could write some test for it.