### PR TITLE
[5.4] Add missing composer dependency

### DIFF
--- a/src/Illuminate/Notifications/composer.json
+++ b/src/Illuminate/Notifications/composer.json
@@ -17,6 +17,7 @@
         "php": ">=5.6.4",
         "illuminate/broadcasting": "5.4.*",
         "illuminate/bus": "5.4.*",
+        "illuminate/queue": "5.4.*",
         "illuminate/container": "5.4.*",
         "illuminate/contracts": "5.4.*",
         "illuminate/mail": "5.4.*",


### PR DESCRIPTION
Trying to use `illuminate/notifications` alone doesn't install `illuminate/queue` which is mandatory for notifications to function. 

Getting this error instead: `PHP Fatal error:  Trait 'Illuminate\Queue\SerializesModels' not found in /vendor/illuminate/notifications/Notification.php on line 9`. This PR fix it