### PR TITLE
[5.4] Add odd and even indicators to the $loop variable

### DIFF
--- a/src/Illuminate/View/Concerns/ManagesLoops.php
+++ b/src/Illuminate/View/Concerns/ManagesLoops.php
@@ -35,6 +35,8 @@ trait ManagesLoops
             'last' => isset($length) ? $length == 1 : null,
             'depth' => count($this->loopsStack) + 1,
             'parent' => $parent ? (object) $parent : null,
+            'odd' => false,
+            'even' => true,
         ];
     }
 
@@ -53,6 +55,8 @@ trait ManagesLoops
             'first' => $loop['iteration'] == 0,
             'remaining' => isset($loop['count']) ? $loop['remaining'] - 1 : null,
             'last' => isset($loop['count']) ? $loop['iteration'] == $loop['count'] - 1 : null,
+            'odd' => $loop['even'],
+            'even' => $loop['odd'],
         ]);
     }
 

--- a/tests/View/ViewFactoryTest.php
+++ b/tests/View/ViewFactoryTest.php
@@ -440,6 +440,8 @@ class ViewFactoryTest extends TestCase
             'last' => false,
             'depth' => 1,
             'parent' => null,
+            'odd' => false,
+            'even' => true,
         ];
 
         $this->assertEquals([$expectedLoop], $factory->getLoopStack());
@@ -455,6 +457,8 @@ class ViewFactoryTest extends TestCase
             'last' => false,
             'depth' => 2,
             'parent' => (object) $expectedLoop,
+            'odd' => false,
+            'even' => true,
         ];
         $this->assertEquals([$expectedLoop, $secondExpectedLoop], $factory->getLoopStack());
 
@@ -478,6 +482,8 @@ class ViewFactoryTest extends TestCase
             'last' => null,
             'depth' => 1,
             'parent' => null,
+            'odd' => false,
+            'even' => true,
         ];
 
         $this->assertEquals([$expectedLoop], $factory->getLoopStack());
@@ -491,11 +497,25 @@ class ViewFactoryTest extends TestCase
 
         $factory->incrementLoopIndices();
 
+        $expected = [
+            'iteration' => 1,
+            'index' => 0,
+            'remaining' => 3,
+            'odd' => true,
+            'even' => false,
+        ];
+        $this->assertArraySubset($expected, $factory->getLoopStack()[0], true);
+
         $factory->incrementLoopIndices();
 
-        $this->assertEquals(2, $factory->getLoopStack()[0]['iteration']);
-        $this->assertEquals(1, $factory->getLoopStack()[0]['index']);
-        $this->assertEquals(2, $factory->getLoopStack()[0]['remaining']);
+        $expected = [
+            'iteration' => 2,
+            'index' => 1,
+            'remaining' => 2,
+            'odd' => false,
+            'even' => true,
+        ];
+        $this->assertArraySubset($expected, $factory->getLoopStack()[0], true);
     }
 
     public function testReachingEndOfLoop()


### PR DESCRIPTION
Allows the usage of `$loop->odd` and `$loop->even` in the `@foreach` cycles. 