### PR TITLE
[5.3] Display a Password Change feedback to the user

### DIFF
--- a/src/Illuminate/Auth/Console/stubs/make/views/auth/passwords/reset.stub
+++ b/src/Illuminate/Auth/Console/stubs/make/views/auth/passwords/reset.stub
@@ -8,6 +8,12 @@
                 <div class="panel-heading">Reset Password</div>
 
                 <div class="panel-body">
+                    @if (session('status'))
+                        <div class="alert alert-success">
+                            {{ session('status') }}
+                        </div>
+                    @endif
+
                     <form class="form-horizontal" role="form" method="POST" action="{{ url('/password/reset') }}">
                         {{ csrf_field() }}
 


### PR DESCRIPTION
After you have reset your password, there is no feedback given to the user. This fixes it.