### PR TITLE
[5.4] Use ::class notation in tests

### DIFF
--- a/tests/Auth/AuthDatabaseTokenRepositoryTest.php
+++ b/tests/Auth/AuthDatabaseTokenRepositoryTest.php
@@ -17,7 +17,7 @@ class AuthDatabaseTokenRepositoryTest extends TestCase
     {
         $repo = $this->getRepo();
         $repo->getHasher()->shouldReceive('make')->andReturn('hashed-token');
-        $repo->getConnection()->shouldReceive('table')->with('table')->andReturn($query = m::mock('StdClass'));
+        $repo->getConnection()->shouldReceive('table')->with('table')->andReturn($query = m::mock(\StdClass::class));
         $query->shouldReceive('where')->with('email', 'email')->andReturn($query);
         $query->shouldReceive('delete')->once();
         $query->shouldReceive('insert')->once();
@@ -33,7 +33,7 @@ class AuthDatabaseTokenRepositoryTest extends TestCase
     public function testExistReturnsFalseIfNoRowFoundForUser()
     {
         $repo = $this->getRepo();
-        $repo->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($query = m::mock('StdClass'));
+        $repo->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($query = m::mock(\StdClass::class));
         $query->shouldReceive('where')->once()->with('email', 'email')->andReturn($query);
         $query->shouldReceive('first')->andReturn(null);
         $user = m::mock(\Illuminate\Contracts\Auth\CanResetPassword::class);
@@ -46,7 +46,7 @@ class AuthDatabaseTokenRepositoryTest extends TestCase
     {
         $repo = $this->getRepo();
         $repo->getHasher()->shouldReceive('check')->with('token', 'hashed-token')->andReturn(true);
-        $repo->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($query = m::mock('StdClass'));
+        $repo->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($query = m::mock(\StdClass::class));
         $query->shouldReceive('where')->once()->with('email', 'email')->andReturn($query);
         $date = date('Y-m-d H:i:s', time() - 300000);
         $query->shouldReceive('first')->andReturn((object) ['created_at' => $date, 'token' => 'hashed-token']);
@@ -60,7 +60,7 @@ class AuthDatabaseTokenRepositoryTest extends TestCase
     {
         $repo = $this->getRepo();
         $repo->getHasher()->shouldReceive('check')->with('token', 'hashed-token')->andReturn(true);
-        $repo->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($query = m::mock('StdClass'));
+        $repo->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($query = m::mock(\StdClass::class));
         $query->shouldReceive('where')->once()->with('email', 'email')->andReturn($query);
         $date = date('Y-m-d H:i:s', time() - 600);
         $query->shouldReceive('first')->andReturn((object) ['created_at' => $date, 'token' => 'hashed-token']);
@@ -74,7 +74,7 @@ class AuthDatabaseTokenRepositoryTest extends TestCase
     {
         $repo = $this->getRepo();
         $repo->getHasher()->shouldReceive('check')->with('wrong-token', 'hashed-token')->andReturn(false);
-        $repo->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($query = m::mock('StdClass'));
+        $repo->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($query = m::mock(\StdClass::class));
         $query->shouldReceive('where')->once()->with('email', 'email')->andReturn($query);
         $date = date('Y-m-d H:i:s', time() - 600);
         $query->shouldReceive('first')->andReturn((object) ['created_at' => $date, 'token' => 'hashed-token']);
@@ -87,7 +87,7 @@ class AuthDatabaseTokenRepositoryTest extends TestCase
     public function testDeleteMethodDeletesByToken()
     {
         $repo = $this->getRepo();
-        $repo->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($query = m::mock('StdClass'));
+        $repo->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($query = m::mock(\StdClass::class));
         $query->shouldReceive('where')->once()->with('token', 'token')->andReturn($query);
         $query->shouldReceive('delete')->once();
 
@@ -97,7 +97,7 @@ class AuthDatabaseTokenRepositoryTest extends TestCase
     public function testDeleteExpiredMethodDeletesExpiredTokens()
     {
         $repo = $this->getRepo();
-        $repo->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($query = m::mock('StdClass'));
+        $repo->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($query = m::mock(\StdClass::class));
         $query->shouldReceive('where')->once()->with('created_at', '<', m::any())->andReturn($query);
         $query->shouldReceive('delete')->once();
 

--- a/tests/Auth/AuthDatabaseTokenRepositoryTest.php
+++ b/tests/Auth/AuthDatabaseTokenRepositoryTest.php
@@ -21,7 +21,7 @@ class AuthDatabaseTokenRepositoryTest extends TestCase
         $query->shouldReceive('where')->with('email', 'email')->andReturn($query);
         $query->shouldReceive('delete')->once();
         $query->shouldReceive('insert')->once();
-        $user = m::mock('Illuminate\Contracts\Auth\CanResetPassword');
+        $user = m::mock(\Illuminate\Contracts\Auth\CanResetPassword::class);
         $user->shouldReceive('getEmailForPasswordReset')->andReturn('email');
 
         $results = $repo->create($user);
@@ -36,7 +36,7 @@ class AuthDatabaseTokenRepositoryTest extends TestCase
         $repo->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($query = m::mock('StdClass'));
         $query->shouldReceive('where')->once()->with('email', 'email')->andReturn($query);
         $query->shouldReceive('first')->andReturn(null);
-        $user = m::mock('Illuminate\Contracts\Auth\CanResetPassword');
+        $user = m::mock(\Illuminate\Contracts\Auth\CanResetPassword::class);
         $user->shouldReceive('getEmailForPasswordReset')->andReturn('email');
 
         $this->assertFalse($repo->exists($user, 'token'));
@@ -50,7 +50,7 @@ class AuthDatabaseTokenRepositoryTest extends TestCase
         $query->shouldReceive('where')->once()->with('email', 'email')->andReturn($query);
         $date = date('Y-m-d H:i:s', time() - 300000);
         $query->shouldReceive('first')->andReturn((object) ['created_at' => $date, 'token' => 'hashed-token']);
-        $user = m::mock('Illuminate\Contracts\Auth\CanResetPassword');
+        $user = m::mock(\Illuminate\Contracts\Auth\CanResetPassword::class);
         $user->shouldReceive('getEmailForPasswordReset')->andReturn('email');
 
         $this->assertFalse($repo->exists($user, 'token'));
@@ -64,7 +64,7 @@ class AuthDatabaseTokenRepositoryTest extends TestCase
         $query->shouldReceive('where')->once()->with('email', 'email')->andReturn($query);
         $date = date('Y-m-d H:i:s', time() - 600);
         $query->shouldReceive('first')->andReturn((object) ['created_at' => $date, 'token' => 'hashed-token']);
-        $user = m::mock('Illuminate\Contracts\Auth\CanResetPassword');
+        $user = m::mock(\Illuminate\Contracts\Auth\CanResetPassword::class);
         $user->shouldReceive('getEmailForPasswordReset')->andReturn('email');
 
         $this->assertTrue($repo->exists($user, 'token'));
@@ -78,7 +78,7 @@ class AuthDatabaseTokenRepositoryTest extends TestCase
         $query->shouldReceive('where')->once()->with('email', 'email')->andReturn($query);
         $date = date('Y-m-d H:i:s', time() - 600);
         $query->shouldReceive('first')->andReturn((object) ['created_at' => $date, 'token' => 'hashed-token']);
-        $user = m::mock('Illuminate\Contracts\Auth\CanResetPassword');
+        $user = m::mock(\Illuminate\Contracts\Auth\CanResetPassword::class);
         $user->shouldReceive('getEmailForPasswordReset')->andReturn('email');
 
         $this->assertFalse($repo->exists($user, 'wrong-token'));
@@ -107,8 +107,8 @@ class AuthDatabaseTokenRepositoryTest extends TestCase
     protected function getRepo()
     {
         return new DatabaseTokenRepository(
-            m::mock('Illuminate\Database\Connection'),
-            m::mock('Illuminate\Contracts\Hashing\Hasher'),
+            m::mock(\Illuminate\Database\Connection::class),
+            m::mock(\Illuminate\Contracts\Hashing\Hasher::class),
             'table', 'key');
     }
 }

--- a/tests/Auth/AuthDatabaseUserProviderTest.php
+++ b/tests/Auth/AuthDatabaseUserProviderTest.php
@@ -15,24 +15,24 @@ class AuthDatabaseUserProviderTest extends TestCase
 
     public function testRetrieveByIDReturnsUserWhenUserIsFound()
     {
-        $conn = m::mock('Illuminate\Database\Connection');
+        $conn = m::mock(\Illuminate\Database\Connection::class);
         $conn->shouldReceive('table')->once()->with('foo')->andReturn($conn);
         $conn->shouldReceive('find')->once()->with(1)->andReturn(['id' => 1, 'name' => 'Dayle']);
-        $hasher = m::mock('Illuminate\Contracts\Hashing\Hasher');
+        $hasher = m::mock(\Illuminate\Contracts\Hashing\Hasher::class);
         $provider = new DatabaseUserProvider($conn, $hasher, 'foo');
         $user = $provider->retrieveById(1);
 
-        $this->assertInstanceOf('Illuminate\Auth\GenericUser', $user);
+        $this->assertInstanceOf(\Illuminate\Auth\GenericUser::class, $user);
         $this->assertEquals(1, $user->getAuthIdentifier());
         $this->assertEquals('Dayle', $user->name);
     }
 
     public function testRetrieveByIDReturnsNullWhenUserIsNotFound()
     {
-        $conn = m::mock('Illuminate\Database\Connection');
+        $conn = m::mock(\Illuminate\Database\Connection::class);
         $conn->shouldReceive('table')->once()->with('foo')->andReturn($conn);
         $conn->shouldReceive('find')->once()->with(1)->andReturn(null);
-        $hasher = m::mock('Illuminate\Contracts\Hashing\Hasher');
+        $hasher = m::mock(\Illuminate\Contracts\Hashing\Hasher::class);
         $provider = new DatabaseUserProvider($conn, $hasher, 'foo');
         $user = $provider->retrieveById(1);
 
@@ -41,26 +41,26 @@ class AuthDatabaseUserProviderTest extends TestCase
 
     public function testRetrieveByCredentialsReturnsUserWhenUserIsFound()
     {
-        $conn = m::mock('Illuminate\Database\Connection');
+        $conn = m::mock(\Illuminate\Database\Connection::class);
         $conn->shouldReceive('table')->once()->with('foo')->andReturn($conn);
         $conn->shouldReceive('where')->once()->with('username', 'dayle');
         $conn->shouldReceive('first')->once()->andReturn(['id' => 1, 'name' => 'taylor']);
-        $hasher = m::mock('Illuminate\Contracts\Hashing\Hasher');
+        $hasher = m::mock(\Illuminate\Contracts\Hashing\Hasher::class);
         $provider = new DatabaseUserProvider($conn, $hasher, 'foo');
         $user = $provider->retrieveByCredentials(['username' => 'dayle', 'password' => 'foo']);
 
-        $this->assertInstanceOf('Illuminate\Auth\GenericUser', $user);
+        $this->assertInstanceOf(\Illuminate\Auth\GenericUser::class, $user);
         $this->assertEquals(1, $user->getAuthIdentifier());
         $this->assertEquals('taylor', $user->name);
     }
 
     public function testRetrieveByCredentialsReturnsNullWhenUserIsFound()
     {
-        $conn = m::mock('Illuminate\Database\Connection');
+        $conn = m::mock(\Illuminate\Database\Connection::class);
         $conn->shouldReceive('table')->once()->with('foo')->andReturn($conn);
         $conn->shouldReceive('where')->once()->with('username', 'dayle');
         $conn->shouldReceive('first')->once()->andReturn(null);
-        $hasher = m::mock('Illuminate\Contracts\Hashing\Hasher');
+        $hasher = m::mock(\Illuminate\Contracts\Hashing\Hasher::class);
         $provider = new DatabaseUserProvider($conn, $hasher, 'foo');
         $user = $provider->retrieveByCredentials(['username' => 'dayle']);
 
@@ -69,11 +69,11 @@ class AuthDatabaseUserProviderTest extends TestCase
 
     public function testCredentialValidation()
     {
-        $conn = m::mock('Illuminate\Database\Connection');
-        $hasher = m::mock('Illuminate\Contracts\Hashing\Hasher');
+        $conn = m::mock(\Illuminate\Database\Connection::class);
+        $hasher = m::mock(\Illuminate\Contracts\Hashing\Hasher::class);
         $hasher->shouldReceive('check')->once()->with('plain', 'hash')->andReturn(true);
         $provider = new DatabaseUserProvider($conn, $hasher, 'foo');
-        $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');
+        $user = m::mock(\Illuminate\Contracts\Auth\Authenticatable::class);
         $user->shouldReceive('getAuthPassword')->once()->andReturn('hash');
         $result = $provider->validateCredentials($user, ['password' => 'plain']);
 

--- a/tests/Auth/AuthEloquentUserProviderTest.php
+++ b/tests/Auth/AuthEloquentUserProviderTest.php
@@ -40,11 +40,11 @@ class AuthEloquentUserProviderTest extends TestCase
 
     public function testCredentialValidation()
     {
-        $conn = m::mock('Illuminate\Database\Connection');
-        $hasher = m::mock('Illuminate\Contracts\Hashing\Hasher');
+        $conn = m::mock(\Illuminate\Database\Connection::class);
+        $hasher = m::mock(\Illuminate\Contracts\Hashing\Hasher::class);
         $hasher->shouldReceive('check')->once()->with('plain', 'hash')->andReturn(true);
         $provider = new EloquentUserProvider($hasher, 'foo');
-        $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');
+        $user = m::mock(\Illuminate\Contracts\Auth\Authenticatable::class);
         $user->shouldReceive('getAuthPassword')->once()->andReturn('hash');
         $result = $provider->validateCredentials($user, ['password' => 'plain']);
 
@@ -53,18 +53,18 @@ class AuthEloquentUserProviderTest extends TestCase
 
     public function testModelsCanBeCreated()
     {
-        $hasher = m::mock('Illuminate\Contracts\Hashing\Hasher');
-        $provider = new EloquentUserProvider($hasher, 'Illuminate\Tests\Auth\EloquentProviderUserStub');
+        $hasher = m::mock(\Illuminate\Contracts\Hashing\Hasher::class);
+        $provider = new EloquentUserProvider($hasher, \Illuminate\Tests\Auth\EloquentProviderUserStub::class);
         $model = $provider->createModel();
 
-        $this->assertInstanceOf('Illuminate\Tests\Auth\EloquentProviderUserStub', $model);
+        $this->assertInstanceOf(\Illuminate\Tests\Auth\EloquentProviderUserStub::class, $model);
     }
 
     protected function getProviderMock()
     {
-        $hasher = m::mock('Illuminate\Contracts\Hashing\Hasher');
+        $hasher = m::mock(\Illuminate\Contracts\Hashing\Hasher::class);
 
-        return $this->getMockBuilder('Illuminate\Auth\EloquentUserProvider')->setMethods(['createModel'])->setConstructorArgs([$hasher, 'foo'])->getMock();
+        return $this->getMockBuilder(\Illuminate\Auth\EloquentUserProvider::class)->setMethods(['createModel'])->setConstructorArgs([$hasher, 'foo'])->getMock();
     }
 }
 

--- a/tests/Auth/AuthEloquentUserProviderTest.php
+++ b/tests/Auth/AuthEloquentUserProviderTest.php
@@ -16,7 +16,7 @@ class AuthEloquentUserProviderTest extends TestCase
     public function testRetrieveByIDReturnsUser()
     {
         $provider = $this->getProviderMock();
-        $mock = m::mock('stdClass');
+        $mock = m::mock(\StdClass::class);
         $mock->shouldReceive('newQuery')->once()->andReturn($mock);
         $mock->shouldReceive('find')->once()->with(1)->andReturn('bar');
         $provider->expects($this->once())->method('createModel')->will($this->returnValue($mock));
@@ -28,7 +28,7 @@ class AuthEloquentUserProviderTest extends TestCase
     public function testRetrieveByCredentialsReturnsUser()
     {
         $provider = $this->getProviderMock();
-        $mock = m::mock('stdClass');
+        $mock = m::mock(\StdClass::class);
         $mock->shouldReceive('newQuery')->once()->andReturn($mock);
         $mock->shouldReceive('where')->once()->with('username', 'dayle');
         $mock->shouldReceive('first')->once()->andReturn('bar');

--- a/tests/Auth/AuthGuardTest.php
+++ b/tests/Auth/AuthGuardTest.php
@@ -69,7 +69,7 @@ class AuthGuardTest extends TestCase
     public function testAttemptCallsRetrieveByCredentials()
     {
         $guard = $this->getGuard();
-        $guard->setDispatcher($events = m::mock('Illuminate\Contracts\Events\Dispatcher'));
+        $guard->setDispatcher($events = m::mock(\Illuminate\Contracts\Events\Dispatcher::class));
         $events->shouldReceive('dispatch')->once()->with(m::type(Attempting::class));
         $events->shouldReceive('dispatch')->once()->with(m::type(Failed::class));
         $guard->getProvider()->shouldReceive('retrieveByCredentials')->once()->with(['foo']);
@@ -79,10 +79,10 @@ class AuthGuardTest extends TestCase
     public function testAttemptReturnsUserInterface()
     {
         list($session, $provider, $request, $cookie) = $this->getMocks();
-        $guard = $this->getMockBuilder('Illuminate\Auth\SessionGuard')->setMethods(['login'])->setConstructorArgs(['default', $provider, $session, $request])->getMock();
-        $guard->setDispatcher($events = m::mock('Illuminate\Contracts\Events\Dispatcher'));
+        $guard = $this->getMockBuilder(\Illuminate\Auth\SessionGuard::class)->setMethods(['login'])->setConstructorArgs(['default', $provider, $session, $request])->getMock();
+        $guard->setDispatcher($events = m::mock(\Illuminate\Contracts\Events\Dispatcher::class));
         $events->shouldReceive('dispatch')->once()->with(m::type(Attempting::class));
-        $user = $this->createMock('Illuminate\Contracts\Auth\Authenticatable');
+        $user = $this->createMock(\Illuminate\Contracts\Auth\Authenticatable::class);
         $guard->getProvider()->shouldReceive('retrieveByCredentials')->once()->andReturn($user);
         $guard->getProvider()->shouldReceive('validateCredentials')->with($user, ['foo'])->andReturn(true);
         $guard->expects($this->once())->method('login')->with($this->equalTo($user));
@@ -92,7 +92,7 @@ class AuthGuardTest extends TestCase
     public function testAttemptReturnsFalseIfUserNotGiven()
     {
         $mock = $this->getGuard();
-        $mock->setDispatcher($events = m::mock('Illuminate\Contracts\Events\Dispatcher'));
+        $mock->setDispatcher($events = m::mock(\Illuminate\Contracts\Events\Dispatcher::class));
         $events->shouldReceive('dispatch')->once()->with(m::type(Attempting::class));
         $events->shouldReceive('dispatch')->once()->with(m::type(Failed::class));
         $mock->getProvider()->shouldReceive('retrieveByCredentials')->once()->andReturn(null);
@@ -102,8 +102,8 @@ class AuthGuardTest extends TestCase
     public function testLoginStoresIdentifierInSession()
     {
         list($session, $provider, $request, $cookie) = $this->getMocks();
-        $mock = $this->getMockBuilder('Illuminate\Auth\SessionGuard')->setMethods(['getName'])->setConstructorArgs(['default', $provider, $session, $request])->getMock();
-        $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');
+        $mock = $this->getMockBuilder(\Illuminate\Auth\SessionGuard::class)->setMethods(['getName'])->setConstructorArgs(['default', $provider, $session, $request])->getMock();
+        $user = m::mock(\Illuminate\Contracts\Auth\Authenticatable::class);
         $mock->expects($this->once())->method('getName')->will($this->returnValue('foo'));
         $user->shouldReceive('getAuthIdentifier')->once()->andReturn('bar');
         $mock->getSession()->shouldReceive('put')->with('foo', 'bar')->once();
@@ -114,11 +114,11 @@ class AuthGuardTest extends TestCase
     public function testLoginFiresLoginAndAuthenticatedEvents()
     {
         list($session, $provider, $request, $cookie) = $this->getMocks();
-        $mock = $this->getMockBuilder('Illuminate\Auth\SessionGuard')->setMethods(['getName'])->setConstructorArgs(['default', $provider, $session, $request])->getMock();
-        $mock->setDispatcher($events = m::mock('Illuminate\Contracts\Events\Dispatcher'));
-        $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');
-        $events->shouldReceive('dispatch')->once()->with(m::type('Illuminate\Auth\Events\Login'));
-        $events->shouldReceive('dispatch')->once()->with(m::type('Illuminate\Auth\Events\Authenticated'));
+        $mock = $this->getMockBuilder(\Illuminate\Auth\SessionGuard::class)->setMethods(['getName'])->setConstructorArgs(['default', $provider, $session, $request])->getMock();
+        $mock->setDispatcher($events = m::mock(\Illuminate\Contracts\Events\Dispatcher::class));
+        $user = m::mock(\Illuminate\Contracts\Auth\Authenticatable::class);
+        $events->shouldReceive('dispatch')->once()->with(m::type(\Illuminate\Auth\Events\Login::class));
+        $events->shouldReceive('dispatch')->once()->with(m::type(\Illuminate\Auth\Events\Authenticated::class));
         $mock->expects($this->once())->method('getName')->will($this->returnValue('foo'));
         $user->shouldReceive('getAuthIdentifier')->once()->andReturn('bar');
         $mock->getSession()->shouldReceive('put')->with('foo', 'bar')->once();
@@ -129,7 +129,7 @@ class AuthGuardTest extends TestCase
     public function testFailedAttemptFiresFailedEvent()
     {
         $guard = $this->getGuard();
-        $guard->setDispatcher($events = m::mock('Illuminate\Contracts\Events\Dispatcher'));
+        $guard->setDispatcher($events = m::mock(\Illuminate\Contracts\Events\Dispatcher::class));
         $events->shouldReceive('dispatch')->once()->with(m::type(Attempting::class));
         $events->shouldReceive('dispatch')->once()->with(m::type(Failed::class));
         $guard->getProvider()->shouldReceive('retrieveByCredentials')->once()->with(['foo'])->andReturn(null);
@@ -138,7 +138,7 @@ class AuthGuardTest extends TestCase
 
     public function testAuthenticateReturnsUserWhenUserIsNotNull()
     {
-        $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');
+        $user = m::mock(\Illuminate\Contracts\Auth\Authenticatable::class);
         $guard = $this->getGuard()->setUser($user);
 
         $this->assertEquals($user, $guard->authenticate());
@@ -146,9 +146,9 @@ class AuthGuardTest extends TestCase
 
     public function testSetUserFiresAuthenticatedEvent()
     {
-        $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');
+        $user = m::mock(\Illuminate\Contracts\Auth\Authenticatable::class);
         $guard = $this->getGuard();
-        $guard->setDispatcher($events = m::mock('Illuminate\Contracts\Events\Dispatcher'));
+        $guard->setDispatcher($events = m::mock(\Illuminate\Contracts\Events\Dispatcher::class));
         $events->shouldReceive('dispatch')->once()->with(m::type(Authenticated::class));
         $guard->setUser($user);
     }
@@ -166,7 +166,7 @@ class AuthGuardTest extends TestCase
 
     public function testIsAuthedReturnsTrueWhenUserIsNotNull()
     {
-        $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');
+        $user = m::mock(\Illuminate\Contracts\Auth\Authenticatable::class);
         $mock = $this->getGuard();
         $mock->setUser($user);
         $this->assertTrue($mock->check());
@@ -176,7 +176,7 @@ class AuthGuardTest extends TestCase
     public function testIsAuthedReturnsFalseWhenUserIsNull()
     {
         list($session, $provider, $request, $cookie) = $this->getMocks();
-        $mock = $this->getMockBuilder('Illuminate\Auth\SessionGuard')->setMethods(['user'])->setConstructorArgs(['default', $provider, $session, $request])->getMock();
+        $mock = $this->getMockBuilder(\Illuminate\Auth\SessionGuard::class)->setMethods(['user'])->setConstructorArgs(['default', $provider, $session, $request])->getMock();
         $mock->expects($this->exactly(2))->method('user')->will($this->returnValue(null));
         $this->assertFalse($mock->check());
         $this->assertTrue($mock->guest());
@@ -184,7 +184,7 @@ class AuthGuardTest extends TestCase
 
     public function testUserMethodReturnsCachedUser()
     {
-        $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');
+        $user = m::mock(\Illuminate\Contracts\Auth\Authenticatable::class);
         $mock = $this->getGuard();
         $mock->setUser($user);
         $this->assertSame($user, $mock->user());
@@ -201,7 +201,7 @@ class AuthGuardTest extends TestCase
     {
         $mock = $this->getGuard();
         $mock->getSession()->shouldReceive('get')->once()->andReturn(1);
-        $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');
+        $user = m::mock(\Illuminate\Contracts\Auth\Authenticatable::class);
         $mock->getProvider()->shouldReceive('retrieveById')->once()->with(1)->andReturn($user);
         $this->assertSame($user, $mock->user());
         $this->assertSame($user, $mock->getUser());
@@ -210,9 +210,9 @@ class AuthGuardTest extends TestCase
     public function testLogoutRemovesSessionTokenAndRememberMeCookie()
     {
         list($session, $provider, $request, $cookie) = $this->getMocks();
-        $mock = $this->getMockBuilder('Illuminate\Auth\SessionGuard')->setMethods(['getName', 'getRecallerName', 'recaller'])->setConstructorArgs(['default', $provider, $session, $request])->getMock();
-        $mock->setCookieJar($cookies = m::mock('Illuminate\Cookie\CookieJar'));
-        $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');
+        $mock = $this->getMockBuilder(\Illuminate\Auth\SessionGuard::class)->setMethods(['getName', 'getRecallerName', 'recaller'])->setConstructorArgs(['default', $provider, $session, $request])->getMock();
+        $mock->setCookieJar($cookies = m::mock(\Illuminate\Cookie\CookieJar::class));
+        $user = m::mock(\Illuminate\Contracts\Auth\Authenticatable::class);
         $user->shouldReceive('setRememberToken')->once();
         $mock->expects($this->once())->method('getName')->will($this->returnValue('foo'));
         $mock->expects($this->once())->method('getRecallerName')->will($this->returnValue('bar'));
@@ -231,9 +231,9 @@ class AuthGuardTest extends TestCase
     public function testLogoutDoesNotEnqueueRememberMeCookieForDeletionIfCookieDoesntExist()
     {
         list($session, $provider, $request, $cookie) = $this->getMocks();
-        $mock = $this->getMockBuilder('Illuminate\Auth\SessionGuard')->setMethods(['getName', 'recaller'])->setConstructorArgs(['default', $provider, $session, $request])->getMock();
-        $mock->setCookieJar($cookies = m::mock('Illuminate\Cookie\CookieJar'));
-        $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');
+        $mock = $this->getMockBuilder(\Illuminate\Auth\SessionGuard::class)->setMethods(['getName', 'recaller'])->setConstructorArgs(['default', $provider, $session, $request])->getMock();
+        $mock->setCookieJar($cookies = m::mock(\Illuminate\Cookie\CookieJar::class));
+        $user = m::mock(\Illuminate\Contracts\Auth\Authenticatable::class);
         $user->shouldReceive('setRememberToken')->once();
         $mock->expects($this->once())->method('getName')->will($this->returnValue('foo'));
         $mock->expects($this->once())->method('recaller')->will($this->returnValue(null));
@@ -248,15 +248,15 @@ class AuthGuardTest extends TestCase
     public function testLogoutFiresLogoutEvent()
     {
         list($session, $provider, $request, $cookie) = $this->getMocks();
-        $mock = $this->getMockBuilder('Illuminate\Auth\SessionGuard')->setMethods(['clearUserDataFromStorage'])->setConstructorArgs(['default', $provider, $session, $request])->getMock();
+        $mock = $this->getMockBuilder(\Illuminate\Auth\SessionGuard::class)->setMethods(['clearUserDataFromStorage'])->setConstructorArgs(['default', $provider, $session, $request])->getMock();
         $mock->expects($this->once())->method('clearUserDataFromStorage');
-        $mock->setDispatcher($events = m::mock('Illuminate\Contracts\Events\Dispatcher'));
-        $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');
+        $mock->setDispatcher($events = m::mock(\Illuminate\Contracts\Events\Dispatcher::class));
+        $user = m::mock(\Illuminate\Contracts\Auth\Authenticatable::class);
         $user->shouldReceive('setRememberToken')->once();
         $provider->shouldReceive('updateRememberToken')->once();
         $events->shouldReceive('dispatch')->once()->with(m::type(Authenticated::class));
         $mock->setUser($user);
-        $events->shouldReceive('dispatch')->once()->with(m::type('Illuminate\Auth\Events\Logout'));
+        $events->shouldReceive('dispatch')->once()->with(m::type(\Illuminate\Auth\Events\Logout::class));
         $mock->logout();
     }
 
@@ -270,7 +270,7 @@ class AuthGuardTest extends TestCase
         $cookie->shouldReceive('queue')->once()->with($foreverCookie);
         $guard->getSession()->shouldReceive('put')->once()->with($guard->getName(), 'foo');
         $session->shouldReceive('migrate')->once();
-        $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');
+        $user = m::mock(\Illuminate\Contracts\Auth\Authenticatable::class);
         $user->shouldReceive('getAuthIdentifier')->andReturn('foo');
         $user->shouldReceive('getRememberToken')->andReturn('recaller');
         $user->shouldReceive('setRememberToken')->never();
@@ -288,7 +288,7 @@ class AuthGuardTest extends TestCase
         $cookie->shouldReceive('queue')->once()->with($foreverCookie);
         $guard->getSession()->shouldReceive('put')->once()->with($guard->getName(), 'foo');
         $session->shouldReceive('migrate')->once();
-        $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');
+        $user = m::mock(\Illuminate\Contracts\Auth\Authenticatable::class);
         $user->shouldReceive('getAuthIdentifier')->andReturn('foo');
         $user->shouldReceive('getRememberToken')->andReturn(null);
         $user->shouldReceive('setRememberToken')->once();
@@ -300,9 +300,9 @@ class AuthGuardTest extends TestCase
     {
         list($session, $provider, $request, $cookie) = $this->getMocks();
 
-        $guard = m::mock('Illuminate\Auth\SessionGuard', ['default', $provider, $session])->makePartial();
+        $guard = m::mock(\Illuminate\Auth\SessionGuard::class, ['default', $provider, $session])->makePartial();
 
-        $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');
+        $user = m::mock(\Illuminate\Contracts\Auth\Authenticatable::class);
         $guard->getProvider()->shouldReceive('retrieveById')->once()->with(10)->andReturn($user);
         $guard->shouldReceive('login')->once()->with($user, false);
 
@@ -312,7 +312,7 @@ class AuthGuardTest extends TestCase
     public function testLoginUsingIdFailure()
     {
         list($session, $provider, $request, $cookie) = $this->getMocks();
-        $guard = m::mock('Illuminate\Auth\SessionGuard', ['default', $provider, $session])->makePartial();
+        $guard = m::mock(\Illuminate\Auth\SessionGuard::class, ['default', $provider, $session])->makePartial();
 
         $guard->getProvider()->shouldReceive('retrieveById')->once()->with(11)->andReturn(null);
         $guard->shouldNotReceive('login');
@@ -323,9 +323,9 @@ class AuthGuardTest extends TestCase
     public function testOnceUsingIdSetsUser()
     {
         list($session, $provider, $request, $cookie) = $this->getMocks();
-        $guard = m::mock('Illuminate\Auth\SessionGuard', ['default', $provider, $session])->makePartial();
+        $guard = m::mock(\Illuminate\Auth\SessionGuard::class, ['default', $provider, $session])->makePartial();
 
-        $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');
+        $user = m::mock(\Illuminate\Contracts\Auth\Authenticatable::class);
         $guard->getProvider()->shouldReceive('retrieveById')->once()->with(10)->andReturn($user);
         $guard->shouldReceive('setUser')->once()->with($user);
 
@@ -335,7 +335,7 @@ class AuthGuardTest extends TestCase
     public function testOnceUsingIdFailure()
     {
         list($session, $provider, $request, $cookie) = $this->getMocks();
-        $guard = m::mock('Illuminate\Auth\SessionGuard', ['default', $provider, $session])->makePartial();
+        $guard = m::mock(\Illuminate\Auth\SessionGuard::class, ['default', $provider, $session])->makePartial();
 
         $guard->getProvider()->shouldReceive('retrieveById')->once()->with(11)->andReturn(null);
         $guard->shouldNotReceive('setUser');
@@ -350,7 +350,7 @@ class AuthGuardTest extends TestCase
         $request = \Symfony\Component\HttpFoundation\Request::create('/', 'GET', [], [$guard->getRecallerName() => 'id|recaller']);
         $guard = new \Illuminate\Auth\SessionGuard('default', $provider, $session, $request);
         $guard->getSession()->shouldReceive('get')->once()->with($guard->getName())->andReturn(null);
-        $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');
+        $user = m::mock(\Illuminate\Contracts\Auth\Authenticatable::class);
         $guard->getProvider()->shouldReceive('retrieveByToken')->once()->with('id', 'recaller')->andReturn($user);
         $user->shouldReceive('getAuthIdentifier')->once()->andReturn('bar');
         $guard->getSession()->shouldReceive('put')->with($guard->getName(), 'bar')->once();
@@ -362,8 +362,8 @@ class AuthGuardTest extends TestCase
     public function testLoginOnceSetsUser()
     {
         list($session, $provider, $request, $cookie) = $this->getMocks();
-        $guard = m::mock('Illuminate\Auth\SessionGuard', ['default', $provider, $session])->makePartial();
-        $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');
+        $guard = m::mock(\Illuminate\Auth\SessionGuard::class, ['default', $provider, $session])->makePartial();
+        $user = m::mock(\Illuminate\Contracts\Auth\Authenticatable::class);
         $guard->getProvider()->shouldReceive('retrieveByCredentials')->once()->with(['foo'])->andReturn($user);
         $guard->getProvider()->shouldReceive('validateCredentials')->once()->with($user, ['foo'])->andReturn(true);
         $guard->shouldReceive('setUser')->once()->with($user);
@@ -373,8 +373,8 @@ class AuthGuardTest extends TestCase
     public function testLoginOnceFailure()
     {
         list($session, $provider, $request, $cookie) = $this->getMocks();
-        $guard = m::mock('Illuminate\Auth\SessionGuard', ['default', $provider, $session])->makePartial();
-        $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');
+        $guard = m::mock(\Illuminate\Auth\SessionGuard::class, ['default', $provider, $session])->makePartial();
+        $user = m::mock(\Illuminate\Contracts\Auth\Authenticatable::class);
         $guard->getProvider()->shouldReceive('retrieveByCredentials')->once()->with(['foo'])->andReturn($user);
         $guard->getProvider()->shouldReceive('validateCredentials')->once()->with($user, ['foo'])->andReturn(false);
         $this->assertFalse($guard->once(['foo']));
@@ -390,15 +390,15 @@ class AuthGuardTest extends TestCase
     protected function getMocks()
     {
         return [
-            m::mock('Illuminate\Contracts\Session\Session'),
-            m::mock('Illuminate\Contracts\Auth\UserProvider'),
+            m::mock(\Illuminate\Contracts\Session\Session::class),
+            m::mock(\Illuminate\Contracts\Auth\UserProvider::class),
             \Symfony\Component\HttpFoundation\Request::create('/', 'GET'),
-            m::mock('Illuminate\Cookie\CookieJar'),
+            m::mock(\Illuminate\Cookie\CookieJar::class),
         ];
     }
 
     protected function getCookieJar()
     {
-        return new \Illuminate\Cookie\CookieJar(Request::create('/foo', 'GET'), m::mock('Illuminate\Contracts\Encryption\Encrypter'), ['domain' => 'foo.com', 'path' => '/', 'secure' => false, 'httpOnly' => false]);
+        return new \Illuminate\Cookie\CookieJar(Request::create('/foo', 'GET'), m::mock(\Illuminate\Contracts\Encryption\Encrypter::class), ['domain' => 'foo.com', 'path' => '/', 'secure' => false, 'httpOnly' => false]);
     }
 }

--- a/tests/Auth/AuthPasswordBrokerTest.php
+++ b/tests/Auth/AuthPasswordBrokerTest.php
@@ -16,7 +16,7 @@ class AuthPasswordBrokerTest extends TestCase
     public function testIfUserIsNotFoundErrorRedirectIsReturned()
     {
         $mocks = $this->getMocks();
-        $broker = $this->getMockBuilder('Illuminate\Auth\Passwords\PasswordBroker')->setMethods(['getUser', 'makeErrorRedirect'])->setConstructorArgs(array_values($mocks))->getMock();
+        $broker = $this->getMockBuilder(\Illuminate\Auth\Passwords\PasswordBroker::class)->setMethods(['getUser', 'makeErrorRedirect'])->setConstructorArgs(array_values($mocks))->getMock();
         $broker->expects($this->once())->method('getUser')->will($this->returnValue(null));
 
         $this->assertEquals(PasswordBroker::INVALID_USER, $broker->sendResetLink(['credentials']));
@@ -36,7 +36,7 @@ class AuthPasswordBrokerTest extends TestCase
     public function testUserIsRetrievedByCredentials()
     {
         $broker = $this->getBroker($mocks = $this->getMocks());
-        $mocks['users']->shouldReceive('retrieveByCredentials')->once()->with(['foo'])->andReturn($user = m::mock('Illuminate\Contracts\Auth\CanResetPassword'));
+        $mocks['users']->shouldReceive('retrieveByCredentials')->once()->with(['foo'])->andReturn($user = m::mock(\Illuminate\Contracts\Auth\CanResetPassword::class));
 
         $this->assertEquals($user, $broker->getUser(['foo']));
     }
@@ -44,8 +44,8 @@ class AuthPasswordBrokerTest extends TestCase
     public function testBrokerCreatesTokenAndRedirectsWithoutError()
     {
         $mocks = $this->getMocks();
-        $broker = $this->getMockBuilder('Illuminate\Auth\Passwords\PasswordBroker')->setMethods(['emailResetLink', 'getUri'])->setConstructorArgs(array_values($mocks))->getMock();
-        $mocks['users']->shouldReceive('retrieveByCredentials')->once()->with(['foo'])->andReturn($user = m::mock('Illuminate\Contracts\Auth\CanResetPassword'));
+        $broker = $this->getMockBuilder(\Illuminate\Auth\Passwords\PasswordBroker::class)->setMethods(['emailResetLink', 'getUri'])->setConstructorArgs(array_values($mocks))->getMock();
+        $mocks['users']->shouldReceive('retrieveByCredentials')->once()->with(['foo'])->andReturn($user = m::mock(\Illuminate\Contracts\Auth\CanResetPassword::class));
         $mocks['tokens']->shouldReceive('create')->once()->with($user)->andReturn('token');
         $callback = function () {
         };
@@ -67,7 +67,7 @@ class AuthPasswordBrokerTest extends TestCase
     {
         $creds = ['password' => 'foo', 'password_confirmation' => 'bar'];
         $broker = $this->getBroker($mocks = $this->getMocks());
-        $mocks['users']->shouldReceive('retrieveByCredentials')->once()->with($creds)->andReturn($user = m::mock('Illuminate\Contracts\Auth\CanResetPassword'));
+        $mocks['users']->shouldReceive('retrieveByCredentials')->once()->with($creds)->andReturn($user = m::mock(\Illuminate\Contracts\Auth\CanResetPassword::class));
 
         $this->assertEquals(PasswordBroker::INVALID_PASSWORD, $broker->reset($creds, function () {
         }));
@@ -77,7 +77,7 @@ class AuthPasswordBrokerTest extends TestCase
     {
         $creds = ['password' => null, 'password_confirmation' => null];
         $broker = $this->getBroker($mocks = $this->getMocks());
-        $mocks['users']->shouldReceive('retrieveByCredentials')->once()->with($creds)->andReturn($user = m::mock('Illuminate\Contracts\Auth\CanResetPassword'));
+        $mocks['users']->shouldReceive('retrieveByCredentials')->once()->with($creds)->andReturn($user = m::mock(\Illuminate\Contracts\Auth\CanResetPassword::class));
 
         $this->assertEquals(PasswordBroker::INVALID_PASSWORD, $broker->reset($creds, function () {
         }));
@@ -87,7 +87,7 @@ class AuthPasswordBrokerTest extends TestCase
     {
         $creds = ['password' => 'abc', 'password_confirmation' => 'abc'];
         $broker = $this->getBroker($mocks = $this->getMocks());
-        $mocks['users']->shouldReceive('retrieveByCredentials')->once()->with($creds)->andReturn($user = m::mock('Illuminate\Contracts\Auth\CanResetPassword'));
+        $mocks['users']->shouldReceive('retrieveByCredentials')->once()->with($creds)->andReturn($user = m::mock(\Illuminate\Contracts\Auth\CanResetPassword::class));
 
         $this->assertEquals(PasswordBroker::INVALID_PASSWORD, $broker->reset($creds, function () {
         }));
@@ -100,7 +100,7 @@ class AuthPasswordBrokerTest extends TestCase
         $broker->validator(function ($credentials) {
             return strlen($credentials['password']) >= 7;
         });
-        $mocks['users']->shouldReceive('retrieveByCredentials')->once()->with($creds)->andReturn($user = m::mock('Illuminate\Contracts\Auth\CanResetPassword'));
+        $mocks['users']->shouldReceive('retrieveByCredentials')->once()->with($creds)->andReturn($user = m::mock(\Illuminate\Contracts\Auth\CanResetPassword::class));
 
         $this->assertEquals(PasswordBroker::INVALID_PASSWORD, $broker->reset($creds, function () {
         }));
@@ -109,8 +109,8 @@ class AuthPasswordBrokerTest extends TestCase
     public function testRedirectReturnedByRemindWhenRecordDoesntExistInTable()
     {
         $creds = ['token' => 'token'];
-        $broker = $this->getMockBuilder('Illuminate\Auth\Passwords\PasswordBroker')->setMethods(['validateNewPassword'])->setConstructorArgs(array_values($mocks = $this->getMocks()))->getMock();
-        $mocks['users']->shouldReceive('retrieveByCredentials')->once()->with(array_except($creds, ['token']))->andReturn($user = m::mock('Illuminate\Contracts\Auth\CanResetPassword'));
+        $broker = $this->getMockBuilder(\Illuminate\Auth\Passwords\PasswordBroker::class)->setMethods(['validateNewPassword'])->setConstructorArgs(array_values($mocks = $this->getMocks()))->getMock();
+        $mocks['users']->shouldReceive('retrieveByCredentials')->once()->with(array_except($creds, ['token']))->andReturn($user = m::mock(\Illuminate\Contracts\Auth\CanResetPassword::class));
         $broker->expects($this->once())->method('validateNewPassword')->will($this->returnValue(true));
         $mocks['tokens']->shouldReceive('exists')->with($user, 'token')->andReturn(false);
 
@@ -121,8 +121,8 @@ class AuthPasswordBrokerTest extends TestCase
     public function testResetRemovesRecordOnReminderTableAndCallsCallback()
     {
         unset($_SERVER['__password.reset.test']);
-        $broker = $this->getMockBuilder('Illuminate\Auth\Passwords\PasswordBroker')->setMethods(['validateReset', 'getPassword', 'getToken'])->setConstructorArgs(array_values($mocks = $this->getMocks()))->getMock();
-        $broker->expects($this->once())->method('validateReset')->will($this->returnValue($user = m::mock('Illuminate\Contracts\Auth\CanResetPassword')));
+        $broker = $this->getMockBuilder(\Illuminate\Auth\Passwords\PasswordBroker::class)->setMethods(['validateReset', 'getPassword', 'getToken'])->setConstructorArgs(array_values($mocks = $this->getMocks()))->getMock();
+        $broker->expects($this->once())->method('validateReset')->will($this->returnValue($user = m::mock(\Illuminate\Contracts\Auth\CanResetPassword::class)));
         $mocks['tokens']->shouldReceive('delete')->once()->with('token');
         $callback = function ($user, $password) {
             $_SERVER['__password.reset.test'] = compact('user', 'password');
@@ -142,9 +142,9 @@ class AuthPasswordBrokerTest extends TestCase
     protected function getMocks()
     {
         $mocks = [
-            'tokens' => m::mock('Illuminate\Auth\Passwords\TokenRepositoryInterface'),
-            'users'  => m::mock('Illuminate\Contracts\Auth\UserProvider'),
-            'mailer' => m::mock('Illuminate\Contracts\Mail\Mailer'),
+            'tokens' => m::mock(\Illuminate\Auth\Passwords\TokenRepositoryInterface::class),
+            'users'  => m::mock(\Illuminate\Contracts\Auth\UserProvider::class),
+            'mailer' => m::mock(\Illuminate\Contracts\Mail\Mailer::class),
             'view'   => 'resetLinkView',
         ];
 

--- a/tests/Bus/BusDispatcherTest.php
+++ b/tests/Bus/BusDispatcherTest.php
@@ -19,20 +19,20 @@ class BusDispatcherTest extends TestCase
     {
         $container = new Container;
         $dispatcher = new Dispatcher($container, function () {
-            $mock = m::mock('Illuminate\Contracts\Queue\Queue');
+            $mock = m::mock(\Illuminate\Contracts\Queue\Queue::class);
             $mock->shouldReceive('push')->once();
 
             return $mock;
         });
 
-        $dispatcher->dispatch(m::mock('Illuminate\Contracts\Queue\ShouldQueue'));
+        $dispatcher->dispatch(m::mock(\Illuminate\Contracts\Queue\ShouldQueue::class));
     }
 
     public function testCommandsThatShouldQueueIsQueuedUsingCustomHandler()
     {
         $container = new Container;
         $dispatcher = new Dispatcher($container, function () {
-            $mock = m::mock('Illuminate\Contracts\Queue\Queue');
+            $mock = m::mock(\Illuminate\Contracts\Queue\Queue::class);
             $mock->shouldReceive('push')->once();
 
             return $mock;
@@ -45,8 +45,8 @@ class BusDispatcherTest extends TestCase
     {
         $container = new Container;
         $dispatcher = new Dispatcher($container, function () {
-            $mock = m::mock('Illuminate\Contracts\Queue\Queue');
-            $mock->shouldReceive('laterOn')->once()->with('foo', 10, m::type('Illuminate\Tests\Bus\BusDispatcherTestSpecificQueueAndDelayCommand'));
+            $mock = m::mock(\Illuminate\Contracts\Queue\Queue::class);
+            $mock->shouldReceive('laterOn')->once()->with('foo', 10, m::type(\Illuminate\Tests\Bus\BusDispatcherTestSpecificQueueAndDelayCommand::class));
 
             return $mock;
         });
@@ -57,7 +57,7 @@ class BusDispatcherTest extends TestCase
     public function testDispatchNowShouldNeverQueue()
     {
         $container = new Container;
-        $mock = m::mock('Illuminate\Contracts\Queue\Queue');
+        $mock = m::mock(\Illuminate\Contracts\Queue\Queue::class);
         $mock->shouldReceive('push')->never();
         $dispatcher = new Dispatcher($container, function () use ($mock) {
             return $mock;
@@ -69,7 +69,7 @@ class BusDispatcherTest extends TestCase
     public function testDispatcherCanDispatchStandAloneHandler()
     {
         $container = new Container;
-        $mock = m::mock('Illuminate\Contracts\Queue\Queue');
+        $mock = m::mock(\Illuminate\Contracts\Queue\Queue::class);
         $dispatcher = new Dispatcher($container, function () use ($mock) {
             return $mock;
         });
@@ -96,7 +96,7 @@ class BusDispatcherTest extends TestCase
         });
 
         $dispatcher = new Dispatcher($container, function () {
-            $mock = m::mock('Illuminate\Contracts\Queue\Queue');
+            $mock = m::mock(\Illuminate\Contracts\Queue\Queue::class);
             $mock->shouldReceive('push')->once();
 
             return $mock;

--- a/tests/Cache/CacheApcStoreTest.php
+++ b/tests/Cache/CacheApcStoreTest.php
@@ -8,7 +8,7 @@ class CacheApcStoreTest extends TestCase
 {
     public function testGetReturnsNullWhenNotFound()
     {
-        $apc = $this->getMockBuilder('Illuminate\Cache\ApcWrapper')->setMethods(['get'])->getMock();
+        $apc = $this->getMockBuilder(\Illuminate\Cache\ApcWrapper::class)->setMethods(['get'])->getMock();
         $apc->expects($this->once())->method('get')->with($this->equalTo('foobar'))->will($this->returnValue(null));
         $store = new \Illuminate\Cache\ApcStore($apc, 'foo');
         $this->assertNull($store->get('bar'));
@@ -16,7 +16,7 @@ class CacheApcStoreTest extends TestCase
 
     public function testAPCValueIsReturned()
     {
-        $apc = $this->getMockBuilder('Illuminate\Cache\ApcWrapper')->setMethods(['get'])->getMock();
+        $apc = $this->getMockBuilder(\Illuminate\Cache\ApcWrapper::class)->setMethods(['get'])->getMock();
         $apc->expects($this->once())->method('get')->will($this->returnValue('bar'));
         $store = new \Illuminate\Cache\ApcStore($apc);
         $this->assertEquals('bar', $store->get('foo'));
@@ -24,7 +24,7 @@ class CacheApcStoreTest extends TestCase
 
     public function testGetMultipleReturnsNullWhenNotFoundAndValueWhenFound()
     {
-        $apc = $this->getMockBuilder('Illuminate\Cache\ApcWrapper')->setMethods(['get'])->getMock();
+        $apc = $this->getMockBuilder(\Illuminate\Cache\ApcWrapper::class)->setMethods(['get'])->getMock();
         $apc->expects($this->exactly(3))->method('get')->willReturnMap([
             ['foo', 'qux'],
             ['bar', null],
@@ -40,7 +40,7 @@ class CacheApcStoreTest extends TestCase
 
     public function testSetMethodProperlyCallsAPC()
     {
-        $apc = $this->getMockBuilder('Illuminate\Cache\ApcWrapper')->setMethods(['put'])->getMock();
+        $apc = $this->getMockBuilder(\Illuminate\Cache\ApcWrapper::class)->setMethods(['put'])->getMock();
         $apc->expects($this->once())->method('put')->with($this->equalTo('foo'), $this->equalTo('bar'), $this->equalTo(60));
         $store = new \Illuminate\Cache\ApcStore($apc);
         $store->put('foo', 'bar', 1);
@@ -48,7 +48,7 @@ class CacheApcStoreTest extends TestCase
 
     public function testSetMultipleMethodProperlyCallsAPC()
     {
-        $apc = $this->getMockBuilder('Illuminate\Cache\ApcWrapper')->setMethods(['put'])->getMock();
+        $apc = $this->getMockBuilder(\Illuminate\Cache\ApcWrapper::class)->setMethods(['put'])->getMock();
         $apc->expects($this->exactly(3))->method('put')->withConsecutive([
             $this->equalTo('foo'), $this->equalTo('bar'), $this->equalTo(60),
         ], [
@@ -66,7 +66,7 @@ class CacheApcStoreTest extends TestCase
 
     public function testIncrementMethodProperlyCallsAPC()
     {
-        $apc = $this->getMockBuilder('Illuminate\Cache\ApcWrapper')->setMethods(['increment'])->getMock();
+        $apc = $this->getMockBuilder(\Illuminate\Cache\ApcWrapper::class)->setMethods(['increment'])->getMock();
         $apc->expects($this->once())->method('increment')->with($this->equalTo('foo'), $this->equalTo(5));
         $store = new \Illuminate\Cache\ApcStore($apc);
         $store->increment('foo', 5);
@@ -74,7 +74,7 @@ class CacheApcStoreTest extends TestCase
 
     public function testDecrementMethodProperlyCallsAPC()
     {
-        $apc = $this->getMockBuilder('Illuminate\Cache\ApcWrapper')->setMethods(['decrement'])->getMock();
+        $apc = $this->getMockBuilder(\Illuminate\Cache\ApcWrapper::class)->setMethods(['decrement'])->getMock();
         $apc->expects($this->once())->method('decrement')->with($this->equalTo('foo'), $this->equalTo(5));
         $store = new \Illuminate\Cache\ApcStore($apc);
         $store->decrement('foo', 5);
@@ -82,7 +82,7 @@ class CacheApcStoreTest extends TestCase
 
     public function testStoreItemForeverProperlyCallsAPC()
     {
-        $apc = $this->getMockBuilder('Illuminate\Cache\ApcWrapper')->setMethods(['put'])->getMock();
+        $apc = $this->getMockBuilder(\Illuminate\Cache\ApcWrapper::class)->setMethods(['put'])->getMock();
         $apc->expects($this->once())->method('put')->with($this->equalTo('foo'), $this->equalTo('bar'), $this->equalTo(0));
         $store = new \Illuminate\Cache\ApcStore($apc);
         $store->forever('foo', 'bar');
@@ -90,7 +90,7 @@ class CacheApcStoreTest extends TestCase
 
     public function testForgetMethodProperlyCallsAPC()
     {
-        $apc = $this->getMockBuilder('Illuminate\Cache\ApcWrapper')->setMethods(['delete'])->getMock();
+        $apc = $this->getMockBuilder(\Illuminate\Cache\ApcWrapper::class)->setMethods(['delete'])->getMock();
         $apc->expects($this->once())->method('delete')->with($this->equalTo('foo'));
         $store = new \Illuminate\Cache\ApcStore($apc);
         $store->forget('foo');
@@ -98,7 +98,7 @@ class CacheApcStoreTest extends TestCase
 
     public function testFlushesCached()
     {
-        $apc = $this->getMockBuilder('Illuminate\Cache\ApcWrapper')->setMethods(['flush'])->getMock();
+        $apc = $this->getMockBuilder(\Illuminate\Cache\ApcWrapper::class)->setMethods(['flush'])->getMock();
         $apc->expects($this->once())->method('flush')->willReturn(true);
         $store = new \Illuminate\Cache\ApcStore($apc);
         $result = $store->flush();

--- a/tests/Cache/CacheArrayStoreTest.php
+++ b/tests/Cache/CacheArrayStoreTest.php
@@ -32,7 +32,7 @@ class CacheArrayStoreTest extends TestCase
 
     public function testStoreItemForeverProperlyStoresInArray()
     {
-        $mock = $this->getMockBuilder('Illuminate\Cache\ArrayStore')->setMethods(['put'])->getMock();
+        $mock = $this->getMockBuilder(\Illuminate\Cache\ArrayStore::class)->setMethods(['put'])->getMock();
         $mock->expects($this->once())->method('put')->with($this->equalTo('foo'), $this->equalTo('bar'), $this->equalTo(0));
         $mock->forever('foo', 'bar');
     }

--- a/tests/Cache/CacheDatabaseStoreTest.php
+++ b/tests/Cache/CacheDatabaseStoreTest.php
@@ -17,7 +17,7 @@ class CacheDatabaseStoreTest extends TestCase
     public function testNullIsReturnedWhenItemNotFound()
     {
         $store = $this->getStore();
-        $table = m::mock('StdClass');
+        $table = m::mock(\StdClass::class);
         $store->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($table);
         $table->shouldReceive('where')->once()->with('key', '=', 'prefixfoo')->andReturn($table);
         $table->shouldReceive('first')->once()->andReturn(null);
@@ -28,7 +28,7 @@ class CacheDatabaseStoreTest extends TestCase
     public function testNullIsReturnedAndItemDeletedWhenItemIsExpired()
     {
         $store = $this->getMockBuilder(\Illuminate\Cache\DatabaseStore::class)->setMethods(['forget'])->setConstructorArgs($this->getMocks())->getMock();
-        $table = m::mock('StdClass');
+        $table = m::mock(\StdClass::class);
         $store->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($table);
         $table->shouldReceive('where')->once()->with('key', '=', 'prefixfoo')->andReturn($table);
         $table->shouldReceive('first')->once()->andReturn((object) ['expiration' => 1]);
@@ -40,7 +40,7 @@ class CacheDatabaseStoreTest extends TestCase
     public function testDecryptedValueIsReturnedWhenItemIsValid()
     {
         $store = $this->getStore();
-        $table = m::mock('StdClass');
+        $table = m::mock(\StdClass::class);
         $store->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($table);
         $table->shouldReceive('where')->once()->with('key', '=', 'prefixfoo')->andReturn($table);
         $table->shouldReceive('first')->once()->andReturn((object) ['value' => 'bar', 'expiration' => 999999999999999]);
@@ -52,7 +52,7 @@ class CacheDatabaseStoreTest extends TestCase
     public function testEncryptedValueIsInsertedWhenNoExceptionsAreThrown()
     {
         $store = $this->getMockBuilder(\Illuminate\Cache\DatabaseStore::class)->setMethods(['getTime'])->setConstructorArgs($this->getMocks())->getMock();
-        $table = m::mock('StdClass');
+        $table = m::mock(\StdClass::class);
         $store->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($table);
         $store->getEncrypter()->shouldReceive('encrypt')->once()->with('bar')->andReturn('bar');
         $store->expects($this->once())->method('getTime')->will($this->returnValue(1));
@@ -64,7 +64,7 @@ class CacheDatabaseStoreTest extends TestCase
     public function testEncryptedValueIsUpdatedWhenInsertThrowsException()
     {
         $store = $this->getMockBuilder(\Illuminate\Cache\DatabaseStore::class)->setMethods(['getTime'])->setConstructorArgs($this->getMocks())->getMock();
-        $table = m::mock('StdClass');
+        $table = m::mock(\StdClass::class);
         $store->getConnection()->shouldReceive('table')->with('table')->andReturn($table);
         $store->getEncrypter()->shouldReceive('encrypt')->once()->with('bar')->andReturn('bar');
         $store->expects($this->once())->method('getTime')->will($this->returnValue(1));
@@ -87,7 +87,7 @@ class CacheDatabaseStoreTest extends TestCase
     public function testItemsMayBeRemovedFromCache()
     {
         $store = $this->getStore();
-        $table = m::mock('StdClass');
+        $table = m::mock(\StdClass::class);
         $store->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($table);
         $table->shouldReceive('where')->once()->with('key', '=', 'prefixfoo')->andReturn($table);
         $table->shouldReceive('delete')->once();
@@ -98,7 +98,7 @@ class CacheDatabaseStoreTest extends TestCase
     public function testItemsMayBeFlushedFromCache()
     {
         $store = $this->getStore();
-        $table = m::mock('StdClass');
+        $table = m::mock(\StdClass::class);
         $store->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($table);
         $table->shouldReceive('delete')->once()->andReturn(2);
 
@@ -109,8 +109,8 @@ class CacheDatabaseStoreTest extends TestCase
     public function testIncrementReturnsCorrectValues()
     {
         $store = $this->getStore();
-        $table = m::mock('StdClass');
-        $cache = m::mock('StdClass');
+        $table = m::mock(\StdClass::class);
+        $cache = m::mock(\StdClass::class);
 
         $store->getConnection()->shouldReceive('transaction')->once()->with(m::type('Closure'))->andReturnUsing(function ($closure) {
             return $closure();
@@ -151,8 +151,8 @@ class CacheDatabaseStoreTest extends TestCase
     public function testDecrementReturnsCorrectValues()
     {
         $store = $this->getStore();
-        $table = m::mock('StdClass');
-        $cache = m::mock('StdClass');
+        $table = m::mock(\StdClass::class);
+        $cache = m::mock(\StdClass::class);
 
         $store->getConnection()->shouldReceive('transaction')->once()->with(m::type('Closure'))->andReturnUsing(function ($closure) {
             return $closure();

--- a/tests/Cache/CacheDatabaseStoreTest.php
+++ b/tests/Cache/CacheDatabaseStoreTest.php
@@ -27,7 +27,7 @@ class CacheDatabaseStoreTest extends TestCase
 
     public function testNullIsReturnedAndItemDeletedWhenItemIsExpired()
     {
-        $store = $this->getMockBuilder('Illuminate\Cache\DatabaseStore')->setMethods(['forget'])->setConstructorArgs($this->getMocks())->getMock();
+        $store = $this->getMockBuilder(\Illuminate\Cache\DatabaseStore::class)->setMethods(['forget'])->setConstructorArgs($this->getMocks())->getMock();
         $table = m::mock('StdClass');
         $store->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($table);
         $table->shouldReceive('where')->once()->with('key', '=', 'prefixfoo')->andReturn($table);
@@ -51,7 +51,7 @@ class CacheDatabaseStoreTest extends TestCase
 
     public function testEncryptedValueIsInsertedWhenNoExceptionsAreThrown()
     {
-        $store = $this->getMockBuilder('Illuminate\Cache\DatabaseStore')->setMethods(['getTime'])->setConstructorArgs($this->getMocks())->getMock();
+        $store = $this->getMockBuilder(\Illuminate\Cache\DatabaseStore::class)->setMethods(['getTime'])->setConstructorArgs($this->getMocks())->getMock();
         $table = m::mock('StdClass');
         $store->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($table);
         $store->getEncrypter()->shouldReceive('encrypt')->once()->with('bar')->andReturn('bar');
@@ -63,7 +63,7 @@ class CacheDatabaseStoreTest extends TestCase
 
     public function testEncryptedValueIsUpdatedWhenInsertThrowsException()
     {
-        $store = $this->getMockBuilder('Illuminate\Cache\DatabaseStore')->setMethods(['getTime'])->setConstructorArgs($this->getMocks())->getMock();
+        $store = $this->getMockBuilder(\Illuminate\Cache\DatabaseStore::class)->setMethods(['getTime'])->setConstructorArgs($this->getMocks())->getMock();
         $table = m::mock('StdClass');
         $store->getConnection()->shouldReceive('table')->with('table')->andReturn($table);
         $store->getEncrypter()->shouldReceive('encrypt')->once()->with('bar')->andReturn('bar');
@@ -79,7 +79,7 @@ class CacheDatabaseStoreTest extends TestCase
 
     public function testForeverCallsStoreItemWithReallyLongTime()
     {
-        $store = $this->getMockBuilder('Illuminate\Cache\DatabaseStore')->setMethods(['put'])->setConstructorArgs($this->getMocks())->getMock();
+        $store = $this->getMockBuilder(\Illuminate\Cache\DatabaseStore::class)->setMethods(['put'])->setConstructorArgs($this->getMocks())->getMock();
         $store->expects($this->once())->method('put')->with($this->equalTo('foo'), $this->equalTo('bar'), $this->equalTo(5256000));
         $store->forever('foo', 'bar');
     }
@@ -192,11 +192,11 @@ class CacheDatabaseStoreTest extends TestCase
 
     protected function getStore()
     {
-        return new DatabaseStore(m::mock('Illuminate\Database\Connection'), m::mock('Illuminate\Contracts\Encryption\Encrypter'), 'table', 'prefix');
+        return new DatabaseStore(m::mock(\Illuminate\Database\Connection::class), m::mock(\Illuminate\Contracts\Encryption\Encrypter::class), 'table', 'prefix');
     }
 
     protected function getMocks()
     {
-        return [m::mock('Illuminate\Database\Connection'), m::mock('Illuminate\Contracts\Encryption\Encrypter'), 'table', 'prefix'];
+        return [m::mock(\Illuminate\Database\Connection::class), m::mock(\Illuminate\Contracts\Encryption\Encrypter::class), 'table', 'prefix'];
     }
 }

--- a/tests/Cache/CacheEventsTest.php
+++ b/tests/Cache/CacheEventsTest.php
@@ -177,7 +177,7 @@ class CacheEventTest extends TestCase
 
     protected function getDispatcher()
     {
-        return m::mock('Illuminate\Events\Dispatcher');
+        return m::mock(\Illuminate\Events\Dispatcher::class);
     }
 
     protected function getRepository($dispatcher)

--- a/tests/Cache/CacheFileStoreTest.php
+++ b/tests/Cache/CacheFileStoreTest.php
@@ -33,7 +33,7 @@ class CacheFileStoreTest extends TestCase
         $files = $this->mockFilesystem();
         $contents = '0000000000';
         $files->expects($this->once())->method('get')->will($this->returnValue($contents));
-        $store = $this->getMockBuilder('Illuminate\Cache\FileStore')->setMethods(['forget'])->setConstructorArgs([$files, __DIR__])->getMock();
+        $store = $this->getMockBuilder(\Illuminate\Cache\FileStore::class)->setMethods(['forget'])->setConstructorArgs([$files, __DIR__])->getMock();
         $store->expects($this->once())->method('forget');
         $value = $store->get('foo');
         $this->assertNull($value);
@@ -51,7 +51,7 @@ class CacheFileStoreTest extends TestCase
     public function testStoreItemProperlyStoresValues()
     {
         $files = $this->mockFilesystem();
-        $store = $this->getMockBuilder('Illuminate\Cache\FileStore')->setMethods(['expiration'])->setConstructorArgs([$files, __DIR__])->getMock();
+        $store = $this->getMockBuilder(\Illuminate\Cache\FileStore::class)->setMethods(['expiration'])->setConstructorArgs([$files, __DIR__])->getMock();
         $store->expects($this->once())->method('expiration')->with($this->equalTo(10))->will($this->returnValue(1111111111));
         $contents = '1111111111'.serialize('Hello World');
         $hash = sha1('foo');
@@ -154,6 +154,6 @@ class CacheFileStoreTest extends TestCase
 
     protected function mockFilesystem()
     {
-        return $this->createMock('Illuminate\Filesystem\Filesystem');
+        return $this->createMock(\Illuminate\Filesystem\Filesystem::class);
     }
 }

--- a/tests/Cache/CacheMemcachedConnectorTest.php
+++ b/tests/Cache/CacheMemcachedConnectorTest.php
@@ -118,7 +118,7 @@ class CacheMemcachedConnectorTest extends TestCase
 
     protected function connectorMock()
     {
-        return $this->getMockBuilder('Illuminate\Cache\MemcachedConnector')->setMethods(['createMemcachedInstance'])->getMock();
+        return $this->getMockBuilder(\Illuminate\Cache\MemcachedConnector::class)->setMethods(['createMemcachedInstance'])->getMock();
     }
 
     protected function connect(

--- a/tests/Cache/CacheMemcachedConnectorTest.php
+++ b/tests/Cache/CacheMemcachedConnectorTest.php
@@ -108,7 +108,7 @@ class CacheMemcachedConnectorTest extends TestCase
 
     protected function memcachedMockWithAddServer($returnedVersion = [])
     {
-        $memcached = m::mock('stdClass');
+        $memcached = m::mock(\StdClass::class);
         $memcached->shouldReceive('addServer')->once()->with($this->getHost(), $this->getPort(), $this->getWeight());
         $memcached->shouldReceive('getVersion')->once()->andReturn($returnedVersion);
         $memcached->shouldReceive('getServerList')->once()->andReturn([]);

--- a/tests/Cache/CacheMemcachedStoreTest.php
+++ b/tests/Cache/CacheMemcachedStoreTest.php
@@ -14,7 +14,7 @@ class CacheMemcachedStoreTest extends TestCase
             $this->markTestSkipped('Memcached module not installed');
         }
 
-        $memcache = $this->getMockBuilder('StdClass')->setMethods(['get', 'getResultCode'])->getMock();
+        $memcache = $this->getMockBuilder(\StdClass::class)->setMethods(['get', 'getResultCode'])->getMock();
         $memcache->expects($this->once())->method('get')->with($this->equalTo('foo:bar'))->will($this->returnValue(null));
         $memcache->expects($this->once())->method('getResultCode')->will($this->returnValue(1));
         $store = new MemcachedStore($memcache, 'foo');
@@ -27,7 +27,7 @@ class CacheMemcachedStoreTest extends TestCase
             $this->markTestSkipped('Memcached module not installed');
         }
 
-        $memcache = $this->getMockBuilder('StdClass')->setMethods(['get', 'getResultCode'])->getMock();
+        $memcache = $this->getMockBuilder(\StdClass::class)->setMethods(['get', 'getResultCode'])->getMock();
         $memcache->expects($this->once())->method('get')->will($this->returnValue('bar'));
         $memcache->expects($this->once())->method('getResultCode')->will($this->returnValue(0));
         $store = new MemcachedStore($memcache);
@@ -40,7 +40,7 @@ class CacheMemcachedStoreTest extends TestCase
             $this->markTestSkipped('Memcached module not installed');
         }
 
-        $memcache = $this->getMockBuilder('StdClass')->setMethods(['getMulti', 'getResultCode'])->getMock();
+        $memcache = $this->getMockBuilder(\StdClass::class)->setMethods(['getMulti', 'getResultCode'])->getMock();
         $memcache->expects($this->once())->method('getMulti')->with(
             ['foo:foo', 'foo:bar', 'foo:baz']
         )->will($this->returnValue([

--- a/tests/Cache/CacheRedisStoreTest.php
+++ b/tests/Cache/CacheRedisStoreTest.php
@@ -143,6 +143,6 @@ class CacheRedisStoreTest extends TestCase
 
     protected function getRedis()
     {
-        return new \Illuminate\Cache\RedisStore(m::mock('Illuminate\Contracts\Redis\Factory'), 'prefix');
+        return new \Illuminate\Cache\RedisStore(m::mock(\Illuminate\Contracts\Redis\Factory::class), 'prefix');
     }
 }

--- a/tests/Cache/CacheRepositoryTest.php
+++ b/tests/Cache/CacheRepositoryTest.php
@@ -147,8 +147,8 @@ class CacheRepositoryTest extends TestCase
 
     protected function getRepository()
     {
-        $dispatcher = new \Illuminate\Events\Dispatcher(m::mock('Illuminate\Container\Container'));
-        $repository = new \Illuminate\Cache\Repository(m::mock('Illuminate\Contracts\Cache\Store'));
+        $dispatcher = new \Illuminate\Events\Dispatcher(m::mock(\Illuminate\Container\Container::class));
+        $repository = new \Illuminate\Cache\Repository(m::mock(\Illuminate\Contracts\Cache\Store::class));
 
         $repository->setEventDispatcher($dispatcher);
 

--- a/tests/Cache/CacheTableCommandTest.php
+++ b/tests/Cache/CacheTableCommandTest.php
@@ -17,10 +17,10 @@ class CacheTableCommandTest extends TestCase
     public function testCreateMakesMigration()
     {
         $command = new CacheTableCommandTestStub(
-            $files = m::mock('Illuminate\Filesystem\Filesystem'),
-            $composer = m::mock('Illuminate\Support\Composer')
+            $files = m::mock(\Illuminate\Filesystem\Filesystem::class),
+            $composer = m::mock(\Illuminate\Support\Composer::class)
         );
-        $creator = m::mock('Illuminate\Database\Migrations\MigrationCreator')->shouldIgnoreMissing();
+        $creator = m::mock(\Illuminate\Database\Migrations\MigrationCreator::class)->shouldIgnoreMissing();
 
         $app = new Application();
         $app->useDatabasePath(__DIR__);

--- a/tests/Cache/CacheTaggedCacheTest.php
+++ b/tests/Cache/CacheTaggedCacheTest.php
@@ -68,7 +68,7 @@ class CacheTaggedCacheTest extends TestCase
         $tagSet->shouldReceive('getNames')->andReturn(['foo', 'bar']);
         $redis = new \Illuminate\Cache\RedisTaggedCache($store, $tagSet);
         $store->shouldReceive('getPrefix')->andReturn('prefix:');
-        $store->shouldReceive('connection')->andReturn($conn = m::mock('StdClass'));
+        $store->shouldReceive('connection')->andReturn($conn = m::mock(\StdClass::class));
         $conn->shouldReceive('sadd')->once()->with('prefix:foo:forever_ref', 'prefix:'.sha1('foo|bar').':key1');
         $conn->shouldReceive('sadd')->once()->with('prefix:bar:forever_ref', 'prefix:'.sha1('foo|bar').':key1');
 
@@ -85,7 +85,7 @@ class CacheTaggedCacheTest extends TestCase
         $tagSet->shouldReceive('getNames')->andReturn(['foo', 'bar']);
         $redis = new \Illuminate\Cache\RedisTaggedCache($store, $tagSet);
         $store->shouldReceive('getPrefix')->andReturn('prefix:');
-        $store->shouldReceive('connection')->andReturn($conn = m::mock('StdClass'));
+        $store->shouldReceive('connection')->andReturn($conn = m::mock(\StdClass::class));
         $conn->shouldReceive('sadd')->once()->with('prefix:foo:standard_ref', 'prefix:'.sha1('foo|bar').':key1');
         $conn->shouldReceive('sadd')->once()->with('prefix:bar:standard_ref', 'prefix:'.sha1('foo|bar').':key1');
         $store->shouldReceive('push')->with(sha1('foo|bar').':key1', 'key1:value');
@@ -100,7 +100,7 @@ class CacheTaggedCacheTest extends TestCase
         $tagSet->shouldReceive('getNamespace')->andReturn('foo|bar');
         $redis = new \Illuminate\Cache\RedisTaggedCache($store, $tagSet);
         $store->shouldReceive('getPrefix')->andReturn('prefix:');
-        $store->shouldReceive('connection')->andReturn($conn = m::mock('StdClass'));
+        $store->shouldReceive('connection')->andReturn($conn = m::mock(\StdClass::class));
 
         // Forever tag keys
         $conn->shouldReceive('smembers')->once()->with('prefix:foo:forever_ref')->andReturn(['key1', 'key2']);

--- a/tests/Cache/CacheTaggedCacheTest.php
+++ b/tests/Cache/CacheTaggedCacheTest.php
@@ -62,8 +62,8 @@ class CacheTaggedCacheTest extends TestCase
 
     public function testRedisCacheTagsPushForeverKeysCorrectly()
     {
-        $store = m::mock('Illuminate\Contracts\Cache\Store');
-        $tagSet = m::mock('Illuminate\Cache\TagSet', [$store, ['foo', 'bar']]);
+        $store = m::mock(\Illuminate\Contracts\Cache\Store::class);
+        $tagSet = m::mock(\Illuminate\Cache\TagSet::class, [$store, ['foo', 'bar']]);
         $tagSet->shouldReceive('getNamespace')->andReturn('foo|bar');
         $tagSet->shouldReceive('getNames')->andReturn(['foo', 'bar']);
         $redis = new \Illuminate\Cache\RedisTaggedCache($store, $tagSet);
@@ -79,8 +79,8 @@ class CacheTaggedCacheTest extends TestCase
 
     public function testRedisCacheTagsPushStandardKeysCorrectly()
     {
-        $store = m::mock('Illuminate\Contracts\Cache\Store');
-        $tagSet = m::mock('Illuminate\Cache\TagSet', [$store, ['foo', 'bar']]);
+        $store = m::mock(\Illuminate\Contracts\Cache\Store::class);
+        $tagSet = m::mock(\Illuminate\Cache\TagSet::class, [$store, ['foo', 'bar']]);
         $tagSet->shouldReceive('getNamespace')->andReturn('foo|bar');
         $tagSet->shouldReceive('getNames')->andReturn(['foo', 'bar']);
         $redis = new \Illuminate\Cache\RedisTaggedCache($store, $tagSet);
@@ -95,8 +95,8 @@ class CacheTaggedCacheTest extends TestCase
 
     public function testRedisCacheTagsCanBeFlushed()
     {
-        $store = m::mock('Illuminate\Contracts\Cache\Store');
-        $tagSet = m::mock('Illuminate\Cache\TagSet', [$store, ['foo', 'bar']]);
+        $store = m::mock(\Illuminate\Contracts\Cache\Store::class);
+        $tagSet = m::mock(\Illuminate\Cache\TagSet::class, [$store, ['foo', 'bar']]);
         $tagSet->shouldReceive('getNamespace')->andReturn('foo|bar');
         $redis = new \Illuminate\Cache\RedisTaggedCache($store, $tagSet);
         $store->shouldReceive('getPrefix')->andReturn('prefix:');

--- a/tests/Cache/ClearCommandTest.php
+++ b/tests/Cache/ClearCommandTest.php
@@ -17,10 +17,10 @@ class ClearCommandTest extends TestCase
     public function testClearWithNoStoreArgument()
     {
         $command = new ClearCommandTestStub(
-            $cacheManager = m::mock('Illuminate\Cache\CacheManager')
+            $cacheManager = m::mock(\Illuminate\Cache\CacheManager::class)
         );
 
-        $cacheRepository = m::mock('Illuminate\Contracts\Cache\Repository');
+        $cacheRepository = m::mock(\Illuminate\Contracts\Cache\Repository::class);
 
         $app = new Application();
         $command->setLaravel($app);
@@ -34,10 +34,10 @@ class ClearCommandTest extends TestCase
     public function testClearWithStoreArgument()
     {
         $command = new ClearCommandTestStub(
-            $cacheManager = m::mock('Illuminate\Cache\CacheManager')
+            $cacheManager = m::mock(\Illuminate\Cache\CacheManager::class)
         );
 
-        $cacheRepository = m::mock('Illuminate\Contracts\Cache\Repository');
+        $cacheRepository = m::mock(\Illuminate\Contracts\Cache\Repository::class);
 
         $app = new Application();
         $command->setLaravel($app);
@@ -54,10 +54,10 @@ class ClearCommandTest extends TestCase
     public function testClearWithInvalidStoreArgument()
     {
         $command = new ClearCommandTestStub(
-            $cacheManager = m::mock('Illuminate\Cache\CacheManager')
+            $cacheManager = m::mock(\Illuminate\Cache\CacheManager::class)
         );
 
-        $cacheRepository = m::mock('Illuminate\Contracts\Cache\Repository');
+        $cacheRepository = m::mock(\Illuminate\Contracts\Cache\Repository::class);
 
         $app = new Application();
         $command->setLaravel($app);
@@ -71,10 +71,10 @@ class ClearCommandTest extends TestCase
     public function testClearWithTagsOption()
     {
         $command = new ClearCommandTestStub(
-            $cacheManager = m::mock('Illuminate\Cache\CacheManager')
+            $cacheManager = m::mock(\Illuminate\Cache\CacheManager::class)
         );
 
-        $cacheRepository = m::mock('Illuminate\Contracts\Cache\Repository');
+        $cacheRepository = m::mock(\Illuminate\Contracts\Cache\Repository::class);
 
         $app = new Application();
         $command->setLaravel($app);
@@ -89,10 +89,10 @@ class ClearCommandTest extends TestCase
     public function testClearWithStoreArgumentAndTagsOption()
     {
         $command = new ClearCommandTestStub(
-            $cacheManager = m::mock('Illuminate\Cache\CacheManager')
+            $cacheManager = m::mock(\Illuminate\Cache\CacheManager::class)
         );
 
-        $cacheRepository = m::mock('Illuminate\Contracts\Cache\Repository');
+        $cacheRepository = m::mock(\Illuminate\Contracts\Cache\Repository::class);
 
         $app = new Application();
         $command->setLaravel($app);

--- a/tests/Console/ConsoleApplicationTest.php
+++ b/tests/Console/ConsoleApplicationTest.php
@@ -15,8 +15,8 @@ class ConsoleApplicationTest extends TestCase
     public function testAddSetsLaravelInstance()
     {
         $app = $this->getMockConsole(['addToParent']);
-        $command = m::mock('Illuminate\Console\Command');
-        $command->shouldReceive('setLaravel')->once()->with(m::type('Illuminate\Contracts\Foundation\Application'));
+        $command = m::mock(\Illuminate\Console\Command::class);
+        $command->shouldReceive('setLaravel')->once()->with(m::type(\Illuminate\Contracts\Foundation\Application::class));
         $app->expects($this->once())->method('addToParent')->with($this->equalTo($command))->will($this->returnValue($command));
         $result = $app->add($command);
 
@@ -47,10 +47,10 @@ class ConsoleApplicationTest extends TestCase
 
     protected function getMockConsole(array $methods)
     {
-        $app = m::mock('Illuminate\Contracts\Foundation\Application', ['version' => '5.4']);
-        $events = m::mock('Illuminate\Contracts\Events\Dispatcher', ['dispatch' => null]);
+        $app = m::mock(\Illuminate\Contracts\Foundation\Application::class, ['version' => '5.4']);
+        $events = m::mock(\Illuminate\Contracts\Events\Dispatcher::class, ['dispatch' => null]);
 
-        $console = $this->getMockBuilder('Illuminate\Console\Application')->setMethods($methods)->setConstructorArgs([
+        $console = $this->getMockBuilder(\Illuminate\Console\Application::class)->setMethods($methods)->setConstructorArgs([
             $app, $events, 'test-version',
         ])->getMock();
 

--- a/tests/Console/ConsoleEventSchedulerTest.php
+++ b/tests/Console/ConsoleEventSchedulerTest.php
@@ -13,7 +13,7 @@ class ConsoleEventSchedulerTest extends TestCase
         parent::setUp();
 
         \Illuminate\Container\Container::getInstance()->instance(
-            'Illuminate\Console\Scheduling\Schedule', $this->schedule = new Schedule(m::mock('Illuminate\Contracts\Cache\Repository'))
+            \Illuminate\Console\Scheduling\Schedule::class, $this->schedule = new Schedule(m::mock(\Illuminate\Contracts\Cache\Repository::class))
         );
     }
 

--- a/tests/Console/ConsoleScheduledEventTest.php
+++ b/tests/Console/ConsoleScheduledEventTest.php
@@ -35,7 +35,7 @@ class ConsoleScheduledEventTest extends TestCase
         $app->shouldReceive('isDownForMaintenance')->andReturn(false);
         $app->shouldReceive('environment')->andReturn('production');
 
-        $event = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php foo');
+        $event = new Event(m::mock(\Illuminate\Contracts\Cache\Repository::class), 'php foo');
         $this->assertEquals('* * * * * *', $event->getExpression());
         $this->assertTrue($event->isDue($app));
         $this->assertTrue($event->skip(function () {
@@ -45,25 +45,25 @@ class ConsoleScheduledEventTest extends TestCase
             return true;
         })->filtersPass($app));
 
-        $event = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php foo');
+        $event = new Event(m::mock(\Illuminate\Contracts\Cache\Repository::class), 'php foo');
         $this->assertEquals('* * * * * *', $event->getExpression());
         $this->assertFalse($event->environments('local')->isDue($app));
 
-        $event = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php foo');
+        $event = new Event(m::mock(\Illuminate\Contracts\Cache\Repository::class), 'php foo');
         $this->assertEquals('* * * * * *', $event->getExpression());
         $this->assertFalse($event->when(function () {
             return false;
         })->filtersPass($app));
 
         // chained rules should be commutative
-        $eventA = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php foo');
-        $eventB = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php foo');
+        $eventA = new Event(m::mock(\Illuminate\Contracts\Cache\Repository::class), 'php foo');
+        $eventB = new Event(m::mock(\Illuminate\Contracts\Cache\Repository::class), 'php foo');
         $this->assertEquals(
             $eventA->daily()->hourly()->getExpression(),
             $eventB->hourly()->daily()->getExpression());
 
-        $eventA = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php foo');
-        $eventB = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php foo');
+        $eventA = new Event(m::mock(\Illuminate\Contracts\Cache\Repository::class), 'php foo');
+        $eventB = new Event(m::mock(\Illuminate\Contracts\Cache\Repository::class), 'php foo');
         $this->assertEquals(
             $eventA->weekdays()->hourly()->getExpression(),
             $eventB->hourly()->weekdays()->getExpression());
@@ -76,11 +76,11 @@ class ConsoleScheduledEventTest extends TestCase
         $app->shouldReceive('environment')->andReturn('production');
         Carbon::setTestNow(Carbon::create(2015, 1, 1, 0, 0, 0));
 
-        $event = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php foo');
+        $event = new Event(m::mock(\Illuminate\Contracts\Cache\Repository::class), 'php foo');
         $this->assertEquals('* * * * 4 *', $event->thursdays()->getExpression());
         $this->assertTrue($event->isDue($app));
 
-        $event = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php foo');
+        $event = new Event(m::mock(\Illuminate\Contracts\Cache\Repository::class), 'php foo');
         $this->assertEquals('0 19 * * 3 *', $event->wednesdays()->at('19:00')->timezone('EST')->getExpression());
         $this->assertTrue($event->isDue($app));
     }
@@ -92,7 +92,7 @@ class ConsoleScheduledEventTest extends TestCase
         $app->shouldReceive('environment')->andReturn('production');
         Carbon::setTestNow(Carbon::now()->startOfDay()->addHours(9));
 
-        $event = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php foo');
+        $event = new Event(m::mock(\Illuminate\Contracts\Cache\Repository::class), 'php foo');
         $this->assertTrue($event->between('8:00', '10:00')->filtersPass($app));
         $this->assertTrue($event->between('9:00', '9:00')->filtersPass($app));
         $this->assertFalse($event->between('10:00', '11:00')->filtersPass($app));

--- a/tests/Console/Scheduling/EventTest.php
+++ b/tests/Console/Scheduling/EventTest.php
@@ -17,14 +17,14 @@ class EventTest extends TestCase
     {
         $quote = (DIRECTORY_SEPARATOR == '\\') ? '"' : "'";
 
-        $event = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php -i');
+        $event = new Event(m::mock(\Illuminate\Contracts\Cache\Repository::class), 'php -i');
 
         $defaultOutput = (DIRECTORY_SEPARATOR == '\\') ? 'NUL' : '/dev/null';
         $this->assertSame("php -i > {$quote}{$defaultOutput}{$quote} 2>&1", $event->buildCommand());
 
         $quote = (DIRECTORY_SEPARATOR == '\\') ? '"' : "'";
 
-        $event = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php -i');
+        $event = new Event(m::mock(\Illuminate\Contracts\Cache\Repository::class), 'php -i');
         $event->runInBackground();
 
         $defaultOutput = (DIRECTORY_SEPARATOR == '\\') ? 'NUL' : '/dev/null';
@@ -35,12 +35,12 @@ class EventTest extends TestCase
     {
         $quote = (DIRECTORY_SEPARATOR == '\\') ? '"' : "'";
 
-        $event = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php -i');
+        $event = new Event(m::mock(\Illuminate\Contracts\Cache\Repository::class), 'php -i');
 
         $event->sendOutputTo('/dev/null');
         $this->assertSame("php -i > {$quote}/dev/null{$quote} 2>&1", $event->buildCommand());
 
-        $event = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php -i');
+        $event = new Event(m::mock(\Illuminate\Contracts\Cache\Repository::class), 'php -i');
 
         $event->sendOutputTo('/my folder/foo.log');
         $this->assertSame("php -i > {$quote}/my folder/foo.log{$quote} 2>&1", $event->buildCommand());
@@ -50,7 +50,7 @@ class EventTest extends TestCase
     {
         $quote = (DIRECTORY_SEPARATOR == '\\') ? '"' : "'";
 
-        $event = new Event(m::mock('Illuminate\Contracts\Cache\Repository'), 'php -i');
+        $event = new Event(m::mock(\Illuminate\Contracts\Cache\Repository::class), 'php -i');
 
         $event->appendOutputTo('/dev/null');
         $this->assertSame("php -i >> {$quote}/dev/null{$quote} 2>&1", $event->buildCommand());

--- a/tests/Console/Scheduling/FrequencyTest.php
+++ b/tests/Console/Scheduling/FrequencyTest.php
@@ -16,7 +16,7 @@ class FrequencyTest extends TestCase
     public function setUp()
     {
         $this->event = new Event(
-            m::mock('Illuminate\Contracts\Cache\Repository'),
+            m::mock(\Illuminate\Contracts\Cache\Repository::class),
             'php foo'
         );
     }

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -265,7 +265,7 @@ class ContainerTest extends TestCase
     public function testResolvingCallbacksAreCalledForType()
     {
         $container = new Container;
-        $container->resolving('StdClass', function ($object) {
+        $container->resolving(\StdClass::class, function ($object) {
             return $object->name = 'taylor';
         });
         $container->bind('foo', function () {
@@ -364,14 +364,14 @@ class ContainerTest extends TestCase
             return func_get_args();
         });
 
-        $this->assertInstanceOf('stdClass', $result[0]);
+        $this->assertInstanceOf(\StdClass::class, $result[0]);
         $this->assertEquals([], $result[1]);
 
         $result = $container->call(function (StdClass $foo, $bar = []) {
             return func_get_args();
         }, ['bar' => 'taylor']);
 
-        $this->assertInstanceOf('stdClass', $result[0]);
+        $this->assertInstanceOf(\StdClass::class, $result[0]);
         $this->assertEquals('taylor', $result[1]);
 
         /*
@@ -384,7 +384,7 @@ class ContainerTest extends TestCase
         $this->assertInstanceOf('Closure', $result);
         $result = $result();
 
-        $this->assertInstanceOf('stdClass', $result[0]);
+        $this->assertInstanceOf(\StdClass::class, $result[0]);
         $this->assertEquals('taylor', $result[1]);
     }
 
@@ -761,7 +761,7 @@ class ContainerTest extends TestCase
     public function testResolvingCallbacksShouldBeFiredWhenCalledWithAliases()
     {
         $container = new Container;
-        $container->alias('StdClass', 'std');
+        $container->alias(\StdClass::class, 'std');
         $container->resolving('std', function ($object) {
             return $object->name = 'taylor';
         });

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -58,34 +58,34 @@ class ContainerTest extends TestCase
     public function testAutoConcreteResolution()
     {
         $container = new Container;
-        $this->assertInstanceOf('Illuminate\Tests\Container\ContainerConcreteStub', $container->make('Illuminate\Tests\Container\ContainerConcreteStub'));
+        $this->assertInstanceOf(\Illuminate\Tests\Container\ContainerConcreteStub::class, $container->make(\Illuminate\Tests\Container\ContainerConcreteStub::class));
     }
 
     public function testSharedConcreteResolution()
     {
         $container = new Container;
-        $container->singleton('Illuminate\Tests\Container\ContainerConcreteStub');
+        $container->singleton(\Illuminate\Tests\Container\ContainerConcreteStub::class);
 
-        $var1 = $container->make('Illuminate\Tests\Container\ContainerConcreteStub');
-        $var2 = $container->make('Illuminate\Tests\Container\ContainerConcreteStub');
+        $var1 = $container->make(\Illuminate\Tests\Container\ContainerConcreteStub::class);
+        $var2 = $container->make(\Illuminate\Tests\Container\ContainerConcreteStub::class);
         $this->assertSame($var1, $var2);
     }
 
     public function testAbstractToConcreteResolution()
     {
         $container = new Container;
-        $container->bind('Illuminate\Tests\Container\IContainerContractStub', 'Illuminate\Tests\Container\ContainerImplementationStub');
-        $class = $container->make('Illuminate\Tests\Container\ContainerDependentStub');
-        $this->assertInstanceOf('Illuminate\Tests\Container\ContainerImplementationStub', $class->impl);
+        $container->bind(\Illuminate\Tests\Container\IContainerContractStub::class, \Illuminate\Tests\Container\ContainerImplementationStub::class);
+        $class = $container->make(\Illuminate\Tests\Container\ContainerDependentStub::class);
+        $this->assertInstanceOf(\Illuminate\Tests\Container\ContainerImplementationStub::class, $class->impl);
     }
 
     public function testNestedDependencyResolution()
     {
         $container = new Container;
-        $container->bind('Illuminate\Tests\Container\IContainerContractStub', 'Illuminate\Tests\Container\ContainerImplementationStub');
-        $class = $container->make('Illuminate\Tests\Container\ContainerNestedDependentStub');
-        $this->assertInstanceOf('Illuminate\Tests\Container\ContainerDependentStub', $class->inner);
-        $this->assertInstanceOf('Illuminate\Tests\Container\ContainerImplementationStub', $class->inner->impl);
+        $container->bind(\Illuminate\Tests\Container\IContainerContractStub::class, \Illuminate\Tests\Container\ContainerImplementationStub::class);
+        $class = $container->make(\Illuminate\Tests\Container\ContainerNestedDependentStub::class);
+        $this->assertInstanceOf(\Illuminate\Tests\Container\ContainerDependentStub::class, $class->inner);
+        $this->assertInstanceOf(\Illuminate\Tests\Container\ContainerImplementationStub::class, $class->inner->impl);
     }
 
     public function testContainerIsPassedToResolvers()
@@ -204,14 +204,14 @@ class ContainerTest extends TestCase
         ContainerLazyExtendStub::$initialized = false;
 
         $container = new Container;
-        $container->bind('Illuminate\Tests\Container\ContainerLazyExtendStub');
-        $container->extend('Illuminate\Tests\Container\ContainerLazyExtendStub', function ($obj, $container) {
+        $container->bind(\Illuminate\Tests\Container\ContainerLazyExtendStub::class);
+        $container->extend(\Illuminate\Tests\Container\ContainerLazyExtendStub::class, function ($obj, $container) {
             $obj->init();
 
             return $obj;
         });
         $this->assertFalse(ContainerLazyExtendStub::$initialized);
-        $container->make('Illuminate\Tests\Container\ContainerLazyExtendStub');
+        $container->make(\Illuminate\Tests\Container\ContainerLazyExtendStub::class);
         $this->assertTrue(ContainerLazyExtendStub::$initialized);
     }
 
@@ -229,8 +229,8 @@ class ContainerTest extends TestCase
     public function testResolutionOfDefaultParameters()
     {
         $container = new Container;
-        $instance = $container->make('Illuminate\Tests\Container\ContainerDefaultValueStub');
-        $this->assertInstanceOf('Illuminate\Tests\Container\ContainerConcreteStub', $instance->stub);
+        $instance = $container->make(\Illuminate\Tests\Container\ContainerDefaultValueStub::class);
+        $this->assertInstanceOf(\Illuminate\Tests\Container\ContainerConcreteStub::class, $instance->stub);
         $this->assertEquals('taylor', $instance->default);
     }
 
@@ -334,7 +334,7 @@ class ContainerTest extends TestCase
     public function testInternalClassWithDefaultParameters()
     {
         $container = new Container;
-        $container->make('Illuminate\Tests\Container\ContainerMixedPrimitiveStub', []);
+        $container->make(\Illuminate\Tests\Container\ContainerMixedPrimitiveStub::class, []);
     }
 
     /**
@@ -344,7 +344,7 @@ class ContainerTest extends TestCase
     public function testBindingResolutionExceptionMessage()
     {
         $container = new Container;
-        $container->make('Illuminate\Tests\Container\IContainerContractStub', []);
+        $container->make(\Illuminate\Tests\Container\IContainerContractStub::class, []);
     }
 
     /**
@@ -354,7 +354,7 @@ class ContainerTest extends TestCase
     public function testBindingResolutionExceptionMessageIncludesBuildStack()
     {
         $container = new Container;
-        $container->make('Illuminate\Tests\Container\ContainerTestContextInjectOne', []);
+        $container->make(\Illuminate\Tests\Container\ContainerTestContextInjectOne::class, []);
     }
 
     public function testCallWithDependencies()
@@ -405,16 +405,16 @@ class ContainerTest extends TestCase
 
         $container = new Container;
         $result = $container->call('Illuminate\Tests\Container\ContainerTestCallStub@inject');
-        $this->assertInstanceOf('Illuminate\Tests\Container\ContainerConcreteStub', $result[0]);
+        $this->assertInstanceOf(\Illuminate\Tests\Container\ContainerConcreteStub::class, $result[0]);
         $this->assertEquals('taylor', $result[1]);
 
         $container = new Container;
         $result = $container->call('Illuminate\Tests\Container\ContainerTestCallStub@inject', ['default' => 'foo']);
-        $this->assertInstanceOf('Illuminate\Tests\Container\ContainerConcreteStub', $result[0]);
+        $this->assertInstanceOf(\Illuminate\Tests\Container\ContainerConcreteStub::class, $result[0]);
         $this->assertEquals('foo', $result[1]);
 
         $container = new Container;
-        $result = $container->call('Illuminate\Tests\Container\ContainerTestCallStub', ['foo', 'bar'], 'work');
+        $result = $container->call(\Illuminate\Tests\Container\ContainerTestCallStub::class, ['foo', 'bar'], 'work');
         $this->assertEquals(['foo', 'bar'], $result);
     }
 
@@ -430,15 +430,15 @@ class ContainerTest extends TestCase
     {
         $container = new Container;
         $result = $container->call('Illuminate\Tests\Container\ContainerStaticMethodStub::inject');
-        $this->assertInstanceOf('Illuminate\Tests\Container\ContainerConcreteStub', $result[0]);
+        $this->assertInstanceOf(\Illuminate\Tests\Container\ContainerConcreteStub::class, $result[0]);
         $this->assertEquals('taylor', $result[1]);
     }
 
     public function testCallWithGlobalMethodName()
     {
         $container = new Container;
-        $result = $container->call('Illuminate\Tests\Container\containerTestInject');
-        $this->assertInstanceOf('Illuminate\Tests\Container\ContainerConcreteStub', $result[0]);
+        $result = $container->call(\Illuminate\Tests\Container\containerTestInject::class);
+        $this->assertInstanceOf(\Illuminate\Tests\Container\ContainerConcreteStub::class, $result[0]);
         $this->assertEquals('taylor', $result[1]);
     }
 
@@ -463,47 +463,47 @@ class ContainerTest extends TestCase
     {
         $container = new Container;
 
-        $container->bind('Illuminate\Tests\Container\IContainerContractStub', 'Illuminate\Tests\Container\ContainerImplementationStub');
+        $container->bind(\Illuminate\Tests\Container\IContainerContractStub::class, \Illuminate\Tests\Container\ContainerImplementationStub::class);
 
-        $container->when('Illuminate\Tests\Container\ContainerTestContextInjectOne')->needs('Illuminate\Tests\Container\IContainerContractStub')->give('Illuminate\Tests\Container\ContainerImplementationStub');
-        $container->when('Illuminate\Tests\Container\ContainerTestContextInjectTwo')->needs('Illuminate\Tests\Container\IContainerContractStub')->give('Illuminate\Tests\Container\ContainerImplementationStubTwo');
+        $container->when(\Illuminate\Tests\Container\ContainerTestContextInjectOne::class)->needs(\Illuminate\Tests\Container\IContainerContractStub::class)->give(\Illuminate\Tests\Container\ContainerImplementationStub::class);
+        $container->when(\Illuminate\Tests\Container\ContainerTestContextInjectTwo::class)->needs(\Illuminate\Tests\Container\IContainerContractStub::class)->give(\Illuminate\Tests\Container\ContainerImplementationStubTwo::class);
 
-        $one = $container->make('Illuminate\Tests\Container\ContainerTestContextInjectOne');
-        $two = $container->make('Illuminate\Tests\Container\ContainerTestContextInjectTwo');
+        $one = $container->make(\Illuminate\Tests\Container\ContainerTestContextInjectOne::class);
+        $two = $container->make(\Illuminate\Tests\Container\ContainerTestContextInjectTwo::class);
 
-        $this->assertInstanceOf('Illuminate\Tests\Container\ContainerImplementationStub', $one->impl);
-        $this->assertInstanceOf('Illuminate\Tests\Container\ContainerImplementationStubTwo', $two->impl);
+        $this->assertInstanceOf(\Illuminate\Tests\Container\ContainerImplementationStub::class, $one->impl);
+        $this->assertInstanceOf(\Illuminate\Tests\Container\ContainerImplementationStubTwo::class, $two->impl);
 
         /*
          * Test With Closures
          */
         $container = new Container;
 
-        $container->bind('Illuminate\Tests\Container\IContainerContractStub', 'Illuminate\Tests\Container\ContainerImplementationStub');
+        $container->bind(\Illuminate\Tests\Container\IContainerContractStub::class, \Illuminate\Tests\Container\ContainerImplementationStub::class);
 
-        $container->when('Illuminate\Tests\Container\ContainerTestContextInjectOne')->needs('Illuminate\Tests\Container\IContainerContractStub')->give('Illuminate\Tests\Container\ContainerImplementationStub');
-        $container->when('Illuminate\Tests\Container\ContainerTestContextInjectTwo')->needs('Illuminate\Tests\Container\IContainerContractStub')->give(function ($container) {
-            return $container->make('Illuminate\Tests\Container\ContainerImplementationStubTwo');
+        $container->when(\Illuminate\Tests\Container\ContainerTestContextInjectOne::class)->needs(\Illuminate\Tests\Container\IContainerContractStub::class)->give(\Illuminate\Tests\Container\ContainerImplementationStub::class);
+        $container->when(\Illuminate\Tests\Container\ContainerTestContextInjectTwo::class)->needs(\Illuminate\Tests\Container\IContainerContractStub::class)->give(function ($container) {
+            return $container->make(\Illuminate\Tests\Container\ContainerImplementationStubTwo::class);
         });
 
-        $one = $container->make('Illuminate\Tests\Container\ContainerTestContextInjectOne');
-        $two = $container->make('Illuminate\Tests\Container\ContainerTestContextInjectTwo');
+        $one = $container->make(\Illuminate\Tests\Container\ContainerTestContextInjectOne::class);
+        $two = $container->make(\Illuminate\Tests\Container\ContainerTestContextInjectTwo::class);
 
-        $this->assertInstanceOf('Illuminate\Tests\Container\ContainerImplementationStub', $one->impl);
-        $this->assertInstanceOf('Illuminate\Tests\Container\ContainerImplementationStubTwo', $two->impl);
+        $this->assertInstanceOf(\Illuminate\Tests\Container\ContainerImplementationStub::class, $one->impl);
+        $this->assertInstanceOf(\Illuminate\Tests\Container\ContainerImplementationStubTwo::class, $two->impl);
     }
 
     public function testContextualBindingWorksForExistingInstancedBindings()
     {
         $container = new Container;
 
-        $container->instance('Illuminate\Tests\Container\IContainerContractStub', new ContainerImplementationStub);
+        $container->instance(\Illuminate\Tests\Container\IContainerContractStub::class, new ContainerImplementationStub);
 
-        $container->when('Illuminate\Tests\Container\ContainerTestContextInjectOne')->needs('Illuminate\Tests\Container\IContainerContractStub')->give('Illuminate\Tests\Container\ContainerImplementationStubTwo');
+        $container->when(\Illuminate\Tests\Container\ContainerTestContextInjectOne::class)->needs(\Illuminate\Tests\Container\IContainerContractStub::class)->give(\Illuminate\Tests\Container\ContainerImplementationStubTwo::class);
 
         $this->assertInstanceOf(
-            'Illuminate\Tests\Container\ContainerImplementationStubTwo',
-            $container->make('Illuminate\Tests\Container\ContainerTestContextInjectOne')->impl
+            \Illuminate\Tests\Container\ContainerImplementationStubTwo::class,
+            $container->make(\Illuminate\Tests\Container\ContainerTestContextInjectOne::class)->impl
         );
     }
 
@@ -511,13 +511,13 @@ class ContainerTest extends TestCase
     {
         $container = new Container;
 
-        $container->when('Illuminate\Tests\Container\ContainerTestContextInjectOne')->needs('Illuminate\Tests\Container\IContainerContractStub')->give('Illuminate\Tests\Container\ContainerImplementationStubTwo');
+        $container->when(\Illuminate\Tests\Container\ContainerTestContextInjectOne::class)->needs(\Illuminate\Tests\Container\IContainerContractStub::class)->give(\Illuminate\Tests\Container\ContainerImplementationStubTwo::class);
 
-        $container->instance('Illuminate\Tests\Container\IContainerContractStub', new ContainerImplementationStub);
+        $container->instance(\Illuminate\Tests\Container\IContainerContractStub::class, new ContainerImplementationStub);
 
         $this->assertInstanceOf(
-            'Illuminate\Tests\Container\ContainerImplementationStubTwo',
-            $container->make('Illuminate\Tests\Container\ContainerTestContextInjectOne')->impl
+            \Illuminate\Tests\Container\ContainerImplementationStubTwo::class,
+            $container->make(\Illuminate\Tests\Container\ContainerTestContextInjectOne::class)->impl
         );
     }
 
@@ -526,13 +526,13 @@ class ContainerTest extends TestCase
         $container = new Container;
 
         $container->instance('stub', new ContainerImplementationStub);
-        $container->alias('stub', 'Illuminate\Tests\Container\IContainerContractStub');
+        $container->alias('stub', \Illuminate\Tests\Container\IContainerContractStub::class);
 
-        $container->when('Illuminate\Tests\Container\ContainerTestContextInjectOne')->needs('Illuminate\Tests\Container\IContainerContractStub')->give('Illuminate\Tests\Container\ContainerImplementationStubTwo');
+        $container->when(\Illuminate\Tests\Container\ContainerTestContextInjectOne::class)->needs(\Illuminate\Tests\Container\IContainerContractStub::class)->give(\Illuminate\Tests\Container\ContainerImplementationStubTwo::class);
 
         $this->assertInstanceOf(
-            'Illuminate\Tests\Container\ContainerImplementationStubTwo',
-            $container->make('Illuminate\Tests\Container\ContainerTestContextInjectOne')->impl
+            \Illuminate\Tests\Container\ContainerImplementationStubTwo::class,
+            $container->make(\Illuminate\Tests\Container\ContainerTestContextInjectOne::class)->impl
         );
     }
 
@@ -540,14 +540,14 @@ class ContainerTest extends TestCase
     {
         $container = new Container;
 
-        $container->when('Illuminate\Tests\Container\ContainerTestContextInjectOne')->needs('Illuminate\Tests\Container\IContainerContractStub')->give('Illuminate\Tests\Container\ContainerImplementationStubTwo');
+        $container->when(\Illuminate\Tests\Container\ContainerTestContextInjectOne::class)->needs(\Illuminate\Tests\Container\IContainerContractStub::class)->give(\Illuminate\Tests\Container\ContainerImplementationStubTwo::class);
 
         $container->instance('stub', new ContainerImplementationStub);
-        $container->alias('stub', 'Illuminate\Tests\Container\IContainerContractStub');
+        $container->alias('stub', \Illuminate\Tests\Container\IContainerContractStub::class);
 
         $this->assertInstanceOf(
-            'Illuminate\Tests\Container\ContainerImplementationStubTwo',
-            $container->make('Illuminate\Tests\Container\ContainerTestContextInjectOne')->impl
+            \Illuminate\Tests\Container\ContainerImplementationStubTwo::class,
+            $container->make(\Illuminate\Tests\Container\ContainerTestContextInjectOne::class)->impl
         );
     }
 
@@ -555,14 +555,14 @@ class ContainerTest extends TestCase
     {
         $container = new Container;
 
-        $container->when('Illuminate\Tests\Container\ContainerTestContextInjectOne')->needs('Illuminate\Tests\Container\IContainerContractStub')->give('Illuminate\Tests\Container\ContainerImplementationStubTwo');
+        $container->when(\Illuminate\Tests\Container\ContainerTestContextInjectOne::class)->needs(\Illuminate\Tests\Container\IContainerContractStub::class)->give(\Illuminate\Tests\Container\ContainerImplementationStubTwo::class);
 
         $container->bind('stub', ContainerImplementationStub::class);
-        $container->alias('stub', 'Illuminate\Tests\Container\IContainerContractStub');
+        $container->alias('stub', \Illuminate\Tests\Container\IContainerContractStub::class);
 
         $this->assertInstanceOf(
-            'Illuminate\Tests\Container\ContainerImplementationStubTwo',
-            $container->make('Illuminate\Tests\Container\ContainerTestContextInjectOne')->impl
+            \Illuminate\Tests\Container\ContainerImplementationStubTwo::class,
+            $container->make(\Illuminate\Tests\Container\ContainerTestContextInjectOne::class)->impl
         );
     }
 
@@ -571,18 +571,18 @@ class ContainerTest extends TestCase
         $container = new Container;
 
         $container->instance('stub', new ContainerImplementationStub);
-        $container->alias('stub', 'Illuminate\Tests\Container\IContainerContractStub');
+        $container->alias('stub', \Illuminate\Tests\Container\IContainerContractStub::class);
 
-        $container->when('Illuminate\Tests\Container\ContainerTestContextInjectTwo')->needs('Illuminate\Tests\Container\IContainerContractStub')->give('Illuminate\Tests\Container\ContainerImplementationStubTwo');
+        $container->when(\Illuminate\Tests\Container\ContainerTestContextInjectTwo::class)->needs(\Illuminate\Tests\Container\IContainerContractStub::class)->give(\Illuminate\Tests\Container\ContainerImplementationStubTwo::class);
 
         $this->assertInstanceOf(
-            'Illuminate\Tests\Container\ContainerImplementationStubTwo',
-            $container->make('Illuminate\Tests\Container\ContainerTestContextInjectTwo')->impl
+            \Illuminate\Tests\Container\ContainerImplementationStubTwo::class,
+            $container->make(\Illuminate\Tests\Container\ContainerTestContextInjectTwo::class)->impl
         );
 
         $this->assertInstanceOf(
-            'Illuminate\Tests\Container\ContainerImplementationStub',
-            $container->make('Illuminate\Tests\Container\ContainerTestContextInjectOne')->impl
+            \Illuminate\Tests\Container\ContainerImplementationStub::class,
+            $container->make(\Illuminate\Tests\Container\ContainerTestContextInjectOne::class)->impl
         );
     }
 
@@ -592,17 +592,17 @@ class ContainerTest extends TestCase
 
         $container = new Container;
 
-        $container->instance('Illuminate\Tests\Container\IContainerContractStub', new ContainerImplementationStub);
-        $container->instance('Illuminate\Tests\Container\ContainerTestContextInjectInstantiations', new ContainerTestContextInjectInstantiations);
+        $container->instance(\Illuminate\Tests\Container\IContainerContractStub::class, new ContainerImplementationStub);
+        $container->instance(\Illuminate\Tests\Container\ContainerTestContextInjectInstantiations::class, new ContainerTestContextInjectInstantiations);
 
         $this->assertEquals(1, ContainerTestContextInjectInstantiations::$instantiations);
 
-        $container->when('Illuminate\Tests\Container\ContainerTestContextInjectOne')->needs('Illuminate\Tests\Container\IContainerContractStub')->give('Illuminate\Tests\Container\ContainerTestContextInjectInstantiations');
+        $container->when(\Illuminate\Tests\Container\ContainerTestContextInjectOne::class)->needs(\Illuminate\Tests\Container\IContainerContractStub::class)->give(\Illuminate\Tests\Container\ContainerTestContextInjectInstantiations::class);
 
-        $container->make('Illuminate\Tests\Container\ContainerTestContextInjectOne');
-        $container->make('Illuminate\Tests\Container\ContainerTestContextInjectOne');
-        $container->make('Illuminate\Tests\Container\ContainerTestContextInjectOne');
-        $container->make('Illuminate\Tests\Container\ContainerTestContextInjectOne');
+        $container->make(\Illuminate\Tests\Container\ContainerTestContextInjectOne::class);
+        $container->make(\Illuminate\Tests\Container\ContainerTestContextInjectOne::class);
+        $container->make(\Illuminate\Tests\Container\ContainerTestContextInjectOne::class);
+        $container->make(\Illuminate\Tests\Container\ContainerTestContextInjectOne::class);
 
         $this->assertEquals(1, ContainerTestContextInjectInstantiations::$instantiations);
     }
@@ -610,20 +610,20 @@ class ContainerTest extends TestCase
     public function testContainerTags()
     {
         $container = new Container;
-        $container->tag('Illuminate\Tests\Container\ContainerImplementationStub', 'foo', 'bar');
-        $container->tag('Illuminate\Tests\Container\ContainerImplementationStubTwo', ['foo']);
+        $container->tag(\Illuminate\Tests\Container\ContainerImplementationStub::class, 'foo', 'bar');
+        $container->tag(\Illuminate\Tests\Container\ContainerImplementationStubTwo::class, ['foo']);
 
         $this->assertCount(1, $container->tagged('bar'));
         $this->assertCount(2, $container->tagged('foo'));
-        $this->assertInstanceOf('Illuminate\Tests\Container\ContainerImplementationStub', $container->tagged('foo')[0]);
-        $this->assertInstanceOf('Illuminate\Tests\Container\ContainerImplementationStub', $container->tagged('bar')[0]);
-        $this->assertInstanceOf('Illuminate\Tests\Container\ContainerImplementationStubTwo', $container->tagged('foo')[1]);
+        $this->assertInstanceOf(\Illuminate\Tests\Container\ContainerImplementationStub::class, $container->tagged('foo')[0]);
+        $this->assertInstanceOf(\Illuminate\Tests\Container\ContainerImplementationStub::class, $container->tagged('bar')[0]);
+        $this->assertInstanceOf(\Illuminate\Tests\Container\ContainerImplementationStubTwo::class, $container->tagged('foo')[1]);
 
         $container = new Container;
-        $container->tag(['Illuminate\Tests\Container\ContainerImplementationStub', 'Illuminate\Tests\Container\ContainerImplementationStubTwo'], ['foo']);
+        $container->tag([\Illuminate\Tests\Container\ContainerImplementationStub::class, \Illuminate\Tests\Container\ContainerImplementationStubTwo::class], ['foo']);
         $this->assertCount(2, $container->tagged('foo'));
-        $this->assertInstanceOf('Illuminate\Tests\Container\ContainerImplementationStub', $container->tagged('foo')[0]);
-        $this->assertInstanceOf('Illuminate\Tests\Container\ContainerImplementationStubTwo', $container->tagged('foo')[1]);
+        $this->assertInstanceOf(\Illuminate\Tests\Container\ContainerImplementationStub::class, $container->tagged('foo')[0]);
+        $this->assertInstanceOf(\Illuminate\Tests\Container\ContainerImplementationStubTwo::class, $container->tagged('foo')[1]);
 
         $this->assertEmpty($container->tagged('this_tag_does_not_exist'));
     }
@@ -632,10 +632,10 @@ class ContainerTest extends TestCase
     {
         $container = new Container;
         $containerConcreteStub = new ContainerConcreteStub;
-        $container->instance('Illuminate\Tests\Container\ContainerConcreteStub', $containerConcreteStub);
-        $this->assertTrue($container->isShared('Illuminate\Tests\Container\ContainerConcreteStub'));
-        $container->forgetInstance('Illuminate\Tests\Container\ContainerConcreteStub');
-        $this->assertFalse($container->isShared('Illuminate\Tests\Container\ContainerConcreteStub'));
+        $container->instance(\Illuminate\Tests\Container\ContainerConcreteStub::class, $containerConcreteStub);
+        $this->assertTrue($container->isShared(\Illuminate\Tests\Container\ContainerConcreteStub::class));
+        $container->forgetInstance(\Illuminate\Tests\Container\ContainerConcreteStub::class);
+        $this->assertFalse($container->isShared(\Illuminate\Tests\Container\ContainerConcreteStub::class));
     }
 
     public function testForgetInstancesForgetsAllInstances()
@@ -702,16 +702,16 @@ class ContainerTest extends TestCase
     public function testContainerCanInjectSimpleVariable()
     {
         $container = new Container;
-        $container->when('Illuminate\Tests\Container\ContainerInjectVariableStub')->needs('$something')->give(100);
-        $instance = $container->make('Illuminate\Tests\Container\ContainerInjectVariableStub');
+        $container->when(\Illuminate\Tests\Container\ContainerInjectVariableStub::class)->needs('$something')->give(100);
+        $instance = $container->make(\Illuminate\Tests\Container\ContainerInjectVariableStub::class);
         $this->assertEquals(100, $instance->something);
 
         $container = new Container;
-        $container->when('Illuminate\Tests\Container\ContainerInjectVariableStub')->needs('$something')->give(function ($container) {
-            return $container->make('Illuminate\Tests\Container\ContainerConcreteStub');
+        $container->when(\Illuminate\Tests\Container\ContainerInjectVariableStub::class)->needs('$something')->give(function ($container) {
+            return $container->make(\Illuminate\Tests\Container\ContainerConcreteStub::class);
         });
-        $instance = $container->make('Illuminate\Tests\Container\ContainerInjectVariableStub');
-        $this->assertInstanceOf('Illuminate\Tests\Container\ContainerConcreteStub', $instance->something);
+        $instance = $container->make(\Illuminate\Tests\Container\ContainerInjectVariableStub::class);
+        $this->assertInstanceOf(\Illuminate\Tests\Container\ContainerConcreteStub::class, $instance->something);
     }
 
     public function testContainerGetFactory()
@@ -743,19 +743,19 @@ class ContainerTest extends TestCase
     {
         $container = new Container;
 
-        $container->bind('Illuminate\Tests\Container\IContainerContractStub', 'Illuminate\Tests\Container\ContainerImplementationStub');
-        $container->alias('Illuminate\Tests\Container\IContainerContractStub', 'interface-stub');
+        $container->bind(\Illuminate\Tests\Container\IContainerContractStub::class, \Illuminate\Tests\Container\ContainerImplementationStub::class);
+        $container->alias(\Illuminate\Tests\Container\IContainerContractStub::class, 'interface-stub');
 
-        $container->alias('Illuminate\Tests\Container\ContainerImplementationStub', 'stub-1');
+        $container->alias(\Illuminate\Tests\Container\ContainerImplementationStub::class, 'stub-1');
 
-        $container->when('Illuminate\Tests\Container\ContainerTestContextInjectOne')->needs('interface-stub')->give('stub-1');
-        $container->when('Illuminate\Tests\Container\ContainerTestContextInjectTwo')->needs('interface-stub')->give('Illuminate\Tests\Container\ContainerImplementationStubTwo');
+        $container->when(\Illuminate\Tests\Container\ContainerTestContextInjectOne::class)->needs('interface-stub')->give('stub-1');
+        $container->when(\Illuminate\Tests\Container\ContainerTestContextInjectTwo::class)->needs('interface-stub')->give(\Illuminate\Tests\Container\ContainerImplementationStubTwo::class);
 
-        $one = $container->make('Illuminate\Tests\Container\ContainerTestContextInjectOne');
-        $two = $container->make('Illuminate\Tests\Container\ContainerTestContextInjectTwo');
+        $one = $container->make(\Illuminate\Tests\Container\ContainerTestContextInjectOne::class);
+        $two = $container->make(\Illuminate\Tests\Container\ContainerTestContextInjectTwo::class);
 
-        $this->assertInstanceOf('Illuminate\Tests\Container\ContainerImplementationStub', $one->impl);
-        $this->assertInstanceOf('Illuminate\Tests\Container\ContainerImplementationStubTwo', $two->impl);
+        $this->assertInstanceOf(\Illuminate\Tests\Container\ContainerImplementationStub::class, $one->impl);
+        $this->assertInstanceOf(\Illuminate\Tests\Container\ContainerImplementationStubTwo::class, $two->impl);
     }
 
     public function testResolvingCallbacksShouldBeFiredWhenCalledWithAliases()

--- a/tests/Cookie/Middleware/EncryptCookiesTest.php
+++ b/tests/Cookie/Middleware/EncryptCookiesTest.php
@@ -41,7 +41,7 @@ class EncryptCookiesTest extends TestCase
     public function testSetCookieEncryption()
     {
         $this->router->get($this->setCookiePath, [
-            'middleware' => 'Illuminate\Tests\Cookie\Middleware\EncryptCookiesTestMiddleware',
+            'middleware' => \Illuminate\Tests\Cookie\Middleware\EncryptCookiesTestMiddleware::class,
             'uses' => 'Illuminate\Tests\Cookie\Middleware\EncryptCookiesTestController@setCookies',
         ]);
 
@@ -58,7 +58,7 @@ class EncryptCookiesTest extends TestCase
     public function testQueuedCookieEncryption()
     {
         $this->router->get($this->queueCookiePath, [
-            'middleware' => ['Illuminate\Tests\Cookie\Middleware\EncryptCookiesTestMiddleware', 'Illuminate\Tests\Cookie\Middleware\AddQueuedCookiesToResponseTestMiddleware'],
+            'middleware' => [\Illuminate\Tests\Cookie\Middleware\EncryptCookiesTestMiddleware::class, \Illuminate\Tests\Cookie\Middleware\AddQueuedCookiesToResponseTestMiddleware::class],
             'uses' => 'Illuminate\Tests\Cookie\Middleware\EncryptCookiesTestController@queueCookies',
         ]);
 

--- a/tests/Database/DatabaseConnectionFactoryTest.php
+++ b/tests/Database/DatabaseConnectionFactoryTest.php
@@ -78,7 +78,7 @@ class DatabaseConnectionFactoryTest extends TestCase
      */
     public function testIfDriverIsntSetExceptionIsThrown()
     {
-        $factory = new ConnectionFactory($container = m::mock('Illuminate\Container\Container'));
+        $factory = new ConnectionFactory($container = m::mock(\Illuminate\Container\Container::class));
         $factory->createConnector(['foo']);
     }
 
@@ -87,14 +87,14 @@ class DatabaseConnectionFactoryTest extends TestCase
      */
     public function testExceptionIsThrownOnUnsupportedDriver()
     {
-        $factory = new ConnectionFactory($container = m::mock('Illuminate\Container\Container'));
+        $factory = new ConnectionFactory($container = m::mock(\Illuminate\Container\Container::class));
         $container->shouldReceive('bound')->once()->andReturn(false);
         $factory->createConnector(['driver' => 'foo']);
     }
 
     public function testCustomConnectorsCanBeResolvedViaContainer()
     {
-        $factory = new ConnectionFactory($container = m::mock('Illuminate\Container\Container'));
+        $factory = new ConnectionFactory($container = m::mock(\Illuminate\Container\Container::class));
         $container->shouldReceive('bound')->once()->with('db.connector.foo')->andReturn(true);
         $container->shouldReceive('make')->once()->with('db.connector.foo')->andReturn('connector');
 

--- a/tests/Database/DatabaseConnectionTest.php
+++ b/tests/Database/DatabaseConnectionTest.php
@@ -40,8 +40,8 @@ class DatabaseConnectionTest extends TestCase
 
     public function testSelectProperlyCallsPDO()
     {
-        $pdo = $this->getMockBuilder('Illuminate\Tests\Database\DatabaseConnectionTestMockPDO')->setMethods(['prepare'])->getMock();
-        $writePdo = $this->getMockBuilder('Illuminate\Tests\Database\DatabaseConnectionTestMockPDO')->setMethods(['prepare'])->getMock();
+        $pdo = $this->getMockBuilder(\Illuminate\Tests\Database\DatabaseConnectionTestMockPDO::class)->setMethods(['prepare'])->getMock();
+        $writePdo = $this->getMockBuilder(\Illuminate\Tests\Database\DatabaseConnectionTestMockPDO::class)->setMethods(['prepare'])->getMock();
         $writePdo->expects($this->never())->method('prepare');
         $statement = $this->getMockBuilder('PDOStatement')->setMethods(['execute', 'fetchAll', 'bindValue'])->getMock();
         $statement->expects($this->once())->method('bindValue')->with('foo', 'bar', 2);
@@ -85,7 +85,7 @@ class DatabaseConnectionTest extends TestCase
 
     public function testStatementProperlyCallsPDO()
     {
-        $pdo = $this->getMockBuilder('Illuminate\Tests\Database\DatabaseConnectionTestMockPDO')->setMethods(['prepare'])->getMock();
+        $pdo = $this->getMockBuilder(\Illuminate\Tests\Database\DatabaseConnectionTestMockPDO::class)->setMethods(['prepare'])->getMock();
         $statement = $this->getMockBuilder('PDOStatement')->setMethods(['execute', 'bindValue'])->getMock();
         $statement->expects($this->once())->method('bindValue')->with(1, 'bar', 2);
         $statement->expects($this->once())->method('execute')->will($this->returnValue('foo'));
@@ -102,7 +102,7 @@ class DatabaseConnectionTest extends TestCase
 
     public function testAffectingStatementProperlyCallsPDO()
     {
-        $pdo = $this->getMockBuilder('Illuminate\Tests\Database\DatabaseConnectionTestMockPDO')->setMethods(['prepare'])->getMock();
+        $pdo = $this->getMockBuilder(\Illuminate\Tests\Database\DatabaseConnectionTestMockPDO::class)->setMethods(['prepare'])->getMock();
         $statement = $this->getMockBuilder('PDOStatement')->setMethods(['execute', 'rowCount', 'bindValue'])->getMock();
         $statement->expects($this->once())->method('bindValue')->with('foo', 'bar', 2);
         $statement->expects($this->once())->method('execute');
@@ -120,7 +120,7 @@ class DatabaseConnectionTest extends TestCase
 
     public function testTransactionLevelNotIncrementedOnTransactionException()
     {
-        $pdo = $this->createMock('Illuminate\Tests\Database\DatabaseConnectionTestMockPDO');
+        $pdo = $this->createMock(\Illuminate\Tests\Database\DatabaseConnectionTestMockPDO::class);
         $pdo->expects($this->once())->method('beginTransaction')->will($this->throwException(new \Exception));
         $connection = $this->getMockConnection([], $pdo);
         try {
@@ -132,7 +132,7 @@ class DatabaseConnectionTest extends TestCase
 
     public function testBeginTransactionMethodRetriesOnFailure()
     {
-        $pdo = $this->createMock('Illuminate\Tests\Database\DatabaseConnectionTestMockPDO');
+        $pdo = $this->createMock(\Illuminate\Tests\Database\DatabaseConnectionTestMockPDO::class);
         $pdo->expects($this->exactly(2))->method('beginTransaction');
         $pdo->expects($this->at(0))->method('beginTransaction')->will($this->throwException(new \ErrorException('server has gone away')));
         $connection = $this->getMockConnection(['reconnect'], $pdo);
@@ -143,11 +143,11 @@ class DatabaseConnectionTest extends TestCase
 
     public function testBeginTransactionMethodNeverRetriesIfWithinTransaction()
     {
-        $pdo = $this->createMock('Illuminate\Tests\Database\DatabaseConnectionTestMockPDO');
+        $pdo = $this->createMock(\Illuminate\Tests\Database\DatabaseConnectionTestMockPDO::class);
         $pdo->expects($this->once())->method('beginTransaction');
         $pdo->expects($this->once())->method('exec')->will($this->throwException(new \Exception));
         $connection = $this->getMockConnection(['reconnect'], $pdo);
-        $queryGrammar = $this->createMock('Illuminate\Database\Query\Grammars\Grammar');
+        $queryGrammar = $this->createMock(\Illuminate\Database\Query\Grammars\Grammar::class);
         $queryGrammar->expects($this->once())->method('supportsSavepoints')->will($this->returnValue(true));
         $connection->setQueryGrammar($queryGrammar);
         $connection->expects($this->never())->method('reconnect');
@@ -162,7 +162,7 @@ class DatabaseConnectionTest extends TestCase
 
     public function testSwapPDOWithOpenTransactionResetsTransactionLevel()
     {
-        $pdo = $this->createMock('Illuminate\Tests\Database\DatabaseConnectionTestMockPDO');
+        $pdo = $this->createMock(\Illuminate\Tests\Database\DatabaseConnectionTestMockPDO::class);
         $pdo->expects($this->once())->method('beginTransaction')->will($this->returnValue(true));
         $connection = $this->getMockConnection([], $pdo);
         $connection->beginTransaction();
@@ -172,48 +172,48 @@ class DatabaseConnectionTest extends TestCase
 
     public function testBeganTransactionFiresEventsIfSet()
     {
-        $pdo = $this->createMock('Illuminate\Tests\Database\DatabaseConnectionTestMockPDO');
+        $pdo = $this->createMock(\Illuminate\Tests\Database\DatabaseConnectionTestMockPDO::class);
         $connection = $this->getMockConnection(['getName'], $pdo);
         $connection->expects($this->any())->method('getName')->will($this->returnValue('name'));
-        $connection->setEventDispatcher($events = m::mock('Illuminate\Contracts\Events\Dispatcher'));
-        $events->shouldReceive('dispatch')->once()->with(m::type('Illuminate\Database\Events\TransactionBeginning'));
+        $connection->setEventDispatcher($events = m::mock(\Illuminate\Contracts\Events\Dispatcher::class));
+        $events->shouldReceive('dispatch')->once()->with(m::type(\Illuminate\Database\Events\TransactionBeginning::class));
         $connection->beginTransaction();
     }
 
     public function testCommitedFiresEventsIfSet()
     {
-        $pdo = $this->createMock('Illuminate\Tests\Database\DatabaseConnectionTestMockPDO');
+        $pdo = $this->createMock(\Illuminate\Tests\Database\DatabaseConnectionTestMockPDO::class);
         $connection = $this->getMockConnection(['getName'], $pdo);
         $connection->expects($this->any())->method('getName')->will($this->returnValue('name'));
-        $connection->setEventDispatcher($events = m::mock('Illuminate\Contracts\Events\Dispatcher'));
-        $events->shouldReceive('dispatch')->once()->with(m::type('Illuminate\Database\Events\TransactionCommitted'));
+        $connection->setEventDispatcher($events = m::mock(\Illuminate\Contracts\Events\Dispatcher::class));
+        $events->shouldReceive('dispatch')->once()->with(m::type(\Illuminate\Database\Events\TransactionCommitted::class));
         $connection->commit();
     }
 
     public function testRollBackedFiresEventsIfSet()
     {
-        $pdo = $this->createMock('Illuminate\Tests\Database\DatabaseConnectionTestMockPDO');
+        $pdo = $this->createMock(\Illuminate\Tests\Database\DatabaseConnectionTestMockPDO::class);
         $connection = $this->getMockConnection(['getName'], $pdo);
         $connection->expects($this->any())->method('getName')->will($this->returnValue('name'));
         $connection->beginTransaction();
-        $connection->setEventDispatcher($events = m::mock('Illuminate\Contracts\Events\Dispatcher'));
-        $events->shouldReceive('dispatch')->once()->with(m::type('Illuminate\Database\Events\TransactionRolledBack'));
+        $connection->setEventDispatcher($events = m::mock(\Illuminate\Contracts\Events\Dispatcher::class));
+        $events->shouldReceive('dispatch')->once()->with(m::type(\Illuminate\Database\Events\TransactionRolledBack::class));
         $connection->rollBack();
     }
 
     public function testRedundantRollBackFiresNoEvent()
     {
-        $pdo = $this->createMock('Illuminate\Tests\Database\DatabaseConnectionTestMockPDO');
+        $pdo = $this->createMock(\Illuminate\Tests\Database\DatabaseConnectionTestMockPDO::class);
         $connection = $this->getMockConnection(['getName'], $pdo);
         $connection->expects($this->any())->method('getName')->will($this->returnValue('name'));
-        $connection->setEventDispatcher($events = m::mock('Illuminate\Contracts\Events\Dispatcher'));
+        $connection->setEventDispatcher($events = m::mock(\Illuminate\Contracts\Events\Dispatcher::class));
         $events->shouldNotReceive('dispatch');
         $connection->rollBack();
     }
 
     public function testTransactionMethodRunsSuccessfully()
     {
-        $pdo = $this->getMockBuilder('Illuminate\Tests\Database\DatabaseConnectionTestMockPDO')->setMethods(['beginTransaction', 'commit'])->getMock();
+        $pdo = $this->getMockBuilder(\Illuminate\Tests\Database\DatabaseConnectionTestMockPDO::class)->setMethods(['beginTransaction', 'commit'])->getMock();
         $mock = $this->getMockConnection([], $pdo);
         $pdo->expects($this->once())->method('beginTransaction');
         $pdo->expects($this->once())->method('commit');
@@ -228,7 +228,7 @@ class DatabaseConnectionTest extends TestCase
      */
     public function testTransactionMethodRetriesOnDeadlock()
     {
-        $pdo = $this->getMockBuilder('Illuminate\Tests\Database\DatabaseConnectionTestMockPDO')->setMethods(['beginTransaction', 'commit', 'rollBack'])->getMock();
+        $pdo = $this->getMockBuilder(\Illuminate\Tests\Database\DatabaseConnectionTestMockPDO::class)->setMethods(['beginTransaction', 'commit', 'rollBack'])->getMock();
         $mock = $this->getMockConnection([], $pdo);
         $pdo->expects($this->exactly(3))->method('beginTransaction');
         $pdo->expects($this->exactly(3))->method('rollBack');
@@ -240,7 +240,7 @@ class DatabaseConnectionTest extends TestCase
 
     public function testTransactionMethodRollsbackAndThrows()
     {
-        $pdo = $this->getMockBuilder('Illuminate\Tests\Database\DatabaseConnectionTestMockPDO')->setMethods(['beginTransaction', 'commit', 'rollBack'])->getMock();
+        $pdo = $this->getMockBuilder(\Illuminate\Tests\Database\DatabaseConnectionTestMockPDO::class)->setMethods(['beginTransaction', 'commit', 'rollBack'])->getMock();
         $mock = $this->getMockConnection([], $pdo);
         $pdo->expects($this->once())->method('beginTransaction');
         $pdo->expects($this->once())->method('rollBack');
@@ -295,10 +295,10 @@ class DatabaseConnectionTest extends TestCase
 
     public function testRunMethodRetriesOnFailure()
     {
-        $method = (new \ReflectionClass('Illuminate\Database\Connection'))->getMethod('run');
+        $method = (new \ReflectionClass(\Illuminate\Database\Connection::class))->getMethod('run');
         $method->setAccessible(true);
 
-        $pdo = $this->createMock('Illuminate\Tests\Database\DatabaseConnectionTestMockPDO');
+        $pdo = $this->createMock(\Illuminate\Tests\Database\DatabaseConnectionTestMockPDO::class);
         $mock = $this->getMockConnection(['tryAgainIfCausedByLostConnection'], $pdo);
         $mock->expects($this->once())->method('tryAgainIfCausedByLostConnection');
 
@@ -312,10 +312,10 @@ class DatabaseConnectionTest extends TestCase
      */
     public function testRunMethodNeverRetriesIfWithinTransaction()
     {
-        $method = (new \ReflectionClass('Illuminate\Database\Connection'))->getMethod('run');
+        $method = (new \ReflectionClass(\Illuminate\Database\Connection::class))->getMethod('run');
         $method->setAccessible(true);
 
-        $pdo = $this->getMockBuilder('Illuminate\Tests\Database\DatabaseConnectionTestMockPDO')->setMethods(['beginTransaction'])->getMock();
+        $pdo = $this->getMockBuilder(\Illuminate\Tests\Database\DatabaseConnectionTestMockPDO::class)->setMethods(['beginTransaction'])->getMock();
         $mock = $this->getMockConnection(['tryAgainIfCausedByLostConnection'], $pdo);
         $pdo->expects($this->once())->method('beginTransaction');
         $mock->expects($this->never())->method('tryAgainIfCausedByLostConnection');
@@ -329,10 +329,10 @@ class DatabaseConnectionTest extends TestCase
     public function testFromCreatesNewQueryBuilder()
     {
         $conn = $this->getMockConnection();
-        $conn->setQueryGrammar(m::mock('Illuminate\Database\Query\Grammars\Grammar'));
-        $conn->setPostProcessor(m::mock('Illuminate\Database\Query\Processors\Processor'));
+        $conn->setQueryGrammar(m::mock(\Illuminate\Database\Query\Grammars\Grammar::class));
+        $conn->setPostProcessor(m::mock(\Illuminate\Database\Query\Processors\Processor::class));
         $builder = $conn->table('users');
-        $this->assertInstanceOf('Illuminate\Database\Query\Builder', $builder);
+        $this->assertInstanceOf(\Illuminate\Database\Query\Builder::class, $builder);
         $this->assertEquals('users', $builder->from);
     }
 
@@ -342,7 +342,7 @@ class DatabaseConnectionTest extends TestCase
         $date->shouldReceive('format')->once()->with('foo')->andReturn('bar');
         $bindings = ['test' => $date];
         $conn = $this->getMockConnection();
-        $grammar = m::mock('Illuminate\Database\Query\Grammars\Grammar');
+        $grammar = m::mock(\Illuminate\Database\Query\Grammars\Grammar::class);
         $grammar->shouldReceive('getDateFormat')->once()->andReturn('foo');
         $conn->setQueryGrammar($grammar);
         $result = $conn->prepareBindings($bindings);
@@ -353,8 +353,8 @@ class DatabaseConnectionTest extends TestCase
     {
         $connection = $this->getMockConnection();
         $connection->logQuery('foo', [], time());
-        $connection->setEventDispatcher($events = m::mock('Illuminate\Contracts\Events\Dispatcher'));
-        $events->shouldReceive('dispatch')->once()->with(m::type('Illuminate\Database\Events\QueryExecuted'));
+        $connection->setEventDispatcher($events = m::mock(\Illuminate\Contracts\Events\Dispatcher::class));
+        $events->shouldReceive('dispatch')->once()->with(m::type(\Illuminate\Database\Events\QueryExecuted::class));
         $connection->logQuery('foo', [], null);
     }
 
@@ -372,7 +372,7 @@ class DatabaseConnectionTest extends TestCase
     {
         $connection = $this->getMockConnection();
         $schema = $connection->getSchemaBuilder();
-        $this->assertInstanceOf('Illuminate\Database\Schema\Builder', $schema);
+        $this->assertInstanceOf(\Illuminate\Database\Schema\Builder::class, $schema);
         $this->assertSame($connection, $schema->getConnection());
     }
 
@@ -380,7 +380,7 @@ class DatabaseConnectionTest extends TestCase
     {
         $pdo = $pdo ?: new DatabaseConnectionTestMockPDO;
         $defaults = ['getDefaultQueryGrammar', 'getDefaultPostProcessor', 'getDefaultSchemaGrammar'];
-        $connection = $this->getMockBuilder('Illuminate\Database\Connection')->setMethods(array_merge($defaults, $methods))->setConstructorArgs([$pdo])->getMock();
+        $connection = $this->getMockBuilder(\Illuminate\Database\Connection::class)->setMethods(array_merge($defaults, $methods))->setConstructorArgs([$pdo])->getMock();
         $connection->enableQueryLog();
 
         return $connection;

--- a/tests/Database/DatabaseConnectionTest.php
+++ b/tests/Database/DatabaseConnectionTest.php
@@ -16,7 +16,7 @@ class DatabaseConnectionTest extends TestCase
     public function testSettingDefaultCallsGetDefaultGrammar()
     {
         $connection = $this->getMockConnection();
-        $mock = m::mock('StdClass');
+        $mock = m::mock(\StdClass::class);
         $connection->expects($this->once())->method('getDefaultQueryGrammar')->will($this->returnValue($mock));
         $connection->useDefaultQueryGrammar();
         $this->assertEquals($mock, $connection->getQueryGrammar());
@@ -25,7 +25,7 @@ class DatabaseConnectionTest extends TestCase
     public function testSettingDefaultCallsGetDefaultPostProcessor()
     {
         $connection = $this->getMockConnection();
-        $mock = m::mock('StdClass');
+        $mock = m::mock(\StdClass::class);
         $connection->expects($this->once())->method('getDefaultPostProcessor')->will($this->returnValue($mock));
         $connection->useDefaultPostProcessor();
         $this->assertEquals($mock, $connection->getPostProcessor());

--- a/tests/Database/DatabaseConnectorTest.php
+++ b/tests/Database/DatabaseConnectorTest.php
@@ -25,7 +25,7 @@ class DatabaseConnectorTest extends TestCase
      */
     public function testMySqlConnectCallsCreateConnectionWithProperArguments($dsn, $config)
     {
-        $connector = $this->getMockBuilder('Illuminate\Database\Connectors\MySqlConnector')->setMethods(['createConnection', 'getOptions'])->getMock();
+        $connector = $this->getMockBuilder(\Illuminate\Database\Connectors\MySqlConnector::class)->setMethods(['createConnection', 'getOptions'])->getMock();
         $connection = m::mock('PDO');
         $connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->will($this->returnValue(['options']));
         $connector->expects($this->once())->method('createConnection')->with($this->equalTo($dsn), $this->equalTo($config), $this->equalTo(['options']))->will($this->returnValue($connection));
@@ -50,7 +50,7 @@ class DatabaseConnectorTest extends TestCase
     {
         $dsn = 'pgsql:host=foo;dbname=bar;port=111';
         $config = ['host' => 'foo', 'database' => 'bar', 'port' => 111, 'charset' => 'utf8'];
-        $connector = $this->getMockBuilder('Illuminate\Database\Connectors\PostgresConnector')->setMethods(['createConnection', 'getOptions'])->getMock();
+        $connector = $this->getMockBuilder(\Illuminate\Database\Connectors\PostgresConnector::class)->setMethods(['createConnection', 'getOptions'])->getMock();
         $connection = m::mock('stdClass');
         $connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->will($this->returnValue(['options']));
         $connector->expects($this->once())->method('createConnection')->with($this->equalTo($dsn), $this->equalTo($config), $this->equalTo(['options']))->will($this->returnValue($connection));
@@ -65,7 +65,7 @@ class DatabaseConnectorTest extends TestCase
     {
         $dsn = 'pgsql:host=foo;dbname=bar';
         $config = ['host' => 'foo', 'database' => 'bar', 'schema' => 'public', 'charset' => 'utf8'];
-        $connector = $this->getMockBuilder('Illuminate\Database\Connectors\PostgresConnector')->setMethods(['createConnection', 'getOptions'])->getMock();
+        $connector = $this->getMockBuilder(\Illuminate\Database\Connectors\PostgresConnector::class)->setMethods(['createConnection', 'getOptions'])->getMock();
         $connection = m::mock('stdClass');
         $connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->will($this->returnValue(['options']));
         $connector->expects($this->once())->method('createConnection')->with($this->equalTo($dsn), $this->equalTo($config), $this->equalTo(['options']))->will($this->returnValue($connection));
@@ -81,7 +81,7 @@ class DatabaseConnectorTest extends TestCase
     {
         $dsn = 'pgsql:host=foo;dbname=bar';
         $config = ['host' => 'foo', 'database' => 'bar', 'schema' => ['public', 'user'], 'charset' => 'utf8'];
-        $connector = $this->getMockBuilder('Illuminate\Database\Connectors\PostgresConnector')->setMethods(['createConnection', 'getOptions'])->getMock();
+        $connector = $this->getMockBuilder(\Illuminate\Database\Connectors\PostgresConnector::class)->setMethods(['createConnection', 'getOptions'])->getMock();
         $connection = m::mock('stdClass');
         $connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->will($this->returnValue(['options']));
         $connector->expects($this->once())->method('createConnection')->with($this->equalTo($dsn), $this->equalTo($config), $this->equalTo(['options']))->will($this->returnValue($connection));
@@ -97,7 +97,7 @@ class DatabaseConnectorTest extends TestCase
     {
         $dsn = 'pgsql:host=foo;dbname=bar';
         $config = ['host' => 'foo', 'database' => 'bar', 'charset' => 'utf8', 'application_name' => 'Larvel App'];
-        $connector = $this->getMockBuilder('Illuminate\Database\Connectors\PostgresConnector')->setMethods(['createConnection', 'getOptions'])->getMock();
+        $connector = $this->getMockBuilder(\Illuminate\Database\Connectors\PostgresConnector::class)->setMethods(['createConnection', 'getOptions'])->getMock();
         $connection = m::mock('stdClass');
         $connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->will($this->returnValue(['options']));
         $connector->expects($this->once())->method('createConnection')->with($this->equalTo($dsn), $this->equalTo($config), $this->equalTo(['options']))->will($this->returnValue($connection));
@@ -113,7 +113,7 @@ class DatabaseConnectorTest extends TestCase
     {
         $dsn = 'sqlite::memory:';
         $config = ['database' => ':memory:'];
-        $connector = $this->getMockBuilder('Illuminate\Database\Connectors\SQLiteConnector')->setMethods(['createConnection', 'getOptions'])->getMock();
+        $connector = $this->getMockBuilder(\Illuminate\Database\Connectors\SQLiteConnector::class)->setMethods(['createConnection', 'getOptions'])->getMock();
         $connection = m::mock('stdClass');
         $connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->will($this->returnValue(['options']));
         $connector->expects($this->once())->method('createConnection')->with($this->equalTo($dsn), $this->equalTo($config), $this->equalTo(['options']))->will($this->returnValue($connection));
@@ -126,7 +126,7 @@ class DatabaseConnectorTest extends TestCase
     {
         $dsn = 'sqlite:'.__DIR__;
         $config = ['database' => __DIR__];
-        $connector = $this->getMockBuilder('Illuminate\Database\Connectors\SQLiteConnector')->setMethods(['createConnection', 'getOptions'])->getMock();
+        $connector = $this->getMockBuilder(\Illuminate\Database\Connectors\SQLiteConnector::class)->setMethods(['createConnection', 'getOptions'])->getMock();
         $connection = m::mock('stdClass');
         $connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->will($this->returnValue(['options']));
         $connector->expects($this->once())->method('createConnection')->with($this->equalTo($dsn), $this->equalTo($config), $this->equalTo(['options']))->will($this->returnValue($connection));
@@ -139,7 +139,7 @@ class DatabaseConnectorTest extends TestCase
     {
         $config = ['host' => 'foo', 'database' => 'bar', 'port' => 111];
         $dsn = $this->getDsn($config);
-        $connector = $this->getMockBuilder('Illuminate\Database\Connectors\SqlServerConnector')->setMethods(['createConnection', 'getOptions'])->getMock();
+        $connector = $this->getMockBuilder(\Illuminate\Database\Connectors\SqlServerConnector::class)->setMethods(['createConnection', 'getOptions'])->getMock();
         $connection = m::mock('stdClass');
         $connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->will($this->returnValue(['options']));
         $connector->expects($this->once())->method('createConnection')->with($this->equalTo($dsn), $this->equalTo($config), $this->equalTo(['options']))->will($this->returnValue($connection));
@@ -152,7 +152,7 @@ class DatabaseConnectorTest extends TestCase
     {
         $config = ['host' => 'foo', 'database' => 'bar', 'port' => 111, 'readonly' => true, 'charset' => 'utf-8', 'pooling' => false, 'appname' => 'baz'];
         $dsn = $this->getDsn($config);
-        $connector = $this->getMockBuilder('Illuminate\Database\Connectors\SqlServerConnector')->setMethods(['createConnection', 'getOptions'])->getMock();
+        $connector = $this->getMockBuilder(\Illuminate\Database\Connectors\SqlServerConnector::class)->setMethods(['createConnection', 'getOptions'])->getMock();
         $connection = m::mock('stdClass');
         $connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->will($this->returnValue(['options']));
         $connector->expects($this->once())->method('createConnection')->with($this->equalTo($dsn), $this->equalTo($config), $this->equalTo(['options']))->will($this->returnValue($connection));

--- a/tests/Database/DatabaseConnectorTest.php
+++ b/tests/Database/DatabaseConnectorTest.php
@@ -51,7 +51,7 @@ class DatabaseConnectorTest extends TestCase
         $dsn = 'pgsql:host=foo;dbname=bar;port=111';
         $config = ['host' => 'foo', 'database' => 'bar', 'port' => 111, 'charset' => 'utf8'];
         $connector = $this->getMockBuilder(\Illuminate\Database\Connectors\PostgresConnector::class)->setMethods(['createConnection', 'getOptions'])->getMock();
-        $connection = m::mock('stdClass');
+        $connection = m::mock(\StdClass::class);
         $connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->will($this->returnValue(['options']));
         $connector->expects($this->once())->method('createConnection')->with($this->equalTo($dsn), $this->equalTo($config), $this->equalTo(['options']))->will($this->returnValue($connection));
         $connection->shouldReceive('prepare')->once()->with('set names \'utf8\'')->andReturn($connection);
@@ -66,7 +66,7 @@ class DatabaseConnectorTest extends TestCase
         $dsn = 'pgsql:host=foo;dbname=bar';
         $config = ['host' => 'foo', 'database' => 'bar', 'schema' => 'public', 'charset' => 'utf8'];
         $connector = $this->getMockBuilder(\Illuminate\Database\Connectors\PostgresConnector::class)->setMethods(['createConnection', 'getOptions'])->getMock();
-        $connection = m::mock('stdClass');
+        $connection = m::mock(\StdClass::class);
         $connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->will($this->returnValue(['options']));
         $connector->expects($this->once())->method('createConnection')->with($this->equalTo($dsn), $this->equalTo($config), $this->equalTo(['options']))->will($this->returnValue($connection));
         $connection->shouldReceive('prepare')->once()->with('set names \'utf8\'')->andReturn($connection);
@@ -82,7 +82,7 @@ class DatabaseConnectorTest extends TestCase
         $dsn = 'pgsql:host=foo;dbname=bar';
         $config = ['host' => 'foo', 'database' => 'bar', 'schema' => ['public', 'user'], 'charset' => 'utf8'];
         $connector = $this->getMockBuilder(\Illuminate\Database\Connectors\PostgresConnector::class)->setMethods(['createConnection', 'getOptions'])->getMock();
-        $connection = m::mock('stdClass');
+        $connection = m::mock(\StdClass::class);
         $connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->will($this->returnValue(['options']));
         $connector->expects($this->once())->method('createConnection')->with($this->equalTo($dsn), $this->equalTo($config), $this->equalTo(['options']))->will($this->returnValue($connection));
         $connection->shouldReceive('prepare')->once()->with('set names \'utf8\'')->andReturn($connection);
@@ -98,7 +98,7 @@ class DatabaseConnectorTest extends TestCase
         $dsn = 'pgsql:host=foo;dbname=bar';
         $config = ['host' => 'foo', 'database' => 'bar', 'charset' => 'utf8', 'application_name' => 'Larvel App'];
         $connector = $this->getMockBuilder(\Illuminate\Database\Connectors\PostgresConnector::class)->setMethods(['createConnection', 'getOptions'])->getMock();
-        $connection = m::mock('stdClass');
+        $connection = m::mock(\StdClass::class);
         $connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->will($this->returnValue(['options']));
         $connector->expects($this->once())->method('createConnection')->with($this->equalTo($dsn), $this->equalTo($config), $this->equalTo(['options']))->will($this->returnValue($connection));
         $connection->shouldReceive('prepare')->once()->with('set names \'utf8\'')->andReturn($connection);
@@ -114,7 +114,7 @@ class DatabaseConnectorTest extends TestCase
         $dsn = 'sqlite::memory:';
         $config = ['database' => ':memory:'];
         $connector = $this->getMockBuilder(\Illuminate\Database\Connectors\SQLiteConnector::class)->setMethods(['createConnection', 'getOptions'])->getMock();
-        $connection = m::mock('stdClass');
+        $connection = m::mock(\StdClass::class);
         $connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->will($this->returnValue(['options']));
         $connector->expects($this->once())->method('createConnection')->with($this->equalTo($dsn), $this->equalTo($config), $this->equalTo(['options']))->will($this->returnValue($connection));
         $result = $connector->connect($config);
@@ -127,7 +127,7 @@ class DatabaseConnectorTest extends TestCase
         $dsn = 'sqlite:'.__DIR__;
         $config = ['database' => __DIR__];
         $connector = $this->getMockBuilder(\Illuminate\Database\Connectors\SQLiteConnector::class)->setMethods(['createConnection', 'getOptions'])->getMock();
-        $connection = m::mock('stdClass');
+        $connection = m::mock(\StdClass::class);
         $connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->will($this->returnValue(['options']));
         $connector->expects($this->once())->method('createConnection')->with($this->equalTo($dsn), $this->equalTo($config), $this->equalTo(['options']))->will($this->returnValue($connection));
         $result = $connector->connect($config);
@@ -140,7 +140,7 @@ class DatabaseConnectorTest extends TestCase
         $config = ['host' => 'foo', 'database' => 'bar', 'port' => 111];
         $dsn = $this->getDsn($config);
         $connector = $this->getMockBuilder(\Illuminate\Database\Connectors\SqlServerConnector::class)->setMethods(['createConnection', 'getOptions'])->getMock();
-        $connection = m::mock('stdClass');
+        $connection = m::mock(\StdClass::class);
         $connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->will($this->returnValue(['options']));
         $connector->expects($this->once())->method('createConnection')->with($this->equalTo($dsn), $this->equalTo($config), $this->equalTo(['options']))->will($this->returnValue($connection));
         $result = $connector->connect($config);
@@ -153,7 +153,7 @@ class DatabaseConnectorTest extends TestCase
         $config = ['host' => 'foo', 'database' => 'bar', 'port' => 111, 'readonly' => true, 'charset' => 'utf-8', 'pooling' => false, 'appname' => 'baz'];
         $dsn = $this->getDsn($config);
         $connector = $this->getMockBuilder(\Illuminate\Database\Connectors\SqlServerConnector::class)->setMethods(['createConnection', 'getOptions'])->getMock();
-        $connection = m::mock('stdClass');
+        $connection = m::mock(\StdClass::class);
         $connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->will($this->returnValue(['options']));
         $connector->expects($this->once())->method('createConnection')->with($this->equalTo($dsn), $this->equalTo($config), $this->equalTo(['options']))->will($this->returnValue($connection));
         $result = $connector->connect($config);

--- a/tests/Database/DatabaseEloquentBelongsToManyTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyTest.php
@@ -146,10 +146,10 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
     public function testAttachInsertsPivotTableRecord()
     {
         $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\BelongsToMany::class)->setMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
-        $query = m::mock('stdClass');
+        $query = m::mock(\StdClass::class);
         $query->shouldReceive('from')->once()->with('user_role')->andReturn($query);
         $query->shouldReceive('insert')->once()->with([['user_id' => 1, 'role_id' => 2, 'foo' => 'bar']])->andReturn(true);
-        $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock('StdClass'));
+        $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock(\StdClass::class));
         $mockQueryBuilder->shouldReceive('newQuery')->once()->andReturn($query);
         $relation->expects($this->once())->method('touchIfTouching');
 
@@ -159,7 +159,7 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
     public function testAttachMultipleInsertsPivotTableRecord()
     {
         $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\BelongsToMany::class)->setMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
-        $query = m::mock('stdClass');
+        $query = m::mock(\StdClass::class);
         $query->shouldReceive('from')->once()->with('user_role')->andReturn($query);
         $query->shouldReceive('insert')->once()->with(
             [
@@ -167,7 +167,7 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
                 ['user_id' => 1, 'role_id' => 3, 'baz' => 'boom', 'foo' => 'bar'],
             ]
         )->andReturn(true);
-        $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock('StdClass'));
+        $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock(\StdClass::class));
         $mockQueryBuilder->shouldReceive('newQuery')->once()->andReturn($query);
         $relation->expects($this->once())->method('touchIfTouching');
 
@@ -177,7 +177,7 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
     public function testAttachMethodConvertsCollectionToArrayOfKeys()
     {
         $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\BelongsToMany::class)->setMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
-        $query = m::mock('stdClass');
+        $query = m::mock(\StdClass::class);
         $query->shouldReceive('from')->once()->with('user_role')->andReturn($query);
         $query->shouldReceive('insert')->once()->with(
             [
@@ -186,7 +186,7 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
                 ['user_id' => 1, 'role_id' => 3],
             ]
         )->andReturn(true);
-        $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock('StdClass'));
+        $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock(\StdClass::class));
         $mockQueryBuilder->shouldReceive('newQuery')->once()->andReturn($query);
         $relation->expects($this->once())->method('touchIfTouching');
 
@@ -203,10 +203,10 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
     {
         $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\BelongsToMany::class)->setMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
         $relation->withTimestamps();
-        $query = m::mock('stdClass');
+        $query = m::mock(\StdClass::class);
         $query->shouldReceive('from')->once()->with('user_role')->andReturn($query);
         $query->shouldReceive('insert')->once()->with([['user_id' => 1, 'role_id' => 2, 'foo' => 'bar', 'created_at' => 'time', 'updated_at' => 'time']])->andReturn(true);
-        $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock('StdClass'));
+        $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock(\StdClass::class));
         $mockQueryBuilder->shouldReceive('newQuery')->once()->andReturn($query);
         $relation->getParent()->shouldReceive('freshTimestamp')->once()->andReturn('time');
         $relation->expects($this->once())->method('touchIfTouching');
@@ -218,10 +218,10 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
     {
         $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\BelongsToMany::class)->setMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
         $relation->withTimestamps('custom_created_at', 'custom_updated_at');
-        $query = m::mock('stdClass');
+        $query = m::mock(\StdClass::class);
         $query->shouldReceive('from')->once()->with('user_role')->andReturn($query);
         $query->shouldReceive('insert')->once()->with([['user_id' => 1, 'role_id' => 2, 'foo' => 'bar', 'custom_created_at' => 'time', 'custom_updated_at' => 'time']])->andReturn(true);
-        $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock('StdClass'));
+        $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock(\StdClass::class));
         $mockQueryBuilder->shouldReceive('newQuery')->once()->andReturn($query);
         $relation->getParent()->shouldReceive('freshTimestamp')->once()->andReturn('time');
         $relation->expects($this->once())->method('touchIfTouching');
@@ -233,10 +233,10 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
     {
         $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\BelongsToMany::class)->setMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
         $relation->withPivot('created_at');
-        $query = m::mock('stdClass');
+        $query = m::mock(\StdClass::class);
         $query->shouldReceive('from')->once()->with('user_role')->andReturn($query);
         $query->shouldReceive('insert')->once()->with([['user_id' => 1, 'role_id' => 2, 'foo' => 'bar', 'created_at' => 'time']])->andReturn(true);
-        $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock('StdClass'));
+        $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock(\StdClass::class));
         $mockQueryBuilder->shouldReceive('newQuery')->once()->andReturn($query);
         $relation->getParent()->shouldReceive('freshTimestamp')->once()->andReturn('time');
         $relation->expects($this->once())->method('touchIfTouching');
@@ -248,10 +248,10 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
     {
         $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\BelongsToMany::class)->setMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
         $relation->withPivot('updated_at');
-        $query = m::mock('stdClass');
+        $query = m::mock(\StdClass::class);
         $query->shouldReceive('from')->once()->with('user_role')->andReturn($query);
         $query->shouldReceive('insert')->once()->with([['user_id' => 1, 'role_id' => 2, 'foo' => 'bar', 'updated_at' => 'time']])->andReturn(true);
-        $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock('StdClass'));
+        $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock(\StdClass::class));
         $mockQueryBuilder->shouldReceive('newQuery')->once()->andReturn($query);
         $relation->getParent()->shouldReceive('freshTimestamp')->once()->andReturn('time');
         $relation->expects($this->once())->method('touchIfTouching');
@@ -262,12 +262,12 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
     public function testDetachRemovesPivotTableRecord()
     {
         $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\BelongsToMany::class)->setMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
-        $query = m::mock('stdClass');
+        $query = m::mock(\StdClass::class);
         $query->shouldReceive('from')->once()->with('user_role')->andReturn($query);
         $query->shouldReceive('where')->once()->with('user_id', 1)->andReturn($query);
         $query->shouldReceive('whereIn')->once()->with('role_id', [1, 2, 3]);
         $query->shouldReceive('delete')->once()->andReturn(true);
-        $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock('StdClass'));
+        $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock(\StdClass::class));
         $mockQueryBuilder->shouldReceive('newQuery')->once()->andReturn($query);
         $relation->expects($this->once())->method('touchIfTouching');
 
@@ -277,12 +277,12 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
     public function testDetachWithSingleIDRemovesPivotTableRecord()
     {
         $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\BelongsToMany::class)->setMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
-        $query = m::mock('stdClass');
+        $query = m::mock(\StdClass::class);
         $query->shouldReceive('from')->once()->with('user_role')->andReturn($query);
         $query->shouldReceive('where')->once()->with('user_id', 1)->andReturn($query);
         $query->shouldReceive('whereIn')->once()->with('role_id', [1]);
         $query->shouldReceive('delete')->once()->andReturn(true);
-        $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock('StdClass'));
+        $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock(\StdClass::class));
         $mockQueryBuilder->shouldReceive('newQuery')->once()->andReturn($query);
         $relation->expects($this->once())->method('touchIfTouching');
 
@@ -292,12 +292,12 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
     public function testDetachMethodConvertsCollectionToArrayOfKeys()
     {
         $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\BelongsToMany::class)->setMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
-        $query = m::mock('stdClass');
+        $query = m::mock(\StdClass::class);
         $query->shouldReceive('from')->once()->with('user_role')->andReturn($query);
         $query->shouldReceive('where')->once()->with('user_id', 1)->andReturn($query);
         $query->shouldReceive('whereIn')->once()->with('role_id', [1, 2, 3]);
         $query->shouldReceive('delete')->once()->andReturn(true);
-        $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock('StdClass'));
+        $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock(\StdClass::class));
         $mockQueryBuilder->shouldReceive('newQuery')->once()->andReturn($query);
         $relation->expects($this->once())->method('touchIfTouching');
 
@@ -313,12 +313,12 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
     public function testDetachMethodClearsAllPivotRecordsWhenNoIDsAreGiven()
     {
         $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\BelongsToMany::class)->setMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
-        $query = m::mock('stdClass');
+        $query = m::mock(\StdClass::class);
         $query->shouldReceive('from')->once()->with('user_role')->andReturn($query);
         $query->shouldReceive('where')->once()->with('user_id', 1)->andReturn($query);
         $query->shouldReceive('whereIn')->never();
         $query->shouldReceive('delete')->once()->andReturn(true);
-        $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock('StdClass'));
+        $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock(\StdClass::class));
         $mockQueryBuilder->shouldReceive('newQuery')->once()->andReturn($query);
         $relation->expects($this->once())->method('touchIfTouching');
 
@@ -364,7 +364,7 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
     public function testCreateMethodCreatesNewModelAndInsertsAttachmentRecord()
     {
         $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\BelongsToMany::class)->setMethods(['attach'])->setConstructorArgs($this->getRelationArguments())->getMock();
-        $relation->getRelated()->shouldReceive('newInstance')->once()->andReturn($model = m::mock('StdClass'))->with(['attributes']);
+        $relation->getRelated()->shouldReceive('newInstance')->once()->andReturn($model = m::mock(\StdClass::class))->with(['attributes']);
         $model->shouldReceive('save')->once();
         $model->shouldReceive('getKey')->andReturn('foo');
         $relation->expects($this->once())->method('attach')->with('foo', ['joining']);
@@ -409,7 +409,7 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
     public function testFindOrNewMethodFindsModel()
     {
         $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\BelongsToMany::class)->setMethods(['find'])->setConstructorArgs($this->getRelationArguments())->getMock();
-        $relation->expects($this->once())->method('find')->with('foo')->will($this->returnValue($model = m::mock('StdClass')));
+        $relation->expects($this->once())->method('find')->with('foo')->will($this->returnValue($model = m::mock(\StdClass::class)));
         $relation->getRelated()->shouldReceive('newInstance')->never();
 
         $this->assertInstanceOf(StdClass::class, $relation->findOrNew('foo'));
@@ -419,7 +419,7 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
     {
         $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\BelongsToMany::class)->setMethods(['find'])->setConstructorArgs($this->getRelationArguments())->getMock();
         $relation->expects($this->once())->method('find')->with('foo')->will($this->returnValue(null));
-        $relation->getRelated()->shouldReceive('newInstance')->once()->andReturn($model = m::mock('StdClass'));
+        $relation->getRelated()->shouldReceive('newInstance')->once()->andReturn($model = m::mock(\StdClass::class));
 
         $this->assertInstanceOf(StdClass::class, $relation->findOrNew('foo'));
     }
@@ -428,7 +428,7 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
     {
         $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\BelongsToMany::class)->setMethods(['where'])->setConstructorArgs($this->getRelationArguments())->getMock();
         $relation->expects($this->once())->method('where')->with(['foo'])->will($this->returnValue($relation->getQuery()));
-        $relation->getQuery()->shouldReceive('first')->once()->andReturn($model = m::mock('StdClass'));
+        $relation->getQuery()->shouldReceive('first')->once()->andReturn($model = m::mock(\StdClass::class));
         $relation->getRelated()->shouldReceive('newInstance')->never();
 
         $this->assertInstanceOf(StdClass::class, $relation->firstOrNew(['foo']));
@@ -439,7 +439,7 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
         $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\BelongsToMany::class)->setMethods(['where'])->setConstructorArgs($this->getRelationArguments())->getMock();
         $relation->expects($this->once())->method('where')->with(['foo'])->will($this->returnValue($relation->getQuery()));
         $relation->getQuery()->shouldReceive('first')->once()->andReturn(null);
-        $relation->getRelated()->shouldReceive('newInstance')->once()->andReturn($model = m::mock('StdClass'));
+        $relation->getRelated()->shouldReceive('newInstance')->once()->andReturn($model = m::mock(\StdClass::class));
 
         $this->assertInstanceOf(StdClass::class, $relation->firstOrNew(['foo']));
     }
@@ -448,7 +448,7 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
     {
         $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\BelongsToMany::class)->setMethods(['where', 'create'])->setConstructorArgs($this->getRelationArguments())->getMock();
         $relation->expects($this->once())->method('where')->with(['foo'])->will($this->returnValue($relation->getQuery()));
-        $relation->getQuery()->shouldReceive('first')->once()->andReturn($model = m::mock('StdClass'));
+        $relation->getQuery()->shouldReceive('first')->once()->andReturn($model = m::mock(\StdClass::class));
         $relation->expects($this->never())->method('create')->with(['foo'])->will($this->returnValue(null));
 
         $this->assertInstanceOf(StdClass::class, $relation->firstOrCreate(['foo']));
@@ -459,7 +459,7 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
         $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\BelongsToMany::class)->setMethods(['where', 'create'])->setConstructorArgs($this->getRelationArguments())->getMock();
         $relation->expects($this->once())->method('where')->with(['foo'])->will($this->returnValue($relation->getQuery()));
         $relation->getQuery()->shouldReceive('first')->once()->andReturn(null);
-        $relation->expects($this->once())->method('create')->with(['foo'])->will($this->returnValue($model = m::mock('StdClass')));
+        $relation->expects($this->once())->method('create')->with(['foo'])->will($this->returnValue($model = m::mock(\StdClass::class)));
 
         $this->assertInstanceOf(StdClass::class, $relation->firstOrCreate(['foo']));
     }
@@ -468,7 +468,7 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
     {
         $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\BelongsToMany::class)->setMethods(['where', 'create'])->setConstructorArgs($this->getRelationArguments())->getMock();
         $relation->expects($this->once())->method('where')->with(['foo'])->will($this->returnValue($relation->getQuery()));
-        $relation->getQuery()->shouldReceive('first')->once()->andReturn($model = m::mock('StdClass'));
+        $relation->getQuery()->shouldReceive('first')->once()->andReturn($model = m::mock(\StdClass::class));
         $model->shouldReceive('fill')->once();
         $model->shouldReceive('save')->once();
         $relation->expects($this->never())->method('create')->with(['foo'])->will($this->returnValue(null));
@@ -481,7 +481,7 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
         $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\BelongsToMany::class)->setMethods(['where', 'create'])->setConstructorArgs($this->getRelationArguments())->getMock();
         $relation->expects($this->once())->method('where')->with(['bar'])->will($this->returnValue($relation->getQuery()));
         $relation->getQuery()->shouldReceive('first')->once()->andReturn(null);
-        $relation->expects($this->once())->method('create')->with(['foo'])->will($this->returnValue($model = m::mock('StdClass')));
+        $relation->expects($this->once())->method('create')->with(['foo'])->will($this->returnValue($model = m::mock(\StdClass::class)));
 
         $this->assertInstanceOf(StdClass::class, $relation->updateOrCreate(['bar'], ['foo']));
     }
@@ -492,10 +492,10 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
     public function testSyncMethodSyncsIntermediateTableWithGivenArray($list)
     {
         $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\BelongsToMany::class)->setMethods(['attach', 'detach'])->setConstructorArgs($this->getRelationArguments())->getMock();
-        $query = m::mock('stdClass');
+        $query = m::mock(\StdClass::class);
         $query->shouldReceive('from')->once()->with('user_role')->andReturn($query);
         $query->shouldReceive('where')->once()->with('user_id', 1)->andReturn($query);
-        $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock('StdClass'));
+        $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock(\StdClass::class));
         $mockQueryBuilder->shouldReceive('newQuery')->once()->andReturn($query);
         $query->shouldReceive('pluck')->once()->with('role_id')->andReturn(new BaseCollection([1, 2, 3]));
         $relation->expects($this->once())->method('attach')->with($this->equalTo('x'), $this->equalTo([]), $this->equalTo(false));
@@ -517,10 +517,10 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
     public function testSyncMethodSyncsIntermediateTableWithGivenArrayAndAttributes()
     {
         $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\BelongsToMany::class)->setMethods(['attach', 'detach', 'touchIfTouching', 'updateExistingPivot'])->setConstructorArgs($this->getRelationArguments())->getMock();
-        $query = m::mock('stdClass');
+        $query = m::mock(\StdClass::class);
         $query->shouldReceive('from')->once()->with('user_role')->andReturn($query);
         $query->shouldReceive('where')->once()->with('user_id', 1)->andReturn($query);
-        $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock('StdClass'));
+        $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock(\StdClass::class));
         $mockQueryBuilder->shouldReceive('newQuery')->once()->andReturn($query);
         $query->shouldReceive('pluck')->once()->with('role_id')->andReturn(new BaseCollection([1, 2, 3]));
         $relation->expects($this->once())->method('attach')->with($this->equalTo(4), $this->equalTo(['foo' => 'bar']), $this->equalTo(false));
@@ -534,10 +534,10 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
     public function testSyncMethodDoesntReturnValuesThatWereNotUpdated()
     {
         $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\BelongsToMany::class)->setMethods(['attach', 'detach', 'touchIfTouching', 'updateExistingPivot'])->setConstructorArgs($this->getRelationArguments())->getMock();
-        $query = m::mock('stdClass');
+        $query = m::mock(\StdClass::class);
         $query->shouldReceive('from')->once()->with('user_role')->andReturn($query);
         $query->shouldReceive('where')->once()->with('user_id', 1)->andReturn($query);
-        $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock('StdClass'));
+        $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock(\StdClass::class));
         $mockQueryBuilder->shouldReceive('newQuery')->once()->andReturn($query);
         $query->shouldReceive('pluck')->once()->with('role_id')->andReturn(new BaseCollection([1, 2, 3]));
         $relation->expects($this->once())->method('attach')->with($this->equalTo(4), $this->equalTo(['foo' => 'bar']), $this->equalTo(false));
@@ -556,7 +556,7 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
         $relation->getRelated()->shouldReceive('getQualifiedKeyName')->andReturn('table.id');
         $relation->getQuery()->shouldReceive('select')->once()->with('table.id')->andReturn($relation->getQuery());
         $relation->getQuery()->shouldReceive('pluck')->once()->with('id')->andReturn([1, 2, 3]);
-        $relation->getRelated()->shouldReceive('newQuery')->once()->andReturn($query = m::mock('StdClass'));
+        $relation->getRelated()->shouldReceive('newQuery')->once()->andReturn($query = m::mock(\StdClass::class));
         $query->shouldReceive('whereIn')->once()->with('id', [1, 2, 3])->andReturn($query);
         $query->shouldReceive('update')->once()->with(['updated_at' => '100']);
 
@@ -569,10 +569,10 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
     public function testToggleMethodTogglesIntermediateTableWithGivenArray($list)
     {
         $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\BelongsToMany::class)->setMethods(['attach', 'detach'])->setConstructorArgs($this->getRelationArguments())->getMock();
-        $query = m::mock('stdClass');
+        $query = m::mock(\StdClass::class);
         $query->shouldReceive('from')->once()->with('user_role')->andReturn($query);
         $query->shouldReceive('where')->once()->with('user_id', 1)->andReturn($query);
-        $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock('StdClass'));
+        $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock(\StdClass::class));
         $mockQueryBuilder->shouldReceive('newQuery')->once()->andReturn($query);
         $query->shouldReceive('pluck')->once()->with('role_id')->andReturn(new BaseCollection([1, 2, 3]));
         $relation->expects($this->once())->method('attach')->with($this->equalTo(['x' => []]), $this->equalTo([]), $this->equalTo(false));
@@ -594,10 +594,10 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
     public function testToggleMethodCanLeaveRelatedTimestampsIntact()
     {
         $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\BelongsToMany::class)->setMethods(['attach', 'detach'])->setConstructorArgs($this->getRelationArguments())->getMock();
-        $query = m::mock('stdClass');
+        $query = m::mock(\StdClass::class);
         $query->shouldReceive('from')->once()->with('user_role')->andReturn($query);
         $query->shouldReceive('where')->once()->with('user_id', 1)->andReturn($query);
-        $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock('StdClass'));
+        $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock(\StdClass::class));
         $mockQueryBuilder->shouldReceive('newQuery')->once()->andReturn($query);
         $query->shouldReceive('pluck')->once()->with('role_id')->andReturn(new BaseCollection([1, 2, 3]));
         $relation->expects($this->once())->method('attach')->with($this->equalTo(['x' => []]), $this->equalTo([]), $this->equalTo(false));
@@ -611,10 +611,10 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
     public function testToggleMethodTogglesIntermediateTableWithGivenArrayAndAttributes()
     {
         $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\BelongsToMany::class)->setMethods(['attach', 'detach', 'touchIfTouching', 'updateExistingPivot'])->setConstructorArgs($this->getRelationArguments())->getMock();
-        $query = m::mock('stdClass');
+        $query = m::mock(\StdClass::class);
         $query->shouldReceive('from')->once()->with('user_role')->andReturn($query);
         $query->shouldReceive('where')->once()->with('user_id', 1)->andReturn($query);
-        $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock('StdClass'));
+        $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock(\StdClass::class));
         $mockQueryBuilder->shouldReceive('newQuery')->once()->andReturn($query);
         $query->shouldReceive('pluck')->once()->with('role_id')->andReturn(new BaseCollection([1, 2, 3]));
         $relation->expects($this->once())->method('attach')->with($this->equalTo([4 => ['foo' => 'bar']]), [], $this->equalTo(false));
@@ -638,10 +638,10 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
     public function testSyncMethodConvertsEloquentCollectionToArrayOfKeys()
     {
         $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\BelongsToMany::class)->setMethods(['attach', 'detach', 'touchIfTouching', 'formatRecordsList'])->setConstructorArgs($this->getRelationArguments())->getMock();
-        $query = m::mock('stdClass');
+        $query = m::mock(\StdClass::class);
         $query->shouldReceive('from')->once()->with('user_role')->andReturn($query);
         $query->shouldReceive('where')->once()->with('user_id', 1)->andReturn($query);
-        $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock('StdClass'));
+        $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock(\StdClass::class));
         $mockQueryBuilder->shouldReceive('newQuery')->once()->andReturn($query);
         $query->shouldReceive('pluck')->once()->with('role_id')->andReturn(new BaseCollection([1, 2, 3]));
 
@@ -657,10 +657,10 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
     public function testSyncMethodConvertsBaseCollectionToArrayOfKeys()
     {
         $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\BelongsToMany::class)->setMethods(['attach', 'detach', 'touchIfTouching', 'formatRecordsList'])->setConstructorArgs($this->getRelationArguments())->getMock();
-        $query = m::mock('stdClass');
+        $query = m::mock(\StdClass::class);
         $query->shouldReceive('from')->once()->with('user_role')->andReturn($query);
         $query->shouldReceive('where')->once()->with('user_id', 1)->andReturn($query);
-        $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock('StdClass'));
+        $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock(\StdClass::class));
         $mockQueryBuilder->shouldReceive('newQuery')->once()->andReturn($query);
         $query->shouldReceive('pluck')->once()->with('role_id')->andReturn(new BaseCollection([1, 2, 3]));
 
@@ -677,8 +677,8 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
         $relation->getQuery()->shouldReceive('where')->once()->andReturn($relation);
 
         // Our sync() call will produce a new query
-        $mockQueryBuilder = m::mock('stdClass');
-        $query = m::mock('stdClass');
+        $mockQueryBuilder = m::mock(\StdClass::class);
+        $query = m::mock(\StdClass::class);
         $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder);
         $mockQueryBuilder->shouldReceive('newQuery')->once()->andReturn($query);
 

--- a/tests/Database/DatabaseEloquentBelongsToManyTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyTest.php
@@ -27,7 +27,7 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
         $model2->fill(['name' => 'dayle', 'pivot_user_id' => 3, 'pivot_role_id' => 4]);
         $models = [$model1, $model2];
 
-        $baseBuilder = m::mock('Illuminate\Database\Query\Builder');
+        $baseBuilder = m::mock(\Illuminate\Database\Query\Builder::class);
 
         $relation = $this->getRelation();
         $relation->getParent()->shouldReceive('getConnectionName')->andReturn('foo.connection');
@@ -41,7 +41,7 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
         $relation->getQuery()->shouldReceive('getQuery')->once()->andReturn($baseBuilder);
         $results = $relation->get();
 
-        $this->assertInstanceOf('Illuminate\Database\Eloquent\Collection', $results);
+        $this->assertInstanceOf(\Illuminate\Database\Eloquent\Collection::class, $results);
 
         // Make sure the foreign keys were set on the pivot models...
         $this->assertEquals('user_id', $results[0]->pivot->getForeignKey());
@@ -67,7 +67,7 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
         $model2->fill(['name' => 'dayle', 'pivot_user_id' => 3, 'pivot_role_id' => 4]);
         $models = [$model1, $model2];
 
-        $baseBuilder = m::mock('Illuminate\Database\Query\Builder');
+        $baseBuilder = m::mock(\Illuminate\Database\Query\Builder::class);
 
         $relation = $this->getRelation()->withTimestamps();
         $relation->getParent()->shouldReceive('getConnectionName')->andReturn('foo.connection');
@@ -125,8 +125,8 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
         $relation->getRelated()->shouldReceive('newCollection')->andReturnUsing(function ($array = []) {
             return new Collection($array);
         });
-        $model = m::mock('Illuminate\Database\Eloquent\Model');
-        $model->shouldReceive('setRelation')->once()->with('foo', m::type('Illuminate\Database\Eloquent\Collection'));
+        $model = m::mock(\Illuminate\Database\Eloquent\Model::class);
+        $model->shouldReceive('setRelation')->once()->with('foo', m::type(\Illuminate\Database\Eloquent\Collection::class));
         $models = $relation->initRelation([$model], 'foo');
 
         $this->assertEquals([$model], $models);
@@ -145,7 +145,7 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
 
     public function testAttachInsertsPivotTableRecord()
     {
-        $relation = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\BelongsToMany')->setMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
+        $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\BelongsToMany::class)->setMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
         $query = m::mock('stdClass');
         $query->shouldReceive('from')->once()->with('user_role')->andReturn($query);
         $query->shouldReceive('insert')->once()->with([['user_id' => 1, 'role_id' => 2, 'foo' => 'bar']])->andReturn(true);
@@ -158,7 +158,7 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
 
     public function testAttachMultipleInsertsPivotTableRecord()
     {
-        $relation = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\BelongsToMany')->setMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
+        $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\BelongsToMany::class)->setMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
         $query = m::mock('stdClass');
         $query->shouldReceive('from')->once()->with('user_role')->andReturn($query);
         $query->shouldReceive('insert')->once()->with(
@@ -176,7 +176,7 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
 
     public function testAttachMethodConvertsCollectionToArrayOfKeys()
     {
-        $relation = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\BelongsToMany')->setMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
+        $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\BelongsToMany::class)->setMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
         $query = m::mock('stdClass');
         $query->shouldReceive('from')->once()->with('user_role')->andReturn($query);
         $query->shouldReceive('insert')->once()->with(
@@ -201,7 +201,7 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
 
     public function testAttachInsertsPivotTableRecordWithTimestampsWhenNecessary()
     {
-        $relation = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\BelongsToMany')->setMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
+        $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\BelongsToMany::class)->setMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
         $relation->withTimestamps();
         $query = m::mock('stdClass');
         $query->shouldReceive('from')->once()->with('user_role')->andReturn($query);
@@ -216,7 +216,7 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
 
     public function testAttachInsertsPivotTableRecordWithCustomTimestampColumns()
     {
-        $relation = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\BelongsToMany')->setMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
+        $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\BelongsToMany::class)->setMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
         $relation->withTimestamps('custom_created_at', 'custom_updated_at');
         $query = m::mock('stdClass');
         $query->shouldReceive('from')->once()->with('user_role')->andReturn($query);
@@ -231,7 +231,7 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
 
     public function testAttachInsertsPivotTableRecordWithACreatedAtTimestamp()
     {
-        $relation = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\BelongsToMany')->setMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
+        $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\BelongsToMany::class)->setMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
         $relation->withPivot('created_at');
         $query = m::mock('stdClass');
         $query->shouldReceive('from')->once()->with('user_role')->andReturn($query);
@@ -246,7 +246,7 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
 
     public function testAttachInsertsPivotTableRecordWithAnUpdatedAtTimestamp()
     {
-        $relation = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\BelongsToMany')->setMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
+        $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\BelongsToMany::class)->setMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
         $relation->withPivot('updated_at');
         $query = m::mock('stdClass');
         $query->shouldReceive('from')->once()->with('user_role')->andReturn($query);
@@ -261,7 +261,7 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
 
     public function testDetachRemovesPivotTableRecord()
     {
-        $relation = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\BelongsToMany')->setMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
+        $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\BelongsToMany::class)->setMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
         $query = m::mock('stdClass');
         $query->shouldReceive('from')->once()->with('user_role')->andReturn($query);
         $query->shouldReceive('where')->once()->with('user_id', 1)->andReturn($query);
@@ -276,7 +276,7 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
 
     public function testDetachWithSingleIDRemovesPivotTableRecord()
     {
-        $relation = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\BelongsToMany')->setMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
+        $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\BelongsToMany::class)->setMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
         $query = m::mock('stdClass');
         $query->shouldReceive('from')->once()->with('user_role')->andReturn($query);
         $query->shouldReceive('where')->once()->with('user_id', 1)->andReturn($query);
@@ -291,7 +291,7 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
 
     public function testDetachMethodConvertsCollectionToArrayOfKeys()
     {
-        $relation = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\BelongsToMany')->setMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
+        $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\BelongsToMany::class)->setMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
         $query = m::mock('stdClass');
         $query->shouldReceive('from')->once()->with('user_role')->andReturn($query);
         $query->shouldReceive('where')->once()->with('user_id', 1)->andReturn($query);
@@ -312,7 +312,7 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
 
     public function testDetachMethodClearsAllPivotRecordsWhenNoIDsAreGiven()
     {
-        $relation = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\BelongsToMany')->setMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
+        $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\BelongsToMany::class)->setMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
         $query = m::mock('stdClass');
         $query->shouldReceive('from')->once()->with('user_role')->andReturn($query);
         $query->shouldReceive('where')->once()->with('user_id', 1)->andReturn($query);
@@ -363,7 +363,7 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
 
     public function testCreateMethodCreatesNewModelAndInsertsAttachmentRecord()
     {
-        $relation = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\BelongsToMany')->setMethods(['attach'])->setConstructorArgs($this->getRelationArguments())->getMock();
+        $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\BelongsToMany::class)->setMethods(['attach'])->setConstructorArgs($this->getRelationArguments())->getMock();
         $relation->getRelated()->shouldReceive('newInstance')->once()->andReturn($model = m::mock('StdClass'))->with(['attributes']);
         $model->shouldReceive('save')->once();
         $model->shouldReceive('getKey')->andReturn('foo');
@@ -377,7 +377,7 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
      */
     public function testFindOrFailThrowsException()
     {
-        $relation = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\BelongsToMany')->setMethods(['find'])->setConstructorArgs($this->getRelationArguments())->getMock();
+        $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\BelongsToMany::class)->setMethods(['find'])->setConstructorArgs($this->getRelationArguments())->getMock();
         $relation->expects($this->once())->method('find')->with('foo')->will($this->returnValue(null));
 
         try {
@@ -394,7 +394,7 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
      */
     public function testFirstOrFailThrowsException()
     {
-        $relation = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\BelongsToMany')->setMethods(['first'])->setConstructorArgs($this->getRelationArguments())->getMock();
+        $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\BelongsToMany::class)->setMethods(['first'])->setConstructorArgs($this->getRelationArguments())->getMock();
         $relation->expects($this->once())->method('first')->with(['id' => 'foo'])->will($this->returnValue(null));
 
         try {
@@ -408,7 +408,7 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
 
     public function testFindOrNewMethodFindsModel()
     {
-        $relation = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\BelongsToMany')->setMethods(['find'])->setConstructorArgs($this->getRelationArguments())->getMock();
+        $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\BelongsToMany::class)->setMethods(['find'])->setConstructorArgs($this->getRelationArguments())->getMock();
         $relation->expects($this->once())->method('find')->with('foo')->will($this->returnValue($model = m::mock('StdClass')));
         $relation->getRelated()->shouldReceive('newInstance')->never();
 
@@ -417,7 +417,7 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
 
     public function testFindOrNewMethodReturnsNewModel()
     {
-        $relation = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\BelongsToMany')->setMethods(['find'])->setConstructorArgs($this->getRelationArguments())->getMock();
+        $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\BelongsToMany::class)->setMethods(['find'])->setConstructorArgs($this->getRelationArguments())->getMock();
         $relation->expects($this->once())->method('find')->with('foo')->will($this->returnValue(null));
         $relation->getRelated()->shouldReceive('newInstance')->once()->andReturn($model = m::mock('StdClass'));
 
@@ -426,7 +426,7 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
 
     public function testFirstOrNewMethodFindsFirstModel()
     {
-        $relation = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\BelongsToMany')->setMethods(['where'])->setConstructorArgs($this->getRelationArguments())->getMock();
+        $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\BelongsToMany::class)->setMethods(['where'])->setConstructorArgs($this->getRelationArguments())->getMock();
         $relation->expects($this->once())->method('where')->with(['foo'])->will($this->returnValue($relation->getQuery()));
         $relation->getQuery()->shouldReceive('first')->once()->andReturn($model = m::mock('StdClass'));
         $relation->getRelated()->shouldReceive('newInstance')->never();
@@ -436,7 +436,7 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
 
     public function testFirstOrNewMethodReturnsNewModel()
     {
-        $relation = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\BelongsToMany')->setMethods(['where'])->setConstructorArgs($this->getRelationArguments())->getMock();
+        $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\BelongsToMany::class)->setMethods(['where'])->setConstructorArgs($this->getRelationArguments())->getMock();
         $relation->expects($this->once())->method('where')->with(['foo'])->will($this->returnValue($relation->getQuery()));
         $relation->getQuery()->shouldReceive('first')->once()->andReturn(null);
         $relation->getRelated()->shouldReceive('newInstance')->once()->andReturn($model = m::mock('StdClass'));
@@ -446,7 +446,7 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
 
     public function testFirstOrCreateMethodFindsFirstModel()
     {
-        $relation = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\BelongsToMany')->setMethods(['where', 'create'])->setConstructorArgs($this->getRelationArguments())->getMock();
+        $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\BelongsToMany::class)->setMethods(['where', 'create'])->setConstructorArgs($this->getRelationArguments())->getMock();
         $relation->expects($this->once())->method('where')->with(['foo'])->will($this->returnValue($relation->getQuery()));
         $relation->getQuery()->shouldReceive('first')->once()->andReturn($model = m::mock('StdClass'));
         $relation->expects($this->never())->method('create')->with(['foo'])->will($this->returnValue(null));
@@ -456,7 +456,7 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
 
     public function testFirstOrCreateMethodReturnsNewModel()
     {
-        $relation = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\BelongsToMany')->setMethods(['where', 'create'])->setConstructorArgs($this->getRelationArguments())->getMock();
+        $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\BelongsToMany::class)->setMethods(['where', 'create'])->setConstructorArgs($this->getRelationArguments())->getMock();
         $relation->expects($this->once())->method('where')->with(['foo'])->will($this->returnValue($relation->getQuery()));
         $relation->getQuery()->shouldReceive('first')->once()->andReturn(null);
         $relation->expects($this->once())->method('create')->with(['foo'])->will($this->returnValue($model = m::mock('StdClass')));
@@ -466,7 +466,7 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
 
     public function testUpdateOrCreateMethodFindsFirstModelAndUpdates()
     {
-        $relation = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\BelongsToMany')->setMethods(['where', 'create'])->setConstructorArgs($this->getRelationArguments())->getMock();
+        $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\BelongsToMany::class)->setMethods(['where', 'create'])->setConstructorArgs($this->getRelationArguments())->getMock();
         $relation->expects($this->once())->method('where')->with(['foo'])->will($this->returnValue($relation->getQuery()));
         $relation->getQuery()->shouldReceive('first')->once()->andReturn($model = m::mock('StdClass'));
         $model->shouldReceive('fill')->once();
@@ -478,7 +478,7 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
 
     public function testUpdateOrCreateMethodReturnsNewModel()
     {
-        $relation = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\BelongsToMany')->setMethods(['where', 'create'])->setConstructorArgs($this->getRelationArguments())->getMock();
+        $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\BelongsToMany::class)->setMethods(['where', 'create'])->setConstructorArgs($this->getRelationArguments())->getMock();
         $relation->expects($this->once())->method('where')->with(['bar'])->will($this->returnValue($relation->getQuery()));
         $relation->getQuery()->shouldReceive('first')->once()->andReturn(null);
         $relation->expects($this->once())->method('create')->with(['foo'])->will($this->returnValue($model = m::mock('StdClass')));
@@ -491,7 +491,7 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
      */
     public function testSyncMethodSyncsIntermediateTableWithGivenArray($list)
     {
-        $relation = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\BelongsToMany')->setMethods(['attach', 'detach'])->setConstructorArgs($this->getRelationArguments())->getMock();
+        $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\BelongsToMany::class)->setMethods(['attach', 'detach'])->setConstructorArgs($this->getRelationArguments())->getMock();
         $query = m::mock('stdClass');
         $query->shouldReceive('from')->once()->with('user_role')->andReturn($query);
         $query->shouldReceive('where')->once()->with('user_id', 1)->andReturn($query);
@@ -516,7 +516,7 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
 
     public function testSyncMethodSyncsIntermediateTableWithGivenArrayAndAttributes()
     {
-        $relation = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\BelongsToMany')->setMethods(['attach', 'detach', 'touchIfTouching', 'updateExistingPivot'])->setConstructorArgs($this->getRelationArguments())->getMock();
+        $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\BelongsToMany::class)->setMethods(['attach', 'detach', 'touchIfTouching', 'updateExistingPivot'])->setConstructorArgs($this->getRelationArguments())->getMock();
         $query = m::mock('stdClass');
         $query->shouldReceive('from')->once()->with('user_role')->andReturn($query);
         $query->shouldReceive('where')->once()->with('user_id', 1)->andReturn($query);
@@ -533,7 +533,7 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
 
     public function testSyncMethodDoesntReturnValuesThatWereNotUpdated()
     {
-        $relation = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\BelongsToMany')->setMethods(['attach', 'detach', 'touchIfTouching', 'updateExistingPivot'])->setConstructorArgs($this->getRelationArguments())->getMock();
+        $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\BelongsToMany::class)->setMethods(['attach', 'detach', 'touchIfTouching', 'updateExistingPivot'])->setConstructorArgs($this->getRelationArguments())->getMock();
         $query = m::mock('stdClass');
         $query->shouldReceive('from')->once()->with('user_role')->andReturn($query);
         $query->shouldReceive('where')->once()->with('user_id', 1)->andReturn($query);
@@ -568,7 +568,7 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
      */
     public function testToggleMethodTogglesIntermediateTableWithGivenArray($list)
     {
-        $relation = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\BelongsToMany')->setMethods(['attach', 'detach'])->setConstructorArgs($this->getRelationArguments())->getMock();
+        $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\BelongsToMany::class)->setMethods(['attach', 'detach'])->setConstructorArgs($this->getRelationArguments())->getMock();
         $query = m::mock('stdClass');
         $query->shouldReceive('from')->once()->with('user_role')->andReturn($query);
         $query->shouldReceive('where')->once()->with('user_id', 1)->andReturn($query);
@@ -593,7 +593,7 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
 
     public function testToggleMethodCanLeaveRelatedTimestampsIntact()
     {
-        $relation = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\BelongsToMany')->setMethods(['attach', 'detach'])->setConstructorArgs($this->getRelationArguments())->getMock();
+        $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\BelongsToMany::class)->setMethods(['attach', 'detach'])->setConstructorArgs($this->getRelationArguments())->getMock();
         $query = m::mock('stdClass');
         $query->shouldReceive('from')->once()->with('user_role')->andReturn($query);
         $query->shouldReceive('where')->once()->with('user_id', 1)->andReturn($query);
@@ -610,7 +610,7 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
 
     public function testToggleMethodTogglesIntermediateTableWithGivenArrayAndAttributes()
     {
-        $relation = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\BelongsToMany')->setMethods(['attach', 'detach', 'touchIfTouching', 'updateExistingPivot'])->setConstructorArgs($this->getRelationArguments())->getMock();
+        $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\BelongsToMany::class)->setMethods(['attach', 'detach', 'touchIfTouching', 'updateExistingPivot'])->setConstructorArgs($this->getRelationArguments())->getMock();
         $query = m::mock('stdClass');
         $query->shouldReceive('from')->once()->with('user_role')->andReturn($query);
         $query->shouldReceive('where')->once()->with('user_id', 1)->andReturn($query);
@@ -626,7 +626,7 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
 
     public function testTouchIfTouching()
     {
-        $relation = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\BelongsToMany')->setMethods(['touch', 'touchingParent'])->setConstructorArgs($this->getRelationArguments())->getMock();
+        $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\BelongsToMany::class)->setMethods(['touch', 'touchingParent'])->setConstructorArgs($this->getRelationArguments())->getMock();
         $relation->expects($this->once())->method('touchingParent')->will($this->returnValue(true));
         $relation->getParent()->shouldReceive('touch')->once();
         $relation->getParent()->shouldReceive('touches')->once()->with('relation_name')->andReturn(true);
@@ -637,7 +637,7 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
 
     public function testSyncMethodConvertsEloquentCollectionToArrayOfKeys()
     {
-        $relation = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\BelongsToMany')->setMethods(['attach', 'detach', 'touchIfTouching', 'formatRecordsList'])->setConstructorArgs($this->getRelationArguments())->getMock();
+        $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\BelongsToMany::class)->setMethods(['attach', 'detach', 'touchIfTouching', 'formatRecordsList'])->setConstructorArgs($this->getRelationArguments())->getMock();
         $query = m::mock('stdClass');
         $query->shouldReceive('from')->once()->with('user_role')->andReturn($query);
         $query->shouldReceive('where')->once()->with('user_id', 1)->andReturn($query);
@@ -656,7 +656,7 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
 
     public function testSyncMethodConvertsBaseCollectionToArrayOfKeys()
     {
-        $relation = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\BelongsToMany')->setMethods(['attach', 'detach', 'touchIfTouching', 'formatRecordsList'])->setConstructorArgs($this->getRelationArguments())->getMock();
+        $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\BelongsToMany::class)->setMethods(['attach', 'detach', 'touchIfTouching', 'formatRecordsList'])->setConstructorArgs($this->getRelationArguments())->getMock();
         $query = m::mock('stdClass');
         $query->shouldReceive('from')->once()->with('user_role')->andReturn($query);
         $query->shouldReceive('where')->once()->with('user_id', 1)->andReturn($query);
@@ -671,7 +671,7 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
 
     public function testWherePivotParamsUsedForNewQueries()
     {
-        $relation = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\BelongsToMany')->setMethods(['attach', 'detach', 'touchIfTouching', 'formatRecordsList'])->setConstructorArgs($this->getRelationArguments())->getMock();
+        $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\BelongsToMany::class)->setMethods(['attach', 'detach', 'touchIfTouching', 'formatRecordsList'])->setConstructorArgs($this->getRelationArguments())->getMock();
 
         // we expect to call $relation->wherePivot()
         $relation->getQuery()->shouldReceive('where')->once()->andReturn($relation);
@@ -708,19 +708,19 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
 
     public function getRelationArguments()
     {
-        $parent = m::mock('Illuminate\Database\Eloquent\Model');
+        $parent = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $parent->shouldReceive('getKey')->andReturn(1);
         $parent->shouldReceive('getCreatedAtColumn')->andReturn('created_at');
         $parent->shouldReceive('getUpdatedAtColumn')->andReturn('updated_at');
 
-        $builder = m::mock('Illuminate\Database\Eloquent\Builder');
-        $related = m::mock('Illuminate\Database\Eloquent\Model');
+        $builder = m::mock(\Illuminate\Database\Eloquent\Builder::class);
+        $related = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $builder->shouldReceive('getModel')->andReturn($related);
 
         $related->shouldReceive('getTable')->andReturn('roles');
         $related->shouldReceive('getKeyName')->andReturn('id');
         $related->shouldReceive('newPivot')->andReturnUsing(function () {
-            $reflector = new ReflectionClass('Illuminate\Database\Eloquent\Relations\Pivot');
+            $reflector = new ReflectionClass(\Illuminate\Database\Eloquent\Relations\Pivot::class);
 
             return $reflector->newInstanceArgs(func_get_args());
         });

--- a/tests/Database/DatabaseEloquentBelongsToTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToTest.php
@@ -17,7 +17,7 @@ class DatabaseEloquentBelongsToTest extends TestCase
     public function testUpdateMethodRetrievesModelAndUpdates()
     {
         $relation = $this->getRelation();
-        $mock = m::mock('Illuminate\Database\Eloquent\Model');
+        $mock = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $mock->shouldReceive('fill')->once()->with(['attributes'])->andReturn($mock);
         $mock->shouldReceive('save')->once()->andReturn(true);
         $relation->getQuery()->shouldReceive('first')->once()->andReturn($mock);
@@ -36,7 +36,7 @@ class DatabaseEloquentBelongsToTest extends TestCase
     public function testRelationIsProperlyInitialized()
     {
         $relation = $this->getRelation();
-        $model = m::mock('Illuminate\Database\Eloquent\Model');
+        $model = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $model->shouldReceive('setRelation')->once()->with('foo', null);
         $models = $relation->initRelation([$model], 'foo');
 
@@ -62,10 +62,10 @@ class DatabaseEloquentBelongsToTest extends TestCase
 
     public function testAssociateMethodSetsForeignKeyOnModel()
     {
-        $parent = m::mock('Illuminate\Database\Eloquent\Model');
+        $parent = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $parent->shouldReceive('getAttribute')->once()->with('foreign_key')->andReturn('foreign.value');
         $relation = $this->getRelation($parent);
-        $associate = m::mock('Illuminate\Database\Eloquent\Model');
+        $associate = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $associate->shouldReceive('getAttribute')->once()->with('id')->andReturn(1);
         $parent->shouldReceive('setAttribute')->once()->with('foreign_key', 1);
         $parent->shouldReceive('setRelation')->once()->with('relation', $associate);
@@ -75,7 +75,7 @@ class DatabaseEloquentBelongsToTest extends TestCase
 
     public function testDissociateMethodUnsetsForeignKeyOnModel()
     {
-        $parent = m::mock('Illuminate\Database\Eloquent\Model');
+        $parent = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $parent->shouldReceive('getAttribute')->once()->with('foreign_key')->andReturn('foreign.value');
         $relation = $this->getRelation($parent);
         $parent->shouldReceive('setAttribute')->once()->with('foreign_key', null);
@@ -85,7 +85,7 @@ class DatabaseEloquentBelongsToTest extends TestCase
 
     public function testAssociateMethodSetsForeignKeyOnModelById()
     {
-        $parent = m::mock('Illuminate\Database\Eloquent\Model');
+        $parent = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $parent->shouldReceive('getAttribute')->once()->with('foreign_key')->andReturn('foreign.value');
         $relation = $this->getRelation($parent);
         $parent->shouldReceive('setAttribute')->once()->with('foreign_key', 1);
@@ -118,9 +118,9 @@ class DatabaseEloquentBelongsToTest extends TestCase
 
     protected function getRelation($parent = null, $incrementing = true, $keyType = 'int')
     {
-        $builder = m::mock('Illuminate\Database\Eloquent\Builder');
+        $builder = m::mock(\Illuminate\Database\Eloquent\Builder::class);
         $builder->shouldReceive('where')->with('relation.id', '=', 'foreign.value');
-        $related = m::mock('Illuminate\Database\Eloquent\Model');
+        $related = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $related->incrementing = $incrementing;
         $related->shouldReceive('getKeyType')->andReturn($keyType);
         $related->shouldReceive('getIncrementing')->andReturn($incrementing);

--- a/tests/Database/DatabaseEloquentBelongsToTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToTest.php
@@ -46,9 +46,9 @@ class DatabaseEloquentBelongsToTest extends TestCase
     public function testModelsAreProperlyMatchedToParents()
     {
         $relation = $this->getRelation();
-        $result1 = m::mock('stdClass');
+        $result1 = m::mock(\StdClass::class);
         $result1->shouldReceive('getAttribute')->with('id')->andReturn(1);
-        $result2 = m::mock('stdClass');
+        $result2 = m::mock(\StdClass::class);
         $result2->shouldReceive('getAttribute')->with('id')->andReturn(2);
         $model1 = new EloquentBelongsToModelStub;
         $model1->foreign_key = 1;

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -45,7 +45,7 @@ class DatabaseEloquentBuilderTest extends TestCase
     public function testFindOrNewMethodModelNotFound()
     {
         $model = $this->getMockModel();
-        $model->shouldReceive('findOrNew')->once()->andReturn(m::mock('Illuminate\Database\Eloquent\Model'));
+        $model->shouldReceive('findOrNew')->once()->andReturn(m::mock(\Illuminate\Database\Eloquent\Model::class));
 
         $builder = m::mock('Illuminate\Database\Eloquent\Builder[first]', [$this->getMockQueryBuilder()]);
         $builder->setModel($model);
@@ -55,7 +55,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $result = $model->findOrNew('bar', ['column']);
         $findResult = $builder->find('bar', ['column']);
         $this->assertNull($findResult);
-        $this->assertInstanceOf('Illuminate\Database\Eloquent\Model', $result);
+        $this->assertInstanceOf(\Illuminate\Database\Eloquent\Model::class, $result);
     }
 
     /**
@@ -355,9 +355,9 @@ class DatabaseEloquentBuilderTest extends TestCase
     {
         unset($_SERVER['__test.builder']);
         $builder = new \Illuminate\Database\Eloquent\Builder(new \Illuminate\Database\Query\Builder(
-            m::mock('Illuminate\Database\ConnectionInterface'),
-            m::mock('Illuminate\Database\Query\Grammars\Grammar'),
-            m::mock('Illuminate\Database\Query\Processors\Processor')
+            m::mock(\Illuminate\Database\ConnectionInterface::class),
+            m::mock(\Illuminate\Database\Query\Grammars\Grammar::class),
+            m::mock(\Illuminate\Database\Query\Processors\Processor::class)
         ));
         $builder->macro('fooBar', function ($builder) {
             $_SERVER['__test.builder'] = $builder;
@@ -514,7 +514,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder = $this->getBuilder();
         $builder->getQuery()->shouldReceive('foobar')->once()->andReturn('foo');
 
-        $this->assertInstanceOf('Illuminate\Database\Eloquent\Builder', $builder->foobar());
+        $this->assertInstanceOf(\Illuminate\Database\Eloquent\Builder::class, $builder->foobar());
 
         $builder = $this->getBuilder();
         $builder->getQuery()->shouldReceive('insert')->once()->with(['bar'])->andReturn('foo');
@@ -535,7 +535,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     public function testNestedWhere()
     {
-        $nestedQuery = m::mock('Illuminate\Database\Eloquent\Builder');
+        $nestedQuery = m::mock(\Illuminate\Database\Eloquent\Builder::class);
         $nestedRawQuery = $this->getMockQueryBuilder();
         $nestedQuery->shouldReceive('getQuery')->once()->andReturn($nestedRawQuery);
         $model = $this->getMockModel()->makePartial();
@@ -802,8 +802,8 @@ class DatabaseEloquentBuilderTest extends TestCase
         $processorClass = 'Illuminate\Database\Query\Processors\\'.$database.'Processor';
         $grammar = new $grammarClass;
         $processor = new $processorClass;
-        $connection = m::mock('Illuminate\Database\ConnectionInterface', ['getQueryGrammar' => $grammar, 'getPostProcessor' => $processor]);
-        $resolver = m::mock('Illuminate\Database\ConnectionResolverInterface', ['connection' => $connection]);
+        $connection = m::mock(\Illuminate\Database\ConnectionInterface::class, ['getQueryGrammar' => $grammar, 'getPostProcessor' => $processor]);
+        $resolver = m::mock(\Illuminate\Database\ConnectionResolverInterface::class, ['connection' => $connection]);
         $class = get_class($model);
         $class::setConnectionResolver($resolver);
     }
@@ -815,7 +815,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     protected function getMockModel()
     {
-        $model = m::mock('Illuminate\Database\Eloquent\Model');
+        $model = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $model->shouldReceive('getKeyName')->andReturn('foo');
         $model->shouldReceive('getTable')->andReturn('foo_table');
         $model->shouldReceive('getQualifiedKeyName')->andReturn('foo_table.foo');
@@ -825,7 +825,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     protected function getMockQueryBuilder()
     {
-        $query = m::mock('Illuminate\Database\Query\Builder');
+        $query = m::mock(\Illuminate\Database\Query\Builder::class);
         $query->shouldReceive('from')->with('foo_table');
 
         return $query;
@@ -885,17 +885,17 @@ class EloquentBuilderTestModelParentStub extends \Illuminate\Database\Eloquent\M
 {
     public function foo()
     {
-        return $this->belongsTo('Illuminate\Tests\Database\EloquentBuilderTestModelCloseRelatedStub');
+        return $this->belongsTo(\Illuminate\Tests\Database\EloquentBuilderTestModelCloseRelatedStub::class);
     }
 
     public function address()
     {
-        return $this->belongsTo('Illuminate\Tests\Database\EloquentBuilderTestModelCloseRelatedStub', 'foo_id');
+        return $this->belongsTo(\Illuminate\Tests\Database\EloquentBuilderTestModelCloseRelatedStub::class, 'foo_id');
     }
 
     public function activeFoo()
     {
-        return $this->belongsTo('Illuminate\Tests\Database\EloquentBuilderTestModelCloseRelatedStub', 'foo_id')->where('active', true);
+        return $this->belongsTo(\Illuminate\Tests\Database\EloquentBuilderTestModelCloseRelatedStub::class, 'foo_id')->where('active', true);
     }
 }
 
@@ -903,12 +903,12 @@ class EloquentBuilderTestModelCloseRelatedStub extends \Illuminate\Database\Eloq
 {
     public function bar()
     {
-        return $this->hasMany('Illuminate\Tests\Database\EloquentBuilderTestModelFarRelatedStub');
+        return $this->hasMany(\Illuminate\Tests\Database\EloquentBuilderTestModelFarRelatedStub::class);
     }
 
     public function baz()
     {
-        return $this->hasMany('Illuminate\Tests\Database\EloquentBuilderTestModelFarRelatedStub');
+        return $this->hasMany(\Illuminate\Tests\Database\EloquentBuilderTestModelFarRelatedStub::class);
     }
 }
 
@@ -922,31 +922,31 @@ class EloquentBuilderTestModelSelfRelatedStub extends \Illuminate\Database\Eloqu
 
     public function parentFoo()
     {
-        return $this->belongsTo('Illuminate\Tests\Database\EloquentBuilderTestModelSelfRelatedStub', 'parent_id', 'id', 'parent');
+        return $this->belongsTo(\Illuminate\Tests\Database\EloquentBuilderTestModelSelfRelatedStub::class, 'parent_id', 'id', 'parent');
     }
 
     public function childFoo()
     {
-        return $this->hasOne('Illuminate\Tests\Database\EloquentBuilderTestModelSelfRelatedStub', 'parent_id', 'id');
+        return $this->hasOne(\Illuminate\Tests\Database\EloquentBuilderTestModelSelfRelatedStub::class, 'parent_id', 'id');
     }
 
     public function childFoos()
     {
-        return $this->hasMany('Illuminate\Tests\Database\EloquentBuilderTestModelSelfRelatedStub', 'parent_id', 'id', 'children');
+        return $this->hasMany(\Illuminate\Tests\Database\EloquentBuilderTestModelSelfRelatedStub::class, 'parent_id', 'id', 'children');
     }
 
     public function parentBars()
     {
-        return $this->belongsToMany('Illuminate\Tests\Database\EloquentBuilderTestModelSelfRelatedStub', 'self_pivot', 'child_id', 'parent_id', 'parent_bars');
+        return $this->belongsToMany(\Illuminate\Tests\Database\EloquentBuilderTestModelSelfRelatedStub::class, 'self_pivot', 'child_id', 'parent_id', 'parent_bars');
     }
 
     public function childBars()
     {
-        return $this->belongsToMany('Illuminate\Tests\Database\EloquentBuilderTestModelSelfRelatedStub', 'self_pivot', 'parent_id', 'child_id', 'child_bars');
+        return $this->belongsToMany(\Illuminate\Tests\Database\EloquentBuilderTestModelSelfRelatedStub::class, 'self_pivot', 'parent_id', 'child_id', 'child_bars');
     }
 
     public function bazes()
     {
-        return $this->hasMany('Illuminate\Tests\Database\EloquentBuilderTestModelFarRelatedStub', 'foreign_key', 'id', 'bar');
+        return $this->hasMany(\Illuminate\Tests\Database\EloquentBuilderTestModelFarRelatedStub::class, 'foreign_key', 'id', 'bar');
     }
 }

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -171,7 +171,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder->shouldReceive('forPage')->once()->with(3, 2)->andReturnSelf();
         $builder->shouldReceive('get')->times(3)->andReturn($chunk1, $chunk2, $chunk3);
 
-        $callbackAssertor = m::mock('StdClass');
+        $callbackAssertor = m::mock(\StdClass::class);
         $callbackAssertor->shouldReceive('doSomething')->once()->with($chunk1);
         $callbackAssertor->shouldReceive('doSomething')->once()->with($chunk2);
         $callbackAssertor->shouldReceive('doSomething')->never()->with($chunk3);
@@ -192,7 +192,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder->shouldReceive('forPage')->once()->with(2, 2)->andReturnSelf();
         $builder->shouldReceive('get')->times(2)->andReturn($chunk1, $chunk2);
 
-        $callbackAssertor = m::mock('StdClass');
+        $callbackAssertor = m::mock(\StdClass::class);
         $callbackAssertor->shouldReceive('doSomething')->once()->with($chunk1);
         $callbackAssertor->shouldReceive('doSomething')->once()->with($chunk2);
 
@@ -212,7 +212,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder->shouldReceive('forPage')->never()->with(2, 2);
         $builder->shouldReceive('get')->times(1)->andReturn($chunk1);
 
-        $callbackAssertor = m::mock('StdClass');
+        $callbackAssertor = m::mock(\StdClass::class);
         $callbackAssertor->shouldReceive('doSomething')->once()->with($chunk1);
         $callbackAssertor->shouldReceive('doSomething')->never()->with($chunk2);
 
@@ -232,7 +232,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder->shouldReceive('forPage')->once()->with(1, 0)->andReturnSelf();
         $builder->shouldReceive('get')->times(1)->andReturn($chunk);
 
-        $callbackAssertor = m::mock('StdClass');
+        $callbackAssertor = m::mock(\StdClass::class);
         $callbackAssertor->shouldReceive('doSomething')->never();
 
         $builder->chunk(0, function ($results) use ($callbackAssertor) {
@@ -253,7 +253,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder->shouldReceive('forPageAfterId')->once()->with(2, 11, 'someIdField')->andReturnSelf();
         $builder->shouldReceive('get')->times(3)->andReturn($chunk1, $chunk2, $chunk3);
 
-        $callbackAssertor = m::mock('StdClass');
+        $callbackAssertor = m::mock(\StdClass::class);
         $callbackAssertor->shouldReceive('doSomething')->once()->with($chunk1);
         $callbackAssertor->shouldReceive('doSomething')->once()->with($chunk2);
         $callbackAssertor->shouldReceive('doSomething')->never()->with($chunk3);
@@ -274,7 +274,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder->shouldReceive('forPageAfterId')->once()->with(2, 2, 'someIdField')->andReturnSelf();
         $builder->shouldReceive('get')->times(2)->andReturn($chunk1, $chunk2);
 
-        $callbackAssertor = m::mock('StdClass');
+        $callbackAssertor = m::mock(\StdClass::class);
         $callbackAssertor->shouldReceive('doSomething')->once()->with($chunk1);
         $callbackAssertor->shouldReceive('doSomething')->once()->with($chunk2);
 
@@ -292,7 +292,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder->shouldReceive('forPageAfterId')->once()->with(0, 0, 'someIdField')->andReturnSelf();
         $builder->shouldReceive('get')->times(1)->andReturn($chunk);
 
-        $callbackAssertor = m::mock('StdClass');
+        $callbackAssertor = m::mock(\StdClass::class);
         $callbackAssertor->shouldReceive('doSomething')->never();
 
         $builder->chunkById(0, function ($results) use ($callbackAssertor) {
@@ -407,7 +407,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder->setEagerLoads(['orders' => function ($query) {
             $_SERVER['__eloquent.constrain'] = $query;
         }]);
-        $relation = m::mock('stdClass');
+        $relation = m::mock(\StdClass::class);
         $relation->shouldReceive('addEagerConstraints')->once()->with(['models']);
         $relation->shouldReceive('initRelation')->once()->with(['models'], 'orders')->andReturn(['models']);
         $relation->shouldReceive('getEager')->once()->andReturn(['results']);
@@ -424,8 +424,8 @@ class DatabaseEloquentBuilderTest extends TestCase
     {
         $builder = $this->getBuilder();
         $builder->setModel($this->getMockModel());
-        $builder->getModel()->shouldReceive('orders')->once()->andReturn($relation = m::mock('stdClass'));
-        $relationQuery = m::mock('stdClass');
+        $builder->getModel()->shouldReceive('orders')->once()->andReturn($relation = m::mock(\StdClass::class));
+        $relationQuery = m::mock(\StdClass::class);
         $relation->shouldReceive('getQuery')->andReturn($relationQuery);
         $relationQuery->shouldReceive('with')->once()->with(['lines' => null, 'lines.details' => null]);
         $builder->setEagerLoads(['orders' => null, 'orders.lines' => null, 'orders.lines.details' => null]);
@@ -437,13 +437,13 @@ class DatabaseEloquentBuilderTest extends TestCase
     {
         $builder = $this->getBuilder();
         $builder->setModel($this->getMockModel());
-        $builder->getModel()->shouldReceive('orders')->once()->andReturn($relation = m::mock('stdClass'));
-        $builder->getModel()->shouldReceive('ordersGroups')->once()->andReturn($groupsRelation = m::mock('stdClass'));
+        $builder->getModel()->shouldReceive('orders')->once()->andReturn($relation = m::mock(\StdClass::class));
+        $builder->getModel()->shouldReceive('ordersGroups')->once()->andReturn($groupsRelation = m::mock(\StdClass::class));
 
-        $relationQuery = m::mock('stdClass');
+        $relationQuery = m::mock(\StdClass::class);
         $relation->shouldReceive('getQuery')->andReturn($relationQuery);
 
-        $groupRelationQuery = m::mock('stdClass');
+        $groupRelationQuery = m::mock(\StdClass::class);
         $groupsRelation->shouldReceive('getQuery')->andReturn($groupRelationQuery);
         $groupRelationQuery->shouldReceive('with')->once()->with(['lines' => null, 'lines.details' => null]);
 

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -44,11 +44,11 @@ class DatabaseEloquentCollectionTest extends TestCase
 
     public function testContainsIndicatesIfModelInArray()
     {
-        $mockModel = m::mock('Illuminate\Database\Eloquent\Model');
+        $mockModel = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $mockModel->shouldReceive('getKey')->andReturn(1);
-        $mockModel2 = m::mock('Illuminate\Database\Eloquent\Model');
+        $mockModel2 = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $mockModel2->shouldReceive('getKey')->andReturn(2);
-        $mockModel3 = m::mock('Illuminate\Database\Eloquent\Model');
+        $mockModel3 = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $mockModel3->shouldReceive('getKey')->andReturn(3);
         $c = new Collection([$mockModel, $mockModel2]);
 
@@ -59,10 +59,10 @@ class DatabaseEloquentCollectionTest extends TestCase
 
     public function testContainsIndicatesIfKeyedModelInArray()
     {
-        $mockModel = m::mock('Illuminate\Database\Eloquent\Model');
+        $mockModel = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $mockModel->shouldReceive('getKey')->andReturn('1');
         $c = new Collection([$mockModel]);
-        $mockModel2 = m::mock('Illuminate\Database\Eloquent\Model');
+        $mockModel2 = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $mockModel2->shouldReceive('getKey')->andReturn('2');
         $c->add($mockModel2);
 
@@ -73,10 +73,10 @@ class DatabaseEloquentCollectionTest extends TestCase
 
     public function testContainsKeyAndValueIndicatesIfModelInArray()
     {
-        $mockModel1 = m::mock('Illuminate\Database\Eloquent\Model');
+        $mockModel1 = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $mockModel1->shouldReceive('offsetExists')->with('name')->andReturn(true);
         $mockModel1->shouldReceive('offsetGet')->with('name')->andReturn('Taylor');
-        $mockModel2 = m::mock('Illuminate\Database\Eloquent\Model');
+        $mockModel2 = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $mockModel2->shouldReceive('offsetExists')->andReturn(true);
         $mockModel2->shouldReceive('offsetGet')->with('name')->andReturn('Abigail');
         $c = new Collection([$mockModel1, $mockModel2]);
@@ -88,9 +88,9 @@ class DatabaseEloquentCollectionTest extends TestCase
 
     public function testContainsClosureIndicatesIfModelInArray()
     {
-        $mockModel1 = m::mock('Illuminate\Database\Eloquent\Model');
+        $mockModel1 = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $mockModel1->shouldReceive('getKey')->andReturn(1);
-        $mockModel2 = m::mock('Illuminate\Database\Eloquent\Model');
+        $mockModel2 = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $mockModel2->shouldReceive('getKey')->andReturn(2);
         $c = new Collection([$mockModel1, $mockModel2]);
 
@@ -104,7 +104,7 @@ class DatabaseEloquentCollectionTest extends TestCase
 
     public function testFindMethodFindsModelById()
     {
-        $mockModel = m::mock('Illuminate\Database\Eloquent\Model');
+        $mockModel = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $mockModel->shouldReceive('getKey')->andReturn(1);
         $c = new Collection([$mockModel]);
 
@@ -136,7 +136,7 @@ class DatabaseEloquentCollectionTest extends TestCase
 
     public function testLoadMethodEagerLoadsGivenRelationships()
     {
-        $c = $this->getMockBuilder('Illuminate\Database\Eloquent\Collection')->setMethods(['first'])->setConstructorArgs([['foo']])->getMock();
+        $c = $this->getMockBuilder(\Illuminate\Database\Eloquent\Collection::class)->setMethods(['first'])->setConstructorArgs([['foo']])->getMock();
         $mockItem = m::mock('StdClass');
         $c->expects($this->once())->method('first')->will($this->returnValue($mockItem));
         $mockItem->shouldReceive('newQuery')->once()->andReturn($mockItem);
@@ -149,13 +149,13 @@ class DatabaseEloquentCollectionTest extends TestCase
 
     public function testCollectionDictionaryReturnsModelKeys()
     {
-        $one = m::mock('Illuminate\Database\Eloquent\Model');
+        $one = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $one->shouldReceive('getKey')->andReturn(1);
 
-        $two = m::mock('Illuminate\Database\Eloquent\Model');
+        $two = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $two->shouldReceive('getKey')->andReturn(2);
 
-        $three = m::mock('Illuminate\Database\Eloquent\Model');
+        $three = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $three->shouldReceive('getKey')->andReturn(3);
 
         $c = new Collection([$one, $two, $three]);
@@ -165,13 +165,13 @@ class DatabaseEloquentCollectionTest extends TestCase
 
     public function testCollectionMergesWithGivenCollection()
     {
-        $one = m::mock('Illuminate\Database\Eloquent\Model');
+        $one = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $one->shouldReceive('getKey')->andReturn(1);
 
-        $two = m::mock('Illuminate\Database\Eloquent\Model');
+        $two = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $two->shouldReceive('getKey')->andReturn(2);
 
-        $three = m::mock('Illuminate\Database\Eloquent\Model');
+        $three = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $three->shouldReceive('getKey')->andReturn(3);
 
         $c1 = new Collection([$one, $two]);
@@ -182,8 +182,8 @@ class DatabaseEloquentCollectionTest extends TestCase
 
     public function testMap()
     {
-        $one = m::mock('Illuminate\Database\Eloquent\Model');
-        $two = m::mock('Illuminate\Database\Eloquent\Model');
+        $one = m::mock(\Illuminate\Database\Eloquent\Model::class);
+        $two = m::mock(\Illuminate\Database\Eloquent\Model::class);
 
         $c = new Collection([$one, $two]);
 
@@ -197,8 +197,8 @@ class DatabaseEloquentCollectionTest extends TestCase
 
     public function testMappingToNonModelsReturnsABaseCollection()
     {
-        $one = m::mock('Illuminate\Database\Eloquent\Model');
-        $two = m::mock('Illuminate\Database\Eloquent\Model');
+        $one = m::mock(\Illuminate\Database\Eloquent\Model::class);
+        $two = m::mock(\Illuminate\Database\Eloquent\Model::class);
 
         $c = (new Collection([$one, $two]))->map(function ($item) {
             return 'not-a-model';
@@ -209,13 +209,13 @@ class DatabaseEloquentCollectionTest extends TestCase
 
     public function testCollectionDiffsWithGivenCollection()
     {
-        $one = m::mock('Illuminate\Database\Eloquent\Model');
+        $one = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $one->shouldReceive('getKey')->andReturn(1);
 
-        $two = m::mock('Illuminate\Database\Eloquent\Model');
+        $two = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $two->shouldReceive('getKey')->andReturn(2);
 
-        $three = m::mock('Illuminate\Database\Eloquent\Model');
+        $three = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $three->shouldReceive('getKey')->andReturn(3);
 
         $c1 = new Collection([$one, $two]);
@@ -226,13 +226,13 @@ class DatabaseEloquentCollectionTest extends TestCase
 
     public function testCollectionIntersectsWithGivenCollection()
     {
-        $one = m::mock('Illuminate\Database\Eloquent\Model');
+        $one = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $one->shouldReceive('getKey')->andReturn(1);
 
-        $two = m::mock('Illuminate\Database\Eloquent\Model');
+        $two = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $two->shouldReceive('getKey')->andReturn(2);
 
-        $three = m::mock('Illuminate\Database\Eloquent\Model');
+        $three = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $three->shouldReceive('getKey')->andReturn(3);
 
         $c1 = new Collection([$one, $two]);
@@ -243,10 +243,10 @@ class DatabaseEloquentCollectionTest extends TestCase
 
     public function testCollectionReturnsUniqueItems()
     {
-        $one = m::mock('Illuminate\Database\Eloquent\Model');
+        $one = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $one->shouldReceive('getKey')->andReturn(1);
 
-        $two = m::mock('Illuminate\Database\Eloquent\Model');
+        $two = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $two->shouldReceive('getKey')->andReturn(2);
 
         $c = new Collection([$one, $two, $two]);
@@ -256,13 +256,13 @@ class DatabaseEloquentCollectionTest extends TestCase
 
     public function testOnlyReturnsCollectionWithGivenModelKeys()
     {
-        $one = m::mock('Illuminate\Database\Eloquent\Model');
+        $one = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $one->shouldReceive('getKey')->andReturn(1);
 
-        $two = m::mock('Illuminate\Database\Eloquent\Model');
+        $two = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $two->shouldReceive('getKey')->andReturn(2);
 
-        $three = m::mock('Illuminate\Database\Eloquent\Model');
+        $three = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $three->shouldReceive('getKey')->andReturn(3);
 
         $c = new Collection([$one, $two, $three]);
@@ -274,13 +274,13 @@ class DatabaseEloquentCollectionTest extends TestCase
 
     public function testExceptReturnsCollectionWithoutGivenModelKeys()
     {
-        $one = m::mock('Illuminate\Database\Eloquent\Model');
+        $one = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $one->shouldReceive('getKey')->andReturn(1);
 
-        $two = m::mock('Illuminate\Database\Eloquent\Model');
+        $two = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $two->shouldReceive('getKey')->andReturn('2');
 
-        $three = m::mock('Illuminate\Database\Eloquent\Model');
+        $three = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $three->shouldReceive('getKey')->andReturn(3);
 
         $c = new Collection([$one, $two, $three]);

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -137,7 +137,7 @@ class DatabaseEloquentCollectionTest extends TestCase
     public function testLoadMethodEagerLoadsGivenRelationships()
     {
         $c = $this->getMockBuilder(\Illuminate\Database\Eloquent\Collection::class)->setMethods(['first'])->setConstructorArgs([['foo']])->getMock();
-        $mockItem = m::mock('StdClass');
+        $mockItem = m::mock(\StdClass::class);
         $c->expects($this->once())->method('first')->will($this->returnValue($mockItem));
         $mockItem->shouldReceive('newQuery')->once()->andReturn($mockItem);
         $mockItem->shouldReceive('with')->with(['bar', 'baz'])->andReturn($mockItem);

--- a/tests/Database/DatabaseEloquentHasManyTest.php
+++ b/tests/Database/DatabaseEloquentHasManyTest.php
@@ -123,11 +123,11 @@ class DatabaseEloquentHasManyTest extends TestCase
     public function testRelationIsProperlyInitialized()
     {
         $relation = $this->getRelation();
-        $model = m::mock('Illuminate\Database\Eloquent\Model');
+        $model = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $relation->getRelated()->shouldReceive('newCollection')->andReturnUsing(function ($array = []) {
             return new Collection($array);
         });
-        $model->shouldReceive('setRelation')->once()->with('foo', m::type('Illuminate\Database\Eloquent\Collection'));
+        $model->shouldReceive('setRelation')->once()->with('foo', m::type(\Illuminate\Database\Eloquent\Collection::class));
         $models = $relation->initRelation([$model], 'foo');
 
         $this->assertEquals([$model], $models);
@@ -196,12 +196,12 @@ class DatabaseEloquentHasManyTest extends TestCase
 
     protected function getRelation()
     {
-        $builder = m::mock('Illuminate\Database\Eloquent\Builder');
+        $builder = m::mock(\Illuminate\Database\Eloquent\Builder::class);
         $builder->shouldReceive('whereNotNull')->with('table.foreign_key');
         $builder->shouldReceive('where')->with('table.foreign_key', '=', 1);
-        $related = m::mock('Illuminate\Database\Eloquent\Model');
+        $related = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $builder->shouldReceive('getModel')->andReturn($related);
-        $parent = m::mock('Illuminate\Database\Eloquent\Model');
+        $parent = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $parent->shouldReceive('getAttribute')->with('id')->andReturn(1);
         $parent->shouldReceive('getCreatedAtColumn')->andReturn('created_at');
         $parent->shouldReceive('getUpdatedAtColumn')->andReturn('updated_at');
@@ -211,7 +211,7 @@ class DatabaseEloquentHasManyTest extends TestCase
 
     protected function expectNewModel($relation, $attributes = null)
     {
-        $model = $this->getMockBuilder('Illuminate\Database\Eloquent\Model')->setMethods(['setAttribute', 'save'])->getMock();
+        $model = $this->getMockBuilder(\Illuminate\Database\Eloquent\Model::class)->setMethods(['setAttribute', 'save'])->getMock();
         $relation->getRelated()->shouldReceive('newInstance')->with($attributes)->andReturn($model);
         $model->expects($this->once())->method('setAttribute')->with('foreign_key', 1);
 

--- a/tests/Database/DatabaseEloquentHasManyTest.php
+++ b/tests/Database/DatabaseEloquentHasManyTest.php
@@ -26,7 +26,7 @@ class DatabaseEloquentHasManyTest extends TestCase
     public function testFindOrNewMethodFindsModel()
     {
         $relation = $this->getRelation();
-        $relation->getQuery()->shouldReceive('find')->once()->with('foo', ['*'])->andReturn($model = m::mock('StdClass'));
+        $relation->getQuery()->shouldReceive('find')->once()->with('foo', ['*'])->andReturn($model = m::mock(\StdClass::class));
         $model->shouldReceive('setAttribute')->never();
 
         $this->assertInstanceOf(StdClass::class, $relation->findOrNew('foo'));
@@ -36,7 +36,7 @@ class DatabaseEloquentHasManyTest extends TestCase
     {
         $relation = $this->getRelation();
         $relation->getQuery()->shouldReceive('find')->once()->with('foo', ['*'])->andReturn(null);
-        $relation->getRelated()->shouldReceive('newInstance')->once()->with()->andReturn($model = m::mock('StdClass'));
+        $relation->getRelated()->shouldReceive('newInstance')->once()->with()->andReturn($model = m::mock(\StdClass::class));
         $model->shouldReceive('setAttribute')->once()->with('foreign_key', 1);
 
         $this->assertInstanceOf(StdClass::class, $relation->findOrNew('foo'));
@@ -46,7 +46,7 @@ class DatabaseEloquentHasManyTest extends TestCase
     {
         $relation = $this->getRelation();
         $relation->getQuery()->shouldReceive('where')->once()->with(['foo'])->andReturn($relation->getQuery());
-        $relation->getQuery()->shouldReceive('first')->once()->with()->andReturn($model = m::mock('StdClass'));
+        $relation->getQuery()->shouldReceive('first')->once()->with()->andReturn($model = m::mock(\StdClass::class));
         $model->shouldReceive('setAttribute')->never();
 
         $this->assertInstanceOf(StdClass::class, $relation->firstOrNew(['foo']));
@@ -66,7 +66,7 @@ class DatabaseEloquentHasManyTest extends TestCase
     {
         $relation = $this->getRelation();
         $relation->getQuery()->shouldReceive('where')->once()->with(['foo'])->andReturn($relation->getQuery());
-        $relation->getQuery()->shouldReceive('first')->once()->with()->andReturn($model = m::mock('StdClass'));
+        $relation->getQuery()->shouldReceive('first')->once()->with()->andReturn($model = m::mock(\StdClass::class));
         $relation->getRelated()->shouldReceive('newInstance')->never();
         $model->shouldReceive('setAttribute')->never();
         $model->shouldReceive('save')->never();
@@ -88,7 +88,7 @@ class DatabaseEloquentHasManyTest extends TestCase
     {
         $relation = $this->getRelation();
         $relation->getQuery()->shouldReceive('where')->once()->with(['foo'])->andReturn($relation->getQuery());
-        $relation->getQuery()->shouldReceive('first')->once()->with()->andReturn($model = m::mock('StdClass'));
+        $relation->getQuery()->shouldReceive('first')->once()->with()->andReturn($model = m::mock(\StdClass::class));
         $relation->getRelated()->shouldReceive('newInstance')->never();
         $model->shouldReceive('fill')->once()->with(['bar']);
         $model->shouldReceive('save')->once();
@@ -101,7 +101,7 @@ class DatabaseEloquentHasManyTest extends TestCase
         $relation = $this->getRelation();
         $relation->getQuery()->shouldReceive('where')->once()->with(['foo'])->andReturn($relation->getQuery());
         $relation->getQuery()->shouldReceive('first')->once()->with()->andReturn(null);
-        $relation->getRelated()->shouldReceive('newInstance')->once()->with(['foo'])->andReturn($model = m::mock('StdClass'));
+        $relation->getRelated()->shouldReceive('newInstance')->once()->with(['foo'])->andReturn($model = m::mock(\StdClass::class));
         $model->shouldReceive('save')->once()->andReturn(true);
         $model->shouldReceive('fill')->once()->with(['bar']);
         $model->shouldReceive('setAttribute')->once()->with('foreign_key', 1);

--- a/tests/Database/DatabaseEloquentHasManyThroughTest.php
+++ b/tests/Database/DatabaseEloquentHasManyThroughTest.php
@@ -19,11 +19,11 @@ class DatabaseEloquentHasManyThroughTest extends TestCase
     public function testRelationIsProperlyInitialized()
     {
         $relation = $this->getRelation();
-        $model = m::mock('Illuminate\Database\Eloquent\Model');
+        $model = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $relation->getRelated()->shouldReceive('newCollection')->andReturnUsing(function ($array = []) {
             return new Collection($array);
         });
-        $model->shouldReceive('setRelation')->once()->with('foo', m::type('Illuminate\Database\Eloquent\Collection'));
+        $model->shouldReceive('setRelation')->once()->with('foo', m::type(\Illuminate\Database\Eloquent\Collection::class));
         $models = $relation->initRelation([$model], 'foo');
 
         $this->assertEquals([$model], $models);
@@ -42,19 +42,19 @@ class DatabaseEloquentHasManyThroughTest extends TestCase
 
     public function testEagerConstraintsAreProperlyAddedWithCustomKey()
     {
-        $builder = m::mock('Illuminate\Database\Eloquent\Builder');
+        $builder = m::mock(\Illuminate\Database\Eloquent\Builder::class);
         $builder->shouldReceive('join')->once()->with('users', 'users.id', '=', 'posts.user_id');
         $builder->shouldReceive('where')->with('users.country_id', '=', 1);
 
-        $country = m::mock('Illuminate\Database\Eloquent\Model');
+        $country = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $country->shouldReceive('getKeyName')->andReturn('id');
         $country->shouldReceive('offsetGet')->andReturn(1);
         $country->shouldReceive('getForeignKey')->andReturn('country_id');
 
-        $user = m::mock('Illuminate\Database\Eloquent\Model');
+        $user = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $user->shouldReceive('getTable')->andReturn('users');
         $user->shouldReceive('getQualifiedKeyName')->andReturn('users.id');
-        $post = m::mock('Illuminate\Database\Eloquent\Model');
+        $post = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $post->shouldReceive('getTable')->andReturn('posts');
 
         $builder->shouldReceive('getModel')->andReturn($post);
@@ -136,7 +136,7 @@ class DatabaseEloquentHasManyThroughTest extends TestCase
     {
         $select = ['posts.*', 'users.country_id'];
 
-        $baseBuilder = m::mock('Illuminate\Database\Query\Builder');
+        $baseBuilder = m::mock(\Illuminate\Database\Query\Builder::class);
 
         $relation = $this->getRelation();
         $relation->getRelated()->shouldReceive('newCollection')->once();
@@ -154,7 +154,7 @@ class DatabaseEloquentHasManyThroughTest extends TestCase
     {
         $select = ['users.country_id'];
 
-        $baseBuilder = m::mock('Illuminate\Database\Query\Builder');
+        $baseBuilder = m::mock(\Illuminate\Database\Query\Builder::class);
         $baseBuilder->columns = ['foo', 'bar'];
 
         $relation = $this->getRelation();
@@ -183,7 +183,7 @@ class DatabaseEloquentHasManyThroughTest extends TestCase
      */
     public function testFindOrFailThrowsException()
     {
-        $relation = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\HasManyThrough')->setMethods(['find'])->setConstructorArgs($this->getRelationArguments())->getMock();
+        $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\HasManyThrough::class)->setMethods(['find'])->setConstructorArgs($this->getRelationArguments())->getMock();
         $relation->expects($this->once())->method('find')->with('foo')->will($this->returnValue(null));
 
         try {
@@ -200,7 +200,7 @@ class DatabaseEloquentHasManyThroughTest extends TestCase
      */
     public function testFirstOrFailThrowsException()
     {
-        $relation = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\HasManyThrough')->setMethods(['first'])->setConstructorArgs($this->getRelationArguments())->getMock();
+        $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\HasManyThrough::class)->setMethods(['first'])->setConstructorArgs($this->getRelationArguments())->getMock();
         $relation->expects($this->once())->method('first')->with(['id' => 'foo'])->will($this->returnValue(null));
 
         try {
@@ -262,18 +262,18 @@ class DatabaseEloquentHasManyThroughTest extends TestCase
 
     protected function getRelationArguments()
     {
-        $builder = m::mock('Illuminate\Database\Eloquent\Builder');
+        $builder = m::mock(\Illuminate\Database\Eloquent\Builder::class);
         $builder->shouldReceive('join')->once()->with('users', 'users.id', '=', 'posts.user_id');
         $builder->shouldReceive('where')->with('users.country_id', '=', 1);
 
-        $country = m::mock('Illuminate\Database\Eloquent\Model');
+        $country = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $country->shouldReceive('getKeyName')->andReturn('id');
         $country->shouldReceive('offsetGet')->andReturn(1);
         $country->shouldReceive('getForeignKey')->andReturn('country_id');
-        $user = m::mock('Illuminate\Database\Eloquent\Model');
+        $user = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $user->shouldReceive('getTable')->andReturn('users');
         $user->shouldReceive('getQualifiedKeyName')->andReturn('users.id');
-        $post = m::mock('Illuminate\Database\Eloquent\Model');
+        $post = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $post->shouldReceive('getTable')->andReturn('posts');
 
         $builder->shouldReceive('getModel')->andReturn($post);
@@ -287,17 +287,17 @@ class DatabaseEloquentHasManyThroughTest extends TestCase
 
     protected function getRelationArgumentsForNonPrimaryKey()
     {
-        $builder = m::mock('Illuminate\Database\Eloquent\Builder');
+        $builder = m::mock(\Illuminate\Database\Eloquent\Builder::class);
         $builder->shouldReceive('join')->once()->with('users', 'users.id', '=', 'posts.user_id');
         $builder->shouldReceive('where')->with('users.country_id', '=', 1);
 
-        $country = m::mock('Illuminate\Database\Eloquent\Model');
+        $country = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $country->shouldReceive('offsetGet')->andReturn(1);
         $country->shouldReceive('getForeignKey')->andReturn('country_id');
-        $user = m::mock('Illuminate\Database\Eloquent\Model');
+        $user = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $user->shouldReceive('getTable')->andReturn('users');
         $user->shouldReceive('getQualifiedKeyName')->andReturn('users.id');
-        $post = m::mock('Illuminate\Database\Eloquent\Model');
+        $post = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $post->shouldReceive('getTable')->andReturn('posts');
 
         $builder->shouldReceive('getModel')->andReturn($post);

--- a/tests/Database/DatabaseEloquentHasOneTest.php
+++ b/tests/Database/DatabaseEloquentHasOneTest.php
@@ -76,7 +76,7 @@ class DatabaseEloquentHasOneTest extends TestCase
     public function testSaveMethodSetsForeignKeyOnModel()
     {
         $relation = $this->getRelation();
-        $mockModel = $this->getMockBuilder('Illuminate\Database\Eloquent\Model')->setMethods(['save'])->getMock();
+        $mockModel = $this->getMockBuilder(\Illuminate\Database\Eloquent\Model::class)->setMethods(['save'])->getMock();
         $mockModel->expects($this->once())->method('save')->will($this->returnValue(true));
         $result = $relation->save($mockModel);
 
@@ -87,7 +87,7 @@ class DatabaseEloquentHasOneTest extends TestCase
     public function testCreateMethodProperlyCreatesNewModel()
     {
         $relation = $this->getRelation();
-        $created = $this->getMockBuilder('Illuminate\Database\Eloquent\Model')->setMethods(['save', 'getKey', 'setAttribute'])->getMock();
+        $created = $this->getMockBuilder(\Illuminate\Database\Eloquent\Model::class)->setMethods(['save', 'getKey', 'setAttribute'])->getMock();
         $created->expects($this->once())->method('save')->will($this->returnValue(true));
         $relation->getRelated()->shouldReceive('newInstance')->once()->with(['name' => 'taylor'])->andReturn($created);
         $created->expects($this->once())->method('setAttribute')->with('foreign_key', 1);
@@ -109,7 +109,7 @@ class DatabaseEloquentHasOneTest extends TestCase
     public function testRelationIsProperlyInitialized()
     {
         $relation = $this->getRelation();
-        $model = m::mock('Illuminate\Database\Eloquent\Model');
+        $model = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $model->shouldReceive('setRelation')->once()->with('foo', null);
         $models = $relation->initRelation([$model], 'foo');
 
@@ -153,17 +153,17 @@ class DatabaseEloquentHasOneTest extends TestCase
     public function testRelationCountQueryCanBeBuilt()
     {
         $relation = $this->getRelation();
-        $builder = m::mock('Illuminate\Database\Eloquent\Builder');
+        $builder = m::mock(\Illuminate\Database\Eloquent\Builder::class);
 
-        $baseQuery = m::mock('Illuminate\Database\Query\Builder');
+        $baseQuery = m::mock(\Illuminate\Database\Query\Builder::class);
         $baseQuery->from = 'one';
-        $parentQuery = m::mock('Illuminate\Database\Query\Builder');
+        $parentQuery = m::mock(\Illuminate\Database\Query\Builder::class);
         $parentQuery->from = 'two';
 
         $builder->shouldReceive('getQuery')->once()->andReturn($baseQuery);
         $builder->shouldReceive('getQuery')->once()->andReturn($parentQuery);
 
-        $builder->shouldReceive('select')->once()->with(m::type('Illuminate\Database\Query\Expression'))->andReturnSelf();
+        $builder->shouldReceive('select')->once()->with(m::type(\Illuminate\Database\Query\Expression::class))->andReturnSelf();
         $relation->getParent()->shouldReceive('getTable')->andReturn('table');
         $builder->shouldReceive('whereColumn')->once()->with('table.id', '=', 'table.foreign_key');
 
@@ -172,12 +172,12 @@ class DatabaseEloquentHasOneTest extends TestCase
 
     protected function getRelation()
     {
-        $this->builder = m::mock('Illuminate\Database\Eloquent\Builder');
+        $this->builder = m::mock(\Illuminate\Database\Eloquent\Builder::class);
         $this->builder->shouldReceive('whereNotNull')->with('table.foreign_key');
         $this->builder->shouldReceive('where')->with('table.foreign_key', '=', 1);
-        $this->related = m::mock('Illuminate\Database\Eloquent\Model');
+        $this->related = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $this->builder->shouldReceive('getModel')->andReturn($this->related);
-        $this->parent = m::mock('Illuminate\Database\Eloquent\Model');
+        $this->parent = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $this->parent->shouldReceive('getAttribute')->with('id')->andReturn(1);
         $this->parent->shouldReceive('getCreatedAtColumn')->andReturn('created_at');
         $this->parent->shouldReceive('getUpdatedAtColumn')->andReturn('updated_at');

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -131,22 +131,22 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertTrue(isset($model->friends));
 
         $model = EloquentTestUser::find(1);
-        $this->assertInstanceOf('Illuminate\Tests\Database\EloquentTestUser', $model);
+        $this->assertInstanceOf(\Illuminate\Tests\Database\EloquentTestUser::class, $model);
         $this->assertEquals(1, $model->id);
 
         $model = EloquentTestUser::find(2);
-        $this->assertInstanceOf('Illuminate\Tests\Database\EloquentTestUser', $model);
+        $this->assertInstanceOf(\Illuminate\Tests\Database\EloquentTestUser::class, $model);
         $this->assertEquals(2, $model->id);
 
         $missing = EloquentTestUser::find(3);
         $this->assertNull($missing);
 
         $collection = EloquentTestUser::find([]);
-        $this->assertInstanceOf('Illuminate\Database\Eloquent\Collection', $collection);
+        $this->assertInstanceOf(\Illuminate\Database\Eloquent\Collection::class, $collection);
         $this->assertEquals(0, $collection->count());
 
         $collection = EloquentTestUser::find([1, 2, 3]);
-        $this->assertInstanceOf('Illuminate\Database\Eloquent\Collection', $collection);
+        $this->assertInstanceOf(\Illuminate\Database\Eloquent\Collection::class, $collection);
         $this->assertEquals(2, $collection->count());
 
         $models = EloquentTestUser::where('id', 1)->cursor();
@@ -173,9 +173,9 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $models = EloquentTestUser::oldest('id')->get();
 
         $this->assertEquals(2, $models->count());
-        $this->assertInstanceOf('Illuminate\Database\Eloquent\Collection', $models);
-        $this->assertInstanceOf('Illuminate\Tests\Database\EloquentTestUser', $models[0]);
-        $this->assertInstanceOf('Illuminate\Tests\Database\EloquentTestUser', $models[1]);
+        $this->assertInstanceOf(\Illuminate\Database\Eloquent\Collection::class, $models);
+        $this->assertInstanceOf(\Illuminate\Tests\Database\EloquentTestUser::class, $models[0]);
+        $this->assertInstanceOf(\Illuminate\Tests\Database\EloquentTestUser::class, $models[1]);
         $this->assertEquals('taylorotwell@gmail.com', $models[0]->email);
         $this->assertEquals('abigailotwell@gmail.com', $models[1]->email);
     }
@@ -192,9 +192,9 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $models = EloquentTestUser::oldest('id')->paginate(2);
 
         $this->assertEquals(2, $models->count());
-        $this->assertInstanceOf('Illuminate\Pagination\LengthAwarePaginator', $models);
-        $this->assertInstanceOf('Illuminate\Tests\Database\EloquentTestUser', $models[0]);
-        $this->assertInstanceOf('Illuminate\Tests\Database\EloquentTestUser', $models[1]);
+        $this->assertInstanceOf(\Illuminate\Pagination\LengthAwarePaginator::class, $models);
+        $this->assertInstanceOf(\Illuminate\Tests\Database\EloquentTestUser::class, $models[0]);
+        $this->assertInstanceOf(\Illuminate\Tests\Database\EloquentTestUser::class, $models[1]);
         $this->assertEquals('taylorotwell@gmail.com', $models[0]->email);
         $this->assertEquals('abigailotwell@gmail.com', $models[1]->email);
 
@@ -204,8 +204,8 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $models = EloquentTestUser::oldest('id')->paginate(2);
 
         $this->assertEquals(1, $models->count());
-        $this->assertInstanceOf('Illuminate\Pagination\LengthAwarePaginator', $models);
-        $this->assertInstanceOf('Illuminate\Tests\Database\EloquentTestUser', $models[0]);
+        $this->assertInstanceOf(\Illuminate\Pagination\LengthAwarePaginator::class, $models);
+        $this->assertInstanceOf(\Illuminate\Tests\Database\EloquentTestUser::class, $models[0]);
         $this->assertEquals('foo@gmail.com', $models[0]->email);
     }
 
@@ -217,7 +217,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $models = EloquentTestUser::oldest('id')->paginate(2);
 
         $this->assertEquals(0, $models->count());
-        $this->assertInstanceOf('Illuminate\Pagination\LengthAwarePaginator', $models);
+        $this->assertInstanceOf(\Illuminate\Pagination\LengthAwarePaginator::class, $models);
 
         Paginator::currentPageResolver(function () {
             return 2;
@@ -232,7 +232,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $models = EloquentTestUser::oldest('id')->paginate();
 
         $this->assertEquals(0, $models->count());
-        $this->assertInstanceOf('Illuminate\Pagination\LengthAwarePaginator', $models);
+        $this->assertInstanceOf(\Illuminate\Pagination\LengthAwarePaginator::class, $models);
     }
 
     public function testCountForPaginationWithGrouping()
@@ -385,11 +385,11 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $single = EloquentTestUser::findOrFail(1);
         $multiple = EloquentTestUser::findOrFail([1, 2]);
 
-        $this->assertInstanceOf('Illuminate\Tests\Database\EloquentTestUser', $single);
+        $this->assertInstanceOf(\Illuminate\Tests\Database\EloquentTestUser::class, $single);
         $this->assertEquals('taylorotwell@gmail.com', $single->email);
-        $this->assertInstanceOf('Illuminate\Database\Eloquent\Collection', $multiple);
-        $this->assertInstanceOf('Illuminate\Tests\Database\EloquentTestUser', $multiple[0]);
-        $this->assertInstanceOf('Illuminate\Tests\Database\EloquentTestUser', $multiple[1]);
+        $this->assertInstanceOf(\Illuminate\Database\Eloquent\Collection::class, $multiple);
+        $this->assertInstanceOf(\Illuminate\Tests\Database\EloquentTestUser::class, $multiple[0]);
+        $this->assertInstanceOf(\Illuminate\Tests\Database\EloquentTestUser::class, $multiple[1]);
     }
 
     /**
@@ -418,8 +418,8 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $user = $post->user;
 
         $this->assertTrue(isset($user->post->name));
-        $this->assertInstanceOf('Illuminate\Tests\Database\EloquentTestUser', $user);
-        $this->assertInstanceOf('Illuminate\Tests\Database\EloquentTestPost', $post);
+        $this->assertInstanceOf(\Illuminate\Tests\Database\EloquentTestUser::class, $user);
+        $this->assertInstanceOf(\Illuminate\Tests\Database\EloquentTestPost::class, $post);
         $this->assertEquals('taylorotwell@gmail.com', $user->email);
         $this->assertEquals('First Post', $post->name);
     }
@@ -441,13 +441,13 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $posts = $user->posts;
         $post2 = $user->posts()->where('name', 'Second Post')->first();
 
-        $this->assertInstanceOf('Illuminate\Database\Eloquent\Collection', $posts);
+        $this->assertInstanceOf(\Illuminate\Database\Eloquent\Collection::class, $posts);
         $this->assertEquals(2, $posts->count());
-        $this->assertInstanceOf('Illuminate\Tests\Database\EloquentTestPost', $posts[0]);
-        $this->assertInstanceOf('Illuminate\Tests\Database\EloquentTestPost', $posts[1]);
-        $this->assertInstanceOf('Illuminate\Tests\Database\EloquentTestPost', $post2);
+        $this->assertInstanceOf(\Illuminate\Tests\Database\EloquentTestPost::class, $posts[0]);
+        $this->assertInstanceOf(\Illuminate\Tests\Database\EloquentTestPost::class, $posts[1]);
+        $this->assertInstanceOf(\Illuminate\Tests\Database\EloquentTestPost::class, $post2);
         $this->assertEquals('Second Post', $post2->name);
-        $this->assertInstanceOf('Illuminate\Tests\Database\EloquentTestUser', $post2->user);
+        $this->assertInstanceOf(\Illuminate\Tests\Database\EloquentTestUser::class, $post2->user);
         $this->assertEquals('taylorotwell@gmail.com', $post2->user->email);
     }
 
@@ -463,8 +463,8 @@ class DatabaseEloquentIntegrationTest extends TestCase
 
         $models = EloquentTestUser::on('second_connection')->fromQuery('SELECT * FROM users WHERE email = ?', ['abigailotwell@gmail.com']);
 
-        $this->assertInstanceOf('Illuminate\Database\Eloquent\Collection', $models);
-        $this->assertInstanceOf('Illuminate\Tests\Database\EloquentTestUser', $models[0]);
+        $this->assertInstanceOf(\Illuminate\Database\Eloquent\Collection::class, $models);
+        $this->assertInstanceOf(\Illuminate\Tests\Database\EloquentTestUser::class, $models[0]);
         $this->assertEquals('abigailotwell@gmail.com', $models[0]->email);
         $this->assertEquals('second_connection', $models[0]->getConnectionName());
         $this->assertEquals(1, $models->count());
@@ -723,10 +723,10 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $post->photos()->create(['name' => 'Hero 1']);
         $post->photos()->create(['name' => 'Hero 2']);
 
-        $this->assertInstanceOf('Illuminate\Database\Eloquent\Collection', $user->photos);
-        $this->assertInstanceOf('Illuminate\Tests\Database\EloquentTestPhoto', $user->photos[0]);
-        $this->assertInstanceOf('Illuminate\Database\Eloquent\Collection', $post->photos);
-        $this->assertInstanceOf('Illuminate\Tests\Database\EloquentTestPhoto', $post->photos[0]);
+        $this->assertInstanceOf(\Illuminate\Database\Eloquent\Collection::class, $user->photos);
+        $this->assertInstanceOf(\Illuminate\Tests\Database\EloquentTestPhoto::class, $user->photos[0]);
+        $this->assertInstanceOf(\Illuminate\Database\Eloquent\Collection::class, $post->photos);
+        $this->assertInstanceOf(\Illuminate\Tests\Database\EloquentTestPhoto::class, $post->photos[0]);
         $this->assertEquals(2, $user->photos->count());
         $this->assertEquals(2, $post->photos->count());
         $this->assertEquals('Avatar 1', $user->photos[0]->name);
@@ -736,10 +736,10 @@ class DatabaseEloquentIntegrationTest extends TestCase
 
         $photos = EloquentTestPhoto::orderBy('name')->get();
 
-        $this->assertInstanceOf('Illuminate\Database\Eloquent\Collection', $photos);
+        $this->assertInstanceOf(\Illuminate\Database\Eloquent\Collection::class, $photos);
         $this->assertEquals(4, $photos->count());
-        $this->assertInstanceOf('Illuminate\Tests\Database\EloquentTestUser', $photos[0]->imageable);
-        $this->assertInstanceOf('Illuminate\Tests\Database\EloquentTestPost', $photos[2]->imageable);
+        $this->assertInstanceOf(\Illuminate\Tests\Database\EloquentTestUser::class, $photos[0]->imageable);
+        $this->assertInstanceOf(\Illuminate\Tests\Database\EloquentTestPost::class, $photos[2]->imageable);
         $this->assertEquals('taylorotwell@gmail.com', $photos[1]->imageable->email);
         $this->assertEquals('First Post', $photos[3]->imageable->name);
     }
@@ -747,8 +747,8 @@ class DatabaseEloquentIntegrationTest extends TestCase
     public function testMorphMapIsUsedForCreatingAndFetchingThroughRelation()
     {
         Relation::morphMap([
-            'user' => 'Illuminate\Tests\Database\EloquentTestUser',
-            'post' => 'Illuminate\Tests\Database\EloquentTestPost',
+            'user' => \Illuminate\Tests\Database\EloquentTestUser::class,
+            'post' => \Illuminate\Tests\Database\EloquentTestPost::class,
         ]);
 
         $user = EloquentTestUser::create(['email' => 'taylorotwell@gmail.com']);
@@ -758,10 +758,10 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $post->photos()->create(['name' => 'Hero 1']);
         $post->photos()->create(['name' => 'Hero 2']);
 
-        $this->assertInstanceOf('Illuminate\Database\Eloquent\Collection', $user->photos);
-        $this->assertInstanceOf('Illuminate\Tests\Database\EloquentTestPhoto', $user->photos[0]);
-        $this->assertInstanceOf('Illuminate\Database\Eloquent\Collection', $post->photos);
-        $this->assertInstanceOf('Illuminate\Tests\Database\EloquentTestPhoto', $post->photos[0]);
+        $this->assertInstanceOf(\Illuminate\Database\Eloquent\Collection::class, $user->photos);
+        $this->assertInstanceOf(\Illuminate\Tests\Database\EloquentTestPhoto::class, $user->photos[0]);
+        $this->assertInstanceOf(\Illuminate\Database\Eloquent\Collection::class, $post->photos);
+        $this->assertInstanceOf(\Illuminate\Tests\Database\EloquentTestPhoto::class, $post->photos[0]);
         $this->assertEquals(2, $user->photos->count());
         $this->assertEquals(2, $post->photos->count());
         $this->assertEquals('Avatar 1', $user->photos[0]->name);
@@ -778,8 +778,8 @@ class DatabaseEloquentIntegrationTest extends TestCase
     public function testMorphMapIsUsedWhenFetchingParent()
     {
         Relation::morphMap([
-            'user' => 'Illuminate\Tests\Database\EloquentTestUser',
-            'post' => 'Illuminate\Tests\Database\EloquentTestPost',
+            'user' => \Illuminate\Tests\Database\EloquentTestUser::class,
+            'post' => \Illuminate\Tests\Database\EloquentTestPost::class,
         ]);
 
         $user = EloquentTestUser::create(['email' => 'taylorotwell@gmail.com']);
@@ -787,16 +787,16 @@ class DatabaseEloquentIntegrationTest extends TestCase
 
         $photo = EloquentTestPhoto::first();
         $this->assertEquals('user', $photo->imageable_type);
-        $this->assertInstanceOf('Illuminate\Tests\Database\EloquentTestUser', $photo->imageable);
+        $this->assertInstanceOf(\Illuminate\Tests\Database\EloquentTestUser::class, $photo->imageable);
     }
 
     public function testMorphMapIsMergedByDefault()
     {
         $map1 = [
-            'user' => 'Illuminate\Tests\Database\EloquentTestUser',
+            'user' => \Illuminate\Tests\Database\EloquentTestUser::class,
         ];
         $map2 = [
-            'post' => 'Illuminate\Tests\Database\EloquentTestPost',
+            'post' => \Illuminate\Tests\Database\EloquentTestPost::class,
         ];
 
         Relation::morphMap($map1);
@@ -808,10 +808,10 @@ class DatabaseEloquentIntegrationTest extends TestCase
     public function testMorphMapOverwritesCurrentMap()
     {
         $map1 = [
-            'user' => 'Illuminate\Tests\Database\EloquentTestUser',
+            'user' => \Illuminate\Tests\Database\EloquentTestUser::class,
         ];
         $map2 = [
-            'post' => 'Illuminate\Tests\Database\EloquentTestPost',
+            'post' => \Illuminate\Tests\Database\EloquentTestPost::class,
         ];
 
         Relation::morphMap($map1, false);
@@ -1036,7 +1036,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
             // ignore the exception
         }
 
-        $this->assertInstanceOf('Illuminate\Tests\Database\EloquentTestItem', $item);
+        $this->assertInstanceOf(\Illuminate\Tests\Database\EloquentTestItem::class, $item);
     }
 
     public function testBelongsToManyCustomPivot()
@@ -1096,32 +1096,32 @@ class EloquentTestUser extends Eloquent
 
     public function friends()
     {
-        return $this->belongsToMany('Illuminate\Tests\Database\EloquentTestUser', 'friends', 'user_id', 'friend_id');
+        return $this->belongsToMany(\Illuminate\Tests\Database\EloquentTestUser::class, 'friends', 'user_id', 'friend_id');
     }
 
     public function friendsOne()
     {
-        return $this->belongsToMany('Illuminate\Tests\Database\EloquentTestUser', 'friends', 'user_id', 'friend_id')->wherePivot('user_id', 1);
+        return $this->belongsToMany(\Illuminate\Tests\Database\EloquentTestUser::class, 'friends', 'user_id', 'friend_id')->wherePivot('user_id', 1);
     }
 
     public function friendsTwo()
     {
-        return $this->belongsToMany('Illuminate\Tests\Database\EloquentTestUser', 'friends', 'user_id', 'friend_id')->wherePivot('user_id', 2);
+        return $this->belongsToMany(\Illuminate\Tests\Database\EloquentTestUser::class, 'friends', 'user_id', 'friend_id')->wherePivot('user_id', 2);
     }
 
     public function posts()
     {
-        return $this->hasMany('Illuminate\Tests\Database\EloquentTestPost', 'user_id');
+        return $this->hasMany(\Illuminate\Tests\Database\EloquentTestPost::class, 'user_id');
     }
 
     public function post()
     {
-        return $this->hasOne('Illuminate\Tests\Database\EloquentTestPost', 'user_id');
+        return $this->hasOne(\Illuminate\Tests\Database\EloquentTestPost::class, 'user_id');
     }
 
     public function photos()
     {
-        return $this->morphMany('Illuminate\Tests\Database\EloquentTestPhoto', 'imageable');
+        return $this->morphMany(\Illuminate\Tests\Database\EloquentTestPhoto::class, 'imageable');
     }
 
     public function postWithPhotos()
@@ -1137,8 +1137,8 @@ class EloquentTestUserWithCustomFriendPivot extends EloquentTestUser
 {
     public function friends()
     {
-        return $this->belongsToMany('Illuminate\Tests\Database\EloquentTestUser', 'friends', 'user_id', 'friend_id')
-                        ->using('Illuminate\Tests\Database\EloquentTestFriendPivot')->withPivot('user_id', 'friend_id', 'friend_level_id');
+        return $this->belongsToMany(\Illuminate\Tests\Database\EloquentTestUser::class, 'friends', 'user_id', 'friend_id')
+                        ->using(\Illuminate\Tests\Database\EloquentTestFriendPivot::class)->withPivot('user_id', 'friend_id', 'friend_level_id');
     }
 }
 
@@ -1181,22 +1181,22 @@ class EloquentTestPost extends Eloquent
 
     public function user()
     {
-        return $this->belongsTo('Illuminate\Tests\Database\EloquentTestUser', 'user_id');
+        return $this->belongsTo(\Illuminate\Tests\Database\EloquentTestUser::class, 'user_id');
     }
 
     public function photos()
     {
-        return $this->morphMany('Illuminate\Tests\Database\EloquentTestPhoto', 'imageable');
+        return $this->morphMany(\Illuminate\Tests\Database\EloquentTestPhoto::class, 'imageable');
     }
 
     public function childPosts()
     {
-        return $this->hasMany('Illuminate\Tests\Database\EloquentTestPost', 'parent_id');
+        return $this->hasMany(\Illuminate\Tests\Database\EloquentTestPost::class, 'parent_id');
     }
 
     public function parentPost()
     {
-        return $this->belongsTo('Illuminate\Tests\Database\EloquentTestPost', 'parent_id');
+        return $this->belongsTo(\Illuminate\Tests\Database\EloquentTestPost::class, 'parent_id');
     }
 }
 

--- a/tests/Database/DatabaseEloquentIntegrationWithTablePrefixTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationWithTablePrefixTest.php
@@ -84,8 +84,8 @@ class DatabaseEloquentIntegrationWithTablePrefixTest extends TestCase
 
         $models = EloquentTestUser::fromQuery('SELECT * FROM prefix_users WHERE email = ?', ['abigailotwell@gmail.com']);
 
-        $this->assertInstanceOf('Illuminate\Database\Eloquent\Collection', $models);
-        $this->assertInstanceOf('Illuminate\Tests\Database\EloquentTestUser', $models[0]);
+        $this->assertInstanceOf(\Illuminate\Database\Eloquent\Collection::class, $models);
+        $this->assertInstanceOf(\Illuminate\Tests\Database\EloquentTestUser::class, $models[0]);
         $this->assertEquals('abigailotwell@gmail.com', $models[0]->email);
         $this->assertEquals(1, $models->count());
     }

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -307,7 +307,7 @@ class DatabaseEloquentModelTest extends TestCase
         ];
         $model = new EloquentDateModelStub;
         \Illuminate\Database\Eloquent\Model::setConnectionResolver($resolver = m::mock(\Illuminate\Database\ConnectionResolverInterface::class));
-        $resolver->shouldReceive('connection')->andReturn($mockConnection = m::mock('StdClass'));
+        $resolver->shouldReceive('connection')->andReturn($mockConnection = m::mock(\StdClass::class));
         $mockConnection->shouldReceive('getQueryGrammar')->andReturn($mockConnection);
         $mockConnection->shouldReceive('getDateFormat')->andReturn('Y-m-d H:i:s');
         $instance = $model->newInstance($timestamps);
@@ -323,7 +323,7 @@ class DatabaseEloquentModelTest extends TestCase
         ];
         $model = new EloquentDateModelStub;
         \Illuminate\Database\Eloquent\Model::setConnectionResolver($resolver = m::mock(\Illuminate\Database\ConnectionResolverInterface::class));
-        $resolver->shouldReceive('connection')->andReturn($mockConnection = m::mock('StdClass'));
+        $resolver->shouldReceive('connection')->andReturn($mockConnection = m::mock(\StdClass::class));
         $mockConnection->shouldReceive('getQueryGrammar')->andReturn($mockConnection);
         $mockConnection->shouldReceive('getDateFormat')->andReturn('Y-m-d H:i:s');
         $instance = $model->newInstance($timestamps);
@@ -1299,7 +1299,7 @@ class DatabaseEloquentModelTest extends TestCase
         $model->syncOriginalAttribute('id');
         $model->foo = 2;
 
-        $model->shouldReceive('newQuery')->andReturn($query = m::mock('StdClass'));
+        $model->shouldReceive('newQuery')->andReturn($query = m::mock(\StdClass::class));
         $query->shouldReceive('where')->andReturn($query);
         $query->shouldReceive('increment');
 
@@ -1743,7 +1743,7 @@ class EloquentModelDestroyStub extends Model
     {
         $mock = m::mock(\Illuminate\Database\Eloquent\Builder::class);
         $mock->shouldReceive('whereIn')->once()->with('id', [1, 2, 3])->andReturn($mock);
-        $mock->shouldReceive('get')->once()->andReturn([$model = m::mock('StdClass')]);
+        $mock->shouldReceive('get')->once()->andReturn([$model = m::mock(\StdClass::class)]);
         $model->shouldReceive('delete')->once();
 
         return $mock;

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -91,7 +91,7 @@ class DatabaseEloquentModelTest extends TestCase
     {
         $model = new EloquentModelStub;
         $instance = $model->newInstance(['name' => 'taylor']);
-        $this->assertInstanceOf('Illuminate\Tests\Database\EloquentModelStub', $instance);
+        $this->assertInstanceOf(\Illuminate\Tests\Database\EloquentModelStub::class, $instance);
         $this->assertEquals('taylor', $instance->name);
     }
 
@@ -154,13 +154,13 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testUpdateProcess()
     {
-        $model = $this->getMockBuilder('Illuminate\Tests\Database\EloquentModelStub')->setMethods(['newQueryWithoutScopes', 'updateTimestamps'])->getMock();
-        $query = m::mock('Illuminate\Database\Eloquent\Builder');
+        $model = $this->getMockBuilder(\Illuminate\Tests\Database\EloquentModelStub::class)->setMethods(['newQueryWithoutScopes', 'updateTimestamps'])->getMock();
+        $query = m::mock(\Illuminate\Database\Eloquent\Builder::class);
         $query->shouldReceive('where')->once()->with('id', '=', 1);
         $query->shouldReceive('update')->once()->with(['name' => 'taylor'])->andReturn(1);
         $model->expects($this->once())->method('newQueryWithoutScopes')->will($this->returnValue($query));
         $model->expects($this->once())->method('updateTimestamps');
-        $model->setEventDispatcher($events = m::mock('Illuminate\Contracts\Events\Dispatcher'));
+        $model->setEventDispatcher($events = m::mock(\Illuminate\Contracts\Events\Dispatcher::class));
         $events->shouldReceive('until')->once()->with('eloquent.saving: '.get_class($model), $model)->andReturn(true);
         $events->shouldReceive('until')->once()->with('eloquent.updating: '.get_class($model), $model)->andReturn(true);
         $events->shouldReceive('fire')->once()->with('eloquent.updated: '.get_class($model), $model)->andReturn(true);
@@ -177,12 +177,12 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testUpdateProcessDoesntOverrideTimestamps()
     {
-        $model = $this->getMockBuilder('Illuminate\Tests\Database\EloquentModelStub')->setMethods(['newQueryWithoutScopes'])->getMock();
-        $query = m::mock('Illuminate\Database\Eloquent\Builder');
+        $model = $this->getMockBuilder(\Illuminate\Tests\Database\EloquentModelStub::class)->setMethods(['newQueryWithoutScopes'])->getMock();
+        $query = m::mock(\Illuminate\Database\Eloquent\Builder::class);
         $query->shouldReceive('where')->once()->with('id', '=', 1);
         $query->shouldReceive('update')->once()->with(['created_at' => 'foo', 'updated_at' => 'bar'])->andReturn(1);
         $model->expects($this->once())->method('newQueryWithoutScopes')->will($this->returnValue($query));
-        $model->setEventDispatcher($events = m::mock('Illuminate\Contracts\Events\Dispatcher'));
+        $model->setEventDispatcher($events = m::mock(\Illuminate\Contracts\Events\Dispatcher::class));
         $events->shouldReceive('until');
         $events->shouldReceive('fire');
 
@@ -196,10 +196,10 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testSaveIsCancelledIfSavingEventReturnsFalse()
     {
-        $model = $this->getMockBuilder('Illuminate\Tests\Database\EloquentModelStub')->setMethods(['newQueryWithoutScopes'])->getMock();
-        $query = m::mock('Illuminate\Database\Eloquent\Builder');
+        $model = $this->getMockBuilder(\Illuminate\Tests\Database\EloquentModelStub::class)->setMethods(['newQueryWithoutScopes'])->getMock();
+        $query = m::mock(\Illuminate\Database\Eloquent\Builder::class);
         $model->expects($this->once())->method('newQueryWithoutScopes')->will($this->returnValue($query));
-        $model->setEventDispatcher($events = m::mock('Illuminate\Contracts\Events\Dispatcher'));
+        $model->setEventDispatcher($events = m::mock(\Illuminate\Contracts\Events\Dispatcher::class));
         $events->shouldReceive('until')->once()->with('eloquent.saving: '.get_class($model), $model)->andReturn(false);
         $model->exists = true;
 
@@ -208,10 +208,10 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testUpdateIsCancelledIfUpdatingEventReturnsFalse()
     {
-        $model = $this->getMockBuilder('Illuminate\Tests\Database\EloquentModelStub')->setMethods(['newQueryWithoutScopes'])->getMock();
-        $query = m::mock('Illuminate\Database\Eloquent\Builder');
+        $model = $this->getMockBuilder(\Illuminate\Tests\Database\EloquentModelStub::class)->setMethods(['newQueryWithoutScopes'])->getMock();
+        $query = m::mock(\Illuminate\Database\Eloquent\Builder::class);
         $model->expects($this->once())->method('newQueryWithoutScopes')->will($this->returnValue($query));
-        $model->setEventDispatcher($events = m::mock('Illuminate\Contracts\Events\Dispatcher'));
+        $model->setEventDispatcher($events = m::mock(\Illuminate\Contracts\Events\Dispatcher::class));
         $events->shouldReceive('until')->once()->with('eloquent.saving: '.get_class($model), $model)->andReturn(true);
         $events->shouldReceive('until')->once()->with('eloquent.updating: '.get_class($model), $model)->andReturn(false);
         $model->exists = true;
@@ -222,10 +222,10 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testEventsCanBeFiredWithCustomEventObjects()
     {
-        $model = $this->getMockBuilder('Illuminate\Tests\Database\EloquentModelEventObjectStub')->setMethods(['newQueryWithoutScopes'])->getMock();
-        $query = m::mock('Illuminate\Database\Eloquent\Builder');
+        $model = $this->getMockBuilder(\Illuminate\Tests\Database\EloquentModelEventObjectStub::class)->setMethods(['newQueryWithoutScopes'])->getMock();
+        $query = m::mock(\Illuminate\Database\Eloquent\Builder::class);
         $model->expects($this->once())->method('newQueryWithoutScopes')->will($this->returnValue($query));
-        $model->setEventDispatcher($events = m::mock('Illuminate\Contracts\Events\Dispatcher'));
+        $model->setEventDispatcher($events = m::mock(\Illuminate\Contracts\Events\Dispatcher::class));
         $events->shouldReceive('until')->once()->with(m::type(EloquentModelSavingEventStub::class))->andReturn(false);
         $model->exists = true;
 
@@ -234,9 +234,9 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testUpdateProcessWithoutTimestamps()
     {
-        $model = $this->getMockBuilder('Illuminate\Tests\Database\EloquentModelEventObjectStub')->setMethods(['newQueryWithoutScopes', 'updateTimestamps', 'fireModelEvent'])->getMock();
+        $model = $this->getMockBuilder(\Illuminate\Tests\Database\EloquentModelEventObjectStub::class)->setMethods(['newQueryWithoutScopes', 'updateTimestamps', 'fireModelEvent'])->getMock();
         $model->timestamps = false;
-        $query = m::mock('Illuminate\Database\Eloquent\Builder');
+        $query = m::mock(\Illuminate\Database\Eloquent\Builder::class);
         $query->shouldReceive('where')->once()->with('id', '=', 1);
         $query->shouldReceive('update')->once()->with(['name' => 'taylor'])->andReturn(1);
         $model->expects($this->once())->method('newQueryWithoutScopes')->will($this->returnValue($query));
@@ -252,13 +252,13 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testUpdateUsesOldPrimaryKey()
     {
-        $model = $this->getMockBuilder('Illuminate\Tests\Database\EloquentModelStub')->setMethods(['newQueryWithoutScopes', 'updateTimestamps'])->getMock();
-        $query = m::mock('Illuminate\Database\Eloquent\Builder');
+        $model = $this->getMockBuilder(\Illuminate\Tests\Database\EloquentModelStub::class)->setMethods(['newQueryWithoutScopes', 'updateTimestamps'])->getMock();
+        $query = m::mock(\Illuminate\Database\Eloquent\Builder::class);
         $query->shouldReceive('where')->once()->with('id', '=', 1);
         $query->shouldReceive('update')->once()->with(['id' => 2, 'foo' => 'bar'])->andReturn(1);
         $model->expects($this->once())->method('newQueryWithoutScopes')->will($this->returnValue($query));
         $model->expects($this->once())->method('updateTimestamps');
-        $model->setEventDispatcher($events = m::mock('Illuminate\Contracts\Events\Dispatcher'));
+        $model->setEventDispatcher($events = m::mock(\Illuminate\Contracts\Events\Dispatcher::class));
         $events->shouldReceive('until')->once()->with('eloquent.saving: '.get_class($model), $model)->andReturn(true);
         $events->shouldReceive('until')->once()->with('eloquent.updating: '.get_class($model), $model)->andReturn(true);
         $events->shouldReceive('fire')->once()->with('eloquent.updated: '.get_class($model), $model)->andReturn(true);
@@ -275,7 +275,7 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testTimestampsAreReturnedAsObjects()
     {
-        $model = $this->getMockBuilder('Illuminate\Tests\Database\EloquentDateModelStub')->setMethods(['getDateFormat'])->getMock();
+        $model = $this->getMockBuilder(\Illuminate\Tests\Database\EloquentDateModelStub::class)->setMethods(['getDateFormat'])->getMock();
         $model->expects($this->any())->method('getDateFormat')->will($this->returnValue('Y-m-d'));
         $model->setRawAttributes([
             'created_at' => '2012-12-04',
@@ -288,7 +288,7 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testTimestampsAreReturnedAsObjectsFromPlainDatesAndTimestamps()
     {
-        $model = $this->getMockBuilder('Illuminate\Tests\Database\EloquentDateModelStub')->setMethods(['getDateFormat'])->getMock();
+        $model = $this->getMockBuilder(\Illuminate\Tests\Database\EloquentDateModelStub::class)->setMethods(['getDateFormat'])->getMock();
         $model->expects($this->any())->method('getDateFormat')->will($this->returnValue('Y-m-d H:i:s'));
         $model->setRawAttributes([
             'created_at' => '2012-12-04',
@@ -306,7 +306,7 @@ class DatabaseEloquentModelTest extends TestCase
             'updated_at' => \Carbon\Carbon::now(),
         ];
         $model = new EloquentDateModelStub;
-        \Illuminate\Database\Eloquent\Model::setConnectionResolver($resolver = m::mock('Illuminate\Database\ConnectionResolverInterface'));
+        \Illuminate\Database\Eloquent\Model::setConnectionResolver($resolver = m::mock(\Illuminate\Database\ConnectionResolverInterface::class));
         $resolver->shouldReceive('connection')->andReturn($mockConnection = m::mock('StdClass'));
         $mockConnection->shouldReceive('getQueryGrammar')->andReturn($mockConnection);
         $mockConnection->shouldReceive('getDateFormat')->andReturn('Y-m-d H:i:s');
@@ -322,7 +322,7 @@ class DatabaseEloquentModelTest extends TestCase
             'updated_at' => \Carbon\Carbon::now(),
         ];
         $model = new EloquentDateModelStub;
-        \Illuminate\Database\Eloquent\Model::setConnectionResolver($resolver = m::mock('Illuminate\Database\ConnectionResolverInterface'));
+        \Illuminate\Database\Eloquent\Model::setConnectionResolver($resolver = m::mock(\Illuminate\Database\ConnectionResolverInterface::class));
         $resolver->shouldReceive('connection')->andReturn($mockConnection = m::mock('StdClass'));
         $mockConnection->shouldReceive('getQueryGrammar')->andReturn($mockConnection);
         $mockConnection->shouldReceive('getDateFormat')->andReturn('Y-m-d H:i:s');
@@ -383,13 +383,13 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testInsertProcess()
     {
-        $model = $this->getMockBuilder('Illuminate\Tests\Database\EloquentModelStub')->setMethods(['newQueryWithoutScopes', 'updateTimestamps', 'refresh'])->getMock();
-        $query = m::mock('Illuminate\Database\Eloquent\Builder');
+        $model = $this->getMockBuilder(\Illuminate\Tests\Database\EloquentModelStub::class)->setMethods(['newQueryWithoutScopes', 'updateTimestamps', 'refresh'])->getMock();
+        $query = m::mock(\Illuminate\Database\Eloquent\Builder::class);
         $query->shouldReceive('insertGetId')->once()->with(['name' => 'taylor'], 'id')->andReturn(1);
         $model->expects($this->once())->method('newQueryWithoutScopes')->will($this->returnValue($query));
         $model->expects($this->once())->method('updateTimestamps');
 
-        $model->setEventDispatcher($events = m::mock('Illuminate\Contracts\Events\Dispatcher'));
+        $model->setEventDispatcher($events = m::mock(\Illuminate\Contracts\Events\Dispatcher::class));
         $events->shouldReceive('until')->once()->with('eloquent.saving: '.get_class($model), $model)->andReturn(true);
         $events->shouldReceive('until')->once()->with('eloquent.creating: '.get_class($model), $model)->andReturn(true);
         $events->shouldReceive('fire')->once()->with('eloquent.created: '.get_class($model), $model);
@@ -401,14 +401,14 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEquals(1, $model->id);
         $this->assertTrue($model->exists);
 
-        $model = $this->getMockBuilder('Illuminate\Tests\Database\EloquentModelStub')->setMethods(['newQueryWithoutScopes', 'updateTimestamps', 'refresh'])->getMock();
-        $query = m::mock('Illuminate\Database\Eloquent\Builder');
+        $model = $this->getMockBuilder(\Illuminate\Tests\Database\EloquentModelStub::class)->setMethods(['newQueryWithoutScopes', 'updateTimestamps', 'refresh'])->getMock();
+        $query = m::mock(\Illuminate\Database\Eloquent\Builder::class);
         $query->shouldReceive('insert')->once()->with(['name' => 'taylor']);
         $model->expects($this->once())->method('newQueryWithoutScopes')->will($this->returnValue($query));
         $model->expects($this->once())->method('updateTimestamps');
         $model->setIncrementing(false);
 
-        $model->setEventDispatcher($events = m::mock('Illuminate\Contracts\Events\Dispatcher'));
+        $model->setEventDispatcher($events = m::mock(\Illuminate\Contracts\Events\Dispatcher::class));
         $events->shouldReceive('until')->once()->with('eloquent.saving: '.get_class($model), $model)->andReturn(true);
         $events->shouldReceive('until')->once()->with('eloquent.creating: '.get_class($model), $model)->andReturn(true);
         $events->shouldReceive('fire')->once()->with('eloquent.created: '.get_class($model), $model);
@@ -423,10 +423,10 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testInsertIsCancelledIfCreatingEventReturnsFalse()
     {
-        $model = $this->getMockBuilder('Illuminate\Tests\Database\EloquentModelStub')->setMethods(['newQueryWithoutScopes'])->getMock();
-        $query = m::mock('Illuminate\Database\Eloquent\Builder');
+        $model = $this->getMockBuilder(\Illuminate\Tests\Database\EloquentModelStub::class)->setMethods(['newQueryWithoutScopes'])->getMock();
+        $query = m::mock(\Illuminate\Database\Eloquent\Builder::class);
         $model->expects($this->once())->method('newQueryWithoutScopes')->will($this->returnValue($query));
-        $model->setEventDispatcher($events = m::mock('Illuminate\Contracts\Events\Dispatcher'));
+        $model->setEventDispatcher($events = m::mock(\Illuminate\Contracts\Events\Dispatcher::class));
         $events->shouldReceive('until')->once()->with('eloquent.saving: '.get_class($model), $model)->andReturn(true);
         $events->shouldReceive('until')->once()->with('eloquent.creating: '.get_class($model), $model)->andReturn(false);
 
@@ -436,8 +436,8 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testDeleteProperlyDeletesModel()
     {
-        $model = $this->getMockBuilder('Illuminate\Database\Eloquent\Model')->setMethods(['newQueryWithoutScopes', 'updateTimestamps', 'touchOwners'])->getMock();
-        $query = m::mock('Illuminate\Database\Eloquent\Builder');
+        $model = $this->getMockBuilder(\Illuminate\Database\Eloquent\Model::class)->setMethods(['newQueryWithoutScopes', 'updateTimestamps', 'touchOwners'])->getMock();
+        $query = m::mock(\Illuminate\Database\Eloquent\Builder::class);
         $query->shouldReceive('where')->once()->with('id', '=', 1)->andReturn($query);
         $query->shouldReceive('delete')->once();
         $model->expects($this->once())->method('newQueryWithoutScopes')->will($this->returnValue($query));
@@ -449,8 +449,8 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testPushNoRelations()
     {
-        $model = $this->getMockBuilder('Illuminate\Tests\Database\EloquentModelStub')->setMethods(['newQueryWithoutScopes', 'updateTimestamps', 'refresh'])->getMock();
-        $query = m::mock('Illuminate\Database\Eloquent\Builder');
+        $model = $this->getMockBuilder(\Illuminate\Tests\Database\EloquentModelStub::class)->setMethods(['newQueryWithoutScopes', 'updateTimestamps', 'refresh'])->getMock();
+        $query = m::mock(\Illuminate\Database\Eloquent\Builder::class);
         $query->shouldReceive('insertGetId')->once()->with(['name' => 'taylor'], 'id')->andReturn(1);
         $model->expects($this->once())->method('newQueryWithoutScopes')->will($this->returnValue($query));
         $model->expects($this->once())->method('updateTimestamps');
@@ -465,8 +465,8 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testPushEmptyOneRelation()
     {
-        $model = $this->getMockBuilder('Illuminate\Tests\Database\EloquentModelStub')->setMethods(['newQueryWithoutScopes', 'updateTimestamps', 'refresh'])->getMock();
-        $query = m::mock('Illuminate\Database\Eloquent\Builder');
+        $model = $this->getMockBuilder(\Illuminate\Tests\Database\EloquentModelStub::class)->setMethods(['newQueryWithoutScopes', 'updateTimestamps', 'refresh'])->getMock();
+        $query = m::mock(\Illuminate\Database\Eloquent\Builder::class);
         $query->shouldReceive('insertGetId')->once()->with(['name' => 'taylor'], 'id')->andReturn(1);
         $model->expects($this->once())->method('newQueryWithoutScopes')->will($this->returnValue($query));
         $model->expects($this->once())->method('updateTimestamps');
@@ -483,16 +483,16 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testPushOneRelation()
     {
-        $related1 = $this->getMockBuilder('Illuminate\Tests\Database\EloquentModelStub')->setMethods(['newQueryWithoutScopes', 'updateTimestamps', 'refresh'])->getMock();
-        $query = m::mock('Illuminate\Database\Eloquent\Builder');
+        $related1 = $this->getMockBuilder(\Illuminate\Tests\Database\EloquentModelStub::class)->setMethods(['newQueryWithoutScopes', 'updateTimestamps', 'refresh'])->getMock();
+        $query = m::mock(\Illuminate\Database\Eloquent\Builder::class);
         $query->shouldReceive('insertGetId')->once()->with(['name' => 'related1'], 'id')->andReturn(2);
         $related1->expects($this->once())->method('newQueryWithoutScopes')->will($this->returnValue($query));
         $related1->expects($this->once())->method('updateTimestamps');
         $related1->name = 'related1';
         $related1->exists = false;
 
-        $model = $this->getMockBuilder('Illuminate\Tests\Database\EloquentModelStub')->setMethods(['newQueryWithoutScopes', 'updateTimestamps', 'refresh'])->getMock();
-        $query = m::mock('Illuminate\Database\Eloquent\Builder');
+        $model = $this->getMockBuilder(\Illuminate\Tests\Database\EloquentModelStub::class)->setMethods(['newQueryWithoutScopes', 'updateTimestamps', 'refresh'])->getMock();
+        $query = m::mock(\Illuminate\Database\Eloquent\Builder::class);
         $query->shouldReceive('insertGetId')->once()->with(['name' => 'taylor'], 'id')->andReturn(1);
         $model->expects($this->once())->method('newQueryWithoutScopes')->will($this->returnValue($query));
         $model->expects($this->once())->method('updateTimestamps');
@@ -512,8 +512,8 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testPushEmptyManyRelation()
     {
-        $model = $this->getMockBuilder('Illuminate\Tests\Database\EloquentModelStub')->setMethods(['newQueryWithoutScopes', 'updateTimestamps', 'refresh'])->getMock();
-        $query = m::mock('Illuminate\Database\Eloquent\Builder');
+        $model = $this->getMockBuilder(\Illuminate\Tests\Database\EloquentModelStub::class)->setMethods(['newQueryWithoutScopes', 'updateTimestamps', 'refresh'])->getMock();
+        $query = m::mock(\Illuminate\Database\Eloquent\Builder::class);
         $query->shouldReceive('insertGetId')->once()->with(['name' => 'taylor'], 'id')->andReturn(1);
         $model->expects($this->once())->method('newQueryWithoutScopes')->will($this->returnValue($query));
         $model->expects($this->once())->method('updateTimestamps');
@@ -530,24 +530,24 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testPushManyRelation()
     {
-        $related1 = $this->getMockBuilder('Illuminate\Tests\Database\EloquentModelStub')->setMethods(['newQueryWithoutScopes', 'updateTimestamps', 'refresh'])->getMock();
-        $query = m::mock('Illuminate\Database\Eloquent\Builder');
+        $related1 = $this->getMockBuilder(\Illuminate\Tests\Database\EloquentModelStub::class)->setMethods(['newQueryWithoutScopes', 'updateTimestamps', 'refresh'])->getMock();
+        $query = m::mock(\Illuminate\Database\Eloquent\Builder::class);
         $query->shouldReceive('insertGetId')->once()->with(['name' => 'related1'], 'id')->andReturn(2);
         $related1->expects($this->once())->method('newQueryWithoutScopes')->will($this->returnValue($query));
         $related1->expects($this->once())->method('updateTimestamps');
         $related1->name = 'related1';
         $related1->exists = false;
 
-        $related2 = $this->getMockBuilder('Illuminate\Tests\Database\EloquentModelStub')->setMethods(['newQueryWithoutScopes', 'updateTimestamps', 'refresh'])->getMock();
-        $query = m::mock('Illuminate\Database\Eloquent\Builder');
+        $related2 = $this->getMockBuilder(\Illuminate\Tests\Database\EloquentModelStub::class)->setMethods(['newQueryWithoutScopes', 'updateTimestamps', 'refresh'])->getMock();
+        $query = m::mock(\Illuminate\Database\Eloquent\Builder::class);
         $query->shouldReceive('insertGetId')->once()->with(['name' => 'related2'], 'id')->andReturn(3);
         $related2->expects($this->once())->method('newQueryWithoutScopes')->will($this->returnValue($query));
         $related2->expects($this->once())->method('updateTimestamps');
         $related2->name = 'related2';
         $related2->exists = false;
 
-        $model = $this->getMockBuilder('Illuminate\Tests\Database\EloquentModelStub')->setMethods(['newQueryWithoutScopes', 'updateTimestamps', 'refresh'])->getMock();
-        $query = m::mock('Illuminate\Database\Eloquent\Builder');
+        $model = $this->getMockBuilder(\Illuminate\Tests\Database\EloquentModelStub::class)->setMethods(['newQueryWithoutScopes', 'updateTimestamps', 'refresh'])->getMock();
+        $query = m::mock(\Illuminate\Database\Eloquent\Builder::class);
         $query->shouldReceive('insertGetId')->once()->with(['name' => 'taylor'], 'id')->andReturn(1);
         $model->expects($this->once())->method('newQueryWithoutScopes')->will($this->returnValue($query));
         $model->expects($this->once())->method('updateTimestamps');
@@ -565,16 +565,16 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testNewQueryReturnsEloquentQueryBuilder()
     {
-        $conn = m::mock('Illuminate\Database\Connection');
-        $grammar = m::mock('Illuminate\Database\Query\Grammars\Grammar');
-        $processor = m::mock('Illuminate\Database\Query\Processors\Processor');
+        $conn = m::mock(\Illuminate\Database\Connection::class);
+        $grammar = m::mock(\Illuminate\Database\Query\Grammars\Grammar::class);
+        $processor = m::mock(\Illuminate\Database\Query\Processors\Processor::class);
         $conn->shouldReceive('getQueryGrammar')->once()->andReturn($grammar);
         $conn->shouldReceive('getPostProcessor')->once()->andReturn($processor);
-        EloquentModelStub::setConnectionResolver($resolver = m::mock('Illuminate\Database\ConnectionResolverInterface'));
+        EloquentModelStub::setConnectionResolver($resolver = m::mock(\Illuminate\Database\ConnectionResolverInterface::class));
         $resolver->shouldReceive('connection')->andReturn($conn);
         $model = new EloquentModelStub;
         $builder = $model->newQuery();
-        $this->assertInstanceOf('Illuminate\Database\Eloquent\Builder', $builder);
+        $this->assertInstanceOf(\Illuminate\Database\Eloquent\Builder::class, $builder);
     }
 
     public function testGetAndSetTableOperations()
@@ -595,7 +595,7 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testConnectionManagement()
     {
-        EloquentModelStub::setConnectionResolver($resolver = m::mock('Illuminate\Database\ConnectionResolverInterface'));
+        EloquentModelStub::setConnectionResolver($resolver = m::mock(\Illuminate\Database\ConnectionResolverInterface::class));
         $model = m::mock('Illuminate\Tests\Database\EloquentModelStub[getConnectionName,connection]');
 
         $retval = $model->setConnection('foo');
@@ -892,25 +892,25 @@ class DatabaseEloquentModelTest extends TestCase
     {
         $model = new EloquentModelStub;
         $this->addMockConnection($model);
-        $relation = $model->hasOne('Illuminate\Tests\Database\EloquentModelSaveStub');
+        $relation = $model->hasOne(\Illuminate\Tests\Database\EloquentModelSaveStub::class);
         $this->assertEquals('save_stub.eloquent_model_stub_id', $relation->getQualifiedForeignKeyName());
 
         $model = new EloquentModelStub;
         $this->addMockConnection($model);
-        $relation = $model->hasOne('Illuminate\Tests\Database\EloquentModelSaveStub', 'foo');
+        $relation = $model->hasOne(\Illuminate\Tests\Database\EloquentModelSaveStub::class, 'foo');
         $this->assertEquals('save_stub.foo', $relation->getQualifiedForeignKeyName());
         $this->assertSame($model, $relation->getParent());
-        $this->assertInstanceOf('Illuminate\Tests\Database\EloquentModelSaveStub', $relation->getQuery()->getModel());
+        $this->assertInstanceOf(\Illuminate\Tests\Database\EloquentModelSaveStub::class, $relation->getQuery()->getModel());
     }
 
     public function testMorphOneCreatesProperRelation()
     {
         $model = new EloquentModelStub;
         $this->addMockConnection($model);
-        $relation = $model->morphOne('Illuminate\Tests\Database\EloquentModelSaveStub', 'morph');
+        $relation = $model->morphOne(\Illuminate\Tests\Database\EloquentModelSaveStub::class, 'morph');
         $this->assertEquals('save_stub.morph_id', $relation->getQualifiedForeignKeyName());
         $this->assertEquals('save_stub.morph_type', $relation->getQualifiedMorphType());
-        $this->assertEquals('Illuminate\Tests\Database\EloquentModelStub', $relation->getMorphClass());
+        $this->assertEquals(\Illuminate\Tests\Database\EloquentModelStub::class, $relation->getMorphClass());
     }
 
     public function testCorrectMorphClassIsReturned()
@@ -919,7 +919,7 @@ class DatabaseEloquentModelTest extends TestCase
         $model = new EloquentModelStub;
 
         try {
-            $this->assertEquals('Illuminate\Tests\Database\EloquentModelStub', $model->getMorphClass());
+            $this->assertEquals(\Illuminate\Tests\Database\EloquentModelStub::class, $model->getMorphClass());
         } finally {
             Relation::morphMap([], false);
         }
@@ -929,26 +929,26 @@ class DatabaseEloquentModelTest extends TestCase
     {
         $model = new EloquentModelStub;
         $this->addMockConnection($model);
-        $relation = $model->hasMany('Illuminate\Tests\Database\EloquentModelSaveStub');
+        $relation = $model->hasMany(\Illuminate\Tests\Database\EloquentModelSaveStub::class);
         $this->assertEquals('save_stub.eloquent_model_stub_id', $relation->getQualifiedForeignKeyName());
 
         $model = new EloquentModelStub;
         $this->addMockConnection($model);
-        $relation = $model->hasMany('Illuminate\Tests\Database\EloquentModelSaveStub', 'foo');
+        $relation = $model->hasMany(\Illuminate\Tests\Database\EloquentModelSaveStub::class, 'foo');
 
         $this->assertEquals('save_stub.foo', $relation->getQualifiedForeignKeyName());
         $this->assertSame($model, $relation->getParent());
-        $this->assertInstanceOf('Illuminate\Tests\Database\EloquentModelSaveStub', $relation->getQuery()->getModel());
+        $this->assertInstanceOf(\Illuminate\Tests\Database\EloquentModelSaveStub::class, $relation->getQuery()->getModel());
     }
 
     public function testMorphManyCreatesProperRelation()
     {
         $model = new EloquentModelStub;
         $this->addMockConnection($model);
-        $relation = $model->morphMany('Illuminate\Tests\Database\EloquentModelSaveStub', 'morph');
+        $relation = $model->morphMany(\Illuminate\Tests\Database\EloquentModelSaveStub::class, 'morph');
         $this->assertEquals('save_stub.morph_id', $relation->getQualifiedForeignKeyName());
         $this->assertEquals('save_stub.morph_type', $relation->getQualifiedMorphType());
-        $this->assertEquals('Illuminate\Tests\Database\EloquentModelStub', $relation->getMorphClass());
+        $this->assertEquals(\Illuminate\Tests\Database\EloquentModelStub::class, $relation->getMorphClass());
     }
 
     public function testBelongsToCreatesProperRelation()
@@ -958,7 +958,7 @@ class DatabaseEloquentModelTest extends TestCase
         $relation = $model->belongsToStub();
         $this->assertEquals('belongs_to_stub_id', $relation->getForeignKey());
         $this->assertSame($model, $relation->getParent());
-        $this->assertInstanceOf('Illuminate\Tests\Database\EloquentModelSaveStub', $relation->getQuery()->getModel());
+        $this->assertInstanceOf(\Illuminate\Tests\Database\EloquentModelSaveStub::class, $relation->getQuery()->getModel());
 
         $model = new EloquentModelStub;
         $this->addMockConnection($model);
@@ -977,7 +977,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEquals('morph_to_stub_type', $relation->getMorphType());
         $this->assertEquals('morphToStub', $relation->getRelation());
         $this->assertSame($model, $relation->getParent());
-        $this->assertInstanceOf('Illuminate\Tests\Database\EloquentModelSaveStub', $relation->getQuery()->getModel());
+        $this->assertInstanceOf(\Illuminate\Tests\Database\EloquentModelSaveStub::class, $relation->getQuery()->getModel());
 
         // $this->morphTo(null, 'type', 'id');
         $relation2 = $model->morphToStubWithKeys();
@@ -1003,20 +1003,20 @@ class DatabaseEloquentModelTest extends TestCase
         $model = new EloquentModelStub;
         $this->addMockConnection($model);
 
-        $relation = $model->belongsToMany('Illuminate\Tests\Database\EloquentModelSaveStub');
+        $relation = $model->belongsToMany(\Illuminate\Tests\Database\EloquentModelSaveStub::class);
         $this->assertEquals('eloquent_model_save_stub_eloquent_model_stub.eloquent_model_stub_id', $relation->getQualifiedForeignKeyName());
         $this->assertEquals('eloquent_model_save_stub_eloquent_model_stub.eloquent_model_save_stub_id', $relation->getQualifiedRelatedKeyName());
         $this->assertSame($model, $relation->getParent());
-        $this->assertInstanceOf('Illuminate\Tests\Database\EloquentModelSaveStub', $relation->getQuery()->getModel());
+        $this->assertInstanceOf(\Illuminate\Tests\Database\EloquentModelSaveStub::class, $relation->getQuery()->getModel());
         $this->assertEquals(__FUNCTION__, $relation->getRelationName());
 
         $model = new EloquentModelStub;
         $this->addMockConnection($model);
-        $relation = $model->belongsToMany('Illuminate\Tests\Database\EloquentModelSaveStub', 'table', 'foreign', 'other');
+        $relation = $model->belongsToMany(\Illuminate\Tests\Database\EloquentModelSaveStub::class, 'table', 'foreign', 'other');
         $this->assertEquals('table.foreign', $relation->getQualifiedForeignKeyName());
         $this->assertEquals('table.other', $relation->getQualifiedRelatedKeyName());
         $this->assertSame($model, $relation->getParent());
-        $this->assertInstanceOf('Illuminate\Tests\Database\EloquentModelSaveStub', $relation->getQuery()->getModel());
+        $this->assertInstanceOf(\Illuminate\Tests\Database\EloquentModelSaveStub::class, $relation->getQuery()->getModel());
     }
 
     public function testRelationsWithVariedConnections()
@@ -1025,78 +1025,78 @@ class DatabaseEloquentModelTest extends TestCase
         $model = new EloquentModelStub;
         $model->setConnection('non_default');
         $this->addMockConnection($model);
-        $relation = $model->hasOne('Illuminate\Tests\Database\EloquentNoConnectionModelStub');
+        $relation = $model->hasOne(\Illuminate\Tests\Database\EloquentNoConnectionModelStub::class);
         $this->assertEquals('non_default', $relation->getRelated()->getConnectionName());
 
         $model = new EloquentModelStub;
         $model->setConnection('non_default');
         $this->addMockConnection($model);
-        $relation = $model->hasOne('Illuminate\Tests\Database\EloquentDifferentConnectionModelStub');
+        $relation = $model->hasOne(\Illuminate\Tests\Database\EloquentDifferentConnectionModelStub::class);
         $this->assertEquals('different_connection', $relation->getRelated()->getConnectionName());
 
         // Morph One
         $model = new EloquentModelStub;
         $model->setConnection('non_default');
         $this->addMockConnection($model);
-        $relation = $model->morphOne('Illuminate\Tests\Database\EloquentNoConnectionModelStub', 'type');
+        $relation = $model->morphOne(\Illuminate\Tests\Database\EloquentNoConnectionModelStub::class, 'type');
         $this->assertEquals('non_default', $relation->getRelated()->getConnectionName());
 
         $model = new EloquentModelStub;
         $model->setConnection('non_default');
         $this->addMockConnection($model);
-        $relation = $model->morphOne('Illuminate\Tests\Database\EloquentDifferentConnectionModelStub', 'type');
+        $relation = $model->morphOne(\Illuminate\Tests\Database\EloquentDifferentConnectionModelStub::class, 'type');
         $this->assertEquals('different_connection', $relation->getRelated()->getConnectionName());
 
         // Belongs to
         $model = new EloquentModelStub;
         $model->setConnection('non_default');
         $this->addMockConnection($model);
-        $relation = $model->belongsTo('Illuminate\Tests\Database\EloquentNoConnectionModelStub');
+        $relation = $model->belongsTo(\Illuminate\Tests\Database\EloquentNoConnectionModelStub::class);
         $this->assertEquals('non_default', $relation->getRelated()->getConnectionName());
 
         $model = new EloquentModelStub;
         $model->setConnection('non_default');
         $this->addMockConnection($model);
-        $relation = $model->belongsTo('Illuminate\Tests\Database\EloquentDifferentConnectionModelStub');
+        $relation = $model->belongsTo(\Illuminate\Tests\Database\EloquentDifferentConnectionModelStub::class);
         $this->assertEquals('different_connection', $relation->getRelated()->getConnectionName());
 
         // has many
         $model = new EloquentModelStub;
         $model->setConnection('non_default');
         $this->addMockConnection($model);
-        $relation = $model->hasMany('Illuminate\Tests\Database\EloquentNoConnectionModelStub');
+        $relation = $model->hasMany(\Illuminate\Tests\Database\EloquentNoConnectionModelStub::class);
         $this->assertEquals('non_default', $relation->getRelated()->getConnectionName());
 
         $model = new EloquentModelStub;
         $model->setConnection('non_default');
         $this->addMockConnection($model);
-        $relation = $model->hasMany('Illuminate\Tests\Database\EloquentDifferentConnectionModelStub');
+        $relation = $model->hasMany(\Illuminate\Tests\Database\EloquentDifferentConnectionModelStub::class);
         $this->assertEquals('different_connection', $relation->getRelated()->getConnectionName());
 
         // has many through
         $model = new EloquentModelStub;
         $model->setConnection('non_default');
         $this->addMockConnection($model);
-        $relation = $model->hasManyThrough('Illuminate\Tests\Database\EloquentNoConnectionModelStub', 'Illuminate\Tests\Database\EloquentModelSaveStub');
+        $relation = $model->hasManyThrough(\Illuminate\Tests\Database\EloquentNoConnectionModelStub::class, \Illuminate\Tests\Database\EloquentModelSaveStub::class);
         $this->assertEquals('non_default', $relation->getRelated()->getConnectionName());
 
         $model = new EloquentModelStub;
         $model->setConnection('non_default');
         $this->addMockConnection($model);
-        $relation = $model->hasManyThrough('Illuminate\Tests\Database\EloquentDifferentConnectionModelStub', 'Illuminate\Tests\Database\EloquentModelSaveStub');
+        $relation = $model->hasManyThrough(\Illuminate\Tests\Database\EloquentDifferentConnectionModelStub::class, \Illuminate\Tests\Database\EloquentModelSaveStub::class);
         $this->assertEquals('different_connection', $relation->getRelated()->getConnectionName());
 
         // belongs to many
         $model = new EloquentModelStub;
         $model->setConnection('non_default');
         $this->addMockConnection($model);
-        $relation = $model->belongsToMany('Illuminate\Tests\Database\EloquentNoConnectionModelStub');
+        $relation = $model->belongsToMany(\Illuminate\Tests\Database\EloquentNoConnectionModelStub::class);
         $this->assertEquals('non_default', $relation->getRelated()->getConnectionName());
 
         $model = new EloquentModelStub;
         $model->setConnection('non_default');
         $this->addMockConnection($model);
-        $relation = $model->belongsToMany('Illuminate\Tests\Database\EloquentDifferentConnectionModelStub');
+        $relation = $model->belongsToMany(\Illuminate\Tests\Database\EloquentDifferentConnectionModelStub::class);
         $this->assertEquals('different_connection', $relation->getRelated()->getConnectionName());
     }
 
@@ -1161,7 +1161,7 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testModelObserversCanBeAttachedToModels()
     {
-        EloquentModelStub::setEventDispatcher($events = m::mock('Illuminate\Contracts\Events\Dispatcher'));
+        EloquentModelStub::setEventDispatcher($events = m::mock(\Illuminate\Contracts\Events\Dispatcher::class));
         $events->shouldReceive('listen')->once()->with('eloquent.creating: Illuminate\Tests\Database\EloquentModelStub', 'Illuminate\Tests\Database\EloquentTestObserverStub@creating');
         $events->shouldReceive('listen')->once()->with('eloquent.saved: Illuminate\Tests\Database\EloquentModelStub', 'Illuminate\Tests\Database\EloquentTestObserverStub@saved');
         $events->shouldReceive('forget');
@@ -1171,11 +1171,11 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testModelObserversCanBeAttachedToModelsWithString()
     {
-        EloquentModelStub::setEventDispatcher($events = m::mock('Illuminate\Contracts\Events\Dispatcher'));
+        EloquentModelStub::setEventDispatcher($events = m::mock(\Illuminate\Contracts\Events\Dispatcher::class));
         $events->shouldReceive('listen')->once()->with('eloquent.creating: Illuminate\Tests\Database\EloquentModelStub', 'Illuminate\Tests\Database\EloquentTestObserverStub@creating');
         $events->shouldReceive('listen')->once()->with('eloquent.saved: Illuminate\Tests\Database\EloquentModelStub', 'Illuminate\Tests\Database\EloquentTestObserverStub@saved');
         $events->shouldReceive('forget');
-        EloquentModelStub::observe('Illuminate\Tests\Database\EloquentTestObserverStub');
+        EloquentModelStub::observe(\Illuminate\Tests\Database\EloquentTestObserverStub::class);
         EloquentModelStub::flushEventListeners();
     }
 
@@ -1311,7 +1311,7 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testRelationshipTouchOwnersIsPropagated()
     {
-        $relation = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\BelongsTo')->setMethods(['touch'])->disableOriginalConstructor()->getMock();
+        $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\BelongsTo::class)->setMethods(['touch'])->disableOriginalConstructor()->getMock();
         $relation->expects($this->once())->method('touch');
 
         $model = m::mock('Illuminate\Tests\Database\EloquentModelStub[partner]');
@@ -1328,7 +1328,7 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testRelationshipTouchOwnersIsNotPropagatedIfNoRelationshipResult()
     {
-        $relation = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\BelongsTo')->setMethods(['touch'])->disableOriginalConstructor()->getMock();
+        $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\BelongsTo::class)->setMethods(['touch'])->disableOriginalConstructor()->getMock();
         $relation->expects($this->once())->method('touch');
 
         $model = m::mock('Illuminate\Tests\Database\EloquentModelStub[partner]');
@@ -1507,8 +1507,8 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testIntKeyTypePreserved()
     {
-        $model = $this->getMockBuilder('Illuminate\Tests\Database\EloquentModelStub')->setMethods(['newQueryWithoutScopes', 'updateTimestamps', 'refresh'])->getMock();
-        $query = m::mock('Illuminate\Database\Eloquent\Builder');
+        $model = $this->getMockBuilder(\Illuminate\Tests\Database\EloquentModelStub::class)->setMethods(['newQueryWithoutScopes', 'updateTimestamps', 'refresh'])->getMock();
+        $query = m::mock(\Illuminate\Database\Eloquent\Builder::class);
         $query->shouldReceive('insertGetId')->once()->with([], 'id')->andReturn(1);
         $model->expects($this->once())->method('newQueryWithoutScopes')->will($this->returnValue($query));
 
@@ -1518,8 +1518,8 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testStringKeyTypePreserved()
     {
-        $model = $this->getMockBuilder('Illuminate\Tests\Database\EloquentKeyTypeModelStub')->setMethods(['newQueryWithoutScopes', 'updateTimestamps', 'refresh'])->getMock();
-        $query = m::mock('Illuminate\Database\Eloquent\Builder');
+        $model = $this->getMockBuilder(\Illuminate\Tests\Database\EloquentKeyTypeModelStub::class)->setMethods(['newQueryWithoutScopes', 'updateTimestamps', 'refresh'])->getMock();
+        $query = m::mock(\Illuminate\Database\Eloquent\Builder::class);
         $query->shouldReceive('insertGetId')->once()->with([], 'id')->andReturn('string id');
         $model->expects($this->once())->method('newQueryWithoutScopes')->will($this->returnValue($query));
 
@@ -1579,10 +1579,10 @@ class DatabaseEloquentModelTest extends TestCase
 
     protected function addMockConnection($model)
     {
-        $model->setConnectionResolver($resolver = m::mock('Illuminate\Database\ConnectionResolverInterface'));
-        $resolver->shouldReceive('connection')->andReturn(m::mock('Illuminate\Database\Connection'));
-        $model->getConnection()->shouldReceive('getQueryGrammar')->andReturn(m::mock('Illuminate\Database\Query\Grammars\Grammar'));
-        $model->getConnection()->shouldReceive('getPostProcessor')->andReturn(m::mock('Illuminate\Database\Query\Processors\Processor'));
+        $model->setConnectionResolver($resolver = m::mock(\Illuminate\Database\ConnectionResolverInterface::class));
+        $resolver->shouldReceive('connection')->andReturn(m::mock(\Illuminate\Database\Connection::class));
+        $model->getConnection()->shouldReceive('getQueryGrammar')->andReturn(m::mock(\Illuminate\Database\Query\Grammars\Grammar::class));
+        $model->getConnection()->shouldReceive('getPostProcessor')->andReturn(m::mock(\Illuminate\Database\Query\Processors\Processor::class));
     }
 }
 
@@ -1603,7 +1603,7 @@ class EloquentModelStub extends Model
     public $scopesCalled = [];
     protected $table = 'stub';
     protected $guarded = [];
-    protected $morph_to_stub_type = 'Illuminate\Tests\Database\EloquentModelSaveStub';
+    protected $morph_to_stub_type = \Illuminate\Tests\Database\EloquentModelSaveStub::class;
 
     public function getListItemsAttribute($value)
     {
@@ -1632,7 +1632,7 @@ class EloquentModelStub extends Model
 
     public function belongsToStub()
     {
-        return $this->belongsTo('Illuminate\Tests\Database\EloquentModelSaveStub');
+        return $this->belongsTo(\Illuminate\Tests\Database\EloquentModelSaveStub::class);
     }
 
     public function morphToStub()
@@ -1657,7 +1657,7 @@ class EloquentModelStub extends Model
 
     public function belongsToExplicitKeyStub()
     {
-        return $this->belongsTo('Illuminate\Tests\Database\EloquentModelSaveStub', 'foo');
+        return $this->belongsTo(\Illuminate\Tests\Database\EloquentModelSaveStub::class, 'foo');
     }
 
     public function incorrectRelationStub()
@@ -1729,7 +1729,7 @@ class EloquentModelFindWithWritePdoStub extends Model
 {
     public function newQuery()
     {
-        $mock = m::mock('Illuminate\Database\Eloquent\Builder');
+        $mock = m::mock(\Illuminate\Database\Eloquent\Builder::class);
         $mock->shouldReceive('useWritePdo')->once()->andReturnSelf();
         $mock->shouldReceive('find')->once()->with(1)->andReturn('foo');
 
@@ -1741,7 +1741,7 @@ class EloquentModelDestroyStub extends Model
 {
     public function newQuery()
     {
-        $mock = m::mock('Illuminate\Database\Eloquent\Builder');
+        $mock = m::mock(\Illuminate\Database\Eloquent\Builder::class);
         $mock->shouldReceive('whereIn')->once()->with('id', [1, 2, 3])->andReturn($mock);
         $mock->shouldReceive('get')->once()->andReturn([$model = m::mock('StdClass')]);
         $model->shouldReceive('delete')->once();
@@ -1759,7 +1759,7 @@ class EloquentModelHydrateRawStub extends Model
 
     public function getConnection()
     {
-        $mock = m::mock('Illuminate\Database\Connection');
+        $mock = m::mock(\Illuminate\Database\Connection::class);
         $mock->shouldReceive('select')->once()->with('SELECT ?', ['foo'])->andReturn([]);
 
         return $mock;
@@ -1770,7 +1770,7 @@ class EloquentModelWithStub extends Model
 {
     public function newQuery()
     {
-        $mock = m::mock('Illuminate\Database\Eloquent\Builder');
+        $mock = m::mock(\Illuminate\Database\Eloquent\Builder::class);
         $mock->shouldReceive('with')->once()->with(['foo', 'bar'])->andReturn('foo');
 
         return $mock;

--- a/tests/Database/DatabaseEloquentMorphTest.php
+++ b/tests/Database/DatabaseEloquentMorphTest.php
@@ -62,7 +62,7 @@ class DatabaseEloquentMorphTest extends TestCase
     {
         // Doesn't matter which relation type we use since they share the code...
         $relation = $this->getOneRelation();
-        $created = m::mock('Illuminate\Database\Eloquent\Model');
+        $created = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $created->shouldReceive('setAttribute')->once()->with('morph_id', 1);
         $created->shouldReceive('setAttribute')->once()->with('morph_type', get_class($relation->getParent()));
         $relation->getRelated()->shouldReceive('newInstance')->once()->with(['name' => 'taylor'])->andReturn($created);
@@ -74,7 +74,7 @@ class DatabaseEloquentMorphTest extends TestCase
     public function testFindOrNewMethodFindsModel()
     {
         $relation = $this->getOneRelation();
-        $relation->getQuery()->shouldReceive('find')->once()->with('foo', ['*'])->andReturn($model = m::mock('Illuminate\Database\Eloquent\Model'));
+        $relation->getQuery()->shouldReceive('find')->once()->with('foo', ['*'])->andReturn($model = m::mock(\Illuminate\Database\Eloquent\Model::class));
         $relation->getRelated()->shouldReceive('newInstance')->never();
         $model->shouldReceive('setAttribute')->never();
         $model->shouldReceive('save')->never();
@@ -86,7 +86,7 @@ class DatabaseEloquentMorphTest extends TestCase
     {
         $relation = $this->getOneRelation();
         $relation->getQuery()->shouldReceive('find')->once()->with('foo', ['*'])->andReturn(null);
-        $relation->getRelated()->shouldReceive('newInstance')->once()->with()->andReturn($model = m::mock('Illuminate\Database\Eloquent\Model'));
+        $relation->getRelated()->shouldReceive('newInstance')->once()->with()->andReturn($model = m::mock(\Illuminate\Database\Eloquent\Model::class));
         $model->shouldReceive('setAttribute')->once()->with('morph_id', 1);
         $model->shouldReceive('setAttribute')->once()->with('morph_type', get_class($relation->getParent()));
         $model->shouldReceive('save')->never();
@@ -98,7 +98,7 @@ class DatabaseEloquentMorphTest extends TestCase
     {
         $relation = $this->getOneRelation();
         $relation->getQuery()->shouldReceive('where')->once()->with(['foo'])->andReturn($relation->getQuery());
-        $relation->getQuery()->shouldReceive('first')->once()->with()->andReturn($model = m::mock('Illuminate\Database\Eloquent\Model'));
+        $relation->getQuery()->shouldReceive('first')->once()->with()->andReturn($model = m::mock(\Illuminate\Database\Eloquent\Model::class));
         $relation->getRelated()->shouldReceive('newInstance')->never();
         $model->shouldReceive('setAttribute')->never();
         $model->shouldReceive('save')->never();
@@ -111,7 +111,7 @@ class DatabaseEloquentMorphTest extends TestCase
         $relation = $this->getOneRelation();
         $relation->getQuery()->shouldReceive('where')->once()->with(['foo'])->andReturn($relation->getQuery());
         $relation->getQuery()->shouldReceive('first')->once()->with()->andReturn(null);
-        $relation->getRelated()->shouldReceive('newInstance')->once()->with(['foo'])->andReturn($model = m::mock('Illuminate\Database\Eloquent\Model'));
+        $relation->getRelated()->shouldReceive('newInstance')->once()->with(['foo'])->andReturn($model = m::mock(\Illuminate\Database\Eloquent\Model::class));
         $model->shouldReceive('setAttribute')->once()->with('morph_id', 1);
         $model->shouldReceive('setAttribute')->once()->with('morph_type', get_class($relation->getParent()));
         $model->shouldReceive('save')->never();
@@ -123,7 +123,7 @@ class DatabaseEloquentMorphTest extends TestCase
     {
         $relation = $this->getOneRelation();
         $relation->getQuery()->shouldReceive('where')->once()->with(['foo'])->andReturn($relation->getQuery());
-        $relation->getQuery()->shouldReceive('first')->once()->with()->andReturn($model = m::mock('Illuminate\Database\Eloquent\Model'));
+        $relation->getQuery()->shouldReceive('first')->once()->with()->andReturn($model = m::mock(\Illuminate\Database\Eloquent\Model::class));
         $relation->getRelated()->shouldReceive('newInstance')->never();
         $model->shouldReceive('setAttribute')->never();
         $model->shouldReceive('save')->never();
@@ -136,7 +136,7 @@ class DatabaseEloquentMorphTest extends TestCase
         $relation = $this->getOneRelation();
         $relation->getQuery()->shouldReceive('where')->once()->with(['foo'])->andReturn($relation->getQuery());
         $relation->getQuery()->shouldReceive('first')->once()->with()->andReturn(null);
-        $relation->getRelated()->shouldReceive('newInstance')->once()->with(['foo'])->andReturn($model = m::mock('Illuminate\Database\Eloquent\Model'));
+        $relation->getRelated()->shouldReceive('newInstance')->once()->with(['foo'])->andReturn($model = m::mock(\Illuminate\Database\Eloquent\Model::class));
         $model->shouldReceive('setAttribute')->once()->with('morph_id', 1);
         $model->shouldReceive('setAttribute')->once()->with('morph_type', get_class($relation->getParent()));
         $model->shouldReceive('save')->once()->andReturn(true);
@@ -148,7 +148,7 @@ class DatabaseEloquentMorphTest extends TestCase
     {
         $relation = $this->getOneRelation();
         $relation->getQuery()->shouldReceive('where')->once()->with(['foo'])->andReturn($relation->getQuery());
-        $relation->getQuery()->shouldReceive('first')->once()->with()->andReturn($model = m::mock('Illuminate\Database\Eloquent\Model'));
+        $relation->getQuery()->shouldReceive('first')->once()->with()->andReturn($model = m::mock(\Illuminate\Database\Eloquent\Model::class));
         $relation->getRelated()->shouldReceive('newInstance')->never();
         $model->shouldReceive('setAttribute')->never();
         $model->shouldReceive('fill')->once()->with(['bar']);
@@ -162,7 +162,7 @@ class DatabaseEloquentMorphTest extends TestCase
         $relation = $this->getOneRelation();
         $relation->getQuery()->shouldReceive('where')->once()->with(['foo'])->andReturn($relation->getQuery());
         $relation->getQuery()->shouldReceive('first')->once()->with()->andReturn(null);
-        $relation->getRelated()->shouldReceive('newInstance')->once()->with(['foo'])->andReturn($model = m::mock('Illuminate\Database\Eloquent\Model'));
+        $relation->getRelated()->shouldReceive('newInstance')->once()->with(['foo'])->andReturn($model = m::mock(\Illuminate\Database\Eloquent\Model::class));
         $model->shouldReceive('setAttribute')->once()->with('morph_id', 1);
         $model->shouldReceive('setAttribute')->once()->with('morph_type', get_class($relation->getParent()));
         $model->shouldReceive('save')->once()->andReturn(true);
@@ -174,7 +174,7 @@ class DatabaseEloquentMorphTest extends TestCase
     public function testCreateFunctionOnNamespacedMorph()
     {
         $relation = $this->getNamespacedRelation('namespace');
-        $created = m::mock('Illuminate\Database\Eloquent\Model');
+        $created = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $created->shouldReceive('setAttribute')->once()->with('morph_id', 1);
         $created->shouldReceive('setAttribute')->once()->with('morph_type', 'namespace');
         $relation->getRelated()->shouldReceive('newInstance')->once()->with(['name' => 'taylor'])->andReturn($created);
@@ -185,12 +185,12 @@ class DatabaseEloquentMorphTest extends TestCase
 
     protected function getOneRelation()
     {
-        $builder = m::mock('Illuminate\Database\Eloquent\Builder');
+        $builder = m::mock(\Illuminate\Database\Eloquent\Builder::class);
         $builder->shouldReceive('whereNotNull')->once()->with('table.morph_id');
         $builder->shouldReceive('where')->once()->with('table.morph_id', '=', 1);
-        $related = m::mock('Illuminate\Database\Eloquent\Model');
+        $related = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $builder->shouldReceive('getModel')->andReturn($related);
-        $parent = m::mock('Illuminate\Database\Eloquent\Model');
+        $parent = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $parent->shouldReceive('getAttribute')->with('id')->andReturn(1);
         $parent->shouldReceive('getMorphClass')->andReturn(get_class($parent));
         $builder->shouldReceive('where')->once()->with('table.morph_type', get_class($parent));
@@ -200,12 +200,12 @@ class DatabaseEloquentMorphTest extends TestCase
 
     protected function getManyRelation()
     {
-        $builder = m::mock('Illuminate\Database\Eloquent\Builder');
+        $builder = m::mock(\Illuminate\Database\Eloquent\Builder::class);
         $builder->shouldReceive('whereNotNull')->once()->with('table.morph_id');
         $builder->shouldReceive('where')->once()->with('table.morph_id', '=', 1);
-        $related = m::mock('Illuminate\Database\Eloquent\Model');
+        $related = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $builder->shouldReceive('getModel')->andReturn($related);
-        $parent = m::mock('Illuminate\Database\Eloquent\Model');
+        $parent = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $parent->shouldReceive('getAttribute')->with('id')->andReturn(1);
         $parent->shouldReceive('getMorphClass')->andReturn(get_class($parent));
         $builder->shouldReceive('where')->once()->with('table.morph_type', get_class($parent));
@@ -221,10 +221,10 @@ class DatabaseEloquentMorphTest extends TestCase
             $alias => 'Foo\Bar\EloquentModelNamespacedStub',
         ]);
 
-        $builder = m::mock('Illuminate\Database\Eloquent\Builder');
+        $builder = m::mock(\Illuminate\Database\Eloquent\Builder::class);
         $builder->shouldReceive('whereNotNull')->once()->with('table.morph_id');
         $builder->shouldReceive('where')->once()->with('table.morph_id', '=', 1);
-        $related = m::mock('Illuminate\Database\Eloquent\Model');
+        $related = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $builder->shouldReceive('getModel')->andReturn($related);
         $parent = m::mock('Foo\Bar\EloquentModelNamespacedStub');
         $parent->shouldReceive('getAttribute')->with('id')->andReturn(1);

--- a/tests/Database/DatabaseEloquentMorphToManyTest.php
+++ b/tests/Database/DatabaseEloquentMorphToManyTest.php
@@ -27,7 +27,7 @@ class DatabaseEloquentMorphToManyTest extends TestCase
 
     public function testAttachInsertsPivotTableRecord()
     {
-        $relation = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\MorphToMany')->setMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
+        $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\MorphToMany::class)->setMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
         $query = m::mock('stdClass');
         $query->shouldReceive('from')->once()->with('taggables')->andReturn($query);
         $query->shouldReceive('insert')->once()->with([['taggable_id' => 1, 'taggable_type' => get_class($relation->getParent()), 'tag_id' => 2, 'foo' => 'bar']])->andReturn(true);
@@ -40,7 +40,7 @@ class DatabaseEloquentMorphToManyTest extends TestCase
 
     public function testDetachRemovesPivotTableRecord()
     {
-        $relation = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\MorphToMany')->setMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
+        $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\MorphToMany::class)->setMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
         $query = m::mock('stdClass');
         $query->shouldReceive('from')->once()->with('taggables')->andReturn($query);
         $query->shouldReceive('where')->once()->with('taggable_id', 1)->andReturn($query);
@@ -56,7 +56,7 @@ class DatabaseEloquentMorphToManyTest extends TestCase
 
     public function testDetachMethodClearsAllPivotRecordsWhenNoIDsAreGiven()
     {
-        $relation = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\MorphToMany')->setMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
+        $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\MorphToMany::class)->setMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
         $query = m::mock('stdClass');
         $query->shouldReceive('from')->once()->with('taggables')->andReturn($query);
         $query->shouldReceive('where')->once()->with('taggable_id', 1)->andReturn($query);
@@ -79,15 +79,15 @@ class DatabaseEloquentMorphToManyTest extends TestCase
 
     public function getRelationArguments()
     {
-        $parent = m::mock('Illuminate\Database\Eloquent\Model');
+        $parent = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $parent->shouldReceive('getMorphClass')->andReturn(get_class($parent));
         $parent->shouldReceive('getKey')->andReturn(1);
         $parent->shouldReceive('getCreatedAtColumn')->andReturn('created_at');
         $parent->shouldReceive('getUpdatedAtColumn')->andReturn('updated_at');
         $parent->shouldReceive('getMorphClass')->andReturn(get_class($parent));
 
-        $builder = m::mock('Illuminate\Database\Eloquent\Builder');
-        $related = m::mock('Illuminate\Database\Eloquent\Model');
+        $builder = m::mock(\Illuminate\Database\Eloquent\Builder::class);
+        $related = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $builder->shouldReceive('getModel')->andReturn($related);
 
         $related->shouldReceive('getTable')->andReturn('tags');

--- a/tests/Database/DatabaseEloquentMorphToManyTest.php
+++ b/tests/Database/DatabaseEloquentMorphToManyTest.php
@@ -28,10 +28,10 @@ class DatabaseEloquentMorphToManyTest extends TestCase
     public function testAttachInsertsPivotTableRecord()
     {
         $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\MorphToMany::class)->setMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
-        $query = m::mock('stdClass');
+        $query = m::mock(\StdClass::class);
         $query->shouldReceive('from')->once()->with('taggables')->andReturn($query);
         $query->shouldReceive('insert')->once()->with([['taggable_id' => 1, 'taggable_type' => get_class($relation->getParent()), 'tag_id' => 2, 'foo' => 'bar']])->andReturn(true);
-        $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock('StdClass'));
+        $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock(\StdClass::class));
         $mockQueryBuilder->shouldReceive('newQuery')->once()->andReturn($query);
         $relation->expects($this->once())->method('touchIfTouching');
 
@@ -41,13 +41,13 @@ class DatabaseEloquentMorphToManyTest extends TestCase
     public function testDetachRemovesPivotTableRecord()
     {
         $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\MorphToMany::class)->setMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
-        $query = m::mock('stdClass');
+        $query = m::mock(\StdClass::class);
         $query->shouldReceive('from')->once()->with('taggables')->andReturn($query);
         $query->shouldReceive('where')->once()->with('taggable_id', 1)->andReturn($query);
         $query->shouldReceive('where')->once()->with('taggable_type', get_class($relation->getParent()))->andReturn($query);
         $query->shouldReceive('whereIn')->once()->with('tag_id', [1, 2, 3]);
         $query->shouldReceive('delete')->once()->andReturn(true);
-        $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock('StdClass'));
+        $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock(\StdClass::class));
         $mockQueryBuilder->shouldReceive('newQuery')->once()->andReturn($query);
         $relation->expects($this->once())->method('touchIfTouching');
 
@@ -57,13 +57,13 @@ class DatabaseEloquentMorphToManyTest extends TestCase
     public function testDetachMethodClearsAllPivotRecordsWhenNoIDsAreGiven()
     {
         $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\MorphToMany::class)->setMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
-        $query = m::mock('stdClass');
+        $query = m::mock(\StdClass::class);
         $query->shouldReceive('from')->once()->with('taggables')->andReturn($query);
         $query->shouldReceive('where')->once()->with('taggable_id', 1)->andReturn($query);
         $query->shouldReceive('where')->once()->with('taggable_type', get_class($relation->getParent()))->andReturn($query);
         $query->shouldReceive('whereIn')->never();
         $query->shouldReceive('delete')->once()->andReturn(true);
-        $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock('StdClass'));
+        $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock(\StdClass::class));
         $mockQueryBuilder->shouldReceive('newQuery')->once()->andReturn($query);
         $relation->expects($this->once())->method('touchIfTouching');
 

--- a/tests/Database/DatabaseEloquentMorphToTest.php
+++ b/tests/Database/DatabaseEloquentMorphToTest.php
@@ -41,12 +41,12 @@ class DatabaseEloquentMorphToTest extends TestCase
 
     public function testAssociateMethodSetsForeignKeyAndTypeOnModel()
     {
-        $parent = m::mock('Illuminate\Database\Eloquent\Model');
+        $parent = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $parent->shouldReceive('getAttribute')->once()->with('foreign_key')->andReturn('foreign.value');
 
         $relation = $this->getRelationAssociate($parent);
 
-        $associate = m::mock('Illuminate\Database\Eloquent\Model');
+        $associate = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $associate->shouldReceive('getKey')->once()->andReturn(1);
         $associate->shouldReceive('getMorphClass')->once()->andReturn('Model');
 
@@ -59,7 +59,7 @@ class DatabaseEloquentMorphToTest extends TestCase
 
     public function testDissociateMethodDeletesUnsetsKeyAndTypeOnModel()
     {
-        $parent = m::mock('Illuminate\Database\Eloquent\Model');
+        $parent = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $parent->shouldReceive('getAttribute')->once()->with('foreign_key')->andReturn('foreign.value');
 
         $relation = $this->getRelation($parent);
@@ -73,9 +73,9 @@ class DatabaseEloquentMorphToTest extends TestCase
 
     protected function getRelationAssociate($parent)
     {
-        $builder = m::mock('Illuminate\Database\Eloquent\Builder');
+        $builder = m::mock(\Illuminate\Database\Eloquent\Builder::class);
         $builder->shouldReceive('where')->with('relation.id', '=', 'foreign.value');
-        $related = m::mock('Illuminate\Database\Eloquent\Model');
+        $related = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $related->shouldReceive('getKey')->andReturn(1);
         $related->shouldReceive('getTable')->andReturn('relation');
         $builder->shouldReceive('getModel')->andReturn($related);
@@ -85,9 +85,9 @@ class DatabaseEloquentMorphToTest extends TestCase
 
     public function getRelation($parent = null, $builder = null)
     {
-        $builder = $builder ?: m::mock('Illuminate\Database\Eloquent\Builder');
+        $builder = $builder ?: m::mock(\Illuminate\Database\Eloquent\Builder::class);
         $builder->shouldReceive('where')->with('relation.id', '=', 'foreign.value');
-        $related = m::mock('Illuminate\Database\Eloquent\Model');
+        $related = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $related->shouldReceive('getKeyName')->andReturn('id');
         $related->shouldReceive('getTable')->andReturn('relation');
         $builder->shouldReceive('getModel')->andReturn($related);

--- a/tests/Database/DatabaseEloquentPivotTest.php
+++ b/tests/Database/DatabaseEloquentPivotTest.php
@@ -94,7 +94,7 @@ class DatabaseEloquentPivotTest extends TestCase
         $parent = m::mock('Illuminate\Database\Eloquent\Model[getConnectionName]');
         $parent->guard([]);
         $parent->shouldReceive('getConnectionName')->once()->andReturn('connection');
-        $pivot = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\Pivot')->setMethods(['newQuery'])->setConstructorArgs([$parent, ['foo' => 'bar'], 'table'])->getMock();
+        $pivot = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\Pivot::class)->setMethods(['newQuery'])->setConstructorArgs([$parent, ['foo' => 'bar'], 'table'])->getMock();
         $pivot->setPivotKeys('foreign', 'other');
         $pivot->foreign = 'foreign.value';
         $pivot->other = 'other.value';

--- a/tests/Database/DatabaseEloquentPivotTest.php
+++ b/tests/Database/DatabaseEloquentPivotTest.php
@@ -98,7 +98,7 @@ class DatabaseEloquentPivotTest extends TestCase
         $pivot->setPivotKeys('foreign', 'other');
         $pivot->foreign = 'foreign.value';
         $pivot->other = 'other.value';
-        $query = m::mock('stdClass');
+        $query = m::mock(\StdClass::class);
         $query->shouldReceive('where')->once()->with(['foreign' => 'foreign.value', 'other' => 'other.value'])->andReturn($query);
         $query->shouldReceive('delete')->once()->andReturn(true);
         $pivot->expects($this->once())->method('newQuery')->will($this->returnValue($query));

--- a/tests/Database/DatabaseEloquentRelationTest.php
+++ b/tests/Database/DatabaseEloquentRelationTest.php
@@ -48,7 +48,7 @@ class DatabaseEloquentRelationTest extends TestCase
         Relation::morphMap([EloquentRelationResetModelStub::class]);
 
         $this->assertEquals([
-            'reset' => 'Illuminate\Tests\Database\EloquentRelationResetModelStub',
+            'reset' => \Illuminate\Tests\Database\EloquentRelationResetModelStub::class,
         ], Relation::morphMap());
 
         Relation::morphMap([], false);

--- a/tests/Database/DatabaseMigrationCreatorTest.php
+++ b/tests/Database/DatabaseMigrationCreatorTest.php
@@ -67,8 +67,8 @@ class DatabaseMigrationCreatorTest extends TestCase
 
     protected function getCreator()
     {
-        $files = m::mock('Illuminate\Filesystem\Filesystem');
+        $files = m::mock(\Illuminate\Filesystem\Filesystem::class);
 
-        return $this->getMockBuilder('Illuminate\Database\Migrations\MigrationCreator')->setMethods(['getDatePrefix'])->setConstructorArgs([$files])->getMock();
+        return $this->getMockBuilder(\Illuminate\Database\Migrations\MigrationCreator::class)->setMethods(['getDatePrefix'])->setConstructorArgs([$files])->getMock();
     }
 }

--- a/tests/Database/DatabaseMigrationInstallCommandTest.php
+++ b/tests/Database/DatabaseMigrationInstallCommandTest.php
@@ -14,7 +14,7 @@ class DatabaseMigrationInstallCommandTest extends TestCase
 
     public function testFireCallsRepositoryToInstall()
     {
-        $command = new \Illuminate\Database\Console\Migrations\InstallCommand($repo = m::mock('Illuminate\Database\Migrations\MigrationRepositoryInterface'));
+        $command = new \Illuminate\Database\Console\Migrations\InstallCommand($repo = m::mock(\Illuminate\Database\Migrations\MigrationRepositoryInterface::class));
         $command->setLaravel(new \Illuminate\Foundation\Application);
         $repo->shouldReceive('setSource')->once()->with('foo');
         $repo->shouldReceive('createRepository')->once();

--- a/tests/Database/DatabaseMigrationMakeCommandTest.php
+++ b/tests/Database/DatabaseMigrationMakeCommandTest.php
@@ -16,8 +16,8 @@ class DatabaseMigrationMakeCommandTest extends TestCase
     public function testBasicCreateDumpsAutoload()
     {
         $command = new MigrateMakeCommand(
-            $creator = m::mock('Illuminate\Database\Migrations\MigrationCreator'),
-            $composer = m::mock('Illuminate\Support\Composer'),
+            $creator = m::mock(\Illuminate\Database\Migrations\MigrationCreator::class),
+            $composer = m::mock(\Illuminate\Support\Composer::class),
             __DIR__.'/vendor'
         );
         $app = new \Illuminate\Foundation\Application;
@@ -32,8 +32,8 @@ class DatabaseMigrationMakeCommandTest extends TestCase
     public function testBasicCreateGivesCreatorProperArguments()
     {
         $command = new MigrateMakeCommand(
-            $creator = m::mock('Illuminate\Database\Migrations\MigrationCreator'),
-            m::mock('Illuminate\Support\Composer')->shouldIgnoreMissing(),
+            $creator = m::mock(\Illuminate\Database\Migrations\MigrationCreator::class),
+            m::mock(\Illuminate\Support\Composer::class)->shouldIgnoreMissing(),
             __DIR__.'/vendor'
         );
         $app = new \Illuminate\Foundation\Application;
@@ -47,8 +47,8 @@ class DatabaseMigrationMakeCommandTest extends TestCase
     public function testBasicCreateGivesCreatorProperArgumentsWhenTableIsSet()
     {
         $command = new MigrateMakeCommand(
-            $creator = m::mock('Illuminate\Database\Migrations\MigrationCreator'),
-            m::mock('Illuminate\Support\Composer')->shouldIgnoreMissing(),
+            $creator = m::mock(\Illuminate\Database\Migrations\MigrationCreator::class),
+            m::mock(\Illuminate\Support\Composer::class)->shouldIgnoreMissing(),
             __DIR__.'/vendor'
         );
         $app = new \Illuminate\Foundation\Application;
@@ -62,8 +62,8 @@ class DatabaseMigrationMakeCommandTest extends TestCase
     public function testCanSpecifyPathToCreateMigrationsIn()
     {
         $command = new MigrateMakeCommand(
-            $creator = m::mock('Illuminate\Database\Migrations\MigrationCreator'),
-            m::mock('Illuminate\Support\Composer')->shouldIgnoreMissing(),
+            $creator = m::mock(\Illuminate\Database\Migrations\MigrationCreator::class),
+            m::mock(\Illuminate\Support\Composer::class)->shouldIgnoreMissing(),
             __DIR__.'/vendor'
         );
         $app = new \Illuminate\Foundation\Application;

--- a/tests/Database/DatabaseMigrationMigrateCommandTest.php
+++ b/tests/Database/DatabaseMigrationMigrateCommandTest.php
@@ -16,7 +16,7 @@ class DatabaseMigrationMigrateCommandTest extends TestCase
 
     public function testBasicMigrationsCallMigratorWithProperArguments()
     {
-        $command = new MigrateCommand($migrator = m::mock('Illuminate\Database\Migrations\Migrator'), __DIR__.'/vendor');
+        $command = new MigrateCommand($migrator = m::mock(\Illuminate\Database\Migrations\Migrator::class), __DIR__.'/vendor');
         $app = new ApplicationDatabaseMigrationStub(['path.database' => __DIR__]);
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);
@@ -31,8 +31,8 @@ class DatabaseMigrationMigrateCommandTest extends TestCase
 
     public function testMigrationRepositoryCreatedWhenNecessary()
     {
-        $params = [$migrator = m::mock('Illuminate\Database\Migrations\Migrator'), __DIR__.'/vendor'];
-        $command = $this->getMockBuilder('Illuminate\Database\Console\Migrations\MigrateCommand')->setMethods(['call'])->setConstructorArgs($params)->getMock();
+        $params = [$migrator = m::mock(\Illuminate\Database\Migrations\Migrator::class), __DIR__.'/vendor'];
+        $command = $this->getMockBuilder(\Illuminate\Database\Console\Migrations\MigrateCommand::class)->setMethods(['call'])->setConstructorArgs($params)->getMock();
         $app = new ApplicationDatabaseMigrationStub(['path.database' => __DIR__]);
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);
@@ -48,7 +48,7 @@ class DatabaseMigrationMigrateCommandTest extends TestCase
 
     public function testTheCommandMayBePretended()
     {
-        $command = new MigrateCommand($migrator = m::mock('Illuminate\Database\Migrations\Migrator'), __DIR__.'/vendor');
+        $command = new MigrateCommand($migrator = m::mock(\Illuminate\Database\Migrations\Migrator::class), __DIR__.'/vendor');
         $app = new ApplicationDatabaseMigrationStub(['path.database' => __DIR__]);
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);
@@ -63,7 +63,7 @@ class DatabaseMigrationMigrateCommandTest extends TestCase
 
     public function testTheDatabaseMayBeSet()
     {
-        $command = new MigrateCommand($migrator = m::mock('Illuminate\Database\Migrations\Migrator'), __DIR__.'/vendor');
+        $command = new MigrateCommand($migrator = m::mock(\Illuminate\Database\Migrations\Migrator::class), __DIR__.'/vendor');
         $app = new ApplicationDatabaseMigrationStub(['path.database' => __DIR__]);
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);
@@ -78,7 +78,7 @@ class DatabaseMigrationMigrateCommandTest extends TestCase
 
     public function testStepMayBeSet()
     {
-        $command = new MigrateCommand($migrator = m::mock('Illuminate\Database\Migrations\Migrator'), __DIR__.'/vendor');
+        $command = new MigrateCommand($migrator = m::mock(\Illuminate\Database\Migrations\Migrator::class), __DIR__.'/vendor');
         $app = new ApplicationDatabaseMigrationStub(['path.database' => __DIR__]);
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);

--- a/tests/Database/DatabaseMigrationRepositoryTest.php
+++ b/tests/Database/DatabaseMigrationRepositoryTest.php
@@ -18,7 +18,7 @@ class DatabaseMigrationRepositoryTest extends TestCase
     {
         $repo = $this->getRepository();
         $query = m::mock('stdClass');
-        $connectionMock = m::mock('Illuminate\Database\Connection');
+        $connectionMock = m::mock(\Illuminate\Database\Connection::class);
         $repo->getConnectionResolver()->shouldReceive('connection')->with(null)->andReturn($connectionMock);
         $repo->getConnection()->shouldReceive('table')->once()->with('migrations')->andReturn($query);
         $query->shouldReceive('orderBy')->once()->with('batch', 'asc')->andReturn($query);
@@ -30,12 +30,12 @@ class DatabaseMigrationRepositoryTest extends TestCase
 
     public function testGetLastMigrationsGetsAllMigrationsWithTheLatestBatchNumber()
     {
-        $repo = $this->getMockBuilder('Illuminate\Database\Migrations\DatabaseMigrationRepository')->setMethods(['getLastBatchNumber'])->setConstructorArgs([
-            $resolver = m::mock('Illuminate\Database\ConnectionResolverInterface'), 'migrations',
+        $repo = $this->getMockBuilder(\Illuminate\Database\Migrations\DatabaseMigrationRepository::class)->setMethods(['getLastBatchNumber'])->setConstructorArgs([
+            $resolver = m::mock(\Illuminate\Database\ConnectionResolverInterface::class), 'migrations',
         ])->getMock();
         $repo->expects($this->once())->method('getLastBatchNumber')->will($this->returnValue(1));
         $query = m::mock('stdClass');
-        $connectionMock = m::mock('Illuminate\Database\Connection');
+        $connectionMock = m::mock(\Illuminate\Database\Connection::class);
         $repo->getConnectionResolver()->shouldReceive('connection')->with(null)->andReturn($connectionMock);
         $repo->getConnection()->shouldReceive('table')->once()->with('migrations')->andReturn($query);
         $query->shouldReceive('where')->once()->with('batch', 1)->andReturn($query);
@@ -49,7 +49,7 @@ class DatabaseMigrationRepositoryTest extends TestCase
     {
         $repo = $this->getRepository();
         $query = m::mock('stdClass');
-        $connectionMock = m::mock('Illuminate\Database\Connection');
+        $connectionMock = m::mock(\Illuminate\Database\Connection::class);
         $repo->getConnectionResolver()->shouldReceive('connection')->with(null)->andReturn($connectionMock);
         $repo->getConnection()->shouldReceive('table')->once()->with('migrations')->andReturn($query);
         $query->shouldReceive('insert')->once()->with(['migration' => 'bar', 'batch' => 1]);
@@ -61,7 +61,7 @@ class DatabaseMigrationRepositoryTest extends TestCase
     {
         $repo = $this->getRepository();
         $query = m::mock('stdClass');
-        $connectionMock = m::mock('Illuminate\Database\Connection');
+        $connectionMock = m::mock(\Illuminate\Database\Connection::class);
         $repo->getConnectionResolver()->shouldReceive('connection')->with(null)->andReturn($connectionMock);
         $repo->getConnection()->shouldReceive('table')->once()->with('migrations')->andReturn($query);
         $query->shouldReceive('where')->once()->with('migration', 'foo')->andReturn($query);
@@ -73,8 +73,8 @@ class DatabaseMigrationRepositoryTest extends TestCase
 
     public function testGetNextBatchNumberReturnsLastBatchNumberPlusOne()
     {
-        $repo = $this->getMockBuilder('Illuminate\Database\Migrations\DatabaseMigrationRepository')->setMethods(['getLastBatchNumber'])->setConstructorArgs([
-            m::mock('Illuminate\Database\ConnectionResolverInterface'), 'migrations',
+        $repo = $this->getMockBuilder(\Illuminate\Database\Migrations\DatabaseMigrationRepository::class)->setMethods(['getLastBatchNumber'])->setConstructorArgs([
+            m::mock(\Illuminate\Database\ConnectionResolverInterface::class), 'migrations',
         ])->getMock();
         $repo->expects($this->once())->method('getLastBatchNumber')->will($this->returnValue(1));
 
@@ -85,7 +85,7 @@ class DatabaseMigrationRepositoryTest extends TestCase
     {
         $repo = $this->getRepository();
         $query = m::mock('stdClass');
-        $connectionMock = m::mock('Illuminate\Database\Connection');
+        $connectionMock = m::mock(\Illuminate\Database\Connection::class);
         $repo->getConnectionResolver()->shouldReceive('connection')->with(null)->andReturn($connectionMock);
         $repo->getConnection()->shouldReceive('table')->once()->with('migrations')->andReturn($query);
         $query->shouldReceive('max')->once()->andReturn(1);
@@ -97,7 +97,7 @@ class DatabaseMigrationRepositoryTest extends TestCase
     {
         $repo = $this->getRepository();
         $schema = m::mock('stdClass');
-        $connectionMock = m::mock('Illuminate\Database\Connection');
+        $connectionMock = m::mock(\Illuminate\Database\Connection::class);
         $repo->getConnectionResolver()->shouldReceive('connection')->with(null)->andReturn($connectionMock);
         $repo->getConnection()->shouldReceive('getSchemaBuilder')->once()->andReturn($schema);
         $schema->shouldReceive('create')->once()->with('migrations', m::type('Closure'));
@@ -107,6 +107,6 @@ class DatabaseMigrationRepositoryTest extends TestCase
 
     protected function getRepository()
     {
-        return new DatabaseMigrationRepository(m::mock('Illuminate\Database\ConnectionResolverInterface'), 'migrations');
+        return new DatabaseMigrationRepository(m::mock(\Illuminate\Database\ConnectionResolverInterface::class), 'migrations');
     }
 }

--- a/tests/Database/DatabaseMigrationRepositoryTest.php
+++ b/tests/Database/DatabaseMigrationRepositoryTest.php
@@ -17,7 +17,7 @@ class DatabaseMigrationRepositoryTest extends TestCase
     public function testGetRanMigrationsListMigrationsByPackage()
     {
         $repo = $this->getRepository();
-        $query = m::mock('stdClass');
+        $query = m::mock(\StdClass::class);
         $connectionMock = m::mock(\Illuminate\Database\Connection::class);
         $repo->getConnectionResolver()->shouldReceive('connection')->with(null)->andReturn($connectionMock);
         $repo->getConnection()->shouldReceive('table')->once()->with('migrations')->andReturn($query);
@@ -34,7 +34,7 @@ class DatabaseMigrationRepositoryTest extends TestCase
             $resolver = m::mock(\Illuminate\Database\ConnectionResolverInterface::class), 'migrations',
         ])->getMock();
         $repo->expects($this->once())->method('getLastBatchNumber')->will($this->returnValue(1));
-        $query = m::mock('stdClass');
+        $query = m::mock(\StdClass::class);
         $connectionMock = m::mock(\Illuminate\Database\Connection::class);
         $repo->getConnectionResolver()->shouldReceive('connection')->with(null)->andReturn($connectionMock);
         $repo->getConnection()->shouldReceive('table')->once()->with('migrations')->andReturn($query);
@@ -48,7 +48,7 @@ class DatabaseMigrationRepositoryTest extends TestCase
     public function testLogMethodInsertsRecordIntoMigrationTable()
     {
         $repo = $this->getRepository();
-        $query = m::mock('stdClass');
+        $query = m::mock(\StdClass::class);
         $connectionMock = m::mock(\Illuminate\Database\Connection::class);
         $repo->getConnectionResolver()->shouldReceive('connection')->with(null)->andReturn($connectionMock);
         $repo->getConnection()->shouldReceive('table')->once()->with('migrations')->andReturn($query);
@@ -60,7 +60,7 @@ class DatabaseMigrationRepositoryTest extends TestCase
     public function testDeleteMethodRemovesAMigrationFromTheTable()
     {
         $repo = $this->getRepository();
-        $query = m::mock('stdClass');
+        $query = m::mock(\StdClass::class);
         $connectionMock = m::mock(\Illuminate\Database\Connection::class);
         $repo->getConnectionResolver()->shouldReceive('connection')->with(null)->andReturn($connectionMock);
         $repo->getConnection()->shouldReceive('table')->once()->with('migrations')->andReturn($query);
@@ -84,7 +84,7 @@ class DatabaseMigrationRepositoryTest extends TestCase
     public function testGetLastBatchNumberReturnsMaxBatch()
     {
         $repo = $this->getRepository();
-        $query = m::mock('stdClass');
+        $query = m::mock(\StdClass::class);
         $connectionMock = m::mock(\Illuminate\Database\Connection::class);
         $repo->getConnectionResolver()->shouldReceive('connection')->with(null)->andReturn($connectionMock);
         $repo->getConnection()->shouldReceive('table')->once()->with('migrations')->andReturn($query);
@@ -96,7 +96,7 @@ class DatabaseMigrationRepositoryTest extends TestCase
     public function testCreateRepositoryCreatesProperDatabaseTable()
     {
         $repo = $this->getRepository();
-        $schema = m::mock('stdClass');
+        $schema = m::mock(\StdClass::class);
         $connectionMock = m::mock(\Illuminate\Database\Connection::class);
         $repo->getConnectionResolver()->shouldReceive('connection')->with(null)->andReturn($connectionMock);
         $repo->getConnection()->shouldReceive('getSchemaBuilder')->once()->andReturn($schema);

--- a/tests/Database/DatabaseMigrationResetCommandTest.php
+++ b/tests/Database/DatabaseMigrationResetCommandTest.php
@@ -16,7 +16,7 @@ class DatabaseMigrationResetCommandTest extends TestCase
 
     public function testResetCommandCallsMigratorWithProperArguments()
     {
-        $command = new ResetCommand($migrator = m::mock('Illuminate\Database\Migrations\Migrator'));
+        $command = new ResetCommand($migrator = m::mock(\Illuminate\Database\Migrations\Migrator::class));
         $app = new ApplicationDatabaseResetStub(['path.database' => __DIR__]);
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);
@@ -31,7 +31,7 @@ class DatabaseMigrationResetCommandTest extends TestCase
 
     public function testResetCommandCanBePretended()
     {
-        $command = new ResetCommand($migrator = m::mock('Illuminate\Database\Migrations\Migrator'));
+        $command = new ResetCommand($migrator = m::mock(\Illuminate\Database\Migrations\Migrator::class));
         $app = new ApplicationDatabaseResetStub(['path.database' => __DIR__]);
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);

--- a/tests/Database/DatabaseMigrationRollbackCommandTest.php
+++ b/tests/Database/DatabaseMigrationRollbackCommandTest.php
@@ -16,7 +16,7 @@ class DatabaseMigrationRollbackCommandTest extends TestCase
 
     public function testRollbackCommandCallsMigratorWithProperArguments()
     {
-        $command = new RollbackCommand($migrator = m::mock('Illuminate\Database\Migrations\Migrator'));
+        $command = new RollbackCommand($migrator = m::mock(\Illuminate\Database\Migrations\Migrator::class));
         $app = new ApplicationDatabaseRollbackStub(['path.database' => __DIR__]);
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);
@@ -30,7 +30,7 @@ class DatabaseMigrationRollbackCommandTest extends TestCase
 
     public function testRollbackCommandCallsMigratorWithStepOption()
     {
-        $command = new RollbackCommand($migrator = m::mock('Illuminate\Database\Migrations\Migrator'));
+        $command = new RollbackCommand($migrator = m::mock(\Illuminate\Database\Migrations\Migrator::class));
         $app = new ApplicationDatabaseRollbackStub(['path.database' => __DIR__]);
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);
@@ -44,7 +44,7 @@ class DatabaseMigrationRollbackCommandTest extends TestCase
 
     public function testRollbackCommandCanBePretended()
     {
-        $command = new RollbackCommand($migrator = m::mock('Illuminate\Database\Migrations\Migrator'));
+        $command = new RollbackCommand($migrator = m::mock(\Illuminate\Database\Migrations\Migrator::class));
         $app = new ApplicationDatabaseRollbackStub(['path.database' => __DIR__]);
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);
@@ -58,7 +58,7 @@ class DatabaseMigrationRollbackCommandTest extends TestCase
 
     public function testRollbackCommandCanBePretendedWithStepOption()
     {
-        $command = new RollbackCommand($migrator = m::mock('Illuminate\Database\Migrations\Migrator'));
+        $command = new RollbackCommand($migrator = m::mock(\Illuminate\Database\Migrations\Migrator::class));
         $app = new ApplicationDatabaseRollbackStub(['path.database' => __DIR__]);
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -731,7 +731,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
     protected function getConnection()
     {
-        return m::mock('Illuminate\Database\Connection');
+        return m::mock(\Illuminate\Database\Connection::class);
     }
 
     public function getGrammar()

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -548,7 +548,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
     protected function getConnection()
     {
-        return m::mock('Illuminate\Database\Connection');
+        return m::mock(\Illuminate\Database\Connection::class);
     }
 
     public function getGrammar()

--- a/tests/Database/DatabaseProcessorTest.php
+++ b/tests/Database/DatabaseProcessorTest.php
@@ -14,12 +14,12 @@ class DatabaseProcessorTest extends TestCase
 
     public function testInsertGetIdProcessing()
     {
-        $pdo = $this->createMock('Illuminate\Tests\Database\ProcessorTestPDOStub');
+        $pdo = $this->createMock(\Illuminate\Tests\Database\ProcessorTestPDOStub::class);
         $pdo->expects($this->once())->method('lastInsertId')->with($this->equalTo('id'))->will($this->returnValue('1'));
-        $connection = m::mock('Illuminate\Database\Connection');
+        $connection = m::mock(\Illuminate\Database\Connection::class);
         $connection->shouldReceive('insert')->once()->with('sql', ['foo']);
         $connection->shouldReceive('getPdo')->once()->andReturn($pdo);
-        $builder = m::mock('Illuminate\Database\Query\Builder');
+        $builder = m::mock(\Illuminate\Database\Query\Builder::class);
         $builder->shouldReceive('getConnection')->andReturn($connection);
         $processor = new \Illuminate\Database\Query\Processors\Processor;
         $result = $processor->processInsertGetId($builder, 'sql', ['foo'], 'id');

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1371,9 +1371,9 @@ class DatabaseQueryBuilderTest extends TestCase
     public function testUpdateOrInsertMethod()
     {
         $builder = m::mock('Illuminate\Database\Query\Builder[where,exists,insert]', [
-            m::mock('Illuminate\Database\ConnectionInterface'),
+            m::mock(\Illuminate\Database\ConnectionInterface::class),
             new \Illuminate\Database\Query\Grammars\Grammar,
-            m::mock('Illuminate\Database\Query\Processors\Processor'),
+            m::mock(\Illuminate\Database\Query\Processors\Processor::class),
         ]);
 
         $builder->shouldReceive('where')->once()->with(['email' => 'foo'])->andReturn(m::self());
@@ -1383,9 +1383,9 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertTrue($builder->updateOrInsert(['email' => 'foo'], ['name' => 'bar']));
 
         $builder = m::mock('Illuminate\Database\Query\Builder[where,exists,update]', [
-            m::mock('Illuminate\Database\ConnectionInterface'),
+            m::mock(\Illuminate\Database\ConnectionInterface::class),
             new \Illuminate\Database\Query\Grammars\Grammar,
-            m::mock('Illuminate\Database\Query\Processors\Processor'),
+            m::mock(\Illuminate\Database\Query\Processors\Processor::class),
         ]);
 
         $builder->shouldReceive('where')->once()->with(['email' => 'foo'])->andReturn(m::self());
@@ -1475,9 +1475,9 @@ class DatabaseQueryBuilderTest extends TestCase
     public function testMySqlUpdateWrappingJson()
     {
         $grammar = new \Illuminate\Database\Query\Grammars\MySqlGrammar;
-        $processor = m::mock('Illuminate\Database\Query\Processors\Processor');
+        $processor = m::mock(\Illuminate\Database\Query\Processors\Processor::class);
 
-        $connection = $this->createMock('Illuminate\Database\ConnectionInterface');
+        $connection = $this->createMock(\Illuminate\Database\ConnectionInterface::class);
         $connection->expects($this->once())
                     ->method('update')
                     ->with(
@@ -1493,9 +1493,9 @@ class DatabaseQueryBuilderTest extends TestCase
     public function testMySqlUpdateWithJsonRemovesBindingsCorrectly()
     {
         $grammar = new \Illuminate\Database\Query\Grammars\MySqlGrammar;
-        $processor = m::mock('Illuminate\Database\Query\Processors\Processor');
+        $processor = m::mock(\Illuminate\Database\Query\Processors\Processor::class);
 
-        $connection = m::mock('Illuminate\Database\ConnectionInterface');
+        $connection = m::mock(\Illuminate\Database\ConnectionInterface::class);
         $connection->shouldReceive('update')
                     ->once()
                     ->with(
@@ -1644,7 +1644,7 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $method = 'whereFooBarAndBazOrQux';
         $parameters = ['corge', 'waldo', 'fred'];
-        $builder = m::mock('Illuminate\Database\Query\Builder')->makePartial();
+        $builder = m::mock(\Illuminate\Database\Query\Builder::class)->makePartial();
 
         $builder->shouldReceive('where')->with('foo_bar', '=', $parameters[0], 'and')->once()->andReturnSelf();
         $builder->shouldReceive('where')->with('baz', '=', $parameters[1], 'and')->once()->andReturnSelf();
@@ -1657,7 +1657,7 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $method = 'whereIosVersionAndAndroidVersionOrOrientation';
         $parameters = ['6.1', '4.2', 'Vertical'];
-        $builder = m::mock('Illuminate\Database\Query\Builder')->makePartial();
+        $builder = m::mock(\Illuminate\Database\Query\Builder::class)->makePartial();
 
         $builder->shouldReceive('where')->with('ios_version', '=', '6.1', 'and')->once()->andReturnSelf();
         $builder->shouldReceive('where')->with('android_version', '=', '4.2', 'and')->once()->andReturnSelf();
@@ -2125,41 +2125,41 @@ class DatabaseQueryBuilderTest extends TestCase
     protected function getBuilder()
     {
         $grammar = new \Illuminate\Database\Query\Grammars\Grammar;
-        $processor = m::mock('Illuminate\Database\Query\Processors\Processor');
+        $processor = m::mock(\Illuminate\Database\Query\Processors\Processor::class);
 
-        return new Builder(m::mock('Illuminate\Database\ConnectionInterface'), $grammar, $processor);
+        return new Builder(m::mock(\Illuminate\Database\ConnectionInterface::class), $grammar, $processor);
     }
 
     protected function getPostgresBuilder()
     {
         $grammar = new \Illuminate\Database\Query\Grammars\PostgresGrammar;
-        $processor = m::mock('Illuminate\Database\Query\Processors\Processor');
+        $processor = m::mock(\Illuminate\Database\Query\Processors\Processor::class);
 
-        return new Builder(m::mock('Illuminate\Database\ConnectionInterface'), $grammar, $processor);
+        return new Builder(m::mock(\Illuminate\Database\ConnectionInterface::class), $grammar, $processor);
     }
 
     protected function getMySqlBuilder()
     {
         $grammar = new \Illuminate\Database\Query\Grammars\MySqlGrammar;
-        $processor = m::mock('Illuminate\Database\Query\Processors\Processor');
+        $processor = m::mock(\Illuminate\Database\Query\Processors\Processor::class);
 
-        return new Builder(m::mock('Illuminate\Database\ConnectionInterface'), $grammar, $processor);
+        return new Builder(m::mock(\Illuminate\Database\ConnectionInterface::class), $grammar, $processor);
     }
 
     protected function getSQLiteBuilder()
     {
         $grammar = new \Illuminate\Database\Query\Grammars\SQLiteGrammar;
-        $processor = m::mock('Illuminate\Database\Query\Processors\Processor');
+        $processor = m::mock(\Illuminate\Database\Query\Processors\Processor::class);
 
-        return new Builder(m::mock('Illuminate\Database\ConnectionInterface'), $grammar, $processor);
+        return new Builder(m::mock(\Illuminate\Database\ConnectionInterface::class), $grammar, $processor);
     }
 
     protected function getSqlServerBuilder()
     {
         $grammar = new \Illuminate\Database\Query\Grammars\SqlServerGrammar;
-        $processor = m::mock('Illuminate\Database\Query\Processors\Processor');
+        $processor = m::mock(\Illuminate\Database\Query\Processors\Processor::class);
 
-        return new Builder(m::mock('Illuminate\Database\ConnectionInterface'), $grammar, $processor);
+        return new Builder(m::mock(\Illuminate\Database\ConnectionInterface::class), $grammar, $processor);
     }
 
     protected function getMySqlBuilderWithProcessor()
@@ -2167,7 +2167,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $grammar = new \Illuminate\Database\Query\Grammars\MySqlGrammar;
         $processor = new \Illuminate\Database\Query\Processors\MySqlProcessor;
 
-        return new Builder(m::mock('Illuminate\Database\ConnectionInterface'), $grammar, $processor);
+        return new Builder(m::mock(\Illuminate\Database\ConnectionInterface::class), $grammar, $processor);
     }
 
     /**
@@ -2175,10 +2175,10 @@ class DatabaseQueryBuilderTest extends TestCase
      */
     protected function getMockQueryBuilder()
     {
-        $builder = m::mock('Illuminate\Database\Query\Builder', [
-            m::mock('Illuminate\Database\ConnectionInterface'),
+        $builder = m::mock(\Illuminate\Database\Query\Builder::class, [
+            m::mock(\Illuminate\Database\ConnectionInterface::class),
             new \Illuminate\Database\Query\Grammars\Grammar,
-            m::mock('Illuminate\Database\Query\Processors\Processor'),
+            m::mock(\Illuminate\Database\Query\Processors\Processor::class),
         ])->makePartial();
 
         return $builder;

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1884,7 +1884,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->shouldReceive('forPage')->once()->with(3, 2)->andReturnSelf();
         $builder->shouldReceive('get')->times(3)->andReturn($chunk1, $chunk2, $chunk3);
 
-        $callbackAssertor = m::mock('StdClass');
+        $callbackAssertor = m::mock(\StdClass::class);
         $callbackAssertor->shouldReceive('doSomething')->once()->with($chunk1);
         $callbackAssertor->shouldReceive('doSomething')->once()->with($chunk2);
         $callbackAssertor->shouldReceive('doSomething')->never()->with($chunk3);
@@ -1905,7 +1905,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->shouldReceive('forPage')->once()->with(2, 2)->andReturnSelf();
         $builder->shouldReceive('get')->times(2)->andReturn($chunk1, $chunk2);
 
-        $callbackAssertor = m::mock('StdClass');
+        $callbackAssertor = m::mock(\StdClass::class);
         $callbackAssertor->shouldReceive('doSomething')->once()->with($chunk1);
         $callbackAssertor->shouldReceive('doSomething')->once()->with($chunk2);
 
@@ -1925,7 +1925,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->shouldReceive('forPage')->never()->with(2, 2);
         $builder->shouldReceive('get')->times(1)->andReturn($chunk1);
 
-        $callbackAssertor = m::mock('StdClass');
+        $callbackAssertor = m::mock(\StdClass::class);
         $callbackAssertor->shouldReceive('doSomething')->once()->with($chunk1);
         $callbackAssertor->shouldReceive('doSomething')->never()->with($chunk2);
 
@@ -1945,7 +1945,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->shouldReceive('forPage')->once()->with(1, 0)->andReturnSelf();
         $builder->shouldReceive('get')->times(1)->andReturn($chunk);
 
-        $callbackAssertor = m::mock('StdClass');
+        $callbackAssertor = m::mock(\StdClass::class);
         $callbackAssertor->shouldReceive('doSomething')->never();
 
         $builder->chunk(0, function ($results) use ($callbackAssertor) {
@@ -1966,7 +1966,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->shouldReceive('forPageAfterId')->once()->with(2, 11, 'someIdField')->andReturnSelf();
         $builder->shouldReceive('get')->times(3)->andReturn($chunk1, $chunk2, $chunk3);
 
-        $callbackAssertor = m::mock('StdClass');
+        $callbackAssertor = m::mock(\StdClass::class);
         $callbackAssertor->shouldReceive('doSomething')->once()->with($chunk1);
         $callbackAssertor->shouldReceive('doSomething')->once()->with($chunk2);
         $callbackAssertor->shouldReceive('doSomething')->never()->with($chunk3);
@@ -1987,7 +1987,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->shouldReceive('forPageAfterId')->once()->with(2, 2, 'someIdField')->andReturnSelf();
         $builder->shouldReceive('get')->times(2)->andReturn($chunk1, $chunk2);
 
-        $callbackAssertor = m::mock('StdClass');
+        $callbackAssertor = m::mock(\StdClass::class);
         $callbackAssertor->shouldReceive('doSomething')->once()->with($chunk1);
         $callbackAssertor->shouldReceive('doSomething')->once()->with($chunk2);
 
@@ -2005,7 +2005,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->shouldReceive('forPageAfterId')->once()->with(0, 0, 'someIdField')->andReturnSelf();
         $builder->shouldReceive('get')->times(1)->andReturn($chunk);
 
-        $callbackAssertor = m::mock('StdClass');
+        $callbackAssertor = m::mock(\StdClass::class);
         $callbackAssertor->shouldReceive('doSomething')->never();
 
         $builder->chunkById(0, function ($results) use ($callbackAssertor) {
@@ -2024,7 +2024,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->shouldReceive('forPageAfterId')->once()->with(2, 10, 'table.id')->andReturnSelf();
         $builder->shouldReceive('get')->times(2)->andReturn($chunk1, $chunk2);
 
-        $callbackAssertor = m::mock('StdClass');
+        $callbackAssertor = m::mock(\StdClass::class);
         $callbackAssertor->shouldReceive('doSomething')->once()->with($chunk1);
         $callbackAssertor->shouldReceive('doSomething')->never()->with($chunk2);
 

--- a/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
@@ -510,7 +510,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
 
     protected function getConnection()
     {
-        return m::mock('Illuminate\Database\Connection');
+        return m::mock(\Illuminate\Database\Connection::class);
     }
 
     public function getGrammar()

--- a/tests/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintTest.php
@@ -19,11 +19,11 @@ class DatabaseSchemaBlueprintTest extends TestCase
 
     public function testToSqlRunsCommandsFromBlueprint()
     {
-        $conn = m::mock('Illuminate\Database\Connection');
+        $conn = m::mock(\Illuminate\Database\Connection::class);
         $conn->shouldReceive('statement')->once()->with('foo');
         $conn->shouldReceive('statement')->once()->with('bar');
-        $grammar = m::mock('Illuminate\Database\Schema\Grammars\MySqlGrammar');
-        $blueprint = $this->getMockBuilder('Illuminate\Database\Schema\Blueprint')->setMethods(['toSql'])->setConstructorArgs(['users'])->getMock();
+        $grammar = m::mock(\Illuminate\Database\Schema\Grammars\MySqlGrammar::class);
+        $blueprint = $this->getMockBuilder(\Illuminate\Database\Schema\Blueprint::class)->setMethods(['toSql'])->setConstructorArgs(['users'])->getMock();
         $blueprint->expects($this->once())->method('toSql')->with($this->equalTo($conn), $this->equalTo($grammar))->will($this->returnValue(['foo', 'bar']));
 
         $blueprint->build($conn, $grammar);
@@ -61,7 +61,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
             $table->timestamp('created')->useCurrent();
         });
 
-        $connection = m::mock('Illuminate\Database\Connection');
+        $connection = m::mock(\Illuminate\Database\Connection::class);
 
         $blueprint = clone $base;
         $this->assertEquals(['alter table `users` add `created` timestamp default CURRENT_TIMESTAMP not null'], $blueprint->toSql($connection, new MySqlGrammar));

--- a/tests/Database/DatabaseSchemaBuilderTest.php
+++ b/tests/Database/DatabaseSchemaBuilderTest.php
@@ -15,7 +15,7 @@ class DatabaseSchemaBuilderTest extends TestCase
 
     public function testHasTableCorrectlyCallsGrammar()
     {
-        $connection = m::mock('Illuminate\Database\Connection');
+        $connection = m::mock(\Illuminate\Database\Connection::class);
         $grammar = m::mock('StdClass');
         $connection->shouldReceive('getSchemaGrammar')->andReturn($grammar);
         $builder = new Builder($connection);
@@ -28,7 +28,7 @@ class DatabaseSchemaBuilderTest extends TestCase
 
     public function testTableHasColumns()
     {
-        $connection = m::mock('Illuminate\Database\Connection');
+        $connection = m::mock(\Illuminate\Database\Connection::class);
         $grammar = m::mock('StdClass');
         $connection->shouldReceive('getSchemaGrammar')->andReturn($grammar);
         $builder = m::mock('Illuminate\Database\Schema\Builder[getColumnListing]', [$connection]);
@@ -40,7 +40,7 @@ class DatabaseSchemaBuilderTest extends TestCase
 
     public function testGetColumnTypeAddsPrefix()
     {
-        $connection = m::mock('Illuminate\Database\Connection');
+        $connection = m::mock(\Illuminate\Database\Connection::class);
         $column = m::mock('StdClass');
         $type = m::mock('StdClass');
         $grammar = m::mock('StdClass');

--- a/tests/Database/DatabaseSchemaBuilderTest.php
+++ b/tests/Database/DatabaseSchemaBuilderTest.php
@@ -16,7 +16,7 @@ class DatabaseSchemaBuilderTest extends TestCase
     public function testHasTableCorrectlyCallsGrammar()
     {
         $connection = m::mock(\Illuminate\Database\Connection::class);
-        $grammar = m::mock('StdClass');
+        $grammar = m::mock(\StdClass::class);
         $connection->shouldReceive('getSchemaGrammar')->andReturn($grammar);
         $builder = new Builder($connection);
         $grammar->shouldReceive('compileTableExists')->once()->andReturn('sql');
@@ -29,7 +29,7 @@ class DatabaseSchemaBuilderTest extends TestCase
     public function testTableHasColumns()
     {
         $connection = m::mock(\Illuminate\Database\Connection::class);
-        $grammar = m::mock('StdClass');
+        $grammar = m::mock(\StdClass::class);
         $connection->shouldReceive('getSchemaGrammar')->andReturn($grammar);
         $builder = m::mock('Illuminate\Database\Schema\Builder[getColumnListing]', [$connection]);
         $builder->shouldReceive('getColumnListing')->with('users')->twice()->andReturn(['id', 'firstname']);
@@ -41,9 +41,9 @@ class DatabaseSchemaBuilderTest extends TestCase
     public function testGetColumnTypeAddsPrefix()
     {
         $connection = m::mock(\Illuminate\Database\Connection::class);
-        $column = m::mock('StdClass');
-        $type = m::mock('StdClass');
-        $grammar = m::mock('StdClass');
+        $column = m::mock(\StdClass::class);
+        $type = m::mock(\StdClass::class);
+        $grammar = m::mock(\StdClass::class);
         $connection->shouldReceive('getSchemaGrammar')->once()->andReturn($grammar);
         $builder = new Builder($connection);
         $connection->shouldReceive('getTablePrefix')->once()->andReturn('prefix_');

--- a/tests/Database/DatabaseSeederTest.php
+++ b/tests/Database/DatabaseSeederTest.php
@@ -32,10 +32,10 @@ class DatabaseSeederTest extends TestCase
     public function testCallResolveTheClassAndCallsRun()
     {
         $seeder = new TestSeeder;
-        $seeder->setContainer($container = m::mock('Illuminate\Container\Container'));
+        $seeder->setContainer($container = m::mock(\Illuminate\Container\Container::class));
         $output = m::mock('Symfony\Component\Console\Output\OutputInterface');
         $output->shouldReceive('writeln')->once()->andReturn('foo');
-        $command = m::mock('Illuminate\Console\Command');
+        $command = m::mock(\Illuminate\Console\Command::class);
         $command->shouldReceive('getOutput')->once()->andReturn($output);
         $seeder->setCommand($command);
         $container->shouldReceive('make')->once()->with('ClassName')->andReturn($child = m::mock(Seeder::class));
@@ -49,20 +49,20 @@ class DatabaseSeederTest extends TestCase
     public function testSetContainer()
     {
         $seeder = new TestSeeder;
-        $container = m::mock('Illuminate\Container\Container');
+        $container = m::mock(\Illuminate\Container\Container::class);
         $this->assertEquals($seeder->setContainer($container), $seeder);
     }
 
     public function testSetCommand()
     {
         $seeder = new TestSeeder;
-        $command = m::mock('Illuminate\Console\Command');
+        $command = m::mock(\Illuminate\Console\Command::class);
         $this->assertEquals($seeder->setCommand($command), $seeder);
     }
 
     public function testInjectDependenciesOnRunMethod()
     {
-        $container = m::mock('Illuminate\Container\Container');
+        $container = m::mock(\Illuminate\Container\Container::class);
         $container->shouldReceive('call');
 
         $seeder = new TestDepsSeeder;

--- a/tests/Database/DatabaseSoftDeletingScopeTest.php
+++ b/tests/Database/DatabaseSoftDeletingScopeTest.php
@@ -31,7 +31,7 @@ class DatabaseSoftDeletingScopeTest extends TestCase
         $scope->extend($builder);
         $callback = $builder->getMacro('forceDelete');
         $givenBuilder = m::mock(\Illuminate\Database\Eloquent\Builder::class);
-        $givenBuilder->shouldReceive('getQuery')->andReturn($query = m::mock('StdClass'));
+        $givenBuilder->shouldReceive('getQuery')->andReturn($query = m::mock(\StdClass::class));
         $query->shouldReceive('delete')->once();
 
         $callback($givenBuilder);
@@ -46,7 +46,7 @@ class DatabaseSoftDeletingScopeTest extends TestCase
         $callback = $builder->getMacro('restore');
         $givenBuilder = m::mock(\Illuminate\Database\Eloquent\Builder::class);
         $givenBuilder->shouldReceive('withTrashed')->once();
-        $givenBuilder->shouldReceive('getModel')->once()->andReturn($model = m::mock('StdClass'));
+        $givenBuilder->shouldReceive('getModel')->once()->andReturn($model = m::mock(\StdClass::class));
         $model->shouldReceive('getDeletedAtColumn')->once()->andReturn('deleted_at');
         $givenBuilder->shouldReceive('update')->once()->with(['deleted_at' => null]);
 
@@ -78,7 +78,7 @@ class DatabaseSoftDeletingScopeTest extends TestCase
         $scope->extend($builder);
         $callback = $builder->getMacro('onlyTrashed');
         $givenBuilder = m::mock(\Illuminate\Database\Eloquent\Builder::class);
-        $givenBuilder->shouldReceive('getQuery')->andReturn($query = m::mock('StdClass'));
+        $givenBuilder->shouldReceive('getQuery')->andReturn($query = m::mock(\StdClass::class));
         $givenBuilder->shouldReceive('getModel')->andReturn($model);
         $givenBuilder->shouldReceive('withoutGlobalScope')->with($scope)->andReturn($givenBuilder);
         $model->shouldReceive('getQualifiedDeletedAtColumn')->andReturn('table.deleted_at');
@@ -98,7 +98,7 @@ class DatabaseSoftDeletingScopeTest extends TestCase
         $scope->extend($builder);
         $callback = $builder->getMacro('withoutTrashed');
         $givenBuilder = m::mock(\Illuminate\Database\Eloquent\Builder::class);
-        $givenBuilder->shouldReceive('getQuery')->andReturn($query = m::mock('stdClass'));
+        $givenBuilder->shouldReceive('getQuery')->andReturn($query = m::mock(\StdClass::class));
         $givenBuilder->shouldReceive('getModel')->andReturn($model);
         $givenBuilder->shouldReceive('withoutGlobalScope')->with($scope)->andReturn($givenBuilder);
         $model->shouldReceive('getQualifiedDeletedAtColumn')->andReturn('table.deleted_at');

--- a/tests/Database/DatabaseSoftDeletingScopeTest.php
+++ b/tests/Database/DatabaseSoftDeletingScopeTest.php
@@ -15,8 +15,8 @@ class DatabaseSoftDeletingScopeTest extends TestCase
     public function testApplyingScopeToABuilder()
     {
         $scope = m::mock('Illuminate\Database\Eloquent\SoftDeletingScope[extend]');
-        $builder = m::mock('Illuminate\Database\Eloquent\Builder');
-        $model = m::mock('Illuminate\Database\Eloquent\Model');
+        $builder = m::mock(\Illuminate\Database\Eloquent\Builder::class);
+        $model = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $model->shouldReceive('getQualifiedDeletedAtColumn')->once()->andReturn('table.deleted_at');
         $builder->shouldReceive('whereNull')->once()->with('table.deleted_at');
 
@@ -25,12 +25,12 @@ class DatabaseSoftDeletingScopeTest extends TestCase
 
     public function testForceDeleteExtension()
     {
-        $builder = m::mock('Illuminate\Database\Eloquent\Builder');
+        $builder = m::mock(\Illuminate\Database\Eloquent\Builder::class);
         $builder->shouldDeferMissing();
         $scope = new \Illuminate\Database\Eloquent\SoftDeletingScope;
         $scope->extend($builder);
         $callback = $builder->getMacro('forceDelete');
-        $givenBuilder = m::mock('Illuminate\Database\Eloquent\Builder');
+        $givenBuilder = m::mock(\Illuminate\Database\Eloquent\Builder::class);
         $givenBuilder->shouldReceive('getQuery')->andReturn($query = m::mock('StdClass'));
         $query->shouldReceive('delete')->once();
 
@@ -39,12 +39,12 @@ class DatabaseSoftDeletingScopeTest extends TestCase
 
     public function testRestoreExtension()
     {
-        $builder = m::mock('Illuminate\Database\Eloquent\Builder');
+        $builder = m::mock(\Illuminate\Database\Eloquent\Builder::class);
         $builder->shouldDeferMissing();
         $scope = new \Illuminate\Database\Eloquent\SoftDeletingScope;
         $scope->extend($builder);
         $callback = $builder->getMacro('restore');
-        $givenBuilder = m::mock('Illuminate\Database\Eloquent\Builder');
+        $givenBuilder = m::mock(\Illuminate\Database\Eloquent\Builder::class);
         $givenBuilder->shouldReceive('withTrashed')->once();
         $givenBuilder->shouldReceive('getModel')->once()->andReturn($model = m::mock('StdClass'));
         $model->shouldReceive('getDeletedAtColumn')->once()->andReturn('deleted_at');
@@ -55,13 +55,13 @@ class DatabaseSoftDeletingScopeTest extends TestCase
 
     public function testWithTrashedExtension()
     {
-        $builder = m::mock('Illuminate\Database\Eloquent\Builder');
+        $builder = m::mock(\Illuminate\Database\Eloquent\Builder::class);
         $builder->shouldDeferMissing();
         $scope = m::mock('Illuminate\Database\Eloquent\SoftDeletingScope[remove]');
         $scope->extend($builder);
         $callback = $builder->getMacro('withTrashed');
-        $givenBuilder = m::mock('Illuminate\Database\Eloquent\Builder');
-        $givenBuilder->shouldReceive('getModel')->andReturn($model = m::mock('Illuminate\Database\Eloquent\Model'));
+        $givenBuilder = m::mock(\Illuminate\Database\Eloquent\Builder::class);
+        $givenBuilder->shouldReceive('getModel')->andReturn($model = m::mock(\Illuminate\Database\Eloquent\Model::class));
         $givenBuilder->shouldReceive('withoutGlobalScope')->with($scope)->andReturn($givenBuilder);
         $result = $callback($givenBuilder);
 
@@ -70,14 +70,14 @@ class DatabaseSoftDeletingScopeTest extends TestCase
 
     public function testOnlyTrashedExtension()
     {
-        $builder = m::mock('Illuminate\Database\Eloquent\Builder');
+        $builder = m::mock(\Illuminate\Database\Eloquent\Builder::class);
         $builder->shouldDeferMissing();
-        $model = m::mock('Illuminate\Database\Eloquent\Model');
+        $model = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $model->shouldDeferMissing();
         $scope = m::mock('Illuminate\Database\Eloquent\SoftDeletingScope[remove]');
         $scope->extend($builder);
         $callback = $builder->getMacro('onlyTrashed');
-        $givenBuilder = m::mock('Illuminate\Database\Eloquent\Builder');
+        $givenBuilder = m::mock(\Illuminate\Database\Eloquent\Builder::class);
         $givenBuilder->shouldReceive('getQuery')->andReturn($query = m::mock('StdClass'));
         $givenBuilder->shouldReceive('getModel')->andReturn($model);
         $givenBuilder->shouldReceive('withoutGlobalScope')->with($scope)->andReturn($givenBuilder);
@@ -90,14 +90,14 @@ class DatabaseSoftDeletingScopeTest extends TestCase
 
     public function testWithoutTrashedExtension()
     {
-        $builder = m::mock('Illuminate\Database\Eloquent\Builder');
+        $builder = m::mock(\Illuminate\Database\Eloquent\Builder::class);
         $builder->shouldDeferMissing();
-        $model = m::mock('Illuminate\Database\Eloquent\Model');
+        $model = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $model->shouldDeferMissing();
         $scope = m::mock('Illuminate\Database\Eloquent\SoftDeletingScope[remove]');
         $scope->extend($builder);
         $callback = $builder->getMacro('withoutTrashed');
-        $givenBuilder = m::mock('Illuminate\Database\Eloquent\Builder');
+        $givenBuilder = m::mock(\Illuminate\Database\Eloquent\Builder::class);
         $givenBuilder->shouldReceive('getQuery')->andReturn($query = m::mock('stdClass'));
         $givenBuilder->shouldReceive('getModel')->andReturn($model);
         $givenBuilder->shouldReceive('withoutGlobalScope')->with($scope)->andReturn($givenBuilder);

--- a/tests/Database/DatabaseSoftDeletingTraitTest.php
+++ b/tests/Database/DatabaseSoftDeletingTraitTest.php
@@ -14,7 +14,7 @@ class DatabaseSoftDeletingTraitTest extends TestCase
 
     public function testDeleteSetsSoftDeletedColumn()
     {
-        $model = m::mock('Illuminate\Tests\Database\DatabaseSoftDeletingTraitStub');
+        $model = m::mock(\Illuminate\Tests\Database\DatabaseSoftDeletingTraitStub::class);
         $model->shouldDeferMissing();
         // $model->shouldReceive('newQuery')->andReturn($query = m::mock('StdClass'));
         $model->shouldReceive('newQueryWithoutScopes')->andReturn($query = m::mock('StdClass'));
@@ -27,7 +27,7 @@ class DatabaseSoftDeletingTraitTest extends TestCase
 
     public function testRestore()
     {
-        $model = m::mock('Illuminate\Tests\Database\DatabaseSoftDeletingTraitStub');
+        $model = m::mock(\Illuminate\Tests\Database\DatabaseSoftDeletingTraitStub::class);
         $model->shouldDeferMissing();
         $model->shouldReceive('fireModelEvent')->with('restoring')->andReturn(true);
         $model->shouldReceive('save')->once();
@@ -40,7 +40,7 @@ class DatabaseSoftDeletingTraitTest extends TestCase
 
     public function testRestoreCancel()
     {
-        $model = m::mock('Illuminate\Tests\Database\DatabaseSoftDeletingTraitStub');
+        $model = m::mock(\Illuminate\Tests\Database\DatabaseSoftDeletingTraitStub::class);
         $model->shouldDeferMissing();
         $model->shouldReceive('fireModelEvent')->with('restoring')->andReturn(false);
         $model->shouldReceive('save')->never();

--- a/tests/Database/DatabaseSoftDeletingTraitTest.php
+++ b/tests/Database/DatabaseSoftDeletingTraitTest.php
@@ -16,8 +16,8 @@ class DatabaseSoftDeletingTraitTest extends TestCase
     {
         $model = m::mock(\Illuminate\Tests\Database\DatabaseSoftDeletingTraitStub::class);
         $model->shouldDeferMissing();
-        // $model->shouldReceive('newQuery')->andReturn($query = m::mock('StdClass'));
-        $model->shouldReceive('newQueryWithoutScopes')->andReturn($query = m::mock('StdClass'));
+        // $model->shouldReceive('newQuery')->andReturn($query = m::mock(\StdClass::class));
+        $model->shouldReceive('newQueryWithoutScopes')->andReturn($query = m::mock(\StdClass::class));
         $query->shouldReceive('where')->once()->with('id', 1)->andReturn($query);
         $query->shouldReceive('update')->once()->with(['deleted_at' => 'date-time']);
         $model->delete();

--- a/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
@@ -571,7 +571,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
 
     protected function getConnection()
     {
-        return m::mock('Illuminate\Database\Connection');
+        return m::mock(\Illuminate\Database\Connection::class);
     }
 
     public function getGrammar()

--- a/tests/Events/EventsDispatcherTest.php
+++ b/tests/Events/EventsDispatcherTest.php
@@ -41,7 +41,7 @@ class EventsDispatcherTest extends TestCase
 
     public function testContainerResolutionOfEventHandlers()
     {
-        $d = new Dispatcher($container = m::mock('Illuminate\Container\Container'));
+        $d = new Dispatcher($container = m::mock(\Illuminate\Container\Container::class));
         $container->shouldReceive('make')->once()->with('FooHandler')->andReturn($handler = m::mock('StdClass'));
         $handler->shouldReceive('onFooEvent')->once()->with('foo', 'bar');
         $d->listen('foo', 'FooHandler@onFooEvent');
@@ -50,7 +50,7 @@ class EventsDispatcherTest extends TestCase
 
     public function testContainerResolutionOfEventHandlersWithDefaultMethods()
     {
-        $d = new Dispatcher($container = m::mock('Illuminate\Container\Container'));
+        $d = new Dispatcher($container = m::mock(\Illuminate\Container\Container::class));
         $container->shouldReceive('make')->once()->with('FooHandler')->andReturn($handler = m::mock('StdClass'));
         $handler->shouldReceive('handle')->once()->with('foo', 'bar');
         $d->listen('foo', 'FooHandler');
@@ -169,12 +169,12 @@ class EventsDispatcherTest extends TestCase
     public function testQueuedEventHandlersAreQueued()
     {
         $d = new Dispatcher;
-        $queue = m::mock('Illuminate\Contracts\Queue\Queue');
+        $queue = m::mock(\Illuminate\Contracts\Queue\Queue::class);
 
         $queue->shouldReceive('connection')->once()->with(null)->andReturnSelf();
 
         $queue->shouldReceive('pushOn')->once()->with(null, 'Illuminate\Events\CallQueuedHandler@call', [
-            'class' => 'Illuminate\Tests\Events\TestDispatcherQueuedHandler',
+            'class' => \Illuminate\Tests\Events\TestDispatcherQueuedHandler::class,
             'method' => 'someMethod',
             'data' => serialize(['foo', 'bar']),
         ]);
@@ -190,9 +190,9 @@ class EventsDispatcherTest extends TestCase
     public function testQueuedEventHandlersAreQueuedWithCustomHandlers()
     {
         $d = new Dispatcher;
-        $queue = m::mock('Illuminate\Contracts\Queue\Queue');
+        $queue = m::mock(\Illuminate\Contracts\Queue\Queue::class);
         $queue->shouldReceive('push')->once()->with('Illuminate\Events\CallQueuedHandler@call', [
-            'class' => 'Illuminate\Tests\Events\TestDispatcherQueuedHandlerCustomQueue',
+            'class' => \Illuminate\Tests\Events\TestDispatcherQueuedHandlerCustomQueue::class,
             'method' => 'someMethod',
             'data' => serialize(['foo', 'bar']),
         ]);
@@ -208,7 +208,7 @@ class EventsDispatcherTest extends TestCase
     {
         unset($_SERVER['__event.test']);
         $d = new Dispatcher;
-        $d->listen('Illuminate\Tests\Events\ExampleEvent', function () {
+        $d->listen(\Illuminate\Tests\Events\ExampleEvent::class, function () {
             $_SERVER['__event.test'] = 'baz';
         });
         $d->fire(new ExampleEvent);
@@ -220,7 +220,7 @@ class EventsDispatcherTest extends TestCase
     {
         unset($_SERVER['__event.test']);
         $d = new Dispatcher;
-        $d->listen('Illuminate\Tests\Events\SomeEventInterface', function () {
+        $d->listen(\Illuminate\Tests\Events\SomeEventInterface::class, function () {
             $_SERVER['__event.test'] = 'bar';
         });
         $d->fire(new AnotherEvent);
@@ -232,10 +232,10 @@ class EventsDispatcherTest extends TestCase
     {
         unset($_SERVER['__event.test']);
         $d = new Dispatcher;
-        $d->listen('Illuminate\Tests\Events\AnotherEvent', function () {
+        $d->listen(\Illuminate\Tests\Events\AnotherEvent::class, function () {
             $_SERVER['__event.test1'] = 'fooo';
         });
-        $d->listen('Illuminate\Tests\Events\SomeEventInterface', function () {
+        $d->listen(\Illuminate\Tests\Events\SomeEventInterface::class, function () {
             $_SERVER['__event.test2'] = 'baar';
         });
         $d->fire(new AnotherEvent);

--- a/tests/Events/EventsDispatcherTest.php
+++ b/tests/Events/EventsDispatcherTest.php
@@ -42,7 +42,7 @@ class EventsDispatcherTest extends TestCase
     public function testContainerResolutionOfEventHandlers()
     {
         $d = new Dispatcher($container = m::mock(\Illuminate\Container\Container::class));
-        $container->shouldReceive('make')->once()->with('FooHandler')->andReturn($handler = m::mock('StdClass'));
+        $container->shouldReceive('make')->once()->with('FooHandler')->andReturn($handler = m::mock(\StdClass::class));
         $handler->shouldReceive('onFooEvent')->once()->with('foo', 'bar');
         $d->listen('foo', 'FooHandler@onFooEvent');
         $d->fire('foo', ['foo', 'bar']);
@@ -51,7 +51,7 @@ class EventsDispatcherTest extends TestCase
     public function testContainerResolutionOfEventHandlersWithDefaultMethods()
     {
         $d = new Dispatcher($container = m::mock(\Illuminate\Container\Container::class));
-        $container->shouldReceive('make')->once()->with('FooHandler')->andReturn($handler = m::mock('StdClass'));
+        $container->shouldReceive('make')->once()->with('FooHandler')->andReturn($handler = m::mock(\StdClass::class));
         $handler->shouldReceive('handle')->once()->with('foo', 'bar');
         $d->listen('foo', 'FooHandler');
         $d->fire('foo', ['foo', 'bar']);

--- a/tests/Foundation/FoundationApplicationTest.php
+++ b/tests/Foundation/FoundationApplicationTest.php
@@ -16,11 +16,11 @@ class FoundationApplicationTest extends TestCase
     public function testSetLocaleSetsLocaleAndFiresLocaleChangedEvent()
     {
         $app = new Application;
-        $app['config'] = $config = m::mock('StdClass');
+        $app['config'] = $config = m::mock(\StdClass::class);
         $config->shouldReceive('set')->once()->with('app.locale', 'foo');
-        $app['translator'] = $trans = m::mock('StdClass');
+        $app['translator'] = $trans = m::mock(\StdClass::class);
         $trans->shouldReceive('setLocale')->once()->with('foo');
-        $app['events'] = $events = m::mock('StdClass');
+        $app['events'] = $events = m::mock(\StdClass::class);
         $events->shouldReceive('dispatch')->once()->with(m::type(\Illuminate\Foundation\Events\LocaleUpdated::class));
 
         $app->setLocale('foo');
@@ -63,8 +63,8 @@ class FoundationApplicationTest extends TestCase
         $this->assertTrue($app->bound('foo'));
         $one = $app->make('foo');
         $two = $app->make('foo');
-        $this->assertInstanceOf('StdClass', $one);
-        $this->assertInstanceOf('StdClass', $two);
+        $this->assertInstanceOf(\StdClass::class, $one);
+        $this->assertInstanceOf(\StdClass::class, $two);
         $this->assertSame($one, $two);
     }
 
@@ -83,7 +83,7 @@ class FoundationApplicationTest extends TestCase
         $app = new Application;
         $app->setDeferredServices(['foo' => \Illuminate\Tests\Foundation\ApplicationDeferredServiceProviderCountStub::class]);
         $obj = $app->make('foo');
-        $this->assertInstanceOf('StdClass', $obj);
+        $this->assertInstanceOf(\StdClass::class, $obj);
         $this->assertSame($obj, $app->make('foo'));
         $this->assertEquals(1, ApplicationDeferredServiceProviderCountStub::$count);
     }

--- a/tests/Foundation/FoundationApplicationTest.php
+++ b/tests/Foundation/FoundationApplicationTest.php
@@ -21,14 +21,14 @@ class FoundationApplicationTest extends TestCase
         $app['translator'] = $trans = m::mock('StdClass');
         $trans->shouldReceive('setLocale')->once()->with('foo');
         $app['events'] = $events = m::mock('StdClass');
-        $events->shouldReceive('dispatch')->once()->with(m::type('Illuminate\Foundation\Events\LocaleUpdated'));
+        $events->shouldReceive('dispatch')->once()->with(m::type(\Illuminate\Foundation\Events\LocaleUpdated::class));
 
         $app->setLocale('foo');
     }
 
     public function testServiceProvidersAreCorrectlyRegistered()
     {
-        $provider = m::mock('Illuminate\Tests\Foundation\ApplicationBasicServiceProviderStub');
+        $provider = m::mock(\Illuminate\Tests\Foundation\ApplicationBasicServiceProviderStub::class);
         $class = get_class($provider);
         $provider->shouldReceive('register')->once();
         $app = new Application;
@@ -39,7 +39,7 @@ class FoundationApplicationTest extends TestCase
 
     public function testServiceProvidersAreCorrectlyRegisteredWhenRegisterMethodIsNotPresent()
     {
-        $provider = m::mock('Illuminate\Support\ServiceProvider');
+        $provider = m::mock(\Illuminate\Support\ServiceProvider::class);
         $class = get_class($provider);
         $provider->shouldReceive('register')->never();
         $app = new Application;
@@ -51,7 +51,7 @@ class FoundationApplicationTest extends TestCase
     public function testDeferredServicesMarkedAsBound()
     {
         $app = new Application;
-        $app->setDeferredServices(['foo' => 'Illuminate\Tests\Foundation\ApplicationDeferredServiceProviderStub']);
+        $app->setDeferredServices(['foo' => \Illuminate\Tests\Foundation\ApplicationDeferredServiceProviderStub::class]);
         $this->assertTrue($app->bound('foo'));
         $this->assertEquals('foo', $app->make('foo'));
     }
@@ -59,7 +59,7 @@ class FoundationApplicationTest extends TestCase
     public function testDeferredServicesAreSharedProperly()
     {
         $app = new Application;
-        $app->setDeferredServices(['foo' => 'Illuminate\Tests\Foundation\ApplicationDeferredSharedServiceProviderStub']);
+        $app->setDeferredServices(['foo' => \Illuminate\Tests\Foundation\ApplicationDeferredSharedServiceProviderStub::class]);
         $this->assertTrue($app->bound('foo'));
         $one = $app->make('foo');
         $two = $app->make('foo');
@@ -71,7 +71,7 @@ class FoundationApplicationTest extends TestCase
     public function testDeferredServicesCanBeExtended()
     {
         $app = new Application;
-        $app->setDeferredServices(['foo' => 'Illuminate\Tests\Foundation\ApplicationDeferredServiceProviderStub']);
+        $app->setDeferredServices(['foo' => \Illuminate\Tests\Foundation\ApplicationDeferredServiceProviderStub::class]);
         $app->extend('foo', function ($instance, $container) {
             return $instance.'bar';
         });
@@ -81,7 +81,7 @@ class FoundationApplicationTest extends TestCase
     public function testDeferredServiceProviderIsRegisteredOnlyOnce()
     {
         $app = new Application;
-        $app->setDeferredServices(['foo' => 'Illuminate\Tests\Foundation\ApplicationDeferredServiceProviderCountStub']);
+        $app->setDeferredServices(['foo' => \Illuminate\Tests\Foundation\ApplicationDeferredServiceProviderCountStub::class]);
         $obj = $app->make('foo');
         $this->assertInstanceOf('StdClass', $obj);
         $this->assertSame($obj, $app->make('foo'));
@@ -92,7 +92,7 @@ class FoundationApplicationTest extends TestCase
     {
         ApplicationDeferredServiceProviderStub::$initialized = false;
         $app = new Application;
-        $app->setDeferredServices(['foo' => 'Illuminate\Tests\Foundation\ApplicationDeferredServiceProviderStub']);
+        $app->setDeferredServices(['foo' => \Illuminate\Tests\Foundation\ApplicationDeferredServiceProviderStub::class]);
         $this->assertTrue($app->bound('foo'));
         $this->assertFalse(ApplicationDeferredServiceProviderStub::$initialized);
         $app->extend('foo', function ($instance, $container) {
@@ -106,7 +106,7 @@ class FoundationApplicationTest extends TestCase
     public function testDeferredServicesCanRegisterFactories()
     {
         $app = new Application;
-        $app->setDeferredServices(['foo' => 'Illuminate\Tests\Foundation\ApplicationFactoryProviderStub']);
+        $app->setDeferredServices(['foo' => \Illuminate\Tests\Foundation\ApplicationFactoryProviderStub::class]);
         $this->assertTrue($app->bound('foo'));
         $this->assertEquals(1, $app->make('foo'));
         $this->assertEquals(2, $app->make('foo'));
@@ -117,8 +117,8 @@ class FoundationApplicationTest extends TestCase
     {
         $app = new Application;
         $app->setDeferredServices([
-            'foo' => 'Illuminate\Tests\Foundation\ApplicationMultiProviderStub',
-            'bar' => 'Illuminate\Tests\Foundation\ApplicationMultiProviderStub',
+            'foo' => \Illuminate\Tests\Foundation\ApplicationMultiProviderStub::class,
+            'bar' => \Illuminate\Tests\Foundation\ApplicationMultiProviderStub::class,
         ]);
         $this->assertEquals('foo', $app->make('foo'));
         $this->assertEquals('foobar', $app->make('bar'));
@@ -157,7 +157,7 @@ class FoundationApplicationTest extends TestCase
         $app = new Application;
         $closure = function () {
         };
-        $app->beforeBootstrapping('Illuminate\Foundation\Bootstrap\RegisterFacades', $closure);
+        $app->beforeBootstrapping(\Illuminate\Foundation\Bootstrap\RegisterFacades::class, $closure);
         $this->assertArrayHasKey(0, $app['events']->getListeners('bootstrapping: Illuminate\Foundation\Bootstrap\RegisterFacades'));
         // $this->assertSame($closure, $app['events']->getListeners('bootstrapping: Illuminate\Foundation\Bootstrap\RegisterFacades')[0]);
     }
@@ -167,7 +167,7 @@ class FoundationApplicationTest extends TestCase
         $app = new Application;
         $closure = function () {
         };
-        $app->afterBootstrapping('Illuminate\Foundation\Bootstrap\RegisterFacades', $closure);
+        $app->afterBootstrapping(\Illuminate\Foundation\Bootstrap\RegisterFacades::class, $closure);
         $this->assertArrayHasKey(0, $app['events']->getListeners('bootstrapped: Illuminate\Foundation\Bootstrap\RegisterFacades'));
         // $this->assertSame($closure, $app['events']->getListeners('bootstrapped: Illuminate\Foundation\Bootstrap\RegisterFacades')[0]);
     }

--- a/tests/Foundation/FoundationComposerTest.php
+++ b/tests/Foundation/FoundationComposerTest.php
@@ -18,7 +18,7 @@ class FoundationComposerTest extends TestCase
 
         $composer = $this->getMockBuilder(\Illuminate\Support\Composer::class)->setMethods(['getProcess'])->setConstructorArgs([$files = m::mock(\Illuminate\Filesystem\Filesystem::class), __DIR__])->getMock();
         $files->shouldReceive('exists')->once()->with(__DIR__.'/composer.phar')->andReturn(true);
-        $process = m::mock('stdClass');
+        $process = m::mock(\StdClass::class);
         $composer->expects($this->once())->method('getProcess')->will($this->returnValue($process));
         $process->shouldReceive('setCommandLine')->once()->with($escape.PHP_BINARY.$escape.' composer.phar dump-autoload');
         $process->shouldReceive('run')->once();
@@ -30,7 +30,7 @@ class FoundationComposerTest extends TestCase
     {
         $composer = $this->getMockBuilder(\Illuminate\Support\Composer::class)->setMethods(['getProcess'])->setConstructorArgs([$files = m::mock(\Illuminate\Filesystem\Filesystem::class), __DIR__])->getMock();
         $files->shouldReceive('exists')->once()->with(__DIR__.'/composer.phar')->andReturn(false);
-        $process = m::mock('stdClass');
+        $process = m::mock(\StdClass::class);
         $composer->expects($this->once())->method('getProcess')->will($this->returnValue($process));
         $process->shouldReceive('setCommandLine')->once()->with('composer dump-autoload');
         $process->shouldReceive('run')->once();

--- a/tests/Foundation/FoundationComposerTest.php
+++ b/tests/Foundation/FoundationComposerTest.php
@@ -16,7 +16,7 @@ class FoundationComposerTest extends TestCase
     {
         $escape = '\\' === DIRECTORY_SEPARATOR ? '"' : '\'';
 
-        $composer = $this->getMockBuilder('Illuminate\Support\Composer')->setMethods(['getProcess'])->setConstructorArgs([$files = m::mock('Illuminate\Filesystem\Filesystem'), __DIR__])->getMock();
+        $composer = $this->getMockBuilder(\Illuminate\Support\Composer::class)->setMethods(['getProcess'])->setConstructorArgs([$files = m::mock(\Illuminate\Filesystem\Filesystem::class), __DIR__])->getMock();
         $files->shouldReceive('exists')->once()->with(__DIR__.'/composer.phar')->andReturn(true);
         $process = m::mock('stdClass');
         $composer->expects($this->once())->method('getProcess')->will($this->returnValue($process));
@@ -28,7 +28,7 @@ class FoundationComposerTest extends TestCase
 
     public function testDumpAutoloadRunsTheCorrectCommandWhenComposerIsntPresent()
     {
-        $composer = $this->getMockBuilder('Illuminate\Support\Composer')->setMethods(['getProcess'])->setConstructorArgs([$files = m::mock('Illuminate\Filesystem\Filesystem'), __DIR__])->getMock();
+        $composer = $this->getMockBuilder(\Illuminate\Support\Composer::class)->setMethods(['getProcess'])->setConstructorArgs([$files = m::mock(\Illuminate\Filesystem\Filesystem::class), __DIR__])->getMock();
         $files->shouldReceive('exists')->once()->with(__DIR__.'/composer.phar')->andReturn(false);
         $process = m::mock('stdClass');
         $composer->expects($this->once())->method('getProcess')->will($this->returnValue($process));

--- a/tests/Foundation/FoundationFormRequestTest.php
+++ b/tests/Foundation/FoundationFormRequestTest.php
@@ -17,11 +17,11 @@ class FoundationFormRequestTest extends TestCase
     {
         $request = FoundationTestFormRequestStub::create('/', 'GET', ['name' => 'abigail']);
         $request->setContainer($container = new Container);
-        $factory = m::mock('Illuminate\Validation\Factory');
+        $factory = m::mock(\Illuminate\Validation\Factory::class);
         $factory->shouldReceive('make')->once()->with(['name' => 'abigail'], ['name' => 'required'], [], [])->andReturn(
-            $validator = m::mock('Illuminate\Validation\Validator')
+            $validator = m::mock(\Illuminate\Validation\Validator::class)
         );
-        $container->instance('Illuminate\Contracts\Validation\Factory', $factory);
+        $container->instance(\Illuminate\Contracts\Validation\Factory::class, $factory);
         $validator->shouldReceive('passes')->once()->andReturn(true);
 
         $request->validate($factory);
@@ -35,13 +35,13 @@ class FoundationFormRequestTest extends TestCase
         $request = m::mock('Illuminate\Tests\Foundation\FoundationTestFormRequestStub[response]');
         $request->initialize(['name' => null]);
         $request->setContainer($container = new Container);
-        $factory = m::mock('Illuminate\Validation\Factory');
+        $factory = m::mock(\Illuminate\Validation\Factory::class);
         $factory->shouldReceive('make')->once()->with(['name' => null], ['name' => 'required'], [], [])->andReturn(
-            $validator = m::mock('Illuminate\Validation\Validator')
+            $validator = m::mock(\Illuminate\Validation\Validator::class)
         );
-        $container->instance('Illuminate\Contracts\Validation\Factory', $factory);
+        $container->instance(\Illuminate\Contracts\Validation\Factory::class, $factory);
         $validator->shouldReceive('passes')->once()->andReturn(false);
-        $validator->shouldReceive('getMessageBag')->once()->andReturn($messages = m::mock('Illuminate\Support\MessageBag'));
+        $validator->shouldReceive('getMessageBag')->once()->andReturn($messages = m::mock(\Illuminate\Support\MessageBag::class));
         $messages->shouldReceive('toArray')->once()->andReturn(['name' => ['Name required']]);
         $request->shouldReceive('response')->once()->andReturn(new \Illuminate\Http\Response);
 
@@ -56,11 +56,11 @@ class FoundationFormRequestTest extends TestCase
         $request = m::mock('Illuminate\Tests\Foundation\FoundationTestFormRequestForbiddenStub[forbiddenResponse]');
         $request->initialize(['name' => null]);
         $request->setContainer($container = new Container);
-        $factory = m::mock('Illuminate\Validation\Factory');
+        $factory = m::mock(\Illuminate\Validation\Factory::class);
         $factory->shouldReceive('make')->once()->with(['name' => null], ['name' => 'required'], [], [])->andReturn(
-            $validator = m::mock('Illuminate\Validation\Validator')
+            $validator = m::mock(\Illuminate\Validation\Validator::class)
         );
-        $container->instance('Illuminate\Contracts\Validation\Factory', $factory);
+        $container->instance(\Illuminate\Contracts\Validation\Factory::class, $factory);
         $validator->shouldReceive('passes')->never();
 
         $request->validate($factory);
@@ -69,8 +69,8 @@ class FoundationFormRequestTest extends TestCase
     public function testRedirectResponseIsProperlyCreatedWithGivenErrors()
     {
         $request = FoundationTestFormRequestStub::create('/', 'GET');
-        $request->setRedirector($redirector = m::mock('Illuminate\Routing\Redirector'));
-        $redirector->shouldReceive('to')->once()->with('previous')->andReturn($response = m::mock('Illuminate\Http\RedirectResponse'));
+        $request->setRedirector($redirector = m::mock(\Illuminate\Routing\Redirector::class));
+        $redirector->shouldReceive('to')->once()->with('previous')->andReturn($response = m::mock(\Illuminate\Http\RedirectResponse::class));
         $redirector->shouldReceive('getUrlGenerator')->andReturn($url = m::mock('StdClass'));
         $url->shouldReceive('previous')->once()->andReturn('previous');
         $response->shouldReceive('withInput')->andReturn($response);
@@ -83,11 +83,11 @@ class FoundationFormRequestTest extends TestCase
     {
         $request = FoundationTestFormRequestHooks::create('/', 'GET', ['name' => 'abigail']);
         $request->setContainer($container = new Container);
-        $factory = m::mock('Illuminate\Validation\Factory');
+        $factory = m::mock(\Illuminate\Validation\Factory::class);
         $factory->shouldReceive('make')->once()->with(['name' => 'Taylor'], ['name' => 'required'], [], [])->andReturn(
-            $validator = m::mock('Illuminate\Validation\Validator')
+            $validator = m::mock(\Illuminate\Validation\Validator::class)
         );
-        $container->instance('Illuminate\Contracts\Validation\Factory', $factory);
+        $container->instance(\Illuminate\Contracts\Validation\Factory::class, $factory);
         $validator->shouldReceive('passes')->once()->andReturn(true);
 
         $request->validate($factory);

--- a/tests/Foundation/FoundationFormRequestTest.php
+++ b/tests/Foundation/FoundationFormRequestTest.php
@@ -71,7 +71,7 @@ class FoundationFormRequestTest extends TestCase
         $request = FoundationTestFormRequestStub::create('/', 'GET');
         $request->setRedirector($redirector = m::mock(\Illuminate\Routing\Redirector::class));
         $redirector->shouldReceive('to')->once()->with('previous')->andReturn($response = m::mock(\Illuminate\Http\RedirectResponse::class));
-        $redirector->shouldReceive('getUrlGenerator')->andReturn($url = m::mock('StdClass'));
+        $redirector->shouldReceive('getUrlGenerator')->andReturn($url = m::mock(\StdClass::class));
         $url->shouldReceive('previous')->once()->andReturn('previous');
         $response->shouldReceive('withInput')->andReturn($response);
         $response->shouldReceive('withErrors')->with(['errors'], 'default')->andReturn($response);

--- a/tests/Foundation/FoundationHelpersTest.php
+++ b/tests/Foundation/FoundationHelpersTest.php
@@ -16,10 +16,10 @@ class FoundationHelpersTest extends TestCase
     public function testCache()
     {
         $app = new Application;
-        $app['cache'] = $cache = m::mock('StdClass');
+        $app['cache'] = $cache = m::mock(\StdClass::class);
 
         // 1. cache()
-        $this->assertInstanceOf('StdClass', cache());
+        $this->assertInstanceOf(\StdClass::class, cache());
 
         // 2. cache(['foo' => 'bar'], 1);
         $cache->shouldReceive('put')->once()->with('foo', 'bar', 1);

--- a/tests/Foundation/FoundationProviderRepositoryTest.php
+++ b/tests/Foundation/FoundationProviderRepositoryTest.php
@@ -14,12 +14,12 @@ class FoundationProviderRepositoryTest extends TestCase
 
     public function testServicesAreRegisteredWhenManifestIsNotRecompiled()
     {
-        $app = m::mock('Illuminate\Foundation\Application');
+        $app = m::mock(\Illuminate\Foundation\Application::class);
 
-        $repo = m::mock('Illuminate\Foundation\ProviderRepository[createProvider,loadManifest,shouldRecompile]', [$app, m::mock('Illuminate\Filesystem\Filesystem'), [__DIR__.'/services.php']]);
+        $repo = m::mock('Illuminate\Foundation\ProviderRepository[createProvider,loadManifest,shouldRecompile]', [$app, m::mock(\Illuminate\Filesystem\Filesystem::class), [__DIR__.'/services.php']]);
         $repo->shouldReceive('loadManifest')->once()->andReturn(['eager' => ['foo'], 'deferred' => ['deferred'], 'providers' => ['providers'], 'when' => []]);
         $repo->shouldReceive('shouldRecompile')->once()->andReturn(false);
-        $provider = m::mock('Illuminate\Support\ServiceProvider');
+        $provider = m::mock(\Illuminate\Support\ServiceProvider::class);
 
         $app->shouldReceive('register')->once()->with('foo');
         $app->shouldReceive('runningInConsole')->andReturn(false);
@@ -30,9 +30,9 @@ class FoundationProviderRepositoryTest extends TestCase
 
     public function testManifestIsProperlyRecompiled()
     {
-        $app = m::mock('Illuminate\Foundation\Application');
+        $app = m::mock(\Illuminate\Foundation\Application::class);
 
-        $repo = m::mock('Illuminate\Foundation\ProviderRepository[createProvider,loadManifest,writeManifest,shouldRecompile]', [$app, m::mock('Illuminate\Filesystem\Filesystem'), [__DIR__.'/services.php']]);
+        $repo = m::mock('Illuminate\Foundation\ProviderRepository[createProvider,loadManifest,writeManifest,shouldRecompile]', [$app, m::mock(\Illuminate\Filesystem\Filesystem::class), [__DIR__.'/services.php']]);
 
         $repo->shouldReceive('loadManifest')->once()->andReturn(['eager' => [], 'deferred' => ['deferred']]);
         $repo->shouldReceive('shouldRecompile')->once()->andReturn(true);
@@ -44,7 +44,7 @@ class FoundationProviderRepositoryTest extends TestCase
         $fooMock->shouldReceive('when')->once()->andReturn([]);
 
         // bar mock is added to eagers since it's not reserved
-        $repo->shouldReceive('createProvider')->once()->with('bar')->andReturn($barMock = m::mock('Illuminate\Support\ServiceProvider'));
+        $repo->shouldReceive('createProvider')->once()->with('bar')->andReturn($barMock = m::mock(\Illuminate\Support\ServiceProvider::class));
         $barMock->shouldReceive('isDeferred')->once()->andReturn(false);
         $repo->shouldReceive('writeManifest')->once()->andReturnUsing(function ($manifest) {
             return $manifest;
@@ -59,7 +59,7 @@ class FoundationProviderRepositoryTest extends TestCase
 
     public function testShouldRecompileReturnsCorrectValue()
     {
-        $repo = new \Illuminate\Foundation\ProviderRepository(m::mock('Illuminate\Contracts\Foundation\Application'), new \Illuminate\Filesystem\Filesystem, __DIR__.'/services.php');
+        $repo = new \Illuminate\Foundation\ProviderRepository(m::mock(\Illuminate\Contracts\Foundation\Application::class), new \Illuminate\Filesystem\Filesystem, __DIR__.'/services.php');
         $this->assertTrue($repo->shouldRecompile(null, []));
         $this->assertTrue($repo->shouldRecompile(['providers' => ['foo']], ['foo', 'bar']));
         $this->assertFalse($repo->shouldRecompile(['providers' => ['foo']], ['foo']));
@@ -67,7 +67,7 @@ class FoundationProviderRepositoryTest extends TestCase
 
     public function testLoadManifestReturnsParsedJSON()
     {
-        $repo = new \Illuminate\Foundation\ProviderRepository(m::mock('Illuminate\Contracts\Foundation\Application'), $files = m::mock('Illuminate\Filesystem\Filesystem'), __DIR__.'/services.php');
+        $repo = new \Illuminate\Foundation\ProviderRepository(m::mock(\Illuminate\Contracts\Foundation\Application::class), $files = m::mock(\Illuminate\Filesystem\Filesystem::class), __DIR__.'/services.php');
         $files->shouldReceive('exists')->once()->with(__DIR__.'/services.php')->andReturn(true);
         $files->shouldReceive('getRequire')->once()->with(__DIR__.'/services.php')->andReturn($array = ['users' => ['dayle' => true], 'when' => []]);
 
@@ -76,7 +76,7 @@ class FoundationProviderRepositoryTest extends TestCase
 
     public function testWriteManifestStoresToProperLocation()
     {
-        $repo = new \Illuminate\Foundation\ProviderRepository(m::mock('Illuminate\Contracts\Foundation\Application'), $files = m::mock('Illuminate\Filesystem\Filesystem'), __DIR__.'/services.php');
+        $repo = new \Illuminate\Foundation\ProviderRepository(m::mock(\Illuminate\Contracts\Foundation\Application::class), $files = m::mock(\Illuminate\Filesystem\Filesystem::class), __DIR__.'/services.php');
         $files->shouldReceive('put')->once()->with(__DIR__.'/services.php', '<?php return '.var_export(['foo'], true).';');
 
         $result = $repo->writeManifest(['foo']);

--- a/tests/Foundation/FoundationProviderRepositoryTest.php
+++ b/tests/Foundation/FoundationProviderRepositoryTest.php
@@ -38,7 +38,7 @@ class FoundationProviderRepositoryTest extends TestCase
         $repo->shouldReceive('shouldRecompile')->once()->andReturn(true);
 
         // foo mock is just a deferred provider
-        $repo->shouldReceive('createProvider')->once()->with('foo')->andReturn($fooMock = m::mock('StdClass'));
+        $repo->shouldReceive('createProvider')->once()->with('foo')->andReturn($fooMock = m::mock(\StdClass::class));
         $fooMock->shouldReceive('isDeferred')->once()->andReturn(true);
         $fooMock->shouldReceive('provides')->once()->andReturn(['foo.provides1', 'foo.provides2']);
         $fooMock->shouldReceive('when')->once()->andReturn([]);

--- a/tests/Http/HttpJsonResponseTest.php
+++ b/tests/Http/HttpJsonResponseTest.php
@@ -13,7 +13,7 @@ class HttpJsonResponseTest extends TestCase
     {
         $response = new \Illuminate\Http\JsonResponse(new JsonResponseTestJsonableObject);
         $data = $response->getData();
-        $this->assertInstanceOf('StdClass', $data);
+        $this->assertInstanceOf(\StdClass::class, $data);
         $this->assertEquals('bar', $data->foo);
     }
 
@@ -21,7 +21,7 @@ class HttpJsonResponseTest extends TestCase
     {
         $response = new \Illuminate\Http\JsonResponse(new JsonResponseTestJsonSerializeObject);
         $data = $response->getData();
-        $this->assertInstanceOf('StdClass', $data);
+        $this->assertInstanceOf(\StdClass::class, $data);
         $this->assertEquals('bar', $data->foo);
     }
 
@@ -29,7 +29,7 @@ class HttpJsonResponseTest extends TestCase
     {
         $response = new \Illuminate\Http\JsonResponse(new JsonResponseTestArrayableObject);
         $data = $response->getData();
-        $this->assertInstanceOf('StdClass', $data);
+        $this->assertInstanceOf(\StdClass::class, $data);
         $this->assertEquals('bar', $data->foo);
     }
 
@@ -37,7 +37,7 @@ class HttpJsonResponseTest extends TestCase
     {
         $response = new \Illuminate\Http\JsonResponse(['foo' => 'bar']);
         $data = $response->getData();
-        $this->assertInstanceOf('StdClass', $data);
+        $this->assertInstanceOf(\StdClass::class, $data);
         $this->assertEquals('bar', $data->foo);
     }
 

--- a/tests/Http/HttpRedirectResponseTest.php
+++ b/tests/Http/HttpRedirectResponseTest.php
@@ -31,7 +31,7 @@ class HttpRedirectResponseTest extends TestCase
     {
         $response = new RedirectResponse('foo.bar');
         $response->setRequest(Request::create('/', 'GET', ['name' => 'Taylor', 'age' => 26]));
-        $response->setSession($session = m::mock('Illuminate\Session\Store'));
+        $response->setSession($session = m::mock(\Illuminate\Session\Store::class));
         $session->shouldReceive('flash')->twice();
         $response->with(['name', 'age']);
     }
@@ -51,7 +51,7 @@ class HttpRedirectResponseTest extends TestCase
     {
         $response = new RedirectResponse('foo.bar');
         $response->setRequest(Request::create('/', 'GET', ['name' => 'Taylor', 'age' => 26]));
-        $response->setSession($session = m::mock('Illuminate\Session\Store'));
+        $response->setSession($session = m::mock(\Illuminate\Session\Store::class));
         $session->shouldReceive('flashInput')->once()->with(['name' => 'Taylor', 'age' => 26]);
         $response->withInput();
     }
@@ -60,7 +60,7 @@ class HttpRedirectResponseTest extends TestCase
     {
         $response = new RedirectResponse('foo.bar');
         $response->setRequest(Request::create('/', 'GET', ['name' => 'Taylor', 'age' => 26]));
-        $response->setSession($session = m::mock('Illuminate\Session\Store'));
+        $response->setSession($session = m::mock(\Illuminate\Session\Store::class));
         $session->shouldReceive('flashInput')->once()->with(['name' => 'Taylor']);
         $response->onlyInput('name');
     }
@@ -69,7 +69,7 @@ class HttpRedirectResponseTest extends TestCase
     {
         $response = new RedirectResponse('foo.bar');
         $response->setRequest(Request::create('/', 'GET', ['name' => 'Taylor', 'age' => 26]));
-        $response->setSession($session = m::mock('Illuminate\Session\Store'));
+        $response->setSession($session = m::mock(\Illuminate\Session\Store::class));
         $session->shouldReceive('flashInput')->once()->with(['name' => 'Taylor']);
         $response->exceptInput('age');
     }
@@ -78,10 +78,10 @@ class HttpRedirectResponseTest extends TestCase
     {
         $response = new RedirectResponse('foo.bar');
         $response->setRequest(Request::create('/', 'GET', ['name' => 'Taylor', 'age' => 26]));
-        $response->setSession($session = m::mock('Illuminate\Session\Store'));
-        $session->shouldReceive('get')->with('errors', m::type('Illuminate\Support\ViewErrorBag'))->andReturn(new \Illuminate\Support\ViewErrorBag);
-        $session->shouldReceive('flash')->once()->with('errors', m::type('Illuminate\Support\ViewErrorBag'));
-        $provider = m::mock('Illuminate\Contracts\Support\MessageProvider');
+        $response->setSession($session = m::mock(\Illuminate\Session\Store::class));
+        $session->shouldReceive('get')->with('errors', m::type(\Illuminate\Support\ViewErrorBag::class))->andReturn(new \Illuminate\Support\ViewErrorBag);
+        $session->shouldReceive('flash')->once()->with('errors', m::type(\Illuminate\Support\ViewErrorBag::class));
+        $provider = m::mock(\Illuminate\Contracts\Support\MessageProvider::class);
         $provider->shouldReceive('getMessageBag')->once()->andReturn(new \Illuminate\Support\MessageBag);
         $response->withErrors($provider);
     }
@@ -93,7 +93,7 @@ class HttpRedirectResponseTest extends TestCase
         $this->assertNull($response->getSession());
 
         $request = Request::create('/', 'GET');
-        $session = m::mock('Illuminate\Session\Store');
+        $session = m::mock(\Illuminate\Session\Store::class);
         $response->setRequest($request);
         $response->setSession($session);
         $this->assertSame($request, $response->getRequest());
@@ -104,9 +104,9 @@ class HttpRedirectResponseTest extends TestCase
     {
         $response = new RedirectResponse('foo.bar');
         $response->setRequest(Request::create('/', 'GET', ['name' => 'Taylor', 'age' => 26]));
-        $response->setSession($session = m::mock('Illuminate\Session\Store'));
-        $session->shouldReceive('get')->with('errors', m::type('Illuminate\Support\ViewErrorBag'))->andReturn(new \Illuminate\Support\ViewErrorBag);
-        $session->shouldReceive('flash')->once()->with('errors', m::type('Illuminate\Support\ViewErrorBag'));
+        $response->setSession($session = m::mock(\Illuminate\Session\Store::class));
+        $session->shouldReceive('get')->with('errors', m::type(\Illuminate\Support\ViewErrorBag::class))->andReturn(new \Illuminate\Support\ViewErrorBag);
+        $session->shouldReceive('flash')->once()->with('errors', m::type(\Illuminate\Support\ViewErrorBag::class));
         $provider = ['foo' => 'bar'];
         $response->withErrors($provider);
     }
@@ -115,7 +115,7 @@ class HttpRedirectResponseTest extends TestCase
     {
         $response = new RedirectResponse('foo.bar');
         $response->setRequest(Request::create('/', 'GET', ['name' => 'Taylor', 'age' => 26]));
-        $response->setSession($session = m::mock('Illuminate\Session\Store'));
+        $response->setSession($session = m::mock(\Illuminate\Session\Store::class));
         $session->shouldReceive('flash')->once()->with('foo', 'bar');
         $response->withFoo('bar');
     }

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -410,14 +410,14 @@ class HttpRequestTest extends TestCase
 
     public function testAllInputReturnsInputAndFiles()
     {
-        $file = $this->getMockBuilder('Illuminate\Http\UploadedFile')->setConstructorArgs([__FILE__, 'photo.jpg'])->getMock();
+        $file = $this->getMockBuilder(\Illuminate\Http\UploadedFile::class)->setConstructorArgs([__FILE__, 'photo.jpg'])->getMock();
         $request = Request::create('/?boom=breeze', 'GET', ['foo' => 'bar'], [], ['baz' => $file]);
         $this->assertEquals(['foo' => 'bar', 'baz' => $file, 'boom' => 'breeze'], $request->all());
     }
 
     public function testAllInputReturnsNestedInputAndFiles()
     {
-        $file = $this->getMockBuilder('Illuminate\Http\UploadedFile')->setConstructorArgs([__FILE__, 'photo.jpg'])->getMock();
+        $file = $this->getMockBuilder(\Illuminate\Http\UploadedFile::class)->setConstructorArgs([__FILE__, 'photo.jpg'])->getMock();
         $request = Request::create('/?boom=breeze', 'GET', ['foo' => ['bar' => 'baz']], [], ['foo' => ['photo' => $file]]);
         $this->assertEquals(['foo' => ['bar' => 'baz', 'photo' => $file], 'boom' => 'breeze'], $request->all());
     }
@@ -479,7 +479,7 @@ class HttpRequestTest extends TestCase
     public function testOldMethodCallsSession()
     {
         $request = Request::create('/', 'GET');
-        $session = m::mock('Illuminate\Session\Store');
+        $session = m::mock(\Illuminate\Session\Store::class);
         $session->shouldReceive('getOldInput')->once()->with('foo', 'bar')->andReturn('boom');
         $request->setLaravelSession($session);
         $this->assertEquals('boom', $request->old('foo', 'bar'));
@@ -488,7 +488,7 @@ class HttpRequestTest extends TestCase
     public function testFlushMethodCallsSession()
     {
         $request = Request::create('/', 'GET');
-        $session = m::mock('Illuminate\Session\Store');
+        $session = m::mock(\Illuminate\Session\Store::class);
         $session->shouldReceive('flashInput')->once();
         $request->setLaravelSession($session);
         $request->flush();
@@ -739,7 +739,7 @@ class HttpRequestTest extends TestCase
 
     public function testHttpRequestFlashCallsSessionFlashInputWithInputData()
     {
-        $session = m::mock('Illuminate\Session\Store');
+        $session = m::mock(\Illuminate\Session\Store::class);
         $session->shouldReceive('flashInput')->once()->with(['name' => 'Taylor', 'email' => 'foo']);
         $request = Request::create('/', 'GET', ['name' => 'Taylor', 'email' => 'foo']);
         $request->setLaravelSession($session);
@@ -748,7 +748,7 @@ class HttpRequestTest extends TestCase
 
     public function testHttpRequestFlashOnlyCallsFlashWithProperParameters()
     {
-        $session = m::mock('Illuminate\Session\Store');
+        $session = m::mock(\Illuminate\Session\Store::class);
         $session->shouldReceive('flashInput')->once()->with(['name' => 'Taylor']);
         $request = Request::create('/', 'GET', ['name' => 'Taylor', 'email' => 'foo']);
         $request->setLaravelSession($session);
@@ -757,7 +757,7 @@ class HttpRequestTest extends TestCase
 
     public function testHttpRequestFlashExceptCallsFlashWithProperParameters()
     {
-        $session = m::mock('Illuminate\Session\Store');
+        $session = m::mock(\Illuminate\Session\Store::class);
         $session->shouldReceive('flashInput')->once()->with(['name' => 'Taylor']);
         $request = Request::create('/', 'GET', ['name' => 'Taylor', 'email' => 'foo']);
         $request->setLaravelSession($session);

--- a/tests/Http/HttpResponseTest.php
+++ b/tests/Http/HttpResponseTest.php
@@ -33,7 +33,7 @@ class HttpResponseTest extends TestCase
 
     public function testRenderablesAreRendered()
     {
-        $mock = m::mock('Illuminate\Contracts\Support\Renderable');
+        $mock = m::mock(\Illuminate\Contracts\Support\Renderable::class);
         $mock->shouldReceive('render')->once()->andReturn('foo');
         $response = new \Illuminate\Http\Response($mock);
         $this->assertEquals('foo', $response->getContent());
@@ -81,7 +81,7 @@ class HttpResponseTest extends TestCase
     {
         $response = new RedirectResponse('foo.bar');
         $response->setRequest(Request::create('/', 'GET', ['name' => 'Taylor', 'age' => 26]));
-        $response->setSession($session = m::mock('Illuminate\Session\Store'));
+        $response->setSession($session = m::mock(\Illuminate\Session\Store::class));
         $session->shouldReceive('flashInput')->once()->with(['name' => 'Taylor']);
         $response->onlyInput('name');
     }
@@ -90,7 +90,7 @@ class HttpResponseTest extends TestCase
     {
         $response = new RedirectResponse('foo.bar');
         $response->setRequest(Request::create('/', 'GET', ['name' => 'Taylor', 'age' => 26]));
-        $response->setSession($session = m::mock('Illuminate\Session\Store'));
+        $response->setSession($session = m::mock(\Illuminate\Session\Store::class));
         $session->shouldReceive('flashInput')->once()->with(['name' => 'Taylor']);
         $response->exceptInput('age');
     }
@@ -99,10 +99,10 @@ class HttpResponseTest extends TestCase
     {
         $response = new RedirectResponse('foo.bar');
         $response->setRequest(Request::create('/', 'GET', ['name' => 'Taylor', 'age' => 26]));
-        $response->setSession($session = m::mock('Illuminate\Session\Store'));
-        $session->shouldReceive('get')->with('errors', m::type('Illuminate\Support\ViewErrorBag'))->andReturn(new \Illuminate\Support\ViewErrorBag);
-        $session->shouldReceive('flash')->once()->with('errors', m::type('Illuminate\Support\ViewErrorBag'));
-        $provider = m::mock('Illuminate\Contracts\Support\MessageProvider');
+        $response->setSession($session = m::mock(\Illuminate\Session\Store::class));
+        $session->shouldReceive('get')->with('errors', m::type(\Illuminate\Support\ViewErrorBag::class))->andReturn(new \Illuminate\Support\ViewErrorBag);
+        $session->shouldReceive('flash')->once()->with('errors', m::type(\Illuminate\Support\ViewErrorBag::class));
+        $provider = m::mock(\Illuminate\Contracts\Support\MessageProvider::class);
         $provider->shouldReceive('getMessageBag')->once()->andReturn(new \Illuminate\Support\MessageBag);
         $response->withErrors($provider);
     }
@@ -114,7 +114,7 @@ class HttpResponseTest extends TestCase
         $this->assertNull($response->getSession());
 
         $request = Request::create('/', 'GET');
-        $session = m::mock('Illuminate\Session\Store');
+        $session = m::mock(\Illuminate\Session\Store::class);
         $response->setRequest($request);
         $response->setSession($session);
         $this->assertSame($request, $response->getRequest());
@@ -125,9 +125,9 @@ class HttpResponseTest extends TestCase
     {
         $response = new RedirectResponse('foo.bar');
         $response->setRequest(Request::create('/', 'GET', ['name' => 'Taylor', 'age' => 26]));
-        $response->setSession($session = m::mock('Illuminate\Session\Store'));
-        $session->shouldReceive('get')->with('errors', m::type('Illuminate\Support\ViewErrorBag'))->andReturn(new \Illuminate\Support\ViewErrorBag);
-        $session->shouldReceive('flash')->once()->with('errors', m::type('Illuminate\Support\ViewErrorBag'));
+        $response->setSession($session = m::mock(\Illuminate\Session\Store::class));
+        $session->shouldReceive('get')->with('errors', m::type(\Illuminate\Support\ViewErrorBag::class))->andReturn(new \Illuminate\Support\ViewErrorBag);
+        $session->shouldReceive('flash')->once()->with('errors', m::type(\Illuminate\Support\ViewErrorBag::class));
         $provider = ['foo' => 'bar'];
         $response->withErrors($provider);
     }
@@ -136,7 +136,7 @@ class HttpResponseTest extends TestCase
     {
         $response = new RedirectResponse('foo.bar');
         $response->setRequest(Request::create('/', 'GET', ['name' => 'Taylor', 'age' => 26]));
-        $response->setSession($session = m::mock('Illuminate\Session\Store'));
+        $response->setSession($session = m::mock(\Illuminate\Session\Store::class));
         $session->shouldReceive('flash')->once()->with('foo', 'bar');
         $response->withFoo('bar');
     }

--- a/tests/Log/LogWriterTest.php
+++ b/tests/Log/LogWriterTest.php
@@ -77,7 +77,7 @@ class LogWriterTest extends TestCase
 
     public function testListenShortcut()
     {
-        $writer = new Writer($monolog = m::mock('Monolog\Logger'), $events = m::mock('Illuminate\Contracts\Events\Dispatcher'));
+        $writer = new Writer($monolog = m::mock('Monolog\Logger'), $events = m::mock(\Illuminate\Contracts\Events\Dispatcher::class));
 
         $callback = function () {
             return 'success';

--- a/tests/Mail/MailMailerTest.php
+++ b/tests/Mail/MailMailerTest.php
@@ -19,7 +19,7 @@ class MailMailerTest extends TestCase
         $mailer = $this->getMockBuilder(\Illuminate\Mail\Mailer::class)->setMethods(['createMessage'])->setConstructorArgs($this->getMocks())->getMock();
         $message = m::mock('Swift_Mime_Message');
         $mailer->expects($this->once())->method('createMessage')->will($this->returnValue($message));
-        $view = m::mock('StdClass');
+        $view = m::mock(\StdClass::class);
         $mailer->getViewFactory()->shouldReceive('make')->once()->with('foo', ['data', 'message' => $message])->andReturn($view);
         $view->shouldReceive('render')->once()->andReturn('rendered.view');
         $message->shouldReceive('setBody')->once()->with('rendered.view', 'text/html');
@@ -39,7 +39,7 @@ class MailMailerTest extends TestCase
         $mailer = $this->getMockBuilder(\Illuminate\Mail\Mailer::class)->setMethods(['createMessage'])->setConstructorArgs($this->getMocks())->getMock();
         $message = m::mock('Swift_Mime_Message');
         $mailer->expects($this->once())->method('createMessage')->will($this->returnValue($message));
-        $view = m::mock('StdClass');
+        $view = m::mock(\StdClass::class);
         $mailer->getViewFactory()->shouldReceive('make')->never();
         $view->shouldReceive('render')->never();
         $message->shouldReceive('setBody')->once()->with('rendered.view', 'text/html');
@@ -60,7 +60,7 @@ class MailMailerTest extends TestCase
         $mailer = $this->getMockBuilder(\Illuminate\Mail\Mailer::class)->setMethods(['createMessage'])->setConstructorArgs($this->getMocks())->getMock();
         $message = m::mock('Swift_Mime_Message');
         $mailer->expects($this->once())->method('createMessage')->will($this->returnValue($message));
-        $view = m::mock('StdClass');
+        $view = m::mock(\StdClass::class);
         $mailer->getViewFactory()->shouldReceive('make')->once()->with('foo', ['data', 'message' => $message])->andReturn($view);
         $mailer->getViewFactory()->shouldReceive('make')->once()->with('bar', ['data', 'message' => $message])->andReturn($view);
         $view->shouldReceive('render')->twice()->andReturn('rendered.view');
@@ -82,7 +82,7 @@ class MailMailerTest extends TestCase
         $mailer = $this->getMockBuilder(\Illuminate\Mail\Mailer::class)->setMethods(['createMessage'])->setConstructorArgs($this->getMocks())->getMock();
         $message = m::mock('Swift_Mime_Message');
         $mailer->expects($this->once())->method('createMessage')->will($this->returnValue($message));
-        $view = m::mock('StdClass');
+        $view = m::mock(\StdClass::class);
         $mailer->getViewFactory()->shouldReceive('make')->once()->with('foo', ['data', 'message' => $message])->andReturn($view);
         $mailer->getViewFactory()->shouldReceive('make')->once()->with('bar', ['data', 'message' => $message])->andReturn($view);
         $view->shouldReceive('render')->twice()->andReturn('rendered.view');
@@ -102,7 +102,7 @@ class MailMailerTest extends TestCase
     {
         unset($_SERVER['__mailer.test']);
         $mailer = $this->getMailer();
-        $view = m::mock('StdClass');
+        $view = m::mock(\StdClass::class);
         $mailer->getViewFactory()->shouldReceive('make')->once()->andReturn($view);
         $view->shouldReceive('render')->once()->andReturn('rendered.view');
         $this->setSwiftMailer($mailer);
@@ -120,7 +120,7 @@ class MailMailerTest extends TestCase
         $mailer = $this->getMailer();
         $mailer->getSwiftMailer()->shouldReceive('getTransport')->andReturn($transport = m::mock('Swift_Transport'));
         $transport->shouldReceive('stop');
-        $view = m::mock('StdClass');
+        $view = m::mock(\StdClass::class);
         $mailer->getViewFactory()->shouldReceive('make')->once()->andReturn($view);
         $view->shouldReceive('render')->once()->andReturn('rendered.view');
         $swift = new FailingSwiftMailerStub;

--- a/tests/Mail/MailMailerTest.php
+++ b/tests/Mail/MailMailerTest.php
@@ -16,7 +16,7 @@ class MailMailerTest extends TestCase
     public function testMailerSendSendsMessageWithProperViewContent()
     {
         unset($_SERVER['__mailer.test']);
-        $mailer = $this->getMockBuilder('Illuminate\Mail\Mailer')->setMethods(['createMessage'])->setConstructorArgs($this->getMocks())->getMock();
+        $mailer = $this->getMockBuilder(\Illuminate\Mail\Mailer::class)->setMethods(['createMessage'])->setConstructorArgs($this->getMocks())->getMock();
         $message = m::mock('Swift_Mime_Message');
         $mailer->expects($this->once())->method('createMessage')->will($this->returnValue($message));
         $view = m::mock('StdClass');
@@ -36,7 +36,7 @@ class MailMailerTest extends TestCase
     public function testMailerSendSendsMessageWithProperViewContentUsingHtmlStrings()
     {
         unset($_SERVER['__mailer.test']);
-        $mailer = $this->getMockBuilder('Illuminate\Mail\Mailer')->setMethods(['createMessage'])->setConstructorArgs($this->getMocks())->getMock();
+        $mailer = $this->getMockBuilder(\Illuminate\Mail\Mailer::class)->setMethods(['createMessage'])->setConstructorArgs($this->getMocks())->getMock();
         $message = m::mock('Swift_Mime_Message');
         $mailer->expects($this->once())->method('createMessage')->will($this->returnValue($message));
         $view = m::mock('StdClass');
@@ -57,7 +57,7 @@ class MailMailerTest extends TestCase
     public function testMailerSendSendsMessageWithProperPlainViewContent()
     {
         unset($_SERVER['__mailer.test']);
-        $mailer = $this->getMockBuilder('Illuminate\Mail\Mailer')->setMethods(['createMessage'])->setConstructorArgs($this->getMocks())->getMock();
+        $mailer = $this->getMockBuilder(\Illuminate\Mail\Mailer::class)->setMethods(['createMessage'])->setConstructorArgs($this->getMocks())->getMock();
         $message = m::mock('Swift_Mime_Message');
         $mailer->expects($this->once())->method('createMessage')->will($this->returnValue($message));
         $view = m::mock('StdClass');
@@ -79,7 +79,7 @@ class MailMailerTest extends TestCase
     public function testMailerSendSendsMessageWithProperPlainViewContentWhenExplicit()
     {
         unset($_SERVER['__mailer.test']);
-        $mailer = $this->getMockBuilder('Illuminate\Mail\Mailer')->setMethods(['createMessage'])->setConstructorArgs($this->getMocks())->getMock();
+        $mailer = $this->getMockBuilder(\Illuminate\Mail\Mailer::class)->setMethods(['createMessage'])->setConstructorArgs($this->getMocks())->getMock();
         $message = m::mock('Swift_Mime_Message');
         $mailer->expects($this->once())->method('createMessage')->will($this->returnValue($message));
         $view = m::mock('StdClass');
@@ -134,7 +134,7 @@ class MailMailerTest extends TestCase
 
     protected function getMailer()
     {
-        return new \Illuminate\Mail\Mailer(m::mock('Illuminate\Contracts\View\Factory'), m::mock('Swift_Mailer'));
+        return new \Illuminate\Mail\Mailer(m::mock(\Illuminate\Contracts\View\Factory::class), m::mock('Swift_Mailer'));
     }
 
     public function setSwiftMailer($mailer)
@@ -149,7 +149,7 @@ class MailMailerTest extends TestCase
 
     protected function getMocks()
     {
-        return [m::mock('Illuminate\Contracts\View\Factory'), m::mock('Swift_Mailer')];
+        return [m::mock(\Illuminate\Contracts\View\Factory::class), m::mock('Swift_Mailer')];
     }
 }
 

--- a/tests/Mail/MailMarkdownTest.php
+++ b/tests/Mail/MailMarkdownTest.php
@@ -13,7 +13,7 @@ class MailMarkdownTest extends TestCase
 
     public function testRenderFunctionReturnsHtml()
     {
-        $viewFactory = \Mockery::mock('Illuminate\View\Factory');
+        $viewFactory = \Mockery::mock(\Illuminate\View\Factory::class);
         $markdown = new \Illuminate\Mail\Markdown($viewFactory);
         $viewFactory->shouldReceive('flushFinderCache')->once();
         $viewFactory->shouldReceive('replaceNamespace')->once()->with('mail', $markdown->htmlComponentPaths())->andReturnSelf();
@@ -28,7 +28,7 @@ class MailMarkdownTest extends TestCase
 
     public function testRenderTextReturnsText()
     {
-        $viewFactory = \Mockery::mock('Illuminate\View\Factory');
+        $viewFactory = \Mockery::mock(\Illuminate\View\Factory::class);
         $markdown = new \Illuminate\Mail\Markdown($viewFactory);
         $viewFactory->shouldReceive('flushFinderCache')->once();
         $viewFactory->shouldReceive('replaceNamespace')->once()->with('mail', $markdown->markdownComponentPaths())->andReturnSelf();
@@ -42,7 +42,7 @@ class MailMarkdownTest extends TestCase
 
     public function testParseReturnsParsedMarkdown()
     {
-        $viewFactory = \Mockery::mock('Illuminate\View\Factory');
+        $viewFactory = \Mockery::mock(\Illuminate\View\Factory::class);
         $markdown = new \Illuminate\Mail\Markdown($viewFactory);
 
         $result = $markdown->parse('# Something');

--- a/tests/Mail/MailMessageTest.php
+++ b/tests/Mail/MailMessageTest.php
@@ -99,7 +99,7 @@ class MailMessageTest extends TestCase
     public function testBasicAttachment()
     {
         $swift = m::mock('StdClass');
-        $message = $this->getMockBuilder('Illuminate\Mail\Message')->setMethods(['createAttachmentFromPath'])->setConstructorArgs([$swift])->getMock();
+        $message = $this->getMockBuilder(\Illuminate\Mail\Message::class)->setMethods(['createAttachmentFromPath'])->setConstructorArgs([$swift])->getMock();
         $attachment = m::mock('StdClass');
         $message->expects($this->once())->method('createAttachmentFromPath')->with($this->equalTo('foo.jpg'))->will($this->returnValue($attachment));
         $swift->shouldReceive('attach')->once()->with($attachment);
@@ -111,7 +111,7 @@ class MailMessageTest extends TestCase
     public function testDataAttachment()
     {
         $swift = m::mock('StdClass');
-        $message = $this->getMockBuilder('Illuminate\Mail\Message')->setMethods(['createAttachmentFromData'])->setConstructorArgs([$swift])->getMock();
+        $message = $this->getMockBuilder(\Illuminate\Mail\Message::class)->setMethods(['createAttachmentFromData'])->setConstructorArgs([$swift])->getMock();
         $attachment = m::mock('StdClass');
         $message->expects($this->once())->method('createAttachmentFromData')->with($this->equalTo('foo'), $this->equalTo('name'))->will($this->returnValue($attachment));
         $swift->shouldReceive('attach')->once()->with($attachment);

--- a/tests/Mail/MailMessageTest.php
+++ b/tests/Mail/MailMessageTest.php
@@ -98,9 +98,9 @@ class MailMessageTest extends TestCase
 
     public function testBasicAttachment()
     {
-        $swift = m::mock('StdClass');
+        $swift = m::mock(\StdClass::class);
         $message = $this->getMockBuilder(\Illuminate\Mail\Message::class)->setMethods(['createAttachmentFromPath'])->setConstructorArgs([$swift])->getMock();
-        $attachment = m::mock('StdClass');
+        $attachment = m::mock(\StdClass::class);
         $message->expects($this->once())->method('createAttachmentFromPath')->with($this->equalTo('foo.jpg'))->will($this->returnValue($attachment));
         $swift->shouldReceive('attach')->once()->with($attachment);
         $attachment->shouldReceive('setContentType')->once()->with('image/jpeg');
@@ -110,9 +110,9 @@ class MailMessageTest extends TestCase
 
     public function testDataAttachment()
     {
-        $swift = m::mock('StdClass');
+        $swift = m::mock(\StdClass::class);
         $message = $this->getMockBuilder(\Illuminate\Mail\Message::class)->setMethods(['createAttachmentFromData'])->setConstructorArgs([$swift])->getMock();
-        $attachment = m::mock('StdClass');
+        $attachment = m::mock(\StdClass::class);
         $message->expects($this->once())->method('createAttachmentFromData')->with($this->equalTo('foo'), $this->equalTo('name'))->will($this->returnValue($attachment));
         $swift->shouldReceive('attach')->once()->with($attachment);
         $attachment->shouldReceive('setContentType')->once()->with('image/jpeg');

--- a/tests/Notifications/NotificationBroadcastChannelTest.php
+++ b/tests/Notifications/NotificationBroadcastChannelTest.php
@@ -21,8 +21,8 @@ class NotificationBroadcastChannelTest extends TestCase
         $notification->id = 1;
         $notifiable = Mockery::mock();
 
-        $events = Mockery::mock('Illuminate\Contracts\Events\Dispatcher');
-        $events->shouldReceive('dispatch')->once()->with(Mockery::type('Illuminate\Notifications\Events\BroadcastNotificationCreated'));
+        $events = Mockery::mock(\Illuminate\Contracts\Events\Dispatcher::class);
+        $events->shouldReceive('dispatch')->once()->with(Mockery::type(\Illuminate\Notifications\Events\BroadcastNotificationCreated::class));
         $channel = new BroadcastChannel($events);
         $channel->send($notifiable, $notification);
     }
@@ -48,7 +48,7 @@ class NotificationBroadcastChannelTest extends TestCase
         $notification->id = 1;
         $notifiable = Mockery::mock();
 
-        $events = Mockery::mock('Illuminate\Contracts\Events\Dispatcher');
+        $events = Mockery::mock(\Illuminate\Contracts\Events\Dispatcher::class);
         $events->shouldReceive('dispatch')->once()->with(Mockery::on(function ($event) {
             return $event->connection == 'sync';
         }));

--- a/tests/Notifications/NotificationMailChannelTest.php
+++ b/tests/Notifications/NotificationMailChannelTest.php
@@ -66,7 +66,7 @@ class NotificationMailChannelTest extends TestCase
         $views = ['html' => $html, 'text' => $text];
 
         $mailer->shouldReceive('send')->with($views, $data, Mockery::on(function ($closure) {
-            $mock = Mockery::mock('Illuminate\Mailer\Message');
+            $mock = Mockery::mock(\Illuminate\Mailer\Message::class);
 
             $mock->shouldReceive('subject')->once()->with('test subject');
 
@@ -105,7 +105,7 @@ class NotificationMailChannelTest extends TestCase
         $views = ['html' => $html, 'text' => $text];
 
         $mailer->shouldReceive('send')->with($views, $data, Mockery::on(function ($closure) {
-            $mock = Mockery::mock('Illuminate\Mailer\Message');
+            $mock = Mockery::mock(\Illuminate\Mailer\Message::class);
 
             $mock->shouldReceive('subject')->once()->with('Notification Mail Channel Test Notification No Subject');
 
@@ -142,7 +142,7 @@ class NotificationMailChannelTest extends TestCase
         $views = ['html' => $html, 'text' => $text];
 
         $mailer->shouldReceive('send')->with($views, $data, Mockery::on(function ($closure) {
-            $mock = Mockery::mock('Illuminate\Mailer\Message');
+            $mock = Mockery::mock(\Illuminate\Mailer\Message::class);
 
             $mock->shouldReceive('subject')->once();
 
@@ -181,7 +181,7 @@ class NotificationMailChannelTest extends TestCase
         $views = ['html' => $html, 'text' => $text];
 
         $mailer->shouldReceive('send')->with($views, $data, Mockery::on(function ($closure) {
-            $mock = Mockery::mock('Illuminate\Mailer\Message');
+            $mock = Mockery::mock(\Illuminate\Mailer\Message::class);
 
             $mock->shouldReceive('subject')->once();
 
@@ -220,7 +220,7 @@ class NotificationMailChannelTest extends TestCase
         $views = ['html' => $html, 'text' => $text];
 
         $mailer->shouldReceive('send')->with($views, $data, Mockery::on(function ($closure) {
-            $mock = Mockery::mock('Illuminate\Mailer\Message');
+            $mock = Mockery::mock(\Illuminate\Mailer\Message::class);
 
             $mock->shouldReceive('subject')->once();
 
@@ -259,7 +259,7 @@ class NotificationMailChannelTest extends TestCase
         $views = ['html' => $html, 'text' => $text];
 
         $mailer->shouldReceive('send')->with($views, $data, Mockery::on(function ($closure) {
-            $mock = Mockery::mock('Illuminate\Mailer\Message');
+            $mock = Mockery::mock(\Illuminate\Mailer\Message::class);
 
             $mock->shouldReceive('subject')->once();
 
@@ -298,7 +298,7 @@ class NotificationMailChannelTest extends TestCase
         $views = ['html' => $html, 'text' => $text];
 
         $mailer->shouldReceive('send')->with($views, $data, Mockery::on(function ($closure) {
-            $mock = Mockery::mock('Illuminate\Mailer\Message');
+            $mock = Mockery::mock(\Illuminate\Mailer\Message::class);
 
             $mock->shouldReceive('subject')->once();
 
@@ -337,7 +337,7 @@ class NotificationMailChannelTest extends TestCase
         $views = ['html' => $html, 'text' => $text];
 
         $mailer->shouldReceive('send')->with($views, $data, Mockery::on(function ($closure) {
-            $mock = Mockery::mock('Illuminate\Mailer\Message');
+            $mock = Mockery::mock(\Illuminate\Mailer\Message::class);
 
             $mock->shouldReceive('subject')->once();
 

--- a/tests/Notifications/NotificationSendQueuedNotificationTest.php
+++ b/tests/Notifications/NotificationSendQueuedNotificationTest.php
@@ -16,7 +16,7 @@ class NotificationSendQueuedNotificationTest extends TestCase
     public function testNotificationsCanBeSent()
     {
         $job = new SendQueuedNotifications('notifiables', 'notification');
-        $manager = Mockery::mock('Illuminate\Notifications\ChannelManager');
+        $manager = Mockery::mock(\Illuminate\Notifications\ChannelManager::class);
         $manager->shouldReceive('sendNow')->once()->with('notifiables', 'notification', null);
         $job->handle($manager);
     }

--- a/tests/Pipeline/PipelineTest.php
+++ b/tests/Pipeline/PipelineTest.php
@@ -17,7 +17,7 @@ class PipelineTest extends TestCase
 
         $result = (new Pipeline(new \Illuminate\Container\Container))
                     ->send('foo')
-                    ->through(['Illuminate\Tests\Pipeline\PipelineTestPipeOne', $pipeTwo])
+                    ->through([\Illuminate\Tests\Pipeline\PipelineTestPipeOne::class, $pipeTwo])
                     ->then(function ($piped) {
                         return $piped;
                     });
@@ -66,7 +66,7 @@ class PipelineTest extends TestCase
     {
         $pipelineInstance = new Pipeline(new \Illuminate\Container\Container);
         $result = $pipelineInstance->send('data')
-            ->through('Illuminate\Tests\Pipeline\PipelineTestPipeOne')
+            ->through(\Illuminate\Tests\Pipeline\PipelineTestPipeOne::class)
             ->via('differentMethod')
             ->then(function ($piped) {
                 return $piped;
@@ -80,7 +80,7 @@ class PipelineTest extends TestCase
     public function testPipelineThrowsExceptionOnResolveWithoutContainer()
     {
         (new Pipeline)->send('data')
-            ->through('Illuminate\Tests\Pipeline\PipelineTestPipeOne')
+            ->through(\Illuminate\Tests\Pipeline\PipelineTestPipeOne::class)
             ->then(function ($piped) {
                 return $piped;
             });

--- a/tests/Queue/QueueBeanstalkdJobTest.php
+++ b/tests/Queue/QueueBeanstalkdJobTest.php
@@ -16,7 +16,7 @@ class QueueBeanstalkdJobTest extends TestCase
     {
         $job = $this->getJob();
         $job->getPheanstalkJob()->shouldReceive('getData')->once()->andReturn(json_encode(['job' => 'foo', 'data' => ['data']]));
-        $job->getContainer()->shouldReceive('make')->once()->with('foo')->andReturn($handler = m::mock('StdClass'));
+        $job->getContainer()->shouldReceive('make')->once()->with('foo')->andReturn($handler = m::mock(\StdClass::class));
         $handler->shouldReceive('fire')->once()->with($job, ['data']);
 
         $job->fire();

--- a/tests/Queue/QueueBeanstalkdJobTest.php
+++ b/tests/Queue/QueueBeanstalkdJobTest.php
@@ -26,7 +26,7 @@ class QueueBeanstalkdJobTest extends TestCase
     {
         $job = $this->getJob();
         $job->getPheanstalkJob()->shouldReceive('getData')->once()->andReturn(json_encode(['job' => 'foo', 'data' => ['data']]));
-        $job->getContainer()->shouldReceive('make')->once()->with('foo')->andReturn($handler = m::mock('Illuminate\Tests\Queue\BeanstalkdJobTestFailedTest'));
+        $job->getContainer()->shouldReceive('make')->once()->with('foo')->andReturn($handler = m::mock(\Illuminate\Tests\Queue\BeanstalkdJobTestFailedTest::class));
         $handler->shouldReceive('failed')->once()->with(['data'], m::type('Exception'));
 
         $job->failed(new \Exception);
@@ -59,7 +59,7 @@ class QueueBeanstalkdJobTest extends TestCase
     protected function getJob()
     {
         return new \Illuminate\Queue\Jobs\BeanstalkdJob(
-            m::mock('Illuminate\Container\Container'),
+            m::mock(\Illuminate\Container\Container::class),
             m::mock('Pheanstalk\Pheanstalk'),
             m::mock('Pheanstalk\Job'),
             'connection-name',

--- a/tests/Queue/QueueBeanstalkdQueueTest.php
+++ b/tests/Queue/QueueBeanstalkdQueueTest.php
@@ -39,7 +39,7 @@ class QueueBeanstalkdQueueTest extends TestCase
     public function testPopProperlyPopsJobOffOfBeanstalkd()
     {
         $queue = new \Illuminate\Queue\BeanstalkdQueue(m::mock('Pheanstalk\Pheanstalk'), 'default', 60);
-        $queue->setContainer(m::mock('Illuminate\Container\Container'));
+        $queue->setContainer(m::mock(\Illuminate\Container\Container::class));
         $pheanstalk = $queue->getPheanstalk();
         $pheanstalk->shouldReceive('watchOnly')->once()->with('default')->andReturn($pheanstalk);
         $job = m::mock('Pheanstalk\Job');
@@ -47,7 +47,7 @@ class QueueBeanstalkdQueueTest extends TestCase
 
         $result = $queue->pop();
 
-        $this->assertInstanceOf('Illuminate\Queue\Jobs\BeanstalkdJob', $result);
+        $this->assertInstanceOf(\Illuminate\Queue\Jobs\BeanstalkdJob::class, $result);
     }
 
     public function testDeleteProperlyRemoveJobsOffBeanstalkd()

--- a/tests/Queue/QueueDatabaseQueueUnitTest.php
+++ b/tests/Queue/QueueDatabaseQueueUnitTest.php
@@ -18,7 +18,7 @@ class QueueDatabaseQueueUnitTest extends TestCase
     {
         $queue = $this->getMockBuilder(\Illuminate\Queue\DatabaseQueue::class)->setMethods(['currentTime'])->setConstructorArgs([$database = m::mock(\Illuminate\Database\Connection::class), 'table', 'default'])->getMock();
         $queue->expects($this->any())->method('currentTime')->will($this->returnValue('time'));
-        $database->shouldReceive('table')->with('table')->andReturn($query = m::mock('StdClass'));
+        $database->shouldReceive('table')->with('table')->andReturn($query = m::mock(\StdClass::class));
         $query->shouldReceive('insertGetId')->once()->andReturnUsing(function ($array) {
             $this->assertEquals('default', $array['queue']);
             $this->assertEquals(json_encode(['job' => 'foo', 'data' => ['data']]), $array['payload']);
@@ -38,7 +38,7 @@ class QueueDatabaseQueueUnitTest extends TestCase
             [$database = m::mock(\Illuminate\Database\Connection::class), 'table', 'default']
         )->getMock();
         $queue->expects($this->any())->method('currentTime')->will($this->returnValue('time'));
-        $database->shouldReceive('table')->with('table')->andReturn($query = m::mock('StdClass'));
+        $database->shouldReceive('table')->with('table')->andReturn($query = m::mock(\StdClass::class));
         $query->shouldReceive('insertGetId')->once()->andReturnUsing(function ($array) {
             $this->assertEquals('default', $array['queue']);
             $this->assertEquals(json_encode(['job' => 'foo', 'data' => ['data']]), $array['payload']);
@@ -87,7 +87,7 @@ class QueueDatabaseQueueUnitTest extends TestCase
         $queue = $this->getMockBuilder(\Illuminate\Queue\DatabaseQueue::class)->setMethods(['currentTime', 'availableAt'])->setConstructorArgs([$database, 'table', 'default'])->getMock();
         $queue->expects($this->any())->method('currentTime')->will($this->returnValue('created'));
         $queue->expects($this->any())->method('availableAt')->will($this->returnValue('available'));
-        $database->shouldReceive('table')->with('table')->andReturn($query = m::mock('StdClass'));
+        $database->shouldReceive('table')->with('table')->andReturn($query = m::mock(\StdClass::class));
         $query->shouldReceive('insert')->once()->andReturnUsing(function ($records) {
             $this->assertEquals([[
                 'queue' => 'queue',

--- a/tests/Queue/QueueDatabaseQueueUnitTest.php
+++ b/tests/Queue/QueueDatabaseQueueUnitTest.php
@@ -16,7 +16,7 @@ class QueueDatabaseQueueUnitTest extends TestCase
 
     public function testPushProperlyPushesJobOntoDatabase()
     {
-        $queue = $this->getMockBuilder('Illuminate\Queue\DatabaseQueue')->setMethods(['currentTime'])->setConstructorArgs([$database = m::mock('Illuminate\Database\Connection'), 'table', 'default'])->getMock();
+        $queue = $this->getMockBuilder(\Illuminate\Queue\DatabaseQueue::class)->setMethods(['currentTime'])->setConstructorArgs([$database = m::mock(\Illuminate\Database\Connection::class), 'table', 'default'])->getMock();
         $queue->expects($this->any())->method('currentTime')->will($this->returnValue('time'));
         $database->shouldReceive('table')->with('table')->andReturn($query = m::mock('StdClass'));
         $query->shouldReceive('insertGetId')->once()->andReturnUsing(function ($array) {
@@ -33,9 +33,9 @@ class QueueDatabaseQueueUnitTest extends TestCase
     public function testDelayedPushProperlyPushesJobOntoDatabase()
     {
         $queue = $this->getMockBuilder(
-            'Illuminate\Queue\DatabaseQueue')->setMethods(
+            \Illuminate\Queue\DatabaseQueue::class)->setMethods(
             ['currentTime'])->setConstructorArgs(
-            [$database = m::mock('Illuminate\Database\Connection'), 'table', 'default']
+            [$database = m::mock(\Illuminate\Database\Connection::class), 'table', 'default']
         )->getMock();
         $queue->expects($this->any())->method('currentTime')->will($this->returnValue('time'));
         $database->shouldReceive('table')->with('table')->andReturn($query = m::mock('StdClass'));
@@ -57,8 +57,8 @@ class QueueDatabaseQueueUnitTest extends TestCase
         $job = new stdClass();
         $job->invalid = "\xc3\x28";
 
-        $queue = $this->getMockForAbstractClass('Illuminate\Queue\Queue');
-        $class = new ReflectionClass('Illuminate\Queue\Queue');
+        $queue = $this->getMockForAbstractClass(\Illuminate\Queue\Queue::class);
+        $class = new ReflectionClass(\Illuminate\Queue\Queue::class);
 
         $createPayload = $class->getMethod('createPayload');
         $createPayload->setAccessible(true);
@@ -71,8 +71,8 @@ class QueueDatabaseQueueUnitTest extends TestCase
     {
         $this->expectException('InvalidArgumentException');
 
-        $queue = $this->getMockForAbstractClass('Illuminate\Queue\Queue');
-        $class = new ReflectionClass('Illuminate\Queue\Queue');
+        $queue = $this->getMockForAbstractClass(\Illuminate\Queue\Queue::class);
+        $class = new ReflectionClass(\Illuminate\Queue\Queue::class);
 
         $createPayload = $class->getMethod('createPayload');
         $createPayload->setAccessible(true);
@@ -83,8 +83,8 @@ class QueueDatabaseQueueUnitTest extends TestCase
 
     public function testBulkBatchPushesOntoDatabase()
     {
-        $database = m::mock('Illuminate\Database\Connection');
-        $queue = $this->getMockBuilder('Illuminate\Queue\DatabaseQueue')->setMethods(['currentTime', 'availableAt'])->setConstructorArgs([$database, 'table', 'default'])->getMock();
+        $database = m::mock(\Illuminate\Database\Connection::class);
+        $queue = $this->getMockBuilder(\Illuminate\Queue\DatabaseQueue::class)->setMethods(['currentTime', 'availableAt'])->setConstructorArgs([$database, 'table', 'default'])->getMock();
         $queue->expects($this->any())->method('currentTime')->will($this->returnValue('created'));
         $queue->expects($this->any())->method('availableAt')->will($this->returnValue('available'));
         $database->shouldReceive('table')->with('table')->andReturn($query = m::mock('StdClass'));

--- a/tests/Queue/QueueListenerTest.php
+++ b/tests/Queue/QueueListenerTest.php
@@ -16,7 +16,7 @@ class QueueListenerTest extends TestCase
     {
         $process = m::mock('Symfony\Component\Process\Process')->makePartial();
         $process->shouldReceive('run')->once();
-        $listener = m::mock('Illuminate\Queue\Listener')->makePartial();
+        $listener = m::mock(\Illuminate\Queue\Listener::class)->makePartial();
         $listener->shouldReceive('memoryExceeded')->once()->with(1)->andReturn(false);
 
         $listener->runProcess($process, 1);
@@ -26,7 +26,7 @@ class QueueListenerTest extends TestCase
     {
         $process = m::mock('Symfony\Component\Process\Process')->makePartial();
         $process->shouldReceive('run')->once();
-        $listener = m::mock('Illuminate\Queue\Listener')->makePartial();
+        $listener = m::mock(\Illuminate\Queue\Listener::class)->makePartial();
         $listener->shouldReceive('memoryExceeded')->once()->with(1)->andReturn(true);
         $listener->shouldReceive('stop')->once();
 

--- a/tests/Queue/QueueManagerTest.php
+++ b/tests/Queue/QueueManagerTest.php
@@ -24,8 +24,8 @@ class QueueManagerTest extends TestCase
         ];
 
         $manager = new QueueManager($app);
-        $connector = m::mock('StdClass');
-        $queue = m::mock('StdClass');
+        $connector = m::mock(\StdClass::class);
+        $queue = m::mock(\StdClass::class);
         $queue->shouldReceive('setConnectionName')->once()->with('sync')->andReturnSelf();
         $connector->shouldReceive('connect')->once()->with(['driver' => 'sync'])->andReturn($queue);
         $manager->addConnector('sync', function () use ($connector) {
@@ -47,8 +47,8 @@ class QueueManagerTest extends TestCase
         ];
 
         $manager = new QueueManager($app);
-        $connector = m::mock('StdClass');
-        $queue = m::mock('StdClass');
+        $connector = m::mock(\StdClass::class);
+        $queue = m::mock(\StdClass::class);
         $queue->shouldReceive('setConnectionName')->once()->with('foo')->andReturnSelf();
         $connector->shouldReceive('connect')->once()->with(['driver' => 'bar'])->andReturn($queue);
         $manager->addConnector('bar', function () use ($connector) {
@@ -69,8 +69,8 @@ class QueueManagerTest extends TestCase
         ];
 
         $manager = new QueueManager($app);
-        $connector = m::mock('StdClass');
-        $queue = m::mock('StdClass');
+        $connector = m::mock(\StdClass::class);
+        $queue = m::mock(\StdClass::class);
         $queue->shouldReceive('setConnectionName')->once()->with('null')->andReturnSelf();
         $connector->shouldReceive('connect')->once()->with(['driver' => 'null'])->andReturn($queue);
         $manager->addConnector('null', function () use ($connector) {

--- a/tests/Queue/QueueManagerTest.php
+++ b/tests/Queue/QueueManagerTest.php
@@ -20,7 +20,7 @@ class QueueManagerTest extends TestCase
                 'queue.default' => 'sync',
                 'queue.connections.sync' => ['driver' => 'sync'],
             ],
-            'encrypter' => $encrypter = m::mock('Illuminate\Contracts\Encryption\Encrypter'),
+            'encrypter' => $encrypter = m::mock(\Illuminate\Contracts\Encryption\Encrypter::class),
         ];
 
         $manager = new QueueManager($app);
@@ -43,7 +43,7 @@ class QueueManagerTest extends TestCase
                 'queue.default' => 'sync',
                 'queue.connections.foo' => ['driver' => 'bar'],
             ],
-            'encrypter' => $encrypter = m::mock('Illuminate\Contracts\Encryption\Encrypter'),
+            'encrypter' => $encrypter = m::mock(\Illuminate\Contracts\Encryption\Encrypter::class),
         ];
 
         $manager = new QueueManager($app);
@@ -65,7 +65,7 @@ class QueueManagerTest extends TestCase
             'config' => [
                 'queue.default' => 'null',
             ],
-            'encrypter' => $encrypter = m::mock('Illuminate\Contracts\Encryption\Encrypter'),
+            'encrypter' => $encrypter = m::mock(\Illuminate\Contracts\Encryption\Encrypter::class),
         ];
 
         $manager = new QueueManager($app);

--- a/tests/Queue/QueueRedisJobTest.php
+++ b/tests/Queue/QueueRedisJobTest.php
@@ -15,7 +15,7 @@ class QueueRedisJobTest extends TestCase
     public function testFireProperlyCallsTheJobHandler()
     {
         $job = $this->getJob();
-        $job->getContainer()->shouldReceive('make')->once()->with('foo')->andReturn($handler = m::mock('StdClass'));
+        $job->getContainer()->shouldReceive('make')->once()->with('foo')->andReturn($handler = m::mock(\StdClass::class));
         $handler->shouldReceive('fire')->once()->with($job, ['data']);
 
         $job->fire();

--- a/tests/Queue/QueueRedisQueueTest.php
+++ b/tests/Queue/QueueRedisQueueTest.php
@@ -14,7 +14,7 @@ class QueueRedisQueueTest extends TestCase
 
     public function testPushProperlyPushesJobOntoRedis()
     {
-        $queue = $this->getMockBuilder('Illuminate\Queue\RedisQueue')->setMethods(['getRandomId'])->setConstructorArgs([$redis = m::mock('Illuminate\Contracts\Redis\Factory'), 'default'])->getMock();
+        $queue = $this->getMockBuilder(\Illuminate\Queue\RedisQueue::class)->setMethods(['getRandomId'])->setConstructorArgs([$redis = m::mock(\Illuminate\Contracts\Redis\Factory::class), 'default'])->getMock();
         $queue->expects($this->once())->method('getRandomId')->will($this->returnValue('foo'));
         $redis->shouldReceive('connection')->once()->andReturn($redis);
         $redis->shouldReceive('rpush')->once()->with('queues:default', json_encode(['job' => 'foo', 'data' => ['data'], 'id' => 'foo', 'attempts' => 0]));
@@ -25,7 +25,7 @@ class QueueRedisQueueTest extends TestCase
 
     public function testDelayedPushProperlyPushesJobOntoRedis()
     {
-        $queue = $this->getMockBuilder('Illuminate\Queue\RedisQueue')->setMethods(['availableAt', 'getRandomId'])->setConstructorArgs([$redis = m::mock('Illuminate\Contracts\Redis\Factory'), 'default'])->getMock();
+        $queue = $this->getMockBuilder(\Illuminate\Queue\RedisQueue::class)->setMethods(['availableAt', 'getRandomId'])->setConstructorArgs([$redis = m::mock(\Illuminate\Contracts\Redis\Factory::class), 'default'])->getMock();
         $queue->expects($this->once())->method('getRandomId')->will($this->returnValue('foo'));
         $queue->expects($this->once())->method('availableAt')->with(1)->will($this->returnValue(2));
 
@@ -43,7 +43,7 @@ class QueueRedisQueueTest extends TestCase
     public function testDelayedPushWithDateTimeProperlyPushesJobOntoRedis()
     {
         $date = \Carbon\Carbon::now();
-        $queue = $this->getMockBuilder('Illuminate\Queue\RedisQueue')->setMethods(['availableAt', 'getRandomId'])->setConstructorArgs([$redis = m::mock('Illuminate\Contracts\Redis\Factory'), 'default'])->getMock();
+        $queue = $this->getMockBuilder(\Illuminate\Queue\RedisQueue::class)->setMethods(['availableAt', 'getRandomId'])->setConstructorArgs([$redis = m::mock(\Illuminate\Contracts\Redis\Factory::class), 'default'])->getMock();
         $queue->expects($this->once())->method('getRandomId')->will($this->returnValue('foo'));
         $queue->expects($this->once())->method('availableAt')->with($date)->will($this->returnValue(2));
 

--- a/tests/Queue/QueueSqsJobTest.php
+++ b/tests/Queue/QueueSqsJobTest.php
@@ -29,7 +29,7 @@ class QueueSqsJobTest extends TestCase
             ->getMock();
 
         // Use Mockery to mock the IoC Container
-        $this->mockedContainer = m::mock('Illuminate\Container\Container');
+        $this->mockedContainer = m::mock(\Illuminate\Container\Container::class);
 
         $this->mockedJob = 'foo';
         $this->mockedData = ['data'];
@@ -63,7 +63,7 @@ class QueueSqsJobTest extends TestCase
             ->setMethods(['deleteMessage'])
             ->disableOriginalConstructor()
             ->getMock();
-        $queue = $this->getMockBuilder('Illuminate\Queue\SqsQueue')->setMethods(['getQueue'])->setConstructorArgs([$this->mockedSqsClient, $this->queueName, $this->account])->getMock();
+        $queue = $this->getMockBuilder(\Illuminate\Queue\SqsQueue::class)->setMethods(['getQueue'])->setConstructorArgs([$this->mockedSqsClient, $this->queueName, $this->account])->getMock();
         $queue->setContainer($this->mockedContainer);
         $job = $this->getJob();
         $job->getSqs()->expects($this->once())->method('deleteMessage')->with(['QueueUrl' => $this->queueUrl, 'ReceiptHandle' => $this->mockedReceiptHandle]);
@@ -76,7 +76,7 @@ class QueueSqsJobTest extends TestCase
             ->setMethods(['changeMessageVisibility'])
             ->disableOriginalConstructor()
             ->getMock();
-        $queue = $this->getMockBuilder('Illuminate\Queue\SqsQueue')->setMethods(['getQueue'])->setConstructorArgs([$this->mockedSqsClient, $this->queueName, $this->account])->getMock();
+        $queue = $this->getMockBuilder(\Illuminate\Queue\SqsQueue::class)->setMethods(['getQueue'])->setConstructorArgs([$this->mockedSqsClient, $this->queueName, $this->account])->getMock();
         $queue->setContainer($this->mockedContainer);
         $job = $this->getJob();
         $job->getSqs()->expects($this->once())->method('changeMessageVisibility')->with(['QueueUrl' => $this->queueUrl, 'ReceiptHandle' => $this->mockedReceiptHandle, 'VisibilityTimeout' => $this->releaseDelay]);

--- a/tests/Queue/QueueSqsJobTest.php
+++ b/tests/Queue/QueueSqsJobTest.php
@@ -52,7 +52,7 @@ class QueueSqsJobTest extends TestCase
     public function testFireProperlyCallsTheJobHandler()
     {
         $job = $this->getJob();
-        $job->getContainer()->shouldReceive('make')->once()->with('foo')->andReturn($handler = m::mock('StdClass'));
+        $job->getContainer()->shouldReceive('make')->once()->with('foo')->andReturn($handler = m::mock(\StdClass::class));
         $handler->shouldReceive('fire')->once()->with($job, ['data']);
         $job->fire();
     }

--- a/tests/Queue/QueueSqsQueueTest.php
+++ b/tests/Queue/QueueSqsQueueTest.php
@@ -50,18 +50,18 @@ class QueueSqsQueueTest extends TestCase
 
     public function testPopProperlyPopsJobOffOfSqs()
     {
-        $queue = $this->getMockBuilder('Illuminate\Queue\SqsQueue')->setMethods(['getQueue'])->setConstructorArgs([$this->sqs, $this->queueName, $this->account])->getMock();
-        $queue->setContainer(m::mock('Illuminate\Container\Container'));
+        $queue = $this->getMockBuilder(\Illuminate\Queue\SqsQueue::class)->setMethods(['getQueue'])->setConstructorArgs([$this->sqs, $this->queueName, $this->account])->getMock();
+        $queue->setContainer(m::mock(\Illuminate\Container\Container::class));
         $queue->expects($this->once())->method('getQueue')->with($this->queueName)->will($this->returnValue($this->queueUrl));
         $this->sqs->shouldReceive('receiveMessage')->once()->with(['QueueUrl' => $this->queueUrl, 'AttributeNames' => ['ApproximateReceiveCount']])->andReturn($this->mockedReceiveMessageResponseModel);
         $result = $queue->pop($this->queueName);
-        $this->assertInstanceOf('Illuminate\Queue\Jobs\SqsJob', $result);
+        $this->assertInstanceOf(\Illuminate\Queue\Jobs\SqsJob::class, $result);
     }
 
     public function testDelayedPushWithDateTimeProperlyPushesJobOntoSqs()
     {
         $now = \Carbon\Carbon::now();
-        $queue = $this->getMockBuilder('Illuminate\Queue\SqsQueue')->setMethods(['createPayload', 'secondsUntil', 'getQueue'])->setConstructorArgs([$this->sqs, $this->queueName, $this->account])->getMock();
+        $queue = $this->getMockBuilder(\Illuminate\Queue\SqsQueue::class)->setMethods(['createPayload', 'secondsUntil', 'getQueue'])->setConstructorArgs([$this->sqs, $this->queueName, $this->account])->getMock();
         $queue->expects($this->once())->method('createPayload')->with($this->mockedJob, $this->mockedData)->will($this->returnValue($this->mockedPayload));
         $queue->expects($this->once())->method('secondsUntil')->with($now)->will($this->returnValue(5));
         $queue->expects($this->once())->method('getQueue')->with($this->queueName)->will($this->returnValue($this->queueUrl));
@@ -72,7 +72,7 @@ class QueueSqsQueueTest extends TestCase
 
     public function testDelayedPushProperlyPushesJobOntoSqs()
     {
-        $queue = $this->getMockBuilder('Illuminate\Queue\SqsQueue')->setMethods(['createPayload', 'secondsUntil', 'getQueue'])->setConstructorArgs([$this->sqs, $this->queueName, $this->account])->getMock();
+        $queue = $this->getMockBuilder(\Illuminate\Queue\SqsQueue::class)->setMethods(['createPayload', 'secondsUntil', 'getQueue'])->setConstructorArgs([$this->sqs, $this->queueName, $this->account])->getMock();
         $queue->expects($this->once())->method('createPayload')->with($this->mockedJob, $this->mockedData)->will($this->returnValue($this->mockedPayload));
         $queue->expects($this->once())->method('secondsUntil')->with($this->mockedDelay)->will($this->returnValue($this->mockedDelay));
         $queue->expects($this->once())->method('getQueue')->with($this->queueName)->will($this->returnValue($this->queueUrl));
@@ -83,7 +83,7 @@ class QueueSqsQueueTest extends TestCase
 
     public function testPushProperlyPushesJobOntoSqs()
     {
-        $queue = $this->getMockBuilder('Illuminate\Queue\SqsQueue')->setMethods(['createPayload', 'getQueue'])->setConstructorArgs([$this->sqs, $this->queueName, $this->account])->getMock();
+        $queue = $this->getMockBuilder(\Illuminate\Queue\SqsQueue::class)->setMethods(['createPayload', 'getQueue'])->setConstructorArgs([$this->sqs, $this->queueName, $this->account])->getMock();
         $queue->expects($this->once())->method('createPayload')->with($this->mockedJob, $this->mockedData)->will($this->returnValue($this->mockedPayload));
         $queue->expects($this->once())->method('getQueue')->with($this->queueName)->will($this->returnValue($this->queueUrl));
         $this->sqs->shouldReceive('sendMessage')->once()->with(['QueueUrl' => $this->queueUrl, 'MessageBody' => $this->mockedPayload])->andReturn($this->mockedSendMessageResponseModel);

--- a/tests/Queue/QueueSyncQueueTest.php
+++ b/tests/Queue/QueueSyncQueueTest.php
@@ -22,8 +22,8 @@ class QueueSyncQueueTest extends TestCase
         $container = new \Illuminate\Container\Container;
         $sync->setContainer($container);
 
-        $sync->push('Illuminate\Tests\Queue\SyncQueueTestHandler', ['foo' => 'bar']);
-        $this->assertInstanceOf('Illuminate\Queue\Jobs\SyncJob', $_SERVER['__sync.test'][0]);
+        $sync->push(\Illuminate\Tests\Queue\SyncQueueTestHandler::class, ['foo' => 'bar']);
+        $this->assertInstanceOf(\Illuminate\Queue\Jobs\SyncJob::class, $_SERVER['__sync.test'][0]);
         $this->assertEquals(['foo' => 'bar'], $_SERVER['__sync.test'][1]);
     }
 
@@ -34,14 +34,14 @@ class QueueSyncQueueTest extends TestCase
         $sync = new \Illuminate\Queue\SyncQueue;
         $container = new \Illuminate\Container\Container;
         Container::setInstance($container);
-        $events = m::mock('Illuminate\Contracts\Events\Dispatcher');
+        $events = m::mock(\Illuminate\Contracts\Events\Dispatcher::class);
         $events->shouldReceive('fire')->times(3);
         $container->instance('events', $events);
-        $container->instance('Illuminate\Contracts\Events\Dispatcher', $events);
+        $container->instance(\Illuminate\Contracts\Events\Dispatcher::class, $events);
         $sync->setContainer($container);
 
         try {
-            $sync->push('Illuminate\Tests\Queue\FailingSyncQueueTestHandler', ['foo' => 'bar']);
+            $sync->push(\Illuminate\Tests\Queue\FailingSyncQueueTestHandler::class, ['foo' => 'bar']);
         } catch (Exception $e) {
             $this->assertTrue($_SERVER['__sync.failed']);
         }

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -181,7 +181,7 @@ class RouteRegistrarTest extends TestCase
     public function testCanRegisterResource()
     {
         $this->router->middleware('resource-middleware')
-                     ->resource('users', 'Illuminate\Tests\Routing\RouteRegistrarControllerStub');
+                     ->resource('users', \Illuminate\Tests\Routing\RouteRegistrarControllerStub::class);
 
         $this->seeResponse('deleted', Request::create('users/1', 'DELETE'));
         $this->seeMiddleware('resource-middleware');

--- a/tests/Routing/RoutingRedirectorTest.php
+++ b/tests/Routing/RoutingRedirectorTest.php
@@ -18,10 +18,10 @@ class RoutingRedirectorTest extends TestCase
     {
         $this->headers = m::mock('Symfony\Component\HttpFoundation\HeaderBag');
 
-        $this->request = m::mock('Illuminate\Http\Request');
+        $this->request = m::mock(\Illuminate\Http\Request::class);
         $this->request->headers = $this->headers;
 
-        $this->url = m::mock('Illuminate\Routing\UrlGenerator');
+        $this->url = m::mock(\Illuminate\Routing\UrlGenerator::class);
         $this->url->shouldReceive('getRequest')->andReturn($this->request);
         $this->url->shouldReceive('to')->with('bar', [], null)->andReturn('http://foo.com/bar');
         $this->url->shouldReceive('to')->with('bar', [], true)->andReturn('https://foo.com/bar');
@@ -29,7 +29,7 @@ class RoutingRedirectorTest extends TestCase
         $this->url->shouldReceive('to')->with('http://foo.com/bar', [], null)->andReturn('http://foo.com/bar');
         $this->url->shouldReceive('to')->with('/', [], null)->andReturn('http://foo.com/');
 
-        $this->session = m::mock('Illuminate\Session\Store');
+        $this->session = m::mock(\Illuminate\Session\Store::class);
 
         $this->redirect = new Redirector($this->url);
         $this->redirect->setSession($this->session);
@@ -44,7 +44,7 @@ class RoutingRedirectorTest extends TestCase
     {
         $response = $this->redirect->to('bar');
 
-        $this->assertInstanceOf('Illuminate\Http\RedirectResponse', $response);
+        $this->assertInstanceOf(\Illuminate\Http\RedirectResponse::class, $response);
         $this->assertEquals('http://foo.com/bar', $response->getTargetUrl());
         $this->assertEquals(302, $response->getStatusCode());
         $this->assertEquals($this->session, $response->getSession());

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -303,7 +303,7 @@ class RoutingRouteTest extends TestCase
         });
 
         $this->assertEquals('hello', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
-        $this->assertInstanceOf('stdClass', $_SERVER['__test.route_inject'][0]);
+        $this->assertInstanceOf(\StdClass::class, $_SERVER['__test.route_inject'][0]);
         $this->assertEquals('bar', $_SERVER['__test.route_inject'][1]);
 
         unset($_SERVER['__test.route_inject']);

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -211,9 +211,9 @@ class RoutingRouteTest extends TestCase
         $this->assertEquals('hello', $router->dispatch(Request::create('foo/bar', 'POST'))->getContent());
         $router->get('foo/bar')->uses(function () {
             return 'middleware';
-        })->middleware('Illuminate\Tests\Routing\RouteTestControllerMiddleware');
+        })->middleware(\Illuminate\Tests\Routing\RouteTestControllerMiddleware::class);
         $this->assertEquals('middleware', $router->dispatch(Request::create('foo/bar'))->getContent());
-        $this->assertContains('Illuminate\Tests\Routing\RouteTestControllerMiddleware', $router->getCurrentRoute()->middleware());
+        $this->assertContains(\Illuminate\Tests\Routing\RouteTestControllerMiddleware::class, $router->getCurrentRoute()->middleware());
         $router->get('foo/bar');
         $router->dispatch(Request::create('foo/bar', 'GET'));
     }
@@ -240,8 +240,8 @@ class RoutingRouteTest extends TestCase
             return 'hello';
         }]);
 
-        $router->aliasMiddleware('two', 'Illuminate\Tests\Routing\RoutingTestMiddlewareGroupTwo');
-        $router->middlewareGroup('web', ['Illuminate\Tests\Routing\RoutingTestMiddlewareGroupOne', 'two:taylor']);
+        $router->aliasMiddleware('two', \Illuminate\Tests\Routing\RoutingTestMiddlewareGroupTwo::class);
+        $router->middlewareGroup('web', [\Illuminate\Tests\Routing\RoutingTestMiddlewareGroupOne::class, 'two:taylor']);
 
         $this->assertEquals('caught taylor', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
         $this->assertTrue($_SERVER['__middleware.group']);
@@ -257,9 +257,9 @@ class RoutingRouteTest extends TestCase
             return 'hello';
         }]);
 
-        $router->aliasMiddleware('two', 'Illuminate\Tests\Routing\RoutingTestMiddlewareGroupTwo');
+        $router->aliasMiddleware('two', \Illuminate\Tests\Routing\RoutingTestMiddlewareGroupTwo::class);
         $router->middlewareGroup('first', ['two:abigail']);
-        $router->middlewareGroup('web', ['Illuminate\Tests\Routing\RoutingTestMiddlewareGroupOne', 'first']);
+        $router->middlewareGroup('web', [\Illuminate\Tests\Routing\RoutingTestMiddlewareGroupOne::class, 'first']);
 
         $this->assertEquals('caught abigail', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
         $this->assertTrue($_SERVER['__middleware.group']);
@@ -594,7 +594,7 @@ class RoutingRouteTest extends TestCase
         $router->get('foo/{bar}', ['middleware' => SubstituteBindings::class, 'uses' => function ($name) {
             return $name;
         }]);
-        $router->bind('bar', 'Illuminate\Tests\Routing\RouteBindingStub');
+        $router->bind('bar', \Illuminate\Tests\Routing\RouteBindingStub::class);
         $this->assertEquals('TAYLOR', $router->dispatch(Request::create('foo/taylor', 'GET'))->getContent());
     }
 
@@ -641,7 +641,7 @@ class RoutingRouteTest extends TestCase
         $router->get('foo/{bar}', ['middleware' => SubstituteBindings::class, 'uses' => function ($name) {
             return $name;
         }]);
-        $router->model('bar', 'Illuminate\Tests\Routing\RouteModelBindingStub');
+        $router->model('bar', \Illuminate\Tests\Routing\RouteModelBindingStub::class);
         $this->assertEquals('TAYLOR', $router->dispatch(Request::create('foo/taylor', 'GET'))->getContent());
     }
 
@@ -654,7 +654,7 @@ class RoutingRouteTest extends TestCase
         $router->get('foo/{bar}', ['middleware' => SubstituteBindings::class, 'uses' => function ($name) {
             return $name;
         }]);
-        $router->model('bar', 'Illuminate\Tests\Routing\RouteModelBindingNullStub');
+        $router->model('bar', \Illuminate\Tests\Routing\RouteModelBindingNullStub::class);
         $router->dispatch(Request::create('foo/taylor', 'GET'))->getContent();
     }
 
@@ -664,7 +664,7 @@ class RoutingRouteTest extends TestCase
         $router->get('foo/{bar}', ['middleware' => SubstituteBindings::class, 'uses' => function ($name) {
             return $name;
         }]);
-        $router->model('bar', 'Illuminate\Tests\Routing\RouteModelBindingNullStub', function () {
+        $router->model('bar', \Illuminate\Tests\Routing\RouteModelBindingNullStub::class, function () {
             return 'missing';
         });
         $this->assertEquals('missing', $router->dispatch(Request::create('foo/taylor', 'GET'))->getContent());
@@ -676,7 +676,7 @@ class RoutingRouteTest extends TestCase
         $router->get('foo/{bar}', ['middleware' => SubstituteBindings::class, 'uses' => function ($name) {
             return $name;
         }]);
-        $router->model('bar', 'Illuminate\Tests\Routing\RouteModelBindingNullStub', function ($value) {
+        $router->model('bar', \Illuminate\Tests\Routing\RouteModelBindingNullStub::class, function ($value) {
             return (new RouteModelBindingClosureStub())->findAlternate($value);
         });
         $this->assertEquals('tayloralt', $router->dispatch(Request::create('foo/TAYLOR', 'GET'))->getContent());
@@ -689,11 +689,11 @@ class RoutingRouteTest extends TestCase
         $container->singleton(Registrar::class, function () use ($router) {
             return $router;
         });
-        $container->bind('Illuminate\Tests\Routing\RouteModelInterface', 'Illuminate\Tests\Routing\RouteModelBindingStub');
+        $container->bind(\Illuminate\Tests\Routing\RouteModelInterface::class, \Illuminate\Tests\Routing\RouteModelBindingStub::class);
         $router->get('foo/{bar}', ['middleware' => SubstituteBindings::class, 'uses' => function ($name) {
             return $name;
         }]);
-        $router->model('bar', 'Illuminate\Tests\Routing\RouteModelInterface');
+        $router->model('bar', \Illuminate\Tests\Routing\RouteModelInterface::class);
         $this->assertEquals('TAYLOR', $router->dispatch(Request::create('foo/taylor', 'GET'))->getContent());
     }
 
@@ -888,7 +888,7 @@ class RoutingRouteTest extends TestCase
     public function testInvalidActionException()
     {
         $router = $this->getRouter();
-        $router->get('/', ['uses' => 'Illuminate\Tests\Routing\RouteTestControllerStub']);
+        $router->get('/', ['uses' => \Illuminate\Tests\Routing\RouteTestControllerStub::class]);
 
         $router->dispatch(Request::create('/'));
     }
@@ -1075,11 +1075,11 @@ class RoutingRouteTest extends TestCase
 
         $router->dispatchToRoute($request);
 
-        $this->assertInstanceOf('Illuminate\Http\Request', $_SERVER['__router.request']);
+        $this->assertInstanceOf(\Illuminate\Http\Request::class, $_SERVER['__router.request']);
         $this->assertEquals($_SERVER['__router.request'], $request);
         unset($_SERVER['__router.request']);
 
-        $this->assertInstanceOf('Illuminate\Routing\Route', $_SERVER['__router.route']);
+        $this->assertInstanceOf(\Illuminate\Routing\Route::class, $_SERVER['__router.route']);
         $this->assertEquals($_SERVER['__router.route']->uri(), $route->uri());
         unset($_SERVER['__router.route']);
     }
@@ -1109,7 +1109,7 @@ class RoutingRouteTest extends TestCase
 
         $this->assertEquals('Hello World', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
         $this->assertTrue($_SERVER['route.test.controller.middleware']);
-        $this->assertEquals('Illuminate\Http\Response', $_SERVER['route.test.controller.middleware.class']);
+        $this->assertEquals(\Illuminate\Http\Response::class, $_SERVER['route.test.controller.middleware.class']);
         $this->assertEquals(0, $_SERVER['route.test.controller.middleware.parameters.one']);
         $this->assertEquals(['foo', 'bar'], $_SERVER['route.test.controller.middleware.parameters.two']);
         $this->assertFalse(isset($_SERVER['route.test.controller.except.middleware']));
@@ -1125,15 +1125,15 @@ class RoutingRouteTest extends TestCase
         $router = $this->getRouter();
 
         $router->middlewareGroup('web', [
-            'Illuminate\Tests\Routing\RouteTestControllerMiddleware',
-            'Illuminate\Tests\Routing\RouteTestControllerMiddlewareTwo',
+            \Illuminate\Tests\Routing\RouteTestControllerMiddleware::class,
+            \Illuminate\Tests\Routing\RouteTestControllerMiddlewareTwo::class,
         ]);
 
         $router->get('foo/bar', 'Illuminate\Tests\Routing\RouteTestControllerMiddlewareGroupStub@index');
 
         $this->assertEquals('caught', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
         $this->assertTrue($_SERVER['route.test.controller.middleware']);
-        $this->assertEquals('Illuminate\Http\Response', $_SERVER['route.test.controller.middleware.class']);
+        $this->assertEquals(\Illuminate\Http\Response::class, $_SERVER['route.test.controller.middleware.class']);
     }
 
     public function testImplicitBindings()
@@ -1182,7 +1182,7 @@ class RoutingRouteTest extends TestCase
             return $router;
         });
 
-        $container->bind('Illuminate\Tests\Routing\RoutingTestUserModel', 'Illuminate\Tests\Routing\RoutingTestExtendedUserModel');
+        $container->bind(\Illuminate\Tests\Routing\RoutingTestUserModel::class, \Illuminate\Tests\Routing\RoutingTestExtendedUserModel::class);
         $router->get('foo/{bar}', [
             'middleware' => SubstituteBindings::class,
             'uses' => function (RoutingTestUserModel $bar) use ($phpunit) {
@@ -1195,12 +1195,12 @@ class RoutingRouteTest extends TestCase
     public function testDispatchingCallableActionClasses()
     {
         $router = $this->getRouter();
-        $router->get('foo/bar', 'Illuminate\Tests\Routing\ActionStub');
+        $router->get('foo/bar', \Illuminate\Tests\Routing\ActionStub::class);
 
         $this->assertEquals('hello', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
 
         $router->get('foo/bar2', [
-            'uses' => 'Illuminate\Tests\Routing\ActionStub',
+            'uses' => \Illuminate\Tests\Routing\ActionStub::class,
         ]);
 
         $this->assertEquals('hello', $router->dispatch(Request::create('foo/bar2', 'GET'))->getContent());
@@ -1224,10 +1224,10 @@ class RouteTestControllerStub extends Controller
 {
     public function __construct()
     {
-        $this->middleware('Illuminate\Tests\Routing\RouteTestControllerMiddleware');
+        $this->middleware(\Illuminate\Tests\Routing\RouteTestControllerMiddleware::class);
         $this->middleware('Illuminate\Tests\Routing\RouteTestControllerParameterizedMiddlewareOne:0');
         $this->middleware('Illuminate\Tests\Routing\RouteTestControllerParameterizedMiddlewareTwo:foo,bar');
-        $this->middleware('Illuminate\Tests\Routing\RouteTestControllerExceptMiddleware', ['except' => 'index']);
+        $this->middleware(\Illuminate\Tests\Routing\RouteTestControllerExceptMiddleware::class, ['except' => 'index']);
     }
 
     public function index()

--- a/tests/Session/EncryptedSessionStoreTest.php
+++ b/tests/Session/EncryptedSessionStoreTest.php
@@ -43,7 +43,7 @@ class EncryptedSessionStoreTest extends TestCase
 
     public function getSession()
     {
-        $reflection = new ReflectionClass('Illuminate\Session\EncryptedStore');
+        $reflection = new ReflectionClass(\Illuminate\Session\EncryptedStore::class);
 
         return $reflection->newInstanceArgs($this->getMocks());
     }
@@ -53,7 +53,7 @@ class EncryptedSessionStoreTest extends TestCase
         return [
             $this->getSessionName(),
             m::mock('SessionHandlerInterface'),
-            m::mock('Illuminate\Contracts\Encryption\Encrypter'),
+            m::mock(\Illuminate\Contracts\Encryption\Encrypter::class),
             $this->getSessionId(),
         ];
     }

--- a/tests/Session/SessionStoreTest.php
+++ b/tests/Session/SessionStoreTest.php
@@ -342,7 +342,7 @@ class SessionStoreTest extends TestCase
 
     public function getSession()
     {
-        $reflection = new ReflectionClass('Illuminate\Session\Store');
+        $reflection = new ReflectionClass(\Illuminate\Session\Store::class);
 
         return $reflection->newInstanceArgs($this->getMocks());
     }

--- a/tests/Session/SessionTableCommandTest.php
+++ b/tests/Session/SessionTableCommandTest.php
@@ -17,10 +17,10 @@ class SessionTableCommandTest extends TestCase
     public function testCreateMakesMigration()
     {
         $command = new SessionTableCommandTestStub(
-            $files = m::mock('Illuminate\Filesystem\Filesystem'),
-            $composer = m::mock('Illuminate\Support\Composer')
+            $files = m::mock(\Illuminate\Filesystem\Filesystem::class),
+            $composer = m::mock(\Illuminate\Support\Composer::class)
         );
-        $creator = m::mock('Illuminate\Database\Migrations\MigrationCreator')->shouldIgnoreMissing();
+        $creator = m::mock(\Illuminate\Database\Migrations\MigrationCreator::class)->shouldIgnoreMissing();
 
         $app = new Application();
         $app->useDatabasePath(__DIR__);

--- a/tests/Support/SupportCapsuleManagerTraitTest.php
+++ b/tests/Support/SupportCapsuleManagerTraitTest.php
@@ -23,17 +23,17 @@ class SupportCapsuleManagerTraitTest extends TestCase
 
         $this->assertNull($this->setupContainer($app));
         $this->assertEquals($app, $this->getContainer());
-        $this->assertInstanceOf('Illuminate\Support\Fluent', $app['config']);
+        $this->assertInstanceOf(\Illuminate\Support\Fluent::class, $app['config']);
     }
 
     public function testSetupContainerForCapsuleWhenConfigIsBound()
     {
         $this->container = null;
         $app = new Container;
-        $app['config'] = m::mock('Illuminate\Config\Repository');
+        $app['config'] = m::mock(\Illuminate\Config\Repository::class);
 
         $this->assertNull($this->setupContainer($app));
         $this->assertEquals($app, $this->getContainer());
-        $this->assertInstanceOf('Illuminate\Config\Repository', $app['config']);
+        $this->assertInstanceOf(\Illuminate\Config\Repository::class, $app['config']);
     }
 }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -161,9 +161,9 @@ class SupportCollectionTest extends TestCase
 
     public function testToArrayCallsToArrayOnEachItemInCollection()
     {
-        $item1 = m::mock('Illuminate\Contracts\Support\Arrayable');
+        $item1 = m::mock(\Illuminate\Contracts\Support\Arrayable::class);
         $item1->shouldReceive('toArray')->once()->andReturn('foo.array');
-        $item2 = m::mock('Illuminate\Contracts\Support\Arrayable');
+        $item2 = m::mock(\Illuminate\Contracts\Support\Arrayable::class);
         $item2->shouldReceive('toArray')->once()->andReturn('bar.array');
         $c = new Collection([$item1, $item2]);
         $results = $c->toArray();
@@ -175,7 +175,7 @@ class SupportCollectionTest extends TestCase
     {
         $item1 = m::mock('JsonSerializable');
         $item1->shouldReceive('jsonSerialize')->once()->andReturn('foo.json');
-        $item2 = m::mock('Illuminate\Contracts\Support\Arrayable');
+        $item2 = m::mock(\Illuminate\Contracts\Support\Arrayable::class);
         $item2->shouldReceive('toArray')->once()->andReturn('bar.array');
         $c = new Collection([$item1, $item2]);
         $results = $c->jsonSerialize();

--- a/tests/Support/SupportFacadeTest.php
+++ b/tests/Support/SupportFacadeTest.php
@@ -23,7 +23,7 @@ class SupportFacadeTest extends TestCase
     public function testFacadeCallsUnderlyingApplication()
     {
         $app = new ApplicationStub;
-        $app->setAttributes(['foo' => $mock = m::mock('StdClass')]);
+        $app->setAttributes(['foo' => $mock = m::mock(\StdClass::class)]);
         $mock->shouldReceive('bar')->once()->andReturn('baz');
         FacadeStub::setFacadeApplication($app);
         $this->assertEquals('baz', FacadeStub::bar());

--- a/tests/Support/SupportFluentTest.php
+++ b/tests/Support/SupportFluentTest.php
@@ -69,7 +69,7 @@ class SupportFluentTest extends TestCase
         $this->assertEquals('Taylor', $fluent->name);
         $this->assertTrue($fluent->developer);
         $this->assertEquals(25, $fluent->age);
-        $this->assertInstanceOf('Illuminate\Support\Fluent', $fluent->programmer());
+        $this->assertInstanceOf(\Illuminate\Support\Fluent::class, $fluent->programmer());
     }
 
     public function testIssetMagicMethod()
@@ -94,7 +94,7 @@ class SupportFluentTest extends TestCase
 
     public function testToJsonEncodesTheToArrayResult()
     {
-        $fluent = $this->getMockBuilder('Illuminate\Support\Fluent')->setMethods(['toArray'])->getMock();
+        $fluent = $this->getMockBuilder(\Illuminate\Support\Fluent::class)->setMethods(['toArray'])->getMock();
         $fluent->expects($this->once())->method('toArray')->will($this->returnValue('foo'));
         $results = $fluent->toJson();
 

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -239,7 +239,7 @@ class SupportHelpersTest extends TestCase
     {
         $str = 'A \'quote\' is <b>bold</b>';
         $this->assertEquals('A &#039;quote&#039; is &lt;b&gt;bold&lt;/b&gt;', e($str));
-        $html = m::mock('Illuminate\Contracts\Support\Htmlable');
+        $html = m::mock(\Illuminate\Contracts\Support\Htmlable::class);
         $html->shouldReceive('toHtml')->andReturn($str);
         $this->assertEquals($str, e($html));
     }
@@ -660,17 +660,17 @@ class SupportHelpersTest extends TestCase
     public function testClassUsesRecursiveShouldReturnTraitsOnParentClasses()
     {
         $this->assertEquals([
-            'Illuminate\Tests\Support\SupportTestTraitOne' => 'Illuminate\Tests\Support\SupportTestTraitOne',
-            'Illuminate\Tests\Support\SupportTestTraitTwo' => 'Illuminate\Tests\Support\SupportTestTraitTwo',
+            \Illuminate\Tests\Support\SupportTestTraitOne::class => \Illuminate\Tests\Support\SupportTestTraitOne::class,
+            \Illuminate\Tests\Support\SupportTestTraitTwo::class => \Illuminate\Tests\Support\SupportTestTraitTwo::class,
         ],
-        class_uses_recursive('Illuminate\Tests\Support\SupportTestClassTwo'));
+        class_uses_recursive(\Illuminate\Tests\Support\SupportTestClassTwo::class));
     }
 
     public function testClassUsesRecursiveAcceptsObject()
     {
         $this->assertEquals([
-            'Illuminate\Tests\Support\SupportTestTraitOne' => 'Illuminate\Tests\Support\SupportTestTraitOne',
-            'Illuminate\Tests\Support\SupportTestTraitTwo' => 'Illuminate\Tests\Support\SupportTestTraitTwo',
+            \Illuminate\Tests\Support\SupportTestTraitOne::class => \Illuminate\Tests\Support\SupportTestTraitOne::class,
+            \Illuminate\Tests\Support\SupportTestTraitTwo::class => \Illuminate\Tests\Support\SupportTestTraitTwo::class,
         ],
         class_uses_recursive(new SupportTestClassTwo));
     }

--- a/tests/Support/SupportNamespacedItemResolverTest.php
+++ b/tests/Support/SupportNamespacedItemResolverTest.php
@@ -19,7 +19,7 @@ class SupportNamespacedItemResolverTest extends TestCase
 
     public function testParsedItemsAreCached()
     {
-        $r = $this->getMockBuilder('Illuminate\Support\NamespacedItemResolver')->setMethods(['parseBasicSegments', 'parseNamespacedSegments'])->getMock();
+        $r = $this->getMockBuilder(\Illuminate\Support\NamespacedItemResolver::class)->setMethods(['parseBasicSegments', 'parseNamespacedSegments'])->getMock();
         $r->setParsedKey('foo.bar', ['foo']);
         $r->expects($this->never())->method('parseBasicSegments');
         $r->expects($this->never())->method('parseNamespacedSegments');

--- a/tests/Support/SupportServiceProviderTest.php
+++ b/tests/Support/SupportServiceProviderTest.php
@@ -10,7 +10,7 @@ class SupportServiceProviderTest extends TestCase
 {
     public function setUp()
     {
-        $app = m::mock('Illuminate\\Foundation\\Application')->makePartial();
+        $app = m::mock(\Illuminate\Foundation\Application::class)->makePartial();
         $one = new ServiceProviderForTestingOne($app);
         $one->boot();
         $two = new ServiceProviderForTestingTwo($app);
@@ -24,7 +24,7 @@ class SupportServiceProviderTest extends TestCase
 
     public function testSimpleAssetsArePublishedCorrectly()
     {
-        $toPublish = ServiceProvider::pathsToPublish('Illuminate\Tests\Support\ServiceProviderForTestingOne');
+        $toPublish = ServiceProvider::pathsToPublish(\Illuminate\Tests\Support\ServiceProviderForTestingOne::class);
         $this->assertArrayHasKey('source/unmarked/one', $toPublish, 'Service provider does not return expected published path key.');
         $this->assertArrayHasKey('source/tagged/one', $toPublish, 'Service provider does not return expected published path key.');
         $this->assertEquals(['source/unmarked/one' => 'destination/unmarked/one', 'source/tagged/one' => 'destination/tagged/one'], $toPublish, 'Service provider does not return expected set of published paths.');
@@ -32,7 +32,7 @@ class SupportServiceProviderTest extends TestCase
 
     public function testMultipleAssetsArePublishedCorrectly()
     {
-        $toPublish = ServiceProvider::pathsToPublish('Illuminate\Tests\Support\ServiceProviderForTestingTwo');
+        $toPublish = ServiceProvider::pathsToPublish(\Illuminate\Tests\Support\ServiceProviderForTestingTwo::class);
         $this->assertArrayHasKey('source/unmarked/two/a', $toPublish, 'Service provider does not return expected published path key.');
         $this->assertArrayHasKey('source/unmarked/two/b', $toPublish, 'Service provider does not return expected published path key.');
         $this->assertArrayHasKey('source/unmarked/two/c', $toPublish, 'Service provider does not return expected published path key.');
@@ -50,7 +50,7 @@ class SupportServiceProviderTest extends TestCase
 
     public function testSimpleTaggedAssetsArePublishedCorrectly()
     {
-        $toPublish = ServiceProvider::pathsToPublish('Illuminate\Tests\Support\ServiceProviderForTestingOne', 'some_tag');
+        $toPublish = ServiceProvider::pathsToPublish(\Illuminate\Tests\Support\ServiceProviderForTestingOne::class, 'some_tag');
         $this->assertArrayNotHasKey('source/tagged/two/a', $toPublish, 'Service provider does return unexpected tagged path key.');
         $this->assertArrayNotHasKey('source/tagged/two/b', $toPublish, 'Service provider does return unexpected tagged path key.');
         $this->assertArrayHasKey('source/tagged/one', $toPublish, 'Service provider does not return expected tagged path key.');
@@ -59,7 +59,7 @@ class SupportServiceProviderTest extends TestCase
 
     public function testMultipleTaggedAssetsArePublishedCorrectly()
     {
-        $toPublish = ServiceProvider::pathsToPublish('Illuminate\Tests\Support\ServiceProviderForTestingTwo', 'some_tag');
+        $toPublish = ServiceProvider::pathsToPublish(\Illuminate\Tests\Support\ServiceProviderForTestingTwo::class, 'some_tag');
         $this->assertArrayHasKey('source/tagged/two/a', $toPublish, 'Service provider does not return expected tagged path key.');
         $this->assertArrayHasKey('source/tagged/two/b', $toPublish, 'Service provider does not return expected tagged path key.');
         $this->assertArrayNotHasKey('source/tagged/one', $toPublish, 'Service provider does return unexpected tagged path key.');

--- a/tests/Translation/TranslationFileLoaderTest.php
+++ b/tests/Translation/TranslationFileLoaderTest.php
@@ -15,7 +15,7 @@ class TranslationFileLoaderTest extends TestCase
 
     public function testLoadMethodWithoutNamespacesProperlyCallsLoader()
     {
-        $loader = new FileLoader($files = m::mock('Illuminate\Filesystem\Filesystem'), __DIR__);
+        $loader = new FileLoader($files = m::mock(\Illuminate\Filesystem\Filesystem::class), __DIR__);
         $files->shouldReceive('exists')->once()->with(__DIR__.'/en/foo.php')->andReturn(true);
         $files->shouldReceive('getRequire')->once()->with(__DIR__.'/en/foo.php')->andReturn(['messages']);
 
@@ -24,7 +24,7 @@ class TranslationFileLoaderTest extends TestCase
 
     public function testLoadMethodWithNamespacesProperlyCallsLoader()
     {
-        $loader = new FileLoader($files = m::mock('Illuminate\Filesystem\Filesystem'), __DIR__);
+        $loader = new FileLoader($files = m::mock(\Illuminate\Filesystem\Filesystem::class), __DIR__);
         $files->shouldReceive('exists')->once()->with('bar/en/foo.php')->andReturn(true);
         $files->shouldReceive('exists')->once()->with(__DIR__.'/vendor/namespace/en/foo.php')->andReturn(false);
         $files->shouldReceive('getRequire')->once()->with('bar/en/foo.php')->andReturn(['foo' => 'bar']);
@@ -35,7 +35,7 @@ class TranslationFileLoaderTest extends TestCase
 
     public function testLoadMethodWithNamespacesProperlyCallsLoaderAndLoadsLocalOverrides()
     {
-        $loader = new FileLoader($files = m::mock('Illuminate\Filesystem\Filesystem'), __DIR__);
+        $loader = new FileLoader($files = m::mock(\Illuminate\Filesystem\Filesystem::class), __DIR__);
         $files->shouldReceive('exists')->once()->with('bar/en/foo.php')->andReturn(true);
         $files->shouldReceive('exists')->once()->with(__DIR__.'/vendor/namespace/en/foo.php')->andReturn(true);
         $files->shouldReceive('getRequire')->once()->with('bar/en/foo.php')->andReturn(['foo' => 'bar']);
@@ -47,7 +47,7 @@ class TranslationFileLoaderTest extends TestCase
 
     public function testEmptyArraysReturnedWhenFilesDontExist()
     {
-        $loader = new FileLoader($files = m::mock('Illuminate\Filesystem\Filesystem'), __DIR__);
+        $loader = new FileLoader($files = m::mock(\Illuminate\Filesystem\Filesystem::class), __DIR__);
         $files->shouldReceive('exists')->once()->with(__DIR__.'/en/foo.php')->andReturn(false);
         $files->shouldReceive('getRequire')->never();
 
@@ -56,7 +56,7 @@ class TranslationFileLoaderTest extends TestCase
 
     public function testEmptyArraysReturnedWhenFilesDontExistForNamespacedItems()
     {
-        $loader = new FileLoader($files = m::mock('Illuminate\Filesystem\Filesystem'), __DIR__);
+        $loader = new FileLoader($files = m::mock(\Illuminate\Filesystem\Filesystem::class), __DIR__);
         $files->shouldReceive('getRequire')->never();
 
         $this->assertEquals([], $loader->load('en', 'foo', 'bar'));
@@ -64,7 +64,7 @@ class TranslationFileLoaderTest extends TestCase
 
     public function testLoadMethodForJSONProperlyCallsLoader()
     {
-        $loader = new FileLoader($files = m::mock('Illuminate\Filesystem\Filesystem'), __DIR__);
+        $loader = new FileLoader($files = m::mock(\Illuminate\Filesystem\Filesystem::class), __DIR__);
         $files->shouldReceive('exists')->once()->with(__DIR__.'/en.json')->andReturn(true);
         $files->shouldReceive('get')->once()->with(__DIR__.'/en.json')->andReturn('{"foo":"bar"}');
 

--- a/tests/Translation/TranslationTranslatorTest.php
+++ b/tests/Translation/TranslationTranslatorTest.php
@@ -14,28 +14,28 @@ class TranslationTranslatorTest extends TestCase
 
     public function testHasMethodReturnsFalseWhenReturnedTranslationIsNull()
     {
-        $t = $this->getMockBuilder('Illuminate\Translation\Translator')->setMethods(['get'])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
+        $t = $this->getMockBuilder(\Illuminate\Translation\Translator::class)->setMethods(['get'])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
         $t->expects($this->once())->method('get')->with($this->equalTo('foo'), $this->equalTo([]), $this->equalTo('bar'))->will($this->returnValue('foo'));
         $this->assertFalse($t->has('foo', 'bar'));
 
-        $t = $this->getMockBuilder('Illuminate\Translation\Translator')->setMethods(['get'])->setConstructorArgs([$this->getLoader(), 'en', 'sp'])->getMock();
+        $t = $this->getMockBuilder(\Illuminate\Translation\Translator::class)->setMethods(['get'])->setConstructorArgs([$this->getLoader(), 'en', 'sp'])->getMock();
         $t->expects($this->once())->method('get')->with($this->equalTo('foo'), $this->equalTo([]), $this->equalTo('bar'))->will($this->returnValue('bar'));
         $this->assertTrue($t->has('foo', 'bar'));
 
-        $t = $this->getMockBuilder('Illuminate\Translation\Translator')->setMethods(['get'])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
+        $t = $this->getMockBuilder(\Illuminate\Translation\Translator::class)->setMethods(['get'])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
         $t->expects($this->once())->method('get')->with($this->equalTo('foo'), $this->equalTo([]), $this->equalTo('bar'), false)->will($this->returnValue('bar'));
         $this->assertTrue($t->hasForLocale('foo', 'bar'));
 
-        $t = $this->getMockBuilder('Illuminate\Translation\Translator')->setMethods(['get'])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
+        $t = $this->getMockBuilder(\Illuminate\Translation\Translator::class)->setMethods(['get'])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
         $t->expects($this->once())->method('get')->with($this->equalTo('foo'), $this->equalTo([]), $this->equalTo('bar'), false)->will($this->returnValue('foo'));
         $this->assertFalse($t->hasForLocale('foo', 'bar'));
 
-        $t = $this->getMockBuilder('Illuminate\Translation\Translator')->setMethods(['load', 'getLine'])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
+        $t = $this->getMockBuilder(\Illuminate\Translation\Translator::class)->setMethods(['load', 'getLine'])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
         $t->expects($this->any())->method('load')->with($this->equalTo('*'), $this->equalTo('foo'), $this->equalTo('en'))->will($this->returnValue(null));
         $t->expects($this->once())->method('getLine')->with($this->equalTo('*'), $this->equalTo('foo'), $this->equalTo('en'), null, $this->equalTo([]))->will($this->returnValue('bar'));
         $this->assertTrue($t->hasForLocale('foo'));
 
-        $t = $this->getMockBuilder('Illuminate\Translation\Translator')->setMethods(['load', 'getLine'])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
+        $t = $this->getMockBuilder(\Illuminate\Translation\Translator::class)->setMethods(['load', 'getLine'])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
         $t->expects($this->any())->method('load')->with($this->equalTo('*'), $this->equalTo('foo'), $this->equalTo('en'))->will($this->returnValue(null));
         $t->expects($this->once())->method('getLine')->with($this->equalTo('*'), $this->equalTo('foo'), $this->equalTo('en'), null, $this->equalTo([]))->will($this->returnValue('foo'));
         $this->assertFalse($t->hasForLocale('foo'));
@@ -51,7 +51,7 @@ class TranslationTranslatorTest extends TestCase
 
     public function testGetMethodProperlyLoadsAndRetrievesItemWithCapitalization()
     {
-        $t = $this->getMockBuilder('Illuminate\Translation\Translator')->setMethods(null)->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
+        $t = $this->getMockBuilder(\Illuminate\Translation\Translator::class)->setMethods(null)->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
         $t->getLoader()->shouldReceive('load')->once()->with('en', 'bar', 'foo')->andReturn(['foo' => 'foo', 'baz' => 'breeze :Foo :BAR']);
         $this->assertEquals('breeze Bar FOO', $t->get('foo::bar.baz', ['foo' => 'bar', 'bar' => 'foo'], 'en'));
         $this->assertEquals('foo', $t->get('foo::bar.foo'));
@@ -75,9 +75,9 @@ class TranslationTranslatorTest extends TestCase
 
     public function testChoiceMethodProperlyLoadsAndRetrievesItem()
     {
-        $t = $this->getMockBuilder('Illuminate\Translation\Translator')->setMethods(['get'])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
+        $t = $this->getMockBuilder(\Illuminate\Translation\Translator::class)->setMethods(['get'])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
         $t->expects($this->once())->method('get')->with($this->equalTo('foo'), $this->equalTo(['replace']), $this->equalTo('en'))->will($this->returnValue('line'));
-        $t->setSelector($selector = m::mock('Illuminate\Translation\MessageSelector'));
+        $t->setSelector($selector = m::mock(\Illuminate\Translation\MessageSelector::class));
         $selector->shouldReceive('choose')->once()->with('line', 10)->andReturn('choiced');
 
         $t->choice('foo', 10, ['replace']);
@@ -85,9 +85,9 @@ class TranslationTranslatorTest extends TestCase
 
     public function testChoiceMethodProperlyCountsCollectionsAndLoadsAndRetrievesItem()
     {
-        $t = $this->getMockBuilder('Illuminate\Translation\Translator')->setMethods(['get'])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
+        $t = $this->getMockBuilder(\Illuminate\Translation\Translator::class)->setMethods(['get'])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
         $t->expects($this->exactly(2))->method('get')->with($this->equalTo('foo'), $this->equalTo(['replace']), $this->equalTo('en'))->will($this->returnValue('line'));
-        $t->setSelector($selector = m::mock('Illuminate\Translation\MessageSelector'));
+        $t->setSelector($selector = m::mock(\Illuminate\Translation\MessageSelector::class));
         $selector->shouldReceive('choose')->twice()->with('line', 3)->andReturn('choiced');
 
         $values = ['foo', 'bar', 'baz'];
@@ -159,6 +159,6 @@ class TranslationTranslatorTest extends TestCase
 
     protected function getLoader()
     {
-        return m::mock('Illuminate\Translation\LoaderInterface');
+        return m::mock(\Illuminate\Translation\LoaderInterface::class);
     }
 }

--- a/tests/Validation/ValidationDatabasePresenceVerifierTest.php
+++ b/tests/Validation/ValidationDatabasePresenceVerifierTest.php
@@ -14,7 +14,7 @@ class ValidationDatabasePresenceVerifierTest extends TestCase
 
     public function testBasicCount()
     {
-        $verifier = new \Illuminate\Validation\DatabasePresenceVerifier($db = m::mock('Illuminate\Database\ConnectionResolverInterface'));
+        $verifier = new \Illuminate\Validation\DatabasePresenceVerifier($db = m::mock(\Illuminate\Database\ConnectionResolverInterface::class));
         $verifier->setConnection('connection');
         $db->shouldReceive('connection')->once()->with('connection')->andReturn($conn = m::mock('StdClass'));
         $conn->shouldReceive('table')->once()->with('table')->andReturn($builder = m::mock('StdClass'));
@@ -33,7 +33,7 @@ class ValidationDatabasePresenceVerifierTest extends TestCase
 
     public function testBasicCountWithClosures()
     {
-        $verifier = new \Illuminate\Validation\DatabasePresenceVerifier($db = m::mock('Illuminate\Database\ConnectionResolverInterface'));
+        $verifier = new \Illuminate\Validation\DatabasePresenceVerifier($db = m::mock(\Illuminate\Database\ConnectionResolverInterface::class));
         $verifier->setConnection('connection');
         $db->shouldReceive('connection')->once()->with('connection')->andReturn($conn = m::mock('StdClass'));
         $conn->shouldReceive('table')->once()->with('table')->andReturn($builder = m::mock('StdClass'));

--- a/tests/Validation/ValidationDatabasePresenceVerifierTest.php
+++ b/tests/Validation/ValidationDatabasePresenceVerifierTest.php
@@ -16,8 +16,8 @@ class ValidationDatabasePresenceVerifierTest extends TestCase
     {
         $verifier = new \Illuminate\Validation\DatabasePresenceVerifier($db = m::mock(\Illuminate\Database\ConnectionResolverInterface::class));
         $verifier->setConnection('connection');
-        $db->shouldReceive('connection')->once()->with('connection')->andReturn($conn = m::mock('StdClass'));
-        $conn->shouldReceive('table')->once()->with('table')->andReturn($builder = m::mock('StdClass'));
+        $db->shouldReceive('connection')->once()->with('connection')->andReturn($conn = m::mock(\StdClass::class));
+        $conn->shouldReceive('table')->once()->with('table')->andReturn($builder = m::mock(\StdClass::class));
         $builder->shouldReceive('useWritePdo')->once()->andReturn($builder);
         $builder->shouldReceive('where')->with('column', '=', 'value')->andReturn($builder);
         $extra = ['foo' => 'NULL', 'bar' => 'NOT_NULL', 'baz' => 'taylor', 'faz' => true, 'not' => '!admin'];
@@ -35,8 +35,8 @@ class ValidationDatabasePresenceVerifierTest extends TestCase
     {
         $verifier = new \Illuminate\Validation\DatabasePresenceVerifier($db = m::mock(\Illuminate\Database\ConnectionResolverInterface::class));
         $verifier->setConnection('connection');
-        $db->shouldReceive('connection')->once()->with('connection')->andReturn($conn = m::mock('StdClass'));
-        $conn->shouldReceive('table')->once()->with('table')->andReturn($builder = m::mock('StdClass'));
+        $db->shouldReceive('connection')->once()->with('connection')->andReturn($conn = m::mock(\StdClass::class));
+        $conn->shouldReceive('table')->once()->with('table')->andReturn($builder = m::mock(\StdClass::class));
         $builder->shouldReceive('useWritePdo')->once()->andReturn($builder);
         $builder->shouldReceive('where')->with('column', '=', 'value')->andReturn($builder);
         $closure = function ($query) {

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -208,7 +208,7 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, [], ['name' => 'required']);
         $v->setContainer($container = m::mock(\Illuminate\Container\Container::class));
         $v->addReplacer('required', 'Foo@bar');
-        $container->shouldReceive('make')->once()->with('Foo')->andReturn($foo = m::mock('StdClass'));
+        $container->shouldReceive('make')->once()->with('Foo')->andReturn($foo = m::mock(\StdClass::class));
         $foo->shouldReceive('bar')->once()->andReturn('replaced!');
         $v->passes();
         $v->messages()->setFormat(':message');
@@ -2408,7 +2408,7 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['name' => 'taylor'], ['name' => 'foo']);
         $v->setContainer($container = m::mock(\Illuminate\Container\Container::class));
         $v->addExtension('foo', 'Foo@bar');
-        $container->shouldReceive('make')->once()->with('Foo')->andReturn($foo = m::mock('StdClass'));
+        $container->shouldReceive('make')->once()->with('Foo')->andReturn($foo = m::mock(\StdClass::class));
         $foo->shouldReceive('bar')->once()->andReturn(false);
         $this->assertFalse($v->passes());
         $v->messages()->setFormat(':message');
@@ -2422,7 +2422,7 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['name' => 'taylor'], ['name' => 'foo']);
         $v->setContainer($container = m::mock(\Illuminate\Container\Container::class));
         $v->addExtension('foo', 'Foo');
-        $container->shouldReceive('make')->once()->with('Foo')->andReturn($foo = m::mock('StdClass'));
+        $container->shouldReceive('make')->once()->with('Foo')->andReturn($foo = m::mock(\StdClass::class));
         $foo->shouldReceive('validate')->once()->andReturn(false);
         $this->assertFalse($v->passes());
         $v->messages()->setFormat(':message');

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -206,7 +206,7 @@ class ValidationValidatorTest extends TestCase
         $trans = $this->getIlluminateArrayTranslator();
         $trans->addLines(['validation.foo' => 'foo!'], 'en');
         $v = new Validator($trans, [], ['name' => 'required']);
-        $v->setContainer($container = m::mock('Illuminate\Container\Container'));
+        $v->setContainer($container = m::mock(\Illuminate\Container\Container::class));
         $v->addReplacer('required', 'Foo@bar');
         $container->shouldReceive('make')->once()->with('Foo')->andReturn($foo = m::mock('StdClass'));
         $foo->shouldReceive('bar')->once()->andReturn('replaced!');
@@ -1377,42 +1377,42 @@ class ValidationValidatorTest extends TestCase
     {
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['email' => 'foo'], ['email' => 'Unique:users']);
-        $mock = m::mock('Illuminate\Validation\PresenceVerifierInterface');
+        $mock = m::mock(\Illuminate\Validation\PresenceVerifierInterface::class);
         $mock->shouldReceive('setConnection')->once()->with(null);
         $mock->shouldReceive('getCount')->once()->with('users', 'email', 'foo', null, null, [])->andReturn(0);
         $v->setPresenceVerifier($mock);
         $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['email' => 'foo'], ['email' => 'Unique:connection.users']);
-        $mock = m::mock('Illuminate\Validation\PresenceVerifierInterface');
+        $mock = m::mock(\Illuminate\Validation\PresenceVerifierInterface::class);
         $mock->shouldReceive('setConnection')->once()->with('connection');
         $mock->shouldReceive('getCount')->once()->with('users', 'email', 'foo', null, null, [])->andReturn(0);
         $v->setPresenceVerifier($mock);
         $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['email' => 'foo'], ['email' => 'Unique:users,email_addr,1']);
-        $mock = m::mock('Illuminate\Validation\PresenceVerifierInterface');
+        $mock = m::mock(\Illuminate\Validation\PresenceVerifierInterface::class);
         $mock->shouldReceive('setConnection')->once()->with(null);
         $mock->shouldReceive('getCount')->once()->with('users', 'email_addr', 'foo', '1', 'id', [])->andReturn(1);
         $v->setPresenceVerifier($mock);
         $this->assertFalse($v->passes());
 
         $v = new Validator($trans, ['email' => 'foo'], ['email' => 'Unique:users,email_addr,1,id_col']);
-        $mock = m::mock('Illuminate\Validation\PresenceVerifierInterface');
+        $mock = m::mock(\Illuminate\Validation\PresenceVerifierInterface::class);
         $mock->shouldReceive('setConnection')->once()->with(null);
         $mock->shouldReceive('getCount')->once()->with('users', 'email_addr', 'foo', '1', 'id_col', [])->andReturn(2);
         $v->setPresenceVerifier($mock);
         $this->assertFalse($v->passes());
 
         $v = new Validator($trans, ['users' => [['id' => 1, 'email' => 'foo']]], ['users.*.email' => 'Unique:users,email,[users.*.id]']);
-        $mock = m::mock('Illuminate\Validation\PresenceVerifierInterface');
+        $mock = m::mock(\Illuminate\Validation\PresenceVerifierInterface::class);
         $mock->shouldReceive('setConnection')->once()->with(null);
         $mock->shouldReceive('getCount')->once()->with('users', 'email', 'foo', '1', 'id', [])->andReturn(1);
         $v->setPresenceVerifier($mock);
         $this->assertFalse($v->passes());
 
         $v = new Validator($trans, ['email' => 'foo'], ['email' => 'Unique:users,email_addr,NULL,id_col,foo,bar']);
-        $mock = m::mock('Illuminate\Validation\PresenceVerifierInterface');
+        $mock = m::mock(\Illuminate\Validation\PresenceVerifierInterface::class);
         $mock->shouldReceive('setConnection')->once()->with(null);
         $mock->shouldReceive('getCount')->once()->with('users', 'email_addr', 'foo', null, 'id_col', ['foo' => 'bar'])->andReturn(2);
         $v->setPresenceVerifier($mock);
@@ -1425,7 +1425,7 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, [['email' => 'foo', 'type' => 'bar']], [
             '*.email' => 'unique:users', '*.type' => 'exists:user_types',
         ]);
-        $mock = m::mock('Illuminate\Validation\PresenceVerifierInterface');
+        $mock = m::mock(\Illuminate\Validation\PresenceVerifierInterface::class);
         $mock->shouldReceive('setConnection')->twice()->with(null);
         $mock->shouldReceive('getCount')->with('users', 'email', 'foo', null, null, [])->andReturn(0);
         $mock->shouldReceive('getCount')->with('user_types', 'type', 'bar', null, null, [])->andReturn(1);
@@ -1439,7 +1439,7 @@ class ValidationValidatorTest extends TestCase
             '*.email' => (new Unique('users'))->where($closure),
             '*.type' => (new Exists('user_types'))->where($closure),
         ]);
-        $mock = m::mock('Illuminate\Validation\PresenceVerifierInterface');
+        $mock = m::mock(\Illuminate\Validation\PresenceVerifierInterface::class);
         $mock->shouldReceive('setConnection')->twice()->with(null);
         $mock->shouldReceive('getCount')->with('users', 'email', 'foo', null, 'id', [$closure])->andReturn(0);
         $mock->shouldReceive('getCount')->with('user_types', 'type', 'bar', null, null, [$closure])->andReturn(1);
@@ -1451,7 +1451,7 @@ class ValidationValidatorTest extends TestCase
     {
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['email' => 'foo'], ['email' => 'Exists:users']);
-        $mock = m::mock('Illuminate\Validation\PresenceVerifierInterface');
+        $mock = m::mock(\Illuminate\Validation\PresenceVerifierInterface::class);
         $mock->shouldReceive('setConnection')->once()->with(null);
         $mock->shouldReceive('getCount')->once()->with('users', 'email', 'foo', null, null, [])->andReturn(true);
         $v->setPresenceVerifier($mock);
@@ -1459,28 +1459,28 @@ class ValidationValidatorTest extends TestCase
 
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['email' => 'foo'], ['email' => 'Exists:users,email,account_id,1,name,taylor']);
-        $mock = m::mock('Illuminate\Validation\PresenceVerifierInterface');
+        $mock = m::mock(\Illuminate\Validation\PresenceVerifierInterface::class);
         $mock->shouldReceive('setConnection')->once()->with(null);
         $mock->shouldReceive('getCount')->once()->with('users', 'email', 'foo', null, null, ['account_id' => 1, 'name' => 'taylor'])->andReturn(true);
         $v->setPresenceVerifier($mock);
         $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['email' => 'foo'], ['email' => 'Exists:users,email_addr']);
-        $mock = m::mock('Illuminate\Validation\PresenceVerifierInterface');
+        $mock = m::mock(\Illuminate\Validation\PresenceVerifierInterface::class);
         $mock->shouldReceive('setConnection')->once()->with(null);
         $mock->shouldReceive('getCount')->once()->with('users', 'email_addr', 'foo', null, null, [])->andReturn(false);
         $v->setPresenceVerifier($mock);
         $this->assertFalse($v->passes());
 
         $v = new Validator($trans, ['email' => ['foo']], ['email' => 'Exists:users,email_addr']);
-        $mock = m::mock('Illuminate\Validation\PresenceVerifierInterface');
+        $mock = m::mock(\Illuminate\Validation\PresenceVerifierInterface::class);
         $mock->shouldReceive('setConnection')->once()->with(null);
         $mock->shouldReceive('getMultiCount')->once()->with('users', 'email_addr', ['foo'], [])->andReturn(false);
         $v->setPresenceVerifier($mock);
         $this->assertFalse($v->passes());
 
         $v = new Validator($trans, ['email' => 'foo'], ['email' => 'Exists:connection.users']);
-        $mock = m::mock('Illuminate\Validation\PresenceVerifierInterface');
+        $mock = m::mock(\Illuminate\Validation\PresenceVerifierInterface::class);
         $mock->shouldReceive('setConnection')->once()->with('connection');
         $mock->shouldReceive('getCount')->once()->with('users', 'email', 'foo', null, null, [])->andReturn(true);
         $v->setPresenceVerifier($mock);
@@ -1491,14 +1491,14 @@ class ValidationValidatorTest extends TestCase
     {
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['id' => 'foo'], ['id' => 'Integer|Exists:users,id']);
-        $mock = m::mock('Illuminate\Validation\PresenceVerifierInterface');
+        $mock = m::mock(\Illuminate\Validation\PresenceVerifierInterface::class);
         $mock->shouldReceive('getCount')->never();
         $v->setPresenceVerifier($mock);
         $this->assertFalse($v->passes());
 
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['id' => '1'], ['id' => 'Integer|Exists:users,id']);
-        $mock = m::mock('Illuminate\Validation\PresenceVerifierInterface');
+        $mock = m::mock(\Illuminate\Validation\PresenceVerifierInterface::class);
         $mock->shouldReceive('setConnection')->once()->with(null);
         $mock->shouldReceive('getCount')->once()->with('users', 'id', '1', null, null, [])->andReturn(true);
         $v->setPresenceVerifier($mock);
@@ -2406,7 +2406,7 @@ class ValidationValidatorTest extends TestCase
         $trans = $this->getIlluminateArrayTranslator();
         $trans->addLines(['validation.foo' => 'foo!'], 'en');
         $v = new Validator($trans, ['name' => 'taylor'], ['name' => 'foo']);
-        $v->setContainer($container = m::mock('Illuminate\Container\Container'));
+        $v->setContainer($container = m::mock(\Illuminate\Container\Container::class));
         $v->addExtension('foo', 'Foo@bar');
         $container->shouldReceive('make')->once()->with('Foo')->andReturn($foo = m::mock('StdClass'));
         $foo->shouldReceive('bar')->once()->andReturn(false);
@@ -2420,7 +2420,7 @@ class ValidationValidatorTest extends TestCase
         $trans = $this->getIlluminateArrayTranslator();
         $trans->addLines(['validation.foo' => 'foo!'], 'en');
         $v = new Validator($trans, ['name' => 'taylor'], ['name' => 'foo']);
-        $v->setContainer($container = m::mock('Illuminate\Container\Container'));
+        $v->setContainer($container = m::mock(\Illuminate\Container\Container::class));
         $v->addExtension('foo', 'Foo');
         $container->shouldReceive('make')->once()->with('Foo')->andReturn($foo = m::mock('StdClass'));
         $foo->shouldReceive('validate')->once()->andReturn(false);
@@ -3258,7 +3258,7 @@ class ValidationValidatorTest extends TestCase
 
     protected function getTranslator()
     {
-        return m::mock('Illuminate\Contracts\Translation\Translator');
+        return m::mock(\Illuminate\Contracts\Translation\Translator::class);
     }
 
     public function getIlluminateArrayTranslator()

--- a/tests/View/Blade/BladeAppendTest.php
+++ b/tests/View/Blade/BladeAppendTest.php
@@ -21,6 +21,6 @@ class BladeAppendTest extends TestCase
 
     protected function getFiles()
     {
-        return m::mock('Illuminate\Filesystem\Filesystem');
+        return m::mock(\Illuminate\Filesystem\Filesystem::class);
     }
 }

--- a/tests/View/Blade/BladeBreakStatementsTest.php
+++ b/tests/View/Blade/BladeBreakStatementsTest.php
@@ -43,6 +43,6 @@ test
 
     protected function getFiles()
     {
-        return m::mock('Illuminate\Filesystem\Filesystem');
+        return m::mock(\Illuminate\Filesystem\Filesystem::class);
     }
 }

--- a/tests/View/Blade/BladeCanStatementsTest.php
+++ b/tests/View/Blade/BladeCanStatementsTest.php
@@ -31,6 +31,6 @@ sneeze
 
     protected function getFiles()
     {
-        return m::mock('Illuminate\Filesystem\Filesystem');
+        return m::mock(\Illuminate\Filesystem\Filesystem::class);
     }
 }

--- a/tests/View/Blade/BladeCannotStatementsTest.php
+++ b/tests/View/Blade/BladeCannotStatementsTest.php
@@ -31,6 +31,6 @@ sneeze
 
     protected function getFiles()
     {
-        return m::mock('Illuminate\Filesystem\Filesystem');
+        return m::mock(\Illuminate\Filesystem\Filesystem::class);
     }
 }

--- a/tests/View/Blade/BladeCommentsTest.php
+++ b/tests/View/Blade/BladeCommentsTest.php
@@ -30,6 +30,6 @@ this is a comment
 
     protected function getFiles()
     {
-        return m::mock('Illuminate\Filesystem\Filesystem');
+        return m::mock(\Illuminate\Filesystem\Filesystem::class);
     }
 }

--- a/tests/View/Blade/BladeContinueStatementsTest.php
+++ b/tests/View/Blade/BladeContinueStatementsTest.php
@@ -43,6 +43,6 @@ test
 
     protected function getFiles()
     {
-        return m::mock('Illuminate\Filesystem\Filesystem');
+        return m::mock(\Illuminate\Filesystem\Filesystem::class);
     }
 }

--- a/tests/View/Blade/BladeCustomTest.php
+++ b/tests/View/Blade/BladeCustomTest.php
@@ -78,6 +78,6 @@ class BladeCustomTest extends TestCase
 
     protected function getFiles()
     {
-        return m::mock('Illuminate\Filesystem\Filesystem');
+        return m::mock(\Illuminate\Filesystem\Filesystem::class);
     }
 }

--- a/tests/View/Blade/BladeEachTest.php
+++ b/tests/View/Blade/BladeEachTest.php
@@ -22,6 +22,6 @@ class BladeEachTest extends TestCase
 
     protected function getFiles()
     {
-        return m::mock('Illuminate\Filesystem\Filesystem');
+        return m::mock(\Illuminate\Filesystem\Filesystem::class);
     }
 }

--- a/tests/View/Blade/BladeEchoTest.php
+++ b/tests/View/Blade/BladeEchoTest.php
@@ -105,6 +105,6 @@ class BladeEchoTest extends TestCase
 
     protected function getFiles()
     {
-        return m::mock('Illuminate\Filesystem\Filesystem');
+        return m::mock(\Illuminate\Filesystem\Filesystem::class);
     }
 }

--- a/tests/View/Blade/BladeElseIfStatementsTest.php
+++ b/tests/View/Blade/BladeElseIfStatementsTest.php
@@ -31,6 +31,6 @@ boom
 
     protected function getFiles()
     {
-        return m::mock('Illuminate\Filesystem\Filesystem');
+        return m::mock(\Illuminate\Filesystem\Filesystem::class);
     }
 }

--- a/tests/View/Blade/BladeElseStatementsTest.php
+++ b/tests/View/Blade/BladeElseStatementsTest.php
@@ -47,6 +47,6 @@ boom
 
     protected function getFiles()
     {
-        return m::mock('Illuminate\Filesystem\Filesystem');
+        return m::mock(\Illuminate\Filesystem\Filesystem::class);
     }
 }

--- a/tests/View/Blade/BladeEndSectionTest.php
+++ b/tests/View/Blade/BladeEndSectionTest.php
@@ -21,6 +21,6 @@ class BladeStopTest extends TestCase
 
     protected function getFiles()
     {
-        return m::mock('Illuminate\Filesystem\Filesystem');
+        return m::mock(\Illuminate\Filesystem\Filesystem::class);
     }
 }

--- a/tests/View/Blade/BladeEndSectionsTest.php
+++ b/tests/View/Blade/BladeEndSectionsTest.php
@@ -21,6 +21,6 @@ class BladeEndSectionsTest extends TestCase
 
     protected function getFiles()
     {
-        return m::mock('Illuminate\Filesystem\Filesystem');
+        return m::mock(\Illuminate\Filesystem\Filesystem::class);
     }
 }

--- a/tests/View/Blade/BladeEndphpStatementsTest.php
+++ b/tests/View/Blade/BladeEndphpStatementsTest.php
@@ -23,6 +23,6 @@ class BladeEndphpStatementsTest extends TestCase
 
     protected function getFiles()
     {
-        return m::mock('Illuminate\Filesystem\Filesystem');
+        return m::mock(\Illuminate\Filesystem\Filesystem::class);
     }
 }

--- a/tests/View/Blade/BladeEscapedTest.php
+++ b/tests/View/Blade/BladeEscapedTest.php
@@ -29,6 +29,6 @@ class BladeEscapedTest extends TestCase
 
     protected function getFiles()
     {
-        return m::mock('Illuminate\Filesystem\Filesystem');
+        return m::mock(\Illuminate\Filesystem\Filesystem::class);
     }
 }

--- a/tests/View/Blade/BladeExpressionTest.php
+++ b/tests/View/Blade/BladeExpressionTest.php
@@ -29,6 +29,6 @@ class BladeExpressionTest extends TestCase
 
     protected function getFiles()
     {
-        return m::mock('Illuminate\Filesystem\Filesystem');
+        return m::mock(\Illuminate\Filesystem\Filesystem::class);
     }
 }

--- a/tests/View/Blade/BladeExtendsTest.php
+++ b/tests/View/Blade/BladeExtendsTest.php
@@ -43,6 +43,6 @@ test';
 
     protected function getFiles()
     {
-        return m::mock('Illuminate\Filesystem\Filesystem');
+        return m::mock(\Illuminate\Filesystem\Filesystem::class);
     }
 }

--- a/tests/View/Blade/BladeForStatementsTest.php
+++ b/tests/View/Blade/BladeForStatementsTest.php
@@ -43,6 +43,6 @@ test
 
     protected function getFiles()
     {
-        return m::mock('Illuminate\Filesystem\Filesystem');
+        return m::mock(\Illuminate\Filesystem\Filesystem::class);
     }
 }

--- a/tests/View/Blade/BladeForeachStatementsTest.php
+++ b/tests/View/Blade/BladeForeachStatementsTest.php
@@ -100,6 +100,6 @@ tag info
 
     protected function getFiles()
     {
-        return m::mock('Illuminate\Filesystem\Filesystem');
+        return m::mock(\Illuminate\Filesystem\Filesystem::class);
     }
 }

--- a/tests/View/Blade/BladeForelseStatementsTest.php
+++ b/tests/View/Blade/BladeForelseStatementsTest.php
@@ -93,6 +93,6 @@ empty
 
     protected function getFiles()
     {
-        return m::mock('Illuminate\Filesystem\Filesystem');
+        return m::mock(\Illuminate\Filesystem\Filesystem::class);
     }
 }

--- a/tests/View/Blade/BladeHasSectionTest.php
+++ b/tests/View/Blade/BladeHasSectionTest.php
@@ -27,6 +27,6 @@ breeze
 
     protected function getFiles()
     {
-        return m::mock('Illuminate\Filesystem\Filesystem');
+        return m::mock(\Illuminate\Filesystem\Filesystem::class);
     }
 }

--- a/tests/View/Blade/BladeIfStatementsTest.php
+++ b/tests/View/Blade/BladeIfStatementsTest.php
@@ -27,6 +27,6 @@ breeze
 
     protected function getFiles()
     {
-        return m::mock('Illuminate\Filesystem\Filesystem');
+        return m::mock(\Illuminate\Filesystem\Filesystem::class);
     }
 }

--- a/tests/View/Blade/BladeIncludeIfTest.php
+++ b/tests/View/Blade/BladeIncludeIfTest.php
@@ -22,6 +22,6 @@ class BladeIncludeIfTest extends TestCase
 
     protected function getFiles()
     {
-        return m::mock('Illuminate\Filesystem\Filesystem');
+        return m::mock(\Illuminate\Filesystem\Filesystem::class);
     }
 }

--- a/tests/View/Blade/BladeIncludeTest.php
+++ b/tests/View/Blade/BladeIncludeTest.php
@@ -22,6 +22,6 @@ class BladeIncludeTest extends TestCase
 
     protected function getFiles()
     {
-        return m::mock('Illuminate\Filesystem\Filesystem');
+        return m::mock(\Illuminate\Filesystem\Filesystem::class);
     }
 }

--- a/tests/View/Blade/BladeLangTest.php
+++ b/tests/View/Blade/BladeLangTest.php
@@ -30,6 +30,6 @@ class BladeLangTest extends TestCase
 
     protected function getFiles()
     {
-        return m::mock('Illuminate\Filesystem\Filesystem');
+        return m::mock(\Illuminate\Filesystem\Filesystem::class);
     }
 }

--- a/tests/View/Blade/BladeOverwriteSectionTest.php
+++ b/tests/View/Blade/BladeOverwriteSectionTest.php
@@ -21,6 +21,6 @@ class BladeOverwriteSectionTest extends TestCase
 
     protected function getFiles()
     {
-        return m::mock('Illuminate\Filesystem\Filesystem');
+        return m::mock(\Illuminate\Filesystem\Filesystem::class);
     }
 }

--- a/tests/View/Blade/BladePhpStatementsTest.php
+++ b/tests/View/Blade/BladePhpStatementsTest.php
@@ -31,6 +31,6 @@ class BladePhpStatementsTest extends TestCase
 
     protected function getFiles()
     {
-        return m::mock('Illuminate\Filesystem\Filesystem');
+        return m::mock(\Illuminate\Filesystem\Filesystem::class);
     }
 }

--- a/tests/View/Blade/BladePushTest.php
+++ b/tests/View/Blade/BladePushTest.php
@@ -27,6 +27,6 @@ test
 
     protected function getFiles()
     {
-        return m::mock('Illuminate\Filesystem\Filesystem');
+        return m::mock(\Illuminate\Filesystem\Filesystem::class);
     }
 }

--- a/tests/View/Blade/BladeSectionTest.php
+++ b/tests/View/Blade/BladeSectionTest.php
@@ -22,6 +22,6 @@ class BladeSectionTest extends TestCase
 
     protected function getFiles()
     {
-        return m::mock('Illuminate\Filesystem\Filesystem');
+        return m::mock(\Illuminate\Filesystem\Filesystem::class);
     }
 }

--- a/tests/View/Blade/BladeShowTest.php
+++ b/tests/View/Blade/BladeShowTest.php
@@ -21,6 +21,6 @@ class BladeShowTest extends TestCase
 
     protected function getFiles()
     {
-        return m::mock('Illuminate\Filesystem\Filesystem');
+        return m::mock(\Illuminate\Filesystem\Filesystem::class);
     }
 }

--- a/tests/View/Blade/BladeStackTest.php
+++ b/tests/View/Blade/BladeStackTest.php
@@ -23,6 +23,6 @@ class BladeStackTest extends TestCase
 
     protected function getFiles()
     {
-        return m::mock('Illuminate\Filesystem\Filesystem');
+        return m::mock(\Illuminate\Filesystem\Filesystem::class);
     }
 }

--- a/tests/View/Blade/BladeUnlessStatementsTest.php
+++ b/tests/View/Blade/BladeUnlessStatementsTest.php
@@ -27,6 +27,6 @@ breeze
 
     protected function getFiles()
     {
-        return m::mock('Illuminate\Filesystem\Filesystem');
+        return m::mock(\Illuminate\Filesystem\Filesystem::class);
     }
 }

--- a/tests/View/Blade/BladeUnsetStatementsTest.php
+++ b/tests/View/Blade/BladeUnsetStatementsTest.php
@@ -23,6 +23,6 @@ class BladeUnsetStatementsTest extends TestCase
 
     protected function getFiles()
     {
-        return m::mock('Illuminate\Filesystem\Filesystem');
+        return m::mock(\Illuminate\Filesystem\Filesystem::class);
     }
 }

--- a/tests/View/Blade/BladeVerbatimTest.php
+++ b/tests/View/Blade/BladeVerbatimTest.php
@@ -51,6 +51,6 @@ class BladeVerbatimTest extends TestCase
 
     protected function getFiles()
     {
-        return m::mock('Illuminate\Filesystem\Filesystem');
+        return m::mock(\Illuminate\Filesystem\Filesystem::class);
     }
 }

--- a/tests/View/Blade/BladeWhileStatementsTest.php
+++ b/tests/View/Blade/BladeWhileStatementsTest.php
@@ -43,6 +43,6 @@ test
 
     protected function getFiles()
     {
-        return m::mock('Illuminate\Filesystem\Filesystem');
+        return m::mock(\Illuminate\Filesystem\Filesystem::class);
     }
 }

--- a/tests/View/Blade/BladeYieldTest.php
+++ b/tests/View/Blade/BladeYieldTest.php
@@ -23,6 +23,6 @@ class BladeYieldTest extends TestCase
 
     protected function getFiles()
     {
-        return m::mock('Illuminate\Filesystem\Filesystem');
+        return m::mock(\Illuminate\Filesystem\Filesystem::class);
     }
 }

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -93,7 +93,7 @@ class ViewBladeCompilerTest extends TestCase
 
     protected function getFiles()
     {
-        return m::mock('Illuminate\Filesystem\Filesystem');
+        return m::mock(\Illuminate\Filesystem\Filesystem::class);
     }
 
     public function testGetTagsProvider()

--- a/tests/View/ViewCompilerEngineTest.php
+++ b/tests/View/ViewCompilerEngineTest.php
@@ -39,6 +39,6 @@ class ViewCompilerEngineTest extends TestCase
 
     protected function getEngine()
     {
-        return new CompilerEngine(m::mock('Illuminate\View\Compilers\CompilerInterface'));
+        return new CompilerEngine(m::mock(\Illuminate\View\Compilers\CompilerInterface::class));
     }
 }

--- a/tests/View/ViewFactoryTest.php
+++ b/tests/View/ViewFactoryTest.php
@@ -20,7 +20,7 @@ class ViewFactoryTest extends TestCase
 
         $factory = $this->getFactory();
         $factory->getFinder()->shouldReceive('find')->once()->with('view')->andReturn('path.php');
-        $factory->getEngineResolver()->shouldReceive('resolve')->once()->with('php')->andReturn($engine = m::mock('Illuminate\View\Engines\EngineInterface'));
+        $factory->getEngineResolver()->shouldReceive('resolve')->once()->with('php')->andReturn($engine = m::mock(\Illuminate\View\Engines\EngineInterface::class));
         $factory->getFinder()->shouldReceive('addExtension')->once()->with('php');
         $factory->setDispatcher(new \Illuminate\Events\Dispatcher);
         $factory->creator('view', function ($view) {
@@ -82,7 +82,7 @@ class ViewFactoryTest extends TestCase
         $factory->getFinder()->shouldReceive('addExtension')->once()->with('foo');
         $factory->getEngineResolver()->shouldReceive('register')->once()->with('bar', $resolver);
         $factory->getFinder()->shouldReceive('find')->once()->with('view')->andReturn('path.foo');
-        $factory->getEngineResolver()->shouldReceive('resolve')->once()->with('bar')->andReturn($engine = m::mock('Illuminate\View\Engines\EngineInterface'));
+        $factory->getEngineResolver()->shouldReceive('resolve')->once()->with('bar')->andReturn($engine = m::mock(\Illuminate\View\Engines\EngineInterface::class));
         $factory->getDispatcher()->shouldReceive('fire');
 
         $factory->addExtension('foo', 'bar', $resolver);
@@ -153,7 +153,7 @@ class ViewFactoryTest extends TestCase
     {
         $factory = $this->getFactory();
         $factory->getDispatcher()->shouldReceive('listen')->once()->with('composing: foo', m::type('Closure'));
-        $factory->setContainer($container = m::mock('Illuminate\Container\Container'));
+        $factory->setContainer($container = m::mock(\Illuminate\Container\Container::class));
         $container->shouldReceive('make')->once()->with('FooComposer')->andReturn($composer = m::mock('StdClass'));
         $composer->shouldReceive('compose')->once()->with('view')->andReturn('composed');
         $callback = $factory->composer('foo', 'FooComposer');
@@ -166,7 +166,7 @@ class ViewFactoryTest extends TestCase
     {
         $factory = $this->getFactory();
         $factory->getDispatcher()->shouldReceive('listen')->once()->with('composing: foo', m::type('Closure'));
-        $factory->setContainer($container = m::mock('Illuminate\Container\Container'));
+        $factory->setContainer($container = m::mock(\Illuminate\Container\Container::class));
         $container->shouldReceive('make')->once()->with('FooComposer')->andReturn($composer = m::mock('StdClass'));
         $composer->shouldReceive('doComposer')->once()->with('view')->andReturn('composed');
         $callback = $factory->composer('foo', 'FooComposer@doComposer');
@@ -178,7 +178,7 @@ class ViewFactoryTest extends TestCase
     public function testCallComposerCallsProperEvent()
     {
         $factory = $this->getFactory();
-        $view = m::mock('Illuminate\View\View');
+        $view = m::mock(\Illuminate\View\View::class);
         $view->shouldReceive('name')->once()->andReturn('name');
         $factory->getDispatcher()->shouldReceive('fire')->once()->with('composing: name', [$view]);
 
@@ -353,7 +353,7 @@ class ViewFactoryTest extends TestCase
     {
         $factory = $this->getFactory();
         $factory->getFinder()->shouldReceive('find')->twice()->with('foo.bar')->andReturn('path.php');
-        $factory->getEngineResolver()->shouldReceive('resolve')->twice()->with('php')->andReturn(m::mock('Illuminate\View\Engines\EngineInterface'));
+        $factory->getEngineResolver()->shouldReceive('resolve')->twice()->with('php')->andReturn(m::mock(\Illuminate\View\Engines\EngineInterface::class));
         $factory->getDispatcher()->shouldReceive('fire');
         $factory->make('foo/bar');
         $factory->make('foo.bar');
@@ -363,7 +363,7 @@ class ViewFactoryTest extends TestCase
     {
         $factory = $this->getFactory();
         $factory->getFinder()->shouldReceive('find')->twice()->with('vendor/package::foo.bar')->andReturn('path.php');
-        $factory->getEngineResolver()->shouldReceive('resolve')->twice()->with('php')->andReturn(m::mock('Illuminate\View\Engines\EngineInterface'));
+        $factory->getEngineResolver()->shouldReceive('resolve')->twice()->with('php')->andReturn(m::mock(\Illuminate\View\Engines\EngineInterface::class));
         $factory->getDispatcher()->shouldReceive('fire');
         $factory->make('vendor/package::foo/bar');
         $factory->make('vendor/package::foo.bar');
@@ -385,7 +385,7 @@ class ViewFactoryTest extends TestCase
      */
     public function testExceptionsInSectionsAreThrown()
     {
-        $engine = new \Illuminate\View\Engines\CompilerEngine(m::mock('Illuminate\View\Compilers\CompilerInterface'));
+        $engine = new \Illuminate\View\Engines\CompilerEngine(m::mock(\Illuminate\View\Compilers\CompilerInterface::class));
         $engine->getCompiler()->shouldReceive('getCompiledPath')->andReturnUsing(function ($path) {
             return $path;
         });
@@ -531,18 +531,18 @@ class ViewFactoryTest extends TestCase
     protected function getFactory()
     {
         return new Factory(
-            m::mock('Illuminate\View\Engines\EngineResolver'),
-            m::mock('Illuminate\View\ViewFinderInterface'),
-            m::mock('Illuminate\Contracts\Events\Dispatcher')
+            m::mock(\Illuminate\View\Engines\EngineResolver::class),
+            m::mock(\Illuminate\View\ViewFinderInterface::class),
+            m::mock(\Illuminate\Contracts\Events\Dispatcher::class)
         );
     }
 
     protected function getFactoryArgs()
     {
         return [
-            m::mock('Illuminate\View\Engines\EngineResolver'),
-            m::mock('Illuminate\View\ViewFinderInterface'),
-            m::mock('Illuminate\Contracts\Events\Dispatcher'),
+            m::mock(\Illuminate\View\Engines\EngineResolver::class),
+            m::mock(\Illuminate\View\ViewFinderInterface::class),
+            m::mock(\Illuminate\Contracts\Events\Dispatcher::class),
         ];
     }
 }

--- a/tests/View/ViewFactoryTest.php
+++ b/tests/View/ViewFactoryTest.php
@@ -48,8 +48,8 @@ class ViewFactoryTest extends TestCase
     public function testRenderEachCreatesViewForEachItemInArray()
     {
         $factory = m::mock('Illuminate\View\Factory[make]', $this->getFactoryArgs());
-        $factory->shouldReceive('make')->once()->with('foo', ['key' => 'bar', 'value' => 'baz'])->andReturn($mockView1 = m::mock('StdClass'));
-        $factory->shouldReceive('make')->once()->with('foo', ['key' => 'breeze', 'value' => 'boom'])->andReturn($mockView2 = m::mock('StdClass'));
+        $factory->shouldReceive('make')->once()->with('foo', ['key' => 'bar', 'value' => 'baz'])->andReturn($mockView1 = m::mock(\StdClass::class));
+        $factory->shouldReceive('make')->once()->with('foo', ['key' => 'breeze', 'value' => 'boom'])->andReturn($mockView2 = m::mock(\StdClass::class));
         $mockView1->shouldReceive('render')->once()->andReturn('dayle');
         $mockView2->shouldReceive('render')->once()->andReturn('rees');
 
@@ -61,7 +61,7 @@ class ViewFactoryTest extends TestCase
     public function testEmptyViewsCanBeReturnedFromRenderEach()
     {
         $factory = m::mock('Illuminate\View\Factory[make]', $this->getFactoryArgs());
-        $factory->shouldReceive('make')->once()->with('foo')->andReturn($mockView = m::mock('StdClass'));
+        $factory->shouldReceive('make')->once()->with('foo')->andReturn($mockView = m::mock(\StdClass::class));
         $mockView->shouldReceive('render')->once()->andReturn('empty');
 
         $this->assertEquals('empty', $factory->renderEach('view', [], 'iterator', 'foo'));
@@ -154,7 +154,7 @@ class ViewFactoryTest extends TestCase
         $factory = $this->getFactory();
         $factory->getDispatcher()->shouldReceive('listen')->once()->with('composing: foo', m::type('Closure'));
         $factory->setContainer($container = m::mock(\Illuminate\Container\Container::class));
-        $container->shouldReceive('make')->once()->with('FooComposer')->andReturn($composer = m::mock('StdClass'));
+        $container->shouldReceive('make')->once()->with('FooComposer')->andReturn($composer = m::mock(\StdClass::class));
         $composer->shouldReceive('compose')->once()->with('view')->andReturn('composed');
         $callback = $factory->composer('foo', 'FooComposer');
         $callback = $callback[0];
@@ -167,7 +167,7 @@ class ViewFactoryTest extends TestCase
         $factory = $this->getFactory();
         $factory->getDispatcher()->shouldReceive('listen')->once()->with('composing: foo', m::type('Closure'));
         $factory->setContainer($container = m::mock(\Illuminate\Container\Container::class));
-        $container->shouldReceive('make')->once()->with('FooComposer')->andReturn($composer = m::mock('StdClass'));
+        $container->shouldReceive('make')->once()->with('FooComposer')->andReturn($composer = m::mock(\StdClass::class));
         $composer->shouldReceive('doComposer')->once()->with('view')->andReturn('composed');
         $callback = $factory->composer('foo', 'FooComposer@doComposer');
         $callback = $callback[0];
@@ -259,7 +259,7 @@ class ViewFactoryTest extends TestCase
     public function testTranslation()
     {
         $container = new \Illuminate\Container\Container;
-        $container->instance('translator', $translator = m::mock('StdClass'));
+        $container->instance('translator', $translator = m::mock(\StdClass::class));
         $translator->shouldReceive('getFromJson')->with('Foo', ['name' => 'taylor'])->andReturn('Bar');
         $factory = $this->getFactory();
         $factory->setContainer($container);

--- a/tests/View/ViewFileViewFinderTest.php
+++ b/tests/View/ViewFileViewFinderTest.php
@@ -143,6 +143,6 @@ class ViewFinderTest extends TestCase
 
     protected function getFinder()
     {
-        return new \Illuminate\View\FileViewFinder(m::mock('Illuminate\Filesystem\Filesystem'), [__DIR__]);
+        return new \Illuminate\View\FileViewFinder(m::mock(\Illuminate\Filesystem\Filesystem::class), [__DIR__]);
     }
 }

--- a/tests/View/ViewTest.php
+++ b/tests/View/ViewTest.php
@@ -69,8 +69,8 @@ class ViewTest extends TestCase
     public function testRenderSectionsReturnsEnvironmentSections()
     {
         $view = m::mock('Illuminate\View\View[render]', [
-            m::mock('Illuminate\View\Factory'),
-            m::mock('Illuminate\View\Engines\EngineInterface'),
+            m::mock(\Illuminate\View\Factory::class),
+            m::mock(\Illuminate\View\Engines\EngineInterface::class),
             'view',
             'path',
             [],
@@ -101,12 +101,12 @@ class ViewTest extends TestCase
         $view->getFactory()->shouldReceive('make')->once()->with('foo', ['data']);
         $result = $view->nest('key', 'foo', ['data']);
 
-        $this->assertInstanceOf('Illuminate\View\View', $result);
+        $this->assertInstanceOf(\Illuminate\View\View::class, $result);
     }
 
     public function testViewAcceptsArrayableImplementations()
     {
-        $arrayable = m::mock('Illuminate\Contracts\Support\Arrayable');
+        $arrayable = m::mock(\Illuminate\Contracts\Support\Arrayable::class);
         $arrayable->shouldReceive('toArray')->once()->andReturn(['foo' => 'bar', 'baz' => ['qux', 'corge']]);
 
         $view = $this->getView($arrayable);
@@ -182,7 +182,7 @@ class ViewTest extends TestCase
         $view->getFactory()->shouldReceive('decrementRender')->once()->ordered();
         $view->getFactory()->shouldReceive('flushStateIfDoneRendering')->once();
 
-        $view->renderable = m::mock('Illuminate\Contracts\Support\Renderable');
+        $view->renderable = m::mock(\Illuminate\Contracts\Support\Renderable::class);
         $view->renderable->shouldReceive('render')->once()->andReturn('text');
         $this->assertEquals('contents', $view->render());
     }
@@ -208,7 +208,7 @@ class ViewTest extends TestCase
         $view = $this->getView();
         $errors = ['foo' => 'bar', 'qu' => 'ux'];
         $this->assertSame($view, $view->withErrors($errors));
-        $this->assertInstanceOf('Illuminate\Support\MessageBag', $view->errors);
+        $this->assertInstanceOf(\Illuminate\Support\MessageBag::class, $view->errors);
         $foo = $view->errors->get('foo');
         $this->assertEquals($foo[0], 'bar');
         $qu = $view->errors->get('qu');
@@ -222,8 +222,8 @@ class ViewTest extends TestCase
     protected function getView($data = [])
     {
         return new View(
-            m::mock('Illuminate\View\Factory'),
-            m::mock('Illuminate\View\Engines\EngineInterface'),
+            m::mock(\Illuminate\View\Factory::class),
+            m::mock(\Illuminate\View\Engines\EngineInterface::class),
             'view',
             'path',
             $data


### PR DESCRIPTION
Use `::class` notation in tests.

---

See #17357 and #17148 by @alexbowers 

---

**Notes:**

- This PR only apply to `/tests` code.
- All FQN were let as it on purpose.