### PR TITLE
[5.3] Merge a model into simple query

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1515,13 +1515,34 @@ class Builder
         if ($query instanceof Closure) {
             call_user_func($query, $query = $this->newQuery());
         }
-
+        
+        if ($query instanceof Model) {
+            return $this->merge($query);
+        }
+        
         $this->unions[] = compact('query', 'all');
 
         $this->addBinding($query->getBindings(), 'union');
 
         return $this;
     }
+    
+    /**
+     * Merge model record into simple query
+     *
+     * @param Model $model
+     * @return Builder|static
+     * @throws InvalidArgumentException
+     */
+    protected function merge(Model $model)
+    {
+        if ($model->getTable() === $this->from ) {
+            return $this->union(
+                \DB::table($this->from)->where($model->getKeyName(), $model->getKey())
+            );
+        }
+        throw new InvalidArgumentException();
+    }    
 
     /**
      * Add a union all statement to the query.

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1532,7 +1532,8 @@ class Builder
      *
      * @param Model $model
      * @return Builder|static
-     * @throws InvalidArgumentException
+     *
+     * @throws \InvalidArgumentException
      */
     protected function merge(Model $model)
     {

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Str;
 use InvalidArgumentException;
 use Illuminate\Support\Collection;
 use Illuminate\Pagination\Paginator;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\ConnectionInterface;
@@ -1530,8 +1531,8 @@ class Builder
     /**
      * Merge model record into simple query.
      *
-     * @param Model $model
-     * @return Builder|static
+     * @param \Illuminate\Database\Eloquent\Model $model
+     * @return \Illuminate\Database\Query\Builder|static
      *
      * @throws \InvalidArgumentException
      */

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1526,7 +1526,7 @@ class Builder
 
         return $this;
     }
-    
+
     /**
      * Merge model record into simple query.
      *

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1515,11 +1515,11 @@ class Builder
         if ($query instanceof Closure) {
             call_user_func($query, $query = $this->newQuery());
         }
-        
+
         if ($query instanceof Model) {
             return $this->merge($query);
         }
-        
+
         $this->unions[] = compact('query', 'all');
 
         $this->addBinding($query->getBindings(), 'union');
@@ -1528,7 +1528,7 @@ class Builder
     }
     
     /**
-     * Merge model record into simple query
+     * Merge model record into simple query.
      *
      * @param Model $model
      * @return Builder|static
@@ -1536,13 +1536,13 @@ class Builder
      */
     protected function merge(Model $model)
     {
-        if ($model->getTable() === $this->from ) {
+        if ($model->getTable() === $this->from) {
             return $this->union(
                 \DB::table($this->from)->where($model->getKeyName(), $model->getKey())
             );
         }
         throw new InvalidArgumentException();
-    }    
+    }
 
     /**
      * Add a union all statement to the query.


### PR DESCRIPTION
A simple way to merge a model instance into a simple query

 $user = App\User::find(29);
 $users = \DB::table('users')->where('id', '>', 50)->union($user)->get()
