### PR TITLE
Fix for union pagination wrong sql query

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1702,15 +1702,18 @@ class Builder
      */
     public function getCountForPagination($columns = ['*'])
     {
-        $this->backupFieldsForCount();
-
-        $this->aggregate = ['function' => 'count', 'columns' => $this->clearSelectAliases($columns)];
-
-        $results = $this->get()->all();
-
-        $this->aggregate = null;
-
-        $this->restoreFieldsForCount();
+        if(count($this->unions) < 1){
+            $this->backupFieldsForCount();
+            $this->aggregate = ['function' => 'count', 'columns' => $this->clearSelectAliases($columns)];
+            $results = $this->get()->all();
+            $this->aggregate = null;
+            $this->restoreFieldsForCount();
+        }else{
+            $results = $this->newQuery()
+                    ->selectRaw("COUNT(*) as aggregate FROM (".$this->toSql().") as aggregate_query")
+                    ->mergeBindings($this)
+                    ->get()->all();
+        }
 
         if (isset($this->groups)) {
             return count($results);


### PR DESCRIPTION
Hello guys,

This is related to a old issue #14837 and it's only for 5.3.
There needs to be a fix also for 5.4, since I was able to replicate it also there but it will be different from this since the Database/Query.php has changed a lot on 5.4.

Description of the error:
In my case I needed to unify two queries of the same table, auction products and non auction products, which are a bit different.
The problem is you get a Cardinality error when calling paginate after doing some unions which is wrong. This happens because laravel calls the aggregate function, which is not effective in this case, which clears the select etc, what you would like to do is create an aggregate wrapping the query.
This is the solution I found, by changing database/builder.php -> getCountForPagination();