### PR TITLE
[5.4] Change how frequencies are tested for schedule

### DIFF
--- a/tests/Console/ConsoleScheduledEventTest.php
+++ b/tests/Console/ConsoleScheduledEventTest.php
@@ -53,30 +53,6 @@ class ConsoleScheduledEventTest extends TestCase
             return false;
         })->filtersPass($app));
 
-        $event = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php foo');
-        $this->assertEquals('*/5 * * * * *', $event->everyFiveMinutes()->getExpression());
-
-        $event = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php foo');
-        $this->assertEquals('0 0 * * * *', $event->daily()->getExpression());
-
-        $event = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php foo');
-        $this->assertEquals('0 3,15 * * * *', $event->twiceDaily(3, 15)->getExpression());
-
-        $event = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php foo');
-        $this->assertEquals('*/5 * * * 3 *', $event->everyFiveMinutes()->wednesdays()->getExpression());
-
-        $event = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php foo');
-        $this->assertEquals('0 * * * * *', $event->everyFiveMinutes()->hourly()->getExpression());
-
-        $event = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php foo');
-        $this->assertEquals('0 15 4 * * *', $event->monthlyOn(4, '15:00')->getExpression());
-
-        $event = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php foo');
-        $this->assertEquals('0 0 * * 1-5 *', $event->weekdays()->daily()->getExpression());
-
-        $event = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php foo');
-        $this->assertEquals('0 * * * 1-5 *', $event->weekdays()->hourly()->getExpression());
-
         // chained rules should be commutative
         $eventA = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php foo');
         $eventB = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php foo');

--- a/tests/Console/Scheduling/FrequencyTest.php
+++ b/tests/Console/Scheduling/FrequencyTest.php
@@ -1,7 +1,8 @@
 <?php
 
+use Mockery as m;
 use PHPUnit\Framework\TestCase;
