### PR TITLE
[5.4] Support numeric arguments in break and continue

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesLoops.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesLoops.php
@@ -97,7 +97,7 @@ trait CompilesLoops
     protected function compileBreak($expression)
     {
         if ($expression) {
-            preg_match('/\(\s*(\d+)\s*\)$/', $expression, $matches);
+            preg_match('/\(\s*(-?\d+)\s*\)$/', $expression, $matches);
 
             return $matches ? '<?php break '.max(1, $matches[1]).'; ?>' : "<?php if{$expression} break; ?>";
         }
@@ -114,7 +114,7 @@ trait CompilesLoops
     protected function compileContinue($expression)
     {
         if ($expression) {
-            preg_match('/\(\s*(\d+)\s*\)$/', $expression, $matches);
+            preg_match('/\(\s*(-?\d+)\s*\)$/', $expression, $matches);
 
             return $matches ? '<?php continue '.max(1, $matches[1]).'; ?>' : "<?php if{$expression} continue; ?>";
         }

--- a/src/Illuminate/View/Compilers/Concerns/CompilesLoops.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesLoops.php
@@ -98,7 +98,7 @@ trait CompilesLoops
     {
         if ($expression) {
             preg_match('/\(\s*(\d)\s*\)$/', $expression, $matches);
-            return $matches ? '<?php break ' . $matches[1] . '; ?>' : "<?php if{$expression} break; ?>";
+            return $matches ? '<?php break ' . max(1, $matches[1]) . '; ?>' : "<?php if{$expression} break; ?>";
         }
 
         return '<?php break; ?>';
@@ -114,7 +114,7 @@ trait CompilesLoops
     {
         if ($expression) {
             preg_match('/\(\s*(\d)\s*\)$/', $expression, $matches);
-            return $matches ? '<?php continue ' . $matches[1] . '; ?>' : "<?php if{$expression} continue; ?>";
+            return $matches ? '<?php continue ' . max(1, $matches[1]) . '; ?>' : "<?php if{$expression} continue; ?>";
         }
 
         return '<?php continue; ?>';

--- a/src/Illuminate/View/Compilers/Concerns/CompilesLoops.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesLoops.php
@@ -96,7 +96,12 @@ trait CompilesLoops
      */
     protected function compileBreak($expression)
     {
-        return $expression ? "<?php if{$expression} break; ?>" : '<?php break; ?>';
+        if ($expression) {
+            preg_match('/\(\s*(\d)\s*\)$/', $expression, $matches);
+            return $matches ? '<?php break ' . $matches[1] . '; ?>' : "<?php if{$expression} break; ?>";
+        }
+
+        return '<?php break; ?>';
     }
 
     /**
@@ -107,7 +112,12 @@ trait CompilesLoops
      */
     protected function compileContinue($expression)
     {
-        return $expression ? "<?php if{$expression} continue; ?>" : '<?php continue; ?>';
+        if ($expression) {
+            preg_match('/\(\s*(\d)\s*\)$/', $expression, $matches);
+            return $matches ? '<?php continue ' . $matches[1] . '; ?>' : "<?php if{$expression} continue; ?>";
+        }
+
+        return '<?php continue; ?>';
     }
 
     /**

--- a/src/Illuminate/View/Compilers/Concerns/CompilesLoops.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesLoops.php
@@ -98,6 +98,7 @@ trait CompilesLoops
     {
         if ($expression) {
             preg_match('/\(\s*(\d+)\s*\)$/', $expression, $matches);
+            
             return $matches ? '<?php break '.max(1, $matches[1]).'; ?>' : "<?php if{$expression} break; ?>";
         }
 
@@ -114,6 +115,7 @@ trait CompilesLoops
     {
         if ($expression) {
             preg_match('/\(\s*(\d+)\s*\)$/', $expression, $matches);
+            
             return $matches ? '<?php continue '.max(1, $matches[1]).'; ?>' : "<?php if{$expression} continue; ?>";
         }
 

--- a/src/Illuminate/View/Compilers/Concerns/CompilesLoops.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesLoops.php
@@ -97,7 +97,7 @@ trait CompilesLoops
     protected function compileBreak($expression)
     {
         if ($expression) {
-            preg_match('/\(\s*(\d)\s*\)$/', $expression, $matches);
+            preg_match('/\(\s*(\d+)\s*\)$/', $expression, $matches);
             return $matches ? '<?php break ' . max(1, $matches[1]) . '; ?>' : "<?php if{$expression} break; ?>";
         }
 
@@ -113,7 +113,7 @@ trait CompilesLoops
     protected function compileContinue($expression)
     {
         if ($expression) {
-            preg_match('/\(\s*(\d)\s*\)$/', $expression, $matches);
+            preg_match('/\(\s*(\d+)\s*\)$/', $expression, $matches);
             return $matches ? '<?php continue ' . max(1, $matches[1]) . '; ?>' : "<?php if{$expression} continue; ?>";
         }
 

--- a/src/Illuminate/View/Compilers/Concerns/CompilesLoops.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesLoops.php
@@ -98,7 +98,7 @@ trait CompilesLoops
     {
         if ($expression) {
             preg_match('/\(\s*(\d+)\s*\)$/', $expression, $matches);
-            
+
             return $matches ? '<?php break '.max(1, $matches[1]).'; ?>' : "<?php if{$expression} break; ?>";
         }
 
@@ -115,7 +115,7 @@ trait CompilesLoops
     {
         if ($expression) {
             preg_match('/\(\s*(\d+)\s*\)$/', $expression, $matches);
-            
+
             return $matches ? '<?php continue '.max(1, $matches[1]).'; ?>' : "<?php if{$expression} continue; ?>";
         }
 

--- a/src/Illuminate/View/Compilers/Concerns/CompilesLoops.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesLoops.php
@@ -98,7 +98,7 @@ trait CompilesLoops
     {
         if ($expression) {
             preg_match('/\(\s*(\d+)\s*\)$/', $expression, $matches);
-            return $matches ? '<?php break ' . max(1, $matches[1]) . '; ?>' : "<?php if{$expression} break; ?>";
+            return $matches ? '<?php break '.max(1, $matches[1]).'; ?>' : "<?php if{$expression} break; ?>";
         }
 
         return '<?php break; ?>';
@@ -114,7 +114,7 @@ trait CompilesLoops
     {
         if ($expression) {
             preg_match('/\(\s*(\d+)\s*\)$/', $expression, $matches);
-            return $matches ? '<?php continue ' . max(1, $matches[1]) . '; ?>' : "<?php if{$expression} continue; ?>";
+            return $matches ? '<?php continue '.max(1, $matches[1]).'; ?>' : "<?php if{$expression} continue; ?>";
         }
 
         return '<?php continue; ?>';

--- a/tests/View/Blade/BladeBreakStatementsTest.php
+++ b/tests/View/Blade/BladeBreakStatementsTest.php
@@ -41,6 +41,48 @@ test
         $this->assertEquals($expected, $compiler->compileString($string));
     }
 
+    public function testBreakStatementsWithArgumentAreCompiled()
+    {
+        $compiler = new BladeCompiler($this->getFiles(), __DIR__);
+        $string = '@for ($i = 0; $i < 10; $i++)
+test
+@break(2)
+@endfor';
+        $expected = '<?php for($i = 0; $i < 10; $i++): ?>
+test
+<?php break 2; ?>
+<?php endfor; ?>';
+        $this->assertEquals($expected, $compiler->compileString($string));
+    }
+
+    public function testBreakStatementsWithSpacedArgumentAreCompiled()
+    {
+        $compiler = new BladeCompiler($this->getFiles(), __DIR__);
+        $string = '@for ($i = 0; $i < 10; $i++)
+test
+@break( 2 )
+@endfor';
+        $expected = '<?php for($i = 0; $i < 10; $i++): ?>
+test
+<?php break 2; ?>
+<?php endfor; ?>';
+        $this->assertEquals($expected, $compiler->compileString($string));
+    }
+
+    public function testBreakStatementsWithFaultyArgumentAreCompiled()
+    {
+        $compiler = new BladeCompiler($this->getFiles(), __DIR__);
+        $string = '@for ($i = 0; $i < 10; $i++)
+test
+@break(-2)
+@endfor';
+        $expected = '<?php for($i = 0; $i < 10; $i++): ?>
+test
+<?php break 1; ?>
+<?php endfor; ?>';
+        $this->assertEquals($expected, $compiler->compileString($string));
+    }
+
     protected function getFiles()
     {
         return m::mock('Illuminate\Filesystem\Filesystem');

--- a/tests/View/Blade/BladeContinueStatementsTest.php
+++ b/tests/View/Blade/BladeContinueStatementsTest.php
@@ -41,6 +41,48 @@ test
         $this->assertEquals($expected, $compiler->compileString($string));
     }
 
+    public function testContinueStatementsWithArgumentAreCompiled()
+    {
+        $compiler = new BladeCompiler($this->getFiles(), __DIR__);
+        $string = '@for ($i = 0; $i < 10; $i++)
+test
+@continue(2)
+@endfor';
+        $expected = '<?php for($i = 0; $i < 10; $i++): ?>
+test
+<?php continue 2; ?>
+<?php endfor; ?>';
+        $this->assertEquals($expected, $compiler->compileString($string));
+    }
+
+    public function testContinueStatementsWithSpacedArgumentAreCompiled()
+    {
+        $compiler = new BladeCompiler($this->getFiles(), __DIR__);
+        $string = '@for ($i = 0; $i < 10; $i++)
+test
+@continue( 2 )
+@endfor';
+        $expected = '<?php for($i = 0; $i < 10; $i++): ?>
+test
+<?php continue 2; ?>
+<?php endfor; ?>';
+        $this->assertEquals($expected, $compiler->compileString($string));
+    }
+
+    public function testContinueStatementsWithFaultyArgumentAreCompiled()
+    {
+        $compiler = new BladeCompiler($this->getFiles(), __DIR__);
+        $string = '@for ($i = 0; $i < 10; $i++)
+test
+@continue(-2)
+@endfor';
+        $expected = '<?php for($i = 0; $i < 10; $i++): ?>
+test
+<?php continue 1; ?>
+<?php endfor; ?>';
+        $this->assertEquals($expected, $compiler->compileString($string));
+    }
+
     protected function getFiles()
     {
         return m::mock('Illuminate\Filesystem\Filesystem');


### PR DESCRIPTION
### Description
As per the [PHP documentation](http://php.net/manual/en/control-structures.break.php)
>break accepts an optional numeric argument which tells it how many nested enclosing structures are to be broken out of. The default value is 1, only the immediate enclosing structure is broken out of.

### Usage

To break out of 2 nested loops:

`@break(2)` compiles to `break 2;`

### Compatibility

* Previous expressions like `($user->id == 2)` are supported
* Checks for formatting with varying white-space: `@continue( 2 )` compiles to `continue 2;`
* Check the minimum amount of structures to break out of: 1
