### PR TITLE
[5.3] Sort Composer packages by default

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -109,5 +109,8 @@
         "symfony/dom-crawler": "Required to use most of the crawler integration testing tools (3.1.*).",
         "symfony/psr-http-message-bridge": "Required to use psr7 bridging features (0.2.*)."
     },
+    "config": {
+        "sort-packages": true
+    },
     "minimum-stability": "dev"
 }


### PR DESCRIPTION
Figured this would be useful here as well coming from https://github.com/laravel/laravel/pull/4074

Composer will now automatically sort packages when you require them.