### PR TITLE
[5.4] Able to use multiple Redis cluster and non-cluster instances together

### DIFF
--- a/src/Illuminate/Redis/Database.php
+++ b/src/Illuminate/Redis/Database.php
@@ -10,8 +10,9 @@ abstract class Database implements DatabaseContract
     /**
      * Get a specific Redis connection instance.
      *
-     * @param  string  $name
-     * @return \Predis\ClientInterface|null
+     * @param string $name
+     *
+     * @return \Predis\ClientInterface|\RedisCluster|\Redis|null
      */
     public function connection($name = 'default')
     {
@@ -21,8 +22,9 @@ abstract class Database implements DatabaseContract
     /**
      * Run a command against the Redis database.
      *
-     * @param  string  $method
-     * @param  array   $parameters
+     * @param string $method
+     * @param array  $parameters
+     *
      * @return mixed
      */
     public function command($method, array $parameters = [])
@@ -33,8 +35,9 @@ abstract class Database implements DatabaseContract
     /**
      * Dynamically make a Redis command.
      *
-     * @param  string  $method
-     * @param  array   $parameters
+     * @param string $method
+     * @param array  $parameters
+     *
      * @return mixed
      */
     public function __call($method, $parameters)

--- a/src/Illuminate/Redis/Database.php
+++ b/src/Illuminate/Redis/Database.php
@@ -10,8 +10,7 @@ abstract class Database implements DatabaseContract
     /**
      * Get a specific Redis connection instance.
      *
-     * @param string $name
-     *
+     * @param  string  $name
      * @return \Predis\ClientInterface|\RedisCluster|\Redis|null
      */
     public function connection($name = 'default')
@@ -22,9 +21,8 @@ abstract class Database implements DatabaseContract
     /**
      * Run a command against the Redis database.
      *
-     * @param string $method
-     * @param array  $parameters
-     *
+     * @param  string  $method
+     * @param  array   $parameters
      * @return mixed
      */
     public function command($method, array $parameters = [])
@@ -35,9 +33,8 @@ abstract class Database implements DatabaseContract
     /**
      * Dynamically make a Redis command.
      *
-     * @param string $method
-     * @param array  $parameters
-     *
+     * @param  string  $method
+     * @param  array   $parameters
      * @return mixed
      */
     public function __call($method, $parameters)

--- a/src/Illuminate/Redis/PhpRedisDatabase.php
+++ b/src/Illuminate/Redis/PhpRedisDatabase.php
@@ -20,6 +20,7 @@ class PhpRedisDatabase extends Database
      * Create a new Redis connection instance.
      *
      * @param array $servers
+     * @return void
      */
     public function __construct(array $servers = [])
     {
@@ -42,6 +43,7 @@ class PhpRedisDatabase extends Database
      *
      * @param array $clusters
      * @param array $options
+     * @return void
      */
     protected function createClusters(array $clusters, array $options = [])
     {
@@ -62,7 +64,6 @@ class PhpRedisDatabase extends Database
      * @param array  $servers
      * @param array  $options
      * @param string $connection
-     *
      * @return array
      */
     protected function createAggregateClient(array $servers, array $options = [], $connection = 'default')
@@ -77,7 +78,6 @@ class PhpRedisDatabase extends Database
      *
      * @param array $servers
      * @param array $options
-     *
      * @return array
      */
     protected function createSingleClients(array $servers, array $options = [])
@@ -96,7 +96,6 @@ class PhpRedisDatabase extends Database
      * Build a single cluster seed string from array.
      *
      * @param array $server
-     *
      * @return string
      */
     protected function buildClusterSeed(array $server)
@@ -127,6 +126,7 @@ class PhpRedisDatabase extends Database
      * @param array|string $channels
      * @param \Closure     $callback
      * @param string       $connection
+     * @return void
      */
     public function psubscribe($channels, Closure $callback, $connection = null)
     {
@@ -138,7 +138,6 @@ class PhpRedisDatabase extends Database
      *
      * @param array $servers
      * @param array $options
-     *
      * @return RedisCluster
      */
     protected function createRedisClusterInstance(array $servers, array $options)
@@ -157,7 +156,6 @@ class PhpRedisDatabase extends Database
      *
      * @param array $server
      * @param array $options
-     *
      * @return Redis
      */
     protected function createRedisInstance(array $server, array $options)
@@ -172,19 +170,19 @@ class PhpRedisDatabase extends Database
             $client->connect($server['host'], $server['port'], $timeout);
         }
 
-        if (!empty($server['prefix'])) {
+        if (! empty($server['prefix'])) {
             $client->setOption(Redis::OPT_PREFIX, $server['prefix']);
         }
 
-        if (!empty($server['read_timeout'])) {
+        if (! empty($server['read_timeout'])) {
             $client->setOption(Redis::OPT_READ_TIMEOUT, $server['read_timeout']);
         }
 
-        if (!empty($server['password'])) {
+        if (! empty($server['password'])) {
             $client->auth($server['password']);
         }
 
-        if (!empty($server['database'])) {
+        if (! empty($server['database'])) {
             $client->select($server['database']);
         }
 

--- a/src/Illuminate/Redis/PhpRedisDatabase.php
+++ b/src/Illuminate/Redis/PhpRedisDatabase.php
@@ -19,7 +19,7 @@ class PhpRedisDatabase extends Database
     /**
      * Create a new Redis connection instance.
      *
-     * @param array $servers
+     * @param  array  $servers
      * @return void
      */
     public function __construct(array $servers = [])
@@ -41,8 +41,8 @@ class PhpRedisDatabase extends Database
     /**
      * Create multiple clusters (aggregate clients).
      *
-     * @param array $clusters
-     * @param array $options
+     * @param  array  $clusters
+     * @param  array  $options
      * @return void
      */
     protected function createClusters(array $clusters, array $options = [])
@@ -61,9 +61,9 @@ class PhpRedisDatabase extends Database
     /**
      * Create a new aggregate client supporting sharding.
      *
-     * @param array  $servers
-     * @param array  $options
-     * @param string $connection
+     * @param  array  $servers
+     * @param  array  $options
+     * @param  string  $connection
      * @return array
      */
     protected function createAggregateClient(array $servers, array $options = [], $connection = 'default')
@@ -76,8 +76,8 @@ class PhpRedisDatabase extends Database
     /**
      * Create an array of single connection clients.
      *
-     * @param array $servers
-     * @param array $options
+     * @param  array  $servers
+     * @param  array  $options
      * @return array
      */
     protected function createSingleClients(array $servers, array $options = [])
@@ -95,7 +95,7 @@ class PhpRedisDatabase extends Database
     /**
      * Build a single cluster seed string from array.
      *
-     * @param array $server
+     * @param  array  $server
      * @return string
      */
     protected function buildClusterSeed(array $server)
@@ -110,10 +110,11 @@ class PhpRedisDatabase extends Database
     /**
      * Subscribe to a set of given channels for messages.
      *
-     * @param array|string $channels
-     * @param \Closure     $callback
-     * @param string       $connection
-     * @param string       $method
+     * @param  array|string  $channels
+     * @param  \Closure  $callback
+     * @param  string  $connection
+     * @param  string  $method
+     * @return void
      */
     public function subscribe($channels, Closure $callback, $connection = null, $method = 'subscribe')
     {
@@ -123,9 +124,9 @@ class PhpRedisDatabase extends Database
     /**
      * Subscribe to a set of given channels with wildcards.
      *
-     * @param array|string $channels
-     * @param \Closure     $callback
-     * @param string       $connection
+     * @param  array|string  $channels
+     * @param  \Closure  $callback
+     * @param  string  $connection
      * @return void
      */
     public function psubscribe($channels, Closure $callback, $connection = null)
@@ -136,8 +137,8 @@ class PhpRedisDatabase extends Database
     /**
      * Create a new redis cluster instance.
      *
-     * @param array $servers
-     * @param array $options
+     * @param  array  $servers
+     * @param  array  $options
      * @return RedisCluster
      */
     protected function createRedisClusterInstance(array $servers, array $options)
@@ -154,8 +155,8 @@ class PhpRedisDatabase extends Database
     /**
      * Create a new redis instance.
      *
-     * @param array $server
-     * @param array $options
+     * @param  array  $server
+     * @param  array  $options
      * @return Redis
      */
     protected function createRedisInstance(array $server, array $options)

--- a/src/Illuminate/Redis/PredisDatabase.php
+++ b/src/Illuminate/Redis/PredisDatabase.php
@@ -18,7 +18,7 @@ class PredisDatabase extends Database
     /**
      * Create a new Redis connection instance.
      *
-     * @param array $servers
+     * @param  array  $servers
      * @return void
      */
     public function __construct(array $servers = [])
@@ -40,8 +40,8 @@ class PredisDatabase extends Database
     /**
      * Create multiple clusters (aggregate clients).
      *
-     * @param array $clusters
-     * @param array $options
+     * @param  array  $clusters
+     * @param  array  $options
      * @return void
      */
     protected function createClusters(array $clusters, array $options = [])
@@ -60,9 +60,9 @@ class PredisDatabase extends Database
     /**
      * Create a new aggregate client supporting sharding.
      *
-     * @param array  $servers
-     * @param array  $options
-     * @param string $connection
+     * @param  array  $servers
+     * @param  array  $options
+     * @param  string  $connection
      * @return array
      */
     protected function createAggregateClient(array $servers, array $options = [], $connection = 'default')
@@ -73,8 +73,8 @@ class PredisDatabase extends Database
     /**
      * Create an array of single connection clients.
      *
-     * @param array $servers
-     * @param array $options
+     * @param  array  $servers
+     * @param  array  $options
      * @return array
      */
     protected function createSingleClients(array $servers, array $options = [])
@@ -91,10 +91,10 @@ class PredisDatabase extends Database
     /**
      * Subscribe to a set of given channels for messages.
      *
-     * @param array|string $channels
-     * @param \Closure     $callback
-     * @param string       $connection
-     * @param string       $method
+     * @param  array|string  $channels
+     * @param  \Closure  $callback
+     * @param  string  $connection
+     * @param  string  $method
      * @return void
      */
     public function subscribe($channels, Closure $callback, $connection = null, $method = 'subscribe')
@@ -115,9 +115,9 @@ class PredisDatabase extends Database
     /**
      * Subscribe to a set of given channels with wildcards.
      *
-     * @param array|string $channels
-     * @param \Closure     $callback
-     * @param string       $connection
+     * @param  array|string  $channels
+     * @param  \Closure  $callback
+     * @param  string  $connection
      * @return void
      */
     public function psubscribe($channels, Closure $callback, $connection = null)

--- a/src/Illuminate/Redis/PredisDatabase.php
+++ b/src/Illuminate/Redis/PredisDatabase.php
@@ -19,6 +19,7 @@ class PredisDatabase extends Database
      * Create a new Redis connection instance.
      *
      * @param array $servers
+     * @return void
      */
     public function __construct(array $servers = [])
     {
@@ -41,6 +42,7 @@ class PredisDatabase extends Database
      *
      * @param array $clusters
      * @param array $options
+     * @return void
      */
     protected function createClusters(array $clusters, array $options = [])
     {
@@ -61,7 +63,6 @@ class PredisDatabase extends Database
      * @param array  $servers
      * @param array  $options
      * @param string $connection
-     *
      * @return array
      */
     protected function createAggregateClient(array $servers, array $options = [], $connection = 'default')
@@ -74,7 +75,6 @@ class PredisDatabase extends Database
      *
      * @param array $servers
      * @param array $options
-     *
      * @return array
      */
     protected function createSingleClients(array $servers, array $options = [])
@@ -95,6 +95,7 @@ class PredisDatabase extends Database
      * @param \Closure     $callback
      * @param string       $connection
      * @param string       $method
+     * @return void
      */
     public function subscribe($channels, Closure $callback, $connection = null, $method = 'subscribe')
     {
@@ -117,6 +118,7 @@ class PredisDatabase extends Database
      * @param array|string $channels
      * @param \Closure     $callback
      * @param string       $connection
+     * @return void
      */
     public function psubscribe($channels, Closure $callback, $connection = null)
     {

--- a/src/Illuminate/Redis/RedisServiceProvider.php
+++ b/src/Illuminate/Redis/RedisServiceProvider.php
@@ -16,6 +16,8 @@ class RedisServiceProvider extends ServiceProvider
 
     /**
      * Register the service provider.
+     *
+     * @return void
      */
     public function register()
     {

--- a/src/Illuminate/Redis/RedisServiceProvider.php
+++ b/src/Illuminate/Redis/RedisServiceProvider.php
@@ -16,8 +16,6 @@ class RedisServiceProvider extends ServiceProvider
 
     /**
      * Register the service provider.
-     *
-     * @return void
      */
     public function register()
     {

--- a/tests/Redis/PhpRedisConnectionTest.php
+++ b/tests/Redis/PhpRedisConnectionTest.php
@@ -96,5 +96,5 @@ class RedisStub
 }
 
 class RedisClusterStub
-{  
+{
 }

--- a/tests/Redis/PhpRedisConnectionTest.php
+++ b/tests/Redis/PhpRedisConnectionTest.php
@@ -1,8 +1,10 @@
 <?php
 
-class RedisConnectionTest extends PHPUnit_Framework_TestCase
+use Illuminate\Redis\PhpRedisDatabase;
+
+class PhpRedisConnectionTest extends PHPUnit_Framework_TestCase
 {
-    public function testRedisNotCreateClusterAndOptionsAndClustersServer()
+    public function testPhpRedisNotCreateClusterAndOptionsAndClustersServer()
     {
         $redis = $this->getRedis(false);
 
@@ -16,25 +18,28 @@ class RedisConnectionTest extends PHPUnit_Framework_TestCase
         $this->assertNull($client, 'clusters parameter should not create as redis server');
     }
 
-    public function testRedisClusterNotCreateClusterAndOptionsServer()
+    public function testPhpRedisClusterNotCreateClusterAndOptionsServer()
     {
         $redis = $this->getRedis(true);
+
         $client = $redis->connection();
 
-        $this->assertCount(1, $client->getConnection());
+        $this->assertInstanceOf(RedisClusterStub::class, $client);
     }
 
-    public function testRedisClusterCreateMultipleClustersAndNotCreateOptionsServer()
+    public function testPhpRedisClusterCreateMultipleClustersAndNotCreateOptionsServer()
     {
         $redis = $this->getRedis();
+
         $clusterOne = $redis->connection('cluster-1');
         $clusterTwo = $redis->connection('cluster-2');
 
-        $this->assertCount(1, $clusterOne->getConnection());
-        $this->assertCount(1, $clusterTwo->getConnection());
+        $this->assertInstanceOf(RedisClusterStub::class, $clusterOne);
+        $this->assertInstanceOf(RedisClusterStub::class, $clusterTwo);
 
         $client = $redis->connection('options');
         $this->assertNull($client, 'options parameter should not create as redis server');
+
     }
 
     protected function getRedis($cluster = false)
@@ -42,8 +47,8 @@ class RedisConnectionTest extends PHPUnit_Framework_TestCase
         $servers = [
             'cluster' => $cluster,
             'default' => [
-                'host'     => '127.0.0.1',
-                'port'     => 6379,
+                'host' => '127.0.0.1',
+                'port' => 6379,
                 'database' => 0,
             ],
             'options' => [
@@ -55,21 +60,38 @@ class RedisConnectionTest extends PHPUnit_Framework_TestCase
                 ],
                 'cluster-1' => [
                     [
-                        'host'     => '127.0.0.1',
-                        'port'     => 6379,
+                        'host' => '127.0.0.1',
+                        'port' => 6379,
                         'database' => 0,
                     ],
                 ],
                 'cluster-2' => [
                     [
-                        'host'     => '127.0.0.1',
-                        'port'     => 6379,
+                        'host' => '127.0.0.1',
+                        'port' => 6379,
                         'database' => 0,
                     ]
                 ],
             ],
         ];
 
-        return new Illuminate\Redis\PredisDatabase($servers);
+        return new PhpRedisDatabaseStub($servers);
     }
 }
+
+class PhpRedisDatabaseStub extends PhpRedisDatabase
+{
+    protected function createRedisClusterInstance(array $servers, array $options)
+    {
+        return new RedisClusterStub();
+    }
+
+    protected function createRedisInstance(array $server, array $options)
+    {
+        return new RedisStub;
+    }
+}
+
+class RedisStub {}
+
+class RedisClusterStub {}

--- a/tests/Redis/PhpRedisConnectionTest.php
+++ b/tests/Redis/PhpRedisConnectionTest.php
@@ -39,7 +39,6 @@ class PhpRedisConnectionTest extends PHPUnit_Framework_TestCase
 
         $client = $redis->connection('options');
         $this->assertNull($client, 'options parameter should not create as redis server');
-
     }
 
     protected function getRedis($cluster = false)
@@ -94,10 +93,8 @@ class PhpRedisDatabaseStub extends PhpRedisDatabase
 
 class RedisStub
 {
-
 }
 
 class RedisClusterStub
-{
-    
+{  
 }

--- a/tests/Redis/PhpRedisConnectionTest.php
+++ b/tests/Redis/PhpRedisConnectionTest.php
@@ -56,7 +56,7 @@ class PhpRedisConnectionTest extends PHPUnit_Framework_TestCase
             ],
             'clusters' => [
                 'options' => [
-                    'prefix' => 'cluster:'
+                    'prefix' => 'cluster:',
                 ],
                 'cluster-1' => [
                     [
@@ -70,7 +70,7 @@ class PhpRedisConnectionTest extends PHPUnit_Framework_TestCase
                         'host' => '127.0.0.1',
                         'port' => 6379,
                         'database' => 0,
-                    ]
+                    ],
                 ],
             ],
         ];
@@ -92,6 +92,12 @@ class PhpRedisDatabaseStub extends PhpRedisDatabase
     }
 }
 
-class RedisStub {}
+class RedisStub
+{
 
-class RedisClusterStub {}
+}
+
+class RedisClusterStub
+{
+    
+}

--- a/tests/Redis/RedisConnectionTest.php
+++ b/tests/Redis/RedisConnectionTest.php
@@ -51,7 +51,7 @@ class RedisConnectionTest extends PHPUnit_Framework_TestCase
             ],
             'clusters' => [
                 'options' => [
-                    'prefix' => 'cluster:'
+                    'prefix' => 'cluster:',
                 ],
                 'cluster-1' => [
                     [
@@ -65,7 +65,7 @@ class RedisConnectionTest extends PHPUnit_Framework_TestCase
                         'host'     => '127.0.0.1',
                         'port'     => 6379,
                         'database' => 0,
-                    ]
+                    ],
                 ],
             ],
         ];


### PR DESCRIPTION
This PR allows user to create and use multiple Redis cluster as well as non-cluster instances.

**Sample configs:**

1. Multiple Redis clusters:

```php
    'redis' => [
        'clusters' => [
            'redis-cluster-1' => [
                [
                    'host'     => '127.0.0.1',
                    'port'     => 6379,
                    'database' => 0,
                ],
                [
                    'host'     => '127.0.0.1',
                    'port'     => 6380,
                    'database' => 0,
                ],
            ],
            'redis-cluster-2' => [
                [
                    'host'     => '127.0.0.1',
                    'port'     => 7379,
                    'database' => 0,
                ],
                [
                    'host'     => '127.0.0.1',
                    'port'     => 7380,
                    'database' => 0,
                ],
            ],
        ],
    ],
```

2. Multiple Redis clusters with different options:

```php
    'redis' => [
        'clusters' => [
            'redis-cluster-1' => [
                'options' => [
                    'cluster' => 'redis',
                ],
                [
                    'host'     => '127.0.0.1',
                    'port'     => 6379,
                    'database' => 0,
                ],
                [
                    'host'     => '127.0.0.1',
                    'port'     => 6380,
                    'database' => 0,
                ],
            ],
            'redis-cluster-2' => [
                'options' => [
                    'cluster' => 'predis',
                ],
                [
                    'host'     => '127.0.0.1',
                    'port'     => 7379,
                    'database' => 0,
                ],
                [
                    'host'     => '127.0.0.1',
                    'port'     => 7380,
                    'database' => 0,
                ],
            ],
        ],
    ],
```

3. Single Redis cluster and two non-cluster instances:

```php
    'redis' => [
        'default' => [
            'host' => '127.0.0.1',
            'port' => 16379,
            'database' => 0,
        ],
        'queue' => [
            'host' => '127.0.0.1',
            'port' => 26379,
            'database' => 0,
        ],
        'clusters' => [
            'redis-cluster' => [
                [
                    'host'     => '127.0.0.1',
                    'port'     => 6379,
                    'database' => 0,
                ],
                [
                    'host'     => '127.0.0.1',
                    'port'     => 6380,
                    'database' => 0,
                ],
            ],
        ],
    ],
```

4. **It won't break anything!** (unless you're using `clusters` as a key!)
(Maybe we can deprecate `cluster` option after merging this PR?)

```php
   'redis' => [
        'cluster' => true,
        'default' => [
            'host' => '127.0.0.1',
            'port' => 16379,
            'database' => 0,
        ],
        'clusters' => [
            'redis-cluster-1' => [
                [
                    'host'     => '127.0.0.1',
                    'port'     => 6379,
                    'database' => 0,
                ]
            ],
            'redis-cluster-2' => [
                [
                    'host'     => '127.0.0.1',
                    'port'     => 7379,
                    'database' => 0,
                ]
            ],
        ],
    ],
```
With above config, we have 3 connections which all of them are clusters: `default`, `redis-cluster-1`, `redis-cluster-2`

-------
I also add some tests for `PhpRedis`. They're not good but better than nothing!! If you can make them better, Please tell me or of course you can send an another PR :D
