### PR TITLE
[5.4] Fix the way the request post parameters are set

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -337,7 +337,9 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
 
         $request->content = $content;
 
-        $request->request = $request->getInputSource();
+        if($request->isJson()) {
+            $request->request = $request->json();
+        }
 
         return $request;
     }

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -337,7 +337,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
 
         $request->content = $content;
 
-        if($request->isJson()) {
+        if ($request->isJson()) {
             $request->request = $request->json();
         }
 

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -646,7 +646,7 @@ class HttpRequestTest extends TestCase
     public function testCreateFromBase()
     {
         $query = [
-            'foobar' => 'bar'
+            'foobar' => 'bar',
         ];
 
         $body = [

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -645,6 +645,10 @@ class HttpRequestTest extends TestCase
 
     public function testCreateFromBase()
     {
+        $query = [
+            'foobar' => 'bar'
+        ];
+
         $body = [
             'foo' => 'bar',
             'baz' => ['qux'],
@@ -654,11 +658,17 @@ class HttpRequestTest extends TestCase
             'CONTENT_TYPE' => 'application/json',
         ];
 
-        $base = SymfonyRequest::create('/', 'GET', [], [], [], $server, json_encode($body));
+        $base = SymfonyRequest::create('/', 'GET', $query, [], [], $server, json_encode($body));
 
         $request = Request::createFromBase($base);
 
         $this->assertEquals($request->request->all(), $body);
+
+        $base = SymfonyRequest::create('/', 'GET', $query, [], [], [], null);
+
+        $request = Request::createFromBase($base);
+
+        $this->assertEquals($request->request->all(), []);
     }
 
     /**


### PR DESCRIPTION
 On request creation, the post parameters bag if filled with query parameters on any
 request that is not json. This change fix that, and only json request content will be
 parsed and added to the request post parameters.