### PR TITLE
[5.3] Add partition collection method

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -726,6 +726,23 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
+     * Output a collection with two elements. Items in the first element did pass
+     * the given $callback, items in the second element did not.
+     *
+     * @param  callable $callback
+     * @return static
+     */
+    public function partition(callable $callback) {
+        $partitions = [new static(), new static()];
+
+        foreach ($this->items as $item) {
+            $partitions[! (int) $callback($item)][] = $item;
+        }
+
+        return new static($partitions);
+    }
+
+    /**
      * Pass the collection to the given callback and return the result.
      *
      * @param  callable $callback

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -732,7 +732,8 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      * @param  callable $callback
      * @return static
      */
-    public function partition(callable $callback) {
+    public function partition(callable $callback)
+    {
         $partitions = [new static(), new static()];
 
         foreach ($this->items as $item) {

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -726,11 +726,11 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
-     * Output a collection with two elements. Items in the first element did pass
+     * Returns an array with two elements. Items in the first element did pass
      * the given $callback, items in the second element did not.
      *
      * @param  callable $callback
-     * @return static
+     * @return array
      */
     public function partition(callable $callback)
     {
@@ -740,7 +740,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
             $partitions[! (int) $callback($item)][] = $item;
         }
 
-        return new static($partitions);
+        return $partitions;
     }
 
     /**

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -726,8 +726,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
-     * Returns an array with two elements. Items in the first element did pass
-     * the given $callback, items in the second element did not.
+     * Partition the collection into two array using the given callback.
      *
      * @param  callable $callback
      * @return array

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1645,12 +1645,12 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
     {
         $collection = new Collection(range(1, 10));
 
-        $collection = $collection->partition(function ($i) {
+        list($firstPartition, $secondPartition) = $collection->partition(function ($i) {
             return $i <= 5;
         });
 
-        $this->assertEquals([1, 2, 3, 4, 5], $collection[0]->toArray());
-        $this->assertEquals([6, 7, 8, 9, 10], $collection[1]->toArray());
+        $this->assertEquals([1, 2, 3, 4, 5], $firstPartition->toArray());
+        $this->assertEquals([6, 7, 8, 9, 10], $secondPartition->toArray());
     }
 
     public function testPartitionEmptyCollection()

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1640,6 +1640,27 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
             })->toArray()
         );
     }
+
+    public function testPartition()
+    {
+        $collection = new Collection(range(1, 10));
+
+        $collection = $collection->partition(function ($i) {
+            return $i <= 5;
+        });
+
+        $this->assertEquals([1, 2, 3, 4, 5], $collection[0]->toArray());
+        $this->assertEquals([6, 7, 8, 9, 10], $collection[1]->toArray());
+    }
+
+    public function testPartitionEmptyCollection()
+    {
+        $collection = new Collection();
+
+        $this->assertCount(2, $collection->partition(function () {
+            return true;
+        }));
+    }
 }
 
 class TestAccessorEloquentTestStub


### PR DESCRIPTION
The partition method returns a collection with two elements. Items in the first element did pass the given `$callback`, items in the second element did not.

Here's an example:

```php
collect(range(1, 10))->partition(function ($i) {
    return $i <= 5;
});

// returns a new collection
// first element is a collection with items 1, 2 ,3, 4, 5
// second element is a collection with items 5, 6, 7, 8, 9, 10
```