### PR TITLE
[5.4] Tweak DatabaseQueue to not require locking

### DIFF
--- a/src/Illuminate/Queue/Console/stubs/jobs.stub
+++ b/src/Illuminate/Queue/Console/stubs/jobs.stub
@@ -21,6 +21,7 @@ class Create{{tableClassName}}Table extends Migration
             $table->unsignedInteger('reserved_at')->nullable();
             $table->unsignedInteger('available_at');
             $table->unsignedInteger('created_at');
+            $table->string('reserved_by')->nullable()->unique();
             $table->index(['queue', 'reserved_at']);
         });
     }

--- a/tests/Queue/QueueDatabaseQueueIntegrationTest.php
+++ b/tests/Queue/QueueDatabaseQueueIntegrationTest.php
@@ -63,6 +63,7 @@ class QueueDatabaseQueueIntegrationTest extends PHPUnit_Framework_TestCase
             $table->unsignedInteger('reserved_at')->nullable();
             $table->unsignedInteger('available_at');
             $table->unsignedInteger('created_at');
+            $table->string('reserved_by')->nullable()->unique();
             $table->index(['queue', 'reserved_at']);
         });
     }
@@ -112,6 +113,7 @@ class QueueDatabaseQueueIntegrationTest extends PHPUnit_Framework_TestCase
                 'reserved_at' => null,
                 'available_at' => Carbon::now()->subSeconds(1)->getTimestamp(),
                 'created_at' => Carbon::now()->getTimestamp(),
+                'reserved_by' => null,
             ]);
 
         $popped_job = $this->queue->pop($mock_queue_name);
@@ -132,6 +134,7 @@ class QueueDatabaseQueueIntegrationTest extends PHPUnit_Framework_TestCase
             'reserved_at' => null,
             'available_at' => Carbon::now()->subSeconds(1)->getTimestamp(),
             'created_at' => Carbon::now()->getTimestamp(),
+            'reserved_by' => null,
         ];
 
         $this->connection()->table('jobs')->insert($job);
@@ -159,6 +162,7 @@ class QueueDatabaseQueueIntegrationTest extends PHPUnit_Framework_TestCase
                 'reserved_at' => null,
                 'available_at' => Carbon::now()->addSeconds(60)->getTimestamp(),
                 'created_at' => Carbon::now()->getTimestamp(),
+                'reserved_by' => null,
             ]);
 
         $popped_job = $this->queue->pop($mock_queue_name);
@@ -181,6 +185,7 @@ class QueueDatabaseQueueIntegrationTest extends PHPUnit_Framework_TestCase
                 'reserved_at' => Carbon::now()->subDay()->getTimestamp(),
                 'available_at' => Carbon::now()->addDay()->getTimestamp(),
                 'created_at' => Carbon::now()->getTimestamp(),
+                'reserved_by' => 'foobar',
             ]);
 
         $popped_job = $this->queue->pop($mock_queue_name);
@@ -203,6 +208,7 @@ class QueueDatabaseQueueIntegrationTest extends PHPUnit_Framework_TestCase
                 'reserved_at' => Carbon::now()->addDay()->getTimestamp(),
                 'available_at' => Carbon::now()->subDay()->getTimestamp(),
                 'created_at' => Carbon::now()->getTimestamp(),
+                'reserved_by' => 'foobar',
             ]);
 
         $popped_job = $this->queue->pop($mock_queue_name);

--- a/tests/Queue/QueueDatabaseQueueUnitTest.php
+++ b/tests/Queue/QueueDatabaseQueueUnitTest.php
@@ -20,6 +20,7 @@ class QueueDatabaseQueueUnitTest extends PHPUnit_Framework_TestCase
             $this->assertEquals(0, $array['attempts']);
             $this->assertNull($array['reserved_at']);
             $this->assertInternalType('int', $array['available_at']);
+            $this->assertNull($array['reserved_by']);
         });
 
         $queue->push('foo', ['data']);
@@ -40,6 +41,7 @@ class QueueDatabaseQueueUnitTest extends PHPUnit_Framework_TestCase
             $this->assertEquals(0, $array['attempts']);
             $this->assertNull($array['reserved_at']);
             $this->assertInternalType('int', $array['available_at']);
+            $this->assertNull($array['reserved_by']);
         });
 
         $queue->later(10, 'foo', ['data']);
@@ -105,6 +107,7 @@ class QueueDatabaseQueueUnitTest extends PHPUnit_Framework_TestCase
                 'reserved_at' => null,
                 'available_at' => 'available',
                 'created_at' => 'created',
+                'reserved_by' => null,
             ], [
                 'queue' => 'queue',
                 'payload' => json_encode(['job' => 'bar', 'data' => ['data']]),
@@ -112,6 +115,7 @@ class QueueDatabaseQueueUnitTest extends PHPUnit_Framework_TestCase
                 'reserved_at' => null,
                 'available_at' => 'available',
                 'created_at' => 'created',
+                'reserved_by' => null,
             ]], $records);
         });
 


### PR DESCRIPTION
Using `SELECT ... FOR UPDATE` is expensive and can cause deadlocks ([as described here](https://blog.engineyard.com/2011/5-subtle-ways-youre-using-mysql-as-a-queue-and-why-itll-bite-you)) which just ends up making both your workers and DB unhappy.

This switches the approach to try to update a single row with a reservation tag and then looks up that job if anything was updated. Running this results in no exceptions (like deadlocks) compared to the current implementation.