### PR TITLE
[5.4] Test and fix RedisQueue for phpredis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ services:
 before_install:
   - if [[ $TRAVIS_PHP_VERSION != 7.1 ]] ; then phpenv config-rm xdebug.ini; fi
   - echo "extension = memcached.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
+  - echo "extension = redis.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
   - travis_retry composer self-update
 
 install:

--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -123,7 +123,7 @@ class RedisQueue extends Queue implements QueueContract
     protected function laterRaw($delay, $payload, $queue = null)
     {
         $this->getConnection()->zadd(
-            $this->getQueue($queue).':delayed', $this->availableAt($delay), $payload
+            $this->getQueue($queue).':delayed', [$payload => $this->availableAt($delay)]
         );
 
         return Arr::get(json_decode($payload, true), 'id');
@@ -212,7 +212,7 @@ class RedisQueue extends Queue implements QueueContract
      * Delete a reserved job from the queue.
      *
      * @param  string  $queue
-     * @param  \Illuminate\Queues\Jobs\RedisJob  $job
+     * @param  \Illuminate\Queue\Jobs\RedisJob  $job
      * @return void
      */
     public function deleteReserved($queue, $job)
@@ -224,7 +224,7 @@ class RedisQueue extends Queue implements QueueContract
      * Delete a reserved job from the reserved queue and release it.
      *
      * @param  string  $queue
-     * @param  \Illuminate\Queues\Jobs\RedisJob  $job
+     * @param  \Illuminate\Queue\Jobs\RedisJob  $job
      * @param  int  $delay
      * @return void
      */

--- a/tests/Cache/RedisCacheIntegrationTest.php
+++ b/tests/Cache/RedisCacheIntegrationTest.php
@@ -25,31 +25,46 @@ class RedisCacheIntegrationTest extends TestCase
         $this->tearDownRedis();
     }
 
-    public function testRedisCacheAddTwice()
+    /**
+     * @dataProvider redisDriverProvider
+     *
+     * @param string $driver
+     */
+    public function testRedisCacheAddTwice($driver)
     {
-        $store = new RedisStore($this->redis);
+        $store = new RedisStore($this->redis[$driver]);
         $repository = new Repository($store);
         $this->assertTrue($repository->add('k', 'v', 60));
         $this->assertFalse($repository->add('k', 'v', 60));
+        $this->assertGreaterThan(3500, $this->redis[$driver]->connection()->ttl('k'));
     }
 
     /**
      * Breaking change.
+     *
+     * @dataProvider redisDriverProvider
+     *
+     * @param string $driver
      */
-    public function testRedisCacheAddFalse()
+    public function testRedisCacheAddFalse($driver)
     {
-        $store = new RedisStore($this->redis);
+        $store = new RedisStore($this->redis[$driver]);
         $repository = new Repository($store);
         $repository->forever('k', false);
         $this->assertFalse($repository->add('k', 'v', 60));
+        $this->assertEquals(-1, $this->redis[$driver]->connection()->ttl('k'));
     }
 
     /**
      * Breaking change.
+     *
+     * @dataProvider redisDriverProvider
+     *
+     * @param string $driver
      */
