### PR TITLE
Check if the Request has a key in only()

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -352,7 +352,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
         $input = $this->all();
 
         foreach ($keys as $key) {
-            if($this->has($key))
+            if($this->has($key)) {
                 Arr::set($results, $key, data_get($input, $key));
             }
         }

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -352,7 +352,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
         $input = $this->all();
 
         foreach ($keys as $key) {
-            if($this->has($key)) {
+            if ($this->has($key)) {
                 Arr::set($results, $key, data_get($input, $key));
             }
         }

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -352,7 +352,9 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
         $input = $this->all();
 
         foreach ($keys as $key) {
-            Arr::set($results, $key, data_get($input, $key));
+            if($this->has($key))
+                Arr::set($results, $key, data_get($input, $key));
+            }
         }
 
         return $results;

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -248,7 +248,7 @@ class HttpRequestTest extends PHPUnit_Framework_TestCase
 
         $request = Request::create('/', 'GET', ['developer' => ['name' => 'Taylor', 'age' => 25]]);
         $this->assertEquals(['developer' => ['age' => 25]], $request->only('developer.age'));
-        $this->assertEquals(['developer' => ['name' => 'Taylor'], 'test' => null], $request->only('developer.name', 'test'));
+        $this->assertEquals(['developer' => ['name' => 'Taylor']], $request->only('developer.name', 'test'));
     }
 
     public function testExceptMethod()


### PR DESCRIPTION
Why?
When updating a model one would want to use the `only()` method on the `Request` object but if you have notNull constraints on the model and you are only updating part of it with a `PATCH` request you will get an error because of the `notNull` constraint.

Say you have a `Post` and the post has some fields 
``` php
[
	‘title’ => ‘string|required’,
	‘body’ => ‘text’,
	‘cetegory_id’ => ‘int|nullable’
]
```

if you just want to update the `category_id` with an Ajax `PATCH` request and you are using 

```php
$post->update(request()->only(‘title’, ‘body’, ‘category_id’));
```

you will get an error about a “Not Null constraint” on the title. This is because the `only()` method adds all the keys provided to the returned array even of they are not in the request (it just sets them to *null*).

So I have added an if statement to first check if the keys are included in the request object before adding them to the `$results` array.

```php
/**
 * Get a subset containing the provided keys with values from the input data.
 *
 * @param  array|mixed  $keys
 * @return array
 */
public function only($keys)
{
    $keys = is_array($keys) ? $keys : func_get_args();

    $results = [];

    $input = $this->all();

    foreach ($keys as $key) {
+       if($this->has($key)){
            Arr::set($results, $key, data_get($input, $key));
+       }
    }

    return $results;
}
```