### PR TITLE
[5.3] kill timedout process

### DIFF
--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -99,6 +99,10 @@ class Worker
         pcntl_async_signals(true);
 
         pcntl_signal(SIGALRM, function () {
+            if (extension_loaded('posix')) {
+                posix_kill(getmypid(), SIGKILL);
+            }
+
             exit(1);
         });
 


### PR DESCRIPTION
This is to prevent long/infinite execution of the shut down functions and destructors after timeout detection.

In order to safely allow the shutdown process, I tried to register another alarm inside the current SIGARLM handler, but it did not work.

However killing via SIGKILL seems to be working on my computer.

It is now a bit safer and I personally prefer it. Not sure if everybody is OK with it.