### PR TITLE
Update KeyGenerateCommand to only match "APP_KEY="

### DIFF
--- a/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
+++ b/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
@@ -77,8 +77,8 @@ class KeyGenerateCommand extends Command
      */
     protected function writeNewEnvironmentFileWith($key)
     {
-        file_put_contents($this->laravel->environmentFilePath(), str_replace(
-            'APP_KEY='.$this->laravel['config']['app.key'],
+        file_put_contents($this->laravel->environmentFilePath(), preg_replace(
+            '/\bAPP_KEY=\B/i'.$this->laravel['config']['app.key'],
             'APP_KEY='.$key,
             file_get_contents($this->laravel->environmentFilePath())
         ));


### PR DESCRIPTION
The KeyGenerateCommand was matching any key that contained "APP_KEY=". Changed str_replace to preg_replace to only match "APP_KEY=".

Addresses #17140 