### PR TITLE
[5.3] Allow float value as expiration in Memcached cache store

### DIFF
--- a/src/Illuminate/Cache/MemcachedStore.php
+++ b/src/Illuminate/Cache/MemcachedStore.php
@@ -199,7 +199,7 @@ class MemcachedStore extends TaggableStore implements Store
      */
     protected function toTimestamp($minutes)
     {
-        return $minutes > 0 ? Carbon::now()->addMinutes($minutes)->getTimestamp() : 0;
+        return $minutes > 0 ? Carbon::now()->addSeconds($minutes * 60)->getTimestamp() : 0;
     }
 
     /**


### PR DESCRIPTION
Since the rest of drivers accept float values, however Carbon::addMinutes() will convert the float to integer so `0.9` will be `0` causing no caching to happen.