### PR TITLE
[5.4] Update pluck documentation to accept array

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -614,7 +614,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Get the values of a given key.
      *
-     * @param  string  $value
+     * @param  string|array  $value
      * @param  string|null  $key
      * @return static
      */

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -304,6 +304,16 @@ class SupportArrTest extends TestCase
         $this->assertEquals(['Taylor', 'Abigail'], $array);
     }
 
+    public function testPluckWithArrayValue()
+    {
+        $array = [
+            ['developer' => ['name' => 'Taylor']],
+            ['developer' => ['name' => 'Abigail']],
+        ];
+        $array = Arr::pluck($array, ['developer', 'name']);
+        $this->assertEquals(['Taylor', 'Abigail'], $array);
+    }
+
     public function testPluckWithKeys()
     {
         $array = [


### PR DESCRIPTION
Since Arr::pluck [accepts](https://github.com/laravel/framework/blob/01be2355d40bcacaaf06ae6b21d1d687d0d07dd2/src/Illuminate/Support/Arr.php#L344) it as well. I also added a test for Arr where this behaviour is explicitly stated.