### PR TITLE
[5.4] Added "contains" operator to where clause in collections

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -329,7 +329,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
                 case '>=':  return $retrieved >= $value;
                 case '===': return $retrieved === $value;
                 case '!==': return $retrieved !== $value;
-                case 'like': return strpos($retrieved, $value) !== false;
+                case 'contains': return strpos($retrieved, $value) !== false;
             }
         };
     }

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -329,6 +329,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
                 case '>=':  return $retrieved >= $value;
                 case '===': return $retrieved === $value;
                 case '!==': return $retrieved !== $value;
+                case 'like': return strpos($retrieved, $value) !== false;
             }
         };
     }


### PR DESCRIPTION
The operator "contains" is added to \Illuminate\Support\Collection class in operatorForWhere method, so that we can search for string.