### PR TITLE
[5.4] Add operator support to the "contains" method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -65,17 +65,14 @@ class Collection extends BaseCollection implements QueueableCollection
      * Determine if a key exists in the collection.
      *
      * @param  mixed  $key
+     * @param  mixed  $operator
      * @param  mixed  $value
      * @return bool
      */
-    public function contains($key, $value = null)
+    public function contains($key, $operator = null, $value = null)
     {
-        if (func_num_args() == 2) {
-            return parent::contains($key, $value);
-        }
-
-        if ($this->useAsCallable($key)) {
-            return parent::contains($key);
+        if (func_num_args() > 1 || $this->useAsCallable($key)) {
+            return parent::contains(...func_get_args());
         }
 
         $key = $key instanceof Model ? $key->getKey() : $key;

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -165,22 +165,27 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      * Determine if an item exists in the collection.
      *
      * @param  mixed  $key
+     * @param  mixed  $operator
      * @param  mixed  $value
      * @return bool
      */
-    public function contains($key, $value = null)
+    public function contains($key, $operator = null, $value = null)
     {
+        if (func_num_args() == 1) {
+            if ($this->useAsCallable($key)) {
+                return ! is_null($this->first($key));
+            }
+
+            return in_array($key, $this->items);
+        }
+
         if (func_num_args() == 2) {
-            return $this->contains(function ($item) use ($key, $value) {
-                return data_get($item, $key) == $value;
-            });
+            $value = $operator;
+
+            $operator = '=';
         }
 
-        if ($this->useAsCallable($key)) {
-            return ! is_null($this->first($key));
-        }
-
-        return in_array($key, $this->items);
+        return $this->contains($this->operatorForWhere($key, $operator, $value));
     }
 
     /**

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -30,6 +30,15 @@ class DatabaseEloquentCollectionTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(10, $c->min('foo'));
     }
 
+    public function testContainsWithMultipleArguments()
+    {
+        $c = new Collection([['id' => 1], ['id' => 2]]);
+
+        $this->assertTrue($c->contains('id', 1));
+        $this->assertTrue($c->contains('id', '>=', 2));
+        $this->assertFalse($c->contains('id', '>', 2));
+    }
+
     public function testContainsIndicatesIfModelInArray()
     {
         $mockModel = m::mock('Illuminate\Database\Eloquent\Model');

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1244,6 +1244,16 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($c->containsStrict(''));
     }
 
+    public function testContainsWithOperator()
+    {
+        $c = new Collection([['v' => 1], ['v' => 3], ['v' => '4'], ['v' => 5]]);
+
+        $this->assertTrue($c->contains('v', '=', 4));
+        $this->assertTrue($c->contains('v', '==', 4));
+        $this->assertFalse($c->contains('v', '===', 4));
+        $this->assertTrue($c->contains('v', '>', 4));
+    }
+
     public function testGettingSumFromCollection()
     {
         $c = new Collection([(object) ['foo' => 50], (object) ['foo' => 50]]);


### PR DESCRIPTION
So you can now do this:

```php
$anyAdult = $users->contains('age', '>=', 18);
```