### PR TITLE
[5.3] Remove a duplicate $this->initialRules = $rules; 

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -194,7 +194,6 @@ class Validator implements ValidatorContract
     public function __construct(TranslatorInterface $translator, array $data, array $rules,
                                 array $messages = [], array $customAttributes = [])
     {
-        $this->initialRules = $rules;
         $this->translator = $translator;
         $this->customMessages = $messages;
         $this->customAttributes = $customAttributes;


### PR DESCRIPTION
I found out that initialRules is set in the constructor. But it is also being set by setRules($rules)

That's why I don't think this line needs to stay in the constructor