### PR TITLE
[5.3] Eloquent relations attribute setters

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -6,6 +6,7 @@ use Closure;
 use Exception;
 use ArrayAccess;
 use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Relations\MutableRelation;
 use LogicException;
 use JsonSerializable;
 use DateTimeInterface;
@@ -2865,6 +2866,12 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
             return $this->{$method}($value);
         }
 
+        // If the "attribute" exists as a method on the model, we will just assume
+        // it is a relationship and will set the relationship value.
+        elseif (($value instanceof self || $value instanceof Collection) && method_exists($this, $key)) {
+            $this->setRelationValue($key, $value);
+        }
+
         // If an attribute is listed as a "date", we'll convert it from a DateTime
         // instance into a form proper for storage on the database tables using
         // the connection grammar's date format. We will auto set the values.
@@ -3292,6 +3299,25 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         $this->relations = $relations;
 
         return $this;
+    }
+
+    /**
+     * Set the relationship value on the model.
+     *
+     * @param $method
+     * @param $value
+     *
+     * @return void
+     */
+    public function setRelationValue($method, $value)
+    {
+        $relation = $this->$method();
+
+        if (! $relation instanceof MutableRelation) {
+            throw new LogicException("{$method}() must return a mutable relation");
+        }
+
+        $relation->setValue($value);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
@@ -7,7 +7,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Query\Expression;
 use Illuminate\Database\Eloquent\Collection;
 
-class BelongsTo extends Relation
+class BelongsTo extends Relation implements MutableRelation
 {
     /**
      * The foreign key of the parent model.
@@ -64,6 +64,18 @@ class BelongsTo extends Relation
     public function getResults()
     {
         return $this->query->first();
+    }
+
+    /**
+     * Set the the relationship value.
+     *
+     * @param $value
+     *
+     * @return void
+     */
+    public function setValue($value)
+    {
+        $this->associate($value);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -9,7 +9,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 
-class BelongsToMany extends Relation
+class BelongsToMany extends Relation implements MutableRelation
 {
     /**
      * The intermediate table for the relation.
@@ -110,6 +110,18 @@ class BelongsToMany extends Relation
     public function getResults()
     {
         return $this->get();
+    }
+
+    /**
+     * Set the the relationship value.
+     *
+     * @param $value
+     *
+     * @return void
+     */
+    public function setValue($value)
+    {
+        $this->sync($value);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/HasMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasMany.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Database\Eloquent\Relations;
 
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Model;
 
 class HasMany extends HasOneOrMany
 {
@@ -14,6 +15,18 @@ class HasMany extends HasOneOrMany
     public function getResults()
     {
         return $this->query->get();
+    }
+
+    /**
+     * Set the the relationship value.
+     *
+     * @param $value
+     *
+     * @return void
+     */
+    public function setValue($value)
+    {
+        $this->saveMany($value instanceof Model ? [$value] : $value);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/HasOne.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOne.php
@@ -40,6 +40,18 @@ class HasOne extends HasOneOrMany
     }
 
     /**
+     * Set the the relationship value.
+     *
+     * @param $value
+     *
+     * @return void
+     */
+    public function setValue($value)
+    {
+        $this->save($value);
+    }
+
+    /**
      * Initialize the relation on a set of models.
      *
      * @param  array   $models

--- a/src/Illuminate/Database/Eloquent/Relations/MorphMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphMany.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Database\Eloquent\Relations;
 
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Model;
 
 class MorphMany extends MorphOneOrMany
 {
@@ -14,6 +15,18 @@ class MorphMany extends MorphOneOrMany
     public function getResults()
     {
         return $this->query->get();
+    }
+
+    /**
+     * Set the the relationship value.
+     *
+     * @param $value
+     *
+     * @return void
+     */
+    public function setValue($value)
+    {
+        $this->saveMany($value instanceof Model ? [$value] : $value);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/MorphOne.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphOne.php
@@ -17,6 +17,18 @@ class MorphOne extends MorphOneOrMany
     }
 
     /**
+     * Set the the relationship value.
+     *
+     * @param $value
+     *
+     * @return void
+     */
+    public function setValue($value)
+    {
+        $this->save($value);
+    }
+
+    /**
      * Initialize the relation on a set of models.
      *
      * @param  array   $models

--- a/src/Illuminate/Database/Eloquent/Relations/MutableRelation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MutableRelation.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Relations;
+
+interface MutableRelation
+{
+    /**
+     * Set the the relationship value.
+     *
+     * @param $value
+     *
+     * @return void
+     */
+    public function setValue($value);
+}

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1501,6 +1501,42 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
         $this->assertFalse($result);
     }
 
+    public function testSetRelationValueFromAttribute()
+    {
+        // Related model
+        $relatedModel = m::mock('Illuminate\Database\Eloquent\Model');
+
+        $model = $this->getMockBuilder('EloquentModelStub')->setMethods(['setRelationValue'])->getMock();
+        $model->expects($this->once())->method('setRelationValue')->with('belongsToStub', $relatedModel);
+
+        $model->belongsToStub = $relatedModel;
+
+        // Related collection
+        $relatedCollection = m::mock('Illuminate\Database\Eloquent\Collection');
+
+        $model = $this->getMockBuilder('EloquentModelStub')->setMethods(['setRelationValue'])->getMock();
+        $model->expects($this->once())->method('setRelationValue')->with('belongsToStub', $relatedCollection);
+
+        $model->belongsToStub = $relatedCollection;
+
+        // Method doesn't exist
+        $related = m::mock('Illuminate\Database\Eloquent\Model');
+
+        $model = $this->getMockBuilder('EloquentModelStub')->setMethods(['setRelationValue'])->getMock();
+        $model->expects($this->never())->method('setRelationValue');
+
+        $model->nonExistingMethod = $related;
+
+        // Method exists but it's not a relation
+        $related = m::mock('Illuminate\Database\Eloquent\Model');
+
+        $model = new EloquentModelStub();
+
+        $this->expectException(\LogicException::class);
+
+        $model->incorrectRelationStub = $related;
+    }
+
     protected function addMockConnection($model)
     {
         $model->setConnectionResolver($resolver = m::mock('Illuminate\Database\ConnectionResolverInterface'));


### PR DESCRIPTION
The PR aims to make setting relationships easier by using an attribute syntax

```php
class Post extends Model
{
   public function user()
   {
      return $this->belongsTo(User::class);
   }
}

class User extends Model
{
    public function posts()
   {
            return $this->hasMany(Post::class);
   }
}
```

```php
$user = User::find(1);

$post->user = $user;

//Is the same as

$post->user()->associate($user);
```

```php
$posts = Post::find([1, 2, 3]);

$user->posts = $posts

//Is the same as

$user->posts()->saveMany($posts);
```