### PR TITLE
[5.4] Remember embedded files to remove duplication

### DIFF
--- a/src/Illuminate/Mail/Message.php
+++ b/src/Illuminate/Mail/Message.php
@@ -13,6 +13,13 @@ class Message
      * @var \Swift_Message
      */
     protected $swift;
+    
+    /**
+     * CIDs of files embedded in the message.
+     *
+     * @var array
+     */
+    protected $embeddedFiles = [];
 
     /**
      * Create a new message instance.
@@ -240,7 +247,15 @@ class Message
      */
     public function embed($file)
     {
-        return $this->swift->embed(Swift_Image::fromPath($file));
+        if(isset($this->embeddedFiles[$file])) {
+            return $this->embeddedFiles[$file];
+        }
+
+        $cid = $this->swift->embed(Swift_Image::fromPath($file));
+
+        $this->embeddedFiles[$file] = $cid;
+
+        return $cid;
     }
 
     /**


### PR DESCRIPTION
Remember all embedded files to avoid unnecessary duplication.

Discussed in more detail [here](https://github.com/laravel/internals/issues/411).