### PR TITLE
[5.3] Add fluent builder for SlackMessageAttachmentField

### DIFF
--- a/src/Illuminate/Notifications/Channels/SlackWebhookChannel.php
+++ b/src/Illuminate/Notifications/Channels/SlackWebhookChannel.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Notifications\Channels;
 
 use GuzzleHttp\Client as HttpClient;
+use Illuminate\Notifications\Messages\SlackAttachmentField;
 use Illuminate\Notifications\Notification;
 use Illuminate\Notifications\Messages\SlackMessage;
 use Illuminate\Notifications\Messages\SlackAttachment;
@@ -99,6 +100,10 @@ class SlackWebhookChannel
     protected function fields(SlackAttachment $attachment)
     {
         return collect($attachment->fields)->map(function ($value, $key) {
+            if ($value instanceof SlackAttachmentField) {
+                return $value->toArray();
+            }
+
             return ['title' => $key, 'value' => $value, 'short' => true];
         })->values()->all();
     }

--- a/src/Illuminate/Notifications/Messages/SlackAttachment.php
+++ b/src/Illuminate/Notifications/Messages/SlackAttachment.php
@@ -111,6 +111,31 @@ class SlackAttachment
     }
 
     /**
+     * Add a field to the attachment.
+     *
+     * @param  \Closure|array $title
+     * @param  string $content
+     * @return $this
+     */
+    public function field($title, $content = '')
+    {
+        if (is_callable($title)) {
+            $callback = $title;
+
+            $attachmentField = new SlackAttachmentField();
+
+            $callback($attachmentField);
+            $this->fields[] = $attachmentField;
+
+            return $this;
+        }
+
+        $this->fields[$title] = $content;
+
+        return $this;
+    }
+
+    /**
      * Set the fields of the attachment.
      *
      * @param  array  $fields

--- a/src/Illuminate/Notifications/Messages/SlackAttachmentField.php
+++ b/src/Illuminate/Notifications/Messages/SlackAttachmentField.php
@@ -65,7 +65,7 @@ class SlackAttachmentField
     /**
      * @return $this
      */
-    public function doNotDisplaySideBySide()
+    public function dontDisplaySideBySide()
     {
         $this->short = false;
 

--- a/src/Illuminate/Notifications/Messages/SlackAttachmentField.php
+++ b/src/Illuminate/Notifications/Messages/SlackAttachmentField.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Illuminate\Notifications\Messages;
+
+class SlackAttachmentField
+{
+    /**
+     * The title field of the attachment field.
+     *
+     * @var string
+     */
+    protected $title;
+
+    /**
+     * The content of the attachment field.
+     *
+     * @var string
+     */
+    protected $content;
+
+    /**
+     * Whether the content is short enough to fit side by side with
+     * other contents.
+     *
+     * @var bool
+     */
+    protected $short = true;
+
+    /**
+     * Set the title of the field.
+     *
+     * @param string $title
+     * @return $this
+     */
+    public function title($title)
+    {
+        $this->title = $title;
+
+        return $this;
+    }
+
+    /**
+     * Set the content of the field.
+     *
+     * @param string $content
+     * @return $this
+     */
+    public function content($content)
+    {
+        $this->content = $content;
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function displaySideBySide()
+    {
+        $this->short = true;
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function doNotDisplaySideBySide()
+    {
+        $this->short = false;
+
+        return $this;
+    }
+
+    /**
+     * Get the array representation of the attachment field.
+     *
+     * @return array
+     */
+    public function toArray()
+    {
+        return [
+            'title' => $this->title,
+            'value' => $this->content,
+            'short' => $this->short,
+        ];
+    }
+}

--- a/tests/Notifications/NotificationSlackChannelTest.php
+++ b/tests/Notifications/NotificationSlackChannelTest.php
@@ -108,7 +108,7 @@ class NotificationSlackChannelTest extends PHPUnit_Framework_TestCase
                                     'title' => 'Special powers',
                                     'value' => 'Zonda',
                                     'short' => false,
-                                ]
+                                ],
                             ],
                         ],
                     ],

--- a/tests/Notifications/NotificationSlackChannelTest.php
+++ b/tests/Notifications/NotificationSlackChannelTest.php
@@ -182,7 +182,7 @@ class NotificationSlackChannelWithAttachmentFieldBuilderTestNotification extends
                         $attachmentField
                             ->title('Special powers')
                             ->content('Zonda')
-                            ->doNotDisplaySideBySide();
+                            ->dontDisplaySideBySide();
                     });
             });
     }

