### PR TITLE
[5.3] Update Connection.php

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -829,7 +829,7 @@ class Connection implements ConnectionInterface
      */
     protected function reconnectIfMissingConnection()
     {
-        if (is_null($this->getPdo()) || is_null($this->getReadPdo())) {
+        if (is_null($this->pdo)) {
             $this->reconnect();
         }
     }


### PR DESCRIPTION
reconnectIfMissingConnection() calls getPdo(). This executes the callback which is not desired for read/write connections where the read is being used. Checking is_null($this->pdo) instead allows for the callback to not be called until it is needed.