### PR TITLE
[5.3] Add support for implicit keys in first() and has()

### DIFF
--- a/src/Illuminate/Support/MessageBag.php
+++ b/src/Illuminate/Support/MessageBag.php
@@ -146,7 +146,9 @@ class MessageBag implements Arrayable, Countable, Jsonable, JsonSerializable, Me
     {
         $messages = is_null($key) ? $this->all($format) : $this->get($key, $format);
 
-        return count($messages) > 0 ? $messages[0] : '';
+        $firstMessage = array_first($messages, null, '') ;
+
+        return is_array($firstMessage) ? array_first($firstMessage) : $firstMessage;
     }
 
     /**

--- a/src/Illuminate/Support/MessageBag.php
+++ b/src/Illuminate/Support/MessageBag.php
@@ -146,7 +146,7 @@ class MessageBag implements Arrayable, Countable, Jsonable, JsonSerializable, Me
     {
         $messages = is_null($key) ? $this->all($format) : $this->get($key, $format);
 
-        $firstMessage = array_first($messages, null, '') ;
+        $firstMessage = array_first($messages, null, '');
 
         return is_array($firstMessage) ? array_first($firstMessage) : $firstMessage;
     }

--- a/tests/Support/SupportMessageBagTest.php
+++ b/tests/Support/SupportMessageBagTest.php
@@ -74,6 +74,24 @@ class SupportMessageBagTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('bar', $container->first('foo'));
     }
 
+    public function testFirstReturnsEmptyStringIfNoMessagesFound()
+    {
+        $container = new MessageBag;
+        $container->setFormat(':message');
+        $messages = $container->getMessages();
+        $this->assertEquals('', $container->first('foo'));
+    }
+
+    public function testFirstReturnsSingleMessageFromDotKeys()
+    {
+        $container = new MessageBag;
+        $container->setFormat(':message');
+        $container->add('name.first', 'jon');
+        $container->add('name.last', 'snow');
+        $messages = $container->getMessages();
+        $this->assertEquals('jon', $container->first('name.*'));
+    }
+
     public function testHasIndicatesExistence()
     {
         $container = new MessageBag;
@@ -81,6 +99,16 @@ class SupportMessageBagTest extends PHPUnit_Framework_TestCase
         $container->add('foo', 'bar');
         $this->assertTrue($container->has('foo'));
         $this->assertFalse($container->has('bar'));
+    }
+
+    public function testHasIndicatesExistenceFromDotKeys()
+    {
+        $container = new MessageBag;
+        $container->setFormat(':message');
+        $container->add('name.first', 'jon');
+        $container->add('name.last', 'snow');
+        $this->assertTrue($container->has('name.*'));
+        $this->assertFalse($container->has('age.*'));
     }
 
     public function testHasAnyIndicatesExistence()


### PR DESCRIPTION
In case the bag has the following messages:

```
['user.0.email' => 'email is required']
```

`$messages->first('user.*.email')` will return 'email is required'

and `$messages->has('user.*.email')` will return true.

Currently these two methods don't work with implicit keys, only `get()` currently works.