### PR TITLE
[5.4] Add customization of the Notification "type"

### DIFF
--- a/src/Illuminate/Notifications/Events/BroadcastNotificationCreated.php
+++ b/src/Illuminate/Notifications/Events/BroadcastNotificationCreated.php
@@ -91,7 +91,7 @@ class BroadcastNotificationCreated implements ShouldBroadcast
 
         return $class.'.'.$this->notifiable->getKey();
     }
-    
+
     /**
      * Returns the notification type that will be set as the "type" with the broadcasted event.
      *
@@ -102,7 +102,7 @@ class BroadcastNotificationCreated implements ShouldBroadcast
         if (method_exists($this->notification, 'notificationType')) {
             return $this->notification->notificationType();
         }
-        
+ 
         return get_class($this->notification);
     }
 }

--- a/src/Illuminate/Notifications/Events/BroadcastNotificationCreated.php
+++ b/src/Illuminate/Notifications/Events/BroadcastNotificationCreated.php
@@ -102,7 +102,7 @@ class BroadcastNotificationCreated implements ShouldBroadcast
         if (method_exists($this->notification, 'notificationType')) {
             return $this->notification->notificationType();
         }
- 
+
         return get_class($this->notification);
     }
 }

--- a/src/Illuminate/Notifications/Events/BroadcastNotificationCreated.php
+++ b/src/Illuminate/Notifications/Events/BroadcastNotificationCreated.php
@@ -72,7 +72,7 @@ class BroadcastNotificationCreated implements ShouldBroadcast
     {
         return array_merge($this->data, [
             'id' => $this->notification->id,
-            'type' => get_class($this->notification),
+            'type' => $this->notificationType(),
         ]);
     }
 
@@ -90,5 +90,19 @@ class BroadcastNotificationCreated implements ShouldBroadcast
         $class = str_replace('\\', '.', get_class($this->notifiable));
 
         return $class.'.'.$this->notifiable->getKey();
+    }
+    
+    /**
+     * Returns the notification type that will be set as the "type" with the broadcasted event.
+     *
+     * @return string
+     */
+    protected function notificationType()
+    {
+        if (method_exists($this->notification, 'notificationType')) {
+            return $this->notification->notificationType();
+        }
+        
+        return get_class($this->notification);
     }
 }


### PR DESCRIPTION
When building front end notifications, especially on complex applications, notification class names could be extremely long. To get around this, adding the ability for a developer to set the "type" on their Notification class would help with this.

Another perk is you would not be exposing your namespaces to the frontend, but take that as you may.

So now I can have the following:

```php
class ContactCreatedNotification extends Notification
{
    public function notificationType()
    {
        return 'contact-created';
    }
}
```

Then on my frontend, I would have a generic implementation for VueJS:

```javascript
Echo.private(`user.${this.user.id}`)
    .notification((notification) => {
        Bus.$emit(notification.type, notification);
    });
```

Now somewhere within my VueJS app I can listen for the event by doing:

```javascript
Bus.$on('contact-created', (notification) => {
    // Handle it.
});
```

Thoughts?