### PR TITLE
[5.4] Move model methods to builder

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -411,6 +411,40 @@ class Builder
     }
 
     /**
+     * Save a new model and return the instance.
+     *
+     * @param  array  $attributes
+     * @return static
+     */
+    public function create(array $attributes = [])
+    {
+        $instance = $this->model->newInstance($attributes)->setConnection(
+            $this->query->getConnection()->getName()
+        );
+
+        $instance->save();
+
+        return $instance;
+    }
+
+    /**
+     * Save a new model and return the instance. Allow mass-assignment.
+     *
+     * @param  array  $attributes
+     * @return static
+     */
+    public function forceCreate(array $attributes)
+    {
+        $instance = $this->model->newInstance($attributes)->setConnection(
+            $this->query->getConnection()->getName()
+        );
+
+        return $this->model->unguarded(function () use ($attributes, $instance) {
+            return $instance->create($attributes);
+        });
+    }
+
+    /**
      * Get a single column's value from the first result of a query.
      *
      * @param  string  $column

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -414,7 +414,7 @@ class Builder
      * Save a new model and return the instance.
      *
      * @param  array  $attributes
-     * @return static
+     * @return \Illuminate\Database\Eloquent\Model
      */
     public function create(array $attributes = [])
     {
@@ -431,7 +431,7 @@ class Builder
      * Save a new model and return the instance. Allow mass-assignment.
      *
      * @param  array  $attributes
-     * @return static
+     * @return \Illuminate\Database\Eloquent\Model
      */
     public function forceCreate(array $attributes)
     {

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -321,46 +321,6 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     }
 
     /**
-     * Save a new model and return the instance.
-     *
-     * @param  array  $attributes
-     * @param  string|null  $connection
-     * @return static
-     */
-    public static function create(array $attributes = [], $connection = null)
-    {
-        $instance = new static($attributes);
-
-        if ($connection) {
-            $instance->setConnection($connection);
-        }
-
-        return tap($instance, function ($model) {
-            $model->save();
-        });
-    }
-
-    /**
-     * Save a new model and return the instance. Allow mass-assignment.
-     *
-     * @param  array  $attributes
-     * @param  string|null  $connection
-     * @return static
-     */
-    public static function forceCreate(array $attributes, $connection = null)
-    {
-        $instance = (new static);
-
-        if ($connection) {
-            $instance->setConnection($connection);
-        }
-
-        return static::unguarded(function () use ($attributes, $instance) {
-            return $instance->create($attributes);
-        });
-    }
-
-    /**
      * Create a collection of models from plain arrays.
      *
      * @param  array  $items


### PR DESCRIPTION
This PR moves the `create` and `forceCreate` methods to the Builder, this will allow stuff like:

```
User::on('myCustomConnection')->create();
```