### PR TITLE
[5.4] Added the ability to filter directly on the count method

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1340,11 +1340,14 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Count the number of items in the collection.
      *
+     * @param callable|null $callback
      * @return int
      */
-    public function count()
+    public function count(callable $callback = null)
     {
-        return count($this->items);
+        $items = $callback === null ? $this->items : $this->filter($callback)->toArray();
+
+        return count($items);
     }
 
     /**

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1316,6 +1316,25 @@ class SupportCollectionTest extends TestCase
         $this->assertTrue($c->contains('v', '>', 4));
     }
 
+    public function testCount()
+    {
+        $c = new Collection([1,3,5,7]);
+
+        $this->assertEquals(4, $c->count());
+    }
+
+    /**
+     * @group nathan
+     */
+    public function testCountWithFilter()
+    {
+        $c = new Collection([1,3,5,7]);
+
+        $this->assertEquals(3, $c->count(function($v) {
+            return $v>1;
+        }));
+    }
+
     public function testGettingSumFromCollection()
     {
         $c = new Collection([(object) ['foo' => 50], (object) ['foo' => 50]]);

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1332,10 +1332,10 @@ class SupportCollectionTest extends TestCase
         }));
 
 
-        $c = new Collection([ ['id'=>7, 'name'=>'foo'], ['id'=>12, 'name'=>'bar'], ['id'=>12, 'name'=>'baz']]);
+        $c = new Collection([['id'=>7, 'name'=>'foo'], ['id'=>12, 'name'=>'bar'], ['id'=>12, 'name'=>'baz']]);
 
         $this->assertEquals(2, $c->count(function ($v) {
-            return substr($v['name'],0,1)==='b';
+            return substr($v['name'], 0, 1 )=== 'b';
         }));
     }
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1331,7 +1331,6 @@ class SupportCollectionTest extends TestCase
             return $v > 1;
         }));
 
-
         $c = new Collection([['id'=>7, 'name'=>'foo'], ['id'=>12, 'name'=>'bar'], ['id'=>12, 'name'=>'baz']]);
 
         $this->assertEquals(2, $c->count(function ($v) {

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1335,7 +1335,7 @@ class SupportCollectionTest extends TestCase
         $c = new Collection([['id'=>7, 'name'=>'foo'], ['id'=>12, 'name'=>'bar'], ['id'=>12, 'name'=>'baz']]);
 
         $this->assertEquals(2, $c->count(function ($v) {
-            return substr($v['name'], 0, 1 )=== 'b';
+            return substr($v['name'], 0, 1)=== 'b';
         }));
     }
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1318,7 +1318,7 @@ class SupportCollectionTest extends TestCase
 
     public function testCount()
     {
-        $c = new Collection([1,3,5,7]);
+        $c = new Collection([1, 3, 5, 7]);
 
         $this->assertEquals(4, $c->count());
     }
@@ -1328,10 +1328,17 @@ class SupportCollectionTest extends TestCase
      */
     public function testCountWithFilter()
     {
-        $c = new Collection([1,3,5,7]);
+        $c = new Collection([1, 3, 5, 7]);
 
-        $this->assertEquals(3, $c->count(function($v) {
-            return $v>1;
+        $this->assertEquals(3, $c->count(function ($v) {
+            return $v > 1;
+        }));
+
+
+        $c = new Collection([ ['id'=>7, 'name'=>'foo'], ['id'=>12, 'name'=>'bar'], ['id'=>12, 'name'=>'baz']]);
+
+        $this->assertEquals(2, $c->count(function ($v) {
+            return substr($v['name'],0,1)==='b';
         }));
     }
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1335,7 +1335,7 @@ class SupportCollectionTest extends TestCase
         $c = new Collection([['id'=>7, 'name'=>'foo'], ['id'=>12, 'name'=>'bar'], ['id'=>12, 'name'=>'baz']]);
 
         $this->assertEquals(2, $c->count(function ($v) {
-            return substr($v['name'], 0, 1)=== 'b';
+            return substr($v['name'], 0, 1) === 'b';
         }));
     }
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1323,9 +1323,6 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(4, $c->count());
     }
 
-    /**
-     * @group nathan
-     */
     public function testCountWithFilter()
     {
         $c = new Collection([1, 3, 5, 7]);


### PR DESCRIPTION
Add ability to pass a filter callback to the count method.

This will perform the filter then do the count.

This is similar to the count function in .NET's linq library.