-use Illuminate\Console\Scheduling\ManagesFrequencies;
+use Illuminate\Console\Scheduling\Event;
 
 class FrequencyTest extends TestCase
 {
@@ -12,19 +13,10 @@ class FrequencyTest extends TestCase
 
     public function setUp()
     {
-        /*
-         * Fake the Illuminate\Console\Scheduling\Event class
-         */
-        $this->event = new class {
-            use ManagesFrequencies;
-
-            public $expression = '* * * * * *';
-
-            public function getExpression()
-            {
-                return $this->expression;
-            }
-        };
+        $this->event = new Event(
+            m::mock('Illuminate\Contracts\Cache\Repository'),
+            'php foo'
+        );
     }
 
     public function testEveryMinute()

--- a/tests/Console/Scheduling/FrequencyTest.php
+++ b/tests/Console/Scheduling/FrequencyTest.php
@@ -1,19 +1,18 @@
 <?php
 
-use Illuminate\Console\Scheduling\ManagesFrequencies;
-use Mockery as m;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Console\Scheduling\ManagesFrequencies;
 
 class FrequencyTest extends TestCase
 {
-    /**
+    /*
      * @var \Illuminate\Console\Scheduling\Event
      */
     protected $event;
 
     public function setUp()
     {
-        /**
+        /*
          * Fake the Illuminate\Console\Scheduling\Event class
          */
         $this->event = new class {
@@ -36,7 +35,7 @@ class FrequencyTest extends TestCase
 
     public function testEveryFiveMinutes()
     {
-        $this->assertEquals("*/5 * * * * *", $this->event->everyFiveMinutes()->getExpression());
+        $this->assertEquals('*/5 * * * * *', $this->event->everyFiveMinutes()->getExpression());
     }
 
     public function testDaily()

--- a/tests/Console/Scheduling/FrequencyTest.php
+++ b/tests/Console/Scheduling/FrequencyTest.php
@@ -1,0 +1,167 @@
+<?php
+
+use Illuminate\Console\Scheduling\ManagesFrequencies;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+
+class FrequencyTest extends TestCase
+{
+    /**
+     * @var \Illuminate\Console\Scheduling\Event
+     */
+    protected $event;
+
+    public function setUp()
+    {
+        /**
+         * Fake the Illuminate\Console\Scheduling\Event class
+         */
+        $this->event = new class {
+            use ManagesFrequencies;
+
+            public $expression = '* * * * * *';
+
+            public function getExpression()
+            {
+                return $this->expression;
+            }
+        };
+    }
+
+    /**
+     * @test
+     */
+    function every_minute()
+    {
+        $this->assertEquals('* * * * * *', $this->event->getExpression());
+        $this->assertEquals('* * * * * *', $this->event->everyMinute()->getExpression());
+    }
+
+    /**
+     * @test
+     */
+    function every_five_minutes()
+    {
+        $this->assertEquals("*/5 * * * * *", $this->event->everyFiveMinutes()->getExpression());
+    }
+
+    /**
+     * @test
+     */
+    function daily()
+    {
+        $this->assertEquals('0 0 * * * *', $this->event->daily()->getExpression());
+    }
+
+    /**
+     * @test
+     */
+    function twice_daily()
+    {
+        $this->assertEquals('0 3,15 * * * *', $this->event->twiceDaily(3, 15)->getExpression());
+    }
+
+    /**
+     * @test
+     */
+    function override_with_hourly()
+    {
+        $this->assertEquals('0 * * * * *', $this->event->everyFiveMinutes()->hourly()->getExpression());
+    }
+
+    /**
+     * @test
+     */
+    function monthly_on()
+    {
+        $this->assertEquals('0 15 4 * * *', $this->event->monthlyOn(4, '15:00')->getExpression());
+    }
+
+    /**
+     * @test
+     */
+    function monthly_on_with_minutes()
+    {
+        $this->assertEquals('15 15 4 * * *', $this->event->monthlyOn(4, '15:15')->getExpression());
+    }
+
+    /**
+     * @test
+     */
+    function weekdays_daily()
+    {
+        $this->assertEquals('0 0 * * 1-5 *', $this->event->weekdays()->daily()->getExpression());
+    }
+
+    /**
+     * @test
+     */
+    function weekdays_hourly()
+    {
+        $this->assertEquals('0 * * * 1-5 *', $this->event->weekdays()->hourly()->getExpression());
+    }
+
+    /**
+     * @test
+     */
+    function weekdays()
+    {
+        $this->assertEquals('* * * * 1-5 *', $this->event->weekdays()->getExpression());
+    }
+
+    /**
+     * @test
+     */
+    function sunday()
+    {
+        $this->assertEquals('* * * * 0 *', $this->event->sundays()->getExpression());
+    }
+
+    /**
+     * @test
+     */
+    function monday()
+    {
+        $this->assertEquals('* * * * 1 *', $this->event->mondays()->getExpression());
+    }
+
+    /**
+     * @test
+     */
+    function tuesday()
+    {
+        $this->assertEquals('* * * * 2 *', $this->event->tuesdays()->getExpression());
+    }
+
+    /**
+     * @test
+     */
+    function wednesday()
+    {
+        $this->assertEquals('* * * * 3 *', $this->event->wednesdays()->getExpression());
+    }
+
+    /**
+     * @test
+     */
+    function thursday()
+    {
+        $this->assertEquals('* * * * 4 *', $this->event->thursdays()->getExpression());
+    }
+
+    /**
+     * @test
+     */
+    function friday()
+    {
+        $this->assertEquals('* * * * 5 *', $this->event->fridays()->getExpression());
+    }
+
+    /**
+     * @test
+     */
+    function saturday()
+    {
+        $this->assertEquals('* * * * 6 *', $this->event->saturdays()->getExpression());
+    }
+}

--- a/tests/Console/Scheduling/FrequencyTest.php
+++ b/tests/Console/Scheduling/FrequencyTest.php
@@ -28,139 +28,88 @@ class FrequencyTest extends TestCase
         };
     }
 
-    /**
-     * @test
-     */
-    function every_minute()
+    public function testEveryMinute()
     {
         $this->assertEquals('* * * * * *', $this->event->getExpression());
         $this->assertEquals('* * * * * *', $this->event->everyMinute()->getExpression());
     }
 
-    /**
-     * @test
-     */
-    function every_five_minutes()
+    public function testEveryFiveMinutes()
     {
         $this->assertEquals("*/5 * * * * *", $this->event->everyFiveMinutes()->getExpression());
     }
 
-    /**
-     * @test
-     */
-    function daily()
+    public function testDaily()
     {
         $this->assertEquals('0 0 * * * *', $this->event->daily()->getExpression());
     }
 
-    /**
-     * @test
-     */
-    function twice_daily()
+    public function testTwiceDaily()
     {
         $this->assertEquals('0 3,15 * * * *', $this->event->twiceDaily(3, 15)->getExpression());
     }
 
-    /**
-     * @test
-     */
-    function override_with_hourly()
+    public function testOverrideWithHourly()
     {
         $this->assertEquals('0 * * * * *', $this->event->everyFiveMinutes()->hourly()->getExpression());
     }
 
-    /**
-     * @test
-     */
-    function monthly_on()
+    public function testMonthlyOn()
     {
         $this->assertEquals('0 15 4 * * *', $this->event->monthlyOn(4, '15:00')->getExpression());
     }
 
-    /**
-     * @test
-     */
-    function monthly_on_with_minutes()
+    public function testMonthlyOnWithMinutes()
     {
         $this->assertEquals('15 15 4 * * *', $this->event->monthlyOn(4, '15:15')->getExpression());
     }
 
-    /**
-     * @test
-     */
-    function weekdays_daily()
+    public function testWeekdaysDaily()
     {
         $this->assertEquals('0 0 * * 1-5 *', $this->event->weekdays()->daily()->getExpression());
     }
 
-    /**
-     * @test
-     */
-    function weekdays_hourly()
+    public function testWeekdaysHourly()
     {
         $this->assertEquals('0 * * * 1-5 *', $this->event->weekdays()->hourly()->getExpression());
     }
 
-    /**
-     * @test
-     */
-    function weekdays()
+    public function testWeekdays()
     {
         $this->assertEquals('* * * * 1-5 *', $this->event->weekdays()->getExpression());
     }
 
-    /**
-     * @test
-     */
-    function sunday()
+    public function testSundays()
     {
         $this->assertEquals('* * * * 0 *', $this->event->sundays()->getExpression());
     }
 
-    /**
-     * @test
-     */
-    function monday()
+    public function testMondays()
     {
         $this->assertEquals('* * * * 1 *', $this->event->mondays()->getExpression());
     }
 
-    /**
-     * @test
-     */
-    function tuesday()
+    public function testTuesdays()
     {
         $this->assertEquals('* * * * 2 *', $this->event->tuesdays()->getExpression());
     }
 
-    /**
-     * @test
-     */
-    function wednesday()
+    public function testWednesdays()
     {
         $this->assertEquals('* * * * 3 *', $this->event->wednesdays()->getExpression());
     }
 
-    /**
-     * @test
-     */
-    function thursday()
+    public function testThursdays()
     {
         $this->assertEquals('* * * * 4 *', $this->event->thursdays()->getExpression());
     }
 
-    /**
-     * @test
-     */
-    function friday()
+    public function testFridays()
     {
         $this->assertEquals('* * * * 5 *', $this->event->fridays()->getExpression());
     }
 
-    /**
-     * @test
-     */
-    function saturday()
+    public function testSaturdays()
     {
         $this->assertEquals('* * * * 6 *', $this->event->saturdays()->getExpression());
     }


### PR DESCRIPTION
A change to how schedules are tested for their expression.

I opted to not use mocks, since Cache is not required for the tests to happen.

This, unfortunately, requries PHP 7.0+ to be done in this way, so if you wish to have support for the 5.6+, then this will be required:

```php
$this->event = new Event(
    m::mock('Illuminate\Contracts\Cache\Repository'),
    'php foo'
);
```

If https://github.com/laravel/framework/pull/17084 gets accepted, then this test is required:

```
/**
 * @test
 */
function every_x_minutes()
{
    $this->assertEquals("*/6 * * * * *", $this->event->everyXMinutes(6)->getExpression());
}
```

If https://github.com/laravel/framework/pull/17085 gets accepted, then this test is required:
```
/**
 * @test
 */
function weekends()
{
    $this->assertEquals("* * * * 0,6 *", $this->event->weekends()->getExpression());
}
```