### PR TITLE
[5.4] Use implicit binding when generating controllers with make:model

### DIFF
--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -73,9 +73,11 @@ class ModelMakeCommand extends GeneratorCommand
     {
         $controller = Str::studly(class_basename($this->argument('name')));
 
+        $modelName = $this->qualifyClass($this->getNameInput());
+
         $this->call('make:controller', [
             'name' => "{$controller}Controller",
-            '--resource' => $this->option('resource'),
+            '--model' => $this->option('resource') ? $modelName : null,
         ]);
     }
 


### PR DESCRIPTION
When generating controllers with `make:model --controller --resource` use `--model` instead of `--resource` to generate the controller, so it will implement route implicit binding by default.