### PR TITLE
[5.3] Add auth redirect path generation method

### DIFF
--- a/src/Illuminate/Foundation/Auth/RedirectsUsers.php
+++ b/src/Illuminate/Foundation/Auth/RedirectsUsers.php
@@ -11,6 +11,10 @@ trait RedirectsUsers
      */
     public function redirectPath()
     {
+        if (method_exists($this, 'redirectTo')) {
+            return $this->redirectTo();
+        }
+
         return property_exists($this, 'redirectTo') ? $this->redirectTo : '/home';
     }
 }


### PR DESCRIPTION
Adds call of `redirectTo` method in `Illuminate\Foundation\Auth\RedirectsUsers` trait.

It's pretty same as property `$this->redirectTo`, but if we will have method - there would be an ability to write custom redirect logic after authentication, registration or password reset. For example we can resolve where user should be redirected by using retrieved data from user data, session, cookies, etc...

If there is no `redirectTo()` method exists in your controller - `redirectTo` property will be used.

I thought about name of the method. Just left same as property. Another one was: `resolveRedirectTo()`.