### PR TITLE
[5.4] mapWithKeys shouldn't reindex the collection

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -302,9 +302,10 @@ class Collection extends BaseCollection implements QueueableCollection
     /**
      * Collapse the collection of items into a single array.
      *
+     * @param  bool  $reIndex
      * @return \Illuminate\Support\Collection
      */
-    public function collapse()
+    public function collapse($reIndex = true)
     {
         return $this->toBase()->collapse();
     }

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -307,7 +307,7 @@ class Collection extends BaseCollection implements QueueableCollection
      */
     public function collapse($reIndex = true)
     {
-        return $this->toBase()->collapse();
+        return $this->toBase()->collapse($reIndex);
     }
 
     /**

--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -41,9 +41,10 @@ class Arr
      * Collapse an array of arrays into a single array.
      *
      * @param  array  $array
+     * @param  bool   $reIndex
      * @return array
      */
-    public static function collapse($array)
+    public static function collapse($array, $reIndex = true)
     {
         $results = [];
 
@@ -54,7 +55,7 @@ class Arr
                 continue;
             }
 
-            $results = array_merge($results, $values);
+            $results = $reIndex ? array_merge($results, $values) : ($results + $values);
         }
 
         return $results;

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -144,11 +144,12 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Collapse the collection of items into a single array.
      *
+     * @param  bool  $reIndex
      * @return static
      */
-    public function collapse()
+    public function collapse($reIndex = true)
     {
-        return new static(Arr::collapse($this->items));
+        return new static(Arr::collapse($this->items, $reIndex));
     }
 
     /**
@@ -616,7 +617,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      */
     public function mapWithKeys(callable $callback)
     {
-        return $this->flatMap($callback);
+        return $this->map($callback)->collapse(false);
     }
 
     /**

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -947,7 +947,7 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
             $data->all()
         );
     }
-    
+
     public function testMapWithKeysIntegerKeys()
     {
         $data = new Collection([
@@ -959,7 +959,7 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
             return [$item['id'] => $item];
         });
         $this->assertEquals(
-            [1,2,3],
+            [1, 2, 3],
             $data->keys()->all()
         );
     }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -947,6 +947,22 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
             $data->all()
         );
     }
+    
+    public function testMapWithKeysIntegerKeys()
+    {
+        $data = new Collection([
+            ['id' => 1, 'name' => 'A'],
+            ['id' => 2, 'name' => 'B'],
+            ['id' => 3, 'name' => 'C'],
+        ]);
+        $data = $data->mapWithKeys(function ($item) {
+            return [$item['id'] => $item];
+        });
+        $this->assertEquals(
+            [1,2,3],
+            $data->keys()->all()
+        );
+    }
 
     public function testTransform()
     {


### PR DESCRIPTION
``` mapWithKeys ``` shouldn't reindex the array when using numeric keys, added a flag to change this behavior and the tests accordingly.

Refs: #15409, #16142 

This was a predicted behavior: https://github.com/laravel/framework/pull/14430#r74266705 but since people are using it for this purpose and the name is kinda misleading i thought we should address this...

**Update:** If this should be the intended behavior then we could add a note to the docs about it...