### PR TITLE
[5.4] Replace Laravel URL by application URL in notification.stub

### DIFF
--- a/src/Illuminate/Foundation/Console/stubs/notification.stub
+++ b/src/Illuminate/Foundation/Console/stubs/notification.stub
@@ -42,7 +42,7 @@ class DummyClass extends Notification
     {
         return (new MailMessage)
                     ->line('The introduction to the notification.')
-                    ->action('Notification Action', 'https://laravel.com')
+                    ->action('Notification Action', url('/'))
                     ->line('Thank you for using our application!');
     }
 


### PR DESCRIPTION
More info here: https://github.com/laravel/framework/pull/17159