### PR TITLE
[5.3] Backup offset/limit properties when running pagination/chunk queries

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1730,7 +1730,7 @@ class Builder
     }
 
     /**
-     * Backup some fields for the pagination count.
+     * Backup then remove some fields for the pagination count.
      *
      * @return void
      */

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -230,7 +230,11 @@ class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase
 
     public function testChunkPaginatesUsingIdWithLastChunkComplete()
     {
-        $builder = m::mock('Illuminate\Database\Eloquent\Builder[forPageAfterId,get]', [$this->getMockQueryBuilder()]);
+        $baseBuilder = $this->getMockQueryBuilder();
+        $baseBuilder->shouldReceive('getRawBindings')->andReturn([]);
+        $baseBuilder->shouldReceive('setBindings');
+        $builder = m::mock('Illuminate\Database\Eloquent\Builder[forPageAfterId,get]', [$baseBuilder]);
+
         $chunk1 = new Collection([(object) ['someIdField' => 1], (object) ['someIdField' => 2]]);
         $chunk2 = new Collection([(object) ['someIdField' => 10], (object) ['someIdField' => 11]]);
         $chunk3 = new Collection([]);
@@ -251,7 +255,11 @@ class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase
 
     public function testChunkPaginatesUsingIdWithLastChunkPartial()
     {
-        $builder = m::mock('Illuminate\Database\Eloquent\Builder[forPageAfterId,get]', [$this->getMockQueryBuilder()]);
+        $baseBuilder = $this->getMockQueryBuilder();
+        $baseBuilder->shouldReceive('getRawBindings')->andReturn([]);
+        $baseBuilder->shouldReceive('setBindings');
+        $builder = m::mock('Illuminate\Database\Eloquent\Builder[forPageAfterId,get]', [$baseBuilder]);
+
         $chunk1 = new Collection([(object) ['someIdField' => 1], (object) ['someIdField' => 2]]);
         $chunk2 = new Collection([(object) ['someIdField' => 10]]);
         $builder->shouldReceive('forPageAfterId')->once()->with(2, 0, 'someIdField')->andReturnSelf();
@@ -269,7 +277,11 @@ class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase
 
     public function testChunkPaginatesUsingIdWithCountZero()
     {
-        $builder = m::mock('Illuminate\Database\Eloquent\Builder[forPageAfterId,get]', [$this->getMockQueryBuilder()]);
+        $baseBuilder = $this->getMockQueryBuilder();
+        $baseBuilder->shouldReceive('getRawBindings')->andReturn([]);
+        $baseBuilder->shouldReceive('setBindings');
+        $builder = m::mock('Illuminate\Database\Eloquent\Builder[forPageAfterId,get]', [$baseBuilder]);
+
         $chunk = new Collection([]);
         $builder->shouldReceive('forPageAfterId')->once()->with(0, 0, 'someIdField')->andReturnSelf();
         $builder->shouldReceive('get')->times(1)->andReturn($chunk);

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -230,6 +230,107 @@ class DatabaseEloquentIntegrationTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(3, $query->getCountForPagination());
     }
 
+    public function testPaginatePreservesOffsetAndLimitOnInstance()
+    {
+        EloquentTestUser::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']);
+        EloquentTestUser::create(['id' => 2, 'email' => 'abigailotwell@gmail.com']);
+        EloquentTestUser::create(['id' => 3, 'email' => 'foo@gmail.com']);
+
+        Paginator::currentPageResolver(function () {
+            return 1;
+        });
+
+        $query = EloquentTestUser::oldest('id');
+        $models = $query->paginate(2);
+        $models = $query->get();
+        $this->assertEquals(3, $models->count());
+
+        $baseQuery = EloquentTestUser::oldest('id')->getQuery();
+        $models = $baseQuery->paginate(2);
+        $models = $baseQuery->get();
+        $this->assertEquals(3, $models->count());
+    }
+
+    public function testChunkPreservesOffsetAndLimitOnInstance()
+    {
+        EloquentTestUser::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']);
+        EloquentTestUser::create(['id' => 2, 'email' => 'abigailotwell@gmail.com']);
+        EloquentTestUser::create(['id' => 3, 'email' => 'foo@gmail.com']);
+
+        $query = EloquentTestUser::oldest('id');
+        $query->chunk(2, function () {
+        });
+        $models = $query->get();
+        $this->assertEquals(3, $models->count());
+
+        $baseQuery = EloquentTestUser::oldest('id')->getQuery();
+        $baseQuery->chunk(2, function () {
+        });
+        $models = $baseQuery->get();
+        $this->assertEquals(3, $models->count());
+    }
+
+    public function testChunkPreservesOffsetAndLimitOnInstanceWhenEarlyReturn()
+    {
+        EloquentTestUser::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']);
+        EloquentTestUser::create(['id' => 2, 'email' => 'abigailotwell@gmail.com']);
+        EloquentTestUser::create(['id' => 3, 'email' => 'foo@gmail.com']);
+
+        $query = EloquentTestUser::oldest('id');
+        $query->chunk(2, function () {
+            return false;
+        });
+        $models = $query->get();
+        $this->assertEquals(3, $models->count());
+
+        $baseQuery = EloquentTestUser::oldest('id')->getQuery();
+        $baseQuery->chunk(2, function () {
+            return false;
+        });
+        $models = $baseQuery->get();
+        $this->assertEquals(3, $models->count());
+    }
+
+    public function testChunkByIdPreservesOffsetAndLimitOnInstance()
+    {
+        EloquentTestUser::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']);
+        EloquentTestUser::create(['id' => 2, 'email' => 'abigailotwell@gmail.com']);
+        EloquentTestUser::create(['id' => 3, 'email' => 'foo@gmail.com']);
+
+        $query = EloquentTestUser::oldest('id');
+        $query->chunkById(2, function () {
+        });
+        $models = $query->get();
+        $this->assertEquals(3, $models->count());
+
+        $baseQuery = EloquentTestUser::oldest('id')->getQuery();
+        $baseQuery->chunkById(2, function () {
+        });
+        $models = $baseQuery->get();
+        $this->assertEquals(3, $models->count());
+    }
+
+    public function testChunkByIdPreservesOffsetAndLimitOnInstanceWhenEarlyReturn()
+    {
+        EloquentTestUser::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']);
+        EloquentTestUser::create(['id' => 2, 'email' => 'abigailotwell@gmail.com']);
+        EloquentTestUser::create(['id' => 3, 'email' => 'foo@gmail.com']);
+
+        $query = EloquentTestUser::oldest('id');
+        $query->chunkById(2, function () {
+            return false;
+        });
+        $models = $query->get();
+        $this->assertEquals(3, $models->count());
+
+        $baseQuery = EloquentTestUser::oldest('id')->getQuery();
+        $baseQuery->chunkById(2, function () {
+            return false;
+        });
+        $models = $baseQuery->get();
+        $this->assertEquals(3, $models->count());
+    }
+
     public function testFirstOrCreate()
     {
         $user1 = EloquentTestUser::firstOrCreate(['email' => 'taylorotwell@gmail.com']);


### PR DESCRIPTION
Still preparing the field for https://github.com/laravel/internals/issues/103.

Sample code that would be failing currently:
```php
// get a paginator
$paginator = $query->paginate(...);

// leftover offset/limit clauses are unexpectedly applied here:
$topMovies = $query->where('rating', '>=', '9')->get();
```

Sadly tests can't be added for this, `forPage` being mocked.