### PR TITLE
[5.4] Remove unused parameters and improve variable interpolation

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesAuthorizations.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesAuthorizations.php
@@ -51,10 +51,9 @@ trait CompilesAuthorizations
     /**
      * Compile the end-can statements into valid PHP.
      *
-     * @param  string  $expression
      * @return string
      */
-    protected function compileEndcan($expression)
+    protected function compileEndcan()
     {
         return '<?php endif; ?>';
     }

--- a/src/Illuminate/View/Compilers/Concerns/CompilesAuthorizations.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesAuthorizations.php
@@ -62,10 +62,9 @@ trait CompilesAuthorizations
     /**
      * Compile the end-cannot statements into valid PHP.
      *
-     * @param  string  $expression
      * @return string
      */
-    protected function compileEndcannot($expression)
+    protected function compileEndcannot()
     {
         return '<?php endif; ?>';
     }

--- a/src/Illuminate/View/Compilers/Concerns/CompilesComponents.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesComponents.php
@@ -18,10 +18,9 @@ trait CompilesComponents
     /**
      * Compile the end-component statements into valid PHP.
      *
-     * @param  string  $expression
      * @return string
      */
-    protected function compileEndComponent($expression)
+    protected function compileEndComponent()
     {
         return '<?php echo $__env->renderComponent(); ?>';
     }
@@ -40,10 +39,9 @@ trait CompilesComponents
     /**
      * Compile the end-slot statements into valid PHP.
      *
-     * @param  string  $expression
      * @return string
      */
-    protected function compileEndSlot($expression)
+    protected function compileEndSlot()
     {
         return '<?php $__env->endSlot(); ?>';
     }

--- a/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
@@ -51,10 +51,9 @@ trait CompilesConditionals
     /**
      * Compile the else statements into valid PHP.
      *
-     * @param  string  $expression
      * @return string
      */
-    protected function compileElse($expression)
+    protected function compileElse()
     {
         return '<?php else: ?>';
     }
@@ -62,10 +61,9 @@ trait CompilesConditionals
     /**
      * Compile the end-if statements into valid PHP.
      *
-     * @param  string  $expression
      * @return string
      */
-    protected function compileEndif($expression)
+    protected function compileEndif()
     {
         return '<?php endif; ?>';
     }
@@ -73,10 +71,9 @@ trait CompilesConditionals
     /**
      * Compile the end-unless statements into valid PHP.
      *
-     * @param  string  $expression
      * @return string
      */
-    protected function compileEndunless($expression)
+    protected function compileEndunless()
     {
         return '<?php endif; ?>';
     }

