### PR TITLE
Resolve sub-folders for local filesystem on FilesystemAdapter.

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -327,6 +327,16 @@ class FilesystemAdapter implements FilesystemContract, CloudFilesystemContract
             return trim($config->get('url'), '/').'/'.ltrim($path, '/');
         }
 
+        // If the visibility of the file system is public and the developer chose to use a sub-folder
+        // in the local storage, then we need to grab the sub-folders specified after public for the
+        // symbolic link to fully resolve the file path.
+        if ($config->get('visibility') == 'public' && ! Str::endsWith($path, 'public')) {
+            $adapter = $this->driver->getAdapter();
+            $needle = 'public/';
+
+            return '/storage/'.Str::substr($adapter->getPathPrefix(), strpos($adapter->getPathPrefix(), $needle) + strlen($needle)).$path;
+        }
+
         $path = '/storage/'.$path;
 
         // If the path contains "storage/public", it probably means the developer is using


### PR DESCRIPTION
Replica of #17099 

## Problem

When defining multiple local file system in different sub-folders of `public/`, the `Storage::url()` method will not resolve the correct file path even if specified a disk: `Storage::disk('disk-name')->url('file');`.

The follow scenario shows this.

## Example

```
        'attachments' => [
            'driver' => 'local',
            'root' => storage_path('app/public/attachments/'),
            'visibility' => 'public'
        ],

        'images' => [
            'driver' => 'local',
            'root' => storage_path('app/public/images/'),
            'visibility' => 'public'
        ],
```

Currently, we need to grab the URL for a file like this: `Storage::url('images/file.png');` or `Storage::url('attachments/file.png');` while with the proposal change it would be possible for this: `Storage::disk('images')->url('file.png');` or `Storage::disk('attachments')->url('file.png');`, where each `file.png` will be different files in their respective storage.

## Conclusion

When working with local file system, the url method will only prepend the folder `'/storage/'` to the specified path of the file. In the event of the developer specifying multiple local storage and each one having it's own sub-folder in the public folder, the url() method will not correctly resolve the file even if a disk is specified.