### PR TITLE
[5.2] Update PsySH dependency.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "mtdowling/cron-expression": "~1.0",
         "nesbot/carbon": "~1.20",
         "paragonie/random_compat": "~1.4",
-        "psy/psysh": "0.7.*",
+        "psy/psysh": "0.7.*|0.8.*",
         "swiftmailer/swiftmailer": "~5.1",
         "symfony/console": "2.8.*|3.0.*",
         "symfony/debug": "2.8.*|3.0.*",


### PR DESCRIPTION
With the release of PsySH 0.8, I noticed a related commit to the 5.3 branch: https://github.com/laravel/framework/commit/0164218e939cf20f493c11fb8c8b17c2c9c4ecd6.

Also, PsySH's dependency on PHP-Parser was updated earlier: https://github.com/bobthecow/psysh/commit/d0082a509570fd81c31eae9f8e7fb96a83f455ab#diff-b5d0ee8c97c7abd7e3fa29b9a27d1780

This is causing a problem for a dependency ([tebru/retrofit-php](https://github.com/tebru/retrofit-php)) I am using on a couple Laravel 5.2 projects. This change would allow me to specify PsySH 0.8 and PHP-Parser 1.3 in order that my dependencies resolve. I ran tests replacing PsySH 0.7 with 0.8 on the 5.2 branch, I believe the tests are a go.