### PR TITLE
[5.4] [WIP] Move array functions from Collection to Arr

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -172,20 +172,14 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     public function contains($key, $operator = null, $value = null)
     {
         if (func_num_args() == 1) {
-            if ($this->useAsCallable($key)) {
-                return ! is_null($this->first($key));
-            }
-
-            return in_array($key, $this->items);
+            return Arr::contains($this->items, $key);
         }
 
         if (func_num_args() == 2) {
-            $value = $operator;
-
-            $operator = '=';
+            return Arr::contains($this->items, $key, $operator);
         }
 
-        return $this->contains($this->operatorForWhere($key, $operator, $value));
+        return Arr::contains($this->items, $key, $operator, $value);
     }
 
     /**
@@ -301,11 +295,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      */
     public function filter(callable $callback = null)
     {
-        if ($callback) {
-            return new static(Arr::where($this->items, $callback));
-        }
-
-        return new static(array_filter($this->items));
+        return new static(Arr::filter($this->items, $callback));
     }
 
     /**
@@ -319,12 +309,10 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     public function where($key, $operator, $value = null)
     {
         if (func_num_args() == 2) {
-            $value = $operator;
-
-            $operator = '=';
+            return new static(Arr::where($this->items, $key, $operator));
         }
 
-        return $this->filter($this->operatorForWhere($key, $operator, $value));
+        return new static(Arr::where($this->items, $key, $operator, $value));
     }
 
     /**
@@ -631,11 +619,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      */
     public function map(callable $callback)
     {
-        $keys = array_keys($this->items);
-
-        $items = array_map($callback, $this->items, $keys);
-
-        return new static(array_combine($keys, $items));
+        return new static(Arr::map($this->items, $callback));
     }
 
     /**
@@ -648,17 +632,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      */
     public function mapWithKeys(callable $callback)
     {
-        $result = [];
-
-        foreach ($this->items as $key => $value) {
-            $assoc = $callback($value, $key);
-
-            foreach ($assoc as $mapKey => $mapValue) {
-                $result[$mapKey] = $mapValue;
-            }
-        }
-
-        return new static($result);
+        return new static(Arr::mapWithKeys($this->items, $callback));
     }
 
     /**
@@ -669,7 +643,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      */
     public function flatMap(callable $callback)
     {
-        return $this->map($callback)->collapse();
+        return new static(Arr::flatMap($this->items, $callback));
     }
 
     /**
@@ -921,7 +895,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      */
     public function reduce(callable $callback, $initial = null)
     {
-        return array_reduce($this->items, $callback, $initial);
+        return Arr::reduce($this->items, $callback, $initial);
     }
 
     /**

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -290,13 +290,14 @@ if (! function_exists('array_sort_recursive')) {
 
 if (! function_exists('array_where')) {
     /**
-     * Filter the array using the given callback.
+     * Filter an array by the given key value pair.
      *
      * @param  array  $array
-     * @param  callable  $callback
-     * @return array
+     * @param  mixed  $operator
+     * @param  mixed  $value
+     * @return static
      */
-    function array_where($array, callable $callback)
+    function array_where($array, $key, $operator, $value = null)
     {
         return Arr::where($array, $callback);
     }

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1011,7 +1011,7 @@ class Validator implements ValidatorContract
 
         $attributeData = $this->extractDataFromPath($explicitPath);
 
-        $otherValues = Arr::where(Arr::dot($attributeData), function ($value, $key) use ($parameters) {
+        $otherValues = Arr::filter(Arr::dot($attributeData), function ($value, $key) use ($parameters) {
             return Str::is($parameters[0], $key);
         });
 
@@ -1338,7 +1338,7 @@ class Validator implements ValidatorContract
 
         $attributeData = $this->extractDataFromPath($explicitPath);
 
-        $data = Arr::where(Arr::dot($attributeData), function ($value, $key) use ($attribute, $attributeName) {
+        $data = Arr::filter(Arr::dot($attributeData), function ($value, $key) use ($attribute, $attributeName) {
             return $key != $attribute && Str::is($attributeName, $key);
         });
 


### PR DESCRIPTION
This is a little proof of concept of what it would look like if methods would be moved from `Collection` to `Arr` to streamline their API's.

Original proposition: https://github.com/laravel/internals/issues/331

New methods on `Arr`:

- `map` (benefit over `array_map`: it also passes keys to the callable by default; it also has a more logical parameter order in this context)
- `filter` (benefit over `array_filter`: it also passes keys to the callable by default)
- `reduce` (no benefit over `array_reduce`, doubtful about this one, but having it here is nice for consistency)
- `where` (now works like `Collection::where`, with key-operator-value)
- Also `contains`, `mapWithKeys` and `flatMap`
- The `array_where` has been changed to behave like `Arr::where` in this PR

Besides two `Arr::where` calls in the validator class, these changes didn't break anything outside of `Collection` and `Arr`. Nothing has changed in `Collection`'s public API.

---

If you agree with the changes—and don't mind breaking `where`—I'll finish this up.

**Todo**

- Transfer the remaining methods from `Collection` to `Arr`
- `useAsCallable` and `operatorForWhere` exist on both `Collection` and `Arr` at the moment, if everything would move to `Arr` this would be resolved
- Update `Arr`'s unit tests