### PR TITLE
[5.4] Fix call to zadd in redis queue

### DIFF
--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -123,7 +123,7 @@ class RedisQueue extends Queue implements QueueContract
     protected function laterRaw($delay, $payload, $queue = null)
     {
         $this->getConnection()->zadd(
-            $this->getQueue($queue).':delayed', $this->availableAt($delay), $payload
+            $this->getQueue($queue).':delayed', [$this->availableAt($delay) => $payload]
         );
 
         return Arr::get(json_decode($payload, true), 'id');

--- a/tests/Queue/QueueRedisQueueTest.php
+++ b/tests/Queue/QueueRedisQueueTest.php
@@ -32,8 +32,7 @@ class QueueRedisQueueTest extends TestCase
         $redis->shouldReceive('connection')->once()->andReturn($redis);
         $redis->shouldReceive('zadd')->once()->with(
             'queues:default:delayed',
-            2,
-            json_encode(['displayName' => 'foo', 'job' => 'foo', 'maxTries' => null, 'timeout' => null, 'data' => ['data'], 'id' => 'foo', 'attempts' => 0])
+            [2 => json_encode(['displayName' => 'foo', 'job' => 'foo', 'maxTries' => null, 'timeout' => null, 'data' => ['data'], 'id' => 'foo', 'attempts' => 0])]
         );
 
         $id = $queue->later(1, 'foo', ['data']);
@@ -50,8 +49,7 @@ class QueueRedisQueueTest extends TestCase
         $redis->shouldReceive('connection')->once()->andReturn($redis);
         $redis->shouldReceive('zadd')->once()->with(
             'queues:default:delayed',
-            2,
-            json_encode(['displayName' => 'foo', 'job' => 'foo', 'maxTries' => null, 'timeout' => null, 'data' => ['data'], 'id' => 'foo', 'attempts' => 0])
+            [2 => json_encode(['displayName' => 'foo', 'job' => 'foo', 'maxTries' => null, 'timeout' => null, 'data' => ['data'], 'id' => 'foo', 'attempts' => 0])]
         );
 
         $queue->later($date, 'foo', ['data']);


### PR DESCRIPTION
It currently accepts an array as the second argument: https://github.com/laravel/framework/pull/17488/files#diff-37c3b800861ce421e53c735b12bc8ec6R115