### PR TITLE
[5.4] QueryException : no need to set $previous twice.

### DIFF
--- a/src/Illuminate/Database/QueryException.php
+++ b/src/Illuminate/Database/QueryException.php
@@ -35,7 +35,6 @@ class QueryException extends PDOException
 
         $this->sql = $sql;
         $this->bindings = $bindings;
-        $this->previous = $previous;
         $this->code = $previous->getCode();
         $this->message = $this->formatMessage($sql, $bindings, $previous);
 


### PR DESCRIPTION
QueryException : no need to set $previous twice.