### PR TITLE
[5.3] Adds additional check of keyType to avoid using an invalid type for eager load constraints

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2378,6 +2378,16 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     }
 
     /**
+     * Get the value indicating the auto incrementing key type.
+     *
+     * @return string
+     */
+    public function getKeyType()
+    {
+        return $this->keyType;
+    }
+
+    /**
      * Set whether IDs are incrementing.
      *
      * @param  bool  $value

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
@@ -174,7 +174,7 @@ class BelongsTo extends Relation
         // null or 0 in (depending on if incrementing keys are in use) so the query wont
         // fail plus returns zero results, which should be what the developer expects.
         if (count($keys) === 0) {
-            return [$this->related->getIncrementing() ? 0 : null];
+            return [$this->related->getIncrementing() && $this->related->getKeyType() === 'int' ? 0 : null];
         }
 
         return array_values(array_unique($keys));

--- a/tests/Database/DatabaseEloquentBelongsToTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToTest.php
@@ -97,6 +97,14 @@ class DatabaseEloquentBelongsToTest extends PHPUnit_Framework_TestCase
         $relation->addEagerConstraints($models);
     }
 
+    public function testDefaultEagerConstraintsWhenIncrementingAndNonIntKeyType()
+    {
+        $relation = $this->getRelation(null, false, 'string');
+        $relation->getQuery()->shouldReceive('whereIn')->once()->with('relation.id', m::mustBe([null]));
+        $models = [new MissingEloquentBelongsToModelStub, new MissingEloquentBelongsToModelStub];
+        $relation->addEagerConstraints($models);
+    }
+
     public function testDefaultEagerConstraintsWhenNotIncrementing()
     {
         $relation = $this->getRelation(null, false);
@@ -105,12 +113,13 @@ class DatabaseEloquentBelongsToTest extends PHPUnit_Framework_TestCase
         $relation->addEagerConstraints($models);
     }
 
-    protected function getRelation($parent = null, $incrementing = true)
+    protected function getRelation($parent = null, $incrementing = true, $keyType = 'int')
     {
         $builder = m::mock('Illuminate\Database\Eloquent\Builder');
         $builder->shouldReceive('where')->with('relation.id', '=', 'foreign.value');
         $related = m::mock('Illuminate\Database\Eloquent\Model');
         $related->incrementing = $incrementing;
+        $related->shouldReceive('getKeyType')->andReturn($keyType);
         $related->shouldReceive('getIncrementing')->andReturn($incrementing);
         $related->shouldReceive('getKeyName')->andReturn('id');
         $related->shouldReceive('getTable')->andReturn('relation');


### PR DESCRIPTION
Original PR was made against 5.2, see [here](https://github.com/laravel/framework/pull/16440)