### PR TITLE
[5.4] FIX: Apply overrides in factory()->raw() method

### DIFF
--- a/src/Illuminate/Database/Eloquent/FactoryBuilder.php
+++ b/src/Illuminate/Database/Eloquent/FactoryBuilder.php
@@ -151,7 +151,7 @@ class FactoryBuilder
     public function raw(array $attributes = [])
     {
         if ($this->amount === null) {
-            return $this->getRawAttributes();
+            return $this->getRawAttributes($attributes);
         }
 
         if ($this->amount < 1) {


### PR DESCRIPTION
This PR fixes bug in `factory()->raw()` method, where `$attributes` array (_overrides_) were not passed into the `$this->getRawAttributes()`call.

This was introduced by me in #17734. I apologise for that.