### PR TITLE
[5.4] Remove absolute paths for JS and CSS

### DIFF
--- a/src/Illuminate/Auth/Console/stubs/make/views/layouts/app.stub
+++ b/src/Illuminate/Auth/Console/stubs/make/views/layouts/app.stub
@@ -11,7 +11,7 @@
     <title>{{ config('app.name', 'Laravel') }}</title>
 
     <!-- Styles -->
-    <link href="/css/app.css" rel="stylesheet">
+    <link href="{{ config('app.path') }}/css/app.css" rel="stylesheet">
 
     <!-- Scripts -->
     <script>
@@ -82,6 +82,6 @@
     </div>
 
     <!-- Scripts -->
-    <script src="/js/app.js"></script>
+    <script src="{{ config('app.path') }}/js/app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
I had the same problem as reported in issue #16331.  These changes utilize the app.path config variable to ensure the URLs are correct for installations that are not in the Apache web root directory.

To reproduce:

1. Create a new Laravel application
2. Make that application's Public directory available via an Apache alias that is not the same as the server's document root. For example http://mysite/laravelapp/ instead of http://mysite/
3. Run php artisan make:auth
4. Attempt to load the login screen at http://mysite/laravelapp/login
5. The formatting of the page will be incorrect (missing CSS/JS)
