### PR TITLE
[5.4] Support for calling artisan in different queues

### DIFF
--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -222,9 +222,9 @@ class Kernel implements KernelContract
     /**
      * Queue the given console command.
      *
-     * @param  string $command
+     * @param  string  $command
      * @param  array  $parameters
-     * @param  string $queue
+     * @param  string|null  $queue
      *
      * @return void
      */

--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -222,14 +222,18 @@ class Kernel implements KernelContract
     /**
      * Queue the given console command.
      *
-     * @param  string  $command
-     * @param  array   $parameters
+     * @param  string $command
+     * @param  array  $parameters
+     * @param  string $queue
+     *
      * @return void
      */
-    public function queue($command, array $parameters = [])
+    public function queue($command, array $parameters = [], $queue = null)
     {
         $this->app['Illuminate\Contracts\Queue\Queue']->push(
-            'Illuminate\Foundation\Console\QueuedJob', func_get_args()
+            'Illuminate\Foundation\Console\QueuedJob',
+            [$command, $parameters],
+            $queue
         );
     }
 


### PR DESCRIPTION
```php
// Support for calling artisan in different queues. For example
Artisan::queue('test', ['id' => $id], "queue-2");
Artisan::queue('test', ['id' => $id], "queue-1");

```