### PR TITLE
[5.3] (#17283) Fixed Callbacks not being made Serializable in Illuminate\Mail\Mailable

### DIFF
--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -126,6 +126,8 @@ class Mailable implements MailableContract
      */
     public function queue(Queue $queue)
     {
+        $this->makeCallbacksSerializable();
+
         $connection = property_exists($this, 'connection') ? $this->connection : null;
 
         $queueName = property_exists($this, 'queue') ? $this->queue : null;
@@ -150,6 +152,8 @@ class Mailable implements MailableContract
      */
     public function later($delay, Queue $queue)
     {
+        $this->makeCallbacksSerializable();
+
         $connection = property_exists($this, 'connection') ? $this->connection : null;
 
         $queueName = property_exists($this, 'queue') ? $this->queue : null;
@@ -508,6 +512,28 @@ class Mailable implements MailableContract
         }
 
         $this->callbacks[] = $callback;
+
+        return $this;
+    }
+
+    /**
+     * Makes all the callbacks serializable.
+     *
+     * @return $this
+     */
+    public function makeCallbacksSerializable()
+    {
+        $callbacks = [];
+
+        foreach ($this->callbacks as $callback) {
+            if (! ($callback instanceof SerializableClosure)) {
+                $callback = new SerializableClosure($callback);
+            }
+
+            $callbacks[] = $callback;
+        }
+
+        $this->callbacks = $callbacks;
 
         return $this;
     }

--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -8,10 +8,10 @@ use BadMethodCallException;
 use Illuminate\Support\Str;
 use Illuminate\Support\Collection;
 use Illuminate\Container\Container;
+use SuperClosure\SerializableClosure;
 use Illuminate\Contracts\Queue\Factory as Queue;
 use Illuminate\Contracts\Mail\Mailer as MailerContract;
 use Illuminate\Contracts\Mail\Mailable as MailableContract;
-use SuperClosure\SerializableClosure;
 
 class Mailable implements MailableContract
 {
@@ -503,7 +503,7 @@ class Mailable implements MailableContract
      */
     public function withSwiftMessage($callback)
     {
-        if ( !($callback instanceof SerializableClosure) ) {
+        if (! ($callback instanceof SerializableClosure)) {
             $callback = new SerializableClosure($callback);
         }
 

--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -11,6 +11,7 @@ use Illuminate\Container\Container;
 use Illuminate\Contracts\Queue\Factory as Queue;
 use Illuminate\Contracts\Mail\Mailer as MailerContract;
 use Illuminate\Contracts\Mail\Mailable as MailableContract;
+use SuperClosure\SerializableClosure;
 
 class Mailable implements MailableContract
 {
@@ -502,6 +503,10 @@ class Mailable implements MailableContract
      */
     public function withSwiftMessage($callback)
     {
+        if ( !($callback instanceof SerializableClosure) ) {
+            $callback = new SerializableClosure($callback);
+        }
+
         $this->callbacks[] = $callback;
 
         return $this;


### PR DESCRIPTION
Fixes #17283 

__Problem__
The callbacks passed to the `withSwiftMessage()` function of the `Illuminate\Mail\Mailable` are not being made serializable. So, when somebody uses this function to run a callback on the message before sending & then pushes the mail onto a job queue, the process fails with the error:
`local.ERROR: Exception: Serialization of 'Closure' is not allowed in /data/vendor/laravel/framework/src/Illuminate/Queue/Queue.php:86`