### PR TITLE
[5.3] Added HasOne Through and BelongsTo Through

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -6,6 +6,7 @@ use Closure;
 use Exception;
 use ArrayAccess;
 use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Relations\HasOneThrough;
 use LogicException;
 use JsonSerializable;
 use DateTimeInterface;
@@ -29,7 +30,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Query\Builder as QueryBuilder;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
-use Illuminate\Database\Eloquent\Relations\HasOneThrough;
+use Illuminate\Database\Eloquent\Relations\BelongsToThrough;
 use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 use Illuminate\Database\ConnectionResolverInterface as Resolver;
 
@@ -732,12 +733,12 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      *
      * @param string      $related           Class name of related Model
      * @param string      $through           Class name of through Model
-     * @param string|null $throughForeignKey Foreign key to Through model from $this Model
-     * @param string|null $relatedForeignKey Foreign key to Related model from Through model
+     * @param string|null $throughForeignKey Foreign key from Through model to $this Model
+     * @param string|null $relatedForeignKey Foreign key from Related model to Through model
      *
      * @return \Illuminate\Database\Eloquent\Relations\HasOneThrough
      */
-    public function hasOneThrough($related, $through, $throughForeignKey = null, $relatedForeignKey = null)
+    public function hasOneThrough($related, $through, $throughForeignKey = null, $relatedForeignKey)
     {
         $related = new $related;
         $through = new $through;
@@ -807,6 +808,26 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         $otherKey = $otherKey ?: $instance->getKeyName();
 
         return new BelongsTo($query, $this, $foreignKey, $otherKey, $relation);
+    }
+
+    /**
+     * Define an inverse one-to-one relationship that goes through an intermediate model.
+     *
+     * @param string      $related           Class name of related Model
+     * @param string      $through           Class name of through Model
+     * @param string|null $throughForeignKey Foreign key to Through model from $this Model
+     * @param string|null $relatedForeignKey Foreign key to Related model from Through model
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsToThrough
+     */
+    public function belongsToThrough($related, $through, $throughForeignKey = null, $relatedForeignKey = null)
+    {
+        $related = new $related;
+        $through = new $through;
+        $throughForeignKey = $throughForeignKey ?: $through->getForeignKey();
+        $relatedForeignKey = $relatedForeignKey ?: $related->getForeignKey();
+
+        return new BelongsToThrough($related->newQuery(), $this, $through, $throughForeignKey, $relatedForeignKey);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -730,21 +730,21 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     /**
      * Define a one-to-one relationship that goes through an intermediate model.
      *
-     * @param string      $related      Class name of related Model
-     * @param string      $through      Class name of through Model
-     * @param string|null $farParentKey Foreign key to through
-     * @param string|null $parentKey    Foreign key to related
+     * @param string      $related           Class name of related Model
+     * @param string      $through           Class name of through Model
+     * @param string|null $throughForeignKey Foreign key to Through model from $this Model
+     * @param string|null $relatedForeignKey Foreign key to Related model from Through model
      *
      * @return \Illuminate\Database\Eloquent\Relations\HasOneThrough
      */
-    public function hasOneThrough($related, $through, $farParentKey = null, $parentKey = null)
+    public function hasOneThrough($related, $through, $throughForeignKey = null, $relatedForeignKey = null)
     {
-        $related      = new $related;
-        $through      = new $through;
-        $farParentKey = $farParentKey ?: $through->getForeignKey();
-        $parentKey    = $parentKey    ?: $related->getForeignKey();
+        $related           = new $related;
+        $through           = new $through;
+        $throughForeignKey = $throughForeignKey ?: $through->getForeignKey();
+        $relatedForeignKey = $relatedForeignKey ?: $related->getForeignKey();
 
-        return new HasOneThrough($related->newQuery(), $this, $through, $farParentKey, $parentKey);
+        return new HasOneThrough($related->newQuery(), $this, $through, $throughForeignKey, $relatedForeignKey);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -733,19 +733,19 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      *
      * @param string      $related           Class name of related Model
      * @param string      $through           Class name of through Model
-     * @param string|null $throughForeignKey Foreign key from Through model to $this Model
-     * @param string|null $relatedForeignKey Foreign key from Related model to Through model
+     * @param string|null $thisForeignKey    Foreign key from Through model to $this Model
+     * @param string|null $throughForeignKey Foreign key from Related model to Through model
      *
      * @return \Illuminate\Database\Eloquent\Relations\HasOneThrough
      */
-    public function hasOneThrough($related, $through, $throughForeignKey, $relatedForeignKey)
+    public function hasOneThrough($related, $through, $thisForeignKey = null, $throughForeignKey = null)
     {
         $related = new $related;
         $through = new $through;
+        $thisForeignKey = $thisForeignKey ?: $this->getForeignKey();
         $throughForeignKey = $throughForeignKey ?: $through->getForeignKey();
-        $relatedForeignKey = $relatedForeignKey ?: $related->getForeignKey();
 
-        return new HasOneThrough($related->newQuery(), $this, $through, $throughForeignKey, $relatedForeignKey);
+        return new HasOneThrough($related->newQuery(), $this, $through, $thisForeignKey, $throughForeignKey);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -6,7 +6,6 @@ use Closure;
 use Exception;
 use ArrayAccess;
 use Carbon\Carbon;
-use Illuminate\Database\Eloquent\Relations\HasOneThrough;
 use LogicException;
 use JsonSerializable;
 use DateTimeInterface;
@@ -30,6 +29,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Query\Builder as QueryBuilder;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasOneThrough;
 use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 use Illuminate\Database\ConnectionResolverInterface as Resolver;
 

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -6,6 +6,7 @@ use Closure;
 use Exception;
 use ArrayAccess;
 use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Relations\HasOneThrough;
 use LogicException;
 use JsonSerializable;
 use DateTimeInterface;
@@ -724,6 +725,26 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         $localKey = $localKey ?: $this->getKeyName();
 
         return new HasOne($instance->newQuery(), $this, $instance->getTable().'.'.$foreignKey, $localKey);
+    }
+
+    /**
+     * Define a one-to-one relationship that goes through an intermediate model.
+     *
+     * @param string      $related      Class name of related Model
+     * @param string      $through      Class name of through Model
+     * @param string|null $farParentKey Foreign key to through
+     * @param string|null $parentKey    Foreign key to related
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\HasOneThrough
+     */
+    public function hasOneThrough($related, $through, $farParentKey = null, $parentKey = null)
+    {
+        $related      = new $related;
+        $through      = new $through;
+        $farParentKey = $farParentKey ?: $through->getForeignKey();
+        $parentKey    = $parentKey    ?: $related->getForeignKey();
+
+        return new HasOneThrough($related->newQuery(), $this, $through, $farParentKey, $parentKey);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -739,8 +739,8 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public function hasOneThrough($related, $through, $throughForeignKey = null, $relatedForeignKey = null)
     {
-        $related           = new $related;
-        $through           = new $through;
+        $related = new $related;
+        $through = new $through;
         $throughForeignKey = $throughForeignKey ?: $through->getForeignKey();
         $relatedForeignKey = $relatedForeignKey ?: $related->getForeignKey();
 

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -6,7 +6,6 @@ use Closure;
 use Exception;
 use ArrayAccess;
 use Carbon\Carbon;
-use Illuminate\Database\Eloquent\Relations\HasOneThrough;
 use LogicException;
 use JsonSerializable;
 use DateTimeInterface;
@@ -22,16 +21,17 @@ use Illuminate\Database\Eloquent\Relations\Pivot;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
-use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Eloquent\Relations\MorphOne;
+use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Collection as BaseCollection;
-use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Database\Query\Builder as QueryBuilder;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
-use Illuminate\Database\Eloquent\Relations\BelongsToThrough;
+use Illuminate\Database\Eloquent\Relations\HasOneThrough;
 use Illuminate\Database\Eloquent\Relations\HasManyThrough;
+use Illuminate\Database\Eloquent\Relations\BelongsToThrough;
 use Illuminate\Database\ConnectionResolverInterface as Resolver;
 
 abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializable, QueueableEntity, UrlRoutable
@@ -738,7 +738,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      *
      * @return \Illuminate\Database\Eloquent\Relations\HasOneThrough
      */
-    public function hasOneThrough($related, $through, $throughForeignKey = null, $relatedForeignKey)
+    public function hasOneThrough($related, $through, $throughForeignKey, $relatedForeignKey)
     {
         $related = new $related;
         $through = new $through;

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToThrough.php
@@ -242,7 +242,6 @@ class BelongsToThrough extends Relation
             $models = $builder->eagerLoadRelations($models);
         }
 
-
         return new Collection($models);
     }
 

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneThrough.php
@@ -1,0 +1,270 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Relations;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * HasOneThrough relation defines a one-to-one relationship between two models that uses a third
+ * intermediate model as the connection:
+ *
+ * <code>
+ * select * from Related
+ * inner join Parent    on Parent.ForeignKey    = Related.PrimaryKey
+ * inner join FarParent on FarParent.ForeignKey = Parent.PrimaryKey
+ * where
+ *     FarParent.PrimaryKey = ?
+ * and FarParent.PrimaryKey is not null
+ * </code>
+ *
+ * You can use a <code>Closure</code> to define how to construct the <em>Related Model</em> by setting .
+ *
+ *
+ * @package Illuminate\Database\Eloquent\Relations
+ * @author  Peter Scopes <peter.scopes@gmail.com>
+ */
+class HasOneThrough extends Relation
+{
+    /**
+     * The distance parent model instance.
+     *
+     * @var \Illuminate\Database\Eloquent\Model
+     */
+    protected $farParent;
+
+    /**
+     * The foreign key of the far parent model.
+     *
+     * @var string
+     */
+    protected $farParentKey;
+
+    /**
+     * The foreign key of the parent model.
+     *
+     * @var string
+     */
+    protected $parentKey;
+
+
+    /**
+     * Create a new has one through relationship instance.
+     *
+     * @param \Illuminate\Database\Eloquent\Builder $query
+     * @param \Illuminate\Database\Eloquent\Model   $farParent
+     * @param \Illuminate\Database\Eloquent\Model   $parent
+     * @param string                                $farParentKey Foreign key to parent
+     * @param string                                $parentKey    Foreign key to related
+     */
+    public function __construct(Builder $query, Model $farParent, Model $parent, $farParentKey, $parentKey)
+    {
+        $this->parentKey    = $parentKey;
+        $this->farParentKey = $farParentKey;
+        $this->farParent    = $farParent;
+
+        parent::__construct($query, $parent);
+    }
+
+    /**
+     * Get the far parent model of the relation.
+     *
+     * @return \Illuminate\Database\Eloquent\Model
+     */
+    public function getFarParent()
+    {
+        return $this->farParent;
+    }
+
+    /**
+     * Set the base constraints on the relation query.
+     *
+     * @return void
+     */
+    public function addConstraints()
+    {
+        $farParentLocalKey = $this->farParent->getQualifiedKeyName();
+
+        $this->setJoin();
+
+        if (static::$constraints) {
+            $this->query->where($farParentLocalKey, '=', $this->farParent->getKey());
+
+            $this->query->whereNotNull($farParentLocalKey);
+        }
+    }
+
+    /**
+     * Add the constraints for a relationship query.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @param  \Illuminate\Database\Eloquent\Builder  $parent
+     * @param  array|mixed $columns
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function getRelationQuery(Builder $query, Builder $parent, $columns = ['*'])
+    {
+        $this->setJoin($query);
+
+        $query->select($columns);
+
+        $this->query->where($this->farParent->getQualifiedKeyName(), '=', $this->farParent->getKey());
+
+        return $this->query->whereNotNull($this->farParent->getQualifiedKeyName());
+    }
+
+    /**
+     * @param Builder|null $query
+     */
+    protected function setJoin(Builder $query = null)
+    {
+        $query = $query ?: $this->query;
+
+        $relatedLocalKey     = $this->related->getQualifiedKeyName();
+        $parentForeignKey    = $this->parent->getTable().'.'.$this->parentKey;
+        $parentLocalKey      = $this->parent->getQualifiedKeyName();
+        $farParentForeignKey = $this->farParent->getTable().'.'.$this->farParentKey;
+
+        $query->join($this->parent->getTable(), $parentForeignKey, '=', $relatedLocalKey);
+        $query->join($this->farParent->getTable(), $farParentForeignKey, '=', $parentLocalKey);
+    }
+
+    /**
+     * Set the constraints for an eager load of the relation.
+     *
+     * @param  array  $models
+     * @return void
+     */
+    public function addEagerConstraints(array $models)
+    {
+        $table = $this->parent->getTable();
+
+        $this->query->whereIn($table.'.'.$this->parentKey, $this->getKeys($models, $this->related->getKeyName()));
+    }
+
+    /**
+     * Initialize the relation on a set of models.
+     *
+     * @param  array   $models
+     * @param  string  $relation
+     * @return array
+     */
+    public function initRelation(array $models, $relation)
+    {
+        foreach ($models as $model) {
+            $model->setRelation($relation, null);
+        }
+
+        return $models;
+    }
+
+    /**
+     * Match the eagerly loaded results to their parents.
+     *
+     * @param  array                                    $models   Parent models
+     * @param  \Illuminate\Database\Eloquent\Collection $results  Related models
+     * @param  string                                   $relation
+     *
+     * @return array
+     */
+    public function match(array $models, Collection $results, $relation)
+    {
+        $dictionary = $this->buildDictionary($results);
+
+        // Once we have the dictionary we can simply spin through the parent models to
+        // link them up with their children using the keyed dictionary to make the
+        // matching very convenient and easy work. Then we'll just return them.
+        foreach ($models as $model) {
+            $key = $model->getKey();
+
+            if (isset($dictionary[$key])) {
+                $value = $dictionary[$key];
+
+                $model->setRelation($relation, $value);
+            }
+        }
+
+        return $models;
+    }
+
+    /**
+     * Build model dictionary keyed by the relation's foreign key.
+     *
+     * @param  \Illuminate\Database\Eloquent\Collection  $results
+     * @return array
+     */
+    protected function buildDictionary(Collection $results)
+    {
+        $dictionary = [];
+
+        // First we will create a dictionary of models keyed by the foreign key of the
+        // relationship as this will allow us to quickly access all of the related
+        // models without having to do nested looping which will be quite slow.
+        foreach ($results as $result) {
+            $dictionary[$result->{$this->parentKey}] = $result;
+        }
+
+        return $dictionary;
+    }
+
+    /**
+     * Get the results of the relationship.
+     *
+     * @return mixed
+     */
+    public function getResults()
+    {
+        return $this->first();
+    }
+
+    /**
+     * Execute the query as a "select" statement.
+     *
+     * @param array $columns
+     *
+     * @return mixed
+     */
+    public function first($columns = ['*'])
+    {
+        // First we'll add the proper select columns onto the query so it is run with
+        // the proper columns. Then, we will get the results and hydrate out pivot
+        // models with the result of those columns as a separate model relation.
+        $columns = $this->query->getQuery()->columns ? [] : $columns;
+
+        $select = $this->getSelectColumns($columns);
+
+        $builder = $this->query->applyScopes();
+
+        $models = $builder->addSelect($select)->getModels();
+
+        // If we actually found models we will also eager load any relationships that
+        // have been specified as needing to be eager loaded. This will solve the
+        // n + 1 query problem for the developer and also increase performance.
+        if (count($models) > 0) {
+            $models = $builder->eagerLoadRelations($models);
+
+            return reset($models);
+        }
+
+        return null;
+    }
+
+    /**
+     * Set the select clause for the relation query.
+     *
+     * @param  array  $columns
+     * @return array
+     */
+    protected function getSelectColumns(array $columns = ['*'])
+    {
+        if ($columns == ['*']) {
+            $columns = [$this->related->getTable().'.*'];
+        }
+
+        return array_merge($columns, [
+            $this->parent->getTable().'.'.$this->parentKey,
+            $this->farParent->getTable().'.'.$this->farParentKey
+        ]);
+    }
+}

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneThrough.php
@@ -8,7 +8,7 @@ use Illuminate\Database\Eloquent\Collection;
 
 /**
  * HasOneThrough relation defines a one-to-one relationship between two models that uses a third
- * intermediate model as the connection:
+ * intermediate model as the connection.
  *
  * <code>
  * select * from Related
@@ -20,8 +20,7 @@ use Illuminate\Database\Eloquent\Collection;
  * </code>
  *
  *
- * @package Illuminate\Database\Eloquent\Relations
- * @author  Peter Scopes <peter.scopes@gmail.com>
+ * @author Peter Scopes <peter.scopes@gmail.com>
  */
 class HasOneThrough extends Relation
 {
@@ -46,7 +45,6 @@ class HasOneThrough extends Relation
      */
     protected $parentKey;
 
-
     /**
      * Create a new has one through relationship instance.
      *
@@ -58,9 +56,9 @@ class HasOneThrough extends Relation
      */
     public function __construct(Builder $query, Model $farParent, Model $parent, $farParentKey, $parentKey)
     {
-        $this->parentKey    = $parentKey;
+        $this->parentKey = $parentKey;
         $this->farParentKey = $farParentKey;
-        $this->farParent    = $farParent;
+        $this->farParent = $farParent;
 
         parent::__construct($query, $parent);
     }
@@ -119,9 +117,9 @@ class HasOneThrough extends Relation
     {
         $query = $query ?: $this->query;
 
-        $relatedLocalKey     = $this->related->getQualifiedKeyName();
-        $parentForeignKey    = $this->parent->getTable().'.'.$this->parentKey;
-        $parentLocalKey      = $this->parent->getQualifiedKeyName();
+        $relatedLocalKey = $this->related->getQualifiedKeyName();
+        $parentForeignKey = $this->parent->getTable().'.'.$this->parentKey;
+        $parentLocalKey = $this->parent->getQualifiedKeyName();
         $farParentForeignKey = $this->farParent->getTable().'.'.$this->farParentKey;
 
         $query->join($this->parent->getTable(), $parentForeignKey, '=', $relatedLocalKey);
@@ -244,8 +242,6 @@ class HasOneThrough extends Relation
 
             return reset($models);
         }
-
-        return null;
     }
 
     /**
@@ -262,7 +258,7 @@ class HasOneThrough extends Relation
 
         return array_merge($columns, [
             $this->parent->getTable().'.'.$this->parentKey,
-            $this->farParent->getTable().'.'.$this->farParentKey
+            $this->farParent->getTable().'.'.$this->farParentKey,
         ]);
     }
 }

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneThrough.php
@@ -45,7 +45,6 @@ class HasOneThrough extends Relation
      */
     protected $parentKey;
 
-
     /**
      * Create a new has one through relationship instance.
      *
@@ -57,9 +56,9 @@ class HasOneThrough extends Relation
      */
     public function __construct(Builder $query, Model $farParent, Model $parent, $farParentKey, $parentKey)
     {
-        $this->parentKey    = $parentKey;
+        $this->parentKey = $parentKey;
         $this->farParentKey = $farParentKey;
-        $this->farParent    = $farParent;
+        $this->farParent = $farParent;
 
         parent::__construct($query, $parent);
     }
@@ -118,9 +117,9 @@ class HasOneThrough extends Relation
     {
         $query = $query ?: $this->query;
 
-        $relatedLocalKey     = $this->related->getQualifiedKeyName();
-        $parentForeignKey    = $this->parent->getTable().'.'.$this->parentKey;
-        $parentLocalKey      = $this->parent->getQualifiedKeyName();
+        $relatedLocalKey = $this->related->getQualifiedKeyName();
+        $parentForeignKey = $this->parent->getTable().'.'.$this->parentKey;
+        $parentLocalKey = $this->parent->getQualifiedKeyName();
         $farParentForeignKey = $this->farParent->getTable().'.'.$this->farParentKey;
 
         $query->join($this->parent->getTable(), $parentForeignKey, '=', $relatedLocalKey);
@@ -260,7 +259,7 @@ class HasOneThrough extends Relation
         }
 
         return array_merge($columns, [
-            $this->farParent->getTable().'.'.$this->farParentKey
+            $this->farParent->getTable().'.'.$this->farParentKey,
         ]);
     }
 }

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneThrough.php
@@ -19,8 +19,6 @@ use Illuminate\Database\Eloquent\Collection;
  * and FarParent.PrimaryKey is not null
  * </code>
  *
- * You can use a <code>Closure</code> to define how to construct the <em>Related Model</em> by setting .
- *
  *
  * @package Illuminate\Database\Eloquent\Relations
  * @author  Peter Scopes <peter.scopes@gmail.com>

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneThrough.php
@@ -58,8 +58,8 @@ class HasOneThrough extends Relation
     public function __construct(Builder $query, Model $farParent, Model $parent, $parentForeignKey, $relatedForeignKey)
     {
         $this->relatedForeignKey = $relatedForeignKey;
-        $this->parentForeignKey  = $parentForeignKey;
-        $this->farParent         = $farParent;
+        $this->parentForeignKey = $parentForeignKey;
+        $this->farParent = $farParent;
 
         parent::__construct($query, $parent);
     }
@@ -241,7 +241,6 @@ class HasOneThrough extends Relation
             $models = $builder->eagerLoadRelations($models);
         }
 
