### PR TITLE
[5.4] Scheduler Improvements

### DIFF
--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -58,6 +58,13 @@ class Command extends SymfonyCommand
     protected $description;
 
     /**
+     * Indicates whether the command should be shown in the Artisan command list.
+     *
+     * @var bool
+     */
+    protected $hidden = false;
+
+    /**
      * The default verbosity of output commands.
      *
      * @var int
@@ -94,6 +101,8 @@ class Command extends SymfonyCommand
         }
 
         $this->setDescription($this->description);
+
+        $this->setHidden($this->hidden);
 
         if (! isset($this->signature)) {
             $this->specifyParameters();

--- a/src/Illuminate/Console/ScheduleServiceProvider.php
+++ b/src/Illuminate/Console/ScheduleServiceProvider.php
@@ -20,7 +20,10 @@ class ScheduleServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->commands('Illuminate\Console\Scheduling\ScheduleRunCommand');
+        $this->commands([
+            'Illuminate\Console\Scheduling\ScheduleRunCommand',
+            'Illuminate\Console\Scheduling\ScheduleFinishCommand',
+        ]);
     }
 
     /**
@@ -32,6 +35,7 @@ class ScheduleServiceProvider extends ServiceProvider
     {
         return [
             'Illuminate\Console\Scheduling\ScheduleRunCommand',
+            'Illuminate\Console\Scheduling\ScheduleFinishCommand',
         ];
     }
 }

--- a/src/Illuminate/Console/Scheduling/CommandBuilder.php
+++ b/src/Illuminate/Console/Scheduling/CommandBuilder.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Illuminate\Console\Scheduling;
+
+use Illuminate\Console\Application;
+use Symfony\Component\Process\ProcessUtils;
+
+class CommandBuilder
+{
+    /**
+     * Build the command for the given event.
+     *
+     * @param  \Illuminate\Console\Scheduling\Event  $event
+     * @return string
+     */
+    public function buildCommand(Event $event)
+    {
+        if ($event->runInBackground) {
+            return $this->buildBackgroundCommand($event);
+        } else {
+            return $this->buildForegroundCommand($event);
+        }
+    }
+
+    /**
+     * Build the command for running the event in the foreground.
+     *
+     * @param  \Illuminate\Console\Scheduling\Event  $event
+     * @return string
+     */
+    protected function buildForegroundCommand(Event $event)
+    {
+        $output = ProcessUtils::escapeArgument($event->output);
+
+        return $this->finalize($event, $event->command.($event->shouldAppendOutput ? ' >> ' : ' > ').$output.' 2>&1');
+    }
+
+    /**
+     * Build the command for running the event in the foreground.
+     *
+     * @param  \Illuminate\Console\Scheduling\Event  $event
+     * @return string
+     */
+    protected function buildBackgroundCommand(Event $event)
+    {
+        $output = ProcessUtils::escapeArgument($event->output);
+
+        $redirect = $event->shouldAppendOutput ? ' >> ' : ' > ';
+
+        $finished = Application::formatCommandString('schedule:finish').' "'.$event->mutexName().'"';
+
+        return $this->finalize($event,
+            '('.$event->command.$redirect.$output.' 2>&1 '.(windows_os() ? '&' : ';').' '.$finished.') > '
+            .ProcessUtils::escapeArgument($event->getDefaultOutput()).' 2>&1 &'
+        );
+    }
+
+    /**
+     * Finalize the event's command syntax.
+     *
+     * @param  \Illuminate\Console\Scheduling\Event  $event
+     * @param  string  $command
+     * @return string
+     */
+    protected function finalize(Event $event, $command)
+    {
+        return $event->user && ! windows_os() ? 'sudo -u '.$event->user.' -- sh -c \''.$command.'\'' : $command;
+    }
+}

--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -6,11 +6,9 @@ use Closure;
 use Carbon\Carbon;
 use LogicException;
 use Cron\CronExpression;
-use Illuminate\Console\Application;
 use GuzzleHttp\Client as HttpClient;
 use Illuminate\Contracts\Mail\Mailer;
 use Symfony\Component\Process\Process;
-use Symfony\Component\Process\ProcessUtils;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Cache\Repository as Cache;
 