-    public function testRedisCacheAddNull()
+    public function testRedisCacheAddNull($driver)
     {
-        $store = new RedisStore($this->redis);
+        $store = new RedisStore($this->redis[$driver]);
         $repository = new Repository($store);
         $repository->forever('k', null);
         $this->assertFalse($repository->add('k', 'v', 60));

--- a/tests/Queue/QueueRedisQueueTest.php
+++ b/tests/Queue/QueueRedisQueueTest.php
@@ -32,8 +32,9 @@ class QueueRedisQueueTest extends TestCase
         $redis->shouldReceive('connection')->once()->andReturn($redis);
         $redis->shouldReceive('zadd')->once()->with(
             'queues:default:delayed',
-            2,
-            json_encode(['displayName' => 'foo', 'job' => 'foo', 'maxTries' => null, 'timeout' => null, 'data' => ['data'], 'id' => 'foo', 'attempts' => 0])
+            [
+                json_encode(['displayName' => 'foo', 'job' => 'foo', 'maxTries' => null, 'timeout' => null, 'data' => ['data'], 'id' => 'foo', 'attempts' => 0]) => 2,
+            ]
         );
 
         $id = $queue->later(1, 'foo', ['data']);
@@ -50,8 +51,9 @@ class QueueRedisQueueTest extends TestCase
         $redis->shouldReceive('connection')->once()->andReturn($redis);
         $redis->shouldReceive('zadd')->once()->with(
             'queues:default:delayed',
-            2,
-            json_encode(['displayName' => 'foo', 'job' => 'foo', 'maxTries' => null, 'timeout' => null, 'data' => ['data'], 'id' => 'foo', 'attempts' => 0])
+            [
+                json_encode(['displayName' => 'foo', 'job' => 'foo', 'maxTries' => null, 'timeout' => null, 'data' => ['data'], 'id' => 'foo', 'attempts' => 0]) => 2,
+            ]
         );
 
         $queue->later($date, 'foo', ['data']);

--- a/tests/Queue/RedisQueueIntegrationTest.php
+++ b/tests/Queue/RedisQueueIntegrationTest.php
@@ -24,9 +24,6 @@ class RedisQueueIntegrationTest extends TestCase
         Carbon::setTestNow();
         parent::setUp();
         $this->setUpRedis();
-
-        $this->queue = new RedisQueue($this->redis);
-        $this->queue->setContainer(m::mock(Container::class));
     }
 
     public function tearDown()
@@ -37,8 +34,15 @@ class RedisQueueIntegrationTest extends TestCase
         m::close();
     }
 
