### PR TITLE
[5.4] Do not call enforceOrderBy in chunkById

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -433,8 +433,6 @@ class Builder
      */
     public function chunkById($count, callable $callback, $column = 'id')
     {
-        $this->enforceOrderBy();
-
         $lastId = 0;
 
         do {

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1844,8 +1844,6 @@ class Builder
      */
     public function chunkById($count, callable $callback, $column = 'id', $alias = null)
     {
-        $this->enforceOrderBy();
-
         $alias = $alias ?: $column;
 
         $lastId = 0;


### PR DESCRIPTION
Fixes an overlook from #16283.

`chunkById` is already applying an "order by" clause, see `forPageAfterId` in [Builder.php](https://github.com/laravel/framework/blob/master/src/Illuminate/Database/Query/Builder.php). Therefore, we don't have to, and should not, require an "order by" beforehand.

<br>Note: though `enforceOrderBy` is now used at only one place, I'm not inlining it in `chunk`, this way the code of `chunk` is cleaner, and users can redefine `enforceOrderBy`.