-
         return new Collection($models);
     }
 
@@ -258,7 +257,7 @@ class HasOneThrough extends Relation
         }
 
         return array_merge($columns, [
-            $this->parent->getTable().'.'.$this->parentForeignKey
+            $this->parent->getTable().'.'.$this->parentForeignKey,
         ]);
     }
 }

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneThrough.php
@@ -2,9 +2,9 @@
 
 namespace Illuminate\Database\Eloquent\Relations;
 
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
-use Illuminate\Database\Eloquent\Model;
 
 /**
  * HasOneThrough relation defines a one-to-one relationship between two models that uses a third

--- a/tests/Database/DatabaseEloquentBelongsToThroughTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToThroughTest.php
@@ -55,13 +55,13 @@ class DatabaseEloquentBelongsToThroughTest extends PHPUnit_Framework_TestCase
         // Insert users
         $this->connection()->insert(
             'insert into users (email, eloquent_belongs_to_through_model_country_id) values (\'foobar@example.com\', ?), (\'barfoo@example.com\', ?)',
-            array_column($this->connection()->select('select id from countries'), 'id')
+            $this->object_array_column($this->connection()->select('select id from countries'), 'id')
         );
 
         // Insert posts
         $this->connection()->insert(
             'insert into posts (title, eloquent_belongs_to_through_model_user_id) values (\'FooBar\', ?), (\'BarFoo\', ?)',
-            array_column($this->connection()->select('select id from users'), 'id')
+            $this->object_array_column($this->connection()->select('select id from users'), 'id')
         );
     }
 
@@ -234,6 +234,22 @@ class DatabaseEloquentBelongsToThroughTest extends PHPUnit_Framework_TestCase
     protected function schema($connection = 'default')
     {
         return $this->connection($connection)->getSchemaBuilder();
+    }
+
+    /**
+     * @param array  $array array of stdClass
+     * @param string $property
+     *
+     * @return array
+     */
+    protected function object_array_column($array, $property)
+    {
+        $columns = [];
+        foreach ($array as $item) {
+            $columns[] = $item->{$property};
+        }
+
+        return $columns;
     }
 }
 

