### PR TITLE
[5.4] Fix eager load on belongsTo when ID is 0

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
@@ -121,7 +121,11 @@ class BelongsTo extends Relation
         // execute a "where in" statement to gather up all of those related records.
         $keys = collect($models)->map(function ($model) {
             return $model->{$this->foreignKey};
-        })->filter()->all();
+        })->filter(function($value) {
+            return (! is_null($value)) &&
+                (! is_bool($value) || $value !== false) &&
+                (! is_string($value) || $value !== '');
+        })->all();
 
         // If there are no keys that were not null we will just return an array with either
         // null or 0 in (depending on if incrementing keys are in use) so the query wont

--- a/tests/Database/DatabaseEloquentBelongsToTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToTest.php
@@ -30,6 +30,8 @@ class DatabaseEloquentBelongsToTest extends TestCase
         $relation = $this->getRelation();
         $relation->getQuery()->shouldReceive('whereIn')->once()->with('relation.id', ['foreign.value', 'foreign.value.two']);
         $models = [new EloquentBelongsToModelStub, new EloquentBelongsToModelStub, new AnotherEloquentBelongsToModelStub];
+        $relation->getQuery()->shouldReceive('whereIn')->once()->with('relation.id', ['foreign.value', 'foreign.value.two', 0]);
+        $models = [new EloquentBelongsToModelStub, new EloquentBelongsToModelStub, new AnotherEloquentBelongsToModelStub, new EloquentBelongsToModelStubWithIdZero];
         $relation->addEagerConstraints($models);
     }
 
@@ -141,6 +143,11 @@ class EloquentBelongsToModelStub extends \Illuminate\Database\Eloquent\Model
 class AnotherEloquentBelongsToModelStub extends \Illuminate\Database\Eloquent\Model
 {
     public $foreign_key = 'foreign.value.two';
+}
+
+class EloquentBelongsToModelStubWithIdZero extends \Illuminate\Database\Eloquent\Model
+{
+    public $foreign_key = 0;   
 }
 
 class MissingEloquentBelongsToModelStub extends \Illuminate\Database\Eloquent\Model


### PR DESCRIPTION
Since array_filter by default removes elements which are equal to 0, when having a record with and ID = 0 the eager load won't work properly.