### PR TITLE
[5.3] Add array transport in order to store Swift messages in memory

### DIFF
--- a/src/Illuminate/Mail/Transport/ArrayTransport.php
+++ b/src/Illuminate/Mail/Transport/ArrayTransport.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Illuminate\Mail\Transport;
+
+use Swift_Mime_Message;
+use Illuminate\Support\Collection;
+
+class ArrayTransport extends Transport
+{
+    /**
+     * The collection of Swift Messages.
+     *
+     * @var \Illuminate\Support\Collection
+     */
+    protected $messages;
+
+    /**
+     * Create a new array transport instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        $this->messages = new Collection;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function send(Swift_Mime_Message $message, &$failedRecipients = null)
+    {
+        $this->beforeSendPerformed($message);
+
+        $this->messages[] = $message;
+
+        return $this->numberOfRecipients($message);
+    }
+
+    /**
+     * Return the collection of messages.
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    public function getMessages()
+    {
+        return $this->messages;
+    }
+
+    public function clearMessages()
+    {
+        return $this->messages = new Collection;
+    }
+}

--- a/src/Illuminate/Mail/TransportManager.php
+++ b/src/Illuminate/Mail/TransportManager.php
@@ -10,6 +10,7 @@ use Swift_MailTransport as MailTransport;
 use Swift_SmtpTransport as SmtpTransport;
 use Illuminate\Mail\Transport\LogTransport;
 use Illuminate\Mail\Transport\SesTransport;
+use Illuminate\Mail\Transport\ArrayTransport;
 use Illuminate\Mail\Transport\MailgunTransport;
 use Illuminate\Mail\Transport\MandrillTransport;
 use Illuminate\Mail\Transport\SparkPostTransport;
@@ -148,6 +149,14 @@ class TransportManager extends Manager
     protected function createLogDriver()
     {
         return new LogTransport($this->app->make('Psr\Log\LoggerInterface'));
+    }
+
+    /**
+     * Create an instance of the Array Swift Transport Driver.
+     */
+    protected function createArrayDriver()
+    {
+        return new ArrayTransport();
     }
 
     /**


### PR DESCRIPTION
This provides an option or alternative to test mail messages, using this new array driver, the messages can be stored in a collection and retrieved later for either unit testing or to display them in a debug bar at the bottom of the page, etc.

Right now I don't see any other way to programatically retrieve these messages, we either save them in a log or send them. 