### PR TITLE
[5.4] @default directive proposal

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
@@ -80,4 +80,26 @@ trait CompilesConditionals
     {
         return '<?php endif; ?>';
     }
+
+    /**
+     * Compile the default statements into valid PHP.
+     *
+     * @param  string  $expression
+     * @return string
+     */
+    protected function compileDefault($expression)
+    {
+        return "<?php if (isset{$expression} && (string) {$expression} != ''): echo e{$expression}; else: ?>";
+    }
+
+    /**
+     * Compile the end default statements into valid PHP.
+     *
+     * @param  string  $expression
+     * @return string
+     */
+    protected function compileEnddefault($expression)
+    {
+        return '<?php endif; ?>';
+    }
 }

--- a/tests/View/Blade/BladeDefaultTest.php
+++ b/tests/View/Blade/BladeDefaultTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Illuminate\Tests\Blade;
+
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+use Illuminate\View\Compilers\BladeCompiler;
+
+class BladeDefaultTest extends TestCase
+{
+    public function tearDown()
+    {
+        m::close();
+    }
+
+    public function testDefaultStatementsAreCompiled()
+    {
+        $compiler = new BladeCompiler($this->getFiles(), __DIR__);
+        $this->assertEquals('<?php if (isset($var) && (string) ($var) != \'\'): echo e($var); else: ?>', $compiler->compileString('@default($var)'));
+    }
+
+    public function testEndDefaultStatementsAreCompiled()
+    {
+        $compiler = new BladeCompiler($this->getFiles(), __DIR__);
+        $this->assertEquals('<?php endif; ?>', $compiler->compileString('@enddefault'));
+    }
+
+    protected function getFiles()
+    {
+        return m::mock('Illuminate\Filesystem\Filesystem');
+    }
+}


### PR DESCRIPTION
I think that right now there is no way to have default slot values (as in Vue).

But since they are just variables I had the idea of creating a simple Blade directive to handle those cases:

```
@default($description)
    <p>Lorem ipsum</p>
@enddefault
```

if `$description` is not defined or it is empty it will print `Lorem ipsum` otherwise it will print the value of `$description`.

This is not limited to slots but can be used with any variable. 
