### PR TITLE
[5.3] fix failing tests in 5.3 and 5.4

### DIFF
--- a/tests/Queue/RedisQueueIntegrationTest.php
+++ b/tests/Queue/RedisQueueIntegrationTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Carbon\Carbon;
 use Mockery as m;
 use Illuminate\Redis\Database;
 use Illuminate\Queue\RedisQueue;
@@ -25,6 +26,7 @@ class RedisQueueIntegrationTest extends PHPUnit_Framework_TestCase
 
     public function setUp()
     {
+        Carbon::setTestNow();
         parent::setUp();
 
         $host = getenv('REDIS_HOST') ?: '127.0.0.1';
@@ -63,6 +65,7 @@ class RedisQueueIntegrationTest extends PHPUnit_Framework_TestCase
 
     public function tearDown()
     {
+        Carbon::setTestNow(Carbon::now());
         parent::tearDown();
         m::close();
         if ($this->redis) {


### PR DESCRIPTION
The tests are already failing. To make sure they are failing put a sleep in `RedisQueueIntegrationTest::setUp()`. As you may recall, I had sent a PR for that, but you reverted it because of the difficulties in resolving the conflicts with 5.4. This is a much lighter change and I don't think there will be a conflict at all. In the case of any problem in merging and conflict resolving, I can still send the PR to 5.4 as well.

After this being fixed, I can resubmit a PR to test php-redis as well as predis. If you recall, tests in that PR was failing due to the issue I am trying to fix in this PR.