### PR TITLE
Feature: Check if a null object can be returned if a relationship result is null

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -161,6 +161,13 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     protected $casts = [];
 
     /**
+     * Map relationships to null objects that should be returned if the result is null.
+     *
+     * @var array
+     */
+    protected $relationship_null_objects = [];
+
+    /**
      * The relationships that should be touched on save.
      *
      * @var array
@@ -2710,7 +2717,13 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
                 .'Illuminate\Database\Eloquent\Relations\Relation');
         }
 
-        $this->setRelation($method, $results = $relations->getResults());
+        $results = $relations->getResults();
+
+        if ($results === null && array_key_exists($method, $this->relationship_null_objects)) {
+            $results = new $this->relationship_null_objects[$method];
+        }
+
+        $this->setRelation($method, $results);
 
         return $results;
     }


### PR DESCRIPTION
If a relationship result returns null, check if a null object to return has been mapped for this relationship.

This provides value if you need behaviour for a relationship that does not exist.

At my work, we use these null objects to fill in the gaps for missing data. We typically have our null models extend our base model and implement a `Voided` trait which makes the save method not persist and return false.

```
<?php

namespace App\Traits;

trait Voided
{
    public function save(array $options = [])
    {
        return false;
    }
}

```

In a model, you can map a relationship to a class name of the null object using the `$relationship_null_objects` class variable:

```
<?php

namespace App;

class User extends Model
{
    protected $relationship_null_objects = [
        'company' => NullCompany::class,
    ];

    public function company()
    {
        return $this->belongsTo(Company::class, 'company_id');
    }
}

```

If the user has no company, because of the above lookup array, the company relationship will return a `NullCompany`:

```
<?php

namespace App;

class NullCompany extends Model
{
    use Traits\Voided;

    public function customers()
    {
        return collect([]);
    }
}

```
