### PR TITLE
[5.3] Custom event names throught broadcasting

### DIFF
--- a/src/Illuminate/Notifications/Events/BroadcastNotificationCreated.php
+++ b/src/Illuminate/Notifications/Events/BroadcastNotificationCreated.php
@@ -61,12 +61,12 @@ class BroadcastNotificationCreated implements ShouldBroadcast
 
         return [new PrivateChannel($this->channelName())];
     }
-    
+
     /**
-    * Set broadcasting event name.
-    *
-    * @return string 
-    */
+     * Set broadcasting event name.
+     *
+     * @return string 
+     */
     public function broadcastAs()
     {
         if (method_exists($this->notification, 'broadcastAs')) {

--- a/src/Illuminate/Notifications/Events/BroadcastNotificationCreated.php
+++ b/src/Illuminate/Notifications/Events/BroadcastNotificationCreated.php
@@ -61,6 +61,20 @@ class BroadcastNotificationCreated implements ShouldBroadcast
 
         return [new PrivateChannel($this->channelName())];
     }
+    
+    /**
+    * Set broadcasting event name.
+    *
+    * @return string 
+    */
+    public function broadcastAs()
+    {
+        if (method_exists($this->notification, 'broadcastAs')) {
+            return $this->notification->broadcastAs();
+        }
+
+        return get_class($this);
+    }
 
     /**
      * Get the data that should be sent with the broadcasted event.

--- a/src/Illuminate/Notifications/Events/BroadcastNotificationCreated.php
+++ b/src/Illuminate/Notifications/Events/BroadcastNotificationCreated.php
@@ -65,7 +65,7 @@ class BroadcastNotificationCreated implements ShouldBroadcast
     /**
      * Set broadcasting event name.
      *
-     * @return string 
+     * @return string
      */
     public function broadcastAs()
     {


### PR DESCRIPTION
As I found when using `Notifiable` trait on eloquent model (like Users) and when trying to send notifications:
`$user->notify(new TicketCreated());`

Laravel echo will always get notification with event name of `Illuminate\Notifications\Events\BroadcastNotificationCreated`, we can change channel name but not event name. 

So I extended class and added this possibly - if notification class (in my example `TicketCreated`) will have method named `broadcastAs()` it will take name from there.