### PR TITLE
[5.4] Cache the file hashname

### DIFF
--- a/src/Illuminate/Http/FileHelpers.php
+++ b/src/Illuminate/Http/FileHelpers.php
@@ -7,6 +7,13 @@ use Illuminate\Support\Str;
 trait FileHelpers
 {
     /**
+     * The file hash name.
+     *
+     * @var string
+     */
+    private $hashNameCache = null;
+
+    /**
      * Get the fully qualified path to the file.
      *
      * @return string
@@ -48,6 +55,8 @@ trait FileHelpers
             $path = rtrim($path, '/').'/';
         }
 
-        return $path.Str::random(40).'.'.$this->guessExtension();
+        $hash = $this->hashNameCache ?: $this->hashNameCache = Str::random(40);
+
+        return $path.$hash.'.'.$this->guessExtension();
     }
 }


### PR DESCRIPTION
Currently calling `request()->file('profile')->hashName()` multiple times returns different values, this PR makes sure every file hash its has generated only once.

Imaging a scenario where you store a file using `$file->store('profile')`, you need to save the file name in the DB for later use, if you run `$file->hashName()` after calling `store()` a new name will be generated.