### PR TITLE
[5.4] Generate model with make:controller

### DIFF
--- a/src/Illuminate/Routing/Console/ControllerMakeCommand.php
+++ b/src/Illuminate/Routing/Console/ControllerMakeCommand.php
@@ -74,6 +74,12 @@ class ControllerMakeCommand extends GeneratorCommand
         if ($this->option('model')) {
             $modelClass = $this->parseModel($this->option('model'));
 
+            if (! class_exists($modelClass)) {
+                if ($this->confirm("The model $modelClass does not exist. Do you want to generate it?")) {
+                    $this->call('make:model', ['name' => $modelClass]);
+                }
+            }
+
             $replace = [
                 'DummyFullModelClass' => $modelClass,
                 'DummyModelClass' => class_basename($modelClass),


### PR DESCRIPTION
Ask the user if he wants to generate the model if the model does not exist when using:

`php artisan make:controller SomethingController --model=NonExistentModel`

https://s27.postimg.org/rpv92zkcj/Screen_Shot_2017_01_26_at_21_37_55.png