### PR TITLE
[5.4] Fix Mailgun transport

### DIFF
--- a/src/Illuminate/Mail/Transport/MailgunTransport.php
+++ b/src/Illuminate/Mail/Transport/MailgunTransport.php
@@ -76,7 +76,8 @@ class MailgunTransport extends Transport
     {
         return [
             'auth' => [
-                'api' => $this->key,
+                'api',
+                $this->key,
             ],
             'multipart' => [
                 [


### PR DESCRIPTION
Guzzle needs 2 elements in the auth array, and it also needs them to have numeric keys:

    $modify['set_headers']['Authorization'] = 'Basic '
        . base64_encode("$value[0]:$value[1]");
    break;

And I know numeric is the default for arrays keys in PHP, but sometimes is just better, for devs, to be explicit. It could have prevented that change in the past.