### PR TITLE
[5.3] Fix Auth::onceUsingId by reversing the order of retrieving the id in SessionGuard

### DIFF
--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -163,13 +163,11 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
             return;
         }
 
-        $id = $this->session->get($this->getName());
-
-        if (is_null($id) && $this->user()) {
-            $id = $this->user()->getAuthIdentifier();
+        if ($this->user()) {
+            return $this->user()->getAuthIdentifier();
         }
 
-        return $id;
+        return $this->session->get($this->getName());
     }
 
     /**


### PR DESCRIPTION
I was using ``Auth::onceUsingId()`` in one of my middleware, and when implementing this I noticed that ``Auth::id()`` and ``Auth::user()->id`` didn't return the same id anymore. ``Auth::id()`` was returning the ID of the user that was logged in before calling  ``Auth::onceUsingId()``, while ``Auth::user()`` returned the new logged in user.

This pull requests reverses the order in which the id is retrieved, so that the overridden user will always be returned if it has one, otherwise it looks at the current session. This fixes the issue explained above.