### PR TITLE
[5.4] Check if a null object can be returned if a relationship result is null

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -35,6 +35,13 @@ trait HasAttributes
     protected $casts = [];
 
     /**
+     * Map relationships to null objects that should be returned if the result is null.
+     *
+     * @var array
+     */
+    protected $relationshipNullObjects = [];
+
+    /**
      * The attributes that should be mutated to dates.
      *
      * @var array
@@ -404,6 +411,9 @@ trait HasAttributes
         }
 
         return tap($relation->getResults(), function ($results) use ($method) {
+            if ($results === null && array_key_exists($method, $this->relationshipNullObjects)) {
+                $results = new $this->relationshipNullObjects[$method];
+            }
             $this->setRelation($method, $results);
         });
     }


### PR DESCRIPTION
Related to #17306. This feature is for 5.4 because it's not easily merged from 5.3.

If a relationship result returns null, check if a null object to return has been mapped for this relationship.

This provides value if you need behaviour for a relationship that does not exist.

At my work, we use these null objects to fill in the gaps for missing data. We typically have our null models extend our base model and implement a `Voided` trait which makes the save method not persist and return false.

```
<?php

namespace App\Traits;

trait Voided
{
    public function save(array $options = [])
    {
        return false;
    }
}

```

In a model, you can map a relationship to a class name of the null object using the `$relationshipNullObjects` class variable:

```
<?php

namespace App;

class User extends Model
{
    protected $relationshipNullObjects = [
        'company' => NullCompany::class,
    ];

    public function company()
    {
        return $this->belongsTo(Company::class, 'company_id');
    }
}

```

If the user has no company, because of the above lookup array, the company relationship will return a `NullCompany`:

```
<?php

namespace App;

class NullCompany extends Model
{
    use Traits\Voided;

    public function customers()
    {
        return collect([]);
    }
}

```
