### PR TITLE
[5.4] Fix BelongsTo not accepting id == 0 in foreign relations

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
@@ -116,12 +116,16 @@ class BelongsTo extends Relation
      */
     protected function getEagerModelKeys(array $models)
     {
+        $keys = [];
+
         // First we need to gather all of the keys from the parent models so we know what
         // to query for via the eager loading query. We will add them to an array then
         // execute a "where in" statement to gather up all of those related records.
-        $keys = collect($models)->map(function ($model) {
-            return $model->{$this->foreignKey};
-        })->filter()->all();
+        foreach ($models as $model) {
+            if (! is_null($value = $model->{$this->foreignKey})) {
+                $keys[] = $value;
+            }
+        }
 
         // If there are no keys that were not null we will just return an array with either
         // null or 0 in (depending on if incrementing keys are in use) so the query wont

--- a/tests/Database/DatabaseEloquentBelongsToTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToTest.php
@@ -33,6 +33,14 @@ class DatabaseEloquentBelongsToTest extends TestCase
         $relation->addEagerConstraints($models);
     }
 
+    public function testIdsInEagerConstraintsCanBeZero()
+    {
+        $relation = $this->getRelation();
+        $relation->getQuery()->shouldReceive('whereIn')->once()->with('relation.id', ['foreign.value', 0]);
+        $models = [new EloquentBelongsToModelStub, new EloquentBelongsToModelStubWithZeroId];
+        $relation->addEagerConstraints($models);
+    }
+
     public function testRelationIsProperlyInitialized()
     {
         $relation = $this->getRelation();
@@ -141,6 +149,11 @@ class EloquentBelongsToModelStub extends \Illuminate\Database\Eloquent\Model
 class AnotherEloquentBelongsToModelStub extends \Illuminate\Database\Eloquent\Model
 {
     public $foreign_key = 'foreign.value.two';
+}
+
+class EloquentBelongsToModelStubWithZeroId extends \Illuminate\Database\Eloquent\Model
+{
+    public $foreign_key = 0;
 }
 
 class MissingEloquentBelongsToModelStub extends \Illuminate\Database\Eloquent\Model


### PR DESCRIPTION
BelongsTo is not able to eager load relations when the id == 0. 

This is a bug introduced in 5.4.

[The code in 5.3](https://github.com/laravel/framework/blob/5.3/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php#L168) only checked for nulls:

        foreach ($models as $model) {
            if (! is_null($value = $model->{$this->foreignKey})) {
                $keys[] = $value;
            }
        }

In 5.4, as it is using `array_filter()`, it's now also excluding `''`, `false` and `0`.