### PR TITLE
[5.4] Remove duplicated test for __call()

### DIFF
--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1663,10 +1663,6 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
         $collection = collect([$person1, $person2]);
 
         $this->assertEquals(['Taylor', 'Yaz'], $collection->map->name->toArray());
-
-        $collection = collect([new TestSupportCollectionHigherOrderItem, new TestSupportCollectionHigherOrderItem]);
-
-        $this->assertEquals(['TAYLOR', 'TAYLOR'], $collection->each->uppercase()->map->name->toArray());
     }
 }
 


### PR DESCRIPTION
There wasn't any modification of the `__call` method with the `HigherOrderCollectionMapFromArrays` addition (https://github.com/laravel/framework/pull/16274), so we don't need to test it again.
In my mind the removed test was just a vestige of a copy/paste.