### PR TITLE
[5.3] Optional starting slash for elixir asset

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -398,6 +398,8 @@ if (! function_exists('elixir')) {
             }
         }
 
+        $file = ltrim($file, '/');
+
         if (isset($manifest[$file])) {
             return '/'.trim($buildDirectory.'/'.$manifest[$file], '/');
         }


### PR DESCRIPTION
The `elixir()` helper function requires urls to be passed without beginning slash. Otherwise an exception will be thrown.

Before this PR, `elixir('/assets/img/logo.png')` would result in an exception being thrown because the starting slash is not expected. This is because of the strict match with the asset keys in the manifest and those never start with a slash.

With this small addition, the starting slash will be allowed as well and gets silently accepted without error.

