### PR TITLE
[5.4] Add @wrapper/@endwrapper statement to Blade templates

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -936,6 +936,32 @@ class BladeCompiler extends Compiler implements CompilerInterface
     }
 
     /**
+     * Compile the wrapper statements into valid PHP.
+     *
+     * @param  string  $expression
+     *
+     * @return string
+     */
+    protected function compileWrapper($expression)
+    {
+        $value = $this->stripParentheses($expression);
+        return "<?php \$__env->beginWrapper($value); ?>";
+    }
+
+    /**
+     * Compile the endwrapper statements into valid PHP.
+     *
+     * @return string
+     */
+    protected function compileEndwrapper()
+    {
+        $s = "<?php list(\$name, \$child) = \$__env->endWrapper(); ?>";
+        $s .= "<?php \$wrapper = \$__env->make(\$name, array_except(get_defined_vars(), array('__data', '__path')))->render(); ?>";
+        $s .= "<?php echo preg_replace('/@child/', \$child, \$wrapper); ?>";
+        return $s;
+    }
+
+    /**
      * Strip the parentheses from the given expression.
      *
      * @param  string  $expression

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -945,6 +945,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
     protected function compileWrapper($expression)
     {
         $value = $this->stripParentheses($expression);
+
         return "<?php \$__env->beginWrapper($value); ?>";
     }
 
@@ -955,9 +956,10 @@ class BladeCompiler extends Compiler implements CompilerInterface
      */
     protected function compileEndwrapper()
     {
-        $s = "<?php list(\$name, \$child) = \$__env->endWrapper(); ?>";
+        $s = '<?php list($name, $child) = $__env->endWrapper(); ?>';
         $s .= "<?php \$wrapper = \$__env->make(\$name, array_except(get_defined_vars(), array('__data', '__path')))->render(); ?>";
         $s .= "<?php echo preg_replace('/@child/', \$child, \$wrapper); ?>";
+
         return $s;
     }
 

--- a/src/Illuminate/View/Factory.php
+++ b/src/Illuminate/View/Factory.php
@@ -115,6 +115,13 @@ class Factory implements FactoryContract
     protected $pushStack = [];
 
     /**
+     * The stack of in-progress wrappers.
+     *
+     * @var array
+     */
+    protected $wrapperStack = [];
+
+    /**
      * The number of active rendering operations.
      *
      * @var int
@@ -753,6 +760,31 @@ class Factory implements FactoryContract
     }
 
     /**
+     * Begin a wrapper block.
+     *
+     * @param  string  $name
+     * @return void
+     */
+    public function beginWrapper($name)
+    {
+        if (ob_start()) {
+            $this->wrapperStack[] = $name;
+        }
+    }
+
+    /**
+     * Return the name and content of the wrapper.
+     *
+     * @return string
+     */
+    public function endWrapper()
+    {
+        $child = ob_get_clean();
+        $name = array_pop($this->wrapperStack);
+        return [$name, $child];
+    }
+
+    /**
      * Flush all of the section contents.
      *
      * @return void
@@ -766,6 +798,8 @@ class Factory implements FactoryContract
 
         $this->pushes = [];
         $this->pushStack = [];
+
+        $this->wrapperStack = [];
     }
 
     /**

--- a/src/Illuminate/View/Factory.php
+++ b/src/Illuminate/View/Factory.php
@@ -781,6 +781,7 @@ class Factory implements FactoryContract
     {
         $child = ob_get_clean();
         $name = array_pop($this->wrapperStack);
+
         return [$name, $child];
     }
 

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -751,6 +751,18 @@ empty
         $this->assertEquals('<?php echo $__env->yieldContent(\'title\'); ?> - <?php echo e(Config::get(\'site.title\')); ?>', $compiler->compileString("@yield('title') - {{Config::get('site.title')}}"));
     }
 
+    public function testWrapperIsCompiled()
+    {
+        $compiler = new BladeCompiler($this->getFiles(), __DIR__);
+        $string = '@wrapper(\'foo\')
+test
+@endwrapper';
+        $expected = '<?php $__env->beginWrapper(\'foo\'); ?>
+test
+<?php list($name, $child) = $__env->endWrapper(); ?><?php $wrapper = $__env->make($name, array_except(get_defined_vars(), array(\'__data\', \'__path\')))->render(); ?><?php echo preg_replace(\'/@child/\', $child, $wrapper); ?>';
+        $this->assertEquals($expected, $compiler->compileString($string));
+    }
+
     public function testCustomExtensionsAreCompiled()
     {
         $compiler = new BladeCompiler($this->getFiles(), __DIR__);

--- a/tests/View/ViewFlowTest.php
+++ b/tests/View/ViewFlowTest.php
@@ -210,6 +210,28 @@ yield:
         $this->assertEquals("yield:\n@parent\n", $factory->make('extends-variable', ['title' => '@parent'])->render());
     }
 
+    public function testWrapper()
+    {
+        $files = new Filesystem;
+        $compiler = new BladeCompiler($this->getFiles(), __DIR__);
+
+        $files->put($this->tempDir.'/wrapped.php', $compiler->compileString('
+before wrapper
+@wrapper("wrapper")
+    contents
+@endwrapper
+after wrapper
+'));
+        $files->put($this->tempDir.'/wrapper.php', $compiler->compileString('
+before
+@child
+after
+'));
+
+        $factory = $this->prepareCommonFactory();
+        $this->assertEquals("before wrapper\nbefore\n    contents\n\nafter\nafter wrapper\n", $factory->make('wrapped')->render());
+    }
+
     protected function prepareCommonFactory()
     {
         $engine = new CompilerEngine(m::mock('Illuminate\View\Compilers\CompilerInterface'));


### PR DESCRIPTION
These two new Blade directives @wrapper/@endwrapper allow you to wrap pieces of your view with the contents of another view.

This solves the problem with @section where you can only prepend or append from within the child template.

Example:

    @wrapper('view.name')
         Contents
    @endwrapper

In another view:

    Before
    @child
    After

This is the result that you'll get:

    Before
    Contents
    After
