### PR TITLE
[5.4][WIP] Localized routes

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -1042,6 +1042,27 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     }
 
     /**
+     * Get the application fallback locale.
+     *
+     * @return string
+     */
+    public function getFallbackLocale()
+    {
+        return $this['config']->get('app.fallback_locale');
+    }
+
+    /**
+     * Determine if the application supports the given locale.
+     *
+     * @param  string  $Locale
+     * @return bool
+     */
+    public function hasLocale($locale)
+    {
+        return in_array($locale, $this['config']->get('app.locales'));
+    }
+
+    /**
      * Set the current application locale.
      *
      * @param  string  $locale

--- a/src/Illuminate/Foundation/Http/Kernel.php
+++ b/src/Illuminate/Foundation/Http/Kernel.php
@@ -143,6 +143,8 @@ class Kernel implements KernelContract
 
         $this->bootstrap();
 
+        $request->setDefaultLocale($this->app->getFallbackLocale());
+
         return (new Pipeline($this->app))
                     ->send($request)
                     ->through($this->app->shouldSkipMiddleware() ? [] : $this->middleware)

--- a/src/Illuminate/Http/Middleware/LocalizeRequest.php
+++ b/src/Illuminate/Http/Middleware/LocalizeRequest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Illuminate\Http\Middleware;
+
+use Closure;
+use Illuminate\Contracts\Foundation\Application;
+
+class LocalizeRequest
+{
+    /**
+     * The application instance.
+     *
+     * @var \Illuminate\Contracts\Foundation\Application
+     */
+    protected $app;
+
+    /**
+     * Create a new Middleware instance.
+     *
+     * @param  \Illuminate\Contracts\Foundation\Application  $app
+     * @return void
+     */
+    public function __construct(Application $app)
+    {
+        $this->app = $app;
+    }
+
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request $request
+     * @param  \Closure $next
+     * @return mixed
+     */
+    public function handle($request, Closure $next)
+    {
+        $guessedLocale = $request->segment(1);
+
+        $locale = $this->app->hasLocale($guessedLocale) ?
+                        $guessedLocale : $this->app->getFallbackLocale();
+
+        $request->setLocale($locale);
+
+        $this->app->setLocale($locale);
+
+        return $next($request);
+    }
+}

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -156,7 +156,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
 
     /**
      * Return the locale of the request.
-     * 
+     *
      * @return string
      */
     public function getLocale()

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -139,6 +139,32 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
     }
 
     /**
+     * Get the current path for the Router.
+     *
+     * @return string
+     */
+    public function pathForRouter()
+    {
+        $path = $this->path();
+
+        if ($this->locale) {
+            $path = str_replace_first($this->locale.'/', '', $path);
+        }
+
+        return $path;
+    }
+
+    /**
+     * Return the locale of the request.
+     * 
+     * @return string
+     */
+    public function getLocale()
+    {
+        return $this->locale;
+    }
+
+    /**
      * Get the current encoded path info for the request.
      *
      * @return string
@@ -935,6 +961,16 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
         } else {
             return $route->parameter($param);
         }
+    }
+
+    /**
+     * Determine if the request locale is the default one.
+     *
+     * @return bool
+     */
+    public function hasDefaultLocale()
+    {
+        return $this->locale == $this->defaultLocale;
     }
 
     /**

--- a/src/Illuminate/Routing/Matching/UriValidator.php
+++ b/src/Illuminate/Routing/Matching/UriValidator.php
@@ -16,7 +16,7 @@ class UriValidator implements ValidatorInterface
      */
     public function matches(Route $route, Request $request)
     {
-        $path = $request->path() == '/' ? '/' : '/'.$request->path();
+        $path = $request->pathForRouter() == '/' ? '/' : '/'.$request->pathForRouter();
 
         return preg_match($route->getCompiled()->getRegex(), rawurldecode($path));
     }

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -522,7 +522,7 @@ class Route
      */
     protected function bindPathParameters(Request $request)
     {
-        preg_match($this->compiled->getRegex(), '/'.$request->decodedPath(), $matches);
+        preg_match($this->compiled->getRegex(), '/'.rawurldecode($request->pathForRouter()), $matches);
 
         return $matches;
     }

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -622,6 +622,10 @@ class UrlGenerator implements UrlGeneratorContract
             $root = $this->cachedRoot;
         }
 
+        if ($this->request->getLocale() && ! $this->request->hasDefaultLocale()) {
+            $root .= '/'.$this->request->getLocale();
+        }
+
         $start = Str::startsWith($root, 'http://') ? 'http://' : 'https://';
 
         return preg_replace('~'.$start.'~', $scheme, $root, 1);


### PR DESCRIPTION
This is a WIP attempt to add support for multilingual routes in Laravel 5.4, I've been trying to apply the least changes and keep things in place.

- A key to be added to `config/app.php` with the name `locales` which holds an array of locales the application may support.
- A `\Illuminate\Http\Middleware\LocalizeRequest` middleware need to be added to the global middleware stack *only* if the application supports localization.

This middleware will try to guess the desired locale based on the request URI, once a locale is found we inform the request about it using `Request::setLocale()` which will make sure the router skips the locale information from the given URI before attempting to match any requests with the application defined routes.

So if the URL is `ar/contacts-us/form` the router will find a match with the route `/contact-us/form`, without this middleware an HTTPNotFound exception would be thrown because the route definition doesn't match the request path.

With this in hand, the URL generator will prepend the locale string to all generated URLs in case the locale isn't the default one, so `url('some/path')` will be generated as `http://app.dev/ar/some/path` in case `ar` is not the default locale.

The current way the middleware guesses the locale is by looking at the first segment of the URL and see if it matches any of the locales registered in the application, there's another scenario where the locale is given as a sub domain `ar.laravel.com` but this PR doesn't tackle this at the moment.