### PR TITLE
[5.3] Throws exception instead of rendering error page if app is on testing env

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -127,6 +127,10 @@ class Handler implements ExceptionHandlerContract
      */
     public function render($request, Exception $e)
     {
+        if ($this->container['env'] === 'testing') {
+            throw $e;
+        }
+
         $e = $this->prepareException($e);
 
         if ($e instanceof HttpResponseException) {


### PR DESCRIPTION
Hi guys,  
This is something that always bothers me and I do not find intuitive at all. When running integration tests sometimes you'll not get an exception thrown or will receive a giant HTML page (the error page). IIRC @adamwathan has a post about this.  

For instance, if you write a simple test that just posts to `foobar`, e.g `$this->post('foobar')` it passes even though the route does not exist.  

I'm not sure if this is the best solution and I know this can be done in `app/Exceptions/Handler.php` just fine but I just don't find this intuitive at all.   

Let me know what you think!