### PR TITLE
[5.3] Fix #16593 and fix bug introduced in #16607

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -401,7 +401,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
      */
     public function compileEchoDefaults($value)
     {
-        return preg_replace('/^(?=\$)(.+?)(?:\s+or\s+)(.+?)$/s', 'isset($1) ? $1 : $2', $value);
+        return preg_replace('/^(\$.+(?:\[[\'"].+[\'"]\])|[^\[\]\'"]+)(?:\s+or\s+)(.+)$/s', 'isset($1) ? $1 : $2', $value);
     }
 
     /**

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -401,7 +401,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
      */
     public function compileEchoDefaults($value)
     {
-        return preg_replace('/^(\$.+(?:\[[\'"].+[\'"]\])|[^\[\]\'"]+)(?:\s+or\s+)(.+)$/s', 'isset($1) ? $1 : $2', $value);
+        return preg_replace('/^(\$.+(?:\[[\'"].+[\'"]\])|[^\[\]\'"]*)(?:\s+or\s+)(.+)$/s', 'isset($1) ? $1 : $2', $value);
     }
 
     /**

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -168,6 +168,27 @@ class ViewBladeCompilerTest extends PHPUnit_Framework_TestCase
             $name[\'key " or " space\']
         }}'));
 
+        $this->assertEquals('<?php echo e(isset($name["a"]["b"]) ? $name["a"]["b"] : "foo"); ?>', $compiler->compileString('{{{$name["a"]["b"] or "foo"}}}'));
+        $this->assertEquals('<?php echo e(isset($name["a"]["b"]) ? $name["a"]["b"] : "foo"); ?>', $compiler->compileString('{{ $name["a"]["b"] or "foo" }}'));
+        $this->assertEquals('<?php echo e(isset($name["a"]["b"]) ? $name["a"]["b"] : "foo"); ?>', $compiler->compileString('{{$name["a"]["b"] or "foo"}}'));
+        $this->assertEquals('<?php echo e(isset($name["a"]["b"]) ? $name["a"]["b"] : "foo"); ?>', $compiler->compileString('{{
+            $name["a"]["b"] or "foo"
+        }}'));
+
+        $this->assertEquals('<?php echo e(isset($name["a or b"]["c"]) ? $name["a or b"]["c"] : "foo"); ?>', $compiler->compileString('{{{$name["a or b"]["c"] or "foo"}}}'));
+        $this->assertEquals('<?php echo e(isset($name["a or b"]["c"]) ? $name["a or b"]["c"] : "foo"); ?>', $compiler->compileString('{{ $name["a or b"]["c"] or "foo" }}'));
+        $this->assertEquals('<?php echo e(isset($name["a or b"]["c"]) ? $name["a or b"]["c"] : "foo"); ?>', $compiler->compileString('{{$name["a or b"]["c"] or "foo"}}'));
+        $this->assertEquals('<?php echo e(isset($name["a or b"]["c"]) ? $name["a or b"]["c"] : "foo"); ?>', $compiler->compileString('{{
+            $name["a or b"]["c"] or "foo"
+        }}'));
+
+        $this->assertEquals('<?php echo e(isset($name["a"]["b or c"]) ? $name["a"]["b or c"] : "foo"); ?>', $compiler->compileString('{{{$name["a"]["b or c"] or "foo"}}}'));
+        $this->assertEquals('<?php echo e(isset($name["a"]["b or c"]) ? $name["a"]["b or c"] : "foo"); ?>', $compiler->compileString('{{ $name["a"]["b or c"] or "foo" }}'));
+        $this->assertEquals('<?php echo e(isset($name["a"]["b or c"]) ? $name["a"]["b or c"] : "foo"); ?>', $compiler->compileString('{{$name["a"]["b or c"] or "foo"}}'));
+        $this->assertEquals('<?php echo e(isset($name["a"]["b or c"]) ? $name["a"]["b or c"] : "foo"); ?>', $compiler->compileString('{{
+            $name["a"]["b or c"] or "foo"
+        }}'));
+
         $this->assertEquals('<?php echo e(isset($name) ? $name : "foo"); ?>', $compiler->compileString('{{ $name or "foo" }}'));
         $this->assertEquals('<?php echo e(isset($user->name) ? $user->name : "foo"); ?>', $compiler->compileString('{{ $user->name or "foo" }}'));
         $this->assertEquals('<?php echo e(isset($name) ? $name : "foo"); ?>', $compiler->compileString('{{$name or "foo"}}'));

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -140,16 +140,32 @@ class ViewBladeCompilerTest extends PHPUnit_Framework_TestCase
             $name["key or space"]
         }}'));
 
+        $this->assertEquals('<?php echo e(isset($name["key"]) ? $name["key"] : "foo"); ?>', $compiler->compileString('{{{$name["key"] or "foo"}}}'));
         $this->assertEquals('<?php echo e(isset($name["key"]) ? $name["key"] : "foo"); ?>', $compiler->compileString('{{ $name["key"] or "foo" }}'));
         $this->assertEquals('<?php echo e(isset($name["key"]) ? $name["key"] : "foo"); ?>', $compiler->compileString('{{$name["key"] or "foo"}}'));
         $this->assertEquals('<?php echo e(isset($name["key"]) ? $name["key"] : "foo"); ?>', $compiler->compileString('{{
             $name["key"] or "foo"
         }}'));
 
+        $this->assertEquals('<?php echo e(isset($name["key or space"]) ? $name["key or space"] : "foo"); ?>', $compiler->compileString('{{{$name["key or space"] or "foo"}}}'));
         $this->assertEquals('<?php echo e(isset($name["key or space"]) ? $name["key or space"] : "foo"); ?>', $compiler->compileString('{{ $name["key or space"] or "foo" }}'));
         $this->assertEquals('<?php echo e(isset($name["key or space"]) ? $name["key or space"] : "foo"); ?>', $compiler->compileString('{{$name["key or space"] or "foo"}}'));
         $this->assertEquals('<?php echo e(isset($name["key or space"]) ? $name["key or space"] : "foo"); ?>', $compiler->compileString('{{
             $name["key or space"] or "foo"
+        }}'));
+
+        $this->assertEquals('<?php echo e(isset($name["key \' or \' space"]) ? $name["key \' or \' space"] : "foo"); ?>', $compiler->compileString('{{{$name["key \' or \' space"] or "foo"}}}'));
+        $this->assertEquals('<?php echo e(isset($name["key \' or \' space"]) ? $name["key \' or \' space"] : "foo"); ?>', $compiler->compileString('{{ $name["key \' or \' space"] or "foo" }}'));
+        $this->assertEquals('<?php echo e(isset($name["key \' or \' space"]) ? $name["key \' or \' space"] : "foo"); ?>', $compiler->compileString('{{$name["key \' or \' space"] or "foo"}}'));
+        $this->assertEquals('<?php echo e(isset($name["key \' or \' space"]) ? $name["key \' or \' space"] : "foo"); ?>', $compiler->compileString('{{
+            $name["key \' or \' space"] or "foo"
+        }}'));
+
+        $this->assertEquals('<?php echo e($name[\'key " or " space\']); ?>', $compiler->compileString('{{{$name[\'key " or " space\']}}}'));
+        $this->assertEquals('<?php echo e($name[\'key " or " space\']); ?>', $compiler->compileString('{{$name[\'key " or " space\']}}'));
+        $this->assertEquals('<?php echo e($name[\'key " or " space\']); ?>', $compiler->compileString('{{ $name[\'key " or " space\'] }}'));
+        $this->assertEquals('<?php echo e($name[\'key " or " space\']); ?>', $compiler->compileString('{{
+            $name[\'key " or " space\']
         }}'));
 
         $this->assertEquals('<?php echo e(isset($name) ? $name : "foo"); ?>', $compiler->compileString('{{ $name or "foo" }}'));

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -98,6 +98,60 @@ class ViewBladeCompilerTest extends PHPUnit_Framework_TestCase
         $this->assertEquals("<?php echo e(\$name); ?>\n\n", $compiler->compileString("{{ \$name }}\n"));
         $this->assertEquals("<?php echo e(\$name); ?>\r\n\r\n", $compiler->compileString("{{ \$name }}\r\n"));
 
+        $this->assertEquals('<?php echo e($name["key"]); ?>', $compiler->compileString('{{{$name["key"]}}}'));
+        $this->assertEquals('<?php echo e($name["key"]); ?>', $compiler->compileString('{{$name["key"]}}'));
+        $this->assertEquals('<?php echo e($name["key"]); ?>', $compiler->compileString('{{ $name["key"] }}'));
+        $this->assertEquals('<?php echo e($name["key"]); ?>', $compiler->compileString('{{
+            $name["key"]
+        }}'));
+
+        $this->assertEquals('<?php echo e($name["key with space"]); ?>', $compiler->compileString('{{{$name["key with space"]}}}'));
+        $this->assertEquals('<?php echo e($name["key with space"]); ?>', $compiler->compileString('{{$name["key with space"]}}'));
+        $this->assertEquals('<?php echo e($name["key with space"]); ?>', $compiler->compileString('{{ $name["key with space"] }}'));
+        $this->assertEquals('<?php echo e($name["key with space"]); ?>', $compiler->compileString('{{
+            $name["key with space"]
+        }}'));
+
+        $this->assertEquals('<?php echo e($name[\'key\']); ?>', $compiler->compileString('{{{$name[\'key\']}}}'));
+        $this->assertEquals('<?php echo e($name[\'key\']); ?>', $compiler->compileString('{{$name[\'key\']}}'));
+        $this->assertEquals('<?php echo e($name[\'key\']); ?>', $compiler->compileString('{{ $name[\'key\'] }}'));
+        $this->assertEquals('<?php echo e($name[\'key\']); ?>', $compiler->compileString('{{
+            $name[\'key\']
+        }}'));
+
+        $this->assertEquals('<?php echo e($name[\'key with space\']); ?>', $compiler->compileString('{{{$name[\'key with space\']}}}'));
+        $this->assertEquals('<?php echo e($name[\'key with space\']); ?>', $compiler->compileString('{{$name[\'key with space\']}}'));
+        $this->assertEquals('<?php echo e($name[\'key with space\']); ?>', $compiler->compileString('{{ $name[\'key with space\'] }}'));
+        $this->assertEquals('<?php echo e($name[\'key with space\']); ?>', $compiler->compileString('{{
+            $name[\'key with space\']
+        }}'));
+
+        $this->assertEquals('<?php echo e($name[\'key or space\']); ?>', $compiler->compileString('{{{$name[\'key or space\']}}}'));
+        $this->assertEquals('<?php echo e($name[\'key or space\']); ?>', $compiler->compileString('{{$name[\'key or space\']}}'));
+        $this->assertEquals('<?php echo e($name[\'key or space\']); ?>', $compiler->compileString('{{ $name[\'key or space\'] }}'));
+        $this->assertEquals('<?php echo e($name[\'key or space\']); ?>', $compiler->compileString('{{
+            $name[\'key or space\']
+        }}'));
+
+        $this->assertEquals('<?php echo e($name["key or space"]); ?>', $compiler->compileString('{{{$name["key or space"]}}}'));
+        $this->assertEquals('<?php echo e($name["key or space"]); ?>', $compiler->compileString('{{$name["key or space"]}}'));
+        $this->assertEquals('<?php echo e($name["key or space"]); ?>', $compiler->compileString('{{ $name["key or space"] }}'));
+        $this->assertEquals('<?php echo e($name["key or space"]); ?>', $compiler->compileString('{{
+            $name["key or space"]
+        }}'));
+
+        $this->assertEquals('<?php echo e(isset($name["key"]) ? $name["key"] : "foo"); ?>', $compiler->compileString('{{ $name["key"] or "foo" }}'));
+        $this->assertEquals('<?php echo e(isset($name["key"]) ? $name["key"] : "foo"); ?>', $compiler->compileString('{{$name["key"] or "foo"}}'));
+        $this->assertEquals('<?php echo e(isset($name["key"]) ? $name["key"] : "foo"); ?>', $compiler->compileString('{{
+            $name["key"] or "foo"
+        }}'));
+
+        $this->assertEquals('<?php echo e(isset($name["key or space"]) ? $name["key or space"] : "foo"); ?>', $compiler->compileString('{{ $name["key or space"] or "foo" }}'));
+        $this->assertEquals('<?php echo e(isset($name["key or space"]) ? $name["key or space"] : "foo"); ?>', $compiler->compileString('{{$name["key or space"] or "foo"}}'));
+        $this->assertEquals('<?php echo e(isset($name["key or space"]) ? $name["key or space"] : "foo"); ?>', $compiler->compileString('{{
+            $name["key or space"] or "foo"
+        }}'));
+
         $this->assertEquals('<?php echo e(isset($name) ? $name : "foo"); ?>', $compiler->compileString('{{ $name or "foo" }}'));
         $this->assertEquals('<?php echo e(isset($user->name) ? $user->name : "foo"); ?>', $compiler->compileString('{{ $user->name or "foo" }}'));
         $this->assertEquals('<?php echo e(isset($name) ? $name : "foo"); ?>', $compiler->compileString('{{$name or "foo"}}'));


### PR DESCRIPTION
The regex now handles array syntax, with/without 'or' nicely. 

I've added tests to verify that this fixes #16593 . 