### PR TITLE
[5.3] app:name - add file exists check for ModelFactory.php during namespace replacement

### DIFF
--- a/src/Illuminate/Foundation/Console/AppNameCommand.php
+++ b/src/Illuminate/Foundation/Console/AppNameCommand.php
@@ -223,9 +223,10 @@ class AppNameCommand extends Command
      */
     protected function setDatabaseFactoryNamespaces()
     {
-        $this->replaceIn(
-            $this->laravel->databasePath().'/factories/ModelFactory.php', $this->currentRoot, $this->argument('name')
-        );
+        $modelFactoryFile = $this->laravel->databasePath().'/factories/ModelFactory.php';
+        if ($this->files->exists($modelFactoryFile)) {
+            $this->replaceIn($modelFactoryFile, $this->currentRoot, $this->argument('name'));
+        }
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/AppNameCommand.php
+++ b/src/Illuminate/Foundation/Console/AppNameCommand.php
@@ -223,11 +223,9 @@ class AppNameCommand extends Command
      */
     protected function setDatabaseFactoryNamespaces()
     {
-        $modelFactoryFile = $this->laravel->databasePath().'/factories/ModelFactory.php';
-
-        if ($this->files->exists($modelFactoryFile)) {
-            $this->replaceIn($modelFactoryFile, $this->currentRoot, $this->argument('name'));
-        }
+        $this->replaceIn(
+            $this->laravel->databasePath().'/factories/ModelFactory.php', $this->currentRoot, $this->argument('name')
+        );
     }
 
     /**
@@ -240,7 +238,9 @@ class AppNameCommand extends Command
      */
     protected function replaceIn($path, $search, $replace)
     {
-        $this->files->put($path, str_replace($search, $replace, $this->files->get($path)));
+        if ($this->files->exists($path)) {
+            $this->files->put($path, str_replace($search, $replace, $this->files->get($path)));
+        }
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/AppNameCommand.php
+++ b/src/Illuminate/Foundation/Console/AppNameCommand.php
@@ -224,6 +224,7 @@ class AppNameCommand extends Command
     protected function setDatabaseFactoryNamespaces()
     {
         $modelFactoryFile = $this->laravel->databasePath().'/factories/ModelFactory.php';
+
         if ($this->files->exists($modelFactoryFile)) {
             $this->replaceIn($modelFactoryFile, $this->currentRoot, $this->argument('name'));
         }


### PR DESCRIPTION
Fixes issue #16575
- add file exists check to ModelFactory.php file when performing app:name command