### PR TITLE
[5.3] Add simple custom stubs support for generator commands

### DIFF
--- a/CHANGELOG-5.3.md
+++ b/CHANGELOG-5.3.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- Added custom stub support for generator commands. ([#16486](https://github.com/laravel/framework/pull/16486))
 - Added `AuthenticateSession` middleware ([fc302a6](https://github.com/laravel/framework/commit/fc302a6667f9dcce53395d01d8e6ba752ea62955))
 - Support arrays in `HasOne::withDefault()` ([#16382](https://github.com/laravel/framework/pull/16382))
 - Define route basename for resources ([#16352](https://github.com/laravel/framework/pull/16352))

--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -4,6 +4,7 @@ namespace Illuminate\Console;
 
 use Illuminate\Support\Str;
 use Illuminate\Filesystem\Filesystem;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputArgument;
 
 abstract class GeneratorCommand extends Command
@@ -145,9 +146,23 @@ abstract class GeneratorCommand extends Command
      */
     protected function buildClass($name)
     {
-        $stub = $this->files->get($this->getStub());
+        $stub = $this->files->get($this->resolveStub());
 
         return $this->replaceNamespace($stub, $name)->replaceClass($stub, $name);
+    }
+
+    /**
+     * Resolve the path of the stub.
+     *
+     * @return string
+     */
+    protected function resolveStub()
+    {
+        if ($stub = $this->option('stub')) {
+            return resource_path("stubs/$stub.stub");
+        }
+
+        return $this->getStub();
     }
 
     /**
@@ -214,6 +229,18 @@ abstract class GeneratorCommand extends Command
     {
         return [
             ['name', InputArgument::REQUIRED, 'The name of the class'],
+        ];
+    }
+
+    /**
+     * Get the console command options.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [
+            ['stub', '', InputOption::VALUE_REQUIRED, 'Use custom stub to generate the class'],
         ];
     }
 }

--- a/src/Illuminate/Foundation/Console/ConsoleMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ConsoleMakeCommand.php
@@ -83,8 +83,8 @@ class ConsoleMakeCommand extends GeneratorCommand
      */
     protected function getOptions()
     {
-        return [
+        return array_merge([
             ['command', null, InputOption::VALUE_OPTIONAL, 'The terminal command that should be assigned.', 'command:name'],
-        ];
+        ], parent::getOptions());
     }
 }

--- a/src/Illuminate/Foundation/Console/JobMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/JobMakeCommand.php
@@ -60,8 +60,8 @@ class JobMakeCommand extends GeneratorCommand
      */
     protected function getOptions()
     {
-        return [
+        return array_merge([
             ['sync', null, InputOption::VALUE_NONE, 'Indicates that job should be synchronous.'],
-        ];
+        ], parent::getOptions());
     }
 }

--- a/src/Illuminate/Foundation/Console/ListenerMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ListenerMakeCommand.php
@@ -113,10 +113,10 @@ class ListenerMakeCommand extends GeneratorCommand
      */
     protected function getOptions()
     {
-        return [
+        return array_merge([
             ['event', 'e', InputOption::VALUE_REQUIRED, 'The event class being listened for.'],
 
             ['queued', null, InputOption::VALUE_NONE, 'Indicates the event listener should be queued.'],
-        ];
+        ], parent::getOptions());
     }
 }

--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -87,12 +87,12 @@ class ModelMakeCommand extends GeneratorCommand
      */
     protected function getOptions()
     {
-        return [
+        return array_merge([
             ['migration', 'm', InputOption::VALUE_NONE, 'Create a new migration file for the model.'],
 
             ['controller', 'c', InputOption::VALUE_NONE, 'Create a new controller for the model.'],
 
             ['resource', 'r', InputOption::VALUE_NONE, 'Indicates if the generated controller should be a resource controller'],
-        ];
+        ], parent::getOptions());
     }
 }

--- a/src/Illuminate/Foundation/Console/PolicyMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/PolicyMakeCommand.php
@@ -102,8 +102,8 @@ class PolicyMakeCommand extends GeneratorCommand
      */
     protected function getOptions()
     {
-        return [
+        return array_merge([
             ['model', 'm', InputOption::VALUE_OPTIONAL, 'The model that the policy applies to.'],
-        ];
+        ], parent::getOptions());
     }
 }

--- a/src/Illuminate/Routing/Console/ControllerMakeCommand.php
+++ b/src/Illuminate/Routing/Console/ControllerMakeCommand.php
@@ -60,9 +60,9 @@ class ControllerMakeCommand extends GeneratorCommand
      */
     protected function getOptions()
     {
-        return [
+        return array_merge([
             ['resource', 'r', InputOption::VALUE_NONE, 'Generate a resource controller class.'],
-        ];
+        ], parent::getOptions());
     }
 
     /**


### PR DESCRIPTION
The title says it all.

This PR is to allow the generator commands (`make:controller, make:command, ...`) to create classes using custom stubs.

I added the option `--stub=[name_of_stub]` in the base class of the generator commands to allow to specify your own stub.

Stubs folder are located in `resources/stubs/my_custom_controller.stub`.

### Examples

* `make:controller --stub=api.controller` (File must be located at `resources/stubs/api.controller.stub`)
* `make:event --stub=events/broadcast.stub` (File must be located at `resources/stubs/events/broadcast.stub`)

This feature plays really nice with closure commands, allowing you to create your own generators in a clean way without touch the core:

```php
Artisan::command('make:controller:api {$name}', function ($name) {
    Artisan::call('make:controller', ['name' => $name, '--stub', 'api.controller']);
});
````

Then you could just call something like:

`php artisan make:controller:api TagsController`

You get the basic idea. If you are an usual user of NPM or Yarn, this looks similar to package.json commands or scripts, which is nice (IMO).

### Why ?

I've faced multiple times the problem that I often override Base Classes that ships out of the box with Laravel (`App\Http\Controllers\Controller`) or even I write my own Base classes for my Events or Policies.

The fact is when I do something like that, generators that ships with Laravel, don't work for me anymore 'right out of the box'.

### Is there any donwside?

Not really. The only thing that need to be cleared it's the way Laravel looks for dummy placeholders in your stubs (DummyClass, DummyNamespace, etc ...).

Maybe some documentation about it at the time of this feature gets released (If it's approved, of course) will fix this problem ?

`DummyNamespace` will be replaced with the namespace
`DummyClass` will be replaced with the name of the class

What do you guys think ?
