### PR TITLE
Bugfix: return hit count in incrementLoginAttempts function

### DIFF
--- a/src/Illuminate/Foundation/Auth/ThrottlesLogins.php
+++ b/src/Illuminate/Foundation/Auth/ThrottlesLogins.php
@@ -30,7 +30,7 @@ trait ThrottlesLogins
      */
     protected function incrementLoginAttempts(Request $request)
     {
-        app(RateLimiter::class)->hit(
+        return app(RateLimiter::class)->hit(
             $this->getThrottleKey($request)
         );
     }


### PR DESCRIPTION
return the value returned by the `hit` function of limiter like it is documented in phpdoc

in 5.1 is the first occurrence of this bug. wanted in #17288