### PR TITLE
[5.3] Verify if file exists before rollback

### DIFF
--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -204,8 +204,9 @@ class Migrator
             $this->requireFiles($files);
 
             foreach ($migrations as $migration) {
-                if (!isset($files[$migration->migration]))
+                if (!isset($files[$migration->migration])) {
                     continue;
+                }
                 
                 $migration = (object) $migration;
 

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -204,6 +204,9 @@ class Migrator
             $this->requireFiles($files);
 
             foreach ($migrations as $migration) {
+                if (!isset($files[$migration->migration]))
+                    continue;
+                
                 $migration = (object) $migration;
 
                 $rolledBack[] = $files[$migration->migration];

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -207,7 +207,7 @@ class Migrator
                 if (! isset($files[$migration->migration])) {
                     continue;
                 }
-                
+
                 $migration = (object) $migration;
 
                 $rolledBack[] = $files[$migration->migration];

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -204,7 +204,7 @@ class Migrator
             $this->requireFiles($files);
 
             foreach ($migrations as $migration) {
-                if (!isset($files[$migration->migration])) {
+                if (! isset($files[$migration->migration])) {
                     continue;
                 }
                 


### PR DESCRIPTION
If a single file in migrations database no longer exists or you use another migration folder structure, all rollback will fail. This update solve this.