### PR TITLE
 production environment ignore notice

### DIFF
--- a/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
+++ b/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
@@ -59,7 +59,7 @@ class HandleExceptions
         if (error_reporting() & $level) {
             throw $e;
         } else {
-             $this->getExceptionHandler()->report($e);
+            $this->getExceptionHandler()->report($e);
         }
     }
 

--- a/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
+++ b/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
@@ -28,7 +28,7 @@ class HandleExceptions
     {
         $this->app = $app;
 
-        error_reporting(-1);
+        //error_reporting(-1);
 
         set_error_handler([$this, 'handleError']);
 
@@ -43,7 +43,7 @@ class HandleExceptions
 
     /**
      * Convert a PHP error to an ErrorException.
-     *
+     * If it's production environment. Only report error to log system;
      * @param  int  $level
      * @param  string  $message
      * @param  string  $file
@@ -53,10 +53,13 @@ class HandleExceptions
      *
      * @throws \ErrorException
      */
-    public function handleError($level, $message, $file = '', $line = 0, $context = [])
+    public function handleError($level, $message, $file = '', $line = 0)
     {
+        $e = new ErrorException($message, 0, $level, $file, $line);
         if (error_reporting() & $level) {
-            throw new ErrorException($message, 0, $level, $file, $line);
+            throw $e;
+        }else{
+             $this->getExceptionHandler()->report($e);
         }
     }
 

--- a/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
+++ b/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
@@ -43,7 +43,7 @@ class HandleExceptions
 
     /**
      * Convert a PHP error to an ErrorException.
-     * If it's production environment. Only report error to log system;
+     * If it's production environment. Only report error to log system.
      * @param  int  $level
      * @param  string  $message
      * @param  string  $file
@@ -58,7 +58,7 @@ class HandleExceptions
         $e = new ErrorException($message, 0, $level, $file, $line);
         if (error_reporting() & $level) {
             throw $e;
-        }else{
+        } else {
              $this->getExceptionHandler()->report($e);
         }
     }


### PR DESCRIPTION
If it's production environment. Only report error to log system.
It's not necessary to response 500 because of some error like "undefinde index"