### PR TITLE
[5.4] Bumped the minimum recommended version of dbal

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -101,7 +101,7 @@
     },
     "suggest": {
         "aws/aws-sdk-php": "Required to use the SQS queue driver and SES mail driver (~3.0).",
-        "doctrine/dbal": "Required to rename columns and drop SQLite columns (~2.4).",
+        "doctrine/dbal": "Required to rename columns and drop SQLite columns (~2.5).",
         "fzaninotto/faker": "Required to use the eloquent factory builder (~1.4).",
         "guzzlehttp/guzzle": "Required to use the Mailgun and Mandrill mail drivers and the ping methods on schedules (~5.3|~6.0).",
         "laravel/tinker": "Required to use the tinker console command (~1.0).",

--- a/src/Illuminate/Database/composer.json
+++ b/src/Illuminate/Database/composer.json
@@ -32,7 +32,7 @@
         }
     },
     "suggest": {
-        "doctrine/dbal": "Required to rename columns and drop SQLite columns (~2.4).",
+        "doctrine/dbal": "Required to rename columns and drop SQLite columns (~2.5).",
         "fzaninotto/faker": "Required to use the eloquent factory builder (~1.4).",
         "illuminate/console": "Required to use the database commands (5.4.*).",
         "illuminate/events": "Required to use the observers with Eloquent (5.4.*).",


### PR DESCRIPTION
The new tests on 5.4 demonstrate that this newer version is needed for things to work properly.