### PR TITLE
[5.3] Remove useless loop

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -138,9 +138,7 @@ class Arr
                 return value($default);
             }
 
-            foreach ($array as $item) {
-                return $item;
-            }
+            return $item[0];
         }
 
         foreach ($array as $key => $value) {


### PR DESCRIPTION
Could also use `array_shift()` but bigO of this function is O(n)
Accessing directly the by key is O(1)