### PR TITLE
[5.3] Write output if a job is re-queued

### DIFF
--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -9,6 +9,7 @@ use Illuminate\Contracts\Queue\Job;
 use Illuminate\Queue\WorkerOptions;
 use Illuminate\Queue\Events\JobFailed;
 use Illuminate\Queue\Events\JobProcessed;
+use Illuminate\Queue\Events\JobExceptionOccurred;
 
 class WorkCommand extends Command
 {
@@ -123,11 +124,15 @@ class WorkCommand extends Command
     protected function listenForEvents()
     {
         $this->laravel['events']->listen(JobProcessed::class, function ($event) {
-            $this->writeOutput($event->job, false);
+            $this->writeOutput($event->job, 'success');
+        });
+
+        $this->laravel['events']->listen(JobExceptionOccurred::class, function ($event) {
+            $this->writeOutput($event->job, 'exception');
         });
 
         $this->laravel['events']->listen(JobFailed::class, function ($event) {
-            $this->writeOutput($event->job, true);
+            $this->writeOutput($event->job, 'fail');
 
             $this->logFailedJob($event);
         });
@@ -137,15 +142,24 @@ class WorkCommand extends Command
      * Write the status output for the queue worker.
      *
      * @param  \Illuminate\Contracts\Queue\Job  $job
-     * @param  bool  $failed
+     * @param  bool  $state
      * @return void
      */
-    protected function writeOutput(Job $job, $failed)
+    protected function writeOutput(Job $job, $state)
     {
-        if ($failed) {
-            $this->output->writeln('<error>['.Carbon::now()->format('Y-m-d H:i:s').'] Failed:</error> '.$job->resolveName());
-        } else {
-            $this->output->writeln('<info>['.Carbon::now()->format('Y-m-d H:i:s').'] Processed:</info> '.$job->resolveName());
+
+        switch($state) {
+            case 'fail':
+                $this->output->writeln('<error>['.Carbon::now()->format('Y-m-d H:i:s').'] Failed:</error> '.$job->resolveName());
+                break;
+            case 'success':
+                $this->output->writeln('<info>['.Carbon::now()->format('Y-m-d H:i:s').'] Processed:</info> '.$job->resolveName());
+                break;
+            case 'exception':
+                $this->output->writeln('<comment>['.Carbon::now()->format('Y-m-d H:i:s').'] Re-queued:</comment> '.$job->resolveName());
+                break;
+            default:
+                throw new \InvalidArgumentException;
         }
     }
 

--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -147,8 +147,7 @@ class WorkCommand extends Command
      */
     protected function writeOutput(Job $job, $state)
     {
-
-        switch($state) {
+        switch ($state) {
             case 'fail':
                 $this->output->writeln('<error>['.Carbon::now()->format('Y-m-d H:i:s').'] Failed:</error> '.$job->resolveName());
                 break;


### PR DESCRIPTION
When the job 'fails', it only outputs the **Failed:** message if you have the **--tries** specified, and only if it reaches that amount.

I propose to add a message to indicate that a job has encountered an exception,
and has been re-queued, to let the developer know something is up.