### PR TITLE
[5.4] 	Create a new "every" method on the collection

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -245,6 +245,35 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
+     * Determine if all items in the collection pass the given test.
+     *
+     * @param  string|callable  $key
+     * @param  mixed  $operator
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function every($key, $operator = null, $value = null)
+    {
+        if (func_num_args() == 1) {
+            foreach ($this->items as $k => $v) {
+                if (! $key($v, $k)) {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        if (func_num_args() == 2) {
+            $value = $operator;
+
+            $operator = '=';
+        }
+
+        return $this->every($this->operatorForWhere($key, $operator, $value));
+    }
+
+    /**
      * Get all items except for those with the specified keys.
      *
      * @param  mixed  $keys

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -255,8 +255,10 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     public function every($key, $operator = null, $value = null)
     {
         if (func_num_args() == 1) {
+            $callback = $this->valueRetriever($key);
+
             foreach ($this->items as $k => $v) {
-                if (! $key($v, $k)) {
+                if (! $callback($v, $k)) {
                     return false;
                 }
             }

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -245,30 +245,6 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
-     * Create a new collection consisting of every n-th element.
-     *
-     * @param  int  $step
-     * @param  int  $offset
-     * @return static
-     */
-    public function every($step, $offset = 0)
-    {
-        $new = [];
-
-        $position = 0;
-
-        foreach ($this->items as $item) {
-            if ($position % $step === $offset) {
-                $new[] = $item;
-            }
-
-            $position++;
-        }
-
-        return new static($new);
-    }
-
-    /**
      * Get all items except for those with the specified keys.
      *
      * @param  mixed  $keys
@@ -715,6 +691,30 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
 
             return is_null($result) || $value < $result ? $value : $result;
         });
+    }
+
+    /**
+     * Create a new collection consisting of every n-th element.
+     *
+     * @param  int  $step
+     * @param  int  $offset
+     * @return static
+     */
+    public function nth($step, $offset = 0)
+    {
+        $new = [];
+
+        $position = 0;
+
+        foreach ($this->items as $item) {
+            if ($position % $step === $offset) {
+                $new[] = $item;
+            }
+
+            $position++;
+        }
+
+        return new static($new);
     }
 
     /**

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -32,7 +32,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      * @var array
      */
     protected static $proxies = [
-        'each', 'filter', 'first', 'map', 'partition',
+        'each', 'every', 'filter', 'first', 'map', 'partition',
         'reject', 'sortBy', 'sortByDesc', 'sum',
     ];
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -750,6 +750,7 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
         }));
 
         $c = new Collection([['active' => true], ['active' => true]]);
+        $this->assertTrue($c->every('active'));
         $this->assertTrue($c->every->active);
         $this->assertFalse($c->push(['active' => false])->every->active);
     }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -726,23 +726,6 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
         );
     }
 
-    public function testEvery()
-    {
-        $data = new Collection([
-            6 => 'a',
-            4 => 'b',
-            7 => 'c',
-            1 => 'd',
-            5 => 'e',
-            3 => 'f',
-        ]);
-
-        $this->assertEquals(['a', 'e'], $data->every(4)->all());
-        $this->assertEquals(['b', 'f'], $data->every(4, 1)->all());
-        $this->assertEquals(['c'], $data->every(4, 2)->all());
-        $this->assertEquals(['d'], $data->every(4, 3)->all());
-    }
-
     public function testExcept()
     {
         $data = new Collection(['first' => 'Taylor', 'last' => 'Otwell', 'email' => 'taylorotwell@gmail.com']);
@@ -1040,6 +1023,23 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
             [3, 5, 4],
             $data->keys()->all()
         );
+    }
+
+    public function testNth()
+    {
+        $data = new Collection([
+            6 => 'a',
+            4 => 'b',
+            7 => 'c',
+            1 => 'd',
+            5 => 'e',
+            3 => 'f',
+        ]);
+
+        $this->assertEquals(['a', 'e'], $data->nth(4)->all());
+        $this->assertEquals(['b', 'f'], $data->nth(4, 1)->all());
+        $this->assertEquals(['c'], $data->nth(4, 2)->all());
+        $this->assertEquals(['d'], $data->nth(4, 3)->all());
     }
 
     public function testTransform()

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -726,6 +726,30 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
         );
     }
 
+    public function testEvery()
+    {
+        $c = new Collection([]);
+        $this->assertTrue($c->every('key', 'value'));
+        $this->assertTrue($c->every(function () {
+            return false;
+        }));
+
+        $c = new Collection([['age' => 18], ['age' => 20], ['age' => 20]]);
+        $this->assertFalse($c->every('age', 18));
+        $this->assertTrue($c->every('age', '>=', 18));
+        $this->assertTrue($c->every(function ($item) {
+            return $item['age'] >= 18;
+        }));
+        $this->assertFalse($c->every(function ($item) {
+            return $item['age'] >= 20;
+        }));
+
+        $c = new Collection([null, null]);
+        $this->assertTrue($c->every(function ($item) {
+            return $item === null;
+        }));
+    }
+
     public function testExcept()
     {
         $data = new Collection(['first' => 'Taylor', 'last' => 'Otwell', 'email' => 'taylorotwell@gmail.com']);

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -748,6 +748,10 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($c->every(function ($item) {
             return $item === null;
         }));
+
+        $c = new Collection([['active' => true], ['active' => true]]);
+        $this->assertTrue($c->every->active);
+        $this->assertFalse($c->push(['active' => false])->every->active);
     }
 
     public function testExcept()


### PR DESCRIPTION
Creates a new `every` method, to check if all items in the collection pass a given test:

```php
$ages = collect([['age' => 18], ['age' => 20], ['age' => 24]]);

$allAdult = $ages->every(function ($item) {
    return $item['age'] >= 18;
});
```

You can also pass it a single argument as a key:

```php
$allActive = $users->every('active');
```

You can also pass it a key, operator & value, like you would for the `where` method:

```php
$ages = collect([['age' => 18], ['age' => 20], ['age' => 24]]);

$allAdult = $ages->every('age', '>=', 18);
```

Also works with the higher order method proxies:

```php
$allSubscribed = $users->every->isSubscribed();
```

---

There was an existing infrequently-used method by the name `every`. I've renamed it to `nth`, to match [lodash](https://lodash.com/docs/4.17.2#nth) (not quite the same) and CSS [`:nth-child`](https://css-tricks.com/how-nth-child-works/) (almost the exact same).