### PR TITLE
[5.4] Generate Single Action controller by adding -s or --single to make:controller command

### DIFF
--- a/src/Illuminate/Routing/Console/ControllerMakeCommand.php
+++ b/src/Illuminate/Routing/Console/ControllerMakeCommand.php
@@ -41,6 +41,8 @@ class ControllerMakeCommand extends GeneratorCommand
             return __DIR__.'/stubs/controller.model.stub';
         } elseif ($this->option('resource')) {
             return __DIR__.'/stubs/controller.stub';
+        } elseif ($this->option('single')) {
+            return __DIR__.'/stubs/controller.single.stub';
         }
 
         return __DIR__.'/stubs/controller.plain.stub';
@@ -126,6 +128,8 @@ class ControllerMakeCommand extends GeneratorCommand
             ['model', 'm', InputOption::VALUE_OPTIONAL, 'Generate a resource controller for the given model.'],
 
             ['resource', 'r', InputOption::VALUE_NONE, 'Generate a resource controller class.'],
+
+            ['single', 's', InputOption::VALUE_NONE, 'Generate a single action controller class.'],
         ];
     }
 }

--- a/src/Illuminate/Routing/Console/stubs/controller.single.stub
+++ b/src/Illuminate/Routing/Console/stubs/controller.single.stub
@@ -1,0 +1,20 @@
+<?php
+
+namespace DummyNamespace;
+
+use Illuminate\Http\Request;
+use DummyRootNamespaceHttp\Controllers\Controller;
+
+class DummyClass extends Controller
+{
+    /**
+     * Do some action.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function __invoke(Request $request)
+    {
+        //
+    }
+}


### PR DESCRIPTION
Added the ability to generate [Single Action Controller](https://laravel.com/docs/5.4/controllers#single-action-controllers) by using ```php artisan make:controller SomeAction -s(--single)```