### PR TITLE
[5.4] Localize routes

### DIFF
--- a/src/Illuminate/Routing/Middleware/Localize.php
+++ b/src/Illuminate/Routing/Middleware/Localize.php
@@ -67,7 +67,7 @@ class Localize
      */
     private function getLocaleFromRequest($request)
     {
-        if($this->localeIsValid($locale = $request->segment(1))){
+        if ($this->localeIsValid($locale = $request->segment(1))) {
             return $locale;
         }
     }

--- a/src/Illuminate/Routing/Middleware/Localize.php
+++ b/src/Illuminate/Routing/Middleware/Localize.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Illuminate\Routing\Middleware;
+
+use Closure;
+use Illuminate\Foundation\Application;
+use Illuminate\Contracts\Routing\UrlGenerator;
+
+class Localize
+{
+    /**
+     * The application instance.
+     *
+     * @var \Illuminate\Foundation\Application
+     */
+    protected $app;
+
+    /**
+     * The URL generator instance.
+     *
+     * @var \Illuminate\Contracts\Routing\UrlGenerator
+     */
+    protected $url;
+
+    /**
+     * Create a new request localizer.
+     *
+     * @param  \Illuminate\Foundation\Application  $app
+     * @param  \Illuminate\Contracts\Routing\UrlGenerator  $url
+     * @return void
+     */
+    public function __construct(Application $app, UrlGenerator $url)
+    {
+        $this->app = $app;
+        $this->url = $url;
+    }
+
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     */
+    public function handle($request, Closure $next)
+    {
+        $defaultLocale = $this->app['config']->get('app.fallback_locale');
+
+        if (! $this->requestPathHasLocale($request)) {
+            return redirect(trim($defaultLocale.'/'.$request->path(), '/'));
+        }
+
+        $locale = $this->getLocaleFromRequest($request);
+
+        $this->app->setLocale($locale);
+
+        $this->url->formatPathUsing(function ($path) use ($locale) {
+            return rtrim('/'.$locale.$path, '/');
+        });
+
+        return $next($request);
+    }
+
+    /**
+     * Determine if the request path contains locale information.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return bool
+     */
+    protected function requestPathHasLocale($request)
+    {
+        return in_array($request->segment(1), $this->app['config']->get('app.locales'));
+    }
+
+    /**
+     * Extract the locale from the given request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return string
+     */
+    private function getLocaleFromRequest($request)
+    {
+        return $this->requestPathHasLocale($request) ?
+                        $request->segment(1) : $this->app['config']->get('app.fallback_locale');
+    }
+}

--- a/src/Illuminate/Routing/Middleware/Localize.php
+++ b/src/Illuminate/Routing/Middleware/Localize.php
@@ -46,11 +46,9 @@ class Localize
     {
         $defaultLocale = $this->app['config']->get('app.fallback_locale');
 
-        if (! $this->requestPathHasLocale($request)) {
+        if (! $locale = $this->getLocaleFromRequest($request)) {
             return redirect(trim($defaultLocale.'/'.$request->path(), '/'));
         }
-
-        $locale = $this->getLocaleFromRequest($request);
 
         $this->app->setLocale($locale);
 
@@ -62,25 +60,26 @@ class Localize
     }
 
     /**
-     * Determine if the request path contains locale information.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @return bool
-     */
-    protected function requestPathHasLocale($request)
-    {
-        return in_array($request->segment(1), $this->app['config']->get('app.locales'));
-    }
-
-    /**
      * Extract the locale from the given request.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @return string
+     * @return string|null
      */
     private function getLocaleFromRequest($request)
     {
-        return $this->requestPathHasLocale($request) ?
-                        $request->segment(1) : $this->app['config']->get('app.fallback_locale');
+        if($this->localeIsValid($locale = $request->segment(1))){
+            return $locale;
+        }
+    }
+
+    /**
+     * Determine if the given locale is valid.
+     *
+     * @param  string  $locale
+     * @return bool
+     */
+    private function localeIsValid($locale)
+    {
+        return in_array($locale, $this->app['config']->get('app.locales'));
     }
 }

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -281,6 +281,22 @@ class Router implements RegistrarContract, BindingRegistrar
     }
 
     /**
+     * Localize the registered routes.
+     *
+     * @return void
+     */
+    public function localize()
+    {
+        if ($this->container && $this->container->bound('Illuminate\Routing\RoutesLocalizer')) {
+            $localizer = $this->container->make('Illuminate\Routing\RoutesLocalizer');
+        } else {
+            $localizer = new RoutesLocalizer($this, $this->container['config']);
+        }
+
+        $localizer->localize();
+    }
+
+    /**
      * Register the typical authentication routes for an application.
      *
      * @return void

--- a/src/Illuminate/Routing/RoutesLocalizer.php
+++ b/src/Illuminate/Routing/RoutesLocalizer.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Illuminate\Routing;
+
+use Illuminate\Contracts\Config\Repository;
+
+class RoutesLocalizer
+{
+    /**
+     * The router instance.
+     *
+     * @var \Illuminate\Routing\Router
+     */
+    protected $router;
+
+    /**
+     * The configuration repository instance.
+     *
+     * @var \Illuminate\Routing\Router
+     */
+    protected $config;
+
+    /**
+     * Create a new routes localizer instance.
+     *
+     * @param  \Illuminate\Routing\Router  $router
+     * @param  \Illuminate\Contracts\Config\Repository  $config
+     * @return void
+     */
+    public function __construct(Router $router, Repository $config)
+    {
+        $this->router = $router;
+        $this->config = $config;
+    }
+
+    /**
+     * Localize routes using the given locales.
+     *
+     * @return void
+     */
+    public function localize()
+    {
+        foreach ($this->router->getRoutes() as $route) {
+            if (! $this->routeShouldBeLocalized($route)) {
+                return;
+            }
+
+            foreach ($this->config->get('app.locales') as $locale) {
+                $this->addRouteForLocale($route, $locale);
+            }
+        }
+    }
+
+    /**
+     * Add a route for the locale in the route collection.
+     *
+     * @param  \Illuminate\Routing\Route  $route
+     * @param  string  $locale
+     * @return void
+     */
+    private function addRouteForLocale($route, $locale)
+    {
+        $route = clone $route;
+
+        $routeUri = $route->getUri();
+
+        $route->setUri(
+            $routeUri == '/' ? $locale : $locale.'/'.$routeUri
+        );
+
+        if ($route->getName()) {
+            $route->name('.'.$locale);
+        }
+
+        $this->router->getRoutes()->add($route);
+    }
+
+    /**
+     * Determine if the route should be localized.
+     *
+     * @param  \Illuminate\Routing\Route  $route
+     * @return bool
+     */
+    private function routeShouldBeLocalized($route)
+    {
+        return in_array('localize', $route->gatherMiddleware());
+    }
+}

