### PR TITLE
[5.4] Revert validation rules numeric keys

### DIFF
--- a/src/Illuminate/Contracts/Validation/Validator.php
+++ b/src/Illuminate/Contracts/Validation/Validator.php
@@ -26,7 +26,7 @@ interface Validator extends MessageProvider
      * @param  string  $attribute
      * @param  string|array  $rules
      * @param  callable  $callback
-     * @return void
+     * @return $this
      */
     public function sometimes($attribute, $rules, callable $callback);
 

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -755,10 +755,6 @@ class Validator implements ValidatorContract
             $this->rules, $response->rules
         );
 
-        $this->rules = array_combine(
-            array_keys($response->rules), $this->rules
-        );
-
         $this->implicitAttributes = array_merge(
             $this->implicitAttributes, $response->implicitAttributes
         );

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -2323,6 +2323,13 @@ class ValidationValidatorTest extends TestCase
         $this->assertEquals(['x' => ['Required', 'Confirmed']], $v->getRules());
 
         $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['x' => ''], ['y' => 'Required']);
+        $v->sometimes('x', 'Required', function ($i) {
+            return true;
+        });
+        $this->assertEquals(['x' => ['Required'], 'y' => ['Required']], $v->getRules());
+
+        $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['x' => 'foo'], ['x' => 'Required']);
         $v->sometimes('x', 'Confirmed', function ($i) {
             return $i->x == 'bar';
@@ -3240,13 +3247,6 @@ class ValidationValidatorTest extends TestCase
         $file = new File(__FILE__, false);
         $v = new Validator($trans, ['file' => $file], ['file' => 'Required|mimes:xls']);
         $this->assertFalse($v->passes());
-    }
-
-    public function testValidationCanAcceptNumericKeysForRules()
-    {
-        $trans = $this->getIlluminateArrayTranslator();
-        $v = new Validator($trans, [10 => ''], [10 => 'Required']);
-        $this->assertEquals([10], array_keys($v->getRules()));
     }
 
     protected function getTranslator()


### PR DESCRIPTION
This reverts the changes done in https://github.com/laravel/framework/pull/17300/files

Added a test to cover the case that the PR was breaking.