### PR TITLE
[5.3] Create models sequentially in FactoryBuilder

### DIFF
--- a/src/Illuminate/Database/Eloquent/FactoryBuilder.php
+++ b/src/Illuminate/Database/Eloquent/FactoryBuilder.php
@@ -110,17 +110,15 @@ class FactoryBuilder
      */
     public function create(array $attributes = [])
     {
-        $results = $this->make($attributes);
+        $collection = (new $this->class)->newCollection();
 
-        if ($this->amount === 1) {
-            $results->save();
-        } else {
-            foreach ($results as $result) {
-                $result->save();
-            }
+        while ($collection->count() < $this->amount) {
+            $model = $this->makeInstance($attributes);
+            $model->save();
+            $collection->push($model);
         }
 
-        return $results;
+        return $collection;
     }
 
     /**


### PR DESCRIPTION
This has the FactoryBuilder save models as they're created in `create()`, instead of making a collection and then saving each model.

This is to avoid cases where the factory is meant to avoid duplicates in unique columns by checking what already exists. Currently the models are all made as a collection and then saved, which prevents such checks from avoiding duplicates within the collection.
