### PR TITLE
[5.4] if one factory model is built, return single instance - not a collection

### DIFF
--- a/src/Illuminate/Database/Eloquent/FactoryBuilder.php
+++ b/src/Illuminate/Database/Eloquent/FactoryBuilder.php
@@ -84,7 +84,7 @@ class FactoryBuilder
      */
     public function times($amount)
     {
-        $this->amount = $amount;
+        $this->amount = $amount == 1 ? null : $amount;
 
         return $this;
     }


### PR DESCRIPTION
Currently, building a factory model 1 time will return a collection. It seems like this is a bit flawed and this:

`factory(MyModel::class, 1)->create();` or `factory(MyModel::class)->times(1)->create();`

should have the same result as:

`factory(MyModel::class)->create();`

which would be a single instance of `MyModel`

I didn't see any tests for the `FactoryBuilder`, so if there are any and I missed them I'd be happy to write some tests. If this code change needs to be somewhere else I'd be happy to make that change also but this seemed to be the best spot to put it.