### PR TITLE
[5.3] allow api_token to be sent through as input

### DIFF
--- a/src/Illuminate/Auth/TokenGuard.php
+++ b/src/Illuminate/Auth/TokenGuard.php
@@ -82,6 +82,10 @@ class TokenGuard implements Guard
     {
         $token = $this->request->query($this->inputKey);
 
+         if (empty($token)) {
+            $token = $this->request->input($this->inputKey);
+        }       
+
         if (empty($token)) {
             $token = $this->request->bearerToken();
         }

--- a/src/Illuminate/Auth/TokenGuard.php
+++ b/src/Illuminate/Auth/TokenGuard.php
@@ -82,9 +82,9 @@ class TokenGuard implements Guard
     {
         $token = $this->request->query($this->inputKey);
 
-         if (empty($token)) {
+        if (empty($token)) {
             $token = $this->request->input($this->inputKey);
-        }       
+        }
 
         if (empty($token)) {
             $token = $this->request->bearerToken();


### PR DESCRIPTION
Allow the api_token to be sent through an input rather than just part the query string. This is because some systems do not allow POST requests with inputs to be sent through the query string or  allow modifying the http headers. 