### PR TITLE
[5.3] Allow SlackAttachment color override

### DIFF
--- a/src/Illuminate/Notifications/Channels/SlackWebhookChannel.php
+++ b/src/Illuminate/Notifications/Channels/SlackWebhookChannel.php
@@ -77,7 +77,7 @@ class SlackWebhookChannel
     {
         return collect($message->attachments)->map(function ($attachment) use ($message) {
             return array_filter([
-                'color' => $message->color(),
+                'color' => $attachment->color ?: $message->color(),
                 'title' => $attachment->title,
                 'text' => $attachment->content,
                 'title_link' => $attachment->url,

--- a/src/Illuminate/Notifications/Messages/SlackAttachment.php
+++ b/src/Illuminate/Notifications/Messages/SlackAttachment.php
@@ -26,6 +26,13 @@ class SlackAttachment
     public $content;
 
     /**
+     * The attachment's color.
+     *
+     * @var string
+     */
+    public $color;
+
+    /**
      * The attachment's fields.
      *
      * @var array
@@ -56,6 +63,19 @@ class SlackAttachment
     public function content($content)
     {
         $this->content = $content;
+
+        return $this;
+    }
+
+    /**
+     * Set the color of the attachment.
+     *
+     * @param  string  $color
+     * @return $this
+     */
+    public function color($color)
+    {
+        $this->color = $color;
 
         return $this;
     }


### PR DESCRIPTION
Add `->color()` method to specify a specific color for an attachment, to override the global color.