### PR TITLE
[5.4] Sort foreign keys in with() method | eager loading

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
@@ -134,6 +134,8 @@ class BelongsTo extends Relation
             return [$this->relationHasIncrementingId() ? 0 : null];
         }
 
+        sort($keys);
+
         return array_values(array_unique($keys));
     }
 

--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -205,7 +205,7 @@ abstract class Relation
     {
         return collect($models)->map(function ($value) use ($key) {
             return $key ? $value->getAttribute($key) : $value->getKey();
-        })->values()->unique()->all();
+        })->values()->unique()->sort()->all();
     }
 
     /**


### PR DESCRIPTION
This sorts relation keys.

Example: I have few models: town and street and they are connected via relationship. If on a first page I would call: street::with('town')->paginate(10) the SQL query for with() would look like: ```select * from `towns` where `towns`.`id` in ('1, '2', '3')``` but on a second page it looks like: ```select * from `towns` where `towns`.`id` in ('2, '1', '3')``` and here is the problem that it returns same SQL result but from to different yet same queries.

At BelongsTo.php its possible to do sorting after all unique values are selected. This would sort smaller array.
```php
$keys = array_values(array_unique($keys));

sort($keys);

return $keys;
```