### PR TITLE
Mailer send don't did not have a return value.

### DIFF
--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -193,7 +193,7 @@ class Mailer implements MailerContract, MailQueueContract
 
         $message = $message->getSwiftMessage();
 
-        $this->sendSwiftMessage($message);
+        return $this->sendSwiftMessage($message);
     }
 
     /**


### PR DESCRIPTION
vendor\laravel\framework\src\Illuminate\Mail\Mailer.php on line 196 of function called "send". This function not have a return value and we don't know what happened with request.