### PR TITLE
[5.4] Environment providers

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -539,7 +539,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     {
         $this->registerProviders(array_merge(
             $this->config['app.providers'],
-            $this->config->get('app.providers-'.$this['env'],[])
+            $this->config->get('app.providers-'.$this['env'], [])
         ));
     }
 

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -537,8 +537,19 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
      */
     public function registerConfiguredProviders()
     {
+        $this->registerProviders(array_merge(
+            $this->config['app.providers'],
+            $this->config->get('app.providers-'.$this['env'],[])
+        ));
+    }
+
+    /**
+     * @param array $providers
+     */
+    public function registerProviders(array $providers)
+    {
         (new ProviderRepository($this, new Filesystem, $this->getCachedServicesPath()))
-                    ->load($this->config['app.providers']);
+            ->load($providers);
     }
 
     /**

--- a/tests/Foundation/FoundationEnvironmentProvidersTest.php
+++ b/tests/Foundation/FoundationEnvironmentProvidersTest.php
@@ -1,7 +1,7 @@
 <?php
 
-use Illuminate\Config\Repository;
 use Mockery as m;
+use Illuminate\Config\Repository;
 
 class FoundationEnvironmentProvidersTest extends PHPUnit_Framework_TestCase
 {
@@ -13,7 +13,7 @@ class FoundationEnvironmentProvidersTest extends PHPUnit_Framework_TestCase
     public function testMergeProvidersWithEnvironmentProviders()
     {
         $app = m::mock('\Illuminate\Foundation\Application[registerProviders]');
-        $app->shouldReceive('registerProviders')->once()->with(['foobar','foobar-local']);
+        $app->shouldReceive('registerProviders')->once()->with(['foobar', 'foobar-local']);
 
         $app['config'] = $this->getConfigRepository();
         $app['env'] = 'testing';
@@ -38,14 +38,13 @@ class FoundationEnvironmentProvidersTest extends PHPUnit_Framework_TestCase
         return new Repository([
             'app' => [
                 'providers' => [
-                    'foobar'
+                    'foobar',
                 ],
                 'providers-testing' => [
-                    'foobar-local'
+                    'foobar-local',
                 ],
                 'providers-empty' => [],
-            ]
+            ],
         ]);
     }
-
 }

--- a/tests/Foundation/FoundationEnvironmentProvidersTest.php
+++ b/tests/Foundation/FoundationEnvironmentProvidersTest.php
@@ -1,0 +1,51 @@
+<?php
+
+use Illuminate\Config\Repository;
+use Mockery as m;
+
+class FoundationEnvironmentProvidersTest extends PHPUnit_Framework_TestCase
+{
+    public function tearDown()
+    {
+        m::close();
+    }
+
+    public function testMergeProvidersWithEnvironmentProviders()
+    {
+        $app = m::mock('\Illuminate\Foundation\Application[registerProviders]');
+        $app->shouldReceive('registerProviders')->once()->with(['foobar','foobar-local']);
+
+        $app['config'] = $this->getConfigRepository();
+        $app['env'] = 'testing';
+        $app->registerConfiguredProviders();
+    }
+
+    public function testEnvironmentProvidersAreOptional()
+    {
+        $app = m::mock('\Illuminate\Foundation\Application[registerProviders]');
+        $app->shouldReceive('registerProviders')->twice()->with(['foobar']);
+
+        $app['config'] = $this->getConfigRepository();
+        $app['env'] = 'unknown';
+        $app->registerConfiguredProviders();
+
+        $app['env'] = 'empty';
+        $app->registerConfiguredProviders();
+    }
+
+    private function getConfigRepository()
+    {
+        return new Repository([
+            'app' => [
+                'providers' => [
+                    'foobar'
+                ],
+                'providers-testing' => [
+                    'foobar-local'
+                ],
+                'providers-empty' => [],
+            ]
+        ]);
+    }
+
+}


### PR DESCRIPTION
With this PR a developer is able to register environment specific providers straight from within the `config/app.php` file.

```php
'providers' => [
    ...
    App\Providers\EventServiceProvider::class,
    App\Providers\RouteServiceProvider::class,
],

// Providers for local env only
'providers-local' => [
    \Barryvdh\LaravelIdeHelper\IdeHelperServiceProvider::class,
],
```

The providers array from /config/app.php contains all serviceproviders required for your application.
But this list is environment-agnostic which means it will register all providers no matter which environment it's running in.

There are however some scenarios where packages are meant to only run on local or test devices, not on production. E.g. the [IdeHelper](https://github.com/barryvdh/laravel-ide-helper) package. This could be accomplished via the following:

```php
// Within your AppServiceProvider
if(app()->environment !== 'production')
{
    app()->register(LocalServiceProvider::class);
}
```

## Usage
- With this PR a developer is able to assign providers to a specific environment inside the `config/app.php` file where all providers reside. In addition to the default providers array you can add environment specific ones.  
- They must follow the naming convention: `providers-<environment>`. E.g. providers-local.
By adding a service provider to the e.g. providers-local array, you assert it is registered in the local environment and nowhere else.
- It is possible to add multiple provider lists. One for each environment.

## Example:
```php
'providers' => [
    ...
    App\Providers\EventServiceProvider::class,
    App\Providers\RouteServiceProvider::class,
],

'providers-local' => [
    \Barryvdh\LaravelIdeHelper\IdeHelperServiceProvider::class,
],

'providers-staging' => [
    \MetricsServiceProvider::class,
],
```

## Notes
- This is a minor features that is fully backwards compatible. No breaking changes are introduced with this PR. Environment providers can be omitted entirely or left empty to maintain current registration logic. 
- There is currently no similar logic suggested for the aliases listing. 
- Should this proposal get accepted, It's our opinion that no additional boilerplate is needed for the config/app.php file (such as an empty `providers-local` array for instance). This feature can be launched 'under the radar'.
- As a developer, you still need to make sure that your code works in every environment and avoid dependencies in environments where you omitted the provider to be registered.
