### PR TITLE
[5.4] Change 'fire' to 'dispatch' method when mocking application events

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MocksApplicationServices.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MocksApplicationServices.php
@@ -101,7 +101,7 @@ trait MocksApplicationServices
     {
         $mock = Mockery::mock(EventsDispatcherContract::class);
 
-        $mock->shouldReceive('fire')->andReturnUsing(function ($called) {
+        $mock->shouldReceive('dispatch')->andReturnUsing(function ($called) {
             $this->firedEvents[] = $called;
         });
 


### PR DESCRIPTION
Mock 'dispatch' method instead of 'fire' in EventDispatcher due to Laravel 5.4 change.