### PR TITLE
[5.5] Removes redundant isset

### DIFF
--- a/src/Illuminate/Queue/Jobs/JobName.php
+++ b/src/Illuminate/Queue/Jobs/JobName.php
@@ -26,7 +26,7 @@ class JobName
      */
     public static function resolve($name, $payload)
     {
-        if (isset($payload['displayName']) && ! empty($payload['displayName'])) {
+        if (! empty($payload['displayName'])) {
             return $payload['displayName'];
         }
 


### PR DESCRIPTION
Removes an redundant `isset` call.

`! empty($foo[1])` is the same thing as `isset($foo[1]) && $foo[1]`.