--- a/tests/Database/DatabaseEloquentBelongsToThroughTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToThroughTest.php
@@ -1,8 +1,8 @@
 <?php
 
 use Mockery as m;
-use Illuminate\Database\Capsule\Manager as DB;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Capsule\Manager as DB;
 use Illuminate\Database\Eloquent\Model as Eloquent;
 use Illuminate\Database\Eloquent\Relations\BelongsToThrough;
 
@@ -76,7 +76,6 @@ class DatabaseEloquentBelongsToThroughTest extends PHPUnit_Framework_TestCase
         m::close();
     }
 
-
     /**
      * Integration test for lazy loading of the $post's $country.
      */
@@ -89,7 +88,6 @@ class DatabaseEloquentBelongsToThroughTest extends PHPUnit_Framework_TestCase
         $this->assertNotNull($country);
         $this->assertInstanceOf('EloquentBelongsToThroughModelCountry', $country);
         $this->assertEquals('BarFoo', $country->name);
-
     }
 
     /**
@@ -118,7 +116,6 @@ class DatabaseEloquentBelongsToThroughTest extends PHPUnit_Framework_TestCase
             $this->assertEquals($post->title, $post->country->name);
         }
     }
-
 
     /**
      * Unit test relation is properly initialized.

--- a/tests/Database/DatabaseEloquentBelongsToThroughTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToThroughTest.php
@@ -1,0 +1,103 @@
+<?php
+
+use Mockery as m;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Relations\BelongsToThrough;
+
+class DatabaseEloquentBelongsToThroughTest extends PHPUnit_Framework_TestCase
+{
+    public function tearDown()
+    {
+        m::close();
+    }
+
+    public function testRelationIsProperlyInitialized()
+    {
+        $relation = $this->getRelation();
+        $model = m::mock('Illuminate\Database\Eloquent\Model');
+        $model->shouldReceive('setRelation')->once()->with('foo', null);
+
+        $models = $relation->initRelation([$model], 'foo');
+
+        $this->assertEquals([$model], $models);
+    }
+
+    public function testEagerConstraintsAreProperlyAdded()
+    {
+        $relation = $this->getRelation();
+        $relation->getQuery()->shouldReceive('whereIn')->once()->with('countries.id', [1, 2]);
+        $model1 = new EloquentBelongsToThroughModelStub;
+        $model1->id = 1;
+        $model2 = new EloquentBelongsToThroughModelStub;
+        $model2->id = 2;
+        $relation->addEagerConstraints([$model1, $model2]);
+    }
+
+    public function testModelsAreProperlyMatchedToParents()
+    {
+        $relation = $this->getRelation();
+
+        // Countries
+        $results1 = new EloquentBelongsToThroughModelStub;
+        $results1->user_id = 1;
+        $results2 = new EloquentBelongsToThroughModelStub;
+        $results2->user_id = 2;
+
+        // Posts
+        $model1 = new EloquentBelongsToThroughModelStub;
+        $model1->user_id = 1;
+        $model2 = new EloquentBelongsToThroughModelStub;
+        $model2->user_id = 2;
+
+        $models = $relation->match([$model1, $model2], new Collection([$results1, $results2]), 'foo');
+
+        $this->assertEquals(1, $models[0]->foo->user_id);
+        $this->assertEquals(2, $models[1]->foo->user_id);
+    }
+
+    /**
+     * Creates a new HasOneThrough relationship of a Post having a Country through a User.
+     *
+     * @return BelongsToThrough
+     */
+    protected function getRelation()
+    {
+        list($builder, $country, $user, $farParentKey, $parentKey) = $this->getRelationArguments();
+
+        return new BelongsToThrough($builder, $country, $user, $farParentKey, $parentKey);
+    }
+
+    protected function getRelationArguments()
+    {
+        $builder = m::mock('Illuminate\Database\Eloquent\Builder');
+        $builder->shouldReceive('join')->once()->with('users', 'users.post_id', '=', 'posts.id');
+        $builder->shouldReceive('join')->once()->with('countries', 'countries.user_id', '=', 'users.id');
+        $builder->shouldReceive('where')->with('countries.id', '=', 1);
+        $builder->shouldReceive('whereNotNull')->with('countries.id');
+
+        $country = m::mock('Illuminate\Database\Eloquent\Model');
+        $country->shouldReceive('getTable')->andReturn('countries');
+        $country->shouldReceive('getQualifiedKeyName')->andReturn('countries.id');
+        $country->shouldReceive('getKey')->andReturn(1);
+        $country->shouldReceive('getKeyName')->andReturn('id');
+
+        $user = m::mock('Illuminate\Database\Eloquent\Model');
+        $user->shouldReceive('getTable')->andReturn('users');
+        $user->shouldReceive('getQualifiedKeyName')->andReturn('users.id');
+
+        $post = m::mock('Illuminate\Database\Eloquent\Model');
+        $post->shouldReceive('getQualifiedKeyName')->andReturn('posts.id');
+
+        $builder->shouldReceive('getModel')->andReturn($post);
+
+        $user->shouldReceive('getKey')->andReturn(1);
+        $user->shouldReceive('getCreatedAtColumn')->andReturn('created_at');
+        $user->shouldReceive('getUpdatedAtColumn')->andReturn('updated_at');
+
+        return [$builder, $country, $user, 'user_id', 'post_id'];
+    }
+}
+
+class EloquentBelongsToThroughModelStub extends Illuminate\Database\Eloquent\Model
+{
+}

