### PR TITLE
[5.4] Percise date validation

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1865,9 +1865,9 @@ class Validator implements ValidatorContract
             return false;
         }
 
-        $parsed = date_parse_from_format($parameters[0], $value);
+        $date = DateTime::createFromFormat($parameters[0], $value);
 
-        return $parsed['error_count'] === 0 && $parsed['warning_count'] === 0;
+        return $date && $date->format($parameters[0]) === $value;
     }
 
     /**

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1867,7 +1867,7 @@ class Validator implements ValidatorContract
 
         $date = DateTime::createFromFormat($parameters[0], $value);
 
-        return $date && $date->format($parameters[0]) === $value;
+        return $date && $date->format($parameters[0]) == $value;
     }
 
     /**

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -2134,18 +2134,18 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($v->fails());
 
         $v = new Validator($trans, ['x' => '00-01-01'], ['x' => 'date_format:Y-m-d']);
-        $this->assertTrue($v->passes());
+        $this->assertTrue($v->fails());
 
         $v = new Validator($trans, ['x' => ['Not', 'a', 'date']], ['x' => 'date_format:Y-m-d']);
         $this->assertTrue($v->fails());
 
-        $v = new Validator($trans, ['x' => '2000-01-01T00:00:00Z'], ['x' => 'date_format:Y-m-d\TH:i:sP']);
+        $v = new Validator($trans, ['x' => '2000-01-01T00:00:00Atlantic/Azores'], ['x' => 'date_format:Y-m-d\TH:i:se']);
         $this->assertTrue($v->passes());
 
-        $v = new Validator($trans, ['x' => '2000-01-01T00:00:00Z'], ['x' => 'date_format:Y-m-d\TH:i:sP']);
+        $v = new Validator($trans, ['x' => '2000-01-01T00:00:00Z'], ['x' => 'date_format:Y-m-d\TH:i:sT']);
         $this->assertTrue($v->passes());
 
-        $v = new Validator($trans, ['x' => '2000-01-01T00:00:00+00'], ['x' => 'date_format:Y-m-d\TH:i:sP']);
+        $v = new Validator($trans, ['x' => '2000-01-01T00:00:00+0000'], ['x' => 'date_format:Y-m-d\TH:i:sO']);
         $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['x' => '2000-01-01T00:00:00+00:30'], ['x' => 'date_format:Y-m-d\TH:i:sP']);


### PR DESCRIPTION
Applying https://github.com/laravel/framework/pull/16692 to 5.4 since it was reverted because it broke the code of people depending on the old implementation to pass non-strict formats.