### PR TITLE
[5.4] Allow to get some model data with static calls

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1141,7 +1141,9 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public static function modelQualifiedKeyName()
     {
-        return ($model = new static)->getTable().'.'.$model->getKeyName();
+        $model = new static;
+
+        return $model->getTable().'.'.$model->getKeyName();
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1105,6 +1105,46 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     }
 
     /**
+     * Get the table associated with the model with static call.
+     *
+     * @return string
+     */
+    public static function modelTableName()
+    {
+        return (new static)->getTable();
+    }
+
+    /**
+     * Get the primary key for the model with static call.
+     *
+     * @return string
+     */
+    public static function modelKeyName()
+    {
+        return (new static)->getKeyName();
+    }
+
+    /**
+     * Get the table qualified column name with static call.
+     *
+     * @return string
+     */
+    public static function modelQualifiedColumnName($column)
+    {
+        return (new static)->getTable().'.'.$column;
+    }
+
+    /**
+     * Get the table qualified key name with static call.
+     *
+     * @return string
+     */
+    public static function modelQualifiedKeyName()
+    {
+        return ($model = new static)->getTable().'.'.$model->getKeyName();
+    }
+
+    /**
      * Get the auto incrementing key type.
      *
      * @return string

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1577,6 +1577,26 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertFalse($result);
     }
 
+    public function testModelTableName()
+    {
+        $this->assertSame('stub', EloquentModelStubWithCustomKey::modelTableName());
+    }
+
+    public function testModelKeyName()
+    {
+        $this->assertSame('custom_key', EloquentModelStubWithCustomKey::modelKeyName());
+    }
+
+    public function testModelQualifiedColumnName()
+    {
+        $this->assertSame('stub.something', EloquentModelStubWithCustomKey::modelQualifiedColumnName('something'));
+    }
+
+    public function testModelQualifiedKeyName()
+    {
+        $this->assertSame('stub.custom_key', EloquentModelStubWithCustomKey::modelQualifiedKeyName());
+    }
+
     protected function addMockConnection($model)
     {
         $model->setConnectionResolver($resolver = m::mock('Illuminate\Database\ConnectionResolverInterface'));
@@ -1694,6 +1714,11 @@ class EloquentModelStub extends Model
 class EloquentModelCamelStub extends EloquentModelStub
 {
     public static $snakeAttributes = false;
+}
+
+class EloquentModelStubWithCustomKey extends EloquentModelStub
+{
+    protected $primaryKey = 'custom_key';
 }
 
 class EloquentDateModelStub extends EloquentModelStub


### PR DESCRIPTION
Sometimes it's useful to get model table name, key name or qualified key name (or column name) with static call. But as far as I know it's impossible to do this at the moment so you need to either implement it yourself or copy table name from model what is not the best way.