--- a/tests/Database/DatabaseEloquentBelongsToThroughTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToThroughTest.php
@@ -1,16 +1,128 @@
 <?php
 
 use Mockery as m;
+use Illuminate\Database\Capsule\Manager as DB;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Model as Eloquent;
 use Illuminate\Database\Eloquent\Relations\BelongsToThrough;
 
 class DatabaseEloquentBelongsToThroughTest extends PHPUnit_Framework_TestCase
 {
+    public function setUp()
+    {
+        $db = new DB();
+
+        $db->addConnection([
+            'driver'    => 'sqlite',
+            'database'  => ':memory:',
+        ]);
+
+        $db->bootEloquent();
+        $db->setAsGlobal();
+
+        $this->createSchema();
+        $this->populateDb();
+    }
+
+    protected function createSchema()
+    {
+        $this->schema()->create('posts', function ($table) {
+            $table->increments('id');
+            $table->string('title');
+            $table->integer('eloquent_belongs_to_through_model_user_id');
+            $table->timestamps();
+        });
+
+        $this->schema()->create('users', function ($table) {
+            $table->increments('id');
+            $table->string('email');
+            $table->integer('eloquent_belongs_to_through_model_country_id');
+            $table->timestamps();
+        });
+
+        $this->schema()->create('countries', function ($table) {
+            $table->increments('id');
+            $table->string('name');
+            $table->timestamps();
+        });
+    }
+
+    protected function populateDb()
+    {
+        // Insert countries
+        $this->connection()->insert('insert into countries (name) values (\'FooBar\'), (\'BarFoo\')');
+
+        // Insert users
+        $this->connection()->insert(
+            'insert into users (email, eloquent_belongs_to_through_model_country_id) values (\'foobar@example.com\', ?), (\'barfoo@example.com\', ?)',
+            array_column($this->connection()->select('select id from countries'), 'id')
+        );
+
+        // Insert posts
+        $this->connection()->insert(
+            'insert into posts (title, eloquent_belongs_to_through_model_user_id) values (\'FooBar\', ?), (\'BarFoo\', ?)',
+            array_column($this->connection()->select('select id from users'), 'id')
+        );
+    }
+
     public function tearDown()
     {
+        foreach (['default'] as $connection) {
+            $this->schema($connection)->drop('posts');
+            $this->schema($connection)->drop('users');
+            $this->schema($connection)->drop('countries');
+        }
+
         m::close();
     }
 
+
+    /**
+     * Integration test for lazy loading of the $post's $country.
+     */
+    public function testIntegrationRetrieveLazy()
+    {
+        $post = EloquentBelongsToThroughModelPost::where('title', 'BarFoo')->first();
+
+        $country = $post->country;
+
+        $this->assertNotNull($country);
+        $this->assertInstanceOf('EloquentBelongsToThroughModelCountry', $country);
+        $this->assertEquals('BarFoo', $country->name);
+
+    }
+
+    /**
+     * Integration test for eager loading of the $post's $country.
+     */
+    public function testIntegrationRetrieveEager()
+    {
+        $post = EloquentBelongsToThroughModelPost::where('title', 'FooBar')->with('country')->first();
+
+        $this->assertNotNull($post->country);
+        $this->assertInstanceOf('EloquentBelongsToThroughModelCountry', $post->country);
+        $this->assertEquals('FooBar', $post->country->name);
+    }
+
+    /**
+     * Integration test for multiple eager loading of the $post's $country.
+     */
+    public function testIntegrationRetrieveEagerMultiple()
+    {
+        $posts = EloquentBelongsToThroughModelPost::with('country')->get();
+
+        $this->assertInstanceOf('\Illuminate\Database\Eloquent\Collection', $posts);
+        foreach ($posts as $post) {
+            $this->assertNotNull($post->country);
+            $this->assertInstanceOf('EloquentBelongsToThroughModelCountry', $post->country);
+            $this->assertEquals($post->title, $post->country->name);
+        }
+    }
+
+
+    /**
+     * Unit test relation is properly initialized.
+     */
     public function testRelationIsProperlyInitialized()
     {
         $relation = $this->getRelation();
@@ -22,6 +134,9 @@ class DatabaseEloquentBelongsToThroughTest extends PHPUnit_Framework_TestCase
         $this->assertEquals([$model], $models);
     }
 
+    /**
+     * Unit test eager constraints are properly added.
+     */
     public function testEagerConstraintsAreProperlyAdded()
     {
         $relation = $this->getRelation();
@@ -33,6 +148,9 @@ class DatabaseEloquentBelongsToThroughTest extends PHPUnit_Framework_TestCase
         $relation->addEagerConstraints([$model1, $model2]);
     }
 
+    /**
+     * Unit test models are properly matched to their parents.
+     */
     public function testModelsAreProperlyMatchedToParents()
     {
         $relation = $this->getRelation();
@@ -56,7 +174,7 @@ class DatabaseEloquentBelongsToThroughTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * Creates a new HasOneThrough relationship of a Post having a Country through a User.
+     * Creates a new BelongsToThrough relationship of a Post having a Country through a User.
      *
      * @return BelongsToThrough
      */
@@ -96,8 +214,52 @@ class DatabaseEloquentBelongsToThroughTest extends PHPUnit_Framework_TestCase
 
         return [$builder, $country, $user, 'user_id', 'post_id'];
     }
+
+    /**
+     * Helpers...
+     */
+
+    /**
+     * Get a database connection instance.
+     *
+     * @return \Illuminate\Database\Connection
+     */
+    protected function connection($connection = 'default')
+    {
+        return Eloquent::getConnectionResolver()->connection($connection);
+    }
+
+    /**
+     * Get a schema builder instance.
+     *
+     * @return \Illuminate\Database\Schema\Builder
+     */
+    protected function schema($connection = 'default')
+    {
+        return $this->connection($connection)->getSchemaBuilder();
+    }
 }
 
