### PR TITLE
[5.3] Check for pivot casts on parent model

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Pivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Pivot.php
@@ -171,6 +171,20 @@ class Pivot extends Model
     }
 
     /**
+     * Get the casts array.
+     *
+     * @return array
+     */
+    public function getCasts()
+    {
+        if ($this->parent && method_exists($this->parent, 'getCasts')) {
+            return $this->parent->getCasts();
+        }
+
+        return parent::getCasts();
+    }
+
+    /**
      * Get the name of the "created at" column.
      *
      * @return string


### PR DESCRIPTION
This is a possible fix for https://github.com/laravel/framework/issues/10533 which is re-occuring on 5.3

I don't know whether it's preferred to prefix pivot casts with `pivot.` but at the moment this would just need the column name added to `$casts` for the model that references the pivot.

The drawback to this approach is you're unable to have a column on a model with one type of cast and a pivoting column you're referencing within the same model with a different cast.