### PR TITLE
Add make:observe command to artisan

### DIFF
--- a/src/Illuminate/Foundation/Console/ObserveMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ObserveMakeCommand.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace Illuminate\Foundation\Console;
+
+use Illuminate\Support\Str;
+use Illuminate\Console\GeneratorCommand;
+use Symfony\Component\Console\Input\InputOption;
+
+class ObserveMakeCommand extends GeneratorCommand
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'make:observe';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create a new observe class';
+
+    /**
+     * The type of class being generated.
+     *
+     * @var string
+     */
+    protected $type = 'Observe';
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function fire()
+    {
+        if (! $this->option('model')) {
+            return $this->error('Missing required option: --model');
+        }
+
+        parent::fire();
+    }
+
+    /**
+     * Build the class with the given name.
+     *
+     * @param  string  $name
+     * @return string
+     */
+    protected function buildClass($name)
+    {
+        $stub = parent::buildClass($name);
+
+        $model = $this->option('model');
+
+        return $this->replaceModel($stub, $model);
+    }
+
+    /**
+     * Replace the model for the given stub.
+     *
+     * @param  string  $stub
+     * @param  string  $model
+     * @return string
+     */
+    protected function replaceModel($stub, $model)
+    {
+        $model = str_replace('/', '\\', $model);
+
+        if (Str::startsWith($model, '\\')) {
+            $stub = str_replace('NamespacedDummyModel', trim($model, '\\'), $stub);
+        } else {
+            $stub = str_replace('NamespacedDummyModel', $this->laravel->getNamespace().$model, $stub);
+        }
+
+        $model = class_basename(trim($model, '\\'));
+
+        $stub = str_replace('DummyModel', $model, $stub);
+
+        $stub = str_replace('dummyModelName', Str::camel($model), $stub);
+
+        return str_replace('dummyPluralModelName', Str::plural(Str::camel($model)), $stub);
+    }
+
+    /**
+     * Get the stub file for the generator.
+     *
+     * @return string
+     */
+    protected function getStub()
+    {
+        if ($this->option('model')) {
+            return __DIR__.'/stubs/observe.stub';
+        }
+    }
+
+    /**
+     * Get the default namespace for the class.
+     *
+     * @param  string  $rootNamespace
+     * @return string
+     */
+    protected function getDefaultNamespace($rootNamespace)
+    {
+        return $rootNamespace.'\Observers';
+    }
+
+    /**
+     * Get the console command arguments.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [
+            ['model', 'm', InputOption::VALUE_OPTIONAL, 'The model that the observe applies to.'],
+        ];
+    }
+}

--- a/src/Illuminate/Foundation/Console/ObserveMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ObserveMakeCommand.php
@@ -20,7 +20,7 @@ class ObserveMakeCommand extends GeneratorCommand
      *
      * @var string
      */
