### PR TITLE
[5.3] Custom casting of eloquent properties

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2818,7 +2818,13 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
             return $value;
         }
 
-        switch ($this->getCastType($key)) {
+        $castType = $this->getCastType($key);
+
+        if (method_exists($this, 'castTo' . strtoupper($castType))) {
+            return $this->{'castTo' . $castType}($value);
+        }
+
+        switch ($castType) {
             case 'int':
             case 'integer':
                 return (int) $value;

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1282,6 +1282,7 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
         $model->dateAttribute = '1969-07-20';
         $model->datetimeAttribute = '1969-07-20 22:56:00';
         $model->timestampAttribute = '1969-07-20 22:56:00';
+        $model->customAttribute = 'value';
 
         $this->assertInternalType('int', $model->intAttribute);
         $this->assertInternalType('float', $model->floatAttribute);
@@ -1302,6 +1303,8 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('1969-07-20', $model->dateAttribute->toDateString());
         $this->assertEquals('1969-07-20 22:56:00', $model->datetimeAttribute->toDateTimeString());
         $this->assertEquals(-14173440, $model->timestampAttribute);
+        $this->assertInstanceOf('CustomCastingStub', $model->customAttribute);
+        $this->assertEquals('value', $model->customAttribute->key);
 
         $arr = $model->toArray();
         $this->assertInternalType('int', $arr['intAttribute']);
@@ -1336,6 +1339,7 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
         $model->dateAttribute = null;
         $model->datetimeAttribute = null;
         $model->timestampAttribute = null;
+        $model->customAttribute = null;
 
         $attributes = $model->getAttributes();
 
@@ -1350,6 +1354,7 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
         $this->assertNull($attributes['dateAttribute']);
         $this->assertNull($attributes['datetimeAttribute']);
         $this->assertNull($attributes['timestampAttribute']);
+        $this->assertNull($attributes['customAttribute']);
 
         $this->assertNull($model->intAttribute);
         $this->assertNull($model->floatAttribute);
@@ -1362,6 +1367,7 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
         $this->assertNull($model->dateAttribute);
         $this->assertNull($model->datetimeAttribute);
         $this->assertNull($model->timestampAttribute);
+        $this->assertNull($model->customAttribute);
 
         $array = $model->toArray();
 
@@ -1376,6 +1382,7 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
         $this->assertNull($array['dateAttribute']);
         $this->assertNull($array['datetimeAttribute']);
         $this->assertNull($array['timestampAttribute']);
+        $this->assertNull($array['customAttribute']);
     }
 
     public function testUpdatingNonExistentModelFails()
@@ -1788,11 +1795,26 @@ class EloquentModelCastingStub extends Model
         'dateAttribute' => 'date',
         'datetimeAttribute' => 'datetime',
         'timestampAttribute' => 'timestamp',
+        'customAttribute' => 'custom'
     ];
 
     public function jsonAttributeValue()
     {
         return $this->attributes['jsonAttribute'];
+    }
+
+    public function castToCustom($value){
+        return new CustomCastingStub($value);
+    }
+}
+
+class CustomCastingStub
+{
+    public $key;
+
+    public function __construct($value)
+    {
+        $this->key = $value;
     }
 }
 


### PR DESCRIPTION
currently we gets dates autocast to Carbon objects, and we can cast any property to primitive types.

this PR allows us to cast properties to our own custom-defined types (usually objects i'm guessing).

Here is my use case.  I have an `Order` model that has `subtotal`, `tax`, `shipping`, and `total` fields.  I want them all to be instances of the new `Money\Money` class, so I can work with monetary values easier. To do this I would simply set these fields in my cast property:

```php
protected $casts = [
    'subtotal' => 'money',
    'tax'          => 'money',
    'shipping' => 'money',
    'total'        => 'money,
];
```

Then I just need to define a `castToMoney()` method on the class:

```php
public function castToMoney($value)
{
    return new \Money\Money($value, new \Money\Currency('USD'));
}
```

Now when accessing the property on the model, it would automatically give me back the `Money` object:

```php
$order = \App\Order::first();

$order->total;  //returns Money object

$order->total->getAmount(); //returns the value e.g. 127
```

I think the easiest way to define these 'cast methods' would be as a trait that was imported to models where it was needed. If your models extended a base class, it could also be defined there.

I wasn't able to a good test for how this behaves when the model is turned into an array (`$order->toArray()`). wondering what thoughts would be for this.

I can foresee someone saying why not just define the property with an 'Accessor'. My argument would be that's fine for 1-off field manipulation, but when you are doing the same casting over and over this an easier more consistent way.  If you ever need to swap out one of these 'cast methods' you can do it in one place.

Thanks for any feedback.