### PR TITLE
[5.4] Fix PhpRedis’ ZADD 

### DIFF
--- a/src/Illuminate/Redis/Connections/PhpRedisConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisConnection.php
@@ -97,9 +97,9 @@ class PhpRedisConnection extends Connection
     public function zadd($key, ...$dictionary)
     {
         if (count($dictionary) === 1) {
-            $dictionary = [array_values($dictionary[0]), array_keys($dictionary[0])];
-            array_unshift($dictionary, null);
-            $dictionary = call_user_func_array('array_merge', call_user_func_array('array_map', $dictionary));
+            $dictionary = call_user_func_array('array_merge', call_user_func_array('array_map',
+                [null, array_values($dictionary[0]), array_keys($dictionary[0])]
+            ));
         }
 
         return $this->client->zadd($key, ...$dictionary);

--- a/src/Illuminate/Redis/Connections/PhpRedisConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisConnection.php
@@ -91,19 +91,18 @@ class PhpRedisConnection extends Connection
      * Add one or more members to a sorted set or update its score if it already exists.
      *
      * @param  string  $key
-     * @param  array  $membersAndScoresDictionary
+     * @param  mixed  $dictionary
      * @return int
      */
-    public function zadd($key, array $membersAndScoresDictionary)
+    public function zadd($key, ...$dictionary)
     {
-        $arguments = [];
-
-        foreach ($membersAndScoresDictionary as $score => $member) {
-            $arguments[] = $score;
-            $arguments[] = $member;
+        if (count($dictionary) === 1) {
+            $dictionary = [array_values($dictionary[0]), array_keys($dictionary[0])];
+            array_unshift($dictionary, null);
+            $dictionary = call_user_func_array('array_merge', call_user_func_array('array_map', $dictionary));
         }
 
-        return $this->client->zadd($key, ...$arguments);
+        return $this->client->zadd($key, ...$dictionary);
     }
 
     /**

--- a/src/Illuminate/Redis/Connections/PhpRedisConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisConnection.php
@@ -97,9 +97,14 @@ class PhpRedisConnection extends Connection
     public function zadd($key, ...$dictionary)
     {
         if (count($dictionary) === 1) {
-            $dictionary = call_user_func_array('array_merge', call_user_func_array('array_map',
-                [null, array_values($dictionary[0]), array_keys($dictionary[0])]
-            ));
+            $_dictionary = [];
+
+            foreach ($dictionary[0] as $member => $score) {
+                $_dictionary[] = $score;
+                $_dictionary[] = $member;
+            }
+
+            $dictionary = $_dictionary;
         }
 
         return $this->client->zadd($key, ...$dictionary);


### PR DESCRIPTION
Fixes https://github.com/laravel/framework/issues/17828.

This PR add compatibility for all 3 Predis signature styles to PhpRedis connections.
```php
Redis::zadd('key', 10, 'member');
Redis::zadd('key', 10, 'member1', 20, 'member2');
Redis::zadd('key', ['member1' => 10, 'member2' => 20]);
```

The method signature changed, but the functionality is the same.
