### PR TITLE
[5.4] Add whereKey method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -195,8 +195,10 @@ class Builder
     {
         if (is_array($id)) {
             $this->query->whereIn($this->model->getQualifiedKeyName(), $id);
+
             return $this;
         }
+
         return $this->where($this->model->getQualifiedKeyName(), '=', $id);
     }
 

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -166,9 +166,7 @@ class Builder
             return $this->findMany($id, $columns);
         }
 
-        $this->query->where($this->model->getQualifiedKeyName(), '=', $id);
-
-        return $this->first($columns);
+        return $this->whereKey($id)->first($columns);
     }
 
     /**
@@ -184,9 +182,22 @@ class Builder
             return $this->model->newCollection();
         }
 
-        $this->query->whereIn($this->model->getQualifiedKeyName(), $ids);
+        return $this->whereKey($ids)->get($columns);
+    }
 
-        return $this->get($columns);
+    /**
+     * Add where clause with primary key to the query.
+     *
+     * @param  mixed  $id
+     * @return $this
+     */
+    public function whereKey($id)
+    {
+        if (is_array($id)) {
+            $this->query->whereIn($this->model->getQualifiedKeyName(), $id);
+            return $this;
+        }
+        return $this->where($this->model->getQualifiedKeyName(), '=', $id);
     }
 
     /**


### PR DESCRIPTION
This method will make easier to add condition with primary key (what is not always `id`). It is also useful when you want to get one column only. For example instead of:

```
return ($model = Model::find(1)) ? $model->value('name') : null;
```

or

```
return $model->where('this_is_key_name',1)->value('name');
```


you can use:

```
return $model->whereKey(1)->value('name');
```

This is breaking change (all occurrences of `whereKey(` method in existing app should be changed to `where('key',` so it's in 5.4 as agreed in https://github.com/laravel/framework/pull/16540