### PR TITLE
[5.4] Add deleted callback to Jobs

### DIFF
--- a/src/Illuminate/Queue/CallQueuedHandler.php
+++ b/src/Illuminate/Queue/CallQueuedHandler.php
@@ -102,8 +102,10 @@ class CallQueuedHandler
     /**
      * Call the deleted method on the job instance.
      *
-     * Run EVERY time when the job is deleted from queue
-     * not fun when the job is release in the queue.
+     * Run EVERY time when the job is deleted from queue.
+     *
+     * This isn't called when the job is released in the queue, only when it's leaving it.
+     * Also called after a failure before the failed method.
      *
      * @param  array  $data
      * @return void

--- a/src/Illuminate/Queue/CallQueuedHandler.php
+++ b/src/Illuminate/Queue/CallQueuedHandler.php
@@ -98,4 +98,22 @@ class CallQueuedHandler
             $command->failed($e);
         }
     }
+
+    /**
+     * Call the deleted method on the job instance.
+     *
+     * Run EVERY time when the job is deleted from queue
+     * not fun when the job is release in the queue.
+     *
+     * @param  array  $data
+     * @return void
+     */
+    public function deleted(array $data)
+    {
+        $command = unserialize($data['command']);
+
+        if (method_exists($command, 'deleted')) {
+            $command->deleted();
+        }
+    }
 }

--- a/src/Illuminate/Queue/Jobs/Job.php
+++ b/src/Illuminate/Queue/Jobs/Job.php
@@ -70,6 +70,15 @@ abstract class Job
     public function delete()
     {
         $this->deleted = true;
+        $payload = $this->payload();
+
+        list($class, $method) = $this->parseJob($payload['job']);
+
+        $this->instance = $this->resolve($class);
+
+        if (method_exists($this->instance, 'deleted')) {
+            $this->instance->deleted($payload['data']);
+        }
     }
 
     /**

--- a/src/Illuminate/Queue/Jobs/Job.php
+++ b/src/Illuminate/Queue/Jobs/Job.php
@@ -72,7 +72,7 @@ abstract class Job
         $this->deleted = true;
         $payload = $this->payload();
 
-        list($class, $method) = $this->parseJob($payload['job']);
+        list($class, $method) = JobName::parse($payload['job']);
 
         $this->instance = $this->resolve($class);
 

--- a/tests/Queue/QueueBeanstalkdJobTest.php
+++ b/tests/Queue/QueueBeanstalkdJobTest.php
@@ -38,6 +38,7 @@ class QueueBeanstalkdJobTest extends TestCase
         $job->getPheanstalk()->shouldReceive('delete')->once()->with($job->getPheanstalkJob());
         $job->getPheanstalkJob()->shouldReceive('getData')->once();
         $job->getContainer()->shouldReceive('make')->once()->with('')->andReturn($handler = m::mock('StdClass'));
+
         $job->delete();
     }
 

--- a/tests/Queue/QueueBeanstalkdJobTest.php
+++ b/tests/Queue/QueueBeanstalkdJobTest.php
@@ -36,7 +36,8 @@ class QueueBeanstalkdJobTest extends TestCase
     {
         $job = $this->getJob();
         $job->getPheanstalk()->shouldReceive('delete')->once()->with($job->getPheanstalkJob());
-
+        $job->getPheanstalkJob()->shouldReceive('getData')->once();
+        $job->getContainer()->shouldReceive('make')->once()->with('')->andReturn($handler = m::mock('StdClass'));
         $job->delete();
     }
 

--- a/tests/Queue/QueueRedisJobTest.php
+++ b/tests/Queue/QueueRedisJobTest.php
@@ -24,6 +24,7 @@ class QueueRedisJobTest extends TestCase
     public function testDeleteRemovesTheJobFromRedis()
     {
         $job = $this->getJob();
+        $job->getContainer()->shouldReceive('make')->once()->with('foo')->andReturn($handler = m::mock('StdClass'));
         $job->getRedisQueue()->shouldReceive('deleteReserved')->once()
             ->with('default', json_encode(['job' => 'foo', 'data' => ['data'], 'attempts' => 2]));
 

--- a/tests/Queue/QueueSqsJobTest.php
+++ b/tests/Queue/QueueSqsJobTest.php
@@ -66,6 +66,7 @@ class QueueSqsJobTest extends TestCase
         $queue = $this->getMockBuilder('Illuminate\Queue\SqsQueue')->setMethods(['getQueue'])->setConstructorArgs([$this->mockedSqsClient, $this->queueName, $this->account])->getMock();
         $queue->setContainer($this->mockedContainer);
         $job = $this->getJob();
+        $job->getContainer()->shouldReceive('make')->once()->with('foo')->andReturn($handler = m::mock('StdClass'));
         $job->getSqs()->expects($this->once())->method('deleteMessage')->with(['QueueUrl' => $this->queueUrl, 'ReceiptHandle' => $this->mockedReceiptHandle]);
         $job->delete();
     }

--- a/tests/Queue/RedisQueueIntegrationTest.php
+++ b/tests/Queue/RedisQueueIntegrationTest.php
@@ -24,7 +24,7 @@ class RedisQueueIntegrationTest extends TestCase
         $this->setUpRedis();
 
         $this->queue = new RedisQueue($this->redis);
-        $container   = m::mock(Container::class);
+        $container = m::mock(Container::class);
         $this->queue->setContainer($container);
     }
 

--- a/tests/Queue/RedisQueueIntegrationTest.php
+++ b/tests/Queue/RedisQueueIntegrationTest.php
@@ -24,7 +24,8 @@ class RedisQueueIntegrationTest extends TestCase
         $this->setUpRedis();
 
         $this->queue = new RedisQueue($this->redis);
-        $this->queue->setContainer(m::mock(Container::class));
+        $container   = m::mock(Container::class);
+        $this->queue->setContainer($container);
     }
 
     public function tearDown()
@@ -246,6 +247,7 @@ class RedisQueueIntegrationTest extends TestCase
 
         /** @var \Illuminate\Queue\Jobs\RedisJob $redisJob */
         $redisJob = $this->queue->pop();