-class EloquentBelongsToThroughModelStub extends Illuminate\Database\Eloquent\Model
+// Stub for unit tests
+class EloquentBelongsToThroughModelStub extends Eloquent
 {
+}
+
+// Stubs for integration tests
+class EloquentBelongsToThroughModelPost extends Eloquent
+{
+    protected $table = 'posts';
+
+    public function country()
+    {
+        return $this->belongsToThrough('EloquentBelongsToThroughModelCountry', 'EloquentBelongsToThroughModelUser');
+    }
+}
+class EloquentBelongsToThroughModelUser extends Eloquent
+{
+    protected $table = 'users';
+}
+class EloquentBelongsToThroughModelCountry extends Eloquent
+{
+    protected $table = 'countries';
 }

--- a/tests/Database/DatabaseEloquentHasOneThroughTest.php
+++ b/tests/Database/DatabaseEloquentHasOneThroughTest.php
@@ -14,7 +14,7 @@ class DatabaseEloquentHasOneThroughTest extends PHPUnit_Framework_TestCase
     public function testRelationIsProperlyInitialized()
     {
         $relation = $this->getRelation();
-        $model    = m::mock('Illuminate\Database\Eloquent\Model');
+        $model = m::mock('Illuminate\Database\Eloquent\Model');
         $model->shouldReceive('setRelation')->once()->with('foo', null);
 
         $models = $relation->initRelation([$model], 'foo');
@@ -101,5 +101,4 @@ class DatabaseEloquentHasOneThroughTest extends PHPUnit_Framework_TestCase
 
 class EloquentHasOneThroughModelStub extends Illuminate\Database\Eloquent\Model
 {
-
 }

--- a/tests/Database/DatabaseEloquentHasOneThroughTest.php
+++ b/tests/Database/DatabaseEloquentHasOneThroughTest.php
@@ -1,16 +1,128 @@
 <?php
 
 use Mockery as m;
+use Illuminate\Database\Capsule\Manager as DB;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Model as Eloquent;
 use Illuminate\Database\Eloquent\Relations\HasOneThrough;
 
 class DatabaseEloquentHasOneThroughTest extends PHPUnit_Framework_TestCase
 {
+    public function setUp()
+    {
+        $db = new DB();
+
+        $db->addConnection([
+            'driver'    => 'sqlite',
+            'database'  => ':memory:',
+        ]);
+
+        $db->bootEloquent();
+        $db->setAsGlobal();
+
+        $this->createSchema();
+        $this->populateDb();
+    }
+
+    protected function createSchema()
+    {
+        $this->schema()->create('suppliers', function ($table) {
+            $table->increments('id');
+            $table->string('name');
+            $table->timestamps();
+        });
+
+        $this->schema()->create('accounts', function ($table) {
+            $table->increments('id');
+            $table->string('email');
+            $table->integer('eloquent_has_one_through_model_supplier_id');
+            $table->timestamps();
+        });
+
+        $this->schema()->create('account_histories', function ($table) {
+            $table->increments('id');
+            $table->string('title');
+            $table->integer('eloquent_has_one_through_model_account_id');
+            $table->timestamps();
+        });
+    }
+
+    protected function populateDb()
+    {
+        // Insert suppliers
+        $this->connection()->insert('insert into suppliers (name) values (\'FooBar\'), (\'BarFoo\')');
+
+        // Insert accounts
+        $this->connection()->insert(
+            'insert into accounts (email, eloquent_has_one_through_model_supplier_id) values (\'foobar@example.com\', ?), (\'barfoo@example.com\', ?)',
+            array_column($this->connection()->select('select id from suppliers'), 'id')
+        );
+
+        // Insert account histories
+        $this->connection()->insert(
+            'insert into account_histories (title, eloquent_has_one_through_model_account_id) values (\'FooBar\', ?), (\'BarFoo\', ?)',
+            array_column($this->connection()->select('select id from accounts'), 'id')
+        );
+    }
+
     public function tearDown()
     {
+        foreach (['default'] as $connection) {
+            $this->schema($connection)->drop('account_histories');
+            $this->schema($connection)->drop('accounts');
+            $this->schema($connection)->drop('suppliers');
+        }
+
         m::close();
     }
 
+
+    /**
+     * Integration test for lazy loading of the $supplier's $accountHistory.
+     */
+    public function testIntegrationRetrieveLazy()
+    {
+        $supplier = EloquentHasOneThroughModelSupplier::where('name', 'BarFoo')->first();
+
+        $accountHistory = $supplier->accountHistory;
+
+        $this->assertNotNull($accountHistory);
+        $this->assertInstanceOf('EloquentHasOneThroughModelAccountHistory', $accountHistory);
+        $this->assertEquals('BarFoo', $accountHistory->title);
+    }
+
+    /**
+     * Integration test for eager loading of the $supplier's $accountHistory.
+     */
+    public function testIntegrationRetrieveEager()
+    {
+        $supplier = EloquentHasOneThroughModelSupplier::where('name', 'FooBar')->with('accountHistory')->first();
+
+        $this->assertNotNull($supplier->accountHistory);
+        $this->assertInstanceOf('EloquentHasOneThroughModelAccountHistory', $supplier->accountHistory);
+        $this->assertEquals('FooBar', $supplier->accountHistory->title);
+    }
+
+    /**
+     * Integration test for multiple eager loading of the $supplier's $accountHistory.
+     */
+    public function testIntegrationRetrieveEagerMultiple()
+    {
+        $suppliers = EloquentHasOneThroughModelSupplier::with('accountHistory')->get();
+
+        $this->assertInstanceOf('\Illuminate\Database\Eloquent\Collection', $suppliers);
+        foreach ($suppliers as $supplier) {
+
+            $this->assertNotNull($supplier->accountHistory);
+            $this->assertInstanceOf('EloquentHasOneThroughModelAccountHistory', $supplier->accountHistory);
+            $this->assertEquals($supplier->name, $supplier->accountHistory->title);
+        }
+    }
+
+
+    /**
+     * Unit test relation is properly initialized.
+     */
     public function testRelationIsProperlyInitialized()
     {
         $relation = $this->getRelation();
@@ -22,6 +134,9 @@ class DatabaseEloquentHasOneThroughTest extends PHPUnit_Framework_TestCase
         $this->assertEquals([$model], $models);
     }
 
+    /**
+     * Unit test eager constraints are properly added.
+     */
     public function testEagerConstraintsAreProperlyAdded()
     {
         $relation = $this->getRelation();
@@ -33,6 +148,9 @@ class DatabaseEloquentHasOneThroughTest extends PHPUnit_Framework_TestCase
         $relation->addEagerConstraints([$model1, $model2]);
     }
 
+    /**
+     * Unit test models are properly matched to parents.
+     */
     public function testModelsAreProperlyMatchedToParents()
     {
         $relation = $this->getRelation();
@@ -92,8 +210,52 @@ class DatabaseEloquentHasOneThroughTest extends PHPUnit_Framework_TestCase
 
         return [$builder, $supplier, $account, 'supplier_id', 'account_id'];
     }
+
+    /**
+     * Helpers...
+     */
+
+    /**
+     * Get a database connection instance.
+     *
+     * @return \Illuminate\Database\Connection
+     */
+    protected function connection($connection = 'default')
+    {
+        return Eloquent::getConnectionResolver()->connection($connection);
+    }
+
+    /**
+     * Get a schema builder instance.
+     *
+     * @return \Illuminate\Database\Schema\Builder
+     */
+    protected function schema($connection = 'default')
+    {
+        return $this->connection($connection)->getSchemaBuilder();
+    }
 }
 
-class EloquentHasOneThroughModelStub extends Illuminate\Database\Eloquent\Model
+// Stub for unit tests
+class EloquentHasOneThroughModelStub extends Eloquent
 {
+}
+
+// Stubs for integration tests
+class EloquentHasOneThroughModelSupplier extends Eloquent
+{
+    protected $table = 'suppliers';
+
+    public function accountHistory()
+    {
+        return $this->hasOneThrough('EloquentHasOneThroughModelAccountHistory', 'EloquentHasOneThroughModelAccount');
+    }
+}
+class EloquentHasOneThroughModelAccount extends Eloquent
+{
+    protected $table = 'accounts';
+}
+class EloquentHasOneThroughModelAccountHistory extends Eloquent
+{
+    protected $table = 'account_histories';
 }

--- a/tests/Database/DatabaseEloquentHasOneThroughTest.php
+++ b/tests/Database/DatabaseEloquentHasOneThroughTest.php
@@ -1,8 +1,8 @@
 <?php
 
 use Mockery as m;
-use Illuminate\Database\Capsule\Manager as DB;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Capsule\Manager as DB;
 use Illuminate\Database\Eloquent\Model as Eloquent;
 use Illuminate\Database\Eloquent\Relations\HasOneThrough;
 
@@ -76,7 +76,6 @@ class DatabaseEloquentHasOneThroughTest extends PHPUnit_Framework_TestCase
         m::close();
     }
 
