### PR TITLE
[5.3] Allow middleware to be removed in controller.

### DIFF
--- a/src/Illuminate/Routing/Controller.php
+++ b/src/Illuminate/Routing/Controller.php
@@ -44,6 +44,38 @@ abstract class Controller
     }
 
     /**
+     * Remove middleware.
+     *
+     * @param  string|array  $middleware
+     * @return $this
+     */
+    protected function removeMiddleware($middleware)
+    {
+        foreach ((array) $middleware as $m) {
+            if ($this->hasMiddleware($m)) {
+                $names = array_column($this->middleware, 'middleware');
+                $index = array_search($m, $names);
+                unset($this->middleware[$index]);
+            }
+        }
+
+        return $this;
+    }
+
+    /**
+     * Determine if middleware exists.
+     *
+     * @param  string  $middleware
+     * @return bool
+     */
+    protected function hasMiddleware($middleware)
+    {
+        $names = array_column($this->middleware, 'middleware');
+
+        return !(false === array_search($middleware, $names));
+    }
+
+    /**
      * Execute an action on the controller.
      *
      * @param  string  $method

--- a/src/Illuminate/Routing/Controller.php
+++ b/src/Illuminate/Routing/Controller.php
@@ -72,7 +72,7 @@ abstract class Controller
     {
         $names = array_column($this->middleware, 'middleware');
 
-        return !(false === array_search($middleware, $names));
+        return ! (false === array_search($middleware, $names));
     }
 
     /**


### PR DESCRIPTION
I needed this in a project recently where I had a inheritance of controllers but one of my very edge controllers I needed to remove a single middleware from, but still get all the goodness.

Edge case kinda thing, and maybe not something Laravel will want to promote, but I thought I'd see what thoughts were on including it in the core anyway.