### PR TITLE
[5.4] Fix undefined variable in ConnectionFactory

### DIFF
--- a/src/Illuminate/Database/Connectors/ConnectionFactory.php
+++ b/src/Illuminate/Database/Connectors/ConnectionFactory.php
@@ -175,7 +175,7 @@ class ConnectionFactory
     protected function createPdoResolverWithHosts(array $config)
     {
         return function () use ($config) {
-            foreach (Arr::shuffle($this->parseHosts($config)) as $key => $host) {
+            foreach (Arr::shuffle($hosts = $this->parseHosts($config)) as $key => $host) {
                 $config['host'] = $host;
 
                 try {


### PR DESCRIPTION
[This change](https://github.com/laravel/framework/commit/5ba9db8f120ef1c7c92f997cae15820e537de543#diff-e4a88eb453b8b13937a28e794682dd7dR184) left the `$hosts` variable undefined.