--- a/tests/Notifications/NotificationSlackChannelTest.php
+++ b/tests/Notifications/NotificationSlackChannelTest.php
@@ -107,7 +107,7 @@ class NotificationSlackChannelTest extends PHPUnit_Framework_TestCase
                                 [
                                     'title' => 'Special powers',
                                     'value' => 'Zonda',
-                                    'short' => false
+                                    'short' => false,
                                 ]
                             ],
                         ],
@@ -178,7 +178,7 @@ class NotificationSlackChannelWithAttachmentFieldBuilderTestNotification extends
                 $attachment->title('Laravel', 'https://laravel.com')
                     ->content('Attachment Content')
                     ->field('Project', 'Laravel')
-                    ->field(function($attachmentField) {
+                    ->field(function ($attachmentField) {
                         $attachmentField
                             ->title('Special powers')
                             ->content('Zonda')

--- a/tests/Notifications/NotificationSlackChannelTest.php
+++ b/tests/Notifications/NotificationSlackChannelTest.php
@@ -85,6 +85,37 @@ class NotificationSlackChannelTest extends PHPUnit_Framework_TestCase
             ]
         );
     }
+
+    public function testCorrectPayloadWithAttachmentFieldBuilderIsSentToSlack()
+    {
+        $this->validatePayload(
+            new NotificationSlackChannelWithAttachmentFieldBuilderTestNotification,
+            [
+                'json' => [
+                    'text' => 'Content',
+                    'attachments' => [
+                        [
+                            'title' => 'Laravel',
+                            'text' => 'Attachment Content',
+                            'title_link' => 'https://laravel.com',
+                            'fields' => [
+                                [
+                                    'title' => 'Project',
+                                    'value' => 'Laravel',
+                                    'short' => true,
+                                ],
+                                [
+                                    'title' => 'Special powers',
+                                    'value' => 'Zonda',
+                                    'short' => false
+                                ]
+                            ],
+                        ],
+                    ],
+                ],
+            ]
+        );
+    }
 }
 
 class NotificationSlackChannelTestNotifiable
@@ -134,5 +165,25 @@ class NotificationSlackChannelWithoutOptionalFieldsTestNotification extends Noti
                                         'Project' => 'Laravel',
                                     ]);
                     });
+    }
+}
+
+class NotificationSlackChannelWithAttachmentFieldBuilderTestNotification extends Notification
+{
+    public function toSlack($notifiable)
+    {
+        return (new SlackMessage)
+            ->content('Content')
+            ->attachment(function ($attachment) {
+                $attachment->title('Laravel', 'https://laravel.com')
+                    ->content('Attachment Content')
+                    ->field('Project', 'Laravel')
+                    ->field(function($attachmentField) {
+                        $attachmentField
+                            ->title('Special powers')
+                            ->content('Zonda')
+                            ->doNotDisplaySideBySide();
+                    });
+            });
     }
 }


### PR DESCRIPTION
Currently Laravel only has a `fields` method to attach some fields to a `SlackAttachment`

The example from [the documentation](https://laravel.com/docs/5.3/notifications#formatting-slack-notifications):

```php
 return (new SlackMessage)
                ->success()
                ->content('One of your invoices has been paid!')
                ->attachment(function ($attachment) use ($url) {
                    $attachment->title('Invoice 1322', $url)
                               ->fields([
                                    'Title' => 'Server Expenses',
                                    'Amount' => '$1,234',
                                    'Via' => 'American Express',
                                    'Was Overdue' => ':-1:',
                                ]);
                });
```

That's nice, but under the hood the `short` property of the fields is being set to `false`.  For longer text in attachment there's no way to set this to `true`. So, an attachment like this (taken from [the Slack docs](https://api.slack.com/docs/message-attachments)) isn't possible.

![attachment_fields](https://cloud.githubusercontent.com/assets/483853/20599673/ac41ec9a-b24f-11e6-98f1-8737dda1af0d.png)

This PR adds a builder for a `SlackMessageAttachmentField` in the same spirit as `SlackMessageAttachment`. Using this builder the `short` property can be set to true by calling the `doNotDisplaySideBySide`-method.

Here's how the builder can be used:

```php
//in a Notification

public function toSlack($notifiable)
    {
        return (new SlackMessage)
            ->content('Content')
            ->attachment(function ($attachment) {
                $attachment
                    ->title('Laravel', 'https://laravel.com')
                    ->content('Attachment Content')

                    //build up an attachment field
                    ->field(function($attachmentField) {
                        $attachmentField
                            ->title('Special powers')
                            ->content('Zonda')
                            ->dontDisplaySideBySide();
                    });

                    //manually add one
                    ->field('Project', 'Laravel')
            });
    }
```

Hope you'll like it!