### PR TITLE
[5.4] Fixed Missing Options in queue:listen (#17645)

### DIFF
--- a/src/Illuminate/Queue/Console/ListenCommand.php
+++ b/src/Illuminate/Queue/Console/ListenCommand.php
@@ -92,7 +92,8 @@ class ListenCommand extends Command
     {
         return new ListenerOptions(
             $this->option('env'), $this->option('delay'),
-            $this->option('memory'), $this->option('timeout')
+            $this->option('memory'), $this->option('timeout'),
+            $this->option('tries'), $this->option('force')
         );
     }
 


### PR DESCRIPTION
ListenerOptions was missing force and tries options as parameters.