### PR TITLE
[5.4] Allow route groups to be loaded from a file directly

### DIFF
--- a/src/Illuminate/Contracts/Routing/Registrar.php
+++ b/src/Illuminate/Contracts/Routing/Registrar.php
@@ -2,8 +2,6 @@
 
 namespace Illuminate\Contracts\Routing;
 
-use Closure;
-
 interface Registrar
 {
     /**
@@ -83,11 +81,11 @@ interface Registrar
     /**
      * Create a route group with shared attributes.
      *
-     * @param  array     $attributes
-     * @param  \Closure  $callback
+     * @param  array  $attributes
+     * @param  \Closure|string  $routes
      * @return void
      */
-    public function group(array $attributes, Closure $callback);
+    public function group(array $attributes, $routes);
 
     /**
      * Substitute the route bindings onto the route.

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -320,17 +320,23 @@ class Router implements RegistrarContract, BindingRegistrar
      * Create a route group with shared attributes.
      *
      * @param  array  $attributes
-     * @param  \Closure  $callback
+     * @param  \Closure|string  $routes
      * @return void
      */
-    public function group(array $attributes, Closure $callback)
+    public function group(array $attributes, $routes)
     {
         $this->updateGroupStack($attributes);
 
-        // Once we have updated the group stack, we will execute the user Closure and
-        // merge in the groups attributes when the route is created. After we have
-        // run the callback, we will pop the attributes off of this group stack.
-        call_user_func($callback, $this);
+        // Once we have updated the group stack, we'll load the provided routes and
+        // merge in the group's attributes when the routes are created. After we
+        // have created the routes, we will pop the attributes off the stack.
+        if ($routes instanceof Closure) {
+            $routes($this);
+        } else {
+            $router = $this;
+
+            require $routes;
+        }
 
         array_pop($this->groupStack);
     }

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -729,6 +729,18 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('foo', $routes[0]->getPrefix());
     }
 
+    public function testRouteGroupingFromFile()
+    {
+        $router = $this->getRouter();
+        $router->group(['prefix' => 'api'], __DIR__.'/fixtures/routes.php');
+
+        $route = last($router->getRoutes()->get());
+        $request = Request::create('api/users', 'GET');
+
+        $this->assertTrue($route->matches($request));
+        $this->assertEquals('all-users', $route->bind($request)->run($request));
+    }
+
     public function testRouteGroupingWithAs()
     {
         $router = $this->getRouter();

--- a/tests/Routing/fixtures/routes.php
+++ b/tests/Routing/fixtures/routes.php
@@ -1,0 +1,5 @@
+<?php
+
+$router->get('users', function () {
+    return 'all-users';
+});


### PR DESCRIPTION
Since keeping the route definitions for each group in its own file is a common pattern, this PR allows the file path to be passed directly to the `group` method on the router.

---

Will convert this:

``` php
Route::prefix('api')
     ->middleware('api|auth:api')
     ->namespace($this->namespace)
     ->group(function ($router) {
         require base_path('routes/api.php');
     });
```

into this:

``` php
Route::prefix('api')
     ->middleware('api|auth:api')
     ->namespace($this->namespace)
     ->group(base_path('routes/api.php'));
```

---

This is another attempt at #14572
