### PR TITLE
[5.3] Fix seeJsonStructure for empty response

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -351,7 +351,7 @@ trait MakesHttpRequests
             return $this->seeJson();
         }
 
-        if (! $responseData) {
+        if (is_null($responseData)) {
             $responseData = $this->decodeResponseJson();
         }
 


### PR DESCRIPTION
Fixes #16626. Solution suggested by @miklcct