### PR TITLE
[5.3] Offer an "Attribute Casting" of encrypt

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2799,11 +2799,11 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      * @param string $key
      * @return bool
      */
-    protected function isEncryptCastable($key) 
+    protected function isEncryptCastable($key)
     {
         return $this->hasCast($key, ['encrypt']);
     }
-    
+
     /**
      * Get the type of cast for a model attribute.
      *

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2799,7 +2799,8 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      * @param string $key
      * @return bool
      */
-    protected function isEncryptCastable($key) {
+    protected function isEncryptCastable($key) 
+    {
         return $this->hasCast($key, ['encrypt']);
     }
     
@@ -2853,7 +2854,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
             case 'timestamp':
                 return $this->asTimeStamp($value);
             case 'encrypt':
-                return decrypt($value);                
+                return decrypt($value);
             default:
                 return $value;
         }
@@ -2884,10 +2885,10 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
             $value = $this->fromDateTime($value);
         }
 
-        if($this->isEncryptCastable($key) && ! is_null($value)) {
+        if ($this->isEncryptCastable($key) && ! is_null($value)) {
             $value = $this->asEncrypted($value);
         }
-        
+
         if ($this->isJsonCastable($key) && ! is_null($value)) {
             $value = $this->asJson($value);
         }
@@ -3061,7 +3062,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     {
         return json_encode($value);
     }
-    
+
     /**
      * Decode the given JSON back into an array or object.
      *
@@ -3075,7 +3076,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     }
 
     /**
-     * Encrypt to given value
+     * Encrypt to given value.
      *
      * @param mixed $value
      * @return string
@@ -3084,7 +3085,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     {
         return encrypt($value);
     }
-    
+
     /**
      * Clone the model into a new, non-existing instance.
      *

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2794,6 +2794,16 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     }
 
     /**
+     * Determine whether a value should be encrypted.
+     *
+     * @param string $key
+     * @return bool
+     */
+    protected function isEncryptCastable($key) {
+        return $this->hasCast($key, ['encrypt']);
+    }
+    
+    /**
      * Get the type of cast for a model attribute.
      *
      * @param  string  $key
@@ -2842,6 +2852,8 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
                 return $this->asDateTime($value);
             case 'timestamp':
                 return $this->asTimeStamp($value);
+            case 'encrypt':
+                return decrypt($value);                
             default:
                 return $value;
         }
@@ -2872,6 +2884,10 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
             $value = $this->fromDateTime($value);
         }
 
+        if($this->isEncryptCastable($key) && ! is_null($value)) {
+            $value = $this->asEncrypted($value);
+        }
+        
         if ($this->isJsonCastable($key) && ! is_null($value)) {
             $value = $this->asJson($value);
         }
@@ -3045,7 +3061,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     {
         return json_encode($value);
     }
-
+    
     /**
      * Decode the given JSON back into an array or object.
      *
@@ -3058,6 +3074,17 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         return json_decode($value, ! $asObject);
     }
 
+    /**
+     * Encrypt to given value
+     *
+     * @param mixed $value
+     * @return string
+     */
+    protected function asEncrypted($value)
+    {
+        return encrypt($value);
+    }
+    
     /**
      * Clone the model into a new, non-existing instance.
      *


### PR DESCRIPTION
This would allow the user to easily encrypt and decrypt a field by setting it to that `cast`

For example

```
    protected $casts = [
        'secret' => 'encrypt',
        'data' => 'array'
    ];
```