### PR TITLE
[5.4] Allow schedule:run to run as a daemon

### DIFF
--- a/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
@@ -82,6 +82,8 @@ class ScheduleRunCommand extends Command
 
     /**
      * Trigger due events.
+     *
+     * @return void
      */
     private function doScheduleDueEvents()
     {

--- a/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
@@ -74,7 +74,7 @@ class ScheduleRunCommand extends Command
                 break;
             }
 
-            //pause for a minimum of one second.
+            // pause for a minimum of one second.
             $sleepTime = max(1, $interval - (time() - $start));
             sleep($sleepTime);
         }

--- a/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
@@ -63,8 +63,8 @@ class ScheduleRunCommand extends Command
     {
         $loop = $this->option('loop');
         $interval = $this->option('interval');
-        if (! is_int($interval) && $interval <= 0) {
-            $this->error('Interval must be an 1 <= integer <= 86400');
+        if (! is_numeric($interval)) {
+            $this->error('Interval must be a positive number');
             exit(1);
         }
         while (true) {

--- a/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Console\Scheduling;
 
 use Illuminate\Console\Command;
+use Symfony\Component\Console\Exception\InvalidArgumentException;
 use Symfony\Component\Console\Input\InputOption;
 
 class ScheduleRunCommand extends Command
@@ -64,8 +65,7 @@ class ScheduleRunCommand extends Command
         $daemon = $this->option('daemon');
         $interval = $this->option('interval');
         if (! is_numeric($interval)) {
-            $this->error('Interval must be a positive number');
-            exit(1);
+            throw new InvalidArgumentException('Interval must be a positive number');
         }
         while (true) {
             $start = time();

--- a/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
@@ -85,7 +85,7 @@ class ScheduleRunCommand extends Command
      *
      * @return void
      */
-    private function doScheduleDueEvents()
+    protected function doScheduleDueEvents()
     {
         $events = $this->schedule->dueEvents($this->laravel);
 

--- a/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
@@ -49,8 +49,8 @@ class ScheduleRunCommand extends Command
     public function getOptions()
     {
         return [
-            ['loop', 'l', InputOption::VALUE_NONE, 'Don\'t terminate. Run forever'],
-            ['interval', null, InputOption::VALUE_REQUIRED, 'Run every interval seconds. Default: 60', 60],
+            ['daemon', null, InputOption::VALUE_NONE, 'Run schedule in daemon mode'],
+            ['interval', null, InputOption::VALUE_REQUIRED, 'Run every interval seconds', 60],
         ];
     }
 
@@ -61,7 +61,7 @@ class ScheduleRunCommand extends Command
      */
     public function fire()
     {
-        $loop = $this->option('loop');
+        $daemon = $this->option('daemon');
         $interval = $this->option('interval');
         if (! is_numeric($interval)) {
             $this->error('Interval must be a positive number');
@@ -70,7 +70,7 @@ class ScheduleRunCommand extends Command
         while (true) {
             $start = time();
             $this->doScheduleDueEvents();
-            if (! $loop) {
+            if (! $daemon) {
                 break;
             }
 

--- a/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
@@ -75,8 +75,8 @@ class ScheduleRunCommand extends Command
             }
 
             //pause for a minimum of one second.
-            $sleep_time = max(1, $interval - (time() - $start));
-            sleep($sleep_time);
+            $sleepTime = max(1, $interval - (time() - $start));
+            sleep($sleepTime);
         }
     }
 


### PR DESCRIPTION
Adds an option --loop so the scheduler will run forever. Triggering events once every 60 seconds by default.
Adds an option --interval so the interval can be adapted.

I added this option because it is handy in kubernetes. By running the event scheduler in a loop it can be a well behaved pod.

This is my first contribution to this project. I read the contribution guidelines, but I might have missed something.
