### PR TITLE
[5.3] Add Batch column to migration:status command

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/StatusCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/StatusCommand.php
@@ -55,17 +55,19 @@ class StatusCommand extends BaseCommand
             return $this->error('No migrations found.');
         }
 
-        $ran = $this->migrator->getRepository()->getRan();
+        $ran = $this->migrator->getRepository()->getRanWithBatch();
 
         $migrations = Collection::make($this->getAllMigrationFiles())
                             ->map(function ($migration) use ($ran) {
-                                return in_array($this->migrator->getMigrationName($migration), $ran)
-                                        ? ['<info>Y</info>', $this->migrator->getMigrationName($migration)]
-                                        : ['<fg=red>N</fg=red>', $this->migrator->getMigrationName($migration)];
+                                $name = $this->migrator->getMigrationName($migration);
+
+                                return array_key_exists($name, $ran)
+                                        ? ['<info>Y</info>', $name, $ran[$name]]
+                                        : ['<fg=red>N</fg=red>', $name, ''];
                             });
 
         if (count($migrations) > 0) {
-            $this->table(['Ran?', 'Migration'], $migrations);
+            $this->table(['Ran?', 'Migration', 'Batch'], $migrations);
         } else {
             $this->error('No migrations found');
         }

--- a/src/Illuminate/Database/Migrations/DatabaseMigrationRepository.php
+++ b/src/Illuminate/Database/Migrations/DatabaseMigrationRepository.php
@@ -54,6 +54,19 @@ class DatabaseMigrationRepository implements MigrationRepositoryInterface
     }
 
     /**
+     * Get the ran migrations with batch number.
+     *
+     * @return array
+     */
+    public function getRanWithBatch()
+    {
+        return $this->table()
+            ->orderBy('batch', 'asc')
+            ->orderBy('migration', 'asc')
+            ->pluck('batch', 'migration')->all();
+    }
+
+    /**
      * Get list of migrations.
      *
      * @param  int  $steps

--- a/src/Illuminate/Database/Migrations/MigrationRepositoryInterface.php
+++ b/src/Illuminate/Database/Migrations/MigrationRepositoryInterface.php
@@ -12,6 +12,13 @@ interface MigrationRepositoryInterface
     public function getRan();
 
     /**
+     * Get the ran migrations with the batch number for a given package.
+     *
+     * @return array
+     */
+    public function getRanWithBatch();
+
+    /**
      * Get list of migrations.
      *
      * @param  int  $steps


### PR DESCRIPTION
The developper will have access to the batch number directly from his console.