### PR TITLE
[5.3] Adds ability to test raw content to post, put and patch requests

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -133,13 +133,14 @@ trait MakesHttpRequests
      * @param  string  $uri
      * @param  array  $data
      * @param  array  $headers
+     * @param  string  $content
      * @return $this
      */
-    public function post($uri, array $data = [], array $headers = [])
+    public function post($uri, array $data = [], array $headers = [], $content = null)
     {
         $server = $this->transformHeadersToServerVars($headers);
 
-        $this->call('POST', $uri, $data, [], [], $server);
+        $this->call('POST', $uri, $data, [], [], $server, $content);
 
         return $this;
     }
@@ -163,13 +164,14 @@ trait MakesHttpRequests
      * @param  string  $uri
      * @param  array  $data
      * @param  array  $headers
+     * @param  string  $content
      * @return $this
      */
-    public function put($uri, array $data = [], array $headers = [])
+    public function put($uri, array $data = [], array $headers = [], $content = null)
     {
         $server = $this->transformHeadersToServerVars($headers);
 
-        $this->call('PUT', $uri, $data, [], [], $server);
+        $this->call('PUT', $uri, $data, [], [], $server, $content);
 
         return $this;
     }
@@ -193,13 +195,14 @@ trait MakesHttpRequests
      * @param  string  $uri
      * @param  array  $data
      * @param  array  $headers
+     * @param  string  $content
      * @return $this
      */
-    public function patch($uri, array $data = [], array $headers = [])
+    public function patch($uri, array $data = [], array $headers = [], $content = null)
     {
         $server = $this->transformHeadersToServerVars($headers);
 
-        $this->call('PATCH', $uri, $data, [], [], $server);
+        $this->call('PATCH', $uri, $data, [], [], $server, $content);
 
         return $this;
     }


### PR DESCRIPTION
Adds optional $content variables to `post`, `put`, and `patch` so raw data can be passed through to the Symfony Request during integration testing.

I can make a pull request into 5.4 if you'd prefer.