-    public function testExpiredJobsArePopped()
+    /**
+     * @dataProvider redisDriverProvider
+     *
+     * @param string $driver
+     */
+    public function testExpiredJobsArePopped($driver)
     {
+        $this->setQueue($driver);
+
         $jobs = [
             new RedisQueueIntegrationTestJob(0),
             new RedisQueueIntegrationTestJob(1),
@@ -56,12 +60,19 @@ class RedisQueueIntegrationTest extends TestCase
         $this->assertEquals($jobs[3], unserialize(json_decode($this->queue->pop()->getRawBody())->data->command));
         $this->assertNull($this->queue->pop());
 
-        $this->assertEquals(1, $this->redis->connection()->zcard('queues:default:delayed'));
-        $this->assertEquals(3, $this->redis->connection()->zcard('queues:default:reserved'));
+        $this->assertEquals(1, $this->redis[$driver]->connection()->zcard('queues:default:delayed'));
+        $this->assertEquals(3, $this->redis[$driver]->connection()->zcard('queues:default:reserved'));
     }
 
-    public function testPopProperlyPopsJobOffOfRedis()
+    /**
+     * @dataProvider redisDriverProvider
+     *
+     * @param string $driver
+     */
+    public function testPopProperlyPopsJobOffOfRedis($driver)
     {
+        $this->setQueue($driver);
+
         // Push an item into queue
         $job = new RedisQueueIntegrationTestJob(10);
         $this->queue->push($job);
@@ -79,8 +90,8 @@ class RedisQueueIntegrationTest extends TestCase
         $this->assertEquals($redisJob->getJobId(), json_decode($redisJob->getReservedJob())->id);
 
         // Check reserved queue
-        $this->assertEquals(1, $this->redis->connection()->zcard('queues:default:reserved'));
-        $result = $this->redis->connection()->zrangebyscore('queues:default:reserved', -INF, INF, ['WITHSCORES' => true]);
+        $this->assertEquals(1, $this->redis[$driver]->connection()->zcard('queues:default:reserved'));
+        $result = $this->redis[$driver]->connection()->zrangebyscore('queues:default:reserved', -INF, INF, ['WITHSCORES' => true]);
         $reservedJob = array_keys($result)[0];
         $score = $result[$reservedJob];
         $this->assertLessThanOrEqual($score, $before + 60);
@@ -88,8 +99,14 @@ class RedisQueueIntegrationTest extends TestCase
         $this->assertEquals($job, unserialize(json_decode($reservedJob)->data->command));
     }
 
-    public function testPopProperlyPopsDelayedJobOffOfRedis()
+    /**
+     * @dataProvider redisDriverProvider
+     *
+     * @param string $driver
+     */
+    public function testPopProperlyPopsDelayedJobOffOfRedis($driver)
     {
+        $this->setQueue($driver);
         // Push an item into queue
         $job = new RedisQueueIntegrationTestJob(10);
         $this->queue->later(-10, $job);
@@ -100,8 +117,8 @@ class RedisQueueIntegrationTest extends TestCase
         $after = time();
 
         // Check reserved queue
-        $this->assertEquals(1, $this->redis->connection()->zcard('queues:default:reserved'));
-        $result = $this->redis->connection()->zrangebyscore('queues:default:reserved', -INF, INF, ['WITHSCORES' => true]);
+        $this->assertEquals(1, $this->redis[$driver]->connection()->zcard('queues:default:reserved'));
+        $result = $this->redis[$driver]->connection()->zrangebyscore('queues:default:reserved', -INF, INF, ['WITHSCORES' => true]);
         $reservedJob = array_keys($result)[0];
         $score = $result[$reservedJob];
         $this->assertLessThanOrEqual($score, $before + 60);
@@ -109,9 +126,14 @@ class RedisQueueIntegrationTest extends TestCase
         $this->assertEquals($job, unserialize(json_decode($reservedJob)->data->command));
     }
 
-    public function testPopPopsDelayedJobOffOfRedisWhenExpireNull()
+    /**
+     * @dataProvider redisDriverProvider
+     *
+     * @param string $driver
+     */
+    public function testPopPopsDelayedJobOffOfRedisWhenExpireNull($driver)
     {
-        $this->queue = new RedisQueue($this->redis, 'default', null, null);
+        $this->queue = new RedisQueue($this->redis[$driver], 'default', null, null);
         $this->queue->setContainer(m::mock(Container::class));
 
         // Push an item into queue
@@ -124,8 +146,8 @@ class RedisQueueIntegrationTest extends TestCase
         $after = time();
 
         // Check reserved queue
-        $this->assertEquals(1, $this->redis->connection()->zcard('queues:default:reserved'));
-        $result = $this->redis->connection()->zrangebyscore('queues:default:reserved', -INF, INF, ['WITHSCORES' => true]);
+        $this->assertEquals(1, $this->redis[$driver]->connection()->zcard('queues:default:reserved'));
+        $result = $this->redis[$driver]->connection()->zrangebyscore('queues:default:reserved', -INF, INF, ['WITHSCORES' => true]);
         $reservedJob = array_keys($result)[0];
         $score = $result[$reservedJob];
         $this->assertLessThanOrEqual($score, $before);
@@ -133,9 +155,14 @@ class RedisQueueIntegrationTest extends TestCase
         $this->assertEquals($job, unserialize(json_decode($reservedJob)->data->command));
     }
 
-    public function testNotExpireJobsWhenExpireNull()
+    /**
+     * @dataProvider redisDriverProvider
+     *
+     * @param string $driver
+     */
+    public function testNotExpireJobsWhenExpireNull($driver)
     {
-        $this->queue = new RedisQueue($this->redis, 'default', null, null);
+        $this->queue = new RedisQueue($this->redis[$driver], 'default', null, null);
         $this->queue->setContainer(m::mock(Container::class));
 
         // Make an expired reserved job
@@ -155,8 +182,8 @@ class RedisQueueIntegrationTest extends TestCase
         $after = time();
 
         // Check reserved queue
-        $this->assertEquals(2, $this->redis->connection()->zcard('queues:default:reserved'));
-        $result = $this->redis->connection()->zrangebyscore('queues:default:reserved', -INF, INF, ['WITHSCORES' => true]);
+        $this->assertEquals(2, $this->redis[$driver]->connection()->zcard('queues:default:reserved'));
+        $result = $this->redis[$driver]->connection()->zrangebyscore('queues:default:reserved', -INF, INF, ['WITHSCORES' => true]);
 
         foreach ($result as $payload => $score) {
             $command = unserialize(json_decode($payload)->data->command);
@@ -172,9 +199,14 @@ class RedisQueueIntegrationTest extends TestCase
         }
     }
 
-    public function testExpireJobsWhenExpireSet()
+    /**
+     * @dataProvider redisDriverProvider
+     *
+     * @param string $driver
+     */
+    public function testExpireJobsWhenExpireSet($driver)
     {
-        $this->queue = new RedisQueue($this->redis, 'default', null, 30);
+        $this->queue = new RedisQueue($this->redis[$driver], 'default', null, 30);
         $this->queue->setContainer(m::mock(Container::class));
 
         // Push an item into queue
@@ -187,8 +219,8 @@ class RedisQueueIntegrationTest extends TestCase
         $after = time();
 
         // Check reserved queue
-        $this->assertEquals(1, $this->redis->connection()->zcard('queues:default:reserved'));
-        $result = $this->redis->connection()->zrangebyscore('queues:default:reserved', -INF, INF, ['WITHSCORES' => true]);
+        $this->assertEquals(1, $this->redis[$driver]->connection()->zcard('queues:default:reserved'));
+        $result = $this->redis[$driver]->connection()->zrangebyscore('queues:default:reserved', -INF, INF, ['WITHSCORES' => true]);
         $reservedJob = array_keys($result)[0];
         $score = $result[$reservedJob];
         $this->assertLessThanOrEqual($score, $before + 30);
@@ -196,8 +228,15 @@ class RedisQueueIntegrationTest extends TestCase
         $this->assertEquals($job, unserialize(json_decode($reservedJob)->data->command));
     }
 
-    public function testRelease()
+    /**
+     * @dataProvider redisDriverProvider
+     *
+     * @param string $driver
+     */
+    public function testRelease($driver)
     {
+        $this->setQueue($driver);
+
         //push a job into queue
         $job = new RedisQueueIntegrationTestJob(30);
         $this->queue->push($job);
@@ -210,9 +249,9 @@ class RedisQueueIntegrationTest extends TestCase
         $after = time();
 
         //check the content of delayed queue
-        $this->assertEquals(1, $this->redis->connection()->zcard('queues:default:delayed'));
+        $this->assertEquals(1, $this->redis[$driver]->connection()->zcard('queues:default:delayed'));
 
-        $results = $this->redis->connection()->zrangebyscore('queues:default:delayed', -INF, INF, ['WITHSCORES' => true]);
+        $results = $this->redis[$driver]->connection()->zrangebyscore('queues:default:delayed', -INF, INF, ['WITHSCORES' => true]);
 
         $payload = array_keys($results)[0];
 
@@ -230,8 +269,14 @@ class RedisQueueIntegrationTest extends TestCase
         $this->assertNull($this->queue->pop());
     }
 
-    public function testReleaseInThePast()
+    /**
+     * @dataProvider redisDriverProvider
+     *
+     * @param string $driver
+     */
+    public function testReleaseInThePast($driver)
     {
+        $this->setQueue($driver);
         $job = new RedisQueueIntegrationTestJob(30);
         $this->queue->push($job);
 
@@ -242,8 +287,15 @@ class RedisQueueIntegrationTest extends TestCase
         $this->assertInstanceOf(RedisJob::class, $this->queue->pop());
     }
 
-    public function testDelete()
+    /**
+     * @dataProvider redisDriverProvider
+     *
+     * @param string $driver
+     */
+    public function testDelete($driver)
     {
+        $this->setQueue($driver);
+
         $job = new RedisQueueIntegrationTestJob(30);
         $this->queue->push($job);
 
@@ -252,15 +304,21 @@ class RedisQueueIntegrationTest extends TestCase
 
         $redisJob->delete();
 
-        $this->assertEquals(0, $this->redis->connection()->zcard('queues:default:delayed'));
-        $this->assertEquals(0, $this->redis->connection()->zcard('queues:default:reserved'));
-        $this->assertEquals(0, $this->redis->connection()->llen('queues:default'));
+        $this->assertEquals(0, $this->redis[$driver]->connection()->zcard('queues:default:delayed'));
+        $this->assertEquals(0, $this->redis[$driver]->connection()->zcard('queues:default:reserved'));
+        $this->assertEquals(0, $this->redis[$driver]->connection()->llen('queues:default'));
 
         $this->assertNull($this->queue->pop());
     }
 
-    public function testSize()
+    /**
+     * @dataProvider redisDriverProvider
+     *
+     * @param string $driver
+     */
+    public function testSize($driver)
     {
+        $this->setQueue($driver);
         $this->assertEquals(0, $this->queue->size());
         $this->queue->push(new RedisQueueIntegrationTestJob(1));
         $this->assertEquals(1, $this->queue->size());
@@ -272,6 +330,15 @@ class RedisQueueIntegrationTest extends TestCase
         $this->assertEquals(3, $this->queue->size());
         $job->delete();
         $this->assertEquals(2, $this->queue->size());
+    }
+
+    /**
+     * @param string $driver
+     */
+    private function setQueue($driver)
+    {
+        $this->queue = new RedisQueue($this->redis[$driver]);
+        $this->queue->setContainer(m::mock(Container::class));
     }
 }
 

