### PR TITLE
[5.3] Move deprecated exception methods to DOCBLOCK

### DIFF
--- a/tests/Auth/AuthenticateMiddlewareTest.php
+++ b/tests/Auth/AuthenticateMiddlewareTest.php
@@ -29,10 +29,11 @@ class AuthenticateMiddlewareTest extends PHPUnit_Framework_TestCase
         });
     }
 
+    /**
+     * @expectedException Illuminate\Auth\AuthenticationException
+     */
     public function testDefaultUnauthenticatedThrows()
     {
-        $this->setExpectedException(AuthenticationException::class);
-
         $this->registerAuthDriver('default', false);
 
         $this->authenticate();
@@ -73,10 +74,11 @@ class AuthenticateMiddlewareTest extends PHPUnit_Framework_TestCase
         $this->assertSame($secondary, $this->auth->guard());
     }
 
+    /**
+     * @expectedException Illuminate\Auth\AuthenticationException
+     */
     public function testMultipleDriversUnauthenticatedThrows()
     {
-        $this->setExpectedException(AuthenticationException::class);
-
         $this->registerAuthDriver('default', false);
 
         $this->registerAuthDriver('secondary', false);

--- a/tests/Auth/AuthorizeMiddlewareTest.php
+++ b/tests/Auth/AuthorizeMiddlewareTest.php
@@ -9,7 +9,6 @@ use Illuminate\Container\Container;
 use Illuminate\Auth\Middleware\Authorize;
 use Illuminate\Contracts\Routing\Registrar;
 use Illuminate\Contracts\Auth\Factory as Auth;
-use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Routing\Middleware\SubstituteBindings;
 use Illuminate\Contracts\Auth\Access\Gate as GateContract;
 
@@ -51,10 +50,11 @@ class AuthorizeMiddlewareTest extends PHPUnit_Framework_TestCase
         });
     }
 
+    /**
+     * @expectedException Illuminate\Auth\Access\AuthorizationException
+     */
     public function testSimpleAbilityUnauthorized()
     {
-        $this->setExpectedException(AuthorizationException::class);
-
         $this->gate()->define('view-dashboard', function ($user, $additional = null) {
             $this->assertNull($additional);
 
@@ -89,10 +89,11 @@ class AuthorizeMiddlewareTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($response->content(), 'success');
     }
 
+    /**
+     * @expectedException Illuminate\Auth\Access\AuthorizationException
+     */
     public function testModelTypeUnauthorized()
     {
-        $this->setExpectedException(AuthorizationException::class);
-
         $this->gate()->define('create', function ($user, $model) {
             $this->assertEquals($model, 'App\User');
 
@@ -129,10 +130,11 @@ class AuthorizeMiddlewareTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($response->content(), 'success');
     }
 
+    /**
+     * @expectedException Illuminate\Auth\Access\AuthorizationException
+     */
     public function testModelUnauthorized()
     {
-        $this->setExpectedException(AuthorizationException::class);
-
         $post = new stdClass;
 
         $this->router->bind('post', function () use ($post) {

--- a/tests/Database/DatabaseEloquentBelongsToManyTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyTest.php
@@ -365,12 +365,13 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($model, $relation->create(['attributes'], ['joining']));
     }
 
+    /**
+     * @expectedException Illuminate\Database\Eloquent\ModelNotFoundException
+     */
     public function testFindOrFailThrowsException()
     {
         $relation = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\BelongsToMany')->setMethods(['find'])->setConstructorArgs($this->getRelationArguments())->getMock();
         $relation->expects($this->once())->method('find')->with('foo')->will($this->returnValue(null));
-
-        $this->setExpectedException(Illuminate\Database\Eloquent\ModelNotFoundException::class);
 
         try {
             $relation->findOrFail('foo');
@@ -381,12 +382,13 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase
         }
     }
 
+    /**
+     * @expectedException Illuminate\Database\Eloquent\ModelNotFoundException
+     */
     public function testFirstOrFailThrowsException()
     {
         $relation = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\BelongsToMany')->setMethods(['first'])->setConstructorArgs($this->getRelationArguments())->getMock();
         $relation->expects($this->once())->method('first')->with(['id' => 'foo'])->will($this->returnValue(null));
-
-        $this->setExpectedException(Illuminate\Database\Eloquent\ModelNotFoundException::class);
 
         try {
             $relation->firstOrFail(['id' => 'foo']);

--- a/tests/Database/DatabaseEloquentHasManyThroughTest.php
+++ b/tests/Database/DatabaseEloquentHasManyThroughTest.php
@@ -174,12 +174,13 @@ class DatabaseEloquentHasManyThroughTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('first', $relation->first());
     }
 
+    /**
+     * @expectedException Illuminate\Database\Eloquent\ModelNotFoundException
+     */
     public function testFindOrFailThrowsException()
     {
         $relation = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\HasManyThrough')->setMethods(['find'])->setConstructorArgs($this->getRelationArguments())->getMock();
         $relation->expects($this->once())->method('find')->with('foo')->will($this->returnValue(null));
-
-        $this->setExpectedException(\Illuminate\Database\Eloquent\ModelNotFoundException::class);
 
         try {
             $relation->findOrFail('foo');
@@ -190,12 +191,13 @@ class DatabaseEloquentHasManyThroughTest extends PHPUnit_Framework_TestCase
         }
     }
 
+    /**
+     * @expectedException Illuminate\Database\Eloquent\ModelNotFoundException
+     */
     public function testFirstOrFailThrowsException()
     {
         $relation = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\HasManyThrough')->setMethods(['first'])->setConstructorArgs($this->getRelationArguments())->getMock();
         $relation->expects($this->once())->method('first')->with(['id' => 'foo'])->will($this->returnValue(null));
-
-        $this->setExpectedException(\Illuminate\Database\Eloquent\ModelNotFoundException::class);
 
         try {
             $relation->firstOrFail(['id' => 'foo']);

--- a/tests/Foundation/FoundationHelpersTest.php
+++ b/tests/Foundation/FoundationHelpersTest.php
@@ -31,10 +31,11 @@ class FoundationHelpersTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('default', cache('baz', 'default'));
     }
 
+    /**
+     * @expectedException Exception
+     */
     public function testCacheThrowsAnExceptionIfAnExpirationIsNotProvided()
     {
-        $this->setExpectedException('Exception');
-
         cache(['foo' => 'bar']);
     }
 
@@ -52,4 +53,5 @@ class FoundationHelpersTest extends PHPUnit_Framework_TestCase
 
         unlink(public_path($file));
     }
+
 }


### PR DESCRIPTION
`setExpectedException` is [set to be removed](https://github.com/sebastianbergmann/phpunit/issues/2074#issuecomment-183472385) in PHPUnit 6