### PR TITLE
[5.4] Expose which validation rule fails

### DIFF
--- a/src/Illuminate/Contracts/Support/MessageBag.php
+++ b/src/Illuminate/Contracts/Support/MessageBag.php
@@ -15,10 +15,11 @@ interface MessageBag
      * Add a message to the bag.
      *
      * @param  string  $key
+     * @param  string  $index
      * @param  string  $message
      * @return $this
      */
-    public function add($key, $message);
+    public function add($key, $index, $message);
 
     /**
      * Merge a new array of messages into the bag.

--- a/src/Illuminate/Support/MessageBag.php
+++ b/src/Illuminate/Support/MessageBag.php
@@ -52,13 +52,14 @@ class MessageBag implements Arrayable, Countable, Jsonable, JsonSerializable, Me
      * Add a message to the bag.
      *
      * @param  string  $key
+     * @param  string  $index
      * @param  string  $message
      * @return $this
      */
-    public function add($key, $message)
+    public function add($key, $index, $message)
     {
         if ($this->isUnique($key, $message)) {
-            $this->messages[$key][] = $message;
+            $this->messages[$key][$index] = $message;
         }
 
         return $this;

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -533,7 +533,7 @@ class Validator implements ValidatorContract
      */
     protected function addFailure($attribute, $rule, $parameters)
     {
-        $this->messages->add($attribute, $this->makeReplacements(
+        $this->messages->add($attribute, snake_case($rule), $this->makeReplacements(
             $this->getMessage($attribute, $rule), $attribute, $rule, $parameters
         ));
 

--- a/tests/Support/SupportMessageBagTest.php
+++ b/tests/Support/SupportMessageBagTest.php
@@ -24,12 +24,12 @@ class SupportMessageBagTest extends TestCase
     {
         $container = new MessageBag;
         $container->setFormat(':message');
-        $container->add('foo', 'bar');
-        $container->add('foo', 'baz');
-        $container->add('boom', 'bust');
+        $container->add('foo', 'required', 'bar');
+        $container->add('foo', 'required', 'baz');
+        $container->add('boom', 'required', 'bust');
         $messages = $container->getMessages();
-        $this->assertEquals(['bar', 'baz'], $messages['foo']);
-        $this->assertEquals(['bust'], $messages['boom']);
+        $this->assertEquals(['required'=>['bar', 'baz']], $messages['foo']);
+        $this->assertEquals(['required'=>['bust']], $messages['boom']);
     }
 
     public function testMessagesMayBeMerged()


### PR DESCRIPTION
By this PR, MessageBag now returns the messages as shown below it is useful in some cases.

```
 "email": {
    "required": "The email field is required.",
    "email": "The email must be a valid email address.",
    "confirmed": "The email confirmation does not match.",
    "unique": "The email has already been taken."
  }

```Above example is when JSON Encoded.