### PR TITLE
[5.3] Make 'db' binding not required for the ValidationServiceProvider

### DIFF
--- a/src/Illuminate/Validation/ValidationServiceProvider.php
+++ b/src/Illuminate/Validation/ValidationServiceProvider.php
@@ -53,6 +53,11 @@ class ValidationServiceProvider extends ServiceProvider
      */
     protected function registerPresenceVerifier()
     {
+        // since 'validation.presence' is optional, make the 'db' binding optional as well
+        if (! isset($this->app['db'])) {
+            return;
+        }
+
         $this->app->singleton('validation.presence', function ($app) {
             return new DatabasePresenceVerifier($app['db']);
         });

--- a/tests/Validation/ValidationServiceProviderTest.php
+++ b/tests/Validation/ValidationServiceProviderTest.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Validation\ValidationServiceProvider;
+
+class ValidationServiceProviderTest extends PHPUnit_Framework_TestCase
+{
+    public function testDbIsNotRequired()
+    {
+        $app = new \Illuminate\Container\Container();
+
+        $app->singleton('translator', function ($app) {
+            return $this->getIlluminateArrayTranslator();
+        });
+
+        // when the 'db' binding is required and missing an exception will be thrown, so no assertions required
+        // for this test
+        (new ValidationServiceProvider($app))->register();
+
+        $factory = $app->make('validator');
+
+        $factory->make(['name' => ''], ['name' => 'required'])->passes();
+    }
+
+    /**
+     * Configures and returns an Illuminate\Translation\Translator.
+     *
+     * @return \Illuminate\Translation\Translator
+     */
+    public function getIlluminateArrayTranslator()
+    {
+        return new Illuminate\Translation\Translator(
+            new Illuminate\Translation\ArrayLoader, 'en'
+        );
+    }
+}


### PR DESCRIPTION
When registering a standalone validator with ValidationServiceProvider the provider looks for a 'db' binding for PresenceVerifier althought the PresenceVerifier itself is optional, making the it impossible to register the service provider without a fully functional database setup.

The PR make the databse bit optional and skips the registration of the PresenceVerifier when there is no 'db' binding.