### PR TITLE
[5.4] Fix bug with delete reset token

### DIFF
--- a/src/Illuminate/Auth/Passwords/DatabaseTokenRepository.php
+++ b/src/Illuminate/Auth/Passwords/DatabaseTokenRepository.php
@@ -140,14 +140,14 @@ class DatabaseTokenRepository implements TokenRepositoryInterface
     }
 
     /**
-     * Delete a token record by token.
+     * Delete a token record by user.
      *
-     * @param  string  $token
+     * @param  \Illuminate\Contracts\Auth\CanResetPassword  $user
      * @return void
      */
-    public function delete($token)
+    public function delete(CanResetPasswordContract $user)
     {
-        $this->getTable()->where('token', $token)->delete();
+        $this->deleteExisting($user);
     }
 
     /**

--- a/src/Illuminate/Auth/Passwords/PasswordBroker.php
+++ b/src/Illuminate/Auth/Passwords/PasswordBroker.php
@@ -98,7 +98,7 @@ class PasswordBroker implements PasswordBrokerContract
         // in their persistent storage. Then we'll delete the token and return.
         $callback($user, $password);
 
-        $this->tokens->delete($credentials['token']);
+        $this->tokens->delete($user);
 
         return static::PASSWORD_RESET;
     }

--- a/src/Illuminate/Auth/Passwords/TokenRepositoryInterface.php
+++ b/src/Illuminate/Auth/Passwords/TokenRepositoryInterface.php
@@ -26,10 +26,10 @@ interface TokenRepositoryInterface
     /**
      * Delete a token record.
      *
-     * @param  string  $token
+     * @param  \Illuminate\Contracts\Auth\CanResetPassword  $user
      * @return void
      */
-    public function delete($token);
+    public function delete(CanResetPasswordContract $user);
 
     /**
      * Delete expired tokens.

--- a/tests/Auth/AuthDatabaseTokenRepositoryTest.php
+++ b/tests/Auth/AuthDatabaseTokenRepositoryTest.php
@@ -88,10 +88,12 @@ class AuthDatabaseTokenRepositoryTest extends TestCase
     {
         $repo = $this->getRepo();
         $repo->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($query = m::mock('StdClass'));
-        $query->shouldReceive('where')->once()->with('token', 'token')->andReturn($query);
+        $query->shouldReceive('where')->once()->with('email', 'email')->andReturn($query);
         $query->shouldReceive('delete')->once();
+        $user = m::mock('Illuminate\Contracts\Auth\CanResetPassword');
+        $user->shouldReceive('getEmailForPasswordReset')->andReturn('email');
 
-        $repo->delete('token');
+        $repo->delete($user);
     }
 
     public function testDeleteExpiredMethodDeletesExpiredTokens()

--- a/tests/Auth/AuthPasswordBrokerTest.php
+++ b/tests/Auth/AuthPasswordBrokerTest.php
@@ -123,7 +123,7 @@ class AuthPasswordBrokerTest extends TestCase
         unset($_SERVER['__password.reset.test']);
         $broker = $this->getMockBuilder('Illuminate\Auth\Passwords\PasswordBroker')->setMethods(['validateReset', 'getPassword', 'getToken'])->setConstructorArgs(array_values($mocks = $this->getMocks()))->getMock();
         $broker->expects($this->once())->method('validateReset')->will($this->returnValue($user = m::mock('Illuminate\Contracts\Auth\CanResetPassword')));
-        $mocks['tokens']->shouldReceive('delete')->once()->with('token');
+        $mocks['tokens']->shouldReceive('delete')->once()->with($user);
         $callback = function ($user, $password) {
             $_SERVER['__password.reset.test'] = compact('user', 'password');
 


### PR DESCRIPTION
In commit https://github.com/laravel/framework/commit/c454c87f75c179043a956071a8572af538c926a9, reset token will be hashed first before saving to the database.  So it is not possible to delete the entry based on the public token sent to the user.

I made these changes so that delete method will now accept a user instance and remove all tokens belongs to the user after reset the password.