### PR TITLE
[5.4] Allow collection macros to be proxied

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -27,6 +27,16 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     protected $items = [];
 
     /**
+     * The methods that can be proxied.
+     *
+     * @var array
+     */
+    protected static $proxies = [
+        'each', 'map', 'first', 'partition', 'sortBy',
+        'sortByDesc', 'sum', 'reject', 'filter',
+    ];
+
+    /**
      * Create a new collection.
      *
      * @param  mixed  $items
@@ -46,6 +56,17 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     public static function make($items = [])
     {
         return new static($items);
+    }
+
+    /**
+     * Add a method to the list of proxied methods.
+     *
+     * @param  string  $method
+     * @return void
+     */
+    public static function proxy($method)
+    {
+        static::$proxies[] = $method;
     }
 
     /**
@@ -1388,12 +1409,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      */
     public function __get($key)
     {
-        $proxies = [
-            'each', 'map', 'first', 'partition', 'sortBy',
-            'sortByDesc', 'sum', 'reject', 'filter',
-        ];
-
-        if (! in_array($key, $proxies)) {
+        if (! in_array($key, static::$proxies)) {
             throw new Exception("Property [{$key}] does not exist on this collection instance.");
         }
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -834,6 +834,21 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
         $this->assertSame(['a', 'aa', 'aaa'], $c->foo()->all());
     }
 
+    public function testCanAddMethodsToProxy()
+    {
+        Collection::macro('adults', function ($callback) {
+            return $this->filter(function ($item) use ($callback) {
+                return $callback($item) >= 18;
+            });
+        });
+
+        Collection::proxy('adults');
+
+        $c = new Collection([['age' => 3], ['age' => 12], ['age' => 18], ['age' => 56]]);
+
+        $this->assertSame([['age' => 18], ['age' => 56]], $c->adults->age->values()->all());
+    }
+
     public function testMakeMethod()
     {
         $collection = Collection::make('foo');


### PR DESCRIPTION
Allows macro authors to register their macros to enable them to be proxied.

```php
Collection::macro('foo', function ($callback) {
    //
});

Collection::proxy('foo');
```

Which can later be used with the higher order proxied stuff:

```php
$results = $collection->foo->bar;
```