### PR TITLE
[5.3] Add nullable morph columns

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -902,6 +902,22 @@ class Blueprint
     }
 
     /**
+     * Add nullable proper columns for a polymorphic table.
+     *
+     * @param  string  $name
+     * @param  string|null  $indexName
+     * @return void
+     */
+    public function nullableMorphs($name, $indexName = null)
+    {
+        $this->unsignedInteger("{$name}_id")->nullable();
+
+        $this->string("{$name}_type")->nullable();
+
+        $this->index(["{$name}_id", "{$name}_type"], $indexName);
+    }
+
+    /**
      * Adds the `remember_token` column to the table.
      *
      * @return \Illuminate\Support\Fluent


### PR DESCRIPTION
This will be very helpful for the case when model has `owned_by` polymorpic relation which could be null if owner not set\exists. For example comments could be written by guests and by authenticated users. Or author of an article can be deleted from system, but content will be published still.

Using it in [Laravel Ownership package](https://github.com/cybercog/laravel-ownership#prepare-ownable-model-with-polymorphic-ownership).