### PR TITLE
[5.4][Proposal] Enable global route key name

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2049,7 +2049,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public function getRouteKeyName()
     {
-        return $this->getKeyName();
+        return array_get(config('database'), 'route_key_name', $this->getKeyName());
     }
 
     /**


### PR DESCRIPTION
I have been building quite a few projects over the past few months where all data from routes was retrieved based on UUIDs or other identifiers besides the numeric ID in the database so I was forced to use a BaseModel just to set the route key name for all models, otherwise the BaseModel was useful because there was no shared logic between the Eloquent Models.

```php
<?php

namespace App;

use Illuminate\Database\Eloquent\Model as Eloquent;

class BaseModel extends Eloquent
{
    /**
     * Get the route key for the model.
     *
     * @return string
     */
    public function getRouteKeyName()
    {
        return 'uuid';
    }
}
```

With this PR it would be possible to just set a value called `route_key_name` in the `config/database.php` which would then be used instead of the primary key of a model. If the value isn't set it would just instead use the primary key like it is already doing now.

**config/database.php**
```php
/*
|--------------------------------------------------------------------------
| Route Key
|--------------------------------------------------------------------------
|
| The "Route Key" is used to retrieve Eloquent Models from the database
| that have been defined in routes like /{user}.
|
| By default the Model would be retrieved based on the primary key which
| which usually is "id". When building an API you might only expose the
| UUID or some other secondary/public identifier of records so that all
| records would need to be retrieved by the "uuid" column instead of "id".
|
*/

'route_key_name' => 'uuid',
```