### PR TITLE
[5.3] Remove hard coded (English) prose from scheduled task email subject when description is defined

### DIFF
--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -844,7 +844,7 @@ class Event
     protected function getEmailSubject()
     {
         if ($this->description) {
-            return 'Scheduled Job Output ('.$this->description.')';
+            return $this->description;
         }
 
         return 'Scheduled Job Output';


### PR DESCRIPTION
I feel as if the developer should be in control of the email subject that is used when sending the scheduled job output via email. Currently, the default behavior will always include the text "Scheduled Job Output" in the email subject. I previously submitted [a separate PR](https://github.com/laravel/framework/pull/16598) that provided a less invasive solution for this desired behavior and it was shot down without conversation because "You can already customize the subject by setting a description." 

So, I humbly submit this follow-up PR which changes existing functionality to grant framework consumers the ability to set the entire email subject to any value they desire, including any non-english value because sometimes people use Laravel to communicate with people whose primary language is not english.

I am happy to port the tests over from the previous PR as they would be appropriate here, but I am not going to waste my time if this is going to be arbitrarily shot down without rational discourse.