### PR TITLE
[5.3] Revert #16692 and make date_format work with ISO8601 again

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1841,9 +1841,9 @@ class Validator implements ValidatorContract
             return false;
         }
 
-        $date = DateTime::createFromFormat($parameters[0], $value);
+        $parsed = date_parse_from_format($parameters[0], $value);
 
-        return $date && $date->format($parameters[0]) === $value;
+        return $parsed['error_count'] === 0 && $parsed['warning_count'] === 0;
     }
 
     /**

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -2121,6 +2121,9 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $v = new Validator($trans, ['x' => '22000-01-01'], ['x' => 'date_format:Y-m-d']);
         $this->assertTrue($v->fails());
 
+        $v = new Validator($trans, ['x' => '00-01-01'], ['x' => 'date_format:Y-m-d']);
+        $this->assertTrue($v->passes());
+
         $v = new Validator($trans, ['x' => ['Not', 'a', 'date']], ['x' => 'date_format:Y-m-d']);
         $this->assertTrue($v->fails());
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -2123,6 +2123,18 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
         $v = new Validator($trans, ['x' => ['Not', 'a', 'date']], ['x' => 'date_format:Y-m-d']);
         $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['x' => '2000-01-01T00:00:00Z'], ['x' => 'date_format:Y-m-d\TH:i:sP']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => '2000-01-01T00:00:00Z'], ['x' => 'date_format:Y-m-d\TH:i:sP']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => '2000-01-01T00:00:00+00'], ['x' => 'date_format:Y-m-d\TH:i:sP']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => '2000-01-01T00:00:00+00:30'], ['x' => 'date_format:Y-m-d\TH:i:sP']);
+        $this->assertTrue($v->passes());
     }
 
     public function testBeforeAndAfter()


### PR DESCRIPTION
Fixes https://github.com/laravel/framework/issues/16842

This PR:
- Reverts https://github.com/laravel/framework/pull/16692 because of https://github.com/laravel/framework/issues/16842
- Adds tests for ISO 8601 dates (the problem of #16842 )
- Adds a test for the problem #16692 tried to fix (so it can be flipped once we've a proper fix not breaking the other stuff)

I hope you appreciate this effort for the ongoing quality of the framework.