### PR TITLE
[5.4] Add Request::pick()

### DIFF
--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -194,9 +194,7 @@ trait InteractsWithInput
     {
         $keys = is_array($keys) ? $keys : func_get_args();
 
-        return collect($this->all())->filter(function ($value, $key) use ($keys) {
-            return in_array($key, $keys);
-        })->toArray();
+        return array_intersect_key($this->all(), array_flip($keys));
     }
 
     /**

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -185,6 +185,21 @@ trait InteractsWithInput
     }
 
     /**
+     * Get a subset containing the provided keys with values from the input data.
+     *
+     * @param  array|mixed  $keys
+     * @return array
+     */
+    public function pick($keys)
+    {
+        $keys = is_array($keys) ? $keys : func_get_args();
+
+        return collect($this->all())->filter(function ($value, $key) use ($keys) {
+            return in_array($key, $keys);
+        })->toArray();
+    }
+
+    /**
      * Retrieve a query string item from the request.
      *
      * @param  string  $key

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -267,6 +267,12 @@ class HttpRequestTest extends TestCase
         $this->assertEquals(['name' => 'Taylor'], $request->intersect('name', 'age', 'email'));
     }
 
+    public function testPickMethod()
+    {
+        $request = Request::create('/', 'GET', ['name' => 'Taylor', 'age' => null]);
+        $this->assertEquals(['name' => 'Taylor', 'age' => null], $request->pick('name', 'age', 'email'));
+    }
+
     public function testQueryMethod()
     {
         $request = Request::create('/', 'GET', ['name' => 'Taylor']);


### PR DESCRIPTION
The method works like `intersect()`, however the problem with intersect is that it excludes null, empty, and zero values.

So for example a payload like:

```
{
    "name": "",
    "category": null,
    "level": 0
}
```

Output of `request()->intersect('name', 'category', 'level', 'age')'` will be an empty array.

Output of `request()->only('name', 'category', 'level', 'age')'` will be:

```
[
    "name"=> "",
    "category"=> null,
    "level"=> 0,
    "age" => null
]
```

Output of `request()->pick('name', 'category', 'level', 'age')'` will be:

```
[
    "name"=> "",
    "category"=> null,
    "level"=> 0
]
```