### PR TITLE
[5.4] Default foreign key for belongsTo relationship is now dynamic

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -792,7 +792,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         // foreign key name by using the name of the relationship function, which
         // when combined with an "_id" should conventionally match the columns.
         if (is_null($foreignKey)) {
-            $foreignKey = Str::snake($relation).'_' . $instance->getKeyName();
+            $foreignKey = Str::snake($relation).'_'.$instance->getKeyName();
         }
 
         if (! $instance->getConnectionName()) {

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -786,14 +786,14 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
             $relation = $caller['function'];
         }
 
+        $instance = new $related;
+
         // If no foreign key was supplied, we can use a backtrace to guess the proper
         // foreign key name by using the name of the relationship function, which
         // when combined with an "_id" should conventionally match the columns.
         if (is_null($foreignKey)) {
-            $foreignKey = Str::snake($relation).'_id';
+            $foreignKey = Str::snake($relation).'_' . $instance->getKeyName();
         }
-
-        $instance = new $related;
 
         if (! $instance->getConnectionName()) {
             $instance->setConnection($this->connection);


### PR DESCRIPTION
Following https://github.com/laravel/framework/pull/16396 in order to make foreign keys more dynamics. Before, you needed to reference foreign key on belongsTo relationship if primary key of relation was not `id`:

```
class Foo extends Model 
{
    protected $primaryKey = 'key';
}

class Bar extends Model
{
    public function foo () 
    {
        return $this->belongsTo(Foo::class,'foo_key');
    }
}
```

Now, you should be able to just write:

```
class Bar extends Model
{
    public function foo () 
    {
        return $this->belongsTo(Foo::class);
    }
}
```