### PR TITLE
[5.4] Add support for numeric keys in validation rules

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -755,6 +755,10 @@ class Validator implements ValidatorContract
             $this->rules, $response->rules
         );
 
+        $this->rules = array_combine(
+            array_keys($response->rules), $this->rules
+        );
+
         $this->implicitAttributes = array_merge(
             $this->implicitAttributes, $response->implicitAttributes
         );

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -3239,6 +3239,13 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
     }
 
+    public function testValidationCanAcceptNumericKeysForRules()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, [10 => ''], [10 => 'Required']);
+        $this->assertEquals([10], array_keys($v->getRules()));
+    }
+
     protected function getTranslator()
     {
         return m::mock('Illuminate\Contracts\Translation\Translator');


### PR DESCRIPTION
This fixes an issue where you are unable to use numeric keys for your validation rules due
to the array_merge function in PHP overriding the original array indexes.

Suggested as 5.4 change in pull request #17260 

Modified original implementation slightly to account for 5.4 changes. 