### PR TITLE
[5.3] Bind serve cmd to 127.0.0.1 instead of localhost

### DIFF
--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -55,7 +55,7 @@ class ServeCommand extends Command
     protected function getOptions()
     {
         return [
-            ['host', null, InputOption::VALUE_OPTIONAL, 'The host address to serve the application on.', 'localhost'],
+            ['host', null, InputOption::VALUE_OPTIONAL, 'The host address to serve the application on.', '127.0.0.1'],
 
             ['port', null, InputOption::VALUE_OPTIONAL, 'The port to serve the application on.', 8000],
         ];


### PR DESCRIPTION
On latest Mac (Sierra) and perhaps earlier, `localhost` is using the ipv6 network.

This creates behavior like the following:

```bash
php artisan serve --port=8181

# Works
curl localhost:8181

# Fails: Connection refused
curl 127.0.0.1:8181

# Works
curl "http://[::1]:8181"
```

This is probably a confusing error for those hitting it when using `127.0.0.1`.

We can make sure we bind to ipv4 by either binding to `0.0.0.0` or `127.0.0.1`.  Binding to `127.0.0.1` is safer of course, and doesn't really change expected behavior (since ipv6 is not prevalent still and we're just talking localhost networks here).

This change would behave like this:

```bash
# If 127.0.0.1 would be the new default, we wouldn't need to define it:
php artisan serve --host=127.0.0.1 --port=8181

# Works
curl localhost:8181

# Works
curl 127.0.0.1:8181

# Fails (and anyone using this address would presumably 
# have a good reason for doing so, right?)
curl "http://[::1]:8181"
```

Other OS considerations:

1. Windows: localhost often checks ipv6 first and then goes to ipv4 if nothings listening on v6. This creates considerable lag, so using 127.0.0.1 may work better on Windows as well
2. Linux: I don't believe this is default behavior on even newer versions of Linux, but since we're talking about localhost networks in any case, I don't see any reason not to assume ipv4 over ipv6 would be the expected localhost network to use