### PR TITLE
[5.4] Add tap method to collection

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -827,6 +827,18 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
+     * Pass the collection to the given callback and return the current instance.
+     *
+     * @param  callable $callback
+     * @return $this
+     */
+    public function tap(callable $callback)
+    {
+        $callback(new static($this->items));
+        return $this;
+    }
+
+    /**
      * Get and remove the last item from the collection.
      *
      * @return mixed

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -835,6 +835,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     public function tap(callable $callback)
     {
         $callback(new static($this->items));
+
         return $this;
     }
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1882,6 +1882,19 @@ class SupportCollectionTest extends TestCase
 
         $this->assertSame(['b' => ['free' => false]], $premium->toArray());
     }
+
+    public function testTap()
+    {
+        $collection = new Collection([1, 2, 3]);
+
+        $fromTap = [];
+        $collection = $collection->tap(function ($collection) use (&$fromTap) {
+            $fromTap = $collection->slice(0, 1)->toArray();
+        });
+
+        $this->assertSame([1], $fromTap);
+        $this->assertSame([1, 2, 3], $collection->toArray());
+    }
 }
 
 class TestSupportCollectionHigherOrderItem


### PR DESCRIPTION
I noticed the tap function in helpers and thought it would be pretty useful in collections. The purpose is to "tap into" method chains without modifying the result of the previous call, we seem to do a lot of chaining with collections.

Creating a new collection to pass to the callback because there are some methods which if called on the collection will change the items. eg. the pop method.