### PR TITLE
[5.4] no eval for RedisStore::add() [requires Redis version >= 2.6.12]

### DIFF
--- a/src/Illuminate/Cache/RedisStore.php
+++ b/src/Illuminate/Cache/RedisStore.php
@@ -124,11 +124,7 @@ class RedisStore extends TaggableStore implements Store
      */
     public function add($key, $value, $minutes)
     {
-        $lua = "return redis.call('exists',KEYS[1])<1 and redis.call('setex',KEYS[1],ARGV[2],ARGV[1])";
-
-        return (bool) $this->connection()->eval(
-            $lua, 1, $this->prefix.$key, $this->serialize($value), (int) max(1, $minutes * 60)
-        );
+        return (bool) $this->connection()->set($key, $value, 'EX', (int) max(1, $minutes * 60), 'NX');
     }
 
     /**

--- a/src/Illuminate/Queue/Events/WorkerLooping.php
+++ b/src/Illuminate/Queue/Events/WorkerLooping.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Illuminate\Queue\Events;
+
+use Illuminate\Queue\WorkerOptions;
+
+class WorkerLooping
+{
+    /**
+     * @var WorkerOptions
+     */
+    private $workerOptions;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  WorkerOptions  $workerOptions
+     * @return void
+     */
+    public function __construct(WorkerOptions $workerOptions)
+    {
+        $this->workerOptions = $workerOptions;
+    }
+}

--- a/tests/Cache/RedisCacheIntegrationTest.php
+++ b/tests/Cache/RedisCacheIntegrationTest.php
@@ -31,6 +31,7 @@ class RedisCacheIntegrationTest extends TestCase
         $repository = new Repository($store);
         $this->assertTrue($repository->add('k', 'v', 60));
         $this->assertFalse($repository->add('k', 'v', 60));
+        $this->assertGreaterThan(3500, $this->redis->connection()->ttl('k'));
     }
 
     /**
@@ -42,6 +43,7 @@ class RedisCacheIntegrationTest extends TestCase
         $repository = new Repository($store);
         $repository->forever('k', false);
         $this->assertFalse($repository->add('k', 'v', 60));
+        $this->assertEquals(-1, $this->redis->connection()->ttl('k'));
     }
 
     /**


### PR DESCRIPTION
We already need Redis >= 2.6.0 for RedisStore::add() to work. For the sake of performance, I think it is OK not to support Redis < [2.6.12](https://github.com/antirez/redis/tree/2.6.12). Those are old versions and migration should be easy.