### PR TITLE
[5.4] Rename Http/Exception to Http/Exceptions

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -10,7 +10,7 @@ use Illuminate\Auth\AuthenticationException;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Validation\ValidationException;
 use Illuminate\Auth\Access\AuthorizationException;
-use Illuminate\Http\Exception\HttpResponseException;
+use Illuminate\Http\Exceptions\HttpResponseException;
 use Symfony\Component\Debug\Exception\FlattenException;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Symfony\Component\HttpKernel\Exception\HttpException;

--- a/src/Illuminate/Foundation/Http/Middleware/ValidatePostSize.php
+++ b/src/Illuminate/Foundation/Http/Middleware/ValidatePostSize.php
@@ -3,7 +3,7 @@
 namespace Illuminate\Foundation\Http\Middleware;
 
 use Closure;
-use Illuminate\Http\Exception\PostTooLargeException;
+use Illuminate\Http\Exceptions\PostTooLargeException;
 
 class ValidatePostSize
 {
@@ -14,7 +14,7 @@ class ValidatePostSize
      * @param  \Closure  $next
      * @return mixed
      *
-     * @throws \Illuminate\Http\Exception\PostTooLargeException
+     * @throws \Illuminate\Http\Exceptions\PostTooLargeException
      */
     public function handle($request, Closure $next)
     {

--- a/src/Illuminate/Http/Exceptions/HttpResponseException.php
+++ b/src/Illuminate/Http/Exceptions/HttpResponseException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Illuminate\Http\Exception;
+namespace Illuminate\Http\Exceptions;
 
 use RuntimeException;
 use Symfony\Component\HttpFoundation\Response;

--- a/src/Illuminate/Http/Exceptions/PostTooLargeException.php
+++ b/src/Illuminate/Http/Exceptions/PostTooLargeException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Illuminate\Http\Exception;
+namespace Illuminate\Http\Exceptions;
 
 use Exception;
 

--- a/src/Illuminate/Http/ResponseTrait.php
+++ b/src/Illuminate/Http/ResponseTrait.php
@@ -3,7 +3,7 @@
 namespace Illuminate\Http;
 
 use Exception;
-use Illuminate\Http\Exception\HttpResponseException;
+use Illuminate\Http\Exceptions\HttpResponseException;
 
 trait ResponseTrait
 {
@@ -125,7 +125,7 @@ trait ResponseTrait
     /**
      * Throws the response in a HttpResponseException instance.
      *
-     * @throws \Illuminate\Http\Exception\HttpResponseException
+     * @throws \Illuminate\Http\Exceptions\HttpResponseException
      */
     public function throwResponse()
     {

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -12,7 +12,7 @@ use Illuminate\Routing\Matching\UriValidator;
 use Illuminate\Routing\Matching\HostValidator;
 use Illuminate\Routing\Matching\MethodValidator;
 use Illuminate\Routing\Matching\SchemeValidator;
-use Illuminate\Http\Exception\HttpResponseException;
+use Illuminate\Http\Exceptions\HttpResponseException;
 
 class Route
 {

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -32,7 +32,7 @@ class RoutingRouteTest extends TestCase
 
         $router = $this->getRouter();
         $router->get('foo/bar', function () {
-            throw new \Illuminate\Http\Exception\HttpResponseException(new Response('hello'));
+            throw new \Illuminate\Http\Exceptions\HttpResponseException(new Response('hello'));
         });
         $this->assertEquals('hello', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
 


### PR DESCRIPTION
Like I explained in issue #17394, the Exceptions folder is named "Exception" in the Http package, and "Exceptions" in Foundation and Routing. To make it consistent, I renamed the "Exception" folder to "Exceptions", like @themsaid said.