### PR TITLE
[5.4] Fix auth basic error due to validate not setting lastAttempted

### DIFF
--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -248,7 +248,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
      */
     public function validate(array $credentials = [])
     {
-        $user = $this->provider->retrieveByCredentials($credentials);
+        $this->lastAttempted = $user = $this->provider->retrieveByCredentials($credentials);
 
         return $this->hasValidCredentials($user, $credentials);
     }

--- a/tests/Auth/AuthGuardTest.php
+++ b/tests/Auth/AuthGuardTest.php
@@ -359,6 +359,27 @@ class AuthGuardTest extends TestCase
         $this->assertTrue($guard->viaRemember());
     }
 
+    public function testLoginOnceSetsUser()
+    {
+        list($session, $provider, $request, $cookie) = $this->getMocks();
+        $guard = m::mock('Illuminate\Auth\SessionGuard', ['default', $provider, $session])->makePartial();
+        $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');
+        $guard->getProvider()->shouldReceive('retrieveByCredentials')->once()->with(['foo'])->andReturn($user);
+        $guard->getProvider()->shouldReceive('validateCredentials')->once()->with($user, ['foo'])->andReturn(true);
+        $guard->shouldReceive('setUser')->once()->with($user);
+        $this->assertTrue($guard->once(['foo']));
+    }
+
+    public function testLoginOnceFailure()
+    {
+        list($session, $provider, $request, $cookie) = $this->getMocks();
+        $guard = m::mock('Illuminate\Auth\SessionGuard', ['default', $provider, $session])->makePartial();
+        $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');
+        $guard->getProvider()->shouldReceive('retrieveByCredentials')->once()->with(['foo'])->andReturn($user);
+        $guard->getProvider()->shouldReceive('validateCredentials')->once()->with($user, ['foo'])->andReturn(false);
+        $this->assertFalse($guard->once(['foo']));
+    }
+
     protected function getGuard()
     {
         list($session, $provider, $request, $cookie) = $this->getMocks();


### PR DESCRIPTION
`Auth::once()` (and variants) is broken due to a refactor a month or so ago that removed the original call to `attempt`.

The `validate` method just needed to set `$this->lastAttempted` so that the `setUser` method didn't fail with a type error.