### PR TITLE
[5.3] Allow chaining factory calls to define() and state()

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factory.php
@@ -60,7 +60,7 @@ class Factory implements ArrayAccess
      * @param  string  $class
      * @param  string  $name
      * @param  callable  $attributes
-     * @return void
+     * @return $this
      */
     public function defineAs($class, $name, callable $attributes)
     {
@@ -73,11 +73,13 @@ class Factory implements ArrayAccess
      * @param  string  $class
      * @param  callable  $attributes
      * @param  string  $name
-     * @return void
+     * @return $this
      */
     public function define($class, callable $attributes, $name = 'default')
     {
         $this->definitions[$class][$name] = $attributes;
+
+        return $this;
     }
 
     /**
@@ -86,11 +88,13 @@ class Factory implements ArrayAccess
      * @param  string  $class
      * @param  string  $state
      * @param  callable  $attributes
-     * @return void
+     * @return $this
      */
     public function state($class, $state, callable $attributes)
     {
         $this->states[$class][$state] = $attributes;
+
+        return $this;
     }
 
     /**


### PR DESCRIPTION
This will allow to group each Model definitions

```php
/**
 * Teacher
 */
$factory
    ->define(App\Teacher::class, function (Faker\Generator $faker)
    {
        return [
            //
        ];
    })
    ->state(App\Teacher::class, 'teacher_foo_state', function (Faker\Generator $faker) {
        return [
            //
        ];
    })
    ->state(App\Teacher::class, 'teacher_bar_state', function (Faker\Generator $faker) {
        return [
            //
        ];
    });

/**
 * Student
 */
$factory
    ->define(App\Student::class, function (Faker\Generator $faker)
    {
        return [
            //
        ];
    })
    ->state(App\Student::class, 'student_foo_state', function (Faker\Generator $faker) {
        return [
            //
        ];
    })
    ->state(App\Student::class, 'student_bar_state', function (Faker\Generator $faker) {
        return [
            //
        ];
    });
```