### PR TITLE
[5.4] Default to null if amount isn’t set in 'factory'-helper

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -494,7 +494,7 @@ if (! function_exists('factory')) {
         $arguments = func_get_args();
 
         if (isset($arguments[1]) && is_string($arguments[1])) {
-            return $factory->of($arguments[0], $arguments[1])->times(isset($arguments[2]) ? $arguments[2] : 1);
+            return $factory->of($arguments[0], $arguments[1])->times(isset($arguments[2]) ? $arguments[2] : null);
         } elseif (isset($arguments[1])) {
             return $factory->of($arguments[0])->times($arguments[1]);
         } else {


### PR DESCRIPTION
Related to pull request #17493. Right now the 'factory' helper defaults the third parameter to '1' when the amount isn't set, so it always returns a Collection. After this change the helper only returns a Collection when the amount is set.