### PR TITLE
[5.3] avoid unexpected redis connection problems during tagged flush

### DIFF
--- a/src/Illuminate/Cache/RedisTaggedCache.php
+++ b/src/Illuminate/Cache/RedisTaggedCache.php
@@ -146,7 +146,9 @@ class RedisTaggedCache extends TaggedCache
         $values = array_unique($this->store->connection()->smembers($referenceKey));
 
         if (count($values) > 0) {
-            call_user_func_array([$this->store->connection(), 'del'], $values);
+            foreach (array_chunk($values, 1000) as $values_chunk) {
+                call_user_func_array([$this->store->connection(), 'del'], $values_chunk);
+            }
         }
     }
 

--- a/src/Illuminate/Cache/RedisTaggedCache.php
+++ b/src/Illuminate/Cache/RedisTaggedCache.php
@@ -146,8 +146,8 @@ class RedisTaggedCache extends TaggedCache
         $values = array_unique($this->store->connection()->smembers($referenceKey));
 
         if (count($values) > 0) {
-            foreach (array_chunk($values, 1000) as $values_chunk) {
-                call_user_func_array([$this->store->connection(), 'del'], $values_chunk);
+            foreach (array_chunk($values, 1000) as $valuesChunk) {
+                call_user_func_array([$this->store->connection(), 'del'], $valuesChunk);
             }
         }
     }


### PR DESCRIPTION
If you have a lot of keys inside tag like 1 million you will get following error on "flush"

```
 [Predis\Connection\ConnectionException]
  Error while writing bytes to the server.
```

This small fix can solve it.