### PR TITLE
[5.4] Adjust app() to work with the new container changes

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -93,17 +93,16 @@ if (! function_exists('app')) {
     /**
      * Get the available container instance.
      *
-     * @param  string  $make
-     * @param  array   $parameters
+     * @param  string  $abstract
      * @return mixed|\Illuminate\Foundation\Application
      */
-    function app($make = null, $parameters = [])
+    function app($abstract = null)
     {
-        if (is_null($make)) {
+        if (is_null($abstract)) {
             return Container::getInstance();
         }
 
-        return Container::getInstance()->make($make, $parameters);
+        return Container::getInstance()->make($abstract);
     }
 }
 
@@ -636,12 +635,11 @@ if (! function_exists('resolve')) {
      * Resolve a service from the container.
      *
      * @param  string  $name
-     * @param  array  $parameters
      * @return mixed
      */
-    function resolve($name, $parameters = [])
+    function resolve($name)
     {
-        return app($name, $parameters);
+        return app($name);
     }
 }
 


### PR DESCRIPTION
@taylorotwell Since `resolve()` is just an alias to `app()` maybe is time to stop providing it? If you do not think so, please let me know.