### PR TITLE
Add MAC address validator

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1581,6 +1581,33 @@ class Validator implements ValidatorContract
     }
 
     /**
+     * Validate that an attribute is a valid MAC address.
+     *
+     * @param  string  $attribute
+     * @param  mixed   $value
+     * @param  array   $parameters
+     * @return bool
+     */
+    protected function validateMacAddress($attribute, $value, $parameters)
+    {
+        $this->requireParameterCount(1, $parameters, 'mac_address');
+
+        $validParams = [
+            'any'   => null,
+            'colon' => ['options' => ['separator' => ':']],
+            'dash'  => ['options' => ['separator' => '-']],
+            'dot'   => ['options' => ['separator' => '.']]
+        ];
+
+        if (!in_array($parameters[0], array_keys($validParams))) {
+            return false;
+        }
+
+        $options = $validParams[$parameters[0]];
+        return filter_var($value, FILTER_VALIDATE_MAC, $options) !== false;
+    }
+
+    /**
      * Validate that an attribute is a valid e-mail address.
      *
      * @param  string  $attribute

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1596,14 +1596,15 @@ class Validator implements ValidatorContract
             'any'   => null,
             'colon' => ['options' => ['separator' => ':']],
             'dash'  => ['options' => ['separator' => '-']],
-            'dot'   => ['options' => ['separator' => '.']]
+            'dot'   => ['options' => ['separator' => '.']],
         ];
 
-        if (!in_array($parameters[0], array_keys($validParams))) {
+        if (! in_array($parameters[0], array_keys($validParams))) {
             return false;
         }
 
         $options = $validParams[$parameters[0]];
+
         return filter_var($value, FILTER_VALIDATE_MAC, $options) !== false;
     }
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1519,6 +1519,49 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($v->fails());
     }
 
+    public function testValidateMacAddress()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['mac' => '01-23-45-67-89-ab'], ['mac' => 'MacAddress:any']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['mac' => '01-23-45-67-89-ab'], ['mac' => 'MacAddress:dash']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['mac' => '01-23-45-67-89-ab'], ['mac' => 'MacAddress:foo']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['mac' => '01-23-45-67-89-ab'], ['mac' => 'MacAddress:dot']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['mac' => '01-23-45-67-89-ab'], ['mac' => 'MacAddress:colon']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['mac' => '01-23-45-67-89-AB'], ['mac' => 'MacAddress:any']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['mac' => '01-23-45-67-89-aB'], ['mac' => 'MacAddress:any']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['mac' => '01:23:45:67:89:ab'], ['mac' => 'MacAddress:any']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['mac' => '01:23:45:67:89:AB'], ['mac' => 'MacAddress:any']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['mac' => '01:23:45:67:89:aB'], ['mac' => 'MacAddress:any']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['mac' => '01:23:45-67:89:aB'], ['mac' => 'MacAddress:any']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['mac' => 'xx:23:45:67:89:aB'], ['mac' => 'MacAddress:any']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['mac' => '0123.4567.89ab'], ['mac' => 'MacAddress:any']);
+        $this->assertTrue($v->passes());
+    }
+
     public function testValidateEmail()
     {
         $trans = $this->getIlluminateArrayTranslator();


### PR DESCRIPTION
This is a new feature for the validator. Adds the ability to validate MAC addresses. I thought this is a good idea since there is a MAC address database column type.

How it is implemented is that the validator is in the form `mac_address:separator` where `separator` is one of four values; `colon` - a colon separator, `dash` - a dash separator, `dot` - a dot separator, and `any` which any valid separator can be used.

Feedback is welcomed and hopefully this can ship with 5.4.