### PR TITLE
[5.3] Add support for numeric keys in validation rules.

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -3036,7 +3036,7 @@ class Validator implements ValidatorContract
 
         $rules = $this->explodeRules($this->initialRules);
 
-        $this->rules = array_merge($this->rules, $rules);
+        $this->rules = $rules + $this->rules;
 
         return $this;
     }

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -3267,6 +3267,13 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $this->assertFalse($v->passes());
     }
 
+    public function testValidationCanAcceptNumericKeysForRules() 
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, [10 => ''], [10 => 'Required']);
+        $this->assertEquals([10], array_keys($v->getRules()));
+    }
+
     protected function getTranslator()
     {
         return m::mock('Symfony\Component\Translation\TranslatorInterface');

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -3267,7 +3267,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $this->assertFalse($v->passes());
     }
 
-    public function testValidationCanAcceptNumericKeysForRules() 
+    public function testValidationCanAcceptNumericKeysForRules()
     {
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, [10 => ''], [10 => 'Required']);


### PR DESCRIPTION
This fixes an issue where you are unable to use numeric keys for your validation rules due
to the array_merge function in PHP overriding the original array indexes.