### PR TITLE
[5.3] Before/After validation hooks for FormRequests

### DIFF
--- a/src/Illuminate/Validation/ValidatesWhenResolvedTrait.php
+++ b/src/Illuminate/Validation/ValidatesWhenResolvedTrait.php
@@ -14,6 +14,7 @@ trait ValidatesWhenResolvedTrait
      */
     public function validate()
     {
+        $this->beforeValidation();
         $instance = $this->getValidatorInstance();
 
         if (! $this->passesAuthorization()) {
@@ -21,6 +22,7 @@ trait ValidatesWhenResolvedTrait
         } elseif (! $instance->passes()) {
             $this->failedValidation($instance);
         }
+        $this->afterValidation();
     }
 
     /**
@@ -70,5 +72,25 @@ trait ValidatesWhenResolvedTrait
     protected function failedAuthorization()
     {
         throw new UnauthorizedException;
+    }
+
+    /**
+     * Provide a hook for taking action before validation
+     *
+     * @return void
+     */
+    protected function beforeValidation()
+    {
+        // no default action
+    }
+
+    /**
+     * Provide a hook for taking action after validation
+     *
+     * @return void
+     */
+    protected function afterValidation()
+    {
+        // no default action
     }
 }

--- a/tests/Foundation/FoundationFormRequestTest.php
+++ b/tests/Foundation/FoundationFormRequestTest.php
@@ -76,6 +76,35 @@ class FoundationFormRequestTest extends PHPUnit_Framework_TestCase
 
         $request->response(['errors']);
     }
+
+    public function testValidateFunctionRunsBeforeValidationFunction()
+    {
+        $request = FoundationTestFormRequestHooks::create('/', 'GET', ['name' => 'abigail']);
+        $request->setContainer($container = new Container);
+        $factory = m::mock('Illuminate\Validation\Factory');
+        $factory->shouldReceive('make')->once()->with(['name' => 'Taylor'], ['name' => 'required'], [], [])->andReturn(
+            $validator = m::mock('Illuminate\Validation\Validator')
+        );
+        $container->instance('Illuminate\Contracts\Validation\Factory', $factory);
+        $validator->shouldReceive('passes')->once()->andReturn(true);
+
+        $request->validate($factory);
+    }
+
+    public function testValidateFunctionRunsAfterValidationFunctionIfValidationPasses()
+    {
+        $request = FoundationTestFormRequestStub::create('/', 'GET', ['name' => 'abigail']);
+        $request->setContainer($container = new Container);
+        $factory = m::mock('Illuminate\Validation\Factory');
+        $factory->shouldReceive('make')->once()->with(['name' => 'abigail'], ['name' => 'required'], [], [])->andReturn(
+            $validator = m::mock('Illuminate\Validation\Validator')
+        );
+        $container->instance('Illuminate\Contracts\Validation\Factory', $factory);
+        $validator->shouldReceive('passes')->once()->andReturn(true);
+
+        $request->validate($factory);
+        $this->assertSame('Jeffrey', $request->get('name'));
+    }
 }
 
 class FoundationTestFormRequestStub extends Illuminate\Foundation\Http\FormRequest
@@ -89,6 +118,11 @@ class FoundationTestFormRequestStub extends Illuminate\Foundation\Http\FormReque
     {
         return true;
     }
+
+    public function afterValidation()
+    {
+        $this->replace(['name' => 'Jeffrey']);
+    }
 }
 
 class FoundationTestFormRequestForbiddenStub extends Illuminate\Foundation\Http\FormRequest
@@ -101,5 +135,22 @@ class FoundationTestFormRequestForbiddenStub extends Illuminate\Foundation\Http\
     public function authorize()
     {
         return false;
+    }
+}
+class FoundationTestFormRequestHooks extends Illuminate\Foundation\Http\FormRequest
+{
+    public function rules()
+    {
+        return ['name' => 'required'];
+    }
+
+    public function authorize()
+    {
+        return true;
+    }
+
+    public function beforeValidation()
+    {
+        $this->replace(['name' => 'Taylor']);
     }
 }


### PR DESCRIPTION
I often find that I want to munge data before I run validation and generally override the `validate()` function in `ValidatesWhenResolvedTrait`. I thought that might be useful to others, so figured I'd PR it.

(I admit, I've never had a use for `afterValidation()`, but I'm unable to add a before() function without an after().)

If the PR is accepted, I'll make a PR for the docs.