### PR TITLE
Expose data value to Validator replacers

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -2178,7 +2178,7 @@ class Validator implements ValidatorContract
     protected function doReplacements($message, $attribute, $rule, $parameters)
     {
         $attributeName = $this->getAttribute($attribute);
-        
+
         $value = $this->getValue($attribute);
 
         $message = str_replace(

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -2177,18 +2177,20 @@ class Validator implements ValidatorContract
      */
     protected function doReplacements($message, $attribute, $rule, $parameters)
     {
-        $value = $this->getAttribute($attribute);
+        $attributeName = $this->getAttribute($attribute);
+        
+        $value = $this->getValue($attribute);
 
         $message = str_replace(
             [':attribute', ':ATTRIBUTE', ':Attribute'],
-            [$value, Str::upper($value), Str::ucfirst($value)],
+            [$attributeName, Str::upper($attributeName), Str::ucfirst($attributeName)],
             $message
         );
 
         if (isset($this->replacers[Str::snake($rule)])) {
-            $message = $this->callReplacer($message, $attribute, Str::snake($rule), $parameters);
+            $message = $this->callReplacer($message, $attribute, Str::snake($rule), $parameters, $value);
         } elseif (method_exists($this, $replacer = "replace{$rule}")) {
-            $message = $this->$replacer($message, $attribute, $rule, $parameters);
+            $message = $this->$replacer($message, $attribute, $rule, $parameters, $value);
         }
 
         return $message;


### PR DESCRIPTION
This PR exposes the input value to replacers. This way custom replacers can be set up that extract information from the actual value.

E.g.:

```php
// Custom validator
// Example message: "The number :value is incorrect."
Validator::replacer('phone', function($message, $attribute, $rule, $parameters, $value) {
    return str_replace(':value', $value, $message);
});

// Or even overwrite an existing replacer...
// Example message: "The :attribute is of type :mime but must be a file of type: :values."
Validator::replacer('mimes', function($message, $attribute, $rule, $parameters, $value) {
    $mime = $value instanceof UploadedFile ? $value->getMimeType() : 'undefined';

    return str_replace([':mime', ':values'], [$mime, implode(', ', $parameters)], $message);
});
```

Cross-reference: https://github.com/Propaganistas/Laravel-Phone/issues/45