--- a/tests/Queue/RedisQueueIntegrationTest.php
+++ b/tests/Queue/RedisQueueIntegrationTest.php
@@ -91,7 +91,7 @@ class RedisQueueIntegrationTest extends TestCase
 
         // Check reserved queue
         $this->assertEquals(1, $this->redis[$driver]->connection()->zcard('queues:default:reserved'));
-        $result = $this->redis[$driver]->connection()->zrangebyscore('queues:default:reserved', -INF, INF, ['WITHSCORES' => true]);
+        $result = $this->redis[$driver]->connection()->zrangebyscore('queues:default:reserved', -INF, INF, ['withscores' => true]);
         $reservedJob = array_keys($result)[0];
         $score = $result[$reservedJob];
         $this->assertLessThanOrEqual($score, $before + 60);
@@ -118,7 +118,7 @@ class RedisQueueIntegrationTest extends TestCase
 
         // Check reserved queue
         $this->assertEquals(1, $this->redis[$driver]->connection()->zcard('queues:default:reserved'));
-        $result = $this->redis[$driver]->connection()->zrangebyscore('queues:default:reserved', -INF, INF, ['WITHSCORES' => true]);
+        $result = $this->redis[$driver]->connection()->zrangebyscore('queues:default:reserved', -INF, INF, ['withscores' => true]);
         $reservedJob = array_keys($result)[0];
         $score = $result[$reservedJob];
         $this->assertLessThanOrEqual($score, $before + 60);
