### PR TITLE
[5.3] Fixed runtime error for when facade root not set.

### DIFF
--- a/src/Illuminate/Foundation/Support/Providers/RouteServiceProvider.php
+++ b/src/Illuminate/Foundation/Support/Providers/RouteServiceProvider.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Foundation\Support\Providers;
 
 use Illuminate\Routing\Router;
-use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Contracts\Routing\UrlGenerator;
 
@@ -31,7 +30,7 @@ class RouteServiceProvider extends ServiceProvider
             $this->loadRoutes();
 
             $this->app->booted(function () {
-                Route::getRoutes()->refreshNameLookups();
+                $this->app['router']->getRoutes()->refreshNameLookups();
             });
         }
     }


### PR DESCRIPTION
I've stumbled upon the following error:

> RuntimeException in Facade.php line 234:
>
> A facade root has not been set.

Comparing the `RouteServiceProvider` to previous versions, _only_ in 5.3 I have noticed the facade being used.

I personally don't like facades and thankfully Laravel has never forced me to use them, until this which is a minor tweak :)