### PR TITLE
[5.3] Allow SparkPost transport transmission metadata to be set at runtime

### DIFF
--- a/src/Illuminate/Mail/Transport/SparkPostTransport.php
+++ b/src/Illuminate/Mail/Transport/SparkPostTransport.php
@@ -179,7 +179,8 @@ class SparkPostTransport extends Transport
      *
      * @return string
      */
-    public function getMetadata(){
+    public function getMetadata()
+    {
         return $this->metadata;
     }
 }

--- a/src/Illuminate/Mail/Transport/SparkPostTransport.php
+++ b/src/Illuminate/Mail/Transport/SparkPostTransport.php
@@ -29,18 +29,27 @@ class SparkPostTransport extends Transport
     protected $options = [];
 
     /**
+     * Transmission metadata.
+     *
+     * @var array
+     */
+    protected $metadata = [];
+
+    /**
      * Create a new SparkPost transport instance.
      *
      * @param  \GuzzleHttp\ClientInterface  $client
      * @param  string  $key
      * @param  array  $options
+     * @param  array  $metadata
      * @return void
      */
-    public function __construct(ClientInterface $client, $key, $options = [])
+    public function __construct(ClientInterface $client, $key, $options = [], $metadata = [])
     {
         $this->key = $key;
         $this->client = $client;
         $this->options = $options;
+        $this->metadata = $metadata;
     }
 
     /**
@@ -68,6 +77,10 @@ class SparkPostTransport extends Transport
 
         if ($this->options) {
             $options['json']['options'] = $this->options;
+        }
+
+        if ($this->metadata) {
+            $options['json']['metadata'] = $this->metadata;
         }
 
         $this->client->post('https://api.sparkpost.com/api/v1/transmissions', $options);
@@ -148,5 +161,24 @@ class SparkPostTransport extends Transport
     public function setOptions(array $options)
     {
         return $this->options = $options;
+    }
+
+    /**
+     * Set the transmission metadata being used by the transport.
+     *
+     * @param  array  $metadata
+     * @return array
+     */
+    public function setMetadata(array $metadata)
+    {
+        return $this->metadata = $metadata;
+    }
+    /**
+     * Get the transmission metadata being used by the transport.
+     *
+     * @return string
+     */
+    public function getMetadata(){
+        return $this->metadata;
     }
 }

--- a/src/Illuminate/Mail/Transport/SparkPostTransport.php
+++ b/src/Illuminate/Mail/Transport/SparkPostTransport.php
@@ -173,7 +173,7 @@ class SparkPostTransport extends Transport
     {
         return $this->metadata = $metadata;
     }
-    
+
     /**
      * Get the transmission metadata being used by the transport.
      *

--- a/src/Illuminate/Mail/Transport/SparkPostTransport.php
+++ b/src/Illuminate/Mail/Transport/SparkPostTransport.php
@@ -173,6 +173,7 @@ class SparkPostTransport extends Transport
     {
         return $this->metadata = $metadata;
     }
+    
     /**
      * Get the transmission metadata being used by the transport.
      *


### PR DESCRIPTION
Just as #16254 allowed for setting options at runtime, this allows for metadata to be set.

```
app('swift.transport')->driver('sparkpost')->setMetadata([
    'user_type' => 'students',
    'education_level' => 'college'
]);
```