### PR TITLE
[5.3] Add ability to filter the Collection count method

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1281,11 +1281,14 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Count the number of items in the collection.
      *
+     * @param callable|null $callback
      * @return int
      */
-    public function count()
+    public function count(callable $callback = null)
     {
-        return count($this->items);
+        $items = $callback === null ? $this->items : $this->filter($callback)->toArray();
+
+        return count($items);
     }
 
     /**

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1194,7 +1194,7 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
 
     public function testCount()
     {
-        $c = new Collection([1,3,5,7]);
+        $c = new Collection([1, 3, 5, 7]);
 
         $this->assertEquals(4, $c->count());
     }
@@ -1204,10 +1204,10 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
      */
     public function testCountWithFilter()
     {
-        $c = new Collection([1,3,5,7]);
+        $c = new Collection([1, 3, 5, 7]);
 
-        $this->assertEquals(3, $c->count(function($v) {
-            return $v>1;
+        $this->assertEquals(3, $c->count(function ($v) {
+            return $v > 1;
         }));
     }
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1192,6 +1192,25 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($c->containsStrict(''));
     }
 
+    public function testCount()
+    {
+        $c = new Collection([1,3,5,7]);
+
+        $this->assertEquals(4, $c->count());
+    }
+
+    /**
+     * @group nathan
+     */
+    public function testCountWithFilter()
+    {
+        $c = new Collection([1,3,5,7]);
+
+        $this->assertEquals(3, $c->count(function($v) {
+            return $v>1;
+        }));
+    }
+
     public function testGettingSumFromCollection()
     {
         $c = new Collection([(object) ['foo' => 50], (object) ['foo' => 50]]);


### PR DESCRIPTION
Add ability to pass a filter callback to the count method.

This will perform the filter then do the count.

This is similar to the count function in .NET's linq library.