### PR TITLE
[5.4] Remove the hot file from versionning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ composer.lock
 .DS_Store
 Thumbs.db
 /phpunit.xml
+/public/hot


### PR DESCRIPTION
When you run `npm run hmr`, a `hot` file is created to the public folder for the `mix()` helper to know if it has to server from the webpack server or not. This file does not go away until we run `npm run dev` (or `watch`). 

True, if we use `npm run production` in our production server it goes away too, but in case we don't make it go away in development, I don't think it's necessary to version it.