--- a/src/Illuminate/Console/Scheduling/ScheduleFinishCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleFinishCommand.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Illuminate\Console\Scheduling;
+
+use Illuminate\Console\Command;
+
+class ScheduleFinishCommand extends Command
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $signature = 'schedule:finish {id}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Handle the completion of a scheduled command';
+
+    /**
+     * Indicates whether the command should be shown in the Artisan command list.
+     *
+     * @var bool
+     */
+    protected $hidden = true;
+
+    /**
+     * The schedule instance.
+     *
+     * @var \Illuminate\Console\Scheduling\Schedule
+     */
+    protected $schedule;
+
+    /**
+     * Create a new command instance.
+     *
+     * @param  \Illuminate\Console\Scheduling\Schedule  $schedule
+     * @return void
+     */
+    public function __construct(Schedule $schedule)
+    {
+        $this->schedule = $schedule;
+
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function fire()
+    {
+        collect($this->schedule->events())->filter(function ($value) {
+            return $value->mutexName() == $this->argument('id');
+        })->each->callAfterCallbacks($this->laravel);
+    }
+}

--- a/tests/Console/Scheduling/EventTest.php
+++ b/tests/Console/Scheduling/EventTest.php
@@ -19,8 +19,6 @@ class EventTest extends PHPUnit_Framework_TestCase
         $defaultOutput = (DIRECTORY_SEPARATOR == '\\') ? 'NUL' : '/dev/null';
         $this->assertSame("php -i > {$quote}{$defaultOutput}{$quote} 2>&1", $event->buildCommand());
 
-
-
         $quote = (DIRECTORY_SEPARATOR == '\\') ? '"' : "'";
 
         $event = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php -i');

--- a/tests/Console/Scheduling/EventTest.php
+++ b/tests/Console/Scheduling/EventTest.php
@@ -17,7 +17,17 @@ class EventTest extends PHPUnit_Framework_TestCase
         $event = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php -i');
 
         $defaultOutput = (DIRECTORY_SEPARATOR == '\\') ? 'NUL' : '/dev/null';
-        $this->assertSame("php -i > {$quote}{$defaultOutput}{$quote} 2>&1 &", $event->buildCommand());
+        $this->assertSame("php -i > {$quote}{$defaultOutput}{$quote} 2>&1", $event->buildCommand());
+
+
+
+        $quote = (DIRECTORY_SEPARATOR == '\\') ? '"' : "'";
+
+        $event = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php -i');
+        $event->runInBackground();
+
+        $defaultOutput = (DIRECTORY_SEPARATOR == '\\') ? 'NUL' : '/dev/null';
+        $this->assertSame("(php -i > {$quote}{$defaultOutput}{$quote} 2>&1 ; '".PHP_BINARY."' artisan schedule:finish \"framework/schedule-c65b1c374c37056e0c57fccb0c08d724ce6f5043\") > {$quote}{$defaultOutput}{$quote} 2>&1 &", $event->buildCommand());
     }
 
     public function testBuildCommandSendOutputTo()
@@ -27,12 +37,12 @@ class EventTest extends PHPUnit_Framework_TestCase
         $event = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php -i');
 
         $event->sendOutputTo('/dev/null');
-        $this->assertSame("php -i > {$quote}/dev/null{$quote} 2>&1 &", $event->buildCommand());
+        $this->assertSame("php -i > {$quote}/dev/null{$quote} 2>&1", $event->buildCommand());
 
         $event = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php -i');
 
         $event->sendOutputTo('/my folder/foo.log');
-        $this->assertSame("php -i > {$quote}/my folder/foo.log{$quote} 2>&1 &", $event->buildCommand());
+        $this->assertSame("php -i > {$quote}/my folder/foo.log{$quote} 2>&1", $event->buildCommand());
     }
 
     public function testBuildCommandAppendOutput()
@@ -42,7 +52,7 @@ class EventTest extends PHPUnit_Framework_TestCase
         $event = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php -i');
 
         $event->appendOutputTo('/dev/null');
-        $this->assertSame("php -i >> {$quote}/dev/null{$quote} 2>&1 &", $event->buildCommand());
+        $this->assertSame("php -i >> {$quote}/dev/null{$quote} 2>&1", $event->buildCommand());
     }
 
     /**


### PR DESCRIPTION
This PR adds improvements to the scheduler. Previously, when `->runInBackground()` was used "after" hooks were not run, meaning output was not e-mailed to the developer (when using `emailOutputTo`.

This change provides a new, hidden `schedule:finish` command that is used to fire the after callbacks for a given command by its mutex name. This command will not show in the Artisan console command list since it uses the hidden command feature which is new in Symfony 3.2.