### PR TITLE
[5.4] Validation : no need to use useless variable.

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -499,7 +499,7 @@ trait ValidatesAttributes
 
         $pattern = str_replace('\*', '[^.]+', preg_quote($attributeName, '#'));
 
-        $data = Arr::where(Arr::dot($attributeData), function ($value, $key) use ($attribute, $attributeName, $pattern) {
+        $data = Arr::where(Arr::dot($attributeData), function ($value, $key) use ($attribute, $pattern) {
             return $key != $attribute && (bool) preg_match('#^'.$pattern.'\z#u', $key);
         });
 


### PR DESCRIPTION
No need to use the useless `$attributeName` variable.