### PR TITLE
[5.3] Generate resource controller with type-hinted model instead of just id

### DIFF
--- a/src/Illuminate/Routing/Console/ControllerMakeCommand.php
+++ b/src/Illuminate/Routing/Console/ControllerMakeCommand.php
@@ -2,8 +2,8 @@
 
 namespace Illuminate\Routing\Console;
 
-use Illuminate\Console\GeneratorCommand;
 use Illuminate\Support\Str;
+use Illuminate\Console\GeneratorCommand;
 use Symfony\Component\Console\Input\InputOption;
 
 class ControllerMakeCommand extends GeneratorCommand
@@ -37,7 +37,7 @@ class ControllerMakeCommand extends GeneratorCommand
     protected function getStub()
     {
         if ($this->option('model')) {
-            return __DIR__ . '/stubs/controller.model.stub';
+            return __DIR__.'/stubs/controller.model.stub';
         } elseif ($this->option('resource')) {
             return __DIR__.'/stubs/controller.stub';
         }
@@ -70,7 +70,7 @@ class ControllerMakeCommand extends GeneratorCommand
     }
 
     /**
-     * Parses the model namespace
+     * Parses the model namespace.
      *
      * @param  string  $modelNamespace
      * @return string
@@ -78,10 +78,10 @@ class ControllerMakeCommand extends GeneratorCommand
     protected function parseModel($modelNamespace)
     {
         if (preg_match('([^A-Za-z0-9_/\\\\])', $modelNamespace)) {
-            $this->line("");
-            $this->error("                                          ");
-            $this->error("  Model name contains invalid characters  ");
-            $this->error("                                          ");
+            $this->line('');
+            $this->error('                                          ');
+            $this->error('  Model name contains invalid characters  ');
+            $this->error('                                          ');
             exit(1);
         }
 
@@ -92,8 +92,8 @@ class ControllerMakeCommand extends GeneratorCommand
         $modelNamespace = trim($modelNamespace, '\\');
         $rootNamespace = $this->laravel->getNamespace();
 
-        if (!Str::startsWith($modelNamespace, $rootNamespace)) {
-            $modelNamespace = $rootNamespace . $modelNamespace;
+        if (! Str::startsWith($modelNamespace, $rootNamespace)) {
+            $modelNamespace = $rootNamespace.$modelNamespace;
         }
 
         return $modelNamespace;

--- a/src/Illuminate/Routing/Console/ControllerMakeCommand.php
+++ b/src/Illuminate/Routing/Console/ControllerMakeCommand.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Routing\Console;
 
 use Illuminate\Console\GeneratorCommand;
+use Illuminate\Support\Str;
 use Symfony\Component\Console\Input\InputOption;
 
 class ControllerMakeCommand extends GeneratorCommand
@@ -35,7 +36,9 @@ class ControllerMakeCommand extends GeneratorCommand
      */
     protected function getStub()
     {
-        if ($this->option('resource')) {
+        if ($this->option('model')) {
+            return __DIR__ . '/stubs/controller.model.stub';
+        } elseif ($this->option('resource')) {
             return __DIR__.'/stubs/controller.stub';
         }
 
@@ -62,7 +65,38 @@ class ControllerMakeCommand extends GeneratorCommand
     {
         return [
             ['resource', 'r', InputOption::VALUE_NONE, 'Generate a resource controller class.'],
+            ['model', 'm', InputOption::VALUE_OPTIONAL, 'Use specified model.'],
         ];
+    }
+
+    /**
+     * Parses the model namespace
+     *
+     * @param  string  $modelNamespace
+     * @return string
+     */
+    protected function parseModel($modelNamespace)
+    {
+        if (preg_match('([^A-Za-z0-9_/\\\\])', $modelNamespace)) {
+            $this->line("");
+            $this->error("                                          ");
+            $this->error("  Model name contains invalid characters  ");
+            $this->error("                                          ");
+            exit(1);
+        }
+
+        if (Str::contains($modelNamespace, '/')) {
+            $modelNamespace = str_replace('/', '\\', $modelNamespace);
+        }
+
+        $modelNamespace = trim($modelNamespace, '\\');
+        $rootNamespace = $this->laravel->getNamespace();
+
+        if (!Str::startsWith($modelNamespace, $rootNamespace)) {
+            $modelNamespace = $rootNamespace . $modelNamespace;
+        }
+
+        return $modelNamespace;
     }
 
     /**
@@ -75,8 +109,21 @@ class ControllerMakeCommand extends GeneratorCommand
      */
     protected function buildClass($name)
     {
-        $namespace = $this->getNamespace($name);
+        $controllerNamespace = $this->getNamespace($name);
 
-        return str_replace("use {$namespace}\Controller;\n", '', parent::buildClass($name));
+        $replace = [];
+        if ($this->option('model')) {
+            $modelNamespace = $this->parseModel($this->option('model'));
+            $modelClass = last(explode('\\', $modelNamespace));
+            $replace = [
+                'DummyModelNamespace' => $modelNamespace,
+                'DummyModelClass' => $modelClass,
+                'DummyModelVariable' => lcfirst($modelClass),
+            ];
+        }
+
+        $replace["use {$controllerNamespace}\Controller;\n"] = '';
+
+        return str_replace(array_keys($replace), array_values($replace), parent::buildClass($name));
     }
 }

--- a/src/Illuminate/Routing/Console/stubs/controller.model.stub
+++ b/src/Illuminate/Routing/Console/stubs/controller.model.stub
@@ -1,0 +1,86 @@
+<?php
+
+namespace DummyNamespace;
+
+use DummyModelNamespace;
+use Illuminate\Http\Request;
+use DummyRootNamespaceHttp\Controllers\Controller;
+
+class DummyClass extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function index()
+    {
+        //
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function create()
+    {
+        //
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function store(Request $request)
+    {
+        //
+    }
+
+    /**
+     * Display the specified resource.
+     *
+     * @param  \DummyModelNamespace  $DummyModelVariable
+     * @return \Illuminate\Http\Response
+     */
+    public function show(DummyModelClass $DummyModelVariable)
+    {
+        //
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     *
+     * @param  \DummyModelNamespace  $DummyModelVariable
+     * @return \Illuminate\Http\Response
+     */
+    public function edit(DummyModelClass $DummyModelVariable)
+    {
+        //
+    }
+
+    /**
+     * Update the specified resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \DummyModelNamespace  $DummyModelVariable
+     * @return \Illuminate\Http\Response
+     */
+    public function update(Request $request, DummyModelClass $DummyModelVariable)
+    {
+        //
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     *
+     * @param  \DummyModelNamespace  $DummyModelVariable
+     * @return \Illuminate\Http\Response
+     */
+    public function destroy(DummyModelClass $DummyModelVariable)
+    {
+        //
+    }
+}


### PR DESCRIPTION
Many of my resource controllers are now with type-hinted models, so I do not have in my code `findOrFail`. I have created a new stub and a new option `--model` or `-m` to specify a model to use.