### PR TITLE
[5.3] Catch Throwable in timezone validation

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -6,6 +6,7 @@ use Closure;
 use DateTime;
 use Countable;
 use Exception;
+use Throwable;
 use DateTimeZone;
 use RuntimeException;
 use DateTimeInterface;
@@ -1975,6 +1976,8 @@ class Validator implements ValidatorContract
         try {
             new DateTimeZone($value);
         } catch (Exception $e) {
+            return false;
+        } catch (Throwable $e) {
             return false;
         }
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -2063,6 +2063,9 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
         $v = new Validator($trans, ['foo' => 'GMT'], ['foo' => 'Timezone']);
         $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => ['this_is_not_a_timezone']], ['foo' => 'Timezone']);
+        $this->assertFalse($v->passes());
     }
 
     public function testValidateRegex()


### PR DESCRIPTION
Using PHP 7, DateTimeZone doesn't throw an exception anymore, so we need to go a level up and catch the Throwable