### PR TITLE
[5.3] handle matching array/collection recipients

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -84,6 +84,10 @@ class MailFake implements Mailer
         });
 
         return $recipients->map(function ($recipient) {
+            if (is_array($recipient)) {
+                return $recipient['email'];
+            }
+
             return is_object($recipient) ? $recipient->email : $recipient;
         })->diff($expected)->count() === 0;
     }


### PR DESCRIPTION
in reference to https://github.com/laravel/framework/issues/16094

The following test currently fails:

        $emails = collect([ ['email' => 'example@example.com', 'name'=> 'example'] , ['email' => 'example2@example.com', 'name'=> 'example2'] ]);

        $mailable = new TestMail();

        Mail::to($emails)->send($mailable);

        Mail::assertSentTo(['example@example.com', 'example2@example.com'], TestMail::class);

This PR fixes that by properly handling array  recipients.