### PR TITLE
[5.3] Add isSoftDeleting() method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1146,6 +1146,18 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     }
 
     /**
+     * Determine if the model is currently soft deleting.
+     *
+     * This method protects developers from running isSoftDeleting when trait is missing.
+     *
+     * @return bool
+     */
+    public function isSoftDeleting()
+    {
+        return false;
+    }
+
+    /**
      * Register a saving model event with the dispatcher.
      *
      * @param  \Closure|string  $callback

--- a/src/Illuminate/Database/Eloquent/SoftDeletes.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletes.php
@@ -44,7 +44,7 @@ trait SoftDeletes
      */
     protected function performDeleteOnModel()
     {
-        if ($this->forceDeleting) {
+        if ($this->isForceDeleting()) {
             return $this->newQueryWithoutScopes()->where($this->getKeyName(), $this->getKey())->forceDelete();
         }
 
@@ -123,6 +123,16 @@ trait SoftDeletes
     public static function restored($callback)
     {
         static::registerModelEvent('restored', $callback);
+    }
+
+    /**
+     * Determine if the model is currently soft deleting.
+     *
+     * @return bool
+     */
+    public function isSoftDeleting()
+    {
+        return ! $this->forceDeleting;
     }
 
     /**

--- a/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
@@ -182,6 +182,24 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends PHPUnit_Framework_TestC
         $this->assertNull($users->find(2)->deleted_at);
     }
 
+    public function testIsSoftDeleting()
+    {
+        $comment1 = TestCommentWithoutSoftDelete::create(['body' => 'foo', 'post_id' => 1]);
+        $this->assertFalse($comment1->isSoftDeleting());
+
+        SoftDeletesTestComment::setEventDispatcher(new Illuminate\Events\Dispatcher);
+        $comment2 = SoftDeletesTestComment::create(['body' => 'foo', 'post_id' => 1]);
+
+        $this->assertTrue($comment2->isSoftDeleting());
+
+        $comment2->deleting(function ($c) {
+            $this->assertFalse($c->isSoftDeleting());
+        });
+
+        $comment2->forceDelete();
+        SoftDeletesTestComment::unsetEventDispatcher();
+    }
+
     public function testOnlyTrashedOnlyReturnsTrashedRecords()
     {
         $this->createUsers();


### PR DESCRIPTION
This PR adds a method that safely checks if a model is soft deleting.

Primary projected use case: traits, since they inherently don't know in advance if their implementing class also implements the SoftDeletes trait.

e.g.:

```php
trait SomeTrait {
    /**
     * The "booting" method of the trait.
     *
     * @return void
     */
    protected static function bootSomeTrait()
    {
        static::deleting(function ($model) {
            if (static::isSoftDeleting()) {
                //
            } else {
                //
            }
        });

        if (static::isSoftDeleting()) {
            // restoring() will throw an error if SoftDeletes is not implemented as well.
            static::restoring(function ($model) {
                //
            });
        }
    }
}
```