### PR TITLE
[5.4] Remove superfluous ForceDelete extension from SoftDeletingScope

### DIFF
--- a/src/Illuminate/Database/Eloquent/SoftDeletingScope.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletingScope.php
@@ -9,7 +9,7 @@ class SoftDeletingScope implements Scope
      *
      * @var array
      */
-    protected $extensions = ['ForceDelete', 'Restore', 'WithTrashed', 'WithoutTrashed', 'OnlyTrashed'];
+    protected $extensions = ['Restore', 'WithTrashed', 'WithoutTrashed', 'OnlyTrashed'];
 
     /**
      * Apply the scope to a given Eloquent query builder.
@@ -57,19 +57,6 @@ class SoftDeletingScope implements Scope
         }
 
         return $builder->getModel()->getDeletedAtColumn();
-    }
-
-    /**
-     * Add the force delete extension to the builder.
-     *
-     * @param  \Illuminate\Database\Eloquent\Builder  $builder
-     * @return void
-     */
-    protected function addForceDelete(Builder $builder)
-    {
-        $builder->macro('forceDelete', function (Builder $builder) {
-            return $builder->getQuery()->delete();
-        });
     }
 
     /**

--- a/tests/Database/DatabaseSoftDeletingScopeTest.php
+++ b/tests/Database/DatabaseSoftDeletingScopeTest.php
@@ -23,20 +23,6 @@ class DatabaseSoftDeletingScopeTest extends TestCase
         $scope->apply($builder, $model);
     }
 
-    public function testForceDeleteExtension()
-    {
-        $builder = m::mock('Illuminate\Database\Eloquent\Builder');
-        $builder->shouldDeferMissing();
-        $scope = new \Illuminate\Database\Eloquent\SoftDeletingScope;
-        $scope->extend($builder);
-        $callback = $builder->getMacro('forceDelete');
-        $givenBuilder = m::mock('Illuminate\Database\Eloquent\Builder');
-        $givenBuilder->shouldReceive('getQuery')->andReturn($query = m::mock('StdClass'));
-        $query->shouldReceive('delete')->once();
-
-        $callback($givenBuilder);
-    }
-
     public function testRestoreExtension()
     {
         $builder = m::mock('Illuminate\Database\Eloquent\Builder');


### PR DESCRIPTION
Seeing as `Illuminate\Database\Eloquent\Builder` already has a `forceDelete()` method, there's no point adding a `forceDelete` macro to it in `Illuminate\Database\Eloquent\SoftDeletingScope`as it will never get called (nor would it need to, because the macro does exactly the same thing the native method does).