### PR TITLE
[5.3] Remove unnecessary check

### DIFF
--- a/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
@@ -63,7 +63,7 @@ class ScheduleRunCommand extends Command
             ++$eventsRan;
         }
 
-        if (count($events) === 0 || $eventsRan === 0) {
+        if ($eventsRan === 0) {
             $this->info('No scheduled commands are ready to run.');
         }
     }

--- a/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
@@ -47,11 +47,9 @@ class ScheduleRunCommand extends Command
      */
     public function fire()
     {
-        $events = $this->schedule->dueEvents($this->laravel);
+        $eventsRan = false;
 
-        $eventsRan = 0;
-
-        foreach ($events as $event) {
+        foreach ($this->schedule->dueEvents($this->laravel) as $event) {
             if (! $event->filtersPass($this->laravel)) {
                 continue;
             }
@@ -60,10 +58,10 @@ class ScheduleRunCommand extends Command
 
             $event->run($this->laravel);
 
-            ++$eventsRan;
+            $eventsRan = true;
         }
 
-        if ($eventsRan === 0) {
+        if (! $eventsRan) {
             $this->info('No scheduled commands are ready to run.');
         }
     }


### PR DESCRIPTION
There is no need for `count($events)` - it was made redundant when this commit occurred: https://github.com/laravel/framework/commit/ffabb9a72b47cf7baef64411a126167eea63efcd

Basically the only thing that matters now is the `$eventsRan` count