### PR TITLE
[5.3] Add HourlyAt() option for scheduled events

### DIFF
--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -347,7 +347,7 @@ class Event
     /**
      * Schedule the event to run hourly at a given offset in the hour.
      *
-     * @param  string  $offset
+     * @param  int  $offset
      * @return $this
      */
     public function hourlyAt($offset)

--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -344,10 +344,10 @@ class Event
         return $this->spliceIntoPosition(1, 0);
     }
 
-   /**
+    /**
      * Schedule the event to run hourly at a given offset in the hour.
      *
-     * @param  string  $offset     
+     * @param  string  $offset
      * @return $this
      */
     public function hourlyAt($offset)

--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -344,6 +344,17 @@ class Event
         return $this->spliceIntoPosition(1, 0);
     }
 
+   /**
+     * Schedule the event to run hourly at a given offset in the hour.
+     *
+     * @param  string  $offset     
+     * @return $this
+     */
+    public function hourlyAt($offset)
+    {
+        return $this->spliceIntoPosition(1, $offset);
+    }
+
     /**
      * Schedule the event to run daily.
      *

--- a/tests/Console/ConsoleScheduledEventTest.php
+++ b/tests/Console/ConsoleScheduledEventTest.php
@@ -69,7 +69,7 @@ class ConsoleScheduledEventTest extends PHPUnit_Framework_TestCase
 
         $event = new Event('php foo');
         $this->assertEquals('37 * * * * *', $event->hourlyAt(37)->getExpression());        
-        
+
         $event = new Event('php foo');
         $this->assertEquals('0 15 4 * * *', $event->monthlyOn(4, '15:00')->getExpression());
 

--- a/tests/Console/ConsoleScheduledEventTest.php
+++ b/tests/Console/ConsoleScheduledEventTest.php
@@ -68,7 +68,7 @@ class ConsoleScheduledEventTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('0 * * * * *', $event->everyFiveMinutes()->hourly()->getExpression());
 
         $event = new Event('php foo');
-        $this->assertEquals('37 * * * * *', $event->hourlyAt(37)->getExpression());        
+        $this->assertEquals('37 * * * * *', $event->hourlyAt(37)->getExpression());
 
         $event = new Event('php foo');
         $this->assertEquals('0 15 4 * * *', $event->monthlyOn(4, '15:00')->getExpression());

--- a/tests/Console/ConsoleScheduledEventTest.php
+++ b/tests/Console/ConsoleScheduledEventTest.php
@@ -68,6 +68,9 @@ class ConsoleScheduledEventTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('0 * * * * *', $event->everyFiveMinutes()->hourly()->getExpression());
 
         $event = new Event('php foo');
+        $this->assertEquals('37 * * * * *', $event->hourlyAt(37)->getExpression());        
+        
+        $event = new Event('php foo');
         $this->assertEquals('0 15 4 * * *', $event->monthlyOn(4, '15:00')->getExpression());
 
         $event = new Event('php foo');


### PR DESCRIPTION
This is a simple extension of the `hourly` function to allow for an minute offset.

Basically if you have a few scheduled events you want to run hourly - it is nice to be able to offset them from 0 to a different 'minute' - so they dont all run simultaneously at `:00` and put unnecessary load on the server.