### PR TITLE
[5.4] Reverse stack

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesStacks.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesStacks.php
@@ -47,26 +47,4 @@ trait CompilesStacks
     {
         return '<?php $__env->stopPush(); ?>';
     }
-
-    /**
-     * Compile the prepend statements into valid PHP.
-     *
-     * @param  string  $expression
-     * @return string
-     */
-    protected function compilePrepend($expression)
-    {
-        return "<?php \$__env->startPrepend{$expression}; ?>";
-    }
-
-    /**
-     * Compile the end-prepend statements into valid PHP.
-     *
-     * @param  string  $expression
-     * @return string
-     */
-    protected function compileEndprepend($expression)
-    {
-        return '<?php $__env->stopPrepend(); ?>';
-    }
 }

--- a/src/Illuminate/View/Compilers/Concerns/CompilesStacks.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesStacks.php
@@ -40,10 +40,9 @@ trait CompilesStacks
     /**
      * Compile the end-push statements into valid PHP.
      *
-     * @param  string  $expression
      * @return string
      */
-    protected function compileEndpush($expression)
+    protected function compileEndpush()
     {
         return '<?php $__env->stopPush(); ?>';
     }

--- a/src/Illuminate/View/Compilers/Concerns/CompilesStacks.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesStacks.php
@@ -16,6 +16,17 @@ trait CompilesStacks
     }
 
     /**
+     * Compile the reverse-stack statements into the content.
+     *
+     * @param  string  $expression
+     * @return string
+     */
+    protected function compileReversestack($expression)
+    {
+        return "<?php echo \$__env->yieldReversedPushContent{$expression}; ?>";
+    }
+
+    /**
      * Compile the push statements into valid PHP.
      *
      * @param  string  $expression
@@ -29,10 +40,33 @@ trait CompilesStacks
     /**
      * Compile the end-push statements into valid PHP.
      *
+     * @param  string  $expression
      * @return string
      */
-    protected function compileEndpush()
+    protected function compileEndpush($expression)
     {
         return '<?php $__env->stopPush(); ?>';
+    }
+
+    /**
+     * Compile the prepend statements into valid PHP.
+     *
+     * @param  string  $expression
+     * @return string
+     */
+    protected function compilePrepend($expression)
+    {
+        return "<?php \$__env->startPrepend{$expression}; ?>";
+    }
+
+    /**
+     * Compile the end-prepend statements into valid PHP.
+     *
+     * @param  string  $expression
+     * @return string
+     */
+    protected function compileEndprepend($expression)
+    {
+        return '<?php $__env->stopPrepend(); ?>';
     }
 }

--- a/src/Illuminate/View/Concerns/ManagesStacks.php
+++ b/src/Illuminate/View/Concerns/ManagesStacks.php
@@ -92,6 +92,22 @@ trait ManagesStacks
     }
 
     /**
+     * Get the string contents of a push section in reverse order.
+     *
+     * @param  string  $section
+     * @param  string  $default
+     * @return string
+     */
+    public function yieldReversedPushContent($section, $default = '')
+    {
+        if (isset($this->pushes[$section])) {
+            return implode(array_reverse($this->pushes[$section]));
+        }
+
+        return $default;
+    }
+
+    /**
      * Flush all of the stacks.
      *
      * @return void


### PR DESCRIPTION
A `@reversestack` works like a `@stack` however it yields content in a reverse order.

Applications upgrading from 5.3 can use the new `@reversestack` to maintain the reverse order of yielding used in 5.3