### PR TITLE
[5.4] Bring the pluralization rules back

### DIFF
--- a/src/Illuminate/Translation/MessageSelector.php
+++ b/src/Illuminate/Translation/MessageSelector.php
@@ -107,7 +107,8 @@ class MessageSelector
      * @param  int  $number
      * @return int
      */
-    public function getPluralIndex($locale, $number){
+    public function getPluralIndex($locale, $number)
+    {
         switch ($locale) {
             case 'az':
             case 'bo':

--- a/src/Illuminate/Translation/MessageSelector.php
+++ b/src/Illuminate/Translation/MessageSelector.php
@@ -11,9 +11,10 @@ class MessageSelector
      *
      * @param  string  $line
      * @param  int  $number
+     * @param  string  $locale
      * @return mixed
      */
-    public function choose($line, $number)
+    public function choose($line, $number, $locale)
     {
         $segments = explode('|', $line);
 
@@ -23,8 +24,13 @@ class MessageSelector
 
         $segments = $this->stripConditions($segments);
 
-        return count($segments) == 1 || $number == 1
-                        ? $segments[0] : $segments[1];
+        $pluralIndex = $this->getPluralIndex($locale, $number);
+
+        if (count($segments) == 1 || ! isset($segments[$pluralIndex])) {
+            return $segments[0];
+        }
+
+        return $segments[$pluralIndex];
     }
 
     /**
@@ -88,5 +94,136 @@ class MessageSelector
         return collect($segments)->map(function ($part) {
             return preg_replace('/^[\{\[]([^\[\]\{\}]*)[\}\]]/', '', $part);
         })->all();
+    }
+
+    /**
+     * Get the index to use for pluralization.
+     *
+     * The plural rules are derived from code of the Zend Framework (2010-09-25), which
+     * is subject to the new BSD license (http://framework.zend.com/license/new-bsd).
+     * Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+     *
+     * @param  string  $locale
+     * @param  int  $number
+     *
+     * @return int
+     */
+    public function getPluralIndex($locale, $number){
+        switch ($locale) {
+            case 'az':
+            case 'bo':
+            case 'dz':
+            case 'id':
+            case 'ja':
+            case 'jv':
+            case 'ka':
+            case 'km':
+            case 'kn':
+            case 'ko':
+            case 'ms':
+            case 'th':
+            case 'tr':
+            case 'vi':
+            case 'zh':
+                return 0;
+                break;
+            case 'af':
+            case 'bn':
+            case 'bg':
+            case 'ca':
+            case 'da':
+            case 'de':
+            case 'el':
+            case 'en':
+            case 'eo':
+            case 'es':
+            case 'et':
+            case 'eu':
+            case 'fa':
+            case 'fi':
+            case 'fo':
+            case 'fur':
+            case 'fy':
+            case 'gl':
+            case 'gu':
+            case 'ha':
+            case 'he':
+            case 'hu':
+            case 'is':
+            case 'it':
+            case 'ku':
+            case 'lb':
+            case 'ml':
+            case 'mn':
+            case 'mr':
+            case 'nah':
+            case 'nb':
+            case 'ne':
+            case 'nl':
+            case 'nn':
+            case 'no':
+            case 'om':
+            case 'or':
+            case 'pa':
+            case 'pap':
+            case 'ps':
+            case 'pt':
+            case 'so':
+            case 'sq':
+            case 'sv':
+            case 'sw':
+            case 'ta':
+            case 'te':
+            case 'tk':
+            case 'ur':
+            case 'zu':
+                return ($number == 1) ? 0 : 1;
+            case 'am':
+            case 'bh':
+            case 'fil':
+            case 'fr':
+            case 'gun':
+            case 'hi':
+            case 'hy':
+            case 'ln':
+            case 'mg':
+            case 'nso':
+            case 'xbr':
+            case 'ti':
+            case 'wa':
+                return (($number == 0) || ($number == 1)) ? 0 : 1;
+            case 'be':
+            case 'bs':
+            case 'hr':
+            case 'ru':
+            case 'sr':
+            case 'uk':
+                return (($number % 10 == 1) && ($number % 100 != 11)) ? 0 : ((($number % 10 >= 2) && ($number % 10 <= 4) && (($number % 100 < 10) || ($number % 100 >= 20))) ? 1 : 2);
+            case 'cs':
+            case 'sk':
+                return ($number == 1) ? 0 : ((($number >= 2) && ($number <= 4)) ? 1 : 2);
+            case 'ga':
+                return ($number == 1) ? 0 : (($number == 2) ? 1 : 2);
+            case 'lt':
+                return (($number % 10 == 1) && ($number % 100 != 11)) ? 0 : ((($number % 10 >= 2) && (($number % 100 < 10) || ($number % 100 >= 20))) ? 1 : 2);
+            case 'sl':
+                return ($number % 100 == 1) ? 0 : (($number % 100 == 2) ? 1 : ((($number % 100 == 3) || ($number % 100 == 4)) ? 2 : 3));
+            case 'mk':
+                return ($number % 10 == 1) ? 0 : 1;
+            case 'mt':
+                return ($number == 1) ? 0 : ((($number == 0) || (($number % 100 > 1) && ($number % 100 < 11))) ? 1 : ((($number % 100 > 10) && ($number % 100 < 20)) ? 2 : 3));
+            case 'lv':
+                return ($number == 0) ? 0 : ((($number % 10 == 1) && ($number % 100 != 11)) ? 1 : 2);
+            case 'pl':
+                return ($number == 1) ? 0 : ((($number % 10 >= 2) && ($number % 10 <= 4) && (($number % 100 < 12) || ($number % 100 > 14))) ? 1 : 2);
+            case 'cy':
+                return ($number == 1) ? 0 : (($number == 2) ? 1 : ((($number == 8) || ($number == 11)) ? 2 : 3));
+            case 'ro':
+                return ($number == 1) ? 0 : ((($number == 0) || (($number % 100 > 0) && ($number % 100 < 20))) ? 1 : 2);
+            case 'ar':
+                return ($number == 0) ? 0 : (($number == 1) ? 1 : (($number == 2) ? 2 : ((($number % 100 >= 3) && ($number % 100 <= 10)) ? 3 : ((($number % 100 >= 11) && ($number % 100 <= 99)) ? 4 : 5))));
+            default:
+                return 0;
+        }
     }
 }

--- a/src/Illuminate/Translation/MessageSelector.php
+++ b/src/Illuminate/Translation/MessageSelector.php
@@ -105,7 +105,6 @@ class MessageSelector
      *
      * @param  string  $locale
      * @param  int  $number
-     *
      * @return int
      */
     public function getPluralIndex($locale, $number){

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -210,7 +210,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
         $replace['count'] = $number;
 
         return $this->makeReplacements(
-            $this->getSelector()->choose($line, $number), $replace
+            $this->getSelector()->choose($line, $number, $locale), $replace
         );
     }
 

--- a/tests/Translation/TranslationMessageSelectorTest.php
+++ b/tests/Translation/TranslationMessageSelectorTest.php
@@ -14,7 +14,7 @@ class TranslationMessageSelectorTest extends TestCase
     {
         $selector = new MessageSelector();
 
-        $this->assertEquals($expected, $selector->choose($id, $number));
+        $this->assertEquals($expected, $selector->choose($id, $number, 'en'));
     }
 
     public function chooseTestData()

--- a/tests/Translation/TranslationTranslatorTest.php
+++ b/tests/Translation/TranslationTranslatorTest.php
@@ -78,7 +78,7 @@ class TranslationTranslatorTest extends TestCase
         $t = $this->getMockBuilder('Illuminate\Translation\Translator')->setMethods(['get'])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
         $t->expects($this->once())->method('get')->with($this->equalTo('foo'), $this->equalTo(['replace']), $this->equalTo('en'))->will($this->returnValue('line'));
         $t->setSelector($selector = m::mock('Illuminate\Translation\MessageSelector'));
-        $selector->shouldReceive('choose')->once()->with('line', 10)->andReturn('choiced');
+        $selector->shouldReceive('choose')->once()->with('line', 10, 'en')->andReturn('choiced');
 
         $t->choice('foo', 10, ['replace']);
     }
@@ -88,7 +88,7 @@ class TranslationTranslatorTest extends TestCase
         $t = $this->getMockBuilder('Illuminate\Translation\Translator')->setMethods(['get'])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
         $t->expects($this->exactly(2))->method('get')->with($this->equalTo('foo'), $this->equalTo(['replace']), $this->equalTo('en'))->will($this->returnValue('line'));
         $t->setSelector($selector = m::mock('Illuminate\Translation\MessageSelector'));
-        $selector->shouldReceive('choose')->twice()->with('line', 3)->andReturn('choiced');
+        $selector->shouldReceive('choose')->twice()->with('line', 3, 'en')->andReturn('choiced');
 
         $values = ['foo', 'bar', 'baz'];
         $t->choice('foo', $values, ['replace']);


### PR DESCRIPTION
When we dropped Symfony's Translator in https://github.com/laravel/framework/pull/15563, pluralisation rules for different languages were dropped.

This PR brings the rules back.