### PR TITLE
[5.4] Add fromDot() method to Illuminate\Support\Arr

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -94,6 +94,24 @@ class Arr
     }
 
     /**
+     * Create a new multi-dimensional associative array from a flattened
+     * array in dot notation.
+     *
+     * @param  array  $array
+     * @return array
+     */
+    public static function fromDot($array)
+    {
+        $results = [];
+
+        foreach ($array as $key => $value) {
+            static::set($results, $key, $value);
+        }
+
+        return $results;
+    }
+
+    /**
      * Get all of the given array except for a specified array of items.
      *
      * @param  array  $array

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -84,6 +84,20 @@ if (! function_exists('array_dot')) {
     }
 }
 
+if (! function_exists('array_from_dot')) {
+    /**
+     * Create a new multi-dimensional associative array from a flattened
+     * array in dot notation.
+     *
+     * @param  array   $array
+     * @return array
+     */
+    function array_from_dot($array)
+    {
+        return Arr::fromDot($array);
+    }
+}
+
 if (! function_exists('array_except')) {
     /**
      * Get all of the given array except for a specified array of items.

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -57,6 +57,21 @@ class SupportArrTest extends TestCase
         $this->assertEquals(['foo.bar' => []], $array);
     }
 
+    public function testFromDot()
+    {
+        $array = Arr::fromDot(['foo.bar' => 'baz']);
+        $this->assertEquals(['foo' => ['bar' => 'baz']], $array);
+
+        $array = Arr::fromDot([]);
+        $this->assertEquals([], $array);
+
+        $array = Arr::fromDot(['foo.bar' => []]);
+        $this->assertEquals(['foo' => ['bar' => []]], $array);
+
+        $array = Arr::fromDot(['foo.bar' => [], 'foo.baz' => 'bar']);
+        $this->assertEquals(['foo' => ['bar' => [], 'baz' => 'bar']], $array);
+    }
+
     public function testExcept()
     {
         $array = ['name' => 'Desk', 'price' => 100];


### PR DESCRIPTION
This is a new transformation method on the `Illuminate\Support\Arr` class to complement `Arr::dot()`, by returning a multi-dimensional array from a flattened one, removing the need to manually loop through flattened arrays using `array_set()`. Please see below the intended new documentation entry:

#### `array_from_dot()`

The `array_from_dot` function returns a new multi-dimensional array from a flattened array in "dot" notation:

```php
$array = array_from_dot(['foo.bar' => 'baz']);

// ['foo' => ['bar' => 'baz']];
```

**The name of this method is totally up for discussion!**

Final note: `array_set()` is awesome. Originally had a bit more logic to handle mixed dot/multi-dimensional cases, but assuming a completely flattened array is provided, it is completely adequate for this method. If users want to handle an array with mixed dot notation keys and nested arrays, it should be passed to `array_dot()` first.