### PR TITLE
[5.4] Make date/datetime cast difference more explicit by removing time part.

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2920,6 +2920,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
             case 'collection':
                 return new BaseCollection($this->fromJson($value));
             case 'date':
+                return $this->asDate($value);
             case 'datetime':
                 return $this->asDateTime($value);
             case 'timestamp':
@@ -3026,6 +3027,17 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         $value = $this->asDateTime($value);
 
         return $value->format($format);
+    }
+
+    /**
+     * Return a timestamp as DateTime object with time set to 00:00:00.
+     *
+     * @param  mixed  $value
+     * @return \Carbon\Carbon
+     */
+    protected function asDate($value)
+    {
+        return $this->asDateTime($value)->startOfDay();
     }
 
     /**

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1409,6 +1409,18 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(-14173440, $arr['timestampAttribute']);
     }
 
+    public function testModelDateAttributeCastingResetsTime()
+    {
+        $model = new EloquentModelCastingStub;
+        $model->setDateFormat('Y-m-d H:i:s');
+        $model->dateAttribute = '1969-07-20 22:56:00';
+
+        $this->assertEquals('1969-07-20 00:00:00', $model->dateAttribute->toDateTimeString());
+
+        $arr = $model->toArray();
+        $this->assertEquals('1969-07-20 00:00:00', $arr['dateAttribute']);
+    }
+
     public function testModelAttributeCastingPreservesNull()
     {
         $model = new EloquentModelCastingStub;


### PR DESCRIPTION
Hi,


Currently, both `date` and `datetime` cast types are using the same casting method. However, this can lead to unexpected results when a UNIX timestamp or Carbon instance containing a time part is assigned to a `date` attribute. `date` attributes keep the time part when it is known, but after saving the model and refreshing it, the time part might be lost. Example:

```php
use Carbon\Carbon;
use Illuminate\Database\Eloquent\Model;
class User extends Model
{
    protected $casts = [
        'date_of_birth' => 'date'
    ];
}

$dob = Carbon::now(); // 2016-12-14 15:18:34
$today = Carbon::today(); // 2016-12-14 00:00:00

$user = new User;
$user->date_of_birth = $dob;
$user->save();

if ($dob->eq($today)) {
    print "Born today";
} else {
    print "Not born today";
}

$user = $user->fresh();

if ($dob->eq($today)) {
    print "Born today";
} else {
    print "Not born today";
}

// Actual output:
// Not born today
// Born today

// Expected output:
// Born today
// Born today
```

As the cast types explicitly include both `date` and `datetime`, I think a more consistent approach would be to always remove the time part from `date` attributes.


Kind regards,
Jarno