### PR TITLE
[5.3] Allow Broadcasting a notification now instead on queue

### DIFF
--- a/src/Illuminate/Notifications/Channels/BroadcastChannel.php
+++ b/src/Illuminate/Notifications/Channels/BroadcastChannel.php
@@ -5,6 +5,7 @@ namespace Illuminate\Notifications\Channels;
 use RuntimeException;
 use Illuminate\Notifications\Notification;
 use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Notifications\Messages\BroadcastMessage;
 use Illuminate\Notifications\Events\BroadcastNotificationCreated;
 
 class BroadcastChannel
@@ -36,9 +37,17 @@ class BroadcastChannel
      */
     public function send($notifiable, Notification $notification)
     {
-        return $this->events->fire(new BroadcastNotificationCreated(
-            $notifiable, $notification, $this->getData($notifiable, $notification)
-        ));
+        $message = $this->getData($notifiable, $notification);
+
+        $event = new BroadcastNotificationCreated(
+            $notifiable, $notification, is_array($message) ? $message : $message->data
+        );
+
+        if ($message instanceof BroadcastMessage) {
+            $event->connection = 'sync';
+        }
+
+        return $this->events->fire($event);
     }
 
     /**
@@ -46,7 +55,7 @@ class BroadcastChannel
      *
      * @param  mixed  $notifiable
      * @param  \Illuminate\Notifications\Notification  $notification
-     * @return array
+     * @return mixed
      *
      * @throws \RuntimeException
      */

--- a/src/Illuminate/Notifications/Events/BroadcastNotificationCreated.php
+++ b/src/Illuminate/Notifications/Events/BroadcastNotificationCreated.php
@@ -25,6 +25,13 @@ class BroadcastNotificationCreated implements ShouldBroadcast
     public $notification;
 
     /**
+     * The queue connection.
+     *
+     * @var string
+     */
+    public $connection;
+
+    /**
      * The notification data.
      *
      * @var array
@@ -44,6 +51,10 @@ class BroadcastNotificationCreated implements ShouldBroadcast
         $this->data = $data;
         $this->notifiable = $notifiable;
         $this->notification = $notification;
+
+        if (method_exists($this->notification, 'broadcastNow')) {
+            $this->connection = $this->notification->broadcastNow() ? 'sync' : null;
+        }
     }
 
     /**

--- a/src/Illuminate/Notifications/Events/BroadcastNotificationCreated.php
+++ b/src/Illuminate/Notifications/Events/BroadcastNotificationCreated.php
@@ -51,10 +51,6 @@ class BroadcastNotificationCreated implements ShouldBroadcast
         $this->data = $data;
         $this->notifiable = $notifiable;
         $this->notification = $notification;
-
-        if (method_exists($this->notification, 'broadcastNow')) {
-            $this->connection = $this->notification->broadcastNow() ? 'sync' : null;
-        }
     }
 
     /**

--- a/src/Illuminate/Notifications/Messages/BroadcastMessage.php
+++ b/src/Illuminate/Notifications/Messages/BroadcastMessage.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Illuminate\Notifications\Messages;
+
+class BroadcastMessage
+{
+    /**
+     * The data for the notification.
+     *
+     * @var array
+     */
+    public $data;
+
+    /**
+     * Determine if the message should be broadcasted immediately.
+     *
+     * @var array
+     */
+    public $broadcastNow = false;
+
+    /**
+     * Create a new message instance.
+     *
+     * @param  string  $content
+     * @return void
+     */
+    public function __construct(array $data)
+    {
+        $this->data = $data;
+    }
+
+    /**
+     * Set the message data.
+     *
+     * @param  array  $data
+     * @return $this
+     */
+    public function data($data)
+    {
+        $this->data = $data;
+
+        return $this;
+    }
+
+    /**
+     * Broadcast this message immediately.
+     *
+     * @return $this
+     */
+    public function now()
+    {
+        $this->broadcastNow = true;
+
+        return $this;
+    }
+}

