### PR TITLE
[5.3] Collection::random now supports a random range

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -845,6 +845,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     {
         if ($max > 0) {
             $max = ($max <= $amount) ? $amount + 1 : $max;
+            
             return $this->random(mt_rand($amount, $max));
         }
 

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -836,6 +836,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      * Get one or more items randomly from the collection.
      *
      * @param  int  $amount
+     * @param  int $max
      * @return mixed
      *
      * @throws \InvalidArgumentException

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -845,7 +845,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     {
         if ($max > 0) {
             $max = ($max <= $amount) ? $amount + 1 : $max;
-            
+
             return $this->random(mt_rand($amount, $max));
         }
 

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -840,8 +840,13 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      *
      * @throws \InvalidArgumentException
      */
-    public function random($amount = 1)
+    public function random($amount = 1, $max = 0)
     {
+        if ($max > 0) {
+            $max = ($max <= $amount) ? $amount + 1 : $max;
+            return $this->random(mt_rand($amount, $max));
+        }
+
         if ($amount > ($count = $this->count())) {
             throw new InvalidArgumentException("You requested {$amount} items, but there are only {$count} items in the collection");
         }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -820,10 +820,10 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
         $this->assertInstanceOf(Collection::class, $random);
         $this->assertCount(3, $random);
 
-        $random = $data->random(1, 3);
-        $count  = $random->count();
-        $this->assertGreaterThanOrEqual(1, $count);
-        $this->assertLessThanOrEqual(3, $count);
+        $random = $data->random(2, 5);
+        $count = $random->count();
+        $this->assertGreaterThanOrEqual(2, $count);
+        $this->assertLessThanOrEqual(5, $count);
     }
 
     /**

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -819,6 +819,11 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
         $random = $data->random(3);
         $this->assertInstanceOf(Collection::class, $random);
         $this->assertCount(3, $random);
+
+        $random = $data->random(1, 3);
+        $count  = $random->count();
+        $this->assertGreaterThanOrEqual(1, $count);
+        $this->assertLessThanOrEqual(3, $count);
     }
 
     /**


### PR DESCRIPTION
Hi guys!
This is a minor improvement of Collection::random().

You can now get random elements in a range.
```php
$collection->random(1, 3); // Returns between 1 and 3 elements.
```

If its accepted I can update the doc :)