### PR TITLE
[5.4] add getResultCode function to MemcachedStore

### DIFF
--- a/src/Illuminate/Cache/MemcachedStore.php
+++ b/src/Illuminate/Cache/MemcachedStore.php
@@ -232,4 +232,15 @@ class MemcachedStore extends TaggableStore implements Store
     {
         $this->prefix = ! empty($prefix) ? $prefix.':' : '';
     }
+
+    /**
+     * Return the result code of the last operation.
+     *
+     * @link http://php.net/manual/en/memcached.getresultcode.php
+     * @return int Result code of the last Memcached operation.
+     */
+    public function getResultCode()
+    {
+        return $this->memcached->getResultCode();
+    }
 }


### PR DESCRIPTION
### The issue:
We can't classify return value of MemcachedStore#get is not-found or null or failed when MemcachedStore#get returns null.

So we need to add `getResultCode` function for checking the result. 