### PR TITLE
[5.3] Call loggedOut() method after logging out a user

### DIFF
--- a/src/Illuminate/Foundation/Auth/AuthenticatesUsers.php
+++ b/src/Illuminate/Foundation/Auth/AuthenticatesUsers.php
@@ -155,7 +155,18 @@ trait AuthenticatesUsers
 
         $request->session()->regenerate();
 
-        return redirect('/');
+        return $this->loggedOut($request) ?: redirect('/');
+    }
+
+    /**
+     * The user has been logged out.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return mixed
+     */
+    protected function loggedOut(Request $request)
+    {
+        //
     }
 
     /**


### PR DESCRIPTION
Adding this for convenience to use the same way we use `authenticated()`

It' also useful, in my projects, i have some behavior that happens when logging out a user.