### PR TITLE
Fix for testing mail assertSentTo

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -86,10 +86,10 @@ class MailFake implements Mailer
 
         return $recipients->map(function ($recipient) {
             if (is_array($recipient)) {
-                return $recipient['email'];
+                return $recipient['address'];
             }
 
-            return is_object($recipient) ? $recipient->email : $recipient;
+            return is_object($recipient) ? $recipient->address : $recipient;
         })->diff($expected)->count() === 0;
     }
 


### PR DESCRIPTION
For the issue #16684  I found the problem on the MailFake class in recipientsMatch method.
When the mailable is sent the user email is pased like address and the recipientsMatch in the fake look for  for user->email instead it should look for user->addres, this can be fixed here on the fake class or in the Mailable class on buildRecipients method.  This PR solved the problem on the fake class changing $recipient email attribute for  $recipient address.

I can't found the test for the method.