### PR TITLE
[5.4] Add raw method to FactoryBuilder

### DIFF
--- a/src/Illuminate/Database/Eloquent/FactoryBuilder.php
+++ b/src/Illuminate/Database/Eloquent/FactoryBuilder.php
@@ -143,6 +143,45 @@ class FactoryBuilder
     }
 
     /**
+     * Create an array of raw attribute arrays.
+     *
+     * @param  array  $attributes
+     * @return mixed
+     */
+    public function raw(array $attributes = [])
+    {
+        if ($this->amount === null) {
+            return $this->getRawAttributes();
+        }
+
+        if ($this->amount < 1) {
+            return [];
+        }
+
+        return array_map(function () use ($attributes) {
+            return $this->getRawAttributes($attributes);
+        }, range(1, $this->amount));
+    }
+
+    /**
+     * Get a raw attributes array for the model.
+     *
+     * @param  array  $attributes
+     * @return mixed
+     */
+    protected function getRawAttributes(array $attributes = [])
+    {
+        $definition = call_user_func(
+            $this->definitions[$this->class][$this->name],
+            $this->faker, $attributes
+        );
+
+        return $this->callClosureAttributes(
+            array_merge($this->applyStates($definition, $attributes), $attributes)
+        );
+    }
+
+    /**
      * Make an instance of the model with the given attributes.
      *
      * @param  array  $attributes
@@ -157,14 +196,9 @@ class FactoryBuilder
                 throw new InvalidArgumentException("Unable to locate factory with name [{$this->name}] [{$this->class}].");
             }
 
-            $definition = call_user_func(
-                $this->definitions[$this->class][$this->name],
-                $this->faker, $attributes
+            return new $this->class(
+                $this->getRawAttributes($attributes)
             );
-
-            return new $this->class($this->callClosureAttributes(
-                array_merge($this->applyStates($definition, $attributes), $attributes)
-            ));
         });
     }
 


### PR DESCRIPTION
This PR adds `raw()` method to `Illuminate\Database\Eloquent\FactoryBuilder`.

It allows for calling `factory(User::class)->raw()` which returns raw attributes array (merged with overrides). `raw()` method behaves in a same way as `make()` or `create()` methods do.

It aligns nicely with `Illuminate\Database\Eloquent\Factory::raw()` method which is available inside factories.

This feature is useful when writing tests for a simple endpoint:

```php
function it_creates_an_order()
{
    $request = factory(App\Order::class)->make()->toArray();

    // vs

    $request = factory(App\Order::class)->raw();

    $this->post('/orders', $request);
}
```

Also, it could be used with `hasMany` relationships:

```php
$post->comments()->create(
    factory(App\Comment::class, 3)->raw()
);
```

🌵 