### PR TITLE
[5.4] Install PHP-CS-Fixer 1 locally.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -73,6 +73,7 @@
     "require-dev": {
         "aws/aws-sdk-php": "~3.0",
         "doctrine/dbal": "~2.5",
+        "friendsofphp/php-cs-fixer": "~1",
         "mockery/mockery": "~0.9.4",
         "pda/pheanstalk": "~3.0",
         "phpunit/phpunit": "~5.7",


### PR DESCRIPTION
PHP-CS-Fixer is now in version 2 but the `.php_cs` matches version 1 syntax.
It is not possible anymore to run it without either using version 1 globally or locally.

As the current version is 2, and the global installation is recommended, the only way to go using this feature is to use version 1 locally.