### PR TITLE
[5.4] [WIP] Improve the Eloquent push method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1488,7 +1488,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         foreach ($this->relations as $name => $models) {
             $relation = $this->$name();
 
-            if ($relation instanceof BelongsTo) {
+            if ($relation instanceof BelongsTo || $relation instanceof BelongsToMany) {
                 continue;
             }
 

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1448,18 +1448,53 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public function push()
     {
-        if (! $this->save()) {
-            return false;
-        }
-
         // To sync all of the relationships to the database, we will simply spin through
         // the relationships and save each model via this "push" method, which allows
         // us to recurse into all of these nested relations for the model instance.
-        foreach ($this->relations as $models) {
-            $models = $models instanceof Collection
-                        ? $models->all() : [$models];
+        return $this->pushInverseRelations() && $this->save() && $this->pushRelations();
+    }
 
-            foreach (array_filter($models) as $model) {
+    /**
+     * Push all the inversed related models.
+     *
+     * @return bool
+     */
+    protected function pushInverseRelations()
+    {
+        foreach ($this->relations as $name => $model) {
+            $relation = $this->$name();
+
+            if (! $relation instanceof BelongsTo) {
+                continue;
+            }
+
+            if (! $model->push()) {
+                return false;
+            }
+
+            $relation->associate($model);
+        }
+
+        return true;
+    }
+
+    /**
+     * Push the related models excluding the inverse relations.
+     *
+     * @return bool
+     */
+    protected function pushRelations()
+    {
+        foreach ($this->relations as $name => $models) {
+            $relation = $this->$name();
+
+            if ($relation instanceof BelongsTo) {
+                continue;
+            }
+
+            foreach (collect($models)->filter() as $model) {
+                $model->setAttribute($relation->getPlainForeignKey(), $this->getKey());
+
                 if (! $model->push()) {
                     return false;
                 }


### PR DESCRIPTION
Currently the `push` method has issues when saving inverse ("belongs to") relations.

Let's say we have a new Post that belongs to a new Category:

```
        $category = factory(Category::class)->make();

        $post = factory(Post::class)->make();

        $post->category()->associate($category);

        $post->push();
```

Since the push method saves the model first and all the relations after, we run into this:

1. If the `category_id` field is `not nullable` we will get a constraint error.
2. If it is `nullable` we won't get an error but `category_id` will be null, because the Category will be created *after* the Post.

You can read more about the issue here: https://github.com/laravel/framework/issues/10531

And check my functional tests here: 

https://github.com/sileence/eloquent_push_tests/blob/master/tests/EloquentPushTest.php

This does not work with belongs to many or polymorphic relationships just yet, but I'd like to get some feedback.