### PR TITLE
Making assertions concerning page: encoding issue

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithPages.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithPages.php
@@ -243,8 +243,16 @@ trait InteractsWithPages
             $constraint = new ReversePageConstraint($constraint);
         }
 
+        $encoding = null;
+        if (preg_match('/;\s*charset=\s*([^;]+)\s*(;|$)/', $this->response->headers->get('content-type'), $m)) {
+            $encoding = $m[1];
+        }
+        $dom = new DOMDocument;
+        $html = mb_convert_encoding($this->response->getContent(), 'HTML-ENTITIES', $encoding);
+        $dom->loadHTML($html);
+
         self::assertThat(
-            $this->crawler() ?: $this->response->getContent(),
+            $this->crawler() ?: $dom,
             $constraint, $message
         );
 

--- a/src/Illuminate/Foundation/Testing/Constraints/PageConstraint.php
+++ b/src/Illuminate/Foundation/Testing/Constraints/PageConstraint.php
@@ -39,7 +39,10 @@ abstract class PageConstraint extends PHPUnit_Framework_Constraint
      */
     protected function crawler($crawler)
     {
-        return is_object($crawler) ? $crawler : new Crawler($crawler);
+        return is_object($crawler)
+        && ! $crawler instanceof \DOMDocument
+            ? $crawler
+            : new Crawler($crawler);
     }
 
     /**


### PR DESCRIPTION
For now, when you do this:

```php
$this->seeInElement('.some-selector', '雪');
```

the page is being treated as if it were in non-`UTF-8` encoding. `ISO-8859-1`, according to [this page][encoding]. And it fails unconditionally. This PR fixes this. Although I'm not sure if it's to be merged as is. In which ways can it be amended? We can:

1. Extract getting response's encoding to `Illuminate\Http\Response`.
2. Extract creating `DOMDocument` into separate method.
3. Make use of this [`package`][package] to deal with `DOMDocument`'s intricacies.

What do you say?

[encoding]: http://stackoverflow.com/a/8218649/52499
[package]: https://bitbucket.org/archon810/smartdomdocument