### PR TITLE
[5.4] Idea to test mailable views

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithMailable.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithMailable.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Illuminate\Foundation\Testing\Concerns;
+
+use Illuminate\Contracts\Mail\Mailable;
+
+trait InteractsWithMailable
+{
+    /**
+     * Render and return the mailable HTML view.
+     *
+     * @param  \Illuminate\Mail\Mailable $mailable
+     * @return string
+     */
+    public function renderView(Mailable $mailable)
+    {
+        return $this->render($mailable, 'view');
+    }
+
+    /**
+     * Render and return the mailable HTML view.
+     *
+     * @param  \Illuminate\Mail\Mailable $mailable
+     * @return string
+     */
+    public function renderTextView(Mailable $mailable)
+    {
+        return $this->render($mailable, 'textView');
+    }
+
+    /**
+     * Render and return the mailable view or text view.
+     *
+     * @param  \Illuminate\Mail\Mailable $mailable
+     * @return string
+     */
+    private function render(Mailable $mailable, $view)
+    {
+        $this->app->call([$mailable, 'build']);
+
+        return $this->app->make('view')
+            ->make($mailable->$view, $mailable->buildViewData())
+            ->render();
+    }
+}

--- a/tests/Foundation/FoundationInteractsWithMailableTest.php
+++ b/tests/Foundation/FoundationInteractsWithMailableTest.php
@@ -1,0 +1,73 @@
+<?php
+
+use Mockery as m;
+use Illuminate\Mail\Mailable;
+use Illuminate\Contracts\View\View;
+use Illuminate\Contracts\View\Factory as ViewFactory;
+use Illuminate\Foundation\Testing\Concerns\InteractsWithMailable;
+
+class FoundationInteractsWithMailableTest extends PHPUnit_Framework_TestCase
+{
+    use InteractsWithMailable;
+
+    public $app;
+
+    public function tearDown()
+    {
+        m::close();
+    }
+
+    protected function mockRender(Mailable $mailable, $template, array $data, $result)
+    {
+        $this->app = m::mock(Application::class);
+
+        $this->app->shouldReceive('call')
+            ->withArgs([[$mailable, 'build']])
+            ->andReturnUsing(function () use ($mailable) {
+                $mailable->build();
+            });
+
+        $view = m::mock(View::class);
+        $view->shouldReceive('render')
+            ->andReturn($result);
+
+        $factory = m::mock(ViewFactory::class);
+        $factory->shouldReceive('make')
+            ->once()
+            ->withArgs([$template, $data])
+            ->andReturn($view);
+
+        $this->app->shouldReceive('make')
+            ->once()
+            ->withArgs(['view'])
+            ->andReturn($factory);
+    }
+
+    public function testRenderView()
+    {
+        $mailable = new MailableStub;
+
+        $this->mockRender($mailable, 'mail.view', ['framework' => 'Laravel'], '[View]');
+
+        $this->assertSame('[View]', $this->renderView($mailable));
+    }
+
+    public function testRenderTextView()
+    {
+        $mailable = new MailableStub;
+
+        $this->mockRender($mailable, 'mail.text-view', ['framework' => 'Laravel'], '[Text View]');
+
+        $this->assertSame('[Text View]', $this->renderTextView($mailable));
+    }
+}
+
+class MailableStub extends Mailable
+{
+    public function build()
+    {
+        $this->view('mail.view')
+            ->text('mail.text-view')
+            ->with(['framework' => 'Laravel']);
+    }
+}


### PR DESCRIPTION
Right now there is no easy way to test that a mailable view was rendered correctly, so this is a proposal / idea to solve this problem. The usage would be like this:

```
    use InteractsWithMailable;

    public function testMailableView()
    {
        $user = factory(\App\User::class)->create([
            'name' => 'Duilio'
        ]);

        $result = $this->renderView(new WelcomeMail($user));

        $this->assertContains('Hello Duilio', $result);
    }
```