### PR TITLE
Allow a Collection as an argument of only()

### DIFF
--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1375,6 +1375,7 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
         $data = new Collection(['first' => 'Taylor', 'last' => 'Otwell', 'email' => 'taylorotwell@gmail.com']);
 
         $this->assertEquals($data->all(), $data->only(null)->all());
+        $this->assertEquals($data->all(), $data->only(new Collection(['first', 'missing']))->all());
         $this->assertEquals(['first' => 'Taylor'], $data->only(['first', 'missing'])->all());
         $this->assertEquals(['first' => 'Taylor'], $data->only('first', 'missing')->all());
 


### PR DESCRIPTION
Currently, sending a Collection object as an argument will simply wrap the object in an array and pass it on to the underlying implementation, due to func_get_args().

I think it should either throw an error or properly handle it with getArrayableItems(), obviously the caller can just use ->all() on the collection before sending, but I think it would be better to be more consistent with other Collection functions and allow Collection objects to be passed as an argument.