### PR TITLE
[5.3] Fix error when calling MailFake::send in mailables with dependencies

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Support\Testing\Fakes;
 
 use Illuminate\Support\Collection;
+use Illuminate\Container\Container;
 use Illuminate\Contracts\Mail\Mailer;
 use Illuminate\Contracts\Mail\Mailable;
 use PHPUnit_Framework_Assert as PHPUnit;
@@ -206,7 +207,7 @@ class MailFake implements Mailer
             return;
         }
 
-        $view->build();
+        Container::getInstance()->call([$view, 'build']);
 
         $mailable = new MailableFake;
 


### PR DESCRIPTION
If the mailable has a dependency in the build method (i.e.: `public function build(AuthManager $authManager)`

Then calling: `Mail::fake()` and then `Mail::send(new MailableClassHere)` throws an exception. 

This fixes the problem. 

However it's worth mentioning that `Mail::to($someone)->send(new MailableClassHere)` works because the build method is not called in that case.