### PR TITLE
[5.4] More consistency in AuthorizesRequests.php

### DIFF
--- a/src/Illuminate/Foundation/Auth/Access/AuthorizesRequests.php
+++ b/src/Illuminate/Foundation/Auth/Access/AuthorizesRequests.php
@@ -107,8 +107,8 @@ trait AuthorizesRequests
             'show' => 'view',
             'create' => 'create',
             'store' => 'create',
-            'edit' => 'update',
-            'update' => 'update',
+            'edit' => 'edit',
+            'update' => 'edit',
             'destroy' => 'delete',
         ];
     }

--- a/tests/Auth/AuthorizesResourcesTest.php
+++ b/tests/Auth/AuthorizesResourcesTest.php
@@ -32,14 +32,14 @@ class AuthorizesResourcesTest extends PHPUnit_Framework_TestCase
     {
         $controller = new AuthorizesResourcesController();
 
-        $this->assertHasMiddleware($controller, 'edit', 'can:update,user');
+        $this->assertHasMiddleware($controller, 'edit', 'can:edit,user');
     }
 
     public function testUpdateMethod()
     {
         $controller = new AuthorizesResourcesController();
 
-        $this->assertHasMiddleware($controller, 'update', 'can:update,user');
+        $this->assertHasMiddleware($controller, 'update', 'can:edit,user');
     }
 
     public function testDestroyMethod()


### PR DESCRIPTION
I've changed the resourceAbilityMap to be more consistent with itself.
create and store used create (the view function) and edit and update used the update (the database function).
Now they both use their respective view functions.

I don't know the further implications of this change, it is just a proposal.