### PR TITLE
[5.3] 'When' Pass value as parameter to callback

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -755,9 +755,9 @@ class Builder
     }
 
     /**
-     * Apply the callback's query changes if the given "value" is true.
+     * Apply the callback's query changes if the given "value" is valid.
      *
-     * @param  bool  $value
+     * @param  mixed  $value
      * @param  \Closure  $callback
      * @param  \Closure  $default
      * @return $this

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -767,9 +767,9 @@ class Builder
         $builder = $this;
 
         if ($value) {
-            $builder = call_user_func($callback, $builder);
+            $builder = call_user_func($callback, $builder, $value);
         } elseif ($default) {
-            $builder = call_user_func($default, $builder);
+            $builder = call_user_func($default, $builder, $value);
         }
 
         return $builder;

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -467,9 +467,9 @@ class Builder
         $builder = $this;
 
         if ($value) {
-            $builder = call_user_func($callback, $builder);
+            $builder = call_user_func($callback, $builder, $value);
         } elseif ($default) {
-            $builder = call_user_func($default, $builder);
+            $builder = call_user_func($default, $builder, $value);
         }
 
         return $builder;

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -455,9 +455,9 @@ class Builder
     }
 
     /**
-     * Apply the callback's query changes if the given "value" is true.
+     * Apply the callback's query changes if the given "value" is valid.
      *
-     * @param  bool  $value
+     * @param  mixed  $value
      * @param  \Closure  $callback
      * @param  \Closure  $default
      * @return \Illuminate\Database\Query\Builder

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -580,8 +580,8 @@ class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase
         });
         $this->assertEquals(['foo' => $builder], $builder->delete());
     }
-    
-   public function testWhen()
+
+    public function testWhen()
     {
         $callback = function ($query) {
             return $query->where('id', '=', 1);

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -580,6 +580,41 @@ class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase
         });
         $this->assertEquals(['foo' => $builder], $builder->delete());
     }
+    
+   public function testWhen()
+    {
+        $callback = function ($query) {
+            return $query->where('id', '=', 1);
+        };
+
+        $default = function ($query) {
+            return $query->where('id', '=', 2);
+        };
+
+        $model = new EloquentBuilderTestModelParentStub;
+
+        $builder = $model->when(true, $callback);
+        $this->assertEquals('select * from "eloquent_builder_test_model_parent_stubs" where "id" = ?', $builder->toSql());
+        $this->assertEquals([0 => 1], $builder->getBindings());
+
+        $builder = $model->when(false, $callback, $default);
+        $this->assertEquals('select * from "eloquent_builder_test_model_parent_stubs" where "id" = ?', $builder->toSql());
+        $this->assertEquals([0 => 2], $builder->getBindings());
+    }
+
+    public function testWhenWithParameter()
+    {
+        $callback = function ($query, $parameter) {
+            return $query->where('username', '=', $parameter);
+        };
+
+        $username = 'foo';
+        $model = new EloquentBuilderTestModelParentStub;
+
+        $builder = $model->when($username, $callback);
+        $this->assertEquals('select * from "eloquent_builder_test_model_parent_stubs" where "username" = ?', $builder->toSql());
+        $this->assertEquals([0 => 'foo'], $builder->getBindings());
+    }
 
     public function testWithCount()
     {

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -156,6 +156,29 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase
         $this->assertEquals([0 => 2, 1 => 'foo'], $builder->getBindings());
     }
 
+    public function testWhenCallbackWithParameter()
+    {
+        $callback = function ($query, $parameter) {
+            return $query->where('username', '=', $parameter);
+        };
+
+        $default = function ($query) {
+            return $query->where('id', '=', 1);
+        };
+
+        $username = 'bar';
+        $builder = $this->getBuilder();
+
+        $builder->select('*')->from('users')->when($username, $callback, $default)->where('email', 'foo');
+        $this->assertEquals('select * from "users" where "username" = ? and "email" = ?', $builder->toSql());
+        $this->assertEquals([0 => 'bar', 1 => 'foo'], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->when(null, $callback, $default)->where('email', 'foo');
+        $this->assertEquals('select * from "users" where "id" = ? and "email" = ?', $builder->toSql());
+        $this->assertEquals([0 => 1, 1 => 'foo'], $builder->getBindings());
+    }
+
     public function testBasicWheres()
     {
         $builder = $this->getBuilder();


### PR DESCRIPTION
A more eloquent approach to accomplishing the task.

Before
```php
$results = DB::table('orders')
    ->when($request->customer_id, function($query) use ($request){
        return $query->where('customer_id', $request->customer_id);
    })
    ->get();
```

After
```php
$results = DB::table('orders')
    ->when($request->customer_id, function($query, $id) {
        return $query->where('customer_id', $id);
    })
    ->get();
```

thoughts?