### PR TITLE
[5.3] Fix View compilation bug

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -401,7 +401,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
      */
     public function compileEchoDefaults($value)
     {
-        return preg_replace('/^(?=\$)(.+?)(?:\s+or\s+)(.+?)$/s', 'isset($1) ? $1 : $2', $value);
+        return preg_replace('/^(?=\$)([^\'"]+?)(?:\s+or\s+)(.+?)$/s', 'isset($1) ? $1 : $2', $value);
     }
 
     /**

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -98,6 +98,48 @@ class ViewBladeCompilerTest extends PHPUnit_Framework_TestCase
         $this->assertEquals("<?php echo e(\$name); ?>\n\n", $compiler->compileString("{{ \$name }}\n"));
         $this->assertEquals("<?php echo e(\$name); ?>\r\n\r\n", $compiler->compileString("{{ \$name }}\r\n"));
 
+        $this->assertEquals('<?php echo e($name["key"]); ?>', $compiler->compileString('{{{$name["key"]}}}'));
+        $this->assertEquals('<?php echo e($name["key"]); ?>', $compiler->compileString('{{$name["key"]}}'));
+        $this->assertEquals('<?php echo e($name["key"]); ?>', $compiler->compileString('{{ $name["key"] }}'));
+        $this->assertEquals('<?php echo e($name["key"]); ?>', $compiler->compileString('{{
+            $name["key"]
+        }}'));
+
+        $this->assertEquals('<?php echo e($name["key with space"]); ?>', $compiler->compileString('{{{$name["key with space"]}}}'));
+        $this->assertEquals('<?php echo e($name["key with space"]); ?>', $compiler->compileString('{{$name["key with space"]}}'));
+        $this->assertEquals('<?php echo e($name["key with space"]); ?>', $compiler->compileString('{{ $name["key with space"] }}'));
+        $this->assertEquals('<?php echo e($name["key with space"]); ?>', $compiler->compileString('{{
+            $name["key with space"]
+        }}'));
+
+        $this->assertEquals('<?php echo e($name[\'key\']); ?>', $compiler->compileString('{{{$name[\'key\']}}}'));
+        $this->assertEquals('<?php echo e($name[\'key\']); ?>', $compiler->compileString('{{$name[\'key\']}}'));
+        $this->assertEquals('<?php echo e($name[\'key\']); ?>', $compiler->compileString('{{ $name[\'key\'] }}'));
+        $this->assertEquals('<?php echo e($name[\'key\']); ?>', $compiler->compileString('{{
+            $name[\'key\']
+        }}'));
+
+        $this->assertEquals('<?php echo e($name[\'key with space\']); ?>', $compiler->compileString('{{{$name[\'key with space\']}}}'));
+        $this->assertEquals('<?php echo e($name[\'key with space\']); ?>', $compiler->compileString('{{$name[\'key with space\']}}'));
+        $this->assertEquals('<?php echo e($name[\'key with space\']); ?>', $compiler->compileString('{{ $name[\'key with space\'] }}'));
+        $this->assertEquals('<?php echo e($name[\'key with space\']); ?>', $compiler->compileString('{{
+            $name[\'key with space\']
+        }}'));
+
+        $this->assertEquals('<?php echo e($name[\'key or space\']); ?>', $compiler->compileString('{{{$name[\'key or space\']}}}'));
+        $this->assertEquals('<?php echo e($name[\'key or space\']); ?>', $compiler->compileString('{{$name[\'key or space\']}}'));
+        $this->assertEquals('<?php echo e($name[\'key or space\']); ?>', $compiler->compileString('{{ $name[\'key or space\'] }}'));
+        $this->assertEquals('<?php echo e($name[\'key or space\']); ?>', $compiler->compileString('{{
+            $name[\'key or space\']
+        }}'));
+        
+        $this->assertEquals('<?php echo e($name["key or space"]); ?>', $compiler->compileString('{{{$name["key or space"]}}}'));
+        $this->assertEquals('<?php echo e($name["key or space"]); ?>', $compiler->compileString('{{$name["key or space"]}}'));
+        $this->assertEquals('<?php echo e($name["key or space"]); ?>', $compiler->compileString('{{ $name["key or space"] }}'));
+        $this->assertEquals('<?php echo e($name["key or space"]); ?>', $compiler->compileString('{{
+            $name["key or space"]
+        }}'));
+
         $this->assertEquals('<?php echo e(isset($name) ? $name : "foo"); ?>', $compiler->compileString('{{ $name or "foo" }}'));
         $this->assertEquals('<?php echo e(isset($user->name) ? $user->name : "foo"); ?>', $compiler->compileString('{{ $user->name or "foo" }}'));
         $this->assertEquals('<?php echo e(isset($name) ? $name : "foo"); ?>', $compiler->compileString('{{$name or "foo"}}'));

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -132,7 +132,7 @@ class ViewBladeCompilerTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('<?php echo e($name[\'key or space\']); ?>', $compiler->compileString('{{
             $name[\'key or space\']
         }}'));
-        
+
         $this->assertEquals('<?php echo e($name["key or space"]); ?>', $compiler->compileString('{{{$name["key or space"]}}}'));
         $this->assertEquals('<?php echo e($name["key or space"]); ?>', $compiler->compileString('{{$name["key or space"]}}'));
         $this->assertEquals('<?php echo e($name["key or space"]); ?>', $compiler->compileString('{{ $name["key or space"] }}'));


### PR DESCRIPTION
Having `{{$var['a or b']}}` would generate wrong code, since the key ('a or b') contains 'or' and this or was understood as the 'or' shortcut. 

Fixed the issue by improving the regex used for detecting the 'or' shortcut.