### PR TITLE
[5.4] Change unauthorized to response

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -113,7 +113,7 @@ class Handler implements ExceptionHandlerContract
         } elseif ($e instanceof AuthenticationException) {
             return $this->unauthenticated($request, $e);
         } elseif ($e instanceof AuthorizationException) {
-            return $this->unauthorized($request, $e);            
+            return $this->unauthorized($request, $e);
         } elseif ($e instanceof ValidationException) {
             return $this->convertValidationExceptionToResponse($e, $request);
         }

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -112,6 +112,8 @@ class Handler implements ExceptionHandlerContract
             return $e->getResponse();
         } elseif ($e instanceof AuthenticationException) {
             return $this->unauthenticated($request, $e);
+        } elseif ($e instanceof AuthorizationException) {
+            return $this->unauthorized($request, $e);            
         } elseif ($e instanceof ValidationException) {
             return $this->convertValidationExceptionToResponse($e, $request);
         }
@@ -129,8 +131,6 @@ class Handler implements ExceptionHandlerContract
     {
         if ($e instanceof ModelNotFoundException) {
             $e = new NotFoundHttpException($e->getMessage(), $e);
-        } elseif ($e instanceof AuthorizationException) {
-            $e = new HttpException(403, $e->getMessage());
         }
 
         return $e;


### PR DESCRIPTION
This PR is an idea to change the `unauthorized` exception to be similar to the `unauthenticated` exception - in that you can handle it globally however you like in your `App\Exception` yourself.

I was going to put this in Internals - but I thought it would be easier to show the code as a PR.