### PR TITLE
[5.4] Fix empty inline sections

### DIFF
--- a/src/Illuminate/View/Concerns/ManagesLayouts.php
+++ b/src/Illuminate/View/Concerns/ManagesLayouts.php
@@ -31,12 +31,12 @@ trait ManagesLayouts
      * Start injecting content into a section.
      *
      * @param  string  $section
-     * @param  string  $content
+     * @param  string|null  $content
      * @return void
      */
-    public function startSection($section, $content = '')
+    public function startSection($section, $content = null)
     {
-        if ($content === '') {
+        if ($content === null) {
             if (ob_start()) {
                 $this->sectionStack[] = $section;
             }


### PR DESCRIPTION
Although this is possible in Laravel: `@section('title', '')`

Right now PHPUnit will detect the tests using that code as risky, I realized that happens because Laravel don't close the `ob_start` since `''` is the default parameter, so that's not taken as an inline content but as a section without `@endsection`.

In order to solve the problem I changed the default value to `null`.