### PR TITLE
[5.3] Fix date_format validation for all formats

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1834,7 +1834,7 @@ class Validator implements ValidatorContract
         if (! is_string($value) && ! is_numeric($value)) {
             return false;
         }
-        
+
         $date = DateTime::createFromFormat($parameters[0], $value);
 
         return $date && $date->format($parameters[0]) === $value;

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1834,10 +1834,10 @@ class Validator implements ValidatorContract
         if (! is_string($value) && ! is_numeric($value)) {
             return false;
         }
+        
+        $date = DateTime::createFromFormat($parameters[0], $value);
 
-        $parsed = date_parse_from_format($parameters[0], $value);
-
-        return $parsed['error_count'] === 0 && $parsed['warning_count'] === 0;
+        return $date && $date->format($parameters[0]) === $value;
     }
 
     /**


### PR DESCRIPTION
Fix date_format validation for all format

This PR fixes the case when validation rule is date_format:Y-m-d, It passes the format 16-01-01. But the year should be digit 4. 