### PR TITLE
[5.4] Trim double quotes from section name

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesLayouts.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesLayouts.php
@@ -38,7 +38,7 @@ trait CompilesLayouts
      */
     protected function compileSection($expression)
     {
-        $this->lastSection = trim($expression, "()'");
+        $this->lastSection = trim($expression, "()'\"");
 
         return "<?php \$__env->startSection{$expression}; ?>";
     }


### PR DESCRIPTION
Fixes https://github.com/laravel/framework/issues/17670

TLDR:

`@section('header')` works but `@section("header")` doesn't.