### PR TITLE
[5.3] Use 'sync' as queue name for Sync Queues

### DIFF
--- a/src/Illuminate/Queue/Jobs/SyncJob.php
+++ b/src/Illuminate/Queue/Jobs/SyncJob.php
@@ -76,4 +76,14 @@ class SyncJob extends Job implements JobContract
     {
         return '';
     }
+
+    /**
+     * Get the name of the queue the job belongs to.
+     *
+     * @return string
+     */
+    public function getQueue()
+    {
+        return 'sync';
+    }
 }


### PR DESCRIPTION
Used while logging failed sync jobs when running from within another parent job.

While inserting failure into the db we use `$job->getQueue()` to fill the `queue` field of the table, for Sync jobs the return of this method is null and thus causing database integrity errors since the field is not nullable.