### PR TITLE
Adding batch option to migrate:refresh command

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/RefreshCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/RefreshCommand.php
@@ -41,12 +41,21 @@ class RefreshCommand extends Command
 
         $path = $this->input->getOption('path');
 
+        // If the "batch" flag is specified it means we only want to rollback and re-run
+        // the last batch of migrations. This allows the developer to easily rollback
+        // a number of migrations without counting steps or rolling back them all.
+        $batch = $this->input->getOption('batch');
+
         // If the "step" option is specified it means we only want to rollback a small
         // number of migrations before migrating again. For example, the user might
         // only rollback and remigrate the latest four migrations instead of all.
         $step = $this->input->getOption('step') ?: 0;
 
-        if ($step > 0) {
+        if ($batch) {
+            $this->call('migrate:rollback', [
+                '--database' => $database, '--force' => $force, '--path' => $path,
+            ]);
+        } elseif ($step > 0) {
             $this->call('migrate:rollback', [
                 '--database' => $database, '--force' => $force, '--path' => $path, '--step' => $step,
             ]);
@@ -105,6 +114,8 @@ class RefreshCommand extends Command
     protected function getOptions()
     {
         return [
+            ['batch', null, InputOption::VALUE_NONE, 'Indicates if the last batch of migrations should be reverted & re-run.'],
+
             ['database', null, InputOption::VALUE_OPTIONAL, 'The database connection to use.'],
 
             ['force', null, InputOption::VALUE_NONE, 'Force the operation to run when in production.'],


### PR DESCRIPTION
# Add Batch Option to RefreshCommand

_Recreating https://github.com/laravel/framework/pull/17075 against 5.4_

This change adds a new flag to the migrate:refresh artisan command that reverts and re-runs all migrations that were run in the last batch.

The refresh command already has functionality to support refreshing all migrations from the beginning of a project, or a specific number of migrations via the `step` option, which work well in most situations. However, there are a number of times when it can be useful to rerun every migration in the last batch, without refreshing _all_ migrations, and without having to count the number included to use the `step` option.

## Usage
`php artisan migrate:refresh --batch`
```
$ php artisan help migrate:refresh
Usage:
  migrate:refresh [options]

Options:
      --batch                Indicates if the last batch of migrations should be reverted & re-run.
      --database[=DATABASE]  The database connection to use.
      --force                Force the operation to run when in production.
      ...
```