### PR TITLE
Fix Collections's filter() discarding values == 0

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -305,7 +305,11 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
             return new static(Arr::where($this->items, $callback));
         }
 
-        return new static(array_filter($this->items));
+        return new static(array_filter($this->items, function($value) {
+            return (! is_null($value)) &&
+                (! is_bool($value) || $value !== false) &&
+                (! is_string($value) || $value !== '');
+        }));
     }
 
     /**

--- a/tests/Database/DatabaseEloquentBelongsToTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToTest.php
@@ -28,8 +28,8 @@ class DatabaseEloquentBelongsToTest extends TestCase
     public function testEagerConstraintsAreProperlyAdded()
     {
         $relation = $this->getRelation();
-        $relation->getQuery()->shouldReceive('whereIn')->once()->with('relation.id', ['foreign.value', 'foreign.value.two']);
-        $models = [new EloquentBelongsToModelStub, new EloquentBelongsToModelStub, new AnotherEloquentBelongsToModelStub];
+        $relation->getQuery()->shouldReceive('whereIn')->once()->with('relation.id', ['foreign.value', 'foreign.value.two', 0]);
+        $models = [new EloquentBelongsToModelStub, new EloquentBelongsToModelStub, new AnotherEloquentBelongsToModelStub, new EloquentBelongsToModelStubWithIdZero];
         $relation->addEagerConstraints($models);
     }
 
@@ -141,6 +141,11 @@ class EloquentBelongsToModelStub extends \Illuminate\Database\Eloquent\Model
 class AnotherEloquentBelongsToModelStub extends \Illuminate\Database\Eloquent\Model
 {
     public $foreign_key = 'foreign.value.two';
+}
+
+class EloquentBelongsToModelStubWithIdZero extends \Illuminate\Database\Eloquent\Model
+{
+    public $foreign_key = 0;
 }
 
 class MissingEloquentBelongsToModelStub extends \Illuminate\Database\Eloquent\Model

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -318,6 +318,9 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(['first' => 'Hello', 'second' => 'World'], $c->filter(function ($item, $key) {
             return $key != 'id';
         })->all());
+
+        $c = new Collection(['first' => 'Hello', 'second' => 'World', 'zero' => 0]);
+        $this->assertEquals(['first' => 'Hello', 'second' => 'World', 'zero' => 0], $c->filter()->all());
     }
 
     public function testWhere()


### PR DESCRIPTION
BelongsTo is not able to eager load relations when the `id == 0`. In my opinion `$collection->filter()` should not discard zeroes at all, only nulls, booleans (false) and empty strings (''). And maybe not even booleans, because `false` is also a value (`[something_is_enabled => false]`), but that's something we can probably filter using a closure.

This is a bug introduced in 5.4.