### PR TITLE
[5.3] Add fallback field to SlackAttachment

### DIFF
--- a/src/Illuminate/Notifications/Channels/SlackWebhookChannel.php
+++ b/src/Illuminate/Notifications/Channels/SlackWebhookChannel.php
@@ -86,6 +86,7 @@ class SlackWebhookChannel
                 'footer' => $attachment->footer,
                 'footer_icon' => $attachment->footerIcon,
                 'ts' => $attachment->timestamp,
+                'fallback' => $attachment->fallback,
             ]);
         })->all();
     }

--- a/src/Illuminate/Notifications/Messages/SlackAttachment.php
+++ b/src/Illuminate/Notifications/Messages/SlackAttachment.php
@@ -70,6 +70,13 @@ class SlackAttachment
     public $timestamp;
 
     /**
+     * A plain-text summary of the attachment.
+     *
+     * @var string
+     */
+    public $fallback;
+
+    /**
      * Set the title of the attachment.
      *
      * @param  string  $title
@@ -171,6 +178,19 @@ class SlackAttachment
     public function timestamp(Carbon $timestamp)
     {
         $this->timestamp = $timestamp->getTimestamp();
+
+        return $this;
+    }
+
+    /**
+     * A plain-text summary of the attachment.
+     *
+     * @param  string  $fallback
+     * @return $this
+     */
+    public function fallback($fallback)
+    {
+        $this->fallback = $fallback;
 
         return $this;
     }

--- a/tests/Notifications/NotificationSlackChannelTest.php
+++ b/tests/Notifications/NotificationSlackChannelTest.php
@@ -42,6 +42,7 @@ class NotificationSlackChannelTest extends PHPUnit_Framework_TestCase
                             'title' => 'Laravel',
                             'title_link' => 'https://laravel.com',
                             'text' => 'Attachment Content',
+                            'fallback' => 'Attachment Fallback',
                             'fields' => [
                                 [
                                     'title' => 'Project',
@@ -110,6 +111,7 @@ class NotificationSlackChannelTestNotification extends Notification
                         $timestamp->shouldReceive('getTimestamp')->andReturn(1234567890);
                         $attachment->title('Laravel', 'https://laravel.com')
                                    ->content('Attachment Content')
+                                   ->fallback('Attachment Fallback')
                                    ->fields([
                                         'Project' => 'Laravel',
                                     ])


### PR DESCRIPTION
This PR adds the `fallback` field to `SlackAttachment`.

The function of that field as explained in [the Slack documentation](https://api.slack.com/docs/message-attachments): 
> A plain-text summary of the attachment. This text will be used in clients that don't show formatted text (eg. IRC, mobile notifications) and should not contain any markup.


