### PR TITLE
[5.4] Include the password hash in auth session

### DIFF
--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -129,13 +129,15 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
         $user = null;
 
         if (! is_null($id) && $user = $this->provider->retrieveById($id)) {
+            $this->user = $user;
+
             if ($user->getAuthPassword() == $passwordHash) {
                 $this->fireAuthenticatedEvent($user);
 
-                return $this->user = $user;
+                return $user;
             }
 
-            return null;
+            return $this->logout();
         }
 
         // If the user is null, but we decrypt a "recaller" cookie we can attempt to

--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -129,10 +129,13 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
         $user = null;
 
         if (! is_null($id) && $user = $this->provider->retrieveById($id)) {
-            $this->fireAuthenticatedEvent($user);
+            if ($user->getAuthPassword() == $passwordHash) {
+                $this->fireAuthenticatedEvent($user);
 
-            return  $user->getAuthPassword() == $passwordHash
-                            ? $this->user = $user : null;
+                return $this->user = $user;
+            }
+
+            return null;
         }
 
         // If the user is null, but we decrypt a "recaller" cookie we can attempt to

--- a/tests/Auth/AuthGuardTest.php
+++ b/tests/Auth/AuthGuardTest.php
@@ -196,14 +196,17 @@ class AuthGuardTest extends PHPUnit_Framework_TestCase
         $this->assertNull($mock->user());
     }
 
-    public function testNullIsReturnedForUserIfUserPasswordHashChanged()
+    public function testNullIsReturnedForUserIfUserPasswordHashChangedAndUserIsLoggedOut()
     {
         $mock = $this->getGuard();
         $mock->getSession()->shouldReceive('has')->once()->andReturn(true);
         $mock->getSession()->shouldReceive('get')->once()->andReturn('1||hash');
+        $mock->getSession()->shouldReceive('remove')->once($mock->getName());
         $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');
         $user->shouldReceive('getAuthPassword')->once()->andReturn('diff_hash');
+        $user->shouldReceive('setRememberToken')->once();
         $mock->getProvider()->shouldReceive('retrieveById')->once()->with(1)->andReturn($user);
+        $mock->getProvider()->shouldReceive('updateRememberToken')->once();
         $this->assertNull($mock->user());
     }
 


### PR DESCRIPTION
This PR uses the following format for the auth session `id||password_hash`, while attempting to bring the user from the session we'll compare the password hash with the current one in the DB and fail in case no match were found.

So now if the password hash changes all logged in instances of the user will be logged out, this includes the user who changed the password as well, to prevent kicking that user out the developer needs to use `Auth::refresh()` after changing the password.

```
auth()->user()->update([
    'password' => bcrypt('caro')
]);

Auth::refresh();
```