### PR TITLE
[5.4] Unencodable casted data in models is silently discarded

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -8,9 +8,9 @@ use DateTimeInterface;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Contracts\Support\Arrayable;
-use Illuminate\Database\Eloquent\JsonEncodingException;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Collection as BaseCollection;
+use Illuminate\Database\Eloquent\JsonEncodingException;
 
 trait HasAttributes
 {

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -8,6 +8,7 @@ use DateTimeInterface;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Database\Eloquent\JsonEncodingException;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Collection as BaseCollection;
 
@@ -527,6 +528,9 @@ trait HasAttributes
 
         if ($this->isJsonCastable($key) && ! is_null($value)) {
             $value = $this->asJson($value);
+            if (false === $value) {
+                throw JsonEncodingException::forAttribute($key, json_last_error_msg());
+            }
         }
 
         // If this attribute contains a JSON ->, we'll set the proper value in the

--- a/src/Illuminate/Database/Eloquent/JsonEncodingException.php
+++ b/src/Illuminate/Database/Eloquent/JsonEncodingException.php
@@ -17,4 +17,17 @@ class JsonEncodingException extends RuntimeException
     {
         return new static('Error encoding model ['.get_class($model).'] with ID ['.$model->getKey().'] to JSON: '.$message);
     }
+
+    /**
+     * Create a new JSON encoding exception for an attribute.
+     *
+     * @param  mixed  $key
+     * @param  string $message
+     * @return static
+     * @internal param mixed $key
+     */
+    public static function forAttribute($key, $message)
+    {
+        return new static('Error encoding value of attribute ['.$key.'] to JSON: '.$message);
+    }
 }

--- a/src/Illuminate/Database/Eloquent/JsonEncodingException.php
+++ b/src/Illuminate/Database/Eloquent/JsonEncodingException.php
@@ -24,7 +24,6 @@ class JsonEncodingException extends RuntimeException
      * @param  mixed  $key
      * @param  string $message
      * @return static
-     * @internal param mixed $key
      */
     public static function forAttribute($key, $message)
     {

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1466,6 +1466,22 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertNull($array['timestampAttribute']);
     }
 
+    /**
+     * @expectedException \Illuminate\Database\Eloquent\JsonEncodingException
+     * @expectedExceptionMessage Error encoding value of attribute
+     */
+    public function testModelAttributeCastingFailsOnUnencodableData()
+    {
+        $model = new EloquentModelCastingStub;
+        $model->objectAttribute = ["foo" => "b\xF8r"];
+        $obj = new StdClass;
+        $obj->foo = "b\xF8r";
+        $model->arrayAttribute = $obj;
+        $model->jsonAttribute = ["foo" => "b\xF8r"];
+
+        $model->getAttributes();
+    }
+
     public function testUpdatingNonExistentModelFails()
     {
         $model = new EloquentModelStub;

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1473,11 +1473,11 @@ class DatabaseEloquentModelTest extends TestCase
     public function testModelAttributeCastingFailsOnUnencodableData()
     {
         $model = new EloquentModelCastingStub;
-        $model->objectAttribute = ["foo" => "b\xF8r"];
+        $model->objectAttribute = ['foo' => "b\xF8r"];
         $obj = new StdClass;
         $obj->foo = "b\xF8r";
         $model->arrayAttribute = $obj;
-        $model->jsonAttribute = ["foo" => "b\xF8r"];
+        $model->jsonAttribute = ['foo' => "b\xF8r"];
 
         $model->getAttributes();
     }


### PR DESCRIPTION
I just discovered the hard way that data in a casting attribute that fails to be json encoded, such as iso-8859-1 encoded text, will silently be discarded when saving the model.

This PR will check the result of the encoding and throw a JsonEncodingException with a descriptive error message if encoding fails.