### PR TITLE
Add an case about lose connection

### DIFF
--- a/src/Illuminate/Database/DetectsLostConnections.php
+++ b/src/Illuminate/Database/DetectsLostConnections.php
@@ -28,6 +28,7 @@ trait DetectsLostConnections
             'SSL connection has been closed unexpectedly',
             'Error writing data to the connection',
             'Resource deadlock avoided',
+            'Operation now in progress',
         ]);
     }
 }


### PR DESCRIPTION
mysql will raise error: SQLSTATE[HY000] [2002] Operation now in progress 

just like the post : https://forum.phalconphp.com/discussion/9653/got-sqlstatehy000-2002-operation-now-in-progress-when-using-phal

so this need to be add to causedByLostConnection