-    protected $description = 'Create a new observe class';
+    protected $description = 'Create a new model observer class';
 
     /**
      * The type of class being generated.
@@ -115,7 +115,7 @@ class ObserveMakeCommand extends GeneratorCommand
     protected function getOptions()
     {
         return [
-            ['model', 'm', InputOption::VALUE_OPTIONAL, 'The model that the observe applies to.'],
+            ['model', 'm', InputOption::VALUE_REQUIRED, 'The model that the observe applies to.'],
         ];
     }
 }

--- a/src/Illuminate/Foundation/Console/stubs/observe.stub
+++ b/src/Illuminate/Foundation/Console/stubs/observe.stub
@@ -1,0 +1,120 @@
+<?php
+
+namespace DummyNamespace;
+
+use NamespacedDummyModel;
+
+class DummyClass
+{
+
+    /**
+     * Listen to the dummyModelName creating event.
+     *
+     * @param  \NamespacedDummyModel $dummyModelName
+     * @return void
+     */
+    public function creating(DummyModel $dummyModelName)
+    {
+        //
+    }
+
+    /**
+     * Listen to the dummyModelName created event.
+     *
+     * @param  \NamespacedDummyModel $dummyModelName
+     * @return void
+     */
+    public function created(DummyModel $dummyModelName)
+    {
+        //
+    }
+
+    /**
+     * Listen to the dummyModelName updating event.
+     *
+     * @param  \NamespacedDummyModel $dummyModelName
+     * @return void
+     */
+    public function updating(DummyModel $dummyModelName)
+    {
+        //
+    }
+
+    /**
+     * Listen to the dummyModelName updated event.
+     *
+     * @param  \NamespacedDummyModel $dummyModelName
+     * @return void
+     */
+    public function updated(DummyModel $dummyModelName)
+    {
+        //
+    }
+
+    /**
+     * Listen to the dummyModelName saving event.
+     *
+     * @param  \NamespacedDummyModel $dummyModelName
+     * @return void
+     */
+    public function saving(DummyModel $dummyModelName)
+    {
+        //
+    }
+
+    /**
+     * Listen to the dummyModelName saved event.
+     *
+     * @param  \NamespacedDummyModel $dummyModelName
+     * @return void
+     */
+    public function saved(DummyModel $dummyModelName)
+    {
+        //
+    }
+
+    /**
+     * Listen to the dummyModelName deleting event.
+     *
+     * @param  \NamespacedDummyModel $dummyModelName
+     * @return void
+     */
+    public function deleting(DummyModel $dummyModelName)
+    {
+        //
+    }
+
+    /**
+     * Listen to the dummyModelName deleted event.
+     *
+     * @param  \NamespacedDummyModel $dummyModelName
+     * @return void
+     */
+    public function deleted(DummyModel $dummyModelName)
+    {
+        //
+    }
+
+    /**
+     * Listen to the dummyModelName restoring event.
+     *
+     * @param  \NamespacedDummyModel $dummyModelName
+     * @return void
+     */
+    public function restoring(DummyModel $dummyModelName)
+    {
+        //
+    }
+
+    /**
+     * Listen to the dummyModelName restored event.
+     *
+     * @param  \NamespacedDummyModel $dummyModelName
+     * @return void
+     */
+    public function restored(DummyModel $dummyModelName)
+    {
+        //
+    }
+
+}

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -34,6 +34,7 @@ use Illuminate\Foundation\Console\RequestMakeCommand;
 use Illuminate\Foundation\Console\StorageLinkCommand;
 use Illuminate\Routing\Console\ControllerMakeCommand;
 use Illuminate\Routing\Console\MiddlewareMakeCommand;
+use Illuminate\Foundation\Console\ObserveMakeCommand;
 use Illuminate\Foundation\Console\ListenerMakeCommand;
 use Illuminate\Foundation\Console\ProviderMakeCommand;
 use Illuminate\Foundation\Console\ClearCompiledCommand;
@@ -105,6 +106,7 @@ class ArtisanServiceProvider extends ServiceProvider
         'Serve' => 'command.serve',
         'TestMake' => 'command.test.make',
         'VendorPublish' => 'command.vendor.publish',
+        'ObserveMake' => 'command.observe.make',
     ];
 
     /**
@@ -601,6 +603,18 @@ class ArtisanServiceProvider extends ServiceProvider
     {
         $this->app->singleton('command.notification.table', function ($app) {
             return new NotificationTableCommand($app['files'], $app['composer']);
+        });
+    }
+    
+     /**
+     * Register the command.
+     *
+     * @return void
+     */
+    protected function registerObserveMakeCommand()
+    {
+        $this->app->singleton('command.observe.make', function ($app) {
+            return new ObserveMakeCommand($app['files']);
         });
     }
 

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -30,11 +30,11 @@ use Illuminate\Foundation\Console\ConfigClearCommand;
 use Illuminate\Foundation\Console\ConsoleMakeCommand;
 use Illuminate\Foundation\Console\EnvironmentCommand;
 use Illuminate\Foundation\Console\KeyGenerateCommand;
+use Illuminate\Foundation\Console\ObserveMakeCommand;
 use Illuminate\Foundation\Console\RequestMakeCommand;
 use Illuminate\Foundation\Console\StorageLinkCommand;
 use Illuminate\Routing\Console\ControllerMakeCommand;
 use Illuminate\Routing\Console\MiddlewareMakeCommand;
-use Illuminate\Foundation\Console\ObserveMakeCommand;
 use Illuminate\Foundation\Console\ListenerMakeCommand;
 use Illuminate\Foundation\Console\ProviderMakeCommand;
 use Illuminate\Foundation\Console\ClearCompiledCommand;
@@ -605,8 +605,8 @@ class ArtisanServiceProvider extends ServiceProvider
             return new NotificationTableCommand($app['files'], $app['composer']);
         });
     }
-    
-     /**
+
+    /**
      * Register the command.
      *
      * @return void


### PR DESCRIPTION
The make:observe command will generate an observe class with these methods:

`creating, created, updating, updated, saving, saved, deleting, deleted, restoring, restored`

If 'Observers' directory does not exist, this command will create it.