### PR TITLE
[5.3] Improve interact with database testing 

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
@@ -2,6 +2,9 @@
 
 namespace Illuminate\Foundation\Testing\Concerns;
 
+use PHPUnit_Framework_Constraint_Not as ReverseConstraint;
+use Illuminate\Foundation\Testing\Constraints\HasInDatabase;
+
 trait InteractsWithDatabase
 {
     /**
@@ -10,19 +13,18 @@ trait InteractsWithDatabase
      * @param  string  $table
      * @param  array  $data
      * @param  string  $connection
+     * @param  bool  $reverse
      * @return $this
      */
-    protected function seeInDatabase($table, array $data, $connection = null)
+    protected function seeInDatabase($table, array $data, $connection = null, $reverse = false)
     {
-        $database = $this->app->make('db');
+        $constraint = new HasInDatabase($data, $this->getConnection($connection));
 
-        $connection = $connection ?: $database->getDefaultConnection();
+        if ($reverse) {
+            $constraint = new ReverseConstraint($constraint);
+        }
 
-        $count = $database->connection($connection)->table($table)->where($data)->count();
-
-        $this->assertGreaterThan(0, $count, sprintf(
-            'Unable to find row in database table [%s] that matched attributes [%s].', $table, json_encode($data)
-        ));
+        $this->assertThat($table, $constraint);
 
         return $this;
     }
@@ -63,17 +65,7 @@ trait InteractsWithDatabase
      */
     protected function notSeeInDatabase($table, array $data, $connection = null)
     {
-        $database = $this->app->make('db');
-
-        $connection = $connection ?: $database->getDefaultConnection();
-
-        $count = $database->connection($connection)->table($table)->where($data)->count();
-
-        $this->assertEquals(0, $count, sprintf(
-            'Found unexpected records in database table [%s] that matched attributes [%s].', $table, json_encode($data)
-        ));
-
-        return $this;
+        return $this->seeInDatabase($table, $data, $connection, true);
     }
 
     /**
@@ -87,5 +79,20 @@ trait InteractsWithDatabase
         $this->artisan('db:seed', ['--class' => $class]);
 
         return $this;
+    }
+
+    /**
+     * Get the database connection.
+     *
+     * @param  string|null  $connection
+     * @return \Illuminate\Database\Collection
+     */
+    protected function getConnection($connection = null)
+    {
+        $database = $this->app->make('db');
+
+        $connection = $connection ?: $database->getDefaultConnection();
+
+        return $database->connection($connection);
     }
 }

--- a/src/Illuminate/Foundation/Testing/Constraints/HasInDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Constraints/HasInDatabase.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Illuminate\Foundation\Testing\Constraints;
+
+use PHPUnit_Framework_Constraint;
+use Illuminate\Database\Connection;
+
+class HasInDatabase extends PHPUnit_Framework_Constraint
+{
+    /**
+     * Number of records that will be shown in the console in case of failure.
+     *
+     * @var int
+     */
+    protected $show = 5;
+
+    /**
+     * Database connection.
+     *
+     * @var \Illuminate\Database\Collection
+     */
+    protected $database;
+
+    /**
+     * Data that will be used to narrow the search in the database table.
+     *
+     * @var array
+     */
+    protected $data;
+
+    /**
+     * Name of the queried database table.
+     *
+     * @var string
+     */
+    protected $table;
+
+    /**
+     * Create a new constraint instance.
+     *
+     * @param  array  $data
+     * @param  \Illuminate\Database\Collection  $database
+     */
+    public function __construct(array $data, Connection $database)
+    {
+        $this->data = $data;
+
+        $this->database = $database;
+    }
+
+    /**
+     * Check if the data is found in the given table.
+     *
+     * @param  string  $table
+     * @return bool
+     */
+    public function matches($table)
+    {
+        $this->table = $table;
+
+        return $this->database->table($table)->where($this->data)->count() > 0;
+    }
+
+    /**
+     * Get the description of the failure.
+     *
+     * @param  string  $table
+     * @return string
+     */
+    public function failureDescription($table)
+    {
+        return sprintf(
+            "a row in the table [%s] matches the attributes %s.\n\n%s",
+            $table, $this->toString(), $this->getAdditionalInfo()
+        );
+    }
+
+    /**
+     * Get additional info about the records found in the database table.
+     *
+     * @return string
+     */
+    protected function getAdditionalInfo()
+    {
+        $results = $this->database->table($this->table)->get();
+
+        if ($results->isEmpty()) {
+            return "The table is empty";
+        }
+
+        $description = "Found: " . json_encode($results->take(5));
+
+        if ($results->count() > $this->show) {
+            $description .= sprintf(' and %s others', $results->count() - $this->show);
+        }
+
+        return $description;
+    }
+
+    /**
+     * Get a string representation of the object.
+     *
+     * @return string
+     */
+    public function toString()
+    {
+        return json_encode($this->data);
+    }
+}

--- a/src/Illuminate/Foundation/Testing/Constraints/HasInDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Constraints/HasInDatabase.php
@@ -29,13 +29,6 @@ class HasInDatabase extends PHPUnit_Framework_Constraint
     protected $data;
 
     /**
-     * Name of the queried database table.
-     *
-     * @var string
-     */
-    protected $table;
-
-    /**
      * Create a new constraint instance.
      *
      * @param  array  $data
@@ -56,8 +49,6 @@ class HasInDatabase extends PHPUnit_Framework_Constraint
      */
     public function matches($table)
     {
-        $this->table = $table;
-
         return $this->database->table($table)->where($this->data)->count() > 0;
     }
 
