### PR TITLE
[5.4] Job based queue options

### DIFF
--- a/src/Illuminate/Queue/Jobs/Job.php
+++ b/src/Illuminate/Queue/Jobs/Job.php
@@ -268,6 +268,16 @@ abstract class Job
     }
 
     /**
+     * The number of seconds the job can run.
+     *
+     * @return int
+     */
+    public function timeout()
+    {
+        return $this->getCommand() ? $this->getCommand()->timeout : null;
+    }
+
+    /**
      * Get the name of the queue the job belongs to.
      *
      * @return string

--- a/src/Illuminate/Queue/Jobs/Job.php
+++ b/src/Illuminate/Queue/Jobs/Job.php
@@ -16,6 +16,13 @@ abstract class Job
     protected $instance;
 
     /**
+     * The command instance.
+     *
+     * @var mixed
+     */
+    protected $command;
+
+    /**
      * The IoC container instance.
      *
      * @var \Illuminate\Container\Container
@@ -232,6 +239,32 @@ abstract class Job
     public function payload()
     {
         return json_decode($this->getRawBody(), true);
+    }
+
+    /**
+     * The underlying command.
+     *
+     * @return mixed
+     */
+    public function getCommand(){
+        if ($this->command) {
+            return $this->command;
+        }
+
+        $payload = $this->payload();
+
+        return $this->command = isset($payload['data']['command'])
+                ? unserialize($payload['data']['command']) : null;
+    }
+
+    /**
+     * The number of times to attempt a job.
+     *
+     * @return int
+     */
+    public function retries()
+    {
+        return $this->getCommand() ? $this->getCommand()->retries : null;
     }
 
     /**

--- a/src/Illuminate/Queue/Jobs/Job.php
+++ b/src/Illuminate/Queue/Jobs/Job.php
@@ -246,7 +246,8 @@ abstract class Job
      *
      * @return mixed
      */
-    public function getCommand(){
+    public function getCommand()
+    {
         if ($this->command) {
             return $this->command;
         }
@@ -254,7 +255,7 @@ abstract class Job
         $payload = $this->payload();
 
         return $this->command = isset($payload['data']['command'])
-                ? unserialize($payload['data']['command']) : null;
+            ? unserialize($payload['data']['command']) : null;
     }
 
     /**

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -200,8 +200,6 @@ class Worker
         } catch (Throwable $e) {
             $this->exceptions->report(new FatalThrowableError($e));
         }
-
-        return null;
     }
 
     /**

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -255,6 +255,8 @@ class Worker
      */
     protected function markJobAsFailedIfAlreadyExceedsMaxAttempts($connectionName, $job, $maxTries)
     {
+        $maxTries = $job->retries() !== null ? $job->retries() : $maxTries;
+
         if ($maxTries === 0 || $job->attempts() <= $maxTries) {
             return;
         }
@@ -280,6 +282,8 @@ class Worker
     protected function markJobAsFailedIfHasExceededMaxAttempts(
         $connectionName, $job, $maxTries, $e
     ) {
+        $maxTries = $job->retries() !== null ? $job->retries() : $maxTries;
+
         if ($maxTries === 0 || $job->attempts() < $maxTries) {
             return;
         }
@@ -301,16 +305,14 @@ class Worker
             return;
         }
 
-        try {
-            // If the job has failed, we will delete it, call the "failed" method and then call
-            // an event indicating the job has failed so it can be logged if needed. This is
-            // to allow every developer to better keep monitor of their failed queue jobs.
-            $job->delete();
+        // If the job has failed, we will delete it, call the "failed" method and then call
+        // an event indicating the job has failed so it can be logged if needed. This is
+        // to allow every developer to better keep monitor of their failed queue jobs.
+        $job->delete();
 
-            $job->failed($e);
-        } finally {
-            $this->raiseFailedJobEvent($connectionName, $job, $e);
-        }
+        $job->failed($e);
+
+        $this->raiseFailedJobEvent($connectionName, $job, $e);
     }
 
     /**

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -243,6 +243,11 @@ class WorkerFakeJob
         return [];
     }
 
+    public function retries()
+    {
+        return null;
+    }
+
     public function delete()
     {
         $this->deleted = true;


### PR DESCRIPTION
In reference to https://github.com/laravel/internals/issues/289 and https://github.com/laravel/internals/issues/290, this is an attempt to introduce Job based queue worker options:

```php
class TestJob implements ShouldQueue
{
    use InteractsWithQueue, Queueable, SerializesModels;

    /**
     * The number of retries before the job fails.
     *
     * @var int
     */
    public $retries = 10;

    /**
     * The time the job should run.
     *
     * @var int
     */
    public $timeout = 120;

    public function handle()
    {
        
    }
}
```

The options in the job class will override the options given to the `queue:work`  and `queue:listen` commands.