### PR TITLE
[5.4] Set a custom connection resolver using static setters

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -137,6 +137,13 @@ class Connection implements ConnectionInterface
     protected $doctrineConnection;
 
     /**
+     * The connection resolvers.
+     *
+     * @var array
+     */
+    protected static $resolvers = [];
+
+    /**
      * Create a new database connection instance.
      *
      * @param  \PDO|\Closure     $pdo
@@ -935,6 +942,30 @@ class Connection implements ConnectionInterface
         $this->reconnector = $reconnector;
 
         return $this;
+    }
+
+    /**
+     * Register a connection resolver.
+     *
+     * @param  string  $driver
+     * @param  \Closure  $callback
+     * @return void
+     */
+    public static function resolveConnection($driver, Closure $callback)
+    {
+        static::$resolvers[$driver] = $callback;
+    }
+
+    /**
+     * Get the connection resolver for the given driver.
+     *
+     * @param  string  $driver
+     * @return mixed
+     */
+    public static function getResolver($driver)
+    {
+        return isset(static::$resolvers[$driver]) ?
+                     static::$resolvers[$driver] : null;
     }
 
     /**

--- a/src/Illuminate/Database/Connectors/ConnectionFactory.php
+++ b/src/Illuminate/Database/Connectors/ConnectionFactory.php
@@ -5,6 +5,7 @@ namespace Illuminate\Database\Connectors;
 use PDOException;
 use Illuminate\Support\Arr;
 use InvalidArgumentException;
+use Illuminate\Database\Connection;
 use Illuminate\Database\MySqlConnection;
 use Illuminate\Database\SQLiteConnection;
 use Illuminate\Database\PostgresConnection;
@@ -267,8 +268,8 @@ class ConnectionFactory
      */
     protected function createConnection($driver, $connection, $database, $prefix = '', array $config = [])
     {
-        if ($this->container->bound($key = "db.connection.{$driver}")) {
-            return $this->container->make($key, [$connection, $database, $prefix, $config]);
+        if ($resolver = Connection::getResolver($driver)) {
+            return $resolver($connection, $database, $prefix, $config);
         }
 
         switch ($driver) {


### PR DESCRIPTION
This will allow using a custom connection resolver since the current implementation uses `Container::make()` which doesn't accept a second argument for options anymore.

```php
Illuminate\Database\Connection::resolveConnection('mysql', function($connection, $database, $prefix, $config){
    return new MySqlConnection($connection, $database, $prefix, $config);
});
```