### PR TITLE
[5.4] Call via() on the original notification object

### DIFF
--- a/src/Illuminate/Notifications/NotificationSender.php
+++ b/src/Illuminate/Notifications/NotificationSender.php
@@ -147,7 +147,7 @@ class NotificationSender
         foreach ($notifiables as $notifiable) {
             $notificationId = Uuid::uuid4()->toString();
 
-            foreach ($notification->via($notifiable) as $channel) {
+            foreach ($original->via($notifiable) as $channel) {
                 $notification = clone $original;
 
                 $notification->id = $notificationId;


### PR DESCRIPTION
We reassign the $notification variable inside the loop `$notification = clone $original;`, so when the first iteration of the outer loop is over we'll call `via` on the reassigned variable, which contains an object that got altered later on.