### PR TITLE
[5.3] Properly handle filling JSON attributes on Models

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2877,7 +2877,30 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
             $value = $this->asJson($value);
         }
 
+        if (Str::contains($key, '->')) {
+            return $this->jsonSetAttribute($key, $value);
+        }
+
         $this->attributes[$key] = $value;
+
+        return $this;
+    }
+
+    /**
+     * Set a given JSON attribute on the model.
+     *
+     * @param  string  $key
+     * @param  mixed  $value
+     * @return $this
+     */
+    public function jsonSetAttribute($key, $value){
+        list($key, $path) = explode('->', $key, 2);
+
+        $arrayValue = isset($this->attributes[$key]) ? $this->fromJson($this->attributes[$key]) : [];
+
+        Arr::set($arrayValue, str_replace('->', '.', $path), $value);
+
+        $this->attributes[$key] = $this->asJson($arrayValue);
 
         return $this;
     }

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2893,7 +2893,8 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      * @param  mixed  $value
      * @return $this
      */
-    public function jsonSetAttribute($key, $value){
+    public function jsonSetAttribute($key, $value)
+    {
         list($key, $path) = explode('->', $key, 2);
 
         $arrayValue = isset($this->attributes[$key]) ? $this->fromJson($this->attributes[$key]) : [];

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -813,7 +813,8 @@ class DatabaseEloquentIntegrationTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(1, EloquentTestPost::count());
     }
 
-    public function testSavingJSONFields(){
+    public function testSavingJSONFields()
+    {
         $model = EloquentTestWithJSON::create(['json' => ['x' => 0]]);
         $this->assertEquals(['x' => 0], $model->json);
 
@@ -1178,6 +1179,6 @@ class EloquentTestWithJSON extends Eloquent
     protected $table = 'with_json';
     public $timestamps = false;
     protected $casts = [
-        'json' => 'array'
+        'json' => 'array',
     ];
 }

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -41,6 +41,11 @@ class DatabaseEloquentIntegrationTest extends PHPUnit_Framework_TestCase
             $table->timestamps();
         });
 
+        $this->schema('default')->create('with_json', function ($table) {
+            $table->increments('id');
+            $table->text('json')->default(json_encode([]));
+        });
+
         $this->schema('second_connection')->create('test_items', function ($table) {
             $table->increments('id');
             $table->timestamps();
@@ -808,6 +813,21 @@ class DatabaseEloquentIntegrationTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(1, EloquentTestPost::count());
     }
 
+    public function testSavingJSONFields(){
+        $model = EloquentTestWithJSON::create(['json' => ['x' => 0]]);
+        $this->assertEquals(['x' => 0], $model->json);
+
+        $model->fillable(['json->y', 'json->a->b']);
+
+        $model->update(['json->y' => '1']);
+        $this->assertArrayNotHasKey('json->y', $model->toArray());
+        $this->assertEquals(['x' => 0, 'y' => 1], $model->json);
+
+        $model->update(['json->a->b' => '3']);
+        $this->assertArrayNotHasKey('json->a->b', $model->toArray());
+        $this->assertEquals(['x' => 0, 'y' => 1, 'a' => ['b' => 3]], $model->json);
+    }
+
     /**
      * @expectedException Exception
      */
@@ -1150,4 +1170,14 @@ class EloquentTestItem extends Eloquent
     protected $guarded = [];
     protected $table = 'test_items';
     protected $connection = 'second_connection';
+}
+
+class EloquentTestWithJSON extends Eloquent
+{
+    protected $guarded = [];
+    protected $table = 'with_json';
+    public $timestamps = false;
+    protected $casts = [
+        'json' => 'array'
+    ];
 }

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -794,6 +794,26 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(21, $model->id);
     }
 
+    public function testFillingJSONAttributes()
+    {
+        $model = new EloquentModelStub;
+        $model->fillable(['meta->name', 'meta->price', 'meta->size->width']);
+        $model->fill(['meta->name' => 'foo', 'meta->price' => 'bar', 'meta->size->width' => 'baz']);
+        $this->assertEquals(
+            ['meta' => json_encode(['name' => 'foo', 'price' => 'bar', 'size' => ['width' => 'baz']])],
+            $model->toArray()
+        );
+
+
+        $model = new EloquentModelStub(['meta' => json_encode(['name' => 'Taylor'])]);
+        $model->fillable(['meta->name', 'meta->price', 'meta->size->width']);
+        $model->fill(['meta->name' => 'foo', 'meta->price' => 'bar', 'meta->size->width' => 'baz']);
+        $this->assertEquals(
+            ['meta' => json_encode(['name' => 'foo', 'price' => 'bar', 'size' => ['width' => 'baz']])],
+            $model->toArray()
+        );
+    }
+
     public function testUnguardAllowsAnythingToBeSet()
     {
         $model = new EloquentModelStub;


### PR DESCRIPTION
In reference to https://github.com/laravel/framework/issues/16213

When we do:

```php
$user = User::find(1)->update( ['meta->area' => 'new value'] );
```

The user object after the update will look like

```php
    {
        meta : {area : 'old value'},
        meta->area : "new value"
    }
```

This PR fills the value of `meta` correctly and unsets the `meta->area` attribute, this will present correct output for the model after saving.