### PR TITLE
[5.4] Eloquent Collection keyBy() consistency

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -102,6 +102,11 @@ class Collection extends BaseCollection implements QueueableCollection
         }, $this->items);
     }
 
+    public function keyBy($keyBy)
+    {
+        return $this->toBase()->keyBy($keyBy);
+    }
+
     /**
      * Merge the collection with the given items.
      *

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -337,6 +337,20 @@ class DatabaseEloquentCollectionTest extends PHPUnit_Framework_TestCase
         $c = new Collection([new TestEloquentCollectionModel, (object) ['id' => 'something']]);
         $c->getQueueableClass();
     }
+
+    public function testKeyByReturnsBaseCollectionToSupportKeyOrientedChains()
+    {
+        $one = (new TestEloquentCollectionModel)->forceFill(['name' => 'phone']);
+        $two = (new TestEloquentCollectionModel)->forceFill(['name' => 'address']);
+        $three = (new TestEloquentCollectionModel)->forceFill(['name' => 'unit']);
+        $four = (new TestEloquentCollectionModel)->forceFill(['name' => 'unit']);
+
+        $c = new Collection([$one, $two, $three, $four]);
+
+        $this->assertEquals(BaseCollection::class, get_class($c->keyBy('name')));
+        $this->assertEquals(3, $c->keyBy('name')->count());
+        $this->assertArrayHasKey('phone', $c->keyBy('name'));
+    }
 }
 
 class TestEloquentCollectionModel extends Illuminate\Database\Eloquent\Model


### PR DESCRIPTION
Eloquent returns it's own wrapper on top of Base Collection, which leads to inconsistent behaviour.

`Role::find(1)->fields->keyBy('name')->only('phone')`
Returns empty collection because only() calls getDictionary() which covers previously key'd collection with ones returned from model getKey().

This change revokes base collection in `Illuminate\Database\Eloquent\Collection::keyBy` so the prior has sense with future `only()`, `except()` and others calls.