### PR TITLE
[5.3] Fixed typo

### DIFF
--- a/src/Illuminate/Database/Connectors/Connector.php
+++ b/src/Illuminate/Database/Connectors/Connector.php
@@ -127,7 +127,7 @@ class Connector
      */
     protected function isPersistentConnection($options)
     {
-        if (isset($options[PDO::ATTR_PERSISTENT]) && $options[PDO::ATTR_PERISISTENT]) {
+        if (isset($options[PDO::ATTR_PERSISTENT]) && $options[PDO::ATTR_PERSISTENT]) {
             return true;
         }
 


### PR DESCRIPTION
We both seem to have missed that I that sneaked in there.

PDO::ATTR_PERISISTENT => PDO::ATTR_PERSISTENT