### PR TITLE
[5.3] Allow SparkPost transport transmission options to be set at runtime

### DIFF
--- a/src/Illuminate/Mail/Transport/SparkPostTransport.php
+++ b/src/Illuminate/Mail/Transport/SparkPostTransport.php
@@ -126,4 +126,25 @@ class SparkPostTransport extends Transport
     {
         return $this->key = $key;
     }
+
+    /**
+     * Get the transmission options being used by the transport.
+     *
+     * @return string
+     */
+    public function getOptions()
+    {
+        return $this->options;
+    }
+
+    /**
+     * Set the transmission options being used by the transport.
+     *
+     * @param  array  $options
+     * @return array
+     */
+    public function setOptions($options)
+    {
+        return $this->options = $options;
+    }
 }


### PR DESCRIPTION
This PR addresses [this comment](https://github.com/laravel/framework/pull/14166#issuecomment-258129811) and will allow developers to set the SparkPost transmission options at runtime:

```php
app('swift.transport')->driver('sparkpost')->setOptions([
    'open_tracking' => false,
    'click_tracking' => false,
    'transactional' => true,
]);
```