### PR TITLE
[5.4] Add Schema to notifications.stub for consistency

### DIFF
--- a/src/Illuminate/Notifications/Console/stubs/notifications.stub
+++ b/src/Illuminate/Notifications/Console/stubs/notifications.stub
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
 


### PR DESCRIPTION
This adds `use Illuminate\Support\Facades\Schema;` to the stub file for notification tables.

This is for consistency - as every other stub migration generated by the framework includes this. Same as  `make:migration` also includes this in all generated migration files.


The alternative - as it currently works without including the Facade - should we remove `use Illuminate\Support\Facades\Schema;` from all stubs instead? I tried it and it works on my fresh copy of `5.4` - but I wasnt sure if there might be unintended consequences (perhaps with namespaced migrations?)
