### PR TITLE
[5.3] Collection chunk added param: $preserve_keys

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -984,9 +984,10 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      * Chunk the underlying collection array.
      *
      * @param  int   $size
+     * @param  bool  $preserve_keys
      * @return static
      */
-    public function chunk($size)
+    public function chunk($size, $preserve_keys = true)
     {
         if ($size <= 0) {
             return new static;
@@ -994,7 +995,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
 
         $chunks = [];
 
-        foreach (array_chunk($this->items, $size, true) as $chunk) {
+        foreach (array_chunk($this->items, $size, $preserve_keys) as $chunk) {
             $chunks[] = new static($chunk);
         }
 

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -984,10 +984,10 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      * Chunk the underlying collection array.
      *
      * @param  int   $size
-     * @param  bool  $preserve_keys
+     * @param  bool  $preserveKeys
      * @return static
      */
-    public function chunk($size, $preserve_keys = true)
+    public function chunk($size, $preserveKeys = true)
     {
         if ($size <= 0) {
             return new static;
@@ -995,7 +995,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
 
         $chunks = [];
 
-        foreach (array_chunk($this->items, $size, $preserve_keys) as $chunk) {
+        foreach (array_chunk($this->items, $size, $preserveKeys) as $chunk) {
             $chunks[] = new static($chunk);
         }
 


### PR DESCRIPTION
I bumped into this tonight. We should be able to decide if we want to preserve the keys or not.

I made it backward compatible by keeping it true by default.