### PR TITLE
[5.4] Unused argument is removed

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -687,10 +687,9 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
      * (Overriding Container::make)
      *
      * @param  string  $abstract
-     * @param  array   $parameters
      * @return mixed
      */
-    public function make($abstract, array $parameters = [])
+    public function make($abstract)
     {
         $abstract = $this->getAlias($abstract);
 
@@ -698,7 +697,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
             $this->loadDeferredProvider($abstract);
         }
 
-        return parent::make($abstract, $parameters);
+        return parent::make($abstract);
     }
 
     /**


### PR DESCRIPTION
Container@make is not accepting $parameters argument anymore.

The make() method no longer accepts a second argument of parameters - needing this feature indicates a code smell and you can always construct the object in another way.

https://github.com/laravel/framework/commit/ff993b806dcb21ba8a5367594e87d113338c1670#diff-51bfc610692c3ed3388dec0ec04bd3baL116