### PR TITLE
[5.1] Custom Error Messages for Unauthorized Access

### DIFF
--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -221,7 +221,7 @@ class Gate implements GateContract
             return $result;
         }
 
-        return $result ? $this->allow() : $this->deny();
+        return $result ? $this->allow() : $this->deny($arguments);
     }
 
     /**


### PR DESCRIPTION
## Summary:

After creating a **Policy Class** for the *Current User* and a related *Eloquent Model*, we need to register it with the **Gate Class** to essentially ***manage*** the various (*CRUD*) operations that the User can perform on that Model. 

The `authorize` function implemented in the *Gate Class* takes in *2 arguments* - **`$ability`** [*string*] indicates what **operation** the User ***wants** to perform* on the Model; while **`$arguments`** [*string* or *`Illuminate\Support\Collection`*] indicates what **error message** is to be returned, if the User is ***not permitted** to perform* the operation.

The method in turn calls the *`allow`* and *`deny`* methods implemented in the **`HandlesAuthorization` trait**: returning `null` (*access granted*) or raising an `AuthorizationException` (*access denied*). The exception is constructed with the default message - **"This action is unauthorized."**, unless `$arguments` was provided to override it.

The `deny` method accepts a `$message` parameter which is initialized to the default error message. However, the `$arguments` to override the default was not being passed down from the `authorize` function as a parameter, while calling the `deny` function. Thus, the default error message **could not** be changed.

Here is the [issue](https://github.com/laravel/framework/issues/16606).

## Solution:

Just calling the `deny` method with the given `$arguments`, from the controller, as parameters solves this problem:

    public function authorize($ability, $arguments = []) {
        $result = $this->raw($ability, $arguments);
        if ($result instanceof Response) {
            return $result;
        }
        // return $result ? $this->allow() : $this->deny();
        return $result ? $this->allow() : $this->deny($arguments);
    }