### PR TITLE
[5.5] Adding @set Blade method

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesRawPhp.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesRawPhp.php
@@ -35,4 +35,16 @@ trait CompilesRawPhp
     {
         return "<?php unset{$expression}; ?>";
     }
+
+    /**
+     * Compile the set statements into valid PHP.
+     *
+     * @param  string  $expression
+     * @return string
+     */
+    protected function compileSet($expression)
+    {
+        list($variable, $value) = explode(',', $expression, 2);
+        return "<?php $variable = $value; ?>";
+    }
 }

--- a/src/Illuminate/View/Compilers/Concerns/CompilesRawPhp.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesRawPhp.php
@@ -45,6 +45,7 @@ trait CompilesRawPhp
     protected function compileSet($expression)
     {
         list($variable, $value) = explode(',', $expression, 2);
+
         return "<?php $variable = $value; ?>";
     }
 }

--- a/tests/View/Blade/BladeSetStatementsTest.php
+++ b/tests/View/Blade/BladeSetStatementsTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Illuminate\Tests\Blade;
+
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+use Illuminate\View\Compilers\BladeCompiler;
+
+class BladeSetStatementsTest extends TestCase
+{
+    public function tearDown()
+    {
+        m::close();
+    }
+
+    public function testSetStatementsAreCompiled()
+    {
+        $compiler = new BladeCompiler($this->getFiles(), __DIR__);
+        $string = '@set($var,$value)';
+        $expected = '<?php ($var = $value); ?>';
+        $this->assertEquals($expected, $compiler->compileString($string));
+    }
+
+    protected function getFiles()
+    {
+        return m::mock('Illuminate\Filesystem\Filesystem');
+    }
+}


### PR DESCRIPTION
It was quite a hot topic some time ago. There are still many people, who are using one of the disgusting ways described here: http://laravel-recipes.com/recipes/256/assigning-a-variable-in-a-blade-template

Luckily, currently there is a `@php($variable = $value)` solution which is far better than the above possibilities - but it's still not the best. In my opinion using `@php` tag in Blade templates should be minimalized - actually I have never used it. However, setting temporary view variables is an extremely general problem. It's very common you are constructing for example a link or a bigger expression in the view layer, and (obviously) you don't want to copy-paste that 2 or 3 times (Smarty, and almost every templating engine has this knowledge: http://www.smarty.net/docs/en/language.function.assign.tpl).

In my opinion every common practice is currently implemented - except this one. So either the code will be constructed with some `@php` tags just to support temporary variables (which looks bad), or the projects always have to implement it themselves in the beginning (which is a waste).

The only drawback of the implementation from what I can see is, you can't have commas on the left side, for example `@set($array[intval('7', 8)], 9)` won't work. However, I don't think setting variables like this in views should be considered as generic usage.