### PR TITLE
[5.4] Add salutation option to SimpleMessage notification

### DIFF
--- a/src/Illuminate/Notifications/Messages/SimpleMessage.php
+++ b/src/Illuminate/Notifications/Messages/SimpleMessage.php
@@ -28,6 +28,13 @@ class SimpleMessage
     public $greeting;
 
     /**
+     * The notification's salutation.
+     *
+     * @var string
+     */
+    public $salutation;
+
+    /**
      * The "intro" lines of the notification.
      *
      * @var array
@@ -119,6 +126,19 @@ class SimpleMessage
     }
 
     /**
+     * Set the salutation of the notification.
+     *
+     * @param  string  $salutation
+     * @return $this
+     */
+    public function salutation($salutation)
+    {
+        $this->salutation = $salutation;
+
+        return $this;
+    }
+
+    /**
      * Add a line of text to the notification.
      *
      * @param  \Illuminate\Notifications\Action|string  $line
@@ -189,6 +209,7 @@ class SimpleMessage
             'level' => $this->level,
             'subject' => $this->subject,
             'greeting' => $this->greeting,
+            'salutation' => $this->salutation,
             'introLines' => $this->introLines,
             'outroLines' => $this->outroLines,
             'actionText' => $this->actionText,

--- a/src/Illuminate/Notifications/resources/views/email.blade.php
+++ b/src/Illuminate/Notifications/resources/views/email.blade.php
@@ -42,8 +42,11 @@
 @endforeach
 
 <!-- Salutation -->
-Regards,<br>
-{{ config('app.name') }}
+@if (! empty($salutation))
+    {{ $salutation }}
+@else
+    Regards,<br>{{ config('app.name') }}
+@endif
 
 <!-- Subcopy -->
 @if (isset($actionText))


### PR DESCRIPTION
By default "Regards," is displayed as a salutation at the end of notification emails. Much like the pull #15108 added an optional `greeting()` method, I think that would make sense to also add one for the salutation at the end. What do you think?

```
public function toMail($notifiable)
{
    return (new MailMessage)
                ->line('The introduction to the notification.')
                ->action('Notification Action', 'https://laravel.com')
                ->line('Thank you for using our application!');
                ->salutation('Cheers!')
}
```

This was originally proposed on the 5.3 branch (https://github.com/laravel/framework/pull/17422).