### PR TITLE
[5.4] TrimString Middleware bugfixes (using strict comparison instead of loose comparison)

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/TrimStrings.php
+++ b/src/Illuminate/Foundation/Http/Middleware/TrimStrings.php
@@ -22,7 +22,7 @@ class TrimStrings extends TransformsRequest
      */
     protected function transform($key, $value)
     {
-        if (in_array($key, $this->except)) {
+        if (in_array($key, $this->except, true)) {
             return $value;
         }
 


### PR DESCRIPTION
I found bug on the laravel framework on `TrimString` Middleware. It used loose comparison.

For Example:
```
<html>
<body>
<form method="POST">
    <input type="text" name="foo[]">
    <input type="text" name="foo[]">
    <input type="submit" value="submit">
</form>
</body>
</html>
```

If we use the loose comparison, the first input will not be trimmed because method:
`in_array(0, $this->except)` 

always return true (comparing 0 with string).

if we use strict comparison (by adding true for the 3rd argument), it will be fixed.
`in_array($key, $this->except, true)` 