### PR TITLE
[5.4] Fix parsing explicit rules

### DIFF
--- a/src/Illuminate/Validation/ValidationRuleParser.php
+++ b/src/Illuminate/Validation/ValidationRuleParser.php
@@ -151,7 +151,7 @@ class ValidationRuleParser
         $merge = head($this->explodeRules([$rules]));
 
         $results[$attribute] = array_merge(
-            isset($results[$attribute]) ? $results[$attribute] : [], $merge
+            isset($results[$attribute]) ? $this->explodeExplicitRule($results[$attribute]) : [], $merge
         );
 
         return $results;

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -2639,6 +2639,9 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['foo' => [1, 2, 3, 4]], ['foo' => 'size:4']);
         $this->assertTrue($v->passes());
 
+        $v = new Validator($trans, ['foo' => [1, 2, 3, 4]], ['foo.*' => 'integer', 'foo.0' => 'required']);
+        $this->assertTrue($v->passes());
+
         $v = new Validator($trans, ['foo' => [['bar' => [1, 2, 3]], ['bar' => [1, 2, 3]]]], ['foo.*.bar' => 'size:4']);
         $this->assertFalse($v->passes());
 


### PR DESCRIPTION
This PR fixes the case mentioned in https://github.com/laravel/framework/issues/17660

Using `explodeExplicitRule()` converts a string rule representation to an array, without that `array_merge()` errors.