### PR TITLE
[5.4] Adds a doesntExpectNotification method to MocksApplicationServices trait

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MocksApplicationServices.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MocksApplicationServices.php
@@ -287,4 +287,35 @@ trait MocksApplicationServices
 
         return $this;
     }
+
+    /**
+     * Specify a notification that is not expected to be dispatched.
+     *
+     * @param  string $notification
+     * @param  mixed  $notifiable
+     *
+     * @return $this
+     */
+    protected function doesntExpectNotification($notification, $notifiable = null)
+    {
+        $this->withoutNotifications();
+
+        $this->beforeApplicationDestroyed(function () use ($notifiable, $notification) {
+            foreach ($this->dispatchedNotifications as $dispatched) {
+                $notified = $dispatched['notifiable'];
+
+                if (get_class($dispatched['instance']) === $notification) {
+                    if ($notifiable === null || ($notified === $notifiable ||
+                            $notified->getKey() == $notifiable->getKey())
+                    ) {
+                        throw new Exception(
+                            'The following unexpected notification was dispatched: [' . $notification . ']'
+                        );
+                    }
+                }
+            }
+        });
+
+        return $this;
+    }
 }


### PR DESCRIPTION
When testing notifications I found that I wanted to ensure a notification doesn't get sent under certain circumstances. To do this I have modified the `expectsNotification` method to do the reverse.

### Usage

`$this->doesntExpectNotification(MyNotification::class);`

Will fail if `MyNotification` gets sent to any notifiable.

`$this->doesntExpectNotification(MyNotification::class, $user);`

Will fail if `MyNotification` gets sent to `$user`, if it gets sent to any other notifiable then the test will still pass.