### PR TITLE
[5.4] TestResponse::fromBaseResponse() is not always receiving an illuminate object

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -20,7 +20,7 @@ class TestResponse extends Response
     public static function fromBaseResponse($response)
     {
         $testResponse = new static(
-            $response->getContent(), $response->status()
+            $response->getContent(), $response->getStatusCode()
         );
 
         $testResponse->headers = $response->headers;


### PR DESCRIPTION
- Laravel Version: 5.4.5
- PHP Version: 7.0.3
- Database Driver & Version: MySQL 5.7
- Passport Version: 2.0.1

### Description:

I found an instance when the response given to the TestResponse::fromBaseResponse() method is not an illuminate response, but a symfony response. Calling the status method resulted in an undefined method exception.

I was reluctant to update the param on the docblock as the `original` and `exception` properties are specific to the illuminate response.

### Steps To Reproduce:

* Fresh laravel install
* Install passport
* Run the following test

```php
    public function testingPassportPasswordGrant()
    {
        $client = $this->app->make(ClientRepository::class)
            ->createPasswordGrantClient(null, 'Password Grant Client', 'http://localhost');

        $user = factory(User::class)->create();

        $response = $this->post('/oauth/token', [
            'grant_type' => 'password',
            'client_id' => $client->id,
            'client_secret' => $client->secret,
            'username' => $user->email,
            'password' => 'secret',
            'scope' => '*',
        ]);

        $response->assertStatus(200);
    }
```

```
1) Tests\Feature\ExampleTest::testingPassportPasswordGrant
Error: Call to undefined method Symfony\Component\HttpFoundation\Response::status()

/home/vagrant/Code/testing-new/vendor/laravel/framework/src/Illuminate/Foundation/Testing/TestResponse.php:23
/home/vagrant/Code/testing-new/vendor/laravel/framework/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php:320
/home/vagrant/Code/testing-new/vendor/laravel/framework/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php:239
/home/vagrant/Code/testing-new/vendor/laravel/framework/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php:84
/home/vagrant/Code/testing-new/tests/Feature/ExampleTest.php:53
```