### PR TITLE
[5.3] Fix an issue with sometimes when it comes to wildcard rules

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -619,8 +619,14 @@ class Validator implements ValidatorContract
      */
     protected function passesOptionalCheck($attribute)
     {
+        $data = Arr::dot($this->initializeAttributeOnData($attribute));
+
+        $data = array_merge($data, $this->extractValuesForWildcards(
+            $data, $attribute
+        ));
+
         if ($this->hasRule($attribute, ['Sometimes'])) {
-            return array_key_exists($attribute, Arr::dot($this->data))
+            return array_key_exists($attribute, $data)
                 || in_array($attribute, array_keys($this->data));
         }
 

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -619,13 +619,13 @@ class Validator implements ValidatorContract
      */
     protected function passesOptionalCheck($attribute)
     {
-        $data = Arr::dot($this->initializeAttributeOnData($attribute));
-
-        $data = array_merge($data, $this->extractValuesForWildcards(
-            $data, $attribute
-        ));
-
         if ($this->hasRule($attribute, ['Sometimes'])) {
+            $data = Arr::dot($this->initializeAttributeOnData($attribute));
+
+            $data = array_merge($data, $this->extractValuesForWildcards(
+                $data, $attribute
+            ));
+
             return array_key_exists($attribute, $data)
                 || in_array($attribute, array_keys($this->data));
         }

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -2475,13 +2475,18 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $this->assertFalse($v->passes());
     }
 
-    public function testSometimesFailOnEmptyArrayInImplicitRules()
+    public function testSometimesOnArraysInImplicitRules()
     {
         $trans = $this->getIlluminateArrayTranslator();
 
         $data = ['names' => [['second' => []]]];
         $v = new Validator($trans, $data, ['names.*.second' => 'sometimes|required']);
         $this->assertFalse($v->passes());
+
+        $data = ['names' => [['second' => ['Taylor']]]];
+        $v = new Validator($trans, $data, ['names.*.second' => 'sometimes|required|string']);
+        $this->assertFalse($v->passes());
+        $this->assertEquals(['validation.string'], $v->errors()->get('names.0.second'));
     }
 
     public function testValidateImplicitEachWithAsterisksForRequiredNonExistingKey()


### PR DESCRIPTION
    $data = [
        "cities" => [
            [
                "name" => ["NY"]
            ]
        ]
    ];

    $validator = Validator::make($data, [
        "cities.*.name" => "sometimes|required|string",
    ]);

Currently the validation will pas even though the name is an array instead of a string, that's because `cities.0.name` doesn't exist when `sometimes` checks for it in `passesOptionalCheck()`.

This PR fixes that by appending wildcard keys to the `$data` array before the check.