### PR TITLE
[5.4] Don't use uuid package in http file helper

### DIFF
--- a/src/Illuminate/Http/FileHelpers.php
+++ b/src/Illuminate/Http/FileHelpers.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\Http;
 
-use Ramsey\Uuid\Uuid;
+use Illuminate\Support\Str;
 
 trait FileHelpers
 {
@@ -48,6 +48,6 @@ trait FileHelpers
             $path = rtrim($path, '/').'/';
         }
 
-        return $path.Uuid::uuid4()->getHex().'.'.$this->guessExtension();
+        return $path.Str::random(40).'.'.$this->guessExtension();
     }
 }


### PR DESCRIPTION
We don't need this dependency in our HTTP package, and actually, it was forgotten to be added to the illuminate/http composer.json anyway! Just asking for a random string from our support package is absolutely fine for this use case.