### PR TITLE
[5.4] Correctly generate nested seeders

### DIFF
--- a/src/Illuminate/Database/Console/Seeds/SeederMakeCommand.php
+++ b/src/Illuminate/Database/Console/Seeds/SeederMakeCommand.php
@@ -63,6 +63,19 @@ class SeederMakeCommand extends GeneratorCommand
     }
 
     /**
+     * Build the class with the given name.
+     *
+     * @param  string  $name
+     * @return string
+     */
+    protected function buildClass($name)
+    {
+        $stub = $this->files->get($this->getStub());
+
+        return $this->replaceClass($stub, class_basename($name));
+    }
+
+    /**
      * Get the stub file for the generator.
      *
      * @return string
@@ -80,7 +93,7 @@ class SeederMakeCommand extends GeneratorCommand
      */
     protected function getPath($name)
     {
-        return $this->laravel->databasePath().'/seeds/'.$name.'.php';
+        return $this->laravel->databasePath().'/seeds/'.str_replace('\\', '/', $name).'.php';
     }
 
     /**


### PR DESCRIPTION
Fixes #17407

**Before change:**
```php artisan make:seeder Talks/TalksSeeder```
creates the correct folder structure but the contents of the file has classname as "Talks/TalksSeeder"

```php artisan make:seeder Talks\\TalksSeeder```
throws a protocol error

*Note: make:controller and make:model both work using either of these two options.

**After Change**
both commands above will create the correct folder structure and the seeder class name will be correct in the file.

*Note: This also enables you to use ```php artisan make:seeder Talks//TalksSeeder```*