### PR TITLE
[5.3] Allow the substrings 'private-' or 'presence-' within private/presence channel names

### DIFF
--- a/src/Illuminate/Broadcasting/Broadcasters/PusherBroadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/PusherBroadcaster.php
@@ -41,8 +41,14 @@ class PusherBroadcaster extends Broadcaster
             throw new HttpException(403);
         }
 
+        if (Str::startsWith($request->channel_name, 'private-')) {
+            return parent::verifyUserCanAccessChannel(
+                $request, Str::replaceFirst('private-', '', $request->channel_name)
+            );
+        }
+
         return parent::verifyUserCanAccessChannel(
-            $request, str_replace(['private-', 'presence-'], '', $request->channel_name)
+            $request, Str::replaceFirst('presence-', '', $request->channel_name)
         );
     }
 

--- a/src/Illuminate/Broadcasting/Broadcasters/RedisBroadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/RedisBroadcaster.php
@@ -49,8 +49,14 @@ class RedisBroadcaster extends Broadcaster
             throw new HttpException(403);
         }
 
+        if (Str::startsWith($request->channel_name, 'private-')) {
+            return parent::verifyUserCanAccessChannel(
+                $request, Str::replaceFirst('private-', '', $request->channel_name)
+            );
+        }
+
         return parent::verifyUserCanAccessChannel(
-            $request, str_replace(['private-', 'presence-'], '', $request->channel_name)
+            $request, Str::replaceFirst('presence-', '', $request->channel_name)
         );
     }
 


### PR DESCRIPTION
Fixed an issue that prevented authentication in private or presence channels containing the words 'private' or 'presence' in their channel names.