### PR TITLE
[5.4] Make logout redirect path cofigurable

### DIFF
--- a/src/Illuminate/Foundation/Auth/AuthenticatesUsers.php
+++ b/src/Illuminate/Foundation/Auth/AuthenticatesUsers.php
@@ -155,7 +155,7 @@ trait AuthenticatesUsers
 
         $request->session()->regenerate();
 
-        return redirect('/');
+        return redirect($this->logoutRedirectPath());
     }
 
     /**

--- a/src/Illuminate/Foundation/Auth/RedirectsUsers.php
+++ b/src/Illuminate/Foundation/Auth/RedirectsUsers.php
@@ -13,4 +13,14 @@ trait RedirectsUsers
     {
         return property_exists($this, 'redirectTo') ? $this->redirectTo : '/home';
     }
+
+    /**
+     * Get the logout redirect path.
+     *
+     * @return string
+     */
+    public function logoutRedirectPath()
+    {
+        return property_exists($this, 'logoutRedirectTo') ? $this->logoutRedirectTo : '/';
+    }
 }


### PR DESCRIPTION
When a controller using \Illuminate\Foundation\Auth\AuthenticatesUsers, we can configure the path where users redirect to after login by define the property $redirectTo. But we cannot configure where users redirect to after logout.

This pull request makes logout path configurable. Just define the property $logoutRedirectTo.

For example
```php
class Foo extends BaseController
{
    use AuthenticatesUsers;

    /**
     * Where to redirect users after logout.
     *
     * @var string
     */
    protected $logoutRedirectTo = '/somewhere';

}
```