### PR TITLE
[5.4] Add shortcut for adding a prefix-only route group.

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -323,6 +323,18 @@ class Router implements RegistrarContract, BindingRegistrar
     }
 
     /**
+     * Shortcut for creating a prefix route group.
+     *
+     * @param  string  $prefix
+     * @param  \Closure  $callback
+     * @return void
+     */
+    public function prefix($prefix, Closure $callback)
+    {
+        $this->group(['prefix' => $prefix], $callback);
+    }
+
+    /**
      * Update the group stack with the given attributes.
      *
      * @param  array  $attributes
@@ -460,7 +472,7 @@ class Router implements RegistrarContract, BindingRegistrar
         }
 
         $route = $this->newRoute(
-            $methods, $this->prefix($uri), $action
+            $methods, $this->appendPrefix($uri), $action
         );
 
         // If we have groups that need to be merged, we will merge them now after this
@@ -496,7 +508,7 @@ class Router implements RegistrarContract, BindingRegistrar
      * @param  string  $uri
      * @return string
      */
-    protected function prefix($uri)
+    protected function appendPrefix($uri)
     {
         return trim(trim($this->getLastGroupPrefix(), '/').'/'.trim($uri, '/'), '/') ?: '/';
     }

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -729,6 +729,19 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('foo', $routes[0]->getPrefix());
     }
 
+    public function testPrefixRouteGroupShortcut()
+    {
+        $router = $this->getRouter();
+        $router->prefix('foo', function () use ($router) {
+            $router->get('bar', function () {
+                return 'hello';
+            });
+        });
+        $routes = $router->getRoutes();
+        $routes = $routes->getRoutes();
+        $this->assertEquals('foo', $routes[0]->getPrefix());
+    }
+
     public function testRouteGroupingWithAs()
     {
         $router = $this->getRouter();


### PR DESCRIPTION
This change allows you to define a prefix only route group in this way :

```php
Route::prefix('foo', function () {
    Route::get('bar', function () {});
});
```
instead of 

```php
Route::group(['prefix' => 'foo'], function () {
    Route::get('bar', function () {});
});
```

Note : I had to rename the protected method named `prefix` to `appendPrefix`. 