### PR TITLE
[5.4] Fix injection placement of dependencies for routing method parameters

### DIFF
--- a/src/Illuminate/Routing/RouteDependencyResolverTrait.php
+++ b/src/Illuminate/Routing/RouteDependencyResolverTrait.php
@@ -131,7 +131,7 @@ trait RouteDependencyResolverTrait
      * @param  array $parameters
      * @return array
      */
-    protected function mergeRemainingParameters($arguments, $parameters)
+    protected function mergeRemainingParameters(array $arguments, array $parameters)
     {
         foreach ($arguments as $key => $argument) {
             // Arguments that aren't objects will be a default value or null

--- a/src/Illuminate/Routing/RouteDependencyResolverTrait.php
+++ b/src/Illuminate/Routing/RouteDependencyResolverTrait.php
@@ -84,10 +84,9 @@ trait RouteDependencyResolverTrait
      *
      * @param  \ReflectionParameter  $parameter
      * @param  array  $parameters
-     * @param  array  $originalParameters
      * @return mixed
      */
-    protected function transformDependency(ReflectionParameter $parameter, $parameters)
+    protected function transformDependency(ReflectionParameter $parameter, array $parameters)
     {
         // If the current parameter shouldn't be a class this method will return null
         if ($class = $parameter->getClass()) {

--- a/src/Illuminate/Routing/RouteDependencyResolverTrait.php
+++ b/src/Illuminate/Routing/RouteDependencyResolverTrait.php
@@ -106,8 +106,8 @@ trait RouteDependencyResolverTrait
     /**
      * Remove known classes from an array of parameters
      *
-     * @param array $originalParameters
-     * @param array $classNames
+     * @param  array $originalParameters
+     * @param  array $classNames
      * @return array
      */
     protected function cleanDependenciesFromParameters($originalParameters, $classNames)
@@ -129,8 +129,8 @@ trait RouteDependencyResolverTrait
     /**
      * Merge route parameters into method arguments
      *
-     * @param array $arguments
-     * @param array $parameters
+     * @param  array $arguments
+     * @param  array $parameters
      * @return array
      */
     protected function mergeRemainingParameters($arguments, $parameters)
@@ -164,8 +164,8 @@ trait RouteDependencyResolverTrait
     /**
      * Return a parameter by its class
      *
-     * @param string $class
-     * @param array $parameters
+     * @param  string $class
+     * @param  array $parameters
      * @return mixed
      */
     protected function fetchParameterByClassName($class, array $parameters)
@@ -173,20 +173,5 @@ trait RouteDependencyResolverTrait
         return Arr::first($parameters, function ($value) use ($class) {
             return $value instanceof $class;
         });
-    }
-
-    /**
-     * Splice the given value into the parameter list.
-     *
-     * @param  array  $parameters
-     * @param  string  $key
-     * @param  mixed  $instance
-     * @return void
-     */
-    protected function spliceIntoParameters(array &$parameters, $key, $instance)
-    {
-        array_splice(
-            $parameters, $key, 0, [$instance]
-        );
     }
 }

--- a/src/Illuminate/Routing/RouteDependencyResolverTrait.php
+++ b/src/Illuminate/Routing/RouteDependencyResolverTrait.php
@@ -109,7 +109,7 @@ trait RouteDependencyResolverTrait
      * @param  array $classNames
      * @return array
      */
-    protected function cleanDependenciesFromParameters($originalParameters, $classNames)
+    protected function cleanDependenciesFromParameters(array $originalParameters, array $classNames)
     {
         $parameters = [];
         // Remove any duplicates from class list

--- a/src/Illuminate/Routing/RouteDependencyResolverTrait.php
+++ b/src/Illuminate/Routing/RouteDependencyResolverTrait.php
@@ -61,8 +61,7 @@ trait RouteDependencyResolverTrait
             // If no dependency or default value $instance should be null
             if (is_object($instance)) {
                 $classNames[] = get_class($instance);
-            }
-            elseif ($parameter->isDefaultValueAvailable()) {
+            } elseif ($parameter->isDefaultValueAvailable()) {
                 $instance = $parameter->getDefaultValue();
             }
 
@@ -73,7 +72,7 @@ trait RouteDependencyResolverTrait
         // this way we can inject all non object parameters in their respective order
         $parameters = $this->cleanDependenciesFromParameters($parameters, $classNames);
 
-        if (!empty($parameters)) {
+        if (! empty($parameters)) {
             return $this->mergeRemainingParameters($arguments, $parameters);
         }
 
@@ -104,7 +103,7 @@ trait RouteDependencyResolverTrait
     }
 
     /**
-     * Remove known classes from an array of parameters
+     * Remove known classes from an array of parameters.
      *
      * @param  array $originalParameters
      * @param  array $classNames
@@ -118,7 +117,7 @@ trait RouteDependencyResolverTrait
 
         // Create a new parameters array leaving out any classes from the class list
         foreach ($originalParameters as $key => $parameter) {
-            if (!is_object($parameter) || !in_array(get_class($parameter), $classNames)) {
+            if (! is_object($parameter) || ! in_array(get_class($parameter), $classNames)) {
                 $parameters[$key] = $parameter;
             }
         }
@@ -127,7 +126,7 @@ trait RouteDependencyResolverTrait
     }
 
     /**
-     * Merge route parameters into method arguments
+     * Merge route parameters into method arguments.
      *
      * @param  array $arguments
      * @param  array $parameters
@@ -138,7 +137,7 @@ trait RouteDependencyResolverTrait
         foreach ($arguments as $key => $argument) {
             // Arguments that aren't objects will be a default value or null
             // these values should be filled in order by the parameters
-            if (!is_object($argument)) {
+            if (! is_object($argument)) {
                 $arguments[$key] = array_shift($parameters);
                 if (empty($parameters)) {
                     break;
@@ -162,7 +161,7 @@ trait RouteDependencyResolverTrait
     }
 
     /**
-     * Return a parameter by its class
+     * Return a parameter by its class.
      *
      * @param  string $class
      * @param  array $parameters

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -318,7 +318,7 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('bar', $_SERVER['__test.route_inject'][1]);
         $this->assertEquals('test', $_SERVER['__test.route_inject'][2]);
         $this->assertArrayHasKey(3, $_SERVER['__test.route_inject']);
-        $this->assertInstanceOf('\Illuminate\Http\Request', $_SERVER['__test.route_inject'][3]);
+        $this->assertInstanceOf('Illuminate\Http\Request', $_SERVER['__test.route_inject'][3]);
 
         unset($_SERVER['__test.route_inject']);
     }

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -303,6 +303,26 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase
         unset($_SERVER['__test.route_inject']);
     }
 
+    public function testClassesAndVariablesCanBeInjectedIntoRoutes()
+    {
+        unset($_SERVER['__test.route_inject']);
+        $router = $this->getRouter();
+        $router->get('foo/{var}/{bar?}/{baz?}', function (stdClass $foo, $var, $bar = 'test', Request $baz = null) {
+            $_SERVER['__test.route_inject'] = func_get_args();
+
+            return 'hello';
+        });
+
+        $this->assertEquals('hello', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
+        $this->assertInstanceOf('stdClass', $_SERVER['__test.route_inject'][0]);
+        $this->assertEquals('bar', $_SERVER['__test.route_inject'][1]);
+        $this->assertEquals('test', $_SERVER['__test.route_inject'][2]);
+        $this->assertArrayHasKey(3, $_SERVER['__test.route_inject']);
+        $this->assertInstanceOf('\Illuminate\Http\Request', $_SERVER['__test.route_inject'][3]);
+
+        unset($_SERVER['__test.route_inject']);
+    }
+
     public function testOptionsResponsesAreGeneratedByDefault()
     {
         $router = $this->getRouter();


### PR DESCRIPTION
This addresses the issue https://github.com/laravel/framework/issues/12630.

Originally resolveMethodDependencies() would return $parameters with all dependencies, this array was then be passed straight into the routing method. If there were additional $parameters in the routing method breaking up the dependencies this would be ignored e.g.:
```
Route::get('foo/{bar?}/{user?}', function (Request $request, $bar = 'test', User $user = null) {
    dd($bar);
});
```
Navigating to 'localhost/foo' would result in $bar being a user model.

In the above example resolveMethodDependencies() would produce an array similar too:
```
$parameters = [
    \Illuminate\Http\Request $request,
    \App\User $user,
];
```

With these changes it now adds placeholders (as the default value or null) if no parameter exists, resulting in a parameters array like:
```
$parameters = [
    \Illuminate\Http\Request $request,
    'test'
    \App\User $user,
];
```
Causing $bar to be 'test' in the above example.

I have included a test to highlight this behaviour.

First pull request to the repo, please advise any changes needed.

Merry Christmas!