### PR TITLE
[5.4] Secure password reset tokens against timing attacks and compromised DB

### DIFF
--- a/src/Illuminate/Auth/Passwords/DatabaseTokenRepository.php
+++ b/src/Illuminate/Auth/Passwords/DatabaseTokenRepository.php
@@ -37,14 +37,14 @@ class DatabaseTokenRepository implements TokenRepositoryInterface
      * @var int
      */
     protected $expires;
- 
+
     /**
      * The hasher implementation.
      *
      * @var \Illuminate\Contracts\Hashing\Hasher
      */
     protected $hasher;
-    
+
     /**
      * Create a new token repository instance.
      *

--- a/src/Illuminate/Auth/Passwords/DatabaseTokenRepository.php
+++ b/src/Illuminate/Auth/Passwords/DatabaseTokenRepository.php
@@ -193,7 +193,7 @@ class DatabaseTokenRepository implements TokenRepositoryInterface
     /**
      * Get the hasher instance.
      *
-     * @return \Illuminate\Contracts\Hashing\Hasher 
+     * @return \Illuminate\Contracts\Hashing\Hasher
      */
     public function getHasher()
     {

--- a/src/Illuminate/Auth/Passwords/DatabaseTokenRepository.php
+++ b/src/Illuminate/Auth/Passwords/DatabaseTokenRepository.php
@@ -189,4 +189,14 @@ class DatabaseTokenRepository implements TokenRepositoryInterface
     {
         return $this->connection;
     }
+
+    /**
+     * Get the hasher instance.
+     *
+     * @return \Illuminate\Contracts\Hashing\Hasher 
+     */
+    public function getHasher()
+    {
+        return $this->hasher;
+    }
 }

--- a/src/Illuminate/Auth/Passwords/DatabaseTokenRepository.php
+++ b/src/Illuminate/Auth/Passwords/DatabaseTokenRepository.php
@@ -5,6 +5,7 @@ namespace Illuminate\Auth\Passwords;
 use Carbon\Carbon;
 use Illuminate\Support\Str;
 use Illuminate\Database\ConnectionInterface;
+use Illuminate\Contracts\Hashing\Hasher as HasherContract;
 use Illuminate\Contracts\Auth\CanResetPassword as CanResetPasswordContract;
 
 class DatabaseTokenRepository implements TokenRepositoryInterface
@@ -36,7 +37,14 @@ class DatabaseTokenRepository implements TokenRepositoryInterface
      * @var int
      */
     protected $expires;
-
+ 
+    /**
+     * The hasher implementation.
+     *
+     * @var \Illuminate\Contracts\Hashing\Hasher
+     */
+    protected $hasher;
+    
     /**
      * Create a new token repository instance.
      *
@@ -46,12 +54,13 @@ class DatabaseTokenRepository implements TokenRepositoryInterface
      * @param  int  $expires
      * @return void
      */
-    public function __construct(ConnectionInterface $connection, $table, $hashKey, $expires = 60)
+    public function __construct(ConnectionInterface $connection, HasherContract $hasher, $table, $hashKey, $expires = 60)
     {
         $this->table = $table;
         $this->hashKey = $hashKey;
         $this->expires = $expires * 60;
         $this->connection = $connection;
+        $this->hasher = $hasher;
     }
 
     /**
@@ -96,7 +105,7 @@ class DatabaseTokenRepository implements TokenRepositoryInterface
      */
     protected function getPayload($email, $token)
     {
-        return ['email' => $email, 'token' => $token, 'created_at' => new Carbon];
+        return ['email' => $email, 'token' => $this->hasher->make($token), 'created_at' => new Carbon];
     }
 
     /**
@@ -106,13 +115,13 @@ class DatabaseTokenRepository implements TokenRepositoryInterface
      * @param  string  $token
      * @return bool
      */
