### PR TITLE
[5.3] Fix to prevent recursive where clause addition for chunkById

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -553,6 +553,7 @@ class Builder
      *
      * @param string    $column
      * @param int   $value
+     * @return $this
      */
     protected function chunkIdWhere($column, $value)
     {
@@ -1517,8 +1518,8 @@ class Builder
                 })->values()->all();
 
         return $this->chunkIdWhere($column, $lastId)
-            ->orderBy($column, 'asc')
-            ->take($perPage);
+                    ->orderBy($column, 'asc')
+                    ->take($perPage);
     }
 
     /**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -548,6 +548,24 @@ class Builder
     }
 
     /**
+     * Adds an id limit to assist with Eloquent chunkById.
+     * Subsequent calls override existing limit.
+     *
+     * @param string    $column
+     * @param int   $value
+     */
+    protected function chunkIdWhere($column, $value)
+    {
+        $where = compact('column', 'value');
+        $where['type'] = 'Basic';
+        $where['operator'] = '>';
+        $where['boolean'] = 'and';
+        $this->wheres['chunkId'] = $where;
+
+        return $this;
+    }
+
+    /**
      * Add an array of where clauses to the query.
      *
      * @param  array  $column
@@ -1498,9 +1516,9 @@ class Builder
                     return $order['column'] === $column;
                 })->values()->all();
 
-        return $this->where($column, '>', $lastId)
-                    ->orderBy($column, 'asc')
-                    ->take($perPage);
+        return $this->chunkIdWhere($column, $lastId)
+            ->orderBy($column, 'asc')
+            ->take($perPage);
     }
 
     /**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -549,7 +549,8 @@ class Builder
 
     /**
      * Adds an id limit to assist with Eloquent chunkById.
-     * Subsequent calls override existing limit.
+     *
+     * Subsequent calls override previous limit.
      *
      * @param string    $column
      * @param int   $value


### PR DESCRIPTION
Noticed during a recent meetup presentation that when running chunkById, the id where clause gets appended over and over again.  (Ie you get queries like `SELECT * FROM my_table WHERE id > 50 AND id > 100 AND id > 150 AND ...).

For smaller datasets this isn't a big deal, but as the whole point of chunkById is dealing with increasingly larger datasets, this seems problematic.  Eventually you'll run into query length limits somewhere.  Even if you don't, transmitting so much useless data hurts my sense of performance.

This change is intended to "tag" the chunking where clause so it gets replaced each iteration instead of appended.  I couldn't find anywhere that relies on the Builder where member variable to be numerically indexed, so I don't believe this will be an issue.  Still, I'm not intimately familiar with this framework.

Also, this prevents the usage of more exotic id columns with chunkById.  Frankly I think that's desirable--I would restrict it further to only allowing use of indexed columns if I could.  If there's disagreement with this, another option would be to make the `where` function a wrapper around an internal function that also accepts a tag parameter.