### PR TITLE
[5.4] Styling code blocks in Markdown emails

### DIFF
--- a/src/Illuminate/Mail/resources/views/html/themes/default.css
+++ b/src/Illuminate/Mail/resources/views/html/themes/default.css
@@ -277,3 +277,14 @@ img {
     font-size: 15px;
     text-align: center;
 }
+
+/* Code Blocks */
+
+pre {
+    width: 570px;
+    padding: 15px;
+    margin: 20px 0;
+    border-radius: 3px;
+    background: #F9F9F9;
+    box-shadow: 0 2px 3px rgba(0, 0, 0, 0.16);
+}


### PR DESCRIPTION
Looks like inline scroll is not an option in HTML emails, however; I found that if we gave <pre> a fixed width, the email client will break long lines which will keep the email preview responsive.