### PR TITLE
[5.3] fix withCount aliasing problem

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1089,6 +1089,10 @@ class Builder
             // the resulting column. This allows multiple counts on the same relationship name.
             $segments = explode(' ', $name);
 
+            // We want to forget the alias in the case the last loop set an alias, but the current
+            // loop does not set a new alias.
+            unset($alias);
+
             if (count($segments) == 3 && Str::lower($segments[1]) == 'as') {
                 list($name, $alias) = [$segments[0], $segments[2]];
             }

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -633,6 +633,15 @@ class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('select *, (select count(*) from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id") as "foo_bar_count" from "eloquent_builder_test_model_parent_stubs"', $builder->toSql());
     }
 
+    public function testWithCountMultipleAndPartialRename()
+    {
+        $model = new EloquentBuilderTestModelParentStub;
+
+        $builder = $model->withCount(['foo as foo_bar', 'foo']);
+
+        $this->assertEquals('select *, (select count(*) from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id") as "foo_bar_count", (select count(*) from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id") as "foo_count" from "eloquent_builder_test_model_parent_stubs"', $builder->toSql());
+    }
+
     public function testHasWithContraintsAndHavingInSubquery()
     {
         $model = new EloquentBuilderTestModelParentStub;


### PR DESCRIPTION
Using withCount with multiple tables and the aliasing feature only for the first entry leads to wrong result names.
`$model->withCount(['foo as foo_bar', 'foo']);`

Error is here:
https://github.com/laravel/framework/blob/5.3/src/Illuminate/Database/Eloquent/Builder.php#L1112
The code is in an foreach loop so `isset($alias)` is also true when the last loop set the alias but the current loop does not us an alias. So the name from the last loop is reused instead of the default name.