### PR TITLE
[5.4] Fix foreign key issue when primary key is not 'id'

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2128,7 +2128,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public function getForeignKey()
     {
-        return Str::snake(class_basename($this)).'_id';
+        return Str::snake(class_basename($this)).'_'.$this->primaryKey;
     }
 
     /**


### PR DESCRIPTION
Fixes #16370 which describes scenario when `getForeignKey` method error when the specified primary key for a model is not `id`.

Fix originally suggested by @ElMatella.

Previously added PR #16394  for inclusion in 5.3