### PR TITLE
[5.4] Use Macroable on TestResponse

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -6,11 +6,14 @@ use Closure;
 use Illuminate\Support\Arr;
 use Illuminate\Http\Response;
 use Illuminate\Contracts\View\View;
+use Illuminate\Support\Traits\Macroable;
 use PHPUnit\Framework\Assert as PHPUnit;
 use Symfony\Component\HttpFoundation\Cookie;
 
 class TestResponse extends Response
 {
+    use Macroable;
+
     /**
      * Convert the given response into a TestResponse.
      *

--- a/tests/Foundation/FoundationTestResponseTest.php
+++ b/tests/Foundation/FoundationTestResponseTest.php
@@ -46,6 +46,19 @@ class FoundationTestResponseTest extends TestCase
         $response = new TestResponse(new JsonSerializableSingleResourceStub);
         $response->assertJsonStructure(['*' => ['foo', 'bar', 'foobar']]);
     }
+
+    public function testMacroable()
+    {
+        TestResponse::macro('foo', function () {
+            return 'bar';
+        });
+
+        $response = new TestResponse;
+
+        $this->assertEquals(
+            'bar', $response->foo()
+        );
+    }
 }
 
 class JsonSerializableMixedResourcesStub implements JsonSerializable


### PR DESCRIPTION
This PR adds `Macroable` trait to `Illuminate\Foundation\Testing\TestResponse`.

I often find myself repeating same patterns when testing. In Laravel 5.3, it was possible to create helper methods on `TestCase` class and continue chaining of the `$this->get()` call.

This allows us to achieve the same result in Laravel 5.4.

🌵 