### PR TITLE
[5.3] Fix storedAs virtualAs

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -708,7 +708,9 @@ class MySqlGrammar extends Grammar
      */
     protected function modifyNullable(Blueprint $blueprint, Fluent $column)
     {
-        return $column->nullable ? ' null' : ' not null';
+        if (is_null($column->virtualAs) && is_null($column->storedAs)) {
+            return $column->nullable ? ' null' : ' not null';
+        }
     }
 
     /**

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -357,7 +357,7 @@ class DatabaseMySqlSchemaGrammarTest extends PHPUnit_Framework_TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('alter table `products` add `price` int not null, add `discounted_virtual` int as (price - 5) not null, add `discounted_stored` int as (price - 5) stored not null', $statements[0]);
+        $this->assertEquals('alter table `products` add `price` int not null, add `discounted_virtual` int as (price - 5), add `discounted_stored` int as (price - 5) stored', $statements[0]);
     }
 
     public function testAddingString()


### PR DESCRIPTION
Fixes #16643

Currently the Grammar is appending ``` not null ``` and ``` null ``` when generating the ``` virtualAs ``` and ``` storedAs ``` columns.

This is an invalid syntax since these are generated columns so you can't use that, currently it's throwing:

```
Syntax error or access violation: 1064 You have an error in your SQL syntax
```

Example of current sql:

```sql
alter table `products` add `price` int not null, add `discounted_virtual` int as (price - 5) not null, add `discounted_stored` int as (price - 5) not null stored
```

after this fix

```sql
alter table `products` add `price` int not null, add `discounted_virtual` int as (price - 5), add `discounted_stored` int as (price - 5) stored
```