### PR TITLE
[5.3] Add support to override timestamps columns

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1715,11 +1715,11 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     {
         $time = $this->freshTimestamp();
 
-        if (! $this->isDirty(static::UPDATED_AT)) {
+        if (! $this->isDirty($this->getUpdatedAtColumn())) {
             $this->setUpdatedAt($time);
         }
 
-        if (! $this->exists && ! $this->isDirty(static::CREATED_AT)) {
+        if (! $this->exists && ! $this->isDirty($this->getCreatedAtColumn())) {
             $this->setCreatedAt($time);
         }
     }
@@ -1732,7 +1732,8 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public function setCreatedAt($value)
     {
-        $this->{static::CREATED_AT} = $value;
+        $column = $this->getCreatedAtColumn();
+        $this->{$column} = $value;
 
         return $this;
     }
@@ -1745,7 +1746,8 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public function setUpdatedAt($value)
     {
-        $this->{static::UPDATED_AT} = $value;
+        $column = $this->getUpdatedAtColumn();
+        $this->{$column} = $value;
 
         return $this;
     }
@@ -2935,7 +2937,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public function getDates()
     {
-        $defaults = [static::CREATED_AT, static::UPDATED_AT];
+        $defaults = [$this->getCreatedAtColumn(), $this->getUpdatedAtColumn()];
 
         return $this->timestamps ? array_merge($this->dates, $defaults) : $this->dates;
     }

--- a/src/Illuminate/Database/Eloquent/Relations/Pivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Pivot.php
@@ -46,23 +46,23 @@ class Pivot extends Model
      */
     public function __construct(Model $parent, $attributes, $table, $exists = false)
     {
-        parent::__construct();
+        parent::__construct();     
+
+        // We store off the parent instance so we will access the timestamp column names
+        // for the model, since the pivot model timestamps aren't easily configurable
+        // from the developer's point of view. We can use the parents to get these.
+        $this->parent = $parent;    
 
         // The pivot model is a "dynamic" model since we will set the tables dynamically
         // for the instance. This allows it work for any intermediate tables for the
         // many to many relationship that are defined by this developer's classes.
-        $this->setTable($table);
+        $this->setTable($table);        
 
         $this->setConnection($parent->getConnectionName());
 
         $this->forceFill($attributes);
 
-        $this->syncOriginal();
-
-        // We store off the parent instance so we will access the timestamp column names
-        // for the model, since the pivot model timestamps aren't easily configurable
-        // from the developer's point of view. We can use the parents to get these.
-        $this->parent = $parent;
+        $this->syncOriginal();               
 
         $this->exists = $exists;
 

--- a/src/Illuminate/Database/Eloquent/Relations/Pivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Pivot.php
@@ -46,23 +46,23 @@ class Pivot extends Model
      */
     public function __construct(Model $parent, $attributes, $table, $exists = false)
     {
-        parent::__construct();     
+        parent::__construct();
 
         // We store off the parent instance so we will access the timestamp column names
         // for the model, since the pivot model timestamps aren't easily configurable
         // from the developer's point of view. We can use the parents to get these.
-        $this->parent = $parent;    
+        $this->parent = $parent;
 
         // The pivot model is a "dynamic" model since we will set the tables dynamically
         // for the instance. This allows it work for any intermediate tables for the
         // many to many relationship that are defined by this developer's classes.
-        $this->setTable($table);        
+        $this->setTable($table);
 
         $this->setConnection($parent->getConnectionName());
 
         $this->forceFill($attributes);
 
-        $this->syncOriginal();               
+        $this->syncOriginal();
 
         $this->exists = $exists;
 


### PR DESCRIPTION
Currently the timestamps column names ``` created_at, updated_at ``` are kinda hard coded, there is a getter for these names but sometimes the constant is used instead of using the getter, this PR fix that by always calling the getter instead of the constant this way ppl can easilly change the name of these columns...

Refs #16720