### PR TITLE
[5.4] Properly set the JSON payload of FormRequests

### DIFF
--- a/src/Illuminate/Foundation/Providers/FormRequestServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/FormRequestServiceProvider.php
@@ -56,6 +56,8 @@ class FormRequestServiceProvider extends ServiceProvider
             $current->cookies->all(), $files, $current->server->all(), $current->getContent()
         );
 
+        $form->setJson($current->json());
+
         if ($session = $current->getSession()) {
             $form->setLaravelSession($session);
         }

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -303,6 +303,17 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
     }
 
     /**
+     * Set the JSON payload for the request.
+     *
+     * @param  array  $json
+     * @return void
+     */
+    public function setJson($json)
+    {
+        $this->json = $json;
+    }
+
+    /**
      * Get the input source for the request.
      *
      * @return \Symfony\Component\HttpFoundation\ParameterBag


### PR DESCRIPTION
This PR highlights the cause of the issue experienced in https://github.com/laravel/framework/pull/17753

When the transformation middleware runs, `$request->json()` is called and the returned parameter bag is replaced with the transformed one, later calls to `->json()` presents the modified bag not the original one: https://github.com/laravel/framework/blob/5.4/src/Illuminate/Http/Request.php#L294

For form requests when we initialise it we pass the original content:
https://github.com/laravel/framework/blob/7212b1e9620c36bf806e444f6931cf5f379c68ff/src/Illuminate/Foundation/Providers/FormRequestServiceProvider.php#L56

So when `->json()` is called on the form request, it'll read the original content of the request and thus why the transformation won't take effect.

In this PR I explicitly set the `json` bag of the form request from the json bag of the original request, this way `->json()` won't have to look into the content since there's already a bag present.