### PR TITLE
[5.3] Allow collection partition by key and add preserving keys option

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -737,8 +737,8 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
 
         $callback = $this->valueRetriever($callback);
 
-        foreach ($this->items as $item) {
-            $partitions[(int) ! $callback($item)][] = $item;
+        foreach ($this->items as $key => $item) {
+            $partitions[(int) ! $callback($item)][$key] = $item;
         }
 
         return $partitions;

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -726,17 +726,19 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
-     * Partition the collection into two array using the given callback.
+     * Partition the collection into two arrays using the given callback or key.
      *
-     * @param  callable  $callback
+     * @param  callable|string  $callback
      * @return array
      */
-    public function partition(callable $callback)
+    public function partition($callback)
     {
         $partitions = [new static(), new static()];
 
+        $callback = $this->valueRetriever($callback);
+
         foreach ($this->items as $item) {
-            $partitions[! (int) $callback($item)][] = $item;
+            $partitions[(int) ! $callback($item)][] = $item;
         }
 
         return $partitions;

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -729,11 +729,11 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      * Partition the collection into two arrays using the given callback or key.
      *
      * @param  callable|string  $callback
-     * @return array
+     * @return static
      */
     public function partition($callback)
     {
-        $partitions = [new static(), new static()];
+        $partitions = [new static, new static];
 
         $callback = $this->valueRetriever($callback);
 
@@ -741,7 +741,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
             $partitions[(int) ! $callback($item)][$key] = $item;
         }
 
-        return $partitions;
+        return new static($partitions);
     }
 
     /**

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1640,7 +1640,7 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
         );
     }
 
-    public function testPartition()
+    public function testPartitionWithClosure()
     {
         $collection = new Collection(range(1, 10));
 
@@ -1650,6 +1650,19 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals([1, 2, 3, 4, 5], $firstPartition->toArray());
         $this->assertEquals([6, 7, 8, 9, 10], $secondPartition->toArray());
+    }
+
+    public function testPartitionByKey()
+    {
+        $courses = new Collection([
+            ['free' => true, 'title' => 'Basic'], ['free' => false, 'title' => 'Premium'],
+        ]);
+
+        list($free, $premium) = $courses->partition('free');
+
+        $this->assertSame([['free' => true, 'title' => 'Basic']], $free->toArray());
+
+        $this->assertSame([['free' => false, 'title' => 'Premium']], $premium->toArray());
     }
 
     public function testPartitionEmptyCollection()

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1648,8 +1648,8 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
             return $i <= 5;
         });
 
-        $this->assertEquals([1, 2, 3, 4, 5], $firstPartition->toArray());
-        $this->assertEquals([6, 7, 8, 9, 10], $secondPartition->toArray());
+        $this->assertEquals([1, 2, 3, 4, 5], $firstPartition->values()->toArray());
+        $this->assertEquals([6, 7, 8, 9, 10], $secondPartition->values()->toArray());
     }
 
     public function testPartitionByKey()
@@ -1660,9 +1660,22 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
 
         list($free, $premium) = $courses->partition('free');
 
-        $this->assertSame([['free' => true, 'title' => 'Basic']], $free->toArray());
+        $this->assertSame([['free' => true, 'title' => 'Basic']], $free->values()->toArray());
 
-        $this->assertSame([['free' => false, 'title' => 'Premium']], $premium->toArray());
+        $this->assertSame([['free' => false, 'title' => 'Premium']], $premium->values()->toArray());
+    }
+
+    public function testPartitionPreservesKeys()
+    {
+        $courses = new Collection([
+            'a' => ['free' => true], 'b' => ['free' => false], 'c' => ['free' => true],
+        ]);
+
+        list($free, $premium) = $courses->partition('free');
+
+        $this->assertSame(['a' => ['free' => true], 'c' => ['free' => true]], $free->toArray());
+
+        $this->assertSame(['b' => ['free' => false]], $premium->toArray());
     }
 
     public function testPartitionEmptyCollection()


### PR DESCRIPTION
Some small improvements to the partition method.

- You can partition a collection by key (typically a column with a boolean value like: published/draft, premium/free, featured/not featured, etc.). i.e. `$posts->partition('featured')`.

- I also added the preserve keys option similar to the `groupBy` method. 