### PR TITLE
[5.3] Add missing composer dependency

### DIFF
--- a/src/Illuminate/Notifications/composer.json
+++ b/src/Illuminate/Notifications/composer.json
@@ -17,6 +17,7 @@
         "php": ">=5.6.4",
         "illuminate/broadcasting": "5.3.*",
         "illuminate/bus": "5.3.*",
+        "illuminate/queue": "5.3.*",
         "illuminate/contracts": "5.3.*",
         "illuminate/support": "5.3.*",
         "ramsey/uuid": "~3.0"


### PR DESCRIPTION
Trying to use `illuminate/notifications` alone doesn't install `illuminate/queue` which is mandatory for notifications to function. 

Getting this error instead: `PHP Fatal error:  Trait 'Illuminate\Queue\SerializesModels' not found in /vendor/illuminate/notifications/Notification.php on line 9`. This PR fix it