### PR TITLE
[5.3] Create custom Collection also on empty page

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -497,7 +497,9 @@ class Builder
 
         $total = $query->getCountForPagination();
 
-        $results = $total ? $this->forPage($page, $perPage)->get($columns) : new Collection;
+        $results = $total
+            ? $this->forPage($page, $perPage)->get($columns)
+            : $this->model->newCollection();
 
         return new LengthAwarePaginator($results, $total, $perPage, $page, [
             'path' => Paginator::resolveCurrentPath(),

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1663,7 +1663,7 @@ class Builder
 
         $total = $this->getCountForPagination($columns);
 
-        $results = $total ? $this->forPage($page, $perPage)->get($columns) : [];
+        $results = $total ? $this->forPage($page, $perPage)->get($columns) : collect();
 
         return new LengthAwarePaginator($results, $total, $perPage, $page, [
             'path' => Paginator::resolveCurrentPath(),


### PR DESCRIPTION
Follow-up to #16528. Makes sense that Eloquent Builder passes the same class to LengthAwarePaginator whether the page is empty or not.

This would have worked too:
```php
$results = $this->forPage($page, $perPage)->get($columns);
```
Though in doubt, I kept the optimization from #14188.

<br>The change in Query Builder is not mandatory because LengthAwarePaginator already converts to a base Collection, but it's more straightforward this way.