### PR TITLE
[5.5] Bugfix: return hit count in incrementLoginAttempts function

### DIFF
--- a/src/Illuminate/Foundation/Auth/ThrottlesLogins.php
+++ b/src/Illuminate/Foundation/Auth/ThrottlesLogins.php
@@ -31,7 +31,7 @@ trait ThrottlesLogins
      */
     protected function incrementLoginAttempts(Request $request)
     {
-        $this->limiter()->hit($this->throttleKey($request));
+        return $this->limiter()->hit($this->throttleKey($request));
     }
 
     /**


### PR DESCRIPTION
return the value returned by the `hit` function of limiter like it is documented in phpdoc