### PR TITLE
[5.5] Ensure Arrayable, Jsonable (...) returns a JsonResponse.

### DIFF
--- a/src/Illuminate/Http/Response.php
+++ b/src/Illuminate/Http/Response.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Http;
 
+use Exception;
 use ArrayObject;
 use JsonSerializable;
 use Illuminate\Contracts\Support\Jsonable;
@@ -68,5 +69,24 @@ class Response extends BaseResponse
         }
 
         return json_encode($content);
+    }
+
+    /**
+     * Get a JSON response from the base response.
+     *
+     * @return \Illuminate\Http\JsonResponse
+     * @throws \Exception
+     */
+    public function toJsonResponse()
+    {
+        if (! $this->shouldBeJson($this->original)) {
+            throw new Exception('The Response cannot be converted to a JSON response.');
+        }
+
+        return new JsonResponse(
+            $this->original,
+            $this->statusCode,
+            $this->headers->all()
+        );
     }
 }

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Routing;
 
 use Closure;
+use Exception;
 use Illuminate\Support\Str;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
@@ -489,7 +490,7 @@ class Router implements RegistrarContract, BindingRegistrar
      * Dispatch the request to the application.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @return \Illuminate\Http\Response
+     * @return \Illuminate\Http\Response|\Illuminate\Http\JsonResponse
      */
     public function dispatch(Request $request)
     {
@@ -592,7 +593,7 @@ class Router implements RegistrarContract, BindingRegistrar
      *
      * @param  \Symfony\Component\HttpFoundation\Request  $request
      * @param  mixed  $response
-     * @return \Illuminate\Http\Response
+     * @return \Illuminate\Http\Response|\Illuminate\Http\JsonResponse
      */
     public function prepareResponse($request, $response)
     {
@@ -600,6 +601,14 @@ class Router implements RegistrarContract, BindingRegistrar
             $response = (new HttpFoundationFactory)->createResponse($response);
         } elseif (! $response instanceof SymfonyResponse) {
             $response = new Response($response);
+        }
+
+        if ($response instanceof Response) {
+            try {
+                $response = $response->toJsonResponse();
+            } catch (Exception $e) {
+                //
+            }
         }
 
         return $response->prepare($request);

--- a/tests/Http/HttpResponseTest.php
+++ b/tests/Http/HttpResponseTest.php
@@ -2,10 +2,10 @@
 
 namespace Illuminate\Tests\Http;
 
-use Illuminate\Http\JsonResponse;
 use Mockery as m;
 use Illuminate\Http\Request;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Contracts\Support\Jsonable;
 

--- a/tests/Http/HttpResponseTest.php
+++ b/tests/Http/HttpResponseTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Http;
 
+use Illuminate\Http\JsonResponse;
 use Mockery as m;
 use Illuminate\Http\Request;
 use PHPUnit\Framework\TestCase;
@@ -75,6 +76,26 @@ class HttpResponseTest extends TestCase
         $response = new \Illuminate\Http\Response('foo');
         $response->setStatusCode(404);
         $this->assertSame(404, $response->getStatusCode());
+    }
+
+    public function testToJsonResponse()
+    {
+        $response = new \Illuminate\Http\Response(['foo' => 'bar']);
+        $jsonResponse = $response->toJsonResponse();
+
+        $this->assertInstanceOf(JsonResponse::class, $jsonResponse);
+        $this->assertSame('{"foo":"bar"}', $jsonResponse->getContent());
+        $this->assertSame($response->getStatusCode(), $jsonResponse->getStatusCode());
+    }
+
+    /**
+     * @expectedException \Exception
+     * @expectedExceptionMessage The Response cannot be converted to a JSON response.
+     */
+    public function testTextResponseCannotBeConvertedToJsonResponse()
+    {
+        $response = new \Illuminate\Http\Response('foo');
+        $response->toJsonResponse();
     }
 
     public function testOnlyInputOnRedirect()

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -1228,6 +1228,28 @@ class RoutingRouteTest extends TestCase
         $this->assertEquals('hello', $router->dispatch(Request::create('foo/bar2', 'GET'))->getContent());
     }
 
+    public function testResponseIsReturned()
+    {
+        $router = $this->getRouter();
+        $router->get('foo/bar', function () {
+            return 'hello';
+        });
+
+        $this->assertInstanceOf(\Illuminate\Http\Response::class, $router->dispatch(Request::create('foo/bar', 'GET')));
+        $this->assertNotInstanceOf(\Illuminate\Http\JsonResponse::class, $router->dispatch(Request::create('foo/bar', 'GET')));
+    }
+
+    public function testJsonResponseIsReturned()
+    {
+        $router = $this->getRouter();
+        $router->get('foo/bar', function () {
+            return ['foo', 'bar'];
+        });
+
+        $this->assertNotInstanceOf(\Illuminate\Http\Response::class, $router->dispatch(Request::create('foo/bar', 'GET')));
+        $this->assertInstanceOf(\Illuminate\Http\JsonResponse::class, $router->dispatch(Request::create('foo/bar', 'GET')));
+    }
+
     protected function getRouter()
     {
         $container = new Container;

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -1235,8 +1235,9 @@ class RoutingRouteTest extends TestCase
             return 'hello';
         });
 
-        $this->assertInstanceOf(\Illuminate\Http\Response::class, $router->dispatch(Request::create('foo/bar', 'GET')));
-        $this->assertNotInstanceOf(\Illuminate\Http\JsonResponse::class, $router->dispatch(Request::create('foo/bar', 'GET')));
+        $response = $router->dispatch(Request::create('foo/bar', 'GET'));
+        $this->assertInstanceOf(\Illuminate\Http\Response::class, $response);
+        $this->assertNotInstanceOf(\Illuminate\Http\JsonResponse::class, $response);
     }
 
     public function testJsonResponseIsReturned()
@@ -1246,8 +1247,9 @@ class RoutingRouteTest extends TestCase
             return ['foo', 'bar'];
         });
 
-        $this->assertNotInstanceOf(\Illuminate\Http\Response::class, $router->dispatch(Request::create('foo/bar', 'GET')));
-        $this->assertInstanceOf(\Illuminate\Http\JsonResponse::class, $router->dispatch(Request::create('foo/bar', 'GET')));
+        $response = $router->dispatch(Request::create('foo/bar', 'GET'));
+        $this->assertNotInstanceOf(\Illuminate\Http\Response::class, $response);
+        $this->assertInstanceOf(\Illuminate\Http\JsonResponse::class, $response);
     }
 
     protected function getRouter()


### PR DESCRIPTION
For now only a normal `Response`, mimicing a `JsonResponse` is returned; this enforces a `JsonResponse` to be returned.