### PR TITLE
[5.3] Error when using before validation for negative timestamps

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1966,6 +1966,14 @@ class Validator implements ValidatorContract
         } catch (Exception $e) {
             //
         }
+		
+		try{
+			$dt = new DateTime();
+			$dt->setTimestamp($value);
+			return $dt;
+		} catch(Exception $e){
+			//
+		}
     }
 
     /**


### PR DESCRIPTION
Error when using before validation for negative timestamps (generated by strtotime).

---

See: #16832.