### PR TITLE
[5.3] Use default Slack colors, add warning color

### DIFF
--- a/src/Illuminate/Notifications/Messages/SlackMessage.php
+++ b/src/Illuminate/Notifications/Messages/SlackMessage.php
@@ -7,7 +7,7 @@ use Closure;
 class SlackMessage
 {
     /**
-     * The "level" of the notification (info, success, error).
+     * The "level" of the notification (info, success, error, warning).
      *
      * @var string
      */
@@ -80,6 +80,18 @@ class SlackMessage
     }
 
     /**
+     * Indicate that the notification gives information about a warning.
+     *
+     * @return $this
+     */
+    public function warning()
+    {
+        $this->level = 'warning';
+
+        return $this;
+    }
+    
+    /**
      * Set a custom user icon for the Slack message.
      *
      * @param  string  $username
@@ -147,9 +159,11 @@ class SlackMessage
     {
         switch ($this->level) {
             case 'success':
-                return '#7CD197';
+                return 'good';
             case 'error':
-                return '#F35A00';
+                return 'danger';
+            case 'warning':
+                return 'warning';
         }
     }
 


### PR DESCRIPTION
Slack has 3 default colors, `good`, `danger` and `warning`, see https://api.slack.com/docs/message-guidelines#making_messages_colorful

> When you're not harmonizing with your brand, we suggest using the default light gray. If you're looking for just a little more distinction, consider using optional color values good, warning, or danger.

This changes the hex colors to the suggested default colors and adds the warning color.