### PR TITLE
[5.3] Fix validate timezone on unit test

### DIFF
--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -2064,7 +2064,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $v = new Validator($trans, ['foo' => 'GMT'], ['foo' => 'Timezone']);
         $this->assertTrue($v->passes());
 
-        $v = new Validator($trans, ['foo' => ['this_is_not_a_timezone']], ['foo' => 'Timezone']);
+        $v = new Validator($trans, ['foo' => 'this_is_not_a_timezone'], ['foo' => 'Timezone']);
         $this->assertFalse($v->passes());
     }
 


### PR DESCRIPTION
on fresh install runing unit test fire
PHP TypeError:  DateTimeZone::__construct() expects parameter 1 to be string, array given in /var/www/html/laraframe/src/Illuminate/Validation/Validator.php on line 1987
