### PR TITLE
[5.4] $sequence was overwritten, wrong returning id was used

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -75,7 +75,7 @@ class PostgresGrammar extends Grammar
      */
     public function compileInsertGetId(Builder $query, $values, $sequence)
     {
-        if (! is_null($sequence)) {
+        if (is_null($sequence)) {
             $sequence = 'id';
         }
 


### PR DESCRIPTION
Model create method was not working because it was trying to return the default 'id', method always overrode $sequence.