### PR TITLE
[5.4] Fix storeAs array issue

### DIFF
--- a/src/Illuminate/Http/UploadedFile.php
+++ b/src/Illuminate/Http/UploadedFile.php
@@ -67,6 +67,8 @@ class UploadedFile extends SymfonyUploadedFile
      */
     public function storeAs($path, $name, $options = [])
     {
+        $options = $this->parseOptions($options);
+        
         $disk = Arr::pull($options, 'disk');
 
         return Container::getInstance()->make(FilesystemFactory::class)->disk($disk)->putFileAs(


### PR DESCRIPTION
when managing an uploaded file, $request->uploaded_filename->storeAs($path, $name, 's3') doesn't work when the disk is typed as a string.  

It now accepts string 's3' (as per the docs indicate it should). 