### PR TITLE
[5.4] Removed unneeded equal sign

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -54,7 +54,7 @@ abstract class HasOneOrMany extends Relation
     public function addConstraints()
     {
         if (static::$constraints) {
-            $this->query->where($this->foreignKey, '=', $this->getParentKey());
+            $this->query->where($this->foreignKey, $this->getParentKey());
 
             $this->query->whereNotNull($this->foreignKey);
         }


### PR DESCRIPTION
This sign is not needed since it is added by default when passing just 2 arguments, keeps it consistent with the other relation methods since they also don't use it..