### PR TITLE
[5.3] Add missing placeholder replacements for before_or_equal and after_or_equal validation rules

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -2625,6 +2625,34 @@ class Validator implements ValidatorContract
     }
 
     /**
+     * Replace all place-holders for the before or equal rule.
+     *
+     * @param  string  $message
+     * @param  string  $attribute
+     * @param  string  $rule
+     * @param  array   $parameters
+     * @return string
+     */
+    protected function replaceBeforeOrEqual($message, $attribute, $rule, $parameters)
+    {
+        return $this->replaceBefore($message, $attribute, $rule, $parameters);
+    }
+
+    /**
+     * Replace all place-holders for the after or equal rule.
+     *
+     * @param  string  $message
+     * @param  string  $attribute
+     * @param  string  $rule
+     * @param  array   $parameters
+     * @return string
+     */
+    protected function replaceAfterOrEqual($message, $attribute, $rule, $parameters)
+    {
+        return $this->replaceBefore($message, $attribute, $rule, $parameters);
+    }
+
+    /**
      * Get all attributes.
      *
      * @return array


### PR DESCRIPTION
The validator is missing the `:date` placeholder replacement methods for before_or_equal and after_or_equal rules.