### PR TITLE
Add ability to create multiple classes with one command.

### DIFF
--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -45,13 +45,17 @@ abstract class GeneratorCommand extends Command
     /**
      * Execute the console command.
      *
-     * @return null
+     * @return array
      */
     public function fire()
     {
-        foreach($this->getNameInput() as $name) {
-            $this->generate($name);
+        $generated = [];
+
+        foreach (array_unique($this->getNameInput()) as $name) {
+            $generated[$name] = $this->generate($name);
         }
+
+        return $generated;
     }
 
     protected function generate($rawName)

--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -45,25 +45,32 @@ abstract class GeneratorCommand extends Command
     /**
      * Execute the console command.
      *
-     * @return bool|null
+     * @return null
      */
     public function fire()
     {
-        $name = $this->parseName($this->getNameInput());
+        foreach($this->getNameInput() as $name) {
+            $this->generate($name);
+        }
+    }
+
+    protected function generate($rawName)
+    {
+        $name = $this->parseName($rawName);
 
         $path = $this->getPath($name);
 
-        if ($this->alreadyExists($this->getNameInput())) {
-            $this->error($this->type.' already exists!');
+        if ($this->alreadyExists($rawName)) {
+            $this->error($this->type.' '.$rawName.' already exists!');
 
-            return false;
+            return;
         }
 
         $this->makeDirectory($path);
 
         $this->files->put($path, $this->buildClass($name));
 
-        $this->info($this->type.' created successfully.');
+        $this->info($this->type.' '.$rawName.' created successfully.');
     }
 
     /**
@@ -198,11 +205,11 @@ abstract class GeneratorCommand extends Command
     /**
      * Get the desired class name from the input.
      *
-     * @return string
+     * @return array
      */
     protected function getNameInput()
     {
-        return trim($this->argument('name'));
+        return array_map('trim', (array) $this->argument('name'));
     }
 
     /**
@@ -213,7 +220,7 @@ abstract class GeneratorCommand extends Command
     protected function getArguments()
     {
         return [
-            ['name', InputArgument::REQUIRED, 'The name of the class'],
+            ['name', InputArgument::IS_ARRAY | InputArgument::REQUIRED, 'The name of the class'],
         ];
     }
 }

--- a/src/Illuminate/Foundation/Console/ConsoleMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ConsoleMakeCommand.php
@@ -72,7 +72,7 @@ class ConsoleMakeCommand extends GeneratorCommand
     protected function getArguments()
     {
         return [
-            ['name', InputArgument::REQUIRED, 'The name of the command.'],
+            ['name', InputArgument::IS_ARRAY | InputArgument::REQUIRED, 'The name of the command.'],
         ];
     }
 

--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -41,22 +41,36 @@ class ModelMakeCommand extends GeneratorCommand
         }
 
         if ($this->option('migration')) {
-            $table = Str::plural(Str::snake(class_basename($this->argument('name'))));
-
-            $this->call('make:migration', [
-                'name' => "create_{$table}_table",
-                '--create' => $table,
-            ]);
+            foreach($this->argument('name') as $name) {
+                $this->makeMigration($name);
+            }
         }
 
         if ($this->option('controller')) {
-            $controller = Str::studly(class_basename($this->argument('name')));
-
-            $this->call('make:controller', [
-                'name' => "{$controller}Controller",
-                '--resource' => $this->option('resource'),
-            ]);
+            foreach($this->argument('name') as $name) {
+                $this->makeController($name);
+            }
         }
+    }
+
+    protected function makeMigration($name)
+    {
+        $table = Str::plural(Str::snake(class_basename($name)));
+
+        $this->call('make:migration', [
+            'name' => "create_{$table}_table",
+            '--create' => $table,
+        ]);
+    }
+
+    protected function makeController($name)
+    {
+        $controller = Str::studly(class_basename($name));
+
+        $this->call('make:controller', [
+            'name' => "{$controller}Controller",
+            '--resource' => $this->option('resource'),
+        ]);
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -36,18 +36,16 @@ class ModelMakeCommand extends GeneratorCommand
      */
     public function fire()
     {
-        if (parent::fire() === false) {
-            return;
-        }
+        $generated = array_keys(
+            array_filter(parent::fire())
+        );
 
-        if ($this->option('migration')) {
-            foreach($this->argument('name') as $name) {
+        foreach ($generated as $name) {
+            if ($this->option('migration')) {
                 $this->makeMigration($name);
             }
-        }
 
-        if ($this->option('controller')) {
-            foreach($this->argument('name') as $name) {
+            if ($this->option('controller')) {
                 $this->makeController($name);
             }
         }


### PR DESCRIPTION
Previously discussed [here](https://github.com/laravel/internals/issues/297).

This allows for creating multiple classes with one command call:
Eg.
```
php artisan make:model User Post Comment --migration --controller
```
will create three models and for each of them a migration and a controller.

The change applies to all commands extending the `GeneratorCommand` abstract class.
Besides `GeneratorCommand` there were necessary changes to:
1. `ConsoleMakeCommand` - it overrides the `getArgument` method.
2.  `ModelMakeCommand` - it adds migrations and controllers in the `fire` method, so it needs to loop over all the class names.

One thing left to consider in `ModelMakeCommand` is to check if the model was actually created before making a migration or a controller.