--- a/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
@@ -34,7 +34,7 @@ trait CompilesConditionals
      */
     protected function compileUnless($expression)
     {
-        return "<?php if (! $expression): ?>";
+        return "<?php if (! {$expression}): ?>";
     }
 
     /**

--- a/src/Illuminate/View/Compilers/Concerns/CompilesEchos.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesEchos.php
@@ -46,7 +46,7 @@ trait CompilesEchos
         $callback = function ($matches) {
             $whitespace = empty($matches[3]) ? '' : $matches[3].$matches[3];
 
-            return $matches[1] ? substr($matches[0], 1) : '<?php echo '.$this->compileEchoDefaults($matches[2]).'; ?>'.$whitespace;
+            return $matches[1] ? substr($matches[0], 1) : "<?php echo {$this->compileEchoDefaults($matches[2])}; ?>{$whitespace}";
         };
 
         return preg_replace_callback($pattern, $callback, $value);
@@ -67,7 +67,7 @@ trait CompilesEchos
 
             $wrapped = sprintf($this->echoFormat, $this->compileEchoDefaults($matches[2]));
 
-            return $matches[1] ? substr($matches[0], 1) : '<?php echo '.$wrapped.'; ?>'.$whitespace;
+            return $matches[1] ? substr($matches[0], 1) : "<?php echo {$wrapped}; ?>{$whitespace}";
         };
 
         return preg_replace_callback($pattern, $callback, $value);
@@ -86,7 +86,7 @@ trait CompilesEchos
         $callback = function ($matches) {
             $whitespace = empty($matches[3]) ? '' : $matches[3].$matches[3];
 
-            return $matches[1] ? $matches[0] : '<?php echo e('.$this->compileEchoDefaults($matches[2]).'); ?>'.$whitespace;
+            return $matches[1] ? $matches[0] : "<?php echo e({$this->compileEchoDefaults($matches[2])}); ?>{$whitespace}";
         };
 
         return preg_replace_callback($pattern, $callback, $value);

--- a/src/Illuminate/View/Compilers/Concerns/CompilesIncludes.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesIncludes.php
@@ -25,7 +25,7 @@ trait CompilesIncludes
     {
         $expression = $this->stripParentheses($expression);
 
-        return "<?php echo \$__env->make($expression, array_except(get_defined_vars(), array('__data', '__path')))->render(); ?>";
+        return "<?php echo \$__env->make({$expression}, array_except(get_defined_vars(), array('__data', '__path')))->render(); ?>";
     }
 
     /**
@@ -38,6 +38,6 @@ trait CompilesIncludes
     {
         $expression = $this->stripParentheses($expression);
 
-        return "<?php if (\$__env->exists($expression)) echo \$__env->make($expression, array_except(get_defined_vars(), array('__data', '__path')))->render(); ?>";
+        return "<?php if (\$__env->exists({$expression})) echo \$__env->make({$expression}, array_except(get_defined_vars(), array('__data', '__path')))->render(); ?>";
     }
 }

--- a/src/Illuminate/View/Compilers/Concerns/CompilesInjections.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesInjections.php
@@ -14,6 +14,10 @@ trait CompilesInjections
     {
         $segments = explode(',', preg_replace("/[\(\)\\\"\']/", '', $expression));
 
-        return '<?php $'.trim($segments[0])." = app('".trim($segments[1])."'); ?>";
+        $variable = trim($segments[0]);
+
+        $service = trim($segments[1]);
+
+        return "<?php \${$variable} = app('{$service}'); ?>";
     }
 }

--- a/src/Illuminate/View/Compilers/Concerns/CompilesLayouts.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesLayouts.php
@@ -23,7 +23,7 @@ trait CompilesLayouts
     {
         $expression = $this->stripParentheses($expression);
 
-        $echo = "<?php echo \$__env->make($expression, array_except(get_defined_vars(), array('__data', '__path')))->render(); ?>";
+        $echo = "<?php echo \$__env->make({$expression}, array_except(get_defined_vars(), array('__data', '__path')))->render(); ?>";
 
         $this->footer[] = $echo;
 

--- a/src/Illuminate/View/Compilers/Concerns/CompilesLayouts.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesLayouts.php
@@ -67,10 +67,9 @@ trait CompilesLayouts
     /**
      * Compile the show statements into valid PHP.
      *
-     * @param  string  $expression
      * @return string
      */
-    protected function compileShow($expression)
+    protected function compileShow()
     {
         return '<?php echo $__env->yieldSection(); ?>';
     }
@@ -78,10 +77,9 @@ trait CompilesLayouts
     /**
      * Compile the append statements into valid PHP.
      *
-     * @param  string  $expression
      * @return string
      */
-    protected function compileAppend($expression)
+    protected function compileAppend()
     {
         return '<?php $__env->appendSection(); ?>';
     }
@@ -89,10 +87,9 @@ trait CompilesLayouts
     /**
      * Compile the overwrite statements into valid PHP.
      *
-     * @param  string  $expression
      * @return string
      */
-    protected function compileOverwrite($expression)
+    protected function compileOverwrite()
     {
         return '<?php $__env->stopSection(true); ?>';
     }
@@ -100,10 +97,9 @@ trait CompilesLayouts
     /**
      * Compile the stop statements into valid PHP.
      *
-     * @param  string  $expression
      * @return string
      */
