### PR TITLE
Add caching method for Eloquent models.

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -248,6 +248,20 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     protected static $unguarded = false;
 
     /**
+     * The cached model collection for class.
+     *
+     * @var \Illuminate\Database\Eloquent\Collection
+     */
+    protected static $cache;
+
+    /**
+     * The columns that are currently cached.
+     *
+     * @var array
+     */
+    protected static $cachedColumns;
+
+    /**
      * The cache of the mutated attributes for each class.
      *
      * @var array
@@ -3472,6 +3486,28 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     public static function unsetEventDispatcher()
     {
         static::$dispatcher = null;
+    }
+
+    /**
+     * Cache model collection if not already cached and return results.
+     *
+     * @param  array  $columns
+     * @param  bool  $reset
+     * @return \Illuminate\Database\Eloquent\Collection|static[]
+     */
+    public static function cache(array $columns = ['*'], $reset = false)
+    {
+        $query = new static;
+
+        // Check if the model cache is currently empty or that the given columns
+        // are not equal to the ones already cached. If both are false, set or
+        // reset the cache, update the columns, and return the collection.
+        if (! static::$cache || ! empty(array_diff($columns, static::$cachedColumns)) || $reset == true) {
+            static::$cache = $query->all($columns);
+            static::$cachedColumns = $columns;
+        }
+
+        return static::$cache;
     }
 
     /**


### PR DESCRIPTION
This method provides a convenient and clean way to cache model collections to prevent n + 1 querying.

Example:

```
$products = getThirdPartyData();

for ($i = 0; $i < count($products); $i++) {
    $categoryId = Category::cache()
                          ->where('name', $products[$i]['category'])
                          ->first()
                          ->id;

    Product::create([
        'name' => $products[$i]['name'],
        'category_id' => $categoryId
    ]);
}
```

Some more examples

    // This loop will call query only once.
    for ($i = 0; $i < 100; $i++) {
        $categories = Category::cache();
    }

    // This will reset the cache because the columns have changed.
    $categories = Category::cache(['name', 'description']);

    // This will NOT reset the cache because the columns are the same as the previous one.
    $categories = Category::cache(['name', 'description']);

    // This will reset the cache.
    $categories = Category::cache(['name', 'description'], $reset = true);

    // This will reset the cache because the columns have changed.
    $categories = Category::cache(['email', 'description', 'data']);
