### PR TITLE
[5.5] Ability to pass data to the view when rendering a paginator

### DIFF
--- a/src/Illuminate/Contracts/Pagination/Paginator.php
+++ b/src/Illuminate/Contracts/Pagination/Paginator.php
@@ -103,7 +103,8 @@ interface Paginator
      * Render the paginator using a given view.
      *
      * @param  string|null  $view
+     * @param  array  $data
      * @return string
      */
-    public function render($view = null);
+    public function render($view = null, $data = []);
 }

--- a/src/Illuminate/Pagination/LengthAwarePaginator.php
+++ b/src/Illuminate/Pagination/LengthAwarePaginator.php
@@ -70,25 +70,27 @@ class LengthAwarePaginator extends AbstractPaginator implements Arrayable, Array
      * Render the paginator using the given view.
      *
      * @param  string  $view
+     * @param  array  $data
      * @return string
      */
-    public function links($view = null)
+    public function links($view = null, $data = [])
     {
-        return $this->render($view);
+        return $this->render($view, $data);
     }
 
     /**
      * Render the paginator using the given view.
      *
      * @param  string  $view
+     * @param  array  $data
      * @return string
      */
-    public function render($view = null)
+    public function render($view = null, $data = [])
     {
-        return new HtmlString(static::viewFactory()->make($view ?: static::$defaultView, [
+        return new HtmlString(static::viewFactory()->make($view ?: static::$defaultView, array_merge($data, [
             'paginator' => $this,
             'elements' => $this->elements(),
-        ])->render());
+        ]))->render());
     }
 
     /**

--- a/src/Illuminate/Pagination/Paginator.php
+++ b/src/Illuminate/Pagination/Paginator.php
@@ -87,25 +87,27 @@ class Paginator extends AbstractPaginator implements Arrayable, ArrayAccess, Cou
      * Render the paginator using the given view.
      *
      * @param  string|null  $view
+     * @param  array  $data
      * @return string
      */
-    public function links($view = null)
+    public function links($view = null, $data = [])
     {
-        return $this->render($view);
+        return $this->render($view, $data);
     }
 
     /**
      * Render the paginator using the given view.
      *
      * @param  string|null  $view
+     * @param  array  $data
      * @return string
      */
-    public function render($view = null)
+    public function render($view = null, $data = [])
     {
         return new HtmlString(
-            static::viewFactory()->make($view ?: static::$defaultSimpleView, [
+            static::viewFactory()->make($view ?: static::$defaultSimpleView, array_merge($data, [
                 'paginator' => $this,
-            ])->render()
+            ]))->render()
         );
     }
 


### PR DESCRIPTION
When rendering pagination with a custom view:
```php
{!! $users->links('custom-view') !!}
```
this pull request adds the ability to send data to the view:
```php
{!! $users->links('custom-view', ['foo' => 'bar']) !!}
```

(As an aside, I've just noticed that the [documentation for this](https://laravel.com/docs/master/pagination#displaying-pagination-results) indicates the use of escaping blade tags `{{ $users->links() }}` rather than the non-escaping ones that are required `{!! $users->links() !!}`)