### PR TITLE
[5.4] Add json alias for decodeResponseJson method

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -273,6 +273,16 @@ class TestResponse extends Response
     }
 
     /**
+     * Alias for the "decodeResponseJson" method.
+     *
+     * @return array
+     */
+    public function json()
+    {
+        return $this->decodeResponseJson();
+    }
+
+    /**
      * Assert that the response view has a given piece of bound data.
      *
      * @param  string|array  $key


### PR DESCRIPTION
This PR adds `json()` method to `Illuminate\Foundation\Testing\TestResponse`.

This method serves as an alias for `decodeResponseJson()` method.

It allows for nicer and much more intuitive API:

```php
function it_gets_an_order_by_id()
{
    $order = $this->get('/orders/1')->decodeResponseJson();

    // vs

    $order = $this->get('/orders/1')->json();
}
```

🌵 