### PR TITLE
[5.4] Default log level to debug

### DIFF
--- a/src/Illuminate/Log/LogServiceProvider.php
+++ b/src/Illuminate/Log/LogServiceProvider.php
@@ -132,7 +132,7 @@ class LogServiceProvider extends ServiceProvider
     protected function logLevel()
     {
         if ($this->app->bound('config')) {
-            return $this->app->make('config')->get('app.log_level');
+            return $this->app->make('config')->get('app.log_level', 'debug');
         }
 
         return 'debug';


### PR DESCRIPTION
This change missed passing the default value: https://github.com/laravel/framework/commit/6550153162b4d54d03d37dd9adfd0c95ca0383a9#diff-143a57bc7a6ad4980ca434e6bdfac014

Causing Exception handling of apps with no `log_level` config value set to break down. 