### PR TITLE
[5.3] Allow declaration of $defer in Trait w/o causing FatalError/E-Strict...

### DIFF
--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -221,7 +221,7 @@ abstract class ServiceProvider
      */
     public function isDeferred()
     {
-        return isset($this->defer) ? $this->defer : flase;
+        return isset($this->defer) ? $this->defer : false;
     }
 
     /**

--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -221,7 +221,7 @@ abstract class ServiceProvider
      */
     public function isDeferred()
     {
-        return isset($this->defer) ? $this->defer : FALSE;
+        return isset($this->defer) ? $this->defer : flase;
     }
 
     /**

--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -18,7 +18,7 @@ abstract class ServiceProvider
      *
      * @var bool
      */
-    protected $defer = false;
+    //protected $defer = false;
 
     /**
      * The paths that should be published.
@@ -221,7 +221,7 @@ abstract class ServiceProvider
      */
     public function isDeferred()
     {
-        return $this->defer;
+        return isset($this->defer) ? $this->defer : FALSE;
     }
 
     /**


### PR DESCRIPTION
… by removing declaration of `$defer` in Illuminate\Support\ServiceProvider.php & updating `isDeferred()` to `return isset($this->defer) ? $this->defer : FALSE;` to preserve the default value while removing the obstacle to declaring `$defer` in a trait.

Background from http://php.net/manual/en/language.oop5.traits.php: 
```If a trait defines a property then a class can not define a property with the same name, otherwise an error is issued. It is an E_STRICT if the class definition is compatible (same visibility and initial value) or fatal error otherwise.```

The use case is admittedly obscure, but it's a simple change with no side effects, so there's little reason not to facillitate.
 
Use Case: I utilize a DefersBindingRegistration Trait in my "Laravel Toolkit" which deals with `$defers` and `provides()` (via `return static::BINDINGS;`, if you're curious; I also have a RegistersBindings Trait (which is used by DefersBindingRegistration) which utilizes the same constant, essentially making ServiceProvider creation as simple as dropping in a trait and specifying a map in the constant in cases where little else is being done in the Service Provider).  As it stands, I'm forced to override `isDeferred()` to `return TRUE;` in order to avoid the Fatal Error; obviously, I'd prefer removing the obstacle rather than overriding to compensate, hence the PR.
 
If there's interest, I'll add the relevant tests (and remove the commented out portion of the PR; I've retained it here for clarity).
 
(...and yes, I'd have preferred `return $this->defer ?? FALSE;`, but we can't have nice things (yet)...)

Thanks!