### PR TITLE
[5.3] Apply global to email addres to CC and BCC

### DIFF
--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -189,6 +189,8 @@ class Mailer implements MailerContract, MailQueueContract
 
         if (isset($this->to['address'])) {
             $message->to($this->to['address'], $this->to['name'], true);
+            $message->cc($this->to['address'], $this->to['name'], true);
+            $message->bcc($this->to['address'], $this->to['name'], true);
         }
 
         $message = $message->getSwiftMessage();

--- a/src/Illuminate/Mail/Message.php
+++ b/src/Illuminate/Mail/Message.php
@@ -90,10 +90,17 @@ class Message
      *
      * @param  string|array  $address
      * @param  string|null  $name
+     * @param  bool  $override
      * @return $this
      */
-    public function cc($address, $name = null)
+    public function cc($address, $name = null, $override = false)
     {
+        if ($override) {
+            $this->swift->setTo($address, $name);
+
+            return $this;
+        }
+
         return $this->addAddresses($address, $name, 'Cc');
     }
 
@@ -102,10 +109,17 @@ class Message
      *
      * @param  string|array  $address
      * @param  string|null  $name
+     * @param  bool  $override
      * @return $this
      */
-    public function bcc($address, $name = null)
+    public function bcc($address, $name = null, $override = false)
     {
+        if ($override) {
+            $this->swift->setTo($address, $name);
+
+            return $this;
+        }
+
         return $this->addAddresses($address, $name, 'Bcc');
     }
 

--- a/src/Illuminate/Mail/Message.php
+++ b/src/Illuminate/Mail/Message.php
@@ -96,7 +96,7 @@ class Message
     public function cc($address, $name = null, $override = false)
     {
         if ($override) {
-            $this->swift->setTo($address, $name);
+            $this->swift->setCc($address, $name);
 
             return $this;
         }
@@ -115,7 +115,7 @@ class Message
     public function bcc($address, $name = null, $override = false)
     {
         if ($override) {
-            $this->swift->setTo($address, $name);
+            $this->swift->setBcc($address, $name);
 
             return $this;
         }


### PR DESCRIPTION
As I was testing I noticed that the emails I was sending with Laravel were sent to the BCC address I provided. Unfortunately this wasn't the global "to email address" I set in the `config/mail.php`

I have created this pull request to fix this issue. I hope this will be merged because that's the way how I interpreted "global to address" and I think I'm not the only one. Correct me if I'm wrong!