### PR TITLE
[5.3] Throw exception on Pusher broadcaster error

### DIFF
--- a/src/Illuminate/Broadcasting/Broadcasters/PusherBroadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/PusherBroadcaster.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Broadcasting\Broadcasters;
 
 use Pusher;
+use RuntimeException;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Symfony\Component\HttpKernel\Exception\HttpException;
@@ -90,7 +91,13 @@ class PusherBroadcaster extends Broadcaster
     {
         $socket = Arr::pull($payload, 'socket');
 
-        $this->pusher->trigger($this->formatChannels($channels), $event, $payload, $socket);
+        if (true === $response = $this->pusher->trigger($this->formatChannels($channels), $event, $payload, $socket)) {
+            return;
+        }
+
+        throw new RuntimeException(
+            is_bool($response) ? 'Failed to connect to Pusher.' : $response['body']
+        );
     }
 
     /**

--- a/src/Illuminate/Broadcasting/Broadcasters/PusherBroadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/PusherBroadcaster.php
@@ -91,7 +91,9 @@ class PusherBroadcaster extends Broadcaster
     {
         $socket = Arr::pull($payload, 'socket');
 
-        if (true === $response = $this->pusher->trigger($this->formatChannels($channels), $event, $payload, $socket)) {
+        $response = $this->pusher->trigger($this->formatChannels($channels), $event, $payload, $socket);
+
+        if ((is_array($response) && $response['status'] == 200) || $response === true) {
             return;
         }
 


### PR DESCRIPTION
This PR throws an exception in case we couldn't connect to pusher while broadcasting an event, it currently fails silently since the Pusher library doesn't throw an exception.

In reference to https://github.com/laravel/framework/issues/16379