### PR TITLE
[5.3] Ignore return from closure in has one with default feature.

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/HasOne.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOne.php
@@ -85,10 +85,8 @@ class HasOne extends HasOneOrMany
         );
 
         if (is_callable($this->withDefault)) {
-            return call_user_func($this->withDefault, $instance) ?: $instance;
-        }
-
-        if (is_array($this->withDefault)) {
+            call_user_func($this->withDefault, $instance);
+        } elseif (is_array($this->withDefault)) {
             $instance->forceFill($this->withDefault);
         }
 


### PR DESCRIPTION
In order to prevent a potential issues / inconsistencies with closures not returning a valid model, let's use the closure as a way to customize the default instance but ignoring the returned value.

In order words, passing a closure or an array to `withDefault` will be a way to customize the default instance not to replace it.

Fix: https://github.com/laravel/framework/issues/16614