### PR TITLE
[5.4] Allow routes to be registered fluently

### DIFF
--- a/src/Illuminate/Foundation/Http/Kernel.php
+++ b/src/Illuminate/Foundation/Http/Kernel.php
@@ -98,7 +98,7 @@ class Kernel implements KernelContract
         }
 
         foreach ($this->routeMiddleware as $key => $middleware) {
-            $router->middleware($key, $middleware);
+            $router->aliasMiddleware($key, $middleware);
         }
     }
 

--- a/src/Illuminate/Routing/ControllerDispatcher.php
+++ b/src/Illuminate/Routing/ControllerDispatcher.php
@@ -44,7 +44,7 @@ class ControllerDispatcher
             return $controller->callAction($method, $parameters);
         }
 
-        return call_user_func_array([$controller, $method], $parameters);
+        return $controller->{$method}(...array_values($parameters));
     }
 
     /**

--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -196,7 +196,13 @@ class ResourceRegistrar
     {
         $name = $this->getResourceName($resource, $method, $options);
 
-        return ['as' => $name, 'uses' => $controller.'@'.$method];
+        $action = ['as' => $name, 'uses' => $controller.'@'.$method];
+
+        if (isset($options['middleware'])) {
+            $action['middleware'] = $options['middleware'];
+        }
+
+        return $action;
     }
 
     /**

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -132,10 +132,9 @@ class Route
     /**
      * Run the route action and return the response.
      *
-     * @param  \Illuminate\Http\Request  $request
      * @return mixed
      */
