### PR TITLE
[5.3] Models ids being overlapped

### DIFF
--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -152,6 +152,17 @@ class DatabaseEloquentIntegrationTest extends PHPUnit_Framework_TestCase
         }
     }
 
+    public function testModelsIdsAreNotOverlapped()
+    {
+        EloquentTestUser::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']);
+        EloquentTestPost::create(['id' => 2, 'user_id' => 1, 'name' => 'Foo']);
+
+        $post = EloquentTestPost::join('users', 'posts.user_id', '=', 'users.id')
+            ->where('user_id', 1)->first();
+
+        $this->assertEquals(2, $post->id);
+    }
+
     public function testBasicModelCollectionRetrieval()
     {
         EloquentTestUser::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']);


### PR DESCRIPTION
I wrote a test case for my issue.

It should keep the id from the "main" eloquent model. I don't know if there is an alternative solution.