### PR TITLE
[5.4] Add 'filter by attribute' functionality

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -296,11 +296,15 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Run a filter over each of the items.
      *
-     * @param  callable|null  $callback
+     * @param  mixed|null  $callback
      * @return static
      */
-    public function filter(callable $callback = null)
+    public function filter($callback = null)
     {
+        if (is_string($callback)) {
+            $callback = $this->valueRetriever($callback);
+        }
+
         if ($callback) {
             return new static(Arr::where($this->items, $callback));
         }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -318,6 +318,9 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(['first' => 'Hello', 'second' => 'World'], $c->filter(function ($item, $key) {
             return $key != 'id';
         })->all());
+
+        $c = new Collection([['id' => 1, 'name' => 'Hello'], ['id' => 2, 'name' => null]]);
+        $this->assertEquals([['id' => 1, 'name' => 'Hello']], $c->filter('name')->all());
     }
 
     public function testWhere()


### PR DESCRIPTION
This PR introduces ability to filter a collection by a given attribute. It allows to pass a string to the `Collection::filter` method instead of passing a closure.

Consider following:

```php
$collection = collect([
    ['id' => 1, 'name' => 'John', 'phone' => '+447871617281'],
    ['id' => 2, 'name' => 'Jake', 'phone' => null],
    ['id' => 3, 'name' => 'Marcy', 'phone' => '+447871617281'],
]);

$collection->filter('phone');

// vs

$collection->filter(function ($item) {
    return $item['phone'];
});
```

🌵 