### PR TITLE
[5.3] Use the relation query instance to perform updateOrCreate

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -308,6 +308,39 @@ class HasManyThrough extends Relation
     }
 
     /**
+     * Get the first related model record matching the attributes or instantiate it.
+     *
+     * @param  array  $attributes
+     * @return \Illuminate\Database\Eloquent\Model
+     */
+    public function firstOrNew(array $attributes)
+    {
+        if (is_null($instance = $this->where($attributes)->first())) {
+            $instance = $this->related->newInstance($attributes);
+        }
+
+        return $instance;
+    }
+
+    /**
+     * Create or update a related record matching the attributes, and fill it with values.
+     *
+     * @param  array  $attributes
+     * @param  array  $values
+     * @param  array  $joining
+     * @param  bool   $touch
+     * @return \Illuminate\Database\Eloquent\Model
+     */
+    public function updateOrCreate(array $attributes, array $values = [])
+    {
+        $instance = $this->firstOrNew($attributes);
+
+        $instance->fill($values)->save();
+
+        return $instance;
+    }
+
+    /**
      * Execute the query as a "select" statement.
      *
      * @param  array  $columns


### PR DESCRIPTION
Currently running `updateOrCreate` on a HasManyThrough relation calls the `updateOrCreate` method of Eloquent\Builder, this causes the attributes of the instance returned to be filled with all the fields since the Builder does `select *`, unlike the relation builder which does `select model_table.*`.

So this PR includes the two methods required for an `udpateOrCreate` operation to run successfully.