+        $redisJob->getContainer()->shouldReceive('make')->once()->with('Illuminate\Queue\CallQueuedHandler')->andReturn($handler = m::mock('StdClass'));
 
         $redisJob->delete();
 
@@ -267,6 +269,7 @@ class RedisQueueIntegrationTest extends TestCase
         $this->assertEquals(3, $this->queue->size());
         $job = $this->queue->pop();
         $this->assertEquals(3, $this->queue->size());
+        $job->getContainer()->shouldReceive('make')->once()->with('Illuminate\Queue\CallQueuedHandler')->andReturn($handler = m::mock('StdClass'));
         $job->delete();
         $this->assertEquals(2, $this->queue->size());
     }

--- a/tests/Queue/RedisQueueIntegrationTest.php
+++ b/tests/Queue/RedisQueueIntegrationTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\TestCase;
 use Illuminate\Queue\RedisQueue;
 use Illuminate\Container\Container;
 use Illuminate\Queue\Jobs\RedisJob;
+use Illuminate\Queue\CallQueuedHandler;
 use Illuminate\Tests\Redis\InteractsWithRedis;
 
 class RedisQueueIntegrationTest extends TestCase
@@ -247,7 +248,7 @@ class RedisQueueIntegrationTest extends TestCase
 
         /** @var \Illuminate\Queue\Jobs\RedisJob $redisJob */
         $redisJob = $this->queue->pop();
-        $redisJob->getContainer()->shouldReceive('make')->once()->with('Illuminate\Queue\CallQueuedHandler')->andReturn($handler = m::mock('StdClass'));
+        $redisJob->getContainer()->shouldReceive('make')->once()->with(CallQueuedHandler::class)->andReturn($handler = m::mock('StdClass'));
 
         $redisJob->delete();
 
@@ -269,7 +270,7 @@ class RedisQueueIntegrationTest extends TestCase
         $this->assertEquals(3, $this->queue->size());
         $job = $this->queue->pop();
         $this->assertEquals(3, $this->queue->size());
-        $job->getContainer()->shouldReceive('make')->once()->with('Illuminate\Queue\CallQueuedHandler')->andReturn($handler = m::mock('StdClass'));
+        $job->getContainer()->shouldReceive('make')->once()->with(CallQueuedHandler::class)->andReturn($handler = m::mock('StdClass'));
         $job->delete();
         $this->assertEquals(2, $this->queue->size());
     }


### PR DESCRIPTION
When a job end, this callback will be called on it to tell it it's been deleted from the queue.
It's useful when you want to manage jobs that can only have one instance in the queue.

The code is a vulgar copy/paste from the failed callback only with a rename.

**tl;dr**: It would be used to clean up after the job has finished, like a finally in a try/catch clause.