### PR TITLE
[5.4] Call the parent's dynamic call method directly

### DIFF
--- a/src/Illuminate/Redis/Connections/PhpRedisConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisConnection.php
@@ -86,6 +86,6 @@ class PhpRedisConnection extends Connection
             return $this->proxyToEval($parameters);
         }
 
-        return $this->command($method, $parameters);
+        return parent::__call($method, $parameters);
     }
 }


### PR DESCRIPTION
As well as avoiding confusion over the existence of the parent `__call` method, this will also prevent bugs with changes to the parent's method not being present in the super.