### PR TITLE
[5.4] Job deleted callback + job optimization

### DIFF
--- a/src/Illuminate/Queue/CallQueuedHandler.php
+++ b/src/Illuminate/Queue/CallQueuedHandler.php
@@ -35,12 +35,12 @@ class CallQueuedHandler
     }
 
     /**
-     * Unserialize the command
+     * Unserialize the command from the data array
      *
-     * @param $data
+     * @param array $data
      * @return Job
      */
-    protected function command($data)
+    protected function command(array $data)
     {
         if ($this->jobCommand) {
             return $this->jobCommand;

--- a/src/Illuminate/Queue/CallQueuedHandler.php
+++ b/src/Illuminate/Queue/CallQueuedHandler.php
@@ -15,9 +15,9 @@ class CallQueuedHandler
     protected $dispatcher;
 
     /**
-     * The command that has been unserialized
+     * The command that has been unserialized.
      * This is a cache for the deleted and failed callback.
-     * Set the first time the command method is called
+     * Set the first time the command method is called.
      *
      * @var mixed
      */
@@ -35,7 +35,7 @@ class CallQueuedHandler
     }
 
     /**
-     * Unserialize the command from the data array
+     * Unserialize the command from the data array.
      *
      * @param array $data
      * @return Job

--- a/src/Illuminate/Queue/CallQueuedHandler.php
+++ b/src/Illuminate/Queue/CallQueuedHandler.php
@@ -110,8 +110,8 @@ class CallQueuedHandler
      *
      * The exception that caused the failure will be passed.
      *
-     * @param  array      $data
-     * @param  \Exception $e
+     * @param  array  $data
+     * @param  \Exception  $e
      * @return void
      */
     public function failed(array $data, $e)

--- a/src/Illuminate/Queue/FailingJob.php
+++ b/src/Illuminate/Queue/FailingJob.php
@@ -28,9 +28,9 @@ class FailingJob
             // If the job has failed, we will delete it, call the "failed" method and then call
             // an event indicating the job has failed so it can be logged if needed. This is
             // to allow every developer to better keep monitor of their failed queue jobs.
-            $job->delete();
-
             $job->failed($e);
+
+            $job->delete();
         } finally {
             static::events()->fire(new JobFailed(
                 $connectionName, $job, $e ?: new ManuallyFailedException

--- a/tests/Queue/QueueBeanstalkdJobTest.php
+++ b/tests/Queue/QueueBeanstalkdJobTest.php
@@ -36,6 +36,8 @@ class QueueBeanstalkdJobTest extends TestCase
     {
         $job = $this->getJob();
         $job->getPheanstalk()->shouldReceive('delete')->once()->with($job->getPheanstalkJob());
+        $job->getPheanstalkJob()->shouldReceive('getData')->once();
+        $job->getContainer()->shouldReceive('make')->once()->with('')->andReturn($handler = m::mock('StdClass'));
 
         $job->delete();
     }

--- a/tests/Queue/QueueRedisJobTest.php
+++ b/tests/Queue/QueueRedisJobTest.php
@@ -24,6 +24,7 @@ class QueueRedisJobTest extends TestCase
     public function testDeleteRemovesTheJobFromRedis()
     {
         $job = $this->getJob();
+        $job->getContainer()->shouldReceive('make')->once()->with('foo')->andReturn($handler = m::mock('StdClass'));
         $job->getRedisQueue()->shouldReceive('deleteReserved')->once()
             ->with('default', $job);
 

--- a/tests/Queue/QueueSqsJobTest.php
+++ b/tests/Queue/QueueSqsJobTest.php
@@ -66,6 +66,7 @@ class QueueSqsJobTest extends TestCase
         $queue = $this->getMockBuilder('Illuminate\Queue\SqsQueue')->setMethods(['getQueue'])->setConstructorArgs([$this->mockedSqsClient, $this->queueName, $this->account])->getMock();
         $queue->setContainer($this->mockedContainer);
         $job = $this->getJob();
+        $job->getContainer()->shouldReceive('make')->once()->with('foo')->andReturn($handler = m::mock('StdClass'));
         $job->getSqs()->expects($this->once())->method('deleteMessage')->with(['QueueUrl' => $this->queueUrl, 'ReceiptHandle' => $this->mockedReceiptHandle]);
         $job->delete();
     }

--- a/tests/Queue/RedisQueueIntegrationTest.php
+++ b/tests/Queue/RedisQueueIntegrationTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\TestCase;
 use Illuminate\Queue\RedisQueue;
 use Illuminate\Container\Container;
 use Illuminate\Queue\Jobs\RedisJob;
+use Illuminate\Queue\CallQueuedHandler;
 use Illuminate\Tests\Redis\InteractsWithRedis;
 
 class RedisQueueIntegrationTest extends TestCase
@@ -24,7 +25,8 @@ class RedisQueueIntegrationTest extends TestCase
         $this->setUpRedis();
 
         $this->queue = new RedisQueue($this->redis);
-        $this->queue->setContainer(m::mock(Container::class));
+        $container = m::mock(Container::class);
+        $this->queue->setContainer($container);
     }
 
     public function tearDown()
@@ -246,6 +248,7 @@ class RedisQueueIntegrationTest extends TestCase
 
         /** @var \Illuminate\Queue\Jobs\RedisJob $redisJob */
         $redisJob = $this->queue->pop();
+        $redisJob->getContainer()->shouldReceive('make')->once()->with(CallQueuedHandler::class)->andReturn($handler = m::mock('StdClass'));
 
         $redisJob->delete();
 
@@ -267,6 +270,7 @@ class RedisQueueIntegrationTest extends TestCase
         $this->assertEquals(3, $this->queue->size());
         $job = $this->queue->pop();
         $this->assertEquals(3, $this->queue->size());
+        $job->getContainer()->shouldReceive('make')->once()->with(CallQueuedHandler::class)->andReturn($handler = m::mock('StdClass'));
         $job->delete();
         $this->assertEquals(2, $this->queue->size());
     }


### PR DESCRIPTION
# Purpose

Having the equivalent of a finally in a try/catch clause but for the job. (deleted callback on a job).

# Difference with #17430 

Keep the instance of the CallQueuedHandler in memory for the time the job is involved with it (fire/failed/deleted).

CallQueuedHandler keep the unserialized instance, meaning, the handler only unserialize once the command to avoid multiple call to the database as was pointed out by @taylorotwell .

This patch mean that when a job fail, we don't unserialize it again, it was already done when we called it. This reduce the number of sql request in the case of a failure.