-
     /**
      * Integration test for lazy loading of the $supplier's $accountHistory.
      */
@@ -112,13 +111,11 @@ class DatabaseEloquentHasOneThroughTest extends PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf('\Illuminate\Database\Eloquent\Collection', $suppliers);
         foreach ($suppliers as $supplier) {
-
             $this->assertNotNull($supplier->accountHistory);
             $this->assertInstanceOf('EloquentHasOneThroughModelAccountHistory', $supplier->accountHistory);
             $this->assertEquals($supplier->name, $supplier->accountHistory->title);
         }
     }
-
 
     /**
      * Unit test relation is properly initialized.

--- a/tests/Database/DatabaseEloquentHasOneThroughTest.php
+++ b/tests/Database/DatabaseEloquentHasOneThroughTest.php
@@ -88,7 +88,6 @@ class DatabaseEloquentHasOneThroughTest extends PHPUnit_Framework_TestCase
         $accountHistory = m::mock('Illuminate\Database\Eloquent\Model');
         $accountHistory->shouldReceive('getTable')->andReturn('account_histories');
 
-
         $builder->shouldReceive('getModel')->andReturn($accountHistory);
 
         return [$builder, $supplier, $account, 'supplier_id', 'account_id'];

--- a/tests/Database/DatabaseEloquentHasOneThroughTest.php
+++ b/tests/Database/DatabaseEloquentHasOneThroughTest.php
@@ -25,8 +25,7 @@ class DatabaseEloquentHasOneThroughTest extends PHPUnit_Framework_TestCase
     public function testEagerConstraintsAreProperlyAdded()
     {
         $relation = $this->getRelation();
-        $relation->getQuery()->shouldReceive('whereIn')->once()->with('users.post_id', [1, 2]);
-        $relation->getRelated()->shouldReceive('getKeyName')->once()->andReturn('id');
+        $relation->getQuery()->shouldReceive('whereIn')->once()->with('countries.id', [1, 2]);
         $model1 = new EloquentHasOneThroughModelStub;
         $model1->id = 1;
         $model2 = new EloquentHasOneThroughModelStub;
@@ -40,20 +39,20 @@ class DatabaseEloquentHasOneThroughTest extends PHPUnit_Framework_TestCase
 
         // Countries
         $results1 = new EloquentHasOneThroughModelStub;
-        $results1->post_id = 1;
+        $results1->user_id = 1;
         $results2 = new EloquentHasOneThroughModelStub;
-        $results2->post_id = 2;
+        $results2->user_id = 2;
 
         // Posts
         $model1 = new EloquentHasOneThroughModelStub;
-        $model1->id = 1;
+        $model1->user_id = 1;
         $model2 = new EloquentHasOneThroughModelStub;
-        $model2->id = 2;
+        $model2->user_id = 2;
 
         $models = $relation->match([$model1, $model2], new Collection([$results1, $results2]), 'foo');
 
-        $this->assertEquals(1, $models[0]->foo->post_id);
-        $this->assertEquals(2, $models[1]->foo->post_id);
+        $this->assertEquals(1, $models[0]->foo->user_id);
+        $this->assertEquals(2, $models[1]->foo->user_id);
     }
 
     /**

--- a/tests/Database/DatabaseEloquentHasOneThroughTest.php
+++ b/tests/Database/DatabaseEloquentHasOneThroughTest.php
@@ -1,0 +1,105 @@
+<?php
+
+use Mockery as m;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Relations\HasOneThrough;
+
+class DatabaseEloquentHasOneThroughTest extends PHPUnit_Framework_TestCase
+{
+    public function tearDown()
+    {
+        m::close();
+    }
+
+    public function testRelationIsProperlyInitialized()
+    {
+        $relation = $this->getRelation();
+        $model    = m::mock('Illuminate\Database\Eloquent\Model');
+        $model->shouldReceive('setRelation')->once()->with('foo', null);
+
+        $models = $relation->initRelation([$model], 'foo');
+
+        $this->assertEquals([$model], $models);
+    }
+
+    public function testEagerConstraintsAreProperlyAdded()
+    {
+        $relation = $this->getRelation();
+        $relation->getQuery()->shouldReceive('whereIn')->once()->with('users.post_id', [1, 2]);
+        $relation->getRelated()->shouldReceive('getKeyName')->once()->andReturn('id');
+        $model1 = new EloquentHasOneThroughModelStub;
+        $model1->id = 1;
+        $model2 = new EloquentHasOneThroughModelStub;
+        $model2->id = 2;
+        $relation->addEagerConstraints([$model1, $model2]);
+    }
+
+    public function testModelsAreProperlyMatchedToParents()
+    {
+        $relation = $this->getRelation();
+
+        // Countries
+        $results1 = new EloquentHasOneThroughModelStub;
+        $results1->post_id = 1;
+        $results2 = new EloquentHasOneThroughModelStub;
+        $results2->post_id = 2;
+
+        // Posts
+        $model1 = new EloquentHasOneThroughModelStub;
+        $model1->id = 1;
+        $model2 = new EloquentHasOneThroughModelStub;
+        $model2->id = 2;
+
+        $models = $relation->match([$model1, $model2], new Collection([$results1, $results2]), 'foo');
+
+        $this->assertEquals(1, $models[0]->foo->post_id);
+        $this->assertEquals(2, $models[1]->foo->post_id);
+    }
+
+    /**
+     * Creates a new HasOneThrough relationship of a Post having a Country through a User.
+     *
+     * @return HasOneThrough
+     */
+    protected function getRelation()
+    {
+        list($builder, $country, $user, $farParentKey, $parentKey) = $this->getRelationArguments();
+
+        return new HasOneThrough($builder, $country, $user, $farParentKey, $parentKey);
+    }
+
+    protected function getRelationArguments()
+    {
+        $builder = m::mock('Illuminate\Database\Eloquent\Builder');
+        $builder->shouldReceive('join')->once()->with('users', 'users.post_id', '=', 'posts.id');
+        $builder->shouldReceive('join')->once()->with('countries', 'countries.user_id', '=', 'users.id');
+        $builder->shouldReceive('where')->with('countries.id', '=', 1);
+        $builder->shouldReceive('whereNotNull')->with('countries.id');
+
+        $country = m::mock('Illuminate\Database\Eloquent\Model');
+        $country->shouldReceive('getTable')->andReturn('countries');
+        $country->shouldReceive('getQualifiedKeyName')->andReturn('countries.id');
+        $country->shouldReceive('getKey')->andReturn(1);
+        $country->shouldReceive('getKeyName')->andReturn('id');
+
+        $user = m::mock('Illuminate\Database\Eloquent\Model');
+        $user->shouldReceive('getTable')->andReturn('users');
+        $user->shouldReceive('getQualifiedKeyName')->andReturn('users.id');
+
+        $post = m::mock('Illuminate\Database\Eloquent\Model');
+        $post->shouldReceive('getQualifiedKeyName')->andReturn('posts.id');
+
+        $builder->shouldReceive('getModel')->andReturn($post);
+
+        $user->shouldReceive('getKey')->andReturn(1);
+        $user->shouldReceive('getCreatedAtColumn')->andReturn('created_at');
+        $user->shouldReceive('getUpdatedAtColumn')->andReturn('updated_at');
+
+        return [$builder, $country, $user, 'user_id', 'post_id'];
+    }
+}
+
+class EloquentHasOneThroughModelStub extends Illuminate\Database\Eloquent\Model
+{
+
+}

