### PR TITLE
[5.4] Document ability to give an array to HasOne::withDefault()

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/HasOne.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOne.php
@@ -10,9 +10,10 @@ class HasOne extends HasOneOrMany
     /**
      * Indicates if a default model instance should be used.
      *
-     * Alternatively, may be a Closure to execute to retrieve default value.
+     * Alternatively, may be a Closure to execute to retrieve default value
+     * or an array of attributes to set on the default model instance.
      *
-     * @var \Closure|bool
+     * @var \Closure|array|bool
      */
     protected $withDefault;
 
@@ -85,7 +86,7 @@ class HasOne extends HasOneOrMany
     /**
      * Return a new model instance in case the relationship does not exist.
      *
-     * @param  \Closure|bool  $callback
+     * @param  \Closure|array|bool  $callback
      * @return $this
      */
     public function withDefault($callback = true)


### PR DESCRIPTION
PR #16382 added the ability to pass an array of attributes to set on the default model that can be returned by `hasOne` Eloquent relationships but docblocks hadn’t been updated accordingly to this change. So I thought I’ll fix that :-)