### PR TITLE
[5.4] Do not touch the user timestamps when updating the remember_token.

### DIFF
--- a/src/Illuminate/Auth/EloquentUserProvider.php
+++ b/src/Illuminate/Auth/EloquentUserProvider.php
@@ -75,6 +75,8 @@ class EloquentUserProvider implements UserProvider
     {
         $user->setRememberToken($token);
 
+        $user->timestamps = false;
+
         $user->save();
     }
 

--- a/src/Illuminate/Auth/EloquentUserProvider.php
+++ b/src/Illuminate/Auth/EloquentUserProvider.php
@@ -75,9 +75,13 @@ class EloquentUserProvider implements UserProvider
     {
         $user->setRememberToken($token);
 
+        $timestamps = $user->timestamps;
+
         $user->timestamps = false;
 
         $user->save();
+
+        $user->timestamps = $timestamps;
     }
 
     /**


### PR DESCRIPTION
As discussed with @taylorotwell 

It makes no sense to touch the `updated_at` field of the user when his `remember_token` is set or updated.

Note:

- `\Illuminate\Foundation\Auth\ResetsPasswords::resetPassword` : the password is modified too, so `updated_at` should be modified too.
- In order to have details about when users have logged in/out, https://github.com/antonioribeiro/tracker by @antonioribeiro does the job perfectly

---

Also see https://github.com/laravel/framework/pull/16660#issue-193489253