### PR TITLE
[5.4] Collection pagination

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1790,7 +1790,7 @@ class Builder
     }
 
     /**
-     * Run a pagiantion count query.
+     * Run a pagination count query.
      *
      * @param  array  $columns
      * @return array


### PR DESCRIPTION
This adds `paginate()` and `simplePaginate()` on collections, with same parameters as their respective implementations on the query builder (except for `$columns` parameter, as it's a query builder specific parameter).  While collections already has `forPage()`, one might want an actual `LengthAwarePaginator` or `Paginator` instance for rendering pagination links on non-Eloquent-collections.

I'm not sure if there's a cleaner way to implement this?  Thoughts?  Suggestions welcome! 