### PR TITLE
[5.4] Allow multiple manifest files for mix helper

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -562,32 +562,32 @@ if (! function_exists('mix')) {
     {
         static $manifest;
 
-        if ( $manifestDir && ! starts_with($manifestDir, '/')) {
+        if ($manifestDir && ! starts_with($manifestDir, '/')) {
             $manifestDir = "/{$manifestDir}";
         }
 
-        if ( ! $manifest) {
-            if ( ! file_exists($manifestPath = public_path($manifestDir . '/mix-manifest.json'))) {
+        if (! $manifest) {
+            if (! file_exists($manifestPath = public_path($manifestDir.'/mix-manifest.json'))) {
                 throw new Exception('The Mix manifest does not exist.');
             }
 
             $manifest = json_decode(file_get_contents($manifestPath), true);
         }
 
-        if ( ! starts_with($path, '/')) {
+        if (! starts_with($path, '/')) {
             $path = "/{$path}";
         }
 
-        if ( ! array_key_exists($path, $manifest)) {
+        if (! array_key_exists($path, $manifest)) {
             throw new Exception(
-                "Unable to locate Mix file: {$path}. Please check your " .
+                "Unable to locate Mix file: {$path}. Please check your ".
                 'webpack.mix.js output paths and try again.'
             );
         }
 
-        return file_exists(public_path($manifestDir . '/hot'))
+        return file_exists(public_path($manifestDir.'/hot'))
             ? new HtmlString("http://localhost:8080{$manifest[$path]}")
-            : new HtmlString($manifestDir . $manifest[$path]);
+            : new HtmlString($manifestDir.$manifest[$path]);
     }
 }
 

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -552,8 +552,8 @@ if (! function_exists('mix')) {
     /**
      * Get the path to a versioned Mix file.
      *
-     * @param  string $path
-     * @param  string $manifestDir
+     * @param  string  $path
+     * @param  string  $manifestDir
      * @return \Illuminate\Support\HtmlString
      *
      * @throws \Exception

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -552,38 +552,42 @@ if (! function_exists('mix')) {
     /**
      * Get the path to a versioned Mix file.
      *
-     * @param  string  $path
+     * @param string $path
+     * @param string $manifestDir
      * @return \Illuminate\Support\HtmlString
      *
      * @throws \Exception
      */
-    function mix($path)
+    function mix($path, $manifestDir = '')
     {
         static $manifest;
-        static $shouldHotReload;
 
-        if (! $manifest) {
-            if (! file_exists($manifestPath = public_path('mix-manifest.json'))) {
+        if ( $manifestDir && ! starts_with($manifestDir, '/')) {
+            $manifestDir = "/{$manifestDir}";
+        }
+
+        if ( ! $manifest) {
+            if ( ! file_exists($manifestPath = public_path($manifestDir . '/mix-manifest.json'))) {
                 throw new Exception('The Mix manifest does not exist.');
             }
 
             $manifest = json_decode(file_get_contents($manifestPath), true);
         }
 
-        if (! starts_with($path, '/')) {
+        if ( ! starts_with($path, '/')) {
             $path = "/{$path}";
         }
 
-        if (! array_key_exists($path, $manifest)) {
+        if ( ! array_key_exists($path, $manifest)) {
             throw new Exception(
-                "Unable to locate Mix file: {$path}. Please check your ".
+                "Unable to locate Mix file: {$path}. Please check your " .
                 'webpack.mix.js output paths and try again.'
             );
         }
 
-        return $shouldHotReload = file_exists(public_path('hot'))
-                    ? new HtmlString("http://localhost:8080{$manifest[$path]}")
-                    : new HtmlString($manifest[$path]);
+        return file_exists(public_path($manifestDir . '/hot'))
+            ? new HtmlString("http://localhost:8080{$manifest[$path]}")
+            : new HtmlString($manifestDir . $manifest[$path]);
     }
 }
 

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -552,8 +552,8 @@ if (! function_exists('mix')) {
     /**
      * Get the path to a versioned Mix file.
      *
-     * @param string $path
-     * @param string $manifestDir
+     * @param  string $path
+     * @param  string $manifestDir
      * @return \Illuminate\Support\HtmlString
      *
      * @throws \Exception
@@ -586,8 +586,8 @@ if (! function_exists('mix')) {
         }
 
         return file_exists(public_path($manifestDir.'/hot'))
-            ? new HtmlString("http://localhost:8080{$manifest[$path]}")
-            : new HtmlString($manifestDir.$manifest[$path]);
+                    ? new HtmlString("http://localhost:8080{$manifest[$path]}")
+                    : new HtmlString($manifestDir.$manifest[$path]);
     }
 }
 


### PR DESCRIPTION
If you have multiple laravel mix files (for backend and frontend) you can't use it with the helper.

Example mix File:
```
mix.setPublicPath('./public/admin')
mix.js('./js/app.js', '/js')
```

The mix-manifest.json is successfully saved in /public/admin/

Now you can add it in you blade Template with 
`<script src="{{ mix('js/app.js', 'admin') }}"></script>`

It works with Hot Reload too and not breaking things.