### PR TITLE
[5.4] Don't wrap asset path in default domain

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -583,7 +583,7 @@ if (! function_exists('mix')) {
 
         return $shouldHotReload = file_exists(public_path('hot'))
                     ? new HtmlString("http://localhost:8080{$manifest[$path]}")
-                    : new HtmlString(url($manifest[$path]));
+                    : new HtmlString($manifest[$path]);
     }
 }
 


### PR DESCRIPTION
This PR is made in reference to laravel/internals#392. In essence this brings the `mix` helper function into line with the old `elixir` helper function by just returning a relative path to the compiled asset, rather than an absolute path. This is helpful when the assets are served from another domain, such as a CDN.

In order to do it as-is you would need to strip the default domain from the return value of the function and replace it with the alternate domain, which doesn't feel like all that great of a solution. Either way, by default I think it makes more sense to return a relative path rather than an absolute one.

One alternative would be to add another configuration variable, perhaps an `asset_url` that would be used when generating asset links - it could fallback to the default domain when it isn't set.

I'm not entirely sure if this is a breaking change or not... I can't see why it would be necessarily as it's always going to return an absolute URL with the default domain, and now it's just going to be a relative URL on that same domain.