### PR TITLE
[5.3] Show seed output prior to running, instead of after

### DIFF
--- a/src/Illuminate/Database/Seeder.php
+++ b/src/Illuminate/Database/Seeder.php
@@ -36,11 +36,11 @@ abstract class Seeder
      */
     public function call($class)
     {
-        $this->resolve($class)->run();
-
         if (isset($this->command)) {
-            $this->command->getOutput()->writeln("<info>Seeded:</info> $class");
+            $this->command->getOutput()->writeln("<info>Seeding:</info> $class");
         }
+
+        $this->resolve($class)->run();
     }
 
     /**


### PR DESCRIPTION
Currently the database seeder shows its output prior to running the seed class. For example:

```bash
# runs seed class UserSeeder
Seed: UserSeeder
```

This is a simple change that proposes to show the output _before_ running the seeder:

```bash
Seeding: UserSeeder
# runs seed class UserSeeder
```

This may seem minor, but on a project with long-running seeds it's difficult to know which seed is currently running. It's even more annoying if a seed breaks (for whatever reason), you don't actually know which seed it was (without pulling up the code and looking at the seed order).

![image](https://cloud.githubusercontent.com/assets/882133/21933924/6ceeba94-d975-11e6-9282-88e1173e10a8.png)