### PR TITLE
[5.4] Migration char and string default lenth configurable

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -1049,11 +1049,12 @@ class Connection implements ConnectionInterface
      * Get an option from the configuration options.
      *
      * @param  string  $option
+     * @param  mixed|null  $default
      * @return mixed
      */
-    public function getConfig($option)
+    public function getConfig($option, $default = null)
     {
-        return Arr::get($this->config, $option);
+        return Arr::get($this->config, $option, $default);
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -455,11 +455,15 @@ class Blueprint
      * Create a new char column on the table.
      *
      * @param  string  $column
-     * @param  int  $length
+     * @param  int|null  $length
      * @return \Illuminate\Support\Fluent
      */
-    public function char($column, $length = 255)
+    public function char($column, $length = null)
     {
+        if (is_null($length)) {
+            $length = $this->connection->getConfig('char_default_length', 255);
+        }
+
         return $this->addColumn('char', $column, compact('length'));
     }
 
@@ -467,11 +471,15 @@ class Blueprint
      * Create a new string column on the table.
      *
      * @param  string  $column
-     * @param  int  $length
+     * @param  int|null  $length
      * @return \Illuminate\Support\Fluent
      */
-    public function string($column, $length = 255)
+    public function string($column, $length = null)
     {
+        if (is_null($length)) {
+            $length = $this->connection->getConfig('char_default_length', 255);
+        }
+
         return $this->addColumn('string', $column, compact('length'));
     }
 

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -82,25 +82,23 @@ class Blueprint
     /**
      * Execute the blueprint against the database.
      *
-     * @param  \Illuminate\Database\Connection  $connection
      * @param  \Illuminate\Database\Schema\Grammars\Grammar $grammar
      * @return void
      */
-    public function build(Connection $connection, Grammar $grammar)
+    public function build(Grammar $grammar)
     {
-        foreach ($this->toSql($connection, $grammar) as $statement) {
-            $connection->statement($statement);
+        foreach ($this->toSql($grammar) as $statement) {
+            $this->connection->statement($statement);
         }
     }
 
     /**
      * Get the raw SQL statements for the blueprint.
      *
-     * @param  \Illuminate\Database\Connection  $connection
      * @param  \Illuminate\Database\Schema\Grammars\Grammar  $grammar
      * @return array
      */
-    public function toSql(Connection $connection, Grammar $grammar)
+    public function toSql(Grammar $grammar)
     {
         $this->addImpliedCommands();
 
@@ -113,7 +111,7 @@ class Blueprint
             $method = 'compile'.ucfirst($command->name);
 
             if (method_exists($grammar, $method)) {
-                if (! is_null($sql = $grammar->$method($this, $command, $connection))) {
+                if (! is_null($sql = $grammar->$method($this, $command, $this->connection))) {
                     $statements = array_merge($statements, (array) $sql);
                 }
             }

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -31,6 +31,13 @@ class Blueprint
     protected $commands = [];
 
     /**
+     * The database connection instance.
+     *
+     * @var \Illuminate\Database\Connection
+     */
+    protected $connection;
+
+    /**
      * The storage engine that should be used for the table.
      *
      * @var string
@@ -57,13 +64,15 @@ class Blueprint
     /**
      * Create a new schema blueprint.
      *
+     * @param  \Illuminate\Database\Connection  $connection
      * @param  string  $table
      * @param  \Closure|null  $callback
      * @return void
      */
-    public function __construct($table, Closure $callback = null)
+    public function __construct(Connection $connection, $table, Closure $callback = null)
     {
         $this->table = $table;
+        $this->connection = $connection;
 
         if (! is_null($callback)) {
             $callback($this);

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -226,7 +226,7 @@ class Builder
      */
     protected function build(Blueprint $blueprint)
     {
-        $blueprint->build($this->connection, $this->grammar);
+        $blueprint->build($this->grammar);
     }
 
     /**
@@ -242,7 +242,7 @@ class Builder
             return call_user_func($this->resolver, $table, $callback);
         }
 
-        return new Blueprint($table, $callback);
+        return new Blueprint($this->connection, $table, $callback);
     }
 
     /**

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -12,29 +12,33 @@ class DatabaseMySqlSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testBasicCreateTable()
     {
-        $blueprint = new Blueprint('users');
+        $conn = $this->getConnection();
+        $conn->shouldReceive('getConfig')->once()->with('char_default_length', 255)->andReturn(255);
+
+        $blueprint = new Blueprint($conn, 'users');
         $blueprint->create();
         $blueprint->increments('id');
         $blueprint->string('email');
 
-        $conn = $this->getConnection();
         $conn->shouldReceive('getConfig')->once()->with('charset')->andReturn('utf8');
         $conn->shouldReceive('getConfig')->once()->with('collation')->andReturn('utf8_unicode_ci');
         $conn->shouldReceive('getConfig')->once()->with('engine')->andReturn(null);
 
-        $statements = $blueprint->toSql($conn, $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('create table `users` (`id` int unsigned not null auto_increment primary key, `email` varchar(255) not null) default character set utf8 collate utf8_unicode_ci', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $conn = $this->getConnection();
+        $conn->shouldReceive('getConfig')->once()->with('char_default_length', 255)->andReturn(255);
+
+        $blueprint = new Blueprint($conn, 'users');
         $blueprint->increments('id');
         $blueprint->string('email');
 
-        $conn = $this->getConnection();
         $conn->shouldReceive('getConfig')->andReturn(null);
 
-        $statements = $blueprint->toSql($conn, $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table `users` add `id` int unsigned not null auto_increment primary key, add `email` varchar(255) not null', $statements[0]);
@@ -42,32 +46,36 @@ class DatabaseMySqlSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testEngineCreateTable()
     {
-        $blueprint = new Blueprint('users');
+        $conn = $this->getConnection();
+        $conn->shouldReceive('getConfig')->once()->with('char_default_length', 255)->andReturn(255);
+
+        $blueprint = new Blueprint($conn, 'users');
         $blueprint->create();
         $blueprint->increments('id');
         $blueprint->string('email');
         $blueprint->engine = 'InnoDB';
 
-        $conn = $this->getConnection();
         $conn->shouldReceive('getConfig')->once()->with('charset')->andReturn('utf8');
         $conn->shouldReceive('getConfig')->once()->with('collation')->andReturn('utf8_unicode_ci');
 
-        $statements = $blueprint->toSql($conn, $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('create table `users` (`id` int unsigned not null auto_increment primary key, `email` varchar(255) not null) default character set utf8 collate utf8_unicode_ci engine = InnoDB', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $conn = $this->getConnection();
+        $conn->shouldReceive('getConfig')->once()->with('char_default_length', 255)->andReturn(255);
+
+        $blueprint = new Blueprint($conn, 'users');
         $blueprint->create();
         $blueprint->increments('id');
         $blueprint->string('email');
 
-        $conn = $this->getConnection();
         $conn->shouldReceive('getConfig')->once()->with('charset')->andReturn('utf8');
         $conn->shouldReceive('getConfig')->once()->with('collation')->andReturn('utf8_unicode_ci');
         $conn->shouldReceive('getConfig')->once()->with('engine')->andReturn('InnoDB');
 
-        $statements = $blueprint->toSql($conn, $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('create table `users` (`id` int unsigned not null auto_increment primary key, `email` varchar(255) not null) default character set utf8 collate utf8_unicode_ci engine = InnoDB', $statements[0]);
@@ -75,32 +83,36 @@ class DatabaseMySqlSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testCharsetCollationCreateTable()
     {
-        $blueprint = new Blueprint('users');
+        $conn = $this->getConnection();
+        $conn->shouldReceive('getConfig')->once()->with('char_default_length', 255)->andReturn(255);
+
+        $blueprint = new Blueprint($conn, 'users');
         $blueprint->create();
         $blueprint->increments('id');
         $blueprint->string('email');
         $blueprint->charset = 'utf8mb4';
         $blueprint->collation = 'utf8mb4_unicode_ci';
 
-        $conn = $this->getConnection();
         $conn->shouldReceive('getConfig')->once()->with('engine')->andReturn(null);
 
-        $statements = $blueprint->toSql($conn, $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('create table `users` (`id` int unsigned not null auto_increment primary key, `email` varchar(255) not null) default character set utf8mb4 collate utf8mb4_unicode_ci', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $conn = $this->getConnection();
+        $conn->shouldReceive('getConfig')->once()->with('char_default_length', 255)->andReturn(255);
+
+        $blueprint = new Blueprint($conn, 'users');
         $blueprint->create();
         $blueprint->increments('id');
         $blueprint->string('email')->charset('utf8mb4')->collation('utf8mb4_unicode_ci');
 
-        $conn = $this->getConnection();
         $conn->shouldReceive('getConfig')->once()->with('charset')->andReturn('utf8');
         $conn->shouldReceive('getConfig')->once()->with('collation')->andReturn('utf8_unicode_ci');
         $conn->shouldReceive('getConfig')->once()->with('engine')->andReturn(null);
 
-        $statements = $blueprint->toSql($conn, $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('create table `users` (`id` int unsigned not null auto_increment primary key, `email` varchar(255) character set utf8mb4 collate utf8mb4_unicode_ci not null) default character set utf8 collate utf8_unicode_ci', $statements[0]);
@@ -108,17 +120,19 @@ class DatabaseMySqlSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testBasicCreateTableWithPrefix()
     {
-        $blueprint = new Blueprint('users');
+        $conn = $this->getConnection();
+        $conn->shouldReceive('getConfig')->once()->with('char_default_length', 255)->andReturn(255);
+
+        $blueprint = new Blueprint($conn, 'users');
         $blueprint->create();
         $blueprint->increments('id');
         $blueprint->string('email');
         $grammar = $this->getGrammar();
         $grammar->setTablePrefix('prefix_');
 
-        $conn = $this->getConnection();
         $conn->shouldReceive('getConfig')->andReturn(null);
 
-        $statements = $blueprint->toSql($conn, $grammar);
+        $statements = $blueprint->toSql($grammar);
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('create table `prefix_users` (`id` int unsigned not null auto_increment primary key, `email` varchar(255) not null)', $statements[0]);
@@ -126,9 +140,9 @@ class DatabaseMySqlSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testDropTable()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->drop();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('drop table `users`', $statements[0]);
@@ -136,9 +150,9 @@ class DatabaseMySqlSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testDropTableIfExists()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->dropIfExists();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('drop table if exists `users`', $statements[0]);
@@ -146,23 +160,23 @@ class DatabaseMySqlSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testDropColumn()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->dropColumn('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table `users` drop `foo`', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->dropColumn(['foo', 'bar']);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table `users` drop `foo`, drop `bar`', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->dropColumn('foo', 'bar');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table `users` drop `foo`, drop `bar`', $statements[0]);
@@ -170,9 +184,9 @@ class DatabaseMySqlSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testDropPrimary()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->dropPrimary();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table `users` drop primary key', $statements[0]);
@@ -180,9 +194,9 @@ class DatabaseMySqlSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testDropUnique()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->dropUnique('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table `users` drop index `foo`', $statements[0]);
@@ -190,9 +204,9 @@ class DatabaseMySqlSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testDropIndex()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->dropIndex('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table `users` drop index `foo`', $statements[0]);
@@ -200,9 +214,9 @@ class DatabaseMySqlSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testDropForeign()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->dropForeign('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table `users` drop foreign key `foo`', $statements[0]);
@@ -210,9 +224,9 @@ class DatabaseMySqlSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testDropTimestamps()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->dropTimestamps();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table `users` drop `created_at`, drop `updated_at`', $statements[0]);
@@ -220,9 +234,9 @@ class DatabaseMySqlSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testDropTimestampsTz()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->dropTimestampsTz();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table `users` drop `created_at`, drop `updated_at`', $statements[0]);
@@ -230,9 +244,9 @@ class DatabaseMySqlSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testRenameTable()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->rename('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('rename table `users` to `foo`', $statements[0]);
@@ -240,9 +254,9 @@ class DatabaseMySqlSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingPrimaryKey()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->primary('foo', 'bar');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table `users` add primary key `bar`(`foo`)', $statements[0]);
@@ -250,9 +264,9 @@ class DatabaseMySqlSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingPrimaryKeyWithAlgorithm()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->primary('foo', 'bar', 'hash');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table `users` add primary key `bar` using hash(`foo`)', $statements[0]);
@@ -260,9 +274,9 @@ class DatabaseMySqlSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingUniqueKey()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->unique('foo', 'bar');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table `users` add unique `bar`(`foo`)', $statements[0]);
@@ -270,9 +284,9 @@ class DatabaseMySqlSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingIndex()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->index(['foo', 'bar'], 'baz');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table `users` add index `baz`(`foo`, `bar`)', $statements[0]);
@@ -280,9 +294,9 @@ class DatabaseMySqlSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingIndexWithAlgorithm()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->index(['foo', 'bar'], 'baz', 'hash');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table `users` add index `baz` using hash(`foo`, `bar`)', $statements[0]);
@@ -290,9 +304,9 @@ class DatabaseMySqlSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingForeignKey()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->foreign('foo_id')->references('id')->on('orders');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table `users` add constraint `users_foo_id_foreign` foreign key (`foo_id`) references `orders` (`id`)', $statements[0]);
@@ -300,9 +314,9 @@ class DatabaseMySqlSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingIncrementingID()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->increments('id');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table `users` add `id` int unsigned not null auto_increment primary key', $statements[0]);
@@ -310,9 +324,9 @@ class DatabaseMySqlSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingSmallIncrementingID()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->smallIncrements('id');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table `users` add `id` smallint unsigned not null auto_increment primary key', $statements[0]);
@@ -320,9 +334,9 @@ class DatabaseMySqlSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingBigIncrementingID()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->bigIncrements('id');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table `users` add `id` bigint unsigned not null auto_increment primary key', $statements[0]);
@@ -330,9 +344,12 @@ class DatabaseMySqlSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingColumnInTableFirst()
     {
-        $blueprint = new Blueprint('users');
+        $conn = $this->getConnection();
+        $conn->shouldReceive('getConfig')->once()->with('char_default_length', 255)->andReturn(255);
+
+        $blueprint = new Blueprint($conn, 'users');
         $blueprint->string('name')->first();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table `users` add `name` varchar(255) not null first', $statements[0]);
@@ -340,9 +357,12 @@ class DatabaseMySqlSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingColumnAfterAnotherColumn()
     {
-        $blueprint = new Blueprint('users');
+        $conn = $this->getConnection();
+        $conn->shouldReceive('getConfig')->once()->with('char_default_length', 255)->andReturn(255);
+
+        $blueprint = new Blueprint($conn, 'users');
         $blueprint->string('name')->after('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table `users` add `name` varchar(255) not null after `foo`', $statements[0]);
@@ -350,11 +370,11 @@ class DatabaseMySqlSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingGeneratedColumn()
     {
-        $blueprint = new Blueprint('products');
+        $blueprint = new Blueprint($this->getConnection(), 'products');
         $blueprint->integer('price');
         $blueprint->integer('discounted_virtual')->virtualAs('price - 5');
         $blueprint->integer('discounted_stored')->storedAs('price - 5');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table `products` add `price` int not null, add `discounted_virtual` int as (price - 5) not null, add `discounted_stored` int as (price - 5) stored not null', $statements[0]);
@@ -362,30 +382,33 @@ class DatabaseMySqlSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingString()
     {
-        $blueprint = new Blueprint('users');
+        $conn = $this->getConnection();
+        $conn->shouldReceive('getConfig')->once()->with('char_default_length', 255)->andReturn(255);
+
+        $blueprint = new Blueprint($conn, 'users');
         $blueprint->string('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table `users` add `foo` varchar(255) not null', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->string('foo', 100);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table `users` add `foo` varchar(100) not null', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->string('foo', 100)->nullable()->default('bar');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table `users` add `foo` varchar(100) null default \'bar\'', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->string('foo', 100)->nullable()->default(new Illuminate\Database\Query\Expression('CURRENT TIMESTAMP'));
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table `users` add `foo` varchar(100) null default CURRENT TIMESTAMP', $statements[0]);
@@ -393,9 +416,9 @@ class DatabaseMySqlSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingText()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->text('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table `users` add `foo` text not null', $statements[0]);
@@ -403,16 +426,16 @@ class DatabaseMySqlSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingBigInteger()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->bigInteger('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table `users` add `foo` bigint not null', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->bigInteger('foo', true);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table `users` add `foo` bigint not null auto_increment primary key', $statements[0]);
@@ -420,16 +443,16 @@ class DatabaseMySqlSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingInteger()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->integer('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table `users` add `foo` int not null', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->integer('foo', true);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table `users` add `foo` int not null auto_increment primary key', $statements[0]);
@@ -437,16 +460,16 @@ class DatabaseMySqlSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingMediumInteger()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->mediumInteger('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table `users` add `foo` mediumint not null', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->mediumInteger('foo', true);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table `users` add `foo` mediumint not null auto_increment primary key', $statements[0]);
@@ -454,16 +477,16 @@ class DatabaseMySqlSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingSmallInteger()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->smallInteger('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table `users` add `foo` smallint not null', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->smallInteger('foo', true);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table `users` add `foo` smallint not null auto_increment primary key', $statements[0]);
@@ -471,16 +494,16 @@ class DatabaseMySqlSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingTinyInteger()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->tinyInteger('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table `users` add `foo` tinyint not null', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->tinyInteger('foo', true);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table `users` add `foo` tinyint not null auto_increment primary key', $statements[0]);
@@ -488,9 +511,9 @@ class DatabaseMySqlSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingFloat()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->float('foo', 5, 2);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table `users` add `foo` double(5, 2) not null', $statements[0]);
@@ -498,9 +521,9 @@ class DatabaseMySqlSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingDouble()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->double('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table `users` add `foo` double not null', $statements[0]);
@@ -508,9 +531,9 @@ class DatabaseMySqlSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingDoubleSpecifyingPrecision()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->double('foo', 15, 8);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table `users` add `foo` double(15, 8) not null', $statements[0]);
@@ -518,9 +541,9 @@ class DatabaseMySqlSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingDecimal()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->decimal('foo', 5, 2);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table `users` add `foo` decimal(5, 2) not null', $statements[0]);
@@ -528,9 +551,9 @@ class DatabaseMySqlSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingBoolean()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->boolean('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table `users` add `foo` tinyint(1) not null', $statements[0]);
@@ -538,9 +561,9 @@ class DatabaseMySqlSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingEnum()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->enum('foo', ['bar', 'baz']);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table `users` add `foo` enum(\'bar\', \'baz\') not null', $statements[0]);
@@ -548,9 +571,9 @@ class DatabaseMySqlSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingJson()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->json('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table `users` add `foo` json not null', $statements[0]);
@@ -558,9 +581,9 @@ class DatabaseMySqlSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingJsonb()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->jsonb('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table `users` add `foo` json not null', $statements[0]);
@@ -568,9 +591,9 @@ class DatabaseMySqlSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingDate()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->date('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table `users` add `foo` date not null', $statements[0]);
@@ -578,9 +601,9 @@ class DatabaseMySqlSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingDateTime()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->dateTime('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table `users` add `foo` datetime not null', $statements[0]);
@@ -588,9 +611,9 @@ class DatabaseMySqlSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingDateTimeTz()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->dateTimeTz('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table `users` add `foo` datetime not null', $statements[0]);
@@ -598,9 +621,9 @@ class DatabaseMySqlSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingTime()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->time('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table `users` add `foo` time not null', $statements[0]);
@@ -608,9 +631,9 @@ class DatabaseMySqlSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingTimeTz()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->timeTz('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table `users` add `foo` time not null', $statements[0]);
@@ -618,9 +641,9 @@ class DatabaseMySqlSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingTimeStamp()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->timestamp('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table `users` add `foo` timestamp not null', $statements[0]);
@@ -628,9 +651,9 @@ class DatabaseMySqlSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingTimeStampWithDefault()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->timestamp('foo')->default('2015-07-22 11:43:17');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table `users` add `foo` timestamp not null default \'2015-07-22 11:43:17\'', $statements[0]);
@@ -638,9 +661,9 @@ class DatabaseMySqlSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingTimeStampTz()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->timestampTz('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table `users` add `foo` timestamp not null', $statements[0]);
@@ -648,9 +671,9 @@ class DatabaseMySqlSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingTimeStampTzWithDefault()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->timestampTz('foo')->default('2015-07-22 11:43:17');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table `users` add `foo` timestamp not null default \'2015-07-22 11:43:17\'', $statements[0]);
@@ -658,9 +681,9 @@ class DatabaseMySqlSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingTimeStamps()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->timestamps();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table `users` add `created_at` timestamp null, add `updated_at` timestamp null', $statements[0]);
@@ -668,9 +691,9 @@ class DatabaseMySqlSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingTimeStampsTz()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->timestampsTz();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table `users` add `created_at` timestamp null, add `updated_at` timestamp null', $statements[0]);
@@ -678,9 +701,9 @@ class DatabaseMySqlSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingRememberToken()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->rememberToken();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table `users` add `remember_token` varchar(100) null', $statements[0]);
@@ -688,9 +711,9 @@ class DatabaseMySqlSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingBinary()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->binary('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table `users` add `foo` blob not null', $statements[0]);
@@ -698,9 +721,9 @@ class DatabaseMySqlSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingUuid()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->uuid('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table `users` add `foo` char(36) not null', $statements[0]);
@@ -708,9 +731,9 @@ class DatabaseMySqlSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingIpAddress()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->ipAddress('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table `users` add `foo` varchar(45) not null', $statements[0]);
@@ -718,9 +741,9 @@ class DatabaseMySqlSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingMacAddress()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->macAddress('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table `users` add `foo` varchar(17) not null', $statements[0]);

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -12,19 +12,25 @@ class DatabasePostgresSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testBasicCreateTable()
     {
-        $blueprint = new Blueprint('users');
+        $conn = $this->getConnection();
+        $conn->shouldReceive('getConfig')->once()->with('char_default_length', 255)->andReturn(255);
+
+        $blueprint = new Blueprint($conn, 'users');
         $blueprint->create();
         $blueprint->increments('id');
         $blueprint->string('email');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('create table "users" ("id" serial primary key not null, "email" varchar(255) not null)', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $conn = $this->getConnection();
+        $conn->shouldReceive('getConfig')->once()->with('char_default_length', 255)->andReturn(255);
+
+        $blueprint = new Blueprint($conn, 'users');
         $blueprint->increments('id');
         $blueprint->string('email');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table "users" add column "id" serial primary key not null, add column "email" varchar(255) not null', $statements[0]);
@@ -32,9 +38,9 @@ class DatabasePostgresSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testDropTable()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->drop();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('drop table "users"', $statements[0]);
@@ -42,9 +48,9 @@ class DatabasePostgresSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testDropTableIfExists()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->dropIfExists();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('drop table if exists "users"', $statements[0]);
@@ -52,23 +58,23 @@ class DatabasePostgresSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testDropColumn()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->dropColumn('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table "users" drop column "foo"', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->dropColumn(['foo', 'bar']);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table "users" drop column "foo", drop column "bar"', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->dropColumn('foo', 'bar');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table "users" drop column "foo", drop column "bar"', $statements[0]);
@@ -76,9 +82,9 @@ class DatabasePostgresSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testDropPrimary()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->dropPrimary();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table "users" drop constraint "users_pkey"', $statements[0]);
@@ -86,9 +92,9 @@ class DatabasePostgresSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testDropUnique()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->dropUnique('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table "users" drop constraint "foo"', $statements[0]);
@@ -96,9 +102,9 @@ class DatabasePostgresSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testDropIndex()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->dropIndex('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('drop index "foo"', $statements[0]);
@@ -106,9 +112,9 @@ class DatabasePostgresSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testDropForeign()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->dropForeign('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table "users" drop constraint "foo"', $statements[0]);
@@ -116,9 +122,9 @@ class DatabasePostgresSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testDropTimestamps()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->dropTimestamps();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table "users" drop column "created_at", drop column "updated_at"', $statements[0]);
@@ -126,9 +132,9 @@ class DatabasePostgresSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testDropTimestampsTz()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->dropTimestampsTz();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table "users" drop column "created_at", drop column "updated_at"', $statements[0]);
@@ -136,9 +142,9 @@ class DatabasePostgresSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testRenameTable()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->rename('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table "users" rename to "foo"', $statements[0]);
@@ -146,9 +152,9 @@ class DatabasePostgresSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingPrimaryKey()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->primary('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table "users" add primary key ("foo")', $statements[0]);
@@ -156,9 +162,9 @@ class DatabasePostgresSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingUniqueKey()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->unique('foo', 'bar');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table "users" add constraint "bar" unique ("foo")', $statements[0]);
@@ -166,9 +172,9 @@ class DatabasePostgresSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingIndex()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->index(['foo', 'bar'], 'baz');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('create index "baz" on "users" ("foo", "bar")', $statements[0]);
@@ -176,9 +182,9 @@ class DatabasePostgresSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingIndexWithAlgorithm()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->index(['foo', 'bar'], 'baz', 'hash');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('create index "baz" on "users" using hash ("foo", "bar")', $statements[0]);
@@ -186,9 +192,9 @@ class DatabasePostgresSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingIncrementingID()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->increments('id');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table "users" add column "id" serial primary key not null', $statements[0]);
@@ -196,9 +202,9 @@ class DatabasePostgresSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingSmallIncrementingID()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->smallIncrements('id');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table "users" add column "id" smallserial primary key not null', $statements[0]);
@@ -206,9 +212,9 @@ class DatabasePostgresSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingMediumIncrementingID()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->mediumIncrements('id');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table "users" add column "id" serial primary key not null', $statements[0]);
@@ -216,9 +222,9 @@ class DatabasePostgresSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingBigIncrementingID()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->bigIncrements('id');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table "users" add column "id" bigserial primary key not null', $statements[0]);
@@ -226,23 +232,26 @@ class DatabasePostgresSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingString()
     {
-        $blueprint = new Blueprint('users');
+        $conn = $this->getConnection();
+        $conn->shouldReceive('getConfig')->once()->with('char_default_length', 255)->andReturn(255);
+
+        $blueprint = new Blueprint($conn, 'users');
         $blueprint->string('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table "users" add column "foo" varchar(255) not null', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->string('foo', 100);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table "users" add column "foo" varchar(100) not null', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->string('foo', 100)->nullable()->default('bar');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table "users" add column "foo" varchar(100) null default \'bar\'', $statements[0]);
@@ -250,9 +259,9 @@ class DatabasePostgresSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingText()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->text('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table "users" add column "foo" text not null', $statements[0]);
@@ -260,16 +269,16 @@ class DatabasePostgresSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingBigInteger()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->bigInteger('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table "users" add column "foo" bigint not null', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->bigInteger('foo', true);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table "users" add column "foo" bigserial primary key not null', $statements[0]);
@@ -277,16 +286,16 @@ class DatabasePostgresSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingInteger()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->integer('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table "users" add column "foo" integer not null', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->integer('foo', true);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table "users" add column "foo" serial primary key not null', $statements[0]);
@@ -294,16 +303,16 @@ class DatabasePostgresSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingMediumInteger()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->mediumInteger('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table "users" add column "foo" integer not null', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->mediumInteger('foo', true);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table "users" add column "foo" serial primary key not null', $statements[0]);
@@ -311,16 +320,16 @@ class DatabasePostgresSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingTinyInteger()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->tinyInteger('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table "users" add column "foo" smallint not null', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->tinyInteger('foo', true);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table "users" add column "foo" smallserial primary key not null', $statements[0]);
@@ -328,16 +337,16 @@ class DatabasePostgresSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingSmallInteger()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->smallInteger('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table "users" add column "foo" smallint not null', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->smallInteger('foo', true);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table "users" add column "foo" smallserial primary key not null', $statements[0]);
@@ -345,9 +354,9 @@ class DatabasePostgresSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingFloat()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->float('foo', 5, 2);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table "users" add column "foo" double precision not null', $statements[0]);
@@ -355,9 +364,9 @@ class DatabasePostgresSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingDouble()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->double('foo', 15, 8);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table "users" add column "foo" double precision not null', $statements[0]);
@@ -365,9 +374,9 @@ class DatabasePostgresSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingDecimal()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->decimal('foo', 5, 2);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table "users" add column "foo" decimal(5, 2) not null', $statements[0]);
@@ -375,9 +384,9 @@ class DatabasePostgresSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingBoolean()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->boolean('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table "users" add column "foo" boolean not null', $statements[0]);
@@ -385,9 +394,9 @@ class DatabasePostgresSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingEnum()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->enum('foo', ['bar', 'baz']);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table "users" add column "foo" varchar(255) check ("foo" in (\'bar\', \'baz\')) not null', $statements[0]);
@@ -395,9 +404,9 @@ class DatabasePostgresSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingDate()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->date('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table "users" add column "foo" date not null', $statements[0]);
@@ -405,9 +414,9 @@ class DatabasePostgresSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingJson()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->json('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table "users" add column "foo" json not null', $statements[0]);
@@ -415,9 +424,9 @@ class DatabasePostgresSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingJsonb()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->jsonb('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table "users" add column "foo" jsonb not null', $statements[0]);
@@ -425,9 +434,9 @@ class DatabasePostgresSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingDateTime()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->dateTime('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table "users" add column "foo" timestamp(0) without time zone not null', $statements[0]);
@@ -435,9 +444,9 @@ class DatabasePostgresSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingDateTimeTz()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->dateTimeTz('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table "users" add column "foo" timestamp(0) with time zone not null', $statements[0]);
@@ -445,9 +454,9 @@ class DatabasePostgresSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingTime()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->time('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table "users" add column "foo" time(0) without time zone not null', $statements[0]);
@@ -455,9 +464,9 @@ class DatabasePostgresSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingTimeTz()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->timeTz('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table "users" add column "foo" time(0) with time zone not null', $statements[0]);
@@ -465,9 +474,9 @@ class DatabasePostgresSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingTimeStamp()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->timestamp('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table "users" add column "foo" timestamp(0) without time zone not null', $statements[0]);
@@ -475,9 +484,9 @@ class DatabasePostgresSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingTimeStampTz()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->timestampTz('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table "users" add column "foo" timestamp(0) with time zone not null', $statements[0]);
@@ -485,9 +494,9 @@ class DatabasePostgresSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingTimeStamps()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->timestamps();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table "users" add column "created_at" timestamp(0) without time zone null, add column "updated_at" timestamp(0) without time zone null', $statements[0]);
@@ -495,9 +504,9 @@ class DatabasePostgresSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingTimeStampsTz()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->timestampsTz();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table "users" add column "created_at" timestamp(0) with time zone null, add column "updated_at" timestamp(0) with time zone null', $statements[0]);
@@ -505,9 +514,9 @@ class DatabasePostgresSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingBinary()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->binary('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table "users" add column "foo" bytea not null', $statements[0]);
@@ -515,9 +524,9 @@ class DatabasePostgresSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingUuid()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->uuid('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table "users" add column "foo" uuid not null', $statements[0]);
@@ -525,9 +534,9 @@ class DatabasePostgresSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingIpAddress()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->ipAddress('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table "users" add column "foo" inet not null', $statements[0]);
@@ -535,9 +544,9 @@ class DatabasePostgresSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingMacAddress()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->macAddress('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table "users" add column "foo" macaddr not null', $statements[0]);

--- a/tests/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintTest.php
@@ -20,20 +20,22 @@ class DatabaseSchemaBlueprintTest extends PHPUnit_Framework_TestCase
         $conn->shouldReceive('statement')->once()->with('foo');
         $conn->shouldReceive('statement')->once()->with('bar');
         $grammar = m::mock('Illuminate\Database\Schema\Grammars\MySqlGrammar');
-        $blueprint = $this->getMockBuilder('Illuminate\Database\Schema\Blueprint')->setMethods(['toSql'])->setConstructorArgs(['users'])->getMock();
-        $blueprint->expects($this->once())->method('toSql')->with($this->equalTo($conn), $this->equalTo($grammar))->will($this->returnValue(['foo', 'bar']));
+        $blueprint = $this->getMockBuilder('Illuminate\Database\Schema\Blueprint')->setMethods(['toSql'])->setConstructorArgs([$conn, 'users'])->getMock();
+        $blueprint->expects($this->once())->method('toSql')->with($this->equalTo($grammar))->will($this->returnValue(['foo', 'bar']));
 
-        $blueprint->build($conn, $grammar);
+        $blueprint->build($grammar);
     }
 
     public function testIndexDefaultNames()
     {
-        $blueprint = new Blueprint('users');
+        $connection = m::mock('Illuminate\Database\Connection');
+
+        $blueprint = new Blueprint($connection, 'users');
         $blueprint->unique(['foo', 'bar']);
         $commands = $blueprint->getCommands();
         $this->assertEquals('users_foo_bar_unique', $commands[0]->index);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($connection, 'users');
         $blueprint->index('foo');
         $commands = $blueprint->getCommands();
         $this->assertEquals('users_foo_index', $commands[0]->index);
@@ -41,12 +43,14 @@ class DatabaseSchemaBlueprintTest extends PHPUnit_Framework_TestCase
 
     public function testDropIndexDefaultNames()
     {
-        $blueprint = new Blueprint('users');
+        $connection = m::mock('Illuminate\Database\Connection');
+
+        $blueprint = new Blueprint($connection, 'users');
         $blueprint->dropUnique(['foo', 'bar']);
         $commands = $blueprint->getCommands();
         $this->assertEquals('users_foo_bar_unique', $commands[0]->index);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($connection, 'users');
         $blueprint->dropIndex(['foo']);
         $commands = $blueprint->getCommands();
         $this->assertEquals('users_foo_index', $commands[0]->index);
@@ -54,22 +58,22 @@ class DatabaseSchemaBlueprintTest extends PHPUnit_Framework_TestCase
 
     public function testDefaultCurrentTimestamp()
     {
-        $base = new Blueprint('users', function ($table) {
+        $connection = m::mock('Illuminate\Database\Connection');
+
+        $base = new Blueprint($connection, 'users', function ($table) {
             $table->timestamp('created')->useCurrent();
         });
 
-        $connection = m::mock('Illuminate\Database\Connection');
+        $blueprint = clone $base;
+        $this->assertEquals(['alter table `users` add `created` timestamp default CURRENT_TIMESTAMP not null'], $blueprint->toSql(new MySqlGrammar));
 
         $blueprint = clone $base;
-        $this->assertEquals(['alter table `users` add `created` timestamp default CURRENT_TIMESTAMP not null'], $blueprint->toSql($connection, new MySqlGrammar));
+        $this->assertEquals(['alter table "users" add column "created" timestamp(0) without time zone default CURRENT_TIMESTAMP(0) not null'], $blueprint->toSql(new PostgresGrammar));
 
         $blueprint = clone $base;
-        $this->assertEquals(['alter table "users" add column "created" timestamp(0) without time zone default CURRENT_TIMESTAMP(0) not null'], $blueprint->toSql($connection, new PostgresGrammar));
+        $this->assertEquals(['alter table "users" add column "created" datetime default CURRENT_TIMESTAMP not null'], $blueprint->toSql(new SQLiteGrammar));
 
         $blueprint = clone $base;
-        $this->assertEquals(['alter table "users" add column "created" datetime default CURRENT_TIMESTAMP not null'], $blueprint->toSql($connection, new SQLiteGrammar));
-
-        $blueprint = clone $base;
-        $this->assertEquals(['alter table "users" add "created" datetime default CURRENT_TIMESTAMP not null'], $blueprint->toSql($connection, new SqlServerGrammar));
+        $this->assertEquals(['alter table "users" add "created" datetime default CURRENT_TIMESTAMP not null'], $blueprint->toSql(new SqlServerGrammar));
     }
 }

--- a/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
@@ -12,28 +12,37 @@ class DatabaseSqlServerSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testBasicCreateTable()
     {
-        $blueprint = new Blueprint('users');
+        $conn = $this->getConnection();
+        $conn->shouldReceive('getConfig')->once()->with('char_default_length', 255)->andReturn(255);
+
+        $blueprint = new Blueprint($conn, 'users');
         $blueprint->create();
         $blueprint->increments('id');
         $blueprint->string('email');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('create table "users" ("id" int identity primary key not null, "email" nvarchar(255) not null)', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $conn = $this->getConnection();
+        $conn->shouldReceive('getConfig')->once()->with('char_default_length', 255)->andReturn(255);
+
+        $blueprint = new Blueprint($conn, 'users');
         $blueprint->increments('id');
         $blueprint->string('email');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table "users" add "id" int identity primary key not null, "email" nvarchar(255) not null', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $conn = $this->getConnection();
+        $conn->shouldReceive('getConfig')->once()->with('char_default_length', 255)->andReturn(255);
+
+        $blueprint = new Blueprint($conn, 'users');
         $blueprint->create();
         $blueprint->increments('id');
         $blueprint->string('email');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar()->setTablePrefix('prefix_'));
+        $statements = $blueprint->toSql($this->getGrammar()->setTablePrefix('prefix_'));
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('create table "prefix_users" ("id" int identity primary key not null, "email" nvarchar(255) not null)', $statements[0]);
@@ -41,16 +50,16 @@ class DatabaseSqlServerSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testDropTable()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->drop();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('drop table "users"', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->drop();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar()->setTablePrefix('prefix_'));
+        $statements = $blueprint->toSql($this->getGrammar()->setTablePrefix('prefix_'));
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('drop table "prefix_users"', $statements[0]);
@@ -58,16 +67,16 @@ class DatabaseSqlServerSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testDropTableIfExists()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->dropIfExists();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('if exists (select * from INFORMATION_SCHEMA.TABLES where TABLE_NAME = \'users\') drop table "users"', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->dropIfExists();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar()->setTablePrefix('prefix_'));
+        $statements = $blueprint->toSql($this->getGrammar()->setTablePrefix('prefix_'));
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('if exists (select * from INFORMATION_SCHEMA.TABLES where TABLE_NAME = \'prefix_users\') drop table "prefix_users"', $statements[0]);
@@ -75,23 +84,23 @@ class DatabaseSqlServerSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testDropColumn()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->dropColumn('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table "users" drop column "foo"', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->dropColumn(['foo', 'bar']);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table "users" drop column "foo", "bar"', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->dropColumn('foo', 'bar');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table "users" drop column "foo", "bar"', $statements[0]);
@@ -99,9 +108,9 @@ class DatabaseSqlServerSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testDropPrimary()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->dropPrimary('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table "users" drop constraint "foo"', $statements[0]);
@@ -109,9 +118,9 @@ class DatabaseSqlServerSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testDropUnique()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->dropUnique('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('drop index "foo" on "users"', $statements[0]);
@@ -119,9 +128,9 @@ class DatabaseSqlServerSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testDropIndex()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->dropIndex('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('drop index "foo" on "users"', $statements[0]);
@@ -129,9 +138,9 @@ class DatabaseSqlServerSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testDropForeign()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->dropForeign('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table "users" drop constraint "foo"', $statements[0]);
@@ -139,9 +148,9 @@ class DatabaseSqlServerSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testDropTimestamps()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->dropTimestamps();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table "users" drop column "created_at", "updated_at"', $statements[0]);
@@ -149,9 +158,9 @@ class DatabaseSqlServerSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testDropTimestampsTz()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->dropTimestampsTz();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table "users" drop column "created_at", "updated_at"', $statements[0]);
@@ -159,9 +168,9 @@ class DatabaseSqlServerSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testRenameTable()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->rename('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('sp_rename "users", "foo"', $statements[0]);
@@ -169,9 +178,9 @@ class DatabaseSqlServerSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingPrimaryKey()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->primary('foo', 'bar');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table "users" add constraint "bar" primary key ("foo")', $statements[0]);
@@ -179,9 +188,9 @@ class DatabaseSqlServerSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingUniqueKey()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->unique('foo', 'bar');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('create unique index "bar" on "users" ("foo")', $statements[0]);
@@ -189,9 +198,9 @@ class DatabaseSqlServerSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingIndex()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->index(['foo', 'bar'], 'baz');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('create index "baz" on "users" ("foo", "bar")', $statements[0]);
@@ -199,9 +208,9 @@ class DatabaseSqlServerSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingIncrementingID()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->increments('id');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table "users" add "id" int identity primary key not null', $statements[0]);
@@ -209,9 +218,9 @@ class DatabaseSqlServerSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingSmallIncrementingID()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->smallIncrements('id');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table "users" add "id" smallint identity primary key not null', $statements[0]);
@@ -219,9 +228,9 @@ class DatabaseSqlServerSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingMediumIncrementingID()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->mediumIncrements('id');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table "users" add "id" int identity primary key not null', $statements[0]);
@@ -229,9 +238,9 @@ class DatabaseSqlServerSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingBigIncrementingID()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->bigIncrements('id');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table "users" add "id" bigint identity primary key not null', $statements[0]);
@@ -239,23 +248,26 @@ class DatabaseSqlServerSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingString()
     {
-        $blueprint = new Blueprint('users');
+        $conn = $this->getConnection();
+        $conn->shouldReceive('getConfig')->once()->with('char_default_length', 255)->andReturn(255);
+
+        $blueprint = new Blueprint($conn, 'users');
         $blueprint->string('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table "users" add "foo" nvarchar(255) not null', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->string('foo', 100);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table "users" add "foo" nvarchar(100) not null', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->string('foo', 100)->nullable()->default('bar');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table "users" add "foo" nvarchar(100) null default \'bar\'', $statements[0]);
@@ -263,9 +275,9 @@ class DatabaseSqlServerSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingText()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->text('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table "users" add "foo" nvarchar(max) not null', $statements[0]);
@@ -273,16 +285,16 @@ class DatabaseSqlServerSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingBigInteger()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->bigInteger('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table "users" add "foo" bigint not null', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->bigInteger('foo', true);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table "users" add "foo" bigint identity primary key not null', $statements[0]);
@@ -290,16 +302,16 @@ class DatabaseSqlServerSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingInteger()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->integer('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table "users" add "foo" int not null', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->integer('foo', true);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table "users" add "foo" int identity primary key not null', $statements[0]);
@@ -307,16 +319,16 @@ class DatabaseSqlServerSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingMediumInteger()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->mediumInteger('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table "users" add "foo" int not null', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->mediumInteger('foo', true);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table "users" add "foo" int identity primary key not null', $statements[0]);
@@ -324,16 +336,16 @@ class DatabaseSqlServerSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingTinyInteger()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->tinyInteger('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table "users" add "foo" tinyint not null', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->tinyInteger('foo', true);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table "users" add "foo" tinyint identity primary key not null', $statements[0]);
@@ -341,16 +353,16 @@ class DatabaseSqlServerSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingSmallInteger()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->smallInteger('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table "users" add "foo" smallint not null', $statements[0]);
 
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->smallInteger('foo', true);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table "users" add "foo" smallint identity primary key not null', $statements[0]);
@@ -358,9 +370,9 @@ class DatabaseSqlServerSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingFloat()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->float('foo', 5, 2);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table "users" add "foo" float not null', $statements[0]);
@@ -368,9 +380,9 @@ class DatabaseSqlServerSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingDouble()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->double('foo', 15, 2);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table "users" add "foo" float not null', $statements[0]);
@@ -378,9 +390,9 @@ class DatabaseSqlServerSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingDecimal()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->decimal('foo', 5, 2);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table "users" add "foo" decimal(5, 2) not null', $statements[0]);
@@ -388,9 +400,9 @@ class DatabaseSqlServerSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingBoolean()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->boolean('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table "users" add "foo" bit not null', $statements[0]);
@@ -398,9 +410,9 @@ class DatabaseSqlServerSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingEnum()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->enum('foo', ['bar', 'baz']);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table "users" add "foo" nvarchar(255) not null', $statements[0]);
@@ -408,9 +420,9 @@ class DatabaseSqlServerSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingJson()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->json('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table "users" add "foo" nvarchar(max) not null', $statements[0]);
@@ -418,9 +430,9 @@ class DatabaseSqlServerSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingJsonb()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->jsonb('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table "users" add "foo" nvarchar(max) not null', $statements[0]);
@@ -428,9 +440,9 @@ class DatabaseSqlServerSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingDate()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->date('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table "users" add "foo" date not null', $statements[0]);
@@ -438,9 +450,9 @@ class DatabaseSqlServerSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingDateTime()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->dateTime('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table "users" add "foo" datetime not null', $statements[0]);
@@ -448,9 +460,9 @@ class DatabaseSqlServerSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingDateTimeTz()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->dateTimeTz('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table "users" add "foo" datetimeoffset(0) not null', $statements[0]);
@@ -458,9 +470,9 @@ class DatabaseSqlServerSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingTime()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->time('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table "users" add "foo" time not null', $statements[0]);
@@ -468,9 +480,9 @@ class DatabaseSqlServerSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingTimeTz()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->timeTz('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table "users" add "foo" time not null', $statements[0]);
@@ -478,9 +490,9 @@ class DatabaseSqlServerSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingTimeStamp()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->timestamp('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table "users" add "foo" datetime not null', $statements[0]);
@@ -488,9 +500,9 @@ class DatabaseSqlServerSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingTimeStampTz()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->timestampTz('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table "users" add "foo" datetimeoffset(0) not null', $statements[0]);
@@ -498,9 +510,9 @@ class DatabaseSqlServerSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingTimeStamps()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->timestamps();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table "users" add "created_at" datetime null, "updated_at" datetime null', $statements[0]);
@@ -508,9 +520,9 @@ class DatabaseSqlServerSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingTimeStampsTz()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->timestampsTz();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table "users" add "created_at" datetimeoffset(0) null, "updated_at" datetimeoffset(0) null', $statements[0]);
@@ -518,9 +530,9 @@ class DatabaseSqlServerSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingRememberToken()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->rememberToken();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table "users" add "remember_token" nvarchar(100) null', $statements[0]);
@@ -528,9 +540,9 @@ class DatabaseSqlServerSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingBinary()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->binary('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table "users" add "foo" varbinary(max) not null', $statements[0]);
@@ -538,9 +550,9 @@ class DatabaseSqlServerSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingUuid()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->uuid('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table "users" add "foo" uniqueidentifier not null', $statements[0]);
@@ -548,9 +560,9 @@ class DatabaseSqlServerSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingIpAddress()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->ipAddress('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table "users" add "foo" nvarchar(45) not null', $statements[0]);
@@ -558,9 +570,9 @@ class DatabaseSqlServerSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
     public function testAddingMacAddress()
     {
-        $blueprint = new Blueprint('users');
+        $blueprint = new Blueprint($this->getConnection(), 'users');
         $blueprint->macAddress('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($this->getGrammar());
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table "users" add "foo" nvarchar(17) not null', $statements[0]);


### PR DESCRIPTION
## Why we need this 
When we use mysql, max key length is 767. So we usually use 255 length for utf8 charset. But when we use other charset, 255 may to long. Such as utf8mb4 charset, 191 length is the max for key or index.

Default length of Blueprint::char() and Blueprint::string() are 255. So if we switch charset from utf8 to utf8mb4, we have to edit all migration files. If we change back to utf8 and want 255 length indexed fields, we have to edit all migration files again.

So I think we need make these default values configurable. 

Maybe sometimes we will switch default connection to migrate. Different connection may use different charset, so different default length of char and string are required.

## Usage

Just edit the configuration:

config/database.php
```php
# ...
    'connections' => [
        'foo_connection' => [
            # ...
            'charset' => 'utf8'
            'char_default_length' => 255,
            # ...
            ],
        # ...
        'bar_connection' => [
            # ...
            'charset' => 'utf8mb4'
            'char_default_length' => 191,
            # ...
            ],
        # ...
    ],
# ...
```
So length of $table->string('foo') or $table->char('bar') in migrations will be the value our configure. If we don't configure the 'char_default_length', the default of default will be 255.



## Side effects

For reading configurations we need to inject Illuminate\Database\Connection into Illuminate\Database\Schema\Blueprint.

Then, Blueprint::build() and Blueprint::toSql() don't need connection as parameter anymore.