### PR TITLE
[5.4] Macroable relations

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -5,12 +5,17 @@ namespace Illuminate\Database\Eloquent\Relations;
 use Closure;
 use Illuminate\Support\Arr;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Traits\Macroable;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Query\Expression;
 use Illuminate\Database\Eloquent\Collection;
 
 abstract class Relation
 {
+    use Macroable {
+        __call as macroCall;
+    }
+
     /**
      * The Eloquent query builder instance.
      *
@@ -328,6 +333,10 @@ abstract class Relation
      */
     public function __call($method, $parameters)
     {
+        if (static::hasMacro($method)) {
+            return $this->macroCall($method, $parameters);
+        }
+
         $result = call_user_func_array([$this->query, $method], $parameters);
 
         if ($result === $this->query) {

--- a/tests/Database/DatabaseEloquentRelationTest.php
+++ b/tests/Database/DatabaseEloquentRelationTest.php
@@ -64,6 +64,19 @@ class DatabaseEloquentRelationTest extends TestCase
 
         Relation::morphMap([], false);
     }
+
+    public function testMacroable()
+    {
+        Relation::macro('foo', function () {
+            return 'foo';
+        });
+
+        $model = new EloquentRelationResetModelStub();
+        $relation = new EloquentRelationStub($model->newQuery(), $model);
+
+        $result = $relation->foo();
+        $this->assertEquals('foo', $result);
+    }
 }
 
 class EloquentRelationResetModelStub extends Model


### PR DESCRIPTION
Does what it says on the tin. Makes relations `Macroable` so one could, say, add a `toHasOne` method to `HasMany` without subclassing it.

h/t to @adamwathan for getting the gears turning on this idea.