### PR TITLE
[5.3] Collection::min() incorrectly excludes 0 when calculating minimum

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -649,7 +649,9 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     {
         $callback = $this->valueRetriever($callback);
 
-        return $this->filter()->reduce(function ($result, $item) use ($callback) {
+        return $this->filter(function ($value) {
+            return ! is_null($value);
+        })->reduce(function ($result, $item) use ($callback) {
             $value = $callback($item);
 
             return is_null($result) || $value > $result ? $value : $result;
@@ -699,7 +701,9 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     {
         $callback = $this->valueRetriever($callback);
 
-        return $this->filter()->reduce(function ($result, $item) use ($callback) {
+        return $this->filter(function ($value) {
+            return ! is_null($value);
+        })->reduce(function ($result, $item) use ($callback) {
             $value = $callback($item);
 
             return is_null($result) || $value < $result ? $value : $result;

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1377,6 +1377,9 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
         $c = new Collection([1, null, 3, 4, 5]);
         $this->assertEquals(1, $c->min());
 
+        $c = new Collection([0, 1, 2, 3, 4]);
+        $this->assertEquals(0, $c->min());
+
         $c = new Collection();
         $this->assertNull($c->min());
     }


### PR DESCRIPTION
This commit: https://github.com/laravel/framework/commit/e2d317efcebbdf6651d89100c0b5d80a925bb2f1 introduced a (hopefully unintentional) BC break in min() that causes the following to fail:

```php
collect([0, 1, 2, 3])->min() // returns: 1
```

This is because `filter` calls `array_filter` without a callback which in turn removes all falsy values, not just null ones.

I've also updated the changed code in Collection::max() for consistency.