### PR TITLE
[5.3] [WIP] Support for default value in explicit bindings

### DIFF
--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -639,6 +639,16 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('TAYLOR', $router->dispatch(Request::create('foo/taylor', 'GET'))->getContent());
     }
 
+    public function testModelBindingWithNullReturnDefaultValue()
+        {
+        $router = $this->getRouter();
+        $router->get('foo/{bar}', ['middleware' => SubstituteBindings::class, 'uses' => function ($name = null) {
+            return 'hello world';
+        }]);
+        $router->model('bar', 'RouteModelBindingNullStub');
+        $this->assertEquals('hello world', $router->dispatch(Request::create('foo/taylor', 'GET'))->getContent());
+    }
+
     /**
      * @expectedException Illuminate\Database\Eloquent\ModelNotFoundException
      */

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -642,7 +642,7 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase
     public function testModelBindingWithNullReturnDefaultValue()
         {
         $router = $this->getRouter();
-        $router->get('foo/{bar}', ['middleware' => SubstituteBindings::class, 'uses' => function ($name = null) {
+        $router->get('foo/{bar}', ['middleware' => SubstituteBindings::class, 'uses' => function ($bar = null) {
             return 'hello world';
         }]);
         $router->model('bar', 'RouteModelBindingNullStub');


### PR DESCRIPTION
**Description**
I would like to be allowed to enter a default value when using model aliases, like I am allowed in implicit bindings.

Implicit Binding has **firstOrFail** or **first**, if default value is present.
https://github.com/laravel/framework/blob/5.3/src/Illuminate/Routing/Router.php#L805

I am not 100% sure, but I think explicit bindings goes though **model** on **Router.php** which does not have default value check.

https://github.com/laravel/framework/blob/5.3/src/Illuminate/Routing/Router.php#L926

**What do I expect:**
I expect that 'hello world' should be returned, because a default value for name is set.