### PR TITLE
[5.4] Add macros to Eloquent/Builder

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -40,11 +40,18 @@ class Builder
     protected $eagerLoad = [];
 
     /**
-     * All of the registered builder macros.
+     * All of the globally registered builder macros.
      *
      * @var array
      */
-    protected $macros = [];
+    protected static $macros = [];
+
+    /**
+     * All of the locally registered builder macros.
+     *
+     * @var array
+     */
+    protected $localMacros = [];
 
     /**
      * A replacement for the typical delete function.
@@ -1274,18 +1281,6 @@ class Builder
     }
 
     /**
-     * Extend the builder with a given callback.
-     *
-     * @param  string    $name
-     * @param  \Closure  $callback
-     * @return void
-     */
-    public function macro($name, Closure $callback)
-    {
-        $this->macros[$name] = $callback;
-    }
-
-    /**
      * Get the given macro by name.
      *
      * @param  string  $name
@@ -1293,7 +1288,7 @@ class Builder
      */
     public function getMacro($name)
     {
-        return Arr::get($this->macros, $name);
+        return Arr::get($this->localMacros, $name);
     }
 
     /**
@@ -1305,10 +1300,24 @@ class Builder
      */
     public function __call($method, $parameters)
     {
-        if (isset($this->macros[$method])) {
+        if ($method === 'macro') {
+            $this->localMacros[$parameters[0]] = $parameters[1];
+
+            return;
+        }
+
+        if (isset($this->localMacros[$method])) {
             array_unshift($parameters, $this);
 
-            return $this->macros[$method](...$parameters);
+            return $this->localMacros[$method](...$parameters);
+        }
+
+        if (isset(static::$macros[$method]) and static::$macros[$method] instanceof Closure) {
+            return call_user_func_array(static::$macros[$method]->bindTo($this, static::class), $parameters);
+        }
+
+        if (isset(static::$macros[$method])) {
+            return call_user_func_array(static::$macros[$method]->bindTo($this, static::class), $parameters);
         }
 
         if (method_exists($this->model, $scope = 'scope'.ucfirst($method))) {
@@ -1322,6 +1331,34 @@ class Builder
         $this->query->{$method}(...$parameters);
 
         return $this;
+    }
+
+    /**
+     * Dynamically handle calls into the query instance.
+     *
+     * @param  string  $method
+     * @param  array   $parameters
+     * @return mixed
+     *
+     * @throws \BadMethodCallException
+     */
+    public static function __callStatic($method, $parameters)
+    {
+        if ($method === 'macro') {
+            static::$macros[$parameters[0]] = $parameters[1];
+
+            return;
+        }
+
+        if (! isset(static::$macros[$method])) {
+            throw new BadMethodCallException("Method {$method} does not exist.");
+        }
+
+        if (static::$macros[$method] instanceof Closure) {
+            return call_user_func_array(Closure::bind(static::$macros[$method], null, static::class), $parameters);
+        }
+
+        return call_user_func_array(static::$macros[$method], $parameters);
     }
 
     /**

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -351,7 +351,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertEquals(['bar', 'baz'], $builder->pluck('name')->all());
     }
 
-    public function testMacrosAreCalledOnBuilder()
+    public function testLocalMacrosAreCalledOnBuilder()
     {
         unset($_SERVER['__test.builder']);
         $builder = new \Illuminate\Database\Eloquent\Builder(new \Illuminate\Database\Query\Builder(
@@ -369,6 +369,15 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertEquals($builder, $result);
         $this->assertEquals($builder, $_SERVER['__test.builder']);
         unset($_SERVER['__test.builder']);
+    }
+
+    public function testGlobalMacrosAreCalledOnBuilder()
+    {
+        Builder::macro('foo', function ($bar) {
+            return $bar;
+        });
+
+        $this->assertEquals($this->getBuilder()->foo('bar'), 'bar');
     }
 
     public function testGetModelsProperlyHydratesModels()

--- a/tests/Database/DatabaseSoftDeletingScopeTest.php
+++ b/tests/Database/DatabaseSoftDeletingScopeTest.php
@@ -25,8 +25,11 @@ class DatabaseSoftDeletingScopeTest extends TestCase
 
     public function testRestoreExtension()
     {
-        $builder = m::mock('Illuminate\Database\Eloquent\Builder');
-        $builder->shouldDeferMissing();
+        $builder = new \Illuminate\Database\Eloquent\Builder(new \Illuminate\Database\Query\Builder(
+            m::mock('Illuminate\Database\ConnectionInterface'),
+            m::mock('Illuminate\Database\Query\Grammars\Grammar'),
+            m::mock('Illuminate\Database\Query\Processors\Processor')
+        ));
         $scope = new \Illuminate\Database\Eloquent\SoftDeletingScope;
         $scope->extend($builder);
         $callback = $builder->getMacro('restore');
@@ -41,8 +44,11 @@ class DatabaseSoftDeletingScopeTest extends TestCase
 
     public function testWithTrashedExtension()
     {
-        $builder = m::mock('Illuminate\Database\Eloquent\Builder');
-        $builder->shouldDeferMissing();
+        $builder = new \Illuminate\Database\Eloquent\Builder(new \Illuminate\Database\Query\Builder(
+            m::mock('Illuminate\Database\ConnectionInterface'),
+            m::mock('Illuminate\Database\Query\Grammars\Grammar'),
+            m::mock('Illuminate\Database\Query\Processors\Processor')
+        ));
         $scope = m::mock('Illuminate\Database\Eloquent\SoftDeletingScope[remove]');
         $scope->extend($builder);
         $callback = $builder->getMacro('withTrashed');
@@ -56,8 +62,11 @@ class DatabaseSoftDeletingScopeTest extends TestCase
 
     public function testOnlyTrashedExtension()
     {
-        $builder = m::mock('Illuminate\Database\Eloquent\Builder');
-        $builder->shouldDeferMissing();
+        $builder = new \Illuminate\Database\Eloquent\Builder(new \Illuminate\Database\Query\Builder(
+            m::mock('Illuminate\Database\ConnectionInterface'),
+            m::mock('Illuminate\Database\Query\Grammars\Grammar'),
+            m::mock('Illuminate\Database\Query\Processors\Processor')
+        ));
         $model = m::mock('Illuminate\Database\Eloquent\Model');
         $model->shouldDeferMissing();
         $scope = m::mock('Illuminate\Database\Eloquent\SoftDeletingScope[remove]');
@@ -76,8 +85,11 @@ class DatabaseSoftDeletingScopeTest extends TestCase
 
     public function testWithoutTrashedExtension()
     {
-        $builder = m::mock('Illuminate\Database\Eloquent\Builder');
-        $builder->shouldDeferMissing();
+        $builder = new \Illuminate\Database\Eloquent\Builder(new \Illuminate\Database\Query\Builder(
+            m::mock('Illuminate\Database\ConnectionInterface'),
+            m::mock('Illuminate\Database\Query\Grammars\Grammar'),
+            m::mock('Illuminate\Database\Query\Processors\Processor')
+        ));
         $model = m::mock('Illuminate\Database\Eloquent\Model');
         $model->shouldDeferMissing();
         $scope = m::mock('Illuminate\Database\Eloquent\SoftDeletingScope[remove]');


### PR DESCRIPTION
This adds macroable functionality to the `Eloquent/Builder`, with one exception to the normal implementation — it doesn't use the `Macroable` trait.

This because the class already has it's own locally scoped macro functionality. For example, when you to enable soft deletes on a specific model. Unfortunately this functionality cannot be globally (statically), hence this change.

To use the `macro()` method in both local and static situations, I've removed the method from the class and implemented it via `__call()` and `__callStatic()`.

From my testing, I believe this change maintains 100% [backward compatibility](https://github.com/search?l=PHP&q=%22%24builder-%3Emacro%22&type=Code&utf8=%E2%9C%93).