### PR TITLE
move `<style>` into the head

### DIFF
--- a/src/Illuminate/Mail/resources/views/html/layout.blade.php
+++ b/src/Illuminate/Mail/resources/views/html/layout.blade.php
@@ -3,9 +3,8 @@
 <head>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-</head>
-<body>
-    <style>
+    
+    <style type="text/css">
         @media only screen and (max-width: 600px) {
             .inner-body {
                 width: 100% !important;
@@ -22,6 +21,9 @@
             }
         }
     </style>
+    
+</head>
+<body>
 
     <table class="wrapper" width="100%" cellpadding="0" cellspacing="0">
         <tr>


### PR DESCRIPTION
the `<style>` tag is technically only allowed in the `<head>`. https://www.w3.org/TR/html4/struct/global.html#h-7.4.1

email clients allow it in both places: https://www.campaignmonitor.com/css/

also adding the required `type` attribute