### PR TITLE
[5.5] Allow custom pivot models to support global scopes and soft deletes

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -245,10 +245,10 @@ class BelongsToMany extends Relation
     {
         $this->using = $class;
 
-        $query = (new $class())->newQuery();
-        $query = $query->applyScopes();
+        $query = (new $class())->newQuery()->applyScopes();
 
-        foreach ($query->getQuery()->wheres as $where) {
+        $wheres = $query->getQuery()->wheres ?: [];
+        foreach ($wheres as $where) {
             $this->query->where(
                 array_key_exists('column', $where) ? $where['column'] : null,
                 array_key_exists('operator', $where) ? $where['operator'] : null,

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -236,6 +236,7 @@ class BelongsToMany extends Relation
 
     /**
      * Specify the custom pivot model to use for the relationship.
+     * Also, attach global scopes
      *
      * @param  string  $class
      * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
@@ -244,7 +245,29 @@ class BelongsToMany extends Relation
     {
         $this->using = $class;
 
+        $query = (new $class())->newQuery();
+        $query = $query->applyScopes();
+
+        foreach ($query->getQuery()->wheres as $where) {
+            $this->query->where(
+                array_key_exists('column', $where) ? $where['column'] : null,
+                array_key_exists('operator', $where) ? $where['operator'] : null,
+                array_key_exists('value', $where) ? $where['value'] : null,
+                array_key_exists('boolean', $where) ? $where['boolean'] : null
+            );
+        }
+
         return $this;
+    }
+
+    /**
+     * Whether or not this relationship is using a custom pivot model
+     *
+     * @return boolean
+     */
+    public function hasCustomPivotModel()
+    {
+        return (bool) $this->using;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -236,7 +236,7 @@ class BelongsToMany extends Relation
 
     /**
      * Specify the custom pivot model to use for the relationship.
-     * Also, attach global scopes
+     * Also, attach global scopes.
      *
      * @param  string  $class
      * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
@@ -261,9 +261,9 @@ class BelongsToMany extends Relation
     }
 
     /**
-     * Whether or not this relationship is using a custom pivot model
+     * Whether or not this relationship is using a custom pivot model.
      *
-     * @return boolean
+     * @return bool
      */
     public function hasCustomPivotModel()
     {

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -434,7 +434,7 @@ trait InteractsWithPivotTable
     /**
      * Create a new query builder for the pivot table.
      *
-     * @param \Illuminate\Database\Query\Builder (optional)
+     * @param  \Illuminate\Database\Query\Builder  $query
      * @return \Illuminate\Database\Query\Builder
      */
     protected function newPivotQuery(Builder $query = null)

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -350,7 +350,6 @@ trait InteractsWithPivotTable
         } else {
             $query = $this->newPivotQuery();
         }
-       
 
         // If associated IDs were passed to the method we will only delete those
         // associations, otherwise all of the association ties will be broken.
@@ -376,7 +375,6 @@ trait InteractsWithPivotTable
         } else {
             $results = $query->delete();
         }
-        
 
         if ($touch) {
             $this->touchIfTouching();

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Database\Eloquent\Relations\Concerns;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Collection as BaseCollection;
 
@@ -343,7 +344,13 @@ trait InteractsWithPivotTable
      */
     public function detach($ids = null, $touch = true)
     {
-        $query = $this->newPivotQuery();
+        if ($this->hasCustomPivotModel()) {
+            $using = new $this->using();
+            $query = $this->newPivotQuery($using->newQuery());
+        } else {
+            $query = $this->newPivotQuery();
+        }
+       
 
         // If associated IDs were passed to the method we will only delete those
         // associations, otherwise all of the association ties will be broken.
@@ -359,7 +366,17 @@ trait InteractsWithPivotTable
         // Once we have all of the conditions set on the statement, we are ready
         // to run the delete on the pivot table. Then, if the touch parameter
         // is true, we will go ahead and touch all related models to sync.
-        $results = $query->delete();
+
+        if ($this->hasCustomPivotModel()) {
+            $models = $query->get();
+            $models->each(function ($model) {
+                $model->delete();
+            });
+            $results = $models->isNotEmpty();
+        } else {
+            $results = $query->delete();
+        }
+        
 
         if ($touch) {
             $this->touchIfTouching();
@@ -419,11 +436,12 @@ trait InteractsWithPivotTable
     /**
      * Create a new query builder for the pivot table.
      *
+     * @param \Illuminate\Database\Query\Builder (optional)
      * @return \Illuminate\Database\Query\Builder
      */
-    protected function newPivotQuery()
+    protected function newPivotQuery(Builder $query = null)
     {
-        $query = $this->newPivotStatement();
+        $query = $query ?: $this->newPivotStatement();
 
         foreach ($this->pivotWheres as $arguments) {
             call_user_func_array([$query, 'where'], $arguments);

--- a/src/Illuminate/Database/Eloquent/Relations/MorphToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphToMany.php
@@ -114,9 +114,9 @@ class MorphToMany extends BelongsToMany
      *
      * @return \Illuminate\Database\Query\Builder
      */
-    protected function newPivotQuery()
+    protected function newPivotQuery(Builder $query = null)
     {
-        return parent::newPivotQuery()->where($this->morphType, $this->morphClass);
+        return parent::newPivotQuery($query)->where($this->morphType, $this->morphClass);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/MorphToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphToMany.php
@@ -112,6 +112,7 @@ class MorphToMany extends BelongsToMany
     /**
      * Create a new query builder for the pivot table.
      *
+     * @param  \Illuminate\Database\Query\Builder  $query
      * @return \Illuminate\Database\Query\Builder
      */
     protected function newPivotQuery(Builder $query = null)

--- a/src/Illuminate/Database/Eloquent/Relations/Pivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Pivot.php
@@ -35,7 +35,6 @@ class Pivot extends Model
      */
     protected $guarded = [];
 
-
     /**
      * Whether this Pivot was instantiated directly.
      *

--- a/src/Illuminate/Database/Eloquent/Relations/Pivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Pivot.php
@@ -206,7 +206,7 @@ class Pivot extends Model
     }
 
     /**
-     * Determine if this pivot has a parent or if it's being used as a model
+     * Determine if this pivot has a parent or if it's being used as a model.
      *
      * @return bool
      */

--- a/src/Illuminate/Database/Eloquent/Relations/Pivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Pivot.php
@@ -109,6 +109,10 @@ class Pivot extends Model
      */
     protected function setKeysForSaveQuery(Builder $query)
     {
+        if ($this->instantiatedAsModel) {
+            return parent::setKeysForSaveQuery($query);
+        }
+        
         $query->where($this->foreignKey, $this->getAttribute($this->foreignKey));
 
         return $query->where($this->relatedKey, $this->getAttribute($this->relatedKey));

--- a/src/Illuminate/Database/Eloquent/Relations/Pivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Pivot.php
@@ -37,9 +37,9 @@ class Pivot extends Model
 
 
     /**
-     * Whether this Pivot was instantiated directly
+     * Whether this Pivot was instantiated directly.
      *
-     * @var boolean
+     * @var bool
      */
     protected $instantiatedAsModel = false;
 
@@ -55,13 +55,10 @@ class Pivot extends Model
     public function __construct($parent = null, $attributes = [], $table = null, $exists = false)
     {
         if (! $parent instanceof Model) {
-            
             $attributes = is_array($parent) ? $parent : $attributes;
             parent::__construct($attributes);
             $this->instantiatedAsModel = true;
-
         } else {
-
             parent::__construct();
 
             // The pivot model is a "dynamic" model since we will set the tables dynamically
@@ -112,7 +109,7 @@ class Pivot extends Model
         if ($this->instantiatedAsModel) {
             return parent::setKeysForSaveQuery($query);
         }
-        
+
         $query->where($this->foreignKey, $this->getAttribute($this->foreignKey));
 
         return $query->where($this->relatedKey, $this->getAttribute($this->relatedKey));

--- a/src/Illuminate/Database/Eloquent/Relations/Pivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Pivot.php
@@ -36,16 +36,9 @@ class Pivot extends Model
     protected $guarded = [];
 
     /**
-     * Whether this Pivot was instantiated directly.
-     *
-     * @var bool
-     */
-    protected $instantiatedAsModel = false;
-
-    /**
      * Create a new pivot model instance.
      *
-     * @param  \Illuminate\Database\Eloquent\Model  $parent
+     * @param  mixed   $parent
      * @param  array   $attributes
      * @param  string  $table
      * @param  bool    $exists
@@ -56,7 +49,6 @@ class Pivot extends Model
         if (! $parent instanceof Model) {
             $attributes = is_array($parent) ? $parent : $attributes;
             parent::__construct($attributes);
-            $this->instantiatedAsModel = true;
         } else {
             parent::__construct();
 
@@ -105,7 +97,7 @@ class Pivot extends Model
      */
     protected function setKeysForSaveQuery(Builder $query)
     {
-        if ($this->instantiatedAsModel) {
+        if (! $this->hasParent()) {
             return parent::setKeysForSaveQuery($query);
         }
 
@@ -121,7 +113,7 @@ class Pivot extends Model
      */
     public function delete()
     {
-        return $this->instantiatedAsModel ? parent::delete() : $this->getDeleteQuery()->delete();
+        return $this->hasParent() ? $this->getDeleteQuery()->delete() : parent::delete();
     }
 
     /**
@@ -200,7 +192,7 @@ class Pivot extends Model
      */
     public function getCreatedAtColumn()
     {
-        return $this->instantiatedAsModel ? parent::getCreatedAtColumn() : $this->parent->getCreatedAtColumn();
+        return $this->hasParent() ? $this->parent->getCreatedAtColumn() : parent::getCreatedAtColumn();
     }
 
     /**
@@ -210,6 +202,16 @@ class Pivot extends Model
      */
     public function getUpdatedAtColumn()
     {
-        return $this->instantiatedAsModel ? parent::getUpdatedAtColumn() : $this->parent->getUpdatedAtColumn();
+        return $this->hasParent() ? $this->parent->getUpdatedAtColumn() : parent::getUpdatedAtColumn();
+    }
+
+    /**
+     * Determine if this pivot has a parent or if it's being used as a model
+     *
+     * @return bool
+     */
+    public function hasParent()
+    {
+        return (bool) $this->parent;
     }
 }

--- a/tests/Database/DatabaseEloquentBelongsToManyTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyTest.php
@@ -325,24 +325,6 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
         $this->assertTrue($relation->detach());
     }
 
-    public function testDetachMethodFiresDeleteIndividuallyWhenUsingModel()
-    {
-        $model = m::mock();
-        $model->shouldReceive('delete')->once();
-        $collection = new BaseCollection([$model]);
-        $relation = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\BelongsToMany')->setMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
-        $using = m::mock();
-        $using->shouldReceive('newQuery')->once();
-        $relation->shouldReceive('hasCustomPivotModel')->andReturn(true);
-        $relation->shouldReceive('using')->andReturn($using);
-        $using->shouldReceive('where')->once()->with('user_id', 1)->andReturnSelf();
-        $using->shouldReceive('whereIn')->once()->with('role_id', [1, 2, 3]);
-        $using->shouldReceive('get')->once()->andReturn($collection);
-        $relation->expects($this->once())->method('touchIfTouching');
-
-        $this->assertTrue($relation->detach([1, 2, 3]));
-    }
-
     public function testFirstMethod()
     {
         $relation = m::mock('Illuminate\Database\Eloquent\Relations\BelongsToMany[get]', $this->getRelationArguments());

--- a/tests/Database/DatabaseEloquentBelongsToManyTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyTest.php
@@ -325,6 +325,24 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
         $this->assertTrue($relation->detach());
     }
 
+    public function testDetachMethodFiresDeleteIndividuallyWhenUsingModel()
+    {
+        $model = m::mock();
+        $model->shouldReceive('delete')->once();
+        $collection = new BaseCollection([$model]);
+        $relation = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\BelongsToMany')->setMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
+        $using = m::mock();
+        $using->shouldReceive('newQuery')->once();
+        $relation->shouldReceive('hasCustomPivotModel')->andReturn(true);
+        $relation->shouldReceive('using')->andReturn($using);
+        $using->shouldReceive('where')->once()->with('user_id', 1)->andReturnSelf();
+        $using->shouldReceive('whereIn')->once()->with('role_id', [1, 2, 3]);
+        $using->shouldReceive('get')->once()->andReturn($collection);
+        $relation->expects($this->once())->method('touchIfTouching');
+
+        $this->assertTrue($relation->detach([1, 2, 3]));
+    }
+
     public function testFirstMethod()
     {
         $relation = m::mock('Illuminate\Database\Eloquent\Relations\BelongsToMany[get]', $this->getRelationArguments());

--- a/tests/Database/DatabaseEloquentPivotTest.php
+++ b/tests/Database/DatabaseEloquentPivotTest.php
@@ -105,6 +105,14 @@ class DatabaseEloquentPivotTest extends TestCase
 
         $this->assertTrue($pivot->delete());
     }
+
+    public function testPivotCanBeInstantiatedAsAModel()
+    {
+        $pivot = new DatabaseEloquentPivotTestDateStub(['value' => 'test']);
+        
+        $this->assertInstanceOf(Pivot::class, $pivot);
+        $this->assertEquals('test', $pivot->value);
+    }
 }
 
 class DatabaseEloquentPivotTestDateStub extends \Illuminate\Database\Eloquent\Relations\Pivot

--- a/tests/Database/DatabaseEloquentPivotTest.php
+++ b/tests/Database/DatabaseEloquentPivotTest.php
@@ -108,7 +108,7 @@ class DatabaseEloquentPivotTest extends TestCase
 
     public function testPivotCanBeInstantiatedAsAModel()
     {
-        $pivot = new DatabaseEloquentPivotTest(['value' => 'test']);
+        $pivot = new DatabaseEloquentPivotTestDateStub(['value' => 'test']);
 
         $this->assertInstanceOf(Pivot::class, $pivot);
         $this->assertEquals('test', $pivot->value);

--- a/tests/Database/DatabaseEloquentPivotTest.php
+++ b/tests/Database/DatabaseEloquentPivotTest.php
@@ -108,8 +108,8 @@ class DatabaseEloquentPivotTest extends TestCase
 
     public function testPivotCanBeInstantiatedAsAModel()
     {
-        $pivot = new DatabaseEloquentPivotTestDateStub(['value' => 'test']);
-        
+        $pivot = new DatabaseEloquentPivotTest(['value' => 'test']);
+
         $this->assertInstanceOf(Pivot::class, $pivot);
         $this->assertEquals('test', $pivot->value);
     }


### PR DESCRIPTION
Since 5.4 introduced using custom pivot table models, I thought it would be a good time to bring back up the concept of adding soft deletes and global scopes to BelongsToMany relationships.

This PR allows you to define global scopes and use SoftDeletes on your custom pivot table model and have them apply to your BelongsToMany relationships when you define the relationship with the new using syntax.

This PR doesn't include tests, because I know that Taylor has been against this previously so I didn't want to go through an entire submission process before this was discussed. I have the tests partially written and will commit them pending approval.  