### PR TITLE
[5.4] Always return a collection when calling Collection::random with a parameter

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -892,7 +892,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Get one or more items randomly from the collection.
      *
-     * @param  int  $amount
+     * @param  int|null  $amount
      * @return mixed
      *
      * @throws \InvalidArgumentException
@@ -905,8 +905,12 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
 
         $keys = array_rand($this->items, $amount);
 
-        if ($amount == 1) {
+        if (count(func_get_args()) == 0) {
             return $this->items[$keys];
+        }
+
+        if (! is_array($keys)) {
+            $keys = [$keys];
         }
 
         return new static(array_intersect_key($this->items, array_flip($keys)));

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -814,13 +814,22 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
     {
         $data = new Collection([1, 2, 3, 4, 5, 6]);
 
-        $random = $data->random();
-        $this->assertInternalType('integer', $random);
-        $this->assertContains($random, $data->all());
+        $random = $data->random(1);
+        $this->assertInstanceOf(Collection::class, $random);
+        $this->assertCount(1, $random);
 
         $random = $data->random(3);
         $this->assertInstanceOf(Collection::class, $random);
         $this->assertCount(3, $random);
+    }
+
+    public function testRandomWithoutArgument()
+    {
+        $data = new Collection([1, 2, 3, 4, 5, 6]);
+
+        $random = $data->random();
+        $this->assertInternalType('integer', $random);
+        $this->assertContains($random, $data->all());
     }
 
     /**


### PR DESCRIPTION
See https://github.com/laravel/internals/issues/304

> Currently, if you call `$collection->random(1)`, you'll get a single item back. This makes sense if there isn't a parameter set, but if 1 is explicitly passed through, it should return a new collection instance. This keeps it consistent with passing in any other integer.