### PR TITLE
[5.3] Allow Gate to explicitly check abilities for guests

### DIFF
--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -90,19 +90,22 @@ class Gate implements GateContract
      *
      * @param  string  $ability
      * @param  callable|string  $callback
+     * @param  bool  $allowGuest
      * @return $this
      *
      * @throws \InvalidArgumentException
      */
-    public function define($ability, $callback)
+    public function define($ability, $callback, $allowGuest = false)
     {
         if (is_callable($callback)) {
-            $this->abilities[$ability] = $callback;
+            // Already a callable
         } elseif (is_string($callback) && Str::contains($callback, '@')) {
-            $this->abilities[$ability] = $this->buildAbilityCallback($callback);
+            $callback = $this->buildAbilityCallback($callback);
         } else {
             throw new InvalidArgumentException("Callback must be a callable or a 'Class@method' string.");
         }
+
+        $this->abilities[$ability] = compact('callback', 'allowGuest');
 
         return $this;
     }
@@ -140,11 +143,12 @@ class Gate implements GateContract
      * Register a callback to run before all Gate checks.
      *
      * @param  callable  $callback
+     * @param  bool  $allowGuest
      * @return $this
      */
-    public function before(callable $callback)
+    public function before(callable $callback, $allowGuest = false)
     {
-        $this->beforeCallbacks[] = $callback;
+        $this->beforeCallbacks[] = compact('callback', 'allowGuest');
 
         return $this;
     }
@@ -153,11 +157,12 @@ class Gate implements GateContract
      * Register a callback to run after all Gate checks.
      *
      * @param  callable  $callback
+     * @param  bool  $allowGuest
      * @return $this
      */
-    public function after(callable $callback)
+    public function after(callable $callback, $allowGuest = false)
     {
-        $this->afterCallbacks[] = $callback;
+        $this->afterCallbacks[] = compact('callback', 'allowGuest');
 
         return $this;
     }
@@ -233,9 +238,7 @@ class Gate implements GateContract
      */
     protected function raw($ability, $arguments = [])
     {
-        if (! $user = $this->resolveUser()) {
-            return false;
-        }
+        $user = $this->resolveUser();
 
         $arguments = is_array($arguments) ? $arguments : [$arguments];
 
@@ -278,8 +281,10 @@ class Gate implements GateContract
         $arguments = array_merge([$user, $ability], [$arguments]);
 
         foreach ($this->beforeCallbacks as $before) {
-            if (! is_null($result = $before(...$arguments))) {
-                return $result;
+            if ($user || $before['allowGuest']) {
+                if (! is_null($result = $before['callback'](...$arguments))) {
+                    return $result;
+                }
             }
         }
     }
@@ -298,7 +303,9 @@ class Gate implements GateContract
         $arguments = array_merge([$user, $ability, $result], [$arguments]);
 
         foreach ($this->afterCallbacks as $after) {
-            $after(...$arguments);
+            if ($user || $after['allowGuest']) {
+                $after['callback'](...$arguments);
+            }
         }
     }
 
