### PR TITLE
[5.3] Make test methods chainable

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/ImpersonatesUsers.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/ImpersonatesUsers.php
@@ -15,9 +15,7 @@ trait ImpersonatesUsers
      */
     public function actingAs(UserContract $user, $driver = null)
     {
-        $this->be($user, $driver);
-
-        return $this;
+        return $this->be($user, $driver);
     }
 
     /**
@@ -25,10 +23,12 @@ trait ImpersonatesUsers
      *
      * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
      * @param  string|null  $driver
-     * @return void
+     * @return $this
      */
     public function be(UserContract $user, $driver = null)
     {
         $this->app['auth']->guard($driver)->setUser($user);
+
+        return $this;
     }
 }

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
@@ -80,10 +80,12 @@ trait InteractsWithDatabase
      * Seed a given database connection.
      *
      * @param  string  $class
-     * @return void
+     * @return $this
      */
     public function seed($class = 'DatabaseSeeder')
     {
         $this->artisan('db:seed', ['--class' => $class]);
+
+        return $this;
     }
 }

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithPages.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithPages.php
@@ -101,13 +101,15 @@ trait InteractsWithPages
     /**
      * Clean the crawler and the subcrawlers values to reset the page context.
      *
-     * @return void
+     * @return $this
      */
     protected function resetPageContext()
     {
         $this->crawler = null;
 
         $this->subCrawlers = [];
+
+        return $this;
     }
 
     /**
@@ -201,7 +203,7 @@ trait InteractsWithPages
      *
      * @param  string  $uri
      * @param  string|null  $message
-     * @return void
+     * @return $this
      *
      * @throws \Illuminate\Foundation\Testing\HttpException
      */
@@ -219,6 +221,8 @@ trait InteractsWithPages
 
             throw new HttpException($message, null, $responseException);
         }
+
+        return $this;
     }
 
     /**
@@ -645,7 +649,7 @@ trait InteractsWithPages
      * Assert that a filtered Crawler returns nodes.
      *
      * @param  string  $filter
-     * @return void
+     * @return $this
      *
      * @throws \InvalidArgumentException
      */
@@ -658,6 +662,8 @@ trait InteractsWithPages
                 "Nothing matched the filter [{$filter}] CSS query provided for [{$this->currentUri}]."
             );
         }
+
+        return $this;
     }
 
     /**

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithSession.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithSession.php
@@ -23,7 +23,7 @@ trait InteractsWithSession
      * Set the session to the given array.
      *
      * @param  array  $data
-     * @return void
+     * @return $this
      */
     public function session(array $data)
     {
@@ -32,30 +32,36 @@ trait InteractsWithSession
         foreach ($data as $key => $value) {
             $this->app['session']->put($key, $value);
         }
+
+        return $this;
     }
 
     /**
      * Start the session for the application.
      *
-     * @return void
+     * @return $this
      */
     protected function startSession()
     {
         if (! $this->app['session']->isStarted()) {
             $this->app['session']->start();
         }
+
+        return $this;
     }
 
     /**
      * Flush all of the current session data.
      *
-     * @return void
+     * @return $this
      */
     public function flushSession()
     {
         $this->startSession();
 
         $this->app['session']->flush();
+
+        return $this;
     }
 
     /**
@@ -63,7 +69,7 @@ trait InteractsWithSession
      *
      * @param  string|array  $key
      * @param  mixed  $value
-     * @return void
+     * @return $this
      */
     public function seeInSession($key, $value = null)
     {
@@ -77,7 +83,7 @@ trait InteractsWithSession
      *
      * @param  string|array  $key
      * @param  mixed  $value
-     * @return void
+     * @return $this
      */
     public function assertSessionHas($key, $value = null)
     {
@@ -90,13 +96,15 @@ trait InteractsWithSession
         } else {
             PHPUnit::assertEquals($value, $this->app['session.store']->get($key));
         }
+
+        return $this;
     }
 
     /**
      * Assert that the session has a given list of values.
      *
      * @param  array  $bindings
-     * @return void
+     * @return $this
      */
     public function assertSessionHasAll(array $bindings)
     {
@@ -107,13 +115,15 @@ trait InteractsWithSession
                 $this->assertSessionHas($key, $value);
             }
         }
+
+        return $this;
     }
 
     /**
      * Assert that the session does not have a given key.
      *
      * @param  string|array  $key
-     * @return void
+     * @return $this
      */
     public function assertSessionMissing($key)
     {
@@ -124,6 +134,8 @@ trait InteractsWithSession
         } else {
             PHPUnit::assertFalse($this->app['session.store']->has($key), "Session has unexpected key: $key");
         }
+
+        return $this;
     }
 
     /**
@@ -131,7 +143,7 @@ trait InteractsWithSession
      *
      * @param  string|array  $bindings
      * @param  mixed  $format
-     * @return void
+     * @return $this
      */
     public function assertSessionHasErrors($bindings = [], $format = null)
     {
@@ -148,15 +160,19 @@ trait InteractsWithSession
                 PHPUnit::assertContains($value, $errors->get($key, $format));
             }
         }
+
+        return $this;
     }
 
     /**
      * Assert that the session has old input.
      *
-     * @return void
+     * @return $this
      */
     public function assertHasOldInput()
     {
         $this->assertSessionHas('_old_input');
+
+        return $this;
     }
 }


### PR DESCRIPTION
This modifies a number of test methods that previously returned `void` to return `$this`, allowing for a more fluent interface.