### PR TITLE
[5.4] Decouple translation logic from validator (leave it to translator)

### DIFF
--- a/src/Illuminate/Contracts/Translation/Translator.php
+++ b/src/Illuminate/Contracts/Translation/Translator.php
@@ -4,8 +4,35 @@ namespace Illuminate\Contracts\Translation;
 
 interface Translator
 {
+
+    /**
+     * Determine if a translation exists.
+     *
+     * @param  string  $key
+     * @param  string|null  $locale
+     * @param  bool  $fallback
+     * @return bool
+     */
     public function has($key, $locale = null);
-    public function get($key, $locale = null);
+
+    /**
+     * Get the translation for the given key.
+     *
+     * @param  string  $key
+     * @param  array   $replace
+     * @param  string|null  $locale
+     * @param  bool  $fallback
+     * @return string|array|null
+     */
+    public function get($key, $locale = null, $fallback = true);
+
+    /**
+     * Make the place-holder replacements on a line.
+     *
+     * @param  string  $line
+     * @param  array   $replace
+     * @return string
+     */
     public function format($line, array $replace);
 
     /**

--- a/src/Illuminate/Contracts/Translation/Translator.php
+++ b/src/Illuminate/Contracts/Translation/Translator.php
@@ -4,7 +4,6 @@ namespace Illuminate\Contracts\Translation;
 
 interface Translator
 {
-
     /**
      * Determine if a translation exists.
      *

--- a/src/Illuminate/Contracts/Translation/Translator.php
+++ b/src/Illuminate/Contracts/Translation/Translator.php
@@ -4,6 +4,10 @@ namespace Illuminate\Contracts\Translation;
 
 interface Translator
 {
+    public function has($key, $locale = null);
+    public function get($key, $locale = null);
+    public function format($line, array $replace);
+
     /**
      * Get the translation for a given key.
      *

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -196,11 +196,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
     {
         $line = $this->get($key, $locale = $locale ?: $this->locale ?: $this->fallback);
 
-        if (is_array($number) || $number instanceof Countable) {
-            $number = count($number);
-        }
-
-        return $this->getSelector()->choose($line, $number, $locale);
+        return $this->getSelector()->choose($line, $this->countNumber($number), $locale);
     }
 
     /**
@@ -227,7 +223,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
      */
     public function transChoice($key, $number, array $replace = [], $locale = null)
     {
-        $replace['count'] = $number;
+        $replace['count'] = $this->countNumber($number);
 
         return $this->format($this->choice($key, $number, $locale), $replace);
     }
@@ -252,6 +248,21 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
         $lines = $this->loader->load($locale, $group, $namespace);
 
         $this->loaded[$namespace][$group][$locale] = $lines;
+    }
+
+    /**
+     * Count number of elements or return number
+     *
+     * @param int|array|\Countable $number
+     * @return int
+     */
+    protected function countNumber($number)
+    {
+        if (is_array($number) || $number instanceof Countable) {
+            $number = count($number);
+        }
+
+        return $number;
     }
 
     /**

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -62,7 +62,6 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
         $this->locale = $locale;
     }
 
-
     /**
      * Determine if a translation exists for a given locale.
      *
@@ -76,7 +75,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function has($key, $locale = null, $fallback = true)
     {
@@ -84,7 +83,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function get($key, $locale = null, $fallback = true)
     {
@@ -154,7 +153,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function format($line, array $replace)
     {
@@ -229,7 +228,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
     public function transChoice($key, $number, array $replace = [], $locale = null)
     {
         $replace['count'] = $number;
-        
+
         return $this->format($this->choice($key, $number, $locale), $replace);
     }
 

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -195,13 +195,11 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
      */
     public function choice($key, $number, $locale = null)
     {
-        $line = $this->get($key, $replace, $locale = $locale ?: $this->locale ?: $this->fallback);
+        $line = $this->get($key, $locale = $locale ?: $this->locale ?: $this->fallback);
 
         if (is_array($number) || $number instanceof Countable) {
             $number = count($number);
         }
-
-        $replace['count'] = $number;
 
         return $this->getSelector()->choose($line, $number, $locale);
     }
