### PR TITLE
[5.3] Resource routes uri translations

### DIFF
--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -42,6 +42,16 @@ class ResourceRegistrar
     protected static $singularParameters = true;
 
     /**
+     * Uri translations.
+     *
+     * @var array
+     */
+    protected static $uriTranslations = [
+        'create' => 'create',
+        'edit' => 'edit',
+    ];
+
+    /**
      * Create a new resource registrar instance.
      *
      * @param  \Illuminate\Routing\Router  $router
@@ -290,7 +300,7 @@ class ResourceRegistrar
      */
     protected function addResourceCreate($name, $base, $controller, $options)
     {
-        $uri = $this->getResourceUri($name).'/create';
+        $uri = $this->getResourceUri($name).'/'.static::$uriTranslations['create'];
 
         $action = $this->getResourceAction($name, $controller, 'create', $options);
 
@@ -344,7 +354,7 @@ class ResourceRegistrar
      */
     protected function addResourceEdit($name, $base, $controller, $options)
     {
-        $uri = $this->getResourceUri($name).'/{'.$base.'}/edit';
+        $uri = $this->getResourceUri($name).'/{'.$base.'}/'.static::$uriTranslations['edit'];
 
         $action = $this->getResourceAction($name, $controller, 'edit', $options);
 
@@ -417,5 +427,26 @@ class ResourceRegistrar
     public static function setParameters(array $parameters = [])
     {
         static::$parameterMap = $parameters;
+    }
+
+    /**
+     * Get the uri translations.
+     *
+     * @return array
+     */
+    public static function getUriTranslations()
+    {
+        return static::$uriTranslations;
+    }
+
+    /**
+     * Set the uri translations.
+     *
+     * @param  array $translations
+     * @return void
+     */
+    public static function setUriTranslations(array $translations = [])
+    {
+        static::$uriTranslations = array_merge(static::$uriTranslations, $translations);
     }
 }

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -248,6 +248,17 @@ class Router implements RegistrarContract
     }
 
     /**
+     * Set the uri translations.
+     *
+     * @param  array  $translations
+     * @return void
+     */
+    public function uriTranslations(array $translations = [])
+    {
+        ResourceRegistrar::setUriTranslations($translations);
+    }
+
+    /**
      * Register an array of resource controllers.
      *
      * @param  array  $resources

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -921,6 +921,17 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals('foo-bars/{foo_bar}', $routes[0]->getUri());
         $this->assertEquals('prefix.foo-bars.show', $routes[0]->getName());
+
+        ResourceRegistrar::setUriTranslations([
+            'create' => 'ajouter',
+            'edit' => 'modifier',
+        ]);
+        $router = $this->getRouter();
+        $router->resource('foo', 'FooController');
+        $routes = $router->getRoutes();
+
+        $this->assertEquals('foo/ajouter', $routes->getByName('foo.create')->getUri());
+        $this->assertEquals('foo/{foo}/modifier', $routes->getByName('foo.edit')->getUri());
     }
 
     public function testResourceRoutingParameters()


### PR DESCRIPTION
The PR allows to define the slug for resource routes.

```php
Route::uriTranslations([
    'create' => 'ajouter',
    'edit' => 'modifier'
]);
```

Now when a resource `foo` is added the uri for `create` and `edit` will be

`foo/ajouter`
`foo/{foo}/modifier`

# Why need this ?

When building applications for non english speakers, they always ask `why the urls are in english ?`, and in many cases they require them to be in the application language (which is french for me)

So what i end up doing is using `resource()` for every thing except `create` and `edit` which i add manually.
It become a pain and clutters the routes file.

This PR try to solve that by adding the possibility to customize the slugs used for create and edit routes

