### PR TITLE
Migration groups

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
@@ -62,7 +62,8 @@ class MigrateCommand extends BaseCommand
         // so that migrations may be run for any path within the applications.
         $this->migrator->run($this->getMigrationPaths(), [
             'pretend' => $this->option('pretend'),
-            'step' => $this->option('step'),
+            'step'    => $this->option('step'),
+            'group'   => $this->option('group'),
         ]);
 
         // Once the migrator has run we will grab the note output and send it out to
@@ -109,6 +110,8 @@ class MigrateCommand extends BaseCommand
             ['force', null, InputOption::VALUE_NONE, 'Force the operation to run when in production.'],
 
             ['path', null, InputOption::VALUE_OPTIONAL, 'The path of migrations files to be executed.'],
+
+            ['group', null, InputOption::VALUE_OPTIONAL, 'The group of migrations to be executed.'],
 
             ['pretend', null, InputOption::VALUE_NONE, 'Dump the SQL queries that would be run.'],
 

--- a/src/Illuminate/Database/Console/Migrations/RefreshCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/RefreshCommand.php
@@ -41,18 +41,26 @@ class RefreshCommand extends Command
 
         $path = $this->input->getOption('path');
 
+        $group = $this->input->getOption('group');
+
         // If the "step" option is specified it means we only want to rollback a small
         // number of migrations before migrating again. For example, the user might
         // only rollback and remigrate the latest four migrations instead of all.
         $step = $this->input->getOption('step') ?: 0;
 
-        if ($step > 0) {
+        if ($step > 0 || $group) {
             $this->call('migrate:rollback', [
-                '--database' => $database, '--force' => $force, '--path' => $path, '--step' => $step,
+                '--database' => $database,
+                '--force'    => $force,
+                '--path'     => $path,
+                '--step'     => $step,
+                '--group'    => $group,
             ]);
         } else {
             $this->call('migrate:reset', [
-                '--database' => $database, '--force' => $force, '--path' => $path,
+                '--database' => $database,
+                '--force'    => $force,
+                '--path'     => $path,
             ]);
         }
 
@@ -61,8 +69,9 @@ class RefreshCommand extends Command
         // them in succession. We'll also see if we need to re-seed the database.
         $this->call('migrate', [
             '--database' => $database,
-            '--force' => $force,
-            '--path' => $path,
+            '--force'    => $force,
+            '--path'     => $path,
+            '--group'    => $group,
         ]);
 
         if ($this->needsSeeding()) {
@@ -110,6 +119,8 @@ class RefreshCommand extends Command
             ['force', null, InputOption::VALUE_NONE, 'Force the operation to run when in production.'],
 
             ['path', null, InputOption::VALUE_OPTIONAL, 'The path of migrations files to be executed.'],
+
+            ['group', null, InputOption::VALUE_OPTIONAL, 'The group of migrations to be executed.'],
 
             ['seed', null, InputOption::VALUE_NONE, 'Indicates if the seed task should be re-run.'],
 

--- a/src/Illuminate/Database/Console/Migrations/RollbackCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/RollbackCommand.php
@@ -58,7 +58,11 @@ class RollbackCommand extends BaseCommand
         $this->migrator->setConnection($this->option('database'));
 
         $this->migrator->rollback(
-            $this->getMigrationPaths(), ['pretend' => $this->option('pretend'), 'step' => (int) $this->option('step')]
+            $this->getMigrationPaths(), [
+                    'pretend' => $this->option('pretend'),
+                    'step'    => (int) $this->option('step'),
+                    'group'   => $this->option('group'),
+                ]
         );
 
         // Once the migrator has run we will grab the note output and send it out to
@@ -82,6 +86,8 @@ class RollbackCommand extends BaseCommand
             ['force', null, InputOption::VALUE_NONE, 'Force the operation to run when in production.'],
 
             ['path', null, InputOption::VALUE_OPTIONAL, 'The path of migrations files to be executed.'],
+
+            ['group', null, InputOption::VALUE_OPTIONAL, 'The group of migrations to be executed.'],
 
             ['pretend', null, InputOption::VALUE_NONE, 'Dump the SQL queries that would be run.'],
 

--- a/src/Illuminate/Database/Console/Migrations/StatusCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/StatusCommand.php
@@ -57,7 +57,16 @@ class StatusCommand extends BaseCommand
 
         $ran = $this->migrator->getRepository()->getRan();
 
-        $migrations = Collection::make($this->getAllMigrationFiles())
+        if( $group = $this->option('group') ) {
+            $files = $this->migrator->getMigrationFilesByGroup(
+                $this->getMigrationPaths(),
+                $group
+            );
+        } else {
+            $files = $this->getAllMigrationFiles();
+        }
+
+        $migrations = Collection::make($files)
                             ->map(function ($migration) use ($ran) {
                                 $migrationName = $this->migrator->getMigrationName($migration);
 
@@ -94,6 +103,8 @@ class StatusCommand extends BaseCommand
             ['database', null, InputOption::VALUE_OPTIONAL, 'The database connection to use.'],
 
             ['path', null, InputOption::VALUE_OPTIONAL, 'The path of migrations files to use.'],
+
+            ['group', null, InputOption::VALUE_OPTIONAL, 'The group of migrations to use.'],
         ];
     }
 }

--- a/src/Illuminate/Database/Migrations/Migration.php
+++ b/src/Illuminate/Database/Migrations/Migration.php
@@ -12,6 +12,13 @@ abstract class Migration
     protected $connection;
 
     /**
+     * The group of the migration.
+     *
+     * @var string
+     */
+    protected $group;
+
+    /**
      * Get the migration connection name.
      *
      * @return string
@@ -19,5 +26,15 @@ abstract class Migration
     public function getConnection()
     {
         return $this->connection;
+    }
+
+    /**
+     * Get the migration group.
+     *
+     * @return string
+     */
+    public function getGroup()
+    {
+        return $this->group;
     }
 }


### PR DESCRIPTION
You can group related migrations to easily migrate and roll them back.
For example, a package can group its migrations. When installing, they are migrated, and when uninstalling, only they will be rolled back.

The current implementation doesn't require changes to migrations table. All you have to do is add **$group** property to your migrations:
`protected $group = 'SomeGroup';`
Then you can execute migration commands:
```
artisan migrate --group=SomeGroup
artisan migrate:rollback --group=SomeGroup
artisan migrate:refresh --group=SomeGroup
artisan migrate:status --group=SomeGroup
```
All migrations that belong to **SomeGroup** will be executed.

I think this can be useful, but I haven't thought a lot about the downsides, but here are 2 issues that might occur if this feature is misused:
- Collision: can mistakenly have the same group name of non related migrations. So you might execute unwanted migrations.
- Can mess up the order of migrations: if there are migrations that depend on each other, but they don't belong to the same group, you might roll them back in the wrong order and cause issues. But the point of using groups is to group related migrations, so you should avoid this problem.

Again, I don't know if this will be useful to other people. Please tell me what you think = )