### PR TITLE
[5.3] Remove a duplicate $this->initialRules = $rules;

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -194,7 +194,6 @@ class Validator implements ValidatorContract
     public function __construct(TranslatorInterface $translator, array $data, array $rules,
                                 array $messages = [], array $customAttributes = [])
     {
-        $this->initialRules = $rules;
         $this->translator = $translator;
         $this->customMessages = $messages;
         $this->customAttributes = $customAttributes;

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1491,7 +1491,12 @@ class Validator implements ValidatorContract
         }
 
         if (is_array($value)) {
-            return $verifier->getMultiCount($table, $column, $value, $extra);
+            // If count is equal to recursive count it means the array is not 2 dimensional.
+            // When the array is 2 dimensional we only send the keys as array, as these are the id's
+            if (count($value) === count($value, COUNT_RECURSIVE)) {
+                return $verifier->getMultiCount($table, $column, $value, $extra);
+            }
+            return $verifier->getMultiCount($table, $column, array_keys($value), $extra);
         }
 
         return $verifier->getCount($table, $column, $value, null, null, $extra);


### PR DESCRIPTION
I found out that initialRules is set in the constructor. But it is also being set by setRules($rules)

That's why I don't think this line needs to stay in the constructor