### PR TITLE
Adds the missing return statement.

### DIFF
--- a/src/Illuminate/Auth/GuardHelpers.php
+++ b/src/Illuminate/Auth/GuardHelpers.php
@@ -69,6 +69,8 @@ trait GuardHelpers
         if ($this->user()) {
             return $this->user()->getAuthIdentifier();
         }
+
+        return null;
     }
 
     /**


### PR DESCRIPTION
If the user is null, then the method is void. Adds the missing return line.