--- a/tests/Database/DatabaseEloquentHasOneThroughTest.php
+++ b/tests/Database/DatabaseEloquentHasOneThroughTest.php
@@ -25,7 +25,7 @@ class DatabaseEloquentHasOneThroughTest extends PHPUnit_Framework_TestCase
     public function testEagerConstraintsAreProperlyAdded()
     {
         $relation = $this->getRelation();
-        $relation->getQuery()->shouldReceive('whereIn')->once()->with('countries.id', [1, 2]);
+        $relation->getQuery()->shouldReceive('whereIn')->once()->with('accounts.supplier_id', [1, 2]);
         $model1 = new EloquentHasOneThroughModelStub;
         $model1->id = 1;
         $model2 = new EloquentHasOneThroughModelStub;
@@ -37,64 +37,61 @@ class DatabaseEloquentHasOneThroughTest extends PHPUnit_Framework_TestCase
     {
         $relation = $this->getRelation();
 
-        // Countries
+        // Account Histories
         $results1 = new EloquentHasOneThroughModelStub;
-        $results1->user_id = 1;
+        $results1->supplier_id = 1;
         $results2 = new EloquentHasOneThroughModelStub;
-        $results2->user_id = 2;
+        $results2->supplier_id = 2;
 
-        // Posts
+        // Suppliers
         $model1 = new EloquentHasOneThroughModelStub;
-        $model1->user_id = 1;
+        $model1->id = 1;
         $model2 = new EloquentHasOneThroughModelStub;
-        $model2->user_id = 2;
+        $model2->id = 2;
 
         $models = $relation->match([$model1, $model2], new Collection([$results1, $results2]), 'foo');
 
-        $this->assertEquals(1, $models[0]->foo->user_id);
-        $this->assertEquals(2, $models[1]->foo->user_id);
+        $this->assertEquals(1, $models[0]->foo->supplier_id);
+        $this->assertEquals(2, $models[1]->foo->supplier_id);
     }
 
     /**
-     * Creates a new HasOneThrough relationship of a Post having a Country through a User.
+     * Creates a new HasOneThrough relationship of a Supplier having an Account History through an Account.
      *
      * @return HasOneThrough
      */
     protected function getRelation()
     {
-        list($builder, $country, $user, $farParentKey, $parentKey) = $this->getRelationArguments();
+        list($builder, $supplier, $account, $parentForeignKey, $relatedForeignKey) = $this->getRelationArguments();
 
-        return new HasOneThrough($builder, $country, $user, $farParentKey, $parentKey);
+        return new HasOneThrough($builder, $supplier, $account, $parentForeignKey, $relatedForeignKey);
     }
 
     protected function getRelationArguments()
     {
         $builder = m::mock('Illuminate\Database\Eloquent\Builder');
-        $builder->shouldReceive('join')->once()->with('users', 'users.post_id', '=', 'posts.id');
-        $builder->shouldReceive('join')->once()->with('countries', 'countries.user_id', '=', 'users.id');
-        $builder->shouldReceive('where')->with('countries.id', '=', 1);
-        $builder->shouldReceive('whereNotNull')->with('countries.id');
+        $builder->shouldReceive('join')->once()->with('accounts', 'accounts.id', '=', 'account_histories.account_id');
+        $builder->shouldReceive('where')->with('accounts.supplier_id', '=', 1);
+        $builder->shouldReceive('whereNotNull')->with('accounts.supplier_id');
 
-        $country = m::mock('Illuminate\Database\Eloquent\Model');
-        $country->shouldReceive('getTable')->andReturn('countries');
-        $country->shouldReceive('getQualifiedKeyName')->andReturn('countries.id');
-        $country->shouldReceive('getKey')->andReturn(1);
-        $country->shouldReceive('getKeyName')->andReturn('id');
+        // Suppliers
+        $supplier = m::mock('Illuminate\Database\Eloquent\Model');
+        $supplier->shouldReceive('getKey')->andReturn(1);
+        $supplier->shouldReceive('getKeyName')->andReturn('id');
 
-        $user = m::mock('Illuminate\Database\Eloquent\Model');
-        $user->shouldReceive('getTable')->andReturn('users');
-        $user->shouldReceive('getQualifiedKeyName')->andReturn('users.id');
+        // Accounts
+        $account = m::mock('Illuminate\Database\Eloquent\Model');
+        $account->shouldReceive('getTable')->andReturn('accounts');
+        $account->shouldReceive('getQualifiedKeyName')->andReturn('accounts.id');
 
-        $post = m::mock('Illuminate\Database\Eloquent\Model');
-        $post->shouldReceive('getQualifiedKeyName')->andReturn('posts.id');
+        // Account Histories
+        $accountHistory = m::mock('Illuminate\Database\Eloquent\Model');
+        $accountHistory->shouldReceive('getTable')->andReturn('account_histories');
 
-        $builder->shouldReceive('getModel')->andReturn($post);
 
-        $user->shouldReceive('getKey')->andReturn(1);
-        $user->shouldReceive('getCreatedAtColumn')->andReturn('created_at');
-        $user->shouldReceive('getUpdatedAtColumn')->andReturn('updated_at');
+        $builder->shouldReceive('getModel')->andReturn($accountHistory);
 
-        return [$builder, $country, $user, 'user_id', 'post_id'];
+        return [$builder, $supplier, $account, 'supplier_id', 'account_id'];
     }
 }
 

