### PR TITLE
[5.4] Check for typos in first fluent route segment

### DIFF
--- a/src/Illuminate/Routing/RouteRegistrar.php
+++ b/src/Illuminate/Routing/RouteRegistrar.php
@@ -4,6 +4,7 @@ namespace Illuminate\Routing;
 
 use Closure;
 use BadMethodCallException;
+use InvalidArgumentException;
 
 class RouteRegistrar
 {
@@ -65,9 +66,15 @@ class RouteRegistrar
      * @param  string  $key
      * @param  mixed  $value
      * @return $this
+     *
+     * @throws \InvalidArgumentException
      */
     public function attribute($key, $value)
     {
+        if (! in_array($key, $this->allowedAttributes)) {
+            throw new InvalidArgumentException("Attribute [{$key}] does not exist.");
+        }
+
         $this->attributes[array_get($this->aliases, $key, $key)] = $value;
 
         return $this;


### PR DESCRIPTION
Currently, this will not throw:

```php
Route::midddleware('auth')->get('/', 'HomeController@index');
```

But this will:

```php
Route::as('home')->midddleware('auth')->get('/', 'HomeController@index');
```

---

This PR adds a guard against the first example too.