### PR TITLE
Custom Error Messages for Unauthorized Access

### DIFF
--- a/src/Illuminate/Http/RedirectResponse.php
+++ b/src/Illuminate/Http/RedirectResponse.php
@@ -72,15 +72,30 @@ class RedirectResponse extends BaseRedirectResponse
     {
         $input = $input ?: $this->request->input();
 
-        $this->session->flashInput($data = array_filter($input, $callback = function (&$value) use (&$callback) {
-            if (is_array($value)) {
-                $value = array_filter($value, $callback);
-            }
-
-            return ! $value instanceof UploadedFile;
-        }));
+        $this->session->flashInput($this->removeFilesFromInput($input));
 
         return $this;
+    }
+
+    /**
+     * Remove all uploaded files form the given input array.
+     *
+     * @param  array  $input
+     * @return array
+     */
+    protected function removeFilesFromInput(array $input)
+    {
+        foreach ($input as $key => $value) {
+            if (is_array($value)) {
+                $input[$key] = $this->removeFilesFromInput($value);
+            }
+
+            if ($value instanceof SymfonyUploadedFile) {
+                unset($input[$key]);
+            }
+        }
+
+        return $input;
     }
 
     /**

--- a/src/Illuminate/Http/RedirectResponse.php
+++ b/src/Illuminate/Http/RedirectResponse.php
@@ -8,7 +8,6 @@ use Illuminate\Support\MessageBag;
 use Illuminate\Support\ViewErrorBag;
 use Illuminate\Session\Store as SessionStore;
 use Illuminate\Contracts\Support\MessageProvider;
-use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\RedirectResponse as BaseRedirectResponse;
 
 class RedirectResponse extends BaseRedirectResponse


### PR DESCRIPTION
Summary:

A custom error message can be passed to the **Gate::authorize($ability, [$model, $message])** method. However it was not being passed down to the **HandleAuthorization::deny($message)** trait being used by the Gate Class. It was merely a typo I think.

Solution:

Just passing the $message in the return statement to the **deny** method solves this problem.