### PR TITLE
[5.3] Revert changes to startsWith()

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -403,7 +403,7 @@ class Str
     public static function startsWith($haystack, $needles)
     {
         foreach ((array) $needles as $needle) {
-            if ($needle != '' && strpos((string) $haystack, (string) $needle) === 0) {
+            if ($needle != '' && substr($haystack, 0, strlen($needle)) === (string) $needle) {
                 return true;
             }
         }


### PR DESCRIPTION
Reverts #16761 (followed by #16770).

As showed in https://github.com/laravel/framework/pull/16761#issuecomment-266558361, the new implementation isn't scalable, contrarily to the previous one.