### PR TITLE
[5.4] Add dump method to TestResponse

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -382,4 +382,22 @@ class TestResponse extends Response
     {
         return app('session.store');
     }
+
+    /**
+     * Dump the content from the response.
+     *
+     * @return void
+     */
+    public function dump()
+    {
+        $content = $this->getContent();
+
+        $json = json_decode($content);
+
+        if (json_last_error() === JSON_ERROR_NONE) {
+            $content = $json;
+        }
+
+        dd($content);
+    }
 }


### PR DESCRIPTION
Adds back the dump method:

```php
$response->dump();
```