### PR TITLE
[5.4] Fix persisting user and request info to session table

### DIFF
--- a/src/Illuminate/Session/DatabaseSessionHandler.php
+++ b/src/Illuminate/Session/DatabaseSessionHandler.php
@@ -177,7 +177,7 @@ class DatabaseSessionHandler implements SessionHandlerInterface, ExistenceAwareI
             return $payload;
         }
 
-        return tap($payload, function ($payload) {
+        return tap($payload, function (&$payload) {
             $this->addUserInformation($payload)
                  ->addRequestInformation($payload);
         });


### PR DESCRIPTION
Fixes #17581 

# Problem
The payload is correctly passed by reference in the addUserInformation and addRequestInformation methods, however, for the results of these two methods to be correctly merged with the payload, the payload must be passed by reference in the tap function of the getDefaultPayload method.

# Before
Starting with a fresh laravel app, run ```php artisan session:table``` then ```php artisan make:auth```.
Run ```php artisan migrate```
Then log in and check your sessions table in the database.
The user id, ip address and user agent would be null.

# After
Repeat the above steps and all columns will be populated correctly in db.