@@ -230,6 +228,8 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
      */
     public function transChoice($key, $number, array $replace = [], $locale = null)
     {
+        $replace['count'] = $number;
+        
         return $this->format($this->choice($key, $number, $locale), $replace);
     }
 

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -251,7 +251,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
     }
 
     /**
-     * Count number of elements or return number
+     * Count number of elements or return number.
      *
      * @param int|array|\Countable $number
      * @return int

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -76,12 +76,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
     }
 
     /**
-     * Determine if a translation exists.
-     *
-     * @param  string  $key
-     * @param  string|null  $locale
-     * @param  bool  $fallback
-     * @return bool
+     * @inheritDoc
      */
     public function has($key, $locale = null, $fallback = true)
     {
@@ -89,13 +84,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
     }
 
     /**
-     * Get the translation for the given key.
-     *
-     * @param  string  $key
-     * @param  array   $replace
-     * @param  string|null  $locale
-     * @param  bool  $fallback
-     * @return string|array|null
+     * @inheritDoc
      */
     public function get($key, $locale = null, $fallback = true)
     {
@@ -165,11 +154,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
     }
 
     /**
-     * Make the place-holder replacements on a line.
-     *
-     * @param  string  $line
-     * @param  array   $replace
-     * @return string
+     * @inheritDoc
      */
     public function format($line, array $replace)
     {

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -2042,7 +2042,7 @@ class Validator implements ValidatorContract
         // If the rule being validated is a "size" rule, we will need to gather the
         // specific error message for the type of attribute being validated such
         // as a number, file or string which all have different message types.
-        elseif (in_array($rule, $this->sizeRules)) {
+        if (in_array($rule, $this->sizeRules)) {
             return $this->getSizeMessage($attribute, $rule);
         }
 
@@ -2051,8 +2051,8 @@ class Validator implements ValidatorContract
         // messages out of the translator service for this validation rule.
         $key = "validation.{$lowerRule}";
 
-        if ($key != ($value = $this->translator->trans($key))) {
-            return $value;
+        if ($this->translator->has($key)) {
+            return $this->translator->get($key);
         }
 
         return $this->getInlineMessage(
@@ -2094,14 +2094,14 @@ class Validator implements ValidatorContract
      */
     protected function getCustomMessageFromTranslator($customKey)
     {
-        if (($message = $this->translator->trans($customKey)) !== $customKey) {
-            return $message;
+        if ($this->translator->has($customKey)) {
+            return $this->translator->get($customKey);
         }
 
         $shortKey = preg_replace('/^validation\.custom\./', '', $customKey);
 
         $customMessages = Arr::dot(
-            (array) $this->translator->trans('validation.custom')
+            (array) $this->translator->get('validation.custom')
         );
 
         foreach ($customMessages as $key => $message) {
@@ -2131,7 +2131,7 @@ class Validator implements ValidatorContract
 
         $key = "validation.{$lowerRule}.{$type}";
 
-        return $this->translator->trans($key);
+        return $this->translator->get($key);
     }
 
     /**
@@ -2169,19 +2169,28 @@ class Validator implements ValidatorContract
     {
         $value = $this->getAttribute($attribute);
 
-        $message = str_replace(
-            [':attribute', ':ATTRIBUTE', ':Attribute'],
-            [$value, Str::upper($value), Str::ucfirst($value)],
-            $message
-        );
+        $snakeRule = Str::snake($rule);
 
-        if (isset($this->replacers[Str::snake($rule)])) {
-            $message = $this->callReplacer($message, $attribute, Str::snake($rule), $parameters);
+        $replace = [];
+
+        if (isset($this->replacers[$snakeRule])) {
+            $replace = $this->callReplacer($message, $attribute, $snakeRule, $parameters);
         } elseif (method_exists($this, $replacer = "replace{$rule}")) {
-            $message = $this->$replacer($message, $attribute, $rule, $parameters);
+            $replace = $this->$replacer($message, $attribute, $rule, $parameters);
         }
 
-        return $message;
+        $replace = $replace ?: [];
+
+        $replace = array_merge(
+            $replace,
+            [
+                'attribute' => $value,
+                'ATTRIBUTE' => Str::upper($value),
+                'Attribute' => Str::ucfirst($value)
+            ]
+        );
+
+        return $this->translator->format($message, $replace);
     }
 
     /**
@@ -2281,8 +2290,8 @@ class Validator implements ValidatorContract
 
         $key = "validation.values.{$attribute}.{$value}";
 
-        if (($line = $this->translator->trans($key)) !== $key) {
-            return $line;
+        if ($this->translator->has($key)) {
+            return $this->translator->get($key);
         }
 
         return $value;
@@ -2299,7 +2308,10 @@ class Validator implements ValidatorContract
      */
     protected function replaceBetween($message, $attribute, $rule, $parameters)
     {
-        return str_replace([':min', ':max'], $parameters, $message);
+        return [
+            'min' => $parameters[0],
+            'max' => $parameters[1],
+        ];
     }
 
     /**
@@ -2313,7 +2325,9 @@ class Validator implements ValidatorContract
      */
     protected function replaceDateFormat($message, $attribute, $rule, $parameters)
     {
-        return str_replace(':format', $parameters[0], $message);
+        return [
+            'format' => $parameters[0]
+        ];
     }
 
     /**
@@ -2341,7 +2355,9 @@ class Validator implements ValidatorContract
      */
     protected function replaceDigits($message, $attribute, $rule, $parameters)
     {
-        return str_replace(':digits', $parameters[0], $message);
+        return [
+            'digits' => $parameters[0]
+        ];
     }
 
     /**
@@ -2369,7 +2385,9 @@ class Validator implements ValidatorContract
      */
     protected function replaceMin($message, $attribute, $rule, $parameters)
     {
-        return str_replace(':min', $parameters[0], $message);
+        return [
+            'min' => $parameters[0]
+        ];
     }
 
     /**
@@ -2383,7 +2401,9 @@ class Validator implements ValidatorContract
      */
     protected function replaceMax($message, $attribute, $rule, $parameters)
     {
-        return str_replace(':max', $parameters[0], $message);
+        return [
+            'max' => $parameters[0]
+        ];
     }
 
     /**
@@ -2401,7 +2421,9 @@ class Validator implements ValidatorContract
             $parameter = $this->getDisplayableValue($attribute, $parameter);
         }
 
-        return str_replace(':values', implode(', ', $parameters), $message);
+        return [
+            'values' => implode(', ', $parameters)
+        ];
     }
 
     /**
@@ -2429,7 +2451,9 @@ class Validator implements ValidatorContract
      */
     protected function replaceInArray($message, $attribute, $rule, $parameters)
     {
-        return str_replace(':other', $this->getAttribute($parameters[0]), $message);
+        return [
+            'other' => $this->getAttribute($parameters[0])
+        ];
     }
 
     /**
@@ -2443,7 +2467,9 @@ class Validator implements ValidatorContract
      */
     protected function replaceMimetypes($message, $attribute, $rule, $parameters)
     {
-        return str_replace(':values', implode(', ', $parameters), $message);
+        return [
+            'values' => implode(', ', $parameters),
+        ];
     }
 
     /**
@@ -2457,7 +2483,7 @@ class Validator implements ValidatorContract
      */
     protected function replaceMimes($message, $attribute, $rule, $parameters)
     {
-        return str_replace(':values', implode(', ', $parameters), $message);
+        $this->replaceMimetypes($message, $attribute, $rule, $parameters);
     }
 
     /**
@@ -2471,9 +2497,9 @@ class Validator implements ValidatorContract
      */
     protected function replaceRequiredWith($message, $attribute, $rule, $parameters)
     {
-        $parameters = $this->getAttributeList($parameters);
-
-        return str_replace(':values', implode(' / ', $parameters), $message);
+        return [
+            'values' => implode(' / ', $this->getAttributeList($parameters))
+        ];
     }
 
     /**
@@ -2529,7 +2555,9 @@ class Validator implements ValidatorContract
      */
     protected function replaceSize($message, $attribute, $rule, $parameters)
     {
-        return str_replace(':size', $parameters[0], $message);
+        return [
+            'size' => $parameters[0]
+        ];
     }
 
     /**
@@ -2547,7 +2575,10 @@ class Validator implements ValidatorContract
 
         $parameters[0] = $this->getAttribute($parameters[0]);
 
-        return str_replace([':other', ':value'], $parameters, $message);
+        return [
+            'other' => $parameters[0],
+            'value' => $parameters[1],
+        ];
     }
 
     /**
@@ -2563,7 +2594,10 @@ class Validator implements ValidatorContract
     {
         $other = $this->getAttribute(array_shift($parameters));
 
-        return str_replace([':other', ':values'], [$other, implode(', ', $parameters)], $message);
+        return [
+            'other' => $other,
+            'values' => implode(', ', $parameters),
+        ];
     }
 
     /**
@@ -2577,7 +2611,9 @@ class Validator implements ValidatorContract
      */
     protected function replaceSame($message, $attribute, $rule, $parameters)
     {
-        return str_replace(':other', $this->getAttribute($parameters[0]), $message);
+        return [
+            'other' => $this->getAttribute($parameters[0]),
+        ];
     }
 
     /**
@@ -2592,10 +2628,12 @@ class Validator implements ValidatorContract
     protected function replaceBefore($message, $attribute, $rule, $parameters)
     {
         if (! (strtotime($parameters[0]))) {
-            return str_replace(':date', $this->getAttribute($parameters[0]), $message);
+            $date = $this->getAttribute($parameters[0]);
+        } else {
+            $date = $parameters[0];
         }
 
-        return str_replace(':date', $parameters[0], $message);
+        return compact('date');
     }
 
     /**

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -2186,7 +2186,7 @@ class Validator implements ValidatorContract
             [
                 'attribute' => $value,
                 'ATTRIBUTE' => Str::upper($value),
-                'Attribute' => Str::ucfirst($value)
+                'Attribute' => Str::ucfirst($value),
             ]
         );
 
@@ -2326,7 +2326,7 @@ class Validator implements ValidatorContract
     protected function replaceDateFormat($message, $attribute, $rule, $parameters)
     {
         return [
-            'format' => $parameters[0]
+            'format' => $parameters[0],
         ];
     }
 
@@ -2356,7 +2356,7 @@ class Validator implements ValidatorContract
     protected function replaceDigits($message, $attribute, $rule, $parameters)
     {
         return [
-            'digits' => $parameters[0]
+            'digits' => $parameters[0],
         ];
     }
 
@@ -2386,7 +2386,7 @@ class Validator implements ValidatorContract
     protected function replaceMin($message, $attribute, $rule, $parameters)
     {
         return [
-            'min' => $parameters[0]
+            'min' => $parameters[0],
         ];
     }
 
@@ -2402,7 +2402,7 @@ class Validator implements ValidatorContract
     protected function replaceMax($message, $attribute, $rule, $parameters)
     {
         return [
-            'max' => $parameters[0]
+            'max' => $parameters[0],
         ];
     }
 
@@ -2422,7 +2422,7 @@ class Validator implements ValidatorContract
         }
 
         return [
-            'values' => implode(', ', $parameters)
+            'values' => implode(', ', $parameters),
         ];
     }
 
@@ -2452,7 +2452,7 @@ class Validator implements ValidatorContract
     protected function replaceInArray($message, $attribute, $rule, $parameters)
     {
         return [
-            'other' => $this->getAttribute($parameters[0])
+            'other' => $this->getAttribute($parameters[0]),
         ];
     }
 
@@ -2498,7 +2498,7 @@ class Validator implements ValidatorContract
     protected function replaceRequiredWith($message, $attribute, $rule, $parameters)
     {
         return [
-            'values' => implode(' / ', $this->getAttributeList($parameters))
+            'values' => implode(' / ', $this->getAttributeList($parameters)),
         ];
     }
 
@@ -2556,7 +2556,7 @@ class Validator implements ValidatorContract
     protected function replaceSize($message, $attribute, $rule, $parameters)
     {
         return [
-            'size' => $parameters[0]
+            'size' => $parameters[0],
         ];
     }
 

--- a/tests/Translation/TranslationTranslatorTest.php
+++ b/tests/Translation/TranslationTranslatorTest.php
@@ -12,29 +12,29 @@ class TranslationTranslatorTest extends PHPUnit_Framework_TestCase
     public function testHasMethodReturnsFalseWhenReturnedTranslationIsNull()
     {
         $t = $this->getMockBuilder('Illuminate\Translation\Translator')->setMethods(['get'])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
-        $t->expects($this->once())->method('get')->with($this->equalTo('foo'), $this->equalTo([]), $this->equalTo('bar'))->will($this->returnValue('foo'));
+        $t->expects($this->once())->method('get')->with($this->equalTo('foo'), $this->equalTo('bar'))->will($this->returnValue('foo'));
         $this->assertFalse($t->has('foo', 'bar'));
 
         $t = $this->getMockBuilder('Illuminate\Translation\Translator')->setMethods(['get'])->setConstructorArgs([$this->getLoader(), 'en', 'sp'])->getMock();
-        $t->expects($this->once())->method('get')->with($this->equalTo('foo'), $this->equalTo([]), $this->equalTo('bar'))->will($this->returnValue('bar'));
+        $t->expects($this->once())->method('get')->with($this->equalTo('foo'), $this->equalTo('bar'))->will($this->returnValue('bar'));
         $this->assertTrue($t->has('foo', 'bar'));
 
         $t = $this->getMockBuilder('Illuminate\Translation\Translator')->setMethods(['get'])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
-        $t->expects($this->once())->method('get')->with($this->equalTo('foo'), $this->equalTo([]), $this->equalTo('bar'), false)->will($this->returnValue('bar'));
+        $t->expects($this->once())->method('get')->with($this->equalTo('foo'), $this->equalTo('bar'), false)->will($this->returnValue('bar'));
         $this->assertTrue($t->hasForLocale('foo', 'bar'));
 
         $t = $this->getMockBuilder('Illuminate\Translation\Translator')->setMethods(['get'])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
-        $t->expects($this->once())->method('get')->with($this->equalTo('foo'), $this->equalTo([]), $this->equalTo('bar'), false)->will($this->returnValue('foo'));
+        $t->expects($this->once())->method('get')->with($this->equalTo('foo'), $this->equalTo('bar'), false)->will($this->returnValue('foo'));
         $this->assertFalse($t->hasForLocale('foo', 'bar'));
 
         $t = $this->getMockBuilder('Illuminate\Translation\Translator')->setMethods(['load', 'getLine'])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
         $t->expects($this->once())->method('load')->with($this->equalTo('*'), $this->equalTo('foo'), $this->equalTo('en'))->will($this->returnValue(null));
-        $t->expects($this->once())->method('getLine')->with($this->equalTo('*'), $this->equalTo('foo'), $this->equalTo('en'), null, $this->equalTo([]))->will($this->returnValue('bar'));
+        $t->expects($this->once())->method('getLine')->with($this->equalTo('*'), $this->equalTo('foo'), $this->equalTo('en'), null)->will($this->returnValue('bar'));
         $this->assertTrue($t->hasForLocale('foo'));
 
         $t = $this->getMockBuilder('Illuminate\Translation\Translator')->setMethods(['load', 'getLine'])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
         $t->expects($this->once())->method('load')->with($this->equalTo('*'), $this->equalTo('foo'), $this->equalTo('en'))->will($this->returnValue(null));
-        $t->expects($this->once())->method('getLine')->with($this->equalTo('*'), $this->equalTo('foo'), $this->equalTo('en'), null, $this->equalTo([]))->will($this->returnValue('foo'));
+        $t->expects($this->once())->method('getLine')->with($this->equalTo('*'), $this->equalTo('foo'), $this->equalTo('en'), null)->will($this->returnValue('foo'));
         $this->assertFalse($t->hasForLocale('foo'));
     }
 
@@ -42,56 +42,56 @@ class TranslationTranslatorTest extends PHPUnit_Framework_TestCase
     {
         $t = new Illuminate\Translation\Translator($this->getLoader(), 'en');
         $t->getLoader()->shouldReceive('load')->once()->with('en', 'bar', 'foo')->andReturn(['foo' => 'foo', 'baz' => 'breeze :foo']);
-        $this->assertEquals('breeze bar', $t->get('foo::bar.baz', ['foo' => 'bar'], 'en'));
-        $this->assertEquals('foo', $t->get('foo::bar.foo'));
+        $this->assertEquals('breeze bar', $t->trans('foo::bar.baz', ['foo' => 'bar'], 'en'));
+        $this->assertEquals('foo', $t->trans('foo::bar.foo'));
     }
 
     public function testGetMethodProperlyLoadsAndRetrievesItemWithCapitalization()
     {
         $t = $this->getMockBuilder('Illuminate\Translation\Translator')->setMethods(null)->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
         $t->getLoader()->shouldReceive('load')->once()->with('en', 'bar', 'foo')->andReturn(['foo' => 'foo', 'baz' => 'breeze :Foo :BAR']);
-        $this->assertEquals('breeze Bar FOO', $t->get('foo::bar.baz', ['foo' => 'bar', 'bar' => 'foo'], 'en'));
-        $this->assertEquals('foo', $t->get('foo::bar.foo'));
+        $this->assertEquals('breeze Bar FOO', $t->trans('foo::bar.baz', ['foo' => 'bar', 'bar' => 'foo'], 'en'));
+        $this->assertEquals('foo', $t->trans('foo::bar.foo'));
     }
 
     public function testGetMethodProperlyLoadsAndRetrievesItemWithLongestReplacementsFirst()
     {
         $t = new Illuminate\Translation\Translator($this->getLoader(), 'en');
         $t->getLoader()->shouldReceive('load')->once()->with('en', 'bar', 'foo')->andReturn(['foo' => 'foo', 'baz' => 'breeze :foo :foobar']);
-        $this->assertEquals('breeze bar taylor', $t->get('foo::bar.baz', ['foo' => 'bar', 'foobar' => 'taylor'], 'en'));
-        $this->assertEquals('breeze foo bar baz taylor', $t->get('foo::bar.baz', ['foo' => 'foo bar baz', 'foobar' => 'taylor'], 'en'));
-        $this->assertEquals('foo', $t->get('foo::bar.foo'));
+        $this->assertEquals('breeze bar taylor', $t->trans('foo::bar.baz', ['foo' => 'bar', 'foobar' => 'taylor'], 'en'));
+        $this->assertEquals('breeze foo bar baz taylor', $t->trans('foo::bar.baz', ['foo' => 'foo bar baz', 'foobar' => 'taylor'], 'en'));
+        $this->assertEquals('foo', $t->trans('foo::bar.foo'));
     }
 
     public function testGetMethodProperlyLoadsAndRetrievesItemForGlobalNamespace()
     {
         $t = new Illuminate\Translation\Translator($this->getLoader(), 'en');
         $t->getLoader()->shouldReceive('load')->once()->with('en', 'foo', '*')->andReturn(['bar' => 'breeze :foo']);
-        $this->assertEquals('breeze bar', $t->get('foo.bar', ['foo' => 'bar']));
+        $this->assertEquals('breeze bar', $t->trans('foo.bar', ['foo' => 'bar']));
     }
 
     public function testChoiceMethodProperlyLoadsAndRetrievesItem()
     {
         $t = $this->getMockBuilder('Illuminate\Translation\Translator')->setMethods(['get'])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
-        $t->expects($this->once())->method('get')->with($this->equalTo('foo'), $this->equalTo(['replace']), $this->equalTo('en'))->will($this->returnValue('line'));
+        $t->expects($this->once())->method('get')->with($this->equalTo('foo'), $this->equalTo('en'))->will($this->returnValue('line'));
         $t->setSelector($selector = m::mock('Illuminate\Translation\MessageSelector'));
         $selector->shouldReceive('choose')->once()->with('line', 10, 'en')->andReturn('choiced');
 
-        $t->choice('foo', 10, ['replace']);
+        $t->choice('foo', 10);
     }
 
     public function testChoiceMethodProperlyCountsCollectionsAndLoadsAndRetrievesItem()
     {
         $t = $this->getMockBuilder('Illuminate\Translation\Translator')->setMethods(['get'])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
-        $t->expects($this->exactly(2))->method('get')->with($this->equalTo('foo'), $this->equalTo(['replace']), $this->equalTo('en'))->will($this->returnValue('line'));
+        $t->expects($this->exactly(2))->method('get')->with($this->equalTo('foo'), $this->equalTo('en'))->will($this->returnValue('line'));
         $t->setSelector($selector = m::mock('Illuminate\Translation\MessageSelector'));
         $selector->shouldReceive('choose')->twice()->with('line', 3, 'en')->andReturn('choiced');
 
         $values = ['foo', 'bar', 'baz'];
-        $t->choice('foo', $values, ['replace']);
+        $t->choice('foo', $values);
 
         $values = new Illuminate\Support\Collection(['foo', 'bar', 'baz']);
-        $t->choice('foo', $values, ['replace']);
+        $t->choice('foo', $values);
     }
 
     protected function getLoader()

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -187,10 +187,10 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
     public function testCustomReplacersAreCalled()
     {
         $trans = $this->getIlluminateArrayTranslator();
-        $trans->addLines(['validation.required' => 'foo bar'], 'en');
+        $trans->addLines(['validation.required' => 'foo :bar'], 'en');
         $v = new Validator($trans, ['name' => ''], ['name' => 'Required']);
         $v->addReplacer('required', function ($message, $attribute, $rule, $parameters) {
-            return str_replace('bar', 'taylor', $message);
+            return ['bar' => 'taylor'];
         });
         $this->assertFalse($v->passes());
         $v->messages()->setFormat(':message');
@@ -200,12 +200,12 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
     public function testClassBasedCustomReplacers()
     {
         $trans = $this->getIlluminateArrayTranslator();
-        $trans->addLines(['validation.foo' => 'foo!'], 'en');
+        $trans->addLines(['validation.required' => ':foo'], 'en');
         $v = new Validator($trans, [], ['name' => 'required']);
         $v->setContainer($container = m::mock('Illuminate\Container\Container'));
         $v->addReplacer('required', 'Foo@bar');
         $container->shouldReceive('make')->once()->with('Foo')->andReturn($foo = m::mock('StdClass'));
-        $foo->shouldReceive('bar')->once()->andReturn('replaced!');
+        $foo->shouldReceive('bar')->once()->andReturn(['foo' => 'replaced!']);
         $v->passes();
         $v->messages()->setFormat(':message');
         $this->assertEquals('replaced!', $v->messages()->first('name'));


### PR DESCRIPTION
This PR is simillar to #15564 but it does not change `replace` into `map` (or smilliar names) in method names, as suggested by @garygreen 

You can find explanation what does this PR do and why is it made [here](https://github.com/laravel/framework/pull/15564#issuecomment-249229106)

