### PR TITLE
[5.4] Fix aggregate service provider resolver method

### DIFF
--- a/src/Illuminate/Support/AggregateServiceProvider.php
+++ b/src/Illuminate/Support/AggregateServiceProvider.php
@@ -42,7 +42,7 @@ class AggregateServiceProvider extends ServiceProvider
         $provides = [];
 
         foreach ($this->providers as $provider) {
-            $instance = $this->app->resolveProviderClass($provider);
+            $instance = $this->app->resolveProvider($provider);
 
             $provides = array_merge($provides, $instance->provides());
         }


### PR DESCRIPTION
Fix the error when run `php artisan optimize`.

```
[Symfony\Component\Debug\Exception\FatalThrowableError]                             
Call to undefined method Illuminate\Foundation\Application::resolveProviderClass()
```

Trace:
```
[2016-12-20 00:38:59] local.ERROR: Symfony\Component\Debug\Exception\FatalThrowableError: Call to undefined method Illuminate\Foundation\Application::resolveProviderClass() in /path/to/vendor/laravel/framework/src/Illuminate/Support/AggregateServiceProvider.php:45
Stack trace:
#0 /path/to/vendor/laravel/framework/src/Illuminate/Foundation/ProviderRepository.php(149): Illuminate\Support\AggregateServiceProvider->provides()
#1 /path/to/vendor/laravel/framework/src/Illuminate/Foundation/ProviderRepository.php(60): Illuminate\Foundation\ProviderRepository->compileManifest(Array)
#2 /path/to/vendor/laravel/framework/src/Illuminate/Foundation/Application.php(541): Illuminate\Foundation\ProviderRepository->load(Array)
#3 /path/to/vendor/laravel/framework/src/Illuminate/Foundation/Bootstrap/RegisterProviders.php(17): Illuminate\Foundation\Application->registerConfiguredProviders()
#4 /path/to/vendor/laravel/framework/src/Illuminate/Foundation/Application.php(206): Illuminate\Foundation\Bootstrap\RegisterProviders->bootstrap(Object(Illuminate\Foundation\Application))
#5 /path/to/vendor/laravel/framework/src/Illuminate/Foundation/Console/Kernel.php(267): Illuminate\Foundation\Application->bootstrapWith(Array)
#6 /path/to/vendor/laravel/framework/src/Illuminate/Foundation/Console/Kernel.php(113): Illuminate\Foundation\Console\Kernel->bootstrap()
#7 /path/to/artisan(35): Illuminate\Foundation\Console\Kernel->handle(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#8 {main}  
```