### PR TITLE
[5.4] Use doctrine type of "json_array" for JSON columns

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/ChangeColumn.php
+++ b/src/Illuminate/Database/Schema/Grammars/ChangeColumn.php
@@ -145,6 +145,9 @@ class ChangeColumn
             case 'binary':
                 $type = 'blob';
                 break;
+            case 'json':
+                $type = 'json_array';
+                break;
         }
 
         return Type::getType($type);


### PR DESCRIPTION
Resubmitting #17344 for 5.4. Copy/paste of that PR:

Doctrine doesn't have a `JSON` type, it calls it [`JSON_ARRAY`](https://github.com/doctrine/dbal/blob/2.5/lib/Doctrine/DBAL/Types/Type.php#L38).

Currently, trying to `change()` a JSON column results in this error: 
```
[Doctrine\DBAL\DBALException]
  Unknown column type "json" requested. Any Doctrine type that you use has to be registered with \Doctrine\DBAL\Types\Type::addType(). You can get a list of all the known types with \Doctrine\DBAL\Types\Type::getTypesMap(). If this er
  ror occurs during database introspection then you might have forgot to register all database types for a Doctrine Type. Use AbstractPlatform#registerDoctrineTypeMapping() or have your custom types implement Type#getMappedDatabaseTyp
  es(). If the type name is empty you might have a problem with the cache or forgot some mapping information.
```

This change resolves the issue.