### PR TITLE
[5.4] Use namespaced PHPUnit TestCase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -74,7 +74,7 @@
         "aws/aws-sdk-php": "~3.0",
         "mockery/mockery": "~0.9.4",
         "pda/pheanstalk": "~3.0",
-        "phpunit/phpunit": "~5.4",
+        "phpunit/phpunit": "~5.7",
         "predis/predis": "~1.0",
         "symfony/css-selector": "~3.2",
         "symfony/dom-crawler": "~3.2"

--- a/tests/Auth/AuthAccessGateTest.php
+++ b/tests/Auth/AuthAccessGateTest.php
@@ -1,11 +1,12 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
 use Illuminate\Auth\Access\Gate;
 use Illuminate\Container\Container;
 use Illuminate\Auth\Access\Response;
 use Illuminate\Auth\Access\HandlesAuthorization;
 
-class GateTest extends PHPUnit_Framework_TestCase
+class GateTest extends TestCase
 {
     /**
      * @expectedException \InvalidArgumentException

--- a/tests/Auth/AuthDatabaseTokenRepositoryTest.php
+++ b/tests/Auth/AuthDatabaseTokenRepositoryTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 
-class AuthDatabaseTokenRepositoryTest extends PHPUnit_Framework_TestCase
+class AuthDatabaseTokenRepositoryTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/Auth/AuthDatabaseUserProviderTest.php
+++ b/tests/Auth/AuthDatabaseUserProviderTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 
-class AuthDatabaseUserProviderTest extends PHPUnit_Framework_TestCase
+class AuthDatabaseUserProviderTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/Auth/AuthEloquentUserProviderTest.php
+++ b/tests/Auth/AuthEloquentUserProviderTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 
-class AuthEloquentUserProviderTest extends PHPUnit_Framework_TestCase
+class AuthEloquentUserProviderTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/Auth/AuthGuardTest.php
+++ b/tests/Auth/AuthGuardTest.php
@@ -1,12 +1,13 @@
 <?php
 
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 use Illuminate\Auth\Events\Failed;
 use Illuminate\Auth\Events\Attempting;
 use Illuminate\Auth\Events\Authenticated;
 use Symfony\Component\HttpFoundation\Request;
 
-class AuthGuardTest extends PHPUnit_Framework_TestCase
+class AuthGuardTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/Auth/AuthPasswordBrokerTest.php
+++ b/tests/Auth/AuthPasswordBrokerTest.php
@@ -1,9 +1,10 @@
 <?php
 
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 use Illuminate\Contracts\Auth\PasswordBroker;
 
-class AuthPasswordBrokerTest extends PHPUnit_Framework_TestCase
+class AuthPasswordBrokerTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/Auth/AuthTokenGuardTest.php
+++ b/tests/Auth/AuthTokenGuardTest.php
@@ -2,9 +2,10 @@
 
 use Illuminate\Http\Request;
 use Illuminate\Auth\TokenGuard;
+use PHPUnit\Framework\TestCase;
 use Illuminate\Contracts\Auth\UserProvider;
 
-class AuthTokenGuardTest extends PHPUnit_Framework_TestCase
+class AuthTokenGuardTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/Auth/AuthenticateMiddlewareTest.php
+++ b/tests/Auth/AuthenticateMiddlewareTest.php
@@ -2,6 +2,7 @@
 
 use Mockery as m;
 use Illuminate\Http\Request;
+use PHPUnit\Framework\TestCase;
 use Illuminate\Auth\AuthManager;
 use Illuminate\Auth\RequestGuard;
 use Illuminate\Container\Container;
@@ -9,7 +10,7 @@ use Illuminate\Config\Repository as Config;
 use Illuminate\Auth\AuthenticationException;
 use Illuminate\Auth\Middleware\Authenticate;
 
-class AuthenticateMiddlewareTest extends PHPUnit_Framework_TestCase
+class AuthenticateMiddlewareTest extends TestCase
 {
     protected $auth;
 

--- a/tests/Auth/AuthorizeMiddlewareTest.php
+++ b/tests/Auth/AuthorizeMiddlewareTest.php
@@ -3,6 +3,7 @@
 use Mockery as m;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Router;
+use PHPUnit\Framework\TestCase;
 use Illuminate\Auth\Access\Gate;
 use Illuminate\Events\Dispatcher;
 use Illuminate\Container\Container;
@@ -12,7 +13,7 @@ use Illuminate\Contracts\Auth\Factory as Auth;
 use Illuminate\Routing\Middleware\SubstituteBindings;
 use Illuminate\Contracts\Auth\Access\Gate as GateContract;
 
-class AuthorizeMiddlewareTest extends PHPUnit_Framework_TestCase
+class AuthorizeMiddlewareTest extends TestCase
 {
     protected $container;
     protected $user;

--- a/tests/Auth/AuthorizesResourcesTest.php
+++ b/tests/Auth/AuthorizesResourcesTest.php
@@ -2,10 +2,11 @@
 
 use Illuminate\Http\Request;
 use Illuminate\Routing\Router;
+use PHPUnit\Framework\TestCase;
 use Illuminate\Routing\Controller;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 
-class AuthorizesResourcesTest extends PHPUnit_Framework_TestCase
+class AuthorizesResourcesTest extends TestCase
 {
     public function testCreateMethod()
     {

--- a/tests/Broadcasting/BroadcastEventTest.php
+++ b/tests/Broadcasting/BroadcastEventTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 
-class BroadcastEventTest extends PHPUnit_Framework_TestCase
+class BroadcastEventTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/Broadcasting/BroadcasterTest.php
+++ b/tests/Broadcasting/BroadcasterTest.php
@@ -1,12 +1,13 @@
 <?php
 
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 use Illuminate\Container\Container;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Contracts\Routing\BindingRegistrar;
 use Illuminate\Broadcasting\Broadcasters\Broadcaster;
 
-class BroadcasterTest extends PHPUnit_Framework_TestCase
+class BroadcasterTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/Bus/BusDispatcherTest.php
+++ b/tests/Bus/BusDispatcherTest.php
@@ -2,9 +2,10 @@
 
 use Mockery as m;
 use Illuminate\Bus\Dispatcher;
+use PHPUnit\Framework\TestCase;
 use Illuminate\Container\Container;
 
-class BusDispatcherTest extends PHPUnit_Framework_TestCase
+class BusDispatcherTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/Cache/CacheApcStoreTest.php
+++ b/tests/Cache/CacheApcStoreTest.php
@@ -1,6 +1,8 @@
 <?php
 
-class CacheApcStoreTest extends PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class CacheApcStoreTest extends TestCase
 {
     public function testGetReturnsNullWhenNotFound()
     {

--- a/tests/Cache/CacheArrayStoreTest.php
+++ b/tests/Cache/CacheArrayStoreTest.php
@@ -1,8 +1,9 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
 use Illuminate\Cache\ArrayStore;
 
-class CacheArrayStoreTest extends PHPUnit_Framework_TestCase
+class CacheArrayStoreTest extends TestCase
 {
     public function testItemsCanBeSetAndRetrieved()
     {

--- a/tests/Cache/CacheDatabaseStoreTest.php
+++ b/tests/Cache/CacheDatabaseStoreTest.php
@@ -1,9 +1,10 @@
 <?php
 
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 use Illuminate\Cache\DatabaseStore;
 
-class CacheDatabaseStoreTest extends PHPUnit_Framework_TestCase
+class CacheDatabaseStoreTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/Cache/CacheEventsTest.php
+++ b/tests/Cache/CacheEventsTest.php
@@ -1,12 +1,13 @@
 <?php
 
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 use Illuminate\Cache\Events\CacheHit;
 use Illuminate\Cache\Events\KeyWritten;
 use Illuminate\Cache\Events\CacheMissed;
 use Illuminate\Cache\Events\KeyForgotten;
 
-class CacheEventTest extends PHPUnit_Framework_TestCase
+class CacheEventTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/Cache/CacheFileStoreTest.php
+++ b/tests/Cache/CacheFileStoreTest.php
@@ -1,9 +1,10 @@
 <?php
 
 use Illuminate\Cache\FileStore;
+use PHPUnit\Framework\TestCase;
 use Illuminate\Contracts\Filesystem\FileNotFoundException;
 
-class CacheFileStoreTest extends PHPUnit_Framework_TestCase
+class CacheFileStoreTest extends TestCase
 {
     public function testNullIsReturnedIfFileDoesntExist()
     {

--- a/tests/Cache/CacheManagerTest.php
+++ b/tests/Cache/CacheManagerTest.php
@@ -1,9 +1,10 @@
 <?php
 
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 use Illuminate\Cache\CacheManager;
 
-class CacheManagerTest extends PHPUnit_Framework_TestCase
+class CacheManagerTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/Cache/CacheMemcachedConnectorTest.php
+++ b/tests/Cache/CacheMemcachedConnectorTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 
-class CacheMemcachedConnectorTest extends PHPUnit_Framework_TestCase
+class CacheMemcachedConnectorTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/Cache/CacheMemcachedStoreTest.php
+++ b/tests/Cache/CacheMemcachedStoreTest.php
@@ -1,8 +1,9 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
 use Illuminate\Cache\MemcachedStore;
 
-class CacheMemcachedStoreTest extends PHPUnit_Framework_TestCase
+class CacheMemcachedStoreTest extends TestCase
 {
     public function testGetReturnsNullWhenNotFound()
     {

--- a/tests/Cache/CacheNullStoreTest.php
+++ b/tests/Cache/CacheNullStoreTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Illuminate\Cache\NullStore;
+use PHPUnit\Framework\TestCase;
 
-class CacheNullStoreTest extends PHPUnit_Framework_TestCase
+class CacheNullStoreTest extends TestCase
 {
     public function testItemsCanNotBeCached()
     {

--- a/tests/Cache/CacheRateLimiterTest.php
+++ b/tests/Cache/CacheRateLimiterTest.php
@@ -1,10 +1,11 @@
 <?php
 
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 use Illuminate\Cache\RateLimiter;
 use Illuminate\Contracts\Cache\Repository as Cache;
 
-class CacheRateLimiterTest extends PHPUnit_Framework_TestCase
+class CacheRateLimiterTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/Cache/CacheRedisStoreTest.php
+++ b/tests/Cache/CacheRedisStoreTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 
-class CacheRedisStoreTest extends PHPUnit_Framework_TestCase
+class CacheRedisStoreTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/Cache/CacheRepositoryTest.php
+++ b/tests/Cache/CacheRepositoryTest.php
@@ -2,8 +2,9 @@
 
 use Mockery as m;
 use Carbon\Carbon;
+use PHPUnit\Framework\TestCase;
 
-class CacheRepositoryTest extends PHPUnit_Framework_TestCase
+class CacheRepositoryTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/Cache/CacheTableCommandTest.php
+++ b/tests/Cache/CacheTableCommandTest.php
@@ -1,10 +1,11 @@
 <?php
 
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 use Illuminate\Foundation\Application;
 use Illuminate\Cache\Console\CacheTableCommand;
 
-class CacheTableCommandTest extends PHPUnit_Framework_TestCase
+class CacheTableCommandTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/Cache/CacheTaggedCacheTest.php
+++ b/tests/Cache/CacheTaggedCacheTest.php
@@ -1,9 +1,10 @@
 <?php
 
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 use Illuminate\Cache\ArrayStore;
 
-class CacheTaggedCacheTest extends PHPUnit_Framework_TestCase
+class CacheTaggedCacheTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/Cache/ClearCommandTest.php
+++ b/tests/Cache/ClearCommandTest.php
@@ -1,10 +1,11 @@
 <?php
 
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 use Illuminate\Foundation\Application;
 use Illuminate\Cache\Console\ClearCommand;
 
-class ClearCommandTest extends PHPUnit_Framework_TestCase
+class ClearCommandTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/Cache/RedisCacheIntegrationTest.php
+++ b/tests/Cache/RedisCacheIntegrationTest.php
@@ -1,10 +1,11 @@
 <?php
 
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 use Illuminate\Cache\RedisStore;
 use Illuminate\Cache\Repository;
 
-class RedisCacheTest extends PHPUnit_Framework_TestCase
+class RedisCacheTest extends TestCase
 {
     use InteractsWithRedis;
 

--- a/tests/Config/RepositoryTest.php
+++ b/tests/Config/RepositoryTest.php
@@ -1,8 +1,9 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
 use Illuminate\Config\Repository;
 
-class RepositoryTest extends PHPUnit_Framework_TestCase
+class RepositoryTest extends TestCase
 {
     /**
      * @var \Illuminate\Config\Repository

--- a/tests/Console/ConsoleApplicationTest.php
+++ b/tests/Console/ConsoleApplicationTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 
-class ConsoleApplicationTest extends PHPUnit_Framework_TestCase
+class ConsoleApplicationTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/Console/ConsoleEventSchedulerTest.php
+++ b/tests/Console/ConsoleEventSchedulerTest.php
@@ -1,9 +1,10 @@
 <?php
 
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 use Illuminate\Console\Scheduling\Schedule;
 
-class ConsoleEventSchedulerTest extends PHPUnit_Framework_TestCase
+class ConsoleEventSchedulerTest extends TestCase
 {
     public function setUp()
     {

--- a/tests/Console/ConsoleParserTest.php
+++ b/tests/Console/ConsoleParserTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Illuminate\Console\Parser;
+use PHPUnit\Framework\TestCase;
 
-class ConsoleParserTest extends PHPUnit_Framework_TestCase
+class ConsoleParserTest extends TestCase
 {
     public function testBasicParameterParsing()
     {

--- a/tests/Console/ConsoleScheduledEventTest.php
+++ b/tests/Console/ConsoleScheduledEventTest.php
@@ -2,9 +2,10 @@
 
 use Mockery as m;
 use Carbon\Carbon;
+use PHPUnit\Framework\TestCase;
 use Illuminate\Console\Scheduling\Event;
 
-class ConsoleScheduledEventTest extends PHPUnit_Framework_TestCase
+class ConsoleScheduledEventTest extends TestCase
 {
     /**
      * The default configuration timezone.

--- a/tests/Console/Scheduling/EventTest.php
+++ b/tests/Console/Scheduling/EventTest.php
@@ -1,9 +1,10 @@
 <?php
 
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 use Illuminate\Console\Scheduling\Event;
 
-class EventTest extends PHPUnit_Framework_TestCase
+class EventTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -1,8 +1,9 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
 use Illuminate\Container\Container;
 
-class ContainerContainerTest extends PHPUnit_Framework_TestCase
+class ContainerContainerTest extends TestCase
 {
     public function testContainerSingleton()
     {

--- a/tests/Cookie/CookieTest.php
+++ b/tests/Cookie/CookieTest.php
@@ -1,10 +1,11 @@
 <?php
 
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 use Illuminate\Cookie\CookieJar;
 use Symfony\Component\HttpFoundation\Request;
 
-class CookieTest extends PHPUnit_Framework_TestCase
+class CookieTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/Cookie/Middleware/EncryptCookiesTest.php
+++ b/tests/Cookie/Middleware/EncryptCookiesTest.php
@@ -3,6 +3,7 @@
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Routing\Router;
+use PHPUnit\Framework\TestCase;
 use Illuminate\Cookie\CookieJar;
 use Illuminate\Events\Dispatcher;
 use Illuminate\Routing\Controller;
@@ -13,7 +14,7 @@ use Illuminate\Cookie\Middleware\EncryptCookies;
 use Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse;
 use Illuminate\Contracts\Encryption\Encrypter as EncrypterContract;
 
-class EncryptCookiesTest extends PHPUnit_Framework_TestCase
+class EncryptCookiesTest extends TestCase
 {
     /**
      * @var Router

--- a/tests/Database/DatabaseConnectionFactoryTest.php
+++ b/tests/Database/DatabaseConnectionFactoryTest.php
@@ -1,11 +1,12 @@
 <?php
 
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 use Illuminate\Database\Connection;
 use Illuminate\Database\Capsule\Manager as DB;
 use Illuminate\Database\Connectors\ConnectionFactory;
 
-class DatabaseConnectionFactoryTest extends PHPUnit_Framework_TestCase
+class DatabaseConnectionFactoryTest extends TestCase
 {
     protected $db;
 

--- a/tests/Database/DatabaseConnectionTest.php
+++ b/tests/Database/DatabaseConnectionTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 
-class DatabaseConnectionTest extends PHPUnit_Framework_TestCase
+class DatabaseConnectionTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/Database/DatabaseConnectorTest.php
+++ b/tests/Database/DatabaseConnectorTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 
-class DatabaseConnectorTest extends PHPUnit_Framework_TestCase
+class DatabaseConnectorTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/Database/DatabaseEloquentBelongsToManyTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyTest.php
@@ -1,11 +1,12 @@
 <?php
 
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Collection as BaseCollection;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 
-class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase
+class DatabaseEloquentBelongsToManyTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/Database/DatabaseEloquentBelongsToTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToTest.php
@@ -1,10 +1,11 @@
 <?php
 
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
-class DatabaseEloquentBelongsToTest extends PHPUnit_Framework_TestCase
+class DatabaseEloquentBelongsToTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -1,11 +1,12 @@
 <?php
 
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Collection as BaseCollection;
 
-class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase
+class DatabaseEloquentBuilderTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -1,10 +1,11 @@
 <?php
 
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Collection as BaseCollection;
 
-class DatabaseEloquentCollectionTest extends PHPUnit_Framework_TestCase
+class DatabaseEloquentCollectionTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/Database/DatabaseEloquentGlobalScopesTest.php
+++ b/tests/Database/DatabaseEloquentGlobalScopesTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 
-class DatabaseEloquentGlobalScopesTest extends PHPUnit_Framework_TestCase
+class DatabaseEloquentGlobalScopesTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/Database/DatabaseEloquentHasManyTest.php
+++ b/tests/Database/DatabaseEloquentHasManyTest.php
@@ -1,10 +1,11 @@
 <?php
 
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
-class DatabaseEloquentHasManyTest extends PHPUnit_Framework_TestCase
+class DatabaseEloquentHasManyTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/Database/DatabaseEloquentHasManyThroughTest.php
+++ b/tests/Database/DatabaseEloquentHasManyThroughTest.php
@@ -1,11 +1,12 @@
 <?php
 
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 
-class DatabaseEloquentHasManyThroughTest extends PHPUnit_Framework_TestCase
+class DatabaseEloquentHasManyThroughTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/Database/DatabaseEloquentHasOneTest.php
+++ b/tests/Database/DatabaseEloquentHasOneTest.php
@@ -1,10 +1,11 @@
 <?php
 
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 
-class DatabaseEloquentHasOneTest extends PHPUnit_Framework_TestCase
+class DatabaseEloquentHasOneTest extends TestCase
 {
     protected $builder;
 

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -1,12 +1,13 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
 use Illuminate\Database\Capsule\Manager as DB;
 use Illuminate\Database\Eloquent\Relations\Pivot;
 use Illuminate\Database\Eloquent\Model as Eloquent;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Pagination\AbstractPaginator as Paginator;
 
-class DatabaseEloquentIntegrationTest extends PHPUnit_Framework_TestCase
+class DatabaseEloquentIntegrationTest extends TestCase
 {
     /**
      * Setup the database schema.

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1,11 +1,12 @@
 <?php
 
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Relations\Relation;
 
-class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
+class DatabaseEloquentModelTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/Database/DatabaseEloquentMorphTest.php
+++ b/tests/Database/DatabaseEloquentMorphTest.php
@@ -1,12 +1,13 @@
 <?php
 
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphOne;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
 
-class DatabaseEloquentMorphTest extends PHPUnit_Framework_TestCase
+class DatabaseEloquentMorphTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/Database/DatabaseEloquentMorphToManyTest.php
+++ b/tests/Database/DatabaseEloquentMorphToManyTest.php
@@ -1,9 +1,10 @@
 <?php
 
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
 
-class DatabaseEloquentMorphToManyTest extends PHPUnit_Framework_TestCase
+class DatabaseEloquentMorphToManyTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/Database/DatabaseEloquentMorphToTest.php
+++ b/tests/Database/DatabaseEloquentMorphToTest.php
@@ -1,9 +1,10 @@
 <?php
 
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 
-class DatabaseEloquentMorphToTest extends PHPUnit_Framework_TestCase
+class DatabaseEloquentMorphToTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/Database/DatabaseEloquentPivotTest.php
+++ b/tests/Database/DatabaseEloquentPivotTest.php
@@ -1,9 +1,10 @@
 <?php
 
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 use Illuminate\Database\Eloquent\Relations\Pivot;
 
-class DatabaseEloquentPivotTest extends PHPUnit_Framework_TestCase
+class DatabaseEloquentPivotTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/Database/DatabaseEloquentPolymorphicIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentPolymorphicIntegrationTest.php
@@ -1,11 +1,12 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
 use Illuminate\Database\Connection;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Database\Capsule\Manager as DB;
 use Illuminate\Database\Eloquent\Model as Eloquent;
 
-class DatabaseEloquentPolymorphicIntegrationTest extends PHPUnit_Framework_TestCase
+class DatabaseEloquentPolymorphicIntegrationTest extends TestCase
 {
     public function setUp()
     {

--- a/tests/Database/DatabaseEloquentRelationTest.php
+++ b/tests/Database/DatabaseEloquentRelationTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 use Illuminate\Database\Grammar;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
@@ -8,7 +9,7 @@ use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Query\Builder as QueryBuilder;
 
-class DatabaseEloquentRelationTest extends PHPUnit_Framework_TestCase
+class DatabaseEloquentRelationTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Carbon\Carbon;
+use PHPUnit\Framework\TestCase;
 use Illuminate\Database\Connection;
 use Illuminate\Pagination\Paginator;
 use Illuminate\Database\Query\Builder;
@@ -9,7 +10,7 @@ use Illuminate\Database\Capsule\Manager as DB;
 use Illuminate\Database\Eloquent\Model as Eloquent;
 use Illuminate\Database\Eloquent\SoftDeletingScope;
 
-class DatabaseEloquentSoftDeletesIntegrationTest extends PHPUnit_Framework_TestCase
+class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
 {
     public function setUp()
     {

--- a/tests/Database/DatabaseMigrationCreatorTest.php
+++ b/tests/Database/DatabaseMigrationCreatorTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 
-class DatabaseMigrationCreatorTest extends PHPUnit_Framework_TestCase
+class DatabaseMigrationCreatorTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/Database/DatabaseMigrationInstallCommandTest.php
+++ b/tests/Database/DatabaseMigrationInstallCommandTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 
-class DatabaseMigrationInstallCommandTest extends PHPUnit_Framework_TestCase
+class DatabaseMigrationInstallCommandTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/Database/DatabaseMigrationMakeCommandTest.php
+++ b/tests/Database/DatabaseMigrationMakeCommandTest.php
@@ -1,9 +1,10 @@
 <?php
 
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 use Illuminate\Database\Console\Migrations\MigrateMakeCommand;
 
-class DatabaseMigrationMakeCommandTest extends PHPUnit_Framework_TestCase
+class DatabaseMigrationMakeCommandTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/Database/DatabaseMigrationMigrateCommandTest.php
+++ b/tests/Database/DatabaseMigrationMigrateCommandTest.php
@@ -1,10 +1,11 @@
 <?php
 
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 use Illuminate\Foundation\Application;
 use Illuminate\Database\Console\Migrations\MigrateCommand;
 
-class DatabaseMigrationMigrateCommandTest extends PHPUnit_Framework_TestCase
+class DatabaseMigrationMigrateCommandTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/Database/DatabaseMigrationRefreshCommandTest.php
+++ b/tests/Database/DatabaseMigrationRefreshCommandTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 use Illuminate\Foundation\Application;
 use Illuminate\Database\Migrations\Migrator;
 use Illuminate\Database\Console\Migrations\ResetCommand;
@@ -9,7 +10,7 @@ use Illuminate\Database\Console\Migrations\RefreshCommand;
 use Illuminate\Database\Console\Migrations\RollbackCommand;
 use Symfony\Component\Console\Application as ConsoleApplication;
 
-class DatabaseMigrationRefreshCommandTest extends PHPUnit_Framework_TestCase
+class DatabaseMigrationRefreshCommandTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/Database/DatabaseMigrationRepositoryTest.php
+++ b/tests/Database/DatabaseMigrationRepositoryTest.php
@@ -1,10 +1,11 @@
 <?php
 
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 use Illuminate\Support\Collection;
 use Illuminate\Database\Migrations\DatabaseMigrationRepository;
 
-class DatabaseMigrationRepositoryTest extends PHPUnit_Framework_TestCase
+class DatabaseMigrationRepositoryTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/Database/DatabaseMigrationResetCommandTest.php
+++ b/tests/Database/DatabaseMigrationResetCommandTest.php
@@ -1,10 +1,11 @@
 <?php
 
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 use Illuminate\Foundation\Application;
 use Illuminate\Database\Console\Migrations\ResetCommand;
 
-class DatabaseMigrationResetCommandTest extends PHPUnit_Framework_TestCase
+class DatabaseMigrationResetCommandTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/Database/DatabaseMigrationRollbackCommandTest.php
+++ b/tests/Database/DatabaseMigrationRollbackCommandTest.php
@@ -1,10 +1,11 @@
 <?php
 
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 use Illuminate\Foundation\Application;
 use Illuminate\Database\Console\Migrations\RollbackCommand;
 
-class DatabaseMigrationRollbackCommandTest extends PHPUnit_Framework_TestCase
+class DatabaseMigrationRollbackCommandTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/Database/DatabaseMigratorIntegrationTest.php
+++ b/tests/Database/DatabaseMigratorIntegrationTest.php
@@ -1,11 +1,12 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Database\Migrations\Migrator;
 use Illuminate\Database\Capsule\Manager as DB;
 use Illuminate\Database\Migrations\DatabaseMigrationRepository;
 
-class DatabaseMigratorIntegrationTest extends PHPUnit_Framework_TestCase
+class DatabaseMigratorIntegrationTest extends TestCase
 {
     protected $db;
 

--- a/tests/Database/DatabaseMySqlProcessorTest.php
+++ b/tests/Database/DatabaseMySqlProcessorTest.php
@@ -1,6 +1,8 @@
 <?php
 
-class DatabaseMySqlProcessorTest extends PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class DatabaseMySqlProcessorTest extends TestCase
 {
     public function testProcessColumnListing()
     {

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -1,9 +1,10 @@
 <?php
 
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 use Illuminate\Database\Schema\Blueprint;
 
-class DatabaseMySqlSchemaGrammarTest extends PHPUnit_Framework_TestCase
+class DatabaseMySqlSchemaGrammarTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/Database/DatabasePostgresProcessorTest.php
+++ b/tests/Database/DatabasePostgresProcessorTest.php
@@ -1,6 +1,8 @@
 <?php
 
-class DatabasePostgresProcessorTest extends PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class DatabasePostgresProcessorTest extends TestCase
 {
     public function testProcessColumnListing()
     {

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -1,9 +1,10 @@
 <?php
 
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 use Illuminate\Database\Schema\Blueprint;
 
-class DatabasePostgresSchemaGrammarTest extends PHPUnit_Framework_TestCase
+class DatabasePostgresSchemaGrammarTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/Database/DatabaseProcessorTest.php
+++ b/tests/Database/DatabaseProcessorTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 
-class DatabaseProcessorTest extends PHPUnit_Framework_TestCase
+class DatabaseProcessorTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1,12 +1,13 @@
 <?php
 
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Database\Query\Expression as Raw;
 use Illuminate\Pagination\AbstractPaginator as Paginator;
 
-class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase
+class DatabaseQueryBuilderTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/Database/DatabaseSQLiteProcessorTest.php
+++ b/tests/Database/DatabaseSQLiteProcessorTest.php
@@ -1,6 +1,8 @@
 <?php
 
-class DatabaseSQLiteProcessorTest extends PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class DatabaseSQLiteProcessorTest extends TestCase
 {
     public function testProcessColumnListing()
     {

--- a/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
@@ -1,9 +1,10 @@
 <?php
 
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 use Illuminate\Database\Schema\Blueprint;
 
-class DatabaseSQLiteSchemaGrammarTest extends PHPUnit_Framework_TestCase
+class DatabaseSQLiteSchemaGrammarTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintTest.php
@@ -1,13 +1,14 @@
 <?php
 
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Schema\Grammars\MySqlGrammar;
 use Illuminate\Database\Schema\Grammars\SQLiteGrammar;
 use Illuminate\Database\Schema\Grammars\PostgresGrammar;
 use Illuminate\Database\Schema\Grammars\SqlServerGrammar;
 
-class DatabaseSchemaBlueprintTest extends PHPUnit_Framework_TestCase
+class DatabaseSchemaBlueprintTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/Database/DatabaseSchemaBuilderTest.php
+++ b/tests/Database/DatabaseSchemaBuilderTest.php
@@ -1,9 +1,10 @@
 <?php
 
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 use Illuminate\Database\Schema\Builder;
 
-class DatabaseSchemaBuilderTest extends PHPUnit_Framework_TestCase
+class DatabaseSchemaBuilderTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/Database/DatabaseSeederTest.php
+++ b/tests/Database/DatabaseSeederTest.php
@@ -2,6 +2,7 @@
 
 use Mockery as m;
 use Illuminate\Database\Seeder;
+use PHPUnit\Framework\TestCase;
 
 class TestSeeder extends Seeder
 {
@@ -19,7 +20,7 @@ class TestDepsSeeder extends Seeder
     }
 }
 
-class DatabaseSeederTest extends PHPUnit_Framework_TestCase
+class DatabaseSeederTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/Database/DatabaseSoftDeletingScopeTest.php
+++ b/tests/Database/DatabaseSoftDeletingScopeTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 
-class DatabaseSoftDeletingScopeTest extends PHPUnit_Framework_TestCase
+class DatabaseSoftDeletingScopeTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/Database/DatabaseSoftDeletingTraitTest.php
+++ b/tests/Database/DatabaseSoftDeletingTraitTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 
-class DatabaseSoftDeletingTraitTest extends PHPUnit_Framework_TestCase
+class DatabaseSoftDeletingTraitTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
@@ -1,9 +1,10 @@
 <?php
 
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 use Illuminate\Database\Schema\Blueprint;
 
-class DatabaseSqlServerSchemaGrammarTest extends PHPUnit_Framework_TestCase
+class DatabaseSqlServerSchemaGrammarTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/Database/SeedCommandTest.php
+++ b/tests/Database/SeedCommandTest.php
@@ -1,11 +1,12 @@
 <?php
 
 use Illuminate\Database\Seeder;
+use PHPUnit\Framework\TestCase;
 use Illuminate\Container\Container;
 use Illuminate\Database\Console\Seeds\SeedCommand;
 use Illuminate\Database\ConnectionResolverInterface;
 
-class SeedCommandTest extends PHPUnit_Framework_TestCase
+class SeedCommandTest extends TestCase
 {
     public function testFire()
     {

--- a/tests/Encryption/EncrypterTest.php
+++ b/tests/Encryption/EncrypterTest.php
@@ -1,8 +1,9 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
 use Illuminate\Encryption\Encrypter;
 
-class EncrypterTest extends PHPUnit_Framework_TestCase
+class EncrypterTest extends TestCase
 {
     public function testEncryption()
     {

--- a/tests/Events/EventsDispatcherTest.php
+++ b/tests/Events/EventsDispatcherTest.php
@@ -1,9 +1,10 @@
 <?php
 
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 use Illuminate\Events\Dispatcher;
 
-class EventsDispatcherTest extends PHPUnit_Framework_TestCase
+class EventsDispatcherTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -1,8 +1,9 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
 use Illuminate\Filesystem\Filesystem;
 
-class FilesystemTest extends PHPUnit_Framework_TestCase
+class FilesystemTest extends TestCase
 {
     private $tempDir;
 

--- a/tests/Foundation/FoundationAliasLoaderTest.php
+++ b/tests/Foundation/FoundationAliasLoaderTest.php
@@ -1,8 +1,9 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
 use Illuminate\Foundation\AliasLoader;
 
-class FoundationAliasLoaderTest extends PHPUnit_Framework_TestCase
+class FoundationAliasLoaderTest extends TestCase
 {
     public function testLoaderCanBeCreatedAndRegisteredOnce()
     {

--- a/tests/Foundation/FoundationApplicationTest.php
+++ b/tests/Foundation/FoundationApplicationTest.php
@@ -1,9 +1,10 @@
 <?php
 
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 use Illuminate\Foundation\Application;
 
-class FoundationApplicationTest extends PHPUnit_Framework_TestCase
+class FoundationApplicationTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/Foundation/FoundationAuthenticationTest.php
+++ b/tests/Foundation/FoundationAuthenticationTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 use Illuminate\Auth\AuthManager;
 use Illuminate\Contracts\Auth\Guard;
 use Illuminate\Foundation\Application;
@@ -8,7 +9,7 @@ use Illuminate\Contracts\Auth\UserProvider;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Foundation\Testing\Concerns\InteractsWithAuthentication;
 
-class FoundationAuthenticationTest extends PHPUnit_Framework_TestCase
+class FoundationAuthenticationTest extends TestCase
 {
     use InteractsWithAuthentication;
 

--- a/tests/Foundation/FoundationAuthorizesRequestsTraitTest.php
+++ b/tests/Foundation/FoundationAuthorizesRequestsTraitTest.php
@@ -1,12 +1,13 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
 use Illuminate\Auth\Access\Gate;
 use Illuminate\Container\Container;
 use Illuminate\Auth\Access\Response;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Contracts\Auth\Access\Gate as GateContract;
 
-class FoundationAuthorizesRequestsTraitTest extends PHPUnit_Framework_TestCase
+class FoundationAuthorizesRequestsTraitTest extends TestCase
 {
     public function test_basic_gate_check()
     {

--- a/tests/Foundation/FoundationComposerTest.php
+++ b/tests/Foundation/FoundationComposerTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 
-class FoundationComposerTest extends PHPUnit_Framework_TestCase
+class FoundationComposerTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/Foundation/FoundationEnvironmentDetectorTest.php
+++ b/tests/Foundation/FoundationEnvironmentDetectorTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 
-class FoundationEnvironmentDetectorTest extends PHPUnit_Framework_TestCase
+class FoundationEnvironmentDetectorTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/Foundation/FoundationFormRequestTest.php
+++ b/tests/Foundation/FoundationFormRequestTest.php
@@ -1,9 +1,10 @@
 <?php
 
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 use Illuminate\Container\Container;
 
-class FoundationFormRequestTest extends PHPUnit_Framework_TestCase
+class FoundationFormRequestTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/Foundation/FoundationHelpersTest.php
+++ b/tests/Foundation/FoundationHelpersTest.php
@@ -1,9 +1,10 @@
 <?php
 
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 use Illuminate\Foundation\Application;
 
-class FoundationHelpersTest extends PHPUnit_Framework_TestCase
+class FoundationHelpersTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/Foundation/FoundationInteractsWithDatabaseTest.php
+++ b/tests/Foundation/FoundationInteractsWithDatabaseTest.php
@@ -1,11 +1,12 @@
 <?php
 
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 use Illuminate\Database\Connection;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Foundation\Testing\Concerns\InteractsWithDatabase;
 
-class FoundationInteractsWithDatabaseTest extends PHPUnit_Framework_TestCase
+class FoundationInteractsWithDatabaseTest extends TestCase
 {
     use InteractsWithDatabase;
 

--- a/tests/Foundation/FoundationProviderRepositoryTest.php
+++ b/tests/Foundation/FoundationProviderRepositoryTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 
-class FoundationProviderRepositoryTest extends PHPUnit_Framework_TestCase
+class FoundationProviderRepositoryTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/Hashing/BcryptHasherTest.php
+++ b/tests/Hashing/BcryptHasherTest.php
@@ -1,6 +1,8 @@
 <?php
 
-class BcryptHasherTest extends PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class BcryptHasherTest extends TestCase
 {
     public function testBasicHashing()
     {

--- a/tests/Http/HttpJsonResponseTest.php
+++ b/tests/Http/HttpJsonResponseTest.php
@@ -1,9 +1,10 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Contracts\Support\Arrayable;
 
-class HttpJsonResponseTest extends PHPUnit_Framework_TestCase
+class HttpJsonResponseTest extends TestCase
 {
     public function testSeAndRetrieveJsonableData()
     {

--- a/tests/Http/HttpRedirectResponseTest.php
+++ b/tests/Http/HttpRedirectResponseTest.php
@@ -2,9 +2,10 @@
 
 use Mockery as m;
 use Illuminate\Http\Request;
+use PHPUnit\Framework\TestCase;
 use Illuminate\Http\RedirectResponse;
 
-class HttpRedirectResponseTest extends PHPUnit_Framework_TestCase
+class HttpRedirectResponseTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -3,9 +3,10 @@
 use Mockery as m;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Route;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 
-class HttpRequestTest extends PHPUnit_Framework_TestCase
+class HttpRequestTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/Http/HttpResponseTest.php
+++ b/tests/Http/HttpResponseTest.php
@@ -2,10 +2,11 @@
 
 use Mockery as m;
 use Illuminate\Http\Request;
+use PHPUnit\Framework\TestCase;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Contracts\Support\Jsonable;
 
-class HttpResponseTest extends PHPUnit_Framework_TestCase
+class HttpResponseTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/Log/LogWriterTest.php
+++ b/tests/Log/LogWriterTest.php
@@ -2,8 +2,9 @@
 
 use Mockery as m;
 use Illuminate\Log\Writer;
+use PHPUnit\Framework\TestCase;
 
-class LogWriterTest extends PHPUnit_Framework_TestCase
+class LogWriterTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/Mail/MailMailableTest.php
+++ b/tests/Mail/MailMailableTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Illuminate\Mail\Mailable;
+use PHPUnit\Framework\TestCase;
 
-class MailMailableTest extends PHPUnit_Framework_TestCase
+class MailMailableTest extends TestCase
 {
     public function testMailableSetsRecipientsCorrectly()
     {

--- a/tests/Mail/MailMailerTest.php
+++ b/tests/Mail/MailMailerTest.php
@@ -1,9 +1,10 @@
 <?php
 
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 use Illuminate\Support\HtmlString;
 
-class MailMailerTest extends PHPUnit_Framework_TestCase
+class MailMailerTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/Mail/MailMarkdownTest.php
+++ b/tests/Mail/MailMarkdownTest.php
@@ -1,6 +1,8 @@
 <?php
 
-class MailMarkdownTest extends PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class MailMarkdownTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/Mail/MailMessageTest.php
+++ b/tests/Mail/MailMessageTest.php
@@ -2,8 +2,9 @@
 
 use Mockery as m;
 use Illuminate\Mail\Message;
+use PHPUnit\Framework\TestCase;
 
-class MailMessageTest extends PHPUnit_Framework_TestCase
+class MailMessageTest extends TestCase
 {
     /**
      * @var \Mockery::mock

--- a/tests/Mail/MailSesTransportTest.php
+++ b/tests/Mail/MailSesTransportTest.php
@@ -1,12 +1,13 @@
 <?php
 
 use Aws\Ses\SesClient;
+use PHPUnit\Framework\TestCase;
 use Illuminate\Support\Collection;
 use Illuminate\Mail\TransportManager;
 use Illuminate\Foundation\Application;
 use Illuminate\Mail\Transport\SesTransport;
 
-class MailSesTransportTest extends PHPUnit_Framework_TestCase
+class MailSesTransportTest extends TestCase
 {
     public function testGetTransport()
     {

--- a/tests/Notifications/NotificationActionTest.php
+++ b/tests/Notifications/NotificationActionTest.php
@@ -1,8 +1,9 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
 use Illuminate\Notifications\Action;
 
-class NotificationActionTest extends PHPUnit_Framework_TestCase
+class NotificationActionTest extends TestCase
 {
     public function testActionIsCreatedProperly()
     {

--- a/tests/Notifications/NotificationBroadcastChannelTest.php
+++ b/tests/Notifications/NotificationBroadcastChannelTest.php
@@ -1,10 +1,11 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
 use Illuminate\Notifications\Notification;
 use Illuminate\Broadcasting\PrivateChannel;
 use Illuminate\Notifications\Channels\BroadcastChannel;
 
-class NotificationBroadcastChannelTest extends PHPUnit_Framework_TestCase
+class NotificationBroadcastChannelTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/Notifications/NotificationChannelManagerTest.php
+++ b/tests/Notifications/NotificationChannelManagerTest.php
@@ -1,12 +1,13 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
 use Illuminate\Container\Container;
 use Illuminate\Notifications\Notification;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Notifications\ChannelManager;
 use Illuminate\Contracts\Bus\Dispatcher as Bus;
 
-class NotificationChannelManagerTest extends PHPUnit_Framework_TestCase
+class NotificationChannelManagerTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/Notifications/NotificationDatabaseChannelTest.php
+++ b/tests/Notifications/NotificationDatabaseChannelTest.php
@@ -1,10 +1,11 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
 use Illuminate\Notifications\Notification;
 use Illuminate\Notifications\Channels\DatabaseChannel;
 use Illuminate\Notifications\Messages\DatabaseMessage;
 
-class NotificationDatabaseChannelTest extends PHPUnit_Framework_TestCase
+class NotificationDatabaseChannelTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/Notifications/NotificationMailChannelTest.php
+++ b/tests/Notifications/NotificationMailChannelTest.php
@@ -1,10 +1,11 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
 use Illuminate\Support\HtmlString;
 use Illuminate\Notifications\Notification;
 use Illuminate\Notifications\Messages\MailMessage;
 
-class NotificationMailChannelTest extends PHPUnit_Framework_TestCase
+class NotificationMailChannelTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/Notifications/NotificationMessageTest.php
+++ b/tests/Notifications/NotificationMessageTest.php
@@ -1,8 +1,9 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
 use Illuminate\Notifications\Messages\SimpleMessage as Message;
 
-class NotificationMessageTest extends PHPUnit_Framework_TestCase
+class NotificationMessageTest extends TestCase
 {
     public function testLevelCanBeRetrieved()
     {

--- a/tests/Notifications/NotificationNexmoChannelTest.php
+++ b/tests/Notifications/NotificationNexmoChannelTest.php
@@ -1,9 +1,10 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
 use Illuminate\Notifications\Notification;
 use Illuminate\Notifications\Messages\NexmoMessage;
 
-class NotificationNexmoChannelTest extends PHPUnit_Framework_TestCase
+class NotificationNexmoChannelTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/Notifications/NotificationRoutesNotificationsTest.php
+++ b/tests/Notifications/NotificationRoutesNotificationsTest.php
@@ -1,9 +1,10 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Notifications\Dispatcher;
 
-class NotificationRoutesNotificationsTest extends PHPUnit_Framework_TestCase
+class NotificationRoutesNotificationsTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/Notifications/NotificationSendQueuedNotificationTest.php
+++ b/tests/Notifications/NotificationSendQueuedNotificationTest.php
@@ -1,8 +1,9 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
 use Illuminate\Notifications\SendQueuedNotifications;
 
-class NotificationSendQueuedNotificationTest extends PHPUnit_Framework_TestCase
+class NotificationSendQueuedNotificationTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/Notifications/NotificationSlackChannelTest.php
+++ b/tests/Notifications/NotificationSlackChannelTest.php
@@ -1,9 +1,10 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
 use Illuminate\Notifications\Notification;
 use Illuminate\Notifications\Messages\SlackMessage;
 
-class NotificationSlackChannelTest extends PHPUnit_Framework_TestCase
+class NotificationSlackChannelTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/Pagination/PaginationPaginatorTest.php
+++ b/tests/Pagination/PaginationPaginatorTest.php
@@ -1,11 +1,12 @@
 <?php
 
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 use Illuminate\Pagination\UrlWindow;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Pagination\Paginator as Paginator;
 
-class PaginationPaginatorTest extends PHPUnit_Framework_TestCase
+class PaginationPaginatorTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/Pipeline/PipelineTest.php
+++ b/tests/Pipeline/PipelineTest.php
@@ -1,8 +1,9 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
 use Illuminate\Pipeline\Pipeline;
 
-class PipelineTest extends PHPUnit_Framework_TestCase
+class PipelineTest extends TestCase
 {
     public function testPipelineBasicUsage()
     {

--- a/tests/Queue/QueueBeanstalkdJobTest.php
+++ b/tests/Queue/QueueBeanstalkdJobTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 
-class QueueBeanstalkdJobTest extends PHPUnit_Framework_TestCase
+class QueueBeanstalkdJobTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/Queue/QueueBeanstalkdQueueTest.php
+++ b/tests/Queue/QueueBeanstalkdQueueTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 
-class QueueBeanstalkdQueueTest extends PHPUnit_Framework_TestCase
+class QueueBeanstalkdQueueTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/Queue/QueueDatabaseQueueIntegrationTest.php
+++ b/tests/Queue/QueueDatabaseQueueIntegrationTest.php
@@ -1,13 +1,14 @@
 <?php
 
 use Carbon\Carbon;
+use PHPUnit\Framework\TestCase;
 use Illuminate\Container\Container;
 use \Illuminate\Queue\DatabaseQueue;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Capsule\Manager as DB;
 use Illuminate\Database\Eloquent\Model as Eloquent;
 
-class QueueDatabaseQueueIntegrationTest extends PHPUnit_Framework_TestCase
+class QueueDatabaseQueueIntegrationTest extends TestCase
 {
     /**
      * @var DatabaseQueue The queue instance.

--- a/tests/Queue/QueueDatabaseQueueUnitTest.php
+++ b/tests/Queue/QueueDatabaseQueueUnitTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 
-class QueueDatabaseQueueUnitTest extends PHPUnit_Framework_TestCase
+class QueueDatabaseQueueUnitTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/Queue/QueueListenerTest.php
+++ b/tests/Queue/QueueListenerTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 
-class QueueListenerTest extends PHPUnit_Framework_TestCase
+class QueueListenerTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/Queue/QueueManagerTest.php
+++ b/tests/Queue/QueueManagerTest.php
@@ -1,9 +1,10 @@
 <?php
 
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 use Illuminate\Queue\QueueManager;
 
-class QueueManagerTest extends PHPUnit_Framework_TestCase
+class QueueManagerTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/Queue/QueueRedisJobTest.php
+++ b/tests/Queue/QueueRedisJobTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 
-class QueueRedisJobTest extends PHPUnit_Framework_TestCase
+class QueueRedisJobTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/Queue/QueueRedisQueueTest.php
+++ b/tests/Queue/QueueRedisQueueTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 
-class QueueRedisQueueTest extends PHPUnit_Framework_TestCase
+class QueueRedisQueueTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/Queue/QueueSqsJobTest.php
+++ b/tests/Queue/QueueSqsJobTest.php
@@ -2,8 +2,9 @@
 
 use Mockery as m;
 use Aws\Sqs\SqsClient;
+use PHPUnit\Framework\TestCase;
 
-class QueueSqsJobTest extends PHPUnit_Framework_TestCase
+class QueueSqsJobTest extends TestCase
 {
     public function setUp()
     {

--- a/tests/Queue/QueueSqsQueueTest.php
+++ b/tests/Queue/QueueSqsQueueTest.php
@@ -3,8 +3,9 @@
 use Aws\Result;
 use Mockery as m;
 use Aws\Sqs\SqsClient;
+use PHPUnit\Framework\TestCase;
 
-class QueueSqsQueueTest extends PHPUnit_Framework_TestCase
+class QueueSqsQueueTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/Queue/QueueSyncQueueTest.php
+++ b/tests/Queue/QueueSyncQueueTest.php
@@ -1,9 +1,10 @@
 <?php
 
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 use Illuminate\Container\Container;
 
-class QueueSyncQueueTest extends PHPUnit_Framework_TestCase
+class QueueSyncQueueTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
 use Illuminate\Container\Container;
 use Illuminate\Queue\WorkerOptions;
 use Illuminate\Queue\Events\JobFailed;
@@ -10,7 +11,7 @@ use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Queue\Events\JobExceptionOccurred;
 use Illuminate\Queue\MaxAttemptsExceededException;
 
-class QueueWorkerTest extends PHPUnit_Framework_TestCase
+class QueueWorkerTest extends TestCase
 {
     public $events;
     public $exceptionHandler;

--- a/tests/Queue/RedisQueueIntegrationTest.php
+++ b/tests/Queue/RedisQueueIntegrationTest.php
@@ -1,11 +1,12 @@
 <?php
 
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 use Illuminate\Queue\RedisQueue;
 use Illuminate\Container\Container;
 use Illuminate\Queue\Jobs\RedisJob;
 
-class RedisQueueIntegrationTest extends PHPUnit_Framework_TestCase
+class RedisQueueIntegrationTest extends TestCase
 {
     use InteractsWithRedis;
 

--- a/tests/Redis/InteractsWithRedis.php
+++ b/tests/Redis/InteractsWithRedis.php
@@ -1,6 +1,5 @@
 <?php
 
-
 use Illuminate\Redis\RedisManager;
 
 trait InteractsWithRedis

--- a/tests/Routing/RouteCollectionTest.php
+++ b/tests/Routing/RouteCollectionTest.php
@@ -1,9 +1,10 @@
 <?php
 
 use Illuminate\Routing\Route;
+use PHPUnit\Framework\TestCase;
 use Illuminate\Routing\RouteCollection;
 
-class RouteCollectionTest extends PHPUnit_Framework_TestCase
+class RouteCollectionTest extends TestCase
 {
     /**
      * @var \Illuminate\Routing\RouteCollection

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -3,10 +3,11 @@
 use Mockery as m;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Router;
+use PHPUnit\Framework\TestCase;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Events\Dispatcher;
 
-class RouteRegistrarTest extends PHPUnit_Framework_TestCase
+class RouteRegistrarTest extends TestCase
 {
     /**
      * @var \Illuminate\Routing\Router

--- a/tests/Routing/RoutingRedirectorTest.php
+++ b/tests/Routing/RoutingRedirectorTest.php
@@ -1,9 +1,10 @@
 <?php
 
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 use Illuminate\Routing\Redirector;
 
-class RoutingRedirectorTest extends PHPUnit_Framework_TestCase
+class RoutingRedirectorTest extends TestCase
 {
     protected $headers;
     protected $request;

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -3,6 +3,7 @@
 use Illuminate\Http\Request;
 use Illuminate\Routing\Route;
 use Illuminate\Routing\Router;
+use PHPUnit\Framework\TestCase;
 use Illuminate\Events\Dispatcher;
 use Illuminate\Routing\Controller;
 use Illuminate\Routing\RouteGroup;
@@ -15,7 +16,7 @@ use Illuminate\Auth\Middleware\Authenticate;
 use Symfony\Component\HttpFoundation\Response;
 use Illuminate\Routing\Middleware\SubstituteBindings;
 
-class RoutingRouteTest extends PHPUnit_Framework_TestCase
+class RoutingRouteTest extends TestCase
 {
     public function testBasicDispatchingOfRoutes()
     {

--- a/tests/Routing/RoutingSortedMiddlewareTest.php
+++ b/tests/Routing/RoutingSortedMiddlewareTest.php
@@ -1,8 +1,9 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
 use Illuminate\Routing\SortedMiddleware;
 
-class RoutingSortedMiddlewareTest extends PHPUnit_Framework_TestCase
+class RoutingSortedMiddlewareTest extends TestCase
 {
     public function testMiddlewareCanBeSortedByPriority()
     {

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -2,11 +2,12 @@
 
 use Illuminate\Http\Request;
 use Illuminate\Routing\Route;
+use PHPUnit\Framework\TestCase;
 use Illuminate\Routing\UrlGenerator;
 use Illuminate\Routing\RouteCollection;
 use Illuminate\Contracts\Routing\UrlRoutable;
 
-class RoutingUrlGeneratorTest extends PHPUnit_Framework_TestCase
+class RoutingUrlGeneratorTest extends TestCase
 {
     public function testBasicGeneration()
     {

--- a/tests/Session/EncryptedSessionStoreTest.php
+++ b/tests/Session/EncryptedSessionStoreTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 
-class EncryptedSessionStoreTest extends PHPUnit_Framework_TestCase
+class EncryptedSessionStoreTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/Session/SessionStoreTest.php
+++ b/tests/Session/SessionStoreTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 
-class SessionStoreTest extends PHPUnit_Framework_TestCase
+class SessionStoreTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/Session/SessionTableCommandTest.php
+++ b/tests/Session/SessionTableCommandTest.php
@@ -1,10 +1,11 @@
 <?php
 
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 use Illuminate\Foundation\Application;
 use Illuminate\Session\Console\SessionTableCommand;
 
-class SessionTableCommandTest extends PHPUnit_Framework_TestCase
+class SessionTableCommandTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -1,9 +1,10 @@
 <?php
 
 use Illuminate\Support\Arr;
+use PHPUnit\Framework\TestCase;
 use Illuminate\Support\Collection;
 
-class SupportArrTest extends PHPUnit_Framework_TestCase
+class SupportArrTest extends TestCase
 {
     public function testAccessible()
     {

--- a/tests/Support/SupportCapsuleManagerTraitTest.php
+++ b/tests/Support/SupportCapsuleManagerTraitTest.php
@@ -1,10 +1,11 @@
 <?php
 
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 use Illuminate\Container\Container;
 use Illuminate\Support\Traits\CapsuleManagerTrait;
 
-class SupportCapsuleManagerTraitTest extends PHPUnit_Framework_TestCase
+class SupportCapsuleManagerTraitTest extends TestCase
 {
     use CapsuleManagerTrait;
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1,11 +1,12 @@
 <?php
 
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 use Illuminate\Support\Collection;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Contracts\Support\Arrayable;
 
-class SupportCollectionTest extends PHPUnit_Framework_TestCase
+class SupportCollectionTest extends TestCase
 {
     public function testFirstReturnsFirstItemInCollection()
     {

--- a/tests/Support/SupportFacadeTest.php
+++ b/tests/Support/SupportFacadeTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 
-class SupportFacadeTest extends PHPUnit_Framework_TestCase
+class SupportFacadeTest extends TestCase
 {
     public function setUp()
     {

--- a/tests/Support/SupportFluentTest.php
+++ b/tests/Support/SupportFluentTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Illuminate\Support\Fluent;
+use PHPUnit\Framework\TestCase;
 
-class SupportFluentTest extends PHPUnit_Framework_TestCase
+class SupportFluentTest extends TestCase
 {
     public function testAttributesAreSetByConstructor()
     {

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -2,8 +2,9 @@
 
 use Mockery as m;
 use Illuminate\Support\Str;
+use PHPUnit\Framework\TestCase;
 
-class SupportHelpersTest extends PHPUnit_Framework_TestCase
+class SupportHelpersTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/Support/SupportHtmlStringTest.php
+++ b/tests/Support/SupportHtmlStringTest.php
@@ -1,8 +1,9 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
 use Illuminate\Support\HtmlString;
 
-class SupportHtmlStringTest extends PHPUnit_Framework_TestCase
+class SupportHtmlStringTest extends TestCase
 {
     public function testToHtml()
     {

--- a/tests/Support/SupportMacroableTest.php
+++ b/tests/Support/SupportMacroableTest.php
@@ -1,8 +1,9 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
 use Illuminate\Support\Traits\Macroable;
 
-class SupportMacroableTest extends PHPUnit_Framework_TestCase
+class SupportMacroableTest extends TestCase
 {
     private $macroable;
 

--- a/tests/Support/SupportMessageBagTest.php
+++ b/tests/Support/SupportMessageBagTest.php
@@ -1,9 +1,10 @@
 <?php
 
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 use Illuminate\Support\MessageBag;
 
-class SupportMessageBagTest extends PHPUnit_Framework_TestCase
+class SupportMessageBagTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/Support/SupportNamespacedItemResolverTest.php
+++ b/tests/Support/SupportNamespacedItemResolverTest.php
@@ -1,8 +1,9 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
 use Illuminate\Support\NamespacedItemResolver;
 
-class SupportNamespacedItemResolverTest extends PHPUnit_Framework_TestCase
+class SupportNamespacedItemResolverTest extends TestCase
 {
     public function testResolution()
     {

--- a/tests/Support/SupportPluralizerTest.php
+++ b/tests/Support/SupportPluralizerTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Illuminate\Support\Str;
+use PHPUnit\Framework\TestCase;
 
-class SupportPluralizerTest extends PHPUnit_Framework_TestCase
+class SupportPluralizerTest extends TestCase
 {
     public function testBasicSingular()
     {

--- a/tests/Support/SupportServiceProviderTest.php
+++ b/tests/Support/SupportServiceProviderTest.php
@@ -1,9 +1,10 @@
 <?php
 
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 use Illuminate\Support\ServiceProvider;
 
-class SupportServiceProviderTest extends PHPUnit_Framework_TestCase
+class SupportServiceProviderTest extends TestCase
 {
     public function setUp()
     {

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Illuminate\Support\Str;
+use PHPUnit\Framework\TestCase;
 
-class SupportStrTest extends PHPUnit_Framework_TestCase
+class SupportStrTest extends TestCase
 {
     /**
      * Test the Str::words method.

--- a/tests/Translation/TranslationFileLoaderTest.php
+++ b/tests/Translation/TranslationFileLoaderTest.php
@@ -1,9 +1,10 @@
 <?php
 
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 use Illuminate\Translation\FileLoader;
 
-class TranslationFileLoaderTest extends PHPUnit_Framework_TestCase
+class TranslationFileLoaderTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/Translation/TranslationMessageSelectorTest.php
+++ b/tests/Translation/TranslationMessageSelectorTest.php
@@ -1,8 +1,9 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
 use Illuminate\Translation\MessageSelector;
 
-class TranslationMessageSelectorTest extends PHPUnit_Framework_TestCase
+class TranslationMessageSelectorTest extends TestCase
 {
     /**
      * @dataProvider chooseTestData

--- a/tests/Translation/TranslationTranslatorTest.php
+++ b/tests/Translation/TranslationTranslatorTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 
-class TranslationTranslatorTest extends PHPUnit_Framework_TestCase
+class TranslationTranslatorTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/Validation/ValidationDatabasePresenceVerifierTest.php
+++ b/tests/Validation/ValidationDatabasePresenceVerifierTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 
-class ValidationDatabasePresenceVerifierTest extends PHPUnit_Framework_TestCase
+class ValidationDatabasePresenceVerifierTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/Validation/ValidationDimensionsRuleTest.php
+++ b/tests/Validation/ValidationDimensionsRuleTest.php
@@ -1,9 +1,10 @@
 <?php
 
 use Illuminate\Validation\Rule;
+use PHPUnit\Framework\TestCase;
 use Illuminate\Validation\Rules\Dimensions;
 
-class ValidationDimensionsRuleTest extends PHPUnit_Framework_TestCase
+class ValidationDimensionsRuleTest extends TestCase
 {
     public function testItCorrectlyFormatsAStringVersionOfTheRule()
     {

--- a/tests/Validation/ValidationExistsRuleTest.php
+++ b/tests/Validation/ValidationExistsRuleTest.php
@@ -1,6 +1,8 @@
 <?php
 
-class ValidationExistsRuleTest extends PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class ValidationExistsRuleTest extends TestCase
 {
     public function testItCorrectlyFormatsAStringVersionOfTheRule()
     {

--- a/tests/Validation/ValidationFactoryTest.php
+++ b/tests/Validation/ValidationFactoryTest.php
@@ -1,12 +1,13 @@
 <?php
 
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 use Illuminate\Validation\Factory;
 use Illuminate\Validation\Validator;
 use Illuminate\Validation\PresenceVerifierInterface;
 use Illuminate\Contracts\Translation\Translator as TranslatorInterface;
 
-class ValidationFactoryTest extends PHPUnit_Framework_TestCase
+class ValidationFactoryTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/Validation/ValidationInRuleTest.php
+++ b/tests/Validation/ValidationInRuleTest.php
@@ -1,9 +1,10 @@
 <?php
 
 use Illuminate\Validation\Rule;
+use PHPUnit\Framework\TestCase;
 use Illuminate\Validation\Rules\In;
 
-class ValidationInRuleTest extends PHPUnit_Framework_TestCase
+class ValidationInRuleTest extends TestCase
 {
     public function testItCorrectlyFormatsAStringVersionOfTheRule()
     {

--- a/tests/Validation/ValidationNotInRuleTest.php
+++ b/tests/Validation/ValidationNotInRuleTest.php
@@ -1,9 +1,10 @@
 <?php
 
 use Illuminate\Validation\Rule;
+use PHPUnit\Framework\TestCase;
 use Illuminate\Validation\Rules\NotIn;
 
-class ValidationNotInRuleTest extends PHPUnit_Framework_TestCase
+class ValidationNotInRuleTest extends TestCase
 {
     public function testItCorrectlyFormatsAStringVersionOfTheRule()
     {

--- a/tests/Validation/ValidationRuleTest.php
+++ b/tests/Validation/ValidationRuleTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Illuminate\Validation\Rule;
+use PHPUnit\Framework\TestCase;
 
-class ValidationRuleTest extends PHPUnit_Framework_TestCase
+class ValidationRuleTest extends TestCase
 {
     public function testMacroable()
     {

--- a/tests/Validation/ValidationUniqueRuleTest.php
+++ b/tests/Validation/ValidationUniqueRuleTest.php
@@ -1,6 +1,8 @@
 <?php
 
-class ValidationUniqueRuleTest extends PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class ValidationUniqueRuleTest extends TestCase
 {
     public function testItCorrectlyFormatsAStringVersionOfTheRule()
     {

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -2,12 +2,13 @@
 
 use Mockery as m;
 use Carbon\Carbon;
+use PHPUnit\Framework\TestCase;
 use Illuminate\Validation\Validator;
 use Illuminate\Validation\Rules\Exists;
 use Illuminate\Validation\Rules\Unique;
 use Symfony\Component\HttpFoundation\File\File;
 
-class ValidationValidatorTest extends PHPUnit_Framework_TestCase
+class ValidationValidatorTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -1,9 +1,10 @@
 <?php
 
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 use Illuminate\View\Compilers\BladeCompiler;
 
-class ViewBladeCompilerTest extends PHPUnit_Framework_TestCase
+class ViewBladeCompilerTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/View/ViewCompilerEngineTest.php
+++ b/tests/View/ViewCompilerEngineTest.php
@@ -1,9 +1,10 @@
 <?php
 
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 use Illuminate\View\Engines\CompilerEngine;
 
-class ViewCompilerEngineTest extends PHPUnit_Framework_TestCase
+class ViewCompilerEngineTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/View/ViewEngineResolverTest.php
+++ b/tests/View/ViewEngineResolverTest.php
@@ -1,6 +1,8 @@
 <?php
 
-class ViewEngineResolverTest extends PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class ViewEngineResolverTest extends TestCase
 {
     public function testResolversMayBeResolved()
     {

--- a/tests/View/ViewFactoryTest.php
+++ b/tests/View/ViewFactoryTest.php
@@ -2,8 +2,9 @@
 
 use Mockery as m;
 use Illuminate\View\Factory;
+use PHPUnit\Framework\TestCase;
 
-class ViewFactoryTest extends PHPUnit_Framework_TestCase
+class ViewFactoryTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/View/ViewFileViewFinderTest.php
+++ b/tests/View/ViewFileViewFinderTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 
-class ViewFinderTest extends PHPUnit_Framework_TestCase
+class ViewFinderTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/View/ViewPhpEngineTest.php
+++ b/tests/View/ViewPhpEngineTest.php
@@ -1,9 +1,10 @@
 <?php
 
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 use Illuminate\View\Engines\PhpEngine;
 
-class ViewPhpEngineTest extends PHPUnit_Framework_TestCase
+class ViewPhpEngineTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/View/ViewTest.php
+++ b/tests/View/ViewTest.php
@@ -2,8 +2,9 @@
 
 use Mockery as m;
 use Illuminate\View\View;
+use PHPUnit\Framework\TestCase;
 
-class ViewTest extends PHPUnit_Framework_TestCase
+class ViewTest extends TestCase
 {
     public function tearDown()
     {


### PR DESCRIPTION
Switched to the namespaced `PHPUnit\Framework\TestCase` class from `PHPUnit_Framework_TestCase` in preparation for PHPUnit 6.0 (already available in version 5).

See this tweet by @sebastianbergmann: https://twitter.com/s_bergmann/status/814846275099181056