-    public function run(Request $request)
+    public function run()
     {
         $this->container = $this->container ?: new Container;
 

--- a/src/Illuminate/Routing/RouteRegistrar.php
+++ b/src/Illuminate/Routing/RouteRegistrar.php
@@ -55,6 +55,19 @@ class RouteRegistrar
     }
 
     /**
+     * Route a resource to a controller.
+     *
+     * @param  string  $name
+     * @param  string  $controller
+     * @param  array  $options
+     * @return void
+     */
+    public function resource($name, $controller, array $options = [])
+    {
+        $this->router->resource($name, $controller, $this->attributes + $options);
+    }
+
+    /**
      * Create a route group with shared attributes.
      *
      * @param  \Closure  $callback

--- a/src/Illuminate/Routing/RouteRegistrar.php
+++ b/src/Illuminate/Routing/RouteRegistrar.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Routing;
 
 use Closure;
+use BadMethodCallException;
 
 class RouteRegistrar
 {
@@ -27,6 +28,15 @@ class RouteRegistrar
      */
     protected $passthru = [
         'get', 'post', 'put', 'patch', 'delete', 'options', 'any',
+    ];
+
+    /**
+     * The attributes that can be set through this class.
+     *
+     * @var array
+     */
+    protected $allowedAttributes = [
+        'as', 'domain', 'middleware', 'name', 'namespace', 'prefix',
     ];
 
     /**
@@ -149,6 +159,10 @@ class RouteRegistrar
             return $this->registerRoute($method, ...$parameters);
         }
 
-        return $this->attribute($method, $parameters[0]);
+        if (in_array($method, $this->allowedAttributes)) {
+            return $this->attribute($method, $parameters[0]);
+        }
+
+        throw new BadMethodCallException("Method [{$method}] does not exist.");
     }
 }

--- a/src/Illuminate/Routing/RouteRegistrar.php
+++ b/src/Illuminate/Routing/RouteRegistrar.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace Illuminate\Routing;
+
+use Closure;
+
+class RouteRegistrar
+{
+    /**
+     * The router instance.
+     *
+     * @var \Illuminate\Routing\Router
+     */
+    protected $router;
+
+    /**
+     * The attributes to pass on to the router.
+     *
+     * @var array
+     */
+    protected $attributes = [];
+
+    /**
+     * The methods to dynamically pass through to the router.
+     *
+     * @var array
+     */
+    protected $passthru = [
+        'get', 'post', 'put', 'patch', 'delete', 'options', 'any',
+    ];
+
+    /**
+     * Create a new route registrar instance.
+     *
+     * @param  \Illuminate\Routing\Router  $router
+     * @return void
+     */
+    public function __construct(Router $router)
+    {
+        $this->router = $router;
+    }
+
+    /**
+     * Set the value for a given attribute.
+     *
+     * @param  string  $key
+     * @param  mixed  $value
+     * @return $this
+     */
+    public function attribute($key, $value)
+    {
+        $this->attributes[$key] = $value;
+
+        return $this;
+    }
+
+    /**
+     * Create a route group with shared attributes.
+     *
+     * @param  \Closure  $callback
+     * @return void
+     */
+    public function group($callback)
+    {
+        $this->router->group($this->attributes, $callback);
+    }
+
+    /**
+     * Register a new route with the given verbs.
+     *
+     * @param  array|string  $methods
+     * @param  string  $uri
+     * @param  \Closure|array|string|null  $action
+     * @return \Illuminate\Routing\Route
+     */
+    public function match($methods, $uri, $action = null)
+    {
+        return $this->router->match($methods, $uri, $this->compileAction($action));
+    }
+
+    /**
+     * Register a new route with the router.
+     *
+     * @param  string  $method
+     * @param  string  $uri
+     * @param  \Closure|array|string|null  $action
+     * @return \Illuminate\Routing\Route
+     */
+    protected function registerRoute($method, $uri, $action = null)
+    {
+        if (! is_array($action)) {
+            $action = array_merge($this->attributes, $action ? ['uses' => $action] : []);
+        }
+
+        return $this->router->{$method}($uri, $this->compileAction($action));
+    }
+
+    /**
+     * Compile the action into an array including the attributes.
+     *
+     * @param  \Closure|array|string|null  $action
+     * @return array
+     */
+    protected function compileAction($action)
+    {
+        if (is_null($action)) {
+            return $this->attributes;
+        }
+
+        if (is_string($action) || $action instanceof Closure) {
+            $action = ['uses' => $action];
+        }
+
+        return array_merge($this->attributes, $action);
+    }
+
+    /**
+     * Dynamically handle calls into the route registrar.
+     *
+     * @param  string  $method
+     * @param  array  $parameters
+     * @return \Illuminate\Routing\Route|$this
+     */
+    public function __call($method, $parameters)
+    {
+        if (in_array($method, $this->passthru)) {
+            return $this->registerRoute($method, ...$parameters);
+        }
+
+        return $this->attribute($method, $parameters[0]);
+    }
+}

--- a/src/Illuminate/Routing/RouteRegistrar.php
+++ b/src/Illuminate/Routing/RouteRegistrar.php
@@ -30,6 +30,15 @@ class RouteRegistrar
     ];
 
     /**
+     * The attributes that are aliased.
+     *
+     * @var array
+     */
+    protected $aliases = [
+        'name' => 'as',
+    ];
+
+    /**
      * Create a new route registrar instance.
      *
      * @param  \Illuminate\Routing\Router  $router
@@ -49,7 +58,7 @@ class RouteRegistrar
      */
     public function attribute($key, $value)
     {
-        $this->attributes[$key] = $value;
+        $this->attributes[array_get($this->aliases, $key, $key)] = $value;
 
         return $this;
     }

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -640,7 +640,7 @@ class Router implements RegistrarContract, BindingRegistrar
                         ->through($middleware)
                         ->then(function ($request) use ($route) {
                             return $this->prepareResponse(
-                                $request, $route->run($request)
+                                $request, $route->run()
                             );
                         });
     }

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -21,7 +21,9 @@ use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 
 class Router implements RegistrarContract, BindingRegistrar
 {
-    use Macroable;
+    use Macroable {
+        __call as macroCall;
+    }
 
     /**
      * The event dispatcher instance.
@@ -1222,5 +1224,21 @@ class Router implements RegistrarContract, BindingRegistrar
     public function getPatterns()
     {
         return $this->patterns;
+    }
+
+    /**
+     * Dynamically handle calls into the router instance.
+     *
+     * @param  string  $method
+     * @param  array  $parameters
+     * @return mixed
+     */
+    public function __call($method, $parameters)
+    {
+        if (static::hasMacro($method)) {
+            return $this->macroCall($method, $parameters);
+        }
+
+        return (new RouteRegistrar($this))->attribute($method, $parameters[0]);
     }
 }

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -846,7 +846,7 @@ class Router implements RegistrarContract, BindingRegistrar
      * @param  string  $class
      * @return $this
      */
