### PR TITLE
[5.3] Fixed broken event interface listening

### DIFF
--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -309,10 +309,10 @@ class Dispatcher implements DispatcherContract
             foreach (class_implements($eventName) as $interface) {
                 if (isset($this->listeners[$interface])) {
                     foreach ($this->listeners[$interface] as $priority => $names) {
-                        if (isset($this->listeners[$eventName][$priority])) {
-                            $this->listeners[$eventName][$priority] = array_merge($this->listeners[$eventName][$priority], $names);
+                        if (isset($listeners[$priority])) {
+                            $listeners[$priority] = array_merge($listeners[$priority], $names);
                         } else {
-                            $this->listeners[$eventName][$priority] = $names;
+                            $listeners[$priority] = $names;
                         }
                     }
                 }

--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -305,10 +305,16 @@ class Dispatcher implements DispatcherContract
         $listeners = isset($this->listeners[$eventName])
                             ? $this->listeners[$eventName] : [];
 
-        if (class_exists($eventName, false)) {
+        if (class_exists($eventName)) {
             foreach (class_implements($eventName) as $interface) {
                 if (isset($this->listeners[$interface])) {
-                    $listeners = array_merge_recursive($listeners, $this->listeners[$interface]);
+                    foreach ($this->listeners[$interface] as $priority => $names) {
+                        if (isset($this->listeners[$priority])) {
+                            $this->listeners[$priority] = array_merge($this->listeners[$priority], $names);
+                        } else {
+                            $this->listeners[$priority] = $names;
+                        }
+                    }
                 }
             }
         }

--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -309,10 +309,10 @@ class Dispatcher implements DispatcherContract
             foreach (class_implements($eventName) as $interface) {
                 if (isset($this->listeners[$interface])) {
                     foreach ($this->listeners[$interface] as $priority => $names) {
-                        if (isset($this->listeners[$priority])) {
-                            $this->listeners[$priority] = array_merge($this->listeners[$priority], $names);
+                        if (isset($this->listeners[$eventName][$priority])) {
+                            $this->listeners[$eventName][$priority] = array_merge($this->listeners[$eventName][$priority], $names);
                         } else {
-                            $this->listeners[$priority] = $names;
+                            $this->listeners[$eventName][$priority] = $names;
                         }
                     }
                 }


### PR DESCRIPTION
Unfortunately, array_merge_recursive discards the keys, so the previous implementation didn't work properly with priorities.

Before:
![image](https://cloud.githubusercontent.com/assets/2829600/21336117/3654ba4c-c65b-11e6-8b40-5d1a5abb88be.png)

After:
![image](https://cloud.githubusercontent.com/assets/2829600/21336124/44ec65aa-c65b-11e6-9b0a-468683ccc497.png)
