### PR TITLE
[5.3] Fix 'remember_me' column not found error

### DIFF
--- a/src/Illuminate/Auth/Authenticatable.php
+++ b/src/Illuminate/Auth/Authenticatable.php
@@ -5,6 +5,13 @@ namespace Illuminate\Auth;
 trait Authenticatable
 {
     /**
+     * Variable containing "remember me" column name.
+     *
+     * @var string
+     */
+    protected $remember_column = 'remember_token';
+
+    /**
      * Get the name of the unique identifier for the user.
      *
      * @return string
@@ -41,7 +48,9 @@ trait Authenticatable
      */
     public function getRememberToken()
     {
-        return $this->{$this->getRememberTokenName()};
+        if (! empty($this->getRememberTokenName())) {
+            return $this->{$this->getRememberTokenName()};
+        }
     }
 
     /**
@@ -52,7 +61,9 @@ trait Authenticatable
      */
     public function setRememberToken($value)
     {
-        $this->{$this->getRememberTokenName()} = $value;
+        if (! empty($this->getRememberTokenName())) {
+            $this->{$this->getRememberTokenName()} = $value;
+        }
     }
 
     /**
@@ -62,6 +73,6 @@ trait Authenticatable
      */
     public function getRememberTokenName()
     {
-        return 'remember_token';
+        return $this->remember_column;
     }
 }


### PR DESCRIPTION
Fixes #16509.

Currently if the user removes the `remember_token` field from the table, exception is thrown when the user tries to logout from the system. This PR adds a `remember_column` variable to the `Authenticatable` trait. If the user `remember_token` field from the database, exception upon logout can be avoided by overriding the `$remember_column` value in the `App\User` model as:

```
protected $remember_column = '';
```  