### PR TITLE
[5.4] Execute queries with lock only in write database

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1606,14 +1606,14 @@ class Builder
     /**
      * Lock the selected rows in the table.
      *
-     * @param  bool  $value
+     * @param  string|bool  $value
      * @return $this
      */
     public function lock($value = true)
     {
         $this->lock = $value;
 
-        if ($this->lock) {
+        if (! is_null($this->lock)) {
             $this->useWritePdo();
         }
 

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1729,6 +1729,11 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->getConnection()->shouldReceive('select')->once()
             ->with(m::any(), m::any(), false);
         $builder->select('*')->from('foo')->where('bar', '=', 'baz')->lock()->get();
+
+        $builder = $this->getMySqlBuilderWithProcessor();
+        $builder->getConnection()->shouldReceive('select')->once()
+            ->with(m::any(), m::any(), false);
+        $builder->select('*')->from('foo')->where('bar', '=', 'baz')->lock(false)->get();
     }
 
     public function testBindingOrder()


### PR DESCRIPTION
As in PR #17317 but with the better solution and I added the test as a bug proof.

/cc @JoostK, @GrahamCampbell 