### PR TITLE
[5.4] Use array_wrap() in several places

### DIFF
--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -236,7 +236,7 @@ class Gate implements GateContract
             return false;
         }
 
-        $arguments = is_array($arguments) ? $arguments : [$arguments];
+        $arguments = array_wrap($arguments);
 
         // First we will call the "before" callbacks for the Gate. If any of these give
         // back a non-null response, we will immediately return that result in order

--- a/src/Illuminate/Broadcasting/BroadcastEvent.php
+++ b/src/Illuminate/Broadcasting/BroadcastEvent.php
@@ -42,11 +42,7 @@ class BroadcastEvent
         $name = method_exists($event, 'broadcastAs')
                 ? $event->broadcastAs() : get_class($event);
 
-        $channels = $event->broadcastOn();
-
-        if (! is_array($channels)) {
-            $channels = [$channels];
-        }
+        $channels = array_wrap($event->broadcastOn());
 
         $this->broadcaster->broadcast(
             $channels, $name, $this->getPayloadFromEvent($event)

--- a/src/Illuminate/Database/Connectors/ConnectionFactory.php
+++ b/src/Illuminate/Database/Connectors/ConnectionFactory.php
@@ -199,7 +199,7 @@ class ConnectionFactory
      */
     protected function parseHosts(array $config)
     {
-        $hosts = is_array($config['host']) ? $config['host'] : [$config['host']];
+        $hosts = array_wrap($config['host']);
 
         if (empty($hosts)) {
             throw new InvalidArgumentException('Database hosts array is empty.');

--- a/src/Illuminate/Database/Eloquent/ModelNotFoundException.php
+++ b/src/Illuminate/Database/Eloquent/ModelNotFoundException.php
@@ -30,7 +30,7 @@ class ModelNotFoundException extends RuntimeException
     public function setModel($model, $ids = [])
     {
         $this->model = $model;
-        $this->ids = is_array($ids) ? $ids : [$ids];
+        $this->ids = array_wrap($ids);
 
         $this->message = "No query results for model [{$model}]";
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1320,7 +1320,7 @@ class Builder
         foreach ($groups as $group) {
             $this->groups = array_merge(
                 (array) $this->groups,
-                is_array($group) ? $group : [$group]
+                array_wrap($group)
             );
         }
 
@@ -2019,11 +2019,7 @@ class Builder
      */
     public function count($columns = '*')
     {
-        if (! is_array($columns)) {
-            $columns = [$columns];
-        }
-
-        return (int) $this->aggregate(__FUNCTION__, $columns);
+        return (int) $this->aggregate(__FUNCTION__, array_wrap($columns));
     }
 
     /**

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -363,7 +363,7 @@ class UrlGenerator implements UrlGeneratorContract
      */
     public function formatParameters($parameters)
     {
-        $parameters = is_array($parameters) ? $parameters : [$parameters];
+        $parameters = array_wrap($parameters);
 
         foreach ($parameters as $key => $parameter) {
             if ($parameter instanceof UrlRoutable) {

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -909,9 +909,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
             return $this->items[$keys];
         }
 
-        if (! is_array($keys)) {
-            $keys = [$keys];
-        }
+        $keys = array_wrap($keys);
 
         return new static(array_intersect_key($this->items, array_flip($keys)));
     }


### PR DESCRIPTION
This will replace blocks like:
```php
if (! is_array($value)) {
    $value = [$value];
}
```
or

```php
$value = is_array($value) ? $value : [$value];
```

with the use of `array_wrap()` helper function in several places.