### PR TITLE
[5.4] Resolve relation from service container

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -484,7 +484,7 @@ trait HasRelationships
      */
     protected function newRelatedInstance($class)
     {
-        return tap(new $class, function ($instance) {
+        return tap(resolve($class), function ($instance) {
             if (! $instance->getConnectionName()) {
                 $instance->setConnection($this->connection);
             }


### PR DESCRIPTION
I noticed a limitation when creating packages was that you weren't able to easily extend package models as relations are concretions rather than abstractions.

Resolving the relation from the service container means we can override the package models, and tie them into our own projects by defining them in the service container.