### PR TITLE
[5.4] Add type check before validating URL

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1290,6 +1290,10 @@ trait ValidatesAttributes
      */
     protected function validateUrl($attribute, $value)
     {
+        if (! is_string($value)) {
+            return false;
+        }
+
         /*
          * This pattern is derived from Symfony\Component\Validator\Constraints\UrlValidator (2.7.4).
          *


### PR DESCRIPTION
Fix when passing a non-string value to the URL validator would **break** the application:

> ErrorException
> 
> /var/www/application/vendor/illuminate/validation/Validator.php (1596)
> preg_match() expects parameter 2 to be string, object given

Added the very same check that is done at [`validateActiveUrl()`](https://github.com/laravel/framework/blob/5.4/src/Illuminate/Validation/Concerns/ValidatesAttributes.php#L45) before trying to `preg_match` the URL pattern.

This bug was discovered when a frontend application was sending (by mistake) wrong data to the backend API. The frontend bug was fixed; However the application should not **break** when trying to validate input data.