### PR TITLE
[5.3] Add command alias

### DIFF
--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -95,6 +95,10 @@ class Command extends SymfonyCommand
 
         $this->setDescription($this->description);
 
+        if(! empty($this->alias)) {
+            $this->setAliases([ $this->alias ]);
+        }
+
         if (! isset($this->signature)) {
             $this->specifyParameters();
         }

--- a/src/Illuminate/Foundation/Console/stubs/console.stub
+++ b/src/Illuminate/Foundation/Console/stubs/console.stub
@@ -21,6 +21,13 @@ class DummyClass extends Command
     protected $description = 'Command description';
 
     /**
+     * The console command alias.
+     *
+     * @var string
+     */
+    protected $alias = '';
+
+    /**
      * Create a new command instance.
      *
      * @return void


### PR DESCRIPTION
This PR will allow set alias for artisan commands 

```php
     /**
     * The name and signature of the console command.
     *
     * @var string
     */
    protected $signature = 'database:backup';

 
    /**
     * The console command alias.
     *
     * @var string
     */
    protected $alias = 'db:bkup';
```

so here we could run artisan as 
```
$ php artisan database:backup

# OR

$ php artisan db:bkup
```