### PR TITLE
[5.4] Now sets the connection property of the Migration object

### DIFF
--- a/src/Illuminate/Database/Migrations/Migration.php
+++ b/src/Illuminate/Database/Migrations/Migration.php
@@ -20,4 +20,14 @@ abstract class Migration
     {
         return $this->connection;
     }
+
+    /**
+     * Set the migration connection name.
+     *
+     * @param  string  $connection
+     */
+    public function setConnection($connection)
+    {
+        $this->connection = $connection;
+    }
 }

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -168,6 +168,9 @@ class Migrator
             $name = $this->getMigrationName($file)
         );
 
+        // Set database connection name
+        $migration->setConnection($this->connection);
+
         if ($pretend) {
             return $this->pretendToRun($migration, 'up');
         }


### PR DESCRIPTION
The migration object did not have a setter for the connection property, and the property
was not being set by the MigrateCommand.