### PR TITLE
[5.4] fix redis queue tests for phpredis driver

### DIFF
--- a/tests/Queue/RedisQueueIntegrationTest.php
+++ b/tests/Queue/RedisQueueIntegrationTest.php
@@ -209,7 +209,7 @@ class RedisQueueIntegrationTest extends TestCase
         //check the content of delayed queue
         $this->assertEquals(1, $this->redis->connection()->zcard('queues:default:delayed'));
 
-        $results = $this->redis->connection()->zrangebyscore('queues:default:delayed', -INF, INF, 'withscores');
+        $results = $this->redis->connection()->zrangebyscore('queues:default:delayed', -INF, INF, ['WITHSCORES' => true]);
 
         $payload = array_keys($results)[0];
 


### PR DESCRIPTION
I think we need to add something to .travis.yml to test phpredis as well as predis.
One Test fails when I change InteractsWithRedis::setUpRedis() to use phpredis.