### PR TITLE
[5.3] HasOneThrough relationship

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -730,21 +730,21 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     /**
      * Define a one-to-one relationship that goes through an intermediate model.
      *
-     * @param string      $related      Class name of related Model
-     * @param string      $through      Class name of through Model
-     * @param string|null $farParentKey Foreign key to through
-     * @param string|null $parentKey    Foreign key to related
+     * @param string      $related           Class name of related Model
+     * @param string      $through           Class name of through Model
+     * @param string|null $throughForeignKey Foreign key to Through model from $this Model
+     * @param string|null $relatedForeignKey Foreign key to Related model from Through model
      *
      * @return \Illuminate\Database\Eloquent\Relations\HasOneThrough
      */
-    public function hasOneThrough($related, $through, $farParentKey = null, $parentKey = null)
+    public function hasOneThrough($related, $through, $throughForeignKey = null, $relatedForeignKey = null)
     {
-        $related      = new $related;
-        $through      = new $through;
-        $farParentKey = $farParentKey ?: $through->getForeignKey();
-        $parentKey    = $parentKey    ?: $related->getForeignKey();
+        $related           = new $related;
+        $through           = new $through;
+        $throughForeignKey = $throughForeignKey ?: $through->getForeignKey();
+        $relatedForeignKey = $relatedForeignKey ?: $related->getForeignKey();
 
-        return new HasOneThrough($related->newQuery(), $this, $through, $farParentKey, $parentKey);
+        return new HasOneThrough($related->newQuery(), $this, $through, $throughForeignKey, $relatedForeignKey);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -6,7 +6,6 @@ use Closure;
 use Exception;
 use ArrayAccess;
 use Carbon\Carbon;
-use Illuminate\Database\Eloquent\Relations\HasOneThrough;
 use LogicException;
 use JsonSerializable;
 use DateTimeInterface;
@@ -30,6 +29,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Query\Builder as QueryBuilder;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasOneThrough;
 use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 use Illuminate\Database\ConnectionResolverInterface as Resolver;
 

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -6,6 +6,7 @@ use Closure;
 use Exception;
 use ArrayAccess;
 use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Relations\HasOneThrough;
 use LogicException;
 use JsonSerializable;
 use DateTimeInterface;
@@ -724,6 +725,26 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         $localKey = $localKey ?: $this->getKeyName();
 
         return new HasOne($instance->newQuery(), $this, $instance->getTable().'.'.$foreignKey, $localKey);
+    }
+
+    /**
+     * Define a one-to-one relationship that goes through an intermediate model.
+     *
+     * @param string      $related      Class name of related Model
+     * @param string      $through      Class name of through Model
+     * @param string|null $farParentKey Foreign key to through
+     * @param string|null $parentKey    Foreign key to related
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\HasOneThrough
+     */
+    public function hasOneThrough($related, $through, $farParentKey = null, $parentKey = null)
+    {
+        $related      = new $related;
+        $through      = new $through;
+        $farParentKey = $farParentKey ?: $through->getForeignKey();
+        $parentKey    = $parentKey    ?: $related->getForeignKey();
+
+        return new HasOneThrough($related->newQuery(), $this, $through, $farParentKey, $parentKey);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -739,8 +739,8 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public function hasOneThrough($related, $through, $throughForeignKey = null, $relatedForeignKey = null)
     {
-        $related           = new $related;
-        $through           = new $through;
+        $related = new $related;
+        $through = new $through;
         $throughForeignKey = $throughForeignKey ?: $through->getForeignKey();
         $relatedForeignKey = $relatedForeignKey ?: $related->getForeignKey();
 

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneThrough.php
@@ -1,0 +1,270 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Relations;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * HasOneThrough relation defines a one-to-one relationship between two models that uses a third
+ * intermediate model as the connection:
+ *
+ * <code>
+ * select * from Related
+ * inner join Parent    on Parent.ForeignKey    = Related.PrimaryKey
+ * inner join FarParent on FarParent.ForeignKey = Parent.PrimaryKey
+ * where
+ *     FarParent.PrimaryKey = ?
+ * and FarParent.PrimaryKey is not null
+ * </code>
+ *
+ * You can use a <code>Closure</code> to define how to construct the <em>Related Model</em> by setting .
+ *
+ *
+ * @package Illuminate\Database\Eloquent\Relations
+ * @author  Peter Scopes <peter.scopes@gmail.com>
+ */
+class HasOneThrough extends Relation
+{
+    /**
+     * The distance parent model instance.
+     *
+     * @var \Illuminate\Database\Eloquent\Model
+     */
+    protected $farParent;
+
+    /**
+     * The foreign key of the far parent model.
+     *
+     * @var string
+     */
+    protected $farParentKey;
+
+    /**
+     * The foreign key of the parent model.
+     *
+     * @var string
+     */
+    protected $parentKey;
+
+
+    /**
+     * Create a new has one through relationship instance.
+     *
+     * @param \Illuminate\Database\Eloquent\Builder $query
+     * @param \Illuminate\Database\Eloquent\Model   $farParent
+     * @param \Illuminate\Database\Eloquent\Model   $parent
+     * @param string                                $farParentKey Foreign key to parent
+     * @param string                                $parentKey    Foreign key to related
+     */
+    public function __construct(Builder $query, Model $farParent, Model $parent, $farParentKey, $parentKey)
+    {
+        $this->parentKey    = $parentKey;
+        $this->farParentKey = $farParentKey;
+        $this->farParent    = $farParent;
+
+        parent::__construct($query, $parent);
+    }
+
+    /**
+     * Get the far parent model of the relation.
+     *
+     * @return \Illuminate\Database\Eloquent\Model
+     */
+    public function getFarParent()
+    {
+        return $this->farParent;
+    }
+
+    /**
+     * Set the base constraints on the relation query.
+     *
+     * @return void
+     */
+    public function addConstraints()
+    {
+        $farParentLocalKey = $this->farParent->getQualifiedKeyName();
+
+        $this->setJoin();
+
+        if (static::$constraints) {
+            $this->query->where($farParentLocalKey, '=', $this->farParent->getKey());
+
+            $this->query->whereNotNull($farParentLocalKey);
+        }
+    }
+
+    /**
+     * Add the constraints for a relationship query.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @param  \Illuminate\Database\Eloquent\Builder  $parent
+     * @param  array|mixed $columns
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function getRelationQuery(Builder $query, Builder $parent, $columns = ['*'])
+    {
+        $this->setJoin($query);
+
+        $query->select($columns);
+
+        $this->query->where($this->farParent->getQualifiedKeyName(), '=', $this->farParent->getKey());
+
+        return $this->query->whereNotNull($this->farParent->getQualifiedKeyName());
+    }
+
+    /**
+     * @param Builder|null $query
+     */
+    protected function setJoin(Builder $query = null)
+    {
+        $query = $query ?: $this->query;
+
+        $relatedLocalKey     = $this->related->getQualifiedKeyName();
+        $parentForeignKey    = $this->parent->getTable().'.'.$this->parentKey;
+        $parentLocalKey      = $this->parent->getQualifiedKeyName();
+        $farParentForeignKey = $this->farParent->getTable().'.'.$this->farParentKey;
+
+        $query->join($this->parent->getTable(), $parentForeignKey, '=', $relatedLocalKey);
+        $query->join($this->farParent->getTable(), $farParentForeignKey, '=', $parentLocalKey);
+    }
+
+    /**
+     * Set the constraints for an eager load of the relation.
+     *
+     * @param  array  $models
+     * @return void
+     */
+    public function addEagerConstraints(array $models)
+    {
+        $table = $this->parent->getTable();
+
+        $this->query->whereIn($table.'.'.$this->parentKey, $this->getKeys($models, $this->related->getKeyName()));
+    }
+
+    /**
+     * Initialize the relation on a set of models.
+     *
+     * @param  array   $models
+     * @param  string  $relation
+     * @return array
+     */
+    public function initRelation(array $models, $relation)
+    {
+        foreach ($models as $model) {
+            $model->setRelation($relation, null);
+        }
+
+        return $models;
+    }
+
+    /**
+     * Match the eagerly loaded results to their parents.
+     *
+     * @param  array                                    $models   Parent models
+     * @param  \Illuminate\Database\Eloquent\Collection $results  Related models
+     * @param  string                                   $relation
+     *
+     * @return array
+     */
+    public function match(array $models, Collection $results, $relation)
+    {
+        $dictionary = $this->buildDictionary($results);
+
+        // Once we have the dictionary we can simply spin through the parent models to
+        // link them up with their children using the keyed dictionary to make the
+        // matching very convenient and easy work. Then we'll just return them.
+        foreach ($models as $model) {
+            $key = $model->getKey();
+
+            if (isset($dictionary[$key])) {
+                $value = $dictionary[$key];
+
+                $model->setRelation($relation, $value);
+            }
+        }
+
+        return $models;
+    }
+
+    /**
+     * Build model dictionary keyed by the relation's foreign key.
+     *
+     * @param  \Illuminate\Database\Eloquent\Collection  $results
+     * @return array
+     */
+    protected function buildDictionary(Collection $results)
+    {
+        $dictionary = [];
+
+        // First we will create a dictionary of models keyed by the foreign key of the
+        // relationship as this will allow us to quickly access all of the related
+        // models without having to do nested looping which will be quite slow.
+        foreach ($results as $result) {
+            $dictionary[$result->{$this->parentKey}] = $result;
+        }
+
+        return $dictionary;
+    }
+
+    /**
+     * Get the results of the relationship.
+     *
+     * @return mixed
+     */
+    public function getResults()
+    {
+        return $this->first();
+    }
+
+    /**
+     * Execute the query as a "select" statement.
+     *
+     * @param array $columns
+     *
+     * @return mixed
+     */
+    public function first($columns = ['*'])
+    {
+        // First we'll add the proper select columns onto the query so it is run with
+        // the proper columns. Then, we will get the results and hydrate out pivot
+        // models with the result of those columns as a separate model relation.
+        $columns = $this->query->getQuery()->columns ? [] : $columns;
+
+        $select = $this->getSelectColumns($columns);
+
+        $builder = $this->query->applyScopes();
+
+        $models = $builder->addSelect($select)->getModels();
+
+        // If we actually found models we will also eager load any relationships that
+        // have been specified as needing to be eager loaded. This will solve the
+        // n + 1 query problem for the developer and also increase performance.
+        if (count($models) > 0) {
+            $models = $builder->eagerLoadRelations($models);
+
+            return reset($models);
+        }
+
+        return null;
+    }
+
+    /**
+     * Set the select clause for the relation query.
+     *
+     * @param  array  $columns
+     * @return array
+     */
+    protected function getSelectColumns(array $columns = ['*'])
+    {
+        if ($columns == ['*']) {
+            $columns = [$this->related->getTable().'.*'];
+        }
+
+        return array_merge($columns, [
+            $this->parent->getTable().'.'.$this->parentKey,
+            $this->farParent->getTable().'.'.$this->farParentKey
+        ]);
+    }
+}

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneThrough.php
@@ -8,7 +8,7 @@ use Illuminate\Database\Eloquent\Collection;
 
 /**
  * HasOneThrough relation defines a one-to-one relationship between two models that uses a third
- * intermediate model as the connection:
+ * intermediate model as the connection.
  *
  * <code>
  * select * from Related
@@ -20,8 +20,7 @@ use Illuminate\Database\Eloquent\Collection;
  * </code>
  *
  *
- * @package Illuminate\Database\Eloquent\Relations
- * @author  Peter Scopes <peter.scopes@gmail.com>
+ * @author Peter Scopes <peter.scopes@gmail.com>
  */
 class HasOneThrough extends Relation
 {
@@ -46,7 +45,6 @@ class HasOneThrough extends Relation
      */
     protected $parentKey;
 
-
     /**
      * Create a new has one through relationship instance.
      *
@@ -58,9 +56,9 @@ class HasOneThrough extends Relation
      */
     public function __construct(Builder $query, Model $farParent, Model $parent, $farParentKey, $parentKey)
     {
-        $this->parentKey    = $parentKey;
+        $this->parentKey = $parentKey;
         $this->farParentKey = $farParentKey;
-        $this->farParent    = $farParent;
+        $this->farParent = $farParent;
 
         parent::__construct($query, $parent);
     }
@@ -119,9 +117,9 @@ class HasOneThrough extends Relation
     {
         $query = $query ?: $this->query;
 
-        $relatedLocalKey     = $this->related->getQualifiedKeyName();
-        $parentForeignKey    = $this->parent->getTable().'.'.$this->parentKey;
-        $parentLocalKey      = $this->parent->getQualifiedKeyName();
+        $relatedLocalKey = $this->related->getQualifiedKeyName();
+        $parentForeignKey = $this->parent->getTable().'.'.$this->parentKey;
+        $parentLocalKey = $this->parent->getQualifiedKeyName();
         $farParentForeignKey = $this->farParent->getTable().'.'.$this->farParentKey;
 
         $query->join($this->parent->getTable(), $parentForeignKey, '=', $relatedLocalKey);
@@ -244,8 +242,6 @@ class HasOneThrough extends Relation
 
             return reset($models);
         }
-
-        return null;
     }
 
     /**
@@ -262,7 +258,7 @@ class HasOneThrough extends Relation
 
         return array_merge($columns, [
             $this->parent->getTable().'.'.$this->parentKey,
-            $this->farParent->getTable().'.'.$this->farParentKey
+            $this->farParent->getTable().'.'.$this->farParentKey,
         ]);
     }
 }

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneThrough.php
@@ -45,7 +45,6 @@ class HasOneThrough extends Relation
      */
     protected $parentKey;
 
-
     /**
      * Create a new has one through relationship instance.
      *
@@ -57,9 +56,9 @@ class HasOneThrough extends Relation
      */
     public function __construct(Builder $query, Model $farParent, Model $parent, $farParentKey, $parentKey)
     {
-        $this->parentKey    = $parentKey;
+        $this->parentKey = $parentKey;
         $this->farParentKey = $farParentKey;
-        $this->farParent    = $farParent;
+        $this->farParent = $farParent;
 
         parent::__construct($query, $parent);
     }
@@ -118,9 +117,9 @@ class HasOneThrough extends Relation
     {
         $query = $query ?: $this->query;
 
-        $relatedLocalKey     = $this->related->getQualifiedKeyName();
-        $parentForeignKey    = $this->parent->getTable().'.'.$this->parentKey;
-        $parentLocalKey      = $this->parent->getQualifiedKeyName();
+        $relatedLocalKey = $this->related->getQualifiedKeyName();
+        $parentForeignKey = $this->parent->getTable().'.'.$this->parentKey;
+        $parentLocalKey = $this->parent->getQualifiedKeyName();
         $farParentForeignKey = $this->farParent->getTable().'.'.$this->farParentKey;
 
         $query->join($this->parent->getTable(), $parentForeignKey, '=', $relatedLocalKey);
@@ -260,7 +259,7 @@ class HasOneThrough extends Relation
         }
 
         return array_merge($columns, [
-            $this->farParent->getTable().'.'.$this->farParentKey
+            $this->farParent->getTable().'.'.$this->farParentKey,
         ]);
     }
 }

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneThrough.php
@@ -19,8 +19,6 @@ use Illuminate\Database\Eloquent\Collection;
  * and FarParent.PrimaryKey is not null
  * </code>
  *
