### PR TITLE
[5.3] Avoid redundant "where" clauses on multiple calls to forPageAfterId()

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1493,6 +1493,11 @@ class Builder
      */
     public function forPageAfterId($perPage = 15, $lastId = 0, $column = 'id')
     {
+        $this->wheres = Collection::make($this->wheres)
+                ->reject(function ($where) use ($column) {
+                    return $where['column'] === $column;
+                })->values()->all();
+
         $this->orders = Collection::make($this->orders)
                 ->reject(function ($order) use ($column) {
                     return $order['column'] === $column;

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -8,7 +8,6 @@ use BadMethodCallException;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
-use Illuminate\Support\Collection;
 use Illuminate\Pagination\Paginator;
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\Contracts\Support\Arrayable;
@@ -1493,19 +1492,32 @@ class Builder
      */
     public function forPageAfterId($perPage = 15, $lastId = 0, $column = 'id')
     {
-        $this->wheres = Collection::make($this->wheres)
-                ->reject(function ($where) use ($column) {
-                    return $where['column'] === $column;
-                })->values()->all();
-
-        $this->orders = Collection::make($this->orders)
-                ->reject(function ($order) use ($column) {
-                    return $order['column'] === $column;
-                })->values()->all();
+        $this->wheres = $this->filterOutClauses($this->wheres, $column);
+        $this->orders = $this->filterOutClauses($this->orders, $column);
 
         return $this->where($column, '>', $lastId)
                     ->orderBy($column, 'asc')
                     ->take($perPage);
+    }
+
+    /**
+     * Filter out clauses on a given column from an array of clauses.
+     *
+     * @param  array  $clauses
+     * @param  string  $column
+     * @return array
+     */
+    protected function filterOutClauses($clauses, $column)
+    {
+        if (is_null($clauses)) {
+            return;
+        }
+
+        $clauses = array_filter($clauses, function ($clause) use ($column) {
+            return $clause['column'] !== $column;
+        });
+
+        return array_values($clauses);
     }
 
     /**

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -999,6 +999,24 @@ class DatabaseEloquentIntegrationTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(1, count($results));
     }
 
+    public function testForPageAfterIdDoesntProduceRedundantClauses()
+    {
+        $query = EloquentTestUser::query();
+
+        $this->assertNull($query->toBase()->wheres);
+        $this->assertNull($query->toBase()->orders);
+
+        $query->forPageAfterId(15, 1);
+
+        $this->assertCount(1, $query->toBase()->wheres);
+        $this->assertCount(1, $query->toBase()->orders);
+
+        $query->forPageAfterId(15, 1);
+
+        $this->assertCount(1, $query->toBase()->wheres);
+        $this->assertCount(1, $query->toBase()->orders);
+    }
+
     public function testMorphToRelationsAcrossDatabaseConnections()
     {
         $item = null;


### PR DESCRIPTION
Alternative to #16498.

Also filtering without using Collections, I think it's clearer this way (and about 10x faster).
Note the current code may receive `Collection::make(null)`, thankfully this was working still.