### PR TITLE
[5.4] Add Checks for Years greater than 9999

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -337,6 +337,10 @@ trait ValidatesAttributes
             return false;
         }
 
+        if (is_string($value) && preg_match('#^(\d{5,}[^\d]\d{2}[^\d]\d{2}|\d{2}[^\d]\d{2}[^\d]\d{5,})$#', $value)) {
+            return false;
+        }
+
         $date = date_parse($value);
 
         return checkdate($date['month'], $date['day'], $date['year']);

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -2117,8 +2117,14 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['x' => '2000-01-01'], ['x' => 'date']);
         $this->assertTrue($v->passes());
 
+        $v = new Validator($trans, ['x' => '20000-01-01'], ['x' => 'date']);
+        $this->assertTrue($v->fails());
+
         $v = new Validator($trans, ['x' => '01/01/2000'], ['x' => 'date']);
         $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => '01/01/20000'], ['x' => 'date']);
+        $this->assertTrue($v->fails());
 
         $v = new Validator($trans, ['x' => '1325376000'], ['x' => 'date']);
         $this->assertTrue($v->fails());


### PR DESCRIPTION
PHP has some difficult handling dates with a year over 9999 for example if you pass a date like "20196-05-25" into Carbon (and DateTime) it will throw an error. However, the date validator considers this date to be valid.

```
InvalidArgumentException was thrown!  The separation symbol could not be found Unexpected data found. Data missing  
#0 ./vendor/laravel/framework/src/Illuminate/Database/Eloquent/Model.php(2969): Carbon\Carbon::createFromFormat('Y-m-d H:i:s', '20196-05-25') 
#1 ./vendor/laravel/framework/src/Illuminate/Database/Eloquent/Model.php(2923): Illuminate\Database\Eloquent\Model->asDateTime('20196-05-25') 
#2 ./vendor/laravel/framework/src/Illuminate/Database/Eloquent/Model.php(2878): Illuminate\Database\Eloquent\Model->fromDateTime('20196-05-25') 
#3 ./vendor/laravel/framework/src/Illuminate/Database/Eloquent/Model.php(450): Illuminate\Database\Eloquent\Model->setAttribute('date_at', '20196-05-25')
```

The problem with the `validateDate` is that it is making use of the PHP function `date_parse()` which is changing the year 20196 to 2006 which is then being pumped into `checkdate()` which will validate because `date_parse()` has "corrected" it.

This is loosely related to issue #329 validateDate could be better and is me finally fixing the bug #6329 I reported in 2014 (sorry for the delay).