### PR TITLE
[5.3] Fix date format for SqlServerGrammar (MS SQL)

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
@@ -267,7 +267,7 @@ class SqlServerGrammar extends Grammar
      */
     public function getDateFormat()
     {
-        return 'Y-m-d H:i:s.000';
+        return 'Y-m-d H:i:s.u';
     }
 
     /**


### PR DESCRIPTION
This (extremely small! 😃) PR attempts to fix the date time format when using MS SQL Server. 

A value in my database was set with second fractions (inserted by an external ASP application), as follows: `2016-12-27 8:50:45.740.` Laravel couldn't pick this up and gave me a Carbon error:
`InvalidArgumentException with message 'The format separator does not match'`. This fixes that issue.


This should also properly fix issue #14247 without a workaround. 