### PR TITLE
[5.4] Response : do not call make statically

### DIFF
--- a/src/Illuminate/Routing/ResponseFactory.php
+++ b/src/Illuminate/Routing/ResponseFactory.php
@@ -66,7 +66,7 @@ class ResponseFactory implements FactoryContract
      */
     public function view($view, $data = [], $status = 200, array $headers = [])
     {
-        return static::make($this->view->make($view, $data), $status, $headers);
+        return $this->make($this->view->make($view, $data), $status, $headers);
     }
 
     /**


### PR DESCRIPTION
`make` function is not `static`, no need to call it statically.