### PR TITLE
[5.3] Allow make::seeder to correctly create nested seeders

### DIFF
--- a/src/Illuminate/Database/Console/Seeds/SeederMakeCommand.php
+++ b/src/Illuminate/Database/Console/Seeds/SeederMakeCommand.php
@@ -60,6 +60,19 @@ class SeederMakeCommand extends GeneratorCommand
         parent::fire();
 
         $this->composer->dumpAutoloads();
+    }    
+    
+    /**
+     * Build the class with the given name.
+     *
+     * @param  string  $name
+     * @return string
+     */
+    protected function buildClass($name)
+    {
+        $stub = $this->files->get($this->getStub());
+
+        return $this->replaceClass($stub, class_basename($name));
     }
 
     /**
@@ -80,7 +93,7 @@ class SeederMakeCommand extends GeneratorCommand
      */
     protected function getPath($name)
     {
-        return $this->laravel->databasePath().'/seeds/'.$name.'.php';
+        return $this->laravel->databasePath().'/seeds/'.str_replace('\\', '/', $name).'.php';
     }
 
     /**

--- a/src/Illuminate/Database/Console/Seeds/SeederMakeCommand.php
+++ b/src/Illuminate/Database/Console/Seeds/SeederMakeCommand.php
@@ -60,8 +60,8 @@ class SeederMakeCommand extends GeneratorCommand
         parent::fire();
 
         $this->composer->dumpAutoloads();
-    }    
-    
+    }
+
     /**
      * Build the class with the given name.
      *


### PR DESCRIPTION
Fixes #17407

**Before change:**
```php artisan make:seeder Talks/TalksSeeder```
creates the correct folder structure but the contents of the file has classname as "Talks/TalksSeeder"

```php artisan make:seeder Talks\\TalksSeeder```
throws a protocol error

*Note: make:controller and make:model both work using either of these two options.

**After Change**
both commands above will create the correct folder structure and the seeder class name will be correct in the file.

*Note: This also enable you to use ```php artisan make:seeder Talks//TalksSeeder```*