### PR TITLE
Bugfix - Not escaping \ + * ? [ ^ ] ( $ ) in bindings

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2366,6 +2366,10 @@ class Builder
             $this->bindings[$type][] = $value;
         }
 
+        foreach ($this->bindings[$type] as $key => $binding) {
+            $this->bindings[$type][$key] = quotemeta($binding);
+        }
+
         return $this;
     }
 


### PR DESCRIPTION
Problem: When passing any of these . \ + * ? [ ^ ] ( $ ) to a binding, query builder was not escaping, and passing this to the raw query.

Solutions: Escaping . \ + * ? [ ^ ] ( $ ) in bindings with quotemeta().