### PR TITLE
[5.3] Don't timeout queue when --timeout=0

### DIFF
--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -92,7 +92,7 @@ class Worker
      */
     protected function registerTimeoutHandler(WorkerOptions $options)
     {
-        if (version_compare(PHP_VERSION, '7.1.0') < 0 || ! extension_loaded('pcntl')) {
+        if ($options->timeout == 0 || version_compare(PHP_VERSION, '7.1.0') < 0 || ! extension_loaded('pcntl')) {
             return;
         }
 


### PR DESCRIPTION
`php artisan queue:work --timeout=0` will timeout after 3 seconds.

The default value for `--sleep` is `3`
So even if the `--timeout` is `0` when we sum `$options->timeout + $options->sleep` we still get `3`