-    protected function compileStop($expression)
+    protected function compileStop()
     {
         return '<?php $__env->stopSection(); ?>';
     }
@@ -111,10 +107,9 @@ trait CompilesLayouts
     /**
      * Compile the end-section statements into valid PHP.
      *
-     * @param  string  $expression
      * @return string
      */
-    protected function compileEndsection($expression)
+    protected function compileEndsection()
     {
         return '<?php $__env->stopSection(); ?>';
     }

--- a/src/Illuminate/View/Compilers/Concerns/CompilesLoops.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesLoops.php
@@ -37,10 +37,9 @@ trait CompilesLoops
     /**
      * Compile the for-else-empty statements into valid PHP.
      *
-     * @param  string  $expression
      * @return string
      */
-    protected function compileEmpty($expression)
+    protected function compileEmpty()
     {
         $empty = '$__empty_'.$this->forElseCounter--;
 
@@ -50,10 +49,9 @@ trait CompilesLoops
     /**
      * Compile the end-for-else statements into valid PHP.
      *
-     * @param  string  $expression
      * @return string
      */
-    protected function compileEndforelse($expression)
+    protected function compileEndforelse()
     {
         return '<?php endif; ?>';
     }
@@ -115,10 +113,9 @@ trait CompilesLoops
     /**
      * Compile the end-for statements into valid PHP.
      *
-     * @param  string  $expression
      * @return string
      */
-    protected function compileEndfor($expression)
+    protected function compileEndfor()
     {
         return '<?php endfor; ?>';
     }
@@ -126,10 +123,9 @@ trait CompilesLoops
     /**
      * Compile the end-for-each statements into valid PHP.
      *
-     * @param  string  $expression
      * @return string
      */
-    protected function compileEndforeach($expression)
+    protected function compileEndforeach()
     {
         return '<?php endforeach; $__env->popLoop(); $loop = $__env->getLastLoop(); ?>';
     }
@@ -148,10 +144,9 @@ trait CompilesLoops
     /**
      * Compile the end-while statements into valid PHP.
      *
-     * @param  string  $expression
      * @return string
      */
-    protected function compileEndwhile($expression)
+    protected function compileEndwhile()
     {
         return '<?php endwhile; ?>';
     }

--- a/src/Illuminate/View/Compilers/Concerns/CompilesRawPhp.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesRawPhp.php
@@ -18,10 +18,9 @@ trait CompilesRawPhp
     /**
      * Compile end-php statements into valid PHP.
      *
-     * @param  string  $expression
      * @return string
      */
-    protected function compileEndphp($expression)
+    protected function compileEndphp()
     {
         return ' ?>';
     }

--- a/src/Illuminate/View/Compilers/Concerns/CompilesStacks.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesStacks.php
@@ -29,10 +29,9 @@ trait CompilesStacks
     /**
      * Compile the end-push statements into valid PHP.
      *
-     * @param  string  $expression
      * @return string
      */
-    protected function compileEndpush($expression)
+    protected function compileEndpush()
     {
         return '<?php $__env->stopPush(); ?>';
     }

--- a/src/Illuminate/View/Compilers/Concerns/CompilesTranslations.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesTranslations.php
@@ -17,7 +17,7 @@ trait CompilesTranslations
         } elseif ($expression[1] === '[') {
             return "<?php \$__env->startTranslation{$expression}; ?>";
         } else {
-            return "<?php echo app('translator')->get$expression; ?>";
+            return "<?php echo app('translator')->get{$expression}; ?>";
         }
     }
 
@@ -39,6 +39,6 @@ trait CompilesTranslations
      */
     protected function compileChoice($expression)
     {
-        return "<?php echo app('translator')->choice$expression; ?>";
+        return "<?php echo app('translator')->choice{$expression}; ?>";
     }
 }


### PR DESCRIPTION
First part is the opposite of #17544

Second part is using complex interpolation syntax where it was not used before to make these interpolations clear. Also when concatenating more than 2 strings, this method has a small performance gain and even larger readability improvement.