### PR TITLE
Allow to set a custom path for the mix manifest

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -563,7 +563,7 @@ if (! function_exists('mix')) {
         static $shouldHotReload;
 
         if (! $manifest) {
-            if (! file_exists($manifestPath = public_path('mix-manifest.json'))) {
+            if (! file_exists($manifestPath = public_path(env('MIX_MANIFEST_PATH', 'mix-manifest.json')))) {
                 throw new Exception('The Mix manifest does not exist.');
             }
 


### PR DESCRIPTION
if anyone is customizing their webpack config to use another folder instead of the root of public, instead of writing their own helper they can set the manifest path on the environment variables.

I work in a project that has being in development for 2 years, starting with with Laravel 4.2, so we have had like 3 workflows for our frontend assets, we settle with Webpack like 6 months ago, then we upgraded to Laravel 5.2, by that time we already had our config and paths established, i had to write a simple service to get the filenames from our manifest (witch is stored in `public/dist`) to the view, i would be happy to be able to drop my service and use the built-in function for that and also to enable hot reloading on our development workflow like right away.

I don't know if this is really worth it and would love to hear suggestions on how to make that line simpler hehe, i did not wanted to make a new variable for that, but could be more convenient for code clarity.