### PR TITLE
[5.5] Add where whereWeekOfYear in query builder

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1167,6 +1167,24 @@ class Builder
     }
 
     /**
+     * Add a "where week of year" statement to the query.
+     *
+     * @param  string  $column
+     * @param  string  $operator
+     * @param  mixed  $value
+     * @param  string  $boolean
+     * @return \Illuminate\Database\Query\Builder|static
+     */
+    public function whereWeekOfYear($column, $operator, $value = null, $boolean = 'and')
+    {
+        list($value, $operator) = $this->prepareValueAndOperator(
+            $value, $operator, func_num_args() == 2
+        );
+
+        return $this->addDateBasedWhere('WeekOfYear', $column, $operator, $value, $boolean);
+    }
+
+    /**
      * Add a date based (year, month, day, time) statement to the query.
      *
      * @param  string  $type

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -439,6 +439,18 @@ class Grammar extends BaseGrammar
     }
 
     /**
+     * Compile a "where week of year" clause.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  array  $where
+     * @return string
+     */
+    public function whereWeekOfYear(Builder $query, $where)
+    {
+        return $this->dateBasedWhere('WEEKOFYEAR', $query, $where);
+    }
+
+    /**
      * Compile a date based where clause.
      *
      * @param  string  $type

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -188,6 +188,10 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('users')->whereyear('created_at', 1);
         $this->assertEquals('select * from `users` where year(`created_at`) = ?', $builder->toSql());
+
+        $builder = $this->getMySqlBuilder();
+        $builder->select('*')->from('users')->whereWeekOfYear('created_at', 1);
+        $this->assertEquals('select * from `users` where WEEKOFYEAR(`created_at`) = ?', $builder->toSql());
     }
 
     public function testWhereDayMySql()
@@ -212,6 +216,14 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase
         $builder->select('*')->from('users')->whereYear('created_at', '=', 2014);
         $this->assertEquals('select * from `users` where year(`created_at`) = ?', $builder->toSql());
         $this->assertEquals([0 => 2014], $builder->getBindings());
+    }
+
+    public function testWhereWeekOfYearMySql()
+    {
+        $builder = $this->getMySqlBuilder();
+        $builder->select('*')->from('users')->whereWeekOfYear('created_at', '=', 32);
+        $this->assertEquals('select * from `users` where WEEKOFYEAR(`created_at`) = ?', $builder->toSql());
+        $this->assertEquals([0 => 32], $builder->getBindings());
     }
 
     public function testWhereTimeMySql()
@@ -254,6 +266,14 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase
         $this->assertEquals([0 => 2014], $builder->getBindings());
     }
 
+    public function testWhereWeekOfYearPostgres()
+    {
+        $builder = $this->getPostgresBuilder();
+        $builder->select('*')->from('users')->whereWeekOfYear('created_at', '=', 32);
+        $this->assertEquals('select * from "users" where extract(WEEKOFYEAR from "created_at") = ?', $builder->toSql());
+        $this->assertEquals([0 => 32], $builder->getBindings());
+    }
+
     public function testWhereDaySqlite()
     {
         $builder = $this->getSQLiteBuilder();
@@ -278,6 +298,14 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase
         $this->assertEquals([0 => 2014], $builder->getBindings());
     }
 
+    public function testWhereWeekOfYearSqlite()
+    {
+        $builder = $this->getSQLiteBuilder();
+        $builder->select('*')->from('users')->whereWeekOfYear('created_at', '=', 32);
+        $this->assertEquals('select * from "users" where strftime(\'WEEKOFYEAR\', "created_at") = ?', $builder->toSql());
+        $this->assertEquals([0 => 32], $builder->getBindings());
+    }
+
     public function testWhereDaySqlServer()
     {
         $builder = $this->getSqlServerBuilder();
@@ -300,6 +328,14 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase
         $builder->select('*')->from('users')->whereYear('created_at', '=', 2014);
         $this->assertEquals('select * from [users] where year([created_at]) = ?', $builder->toSql());
         $this->assertEquals([0 => 2014], $builder->getBindings());
+    }
+
+    public function testWhereWeekOfYearSqlServer()
+    {
+        $builder = $this->getSqlServerBuilder();
+        $builder->select('*')->from('users')->whereWeekOfYear('created_at', '=', 32);
+        $this->assertEquals('select * from [users] where WEEKOFYEAR([created_at]) = ?', $builder->toSql());
+        $this->assertEquals([0 => 32], $builder->getBindings());
     }
 
     public function testWhereBetweens()


### PR DESCRIPTION
add a WEEKOFYEAR in query builder, user like

``` 
$users = User::whereWeek('created_at', 32)
    ->get()
 ```

or 
```
$users = DB::table('users')
    ->whereWeek('created_at', 32)
    ->get();
```