### PR TITLE
[5.3] Wrap Eloquent event

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1641,14 +1641,14 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     /**
      * Append the names of the class to the event to distinguish it from
      * other model events that are fired, allowing us to listen on each model
-     * event set individually instead of catching event for all the models. 
+     * event set individually instead of catching event for all the models.
      *
      * @param  string  $event
      * @return string
      */
     public static function getModelEvent($event)
     {
-        return "eloquent.{$event}: " . static::class;
+        return "eloquent.{$event}: ".static::class;
     }
 
     /**
@@ -1662,7 +1662,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     {
         if (! isset(static::$dispatcher)) {
             return true;
-        }     
+        }
 
         $method = $halt ? 'until' : 'fire';
 

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1255,7 +1255,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         $instance = new static;
 
         foreach ($instance->getObservableEvents() as $event) {
-            static::$dispatcher->forget("eloquent.{$event}: ".static::class);
+            static::$dispatcher->forget(static::getModelEvent($event));
         }
     }
 
@@ -1270,9 +1270,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     protected static function registerModelEvent($event, $callback, $priority = 0)
     {
         if (isset(static::$dispatcher)) {
-            $name = static::class;
-
-            static::$dispatcher->listen("eloquent.{$event}: {$name}", $callback, $priority);
+            static::$dispatcher->listen(static::getModelEvent($event), $callback, $priority);
         }
     }
 
@@ -1641,6 +1639,19 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     }
 
     /**
+     * Append the names of the class to the event to distinguish it from
+     * other model events that are fired, allowing us to listen on each model
+     * event set individually instead of catching event for all the models. 
+     *
+     * @param  string  $event
+     * @return string
+     */
+    public static function getModelEvent($event)
+    {
+        return "eloquent.{$event}: " . static::class;
+    }
+
+    /**
      * Fire the given event for the model.
      *
      * @param  string  $event
@@ -1651,16 +1662,11 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     {
         if (! isset(static::$dispatcher)) {
             return true;
-        }
-
-        // We will append the names of the class to the event to distinguish it from
-        // other model events that are fired, allowing us to listen on each model
-        // event set individually instead of catching event for all the models.
-        $event = "eloquent.{$event}: ".static::class;
+        }     
 
         $method = $halt ? 'until' : 'fire';
 
-        return static::$dispatcher->$method($event, $this);
+        return static::$dispatcher->$method(static::getModelEvent($event), $this);
     }
 
     /**


### PR DESCRIPTION
Avoids code duplication and adds the possibility of using it like:

```php
public function subscribe($events)
{
    $events->listen(
        User::getModelEvent('created'),
        static::getListener('onUserCreated')
    );
}
```

Refs: #16718