### PR TITLE
[5.3] Pheanstalk driver requires that PheanstalkJob is passed to delete method

### DIFF
--- a/src/Illuminate/Queue/BeanstalkdQueue.php
+++ b/src/Illuminate/Queue/BeanstalkdQueue.php
@@ -130,7 +130,7 @@ class BeanstalkdQueue extends Queue implements QueueContract
      */
     public function deleteMessage($queue, $id)
     {
-        $this->pheanstalk->useTube($this->getQueue($queue))->delete($id);
+        $this->pheanstalk->useTube($this->getQueue($queue))->delete(new PheanstalkJob($id, ''));
     }
 
     /**


### PR DESCRIPTION
The deleteMessage() method of  Illuminate\Queue\BeanstalkdQueue passes a plain (integer) id to the Pheanstalk driver delete() method, which causes an error due to incompatible signature with the newer versions of Pheanstalk.  

This fix wraps the id in a PheanstalkJob object.