### PR TITLE
fix redis queue can't work in redis cluster

### DIFF
--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -223,7 +223,7 @@ class RedisQueue extends Queue implements QueueContract
      */
     protected function getQueue($queue)
     {
-        return 'queues:'.($queue ?: $this->default);
+        return '{queues:' . ($queue ? : $this->default) . '}';
     }
 
     /**


### PR DESCRIPTION
php artisan queue:work console command can't work in redis cluster 3.0, because in redis cluster, the KEYS call must be in same hash slot.
see
https://redis.io/topics/cluster-spec#keys-hash-tags
https://github.com/laravel/framework/issues/16754