### PR TITLE
[5.4] Add a container alias for the redis connection instance.

### DIFF
--- a/src/Illuminate/Redis/RedisServiceProvider.php
+++ b/src/Illuminate/Redis/RedisServiceProvider.php
@@ -26,6 +26,10 @@ class RedisServiceProvider extends ServiceProvider
 
             return new RedisManager(Arr::pull($config, 'client', 'predis'), $config);
         });
+
+        $this->app->bind('redis.connection', function ($app) {
+            return $app['redis']->connection();
+        });
     }
 
     /**
@@ -35,6 +39,6 @@ class RedisServiceProvider extends ServiceProvider
      */
     public function provides()
     {
-        return ['redis'];
+        return ['redis', 'redis.connection'];
     }
 }


### PR DESCRIPTION
This pull request aims to implement the proposal found here: https://github.com/laravel/internals/issues/400

This will add a new container alias to get the default redis connection.

Signed-off-by: Hunter Skrasek <hunterskrasek@me.com>