### PR TITLE
[5.3] Allow reserved words as table name in sqlite

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -40,7 +40,7 @@ class SQLiteGrammar extends Grammar
      */
     public function compileColumnExists($table)
     {
-        return 'pragma table_info(`'.str_replace('.', '__', $table).'`)';
+        return 'pragma table_info('.$this->wrapTable(str_replace('.', '__', $table)).')';
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -40,7 +40,7 @@ class SQLiteGrammar extends Grammar
      */
     public function compileColumnExists($table)
     {
-        return 'pragma table_info('.str_replace('.', '__', $table).')';
+        return 'pragma table_info(`'.str_replace('.', '__', $table).'`)';
     }
 
     /**


### PR DESCRIPTION
When using sqlite the below fails as group is a reserved word.
`Schema::getColumnListing('group');`
