### PR TITLE
[5.3] Add isNotEmpty() method to Collection class

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -546,6 +546,16 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
+     * Determine if the collection is not empty.
+     *
+     * @return bool
+     */
+    public function isNotEmpty()
+    {
+        return ! $this->isEmpty();
+    }
+
+    /**
      * Determine if the given value is callable, but not a string.
      *
      * @param  mixed  $value

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -96,6 +96,14 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($c->isEmpty());
     }
 
+    public function testEmptyCollectionIsNotEmpty()
+    {
+        $c = new Collection(['foo', 'bar']);
+
+        $this->assertFalse($c->isEmpty());
+        $this->assertTrue($c->isNotEmpty());
+    }
+
     public function testCollectionIsConstructed()
     {
         $collection = new Collection('foo');


### PR DESCRIPTION
This PR introduces `Illuminate\Support\Collection::isNotEmpty()` method which is simply the opposite of `isEmpty()` method.

It removes need for prefixing `Collection::isEmpty()` call with `!` to negate it.

🌵 