### PR TITLE
[5.4] Allow any implementation of ViewFactory in Markdown renderer

### DIFF
--- a/src/Illuminate/Mail/Markdown.php
+++ b/src/Illuminate/Mail/Markdown.php
@@ -5,7 +5,7 @@ namespace Illuminate\Mail;
 use Parsedown;
 use Illuminate\Support\Arr;
 use Illuminate\Support\HtmlString;
-use Illuminate\View\Factory as ViewFactory;
+use Illuminate\Contracts\View\Factory as ViewFactory;
 use TijsVerkoyen\CssToInlineStyles\CssToInlineStyles;
 
 class Markdown


### PR DESCRIPTION
PR to use an interface rather than concrete View factory class in the new markdown renderer for integration with custom implementations of the View factory