### PR TITLE
Bug!!:connections return unexpected.

### DIFF
--- a/src/Illuminate/Database/Connectors/ConnectionFactory.php
+++ b/src/Illuminate/Database/Connectors/ConnectionFactory.php
@@ -209,7 +209,6 @@ class ConnectionFactory
      */
     protected function createConnection($driver, PDO $connection, $database, $prefix = '', array $config = [])
     {
-
         switch ($driver) {
             case 'mysql':
                 return new MySqlConnection($connection, $database, $prefix, $config);

--- a/src/Illuminate/Database/Connectors/ConnectionFactory.php
+++ b/src/Illuminate/Database/Connectors/ConnectionFactory.php
@@ -209,9 +209,6 @@ class ConnectionFactory
      */
     protected function createConnection($driver, PDO $connection, $database, $prefix = '', array $config = [])
     {
-        if ($this->container->bound($key = "db.connection.{$driver}")) {
-            return $this->container->make($key, [$connection, $database, $prefix, $config]);
-        }
 
         switch ($driver) {
             case 'mysql':


### PR DESCRIPTION
this is a bug when two connection uses same driver :
//connections: A and B (B is default)
```
\DB::connection(‘A’); //will return "A" connection
\DB::connection(‘B’); //will also return "A" connection