### PR TITLE
[5.3] Update docblocks

### DIFF
--- a/src/Illuminate/Encryption/Encrypter.php
+++ b/src/Illuminate/Encryption/Encrypter.php
@@ -61,7 +61,7 @@ class Encrypter implements EncrypterContract
     /**
      * Encrypt the given value.
      *
-     * @param  string  $value
+     * @param  mixed  $value
      * @return string
      *
      * @throws \Illuminate\Contracts\Encryption\EncryptException
@@ -93,7 +93,7 @@ class Encrypter implements EncrypterContract
     /**
      * Decrypt the given value.
      *
-     * @param  string  $payload
+     * @param  mixed  $payload
      * @return string
      *
      * @throws \Illuminate\Contracts\Encryption\DecryptException
@@ -117,7 +117,7 @@ class Encrypter implements EncrypterContract
      * Create a MAC for the given value.
      *
      * @param  string  $iv
-     * @param  string  $value
+     * @param  mixed  $value
      * @return string
      */
     protected function hash($iv, $value)


### PR DESCRIPTION
It seems to me because the encrypt and decrypt values are being serialized and unserialized the type is not string but rather mixed. You can encrypt/decrypt something like an array fine.