### PR TITLE
[5.3] Update SwiftMailer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "paragonie/random_compat": "~1.4|~2.0",
         "psy/psysh": "0.7.*|0.8.*",
         "ramsey/uuid": "~3.0",
-        "swiftmailer/swiftmailer": "~5.1",
+        "swiftmailer/swiftmailer": "~5.4",
         "symfony/console": "3.1.*",
         "symfony/debug": "3.1.*",
         "symfony/finder": "3.1.*",


### PR DESCRIPTION
This is due to the vulnerability discovered in SwiftMailer which is now fixed in 5.4.5:

https://github.com/swiftmailer/swiftmailer/pull/847

https://legalhackers.com/advisories/SwiftMailer-Exploit-Remote-Code-Exec-CVE-2016-10074-Vuln.html