### PR TITLE
[5.3] Make exists validator work with arrays that contain the key

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1497,7 +1497,7 @@ class Validator implements ValidatorContract
             if (count($value) === count($value, COUNT_RECURSIVE)) {
                 return $verifier->getMultiCount($table, $column, $value, $extra);
             }
-            
+
             return $verifier->getMultiCount($table, $column, array_keys($value), $extra);
         }
 

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1492,8 +1492,7 @@ class Validator implements ValidatorContract
         }
 
         if (is_array($value)) {
-            // If count is equal to recursive count it means the array is not 2 dimensional.
-            // When the array is 2 dimensional we only send the keys as array, as these are the id's
+            // If a two-dimensional array is passed, extract the keys as values
             if (count($value) === count($value, COUNT_RECURSIVE)) {
                 return $verifier->getMultiCount($table, $column, $value, $extra);
             }

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1492,7 +1492,13 @@ class Validator implements ValidatorContract
         }
 
         if (is_array($value)) {
-            return $verifier->getMultiCount($table, $column, $value, $extra);
+            // If count is equal to recursive count it means the array is not 2 dimensional.
+            // When the array is 2 dimensional we only send the keys as array, as these are the id's
+            if (count($value) === count($value, COUNT_RECURSIVE)) {
+                return $verifier->getMultiCount($table, $column, $value, $extra);
+            }
+            
+            return $verifier->getMultiCount($table, $column, array_keys($value), $extra);
         }
 
         return $verifier->getCount($table, $column, $value, null, null, $extra);


### PR DESCRIPTION
When someone structures their form like data[$id][$field] it is not possible to check if the id is in the database with exists. Because of this I have edited the Validator->getExistCount() function. 

It will first check if we are using a 1 or multiple dimensional array. If it has a 2 dimensional array it will use the keys of the array as id's.

for the example the following rule would now work:
`'data' => 'exists:data_table,id` 