### PR TITLE
[5.4] Set $name in Console\Command 

### DIFF
--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -121,7 +121,7 @@ class Command extends SymfonyCommand
     {
         list($name, $arguments, $options) = Parser::parse($this->signature);
 
-        parent::__construct($name);
+        parent::__construct($this->name = $name);
 
         // After parsing the signature we will spin through the arguments and options
         // and set them on this command. These will already be changed into proper


### PR DESCRIPTION
Symfony's `$name` member is, for some crazy reason, `private`. 

When the parent constructor is called from `configureUsingFluentDefinition()`, only the `$name` member of the subclass (`Symfony\Component\Console\Command\Command`) is set. Since it's private, the overridden $name in `Illuminate\Console\Command` (`$this->name`) is always `null`.

This fix sets the Laravel `Console\Command` $name member before calling the parent constructor.