### PR TITLE
[5.4] Fix flash data on redirect() for tests

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -4,6 +4,7 @@ namespace Illuminate\Foundation\Testing\Concerns;
 
 use Illuminate\Support\Str;
 use Illuminate\Http\Request;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Foundation\Testing\TestResponse;
 use Illuminate\Contracts\Http\Kernel as HttpKernel;
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
@@ -235,6 +236,12 @@ trait MakesHttpRequests
         $response = $kernel->handle(
             $request = Request::createFromBase($symfonyRequest)
         );
+        
+        // if response is an instance of RedirectResponse & session is not null
+        // then reflash the session data to the next request
+        if ($response instanceof RedirectResponse && $response->getSession()) {
+            $response->getSession()->reflash();
+        }
 
         $kernel->terminate($request, $response);
 

--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -236,7 +236,7 @@ trait MakesHttpRequests
         $response = $kernel->handle(
             $request = Request::createFromBase($symfonyRequest)
         );
-        
+
         // if response is an instance of RedirectResponse & session is not null
         // then reflash the session data to the next request
         if ($response instanceof RedirectResponse && $response->getSession()) {


### PR DESCRIPTION
Currently the tests would not persist flash data on redirect(). 

Below is an example test before and after this PR fix.

#### Before
```
public function it_validates_login() {

    $this->visit('/login')
        ->press('Login')
        ->see('The email field is required');    // fails
}
```

#### After
```
public function it_validates_login() {

    $this->visit('/login')
        ->press('Login')
        ->see('The email field is required');    // passes
}
```

Related: #15598