### PR TITLE
[5.4] Cast to html in Eloquent

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -3,11 +3,11 @@
 namespace Illuminate\Database\Eloquent\Concerns;
 
 use Carbon\Carbon;
-use Illuminate\Support\HtmlString;
 use LogicException;
 use DateTimeInterface;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
+use Illuminate\Support\HtmlString;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Collection as BaseCollection;

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Database\Eloquent\Concerns;
 
 use Carbon\Carbon;
+use Illuminate\Support\HtmlString;
 use LogicException;
 use DateTimeInterface;
 use Illuminate\Support\Arr;
@@ -164,6 +165,12 @@ trait HasAttributes
     {
         foreach ($this->getCasts() as $key => $value) {
             if (! array_key_exists($key, $attributes) || in_array($key, $mutatedAttributes)) {
+                continue;
+            }
+
+            // If the attribute cast was html, we don't want to cast the value to an HtmlString
+            // since we will generally want to use a plain text string in the array instead.
+            if ($attributes[$key] && $value === 'html') {
                 continue;
             }
 
@@ -484,6 +491,8 @@ trait HasAttributes
                 return $this->asDateTime($value);
             case 'timestamp':
                 return $this->asTimestamp($value);
+            case 'html':
+                return new HtmlString($value);
             default:
                 return $value;
         }

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1358,6 +1358,7 @@ class DatabaseEloquentModelTest extends TestCase
         $model->dateAttribute = '1969-07-20';
         $model->datetimeAttribute = '1969-07-20 22:56:00';
         $model->timestampAttribute = '1969-07-20 22:56:00';
+        $model->htmlAttribute = '<p>Foo</p>';
 
         $this->assertInternalType('int', $model->intAttribute);
         $this->assertInternalType('float', $model->floatAttribute);
@@ -1378,6 +1379,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEquals('1969-07-20', $model->dateAttribute->toDateString());
         $this->assertEquals('1969-07-20 22:56:00', $model->datetimeAttribute->toDateTimeString());
         $this->assertEquals(-14173440, $model->timestampAttribute);
+        $this->assertInstanceOf('Illuminate\Support\HtmlString', $model->htmlAttribute);
 
         $arr = $model->toArray();
         $this->assertInternalType('int', $arr['intAttribute']);
@@ -1396,6 +1398,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEquals('1969-07-20 00:00:00', $arr['dateAttribute']);
         $this->assertEquals('1969-07-20 22:56:00', $arr['datetimeAttribute']);
         $this->assertEquals(-14173440, $arr['timestampAttribute']);
+        $this->assertEquals('<p>Foo</p>', $arr['htmlAttribute']);
     }
 
     public function testModelDateAttributeCastingResetsTime()
@@ -1876,6 +1879,7 @@ class EloquentModelCastingStub extends Model
         'dateAttribute' => 'date',
         'datetimeAttribute' => 'datetime',
         'timestampAttribute' => 'timestamp',
+        'htmlAttribute' => 'html',
     ];
 
     public function jsonAttributeValue()


### PR DESCRIPTION
This PR adds an `html` cast type, which wraps the value in an `HtmlString`. When converting the model to an array, the value will remain a string.

```php
class Post extends Model
{
    protected $casts = [
        'body' => 'html',
    ];
}
```

Html attributes don't need `{!! !!}` tags anymore.

```
<div>
    {{ $post->body }}
</div>
```

```php
$post->body; // `Illuminate\Support\HtmlString` instance
$post->toArray()['body']; // Plain string
```