### PR TITLE
[5.1] Request object returns empty parameters when make a POST request and spoof it as a GET using X-HTTP-METHOD-OVERRIDE or _method parameter

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -565,7 +565,7 @@ class Request extends SymfonyRequest implements ArrayAccess
             return $this->json();
         }
 
-        return $this->getMethod() == 'GET' ? $this->query : $this->request;
+        return $this->getRealMethod() == 'GET' ? $this->query : $this->request;
     }
 
     /**


### PR DESCRIPTION
Issue already solved on 5.3, but bug is still present on 5.1 LTS.

Reference issue #15348