-    public function middleware($name, $class)
+    public function aliasMiddleware($name, $class)
     {
         $this->middleware[$name] = $class;
 

--- a/tests/Auth/AuthorizesResourcesTest.php
+++ b/tests/Auth/AuthorizesResourcesTest.php
@@ -61,7 +61,7 @@ class AuthorizesResourcesTest extends PHPUnit_Framework_TestCase
     {
         $router = new Router(new Illuminate\Events\Dispatcher);
 
-        $router->middleware('can', 'AuthorizesResourcesMiddleware');
+        $router->aliasMiddleware('can', 'AuthorizesResourcesMiddleware');
         $router->get($method)->uses('AuthorizesResourcesController@'.$method);
 
         $this->assertEquals(

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -1,0 +1,231 @@
+<?php
+
+use Mockery as m;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Router;
+use Illuminate\Container\Container;
+use Illuminate\Contracts\Events\Dispatcher;
+
+class RouteRegistrarTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var \Illuminate\Routing\Router
+     */
+    protected $router;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->router = new Router(m::mock(Dispatcher::class), Container::getInstance());
+    }
+
+    public function tearDown()
+    {
+        m::close();
+    }
+
+    public function testCanRegisterGetRouteWithClosureAction()
+    {
+        $this->router->middleware('get-middleware')->get('users', function () {
+            return 'all-users';
+        });
+
+        $this->seeResponse('all-users', Request::create('users', 'GET'));
+        $this->seeMiddleware('get-middleware');
+    }
+
+    public function testCanRegisterPostRouteWithClosureAction()
+    {
+        $this->router->middleware('post-middleware')->post('users', function () {
+            return 'saved';
+        });
+
+        $this->seeResponse('saved', Request::create('users', 'POST'));
+        $this->seeMiddleware('post-middleware');
+    }
+
+    public function testCanRegisterAnyRouteWithClosureAction()
+    {
+        $this->router->middleware('test-middleware')->any('users', function () {
+            return 'anything';
+        });
+
+        $this->seeResponse('anything', Request::create('users', 'PUT'));
+        $this->seeMiddleware('test-middleware');
+    }
+
+    public function testCanRegisterMatchRouteWithClosureAction()
+    {
+        $this->router->middleware('match-middleware')->match(['DELETE'], 'users', function () {
+            return 'deleted';
+        });
+
+        $this->seeResponse('deleted', Request::create('users', 'DELETE'));
+        $this->seeMiddleware('match-middleware');
+    }
+
+    public function testCanRegisterRouteWithArrayAndClosureAction()
+    {
+        $this->router->middleware('patch-middleware')->patch('users', [function () {
+            return 'updated';
+        }]);
+
+        $this->seeResponse('updated', Request::create('users', 'PATCH'));
+        $this->seeMiddleware('patch-middleware');
+    }
+
+    public function testCanRegisterRouteWithArrayAndClosureUsesAction()
+    {
+        $this->router->middleware('put-middleware')->put('users', ['uses' => function () {
+            return 'replaced';
+        }]);
+
+        $this->seeResponse('replaced', Request::create('users', 'PUT'));
+        $this->seeMiddleware('put-middleware');
+    }
+
+    public function testCanRegisterRouteWithControllerAction()
+    {
+        $this->router->middleware('controller-middleware')
+                     ->get('users', 'RouteRegistrarControllerStub@index');
+
+        $this->seeResponse('controller', Request::create('users', 'GET'));
+        $this->seeMiddleware('controller-middleware');
+    }
+
+    public function testCanRegisterRouteWithArrayAndControllerAction()
+    {
+        $this->router->middleware('controller-middleware')->put('users', [
+            'uses' => 'RouteRegistrarControllerStub@index',
+        ]);
+
+        $this->seeResponse('controller', Request::create('users', 'PUT'));
+        $this->seeMiddleware('controller-middleware');
+    }
+
+    public function testCanRegisterGroupWithMiddleware()
+    {
+        $this->router->middleware('group-middleware')->group(function ($router) {
+            $router->get('users', function () {
+                return 'all-users';
+            });
+        });
+
+        $this->seeResponse('all-users', Request::create('users', 'GET'));
+        $this->seeMiddleware('group-middleware');
+    }
+
+    public function testCanRegisterGroupWithNamespace()
+    {
+        $this->router->namespace('App\Http\Controllers')->group(function ($router) {
+            $router->get('users', 'UsersController@index');
+        });
+
+        $this->assertEquals(
+            'App\Http\Controllers\UsersController@index',
+            $this->getRoute()->getAction()['uses']
+        );
+    }
+
+    public function testCanRegisterGroupWithPrefix()
+    {
+        $this->router->prefix('api')->group(function ($router) {
+            $router->get('users', 'UsersController@index');
+        });
+
+        $this->assertEquals('api/users', $this->getRoute()->getUri());
+    }
+
+    public function testCanRegisterGroupWithNamePrefix()
+    {
+        $this->router->name('api.')->group(function ($router) {
+            $router->get('users', 'UsersController@index')->name('users');
+        });
+
+        $this->assertEquals('api.users', $this->getRoute()->getName());
+    }
+
+    public function testCanRegisterGroupWithDomain()
+    {
+        $this->router->domain('{account}.myapp.com')->group(function ($router) {
+            $router->get('users', 'UsersController@index');
+        });
+
+        $this->assertEquals('{account}.myapp.com', $this->getRoute()->domain());
+    }
+
+    public function testCanRegisterResource()
+    {
+        $this->router->middleware('resource-middleware')
+                     ->resource('users', 'RouteRegistrarControllerStub');
+
+        $this->seeResponse('deleted', Request::create('users/1', 'DELETE'));
+        $this->seeMiddleware('resource-middleware');
+    }
+
+    public function testCanSetRouteName()
+    {
+        $this->router->as('users.index')->get('users', function () {
+            return 'all-users';
+        });
+
+        $this->seeResponse('all-users', Request::create('users', 'GET'));
+        $this->assertEquals('users.index', $this->getRoute()->getName());
+    }
+
+    public function testCanSetRouteNameUsingNameAlias()
+    {
+        $this->router->name('users.index')->get('users', function () {
+            return 'all-users';
+        });
+
+        $this->seeResponse('all-users', Request::create('users', 'GET'));
+        $this->assertEquals('users.index', $this->getRoute()->getName());
+    }
+
+    /**
+     * Get the last route registered with the router.
+     *
+     * @return \Illuminate\Routing\Route
+     */
+    protected function getRoute()
+    {
+        return last($this->router->getRoutes()->get());
+    }
+
+    /**
+     * Assert that the last route has the given middleware.
+     *
+     * @param  string  $middleware
+     * @return void
+     */
+    protected function seeMiddleware($middleware)
+    {
+        $this->assertEquals($middleware, $this->getRoute()->middleware()[0]);
+    }
+
+    /**
+     * Assert that the last route has the given content.
+     *
+     * @param  string  $content
+     * @param  \Illuminate\Http\Request  $request
+     * @return void
+     */
+    protected function seeResponse($content, Request $request)
+    {
+        $route = $this->getRoute();
+
+        $this->assertTrue($route->matches($request));
+
+        $this->assertEquals($content, $route->bind($request)->run());
+    }
+}
+
+class RouteRegistrarControllerStub
+{
+    public function index()
+    {
+        return 'controller';
+    }
+}

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -116,6 +116,7 @@ class RouteRegistrarTest extends PHPUnit_Framework_TestCase
         $this->seeMiddleware('group-middleware');
     }
 
