### PR TITLE
Add table comment support for creating table.

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -31,6 +31,13 @@ class Blueprint
     protected $commands = [];
 
     /**
+     * The comment that should be added to the table.
+     *
+     * @var string
+     */
+    public $comment;
+
+    /**
      * The storage engine that should be used for the table.
      *
      * @var string

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -61,6 +61,11 @@ class MySqlGrammar extends Grammar
 
         $sql .= ' table '.$this->wrapTable($blueprint)." ($columns)";
 
+        // We check if a table comment has been set for the table. If so, we will add the comment to the SQL query.
+        if (isset($blueprint->comment)) {
+            $sql .= " comment '".$blueprint->comment."'";
+        }
+
         // Once we have the primary SQL, we can add the encoding option to the SQL for
         // the table.  Then, we can check if a storage engine has been supplied for
         // the table. If so, we will add the engine declaration to the SQL query.


### PR DESCRIPTION
We can use it as below:
```php

Schema::create('your table', function (Blueprint $table) {

    $table->comment = 'Some blabla';

});

```