### PR TITLE
Fix "session not saved" issue when logout

### DIFF
--- a/src/Illuminate/Foundation/Auth/AuthenticatesUsers.php
+++ b/src/Illuminate/Foundation/Auth/AuthenticatesUsers.php
@@ -153,8 +153,6 @@ trait AuthenticatesUsers
 
         $request->session()->flush();
 
-        $request->session()->regenerate();
-
         return redirect('/');
     }
 


### PR DESCRIPTION
the `$request->session()->regenerate();` generates a new session, then the `$this->manager->driver()->save();` in StartSession middleware will only save the new session.
```php
    public function terminate($request, $response)
    {
        if ($this->sessionHandled && $this->sessionConfigured() && ! $this->usingCookieSessions()) {
            $this->manager->driver()->save();
        }
    }
```

We can call save method manually to fix this bug:
```php
$request->session()->flush();
$request->session()->save();
$request->session()->regenerate();
```

or simply remove the regenerate statement, so the session have been flushed will be saved in StartSession middleware.