### PR TITLE
[5.5] Be less strict for risky tests in PHPUnit 6.

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit backupGlobals="false"
          backupStaticAttributes="false"
+         beStrictAboutTestsThatDoNotTestAnything="false"
          bootstrap="tests/bootstrap.php"
          colors="true"
          convertErrorsToExceptions="true"


### PR DESCRIPTION
PHPunit 6 echoes all risky tests for not actually testing anything. This turns the output into something very unfriendly:

![screen shot 2017-02-10 at 12 29 30](https://cloud.githubusercontent.com/assets/513603/22825297/a5fa2314-ef8c-11e6-9448-0da40b49abce.png)

---

This PR allows not to display them.

![screen shot 2017-02-10 at 12 29 01](https://cloud.githubusercontent.com/assets/513603/22825310/b5d01942-ef8c-11e6-8151-8209cade93d7.png)

