### PR TITLE
Allow Proper Wrapping of Database Names Containing Spaces When Aliasi…

### DIFF
--- a/src/Illuminate/Database/Grammar.php
+++ b/src/Illuminate/Database/Grammar.php
@@ -56,13 +56,13 @@ abstract class Grammar
         // the pieces so we can wrap each of the segments of the expression on it
         // own, and then joins them both back together with the "as" connector.
         if (strpos(strtolower($value), ' as ') !== false) {
-            $segments = explode(' ', $value);
+            $segments = preg_split( '/\s+as\s+/i', $value );
 
             if ($prefixAlias) {
-                $segments[2] = $this->tablePrefix.$segments[2];
+                $segments[1] = $this->tablePrefix.$segments[1];
             }
 
-            return $this->wrap($segments[0]).' as '.$this->wrapValue($segments[2]);
+            return $this->wrap($segments[0]).' as '.$this->wrapValue($segments[1]);
         }
 
         $wrapped = [];


### PR DESCRIPTION
…ng Columns (Perfectly Legal in SQL Server)

Currently, when using SQL Server, if you have a database which includes spaces, the grammar handles wrapping it fine. 

So this:

My Sample Database.dbo.my_table.my_column

Becomes:

[My Sample Database].[dbo].[my_table].[my_column]

But if you also try to alias a column when the database contains spaces, it breaks. 

This:

My Sample Database.dbo.my_table.my_column AS my_aliased_column

Becomes:

[My] AS [Sample]

I have traced the error to Database/Grammar using explode( ' ' ) - the code thinks the spaces in the database name are the spaces around the "AS".

You can fix this by using regex instead of explode, splitting on the "AS" more accurately.

Just replace the explode with this:

$segments = preg_split( '/\s+as\s+/i', $value );

Please note: When you have an Eloquent belongsToMany method that has to include the database name (eg. we need to join across DBs), this type of alias is created automatically, generating this error.