@@ -314,8 +321,8 @@ class Gate implements GateContract
     {
         if ($this->firstArgumentCorrespondsToPolicy($arguments)) {
             return $this->resolvePolicyCallback($user, $ability, $arguments);
-        } elseif (isset($this->abilities[$ability])) {
-            return $this->abilities[$ability];
+        } elseif (isset($this->abilities[$ability]) && ($user || $this->abilities[$ability]['allowGuest'])) {
+            return $this->abilities[$ability]['callback'];
         } else {
             return function () {
                 return false;
@@ -355,10 +362,12 @@ class Gate implements GateContract
         return function () use ($user, $ability, $arguments) {
             $instance = $this->getPolicyFor($arguments[0]);
 
+            $allowGuest = isset($instance->allowGuest) ? (array) $instance->allowGuest : [];
+
             // If we receive a non-null result from the before method, we will return it
             // as the final result. This will allow developers to override the checks
             // in the policy to return a result for all rules defined in the class.
-            if (method_exists($instance, 'before')) {
+            if (method_exists($instance, 'before') && ($user || in_array('before', $allowGuest))) {
                 if (! is_null($result = $instance->before($user, $ability, ...$arguments))) {
                     return $result;
                 }
@@ -379,7 +388,12 @@ class Gate implements GateContract
                 return false;
             }
 
-            return $instance->{$ability}($user, ...$arguments);
+            // If we have a user or the ability is allowed to be checked for guests
+            if ($user || in_array($ability, $allowGuest)) {
+                return $instance->{$ability}($user, ...$arguments);
+            } else {
+                return false;
+            }
         };
     }
 

--- a/tests/Auth/AuthAccessGateTest.php
+++ b/tests/Auth/AuthAccessGateTest.php
@@ -30,6 +30,30 @@ class GateTest extends PHPUnit_Framework_TestCase
         $this->assertFalse($gate->check('bar'));
     }
 
+    public function test_basic_closures_denies_guests_if_not_specified()
+    {
+        $gate = $this->getGateForGuest();
+
+        $gate->define('foo', function ($user) {
+            return true;
+        });
+
+        $this->assertFalse($gate->check('foo'));
+    }
+    
+    public function test_basic_closures_allows_guests_if_specified()
+    {
+        $gate = $this->getGateForGuest();
+
+        $gate->define('foo', function ($user) {
+            $this->assertNull($user);
+
+            return true;
+        }, true);
+
+        $this->assertTrue($gate->check('foo'));
+    }
+
     public function test_before_callbacks_can_override_result_if_necessary()
     {
         $gate = $this->getBasicGate();
@@ -59,6 +83,38 @@ class GateTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($gate->check('foo'));
     }
 
+    public function test_before_callbacks_are_not_called_for_guests_if_not_specified()
+    {
+        $gate = $this->getGateForGuest();
+
+        $gate->define('foo', function ($user) {
+            return true;
+        }, true);
+
+        $gate->before(function ($user, $ability) {
+            $this->fail();
+        });
+
+        $this->assertTrue($gate->check('foo'));
+    }
+
+    public function test_before_callbacks_are_called_for_guests_if_specified()
+    {
+        $gate = $this->getGateForGuest();
+
+        $gate->define('foo', function ($user) {
+            return true;
+        }, true);
+
+        $gate->before(function ($user, $ability) {
+            $this->assertNull($user);
+
+            return false;
+        }, true);
+
+        $this->assertFalse($gate->check('foo'));
+    }
+
     public function test_after_callbacks_are_called_with_result()
     {
         $gate = $this->getBasicGate();
@@ -81,6 +137,40 @@ class GateTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($gate->check('foo'));
         $this->assertFalse($gate->check('bar'));
         $this->assertFalse($gate->check('missing'));
+    }
+
+    public function test_after_callbacks_are_not_called_for_guests_if_not_specified()
+    {
+        $gate = $this->getGateForGuest();
+
+        $gate->define('foo', function ($user) {
+            return true;
+        }, true);
+
+        $gate->after(function ($user, $ability) {
+            $this->fail();
+        });
+
+        $this->assertTrue($gate->check('foo'));
+    }
+
+    public function test_after_callbacks_are_called_for_guests_if_specified()
+    {
+        $gate = $this->getGateForGuest();
+
+        $gate->define('foo', function ($user) {
+            return true;
+        }, true);
+
+        $afterCalled = false;
+
+        $gate->after(function ($user, $ability) use (&$afterCalled) {
+            $this->assertNull($user);
+            $afterCalled = true;
+        }, true);
+
+        $this->assertTrue($gate->check('foo'));
+        $this->assertTrue($afterCalled, 'after method should be called for guests because we marked it for guests');
     }
 
     public function test_current_user_that_is_on_gate_always_injected_into_closure_callbacks()
@@ -209,6 +299,42 @@ class GateTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($gate->forUser((object) ['id' => 2])->check('foo'));
     }
 
+    public function test_policy_denies_guests_if_not_specified()
+    {
+        $gate = $this->getGateForGuest();
+
+        $gate->policy(AccessGateTestDummy::class, AccessGateTestPolicy::class);
+
+        $this->assertFalse($gate->check('update', new AccessGateTestDummy));
+    }
+
+    public function test_policy_allows_guests_if_specified()
+    {
+        $gate = $this->getGateForGuest();
+
+        $gate->policy(AccessGateTestDummy::class, AccessGateTestPolicyWithAllowGuest::class);
+
+        $this->assertTrue($gate->check('view', new AccessGateTestDummy));
+    }
+
+    public function test_policy_before_is_not_called_for_guests_if_not_specified()
+    {
+        $gate = $this->getGateForGuest();
+
+        $gate->policy(AccessGateTestDummy::class, AccessGateTestPolicyWithBefore::class);
+
+        $this->assertFalse($gate->check('update', new AccessGateTestDummy));
+    }
+
+    public function test_policy_before_is_called_for_guests_if_specified()
+    {
+        $gate = $this->getGateForGuest();
+
+        $gate->policy(AccessGateTestDummy::class, AccessGateTestPolicyWithAllowGuest::class);
+
+        $this->assertTrue($gate->check('update', new AccessGateTestDummy));
+    }
+
     /**
      * @expectedException \Illuminate\Auth\Access\AuthorizationException
      */
@@ -251,6 +377,13 @@ class GateTest extends PHPUnit_Framework_TestCase
     {
         return new Gate(new Container, function () use ($isAdmin) {
             return (object) ['id' => 1, 'isAdmin' => $isAdmin];
+        });
+    }
+
+    protected function getGateForGuest()
+    {
+        return new Gate(new Container, function () {
+            return null;
         });
     }
 }
