### PR TITLE
[5.3] Add default parameters to UrlGenerator

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -461,7 +461,7 @@ class UrlGenerator implements UrlGeneratorContract
     protected function replaceRoutableParameters($parameters = [])
     {
         $parameters = array_merge(
-            $this->getDefaultParameters(), 
+            $this->getDefaultParameters(),
             is_array($parameters) ? $parameters : [$parameters]);
 
         foreach ($parameters as $key => $parameter) {

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -72,6 +72,13 @@ class UrlGenerator implements UrlGeneratorContract
     protected $sessionResolver;
 
     /**
+     * Default parameters.
+     *
+     * @var array
+     */
+    protected $defaultParameters = [];
+    
+    /**
      * Characters that should not be URL encoded.
      *
      * @var array
@@ -107,6 +114,26 @@ class UrlGenerator implements UrlGeneratorContract
         $this->setRequest($request);
     }
 
+    /**
+     * Get the default parameters.
+     *
+     * @return array
+     */
+    public function getDefaultParameters()
+    {
+        return $this->defaultParameters;
+    }
+
+    /**
+     * Set the default parameters.
+     *
+     * @return void
+     */
+    public function setDefaultParameters($key, $value)
+    {
+        $this->defaultParameters[$key] = $value;
+    }
+    
     /**
      * Get the full URL for the current request.
      *
@@ -308,7 +335,7 @@ class UrlGenerator implements UrlGeneratorContract
     public function route($name, $parameters = [], $absolute = true)
     {
         if (! is_null($route = $this->routes->getByName($name))) {
-            return $this->toRoute($route, $parameters, $absolute);
+            return $this->toRoute($route, array_merge($this->getDefaultParameters(), $parameters), $absolute);
         }
 
         throw new InvalidArgumentException("Route [{$name}] not defined.");

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -77,7 +77,7 @@ class UrlGenerator implements UrlGeneratorContract
      * @var array
      */
     protected $defaultParameters = [];
-    
+
     /**
      * Characters that should not be URL encoded.
      *
@@ -133,7 +133,7 @@ class UrlGenerator implements UrlGeneratorContract
     {
         $this->defaultParameters[$key] = $value;
     }
-    
+
     /**
      * Get the full URL for the current request.
      *

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -335,7 +335,7 @@ class UrlGenerator implements UrlGeneratorContract
     public function route($name, $parameters = [], $absolute = true)
     {
         if (! is_null($route = $this->routes->getByName($name))) {
-            return $this->toRoute($route, array_merge($this->getDefaultParameters(), $parameters), $absolute);
+            return $this->toRoute($route, $parameters, $absolute);
         }
 
         throw new InvalidArgumentException("Route [{$name}] not defined.");
@@ -460,7 +460,9 @@ class UrlGenerator implements UrlGeneratorContract
      */
     protected function replaceRoutableParameters($parameters = [])
     {
-        $parameters = is_array($parameters) ? $parameters : [$parameters];
+        $parameters = array_merge(
+            $this->getDefaultParameters(), 
+            is_array($parameters) ? $parameters : [$parameters]);
 
         foreach ($parameters as $key => $parameter) {
             if ($parameter instanceof UrlRoutable) {


### PR DESCRIPTION
Adding global parameters like 'locale' for creating URL by named routers without passing smth like ['locale' => config('app.locale')] in every url generator on page.
```
app("url")->setDefaultParameters("locale", app()->getLocale());
```
and create URLs via
```
app('router')->pattern('locale', '(' . implode('|', config('app.locales')). ')');
app('router')->group(['domain' => '{locale}.telenok.com'], function ()
{
    app("router")->post("some-url", array("as" => "some-name", "uses" => "SomeClass@somemethod"));
});
```
Then instead of 
```
<a href="{{  route("some-name") }}">.....</a>
```
you'll get
```
<a href="http://en.telenok.com/some-url">.....</a>
```
