### PR TITLE
[5.5] Ensure Arrayable objects are also morphed by the Response.

### DIFF
--- a/src/Illuminate/Http/Response.php
+++ b/src/Illuminate/Http/Response.php
@@ -5,6 +5,7 @@ namespace Illuminate\Http;
 use ArrayObject;
 use JsonSerializable;
 use Illuminate\Contracts\Support\Jsonable;
+use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Renderable;
 use Symfony\Component\HttpFoundation\Response as BaseResponse;
 
@@ -49,7 +50,8 @@ class Response extends BaseResponse
      */
     protected function shouldBeJson($content)
     {
-        return $content instanceof Jsonable ||
+        return $content instanceof Arrayable ||
+               $content instanceof Jsonable ||
                $content instanceof ArrayObject ||
                $content instanceof JsonSerializable ||
                is_array($content);
@@ -65,6 +67,8 @@ class Response extends BaseResponse
     {
         if ($content instanceof Jsonable) {
             return $content->toJson();
+        } elseif ($content instanceof Arrayable) {
+            return json_encode($content->toArray());
         }
 
         return json_encode($content);

--- a/tests/Http/HttpResponseTest.php
+++ b/tests/Http/HttpResponseTest.php
@@ -3,10 +3,12 @@
 namespace Illuminate\Tests\Http;
 
 use Mockery as m;
+use JsonSerializable;
 use Illuminate\Http\Request;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Contracts\Support\Jsonable;
+use Illuminate\Contracts\Support\Arrayable;
 
 class HttpResponseTest extends TestCase
 {
@@ -17,8 +19,16 @@ class HttpResponseTest extends TestCase
 
     public function testJsonResponsesAreConvertedAndHeadersAreSet()
     {
+        $response = new \Illuminate\Http\Response(new ArrayableStub);
+        $this->assertEquals('{"foo":"bar"}', $response->getContent());
+        $this->assertEquals('application/json', $response->headers->get('Content-Type'));
+
         $response = new \Illuminate\Http\Response(new JsonableStub);
         $this->assertEquals('foo', $response->getContent());
+        $this->assertEquals('application/json', $response->headers->get('Content-Type'));
+
+        $response = new \Illuminate\Http\Response(new ArrayableAndJsonableStub);
+        $this->assertEquals('{"foo":"bar"}', $response->getContent());
         $this->assertEquals('application/json', $response->headers->get('Content-Type'));
 
         $response = new \Illuminate\Http\Response();
@@ -151,6 +161,27 @@ class HttpResponseTest extends TestCase
     }
 }
 
+class ArrayableStub implements Arrayable
+{
+    public function toArray()
+    {
+        return ['foo' => 'bar'];
+    }
+}
+
+class ArrayableAndJsonableStub implements Arrayable, Jsonable
+{
+    public function toJson($options = 0)
+    {
+        return '{"foo":"bar"}';
+    }
+
+    public function toArray()
+    {
+        return [];
+    }
+}
+
 class JsonableStub implements Jsonable
 {
     public function toJson($options = 0)
@@ -159,7 +190,7 @@ class JsonableStub implements Jsonable
     }
 }
 
-class JsonSerializableStub implements \JsonSerializable
+class JsonSerializableStub implements JsonSerializable
 {
     public function jsonSerialize()
     {


### PR DESCRIPTION
Ensure `Arrayable` objects are also morphed by the Response.

---

Still the result of `toJson` will be taken in consideration first.