### PR TITLE
[5.4] No need to set original twice

### DIFF
--- a/src/Illuminate/Http/JsonResponse.php
+++ b/src/Illuminate/Http/JsonResponse.php
@@ -22,8 +22,6 @@ class JsonResponse extends BaseJsonResponse
      */
     public function __construct($data = null, $status = 200, $headers = [], $options = 0)
     {
-        $this->original = $data;
-
         $this->encodingOptions = $options;
 
         parent::__construct($data, $status, $headers);


### PR DESCRIPTION
No need to set `$original` twice in `\Illuminate\Http\JsonResponse`