### PR TITLE
[5.3] Added spec and fix for Router implicit binding through IoC

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -804,7 +804,7 @@ class Router implements RegistrarContract
                 ! $route->getParameter($parameter->name) instanceof Model) {
                 $method = $parameter->isDefaultValueAvailable() ? 'first' : 'firstOrFail';
 
-                $model = $class->newInstance();
+                $model = $this->container->make($class->name);
 
                 $route->setParameter(
                     $parameter->name, $model->where(

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -1409,7 +1409,9 @@ class RoutingTestUserModel extends Model
     }
 }
 
-class RoutingTestExtendedUserModel extends RoutingTestUserModel {}
+class RoutingTestExtendedUserModel extends RoutingTestUserModel
+{
+}
 
 class ActionStub
 {

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -1155,6 +1155,25 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase
         $router->dispatch(Request::create('bar', 'GET'))->getContent();
     }
 
+    public function testImplicitBindingThroughIOC()
+    {
+        $phpunit = $this;
+        $container = new Container;
+        $router = new Router(new Dispatcher, $container);
+        $container->singleton(Registrar::class, function () use ($router) {
+            return $router;
+        });
+
+        $container->bind('RoutingTestUserModel', 'RoutingTestExtendedUserModel');
+        $router->get('foo/{bar}', [
+            'middleware' => SubstituteBindings::class,
+            'uses' => function (RoutingTestUserModel $bar) use ($phpunit) {
+                $phpunit->assertInstanceOf(RoutingTestExtendedUserModel::class, $bar);
+            },
+        ]);
+        $router->dispatch(Request::create('foo/baz', 'GET'))->getContent();
+    }
+
     public function testDispatchingCallableActionClasses()
     {
         $router = $this->getRouter();
@@ -1389,6 +1408,8 @@ class RoutingTestUserModel extends Model
         return $this;
     }
 }
+
+class RoutingTestExtendedUserModel extends RoutingTestUserModel {}
 
 class ActionStub
 {


### PR DESCRIPTION
If a Model has been bound to another one though `$this->app->bind('Model1', 'Model2')`, the implicit binding for the old model in the controllers still resolves to the old model rather than the one it's bound to.

This fixes it.