### PR TITLE
[5.3] Fixes for table prefix and schema in SQL Server blueprint

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -55,7 +55,7 @@ class SqlServerGrammar extends Grammar
     {
         $columns = implode(', ', $this->getColumns($blueprint));
 
-        return 'create table '.$this->wrapTable($blueprint)." ($columns)";
+        return 'create table '.$this->wrapTableWithOptionalSchema($blueprint)." ($columns)";
     }
 
     /**
@@ -137,7 +137,7 @@ class SqlServerGrammar extends Grammar
      */
     public function compileDrop(Blueprint $blueprint, Fluent $command)
     {
-        return 'drop table '.$this->wrapTable($blueprint);
+        return 'drop table '.$this->wrapTableWithOptionalSchema($blueprint);
     }
 
     /**
@@ -152,7 +152,24 @@ class SqlServerGrammar extends Grammar
         $table = $this->getTablePrefix().$blueprint->getTable();
         $where = 'TABLE_NAME = \''.str_replace("'", "''", $table).'\'';
 
-        return 'if exists (select * from INFORMATION_SCHEMA.TABLES where '.$where.') drop table '.$this->wrapTable($blueprint);
+        return 'if exists (select * from INFORMATION_SCHEMA.TABLES where '.$where.') drop table '.$this->wrapTableWithOptionalSchema($blueprint);
+    }
+
+    /**
+     * Wrap a table with optional schema in keyword identifiers.
+     *
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @return string
+     */
+    protected function wrapTableWithOptionalSchema(Blueprint $blueprint)
+    {
+        $segments = explode('.', $blueprint->getTable());
+
+        if (isset($segments[1])) {
+            return $this->wrap($segments[0]).'.'.$this->wrapTable($segments[1]);
+        }
+
+        return $this->wrapTable($segments[0]);
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -149,7 +149,10 @@ class SqlServerGrammar extends Grammar
      */
     public function compileDropIfExists(Blueprint $blueprint, Fluent $command)
     {
-        return 'if exists (select * from INFORMATION_SCHEMA.TABLES where TABLE_NAME = \''.$blueprint->getTable().'\') drop table ['.$blueprint->getTable().']';
+        $table = $this->getTablePrefix().$blueprint->getTable();
+        $where = 'TABLE_NAME = \''.str_replace("'", "''", $table).'\'';
+
+        return 'if exists (select * from INFORMATION_SCHEMA.TABLES where '.$where.') drop table '.$this->wrapTable($blueprint);
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -149,8 +149,16 @@ class SqlServerGrammar extends Grammar
      */
     public function compileDropIfExists(Blueprint $blueprint, Fluent $command)
     {
-        $table = $this->getTablePrefix().$blueprint->getTable();
-        $where = 'TABLE_NAME = \''.str_replace("'", "''", $table).'\'';
+        $segments = explode('.', $blueprint->getTable());
+
+        if (isset($segments[1])) {
+            $schema = $segments[0];
+            $table = $this->getTablePrefix().$segments[1];
+            $where = 'TABLE_SCHEMA = \''.str_replace("'", "''", $schema).'\' and TABLE_NAME = \''.str_replace("'", "''", $table).'\'';
+        } else {
+            $table = $this->getTablePrefix().$segments[0];
+            $where = 'TABLE_NAME = \''.str_replace("'", "''", $table).'\'';
+        }
 
         return 'if exists (select * from INFORMATION_SCHEMA.TABLES where '.$where.') drop table '.$this->wrapTableWithOptionalSchema($blueprint);
     }

--- a/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
@@ -28,6 +28,15 @@ class DatabaseSqlServerSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table "users" add "id" int identity primary key not null, "email" nvarchar(255) not null', $statements[0]);
+
+        $blueprint = new Blueprint('schema.users');
+        $blueprint->create();
+        $blueprint->increments('id');
+        $blueprint->string('email');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar()->setTablePrefix('prefix_'));
+
+        $this->assertEquals(1, count($statements));
+        $this->assertEquals('create table "schema"."prefix_users" ("id" int identity primary key not null, "email" nvarchar(255) not null)', $statements[0]);
     }
 
     public function testDropTable()
@@ -38,6 +47,30 @@ class DatabaseSqlServerSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('drop table "users"', $statements[0]);
+
+        $blueprint = new Blueprint('schema.users');
+        $blueprint->drop();
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar()->setTablePrefix('prefix_'));
+
+        $this->assertEquals(1, count($statements));
+        $this->assertEquals('drop table "schema"."prefix_users"', $statements[0]);
+    }
+
+    public function testDropTableIfExists()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->dropIfExists();
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertEquals(1, count($statements));
+        $this->assertEquals('if exists (select * from INFORMATION_SCHEMA.TABLES where TABLE_NAME = \'users\') drop table "users"', $statements[0]);
+
+        $blueprint = new Blueprint('schema.users');
+        $blueprint->dropIfExists();
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar()->setTablePrefix('prefix_'));
+
+        $this->assertEquals(1, count($statements));
+        $this->assertEquals('if exists (select * from INFORMATION_SCHEMA.TABLES where TABLE_SCHEMA = \'schema\' and TABLE_NAME = \'prefix_users\') drop table "schema"."prefix_users"', $statements[0]);
     }
 
     public function testDropColumn()


### PR DESCRIPTION
* Support table prefix in `dropIfExists()`: fixed the wrap, see #8397 and #13458. I'm also escaping the single quotes.
* Properly wrap if schema provided in table name: it was working "by luck", but broke if there was a table prefix. Example with `wrapTable('foo.bar')`:
  * without prefix: `"foo"."bar"`
  * current with prefix: `"prefix_prefix_foo"."bar"`
  * fixed with prefix: `"foo"."prefix_bar"`
* Support optional schema in `dropIfExists()` for SQL Server: fixes #15841.
* Add tests, especially for table prefix + schema specified. Note there was no `testDropTableIfExists()` test, contrarily to the other drivers.

I can't think of any BC break, there are only fixes here, so maybe this PR should target an earlier branch?