- * You can use a <code>Closure</code> to define how to construct the <em>Related Model</em> by setting .
- *
  *
  * @package Illuminate\Database\Eloquent\Relations
  * @author  Peter Scopes <peter.scopes@gmail.com>

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneThrough.php
@@ -2,9 +2,9 @@
 
 namespace Illuminate\Database\Eloquent\Relations;
 
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
-use Illuminate\Database\Eloquent\Model;
 
 /**
  * HasOneThrough relation defines a one-to-one relationship between two models that uses a third

--- a/tests/Database/DatabaseEloquentHasOneThroughTest.php
+++ b/tests/Database/DatabaseEloquentHasOneThroughTest.php
@@ -14,7 +14,7 @@ class DatabaseEloquentHasOneThroughTest extends PHPUnit_Framework_TestCase
     public function testRelationIsProperlyInitialized()
     {
         $relation = $this->getRelation();
-        $model    = m::mock('Illuminate\Database\Eloquent\Model');
+        $model = m::mock('Illuminate\Database\Eloquent\Model');
         $model->shouldReceive('setRelation')->once()->with('foo', null);
 
         $models = $relation->initRelation([$model], 'foo');
@@ -101,5 +101,4 @@ class DatabaseEloquentHasOneThroughTest extends PHPUnit_Framework_TestCase
 
 class EloquentHasOneThroughModelStub extends Illuminate\Database\Eloquent\Model
 {
-
 }

--- a/tests/Database/DatabaseEloquentHasOneThroughTest.php
+++ b/tests/Database/DatabaseEloquentHasOneThroughTest.php
@@ -25,8 +25,7 @@ class DatabaseEloquentHasOneThroughTest extends PHPUnit_Framework_TestCase
     public function testEagerConstraintsAreProperlyAdded()
     {
         $relation = $this->getRelation();
-        $relation->getQuery()->shouldReceive('whereIn')->once()->with('users.post_id', [1, 2]);
-        $relation->getRelated()->shouldReceive('getKeyName')->once()->andReturn('id');
+        $relation->getQuery()->shouldReceive('whereIn')->once()->with('countries.id', [1, 2]);
         $model1 = new EloquentHasOneThroughModelStub;
         $model1->id = 1;
         $model2 = new EloquentHasOneThroughModelStub;
@@ -40,20 +39,20 @@ class DatabaseEloquentHasOneThroughTest extends PHPUnit_Framework_TestCase
 
         // Countries
         $results1 = new EloquentHasOneThroughModelStub;
-        $results1->post_id = 1;
+        $results1->user_id = 1;
         $results2 = new EloquentHasOneThroughModelStub;
-        $results2->post_id = 2;
+        $results2->user_id = 2;
 
         // Posts
         $model1 = new EloquentHasOneThroughModelStub;
-        $model1->id = 1;
+        $model1->user_id = 1;
         $model2 = new EloquentHasOneThroughModelStub;
-        $model2->id = 2;
+        $model2->user_id = 2;
 
         $models = $relation->match([$model1, $model2], new Collection([$results1, $results2]), 'foo');
 
-        $this->assertEquals(1, $models[0]->foo->post_id);
-        $this->assertEquals(2, $models[1]->foo->post_id);
+        $this->assertEquals(1, $models[0]->foo->user_id);
+        $this->assertEquals(2, $models[1]->foo->user_id);
     }
 
     /**

--- a/tests/Database/DatabaseEloquentHasOneThroughTest.php
+++ b/tests/Database/DatabaseEloquentHasOneThroughTest.php
@@ -1,0 +1,105 @@
+<?php
+
+use Mockery as m;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Relations\HasOneThrough;
+
+class DatabaseEloquentHasOneThroughTest extends PHPUnit_Framework_TestCase
+{
+    public function tearDown()
+    {
+        m::close();
+    }
+
+    public function testRelationIsProperlyInitialized()
+    {
+        $relation = $this->getRelation();
+        $model    = m::mock('Illuminate\Database\Eloquent\Model');
+        $model->shouldReceive('setRelation')->once()->with('foo', null);
+
+        $models = $relation->initRelation([$model], 'foo');
+
+        $this->assertEquals([$model], $models);
+    }
+
+    public function testEagerConstraintsAreProperlyAdded()
+    {
+        $relation = $this->getRelation();
+        $relation->getQuery()->shouldReceive('whereIn')->once()->with('users.post_id', [1, 2]);
+        $relation->getRelated()->shouldReceive('getKeyName')->once()->andReturn('id');
+        $model1 = new EloquentHasOneThroughModelStub;
+        $model1->id = 1;
+        $model2 = new EloquentHasOneThroughModelStub;
+        $model2->id = 2;
+        $relation->addEagerConstraints([$model1, $model2]);
+    }
+
+    public function testModelsAreProperlyMatchedToParents()
+    {
+        $relation = $this->getRelation();
+
+        // Countries
+        $results1 = new EloquentHasOneThroughModelStub;
+        $results1->post_id = 1;
+        $results2 = new EloquentHasOneThroughModelStub;
+        $results2->post_id = 2;
+
+        // Posts
+        $model1 = new EloquentHasOneThroughModelStub;
+        $model1->id = 1;
+        $model2 = new EloquentHasOneThroughModelStub;
+        $model2->id = 2;
+
+        $models = $relation->match([$model1, $model2], new Collection([$results1, $results2]), 'foo');
+
+        $this->assertEquals(1, $models[0]->foo->post_id);
+        $this->assertEquals(2, $models[1]->foo->post_id);
+    }
+
+    /**
+     * Creates a new HasOneThrough relationship of a Post having a Country through a User.
+     *
+     * @return HasOneThrough
+     */
+    protected function getRelation()
+    {
+        list($builder, $country, $user, $farParentKey, $parentKey) = $this->getRelationArguments();
+
+        return new HasOneThrough($builder, $country, $user, $farParentKey, $parentKey);
+    }
+
+    protected function getRelationArguments()
+    {
+        $builder = m::mock('Illuminate\Database\Eloquent\Builder');
+        $builder->shouldReceive('join')->once()->with('users', 'users.post_id', '=', 'posts.id');
+        $builder->shouldReceive('join')->once()->with('countries', 'countries.user_id', '=', 'users.id');
+        $builder->shouldReceive('where')->with('countries.id', '=', 1);
+        $builder->shouldReceive('whereNotNull')->with('countries.id');
+
+        $country = m::mock('Illuminate\Database\Eloquent\Model');
+        $country->shouldReceive('getTable')->andReturn('countries');
+        $country->shouldReceive('getQualifiedKeyName')->andReturn('countries.id');
+        $country->shouldReceive('getKey')->andReturn(1);
+        $country->shouldReceive('getKeyName')->andReturn('id');
+
+        $user = m::mock('Illuminate\Database\Eloquent\Model');
+        $user->shouldReceive('getTable')->andReturn('users');
+        $user->shouldReceive('getQualifiedKeyName')->andReturn('users.id');
+
+        $post = m::mock('Illuminate\Database\Eloquent\Model');
+        $post->shouldReceive('getQualifiedKeyName')->andReturn('posts.id');
+
+        $builder->shouldReceive('getModel')->andReturn($post);
+
+        $user->shouldReceive('getKey')->andReturn(1);
+        $user->shouldReceive('getCreatedAtColumn')->andReturn('created_at');
+        $user->shouldReceive('getUpdatedAtColumn')->andReturn('updated_at');
+
+        return [$builder, $country, $user, 'user_id', 'post_id'];
+    }
+}
+
+class EloquentHasOneThroughModelStub extends Illuminate\Database\Eloquent\Model
+{
+
+}


### PR DESCRIPTION
An implementation of a HasOneThrough relationship. Constructs a relationship between the **FarParent** and **Related** models through the **Parent** model. Internally it creates the following SQL:

```sql
select `Related`.*, `Parent`.`ForeignKey`, `FarParent`.`ForeignKey`
from `Related`
 inner join `Parent`    on `Parent`.`ForeignKey`    = `Related`.`PrimaryKey`
 inner join `FarParent` on `FarParent`.`ForeignKey` = `Parent`.`PrimaryKey`
 where
     `FarParent`.`PrimaryKey` = ?
 and `FarParent`.`PrimaryKey` is not null
limit 1
```

 In part linked to Issue: https://github.com/laravel/framework/issues/8721