### PR TITLE
[5.4] Several modifications to the json localization approach

### DIFF
--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -152,7 +152,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
             }
         }
 
-        return $this->makeJsonReplacements($line ?: $key, $replace);
+        return $this->makeJsonReplacements($key, $line ?: $key, $replace);
     }
 
     /**
@@ -218,19 +218,24 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
     /**
      * Make the place-holder replacements on a JSON loaded line.
      *
+     * @param  string  $key
      * @param  string  $line
      * @param  array   $replace
      * @return string
      */
-    protected function makeJsonReplacements($line, array $replace)
+    protected function makeJsonReplacements($key, $line, array $replace)
     {
-        preg_match_all('#:(?:[a-zA-Z1-9]*)#s', $line, $placeholders);
+        preg_match_all('#:(?:[a-zA-Z1-9]*)#', $key, $placeholders);
 
         $placeholders = $placeholders[0];
 
+        $keyedReplacements = Arr::isAssoc($replace);
+
         foreach ($placeholders as $i => $key) {
-            $line = str_replace_first(
-                $key, isset($replace[$i]) ? $replace[$i] : $key, $line
+            $replacementKey = $keyedReplacements ? str_replace(':', '', $key) : $i;
+
+            $line = str_replace(
+                $key, isset($replace[$replacementKey]) ? $replace[$replacementKey] : $key, $line
             );
         }
 

--- a/tests/Translation/TranslationTranslatorTest.php
+++ b/tests/Translation/TranslationTranslatorTest.php
@@ -104,8 +104,22 @@ class TranslationTranslatorTest extends PHPUnit_Framework_TestCase
     public function testGetJsonReplaces()
     {
         $t = new Illuminate\Translation\Translator($this->getLoader(), 'en');
-        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn(['foo :message' => 'bar :message']);
-        $this->assertEquals('bar baz', $t->getFromJson('foo :message', ['baz']));
+        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn(['foo :i:c :u' => 'bar :i:c :u']);
+        $this->assertEquals('bar onetwo three', $t->getFromJson('foo :i:c :u', ['one', 'two', 'three']));
+    }
+
+    public function testGetJsonReplacesForAssociativeInput()
+    {
+        $t = new Illuminate\Translation\Translator($this->getLoader(), 'en');
+        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn(['foo :i :c' => 'bar :i :c']);
+        $this->assertEquals('bar eye see', $t->getFromJson('foo :i :c', ['i' => 'eye', 'c' => 'see']));
+    }
+
+    public function testGetJsonPreservesOrder()
+    {
+        $t = new Illuminate\Translation\Translator($this->getLoader(), 'en');
+        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn(['to :name I give :greeting' => ':greeting :name']);
+        $this->assertEquals('Greetings David', $t->getFromJson('to :name I give :greeting', ['David', 'Greetings']));
     }
 
     public function testGetJsonForNonExistingJsonKeyLooksForRegularKeys()


### PR DESCRIPTION
Added support for keyed replacements:

```php
__('Hello :name, you have :unread messages.', ['name' => 'David', 'unread' => 123])
```

And also the method now preserves key order between different locales, for example:

```php
// In en/*.php
['to :name I give :greeting' => ':greeting :name']
```

```php
__("to :name I give :greeting", ['David', 'Greetings'])
```

This will print `Greetings David` when the locale is `en`, and `to David I give Greetings` if the locale is yoda.