### PR TITLE
[5.4] Sanitize inputs before the validation

### DIFF
--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -110,6 +110,12 @@ class FormRequest extends Request implements ValidatesWhenResolved
      */
     protected function validationData()
     {
+        if (method_exists($this, 'sanitize')) {
+            $this->merge(
+                $this->container->call([$this, 'sanitize'])
+            );
+        }
+
         return $this->all();
     }
 


### PR DESCRIPTION
This feature allows us to sanitize the inputs before the validation.

## Example :

```php
    // CreatePostFormRequest

    /**
     * Get the validation rules that apply to the request.
     *
     * @return array
     */
    public function rules()
    {
        return [
            'title' => "required",
            'slug' => "required|unique:posts,slug",
        ];
    }

    /**
     * Sanitize the inputs.
     *
     * @return array
     */
    protected function sanitize()
    {
        return [
            'slug' => str_slug($this->get('slug', $this->get('title', ''))),
        ];
    }
```