### PR TITLE
[5.4] Fix contextual bindings when instances and aliases are involved

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -56,7 +56,7 @@ class Container implements ArrayAccess, ContainerContract
 
     /**
      * A flipped cache of registered type aliases
-     * used during contextual binding lookup
+     * used during contextual binding lookup.
      *
      * @var array
      */
@@ -361,7 +361,7 @@ class Container implements ArrayAccess, ContainerContract
     }
 
     /**
-     * Remove an alias from the contextual binding alias cache
+     * Remove an alias from the contextual binding alias cache.
      *
      * @param  string  $searched
      * @return void

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -53,6 +53,13 @@ class Container implements ArrayAccess, ContainerContract
      * @var array
      */
     protected $aliases = [];
+
+    /**
+     * A flipped cache of registered type aliases
+     * used during contextual binding lookup
+     *
+     * @var array
+     */
     protected $aliasAbstracts = [];
 
     /**
@@ -353,7 +360,13 @@ class Container implements ArrayAccess, ContainerContract
         }
     }
 
-    private function removeAbstractAlias($searched)
+    /**
+     * Remove an alias from the contextual binding alias cache
+     *
+     * @param  string  $searched
+     * @return void
+     */
+    protected function removeAbstractAlias($searched)
     {
         if (! isset($this->aliases[$searched])) {
             return;

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -914,7 +914,7 @@ function containerTestInject(ContainerConcreteStub $stub, $default = 'taylor')
 
 class ContainerTestContextInjectInstantiations implements IContainerContractStub
 {
-    public static $instantiations = 0;
+    public static $instantiations;
 
     public function __construct()
     {

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -197,6 +197,8 @@ class ContainerContainerTest extends PHPUnit_Framework_TestCase
 
     public function testExtendIsLazyInitialized()
     {
+        ContainerLazyExtendStub::$initialized = false;
+
         $container = new Container;
         $container->bind('ContainerLazyExtendStub');
         $container->extend('ContainerLazyExtendStub', function ($obj, $container) {

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -487,6 +487,120 @@ class ContainerContainerTest extends PHPUnit_Framework_TestCase
         $this->assertInstanceOf('ContainerImplementationStubTwo', $two->impl);
     }
 
+    public function testContextualBindingWorksForExistingInstancedBindings()
+    {
+        $container = new Container;
+
+        $container->instance('IContainerContractStub', new ContainerImplementationStub);
+
+        $container->when('ContainerTestContextInjectOne')->needs('IContainerContractStub')->give('ContainerImplementationStubTwo');
+
+        $this->assertInstanceOf(
+            'ContainerImplementationStubTwo',
+            $container->make('ContainerTestContextInjectOne')->impl
+        );
+    }
+
+    public function testContextualBindingWorksForNewlyInstancedBindings()
+    {
+        $container = new Container;
+
+        $container->when('ContainerTestContextInjectOne')->needs('IContainerContractStub')->give('ContainerImplementationStubTwo');
+
+        $container->instance('IContainerContractStub', new ContainerImplementationStub);
+
+        $this->assertInstanceOf(
+            'ContainerImplementationStubTwo',
+            $container->make('ContainerTestContextInjectOne')->impl
+        );
+    }
+
+    public function testContextualBindingWorksOnExistingAliasedInstances()
+    {
+        $container = new Container;
+
+        $container->instance('stub', new ContainerImplementationStub);
+        $container->alias('stub', 'IContainerContractStub');
+
+        $container->when('ContainerTestContextInjectOne')->needs('IContainerContractStub')->give('ContainerImplementationStubTwo');
+
+        $this->assertInstanceOf(
+            'ContainerImplementationStubTwo',
+            $container->make('ContainerTestContextInjectOne')->impl
+        );
+    }
+
+    public function testContextualBindingWorksOnNewAliasedInstances()
+    {
+        $container = new Container;
+
+        $container->when('ContainerTestContextInjectOne')->needs('IContainerContractStub')->give('ContainerImplementationStubTwo');
+
+        $container->instance('stub', new ContainerImplementationStub);
+        $container->alias('stub', 'IContainerContractStub');
+
+        $this->assertInstanceOf(
+            'ContainerImplementationStubTwo',
+            $container->make('ContainerTestContextInjectOne')->impl
+        );
+    }
+
+    public function testContextualBindingWorksOnNewAliasedBindings()
+    {
+        $container = new Container;
+
+        $container->when('ContainerTestContextInjectOne')->needs('IContainerContractStub')->give('ContainerImplementationStubTwo');
+
+        $container->bind('stub', ContainerImplementationStub::class);
+        $container->alias('stub', 'IContainerContractStub');
+
+        $this->assertInstanceOf(
+            'ContainerImplementationStubTwo',
+            $container->make('ContainerTestContextInjectOne')->impl
+        );
+    }
+
+    public function testContextualBindingDoesntOverrideNonContextualResolution()
+    {
+        $container = new Container;
+
+        $container->instance('stub', new ContainerImplementationStub);
+        $container->alias('stub', 'IContainerContractStub');
+
+        $container->when('ContainerTestContextInjectTwo')->needs('IContainerContractStub')->give('ContainerImplementationStubTwo');
+
+        $this->assertInstanceOf(
+            'ContainerImplementationStubTwo',
+            $container->make('ContainerTestContextInjectTwo')->impl
+        );
+
+        $this->assertInstanceOf(
+            'ContainerImplementationStub',
+            $container->make('ContainerTestContextInjectOne')->impl
+        );
+    }
+
+    public function testContextuallyBoundInstancesAreNotUnnecessarilyRecreated()
+    {
+        ContainerTestContextInjectInstantiations::$instantiations = 0;
+
+        $container = new Container;
+
+        $container->instance('IContainerContractStub', new ContainerImplementationStub);
+        $container->instance('ContainerTestContextInjectInstantiations', new ContainerTestContextInjectInstantiations);
+
+        $this->assertEquals(1, ContainerTestContextInjectInstantiations::$instantiations);
+
+        $container->when('ContainerTestContextInjectOne')->needs('IContainerContractStub')->give('ContainerTestContextInjectInstantiations');
+
+        $container->make("ContainerTestContextInjectOne");
+        $container->make("ContainerTestContextInjectOne");
+        $container->make("ContainerTestContextInjectOne");
+        $container->make("ContainerTestContextInjectOne");
+
+        $this->assertEquals(1, ContainerTestContextInjectInstantiations::$instantiations);
+    }
+
     public function testContainerTags()
     {
         $container = new Container;
@@ -794,4 +908,14 @@ class ContainerInjectVariableStub
 function containerTestInject(ContainerConcreteStub $stub, $default = 'taylor')
 {
     return func_get_args();
+}
+
+class ContainerTestContextInjectInstantiations implements IContainerContractStub
+{
+    public static $instantiations = 0;
+
+    public function __construct()
+    {
+        static::$instantiations++;
+    }
 }

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -595,10 +595,10 @@ class ContainerContainerTest extends PHPUnit_Framework_TestCase
 
         $container->when('ContainerTestContextInjectOne')->needs('IContainerContractStub')->give('ContainerTestContextInjectInstantiations');
 
-        $container->make("ContainerTestContextInjectOne");
-        $container->make("ContainerTestContextInjectOne");
-        $container->make("ContainerTestContextInjectOne");
-        $container->make("ContainerTestContextInjectOne");
+        $container->make('ContainerTestContextInjectOne');
+        $container->make('ContainerTestContextInjectOne');
+        $container->make('ContainerTestContextInjectOne');
+        $container->make('ContainerTestContextInjectOne');
 
         $this->assertEquals(1, ContainerTestContextInjectInstantiations::$instantiations);
     }


### PR DESCRIPTION
A resubmit of #15637 directed at 5.4.

Ping @taylorotwell, addressing your last comment from the PR:
> So if something needs to be contextually built can it ever be bound as an instance after this PR? For example if I want a controller method to have SomeLogger implementation of the Logger interface, and SomeLogger is bound as an instance, will that be respected or will the container create a new instance every time?

Yes. It does respect it. I've added a test to ensure that only one instance of `SomeLogger` (or in the case of the test `ContainerTestContextInjectInstantiations`) is created and used during contextual binding if there is an instance available.

I couldn't come up with a better name for `ContainerTestContextInjectInstantiations` that followed the conventions of the other classes in the test case. Feel free to change it. :)