### PR TITLE
[5.4] Allow get method to accept multiple arguments

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1620,7 +1620,7 @@ class Builder
     /**
      * Execute the query as a "select" statement.
      *
-     * @param  array  $columns
+     * @param  array|mixed  $columns
      * @return \Illuminate\Support\Collection
      */
     public function get($columns = ['*'])
@@ -1628,7 +1628,7 @@ class Builder
         $original = $this->columns;
 
         if (is_null($original)) {
-            $this->columns = $columns;
+            $this->columns = is_array($columns) ? $columns : func_get_args();
         }
 
         $results = $this->processor->processSelect($this, $this->runSelect());

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -27,7 +27,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase
         $builder->getConnection()->shouldReceive('select')->once()->andReturnUsing(function ($sql) {
             $this->assertEquals('select * from "users"', $sql);
         });
-        $builder->getConnection()->shouldReceive('select')->once()->andReturnUsing(function ($sql) {
+        $builder->getConnection()->shouldReceive('select')->twice()->andReturnUsing(function ($sql) {
             $this->assertEquals('select "foo", "bar" from "users"', $sql);
         });
 
@@ -35,6 +35,9 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase
         $this->assertNull($builder->columns);
 
         $builder->from('users')->get(['foo', 'bar']);
+        $this->assertNull($builder->columns);
+
+        $builder->from('users')->get('foo', 'bar');
         $this->assertNull($builder->columns);
 
         $this->assertEquals('select * from "users"', $builder->toSql());


### PR DESCRIPTION
Allow the query builder `get` method to have the same signature as `select`