### PR TITLE
[5.4] Convert back slashes to forward slashes in the mix-manifest.json file

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -567,7 +567,12 @@ if (! function_exists('mix')) {
                 throw new Exception('The Mix manifest does not exist.');
             }
 
-            $manifest = json_decode(file_get_contents($manifestPath), true);
+            $manifest = collect(json_decode(file_get_contents($manifestPath), true))
+                ->mapWithKeys(function ($path, $key) {
+                    $path = str_replace('\\', '/', $path);
+                    $key = str_replace('\\', '/', $key);
+                    return [$key => $path];
+                })->toArray();
         }
 
         if (! starts_with($path, '/')) {


### PR DESCRIPTION
Original issue here: #17498

## Summary:

Running `npm run dev` on windows builds a `mix-manifest.json` like:

```json
{
  "\\js\\vendor.js": "\\js\\vendor.js",
  "\\js\\app.js": "\\js\\app.js",
  "\\css\\app.css": "\\css\\app.css",
  "\\js\\manifest.js": "\\js\\manifest.js"
}
```

Notice the `\`. This will throw the following error because the key doesn't match the path given. 

```php
mix('/css/app.css');

// Throws: Unable to locate Mix file: /css/app.css. Please check your webpack.mix.js output paths and try again.
```

## Solution

The solution here is to convert `\` to `/`. 

```php
$manifest = collect(json_decode(file_get_contents($manifestPath), true))
    ->mapWithKeys(function ($path, $key) {
        $path = str_replace('\\', '/', $path);
        $key = str_replace('\\', '/', $key);
        return [$key => $path];
    })->toArray();
```

Manifest variable output:

```
[
  "/js/vendor.js" => "/js/vendor.js"
  "/js/app.js" => "/js/app.js"
  "/css/app.css" => "/css/app.css"
  "/js/manifest.js" => "/js/manifest.js"
]
```


