### PR TITLE
[5.3] dont report exception inside signal handler

### DIFF
--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -99,8 +99,6 @@ class Worker
         pcntl_async_signals(true);
 
         pcntl_signal(SIGALRM, function () {
-            $this->exceptions->report(new TimeoutException('A queue worker timed out while processing a job.'));
-
             exit(1);
         });
 


### PR DESCRIPTION
The reasons to keep signal handler simple:
1. The timed-out job will be retried later and if the number of attempts exceeds, it will be reported. Therefore, reporting here is redundant.
2. The reporting process may get stuck forever because of network errors - for example if Bugsnag is used. I am not sure it is possible to register another signal handler inside this one to prevent the issue.