### PR TITLE
[5.4][proposal] Validate domain of an email

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -511,11 +511,23 @@ trait ValidatesAttributes
      *
      * @param  string  $attribute
      * @param  mixed   $value
+     * @param  array   $parameters
      * @return bool
      */
-    protected function validateEmail($attribute, $value)
+    protected function validateEmail($attribute, $value, $parameters)
     {
-        return filter_var($value, FILTER_VALIDATE_EMAIL) !== false;
+        $validSyntax = filter_var($value, FILTER_VALIDATE_EMAIL) !== false;
+
+        // If checkdomain is specified as a parameter, we will check
+        // MX and A records to ensure that the domain really exists.
+        if ($validSyntax && count($parameters) == 1 && $parameters[0] == 'checkdomain') {
+            list($user, $domain) = explode('@', $value);
+
+            // Perform A check only if there's no MX record.
+            return checkdnsrr($domain, 'MX') || checkdnsrr($domain, 'A');
+        }
+
+        return $validSyntax;
     }
 
     /**

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1540,6 +1540,16 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->passes());
     }
 
+    public function testValidateEmailWithDomainCheck()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['x' => 'alice@some-gibberish-domain-that-will-never-exist-qcXKQ9734Fxkkh.com'], ['x' => 'email:checkdomain']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['x' => 'foo@gmail.com'], ['x' => 'email:checkdomain']);
+        $this->assertTrue($v->passes());
+    }
+
     /**
      * @dataProvider validUrls
      */


### PR DESCRIPTION
This pull request adds the possibility to validate the domain part of an email address. This is just an extra check after it has been validated that the given email address looks like an email address.

It checks if there's an MX record associated with the domain and if there isn't, it checks if there's an [A record](http://serverfault.com/a/470651).

Currently, to turn this option on, the validation rule must look like this: `email:checkdomain`. This is the simplest approach, but it might be better like as shown below. I'm not sure, what do you think?

*  `email` -> domain check off
*  `email:checkdomain` -> domain check on
*  `email:checkdomain=false` -> domain check off
*  `email:checkdomain=true` -> domain check on

-----
Note: this is absolutely a  non-breaking change