### PR TITLE
[5.4] Add O(n) `median` and `nthOrder` implementations to `Arr` class.

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -95,29 +95,12 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Get the median of a given key.
      *
-     * @param  null $key
+     * @param string|null $key
      * @return mixed|null
      */
     public function median($key = null)
     {
-        $count = $this->count();
-
-        if ($count == 0) {
-            return;
-        }
-
-        $values = with(isset($key) ? $this->pluck($key) : $this)
-                    ->sort()->values();
-
-        $middle = (int) ($count / 2);
-
-        if ($count % 2) {
-            return $values->get($middle);
-        }
-
-        return (new static([
-            $values->get($middle - 1), $values->get($middle),
-        ]))->average();
+        return Arr::median(with(isset($key) ? $this->pluck($key) : $this)->items);
     }
 
     /**

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -437,6 +437,78 @@ class SupportArrTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($expect, Arr::sortRecursive($array));
     }
 
+    public function testMedian()
+    {
+        $array = range(1, 3);
+        shuffle($array);
+
+        static::assertEquals(2, Arr::median($array));
+
+        $array = range(1, 4);
+        shuffle($array);
+
+        static::assertEquals(2, Arr::median($array));
+    }
+
+    public function testMedianOfStrings()
+    {
+        $array = [
+            '1996-01-06 14:39:17',
+            '1983-05-14 07:51:14',
+            '1983-05-14 07:52:43',
+        ];
+
+        static::assertEquals('1983-05-14 07:52:43', Arr::median($array));
+    }
+
+    public function testNthOrderSimple()
+    {
+        $array = range(1, 20);
+        shuffle($array);
+
+        static::assertEquals(1, Arr::nthOrder($array, 0));
+        static::assertEquals(5, Arr::nthOrder($array, 4));
+        static::assertEquals(10, Arr::nthOrder($array, 9));
+    }
+
+    public function testNthOrderIntegerCallback()
+    {
+        $array = [
+            [1],
+            [8],
+            [7],
+            [2],
+        ];
+
+        static::assertEquals([2], Arr::nthOrder($array, 1, 0));
+    }
+
+    public function testNthOrderStringCallback()
+    {
+        $array = [
+            ['foo' => 1],
+            ['foo' => 8],
+            ['foo' => 7],
+            ['foo' => 2],
+        ];
+
+        static::assertEquals(['foo' => 2], Arr::nthOrder($array, 1, 'foo'));
+    }
+
+    public function testNthOrderCallableCallback()
+    {
+        $array = [
+            ['foo' => 1],
+            ['foo' => 8],
+            ['foo' => 7],
+            ['foo' => 2],
+        ];
+
+        static::assertEquals(['foo' => 2], Arr::nthOrder($array, 1, function ($a, $b) {
+            return $a['foo'] - $b['foo'];
+        }));
+    }
+
     public function testWhere()
     {
         $array = [100, '200', 300, '400', 500];

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1638,7 +1638,7 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
             (object) ['foo' => 0],
             (object) ['foo' => 3],
         ]);
-        $this->assertEquals(1.5, $collection->median('foo'));
+        $this->assertEquals(0, $collection->median('foo'));
     }
 
     public function testMedianOutOfOrderCollection()


### PR DESCRIPTION
This pull adds the Quickselect algorithm for finding arbitrary order statistics in linear time with the `nthOrder` function on `Arr`. It also adds a `median` function, which amounts to sugar on top of `nthOrder`. Laravel's current way of finding medians takes O(n lg n) time, so this is an order-of-magnitude speedup to the process. The pull also updates `Collection` to use this new implementation.

For purposes of generality, the methods return the _element_ with the nth order statistic, not just the value off of that element with the nth order statistic. A user interested in just the value should easily be able to pull it off of the element. In the case of an array of scalars, the element and value are one and the same.

The methods can search not just for numeric values, but arbitrary comparable values. This means, for instance, that the median date can be found. Since the methods can take a comparison callback, the median of any complex, arbitrary ordering can be found. The drawback to generalizing beyond numbers is that it is no longer possible to average a split median. Instead, the lower median is selected, per convention. For numeric contexts in which the numbers follow a non-linear pattern, averaging a split median would still lead to incorrect results, so switching to the lower median should be no worse than averaging, if not better.

The second commit switches the internal implementation of `median` on `Collection` to use this logic. The function retains the same signature: it returns the median value, not element, and takes an optional string argument to pluck a field off of the collection. The differences are that it benefits from the speed-up, gains the ability to take the median of non-numeric fields, which consequently means that it now uses the lower median, where applicable.

I would switch `Collection` to make use of the callable callback, but that would also entail switching it to return the matched element, not the matched value. While I think this preferable, it would significantly change the signature of an established method. 