### PR TITLE
[5.3] Fix the error page being rendered twice

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -6,6 +6,7 @@ use Closure;
 use LogicException;
 use ReflectionMethod;
 use ReflectionFunction;
+use ReflectionException;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Http\Request;
@@ -308,13 +309,29 @@ class Route
      */
     public function controllerMiddleware()
     {
-        if (! $this->isControllerAction()) {
+        if (! $this->isControllerAction() || ! $this->hasValidController()) {
             return [];
         }
 
         return ControllerDispatcher::getMiddleware(
             $this->getController(), $this->getControllerMethod()
         );
+    }
+
+    /**
+     * Checks if the controller class associated with this route is instantiable.
+     *
+     * @return bool
+     */
+    public function hasValidController()
+    {
+        try {
+            $this->container->make(explode('@', $this->action['uses'])[0]);
+        } catch (ReflectionException $e) {
+            return false;
+        }
+
+        return true;
     }
 
     /**

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -1188,6 +1188,23 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('hello', $router->dispatch(Request::create('foo/bar2', 'GET'))->getContent());
     }
 
+    public function testRouteHasValidControllerWorksProperly()
+    {
+        $router = $this->getRouter();
+
+        $route = $router->get('foo/bar', ['uses' => 'NonExistantController@method']);
+        $this->assertEquals(false, $route->hasValidController());
+
+        $route2 = $router->get('foo/bar2', ['uses' => 'RouteTestControllerStub@index']);
+        $this->assertEquals(true, $route2->hasValidController());
+
+        $route3 = $router->get('foo/bar3', 'NonExistantController@method');
+        $this->assertEquals(false, $route3->hasValidController());
+
+        $route4 = $router->get('foo/bar4', 'RouteTestControllerStub@index');
+        $this->assertEquals(true, $route4->hasValidController());
+    }
+
     protected function getRouter()
     {
         $container = new Container;


### PR DESCRIPTION
Fix the error page being rendered twice when route uses a controller that doesn't exist.

This commit is a fix for this issue:

https://github.com/laravel/framework/issues/17007

It happens because the Route class doesn't check whether the controller is valid before attempting to gather its middleware. I've added a check that makes sure the container can resolve it. If not, we won't bother searching for the middleware and return an empty array instead.

This gets rid of the error page being rendered twice.