### PR TITLE
[5.4] [POC] Introduce a @prepend for stack

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesStacks.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesStacks.php
@@ -35,4 +35,25 @@ trait CompilesStacks
     {
         return '<?php $__env->stopPush(); ?>';
     }
+
+    /**
+     * Compile the prepend statements into valid PHP.
+     *
+     * @param  string  $expression
+     * @return string
+     */
+    protected function compilePrepend($expression)
+    {
+        return "<?php \$__env->startPrepend{$expression}; ?>";
+    }
+
+    /**
+     * Compile the end-prepend statements into valid PHP.
+     *
+     * @return string
+     */
+    protected function compileEndprepend()
+    {
+        return '<?php $__env->stopPrepend(); ?>';
+    }
 }

--- a/src/Illuminate/View/Concerns/ManagesStacks.php
+++ b/src/Illuminate/View/Concerns/ManagesStacks.php
@@ -14,6 +14,13 @@ trait ManagesStacks
     protected $pushes = [];
 
     /**
+     * All of the finished, captured prepend sections.
+     *
+     * @var array
+     */
+    protected $prepends = [];
+
+    /**
      * The stack of in-progress push sections.
      *
      * @var array
@@ -56,6 +63,41 @@ trait ManagesStacks
     }
 
     /**
+     * Start prepending content into a push section.
+     *
+     * @param  string  $section
+     * @param  string  $content
+     * @return void
+     */
+    public function startPrepend($section, $content = '')
+    {
+        if ($content === '') {
+            if (ob_start()) {
+                $this->pushStack[] = $section;
+            }
+        } else {
+            $this->extendPrepend($section, $content);
+        }
+    }
+
+    /**
+     * Stop prepending content into a push section.
+     *
+     * @return string
+     * @throws \InvalidArgumentException
+     */
+    public function stopPrepend()
+    {
+        if (empty($this->pushStack)) {
+            throw new InvalidArgumentException('Cannot end a prepend stack without first starting one.');
+        }
+
+        return tap(array_pop($this->pushStack), function ($last) {
+            $this->extendPrepend($last, ob_get_clean());
+        });
+    }
+
+    /**
      * Append content to a given push section.
      *
      * @param  string  $section
@@ -76,6 +118,26 @@ trait ManagesStacks
     }
 
     /**
+     * Prepend content to a given stack.
+     *
+     * @param  string  $section
+     * @param  string  $content
+     * @return void
+     */
+    protected function extendPrepend($section, $content)
+    {
+        if (! isset($this->prepends[$section])) {
+            $this->prepends[$section] = [];
+        }
+
+        if (! isset($this->prepends[$section][$this->renderCount])) {
+            $this->prepends[$section][$this->renderCount] = $content;
+        } else {
+            $this->prepends[$section][$this->renderCount] = $content.$this->prepends[$section][$this->renderCount];
+        }
+    }
+
+    /**
      * Get the string contents of a push section.
      *
      * @param  string  $section
@@ -84,11 +146,21 @@ trait ManagesStacks
      */
     public function yieldPushContent($section, $default = '')
     {
-        if (isset($this->pushes[$section])) {
-            return implode($this->pushes[$section]);
+        if (! isset($this->pushes[$section]) && ! isset($this->prepends[$section])) {
+            return $default;
         }
 
-        return $default;
+        $output = '';
+
+        if (isset($this->prepends[$section])) {
+            $output .= implode(array_reverse($this->prepends[$section]));
+        }
+
+        if (isset($this->pushes[$section])) {
+            $output .= implode($this->pushes[$section]);
+        }
+
+        return $output;
     }
 
     /**


### PR DESCRIPTION
`@push()` will add content to the stack starting from the view being rendered, `@prepend` will add content to the beginning of the stack.

`@stack()` will display the `$prepends` in reverse order + the `$pushes` in normal order.

```
// layout.blade

@stack('letters')
```

```
// master.blade

@extends('layout')

@push('letters', 'A')

@prepend('letters', 'B')
```

```
// welcome.blade

@extends('master')

@push('letters', 'C')

@prepend('letters', 'D')
```

Having `View::make('welcome')`, the output will be:

```
BDCA
```