### PR TITLE
[5.4] Remove unused method from ValidationException

### DIFF
--- a/src/Illuminate/Validation/ValidationException.php
+++ b/src/Illuminate/Validation/ValidationException.php
@@ -34,14 +34,4 @@ class ValidationException extends Exception
         $this->response = $response;
         $this->validator = $validator;
     }
-
-    /**
-     * Get the underlying response instance.
-     *
-     * @return \Symfony\Component\HttpFoundation\Response|null
-     */
-    public function getResponse()
-    {
-        return $this->response;
-    }
 }


### PR DESCRIPTION
Can't find any place that uses this code, and no tests fail by removing it.

The `$response` is public, and can be seen directly accessed in `convertValidationExceptionToResponse`