### PR TITLE
Adds additional check of keyType to avoid using an invalid type for eager load constraints

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2426,7 +2426,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     }
 
     /**
-     * Get the value indicating the auto incrementing key type
+     * Get the value indicating the auto incrementing key type.
      *
      * @return string
      */

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2426,6 +2426,16 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     }
 
     /**
+     * Get the value indicating the auto incrementing key type
+     *
+     * @return string
+     */
+    public function getKeyType()
+    {
+        return $this->keyType;
+    }
+
+    /**
      * Convert the model instance to JSON.
      *
      * @param  int  $options

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
@@ -174,7 +174,7 @@ class BelongsTo extends Relation
         // null or 0 in (depending on if incrementing keys are in use) so the query wont
         // fail plus returns zero results, which should be what the developer expects.
         if (count($keys) === 0) {
-            return [$this->related->getIncrementing() ? 0 : null];
+            return [$this->related->getIncrementing() && $this->related->getKeyType() === 'int' ? 0 : null];
         }
 
         return array_values(array_unique($keys));

--- a/tests/Database/DatabaseEloquentBelongsToTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToTest.php
@@ -97,6 +97,14 @@ class DatabaseEloquentBelongsToTest extends PHPUnit_Framework_TestCase
         $relation->addEagerConstraints($models);
     }
 
+    public function testDefaultEagerConstraintsWhenIncrementingAndNonIntKeyType()
+    {
+        $relation = $this->getRelation(null, false, 'string');
+        $relation->getQuery()->shouldReceive('whereIn')->once()->with('relation.id', m::mustBe([null]));
+        $models = [new MissingEloquentBelongsToModelStub, new MissingEloquentBelongsToModelStub];
+        $relation->addEagerConstraints($models);
+    }
+
     public function testDefaultEagerConstraintsWhenNotIncrementing()
     {
         $relation = $this->getRelation(null, false);
@@ -105,12 +113,13 @@ class DatabaseEloquentBelongsToTest extends PHPUnit_Framework_TestCase
         $relation->addEagerConstraints($models);
     }
 
-    protected function getRelation($parent = null, $incrementing = true)
+    protected function getRelation($parent = null, $incrementing = true, $keyType = 'int')
     {
         $builder = m::mock('Illuminate\Database\Eloquent\Builder');
         $builder->shouldReceive('where')->with('relation.id', '=', 'foreign.value');
         $related = m::mock('Illuminate\Database\Eloquent\Model');
         $related->incrementing = $incrementing;
+        $related->shouldReceive('getKeyType')->andReturn($keyType);
         $related->shouldReceive('getIncrementing')->andReturn($incrementing);
         $related->shouldReceive('getKeyName')->andReturn('id');
         $related->shouldReceive('getTable')->andReturn('relation');


### PR DESCRIPTION
We've recently run into an issue eager loading an optional belongsTo relationship when our primary keys are uuids. Our issue happens when our optional belongsTo relationship is attempted to be eager loaded is not set, and a 0 is returned for the eager model key, and that is an invalid uuid. I know that it is recommended to use incrementing false to avoid this issue, but our codebase uses string uuids generated at the database layer (postgres) rather than the application layer, so technically we needed $incrementing to be set to true (since the database was handling "incrementing" in our case), however our ID type was string rather than int. 

I've added this fix that will additionally check that your model's incrementing keyType is an int, before using 0 as the eager loaded model key. [keyType was implemented here for another uuid related issue](https://github.com/laravel/framework/pull/13985). 

This PR is also to help resolve [this issue](https://github.com/laravel/framework/issues/16427) that I opened yesterday. I believe this fix to be the safest way to address the issue without causing breaking change. 