### PR TITLE
[5.1] Adding the typehint (Contract) in the constructor

### DIFF
--- a/src/Illuminate/Support/Manager.php
+++ b/src/Illuminate/Support/Manager.php
@@ -4,13 +4,14 @@ namespace Illuminate\Support;
 
 use Closure;
 use InvalidArgumentException;
+use Illuminate\Contracts\Foundation\Application;
 
 abstract class Manager
 {
     /**
      * The application instance.
      *
-     * @var \Illuminate\Foundation\Application
+     * @var \Illuminate\Contracts\Foundation\Application
      */
     protected $app;
 
@@ -31,10 +32,10 @@ abstract class Manager
     /**
      * Create a new manager instance.
      *
-     * @param  \Illuminate\Foundation\Application  $app
+     * @param  \Illuminate\Contracts\Foundation\Application  $app
      * @return void
      */
-    public function __construct($app)
+    public function __construct(Application $app)
     {
         $this->app = $app;
     }


### PR DESCRIPTION
This allows us to inject the `app` like this:

```php
$this->app->singleton(AbstractManager::class, Manager::class);

// Instead of:

$this->app->singleton(AbstractManager::class, function($app) {
    return new Manager($app);
});
```