### PR TITLE
[5.4] Execute queries with lock only in write database

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1303,7 +1303,7 @@ class Builder
     {
         $this->lock = $value;
 
-        if ($this->lock) {
+        if (isset($this->lock)) {
             $this->useWritePdo();
         }
 

--- a/src/Illuminate/Http/RedirectResponse.php
+++ b/src/Illuminate/Http/RedirectResponse.php
@@ -8,6 +8,7 @@ use Illuminate\Support\MessageBag;
 use Illuminate\Support\ViewErrorBag;
 use Illuminate\Session\Store as SessionStore;
 use Illuminate\Contracts\Support\MessageProvider;
+use Symfony\Component\HttpFoundation\File\UploadedFile as SymfonyUploadedFile;
 use Symfony\Component\HttpFoundation\RedirectResponse as BaseRedirectResponse;
 
 class RedirectResponse extends BaseRedirectResponse


### PR DESCRIPTION
As we know, in Laravel we can use two instances of a database, first for read and second for write.

When we use $query->lockForUpdate() or $query->lock(true), PDO for write will be used, but when we use $query->sharedLock() or $query->lock(false), we will still use PDO for read.

In Postgres case when we call lock with false as an argument, grammar will compile it to 'for share' in PDO for read. Finally, when we call lock with 'for share' - grammar will return the same result, but builder this time will use PDO for write.

If we use any lock on the read-only database, we'll get the query exception: "SQLSTATE[25006]: Read only sql transaction: 7 ERROR:  cannot execute SELECT FOR SHARE in a read-only transaction", so queries with a lock should always be executed on the write database to avoid the exception.