### PR TITLE
[5.3] Add drop method to collection

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1119,7 +1119,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      * Drop the first {$limit} items from the collection.
      *
      * @param  int  $limit
-     * @return  static
+     * @return static
      */
     public function drop($limit)
     {

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1116,6 +1116,21 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
+     * Drop the first {$limit} items from the collection.
+     *
+     * @param  int  $limit
+     * @return  static
+     */
+    public function drop($limit)
+    {
+        if ($limit < 0) {
+            $limit = abs($limit);
+        }
+
+        return $this->slice($limit, $this->count());
+    }
+
+    /**
      * Transform each item in the collection using a callback.
      *
      * @param  callable  $callback

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1124,10 +1124,10 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     public function drop($limit)
     {
         if ($limit < 0) {
-            $limit = abs($limit);
+            return $this->slice(0, $limit);
         }
 
-        return $this->slice($limit, $this->count());
+        return $this->slice($limit);
     }
 
     /**

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1710,6 +1710,41 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
             return true;
         }));
     }
+
+    public function testDropSingleItemFromCollection()
+    {
+        $expected = [
+            1 => 'bar',
+            2 => 'baz',
+            3 => 'qux',
+        ];
+        $collection = new Collection(['foo', 'bar', 'baz', 'qux']);
+
+        $this->assertEquals($expected, $collection->drop(1)->toArray());
+    }
+
+    public function testDropMultipleItemsFromCollection()
+    {
+        $expected = [3 => 'qux'];
+        $collection = new Collection(['foo', 'bar', 'baz', 'qux']);
+
+        $this->assertEquals($expected, $collection->drop(3)->toArray());
+    }
+
+    public function testDropEmptyCollection()
+    {
+        $collection = new Collection();
+
+        $this->assertEquals([], $collection->drop(2)->toArray());
+    }
+
+    public function testDropNegativeLimit()
+    {
+        $expected = [2 => 'baz'];
+        $collection = new Collection(['foo', 'bar', 'baz']);
+
+        $this->assertEquals($expected, $collection->drop(-2)->toArray());
+    }
 }
 
 class TestAccessorEloquentTestStub

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1740,7 +1740,7 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
 
     public function testDropNegativeLimit()
     {
-        $expected = [2 => 'baz'];
+        $expected = [0 => 'foo'];
         $collection = new Collection(['foo', 'bar', 'baz']);
 
         $this->assertEquals($expected, $collection->drop(-2)->toArray());


### PR DESCRIPTION
Adds a `drop` method to the collection class. It removes the first `$limit` items from the collection. Serves as the counterpart to `take`.

Example:

```php
$collection = new Collection([1, 2, 3, 4]);
$collection->drop(2)->toArray();
// [3, 4]
```