### PR TITLE
[5.4] Better type hints on magic methods

### DIFF
--- a/src/Illuminate/Support/Facades/App.php
+++ b/src/Illuminate/Support/Facades/App.php
@@ -3,6 +3,20 @@
 namespace Illuminate\Support\Facades;
 
 /**
+ *
+ * @method static string version()
+ * @method static string basePath()
+ * @method static string environment()
+ * @method static bool isDownForMaintenance()
+ * @method static void registerConfiguredProviders()
+ * @method static \Illuminate\Support\ServiceProvider register(\Illuminate\Support\ServiceProvider|string $provider, array $options = [], bool $force = false)
+ * @method static void registerDeferredProvider(string $provider, string $service = null)
+ * @method static void boot()
+ * @method static void booting(mixed $callback)
+ * @method static void booted(mixed $callback)
+ * @method static string getCachedCompilePath()
+ * @method static string getCachedServicesPath()
+ *
  * @see \Illuminate\Foundation\Application
  */
 class App extends Facade

--- a/src/Illuminate/Support/Facades/App.php
+++ b/src/Illuminate/Support/Facades/App.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Support\Facades;
 
 /**
- *
  * @method static string version()
  * @method static string basePath()
  * @method static string environment()

--- a/src/Illuminate/Support/Facades/Artisan.php
+++ b/src/Illuminate/Support/Facades/Artisan.php
@@ -3,6 +3,12 @@
 namespace Illuminate\Support\Facades;
 
 /**
+ * @method static int handle(\Symfony\Component\Console\Input\InputInterface $input, \Symfony\Component\Console\Output\OutputInterface $output = null)
+ * @method static int call(string $command, array $parameters = [])
+ * @method static int queue(string $command, array $parameters = [])
+ * @method static array all()
+ * @method static string output()
+ *
  * @see \Illuminate\Contracts\Console\Kernel
  */
 class Artisan extends Facade

--- a/src/Illuminate/Support/Facades/Auth.php
+++ b/src/Illuminate/Support/Facades/Auth.php
@@ -3,6 +3,22 @@
 namespace Illuminate\Support\Facades;
 
 /**
+ * @method static mixed guard(string|null $name = null)
+ * @method static void shouldUse(string $name);
+ * @method static bool check()
+ * @method static bool guest()
+ * @method static \Illuminate\Contracts\Auth\Authenticatable|null user()
+ * @method static int|null id()
+ * @method static bool validate(array $credentials = [])
+ * @method static void setUser(\Illuminate\Contracts\Auth\Authenticatable $user)
+ * @method static bool attempt(array $credentials = [], bool $remember = false, bool $login = true)
+ * @method static bool once(array $credentials = [])
+ * @method static void login(\Illuminate\Contracts\Auth\Authenticatable $user, bool $remember = false)
+ * @method static \Illuminate\Contracts\Auth\Authenticatable loginUsingId(mixed $id, bool $remember = false)
+ * @method static bool onceUsingId(mixed $id)
+ * @method static bool viaRemember()
+ * @method static void logout()
+ *
  * @see \Illuminate\Auth\AuthManager
  * @see \Illuminate\Contracts\Auth\Factory
  * @see \Illuminate\Contracts\Auth\Guard

--- a/src/Illuminate/Support/Facades/Route.php
+++ b/src/Illuminate/Support/Facades/Route.php
@@ -3,6 +3,18 @@
 namespace Illuminate\Support\Facades;
 
 /**
+ * @method static void get(string $uri, \Closure|array|string $action)
+ * @method static void post(string $uri, \Closure|array|string $action)
+ * @method static void put(string $uri, \Closure|array|string $action)
+ * @method static void delete(string $uri, \Closure|array|string $action)
+ * @method static void patch(string $uri, \Closure|array|string $action)
+ * @method static void options(string $uri, \Closure|array|string $action)
+ * @method static void match(array|string $methods, string $uri, \Closure|array|string $action)
+ * @method static void resource(string $name, string $controller, array $options = [])
+ * @method static void group(array $attributes, \Closure $callback)
+ * @method static \Illuminate\Routing\Route substituteBindings(\Illuminate\Routing\Route $route)
+ * @method static void substituteImplicitBindings(\Illuminate\Routing\Route $route)
+ *
  * @see \Illuminate\Routing\Router
  */
 class Route extends Facade


### PR DESCRIPTION
This PR refers to https://github.com/laravel/internals/issues/284

-   [ ] Type hint all `Facade` static methods.
    - [x] Added type hints on the `Route` facade for all methods available on the `Routing\Registrar` interface.
-   [ ] Type hint all methods that currently return `mixed`, if possible.
-   [ ] Build a generator for all previous type hints (see https://github.com/barryvdh/laravel-ide-helper)

