### PR TITLE
Allow route::group to reset it's namespace

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -396,9 +396,9 @@ class Router implements RegistrarContract
      */
     protected static function formatUsesPrefix($new, $old)
     {
-        if(isset($new['resetnamespace']) && $new['resetnamespace'] == true){
+        if (isset($new['resetnamespace']) && $new['resetnamespace'] == true) {
             return trim($new['namespace'], '\\');
-        }else{
+        } else {
             if (isset($new['namespace'])) {
                 return isset($old['namespace'])
                         ? trim($old['namespace'], '\\').'\\'.trim($new['namespace'], '\\')

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -396,10 +396,14 @@ class Router implements RegistrarContract
      */
     protected static function formatUsesPrefix($new, $old)
     {
-        if (isset($new['namespace'])) {
-            return isset($old['namespace'])
-                    ? trim($old['namespace'], '\\').'\\'.trim($new['namespace'], '\\')
-                    : trim($new['namespace'], '\\');
+        if(isset($new['resetnamespace']) && $new['resetnamespace'] == true){
+            return trim($new['namespace'], '\\');
+        }else{
+            if (isset($new['namespace'])) {
+                return isset($old['namespace'])
+                        ? trim($old['namespace'], '\\').'\\'.trim($new['namespace'], '\\')
+                        : trim($new['namespace'], '\\');
+            }
         }
 
         return isset($old['namespace']) ? $old['namespace'] : null;

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -397,7 +397,9 @@ class Router implements RegistrarContract
     protected static function formatUsesPrefix($new, $old)
     {
         if (isset($new['resetnamespace']) && $new['resetnamespace'] == true) {
-            return trim($new['namespace'], '\\');
+            return isset($new['namespace'])
+                    ? trim($new['namespace'], '\\')
+                    : null;
         } else {
             if (isset($new['namespace'])) {
                 return isset($old['namespace'])


### PR DESCRIPTION
I think this feature would be useful when in nested namespace and group prefixes.

Instead of having to repeat a group prefix to access another namespace controller

eg:
```
Route::group(['resetnamespace' => true, ], function(){
        Passport::routes();
    });
```