### PR TITLE
[5.3] Add mime type to disk storage via UploadedFile

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -101,9 +101,10 @@ class FilesystemAdapter implements FilesystemContract, CloudFilesystemContract
      * @param  string  $path
      * @param  \Illuminate\Http\UploadedFile  $file
      * @param  string  $visibility
+     * @param  string  $mimeType
      * @return string|false
      */
-    public function putFile($path, $file, $visibility = null)
+    public function putFile($path, $file, $visibility = null, $mimeType = null)
     {
         return $this->putFileAs($path, $file, $file->hashName(), $visibility);
     }
@@ -115,13 +116,14 @@ class FilesystemAdapter implements FilesystemContract, CloudFilesystemContract
      * @param  \Illuminate\Http\File|\Illuminate\Http\UploadedFile  $file
      * @param  string  $name
      * @param  string  $visibility
+     * @param  string  $mimeType
      * @return string|false
      */
-    public function putFileAs($path, $file, $name, $visibility = null)
+    public function putFileAs($path, $file, $name, $visibility = null, $mimeType = null)
     {
         $stream = fopen($file->getRealPath(), 'r+');
 
-        $result = $this->put($path = trim($path.'/'.$name, '/'), $stream, $visibility);
+        $result = $this->put($path = trim($path.'/'.$name, '/'), $stream, $visibility, $mimeType);
 
         if (is_resource($stream)) {
             fclose($stream);

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -84,7 +84,7 @@ class FilesystemAdapter implements FilesystemContract, CloudFilesystemContract
         if ($visibility = $this->parseVisibility($visibility)) {
             $config['visibility'] = $visibility;
         }
-        if (!empty($mimeType)) {
+        if (! empty($mimeType)) {
             $config['mimetype'] = $mimeType;
         }
 

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -71,18 +71,21 @@ class FilesystemAdapter implements FilesystemContract, CloudFilesystemContract
      * @param  string  $path
      * @param  string|resource  $contents
      * @param  string  $visibility
+     * @param  string  $mimeType
      * @return bool
      */
-    public function put($path, $contents, $visibility = null)
+    public function put($path, $contents, $visibility = null, $mimeType = null)
     {
         if ($contents instanceof File || $contents instanceof UploadedFile) {
             return $this->putFile($path, $contents, $visibility);
         }
 
+        $config = [];
         if ($visibility = $this->parseVisibility($visibility)) {
-            $config = ['visibility' => $visibility];
-        } else {
-            $config = [];
+            $config['visibility'] = $visibility;
+        }
+        if (!empty($mimeType)) {
+            $config['mimetype'] = $mimeType;
         }
 
         if (is_resource($contents)) {

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -106,7 +106,7 @@ class FilesystemAdapter implements FilesystemContract, CloudFilesystemContract
      */
     public function putFile($path, $file, $visibility = null, $mimeType = null)
     {
-        return $this->putFileAs($path, $file, $file->hashName(), $visibility);
+        return $this->putFileAs($path, $file, $file->hashName(), $visibility, $mimeType);
     }
 
     /**

--- a/src/Illuminate/Http/UploadedFile.php
+++ b/src/Illuminate/Http/UploadedFile.php
@@ -16,11 +16,12 @@ class UploadedFile extends SymfonyUploadedFile
      *
      * @param  string  $path
      * @param  string|null  $disk
+     * @param  string|bool|null  $mimeType
      * @return string|false
      */
-    public function store($path, $disk = null)
+    public function store($path, $disk = null, $mimeType = null)
     {
-        return $this->storeAs($path, $this->hashName(), $disk);
+        return $this->storeAs($path, $this->hashName(), $disk, $mimeType);
     }
 
     /**
@@ -28,11 +29,12 @@ class UploadedFile extends SymfonyUploadedFile
      *
      * @param  string  $path
      * @param  string|null  $disk
+     * @param  string|bool|null  $mimeType
      * @return string|false
      */
-    public function storePublicly($path, $disk = null)
+    public function storePublicly($path, $disk = null, $mimeType = null)
     {
-        return $this->storeAs($path, $this->hashName(), $disk, 'public');
+        return $this->storeAs($path, $this->hashName(), $disk, 'public', $mimeType);
     }
 
     /**
@@ -41,11 +43,12 @@ class UploadedFile extends SymfonyUploadedFile
      * @param  string  $path
      * @param  string  $name
      * @param  string|null  $disk
+     * @param  string|bool|null  $mimeType
      * @return string|false
      */
-    public function storePubliclyAs($path, $name, $disk = null)
+    public function storePubliclyAs($path, $name, $disk = null, $mimeType = null)
     {
-        return $this->storeAs($path, $name, $disk, 'public');
+        return $this->storeAs($path, $name, $disk, 'public', $mimeType);
     }
 
     /**
@@ -55,13 +58,18 @@ class UploadedFile extends SymfonyUploadedFile
      * @param  string  $name
      * @param  string|null  $disk
      * @param  string|null  $visibility
+     * @param  string|bool|null  $mimeType
      * @return string|false
      */
-    public function storeAs($path, $name, $disk = null, $visibility = null)
+    public function storeAs($path, $name, $disk = null, $visibility = null, $mimeType = null)
     {
         $factory = Container::getInstance()->make(FilesystemFactory::class);
 
-        return $factory->disk($disk)->putFileAs($path, $this, $name, $visibility);
+        if ($mimeType === true) {
+            $mimeType = $this->getMimeType();
+        }
+
+        return $factory->disk($disk)->putFileAs($path, $this, $name, $visibility, $mimeType);
     }
 
     /**


### PR DESCRIPTION
Although `mimetype` is a supported configuration option for Flysystem, there is no way to pass this though the FileSystemAdapter put() method and consequently any of the convenience functions in UploadedFile.  This commit adds support for a `mimeType` parameter for all of the store functions within UploadedFile and to the `Illuminate\Filesystem\FilesystemAdapter` class.