### PR TITLE
[5.4] Improved Higher Order Collection

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1364,8 +1364,21 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
             'sortByDesc', 'sum', 'reject', 'filter',
         ];
 
+        $property = null;
+
+        foreach ($proxies as $proxy) {
+            if (starts_with($key, $proxy) && $key !== $proxy) {
+                $property = lcfirst(substr($key, strlen($proxy)));
+                $key = $proxy;
+            }
+        }
+
         if (! in_array($key, $proxies)) {
             throw new Exception("Property [{$key}] does not exist on this collection instance.");
+        }
+
+        if ($property !== null) {
+            return (new HigherOrderCollectionProxy($this, $key))->{$property};
         }
 
         return new HigherOrderCollectionProxy($this, $key);

--- a/src/Illuminate/Support/HigherOrderCollectionProxy.php
+++ b/src/Illuminate/Support/HigherOrderCollectionProxy.php
@@ -40,7 +40,7 @@ class HigherOrderCollectionProxy
     public function __get($key)
     {
         return $this->collection->{$this->method}(function ($value) use ($key) {
-            return $value->{$key};
+            return data_get($value, $key);
         });
     }
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1654,6 +1654,20 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals(['TAYLOR', 'TAYLOR'], $collection->each->uppercase()->map->name->toArray());
     }
+
+    public function testHigherOrderCollectionMapFromArrays()
+    {
+        $person1 = ['name' => 'Taylor'];
+        $person2 = ['name' => 'Yaz'];
+
+        $collection = collect([$person1, $person2]);
+
+        $this->assertEquals(['Taylor', 'Yaz'], $collection->map->name->toArray());
+
+        $collection = collect([new TestSupportCollectionHigherOrderItem, new TestSupportCollectionHigherOrderItem]);
+
+        $this->assertEquals(['TAYLOR', 'TAYLOR'], $collection->each->uppercase()->map->name->toArray());
+    }
 }
 
 class TestSupportCollectionHigherOrderItem

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1654,6 +1654,20 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals(['TAYLOR', 'TAYLOR'], $collection->each->uppercase()->map->name->toArray());
     }
+
+    public function testImprovedHigherOrderCollectionMap()
+    {
+        $person1 = (object) ['name' => 'Taylor'];
+        $person2 = (object) ['name' => 'Yaz'];
+
+        $collection = collect([$person1, $person2]);
+
+        $this->assertEquals(['Taylor', 'Yaz'], $collection->mapName->toArray());
+
+        $collection = collect([new TestSupportCollectionHigherOrderItem, new TestSupportCollectionHigherOrderItem]);
+
+        $this->assertEquals(['TAYLOR', 'TAYLOR'], $collection->each->uppercase()->mapName->toArray());
+    }
 }
 
 class TestSupportCollectionHigherOrderItem


### PR DESCRIPTION
This will allow you to use:

```php
$collection->mapName->toArray();
```

instead of 

```php
$collection->map->name->toArray();
```