-    public function exists(CanResetPasswordContract $user, $token)
+    public function exists(CanResetPasswordContract $user, $userToken)
     {
         $email = $user->getEmailForPasswordReset();
 
-        $token = (array) $this->getTable()->where('email', $email)->where('token', $token)->first();
+        $token = (array) $this->getTable()->where('email', $email)->first();
 
-        return $token && ! $this->tokenExpired($token);
+        return $token && ! $this->tokenExpired($token) && $this->hasher->check($userToken, $token['token']);
     }
 
     /**

--- a/src/Illuminate/Auth/Passwords/PasswordBrokerManager.php
+++ b/src/Illuminate/Auth/Passwords/PasswordBrokerManager.php
@@ -91,6 +91,7 @@ class PasswordBrokerManager implements FactoryContract
 
         return new DatabaseTokenRepository(
             $this->app['db']->connection($connection),
+            $this->app['hash'],
             $config['table'],
             $key,
             $config['expire']

--- a/tests/Auth/AuthDatabaseTokenRepositoryTest.php
+++ b/tests/Auth/AuthDatabaseTokenRepositoryTest.php
@@ -90,7 +90,7 @@ class AuthDatabaseTokenRepositoryTest extends PHPUnit_Framework_TestCase
     protected function getRepo()
     {
         return new Illuminate\Auth\Passwords\DatabaseTokenRepository(
-            m::mock('Illuminate\Database\Connection'), 
+            m::mock('Illuminate\Database\Connection'),
             m::mock('Illuminate\Contracts\Hashing\Hasher'),
             'table', 'key');
     }

--- a/tests/Auth/AuthDatabaseTokenRepositoryTest.php
+++ b/tests/Auth/AuthDatabaseTokenRepositoryTest.php
@@ -88,6 +88,9 @@ class AuthDatabaseTokenRepositoryTest extends PHPUnit_Framework_TestCase
 
     protected function getRepo()
     {
-        return new Illuminate\Auth\Passwords\DatabaseTokenRepository(m::mock('Illuminate\Database\Connection'), 'table', 'key');
+        return new Illuminate\Auth\Passwords\DatabaseTokenRepository(
+            m::mock('Illuminate\Database\Connection'), 
+            m::mock('Illuminate\Contracts\Hashing\Hasher'),
+            'table', 'key');
     }
 }

--- a/tests/Auth/AuthDatabaseTokenRepositoryTest.php
+++ b/tests/Auth/AuthDatabaseTokenRepositoryTest.php
@@ -12,6 +12,7 @@ class AuthDatabaseTokenRepositoryTest extends PHPUnit_Framework_TestCase
     public function testCreateInsertsNewRecordIntoTable()
     {
         $repo = $this->getRepo();
+        $repo->getHasher()->shouldReceive('make')->andReturn('hashed-token');
         $repo->getConnection()->shouldReceive('table')->with('table')->andReturn($query = m::mock('StdClass'));
         $query->shouldReceive('where')->with('email', 'email')->andReturn($query);
         $query->shouldReceive('delete')->once();
@@ -30,7 +31,6 @@ class AuthDatabaseTokenRepositoryTest extends PHPUnit_Framework_TestCase
         $repo = $this->getRepo();
         $repo->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($query = m::mock('StdClass'));
         $query->shouldReceive('where')->once()->with('email', 'email')->andReturn($query);
-        $query->shouldReceive('where')->once()->with('token', 'token')->andReturn($query);
         $query->shouldReceive('first')->andReturn(null);
         $user = m::mock('Illuminate\Contracts\Auth\CanResetPassword');
         $user->shouldReceive('getEmailForPasswordReset')->andReturn('email');
@@ -41,11 +41,11 @@ class AuthDatabaseTokenRepositoryTest extends PHPUnit_Framework_TestCase
     public function testExistReturnsFalseIfRecordIsExpired()
     {
         $repo = $this->getRepo();
+        $repo->getHasher()->shouldReceive('check')->with('token', 'hashed-token')->andReturn(true);
         $repo->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($query = m::mock('StdClass'));
         $query->shouldReceive('where')->once()->with('email', 'email')->andReturn($query);
-        $query->shouldReceive('where')->once()->with('token', 'token')->andReturn($query);
         $date = date('Y-m-d H:i:s', time() - 300000);
-        $query->shouldReceive('first')->andReturn((object) ['created_at' => $date]);
+        $query->shouldReceive('first')->andReturn((object) ['created_at' => $date, 'token' => 'hashed-token']);
         $user = m::mock('Illuminate\Contracts\Auth\CanResetPassword');
         $user->shouldReceive('getEmailForPasswordReset')->andReturn('email');
 
@@ -55,16 +55,29 @@ class AuthDatabaseTokenRepositoryTest extends PHPUnit_Framework_TestCase
     public function testExistReturnsTrueIfValidRecordExists()
     {
         $repo = $this->getRepo();
-        $hasher = m::mock('Illuminate\Contracts\Hashing\Hasher');
-        $tokenHash = $hasher->make('token');
+        $repo->getHasher()->shouldReceive('check')->with('token', 'hashed-token')->andReturn(true);
         $repo->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($query = m::mock('StdClass'));
         $query->shouldReceive('where')->once()->with('email', 'email')->andReturn($query);
         $date = date('Y-m-d H:i:s', time() - 600);
-        $query->shouldReceive('first')->andReturn((object) ['created_at' => $date, 'token' => $tokenHash]);
+        $query->shouldReceive('first')->andReturn((object) ['created_at' => $date, 'token' => 'hashed-token']);
         $user = m::mock('Illuminate\Contracts\Auth\CanResetPassword');
         $user->shouldReceive('getEmailForPasswordReset')->andReturn('email');
 
         $this->assertTrue($repo->exists($user, 'token'));
+    }
+
+    public function testExistReturnsFalseIfInvalidToken()
+    {
+        $repo = $this->getRepo();
+        $repo->getHasher()->shouldReceive('check')->with('wrong-token', 'hashed-token')->andReturn(false);
+        $repo->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($query = m::mock('StdClass'));
+        $query->shouldReceive('where')->once()->with('email', 'email')->andReturn($query);
+        $date = date('Y-m-d H:i:s', time() - 600);
+        $query->shouldReceive('first')->andReturn((object) ['created_at' => $date, 'token' => 'hashed-token']);
+        $user = m::mock('Illuminate\Contracts\Auth\CanResetPassword');
+        $user->shouldReceive('getEmailForPasswordReset')->andReturn('email');
+
+        $this->assertFalse($repo->exists($user, 'wrong-token'));
     }
 
     public function testDeleteMethodDeletesByToken()

--- a/tests/Auth/AuthDatabaseTokenRepositoryTest.php
+++ b/tests/Auth/AuthDatabaseTokenRepositoryTest.php
@@ -55,11 +55,12 @@ class AuthDatabaseTokenRepositoryTest extends PHPUnit_Framework_TestCase
     public function testExistReturnsTrueIfValidRecordExists()
     {
         $repo = $this->getRepo();
+        $hasher = m::mock('Illuminate\Contracts\Hashing\Hasher');
+        $tokenHash = $hasher->make('token');
         $repo->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($query = m::mock('StdClass'));
         $query->shouldReceive('where')->once()->with('email', 'email')->andReturn($query);
-        $query->shouldReceive('where')->once()->with('token', 'token')->andReturn($query);
         $date = date('Y-m-d H:i:s', time() - 600);
-        $query->shouldReceive('first')->andReturn((object) ['created_at' => $date]);
+        $query->shouldReceive('first')->andReturn((object) ['created_at' => $date, 'token' => $tokenHash]);
         $user = m::mock('Illuminate\Contracts\Auth\CanResetPassword');
         $user->shouldReceive('getEmailForPasswordReset')->andReturn('email');
 


### PR DESCRIPTION
Before this patch, tokens and e-mails where stored in the database in clear text, and lookups where done using simple where()'s. 

**Problem number 1)**  
If the DB where somehow leaked, you could compromise any account with a password reset in the database. Password resets are practically randomly generated one-time passwords, and should be treated as passwords and at least obscured by SOME kind of hash function - so why not Bcrypt while we are at it? 

See this link for a nice explanation: https://paragonie.com/blog/2016/09/untangling-forget-me-knot-secure-account-recovery-made-simple#secure-password-reset-tokens

**Problem number 2)**
This is more obscure but potentially a fatal flaw for the Laravel framework. A determined attacker could probably exploit it already. 
The problem with using simple where() clauses in the lookup of email + cleartext token, is that MySQL is going to try and optimize this query. 

MySQL lookups aren't meant to be constant time, and shouldn't be either; It's job is to be fast.

This however prevent a possible security flaw, as it will start by matching the e-mail field, and if it exists, it will begin matching the token. 

If I try and recover using email example@example.org (which I know are in the password reset table because I ordered a reset myself), and I use the token AAAAAAAAAAAAAAAAAAAA, maybe 20 times, and average the response time, and then try BAAAAAAAAAAAAAAAAAAAA 20 times and average the response time, I will be able to make a fairly educated guess at when the string comparison stops in the MySQL database, and therefore deduce the cleartext token. 
This will probably take some time, and the time limit on the reset tokens should definitely help combat this already (which is also why I don't see it as critical), BUT if you have a lot of tokens, maybe a slow or misconfigured server, and you are able to do this over and over again without being detected, I'm pretty sure you will get through eventually. 
Even tho the tokens are 64 chars as far as I could deduce, it will only take maybe 20 guesses, for around 66 chars chars (a-Z0-9), and the total token length of 64 = 85.000 guesses. According to the birthday paradox, it will likely only take 42500 guesses most of the time, but even if the token expires, the attacker can just order a newly generated one, and try again. He only has to order a password reset AND guess the token for this reset within an hour ONCE, for it to succeed. 

This is one of the reasons why we hash our passwords for normal user accounts, but I definitely think password reset tokens should get the same attention. 


I hope my pullrequest didn't get too long, and I hope the style guides aren't totally off. It's my first PR but it really nagged me each time I looked at Laravels password resets. 
