### PR TITLE
[5.3] Fix translator "get" method name

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -2229,7 +2229,7 @@ class Validator implements ValidatorContract
             }
 
             $line = Arr::get(
-                $this->translator->get('validation.attributes'),
+                $this->translator->trans('validation.attributes'),
                 $expectedAttributeName
             );
 


### PR DESCRIPTION
Laravel 5.3 updates Symfony Translation package to 3.1 version, which does not have `get` method name.