### PR TITLE
[5.4] Class "Str" not found in TestResponse

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -4,6 +4,7 @@ namespace Illuminate\Foundation\Testing;
 
 use Closure;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
 use Illuminate\Http\Response;
 use Illuminate\Contracts\View\View;
 use Illuminate\Support\Traits\Macroable;


### PR DESCRIPTION
Fixed `Error: Class 'Illuminate\Foundation\Testing\Str' not found` in `vendor/laravel/framework/src/Illuminate/Foundation/Testing/TestResponse.php:235` in function `assertJsonFragment`