### PR TITLE
[5.4] Using factory(*, $number) throws an ErrorException

### DIFF
--- a/src/Illuminate/Database/Eloquent/FactoryBuilder.php
+++ b/src/Illuminate/Database/Eloquent/FactoryBuilder.php
@@ -115,7 +115,7 @@ class FactoryBuilder
         if ($results instanceof Model) {
             $results->save();
         } else {
-            $result->each->save();
+            $results->each->save();
         }
 
         return $results;


### PR DESCRIPTION
`Undefined variable: result`

Quick fix for typo in Illuminate/Database/Eloquent/FactoryBuilder.php:118.