### PR TITLE
[5.4] Replace <br> with newline in notifications::email

### DIFF
--- a/src/Illuminate/Notifications/resources/views/email.blade.php
+++ b/src/Illuminate/Notifications/resources/views/email.blade.php
@@ -45,7 +45,8 @@
 @if (! empty($salutation))
     {{ $salutation }}
 @else
-    Regards,<br>{{ config('app.name') }}
+    Regards,
+    {{ config('app.name') }}
 @endif
 
 <!-- Subcopy -->


### PR DESCRIPTION
This pull request replaces the `<br>` tag in the email notification view with a newline so it's properly rendered.

![screen shot 2017-01-25 at 16 15 59](https://cloud.githubusercontent.com/assets/1123887/22296219/c356d1d4-e319-11e6-83df-5815109fe6ac.png)
