### PR TITLE
[5.3] Update return type

### DIFF
--- a/src/Illuminate/Support/Facades/Facade.php
+++ b/src/Illuminate/Support/Facades/Facade.php
@@ -100,7 +100,7 @@ abstract class Facade
      * Create a fresh mock instance for the given class.
      *
      * @param  string  $name
-     * @return \Mockery\Expectation
+     * @return \Mockery\MockInterface
      */
     protected static function createMockByName($name)
     {


### PR DESCRIPTION
Use \Mockery\MockInterface as return type instead of \Mockery\Expectation