### PR TITLE
[5.3] Cover array validation with empty keys

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -306,7 +306,7 @@ class Validator implements ValidatorContract
     {
         $data = Arr::dot($this->initializeAttributeOnData($attribute));
 
-        $pattern = str_replace('\*', '[^\.]+', preg_quote($attribute));
+        $pattern = str_replace('\*', '[^\.]*', preg_quote($attribute));
 
         $data = array_merge($data, $this->extractValuesForWildcards(
             $data, $attribute
@@ -355,7 +355,7 @@ class Validator implements ValidatorContract
     {
         $keys = [];
 
-        $pattern = str_replace('\*', '[^\.]+', preg_quote($attribute));
+        $pattern = str_replace('\*', '[^\.]*', preg_quote($attribute));
 
         foreach ($data as $key => $value) {
             if ((bool) preg_match('/^'.$pattern.'/', $key, $matches)) {

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -2595,6 +2595,14 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($v->fails());
     }
 
+    public function testCoveringEmptyKeys()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+
+        $v = new Validator($trans, ['foo' => ['' => ['bar' => '']]], ['foo.*.bar' => 'required']);
+        $this->assertTrue($v->fails());
+    }
+
     public function testImplicitEachWithAsterisksWithArrayValues()
     {
         $trans = $this->getIlluminateArrayTranslator();


### PR DESCRIPTION
Having:

```php
$validator = Validator::make(
    [
        'properties' => [
            '' => ['type' => '']
        ]
    ],
    [
        'properties.*.type' => 'required'
    ]);
```

Because the regex is `[^\.]+` an empty space won't be matched, if we replace it with `[^\.]*` it'll match an empty space between the dots as well.