### PR TITLE
[5.4] Add get/set/isLocale() to Application Contract.

### DIFF
--- a/src/Illuminate/Contracts/Foundation/Application.php
+++ b/src/Illuminate/Contracts/Foundation/Application.php
@@ -89,4 +89,19 @@ interface Application extends Container
      * @return string
      */
     public function getCachedServicesPath();
+
+    /**
+     * Get the current application locale.
+     *
+     * @return string
+     */
+    public function getLocale();
+
+    /**
+     * Set the current application locale.
+     *
+     * @param  string  $locale
+     * @return void
+     */
+    public function setLocale($locale);
 }

--- a/src/Illuminate/Contracts/Foundation/Application.php
+++ b/src/Illuminate/Contracts/Foundation/Application.php
@@ -104,4 +104,12 @@ interface Application extends Container
      * @return void
      */
     public function setLocale($locale);
+    
+    /**
+     * Determine if application locale is the given locale.
+     *
+     * @param  string  $locale
+     * @return bool
+     */
+    public function isLocale($locale);
 }


### PR DESCRIPTION
The Application Class implements three methods for [getting, setting and checking](https://github.com/laravel/framework/blob/5.4/src/Illuminate/Foundation/Application.php#L1025:L1059) the app's locale. The [Application Interface](https://github.com/BaglerIT/framework/blob/5.4/src/Illuminate/Contracts/Foundation/Application.php) does not expose these methods.

This pull request adds the three methods to the Application Interface. The method declaration and doc block are copied directly from the Application Class.

The purpose of adding the three methods is to make it possible to get/set/check the application's locale in a package while still following [the advice in the documentation to use contracts](https://laravel.com/docs/5.4/packages#a-note-on-facades).