### PR TITLE
[5.4] Add support for binding methods to the container

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -37,6 +37,13 @@ class Container implements ArrayAccess, ContainerContract
     protected $bindings = [];
 
     /**
+     * The container's method bindings.
+     *
+     * @var array
+     */
+    protected $methodBindings = [];
+
+    /**
      * The container's shared instances.
      *
      * @var array
@@ -230,6 +237,42 @@ class Container implements ArrayAccess, ContainerContract
 
             return $container->$method($concrete, $parameters);
         };
+    }
+
+    /**
+     * Bind a callback to resolve with Container::call
+     *
+     * @param  string  $method
+     * @param  \Closure  $concrete
+     * @return void
+     */
+    public function bindMethod($method, $callback)
+    {
+        $this->methodBindings[$this->normalize($method)] = $callback;
+    }
+
+    /**
+     * Call a method that has been bound to the container
+     *
+     * @param  callable  $callback
+     * @param  mixed  $default
+     * @return mixed
+     */
+    protected function callBoundMethod($callback, $default)
+    {
+        if (!is_array($callback)) {
+            return value($default);
+        }
+
+        $class = is_string($callback[0]) ? $callback[0] : get_class($callback[0]);
+
+        $method = $this->normalize("{$class}@{$callback[1]}");
+
+        if (!isset($this->methodBindings[$method])) {
+            return value($default);
+        }
+
+        return $this->methodBindings[$method]($callback[0], $this);
     }
 
     /**
@@ -503,9 +546,10 @@ class Container implements ArrayAccess, ContainerContract
             return $this->callClass($callback, $parameters, $defaultMethod);
         }
 
-        $dependencies = $this->getMethodDependencies($callback, $parameters);
-
-        return call_user_func_array($callback, $dependencies);
+        return $this->callBoundMethod($callback, function () use ($callback, $parameters) {
+            $dependencies = $this->getMethodDependencies($callback, $parameters);
+            return call_user_func_array($callback, $dependencies);
+        });
     }
 
     /**

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -240,7 +240,7 @@ class Container implements ArrayAccess, ContainerContract
     }
 
     /**
-     * Bind a callback to resolve with Container::call
+     * Bind a callback to resolve with Container::call.
      *
      * @param  string  $method
      * @param  \Closure  $concrete
@@ -252,7 +252,7 @@ class Container implements ArrayAccess, ContainerContract
     }
 
     /**
-     * Call a method that has been bound to the container
+     * Call a method that has been bound to the container.
      *
      * @param  callable  $callback
      * @param  mixed  $default
@@ -260,7 +260,7 @@ class Container implements ArrayAccess, ContainerContract
      */
     protected function callBoundMethod($callback, $default)
     {
-        if (!is_array($callback)) {
+        if (! is_array($callback)) {
             return value($default);
         }
 
@@ -268,7 +268,7 @@ class Container implements ArrayAccess, ContainerContract
 
         $method = $this->normalize("{$class}@{$callback[1]}");
 
-        if (!isset($this->methodBindings[$method])) {
+        if (! isset($this->methodBindings[$method])) {
             return value($default);
         }
 
@@ -548,6 +548,7 @@ class Container implements ArrayAccess, ContainerContract
 
         return $this->callBoundMethod($callback, function () use ($callback, $parameters) {
             $dependencies = $this->getMethodDependencies($callback, $parameters);
+
             return call_user_func_array($callback, $dependencies);
         });
     }

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -509,6 +509,23 @@ class ContainerContainerTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('taylor', $result[1]);
     }
 
+    public function testCallWithBoundMethod()
+    {
+        $container = new Container;
+        $container->bindMethod('ContainerTestCallStub@unresolvable', function ($stub) {
+            return $stub->unresolvable('foo', 'bar');
+        });
+        $result = $container->call('ContainerTestCallStub@unresolvable');
+        $this->assertEquals(['foo', 'bar'], $result);
+
+        $container = new Container;
+        $container->bindMethod('ContainerTestCallStub@unresolvable', function ($stub) {
+            return $stub->unresolvable('foo', 'bar');
+        });
+        $result = $container->call([new ContainerTestCallStub, 'unresolvable']);
+        $this->assertEquals(['foo', 'bar'], $result);
+    }
+
     public function testContainerCanInjectDifferentImplementationsDependingOnContext()
     {
         $container = new Container;
@@ -809,6 +826,11 @@ class ContainerTestCallStub
     }
 
     public function inject(ContainerConcreteStub $stub, $default = 'taylor')
+    {
+        return func_get_args();
+    }
+
+    public function unresolvable($foo, $bar)
     {
         return func_get_args();
     }


### PR DESCRIPTION
Adds support for manually controlling how a method should be called when invoked with Container::call:

```php
$this->app->bindMethod('App\Jobs\SomeJob@handle', function ($job, $app) {
    return $job->handle('foo', 'bar');
});
```

Prior to this, it was impossible to have parameters in the `handle` method of a job that could not be auto-resolved by the container, because there was no way to manually control what the parameters should be.

This means you are forced to use type hints for object parameters and have no ability to use primitives as parameters, or have to use the old undocumented job syntax where dependencies were passed to the constructor instead of to the `handle` method.

For example, it is currently impossible to write a job class like this, where the `handle` method has dependencies that can't be autoresolved:

```php
namespace App\Jobs;

use Illuminate\Bus\Queueable;
use Illuminate\Contracts\Queue\ShouldQueue;

class AddCollaboratorToGitHubRepoJob implements ShouldQueue
{
    use Queueable;

    private $user;

    public function __construct($user)
    {
        $this->user = $user;
    }

    public function handle($githubOwner, $githubRepo, $githubToken)
    {
        (new Client)->put($this->collaboratorUrl($githubOwner, $githubRepo), [
            'headers' => ['Authorization' => "token {$githubToken}"],
            'json' => ['permission' => 'pull']
        ]);
    }

    private function collaboratorUrl($owner, repo)
    {
        return "https://api.github.com/repos/{$owner}/{$repo}/collaborators/{$this->user->github_username}";
    }
}
```

Using the functionality added in this PR, you could specify how handle should be called:

```php
$this->app->bindMethod('App\Jobs\AddCollaboratorToGitHubRepoJob@handle', function ($job, $app) {
    return $job->handle(
        config('services.github.owner'),
        config('services.github.repo'),
        config('services.github.token')
    );
});
```

This PR intentionally adds only the minimal functionality needed to subvert this issue, and doesn't make any effort to support the `when->needs->give` syntax, or passing key => value parameters to optionally override things or any of those fancy more complex features.

Instead, it simply adds support for defining what should happen as a whole, much like you would with a standard container binding:

```php
$this->app->singleton(PaymentGateway::class, function () {
    return new PaymentGateway(config('services.stripe.secret'));
});
```

Additional functionality like that could be added down the road, or we could simply roll with this forever, because it at least does what's needed to fix what's currently impossible.