### PR TITLE
[5.4] Automatically strip unnecessary extension

### DIFF
--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -202,7 +202,9 @@ abstract class GeneratorCommand extends Command
      */
     protected function getNameInput()
     {
-        return trim($this->argument('name'));
+        return strip_extension(
+            trim($this->argument('name'))
+        );
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/ListenerMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ListenerMakeCommand.php
@@ -53,7 +53,7 @@ class ListenerMakeCommand extends GeneratorCommand
     {
         $stub = parent::buildClass($name);
 
-        $event = $this->option('event');
+        $event = strip_extension($this->option('event'));
 
         if (! Str::startsWith($event, $this->laravel->getNamespace()) && ! Str::startsWith($event, 'Illuminate')) {
             $event = $this->laravel->getNamespace().'Events\\'.$event;

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -412,6 +412,24 @@ class Str
     }
 
     /**
+     * Removes extension from the end of a file name.
+     *
+     * @param  string  $value
+     * @param  string  $extension
+     * @return string
+     */
+    public static function stripExtension($value, $extension = 'php')
+    {
+        $extension = '.' . $extension;
+
+        if (Str::endsWith($value, $extension)) {
+            return str_replace_last($extension, '', $value);
+        }
+
+        return $value;
+    }
+
+    /**
      * Convert a value to studly caps case.
      *
      * @param  string  $value

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -824,6 +824,20 @@ if (! function_exists('str_slug')) {
     }
 }
 
+if (! function_exists('strip_extension')) {
+    /**
+     * Removes extension from the end of a file name.
+     *
+     * @param  string  $value
+     * @param  string  $extension
+     * @return string
+     */
+    function strip_extension($value, $extension = 'php')
+    {
+        return Str::stripExtension($value, $extension);
+    }
+}
+
 if (! function_exists('studly_case')) {
     /**
      * Convert a value to studly caps case.

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -181,6 +181,28 @@ class SupportStrTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('laravel_php_framework_', Str::snake('LaravelPhpFramework_', '_'));
     }
 
+    public function testStripExtension()
+    {
+        // It strips extension if found.
+        $this->assertEquals('foo', Str::stripExtension('foo.php'));
+
+        // It strips only one occurrence of the extension.
+        $this->assertEquals('foo.php', Str::stripExtension('foo.php.php'));
+
+        // It doesn't do anything when extension is not found.
+        $this->assertEquals('foo.php.json', Str::stripExtension('foo.php.json'));
+
+        // It strips extension from a full path.
+        $this->assertEquals('/foo/bar/baz', Str::stripExtension('/foo/bar/baz.php'));
+
+        // It strips extensions other than default.
+        $this->assertEquals('foo', Str::stripExtension('foo.json', 'json'));
+        $this->assertEquals('foo.json', Str::stripExtension('foo.json.json', 'json'));
+        $this->assertEquals('foo.json.php', Str::stripExtension('foo.json.php', 'json'));
+        $this->assertEquals('/foo/bar/baz', Str::stripExtension('/foo/bar/baz.json', 'json'));
+    }
+
+
     public function testStudly()
     {
         $this->assertEquals('LaravelPHPFramework', Str::studly('laravel_p_h_p_framework'));


### PR DESCRIPTION
Couple of times I accidentally typed something like
```
php artisan make:model Foo.php
```
The command generated a `Foo.php.php` file with a `Foo.php` class definition in it.
At least for me it is quite annoying to fix it manually, so I added extension stripping to class names in `GeneratorCommand` as well as for event name in `ListenerMakeCommand`.

I extracted the functionality to a helper in order to be able to use it anywhere, if needed.

I haven't found any tests for `GeneratorCommand`(or any class that extends from it), therefore I wrote tests only for the helper method.