### PR TITLE
[5.3] Consolidate tests for first() and last() Collection methods

### DIFF
--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -13,10 +13,34 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('foo', $c->first());
     }
 
+    public function testFirstWithCallback()
+    {
+        $data = new Collection(['foo', 'bar', 'baz']);
+        $result = $data->first(function ($value) {
+            return $value === 'bar';
+        });
+        $this->assertEquals('bar', $result);
+    }
+
+    public function testFirstWithCallbackAndDefault()
+    {
+        $data = new Collection(['foo', 'bar']);
+        $result = $data->first(function ($value) {
+            return $value === 'baz';
+        }, 'default');
+        $this->assertEquals('default', $result);
+    }
+
+    public function testFirstWithDefaultAndWithoutCallback()
+    {
+        $data = new Collection;
+        $result = $data->first(null, 'default');
+        $this->assertEquals('default', $result);
+    }
+
     public function testLastReturnsLastItemInCollection()
     {
         $c = new Collection(['foo', 'bar']);
-
         $this->assertEquals('bar', $c->last());
     }
 
@@ -955,31 +979,6 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
             return $key.'-'.strrev($item);
         });
         $this->assertEquals(['first' => 'first-rolyat', 'last' => 'last-llewto'], $data->all());
-    }
-
-    public function testFirstWithCallback()
-    {
-        $data = new Collection(['foo', 'bar', 'baz']);
-        $result = $data->first(function ($value) {
-            return $value === 'bar';
-        });
-        $this->assertEquals('bar', $result);
-    }
-
-    public function testFirstWithCallbackAndDefault()
-    {
-        $data = new Collection(['foo', 'bar']);
-        $result = $data->first(function ($value) {
-            return $value === 'baz';
-        }, 'default');
-        $this->assertEquals('default', $result);
-    }
-
-    public function testFirstWithDefaultAndWithoutCallback()
-    {
-        $data = new Collection;
-        $result = $data->first(null, 'default');
-        $this->assertEquals('default', $result);
     }
 
     public function testGroupByAttribute()


### PR DESCRIPTION
Disclaimer: this one is a nitpick, but tidying the tests is not a luxury :)

Current situation, note the gap between lines 45 and 960:
```
Search "test(First|Last)" (8 hits)
    Line 10:     public function testFirstReturnsFirstItemInCollection()
    Line 16:     public function testLastReturnsLastItemInCollection()
    Line 23:     public function testLastWithCallback()
    Line 36:     public function testLastWithCallbackAndDefault()
    Line 45:     public function testLastWithDefaultAndWithoutCallback()
    Line 960:    public function testFirstWithCallback()
    Line 969:    public function testFirstWithCallbackAndDefault()
    Line 978:    public function testFirstWithDefaultAndWithoutCallback()
```

This gap was introduced in https://github.com/laravel/framework/pull/2858/files#diff-f565fa2deb7f67254a3a052a4f1d214b.