### PR TITLE
[5.3] Support custom primary keys on User model

### DIFF
--- a/src/Illuminate/Broadcasting/Broadcasters/PusherBroadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/PusherBroadcaster.php
@@ -67,7 +67,7 @@ class PusherBroadcaster extends Broadcaster
         } else {
             return $this->decodePusherResponse(
                 $this->pusher->presence_auth(
-                    $request->channel_name, $request->socket_id, $request->user()->id, $result)
+                    $request->channel_name, $request->socket_id, $request->user()->getKey(), $result)
             );
         }
     }


### PR DESCRIPTION
Currently the ```PusherBroadcaster``` has hardcoded ```$request()->user()->id``` which meant I had to add a dynamic accessor on my ```User``` model (legacy app *shudder*) so it had an ```id``` attribute. 

This looks like an oversight as ```getKey()``` is used everywhere else when referring to primary keys on models. This PR fixes brings back that consistency.