### PR TITLE
[5.3] Testing Mailables: handle mail recipients set from mailable

### DIFF
--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -506,6 +506,46 @@ class Mailable implements MailableContract
     }
 
     /**
+     * Get the sender of the message.
+     *
+     * @return array
+     */
+    public function getFrom()
+    {
+        return $this->from;
+    }
+
+    /**
+     * Get the "to" recipients of the message.
+     *
+     * @return array
+     */
+    public function getTo()
+    {
+        return $this->to;
+    }
+
+    /**
+     * Get the "bcc" recipients of the message.
+     *
+     * @return array
+     */
+    public function getBcc()
+    {
+        return $this->bcc;
+    }
+
+    /**
+     * Get the "cc" recipients of the message.
+     *
+     * @return array
+     */
+    public function getCc()
+    {
+        return $this->cc;
+    }
+
+    /**
      * Dynamically bind parameters to the message.
      *
      * @param  string  $method

--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -206,16 +206,18 @@ class MailFake implements Mailer
             $mailable->mailable = $view;
 
             if ($recipients = $view->getTo()) {
-                $this->mailables[] = $mailable->to($recipients);
+                $mailable->to($recipients);
             }
 
             if ($recipients = $view->getBcc()) {
-                $this->mailables[] = $mailable->bcc($recipients);
+                $mailable->bcc($recipients);
             }
 
             if ($recipients = $view->getCc()) {
-                $this->mailables[] = $mailable->cc($recipients);
+                $mailable->cc($recipients);
             }
+
+            $this->mailables[] = $mailable;
         }
     }
 

--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -228,4 +228,18 @@ class MailFake implements Mailer
     {
         //
     }
+
+    /**
+     * Queue a new e-mail message for sending.
+     *
+     * @param  string|array  $view
+     * @param  array  $data
+     * @param  \Closure|string  $callback
+     * @param  string|null  $queue
+     * @return mixed
+     */
+    public function queue($view, array $data = [], $callback = null, $queue = null)
+    {
+        $this->send($view);
+    }
 }

--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -4,6 +4,7 @@ namespace Illuminate\Support\Testing\Fakes;
 
 use Illuminate\Support\Collection;
 use Illuminate\Contracts\Mail\Mailer;
+use Illuminate\Contracts\Mail\Mailable;
 use PHPUnit_Framework_Assert as PHPUnit;
 
 class MailFake implements Mailer
@@ -197,7 +198,25 @@ class MailFake implements Mailer
      */
     public function send($view, array $data = [], $callback = null)
     {
-        //
+        if ($view instanceof Mailable) {
+            $view->build();
+
+            $mailable = new MailableFake;
+
+            $mailable->mailable = $view;
+
+            if ($recipients = $view->getTo()) {
+                $this->mailables[] = $mailable->to($recipients);
+            }
+
+            if ($recipients = $view->getBcc()) {
+                $this->mailables[] = $mailable->bcc($recipients);
+            }
+
+            if ($recipients = $view->getCc()) {
+                $this->mailables[] = $mailable->cc($recipients);
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
In reference to https://github.com/laravel/framework/issues/16242:

For:

```
public function build()
{
    return $this->view('views.email.mymailable')
        ->to($this->user->email);
}
```

The following currently fails:

```
Mail::send($mailable);

Mail::assertSent(MyMailable::class);
```

You need to use `Mail::to('mail@mail.com')->send($mailable)` for it to work, this PR handles recipients set from within the Mailable build method.

**Update**

Added support for `Mail::queue(MyMailable::class)` as well.