### PR TITLE
[5.3] Fix for Missing argument on fail() of InteractsWithQueue

### DIFF
--- a/src/Illuminate/Queue/InteractsWithQueue.php
+++ b/src/Illuminate/Queue/InteractsWithQueue.php
@@ -38,12 +38,13 @@ trait InteractsWithQueue
     /**
      * Fail the job from the queue.
      *
+     * @param  \Throwable  $e
      * @return void
      */
-    public function fail()
+    public function fail($e)
     {
         if ($this->job) {
-            return $this->job->failed();
+            return $this->job->failed($e);
         }
     }
 


### PR DESCRIPTION
Calling `$this->fail()` using `InteractsWithQueue` throws an Exception

```
Missing argument 1 for Illuminate\Queue\Jobs\Job::failed(), called in vendor/laravel/framework/src/Illuminate/Queue/InteractsWithQueue.php on line 46 and defined in Job.php line 144
```