### PR TITLE
Add the SeeJsonStructureEquals method

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -374,6 +374,48 @@ trait MakesHttpRequests
     }
 
     /**
+     * Assert that the JSON response has exactly the given structure.
+     *
+     * @param  array  $structure
+     * @param  array|null  $responseData
+     * @return $this
+     */
+    public function seeJsonStructureEquals(array $structure, $responseData = null)
+    {
+        if (!$responseData) {
+            $responseData = $this->decodeResponseJson();
+        }
+
+        $structureFirstLevel = array_map(function ($value, $key) {
+            return is_array($value) ? $key : $value;
+        }, $structure, array_keys($structure));
+
+        $responseFirstLevel = array_keys($responseData);
+
+        if ($structureFirstLevel !== ['*']) {
+            $this->assertEquals($structureFirstLevel, $responseFirstLevel, '', 0.0, 10, true);
+        }
+
+        $structureOtherLevels = Arr::where($structure, function ($value) {
+            return is_array($value);
+        });
+
+        foreach ($structureOtherLevels as $key => $childStructure) {
+            if ($key === '*') {
+                $this->assertInternalType('array', $responseData);
+
+                foreach ($responseData as $responseDataItem) {
+                    $this->seeJsonStructureEquals($childStructure, $responseDataItem);
+                }
+            } else {
+                $this->seeJsonStructureEquals($childStructure, $responseData[$key]);
+            }
+        }
+
+        return $this;
+    }
+
+    /**
      * Assert that the response contains the given JSON.
      *
      * @param  array  $data

--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -396,7 +396,7 @@ trait MakesHttpRequests
             $this->assertEquals($structureFirstLevel, $responseFirstLevel, '', 0.0, 10, true);
         }
 
-        $structureOtherLevels = Arr::where($structure, function ($value) {
+        $structureOtherLevels = array_filter($structure, function ($value) {
             return is_array($value);
         });
 

--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -382,7 +382,7 @@ trait MakesHttpRequests
      */
     public function seeJsonStructureEquals(array $structure, $responseData = null)
     {
-        if (!$responseData) {
+        if (! $responseData) {
             $responseData = $this->decodeResponseJson();
         }
 

--- a/tests/Foundation/FoundationMakesHttpRequestsJsonTest.php
+++ b/tests/Foundation/FoundationMakesHttpRequestsJsonTest.php
@@ -52,6 +52,19 @@ class FoundationMakesHttpRequestsJsonTest extends PHPUnit_Framework_TestCase
         $this->seeJsonStructure(['*' => ['foo', 'bar', 'foobar']]);
     }
 
+
+    public function testSeeJsonStructureEquals()
+    {
+        $this->response = new Illuminate\Http\Response(new JsonSerializableMixedResourcesStub);
+
+        $this->seeJsonStructureEquals([
+            'foo',
+            'baz' => ['*' => ['bar' => ['*'], 'foo']],
+            'bars' => ['*' => ['bar', 'foo']],
+            'foobar' => ['foobar_foo', 'foobar_bar'],
+        ]);
+    }
+
     public function testSeeJsonWithNonJson()
     {
         $this->response = new Illuminate\Http\Response(new NonJsonSerializableStub);

--- a/tests/Foundation/FoundationMakesHttpRequestsJsonTest.php
+++ b/tests/Foundation/FoundationMakesHttpRequestsJsonTest.php
@@ -52,7 +52,6 @@ class FoundationMakesHttpRequestsJsonTest extends PHPUnit_Framework_TestCase
         $this->seeJsonStructure(['*' => ['foo', 'bar', 'foobar']]);
     }
 
-
     public function testSeeJsonStructureEquals()
     {
         $this->response = new Illuminate\Http\Response(new JsonSerializableMixedResourcesStub);


### PR DESCRIPTION
With the actual `SeeJsonStructure`, you can't know if some undesirable fields are returned by the application (some fields which shouldn't be public in particular cases for example). 

With this `SeeJsonStructureEquals` method you can check if a response is *exactly* the type of response that you are expecting. No more, no less.

It's a kind of "_security fence_" for our apis 😉  .

Suggestions and feedbacks are obviously welcomed, I'm open !