### PR TITLE
[5.4] Use app name in markdown email header

### DIFF
--- a/src/Illuminate/Mail/resources/views/markdown/message.blade.php
+++ b/src/Illuminate/Mail/resources/views/markdown/message.blade.php
@@ -2,7 +2,7 @@
     {{-- Header --}}
     @slot('header')
         @component('mail::header', ['url' => config('app.url')])
-            Product Name
+            {{ config('app.name') }}
         @endcomponent
     @endslot
 


### PR DESCRIPTION
To match what [`html/message.blade.php`](https://github.com/laravel/framework/blob/tillkruss-patch-1/src/Illuminate/Mail/resources/views/html/message.blade.php) is doing.