### PR TITLE
[5.4] Add `collect` method to Collection class

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -460,7 +460,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
 
         return value($default);
     }
-    
+
     /**
      * Get a new collection from the collection by key.
      *

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -460,6 +460,18 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
 
         return value($default);
     }
+    
+    /**
+     * Get a new collection from the collection by key.
+     *
+     * @param  mixed  $key
+     * @param  mixed  $default
+     * @return static
+     */
+    public function collect($key, $default = null)
+    {
+        return new static($this->get($key, $default));
+    }
 
     /**
      * Group an associative array by a field or using a callback.


### PR DESCRIPTION
I constantly find myself needing to “re-collect” nested arrays after getting them. I propose adding a `collect` method to the Collection class. This provides a simple syntax to achieve this:

Ex.
```php
$items = collect([
  'taco' => [
      'cheese',
      'tortilla' => [
        'flour',
        'salt',
      ],
      'beef',
  ],
]);

//-- before (works with all methods, count is just a simple example)
$tortillaCount = collect($items->get('taco'))->count();

//-- after
$tortillaCount = $items->collect('taco')->count();
```

I already include this using the `macro` method, however, I thought I'd share.