### PR TITLE
[5.4] Escape inline sections

### DIFF
--- a/src/Illuminate/View/Concerns/ManagesLayouts.php
+++ b/src/Illuminate/View/Concerns/ManagesLayouts.php
@@ -41,7 +41,7 @@ trait ManagesLayouts
                 $this->sectionStack[] = $section;
             }
         } else {
-            $this->extendSection($section, $content);
+            $this->extendSection($section, e($content));
         }
     }
 


### PR DESCRIPTION
Subtle but important change (imho). 

This is a possible XSS attack: `@section('title', '</title><script>alert("hi")</script>')`

Of course the problem there is evident, but it is less evident if you have something like:

`@section('title', $user->username)` or `@section('title', $userPost->title)` 

Using: 

```
@section('title')
    {!! $post->title !!}
@endsection
```

Makes it evident that the content is not escaped, but `@section('title', $post->title)` doesn't.