### PR TITLE
[5.3] Idea to add onlyRulesValues for FormRequest

### DIFF
--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -111,7 +111,7 @@ class FormRequest extends Request implements ValidatesWhenResolved
     {
         $rules = $this->rules();
 
-        if (!empty($rules)) {
+        if (! empty($rules)) {
             return $this->only(array_keys($rules));
         }
 

--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -103,6 +103,22 @@ class FormRequest extends Request implements ValidatesWhenResolved
     }
 
     /**
+     * Get a subset containing keys from the validation rules with values.
+     *
+     * @return array
+     */
+    public function onlyRulesValues()
+    {
+        $rules = $this->rules();
+
+        if (!empty($rules)) {
+            return $this->only(array_keys($rules));
+        }
+
+        return [];
+    }
+
+    /**
      * Handle a failed validation attempt.
      *
      * @param  \Illuminate\Contracts\Validation\Validator  $validator

--- a/tests/Foundation/FoundationFormRequestTest.php
+++ b/tests/Foundation/FoundationFormRequestTest.php
@@ -90,6 +90,15 @@ class FoundationFormRequestTest extends PHPUnit_Framework_TestCase
 
         $request->validate($factory);
     }
+
+    public function testOnlyRulesValuesMethod()
+    {
+        $request = FoundationTestFormRequestStub::create('/', 'GET', ['name' => 'Taylor', 'age' => 25]);
+        $this->assertEquals(['name' => 'Taylor'], $request->onlyRulesValues());
+
+        $request = FoundationTestFormRequestWithEmptyRules::create('/', 'GET', ['name' => 'abigail', 'age' => 25]);
+        $this->assertEquals([], $request->onlyRulesValues());
+    }
 }
 
 class FoundationTestFormRequestStub extends Illuminate\Foundation\Http\FormRequest
@@ -132,5 +141,17 @@ class FoundationTestFormRequestHooks extends Illuminate\Foundation\Http\FormRequ
     public function prepareForValidation()
     {
         $this->replace(['name' => 'Taylor']);
+    }
+}
+class FoundationTestFormRequestWithEmptyRules extends Illuminate\Foundation\Http\FormRequest
+{
+    public function rules()
+    {
+        return [];
+    }
+
+    public function authorize()
+    {
+        return true;
     }
 }


### PR DESCRIPTION
Right now we don't have a simple way to get from FormRequest only those fields which were described in rules. It is very will be useful when you have a big list of **$fillable** properties (for mass assignable) in Model and you want to use save() or update() for just add only described(safe) **attributes** (Or you don't want to use $request->only() with described manually attributes).
My idea to add onlyRulesValues which help in simple way:
```php
    public function onlyRulesValues()
    {
        $rules = $this->rules();

        if (!empty($rules)) {
            return $this->only(array_keys($rules));
        }

        return [];
    }

$attributes = $request->getOnlyRulesValues();

$model->save($attributes);
// or
$model->update($attributes);
```