### PR TITLE
[5.3] Fix queue:work --force option in maintenance mode

### DIFF
--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -111,7 +111,7 @@ class WorkCommand extends Command
         return new WorkerOptions(
             $this->option('delay'), $this->option('memory'),
             $this->option('timeout'), $this->option('sleep'),
-            $this->option('tries')
+            $this->option('tries'), $this->option('force')
         );
     }
 

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -71,7 +71,7 @@ class Worker
         while (true) {
             $this->registerTimeoutHandler($options);
 
-            if ($this->daemonShouldRun()) {
+            if ($this->daemonShouldRun($options)) {
                 $this->runNextJob($connectionName, $queue, $options);
             } else {
                 $this->sleep($options->sleep);
@@ -110,11 +110,12 @@ class Worker
     /**
      * Determine if the daemon should process on this iteration.
      *
+     * @param  WorkerOptions  $options
      * @return bool
      */
-    protected function daemonShouldRun()
+    protected function daemonShouldRun(WorkerOptions $options)
     {
-        if ($this->manager->isDownForMaintenance() ||
+        if (($this->manager->isDownForMaintenance() && ! $options->force) ||
             $this->events->until('illuminate.queue.looping') === false) {
             // If the application is down for maintenance or doesn't want the queues to run
             // we will sleep for one second just in case the developer has it set to not

--- a/src/Illuminate/Queue/WorkerOptions.php
+++ b/src/Illuminate/Queue/WorkerOptions.php
@@ -40,6 +40,13 @@ class WorkerOptions
     public $maxTries;
 
     /**
+     * Determine if the worker should run in maintenance mode.
+     *
+     * @var bool
+     */
+    public $force;
+
+    /**
      * Create a new worker options instance.
      *
      * @param  int  $delay
@@ -47,13 +54,15 @@ class WorkerOptions
      * @param  int  $timeout
      * @param  int  $sleep
      * @param  int  $maxTries
+     * @param  bool $force
      */
-    public function __construct($delay = 0, $memory = 128, $timeout = 60, $sleep = 3, $maxTries = 0)
+    public function __construct($delay = 0, $memory = 128, $timeout = 60, $sleep = 3, $maxTries = 0, $force = false)
     {
         $this->delay = $delay;
         $this->sleep = $sleep;
         $this->memory = $memory;
         $this->timeout = $timeout;
         $this->maxTries = $maxTries;
+        $this->force = $force;
     }
 }


### PR DESCRIPTION
This fixes `--force` having no effect when the application is in maintenance mode when running `queue:work`