### PR TITLE
fix key/index handling on utf8mb4 formatted databases. this solves th…

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -39,7 +39,7 @@ class Blueprint
 
     /**
      * The row format for storage engine that should be used for the table.
-     * use full if like to use utf8mb4 encoding
+     * use full if like to use utf8mb4 encoding.
      * @var string
      */
     public $rowFormat;

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -38,6 +38,13 @@ class Blueprint
     public $engine;
 
     /**
+     * The row format for storage engine that should be used for the table.
+     * use full if like to use utf8mb4 encoding
+     * @var string
+     */
+    public $rowFormat;
+
+    /**
      * The default character set that should be used for the table.
      */
     public $charset;

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -74,7 +74,7 @@ class MySqlGrammar extends Grammar
 
         if (isset($blueprint->rowFormat)) {
             $sql .= ' ROW_FORMAT = '.$blueprint->rowFormat;
-        } elseif (! is_null($engine = $connection->getConfig('RowFormat'))) {
+        } elseif (! is_null($rowFormat = $connection->getConfig('RowFormat'))) {
             $sql .= ' ROW_FORMAT = '.$rowFormat;
         }
 

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -72,6 +72,12 @@ class MySqlGrammar extends Grammar
             $sql .= ' engine = '.$engine;
         }
 
+        if (isset($blueprint->rowFormat)) {
+            $sql .= ' ROW_FORMAT = '.$blueprint->rowFormat;
+        } elseif (! is_null($engine = $connection->getConfig('RowFormat'))) {
+            $sql .= ' ROW_FORMAT = '.$rowFormat;
+        }
+
         return $sql;
     }
 


### PR DESCRIPTION
### Problem:

if you try to use the uft8mb4 encoding, e.g. to store some emojis, and you use some index in your migration, you get the error described in https://laracasts.com/discuss/channels/general-discussion/migrations-configure-a-default-string-length-utf8mb4

the solution is my pull request.


fix key/index handling on utf8mb4 formatted databases. this solves the problem in https://laracasts.com/discuss/channels/general-discussion/migrations-configure-a-default-string-length-utf8mb4 by simple using a configuration parameter in your database.php config "RowFormat" => "DYNAMIC" or "COMPRESSED". for some more flexibility you can use $blueprint->rowFormat in your schema builder like the $blueprint->engine parameter'
[fix_schemabuilder_utf8mb4_key_length a58e8c1] fix key/index handling on utf8mb4 formatted databases. this solves the problem in https://laracasts.com/discuss/channels/general-discussion/migrations-configure-a-default-string-length-utf8mb4 by simple using a configuration parameter in your database.php config "RowFormat" => "DYNAMIC" or "COMPRESSED". for some more flexibility you can use $blueprint->rowFormat in your schema builder like the $blueprint->engine parameter

