### PR TITLE
Making Auth::routes() more flexible by accepting some exclusions.

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -965,24 +965,35 @@ class Router implements RegistrarContract, BindingRegistrar
     /**
      * Register the typical authentication routes for an application.
      *
+     * @param array $options
      * @return void
      */
-    public function auth()
+    public function auth(array $options = [])
     {
+        $except = array_get($options, 'except', []);
+
         // Authentication Routes...
-        $this->get('login', 'Auth\LoginController@showLoginForm')->name('login');
-        $this->post('login', 'Auth\LoginController@login');
-        $this->post('logout', 'Auth\LoginController@logout')->name('logout');
+        if (! in_array('login', $except)) {
+            $this->get('login', 'Auth\LoginController@showLoginForm')->name('login');
+            $this->post('login', 'Auth\LoginController@login');
+        }
+        if (! in_array('logout', $except)) {
+            $this->post('logout', 'Auth\LoginController@logout')->name('logout');
+        }
 
         // Registration Routes...
-        $this->get('register', 'Auth\RegisterController@showRegistrationForm')->name('register');
-        $this->post('register', 'Auth\RegisterController@register');
+        if (! in_array('register', $except)) {
+            $this->get('register', 'Auth\RegisterController@showRegistrationForm')->name('register');
+            $this->post('register', 'Auth\RegisterController@register');
+        }
 
         // Password Reset Routes...
-        $this->get('password/reset', 'Auth\ForgotPasswordController@showLinkRequestForm')->name('password.request');
-        $this->post('password/email', 'Auth\ForgotPasswordController@sendResetLinkEmail');
-        $this->get('password/reset/{token}', 'Auth\ResetPasswordController@showResetForm')->name('password.reset');
-        $this->post('password/reset', 'Auth\ResetPasswordController@reset');
+        if (! in_array('passwords', $except)) {
+            $this->get('password/reset', 'Auth\ForgotPasswordController@showLinkRequestForm')->name('password.request');
+            $this->post('password/email', 'Auth\ForgotPasswordController@sendResetLinkEmail');
+            $this->get('password/reset/{token}', 'Auth\ResetPasswordController@showResetForm')->name('password.reset');
+            $this->post('password/reset', 'Auth\ResetPasswordController@reset');
+        }
     }
 
     /**

--- a/src/Illuminate/Support/Facades/Auth.php
+++ b/src/Illuminate/Support/Facades/Auth.php
@@ -39,10 +39,11 @@ class Auth extends Facade
     /**
      * Register the typical authentication routes for an application.
      *
+     * @param array $options
      * @return void
      */
-    public static function routes()
+    public static function routes(array $options = [])
     {
-        static::$app->make('router')->auth();
+        static::$app->make('router')->auth($options);
     }
 }


### PR DESCRIPTION
Not sure if you would be interested by this one but I was wondering how complicated would it be to add the ability to pass options to `Auth::routes()` and exclude some routes automatically generated from it. Turned out to be pretty simple.

Sometimes, you don't necessarily want to have all the routes automatically generated from `Auth::routes()` available within your application.

This is a simple way of enabling some routes or not depending on your needs.

The syntax is similar to when you want to add exceptions to your resource routes:

```php
Auth::routes([
    'except' => [
        'register',
    ]
]);
```

The accepted values for this are `login`, `logout`, `register` and `passwords`.

Open to suggestions.