### PR TITLE
[5.1] Change maintenance down file path (docker use case)

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -860,7 +860,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
      */
     public function isDownForMaintenance()
     {
-        return file_exists($this->storagePath().'/framework/down');
+        return file_exists($this->storagePath().'/framework/state/down');
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/DownCommand.php
+++ b/src/Illuminate/Foundation/Console/DownCommand.php
@@ -27,7 +27,7 @@ class DownCommand extends Command
      */
     public function fire()
     {
-        touch($this->laravel->storagePath().'/framework/down');
+        touch($this->laravel->storagePath().'/framework/state/down');
 
         $this->comment('Application is now in maintenance mode.');
     }

--- a/src/Illuminate/Foundation/Console/UpCommand.php
+++ b/src/Illuminate/Foundation/Console/UpCommand.php
@@ -27,7 +27,7 @@ class UpCommand extends Command
      */
     public function fire()
     {
-        @unlink($this->laravel->storagePath().'/framework/down');
+        @unlink($this->laravel->storagePath().'/framework/state/down');
 
         $this->info('Application is now live.');
     }


### PR DESCRIPTION
Change maintenance down file path so we can in the case you run laravel in a docker container mount the down file on the host by mounting the storage/framework/state folder.

Use case : when doing a blue green deployment with docker container where the aim is to deploy new container version then switch container in the load balancer, the goal is to keep the state of the app. As there is still a bug with docker when trying to mount a single file as a volume if the file does not exists, and as the down file is in framework folder which has the cache, sessions and view folders, we cannot mount this folder. So having the down file in another folder allows us to mount this folder and keep the maintenance state between deployments.

Of course it would be possible to solve this by getting the current state before deploy but would force in case the app is in maintenance to exec a command inside the container to touch the down file.

For a non breaking change, we could default this path in the config to `/framework/down`