+
     public function testCanRegisterGroupWithNamespace()
     {
         $this->router->namespace('App\Http\Controllers')->group(function ($router) {
@@ -227,5 +228,10 @@ class RouteRegistrarControllerStub
     public function index()
     {
         return 'controller';
+    }
+
+    public function destroy()
+    {
+        return 'deleted';
     }
 }

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -116,7 +116,6 @@ class RouteRegistrarTest extends PHPUnit_Framework_TestCase
         $this->seeMiddleware('group-middleware');
     }
 
-
     public function testCanRegisterGroupWithNamespace()
     {
         $this->router->namespace('App\Http\Controllers')->group(function ($router) {

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -155,6 +155,26 @@ class RouteRegistrarTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('{account}.myapp.com', $this->getRoute()->domain());
     }
 
+    public function testCanRegisterGroupWithDomainAndNamePrefix()
+    {
+        $this->router->domain('{account}.myapp.com')->name('api.')->group(function ($router) {
+            $router->get('users', 'UsersController@index')->name('users');
+        });
+
+        $this->assertEquals('{account}.myapp.com', $this->getRoute()->domain());
+        $this->assertEquals('api.users', $this->getRoute()->getName());
+    }
+
+    /**
+     * @expectedException \BadMethodCallException
+     */
+    public function testRegisteringNonApprovedAttributesThrows()
+    {
+        $this->router->domain('foo')->missing('bar')->group(function ($router) {
+            //
+        });
+    }
+
     public function testCanRegisterResource()
     {
         $this->router->middleware('resource-middleware')

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -163,7 +163,7 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase
         $router->get('foo/bar', ['middleware' => 'foo', function () {
             return 'hello';
         }]);
-        $router->middleware('foo', function ($request, $next) {
+        $router->aliasMiddleware('foo', function ($request, $next) {
             return 'caught';
         });
         $this->assertEquals('caught', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
@@ -234,7 +234,7 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase
             return 'hello';
         }]);
 
-        $router->middleware('two', 'RoutingTestMiddlewareGroupTwo');
+        $router->aliasMiddleware('two', 'RoutingTestMiddlewareGroupTwo');
         $router->middlewareGroup('web', ['RoutingTestMiddlewareGroupOne', 'two:taylor']);
 
         $this->assertEquals('caught taylor', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
@@ -251,7 +251,7 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase
             return 'hello';
         }]);
 
-        $router->middleware('two', 'RoutingTestMiddlewareGroupTwo');
+        $router->aliasMiddleware('two', 'RoutingTestMiddlewareGroupTwo');
         $router->middlewareGroup('first', ['two:abigail']);
         $router->middlewareGroup('web', ['RoutingTestMiddlewareGroupOne', 'first']);
 

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -176,7 +176,7 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase
             'uses' => 'RouteTestClosureMiddlewareController@index',
             'middleware' => 'foo',
         ]);
-        $router->middleware('foo', function ($request, $next) {
+        $router->aliasMiddleware('foo', function ($request, $next) {
             $request['foo-middleware'] = 'foo-middleware';
 
             return $next($request);


### PR DESCRIPTION
This enables stuff like:

``` php
Route::name('users.index')->middleware('auth')->get('users', function () {
    // some closure action...
});
```

...so that the calls to `name` and `middleware` are not hanging off the end of the closure.

---

Also, you can now use the `middleware` method with groups:

``` php
Route::middleware('auth')->prefix('api')->group(function () {
    // register some routes...
});
```

---

Finally, you can now register middleware for resources directly:

``` php
Route::middleware('auth')->resource('photo', 'PhotoController');
```

---

**P.S.** This has been previously attempted in #14354. Taking another stab at it here after talking it through with Taylor.