--- a/tests/Notifications/NotificationBroadcastChannelTest.php
+++ b/tests/Notifications/NotificationBroadcastChannelTest.php
@@ -37,6 +37,19 @@ class NotificationBroadcastChannelTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals(new PrivateChannel('custom-channel'), $channels[0]);
     }
+
+    public function testNotificationIsBroadcastedNow()
+    {
+        $notification = new TestNotificationBroadCastedNow;
+        $notification->id = 1;
+        $notifiable = Mockery::mock();
+
+        $event = new Illuminate\Notifications\Events\BroadcastNotificationCreated(
+            $notifiable, $notification, $notification->toArray($notifiable)
+        );
+
+        $this->assertEquals('sync', $event->connection);
+    }
 }
 
 class NotificationBroadcastChannelTestNotification extends Notification
@@ -57,5 +70,17 @@ class CustomChannelsTestNotification extends Notification
     public function broadcastOn()
     {
         return [new PrivateChannel('custom-channel')];
+    }
+}
+
+class TestNotificationBroadCastedNow extends Notification
+{
+    public function toArray($notifiable)
+    {
+        return ['invoice_id' => 1];
+    }
+
+    public function broadcastNow(){
+        return true;
     }
 }

--- a/tests/Notifications/NotificationBroadcastChannelTest.php
+++ b/tests/Notifications/NotificationBroadcastChannelTest.php
@@ -44,11 +44,12 @@ class NotificationBroadcastChannelTest extends PHPUnit_Framework_TestCase
         $notification->id = 1;
         $notifiable = Mockery::mock();
 
-        $event = new Illuminate\Notifications\Events\BroadcastNotificationCreated(
-            $notifiable, $notification, $notification->toArray($notifiable)
-        );
-
-        $this->assertEquals('sync', $event->connection);
+        $events = Mockery::mock('Illuminate\Contracts\Events\Dispatcher');
+        $events->shouldReceive('fire')->once()->with(Mockery::on(function($event){
+            return $event->connection == 'sync';
+        }));
+        $channel = new BroadcastChannel($events);
+        $channel->send($notifiable, $notification);
     }
 }
 
@@ -80,8 +81,8 @@ class TestNotificationBroadCastedNow extends Notification
         return ['invoice_id' => 1];
     }
 
-    public function broadcastNow()
+    public function toBroadcast()
     {
-        return true;
+        return (new \Illuminate\Notifications\Messages\BroadcastMessage([]))->now();
     }
 }

--- a/tests/Notifications/NotificationBroadcastChannelTest.php
+++ b/tests/Notifications/NotificationBroadcastChannelTest.php
@@ -45,7 +45,7 @@ class NotificationBroadcastChannelTest extends PHPUnit_Framework_TestCase
         $notifiable = Mockery::mock();
 
         $events = Mockery::mock('Illuminate\Contracts\Events\Dispatcher');
-        $events->shouldReceive('fire')->once()->with(Mockery::on(function($event){
+        $events->shouldReceive('fire')->once()->with(Mockery::on(function ($event) {
             return $event->connection == 'sync';
         }));
         $channel = new BroadcastChannel($events);

--- a/tests/Notifications/NotificationBroadcastChannelTest.php
+++ b/tests/Notifications/NotificationBroadcastChannelTest.php
@@ -80,7 +80,8 @@ class TestNotificationBroadCastedNow extends Notification
         return ['invoice_id' => 1];
     }
 
-    public function broadcastNow(){
+    public function broadcastNow()
+    {
         return true;
     }
 }


### PR DESCRIPTION
This is an attempt to allow broadcasting notifications immediately instead of doing it via queue, to achieve this you'll need to add the following method in your Notification class:

```
public function broadcastNow(){
    return true;
}
```

This will have the `BroadcastNotificationCreated` $connection set to `sync` so that the queue manager use it as the connection name.

--- 

**Update**

Added a new `BroadcastMessage` that can be returned from `toBroadcast`, this new class has a `now()` method that we use to update the connection name.

```php
public function toBroadcast()
{
    return (new BroadcastMessage([...]))->now();
}
```