### PR TITLE
[5.4] Default named parameters in UrlGenerator

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -163,7 +163,7 @@ class UrlGenerator implements UrlGeneratorContract
 
         if ($url) {
             return $url;
-        } else if ($fallback) {
+        } elseif ($fallback) {
             return $this->to($fallback);
         } else {
             return $this->to('/');
@@ -443,7 +443,7 @@ class UrlGenerator implements UrlGeneratorContract
         return preg_replace_callback('/\{(.*?)\??\}/', function ($m) use (&$parameters, $defaultNamedParameters) {
             if (isset($parameters[$m[1]])) {
                 return Arr::pull($parameters, $m[1]);
-            } else if (isset($defaultNamedParameters[$m[1]])) {
+            } elseif (isset($defaultNamedParameters[$m[1]])) {
                 return $defaultNamedParameters[$m[1]];
             } else {
                 return $m[0];

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -109,6 +109,13 @@ class UrlGenerator implements UrlGeneratorContract
     ];
 
     /**
+     * Default named parameters.
+     *
+     * @var array
+     */
+    protected $defaultNamedParameters = [];
+
+    /**
      * Create a new URL Generator instance.
      *
      * @param  \Illuminate\Routing\RouteCollection  $routes
@@ -298,6 +305,34 @@ class UrlGenerator implements UrlGeneratorContract
     }
 
     /**
+     * Get the default named parameters.
+     *
+     * @return array
+     */
+    public function getDefaultNamedParameters()
+    {
+        return $this->defaultNamedParameters;
+    }
+
+    /**
+     * Set the default named parameters.
+     *
+     * @param  string|array  $key
+     * @param  mixed  $value
+     * @return void
+     */
+    public function setDefaultNamedParameters($key, $value = null)
+    {
+        if (is_array($key)) {
+            foreach ($key as $k => $v) {
+                $this->defaultNamedParameters[$k] = $v;
+            }
+        } else {
+            $this->defaultNamedParameters[$key] = $value;
+        }
+    }
+
+    /**
      * Force the schema for URLs.
      *
      * @param  string  $schema
@@ -403,8 +438,16 @@ class UrlGenerator implements UrlGeneratorContract
      */
     protected function replaceNamedParameters($path, &$parameters)
     {
-        return preg_replace_callback('/\{(.*?)\??\}/', function ($m) use (&$parameters) {
-            return isset($parameters[$m[1]]) ? Arr::pull($parameters, $m[1]) : $m[0];
+        $defaultNamedParameters = $this->getDefaultNamedParameters();
+
+        return preg_replace_callback('/\{(.*?)\??\}/', function ($m) use (&$parameters, $defaultNamedParameters) {
+            if (isset($parameters[$m[1]])) {
+                return Arr::pull($parameters, $m[1]);
+            } else if (isset($defaultNamedParameters[$m[1]])) {
+                return $defaultNamedParameters[$m[1]];
+            } else {
+                return $m[0];
+            }
         }, $path);
     }
 

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -163,7 +163,7 @@ class UrlGenerator implements UrlGeneratorContract
 
         if ($url) {
             return $url;
-        } elseif ($fallback) {
+        } else if ($fallback) {
             return $this->to($fallback);
         } else {
             return $this->to('/');


### PR DESCRIPTION
How to use default named parameters (localize etc).
```
app("url")->setDefaultNamedParameters("locale", app()->getLocale());
```
or
```
app("url")->setDefaultNamedParameters(["locale", app()->getLocale(), "userId" => app("auth")->user()->getKey()]);
```
Just create middleware

```
<?php

namespace App\Http\Middleware;

use Illuminate\Foundation\Application;

class UrlGeneratorParameters {

    protected $app;

    public function __construct(Application $app)
    {
        $this->app = $app;
    }

    /**
     * Handle an incoming request.
     *
     * @param  \Illuminate\Http\Request  $request
     * @param  \Closure  $next
     * @return mixed
     */
    public function handle($request, \Closure $next)
    {
        $this->app->url->setDefaultNamedParameters("locale", config('app.locale'));

        return $next($request);
    }
}
```
In routes/web.php file
```
app('router')->pattern('locale', '(' . implode('|', config('app.locales')). ')');
app('router')->group(['domain' => '{locale}.telenok.com'], function ()
{
    app("router")->post("some-url", array("as" => "some-name", "uses" => "SomeClass@somemethod"));
});
```

Then instead of 
```
<a href="{{  route("some-name") }}">.....</a>
```
you'll get
```
<a href="http://en.telenok.com/some-url">.....</a>
```