### PR TITLE
[5.3] Fix 'remember_me' column not found error

### DIFF
--- a/src/Illuminate/Auth/Authenticatable.php
+++ b/src/Illuminate/Auth/Authenticatable.php
@@ -5,6 +5,13 @@ namespace Illuminate\Auth;
 trait Authenticatable
 {
     /**
+     * Variable containing "remember me" column name.
+     *
+     * @var string
+     */
+    protected $remember_column = 'remember_token';
+
+    /**
      * Get the name of the unique identifier for the user.
      *
      * @return string
@@ -62,6 +69,6 @@ trait Authenticatable
      */
     public function getRememberTokenName()
     {
-        return 'remember_token';
+        return $this->remember_column;
     }
 }

--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -614,9 +614,11 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
      */
     protected function refreshRememberToken(AuthenticatableContract $user)
     {
-        $user->setRememberToken($token = Str::random(60));
+        if (! empty($user->getRememberTokenName())) {
+            $user->setRememberToken($token = Str::random(60));
 
-        $this->provider->updateRememberToken($user, $token);
+            $this->provider->updateRememberToken($user, $token);
+        }
     }
 
     /**
@@ -627,7 +629,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
      */
     protected function createRememberTokenIfDoesntExist(AuthenticatableContract $user)
     {
-        if (empty($user->getRememberToken())) {
+        if (! empty($user->getRememberTokenName()) && empty($user->getRememberToken())) {
             $this->refreshRememberToken($user);
         }
     }


### PR DESCRIPTION
Fixes #16509.

Currently if the user removes the `remember_token` field from the table, exception is thrown when the user tries to logout from the system. This PR adds a `remember_column` variable to the `Authenticatable` trait. If the user `remember_token` field from the database, exception upon logout can be avoided by overriding the `$remember_column` value in the `App\User` model as:

```
protected $remember_column = '';
```  