### PR TITLE
[5.5] add parameter & return type hints to the Str class

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -35,7 +35,7 @@ class Str
      * @param  string  $value
      * @return string
      */
-    public static function ascii($value)
+    public static function ascii(string $value) : string
     {
         foreach (static::charsArray() as $key => $val) {
             $value = str_replace($val, $key, $value);
@@ -50,7 +50,7 @@ class Str
      * @param  string  $value
      * @return string
      */
-    public static function camel($value)
+    public static function camel(string $value) : string
     {
         if (isset(static::$camelCache[$value])) {
             return static::$camelCache[$value];
@@ -66,7 +66,7 @@ class Str
      * @param  string|array  $needles
      * @return bool
      */
-    public static function contains($haystack, $needles)
+    public static function contains(string $haystack, $needles) : bool
     {
         foreach ((array) $needles as $needle) {
             if ($needle != '' && mb_strpos($haystack, $needle) !== false) {
@@ -84,7 +84,7 @@ class Str
      * @param  string|array  $needles
      * @return bool
      */
-    public static function endsWith($haystack, $needles)
+    public static function endsWith(string $haystack, $needles) : bool
     {
         foreach ((array) $needles as $needle) {
             if (substr($haystack, -strlen($needle)) === (string) $needle) {
@@ -102,7 +102,7 @@ class Str
      * @param  string  $cap
      * @return string
      */
-    public static function finish($value, $cap)
+    public static function finish(string $value, string $cap) : string
     {
         $quoted = preg_quote($cap, '/');
 
@@ -116,7 +116,7 @@ class Str
      * @param  string  $value
      * @return bool
      */
-    public static function is($pattern, $value)
+    public static function is(string $pattern, string $value) : bool
     {
         if ($pattern == $value) {
             return true;
@@ -138,7 +138,7 @@ class Str
      * @param  string  $value
      * @return int
      */
-    public static function length($value)
+    public static function length(string $value) : int
     {
         return mb_strlen($value);
     }
@@ -151,7 +151,7 @@ class Str
      * @param  string  $end
      * @return string
      */
-    public static function limit($value, $limit = 100, $end = '...')
+    public static function limit(string $value, int $limit = 100, string $end = '...') : string
     {
         if (mb_strwidth($value, 'UTF-8') <= $limit) {
             return $value;
@@ -166,7 +166,7 @@ class Str
      * @param  string  $value
      * @return string
      */
-    public static function lower($value)
+    public static function lower(string $value) : string
     {
         return mb_strtolower($value, 'UTF-8');
     }
@@ -179,7 +179,7 @@ class Str
      * @param  string  $end
      * @return string
      */
-    public static function words($value, $words = 100, $end = '...')
+    public static function words(string $value, int $words = 100, string $end = '...') : string
     {
         preg_match('/^\s*+(?:\S++\s*+){1,'.$words.'}/u', $value, $matches);
 
@@ -197,7 +197,7 @@ class Str
      * @param  string|null  $default
      * @return array
      */
-    public static function parseCallback($callback, $default = null)
+    public static function parseCallback(string $callback, string $default = null)
     {
         return static::contains($callback, '@') ? explode('@', $callback, 2) : [$callback, $default];
     }
@@ -209,7 +209,7 @@ class Str
      * @param  int     $count
      * @return string
      */
-    public static function plural($value, $count = 2)
+    public static function plural(string $value, int $count = 2) : string
     {
         return Pluralizer::plural($value, $count);
     }
@@ -220,7 +220,7 @@ class Str
      * @param  int  $length
      * @return string
      */
-    public static function random($length = 16)
+    public static function random(int $length = 16) : string
     {
         $string = '';
 
@@ -243,7 +243,7 @@ class Str
      * @param  string  $subject
      * @return string
      */
-    public static function replaceArray($search, array $replace, $subject)
+    public static function replaceArray(string $search, array $replace, string $subject) : string
     {
         foreach ($replace as $value) {
             $subject = static::replaceFirst($search, $value, $subject);
@@ -260,7 +260,7 @@ class Str
      * @param  string  $subject
      * @return string
      */
-    public static function replaceFirst($search, $replace, $subject)
+    public static function replaceFirst(string $search, string $replace, string $subject) : string string
     {
         $position = strpos($subject, $search);
 
@@ -279,7 +279,7 @@ class Str
      * @param  string  $subject
      * @return string
      */
-    public static function replaceLast($search, $replace, $subject)
+    public static function replaceLast(string $search, string $replace, string $subject) : string
     {
         $position = strrpos($subject, $search);
 
@@ -296,7 +296,7 @@ class Str
      * @param  string  $value
      * @return string
      */
-    public static function upper($value)
+    public static function upper(string $value) : string
     {
         return mb_strtoupper($value, 'UTF-8');
     }
@@ -307,7 +307,7 @@ class Str
      * @param  string  $value
      * @return string
      */
-    public static function title($value)
+    public static function title(string $value) : string
     {
         return mb_convert_case($value, MB_CASE_TITLE, 'UTF-8');
     }
@@ -318,7 +318,7 @@ class Str
      * @param  string  $value
      * @return string
      */
-    public static function singular($value)
+    public static function singular(string $value) : string
     {
         return Pluralizer::singular($value);
     }
@@ -330,7 +330,7 @@ class Str
      * @param  string  $separator
      * @return string
      */
-    public static function slug($title, $separator = '-')
+    public static function slug(string $title, string $separator = '-') : string
     {
         $title = static::ascii($title);
 
@@ -355,7 +355,7 @@ class Str
      * @param  string  $delimiter
      * @return string
      */
-    public static function snake($value, $delimiter = '_')
+    public static function snake(string $value, string $delimiter = '_') : string
     {
         $key = $value;
 
@@ -379,7 +379,7 @@ class Str
      * @param  string|array  $needles
      * @return bool
      */
-    public static function startsWith($haystack, $needles)
+    public static function startsWith(string $haystack, $needles) : bool
     {
         foreach ((array) $needles as $needle) {
             if ($needle != '' && substr($haystack, 0, strlen($needle)) === (string) $needle) {
@@ -396,7 +396,7 @@ class Str
      * @param  string  $value
      * @return string
      */
-    public static function studly($value)
+    public static function studly(string $value) : string
     {
         $key = $value;
 
@@ -417,7 +417,7 @@ class Str
      * @param  int|null  $length
      * @return string
      */
-    public static function substr($string, $start, $length = null)
+    public static function substr(string $string, int $start, int $length = null) : string
     {
         return mb_substr($string, $start, $length, 'UTF-8');
     }
@@ -428,7 +428,7 @@ class Str
      * @param  string  $string
      * @return string
      */
-    public static function ucfirst($string)
+    public static function ucfirst(string $string) : string
     {
         return static::upper(static::substr($string, 0, 1)).static::substr($string, 1);
     }
@@ -442,7 +442,7 @@ class Str
      *
      * @return array
      */
-    protected static function charsArray()
+    protected static function charsArray() : array
     {
         static $charsArray;
 

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -66,7 +66,7 @@ class Str
      * @param  string|array  $needles
      * @return bool
      */
-    public static function contains(string $haystack, $needles) : bool
+    public static function contains($haystack, $needles) : bool
     {
         foreach ((array) $needles as $needle) {
             if ($needle != '' && mb_strpos($haystack, $needle) !== false) {
@@ -84,7 +84,7 @@ class Str
      * @param  string|array  $needles
      * @return bool
      */
-    public static function endsWith(string $haystack, $needles) : bool
+    public static function endsWith($haystack, $needles) : bool
     {
         foreach ((array) $needles as $needle) {
             if (substr($haystack, -strlen($needle)) === (string) $needle) {
@@ -379,7 +379,7 @@ class Str
      * @param  string|array  $needles
      * @return bool
      */
-    public static function startsWith(string $haystack, $needles) : bool
+    public static function startsWith($haystack, $needles) : bool
     {
         foreach ((array) $needles as $needle) {
             if ($needle != '' && substr($haystack, 0, strlen($needle)) === (string) $needle) {

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -260,7 +260,7 @@ class Str
      * @param  string  $subject
      * @return string
      */
-    public static function replaceFirst(string $search, string $replace, string $subject) : string string
+    public static function replaceFirst(string $search, string $replace, string $subject) : string
     {
         $position = strpos($subject, $search);
 


### PR DESCRIPTION
Now that Laravel 5.5 will require php >= 7.0 there isn't any reason I'm aware of not to type hint classes like this throughout the framework. 

If this is acceptable, I'll go through the other classes and submit similar PRs...