### PR TITLE
[5.3] Remove unwanted spaces in constraints

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1129,6 +1129,7 @@ class Builder
             // an empty Closure with the loader so that we can treat all the same.
             if (is_numeric($name)) {
                 if (Str::contains($constraints, ':')) {
+                    $constraints = preg_replace('/\s+/', '', $constraints);
                     list($constraints, $columns) = explode(':', $constraints);
 
                     $f = function ($q) use ($columns) {

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -150,7 +150,7 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
     public function testEagerLoadingWithColumns()
     {
         $model = new EloquentModelWithoutRelationStub;
-        $instance = $model->newInstance()->newQuery()->with('foo:bar,baz', 'hadi');
+        $instance = $model->newInstance()->newQuery()->with('foo: bar, baz', 'hadi');
         $builder = m::mock(Builder::class);
         $builder->shouldReceive('select')->once()->with(['bar', 'baz']);
         $this->assertNotNull($instance->getEagerLoads()['hadi']);


### PR DESCRIPTION
Allows columns names be separated by spaces
```php
User::where(...)->with('business: id, name')->get()
```