### PR TITLE
[5.4] Add new JSON loader for translations

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -796,6 +796,21 @@ if (! function_exists('trans_choice')) {
     }
 }
 
+if (! function_exists('__')) {
+    /**
+     * Translate the given message.
+     *
+     * @param  string  $id
+     * @param  array   $replace
+     * @param  string  $locale
+     * @return \Illuminate\Contracts\Translation\Translator|string
+     */
+    function __($id = null, $replace = [], $locale = null)
+    {
+        return app('translator')->getJson($id, $replace, $locale);
+    }
+}
+
 if (! function_exists('url')) {
     /**
      * Generate a url for the application.

--- a/src/Illuminate/Translation/FileLoader.php
+++ b/src/Illuminate/Translation/FileLoader.php
@@ -127,7 +127,7 @@ class FileLoader implements LoaderInterface
     protected function loadJson($path, $locale)
     {
         if ($this->files->exists($full = "{$path}/{$locale}.json")) {
-            return (array) json_decode($this->files->get($full));
+            return json_decode($this->files->get($full), true);
         }
 
         return [];

--- a/src/Illuminate/Translation/FileLoader.php
+++ b/src/Illuminate/Translation/FileLoader.php
@@ -50,6 +50,10 @@ class FileLoader implements LoaderInterface
      */
     public function load($locale, $group, $namespace = null)
     {
+        if ($group == '*' && $namespace == '*') {
+            return $this->loadJson($this->path, $locale);
+        }
+
         if (is_null($namespace) || $namespace == '*') {
             return $this->loadPath($this->path, $locale, $group);
         }
@@ -108,6 +112,22 @@ class FileLoader implements LoaderInterface
     {
         if ($this->files->exists($full = "{$path}/{$locale}/{$group}.php")) {
             return $this->files->getRequire($full);
+        }
+
+        return [];
+    }
+
+    /**
+     * Load a locale from a given JSON file.
+     *
+     * @param  string  $path
+     * @param  string  $locale
+     * @return array
+     */
+    protected function loadJson($path, $locale)
+    {
+        if ($this->files->exists($full = "{$path}/{$locale}.json")) {
+            return (array) json_decode($this->files->get($full));
         }
 
         return [];

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -88,6 +88,33 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
     }
 
     /**
+     * Get the JSON translation for a given key.
+     *
+     * @param  string  $key
+     * @param  array   $replace
+     * @param  string  $locale
+     * @return string
+     */
+    public function getJson($key, array $replace = [], $locale = null)
+    {
+        $locale = $locale ?: $this->locale;
+
+        $this->load('*', '*', $locale);
+
+        $line = Arr::get($this->loaded['*']['*'][$locale], $key);
+
+        if (! isset($line)) {
+            $alternativeLine = $this->get($key, $replace, $locale);
+
+            if ($alternativeLine != $key) {
+                return $alternativeLine;
+            }
+        }
+
+        return $this->makeJsonReplacements($line ?: $key, $replace);
+    }
+
+    /**
      * Get the translation for the given key.
      *
      * @param  string  $key
@@ -181,6 +208,28 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
                 [':'.$key, ':'.Str::upper($key), ':'.Str::ucfirst($key)],
                 [$value, Str::upper($value), Str::ucfirst($value)],
                 $line
+            );
+        }
+
+        return $line;
+    }
+
+    /**
+     * Make the place-holder replacements on a JSON line.
+     *
+     * @param  string  $line
+     * @param  array   $replace
+     * @return string
+     */
+    protected function makeJsonReplacements($line, array $replace)
+    {
+        preg_match_all('#:(?:[a-zA-Z1-9]*)#s', $line, $placeholders);
+
+        $placeholders = $placeholders[0];
+
+        foreach ($placeholders as $i => $key) {
+            $line = str_replace_first(
+                $key, isset($replace[$i]) ? $replace[$i] : $key, $line
             );
         }
 

--- a/tests/Translation/TranslationFileLoaderTest.php
+++ b/tests/Translation/TranslationFileLoaderTest.php
@@ -58,4 +58,13 @@ class TranslationFileLoaderTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals([], $loader->load('en', 'foo', 'bar'));
     }
+
+    public function testLoadMethodForJSONProperlyCallsLoader()
+    {
+        $loader = new FileLoader($files = m::mock('Illuminate\Filesystem\Filesystem'), __DIR__);
+        $files->shouldReceive('exists')->once()->with(__DIR__.'/en.json')->andReturn(true);
+        $files->shouldReceive('get')->once()->with(__DIR__.'/en.json')->andReturn('{"foo":"bar"}');
+
+        $this->assertEquals(['foo' => 'bar'], $loader->load('en', '*', '*'));
+    }
 }

--- a/tests/Translation/TranslationTranslatorTest.php
+++ b/tests/Translation/TranslationTranslatorTest.php
@@ -94,6 +94,52 @@ class TranslationTranslatorTest extends PHPUnit_Framework_TestCase
         $t->choice('foo', $values, ['replace']);
     }
 
