### PR TITLE
[5.3] Model route with default value

### DIFF
--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -639,6 +639,16 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('TAYLOR', $router->dispatch(Request::create('foo/taylor', 'GET'))->getContent());
     }
 
+    public function testModelBindingWithNullReturnDefaultValue()
+        {
+        $router = $this->getRouter();
+        $router->get('foo/{bar}', ['middleware' => SubstituteBindings::class, 'uses' => function ($name = null) {
+            return 'hello world';
+        }]);
+        $router->model('bar', 'RouteModelBindingNullStub');
+        $this->assertEquals('hello world', $router->dispatch(Request::create('foo/taylor', 'GET'))->getContent());
+    }
+
     /**
      * @expectedException Illuminate\Database\Eloquent\ModelNotFoundException
      */


### PR DESCRIPTION
I expect that 'hello world' should be returned, because a default value for name is set.

Refs. https://github.com/laravel/framework/issues/16727