### PR TITLE
[5.3] Add custom email subject support to scheduled tasks

### DIFF
--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -120,6 +120,13 @@ class Event
     public $description;
 
     /**
+     * Customized email subject of the event.
+     *
+     * @var string
+     */
+    public $emailSubject;
+
+    /**
      * Create a new event instance.
      *
      * @param  string  $command
@@ -837,12 +844,29 @@ class Event
     }
 
     /**
+     * Set the customized email subject of the event.
+     *
+     * @param  string  $subject
+     * @return $this
+     */
+    public function emailSubject($subject)
+    {
+        $this->emailSubject = $subject;
+
+        return $this;
+    }
+
+    /**
      * Get the e-mail subject line for output results.
      *
      * @return string
      */
     protected function getEmailSubject()
     {
+        if ($this->emailSubject) {
+            return $this->emailSubject;
+        }
+
         if ($this->description) {
             return 'Scheduled Job Output ('.$this->description.')';
         }

--- a/tests/Console/Scheduling/EventTest.php
+++ b/tests/Console/Scheduling/EventTest.php
@@ -1,52 +1,98 @@
 <?php
 
-use Illuminate\Console\Scheduling\Event;
+namespace {
+    $mockFileGetContents = null;
+}
 
-class EventTest extends PHPUnit_Framework_TestCase
-{
-    public function testBuildCommand()
+namespace Illuminate\Console\Scheduling {
+    use Mockery as m;
+    use Illuminate\Console\Scheduling\Event;
+    use Illuminate\Container\Container;
+
+    function file_get_contents()
     {
-        $quote = (DIRECTORY_SEPARATOR == '\\') ? '"' : "'";
-
-        $event = new Event('php -i');
-
-        $defaultOutput = (DIRECTORY_SEPARATOR == '\\') ? 'NUL' : '/dev/null';
-        $this->assertSame("php -i > {$quote}{$defaultOutput}{$quote} 2>&1 &", $event->buildCommand());
+        global $mockFileGetContents;
+        if (isset($mockFileGetContents) && ! is_null($mockFileGetContents)) {
+            return $mockFileGetContents;
+        } else {
+            return call_user_func_array('\file_get_contents', func_get_args());
+        }
     }
 
-    public function testBuildCommandSendOutputTo()
+    class EventTest extends \PHPUnit_Framework_TestCase
     {
-        $quote = (DIRECTORY_SEPARATOR == '\\') ? '"' : "'";
+        public function testBuildCommand()
+        {
+            $quote = (DIRECTORY_SEPARATOR == '\\') ? '"' : "'";
 
-        $event = new Event('php -i');
+            $event = new Event('php -i');
 
-        $event->sendOutputTo('/dev/null');
-        $this->assertSame("php -i > {$quote}/dev/null{$quote} 2>&1 &", $event->buildCommand());
+            $defaultOutput = (DIRECTORY_SEPARATOR == '\\') ? 'NUL' : '/dev/null';
+            $this->assertSame("php -i > {$quote}{$defaultOutput}{$quote} 2>&1 &", $event->buildCommand());
+        }
 
-        $event = new Event('php -i');
+        public function testBuildCommandSendOutputTo()
+        {
+            $quote = (DIRECTORY_SEPARATOR == '\\') ? '"' : "'";
 
-        $event->sendOutputTo('/my folder/foo.log');
-        $this->assertSame("php -i > {$quote}/my folder/foo.log{$quote} 2>&1 &", $event->buildCommand());
-    }
+            $event = new Event('php -i');
 
-    public function testBuildCommandAppendOutput()
-    {
-        $quote = (DIRECTORY_SEPARATOR == '\\') ? '"' : "'";
+            $event->sendOutputTo('/dev/null');
+            $this->assertSame("php -i > {$quote}/dev/null{$quote} 2>&1 &", $event->buildCommand());
 
-        $event = new Event('php -i');
+            $event = new Event('php -i');
 
-        $event->appendOutputTo('/dev/null');
-        $this->assertSame("php -i >> {$quote}/dev/null{$quote} 2>&1 &", $event->buildCommand());
-    }
+            $event->sendOutputTo('/my folder/foo.log');
+            $this->assertSame("php -i > {$quote}/my folder/foo.log{$quote} 2>&1 &", $event->buildCommand());
+        }
 
-    /**
-     * @expectedException LogicException
-     */
-    public function testEmailOutputToThrowsExceptionIfOutputFileWasNotSpecified()
-    {
-        $event = new Event('php -i');
-        $event->emailOutputTo('foo@example.com');
+        public function testBuildCommandAppendOutput()
+        {
+            $quote = (DIRECTORY_SEPARATOR == '\\') ? '"' : "'";
 
-        $event->buildCommand();
+            $event = new Event('php -i');
+
+            $event->appendOutputTo('/dev/null');
+            $this->assertSame("php -i >> {$quote}/dev/null{$quote} 2>&1 &", $event->buildCommand());
+        }
+
+        /**
+         * @expectedException LogicException
+         */
+        public function testEmailOutputToThrowsExceptionIfOutputFileWasNotSpecified()
+        {
+            $event = new Event('php -i');
+            $event->emailOutputTo('foo@example.com');
+
+            $event->buildCommand();
+        }
+
+        public function testBuildEmailOutputToSubject()
+        {
+            global $mockFileGetContents;
+            $mockFileGetContents = 'test output';
+            $address = 'foo@example.com';
+            $container = new Container;
+            $resolveMailer = function ($subject = 'Scheduled Job Output') use ($address) {
+                return function () use ($address, $subject) {
+                    $mailer = m::mock('Illuminate\Mail\Mailer[sendSwiftMessage]', [m::mock('Illuminate\Contracts\View\Factory'), m::mock('Swift_Mailer')])->shouldAllowMockingProtectedMethods();
+                    $mailer->shouldReceive('sendSwiftMessage')->with(m::on(function ($message) use ($address, $subject) {
+                        $this->assertInstanceOf('Swift_Message', $message);
+                        $this->assertSame([$address => null], $message->getTo());
+                        $this->assertContains($subject, $message->getSubject());
+
+                        return true;
+                    }));
+
+                    return $mailer;
+                };
+            };
+            $event = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php -i');
+            $container->bind('Illuminate\Contracts\Mail\Mailer', $resolveMailer());
+            $event->sendOutputTo('/my folder/foo.log')->emailOutputTo($address)->run($container);
+            $subject = 'custom subject';
+            $container->bind('Illuminate\Contracts\Mail\Mailer', $resolveMailer($subject));
+            $event->sendOutputTo('/my folder/foo.log')->emailSubject($subject)->emailOutputTo($address)->run($container);
+        }
     }
 }


### PR DESCRIPTION
These changes add an optional `emailSubject` attribute to the `Illuminate\Console\Scheduling\Event` which, when set, will become the subject for the notification email that is sent. If this option is not configured, the existing default behavior will resume.

```php
$schedule->command('foo')
         ->daily()
         ->sendOutputTo($filePath)
         ->emailSubject('My awesome custom subject')
         ->emailOutputTo('foo@example.com');
```

This PR also includes an additional unit test to verify these changes. Due to the use of the global `file_get_contents` function and some of the gnarly bits inside the mailing infrastructure, this test case is not as elegant as I would like. It does however exercise the functionality and test the actual email message attributes rather than mock intermediate methods.