### PR TITLE
[5.4] Collection : fix mode return docblock

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -124,7 +124,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      * Get the mode of a given key.
      *
      * @param  mixed  $key
-     * @return array
+     * @return array|null
      */
     public function mode($key = null)
     {


### PR DESCRIPTION
Ensure `\Illuminate\Support\Collection::mode` always returns an array