### PR TITLE
[5.4] Allow FormRequest having new Middleware's affected parameters on vali…

### DIFF
--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -246,4 +246,16 @@ class FormRequest extends Request implements ValidatesWhenResolved
 
         return $this;
     }
+
+    /**
+     * Get all of the input and files for the request.
+     *
+     * @return array
+     */
+    public function all()
+    {
+        $this->merge($this->request->all());
+
+        return parent::all();
+    }
 }


### PR DESCRIPTION
Because for some reason FormRequest seems not to be affected by the new TrimStrings and ConvertEmptyStringsToNull middlewares, all() function need to merge self request before getting all parameters to have trimmed and nulled parameters on validation.