### PR TITLE
issue #17439: Fixed a flaw in str::is() function.

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -118,7 +118,8 @@ class Str
      */
     public static function is($pattern, $value)
     {
-        if ($pattern == $value) {
+        //there should be a strict check as we are dealing with strings.
+        if ($pattern === $value) {
             return true;
         }
 

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -118,8 +118,8 @@ class Str
      */
     public static function is($pattern, $value)
     {
-        //there should be a strict check as we are dealing with strings.
-        if ($pattern === $value) {
+        //typecast to make the check more reliable. 
+        if ((string)$pattern == (string)$value) {
             return true;
         }
 


### PR DESCRIPTION
There is small flaw in the function. As we are dealing with strings there we should do a strict check (===) instead of (==).