### PR TITLE
[5.5] Soft deleted models should still existing

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -736,8 +736,6 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 
         $this->performDeleteOnModel();
 
-        $this->exists = false;
-
         // Once the model has been deleted, we will fire off the deleted event so that
         // the developers may hook into post-delete operations. We will then return
         // a boolean true as the delete is presumably successful on the database.
@@ -766,6 +764,8 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     protected function performDeleteOnModel()
     {
         $this->setKeysForSaveQuery($this->newQueryWithoutScopes())->delete();
+
+        $this->exists = false;
     }
 
     /**


### PR DESCRIPTION
Hi, guys :)

When a model is soft deleted, its "exists" property should keep true. It was not completely removed and technically still existing.

This minor change will allow deleting and immediately forceDelete.

Example:

```
function someExample(Model $instance)
{
   //Independently of it uses SoftDeletes we can call delete()
   $instance->delete();

    if (someConditionToForceDeleteNow) {
        $instance->forceDelete();
    }
    return $instance;
}
```

If the instance was force deleted or not, equally the deleted_at attributes has been set and can be returned in the response.

Without this change, the instance will never be force deleted, and if we do not call the delete() before we will never have the deteleted_at date updated/set.
