### PR TITLE
[5.3] Fix for #16400 callable for $callback parameter added for Schedule::call

### DIFF
--- a/src/Illuminate/Console/Scheduling/Schedule.php
+++ b/src/Illuminate/Console/Scheduling/Schedule.php
@@ -18,7 +18,7 @@ class Schedule
     /**
      * Add a new callback event to the schedule.
      *
-     * @param  string  $callback
+     * @param  string|callable  $callback
      * @param  array   $parameters
      * @return \Illuminate\Console\Scheduling\Event
      */


### PR DESCRIPTION
callable type for $callback parameter added for Schedule::call in PHPDoc block