### PR TITLE
Assert the response has a given data-structure

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -374,6 +374,45 @@ trait MakesHttpRequests
     }
 
     /**
+     * Assert that the JSON response has a given structure with contents.
+     *
+     * @param  array|null  $structuredData
+     * @param  array|null  $responseData
+     * @return $this
+     */
+    public function seeJsonStructureContains(array $structuredData = null, $responseData = null)
+    {
+        if (is_null($structuredData)) {
+            return $this->seeJson();
+        }
+
+        if (! $responseData) {
+            $responseData = json_decode($this->response->getContent(), true);
+        }
+
+        foreach ($structuredData as $key => $value) {
+            if (is_array($value) && $key === '*') {
+                $this->assertInternalType('array', $responseData);
+
+                foreach ($responseData as $responseDataItem) {
+                    $this->seeJsonStructureContains($structuredData['*'], $responseDataItem);
+                }
+            } elseif (is_array($value)) {
+                $this->assertArrayHasKey($key, $responseData);
+                $this->seeJsonStructureContains($structuredData[$key], $responseData[$key]);
+            } else {
+                $this->assertArrayHasKey($key, $responseData);
+                if ($value === '*') {
+                }else{
+                    $this->assertEquals($value, $responseData[$key]);
+                }
+            }
+        }
+
+        return $this;
+    }
+    
+    /**
      * Assert that the response contains the given JSON.
      *
      * @param  array  $data

--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -402,8 +402,7 @@ trait MakesHttpRequests
                 $this->seeJsonStructureContains($structuredData[$key], $responseData[$key]);
             } else {
                 $this->assertArrayHasKey($key, $responseData);
-                if ($value === '*') {
-                }else{
+                if ($value !== '*') {
                     $this->assertEquals($value, $responseData[$key]);
                 }
             }

--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -410,7 +410,7 @@ trait MakesHttpRequests
 
         return $this;
     }
-    
+
     /**
      * Assert that the response contains the given JSON.
      *


### PR DESCRIPTION
Assert that the JSON response has a given structure with contents.
Example:
```
        $jsonStructureContains = [
            'status' => 'success',
            'message' => '*',
            'code' => 2000,
            'data' => [
                'results' => [
                    '*' => [
                        'id' => '*', 'lat' => '*', 'lng' => '*', 'saved_address' => true
                    ]
                ],
                "total" => '*',
                "paginate" => []
            ]
        ];
        $response->seeJsonStructureContains($jsonStructureContains);
```