### PR TITLE
[5.4] Move a property into its designated trait and improve docs

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -105,13 +105,6 @@ class BladeCompiler extends Compiler implements CompilerInterface
     protected $verbatimBlocks = [];
 
     /**
-     * Counter to keep track of nested forelse statements.
-     *
-     * @var int
-     */
-    protected $forElseCounter = 0;
-
-    /**
      * Compile the view at the given path.
      *
      * @param  string  $path

--- a/src/Illuminate/View/Compilers/Concerns/CompilesAuthorizations.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesAuthorizations.php
@@ -38,7 +38,7 @@ trait CompilesAuthorizations
     }
 
     /**
-     * Compile the else-can statements into valid PHP.
+     * Compile the else-cannot statements into valid PHP.
      *
      * @param  string  $expression
      * @return string

--- a/src/Illuminate/View/Compilers/Concerns/CompilesComponents.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesComponents.php
@@ -16,7 +16,7 @@ trait CompilesComponents
     }
 
     /**
-     * Compile the end component statements into valid PHP.
+     * Compile the end-component statements into valid PHP.
      *
      * @param  string  $expression
      * @return string
@@ -38,7 +38,7 @@ trait CompilesComponents
     }
 
     /**
-     * Compile the end slot statements into valid PHP.
+     * Compile the end-slot statements into valid PHP.
      *
      * @param  string  $expression
      * @return string

--- a/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
@@ -5,7 +5,7 @@ namespace Illuminate\View\Compilers\Concerns;
 trait CompilesConditionals
 {
     /**
-     * Compile the has section statements into valid PHP.
+     * Compile the has-section statements into valid PHP.
      *
      * @param  string  $expression
      * @return string
@@ -71,7 +71,7 @@ trait CompilesConditionals
     }
 
     /**
-     * Compile the end unless statements into valid PHP.
+     * Compile the end-unless statements into valid PHP.
      *
      * @param  string  $expression
      * @return string

--- a/src/Illuminate/View/Compilers/Concerns/CompilesIncludes.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesIncludes.php
@@ -29,7 +29,7 @@ trait CompilesIncludes
     }
 
     /**
-     * Compile the include statements into valid PHP.
+     * Compile the include-if statements into valid PHP.
      *
      * @param  string  $expression
      * @return string

--- a/src/Illuminate/View/Compilers/Concerns/CompilesLoops.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesLoops.php
@@ -12,7 +12,7 @@ trait CompilesLoops
     protected $forElseCounter = 0;
 
     /**
-     * Compile the forelse statements into valid PHP.
+     * Compile the for-else statements into valid PHP.
      *
      * @param  string  $expression
      * @return string
@@ -35,7 +35,7 @@ trait CompilesLoops
     }
 
     /**
-     * Compile the forelse statements into valid PHP.
+     * Compile the for-else-empty statements into valid PHP.
      *
      * @param  string  $expression
      * @return string
@@ -70,7 +70,7 @@ trait CompilesLoops
     }
 
     /**
-     * Compile the foreach statements into valid PHP.
+     * Compile the for-each statements into valid PHP.
      *
      * @param  string  $expression
      * @return string

--- a/src/Illuminate/View/Compilers/Concerns/CompilesLoops.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesLoops.php
@@ -5,6 +5,13 @@ namespace Illuminate\View\Compilers\Concerns;
 trait CompilesLoops
 {
     /**
+     * Counter to keep track of nested forelse statements.
+     *
+     * @var int
+     */
+    protected $forElseCounter = 0;
+
+    /**
      * Compile the forelse statements into valid PHP.
      *
      * @param  string  $expression

--- a/src/Illuminate/View/Compilers/Concerns/CompilesRawPhp.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesRawPhp.php
@@ -16,7 +16,7 @@ trait CompilesRawPhp
     }
 
     /**
-     * Compile end-php statement into valid PHP.
+     * Compile end-php statements into valid PHP.
      *
      * @param  string  $expression
      * @return string

--- a/src/Illuminate/View/Compilers/Concerns/CompilesStacks.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesStacks.php
@@ -27,7 +27,7 @@ trait CompilesStacks
     }
 
     /**
-     * Compile the endpush statements into valid PHP.
+     * Compile the end-push statements into valid PHP.
      *
      * @param  string  $expression
      * @return string

--- a/src/Illuminate/View/Compilers/Concerns/CompilesTranslations.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesTranslations.php
@@ -22,7 +22,7 @@ trait CompilesTranslations
     }
 
     /**
-     * Compile the endlang statements into valid PHP.
+     * Compile the end-lang statements into valid PHP.
      *
      * @return string
      */


### PR DESCRIPTION
After reviewing 5.3->5.4 changes for https://github.com/jawee/language-blade I noticed the `forElseCounter` property not being as the close to the code which uses it that it could be.

Also polished the docs surrounding the compile methods so that the names would be hyphenated across the board, plus some minor inconsistencies fixed.