### PR TITLE
[5.4] Fix session exists method

### DIFF
--- a/src/Illuminate/Session/Store.php
+++ b/src/Illuminate/Session/Store.php
@@ -175,7 +175,7 @@ class Store implements Session
     public function exists($key)
     {
         return ! collect(is_array($key) ? $key : func_get_args())->contains(function ($key) {
-            return ! Arr::exists($this->attributes, $key);
+            return ! Arr::has($this->attributes, $key);
         });
     }
 


### PR DESCRIPTION
In session we can use "dot" notation for array keys, but exists method uses Arr::exists (that don't support it), instead Arr::has
```
$data = [
    'key' => 'Value',
];

Session::put('data', $data);

// will return false
Session::exists('data.key');

// will return true
Session::has('data.key');
```