### PR TITLE
[5.3] Guess policy method from class name

### DIFF
--- a/src/Illuminate/Foundation/Auth/Access/AuthorizesRequests.php
+++ b/src/Illuminate/Foundation/Auth/Access/AuthorizesRequests.php
@@ -48,7 +48,7 @@ trait AuthorizesRequests
      */
     protected function parseAbilityAndArguments($ability, $arguments)
     {
-        if (is_string($ability)) {
+        if (is_string($ability) && (! class_exists($ability))) {
             return [$ability, $arguments];
         }
 

--- a/tests/Foundation/FoundationAuthorizesRequestsTraitTest.php
+++ b/tests/Foundation/FoundationAuthorizesRequestsTraitTest.php
@@ -14,13 +14,13 @@ class FoundationAuthorizesRequestsTraitTest extends PHPUnit_Framework_TestCase
 
         $gate = $this->getBasicGate();
 
-        $gate->define('foo', function () {
+        $gate->define('baz', function () {
             $_SERVER['_test.authorizes.trait'] = true;
 
             return true;
         });
 
-        $response = (new FoundationTestAuthorizeTraitClass)->authorize('foo');
+        $response = (new FoundationTestAuthorizeTraitClass)->authorize('baz');
 
         $this->assertInstanceOf(Response::class, $response);
         $this->assertTrue($_SERVER['_test.authorizes.trait']);
@@ -33,11 +33,11 @@ class FoundationAuthorizesRequestsTraitTest extends PHPUnit_Framework_TestCase
     {
         $gate = $this->getBasicGate();
 
-        $gate->define('foo', function () {
+        $gate->define('baz', function () {
             return false;
         });
 
-        (new FoundationTestAuthorizeTraitClass)->authorize('foo');
+        (new FoundationTestAuthorizeTraitClass)->authorize('baz');
     }
 
     public function test_policies_may_be_called()
@@ -54,7 +54,7 @@ class FoundationAuthorizesRequestsTraitTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($_SERVER['_test.authorizes.trait.policy']);
     }
 
-    public function test_policy_method_may_be_guessed()
+    public function test_policy_method_may_be_guessed_passing_model_instance()
     {
         unset($_SERVER['_test.authorizes.trait.policy']);
 
@@ -62,7 +62,21 @@ class FoundationAuthorizesRequestsTraitTest extends PHPUnit_Framework_TestCase
 
         $gate->policy(FoundationAuthorizesRequestTestClass::class, FoundationAuthorizesRequestTestPolicy::class);
 
-        $response = (new FoundationTestAuthorizeTraitClass)->authorize([new FoundationAuthorizesRequestTestClass]);
+        $response = (new FoundationTestAuthorizeTraitClass)->authorize(new FoundationAuthorizesRequestTestClass);
+
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertTrue($_SERVER['_test.authorizes.trait.policy']);
+    }
+
+    public function test_policy_method_may_be_guessed_passing_class_name()
+    {
+        unset($_SERVER['_test.authorizes.trait.policy']);
+
+        $gate = $this->getBasicGate();
+
+        $gate->policy(FoundationAuthorizesRequestTestClass::class, FoundationAuthorizesRequestTestPolicy::class);
+
+        $response = (new FoundationTestAuthorizeTraitClass)->authorize(FoundationAuthorizesRequestTestClass::class);
 
         $this->assertInstanceOf(Response::class, $response);
         $this->assertTrue($_SERVER['_test.authorizes.trait.policy']);
@@ -115,7 +129,14 @@ class FoundationAuthorizesRequestTestPolicy
         return true;
     }
 
-    public function test_policy_method_may_be_guessed()
+    public function test_policy_method_may_be_guessed_passing_model_instance()
+    {
+        $_SERVER['_test.authorizes.trait.policy'] = true;
+
+        return true;
+    }
+
+    public function test_policy_method_may_be_guessed_passing_class_name()
     {
         $_SERVER['_test.authorizes.trait.policy'] = true;
 


### PR DESCRIPTION
Very minor improvement for handling the case of [Actions That Don't Require Models](https://laravel.com/docs/5.3/authorization#authorizing-actions-using-policies) so that the policy and the ability to authorize can be guessed from a class name.

Example:
```
public function create()
{
    $this->authorize(Post::class);

    // ...
}
```