### PR TITLE
[5.3] microoptimization: change array_key_exists() to isset() in Eloquent Model

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2685,7 +2685,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     protected function getAttributeFromArray($key)
     {
-        if (array_key_exists($key, $this->attributes)) {
+        if (isset($this->attributes[$key])) {
             return $this->attributes[$key];
         }
     }
@@ -2758,7 +2758,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public function hasCast($key, $types = null)
     {
-        if (array_key_exists($key, $this->getCasts())) {
+        if (isset($this->getCasts()[$key])) {
             return $types ? in_array($this->getCastType($key), (array) $types, true) : true;
         }
 


### PR DESCRIPTION
Functions `getAttributeFromArray()` and `hasCast()` are called almost on each value in each Eloquent model that creates thousands of calls to them on average request that uses Eloquent models.

Widely known - that speed of array_key_exists() is much slower then isset() - depending of array size it can be from 3x to 10x times slower.

So my proposal is to change array_key_exists() usage to isset() that will **improve performance** of working with Eloquent models  in about 5% without any huge changes in code.
Only thing need to take care that `isset()` will return false also when key exist but `is_null`

### Logic review:

According to logic all cast attributes are some string names of base types ('int', 'string', 'array', etc.) - so value cannot be null in any situation - I think it's safe to use `isset()` here instead of `array_key_exists()`;
```
public function hasCast($key, $types = null)
{
    if (isset($this->getCasts()[$key])) {
        return $types ? in_array($this->getCastType($key), (array) $types, true) : true;
    }
}
```

If attribute with a given key existed - it returned it, else function does not return anything (returns null), after change it will work like "if attribute exists AND is not null - return attribute, else return null". So even if `isset()` returns null and condition gives `false` cause attribute equals null - function will return null anyway. So method will work as previously.
```
protected function getAttributeFromArray($key)
{
    if (isset($this->attributes[$key])) {
        return $this->attributes[$key];
    }
}
```