### PR TITLE
[5.3] Allow Router::auth() to omit registration routes

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -293,9 +293,11 @@ class Router implements RegistrarContract
     /**
      * Register the typical authentication routes for an application.
      *
+     * @param bool $withRegistration
+     *
      * @return void
      */
-    public function auth()
+    public function auth($withRegistration = true)
     {
         // Authentication Routes...
         $this->get('login', 'Auth\LoginController@showLoginForm')->name('login');
@@ -303,8 +305,10 @@ class Router implements RegistrarContract
         $this->post('logout', 'Auth\LoginController@logout')->name('logout');
 
         // Registration Routes...
-        $this->get('register', 'Auth\RegisterController@showRegistrationForm')->name('register');
-        $this->post('register', 'Auth\RegisterController@register');
+        if ($withRegistration) {
+            $this->get('register', 'Auth\RegisterController@showRegistrationForm')->name('register');
+            $this->post('register', 'Auth\RegisterController@register');
+        }
 
         // Password Reset Routes...
         $this->get('password/reset', 'Auth\ForgotPasswordController@showLinkRequestForm');


### PR DESCRIPTION
I work on custom, private applications that do not allow outsiders to register accounts.
Accounts are added by an admin.

This will allow to omit defining those routes which is better then copying and pasting the auth() routes to routes file.