### PR TITLE
[5.4] Add "contains" and "not_contains" validation rules

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1850,7 +1850,7 @@ class Validator implements ValidatorContract
      */
     protected function validateNotContains($attribute, $value, $parameters)
     {
-        return !str_contains($value, $parameters);
+        return ! str_contains($value, $parameters);
     }
 
     /**

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1828,6 +1828,32 @@ class Validator implements ValidatorContract
     }
 
     /**
+     * Validate that an attribute contains at least one of a list of list of substrings.
+     *
+     * @param $attribute
+     * @param $value
+     * @param $parameters
+     * @return bool
+     */
+    protected function validateContains($attribute, $value, $parameters)
+    {
+        return str_contains($value, $parameters);
+    }
+
+    /**
+     * Validate that an attribute contains none of a list of list of substrings.
+     *
+     * @param $attribute
+     * @param $value
+     * @param $parameters
+     * @return bool
+     */
+    protected function validateNotContains($attribute, $value, $parameters)
+    {
+        return !str_contains($value, $parameters);
+    }
+
+    /**
      * Validate that an attribute is a valid date.
      *
      * @param  string  $attribute

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -2099,6 +2099,26 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($v->passes());
     }
 
+    public function testValidateContains()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['x' => 'asdasdf'], ['x' => 'contains:a,x,z']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => 'asdasdf'], ['x' => 'contains:x,y,z']);
+        $this->assertFalse($v->passes());
+    }
+
+    public function testValidateNotContains()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['x' => 'asdasdf'], ['x' => 'not_contains:a,x,z']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['x' => 'asdasdf'], ['x' => 'not_contains:x,y,z']);
+        $this->assertTrue($v->passes());
+    }
+
     public function testValidateDateAndFormat()
     {
         date_default_timezone_set('UTC');


### PR DESCRIPTION
Adding the "not_contains" validation rule, since it is awkward to implement using existing validation rules. Adding the "contains" rule for symmetry.