@@ -147,7 +147,7 @@ class RedisQueueIntegrationTest extends TestCase
 
         // Check reserved queue
         $this->assertEquals(1, $this->redis[$driver]->connection()->zcard('queues:default:reserved'));
-        $result = $this->redis[$driver]->connection()->zrangebyscore('queues:default:reserved', -INF, INF, ['WITHSCORES' => true]);
+        $result = $this->redis[$driver]->connection()->zrangebyscore('queues:default:reserved', -INF, INF, ['withscores' => true]);
         $reservedJob = array_keys($result)[0];
         $score = $result[$reservedJob];
         $this->assertLessThanOrEqual($score, $before);
@@ -183,7 +183,7 @@ class RedisQueueIntegrationTest extends TestCase
 
         // Check reserved queue
         $this->assertEquals(2, $this->redis[$driver]->connection()->zcard('queues:default:reserved'));
-        $result = $this->redis[$driver]->connection()->zrangebyscore('queues:default:reserved', -INF, INF, ['WITHSCORES' => true]);
+        $result = $this->redis[$driver]->connection()->zrangebyscore('queues:default:reserved', -INF, INF, ['withscores' => true]);
 
         foreach ($result as $payload => $score) {
             $command = unserialize(json_decode($payload)->data->command);
@@ -220,7 +220,7 @@ class RedisQueueIntegrationTest extends TestCase
 
         // Check reserved queue
         $this->assertEquals(1, $this->redis[$driver]->connection()->zcard('queues:default:reserved'));
-        $result = $this->redis[$driver]->connection()->zrangebyscore('queues:default:reserved', -INF, INF, ['WITHSCORES' => true]);
+        $result = $this->redis[$driver]->connection()->zrangebyscore('queues:default:reserved', -INF, INF, ['withscores' => true]);
         $reservedJob = array_keys($result)[0];
         $score = $result[$reservedJob];
         $this->assertLessThanOrEqual($score, $before + 30);
@@ -251,7 +251,7 @@ class RedisQueueIntegrationTest extends TestCase
         //check the content of delayed queue
         $this->assertEquals(1, $this->redis[$driver]->connection()->zcard('queues:default:delayed'));
 
-        $results = $this->redis[$driver]->connection()->zrangebyscore('queues:default:delayed', -INF, INF, ['WITHSCORES' => true]);
+        $results = $this->redis[$driver]->connection()->zrangebyscore('queues:default:delayed', -INF, INF, ['withscores' => true]);
 
         $payload = array_keys($results)[0];
 

--- a/tests/Redis/InteractsWithRedis.php
+++ b/tests/Redis/InteractsWithRedis.php
@@ -12,7 +12,7 @@ trait InteractsWithRedis
     private static $connectionFailedOnceWithDefaultsSkip = false;
 
     /**
-     * @var RedisManager
+     * @var RedisManager[]
      */
     private $redis;
 
@@ -27,18 +27,20 @@ trait InteractsWithRedis
             return;
         }
 
