### PR TITLE
[5.4] Add missing methods to QueueFake

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/QueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/QueueFake.php
@@ -209,7 +209,12 @@ class QueueFake implements Queue
      */
     public function bulk($jobs, $data = '', $queue = null)
     {
-        //
+        foreach ($this->jobs as $job) {
+            $this->jobs[get_class($job)][] = [
+                'job' => $job,
+                'queue' => $queue,
+            ];
+        }
     }
 
     /**

--- a/src/Illuminate/Support/Testing/Fakes/QueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/QueueFake.php
@@ -198,4 +198,38 @@ class QueueFake implements Queue
     {
         //
     }
+
+    /**
+     * Push an array of jobs onto the queue.
+     *
+     * @param  array $jobs
+     * @param  mixed $data
+     * @param  string $queue
+     * @return mixed
+     */
+    public function bulk($jobs, $data = '', $queue = null)
+    {
+        //
+    }
+
+    /**
+     * Get the connection name for the queue.
+     *
+     * @return string
+     */
+    public function getConnectionName()
+    {
+        //
+    }
+
+    /**
+     * Set the connection name for the queue.
+     *
+     * @param  string $name
+     * @return $this
+     */
+    public function setConnectionName($name)
+    {
+        return $this;
+    }
 }


### PR DESCRIPTION
As `\Illuminate\Contracts\Queue\Queue` is implemented by `\Illuminate\Support\Testing\Fakes\QueueFake`, add missing methods