### PR TITLE
[5.4] Ignore 5.4 changelog

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -11,4 +11,5 @@
 phpunit.xml.dist export-ignore
 CHANGELOG-5.2.md export-ignore
 CHANGELOG-5.3.md export-ignore
+CHANGELOG-5.4.md export-ignore
 CONTRIBUTING.md export-ignore


### PR DESCRIPTION
Added `CHANGELOG-5.4.md export-ignore` to the `.gitattributes` file.