### PR TITLE
[5.4] Remove unused parameter

### DIFF
--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -210,7 +210,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
         $replace['count'] = $number;
 
         return $this->makeReplacements(
-            $this->getSelector()->choose($line, $number, $locale), $replace
+            $this->getSelector()->choose($line, $number), $replace
         );
     }
 

--- a/tests/Translation/TranslationTranslatorTest.php
+++ b/tests/Translation/TranslationTranslatorTest.php
@@ -76,7 +76,7 @@ class TranslationTranslatorTest extends TestCase
         $t = $this->getMockBuilder('Illuminate\Translation\Translator')->setMethods(['get'])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
         $t->expects($this->once())->method('get')->with($this->equalTo('foo'), $this->equalTo(['replace']), $this->equalTo('en'))->will($this->returnValue('line'));
         $t->setSelector($selector = m::mock('Illuminate\Translation\MessageSelector'));
-        $selector->shouldReceive('choose')->once()->with('line', 10, 'en')->andReturn('choiced');
+        $selector->shouldReceive('choose')->once()->with('line', 10)->andReturn('choiced');
 
         $t->choice('foo', 10, ['replace']);
     }
@@ -86,7 +86,7 @@ class TranslationTranslatorTest extends TestCase
         $t = $this->getMockBuilder('Illuminate\Translation\Translator')->setMethods(['get'])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
         $t->expects($this->exactly(2))->method('get')->with($this->equalTo('foo'), $this->equalTo(['replace']), $this->equalTo('en'))->will($this->returnValue('line'));
         $t->setSelector($selector = m::mock('Illuminate\Translation\MessageSelector'));
-        $selector->shouldReceive('choose')->twice()->with('line', 3, 'en')->andReturn('choiced');
+        $selector->shouldReceive('choose')->twice()->with('line', 3)->andReturn('choiced');
 
         $values = ['foo', 'bar', 'baz'];
         $t->choice('foo', $values, ['replace']);


### PR DESCRIPTION
The `choose()` method doesn't accept a third parameter:

https://github.com/laravel/framework/blob/5.4/src/Illuminate/Translation/MessageSelector.php#L16