### PR TITLE
[5.4] Delete comment

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -265,9 +265,6 @@ abstract class HasOneOrMany extends Relation
      */
     public function create(array $attributes)
     {
-        // Here we will set the raw attributes to avoid hitting the "fill" method so
-        // that we do not have to worry about a mass accessor rules blocking sets
-        // on the models. Otherwise, some of these attributes will not get set.
         return tap($this->related->newInstance($attributes), function ($instance) {
             $instance->setAttribute($this->getForeignKeyName(), $this->getParentKey());
 


### PR DESCRIPTION
`newInstance()` creates a new Model object by using the `new` keyword. Constructing a new model implies using the fill method, so this comment is incorrect.

I figured to remove this comment as a whole, since it didn't make sense to me why a relation's `create()` method would need to bypass mass assignment checks and others such as `updateOrCreate()` don't.