### PR TITLE
[5.4] Use trans() helper function in AuthenticatesUsers

### DIFF
--- a/src/Illuminate/Foundation/Auth/AuthenticatesUsers.php
+++ b/src/Illuminate/Foundation/Auth/AuthenticatesUsers.php
@@ -4,7 +4,6 @@ namespace Illuminate\Foundation\Auth;
 
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\Lang;
 
 trait AuthenticatesUsers
 {
@@ -127,7 +126,7 @@ trait AuthenticatesUsers
         return redirect()->back()
             ->withInput($request->only($this->username(), 'remember'))
             ->withErrors([
-                $this->username() => Lang::get('auth.failed'),
+                $this->username() => trans('auth.failed'),
             ]);
     }
 


### PR DESCRIPTION
Now targetting 5.4 instead of 5.3, as asked in #17195. 