### PR TITLE
Making string length easily configurable

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -55,6 +55,13 @@ class Blueprint
     public $temporary = false;
 
     /**
+     * The default char/string length.
+     *
+     * @var int
+     */
+    protected $defaultLength;
+
+    /**
      * Create a new schema blueprint.
      *
      * @param  string  $table
@@ -68,6 +75,8 @@ class Blueprint
         if (! is_null($callback)) {
             $callback($this);
         }
+
+        $this->defaultLength = config()->get('database.default_length');
     }
 
     /**
@@ -445,8 +454,9 @@ class Blueprint
      * @param  int  $length
      * @return \Illuminate\Support\Fluent
      */
-    public function char($column, $length = 255)
+    public function char($column, $length = null)
     {
+        $length = $length?:$this->defaultLength;
         return $this->addColumn('char', $column, compact('length'));
     }
 
@@ -457,8 +467,10 @@ class Blueprint
      * @param  int  $length
      * @return \Illuminate\Support\Fluent
      */
-    public function string($column, $length = 255)
+    public function string($column, $length = null)
     {
+        $length = $length?:$this->defaultLength;
+
         return $this->addColumn('string', $column, compact('length'));
     }
 

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -457,6 +457,7 @@ class Blueprint
     public function char($column, $length = null)
     {
         $length = $length ?: $this->defaultLength;
+
         return $this->addColumn('char', $column, compact('length'));
     }
 

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -456,7 +456,7 @@ class Blueprint
      */
     public function char($column, $length = null)
     {
-        $length = $length?:$this->defaultLength;
+        $length = $length ?: $this->defaultLength;
         return $this->addColumn('char', $column, compact('length'));
     }
 
@@ -469,7 +469,7 @@ class Blueprint
      */
     public function string($column, $length = null)
     {
-        $length = $length?:$this->defaultLength;
+        $length = $length ?: $this->defaultLength;
 
         return $this->addColumn('string', $column, compact('length'));
     }


### PR DESCRIPTION
This feature is required to avoid some issues due to the new database encoding with specific versions of MariaDB and MySQL.

This allows to the developer to configure the default string and char length, using a new database configuration entry, called default_length.

default_length can be set in the .env file using a new entry called DB_DEFAULT_LENGTH (this is for laravel/laravel repo)