-        $this->redis = new RedisManager('predis', [
-            'cluster' => false,
-            'default' => [
-                'host' => $host,
-                'port' => $port,
-                'database' => 5,
-                'timeout' => 0.5,
-            ],
-        ]);
+        foreach (['predis', 'phpredis'] as $driver) {
+            $this->redis[$driver] = new RedisManager($driver, [
+                'cluster' => false,
+                'default' => [
+                    'host' => $host,
+                    'port' => $port,
+                    'database' => 5,
+                    'timeout' => 0.5,
+                ],
+            ]);
+        }
 
         try {
-            $this->redis->connection()->flushdb();
+            $this->redis['predis']->connection()->flushdb();
         } catch (\Exception $e) {
             if ($host === '127.0.0.1' && $port === 6379 && getenv('REDIS_HOST') === false) {
                 $this->markTestSkipped('Trying default host/port failed, please set environment variable REDIS_HOST & REDIS_PORT to enable '.__CLASS__);
@@ -52,7 +54,15 @@ trait InteractsWithRedis
     public function tearDownRedis()
     {
         if ($this->redis) {
-            $this->redis->connection()->flushdb();
+            $this->redis['predis']->connection()->flushdb();
         }
+    }
+
+    public function redisDriverProvider()
+    {
+        return [
+            ['predis'],
+            ['phpredis'],
+        ];
     }
 }

--- a/tests/Redis/InteractsWithRedis.php
+++ b/tests/Redis/InteractsWithRedis.php
@@ -55,6 +55,8 @@ trait InteractsWithRedis
     {
         if ($this->redis) {
             $this->redis['predis']->connection()->flushdb();
+            $this->redis['predis']->connection()->disconnect();
+            $this->redis['phpredis']->connection()->close();
         }
     }
 


### PR DESCRIPTION
- Tests for both phpredis and predis: see `.travis.yml` file and `InteractsWithRedis` trait.
- Fix `RedisQueue` for phpredis: call to zadd.
- Fix tests: phpredis may be case sensitive so `'WITHSCORES'` should be converted to `'withscores'`