### PR TITLE
[5.4] Make Validator::sometimes() chainable

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -759,7 +759,7 @@ class Validator implements ValidatorContract
      * @param  string|array  $attribute
      * @param  string|array  $rules
      * @param  callable  $callback
-     * @return void
+     * @return $this
      */
     public function sometimes($attribute, $rules, callable $callback)
     {
@@ -770,6 +770,8 @@ class Validator implements ValidatorContract
                 $this->addRules([$key => $rules]);
             }
         }
+
+        return $this;
     }
 
     /**


### PR DESCRIPTION
Since `after()` returns $this I think `sometimes()` should return it too.