### PR TITLE
[5.4] Allow passing an array to `find` on the Eloquent Collection

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -14,12 +14,20 @@ class Collection extends BaseCollection implements QueueableCollection
      *
      * @param  mixed  $key
      * @param  mixed  $default
-     * @return \Illuminate\Database\Eloquent\Model
+     * @return \Illuminate\Database\Eloquent\Model|static
      */
     public function find($key, $default = null)
     {
         if ($key instanceof Model) {
             $key = $key->getKey();
+        }
+
+        if (is_array($key)) {
+            if ($this->isEmpty()) {
+                return new static;
+            }
+
+            return $this->whereIn($this->first()->getKeyName(), $key);
         }
 
         return Arr::first($this->items, function ($model) use ($key) {

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -109,6 +109,28 @@ class DatabaseEloquentCollectionTest extends PHPUnit_Framework_TestCase
         $this->assertSame('taylor', $c->find(2, 'taylor'));
     }
 
+    public function testFindMethodFindsManyModelsById()
+    {
+        $model1 = (new TestEloquentCollectionModel)->forceFill(['id' => 1]);
+        $model2 = (new TestEloquentCollectionModel)->forceFill(['id' => 2]);
+        $model3 = (new TestEloquentCollectionModel)->forceFill(['id' => 3]);
+
+        $c = new Collection;
+        $this->assertInstanceOf(Collection::class, $c->find([]));
+        $this->assertCount(0, $c->find([1]));
+
+        $c->push($model1);
+        $this->assertCount(1, $c->find([1]));
+        $this->assertEquals(1, $c->find([1])->first()->id);
+        $this->assertCount(0, $c->find([2]));
+
+        $c->push($model2)->push($model3);
+        $this->assertCount(1, $c->find([2]));
+        $this->assertEquals(2, $c->find([2])->first()->id);
+        $this->assertCount(2, $c->find([2, 3, 4]));
+        $this->assertEquals([2, 3], $c->find([2, 3, 4])->pluck('id')->all());
+    }
+
     public function testLoadMethodEagerLoadsGivenRelationships()
     {
         $c = $this->getMockBuilder('Illuminate\Database\Eloquent\Collection')->setMethods(['first'])->setConstructorArgs([['foo']])->getMock();


### PR DESCRIPTION
`User::find([1, 2])` currently returns a collection of matching items.

---

With this change, you can now call `find` with an array on an existing collection of users too:

```php
$users->find([1, 2]);
```