### PR TITLE
[5.4] Added support to change the guard instance during runtime

### DIFF
--- a/src/Illuminate/Foundation/Auth/AuthenticatesUsers.php
+++ b/src/Illuminate/Foundation/Auth/AuthenticatesUsers.php
@@ -160,10 +160,11 @@ trait AuthenticatesUsers
     /**
      * Get the guard to be used during authentication.
      *
+     * @param  string  $name
      * @return \Illuminate\Contracts\Auth\StatefulGuard
      */
-    protected function guard()
+    protected function guard($name = null)
     {
-        return Auth::guard();
+        return Auth::guard($name);
     }
 }


### PR DESCRIPTION
This adds the name argument to the `guard()` helper method on the `AuthenticatesUsers` trait. 
This becomes useful when modifying the `attemptLogin` function to authenticate against multiple guards, for example:

```PHP
protected $guards = ['web', 'ldap'];

protected $lastAttempted;

protected function attemptLogin(Request $request)
{
    foreach ($this->guards as $name) {
        $succeeded = $this->guard($name)->attempt(
            $this->credentials($request), $request->has('remember')
        );

        if ($succeeded) {
            $this->lastAttempted = $name;

            return true;
        }
    }

    return false;
}
```