### PR TITLE
Add ability to return In/NotIn Rule using array keys.

### DIFF
--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -38,9 +38,9 @@ class Rule
      * @param  bool  $array_keys
      * @return \Illuminate\Validation\Rules\In
      */
-    public static function in(array $values, bool $array_keys = false)
+    public static function in(array $values, bool $arrayKeys = null)
     {
-        return new Rules\In($values, $array_keys);
+        return new Rules\In($values, $arrayKeys);
     }
 
     /**
@@ -50,9 +50,9 @@ class Rule
      * @param  bool  $array_keys
      * @return \Illuminate\Validation\Rules\NotIn
      */
-    public static function notIn(array $values, bool $array_keys = false)
+    public static function notIn(array $values, bool $arrayKeys = null)
     {
-        return new Rules\NotIn($values, $array_keys);
+        return new Rules\NotIn($values, $arrayKeys);
     }
 
     /**

--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -35,22 +35,24 @@ class Rule
      * Get an in constraint builder instance.
      *
      * @param  array  $values
+     * @param  bool  $array_keys
      * @return \Illuminate\Validation\Rules\In
      */
-    public static function in(array $values)
+    public static function in(array $values, bool $array_keys = false)
     {
-        return new Rules\In($values);
+        return new Rules\In($values, $array_keys);
     }
 
     /**
      * Get a not_in constraint builder instance.
      *
      * @param  array  $values
+     * @param  bool  $array_keys
      * @return \Illuminate\Validation\Rules\NotIn
      */
-    public static function notIn(array $values)
+    public static function notIn(array $values, bool $array_keys = false)
     {
-        return new Rules\NotIn($values);
+        return new Rules\NotIn($values, $array_keys);
     }
 
     /**

--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -56,6 +56,28 @@ class Rule
     }
 
     /**
+     * Get an in constraint builder instance for array keys.
+     *
+     * @param  array  $values
+     * @return \Illuminate\Validation\Rules\In
+     */
+    public static function inKeys(array $values)
+    {
+        return new Rules\In($values, true);
+    }
+
+    /**
+     * Get a not_in constraint builder instance for array keys.
+     *
+     * @param  array  $values
+     * @return \Illuminate\Validation\Rules\NotIn
+     */
+    public static function notInKeys(array $values)
+    {
+        return new Rules\NotIn($values, true);
+    }
+
+    /**
      * Get a unique constraint builder instance.
      *
      * @param  string  $table

--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -35,7 +35,7 @@ class Rule
      * Get an in constraint builder instance.
      *
      * @param  array  $values
-     * @param  bool  $array_keys
+     * @param  bool  $arrayKeys
      * @return \Illuminate\Validation\Rules\In
      */
     public static function in(array $values, $arrayKeys = false)
@@ -47,7 +47,7 @@ class Rule
      * Get a not_in constraint builder instance.
      *
      * @param  array  $values
-     * @param  bool  $array_keys
+     * @param  bool  $arrayKeys
      * @return \Illuminate\Validation\Rules\NotIn
      */
     public static function notIn(array $values, $arrayKeys = false)

--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -38,7 +38,7 @@ class Rule
      * @param  bool  $array_keys
      * @return \Illuminate\Validation\Rules\In
      */
-    public static function in(array $values, bool $arrayKeys = null)
+    public static function in(array $values, $arrayKeys = false)
     {
         return new Rules\In($values, $arrayKeys);
     }
@@ -50,7 +50,7 @@ class Rule
      * @param  bool  $array_keys
      * @return \Illuminate\Validation\Rules\NotIn
      */
-    public static function notIn(array $values, bool $arrayKeys = null)
+    public static function notIn(array $values, $arrayKeys = false)
     {
         return new Rules\NotIn($values, $arrayKeys);
     }

--- a/src/Illuminate/Validation/Rules/In.php
+++ b/src/Illuminate/Validation/Rules/In.php
@@ -20,7 +20,7 @@ class In
      * Create a new in rule instance.
      *
      * @param  array  $values
-     * @param  bool  $array_keys
+     * @param  bool  $arrayKeys
      * @return void
      */
     public function __construct(array $values, $arrayKeys = false)

--- a/src/Illuminate/Validation/Rules/In.php
+++ b/src/Illuminate/Validation/Rules/In.php
@@ -20,11 +20,16 @@ class In
      * Create a new in rule instance.
      *
      * @param  array  $values
+     * @param  bool  $array_keys
      * @return void
      */
-    public function __construct(array $values)
+    public function __construct(array $values, bool $array_keys = false)
     {
-        $this->values = $values;
+        if ($array_keys) {
+            $this->values = array_keys($values);
+        } else {
+            $this->values = $values;
+        }
     }
 
     /**
@@ -34,6 +39,6 @@ class In
      */
     public function __toString()
     {
-        return $this->rule.':'.implode(',', $this->values);
+        return $this->rule . ':' . implode(',', $this->values);
     }
 }

--- a/src/Illuminate/Validation/Rules/In.php
+++ b/src/Illuminate/Validation/Rules/In.php
@@ -23,7 +23,7 @@ class In
      * @param  bool  $array_keys
      * @return void
      */
-    public function __construct(array $values, bool $arrayKeys = null)
+    public function __construct(array $values, $arrayKeys = false)
     {
         $this->values = $arrayKeys ? array_keys($values) : $values;
     }

--- a/src/Illuminate/Validation/Rules/In.php
+++ b/src/Illuminate/Validation/Rules/In.php
@@ -23,13 +23,9 @@ class In
      * @param  bool  $array_keys
      * @return void
      */