--- a/tests/Routing/RouteLocalizationTest.php
+++ b/tests/Routing/RouteLocalizationTest.php
@@ -1,10 +1,9 @@
 <?php
 
-use Illuminate\Foundation\Application;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Router;
 use Illuminate\Events\Dispatcher;
-use Illuminate\Container\Container;
+use Illuminate\Foundation\Application;
 
 class RouteLocalizationTest extends PHPUnit_Framework_TestCase
 {
@@ -14,7 +13,8 @@ class RouteLocalizationTest extends PHPUnit_Framework_TestCase
     protected $app;
     protected $url;
 
-    public function setup(){
+    public function setup()
+    {
         $this->app = new Application();
     }
 
@@ -29,10 +29,10 @@ class RouteLocalizationTest extends PHPUnit_Framework_TestCase
         $this->app['config']->shouldReceive('get')->with('app.locales')->andReturn(['en', 'ar']);
         $this->app['config']->shouldReceive('get')->with('app.fallback_locale')->andReturn('en');
 
-        $this->app['config']->shouldReceive('set')->with("app.locale", "ar");
+        $this->app['config']->shouldReceive('set')->with('app.locale', 'ar');
         $this->app['translator']->shouldReceive('setLocale')->with('ar');
 
-        $this->app['config']->shouldReceive('set')->with("app.locale", "en");
+        $this->app['config']->shouldReceive('set')->with('app.locale', 'en');
         $this->app['translator']->shouldReceive('setLocale')->with('en');
 
         $this->url->shouldReceive('formatPathUsing');
@@ -66,12 +66,12 @@ class RouteLocalizationTest extends PHPUnit_Framework_TestCase
         $redirector = Mockery::mock('Illuminate\Routing\Redirector');
         $redirector->shouldReceive('to')->once()->with('en/foo', 302, [], null);
 
-        $this->app->bind('redirect', function () use ($redirector){
+        $this->app->bind('redirect', function () use ($redirector) {
             return $redirector;
         });
 
         $this->app['config']->shouldReceive('get')->with('app.fallback_locale')->andReturn('en');
-            $this->app['config']->shouldReceive('get')->with('app.locales')->andReturn(['en', 'ar']);
+        $this->app['config']->shouldReceive('get')->with('app.locales')->andReturn(['en', 'ar']);
 
         $router->get('foo', function () {
             return 'foo';

--- a/tests/Routing/RouteLocalizationTest.php
+++ b/tests/Routing/RouteLocalizationTest.php
@@ -1,0 +1,101 @@
+<?php
+
+use Illuminate\Foundation\Application;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Router;
+use Illuminate\Events\Dispatcher;
+use Illuminate\Container\Container;
+
+class RouteLocalizationTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Application
+     */
+    protected $app;
+    protected $url;
+
+    public function setup(){
+        $this->app = new Application();
+    }
+
+    public function testLocalizerMatchesRouteWithLocale()
+    {
+        $router = $this->getRouter();
+
+        $router->get('foo', function () {
+            return 'foo';
+        })->middleware('localize');
+
+        $this->app['config']->shouldReceive('get')->with('app.locales')->andReturn(['en', 'ar']);
+        $this->app['config']->shouldReceive('get')->with('app.fallback_locale')->andReturn('en');
+
+        $this->app['config']->shouldReceive('set')->with("app.locale", "ar");
+        $this->app['translator']->shouldReceive('setLocale')->with('ar');
+
+        $this->app['config']->shouldReceive('set')->with("app.locale", "en");
+        $this->app['translator']->shouldReceive('setLocale')->with('en');
+
+        $this->url->shouldReceive('formatPathUsing');
+
+        $router->localize();
+
+        $this->assertEquals('foo', $router->dispatch(Request::create('ar/foo', 'GET'))->getContent());
+        $this->assertEquals('foo', $router->dispatch(Request::create('en/foo', 'GET'))->getContent());
+    }
+
+    /**
+     * @expectedException Symfony\Component\HttpKernel\Exception\NotFoundHttpException
+     */
+    public function testLocalizerDoesntLocalizeRoutesWithoutTheMiddleware()
+    {
+        $router = $this->getRouter();
+
+        $router->get('foo', function () {
+            return 'foo';
+        });
+
+        $router->localize();
+
+        $this->assertEquals('foo', $router->dispatch(Request::create('ar/foo', 'GET'))->getContent());
+    }
+
+    public function testLocalizerRedirectesToPathWithDefaultLocale()
+    {
+        $router = $this->getRouter();
+
+        $redirector = Mockery::mock('Illuminate\Routing\Redirector');
+        $redirector->shouldReceive('to')->once()->with('en/foo', 302, [], null);
+
+        $this->app->bind('redirect', function () use ($redirector){
+            return $redirector;
+        });
+
+        $this->app['config']->shouldReceive('get')->with('app.fallback_locale')->andReturn('en');
+            $this->app['config']->shouldReceive('get')->with('app.locales')->andReturn(['en', 'ar']);
+
+        $router->get('foo', function () {
+            return 'foo';
+        })->middleware('localize');
+
+        $router->dispatch(Request::create('foo', 'GET'));
+    }
+
+    protected function getRouter()
+    {
+        $this->url = Mockery::mock('Illuminate\Contracts\Routing\UrlGenerator');
+
+        $this->app['config'] = Mockery::mock('Illuminate\Contracts\Config\Repository');
+
+        $this->app['translator'] = Mockery::mock('Illuminate\Translation\Translator');
+
+        $this->app->bind('Illuminate\Contracts\Routing\UrlGenerator', function () {
+            return $this->url;
+        });
+
+        $router = new Router(new Dispatcher, $this->app);
+
+        $router->middleware('localize', 'Illuminate\Routing\Middleware\Localize');
+
+        return $router;
+    }
+}


### PR DESCRIPTION
Following up on: https://github.com/laravel/framework/pull/16453

This PR applies localization on routes that have a `localize` middleware registered, only these routes will be registered once for every locale in `app.locales` configuration.

For example, registering this route `/foo` will lead to laravel registering `/en/foo` and `/ar/foo` as well, so the three routes will be available for the dispatcher.

- Visiting `/en/foo` will present the foo route with the app locale set to `en`.
- Visiting `/ar/foo` will present the foo route with the app locale set to `ar`.
- Visiting `/foo` will redirect the browser to `/en/foo` since `en` is the default locale.

This approach will make all localized routes appear in the `route:list` command.

If the route is named, the locale will be appended to the route name for the generated routes. `foo`, `en.foo`, `ar.foo`.

Using `url('/bar')` will result a `http://app.dev/en/bar` link based on the current locale, that way you don't have to worry about URL generation or Routes registration while building multilingual websites.

To start localizing routes you need to add the following to your RoutesServiceProvider:

    public function register()
    {
        $this->app->booted(function () {
            Route::localize();
        });
    }