### PR TITLE
support guzzle 6 with mandrill mail driver.

### DIFF
--- a/src/Illuminate/Mail/Transport/MandrillTransport.php
+++ b/src/Illuminate/Mail/Transport/MandrillTransport.php
@@ -57,7 +57,7 @@ class MandrillTransport implements Swift_Transport {
 		$client = $this->getHttpClient();
 
 		$client->post('https://mandrillapp.com/api/1.0/messages/send-raw.json', [
-			'body' => [
+			'form_params' => [
 				'key' => $this->key,
 				'raw_message' => (string) $message,
 				'async' => false,


### PR DESCRIPTION
body in guzzle >= 6 is deprecated, using form_params instead.