### PR TITLE
[5.3] Added tests when response is not key-value pair array.

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -328,7 +328,7 @@ trait MakesHttpRequests
     }
 
     /**
-     * Assert that the response doesn't contain JSON.
+     * Assert that the response does not contains JSON.
      *
      * @param  array|null  $data
      * @return $this

--- a/tests/Foundation/FoundationMakesHttpRequestsJsonTest.php
+++ b/tests/Foundation/FoundationMakesHttpRequestsJsonTest.php
@@ -81,6 +81,20 @@ class FoundationMakesHttpRequestsJsonTest extends PHPUnit_Framework_TestCase
 
         $this->fail('Invalid JSON should fail seeJsonEquals');
     }
+
+    public function testSeeJsonResponseOnString()
+    {
+        $this->response = new Illuminate\Http\Response(['foo']);
+
+        try {
+            $this->dontSeeJson(['foo']);
+            $this->seeJsonContains(['foo']);
+        } catch (PHPUnit_Framework_AssertionFailedError $e) {
+            $this->assertStringStartsWith('Invalid JSON', $e->getMessage());
+
+            return;
+        }
+    }
 }
 
 class JsonSerializableMixedResourcesStub implements JsonSerializable


### PR DESCRIPTION
Added tests for JSON response where response was not a key-value pair format like:
```
['foo' => 'bar']
```