### PR TITLE
[5.3] Support adding APP_KEY to .env without it

### DIFF
--- a/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
+++ b/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
@@ -53,9 +53,9 @@ class KeyGenerateCommand extends Command
     {
         $contents = file_get_contents($this->laravel->environmentFilePath());
         $prefix = 'APP_KEY=';
-        if(strpos($contents, $prefix) === false) {
+        if (strpos($contents, $prefix) === false) {
             $search = $contents;
-            $replace = $prefix.$key . "\n" . $contents;
+            $replace = $prefix.$key."\n".$contents;
         } else {
             $search = $prefix.$this->laravel['config']['app.key'];
             $replace = $prefix.$key;

--- a/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
+++ b/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
@@ -51,11 +51,17 @@ class KeyGenerateCommand extends Command
      */
     protected function setKeyInEnvironmentFile($key)
     {
-        file_put_contents($this->laravel->environmentFilePath(), str_replace(
-            'APP_KEY='.$this->laravel['config']['app.key'],
-            'APP_KEY='.$key,
-            file_get_contents($this->laravel->environmentFilePath())
-        ));
+        $contents = file_get_contents($this->laravel->environmentFilePath());
+        $prefix = 'APP_KEY=';
+        if(strpos($contents, $prefix) === false) {
+            $search = $contents;
+            $replace = $prefix.$key . "\n" . $contents;
+        } else {
+            $search = $prefix.$this->laravel['config']['app.key'];
+            $replace = $prefix.$key;
+        }
+
+        file_put_contents($this->laravel->environmentFilePath(), str_replace($search, $replace, $contents));
     }
 
     /**


### PR DESCRIPTION
**Issue:**

If you have a `.env` file that does not contain an `APP_KEY` property, `php artisan key:generate` will fail silently, reporting that it has updated the key. However it actually does nothing.

**Solution:**

Add a check to see if `APP_KEY` exists in the files contents at all, if it doesn't then prepend the new `APP_KEY` to the file. If it does have an instance, retain the original functionality.

**Possible Improvements:**

This command will still fail silently if `file_put_contents` fails, as there is no check to see if that actually succeeds as it will return `false` if it does fail.

Another improvement would be to use `SplFileObject` or even `f(open/close/write etc)` commands instead of `file_(put/get)_contents`