### PR TITLE
[5.3] Implement blade macros feature

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -280,7 +280,6 @@ class BladeCompiler extends Compiler implements CompilerInterface
         $pattern = '/\B@(macro)([ \t]*)(\( ( (?>[^()]+) | (?3) )* \))?/x';
 
         while (preg_match($pattern, $value, $matches)) {
-
             $expression = $this->stripParentheses($matches[3]);
 
             if (Str::endsWith($expression, ')')) {

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -2,11 +2,18 @@
 
 namespace Illuminate\View\Compilers;
 
+use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
+use Illuminate\View\ViewFinderInterface;
 
 class BladeCompiler extends Compiler implements CompilerInterface
 {
+    /**
+     * @var ViewFinderInterface
+     */
+    protected $viewFinder;
+
     /**
      * All of the registered extensions.
      *
@@ -37,6 +44,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
      */
     protected $compilers = [
         'Extensions',
+        'Macros',
         'Statements',
         'Comments',
         'Echos',
@@ -97,6 +105,23 @@ class BladeCompiler extends Compiler implements CompilerInterface
      * @var int
      */
     protected $forelseCounter = 0;
+
+    /**
+     * Create a BladeCompiler instance
+     *
+     *
+     * @param   Filesystem  $files
+     * @param   string  $cachePath
+     * @param   string  ViewFinderInterface $viewFinder
+     *
+     * @return void
+     */
+    public function __construct(Filesystem $files, $cachePath, ViewFinderInterface $viewFinder)
+    {
+        parent::__construct($files, $cachePath);
+
+        $this->viewFinder = $viewFinder;
+    }
 
     /**
      * Compile the view at the given path.
@@ -237,6 +262,48 @@ class BladeCompiler extends Compiler implements CompilerInterface
     {
         foreach ($this->extensions as $compiler) {
             $value = call_user_func($compiler, $value, $this);
+        }
+
+        return $value;
+    }
+
+    /**
+     * Compile Macros
+     * s they are not treated as View instances they should be compiled
+     * before the statements are compiled.
+     *
+     * @param   string $value
+     * @return  string
+     */
+    protected function compileMacros($value)
+    {
+        $pattern = '/\B@(macro)([ \t]*)(\( ( (?>[^()]+) | (?3) )* \))?/x';
+
+        while (preg_match($pattern, $value, $matches)) {
+
+            $expression = $this->stripParentheses($matches[3]);
+
+            if (Str::endsWith($expression, ')')) {
+                $expression = substr($expression, 0, -1);
+            }
+
+            // We replace each occurrence of the @macro
+            // with the contents of its file, and wrap the
+            // imported content around a self-invokable function to satisfy the macro scope,
+            // So file changes are not detected, there is a need to clear compiled views on
+            // development environments.
+            $codeStart = $this->getMacroStartCode();
+
+            $codeEnd = $this->getMacroCodeEnd($expression);
+
+            $view = $this->extractFindableViewForMacro($expression);
+
+            $viewContent = $this->files->get($this->viewFinder->find($view));
+
+            $code = $codeStart . $viewContent . "\n" . $codeEnd;
+
+            $value = Str::replaceFirst($matches[0], $code, $value);
+
         }
 
         return $value;
@@ -1089,5 +1156,79 @@ class BladeCompiler extends Compiler implements CompilerInterface
     public function setEchoFormat($format)
     {
         $this->echoFormat = $format;
+    }
+
+    /**
+     * Macro start code
+     *
+     * @return  string
+     */
+    protected function getMacroStartCode()
+    {
+        $codeStart = <<<HTML
+<?php 
+call_user_func(function (\$macroName, array \$firstMerging, array \$secondMerging = null) {
+    if (\$secondMerging !== null) {
+        \$firstMerging = array_merge(\$secondMerging, \$firstMerging);
+    }
+    \$secondMerging = null;
+    extract(\$firstMerging);
+?>
+HTML;
+
+        return str_replace("\n", '', $codeStart);
+    }
+
+    /**
+     * Macro end code
+     *
+     * @param   string $expression
+     * @return  string
+     */
+    protected function getMacroCodeEnd($expression)
+    {
+        return sprintf("<?php }, %s, array_except(get_defined_vars(), array('__data', '__path'))) ;?>", $expression);
+    }
+
+    /**
+     * Extract findable view from macro
+     *
+     * @param   string $expression
+     * @return  string
+     * @throws \ErrorException
+     */
+    protected function extractFindableViewForMacro($expression)
+    {
+        $exploded = explode(',', $expression);
+
+        $view = trim($exploded[0]);
+
+        if (!Str::startsWith($view, "'") || !Str::endsWith($view, "'") || substr_count($view, "'") !== 2) {
+
+            // What error to throw ?
+            throw new \ErrorException(
+                "The 'macro' directive can only be used with literal strings beginning and ending with \" ' \""
+            );
+
+        }
+
+        $view = str_replace('\'', '', $view);
+
+        $delimiter = ViewFinderInterface::HINT_PATH_DELIMITER;
+
+        if (strpos($view, $delimiter) === false) {
+
+            $view = str_replace('/', '.', $view);
+
+            return $view;
+
+        }
+
+        list($namespace, $view) = explode($delimiter, $view);
+
+        $view = $namespace . $delimiter . str_replace('/', '.', $view);
+
+        return $view;
+
     }
 }

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -302,7 +302,6 @@ class BladeCompiler extends Compiler implements CompilerInterface
             $code = $codeStart.$viewContent."\n".$codeEnd;
 
             $value = Str::replaceFirst($matches[0], $code, $value);
-
         }
 
         return $value;
@@ -1224,6 +1223,5 @@ HTML;
         $view = $namespace.$delimiter.str_replace('/', '.', $view);
 
         return $view;
-
     }
 }

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -107,7 +107,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
     protected $forelseCounter = 0;
 
     /**
-     * Create a BladeCompiler instance
+     * Create a BladeCompiler instance.
      *
      *
      * @param   Filesystem  $files
@@ -300,7 +300,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
 
             $viewContent = $this->files->get($this->viewFinder->find($view));
 
-            $code = $codeStart . $viewContent . "\n" . $codeEnd;
+            $code = $codeStart.$viewContent."\n".$codeEnd;
 
             $value = Str::replaceFirst($matches[0], $code, $value);
 
@@ -1159,20 +1159,20 @@ class BladeCompiler extends Compiler implements CompilerInterface
     }
 
     /**
-     * Macro start code
+     * Macro start code.
      *
      * @return  string
      */
     protected function getMacroStartCode()
     {
-        $codeStart = <<<HTML
+        $codeStart = <<<'HTML'
 <?php 
-call_user_func(function (\$macroName, array \$firstMerging, array \$secondMerging = null) {
-    if (\$secondMerging !== null) {
-        \$firstMerging = array_merge(\$secondMerging, \$firstMerging);
+call_user_func(function ($macroName, array $firstMerging, array $secondMerging = null) {
+    if ($secondMerging !== null) {
+        $firstMerging = array_merge($secondMerging, $firstMerging);
     }
-    \$secondMerging = null;
-    extract(\$firstMerging);
+    $secondMerging = null;
+    extract($firstMerging);
 ?>
 HTML;
 
@@ -1180,7 +1180,7 @@ HTML;
     }
 
     /**
-     * Macro end code
+     * Macro end code.
      *
      * @param   string $expression
      * @return  string
@@ -1191,7 +1191,7 @@ HTML;
     }
 
     /**
-     * Extract findable view from macro
+     * Extract findable view from macro.
      *
      * @param   string $expression
      * @return  string
@@ -1203,13 +1203,11 @@ HTML;
 
         $view = trim($exploded[0]);
 
-        if (!Str::startsWith($view, "'") || !Str::endsWith($view, "'") || substr_count($view, "'") !== 2) {
-
+        if (! Str::startsWith($view, "'") || ! Str::endsWith($view, "'") || substr_count($view, "'") !== 2) {
             // What error to throw ?
             throw new \ErrorException(
                 "The 'macro' directive can only be used with literal strings beginning and ending with \" ' \""
             );
-
         }
 
         $view = str_replace('\'', '', $view);
@@ -1217,16 +1215,14 @@ HTML;
         $delimiter = ViewFinderInterface::HINT_PATH_DELIMITER;
 
         if (strpos($view, $delimiter) === false) {
-
             $view = str_replace('/', '.', $view);
 
             return $view;
-
         }
 
         list($namespace, $view) = explode($delimiter, $view);
 
-        $view = $namespace . $delimiter . str_replace('/', '.', $view);
+        $view = $namespace.$delimiter.str_replace('/', '.', $view);
 
         return $view;
 

--- a/src/Illuminate/View/ViewServiceProvider.php
+++ b/src/Illuminate/View/ViewServiceProvider.php
@@ -74,7 +74,7 @@ class ViewServiceProvider extends ServiceProvider
         $app->singleton('blade.compiler', function ($app) {
             $cache = $app['config']['view.compiled'];
 
-            return new BladeCompiler($app['files'], $cache);
+            return new BladeCompiler($app['files'], $cache, $app['view.finder']);
         });
 
         $resolver->register('blade', function () use ($app) {

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -925,7 +925,7 @@ test';
             ['(((', ')))'],
         ];
     }
-    
+
     protected function getViewFinder()
     {
         return m::mock('Illuminate\View\ViewFinderInterface');

--- a/tests/View/ViewFlowTest.php
+++ b/tests/View/ViewFlowTest.php
@@ -31,7 +31,7 @@ class ViewFlowTest extends PHPUnit_Framework_TestCase
     public function testPushWithExtend()
     {
         $files = new Filesystem;
-        $compiler = new BladeCompiler($this->getFiles(), __DIR__);
+        $compiler = new BladeCompiler($this->getFiles(), __DIR__, $this->getViewFinder());
 
         $files->put($this->tempDir.'/child.php', $compiler->compileString('
 @extends("layout")
@@ -52,7 +52,7 @@ Hello
     public function testPushWithMultipleExtends()
     {
         $files = new Filesystem;
-        $compiler = new BladeCompiler($this->getFiles(), __DIR__);
+        $compiler = new BladeCompiler($this->getFiles(), __DIR__, $this->getViewFinder());
 
         $files->put($this->tempDir.'/a.php', $compiler->compileString('
 a
@@ -77,7 +77,7 @@ c
     public function testPushWithInputAndExtend()
     {
         $files = new Filesystem;
-        $compiler = new BladeCompiler($this->getFiles(), __DIR__);
+        $compiler = new BladeCompiler($this->getFiles(), __DIR__, $this->getViewFinder());
 
         $files->put($this->tempDir.'/aa.php', $compiler->compileString('
 a
@@ -102,7 +102,7 @@ c
     public function testExtends()
     {
         $files = new Filesystem;
-        $compiler = new BladeCompiler($this->getFiles(), __DIR__);
+        $compiler = new BladeCompiler($this->getFiles(), __DIR__, $this->getViewFinder());
 
         $files->put($this->tempDir.'/extends-a.php', $compiler->compileString('
 yield:
@@ -128,7 +128,7 @@ c
     public function testExtendsWithParent()
     {
         $files = new Filesystem;
-        $compiler = new BladeCompiler($this->getFiles(), __DIR__);
+        $compiler = new BladeCompiler($this->getFiles(), __DIR__, $this->getViewFinder());
 
         $files->put($this->tempDir.'/extends-layout.php', $compiler->compileString('
 yield:
@@ -154,7 +154,7 @@ child
     public function testExtendsWithVariable()
     {
         $files = new Filesystem;
-        $compiler = new BladeCompiler($this->getFiles(), __DIR__);
+        $compiler = new BladeCompiler($this->getFiles(), __DIR__, $this->getViewFinder());
 
         $files->put($this->tempDir.'/extends-variable-layout.php', $compiler->compileString('
 yield:
@@ -214,5 +214,10 @@ dad
     protected function getFiles()
     {
         return m::mock('Illuminate\Filesystem\Filesystem');
+    }
+
+    protected function getViewFinder()
+    {
+        return m::mock(\Illuminate\View\ViewFinderInterface::class);
     }
 }


### PR DESCRIPTION
Please see: https://github.com/laravel/framework/issues/16525

**Summary:**

Using `@include` directive only for abstraction on large iterations(for instance a collection) causes increasing render time due to the use of native `include` feature. the purpose of an `@include` in these situations is to satisfy the *Don't repeat yourself problem* but it increases render time even when `opcache` is fully enabled. In addition to this, lots of view events are fired(creating, composing) and lots of try/catch blocks are used.

**Solution:**

- Creating a new directive called `@macro`
- Reading the file content of the macro from the **STRING** given  to the `@macro` directive
- Wrapping the content around a self-callable function to satisfy scoped data
- Replacing the directive with the new generated content. 

**Problems:**
Because of pasting the generated code inside the original view, file changes to the *macro* template are not detected, so views should be always cleared for each request in development environments.