### PR TITLE
Allow configuration of Faker locale through env

### DIFF
--- a/src/Illuminate/Database/DatabaseServiceProvider.php
+++ b/src/Illuminate/Database/DatabaseServiceProvider.php
@@ -75,7 +75,7 @@ class DatabaseServiceProvider extends ServiceProvider
     protected function registerEloquentFactory()
     {
         $this->app->singleton(FakerGenerator::class, function () {
-            return FakerFactory::create();
+            return FakerFactory::create(env('FAKER_LOCALE'));
         });
 
         $this->app->singleton(EloquentFactory::class, function ($app) {


### PR DESCRIPTION
Just a simple change, this just makes it easy to configure the locale for Faker. It's useful when you want your test/seed data to just be a little more relevant to the app it's generated for. If the `FAKER_LOCALE` environment variable is set then it's all good, otherwise it falls back to the US as it does already.

PR made in reference to: laravel/internals#398