### PR TITLE
Call one interface methods from both ArrayAccess and magic methods

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -553,6 +553,28 @@ trait HasAttributes
     }
 
     /**
+     * Determine if an attribute or relation exists on the model.
+     *
+     * @param  string  $key
+     * @return bool
+     */
+    public function issetAttribute($key)
+    {
+        return ! is_null($this->getAttribute($key));
+    }
+
+    /**
+     * Unset an attribute on the model.
+     *
+     * @param  string  $key
+     * @return void
+     */
+    public function unsetAttribute($key)
+    {
+        unset($this->attributes[$key], $this->relations[$key]);
+    }
+
+    /**
      * Determine if the given attribute is a date or date castable.
      *
      * @param  string  $key

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1241,7 +1241,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public function offsetExists($offset)
     {
-        return isset($this->$offset);
+        return $this->issetAttribute($offset);
     }
 
     /**
@@ -1252,7 +1252,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public function offsetGet($offset)
     {
-        return $this->$offset;
+        return $this->getAttribute($offset);
     }
 
     /**
@@ -1264,7 +1264,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public function offsetSet($offset, $value)
     {
-        $this->$offset = $value;
+        $this->setAttribute($offset, $value);
     }
 
     /**
@@ -1275,7 +1275,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public function offsetUnset($offset)
     {
-        unset($this->$offset);
+        $this->unsetAttribute($offset);
     }
 
     /**
@@ -1286,7 +1286,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public function __isset($key)
     {
-        return ! is_null($this->getAttribute($key));
+        return $this->issetAttribute($key);
     }
 
     /**
@@ -1297,7 +1297,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public function __unset($key)
     {
-        unset($this->attributes[$key], $this->relations[$key]);
+        $this->unsetAttribute($key);
     }
 
     /**


### PR DESCRIPTION
This pull request adds 2 more methods `issetAttribute()` and `unsetAttribute()` to Eloquent Model and also forces all `__get()`/`__set()`/`__isset()`/`__unset()` magic methods AND(what is important!) same from all `ArrayAccess` methods. 

### Why this was changed:
It's a known fact - that calling magic methods is slightly slower then direct call or properties handling ([Benchmark article](http://www.garfieldtech.com/blog/magic-benchmarks)). Current Model class version operates with "virtual" properties in `ArrayAccess` methods - that adds very small but redundant performance overhead when using model as array. Also, isset/unset was possible to call only using magic methods, when public `getAttribute()` and `setAttribute()` functions exist. 

### Benefits:
1. You have all the public methods dealing with properties directly avoiding "magic" methods;
2. Your performance will be exactly the same if you use any of `$model->property` or `$model['property']`;
3. Logic of operating with attributes now concentrated in 4 methods with common self-explainable names (***Attribute()) instead of magic methods (I'm talking only about `__isset()`/`__unset()` - `__get()`/`__set()` used `getAttribute()`/`setAttribute()` before);

### Benchmarks:

**Get/Set/Isset/Unset using properties:**
```
    $account = new Model();
    $time = microtime(true);

    for($i = 0; $i<=100000; $i++) {

        $account->testProperty = 'dummy';
        $dummy = $account->testProperty;
        unset($account->testProperty);
        $exists = isset($account->testProperty);
        $account->testProperty = 'dummy2';
    }

    $time = microtime(true) - $time;
```

Before change: **5.45**
After change: **5.48** (+ 0.5%)

**Get/Set/Isset/Unset using ArrayAccess:**
```
    $account = new Model();
    $time = microtime(true);

    for($i = 0; $i<=100000; $i++) {

        $account['testProperty'] = 'dummy';
        $dummy = $account['testProperty'];
        unset($account['testProperty']);
        $exists = isset($account'[testProperty']);
        $account['testProperty'] = 'dummy2';
    }

    $time = microtime(true) - $time;
```

Before change: **5.79**
After change: **5.59** (-3.5%)

**Get/Set/Isset/Unset using direct methods:**
```
// only isset/unset was compared with direct method calls - cause others was not changed

    $account = new Model();
    $time = microtime(true);

    for($i = 0; $i<=100000; $i++) {

        unset($account->testProperty);
        $exists = isset($account->testProperty);
        
        // just to make sure unset/isset are doing smth
        $account->testProperty = 'dummy2';
    }

    $time = microtime(true) - $time;

    //---------------VS------------------

    $account = new Model();
    $time = microtime(true);

    for($i = 0; $i<=100000; $i++) {

        $account->unsetAttribute('testProperty');
        $exists = $account->issetAttribute('testProperty');
        
        // just to make sure unset/isset are doing smth
        $account->testProperty = 'dummy2';
    }

    $time = microtime(true) - $time;
```

Before change: **2.68**
After change: **2.53** (-3.9%)