### PR TITLE
[5.3] Illuminate\Validation\Rules\Unique bug fix

### DIFF
--- a/src/Illuminate/Validation/Rules/Unique.php
+++ b/src/Illuminate/Validation/Rules/Unique.php
@@ -173,7 +173,7 @@ class Unique
         return rtrim(sprintf('unique:%s,%s,%s,%s,%s',
             $this->table,
             $this->column,
-            '"' . $this->ignore . '"' ?: 'NULL',
+            '"'.$this->ignore.'"' ?: 'NULL',
             $this->idColumn,
             $this->formatWheres()
         ), ',');

--- a/src/Illuminate/Validation/Rules/Unique.php
+++ b/src/Illuminate/Validation/Rules/Unique.php
@@ -173,7 +173,7 @@ class Unique
         return rtrim(sprintf('unique:%s,%s,%s,%s,%s',
             $this->table,
             $this->column,
-            '"' . $this->ignore . '"' ?: 'NULL',
+            $this->ignore ? '"' . $this->ignore . '"' : 'NULL',
             $this->idColumn,
             $this->formatWheres()
         ), ',');

--- a/src/Illuminate/Validation/Rules/Unique.php
+++ b/src/Illuminate/Validation/Rules/Unique.php
@@ -173,7 +173,7 @@ class Unique
         return rtrim(sprintf('unique:%s,%s,%s,%s,%s',
             $this->table,
             $this->column,
-            '"'.$this->ignore.'"' ?: 'NULL',
+            $this->ignore ? '"'.$this->ignore.'"' : 'NULL',
             $this->idColumn,
             $this->formatWheres()
         ), ',');

--- a/src/Illuminate/Validation/Rules/Unique.php
+++ b/src/Illuminate/Validation/Rules/Unique.php
@@ -173,7 +173,7 @@ class Unique
         return rtrim(sprintf('unique:%s,%s,%s,%s,%s',
             $this->table,
             $this->column,
-            $this->ignore ?: 'NULL',
+            '"' . $this->ignore . '"' ?: 'NULL',
             $this->idColumn,
             $this->formatWheres()
         ), ',');

--- a/tests/Validation/ValidationUniqueRuleTest.php
+++ b/tests/Validation/ValidationUniqueRuleTest.php
@@ -9,8 +9,13 @@ class ValidationUniqueRuleTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('unique:table,NULL,NULL,id,foo,bar', (string) $rule);
 
         $rule = new Illuminate\Validation\Rules\Unique('table', 'column');
-        $rule->ignore(1, 'id_column');
+        $rule->ignore('Taylor, Otwell', 'id_column');
         $rule->where('foo', 'bar');
-        $this->assertEquals('unique:table,column,"1",id_column,foo,bar', (string) $rule);
+        $this->assertEquals('unique:table,column,"Taylor, Otwell",id_column,foo,bar', (string) $rule);
+
+        $rule = new Illuminate\Validation\Rules\Unique('table', 'column');
+        $rule->ignore(null, 'id_column');
+        $rule->where('foo', 'bar');
+        $this->assertEquals('unique:table,column,NULL,id_column,foo,bar', (string) $rule);
     }
 }

--- a/tests/Validation/ValidationUniqueRuleTest.php
+++ b/tests/Validation/ValidationUniqueRuleTest.php
@@ -11,6 +11,6 @@ class ValidationUniqueRuleTest extends PHPUnit_Framework_TestCase
         $rule = new Illuminate\Validation\Rules\Unique('table', 'column');
         $rule->ignore(1, 'id_column');
         $rule->where('foo', 'bar');
-        $this->assertEquals('unique:table,column,1,id_column,foo,bar', (string) $rule);
+        $this->assertEquals('unique:table,column,"1",id_column,foo,bar', (string) $rule);
     }
 }


### PR DESCRIPTION
With the new validation rules since Laravel 5.3 the following validation fails:

```php
Rule::unique('users', 'name')->ignore('Taylor, Otwell', 'name')
```

When it's parsed in the underneath method in `Illuminate\Validation\Validator`, comma separated arguments will be seen as a separate column, because of the `str_getcsv`. This causes an error on line 1520.

```php
protected function parseParameters($rule, $parameter)
{
    if (strtolower($rule) == 'regex') {
        return [$parameter];
    }

    return str_getcsv($parameter);
}
```

 I solved it with the following PR. Perhaps not the most beautiful approach, so let me know what you think.