### PR TITLE
[5.3] Switch from Superclosure to Opis closure

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "ext-openssl": "*",
         "classpreloader/classpreloader": "~3.0",
         "doctrine/inflector": "~1.0",
-        "jeremeamia/superclosure": "~2.2",
+        "opis/closure": "~2.3",
         "league/flysystem": "~1.0",
         "monolog/monolog": "~1.11",
         "mtdowling/cron-expression": "~1.0",

--- a/src/Illuminate/Mail/Jobs/HandleQueuedMessage.php
+++ b/src/Illuminate/Mail/Jobs/HandleQueuedMessage.php
@@ -4,8 +4,8 @@ namespace Illuminate\Mail\Jobs;
 
 use Closure;
 use Illuminate\Support\Str;
-use SuperClosure\Serializer;
 use Illuminate\Contracts\Mail\Mailer;
+use Opis\Closure\SerializableClosure;
 use Illuminate\Queue\SerializesAndRestoresModelIdentifiers;
 
 class HandleQueuedMessage
@@ -71,7 +71,7 @@ class HandleQueuedMessage
         }
 
         if ($this->callback instanceof Closure) {
-            $this->callback = (new Serializer)->serialize($this->callback);
+            $this->callback = serialize(new SerializableClosure($this->callback));
         }
 
         return array_keys(get_object_vars($this));
@@ -89,7 +89,7 @@ class HandleQueuedMessage
         }
 
         if (Str::contains($this->callback, 'SerializableClosure')) {
-            $this->callback = (new Serializer)->unserialize($this->callback);
+            $this->callback = unserialize($this->callback)->getClosure();
         }
     }
 }


### PR DESCRIPTION
Switching from Superclosure to Opis closure was already mentioned a while back, before the 5.2 release (see https://github.com/laravel/framework/pull/9619) but wasn't discussed after the 5.2 release.

This PR switches the closure serialization library to Opis, simply out of performance reasons. 
The Opis closure analyzer is nearly twice as fast as the Superclosure analyzer without losing any features.