### PR TITLE
[5.3] Allow to add where condition using model key

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -166,7 +166,7 @@ class Builder
             return $this->findMany($id, $columns);
         }
 
-        return $this->byKey($id)->first($columns);
+        return $this->whereKey($id)->first($columns);
     }
 
     /**
@@ -182,7 +182,7 @@ class Builder
             return $this->model->newCollection();
         }
 
-        return $this->byKey($ids)->get($columns);
+        return $this->whereKey($ids)->get($columns);
     }
 
     /**
@@ -191,7 +191,7 @@ class Builder
      * @param  mixed  $id
      * @return $this
      */
-    public function byKey($id)
+    public function whereKey($id)
     {
         if (is_array($id)) {
             $this->query->whereIn($this->model->getQualifiedKeyName(), $id);

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -195,7 +195,7 @@ class Builder
     {
         if (is_array($id)) {
             $this->query->whereIn($this->model->getQualifiedKeyName(), $id);
-            
+
             return $this;
         }
 

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -166,9 +166,7 @@ class Builder
             return $this->findMany($id, $columns);
         }
 
-        $this->query->where($this->model->getQualifiedKeyName(), '=', $id);
-
-        return $this->first($columns);
+        return $this->byKey($id)->first($columns);
     }
 
     /**
@@ -184,9 +182,24 @@ class Builder
             return $this->model->newCollection();
         }
 
-        $this->query->whereIn($this->model->getQualifiedKeyName(), $ids);
+        return $this->byKey($ids)->get($columns);
+    }
 
-        return $this->get($columns);
+    /**
+     * Add where clause with key condition to the query.
+     *
+     * @param  mixed  $id
+     * @return $this
+     */
+    public function byKey($id)
+    {
+        if (is_array($id)) {
+            $this->query->whereIn($this->model->getQualifiedKeyName(), $id);
+            
+            return $this;
+        }
+
+        return $this->where($this->model->getQualifiedKeyName(), '=', $id);
     }
 
     /**


### PR DESCRIPTION
If you want to add condition to get model by key as far as I know there is no way to do it so simple right now.

You need to use `where('id',5)` for example:

```
Model::where('id',5)->where('something_else',6)->first();
```

so you need to use `where` condition and remember the key (sometimes it's not `id`).

Using helper method `byKey` you can now simplify this.

This is quite useful when using `value` method.

For example:

```
return ($model = Model::find(1)) ? $model->value('name') : null
```

vs

```
return $model->byKey(1)->value('name')
```