@@ -71,24 +62,25 @@ class HasInDatabase extends PHPUnit_Framework_Constraint
     {
         return sprintf(
             "a row in the table [%s] matches the attributes %s.\n\n%s",
-            $table, $this->toString(), $this->getAdditionalInfo()
+            $table, $this->toString(), $this->getAdditionalInfo($table)
         );
     }
 
     /**
      * Get additional info about the records found in the database table.
      *
+     * @param  string  $table
      * @return string
      */
-    protected function getAdditionalInfo()
+    protected function getAdditionalInfo($table)
     {
-        $results = $this->database->table($this->table)->get();
+        $results = $this->database->table($table)->get();
 
         if ($results->isEmpty()) {
-            return "The table is empty";
+            return 'The table is empty';
         }
 
-        $description = "Found: " . json_encode($results->take(5));
+        $description = 'Found: '.json_encode($results->take(5));
 
         if ($results->count() > $this->show) {
             $description .= sprintf(' and %s others', $results->count() - $this->show);

--- a/tests/Foundation/FoundationInteractsWithDatabaseTest.php
+++ b/tests/Foundation/FoundationInteractsWithDatabaseTest.php
@@ -1,0 +1,120 @@
+<?php
+
+use Mockery as m;
+
+use Illuminate\Database\Connection;
+use Illuminate\Database\Query\Builder;
+use Illuminate\Foundation\Testing\Concerns\InteractsWithDatabase;
+
+class FoundationInteractsWithDatabaseTest extends PHPUnit_Framework_TestCase
+{
+    use InteractsWithDatabase;
+
+    protected $table = 'products';
+
+    protected $data = ['title' => 'Spark'];
+
+    protected $connection;
+
+    protected $builder;
+
+    protected $builder2;
+
+    public function setUp()
+    {
+        $this->connection = m::mock(Connection::class);
+    }
+
+    public function tearDown()
+    {
+        m::close();
+    }
+
+    public function testSeeInDatabaseFindsResults()
+    {
+        $this->mockCountBuilder(1);
+
+        $this->seeInDatabase($this->table, $this->data);
+    }
+
+    /**
+     * @expectedException \PHPUnit_Framework_ExpectationFailedException
+     * @expectedExceptionMessage The table is empty.
+     */
+    public function testSeeInDatabaseDoesNotFindResults()
+    {
+        $builder = $this->mockCountBuilder(0);
+
+        $builder->shouldReceive('get')->once()->andReturn(collect());
+
+        $this->seeInDatabase($this->table, $this->data);
+    }
+
+    /**
+     * @expectedException \PHPUnit_Framework_ExpectationFailedException
+     * @expectedExceptionMessage Found: [{"title":"Forge"}].
+     */
+    public function testSeeInDatabaseFindsNotMatchingResults()
+    {
+        $builder = $this->mockCountBuilder(0);
+
+        $builder->shouldReceive('get')->once()->andReturn(collect([['title' => 'Forge']]));
+
+        $this->seeInDatabase($this->table, $this->data);
+    }
+
+    /**
+     * @expectedException \PHPUnit_Framework_ExpectationFailedException
+     * @expectedExceptionMessage Found: ["data","data","data","data","data"] and 1 others.
+     */
+    public function testSeeInDatabaseFindsManyNotMatchingResults()
+    {
+        $builder = $this->mockCountBuilder(0);
+
+        $builder->shouldReceive('get')->once()->andReturn(
+            collect(array_fill(0, 6, 'data'))
+        );
+
+        $this->seeInDatabase($this->table, $this->data);
+    }
+
+    public function testDontSeeInDatabaseDoesNotFindResults()
+    {
+        $this->mockCountBuilder(0);
+
+        $this->dontSeeInDatabase($this->table, $this->data);
+    }
+
+    /**
+     * @expectedException \PHPUnit_Framework_ExpectationFailedException
+     * @expectedExceptionMessage a row in the table [products] does not match the attributes {"title":"Spark"}
+     */
+    public function testDontSeeInDatabaseFindsResults()
+    {
+        $builder = $this->mockCountBuilder(1);
+
+        $builder->shouldReceive('get')->once()->andReturn(collect([$this->data]));
+
+        $this->dontSeeInDatabase($this->table, $this->data);
+    }
+
+    protected function mockCountBuilder($countResult)
+    {
+        $builder = m::mock(Builder::class);
+
+        $builder->shouldReceive('where')->with($this->data)->andReturnSelf();
+
+        $builder->shouldReceive('count')->andReturn($countResult);
+
+        $this->connection->shouldReceive('table')
+            ->with($this->table)
+            ->andReturn($builder);
+
+        return $builder;
+    }
+
+    protected function getConnection()
+    {
+        return $this->connection;
+    }
+}

--- a/tests/Foundation/FoundationInteractsWithDatabaseTest.php
+++ b/tests/Foundation/FoundationInteractsWithDatabaseTest.php
@@ -1,7 +1,6 @@
 <?php
 
 use Mockery as m;
-
 use Illuminate\Database\Connection;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Foundation\Testing\Concerns\InteractsWithDatabase;


### PR DESCRIPTION
Right now when `seeInDatabase` fails the developer does not get any feedback about what happened. Is the table empty? Was there a different record? 

So this code will tell the developer if the table is empty or if other results where found. I'm sure it'll get in finding the problem faster.

I'm also adding some tests.