### PR TITLE
[5.4] Remove unused variable

### DIFF
--- a/tests/Broadcasting/BroadcastEventTest.php
+++ b/tests/Broadcasting/BroadcastEventTest.php
@@ -52,7 +52,6 @@ class TestBroadcastEvent
     public $firstName = 'Taylor';
     public $lastName = 'Otwell';
     public $collection;
-    private $title = 'Developer';
 
     public function __construct()
     {


### PR DESCRIPTION
There are two possible outcomes here.

Either, `title` is supposed to be tested against, and it isn't, Or it is legacy, and should be removed. I opted for the latter since couldn't figure out what the true test would be.

