### PR TITLE
[5.4] Fix SessionGuard.php recaller method when request is null

### DIFF
--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -183,7 +183,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
      */
     protected function recaller()
     {
-        if ($recaller = $this->request->cookies->get($this->getRecallerName())) {
+        if (! is_null($this->request) && $recaller = $this->request->cookies->get($this->getRecallerName())) {
             return new Recaller($recaller);
         }
     }


### PR DESCRIPTION
`recaller()` method throws a non-object exception when `$request` is null.  Null appears to be allowed behavior for `$request` as the constructor default is null.  `recaller()` method is called by the `user()` method on line 140 the response is then checked for null on line 142.  I believe in current form the `recaller()` method will never return null if `$request` is null.