### PR TITLE
[5.4] fix using --database option in the migrate command

### DIFF
--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -473,6 +473,10 @@ class Migrator
      */
     public function setConnection($name)
     {
+        if (! is_null($name)) {
+            $this->resolver->setDefaultConnection($name);
+        }
+
         $this->repository->setSource($name);
 
         $this->connection = $name;


### PR DESCRIPTION
This line already existed in 5.3, we need it to instruct the resolver to use the given connection when running the migration, the `resolveConnection()` method is used only when the grammar supports schema transactions:

    protected function runMigration($migration, $method)
    {
        $connection = $this->resolveConnection(
            $migration->getConnection()
        );

        $callback = function () use ($migration, $method) {
            $migration->{$method}();
        };

        $this->getSchemaGrammar($connection)->supportsSchemaTransactions()
                    ? $connection->transaction($callback)
                    : $callback();
    }

In case it doesn't, we need to instruct the connection resolver to use the given connection.