### PR TITLE
[5.3] Clear console application bootstrappers after each test case

### DIFF
--- a/src/Illuminate/Console/Application.php
+++ b/src/Illuminate/Console/Application.php
@@ -80,6 +80,16 @@ class Application extends SymfonyApplication implements ApplicationContract
     }
 
     /**
+     * Clear the console application bootstrappers.
+     *
+     * @return void
+     */
+    public static function clearBootstrappers()
+    {
+        static::$bootstrappers = [];
+    }
+
+    /**
      * Run an Artisan console command by name.
      *
      * @param  string  $command

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -4,6 +4,7 @@ namespace Illuminate\Foundation\Testing;
 
 use Mockery;
 use PHPUnit_Framework_TestCase;
+use Illuminate\Console\Application;
 use Illuminate\Support\Facades\Facade;
 use Illuminate\Database\Eloquent\Model;
 
@@ -146,6 +147,7 @@ abstract class TestCase extends PHPUnit_Framework_TestCase
 
         $this->afterApplicationCreatedCallbacks = [];
         $this->beforeApplicationDestroyedCallbacks = [];
+        Application::clearBootstrappers();
     }
 
     /**


### PR DESCRIPTION
With the upgrade from v5.3.19 to 5.3.20 I noticed a considerable degradation of the runtime of my tests (over 50 % slower). I found that the bootstrappers array implemented in #16012 is never cleared between test cases. Instead, new bootstrappers are added for each test case, stacking them up and making the tests run slower and slower.

This PR implements clearing of the bootstrappers array after each test case. I've already asked @themsaid to have a look at this.