### PR TITLE
[5.3] Allow loading specific columns while eagerloading

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1125,9 +1125,17 @@ class Builder
             // constraints have been specified for the eager load and we'll just put
             // an empty Closure with the loader so that we can treat all the same.
             if (is_numeric($name)) {
-                $f = function () {
-                    //
-                };
+                if (Str::contains($constraints, ':')) {
+                    list($constraints, $columns) = explode(':', $constraints);
+
+                    $f = function ($q) use ($columns) {
+                        $q->select(explode(',', $columns));
+                    };
+                } else {
+                    $f = function () {
+                        //
+                    };
+                }
 
                 list($name, $constraints) = [$constraints, $f];
             }

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -147,6 +147,17 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
         $this->assertEmpty($instance->getEagerLoads());
     }
 
+    public function testEager()
+    {
+        $model = new EloquentModelWithoutRelationStub;
+        $instance = $model->newInstance()->newQuery()->with('foo:bar,baz', 'hadi');
+        $builder = m::mock(Builder::class);
+        $builder->shouldReceive('select')->once()->with(['bar', 'baz']);
+        $this->assertNotNull($instance->getEagerLoads()['hadi']);
+        $this->assertNotNull($instance->getEagerLoads()['foo']);
+        $instance->getEagerLoads()['foo']($builder);
+    }
+
     public function testWithMethodCallsQueryBuilderCorrectlyWithArray()
     {
         $result = EloquentModelWithStub::with(['foo', 'bar']);

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -155,7 +155,8 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
         $builder->shouldReceive('select')->once()->with(['bar', 'baz']);
         $this->assertNotNull($instance->getEagerLoads()['hadi']);
         $this->assertNotNull($instance->getEagerLoads()['foo']);
-        $instance->getEagerLoads()['foo']($builder);
+        $closure = $instance->getEagerLoads()['foo'];
+        $closure($builder);
     }
 
     public function testWithMethodCallsQueryBuilderCorrectlyWithArray()

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -147,7 +147,7 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
         $this->assertEmpty($instance->getEagerLoads());
     }
 
-    public function testEager()
+    public function testEagerLoadingWithColumns()
     {
         $model = new EloquentModelWithoutRelationStub;
         $instance = $model->newInstance()->newQuery()->with('foo:bar,baz', 'hadi');


### PR DESCRIPTION
This allows for:

```php
User::where(...)->with('business:id,name')->get()
```

Which is equivalent to:

```php
User::where(...)->with([
  'business' => function($q){
      $q->select('id', 'name');
  }
])->get()
```