### PR TITLE
[5.3] Storing SES Message-ID in the headers after sending

### DIFF
--- a/src/Illuminate/Mail/Transport/LogTransport.php
+++ b/src/Illuminate/Mail/Transport/LogTransport.php
@@ -35,6 +35,8 @@ class LogTransport extends Transport
 
         $this->logger->debug($this->getMimeEntityString($message));
 
+        $this->sendPerformed($message);
+
         return $this->numberOfRecipients($message);
     }
 

--- a/src/Illuminate/Mail/Transport/MailgunTransport.php
+++ b/src/Illuminate/Mail/Transport/MailgunTransport.php
@@ -78,6 +78,8 @@ class MailgunTransport extends Transport
 
         $this->client->post($this->url, $options);
 
+        $this->sendPerformed($message);
+
         return $this->numberOfRecipients($message);
     }
 

--- a/src/Illuminate/Mail/Transport/MandrillTransport.php
+++ b/src/Illuminate/Mail/Transport/MandrillTransport.php
@@ -56,6 +56,8 @@ class MandrillTransport extends Transport
 
         $this->client->post('https://mandrillapp.com/api/1.0/messages/send-raw.json', $options);
 
+        $this->sendPerformed($message);
+
         return $this->numberOfRecipients($message);
     }
 

--- a/src/Illuminate/Mail/Transport/SesTransport.php
+++ b/src/Illuminate/Mail/Transport/SesTransport.php
@@ -32,12 +32,15 @@ class SesTransport extends Transport
     {
         $this->beforeSendPerformed($message);
 
-        $this->ses->sendRawEmail([
+        $headers = $message->getHeaders();
+
+        // Send the message to SES, storing the SES message id in X-SES-Message-ID
+        $headers->addTextHeader('X-SES-Message-ID',$this->ses->sendRawEmail([
             'Source' => key($message->getSender() ?: $message->getFrom()),
             'RawMessage' => [
                 'Data' => $message->toString(),
             ],
-        ]);
+        ])->get('MessageId'));
 
         $this->sendPerformed($message);
 

--- a/src/Illuminate/Mail/Transport/SesTransport.php
+++ b/src/Illuminate/Mail/Transport/SesTransport.php
@@ -39,6 +39,8 @@ class SesTransport extends Transport
             ],
         ]);
 
+        $this->sendPerformed($message);
+
         return $this->numberOfRecipients($message);
     }
 }

--- a/src/Illuminate/Mail/Transport/SparkPostTransport.php
+++ b/src/Illuminate/Mail/Transport/SparkPostTransport.php
@@ -72,6 +72,8 @@ class SparkPostTransport extends Transport
 
         $this->client->post('https://api.sparkpost.com/api/v1/transmissions', $options);
 
+        $this->sendPerformed($message);
+
         return $this->numberOfRecipients($message);
     }
 

--- a/src/Illuminate/Mail/Transport/Transport.php
+++ b/src/Illuminate/Mail/Transport/Transport.php
@@ -69,6 +69,24 @@ abstract class Transport implements Swift_Transport
     }
 
     /**
+     * Iterate through registered plugins and execute plugins' methods.
+     *
+     * @param \Swift_Mime-Message $message
+     * @return void
+     */
+    protected function sendPerformed(Swift_Mime_Message $message)
+    {
+
+        $event = new Swift_Events_SendEvent($this, $message);
+
+        foreach ($this->plugins as $plugin) {
+            if (method_exists($plugin, 'sendPerformed')) {
+                $plugin->sendPerformed($event);
+            }
+        }
+    }
+
+    /**
      * Get the number of recipients.
      *
      * @param  \Swift_Mime_Message  $message

--- a/tests/Mail/MailSesTransportTest.php
+++ b/tests/Mail/MailSesTransportTest.php
@@ -45,13 +45,39 @@ class MailSesTransportTest extends PHPUnit_Framework_TestCase
             ->getMock();
         $transport = new SesTransport($client);
 
+        // Generate a messageId for our mock to return to ensure that the post-sent message
+        // has X-SES-Message-ID in its headers
+        $messageId = str_random(32);
+        $sendRawEmailMock = new sendRawEmailMock($messageId);
         $client->expects($this->once())
             ->method('sendRawEmail')
             ->with($this->equalTo([
                 'Source' => 'myself@example.com',
                 'RawMessage' => ['Data' => (string) $message],
-            ]));
+            ]))
+            ->willReturn($sendRawEmailMock);
 
         $transport->send($message);
+        $this->assertEquals($messageId, $message->getHeaders()->get('X-SES-Message-ID')->getFieldBody());
+    }
+}
+
+class sendRawEmailMock {
+
+    protected $getResponse = null;
+
+    public function __construct($responseValue)
+    {
+        $this->getResponse = $responseValue;
+    }
+
+    /**
+     * Mock the get() call for the sendRawEmail response
+     * @param  [type] $key [description]
+     * @return [type]      [description]
+     */
+    public function get($key)
+    {
+        return $this->getResponse;
     }
 }


### PR DESCRIPTION
Issue #16364 - this update calls the sendPerformed() plugin function for all the mail transports, and also stores the message ID from Amazon SES into the X-SES-Message-ID header so that sendPerformed() can reference it.