### PR TITLE
[5.3] Fix Eloquent getTimeZone method call to adhere to DateTimeInterface

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2979,7 +2979,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
          // when checking the field. We will just return the DateTime right away.
         if ($value instanceof DateTimeInterface) {
             return new Carbon(
-                $value->format('Y-m-d H:i:s.u'), $value->getTimeZone()
+                $value->format('Y-m-d H:i:s.u'), $value->getTimezone()
             );
         }
 


### PR DESCRIPTION
Somehow the getTimeZone call in the asDateTime method is not actually
set to call the method that the DateTimeInterface defines.

http://php.net/manual/en/class.datetimeinterface.php