### PR TITLE
[5.4] Stub the login method on the TokenGuard so that it may be used during user registration

### DIFF
--- a/src/Illuminate/Auth/TokenGuard.php
+++ b/src/Illuminate/Auth/TokenGuard.php
@@ -5,6 +5,7 @@ namespace Illuminate\Auth;
 use Illuminate\Http\Request;
 use Illuminate\Contracts\Auth\Guard;
 use Illuminate\Contracts\Auth\UserProvider;
+use Illuminate\Contracts\Auth\Authenticatable as AuthenticatableContract;
 
 class TokenGuard implements Guard
 {
@@ -129,5 +130,16 @@ class TokenGuard implements Guard
         $this->request = $request;
 
         return $this;
+    }
+
+    /**
+     * Stub this method so it's possible to use this Guard for user registration.
+     *
+     * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
+     * @param  bool  $remember
+     * @return void
+     */
+    public function login(AuthenticatableContract $user, $remember = false)
+    {
     }
 }


### PR DESCRIPTION
I think it would be really useful and not at all harmful to add a no-op `login` method to the `TokenGuard`.

Doing so allows a developer to use the `TokenGuard` during user registration. This avoids creating any session and associated data which is handy if you're developing an API but would __still__  like to use the `RegistrationController` provided by the framework.

Once this is merged all a developer would have to do is add the following to their `RegistrationController` and they would be good to go.

```php
protected function guard()
{
    return Auth::guard('api');
}

protected function registered(Request $request, $user)
{
    return response()->json(['data' => $user], Response::HTTP_CREATED);
}
```

Note that `Response` in this instance is `Symfony\Component\HttpFoundation\Response`

Fixes #17456

