### PR TITLE
[5.3] Move login attempt to separate method

### DIFF
--- a/src/Illuminate/Foundation/Auth/AuthenticatesUsers.php
+++ b/src/Illuminate/Foundation/Auth/AuthenticatesUsers.php
@@ -39,9 +39,7 @@ trait AuthenticatesUsers
             return $this->sendLockoutResponse($request);
         }
 
-        $credentials = $this->credentials($request);
-
-        if ($this->guard()->attempt($credentials, $request->has('remember'))) {
+        if ($this->attemptLogin($request)) {
             return $this->sendLoginResponse($request);
         }
 
@@ -64,6 +62,17 @@ trait AuthenticatesUsers
         $this->validate($request, [
             $this->username() => 'required', 'password' => 'required',
         ]);
+    }
+
+    /**
+     * @param Request $request
+     * @return bool
+     */
+    protected function attemptLogin(Request $request)
+    {
+        $credentials = $this->credentials($request);
+
+        return $this->guard()->attempt($credentials, $request->has('remember'));
     }
 
     /**


### PR DESCRIPTION
This will make it easier to alter login attempt logic without the need to override the entire login() method. For example to change credentials or add other params. A good use case is if you are checking if someone is "admin".

```php
<?php
namespace App\Http\Controllers\Auth;
//...
class AuthController extends Controller {
    // ...
    protected function attemptLogin(Request $request)
    {
        $credentials = $this->credentials($request);
        $credentials['admin'] = 1;

        return $this->guard()->attempt($credentials, $request->has('remember'));
    }
}
```

If this PR is accepted it will be great to make patch for versions 5.* because it is compatible.