### PR TITLE
Adjust the base64: env check to account for quotes

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -457,7 +457,7 @@ if (! function_exists('env')) {
         }
 
         if (Str::startsWith($value, ['base64:', "'base64:", '"base64:'])) {
-            return base64_decode(trim($value, '"\''));
+            return base64_decode(substr(trim($value, '"\''), 7));
         }
 
         if (strlen($value) > 1 && Str::startsWith($value, '"') && Str::endsWith($value, '"')) {

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -456,8 +456,8 @@ if (! function_exists('env')) {
                 return;
         }
 
-        if (strpos($value, 'base64:') === 0) {
-            return base64_decode(substr($value, 7));
+        if (Str::startsWith($value, ['base64:', "'base64:", '"base64:'])) {
+            return base64_decode(trim($value, '"\''));
         }
 
         if (strlen($value) > 1 && Str::startsWith($value, '"') && Str::endsWith($value, '"')) {


### PR DESCRIPTION
This is in reference to #16186 which added support for prefixing env variables with `base64:` to have them automatically decoded. 

The original PR didn't account for the fact that variables with spaces need to be quoted in the .env file and this should support encoding those. For example: 

```
PRIVATE_KEY1=base64:mytest
PRIVATE_KEY2='base64:——BEGIN RSA PRIVATE KEY-----\n'
PRIVATE_KEY3="base64:——BEGIN RSA PRIVATE KEY-----\n"
```
