### PR TITLE
Clearer error reporting on seeInDatabase()

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
@@ -20,8 +20,24 @@ trait InteractsWithDatabase
 
         $count = $database->connection($connection)->table($table)->where($data)->count();
 
+        $extraInfo = '';
+        if (0 === $count) {
+            $allResults = $database->connection($connection)->table($table)->get();
+            $extraInfo = sprintf('%sAll entries in table "%s":%s%s',
+                PHP_EOL,
+                $table,
+                PHP_EOL,
+                json_encode($allResults, JSON_PRETTY_PRINT)
+            );
+        }
+
         $this->assertGreaterThan(0, $count, sprintf(
-            'Unable to find row in database table [%s] that matched attributes [%s].', $table, json_encode($data)
+            'Unable to find row in database table "%s" that matched attributes: %s%s%s%s',
+            $table,
+            PHP_EOL,
+            json_encode($data, JSON_PRETTY_PRINT),
+            PHP_EOL,
+            $extraInfo
         ));
 
         return $this;


### PR DESCRIPTION
I seem to spend a fair amount of time debugging my unit tests when I encounter an "Unable to find row in database table ..." error using the seeInDatabase() method. The output tells me the data I was looking for in the table (which is already in my unit test) and I have to add extra code such as `$allRows = MyModel::all()->all()` before calling `$this->seeInDatabase(...)` and stepping through with a debugger to see what data is in the table to find out where I'm going wrong.

I can only assume that other people are having a similar experience, I think anyone using an in-memory sqlite database for unit testing will have some frustration debugging these errors.

This change executes a second "SELECT * FROM {table}" query if the count is zero, and formats the JSON data for better reading in the console.