### PR TITLE
[5.4] Let JsonResponse also provide the original data.

### DIFF
--- a/src/Illuminate/Http/JsonResponse.php
+++ b/src/Illuminate/Http/JsonResponse.php
@@ -22,6 +22,8 @@ class JsonResponse extends BaseJsonResponse
      */
     public function __construct($data = null, $status = 200, $headers = [], $options = 0)
     {
+        $this->original = $data;
+
         $this->encodingOptions = $options;
 
         parent::__construct($data, $status, $headers);
@@ -55,6 +57,8 @@ class JsonResponse extends BaseJsonResponse
      */
     public function setData($data = [])
     {
+        $this->original = $data;
+
         if ($data instanceof Arrayable) {
             $this->data = json_encode($data->toArray(), $this->encodingOptions);
         } elseif ($data instanceof Jsonable) {

--- a/src/Illuminate/Http/RedirectResponse.php
+++ b/src/Illuminate/Http/RedirectResponse.php
@@ -33,6 +33,16 @@ class RedirectResponse extends BaseRedirectResponse
     protected $session;
 
     /**
+     * Get the original response content.
+     *
+     * @return null
+     */
+    public function getOriginalContent()
+    {
+        return;
+    }
+
+    /**
      * Flash a piece of data to the session.
      *
      * @param  string|array  $key

--- a/src/Illuminate/Http/Response.php
+++ b/src/Illuminate/Http/Response.php
@@ -13,13 +13,6 @@ class Response extends BaseResponse
     use ResponseTrait;
 
     /**
-     * The original content of the response.
-     *
-     * @var mixed
-     */
-    public $original;
-
-    /**
      * Set the content on the response.
      *
      * @param  mixed  $content
@@ -75,15 +68,5 @@ class Response extends BaseResponse
         }
 
         return json_encode($content);
-    }
-
-    /**
-     * Get the original response content.
-     *
-     * @return mixed
-     */
-    public function getOriginalContent()
-    {
-        return $this->original;
     }
 }

--- a/src/Illuminate/Http/ResponseTrait.php
+++ b/src/Illuminate/Http/ResponseTrait.php
@@ -8,6 +8,13 @@ use Illuminate\Http\Exception\HttpResponseException;
 trait ResponseTrait
 {
     /**
+     * The original content of the response.
+     *
+     * @var mixed
+     */
+    public $original;
+
+    /**
      * The exception that triggered the error response (if applicable).
      *
      * @var \Exception|null
@@ -32,6 +39,16 @@ trait ResponseTrait
     public function content()
     {
         return $this->getContent();
+    }
+
+    /**
+     * Get the original response content.
+     *
+     * @return mixed
+     */
+    public function getOriginalContent()
+    {
+        return $this->original;
     }
 
     /**

--- a/tests/Http/HttpJsonResponseTest.php
+++ b/tests/Http/HttpJsonResponseTest.php
@@ -38,6 +38,16 @@ class HttpJsonResponseTest extends TestCase
         $this->assertEquals('bar', $data->foo);
     }
 
+    public function testGetOriginalContent()
+    {
+        $response = new Illuminate\Http\JsonResponse(new JsonResponseTestArrayableObject);
+        $this->assertInstanceOf(JsonResponseTestArrayableObject::class, $response->getOriginalContent());
+
+        $response = new Illuminate\Http\JsonResponse;
+        $response->setData(new JsonResponseTestArrayableObject);
+        $this->assertInstanceOf(JsonResponseTestArrayableObject::class, $response->getOriginalContent());
+    }
+
     public function testSetAndRetrieveOptions()
     {
         $response = new Illuminate\Http\JsonResponse(['foo' => 'bar']);


### PR DESCRIPTION
`\Illuminate\Http\Response` provides `$original` property and a `getOriginalContent`.
This PR provides the same feature for `\Illuminate\Http\JsonResponse`.

This way when a `Arrayable` object is returned, the orignal object can still be available in a middleware, for instance.