### PR TITLE
Backport chunkById implementation into 5.2

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -391,19 +391,25 @@ class Builder
      */
     public function chunkById($count, callable $callback, $column = 'id')
     {
-        $lastId = null;
+        $lastId = 0;
 
-        $results = $this->forPageAfterId($count, 0, $column)->get();
+        do {
+            $clone = clone $this;
 
-        while (! $results->isEmpty()) {
-            if (call_user_func($callback, $results) === false) {
+            $results = $clone->forPageAfterId($count, $lastId, $column)->get();
+
+            $countResults = $results->count();
+
+            if ($countResults == 0) {
+                break;
+            }
+
+            if ($callback($results) === false) {
                 return false;
             }
 
             $lastId = $results->last()->{$column};
-
-            $results = $this->forPageAfterId($count, $lastId, $column)->get();
-        }
+        } while ($countResults == $count);
 
         return true;
     }

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1788,21 +1788,27 @@ class Builder
      */
     public function chunkById($count, callable $callback, $column = 'id', $alias = null)
     {
-        $lastId = null;
-
         $alias = $alias ?: $column;
 
-        $results = $this->forPageAfterId($count, 0, $column)->get();
+        $lastId = 0;
 
-        while (! empty($results)) {
+        do {
+            $clone = clone $this;
+
+            $results = $clone->forPageAfterId($count, $lastId, $column)->get();
+
+            $countResults = $results->count();
+
+            if ($countResults == 0) {
+                break;
+            }
+
             if (call_user_func($callback, $results) === false) {
                 return false;
             }
 
-            $lastId = last($results)->{$alias};
-
-            $results = $this->forPageAfterId($count, $lastId, $column)->get();
-        }
+            $lastId = $results->last()->{$alias};
+        } while ($countResults == $count);
 
         return true;
     }


### PR DESCRIPTION
The current implementation in 5.2 is incorrect, resulting in multiple
`where` clauses.

For example:

    select id from things where id > 0 and id > 12 and id > 100 and id >
    150 order by id

The current `where` clause should replace the previous ones:

    select id from listings where id > 150 order by id

The cloning introduced in 5.3 solves this issue. This patch backports
that change into the 5.2 branch.