### PR TITLE
[5.4] Support functions in higher order messages

### DIFF
--- a/src/Illuminate/Support/HigherOrderCollectionProxy.php
+++ b/src/Illuminate/Support/HigherOrderCollectionProxy.php
@@ -54,7 +54,15 @@ class HigherOrderCollectionProxy
     public function __call($method, $parameters)
     {
         return $this->collection->{$this->method}(function ($value) use ($method, $parameters) {
-            return $value->{$method}(...$parameters);
+            if (is_object($value)) {
+                return $value->{$method}(...$parameters);
+            }
+
+            if ($method == 'empty') {
+                return empty($value);
+            }
+
+            return $method($value, ...$parameters);
         });
     }
 }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1882,6 +1882,24 @@ class SupportCollectionTest extends TestCase
 
         $this->assertSame(['b' => ['free' => false]], $premium->toArray());
     }
+
+    public function testHigherOrderWithFunctions()
+    {
+        $collection = new Collection(['laravel', 'framework', '']);
+
+        $result = $collection->map->strtoupper()->reject->empty();
+
+        $this->assertSame(['LARAVEL', 'FRAMEWORK'], $result->toArray());
+    }
+
+    public function testHigherOrderWithFunctionsWithExtraArguments()
+    {
+        $collection = new Collection(['===laravel===', '---framework---']);
+
+        $result = $collection->map->substr(3, -3);
+
+        $this->assertSame(['laravel', 'framework'], $result->toArray());
+    }
 }
 
 class TestSupportCollectionHigherOrderItem


### PR DESCRIPTION
```
collect(['laravel', 'framework', ''])
    ->map->strtoupper()
    ->reject->empty();  // Result: ['LARAVEL', 'FRAMEWORK']
```

```
$collection = new Collection(['<br>laravel', '<p>framework</p> <script>']);

$collection->map->strip_tags(['br', 'p']);
```