### PR TITLE
[5.3] Fail tests that don't pass on PHP 7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@ env:
     - setup=basic
 
 matrix:
-  allow_failures:
-    - php: 7.1
   fast_finish: true
   include:
     - php: 5.6


### PR DESCRIPTION
Now that PHP 7.1 is stable, we should make its failed tests fail on Travis.