-    public function __construct(array $values, bool $array_keys = false)
+    public function __construct(array $values, bool $arrayKeys = null)
     {
-        if ($array_keys) {
-            $this->values = array_keys($values);
-        } else {
-            $this->values = $values;
-        }
+        $this->values = $arrayKeys ? array_keys($values) : $values;
     }
 
     /**
@@ -39,6 +35,6 @@ class In
      */
     public function __toString()
     {
-        return $this->rule . ':' . implode(',', $this->values);
+        return $this->rule.':'.implode(',', $this->values);
     }
 }

--- a/src/Illuminate/Validation/Rules/NotIn.php
+++ b/src/Illuminate/Validation/Rules/NotIn.php
@@ -23,7 +23,7 @@ class NotIn
      * @param  bool  $array_keys
      * @return void
      */
-    public function __construct(array $values, bool $arrayKeys = null)
+    public function __construct(array $values, $arrayKeys = false)
     {
         $this->values = $arrayKeys ? array_keys($values) : $values;
     }

--- a/src/Illuminate/Validation/Rules/NotIn.php
+++ b/src/Illuminate/Validation/Rules/NotIn.php
@@ -20,7 +20,7 @@ class NotIn
      * Create a new "not in" rule instance.
      *
      * @param  array  $values
-     * @param  bool  $array_keys
+     * @param  bool  $arrayKeys
      * @return void
      */
     public function __construct(array $values, $arrayKeys = false)

--- a/src/Illuminate/Validation/Rules/NotIn.php
+++ b/src/Illuminate/Validation/Rules/NotIn.php
@@ -23,13 +23,9 @@ class NotIn
      * @param  bool  $array_keys
      * @return void
      */
-    public function __construct(array $values, bool $array_keys = false)
+    public function __construct(array $values, bool $arrayKeys = null)
     {
-        if ($array_keys) {
-            $this->values = array_keys($values);
-        } else {
-            $this->values = $values;
-        }
+        $this->values = $arrayKeys ? array_keys($values) : $values;
     }
 
     /**
@@ -39,6 +35,6 @@ class NotIn
      */
     public function __toString()
     {
-        return $this->rule . ':' . implode(',', $this->values);
+        return $this->rule.':'.implode(',', $this->values);
     }
 }

--- a/src/Illuminate/Validation/Rules/NotIn.php
+++ b/src/Illuminate/Validation/Rules/NotIn.php
@@ -20,11 +20,16 @@ class NotIn
      * Create a new "not in" rule instance.
      *
      * @param  array  $values
+     * @param  bool  $array_keys
      * @return void
      */
-    public function __construct(array $values)
+    public function __construct(array $values, bool $array_keys = false)
     {
-        $this->values = $values;
+        if ($array_keys) {
+            $this->values = array_keys($values);
+        } else {
+            $this->values = $values;
+        }
     }
 
     /**
@@ -34,6 +39,6 @@ class NotIn
      */
     public function __toString()
     {
-        return $this->rule.':'.implode(',', $this->values);
+        return $this->rule . ':' . implode(',', $this->values);
     }
 }

--- a/tests/Validation/ValidationInRuleTest.php
+++ b/tests/Validation/ValidationInRuleTest.php
@@ -15,4 +15,11 @@ class ValidationInRuleTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals('in:1,2,3,4', (string) $rule);
     }
+
+    public function testInRuleWorksWithArrayKeys()
+    {
+        $rule = Rule::in(['zero' => 0, 'one' => 1, 'two' => 2], true);
+
+        $this->assertEquals('in:zero,one,two', (string) $rule);
+    }
 }

--- a/tests/Validation/ValidationInRuleTest.php
+++ b/tests/Validation/ValidationInRuleTest.php
@@ -18,7 +18,7 @@ class ValidationInRuleTest extends PHPUnit_Framework_TestCase
 
     public function testInRuleWorksWithArrayKeys()
     {
-        $rule = Rule::in(['zero' => 0, 'one' => 1, 'two' => 2], true);
+        $rule = Rule::inKeys(['zero' => 0, 'one' => 1, 'two' => 2]);
 
         $this->assertEquals('in:zero,one,two', (string) $rule);
     }

--- a/tests/Validation/ValidationNotInRuleTest.php
+++ b/tests/Validation/ValidationNotInRuleTest.php
@@ -18,7 +18,7 @@ class ValidationNotInRuleTest extends PHPUnit_Framework_TestCase
 
     public function testNotInRuleWorksWithArrayKeys()
     {
-        $rule = Rule::notIn(['zero' => 0, 'one' => 1, 'two' => 2], true);
+        $rule = Rule::notInKeys(['zero' => 0, 'one' => 1, 'two' => 2]);
 
         $this->assertEquals('not_in:zero,one,two', (string) $rule);
     }

--- a/tests/Validation/ValidationNotInRuleTest.php
+++ b/tests/Validation/ValidationNotInRuleTest.php
@@ -15,4 +15,11 @@ class ValidationNotInRuleTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals('not_in:1,2,3,4', (string) $rule);
     }
+
+    public function testNotInRuleWorksWithArrayKeys()
+    {
+        $rule = Rule::notIn(['zero' => 0, 'one' => 1, 'two' => 2], true);
+
+        $this->assertEquals('not_in:zero,one,two', (string) $rule);
+    }
 }


### PR DESCRIPTION
Previously I found myself keep doing something like this

```
Rule::in(array_keys(['zero' => 0, 'one' => 1, 'two' => 2]))
```

This PR improves into

```
Rule::in(['zero' => 0, 'one' => 1, 'two' => 2], true)

or

Rule::inKeys(['zero' => 0, 'one' => 1, 'two' => 2])
```

By default the second parameter is **```false```**, if let's say you wanted to have a validation rules for the array keys, make the second parameters to **```true```**

This PR contains improvements for both In Rules and Not In Rules.