### PR TITLE
[5.3] Prevent isEmptyString from crashing on JSON object

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -308,9 +308,10 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
     {
         $value = $this->input($key);
 
-        $boolOrArray = is_bool($value) || is_array($value);
+        $boolArrayOrObject = is_bool($value) || is_array($value)
+            || is_object($value);
 
-        return ! $boolOrArray && trim((string) $value) === '';
+        return ! $boolArrayOrObject && trim((string) $value) === '';
     }
 
     /**

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -227,6 +227,12 @@ class HttpRequestTest extends PHPUnit_Framework_TestCase
 
         $request = Request::create('/', 'GET', ['foo' => ['bar' => 'baz']]);
         $this->assertTrue($request->has('foo.bar'));
+
+        //tests objects from JSON post requests
+        $object = new stdClass();
+        $object->bar = 'baz';
+        $request = Request::create('/', 'POST', ['foo' => $object]);
+        $this->assertTrue($request->has('foo'));
     }
 
     public function testInputMethod()


### PR DESCRIPTION
My json request:
```
array:4 [
  "product" => array:8 [
    "description" => "Aut expedita adipisci voluptas mollitia dolores neque ad illo. Inventore illo est optio facilis necessitatibus nihil. Quam nobis id assumenda distinctio assumenda aut."
    "price" => 16.38
    "sku" => "2620477974079"
    "name" => "consequatur"
    "companyId" => 123
    "id" => 1
  ]
  "listingId" => 1
  "name" => "Aut voluptatem esse praesentium modi praesentium."
  "productId" => 1
]
```

Stack Trace:
```
in Request.php line 313
at HandleExceptions->handleError('4096', 'Object of class stdClass could not be converted to string', '/pathTo/vendor/laravel/framework/src/Illuminate/Http/Request.php', '313', array('key' => 'product', 'value' => object(stdClass), 'boolOrArray' => false)) in Request.php line 313
at Request->isEmptyString('product') in Request.php line 293
at Request->has('product') in RequestProcessingRepository.php line 180
at RequestProcessingRepository->attachPivots(object(Campaign), object(UpdateCampaign)) in RequestProcessingRepository.php line 57
at RequestProcessingRepository->handleRequest(object(UpdateCampaign)) in Crud.php line 61
at CampaignsController->crudUpdate(object(UpdateCampaign)) in CampaignsController.php line 106
at CampaignsController->update(object(UpdateCampaign), object(Campaign))
at call_user_func_array(array(object(CampaignsController), 'update'), array(object(UpdateCampaign), 'campaign' => object(Campaign))) in Controller.php line 55
...
```