### PR TITLE
[5.4] Suggest generating a new migration when using make:model

### DIFF
--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -40,13 +40,29 @@ class ModelMakeCommand extends GeneratorCommand
             return;
         }
 
-        if ($this->option('migration')) {
+        if ($this->option('migration') || $this->confirmNewMigration()) {
             $this->createMigration();
         }
 
         if ($this->option('controller')) {
             $this->createController();
         }
+    }
+
+    /**
+     * Ask if a new migration should be generated.
+     *
+     * @return bool
+     */
+    protected function confirmNewMigration()
+    {
+        $migrationClass = 'Create'.Str::plural((class_basename($this->argument('name')))).'Table';
+
+        if (class_exists($migrationClass)) {
+            return false;
+        }
+
+        return $this->confirm("A $migrationClass migration was not found. Do you want to generate it?", true);
     }
 
     /**


### PR DESCRIPTION
Maybe this can be convenient too? I always forget to pass the `--migration` option + this can be useful when generating  the model from `make:controller` 

https://s23.postimg.org/pahqwu40b/Screen_Shot_2017_01_27_at_21_34_40.png
