### PR TITLE
[5.3] Fix validating distinct for nested keys

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1338,8 +1338,10 @@ class Validator implements ValidatorContract
 
         $attributeData = $this->extractDataFromPath($explicitPath);
 
-        $data = Arr::where(Arr::dot($attributeData), function ($value, $key) use ($attribute, $attributeName) {
-            return $key != $attribute && Str::is($attributeName, $key);
+        $pattern = str_replace('\*', '[^.]+', preg_quote($attributeName, '#'));
+
+        $data = Arr::where(Arr::dot($attributeData), function ($value, $key) use ($attribute, $attributeName, $pattern) {
+            return $key != $attribute && (bool) preg_match('#^'.$pattern.'\z#u', $key);
         });
 
         return ! in_array($value, array_values($data));

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1340,6 +1340,9 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $v = new Validator($trans, ['foo' => ['bar' => ['id' => 1], 'baz' => ['id' => 2]]], ['foo.*.id' => 'distinct']);
         $this->assertTrue($v->passes());
 
+        $v = new Validator($trans, ['foo' => [['id' => 1, 'nested' => ['id' => 1]]]], ['foo.*.id' => 'distinct']);
+        $this->assertTrue($v->passes());
+
         $v = new Validator($trans, ['foo' => [['id' => 1], ['id' => 1]]], ['foo.*.id' => 'distinct']);
         $this->assertFalse($v->passes());
 


### PR DESCRIPTION
We currently use `Str::is($attributeName, $key)` to see if the given key matches the pattern we use to check for distinct values which is `foo.*.bar`, the problem is that `foo.*.bar` matches `foo.1.nested.bar` which shouldn't be matched, so in this PR I use regex instead of the `is()` helper.

I replace `*` in the pattern with `[^.]+` to match any character by the dot.