### PR TITLE
Revert "[5.4] no eval for RedisStore::add() [requires Redis version >= 2.6.12]"

### DIFF
--- a/src/Illuminate/Cache/RedisStore.php
+++ b/src/Illuminate/Cache/RedisStore.php
@@ -124,7 +124,11 @@ class RedisStore extends TaggableStore implements Store
      */
     public function add($key, $value, $minutes)
     {
-        return (bool) $this->connection()->set($key, $value, 'EX', (int) max(1, $minutes * 60), 'NX');
+        $lua = "return redis.call('exists',KEYS[1])<1 and redis.call('setex',KEYS[1],ARGV[2],ARGV[1])";
+
+        return (bool) $this->connection()->eval(
+            $lua, 1, $this->prefix.$key, $this->serialize($value), (int) max(1, $minutes * 60)
+        );
     }
 
     /**

--- a/tests/Cache/RedisCacheIntegrationTest.php
+++ b/tests/Cache/RedisCacheIntegrationTest.php
@@ -31,7 +31,6 @@ class RedisCacheIntegrationTest extends TestCase
         $repository = new Repository($store);
         $this->assertTrue($repository->add('k', 'v', 60));
         $this->assertFalse($repository->add('k', 'v', 60));
-        $this->assertGreaterThan(3500, $this->redis->connection()->ttl('k'));
     }
 
     /**
@@ -43,7 +42,6 @@ class RedisCacheIntegrationTest extends TestCase
         $repository = new Repository($store);
         $repository->forever('k', false);
         $this->assertFalse($repository->add('k', 'v', 60));
-        $this->assertEquals(-1, $this->redis->connection()->ttl('k'));
     }
 
     /**


### PR DESCRIPTION
Reverts laravel/framework#17477