### PR TITLE
[5.3] Use 'url_root' config value to generate disk url

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -290,7 +290,7 @@ class FilesystemAdapter implements FilesystemContract, CloudFilesystemContract
             $flysystemConfig = $this->driver->getConfig();
 
             if ($flysystemConfig->has('url_root')) {
-                return $flysystemConfig->get('url_root') .'/'. $path;
+                return $flysystemConfig->get('url_root').'/'.$path;
             }
 
             $path = '/storage/'.$path;

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -287,6 +287,12 @@ class FilesystemAdapter implements FilesystemContract, CloudFilesystemContract
 
             return $adapter->getClient()->getObjectUrl($adapter->getBucket(), $path);
         } elseif ($adapter instanceof LocalAdapter) {
+            $flysystemConfig = $this->driver->getConfig();
+
+            if ($flysystemConfig->has('url_root')) {
+                return $flysystemConfig->get('url_root') .'/'. $path;
+            }
+
             $path = '/storage/'.$path;
 
             return Str::contains($path, '/storage/public') ? Str::replaceFirst('/public', '', $path) : $path;

--- a/src/Illuminate/Filesystem/FilesystemManager.php
+++ b/src/Illuminate/Filesystem/FilesystemManager.php
@@ -255,7 +255,7 @@ class FilesystemManager implements FactoryContract
      */
     protected function createFlysystem(AdapterInterface $adapter, array $config)
     {
-        $config = Arr::only($config, ['visibility', 'disable_asserts']);
+        $config = Arr::only($config, ['visibility', 'disable_asserts', 'url_root']);
 
         return new Flysystem($adapter, count($config) > 0 ? $config : null);
     }


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/1449151/20031718/146d5008-a37c-11e6-9bc2-8809256edd61.png)

The value of `url_root` will be used instead of `/storage/`

This is very useful in multi tenant applications, where each tenant should have it's own subdomain for serving files.