### PR TITLE
[5.3] Improve the "with default" option in the has one relation.

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/HasOne.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOne.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Database\Eloquent\Relations;
 
-use Closure;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Collection;
 
@@ -77,12 +76,22 @@ class HasOne extends HasOneOrMany
      */
     protected function getDefaultFor(Model $model)
     {
-        if (is_callable($this->withDefault)) {
-            return call_user_func($this->withDefault);
-        } elseif ($this->withDefault === true) {
-            return $this->related->newInstance()->setAttribute(
-                $this->getPlainForeignKey(), $model->getAttribute($this->localKey)
-            );
+        if (! $this->withDefault) {
+            return;
         }
+
+        $instance = $this->related->newInstance()->setAttribute(
+            $this->getPlainForeignKey(), $model->getAttribute($this->localKey)
+        );
+
+        if (is_callable($this->withDefault)) {
+            return call_user_func($this->withDefault, $instance) ?: $instance;
+        }
+
+        if (is_array($this->withDefault)) {
+            $instance->forceFill($this->withDefault);
+        }
+
+        return $instance;
     }
 }

--- a/tests/Database/DatabaseEloquentHasOneTest.php
+++ b/tests/Database/DatabaseEloquentHasOneTest.php
@@ -23,13 +23,51 @@ class DatabaseEloquentHasOneTest extends PHPUnit_Framework_TestCase
 
         $this->builder->shouldReceive('first')->once()->andReturnNull();
 
-        $newModel = m::mock('Illuminate\Database\Eloquent\Model');
-
-        $newModel->shouldReceive('setAttribute')->once()->with('foreign_key', 1)->andReturn($newModel);
+        $newModel = new EloquentHasOneModelStub();
 
         $this->related->shouldReceive('newInstance')->once()->andReturn($newModel);
 
-        $this->assertInstanceOf('Illuminate\Database\Eloquent\Model', $relation->getResults());
+        $this->assertSame($newModel, $relation->getResults());
+
+        $this->assertSame(1, $newModel->getAttribute('foreign_key'));
+    }
+
+    public function testHasOneWithDynamicDefault()
+    {
+        $relation = $this->getRelation()->withDefault(function ($newModel) {
+            $newModel->username = 'taylor';
+        });
+
+        $this->builder->shouldReceive('first')->once()->andReturnNull();
+
+        $newModel = new EloquentHasOneModelStub();
+
+        $this->related->shouldReceive('newInstance')->once()->andReturn($newModel);
+
+        $this->assertSame($newModel, $relation->getResults());
+
+        $this->assertSame('taylor', $newModel->username);
+
+        $this->assertSame(1, $newModel->getAttribute('foreign_key'));
+    }
+
+    public function testHasOneWithArrayDefault()
+    {
+        $attributes = ['username' => 'taylor'];
+
+        $relation = $this->getRelation()->withDefault($attributes);
+
+        $this->builder->shouldReceive('first')->once()->andReturnNull();
+
+        $newModel = new EloquentHasOneModelStub();
+
+        $this->related->shouldReceive('newInstance')->once()->andReturn($newModel);
+
+        $this->assertSame($newModel, $relation->getResults());
+
+        $this->assertSame('taylor', $newModel->username);
+
+        $this->assertSame(1, $newModel->getAttribute('foreign_key'));
     }
 
     public function testSaveMethodSetsForeignKeyOnModel()


### PR DESCRIPTION
There are 3 commits here:

1. First add test for the closure option.

2. Add option to pass an array of attributes for the default model, i.e.:

```
$this->hasOne(Profile::class)->withDefault(['avatar' => 'default.jpg']);
```

3. Make sure the closure is associated to the parent/related model. I'm allowing the possibility that the closure could return `null`. 