### PR TITLE
[5.3] Added check for empty port to prevent Invalid Handler Error

### DIFF
--- a/src/Illuminate/Database/Connectors/SqlServerConnector.php
+++ b/src/Illuminate/Database/Connectors/SqlServerConnector.php
@@ -155,7 +155,7 @@ class SqlServerConnector extends Connector implements ConnectorInterface
      */
     protected function buildHostString(array $config, $separator)
     {
-        if (isset($config['port'])) {
+        if (isset($config['port']) && !empty($config['port'])) {
             return $config['host'].$separator.$config['port'];
         } else {
             return $config['host'];

--- a/src/Illuminate/Database/Connectors/SqlServerConnector.php
+++ b/src/Illuminate/Database/Connectors/SqlServerConnector.php
@@ -155,7 +155,7 @@ class SqlServerConnector extends Connector implements ConnectorInterface
      */
     protected function buildHostString(array $config, $separator)
     {
-        if (isset($config['port']) && !empty($config['port'])) {
+        if (isset($config['port']) && ! empty($config['port'])) {
             return $config['host'].$separator.$config['port'];
         } else {
             return $config['host'];


### PR DESCRIPTION
Prevents DSN from generating with an extra comma and throwing an Invalid Handler Error when port is specified in the database configuration but not set to a value.

Produces 'sqlsrv:Server=localhost;Database=mydb;' instead of 'sqlsrv:Server=localhost,;Database=mydb;'