### PR TITLE
[5.3] Handle Model creation when empty attributes are passed

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1578,6 +1578,10 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         // are. These attribute arrays must contain an "id" column previously placed
         // there by the developer as the manually determined key for these models.
         else {
+            if (empty($attributes)) {
+                return true;
+            }
+
             $query->insert($attributes);
         }
 

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -79,6 +79,10 @@ class DatabaseEloquentIntegrationTest extends PHPUnit_Framework_TestCase
                 $table->timestamps();
             });
         }
+
+        $this->schema($connection)->create('non_incrementing_users', function ($table) {
+            $table->string('name')->nullable();
+        });
     }
 
     /**
@@ -323,6 +327,14 @@ class DatabaseEloquentIntegrationTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('second_connection', $user1->getConnectionName());
         $this->assertEquals('second_connection', $user2->getConnectionName());
         $this->assertEquals(2, EloquentTestUser::on('second_connection')->count());
+    }
+
+    public function testCreatingModelWithEmptyAttributes()
+    {
+        $model = EloquentTestNonIncrementing::create([]);
+
+        $this->assertFalse($model->exists);
+        $this->assertFalse($model->wasRecentlyCreated);
     }
 
     public function testPluck()
@@ -1084,6 +1096,14 @@ class EloquentTestUser extends Eloquent
             $join->where('photo.imageable_type', 'EloquentTestPost');
         });
     }
+}
+
+class EloquentTestNonIncrementing extends Eloquent
+{
+    protected $table = 'non_incrementing_users';
+    protected $guarded = [];
+    public $incrementing = false;
+    public $timestamps = false;
 }
 
 class EloquentTestUserWithGlobalScope extends EloquentTestUser


### PR DESCRIPTION
When no-timestamps and non-incrementing model is being created with empty attributes `User::create([])` the `$user->exists` would return true although there's no record inserted in the DB.

This PR skips updating the `exists` property and firing the `created` command in the case listed above.