### PR TITLE
[5.3] Add findBy and findByOrFail methods

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -190,8 +190,8 @@ class Builder
     }
     
     /**
-     * Find a model by a single column
-     * 
+     * Find a model by a single column.
+     *
      * @param  string $column
      * @param  mixed  $value
      * @param  array  $columns
@@ -203,7 +203,7 @@ class Builder
 
         return $this->first($columns);
     }
-
+    
     /**
      * Find a model by its primary key or throw an exception.
      *
@@ -227,10 +227,10 @@ class Builder
 
         throw (new ModelNotFoundException)->setModel(get_class($this->model), $id);
     }
-    
+
     /**
-     * Find a model by a single column
-     * 
+     * Find a model by a single column.
+     *
      * @param  string $column
      * @param  mixed  $value
      * @param  array  $columns
@@ -241,7 +241,7 @@ class Builder
     public function findByOrFail($column, $value, $columns = ['*'])
     {
         $result = $this->findBy($column, $value, $columns);
-        if(! is_null($result)) {
+        if (! is_null($result)) {
             return $result;
         }
 

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -245,7 +245,7 @@ class Builder
             return $result;
         }
 
-        throw (new ModelNotFoundException)->setModel(get_class($this->model), $id);
+        throw (new ModelNotFoundException)->setModel(get_class($this->model));
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -188,6 +188,21 @@ class Builder
 
         return $this->get($columns);
     }
+    
+    /**
+     * Find a model by a single column
+     * 
+     * @param  string $column
+     * @param  mixed  $value
+     * @param  array  $columns
+     * @return \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Collection|static[]|static|null
+     */
+    public function findBy($column, $value, $columns = ['*'])
+    {
+        $this->query->where($column, '=', $value);
+
+        return $this->first($columns);
+    }
 
     /**
      * Find a model by its primary key or throw an exception.
@@ -211,6 +226,26 @@ class Builder
         }
 
         throw (new ModelNotFoundException)->setModel(get_class($this->model), $id);
+    }
+    
+    /**
+     * Find a model by a single column
+     * 
+     * @param  string $column
+     * @param  mixed  $value
+     * @param  array  $columns
+     * @return \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Collection|static[]|static|null
+     *
+     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
+     */
+    public function findByOrFail($column, $value, $columns = ['*'])
+    {
+        $result = $this->findBy($column, $value, $columns);
+        if(! is_null($result)) {
+            return $result;
+        }
+
+        throw (new ModelNotFoundException)->setModle(get_class($this->model), $id);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -188,7 +188,7 @@ class Builder
 
         return $this->get($columns);
     }
-    
+
     /**
      * Find a model by a single column.
      *
@@ -203,7 +203,7 @@ class Builder
 
         return $this->first($columns);
     }
-    
+
     /**
      * Find a model by its primary key or throw an exception.
      *

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -245,7 +245,7 @@ class Builder
             return $result;
         }
 
-        throw (new ModelNotFoundException)->setModle(get_class($this->model), $id);
+        throw (new ModelNotFoundException)->setModel(get_class($this->model), $id);
     }
 
     /**

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -23,6 +23,17 @@ class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('baz', $result);
     }
 
+    public function testFindByMethod()
+    {
+        $builder = m::mock('Illuminate\Database\Eloquent\Builder[first]', [$this->getMockQueryBuilder()]);
+        $builder->setModel($this->getMockModel());
+        $builder->getQuery()->shouldReceive('where')->once()->with('foo_table.foo', '=', 'bar');
+        $builder->shouldReceive('first')->with(['column'])->andReturn('baz');
+
+        $result = $builder->findBy('bar', ['column']);
+        $this->assertEquals('baz', $result);
+    }
+
     public function testFindOrNewMethodModelFound()
     {
         $model = $this->getMockModel();
@@ -64,6 +75,18 @@ class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase
         $builder->getQuery()->shouldReceive('where')->once()->with('foo_table.foo', '=', 'bar');
         $builder->shouldReceive('first')->with(['column'])->andReturn(null);
         $result = $builder->findOrFail('bar', ['column']);
+    }
+
+    /**
+     * @expectedException Illuminate\Database\Eloquent\ModelNotFoundException
+     */
+    public function testFindByOrFailMethodThrowsModelNotFoundException()
+    {
+        $builder = m::mock('Illuminate\Database\Eloquent\Builder[first]', [$this->getMockQueryBuilder()]);
+        $builder->setModel($this->getMockModel());
+        $builder->getQuery()->shouldReceive('where')->once()->with('foo_table.foo', '=', 'bar');
+        $builder->shouldReceive('first')->with(['column'])->andReturn(null);
+        $result = $builder->findByOrFail('bar', ['column']);
     }
 
     /**

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -30,7 +30,7 @@ class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase
         $builder->getQuery()->shouldReceive('where')->once()->with('foo_table.foo', '=', 'bar');
         $builder->shouldReceive('first')->with(['column'])->andReturn('baz');
 
-        $result = $builder->findBy('bar', ['column']);
+        $result = $builder->findBy('foo_table.foo', 'bar', ['column']);
         $this->assertEquals('baz', $result);
     }
 
@@ -86,7 +86,7 @@ class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase
         $builder->setModel($this->getMockModel());
         $builder->getQuery()->shouldReceive('where')->once()->with('foo_table.foo', '=', 'bar');
         $builder->shouldReceive('first')->with(['column'])->andReturn(null);
-        $result = $builder->findByOrFail('bar', ['column']);
+        $result = $builder->findByOrFail('foo_table.foo', 'bar', ['column']);
     }
 
     /**


### PR DESCRIPTION
I would like to add a findBy method that would work similarly to find, except it allows you to specify a column. For example, if you have a User model, you will often write the following code to get a single user:
```
$user = User::find(1);
```
But what if you need to find a single user by a username?
```
$user = User::where('username', 'jdoe')->first();
```
What I'm proposing is just a convenience method to make the above more concise:
```
$user = User::findBy('username', 'jdoe');
```

The method will just always return the first result found by searching the column with the specified value. I included findByOrFail to be consistent.

Thanks!