### PR TITLE
[5.3] Remove unnecessary variable

### DIFF
--- a/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
@@ -47,9 +47,13 @@ class ScheduleRunCommand extends Command
      */
     public function fire()
     {
-        $eventsRan = false;
+        $events = $this->schedule->dueEvents($this->laravel);
 
-        foreach ($this->schedule->dueEvents($this->laravel) as $event) {
+        if (empty($events)) {
+            return $this->info('No scheduled commands are ready to run.');
+        }
+
+        foreach ($events as $event) {
             if (! $event->filtersPass($this->laravel)) {
                 continue;
             }
@@ -57,12 +61,6 @@ class ScheduleRunCommand extends Command
             $this->line('<info>Running scheduled command:</info> '.$event->getSummaryForDisplay());
 
             $event->run($this->laravel);
-
-            $eventsRan = true;
-        }
-
-        if (! $eventsRan) {
-            $this->info('No scheduled commands are ready to run.');
         }
     }
 }


### PR DESCRIPTION
This PR removes an unnecessary variable and exits `ScheduleRunCommand::fire()` function before running the loop if there are no `$events`.

🌵 