### PR TITLE
[5.4] Fix \Illuminate\Validation\ValidationRuleParser::explode docblock

### DIFF
--- a/src/Illuminate/Validation/ValidationRuleParser.php
+++ b/src/Illuminate/Validation/ValidationRuleParser.php
@@ -36,7 +36,7 @@ class ValidationRuleParser
      * Parse the human-friendly rules into a full rules array for the validator.
      *
      * @param  array  $rules
-     * @return StdClass
+     * @return \StdClass
      */
     public function explode($rules)
     {


### PR DESCRIPTION
Fix `\Illuminate\Validation\ValidationRuleParser::explode` docblock