+    public function testGetJsonMethod()
+    {
+        $t = new Illuminate\Translation\Translator($this->getLoader(), 'en');
+        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn(['foo' => 'one']);
+        $this->assertEquals('one', $t->getJson('foo'));
+    }
+
+    public function testGetJsonReplaces()
+    {
+        $t = new Illuminate\Translation\Translator($this->getLoader(), 'en');
+        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn(['foo :message' => 'bar :message']);
+        $this->assertEquals('bar baz', $t->getJson('foo :message', ['baz']));
+    }
+
+    public function testGetJsonForNonExistingJsonKeyLooksForRegularKeys()
+    {
+        $t = new Illuminate\Translation\Translator($this->getLoader(), 'en');
+        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
+        $t->getLoader()->shouldReceive('load')->once()->with('en', 'foo', '*')->andReturn(['bar' => 'one']);
+        $this->assertEquals('one', $t->getJson('foo.bar'));
+    }
+
+    public function testGetJsonForNonExistingJsonKeyLooksForRegularKeysAndReplace()
+    {
+        $t = new Illuminate\Translation\Translator($this->getLoader(), 'en');
+        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
+        $t->getLoader()->shouldReceive('load')->once()->with('en', 'foo', '*')->andReturn(['bar' => 'one :message']);
+        $this->assertEquals('one two', $t->getJson('foo.bar', ['message' => 'two']));
+    }
+
+    public function testGetJsonForNonExistingReturnsSameKey()
+    {
+        $t = new Illuminate\Translation\Translator($this->getLoader(), 'en');
+        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
+        $t->getLoader()->shouldReceive('load')->once()->with('en', 'Foo that bar', '*')->andReturn([]);
+        $this->assertEquals('Foo that bar', $t->getJson('Foo that bar'));
+    }
+
+    public function testGetJsonForNonExistingReturnsSameKeyAndReplaces()
+    {
+        $t = new Illuminate\Translation\Translator($this->getLoader(), 'en');
+        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
+        $t->getLoader()->shouldReceive('load')->once()->with('en', 'foo :message', '*')->andReturn([]);
+        $this->assertEquals('foo baz', $t->getJson('foo :message', ['baz']));
+    }
+
     protected function getLoader()
     {
         return m::mock('Illuminate\Translation\LoaderInterface');


### PR DESCRIPTION
This PR introduces a new form of handling localization that's based on .json files instead of current PHP array files, the new format is similar to the popular gettext format except that it loads from json instead of po files.

```php
__('Product ":product" was saved successfully.', [$product->name]);
```

This line will load the `resources/lang/en.json` and look for a `Product ":product" was saved successfully.` key inside it, if key wasn't found it just returns the given string.

The replacement of parameters happens even if the key wasn't found so that you don't have to have translation files for your main language, using the keys only would work.

If no translation was found in the JSON files, Laravel will start looking for translation keys in the old PHP array files located in `resources/lang/en`, in case a match was found it's returned to the user. That way the method is fully backward compatible.

The old translation methods will work as they used to `trans()` & `trans_choice()`, these PR doesn't look into deprecating these methods, it just introduces an alternative approach.