### PR TITLE
Expose which validation rule fails

### DIFF
--- a/src/Illuminate/Support/MessageBag.php
+++ b/src/Illuminate/Support/MessageBag.php
@@ -52,13 +52,14 @@ class MessageBag implements Arrayable, Countable, Jsonable, JsonSerializable, Me
      * Add a message to the bag.
      *
      * @param  string  $key
+     * @param  string  $index
      * @param  string  $message
      * @return $this
      */
-    public function add($key, $message)
+    public function add($key, $index, $message)
     {
         if ($this->isUnique($key, $message)) {
-            $this->messages[$key][] = $message;
+            $this->messages[$key][$index] = $message;
         }
 
         return $this;

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -511,7 +511,7 @@ class Validator implements ValidatorContract
 
         $message = $this->doReplacements($message, $attribute, $rule, $parameters);
 
-        $this->messages->add($attribute, $message);
+        $this->messages->add($attribute, snake_case($rule), $message);
     }
 
     /**


### PR DESCRIPTION
By this PR, MessageBag now returns the messages as shown below it is usefull in some cases.

```
 "email": {
    "required": "The email field is required.",
    "email": "The email must be a valid email address.",
    "confirmed": "The email confirmation does not match.",
    "unique": "The email has already been taken."
  }
```

Above example is when JSON Encoded.