### PR TITLE
[5.4] refactoring mapWithKeys

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -616,7 +616,11 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      */
     public function mapWithKeys(callable $callback)
     {
-        return $this->flatMap($callback);
+        return $this->reduce(function ($items, $item) use($callback) {
+            $item = $callback($item);
+
+            return $items->put(key($item), reset($item));
+        }, new static);
     }
 
     /**

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -616,11 +616,17 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      */
     public function mapWithKeys(callable $callback)
     {
-        return $this->reduce(function ($items, $item) use ($callback) {
-            $item = $callback($item);
+        $result = [];
 
-            return $items->put(key($item), reset($item));
-        }, new static);
+        foreach ($this->items as $item) {
+            $assoc = $callback($item);
+
+            foreach ($assoc as $key => $value) {
+                $result[$key] = $value;
+            }
+        }
+
+        return new static($result);
     }
 
     /**

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -616,7 +616,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      */
     public function mapWithKeys(callable $callback)
     {
-        return $this->reduce(function ($items, $item) use($callback) {
+        return $this->reduce(function ($items, $item) use ($callback) {
             $item = $callback($item);
 
             return $items->put(key($item), reset($item));

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -618,11 +618,11 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     {
         $result = [];
 
-        foreach ($this->items as $item) {
-            $assoc = $callback($item);
+        foreach ($this->items as $key => $value) {
+            $assoc = $callback($value, $key);
 
-            foreach ($assoc as $key => $value) {
-                $result[$key] = $value;
+            foreach ($assoc as $mapKey => $mapValue) {
+                $result[$mapKey] = $mapValue;
             }
         }
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -948,6 +948,22 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
         );
     }
 
+    public function testMapWithKeysIntegerKeys()
+    {
+        $data = new Collection([
+            ['id' => 1, 'name' => 'A'],
+            ['id' => 3, 'name' => 'B'],
+            ['id' => 2, 'name' => 'C'],
+        ]);
+        $data = $data->mapWithKeys(function ($item) {
+            return [$item['id'] => $item];
+        });
+        $this->assertEquals(
+            [1,3,2],
+            $data->keys()->all()
+        );
+    }
+
     public function testTransform()
     {
         $data = new Collection(['first' => 'taylor', 'last' => 'otwell']);

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -959,7 +959,7 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
             return [$item['id'] => $item];
         });
         $this->assertEquals(
-            [1,3,2],
+            [1, 3, 2],
             $data->keys()->all()
         );
     }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -986,6 +986,22 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
             $data->all()
         );
     }
+    
+    public function testMapWithKeysCallbackKey()
+    {
+        $data = new Collection([
+            3 => ['id' => 1, 'name' => 'A'],
+            5 => ['id' => 3, 'name' => 'B'],
+            4 => ['id' => 2, 'name' => 'C'],
+        ]);
+        $data = $data->mapWithKeys(function ($item, $key) {
+            return [$key => $item['id']];
+        });
+        $this->assertSame(
+            [3, 5, 4],
+            $data->keys()->all()
+        );
+    }
 
     public function testTransform()
     {

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -986,7 +986,7 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
             $data->all()
         );
     }
-    
+
     public function testMapWithKeysCallbackKey()
     {
         $data = new Collection([

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -958,9 +958,32 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
         $data = $data->mapWithKeys(function ($item) {
             return [$item['id'] => $item];
         });
-        $this->assertEquals(
+        $this->assertSame(
             [1, 3, 2],
             $data->keys()->all()
+        );
+    }
+
+    public function testMapWithKeysMultipleRows()
+    {
+        $data = new Collection([
+            ['id' => 1, 'name' => 'A'],
+            ['id' => 2, 'name' => 'B'],
+            ['id' => 3, 'name' => 'C'],
+        ]);
+        $data = $data->mapWithKeys(function ($item) {
+            return [$item['id'] => $item['name'], $item['name'] => $item['id']];
+        });
+        $this->assertSame(
+            [
+                1 => 'A',
+                'A' => 1,
+                2 => 'B',
+                'B' => 2,
+                3 => 'C',
+                'C' => 3
+            ],
+            $data->all()
         );
     }
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -981,7 +981,7 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
                 2 => 'B',
                 'B' => 2,
                 3 => 'C',
-                'C' => 3
+                'C' => 3,
             ],
             $data->all()
         );


### PR DESCRIPTION
Ping @vlakoff

With this change ``` mapWithKeys() ``` won't renumber the keys and will also maintain the order of the input array.

Example:

```php
[
    ['id' => 1, 'name' => 'A'],
    ['id' => 3, 'name' => 'B'],
    ['id' => 2, 'name' => 'C'],
]
```

When using the function:

```php
$data->mapWithKeys(function ($item) {
    return [$item['id'] => $item];
 });
```

Results into

```php
[
    1 => 'A',
    3 => 'B',
    2 => 'C'
]
```

Intead of the current behavior:

```php
[
    0 => 'A',
    1 => 'B',
    2 => 'C'
]
```