### PR TITLE
[5.3] Add schedule:list command

### DIFF
--- a/src/Illuminate/Console/ScheduleServiceProvider.php
+++ b/src/Illuminate/Console/ScheduleServiceProvider.php
@@ -21,6 +21,7 @@ class ScheduleServiceProvider extends ServiceProvider
     public function register()
     {
         $this->commands('Illuminate\Console\Scheduling\ScheduleRunCommand');
+        $this->commands('Illuminate\Console\Scheduling\ScheduleListCommand');
     }
 
     /**
@@ -32,6 +33,7 @@ class ScheduleServiceProvider extends ServiceProvider
     {
         return [
             'Illuminate\Console\Scheduling\ScheduleRunCommand',
+            'Illuminate\Console\Scheduling\ScheduleListCommand',
         ];
     }
 }

--- a/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
@@ -69,11 +69,11 @@ class ScheduleListCommand extends Command
             }
 
             // move description to brackets
-            if (!empty($command) && !empty($desc)) {
-                $desc = '(' . $desc . ')';
+            if (! empty($command) && ! empty($desc)) {
+                $desc = '('.$desc.')';
             }
 
-            $this->line($expression . "\t" . trim($command . ' ' . $desc));
+            $this->line($expression."\t".trim($command.' '.$desc));
         }
     }
 }

--- a/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
@@ -51,6 +51,7 @@ class ScheduleListCommand extends Command
 
         if (count($events) === 0) {
             $this->info('No scheduled commands.');
+
             return;
         }
 

--- a/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
@@ -63,12 +63,17 @@ class ScheduleListCommand extends Command
             $command = substr($command, 0, strpos($command, '>'));
             $command = trim(str_replace([PHP_BINARY, 'artisan', '\'', '"'], '', $command));
 
-            // if description contain PHP BINARY, description is empty
-            if (strpos($desc, PHP_BINARY) !== false) {
+            // if description contain 2>&1, it is not really description
+            if (strpos($desc, '2>&1') !== false) {
                 $desc = '';
             }
 
-            $this->line($expression . "\t" . trim($command . ' ') . $desc);
+            // move description to brackets
+            if (!empty($command) && !empty($desc)) {
+                $desc = '(' . $desc . ')';
+            }
+
+            $this->line($expression . "\t" . trim($command . ' ' . $desc));
         }
     }
 }

--- a/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Illuminate\Console\Scheduling;
+
+use Illuminate\Console\Command;
+
+class ScheduleListCommand extends Command
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'schedule:list';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'List all scheduled commands';
+
+    /**
+     * The schedule instance.
+     *
+     * @var \Illuminate\Console\Scheduling\Schedule
+     */
+    protected $schedule;
+
+    /**
+     * Create a new command instance.
+     *
+     * @param  \Illuminate\Console\Scheduling\Schedule  $schedule
+     * @return void
+     */
+    public function __construct(Schedule $schedule)
+    {
+        $this->schedule = $schedule;
+
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function fire()
+    {
+        $events = $this->schedule->events();
+
+        if (count($events) === 0) {
+            $this->info('No scheduled commands.');
+            return;
+        }
+
+        foreach ($events as $event) {
+            $command = $event->buildCommand();
+            $desc = $event->getSummaryForDisplay();
+            $expression = $event->getExpression();
+
+            // show only command name
+            $command = substr($command, 0, strpos($command, '>'));
+            $command = trim(str_replace([PHP_BINARY, 'artisan', '\'', '"'], '', $command));
+
+            // if description contain PHP BINARY, description is empty
+            if (strpos($desc, PHP_BINARY) !== false) {
+                $desc = '';
+            }
+
+            $this->line($expression . "\t" . trim($command . ' ') . $desc);
+        }
+    }
+}


### PR DESCRIPTION
Add `schedule:list` command for listing all scheduled commands:

```
VojtaSvoboda@Mac:~/Www/acme.com% php artisan schedule:list
0 * * * * *	Notify upcomming events
0 * * * * *	cache:clear (Cache clear)
0 0 * * * *	node /home/acme/script.js (Run Node script)
```

For `call` (line 1) it prints description (or string "Closure" if a description is empty).
For `command` (line 2) it prints command name and description (if not empty).
For `exec` (line 3) it prints exec and description (if not empty).

Code used for example above:

```
$schedule->call(function () {
    $this->notifyUpcommingEvents();
})->hourly()->name('Notify upcomming events');

$schedule->command('cache:clear')->hourly()->name('Cache clear');

$schedule->exec('node /home/acme/script.js')->daily()->name('Run Node script');
```