### PR TITLE
[5.4] Set connection while creating a model

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -329,7 +329,11 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public static function create(array $attributes = [], $connection = null)
     {
-        $instance = (new static($attributes))->setConnection($connection);
+        $instance = new static($attributes);
+
+        if ($connection) {
+            $instance->setConnection($connection);
+        }
 
         return tap($instance, function ($model) {
             $model->save();
@@ -345,7 +349,11 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public static function forceCreate(array $attributes, $connection = null)
     {
-        $instance = (new static)->setConnection($connection);
+        $instance = (new static);
+
+        if ($connection) {
+            $instance->setConnection($connection);
+        }
 
         return static::unguarded(function () use ($attributes, $instance) {
             return $instance->create($attributes);

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -324,11 +324,14 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      * Save a new model and return the instance.
      *
      * @param  array  $attributes
+     * @param  string|null  $connection
      * @return static
      */
-    public static function create(array $attributes = [])
+    public static function create(array $attributes = [], $connection = null)
     {
-        return tap(new static($attributes), function ($model) {
+        $instance = (new static($attributes))->setConnection($connection);
+
+        return tap($instance, function ($model) {
             $model->save();
         });
     }
@@ -337,12 +340,15 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      * Save a new model and return the instance. Allow mass-assignment.
      *
      * @param  array  $attributes
+     * @param  string|null  $connection
      * @return static
      */
-    public static function forceCreate(array $attributes)
+    public static function forceCreate(array $attributes, $connection = null)
     {
-        return static::unguarded(function () use ($attributes) {
-            return (new static)->create($attributes);
+        $instance = (new static)->setConnection($connection);
+
+        return static::unguarded(function () use ($attributes, $instance) {
+            return $instance->create($attributes);
         });
     }
 


### PR DESCRIPTION
This PR adds the ability to set the desired connection to create the model on. 

To save a model on a different connection you currently need to do something like:

```php
$model = new User();

$model->setConnection('myConnection');

$model->save();
```

With this PR, by default we create the model on the default model connection, only if a connection is provided to the methods we'll use it to create our model.