### PR TITLE
[5.3] fix time related tests (use Carbon::now instead of time function)

### DIFF
--- a/tests/Cache/CacheMemcachedStoreTest.php
+++ b/tests/Cache/CacheMemcachedStoreTest.php
@@ -59,12 +59,11 @@ class CacheMemcachedStoreTest extends PHPUnit_Framework_TestCase
             $this->markTestSkipped('Memcached module not installed');
         }
 
-        Carbon\Carbon::setTestNow($now = Carbon\Carbon::now());
+        $now = Carbon\Carbon::now();
         $memcache = $this->getMockBuilder('Memcached')->setMethods(['set'])->getMock();
         $memcache->expects($this->once())->method('set')->with($this->equalTo('foo'), $this->equalTo('bar'), $this->equalTo($now->timestamp + 60));
         $store = new MemcachedStore($memcache);
         $store->put('foo', 'bar', 1);
-        Carbon\Carbon::setTestNow();
     }
 
     public function testIncrementMethodProperlyCallsMemcache()

--- a/tests/Cache/CacheRepositoryTest.php
+++ b/tests/Cache/CacheRepositoryTest.php
@@ -68,11 +68,6 @@ class CacheRepositoryTest extends PHPUnit_Framework_TestCase
         });
         $this->assertEquals('bar', $result);
 
-        /*
-         * Use Carbon object...
-         */
-        Carbon::setTestNow(Carbon::now());
-
         $repo = $this->getRepository();
         $repo->getStore()->shouldReceive('get')->andReturn(null);
         $repo->getStore()->shouldReceive('put')->once()->with('foo', 'bar', 602 / 60);
@@ -85,8 +80,6 @@ class CacheRepositoryTest extends PHPUnit_Framework_TestCase
             return 'qux';
         });
         $this->assertEquals('qux', $result);
-
-        Carbon::setTestNow();
     }
 
     public function testRememberForeverMethodCallsForeverAndReturnsDefault()

--- a/tests/Console/ConsoleScheduledEventTest.php
+++ b/tests/Console/ConsoleScheduledEventTest.php
@@ -13,8 +13,14 @@ class ConsoleScheduledEventTest extends PHPUnit_Framework_TestCase
      */
     protected $defaultTimezone;
 
+    /**
+     * @var Carbon
+     */
+    protected $now;
+
     public function setUp()
     {
+        $this->now = Carbon::now();
         $this->defaultTimezone = date_default_timezone_get();
         date_default_timezone_set('UTC');
     }
@@ -22,7 +28,7 @@ class ConsoleScheduledEventTest extends PHPUnit_Framework_TestCase
     public function tearDown()
     {
         date_default_timezone_set($this->defaultTimezone);
-        Carbon::setTestNow(null);
+        Carbon::setTestNow($this->now);
         m::close();
     }
 


### PR DESCRIPTION
`Carbot::setTestNow()` is done in the bootstrap. No need to call `setTextNow()` in other cases, unless really required.
`Queue::getTime()` used to call `time()`. Now it uses `Carbon`. So I have to change (simplify) time related tests in `tests/Queue/RedisQueueIntegrationTest.php` as well, because once in a while the tests fail.

Thanks for your consideration