### PR TITLE
[5.3] Replace Laravel URL by application URL in notification.stub

### DIFF
--- a/src/Illuminate/Foundation/Console/stubs/notification.stub
+++ b/src/Illuminate/Foundation/Console/stubs/notification.stub
@@ -42,7 +42,7 @@ class DummyClass extends Notification
     {
         return (new MailMessage)
                     ->line('The introduction to the notification.')
-                    ->action('Notification Action', 'https://laravel.com')
+                    ->action('Notification Action', config('app.url'))
                     ->line('Thank you for using our application!');
     }
 


### PR DESCRIPTION
Not sure it's better btw (sorry if it's useless). As you want, feel free to close!