### PR TITLE
[5.3] Remove getDateFormat() from SqlServerGrammar

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
@@ -261,16 +261,6 @@ class SqlServerGrammar extends Grammar
     }
 
     /**
-     * Get the format for database stored dates.
-     *
-     * @return string
-     */
-    public function getDateFormat()
-    {
-        return 'Y-m-d H:i:s.000';
-    }
-
-    /**
      * Wrap a single string in keyword identifiers.
      *
      * @param  string  $value


### PR DESCRIPTION
Due to Fix #54648 being included in PHP-7.0.5 and PHP-5.6.20
(see http://git.php.net/?p=php-src.git;a=commitdiff;h=53c036b30bdabedf841fb8716a7cd722bbab09a3)
the pdo-dblib driver now returns dates in a fixed format, the same of all
other PDO drivers.  Overring getDateFormat() in SqlServerGrammar is no longer
needed, and it's actually a bug.

WARNING: this change breaks compatibility with PHP < 7.0.5 and PHP < 5.6.20,
unless you set the correct date format (date format = %Y-%m-%d %H:%M:%S
instead of date format = %Y-%m-%d %H:%M:%S.%z) in locales.conf for FreeTDS.