### PR TITLE
[5.3] Add set application namespace manually

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -1128,6 +1128,17 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     }
 
     /**
+     * Set the application namespace manually.
+     *
+     * @param  string  $namespace
+     * @return void
+     */
+    public function setNamespace($namespace)
+    {
+        $this->namespace = $namespace;
+    }
+
+    /**
      * Get the application namespace.
      *
      * @return string

--- a/tests/Foundation/FoundationApplicationTest.php
+++ b/tests/Foundation/FoundationApplicationTest.php
@@ -168,6 +168,14 @@ class FoundationApplicationTest extends PHPUnit_Framework_TestCase
         $this->assertArrayHasKey(0, $app['events']->getListeners('bootstrapped: Illuminate\Foundation\Bootstrap\RegisterFacades'));
         $this->assertSame($closure, $app['events']->getListeners('bootstrapped: Illuminate\Foundation\Bootstrap\RegisterFacades')[0]);
     }
+
+    public function testSetNamespaceManually()
+    {
+        $app = new Application;
+        $namespace = 'Acme\\';
+        $app->setNamespace($namespace);
+        $this->assertSame($namespace, $app->getNamespace());
+    }
 }
 
 class ApplicationBasicServiceProviderStub extends Illuminate\Support\ServiceProvider


### PR DESCRIPTION
I have a problem where the composer.json file is not placed in the same folder as the project it self.

My folder structure:

```
/composer.json
/lara/app/*
/lara/bootstrap/*
/lara/config/*
...
```

So when the `getNamespace()` methode is used on the `\Illumintate\Foundation\Application` class it will not find my composer.json file.

This problem will be solved easily by adding a `setNamespace` methode to the application class.