--- a/tests/Database/DatabaseEloquentHasOneThroughTest.php
+++ b/tests/Database/DatabaseEloquentHasOneThroughTest.php
@@ -55,13 +55,13 @@ class DatabaseEloquentHasOneThroughTest extends PHPUnit_Framework_TestCase
         // Insert accounts
         $this->connection()->insert(
             'insert into accounts (email, eloquent_has_one_through_model_supplier_id) values (\'foobar@example.com\', ?), (\'barfoo@example.com\', ?)',
-            array_column($this->connection()->select('select id from suppliers'), 'id')
+            $this->object_array_column($this->connection()->select('select id from suppliers'), 'id')
         );
 
         // Insert account histories
         $this->connection()->insert(
             'insert into account_histories (title, eloquent_has_one_through_model_account_id) values (\'FooBar\', ?), (\'BarFoo\', ?)',
-            array_column($this->connection()->select('select id from accounts'), 'id')
+            $this->object_array_column($this->connection()->select('select id from accounts'), 'id')
         );
     }
 
@@ -230,6 +230,22 @@ class DatabaseEloquentHasOneThroughTest extends PHPUnit_Framework_TestCase
     protected function schema($connection = 'default')
     {
         return $this->connection($connection)->getSchemaBuilder();
+    }
+
+    /**
+     * @param array  $array array of stdClass
+     * @param string $property
+     *
+     * @return array
+     */
+    protected function object_array_column($array, $property)
+    {
+        $columns = [];
+        foreach ($array as $item) {
+            $columns[] = $item->{$property};
+        }
+
+        return $columns;
     }
 }
 


### PR DESCRIPTION
I have created a `HasOneThrough` and `BelongsToThrough` Eloquent relationships.

This is fix from https://github.com/laravel/framework/pull/16599 where I actually created a BelongsToThrough rather than a HasOneThrough. I renamed the original class to BelongsToThrough and created a new class called HasOneThrough.

Linked to https://github.com/laravel/framework/issues/8721