### PR TITLE
[5.3] A resource can define the route basename

### DIFF
--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -212,8 +212,7 @@ class ResourceRegistrar
         if (isset($options['names'])) {
             if (is_string($options['names'])) {
                 $resource = $options['names'];
-            }
-            elseif (isset($options['names'][$method])) {
+            } elseif (isset($options['names'][$method])) {
                 return $options['names'][$method];
             }
         }

--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -209,8 +209,13 @@ class ResourceRegistrar
      */
     protected function getResourceName($resource, $method, $options)
     {
-        if (isset($options['names'][$method])) {
-            return $options['names'][$method];
+        if (isset($options['names'])) {
+            if (is_string($options['names'])) {
+                $resource = $options['names'];
+            }
+            elseif (isset($options['names'][$method])) {
+                return $options['names'][$method];
+            }
         }
 
         // If a global prefix has been assigned to all names for this resource, we will

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -1008,6 +1008,17 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase
 
         $this->assertTrue($router->getRoutes()->hasNamedRoute('foo'));
         $this->assertTrue($router->getRoutes()->hasNamedRoute('bar'));
+
+        $router = $this->getRouter();
+        $router->resource('foo', 'FooController', ['names' => 'bar']);
+
+        $this->assertTrue($router->getRoutes()->hasNamedRoute('bar.index'));
+        $this->assertTrue($router->getRoutes()->hasNamedRoute('bar.show'));
+        $this->assertTrue($router->getRoutes()->hasNamedRoute('bar.create'));
+        $this->assertTrue($router->getRoutes()->hasNamedRoute('bar.store'));
+        $this->assertTrue($router->getRoutes()->hasNamedRoute('bar.edit'));
+        $this->assertTrue($router->getRoutes()->hasNamedRoute('bar.update'));
+        $this->assertTrue($router->getRoutes()->hasNamedRoute('bar.destroy'));
     }
 
     public function testRouterFiresRoutedEvent()


### PR DESCRIPTION
Assuming we have a resource `foo` and we want to rename the route names

from `foo.index` to `bar.index`
from `foo.show` to `bar.show`
...

Instead of passing an array of all the 7 resource method names
```php
$router->resource('foo', 'FooController', ['names' => [
    'index' => 'bar.index',
    'show' => 'bar.show',
    ...
]]);
```

we can just pass a string which represents the basename of the resource
```php
$router->resource('foo', 'FooController', ['names' => 'bar']);
```