@@ -301,6 +434,28 @@ class AccessGateTestPolicy
 class AccessGateTestPolicyWithBefore
 {
     public function before($user, $ability)
+    {
+        return true;
+    }
+
+    public function update($user, AccessGateTestDummy $dummy)
+    {
+        return false;
+    }
+}
+
+class AccessGateTestPolicyWithAllowGuest
+{
+    public $allowGuest = ['before', 'view'];
+
+    public function before($user, $ability)
+    {
+        if ($ability == 'update') {
+            return true;
+        }
+    }
+
+    public function view($user, AccessGateTestDummy $dummy)
     {
         return true;
     }

--- a/tests/Auth/AuthAccessGateTest.php
+++ b/tests/Auth/AuthAccessGateTest.php
@@ -40,7 +40,7 @@ class GateTest extends PHPUnit_Framework_TestCase
 
         $this->assertFalse($gate->check('foo'));
     }
-    
+
     public function test_basic_closures_allows_guests_if_specified()
     {
         $gate = $this->getGateForGuest();
@@ -383,7 +383,7 @@ class GateTest extends PHPUnit_Framework_TestCase
     protected function getGateForGuest()
     {
         return new Gate(new Container, function () {
-            return null;
+            // null (no user)
         });
     }
 }

--- a/tests/Auth/AuthAccessGateTest.php
+++ b/tests/Auth/AuthAccessGateTest.php
@@ -312,7 +312,7 @@ class GateTest extends PHPUnit_Framework_TestCase
     {
         $gate = $this->getGateForGuest();
 
-        $gate->policy(AccessGateTestDummy::class, AccessGateTestPolicyWithAllowGuest::class);
+        $gate->policy(AccessGateTestDummy::class, AccessGateTestPolicyWithIncludeGuest::class);
 
         $this->assertTrue($gate->check('view', new AccessGateTestDummy));
     }
@@ -330,7 +330,7 @@ class GateTest extends PHPUnit_Framework_TestCase
     {
         $gate = $this->getGateForGuest();
 
-        $gate->policy(AccessGateTestDummy::class, AccessGateTestPolicyWithAllowGuest::class);
+        $gate->policy(AccessGateTestDummy::class, AccessGateTestPolicyWithIncludeGuest::class);
 
         $this->assertTrue($gate->check('update', new AccessGateTestDummy));
     }
