### PR TITLE
[5.3] Fix match only APP_KEY in replace

### DIFF
--- a/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
+++ b/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
@@ -51,8 +51,8 @@ class KeyGenerateCommand extends Command
      */
     protected function setKeyInEnvironmentFile($key)
     {
-        file_put_contents($this->laravel->environmentFilePath(), str_replace(
-            'APP_KEY='.$this->laravel['config']['app.key'],
+        file_put_contents($this->laravel->environmentFilePath(), preg_replace(
+            $this->getAppKeyPattern(),
             'APP_KEY='.$key,
             file_get_contents($this->laravel->environmentFilePath())
         ));
@@ -68,5 +68,17 @@ class KeyGenerateCommand extends Command
         return 'base64:'.base64_encode(random_bytes(
             $this->laravel['config']['app.cipher'] == 'AES-128-CBC' ? 16 : 32
         ));
+    }
+
+    /**
+     * Get a regex pattern that will match env APP_KEY with any random key
+     *
+     * @return string
+     */
+    protected function getAppKeyPattern()
+    {
+        $escapedKey = preg_quote('='.$this->laravel['config']['app.key'], '/');
+
+        return "/^APP_KEY$escapedKey/m";
     }
 }

--- a/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
+++ b/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
@@ -71,7 +71,7 @@ class KeyGenerateCommand extends Command
     }
 
     /**
-     * Get a regex pattern that will match env APP_KEY with any random key
+     * Get a regex pattern that will match env APP_KEY with any random key.
      *
      * @return string
      */


### PR DESCRIPTION
Changed str_replace to preg_replace to ensure no clashes with other environment variables.

---

Closes #17140.