### PR TITLE
[5.3] Update read/unread notification relationships to use base relationship

### DIFF
--- a/src/Illuminate/Notifications/HasDatabaseNotifications.php
+++ b/src/Illuminate/Notifications/HasDatabaseNotifications.php
@@ -18,9 +18,8 @@ trait HasDatabaseNotifications
      */
     public function readNotifications()
     {
-        return $this->morphMany(DatabaseNotification::class, 'notifiable')
-                            ->whereNotNull('read_at')
-                            ->orderBy('created_at', 'desc');
+        return $this->notifications()
+                            ->whereNotNull('read_at');
     }
 
     /**
@@ -28,8 +27,7 @@ trait HasDatabaseNotifications
      */
     public function unreadNotifications()
     {
-        return $this->morphMany(DatabaseNotification::class, 'notifiable')
-                            ->whereNull('read_at')
-                            ->orderBy('created_at', 'desc');
+        return $this->notifications()
+                            ->whereNull('read_at');
     }
 }


### PR DESCRIPTION
The "read" and "unread" relationships for notifications use the same logic as the base relationship definition, except for the addition of the where clause. This PR updates the "read" and "unread" relationships to build off of the base `notifications()` relationship, instead of redefining the same logic.

The main reason for the PR is to make it easier for those that wish to use their own custom `Model` for the `notifications` table, instead of the built in `DatabaseNotification` model. If one wants to use their own model, one would need to override all three relationships. With this change, one only needs to override the base `notifications()` relationship, and the read/unread relationships can be left alone.