@@ -444,9 +444,9 @@ class AccessGateTestPolicyWithBefore
     }
 }
 
-class AccessGateTestPolicyWithAllowGuest
+class AccessGateTestPolicyWithIncludeGuest
 {
-    public $allowGuest = ['before', 'view'];
+    public $includeGuest = ['before', 'view'];
 
     public function before($user, $ability)
     {


### PR DESCRIPTION
See #10568

Currently, the Gate immediately denies abilities if there is no authenticated user. This PR makes it possible to allow abilities to be checked for guests (closure abilities or abilities in policies).

Say for example, We want to allow guests to comment on posts but we may change our mind in the future, So if we don't use an ability for commenting at all, Then in the future when we change our mind we have to update the views and/or controllers.
But now we can use an ability for commenting and we can mark it to be checked for guests, Then in the future when we change our mind we only have to change the ability's logic.

### Closure abilities

By default, when we define an ability as normal, If no user is logged-in, it will immediately deny the ability:

```PHP
$gate->define('update-article', function ($user, Article $article) {
    // If no user is logged-in, the guest will be denied before reaching here
    return $user->id === $article->user_id;
});
```

but if we want to mark the ability to be checked for guests, We can pass `true` to the third parameter (`includeGuest`) :

```PHP
$gate->define('show-article', function ($user, Article $article) {
    // If user is logged-in or not, this ability will be check because we told it so
    return $user || $article->visibility == 'all';
}, true);
```

**Note** The same applies for the `before` and `after` methods, If we want them to be called for guests we have to explicitly tell it so, Meaning that if we have an ability that is marked to be checked for guests, Then when this ability is called, It will be interrupted **only** by the `before` methods which are marked to be called with guests.

**Note** In case of guest, The `$user` parameter will be `null`.

### Policies

For abilities in policies, To mark any of them to be checked for guests, We can add an attribute named `$includeGuest` and include the names for the abilities that we want them to be checked for guests :

```PHP
// app/policies/ArticlePolicy.php

namespace App\Policies;

use App\Models\Article;

class ArticlePolicy
{
    /**
     * Array of abilities allowed to be checked for guests
     *
     * @var array
     */
    public $includeGuest = ['index', 'view'];

    /**
     * Ability to show index page
     *
     * @return bool
     */
    public function index()
    {
        return true;
    }

    /**
     * Ability to view specific article
     *
     * @param  User|Null  $user
     * @param  Article $article
     * @return bool
     */
    public function view($user, Article $article)
    {
        // View all articles for the users, but only articles with 'all' visibility level for guests
        return $user || $article->visibility == 'all';
    }

    /**
     * Ability to create new article
     *
     * @param  User  $user
     * @param  Article $article
     * @return bool
     */
    public function create($user)
    {
        return $user->isAdmin;
    }

    /**
     * Ability to edit specific article
     *
     * @param  User  $user
     * @param  Article $article
     * @return bool
     */
    public function edit($user, Article $article)
    {
        return $user->id === $article->user_id;
    }

    /**
     * Ability to delete specific article
     *
     * @param  User  $user
     * @param  Article $article
     * @return bool
     */
    public function delete($user, Article $article)
    {
        return $user->id === $article->user_id;
    }
}
```

**Note** Like closure abilities, If the `before` method is not included in the `$includeGuest` attribute, It will not be called with guests.

## The benefit of allowing abilities to be checked for guests

* This way we can always have abilities like `index` and `view` in our policies and making them default to allow all users and guests, And change them when we want, For example if we decide to restrict some page to be only accessible for users (or admins), Then we can remove the `index` item from the `includeGuest` attribute and add some logic in the ability.

* Also it will make it easy to give partial abilities for guests

* And leads for good practice when letting the `Gate` responsible for all the permissions, Even if one of them is currently allowed for all users and guests and could be removed.

* Also will allow (in the future) to use the abilities instead of some middlewares (like the `Auth` middleware), So we won't have to add the `Auth` middleware on the routes we want to allow only for users , This should be the responsibility of the `Gate` to determine.  