### PR TITLE
[5.3] attach() file on tests using the id without failing

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithPages.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithPages.php
@@ -119,7 +119,7 @@ trait InteractsWithPages
      */
     protected function makeRequestUsingForm(Form $form, array $uploads = [])
     {
-        $files = $this->convertUploadsForTesting($form, $uploads);
+        $files = $this->convertUploadsForTesting($form, $this->inputs);
 
         return $this->makeRequest(
             $form->getMethod(), $form->getUri(), $this->extractParametersFromForm($form), [], $files

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithPages.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithPages.php
@@ -114,10 +114,9 @@ trait InteractsWithPages
      * Make a request to the application using the given form.
      *
      * @param  \Symfony\Component\DomCrawler\Form  $form
-     * @param  array  $uploads
      * @return $this
      */
-    protected function makeRequestUsingForm(Form $form, array $uploads = [])
+    protected function makeRequestUsingForm(Form $form)
     {
         $files = $this->convertUploadsForTesting($form, $this->inputs);
 
@@ -564,7 +563,7 @@ trait InteractsWithPages
      */
     protected function press($buttonText)
     {
-        return $this->submitForm($buttonText, $this->inputs, $this->uploads);
+        return $this->submitForm($buttonText, $this->inputs);
     }
 
     /**
@@ -572,12 +571,11 @@ trait InteractsWithPages
      *
      * @param  string  $buttonText
      * @param  array  $inputs
-     * @param  array  $uploads
      * @return $this
      */
-    protected function submitForm($buttonText, $inputs = [], $uploads = [])
+    protected function submitForm($buttonText, $inputs = [])
     {
-        $this->makeRequestUsingForm($this->fillForm($buttonText, $inputs), $uploads);
+        $this->makeRequestUsingForm($this->fillForm($buttonText, $inputs));
 
         return $this;
     }


### PR DESCRIPTION
This fixes https://github.com/laravel/framework/issues/16264

A brief description of what the pull request :

When using testing method `attach('file.txt', '#idOfTheField')``with an id instead of the field `name` attribute value, the test fails, because the `test` attribute on `Illuminate\Http\UploadedFile` is false.

The full explanation is in the issue.