### PR TITLE
[5.4] Add queryFoo For Eloquent Model to extend the query builder

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1470,6 +1470,12 @@ class Builder
             return $this->callScope([$this->model, $scope], $parameters);
         }
 
+        if (method_exists($this->model, $query = 'query'.ucfirst($method))) {
+            array_unshift($parameters, $this);
+
+            return call_user_func_array([$this->model, $query], $parameters);
+        }
+
         if (in_array($method, $this->passthru)) {
             return call_user_func_array([$this->toBase(), $method], $parameters);
         }


### PR DESCRIPTION
As we define the

```php
Foo::scopeBar()
```
we can do
```php
Foo::bar()->get();
$baz->foos()->bar()->count();
```
But sometimes, get(), count(), sum()... are not enough. Such as sum and change unit,

### This pull requent support that:

As we define the
```php
Foo::queryQux();
```
we can do
```php
Foo::bar()->qux();
$baz->foos()->bar()->qux();
```
As we store distance with unit cm, but want output as inch.

We can do this:
```php
Distance::scopeFoo->scopeBar->sumDistanceAsInch();
```
by define

```php
classDistance
{
	// ...
	public function qureySumDistanceAsInch( $query )
	{
		return $query->sum('distance')/2.54;
	}
	// ...
}
```

The usage is samiler with scopes, defining at model but using at qurey builder. But they not return qurey builder, but return the result, they use at the end of qurey chain.