### PR TITLE
Cleanup

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -456,11 +456,7 @@ if (! function_exists('env')) {
                 return;
         }
 
-        if (strlen($value) > 1 && Str::startsWith($value, '"') && Str::endsWith($value, '"')) {
-            return substr($value, 1, -1);
-        }
-
-        return $value;
+        return trim($value, '"');
     }
 }
 


### PR DESCRIPTION
Is there a reason why we have to test value with startWith and endWith when we can simply use trim(). I surely miss something but can't figure out what