### PR TITLE
[5.3] Add salutation option to SimpleMessage notification

### DIFF
--- a/src/Illuminate/Notifications/Messages/SimpleMessage.php
+++ b/src/Illuminate/Notifications/Messages/SimpleMessage.php
@@ -28,6 +28,13 @@ class SimpleMessage
     public $greeting;
 
     /**
+     * The notification's salutation.
+     *
+     * @var string
+     */
+    public $salutation;
+
+    /**
      * The "intro" lines of the notification.
      *
      * @var array
@@ -119,6 +126,19 @@ class SimpleMessage
     }
 
     /**
+     * Set the salutation of the notification.
+     *
+     * @param  string  $salutation
+     * @return $this
+     */
+    public function salutation($salutation)
+    {
+        $this->salutation = $salutation;
+
+        return $this;
+    }
+
+    /**
      * Add a line of text to the notification.
      *
      * @param  \Illuminate\Notifications\Action|string  $line
@@ -189,6 +209,7 @@ class SimpleMessage
             'level' => $this->level,
             'subject' => $this->subject,
             'greeting' => $this->greeting,
+            'salutation' => $this->salutation,
             'introLines' => $this->introLines,
             'outroLines' => $this->outroLines,
             'actionText' => $this->actionText,

--- a/src/Illuminate/Notifications/resources/views/email-plain.blade.php
+++ b/src/Illuminate/Notifications/resources/views/email-plain.blade.php
@@ -18,5 +18,9 @@ if (! empty($outroLines)) {
     echo implode("\n", $outroLines), "\n\n";
 }
 
-echo 'Regards,', "\n";
-echo config('app.name'), "\n";
+if (! empty($salutation)) {
+    echo $salutation, "\n";
+} else {
+    echo 'Regards,', "\n";
+    echo config('app.name'), "\n";
+}

--- a/src/Illuminate/Notifications/resources/views/email.blade.php
+++ b/src/Illuminate/Notifications/resources/views/email.blade.php
@@ -140,7 +140,11 @@ $style = [
 
                                         <!-- Salutation -->
                                         <p style="{{ $style['paragraph'] }}">
-                                            Regards,<br>{{ config('app.name') }}
+                                            @if (! empty($salutation))
+                                                {{ $salutation }}
+                                            @else
+                                                Regards,<br>{{ config('app.name') }}
+                                            @endif
                                         </p>
 
                                         <!-- Sub Copy -->


### PR DESCRIPTION
By default 'Regards,' is displayed as a salutation at the end of notification emails. Much like the pull https://github.com/laravel/framework/pull/15108 added an optional `greeting()` method, I think that would make sense to also add one for the salutation at the end. What do you think?

```
public function toMail($notifiable)
{
    return (new MailMessage)
                ->line('The introduction to the notification.')
                ->action('Notification Action', 'https://laravel.com')
                ->line('Thank you for using our application!');
                ->salutation("Cheers!")
}
```