### PR TITLE
[5.5] Remove usages of the with() helper

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -694,7 +694,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         // We will actually pull the models from the database table and call delete on
         // each of them individually so that their events get fired properly with a
         // correct set of attributes in case the developers wants to check these.
-        $key = with($instance = new static)->getKeyName();
+        $key = ($instance = new static)->getKeyName();
 
         foreach ($instance->whereIn($key, $ids)->get() as $model) {
             if ($model->delete()) {

--- a/src/Illuminate/Database/Query/Processors/MySqlProcessor.php
+++ b/src/Illuminate/Database/Query/Processors/MySqlProcessor.php
@@ -13,7 +13,7 @@ class MySqlProcessor extends Processor
     public function processColumnListing($results)
     {
         return array_map(function ($result) {
-            return with((object) $result)->column_name;
+            return ((object) $result)->column_name;
         }, $results);
     }
 }

--- a/src/Illuminate/Database/Query/Processors/PostgresProcessor.php
+++ b/src/Illuminate/Database/Query/Processors/PostgresProcessor.php
@@ -35,7 +35,7 @@ class PostgresProcessor extends Processor
     public function processColumnListing($results)
     {
         return array_map(function ($result) {
-            return with((object) $result)->column_name;
+            return ((object) $result)->column_name;
         }, $results);
     }
 }

--- a/src/Illuminate/Database/Query/Processors/SQLiteProcessor.php
+++ b/src/Illuminate/Database/Query/Processors/SQLiteProcessor.php
@@ -13,7 +13,7 @@ class SQLiteProcessor extends Processor
     public function processColumnListing($results)
     {
         return array_map(function ($result) {
-            return with((object) $result)->name;
+            return ((object) $result)->name;
         }, $results);
     }
 }

--- a/src/Illuminate/Database/Query/Processors/SqlServerProcessor.php
+++ b/src/Illuminate/Database/Query/Processors/SqlServerProcessor.php
@@ -63,7 +63,7 @@ class SqlServerProcessor extends Processor
     public function processColumnListing($results)
     {
         return array_map(function ($result) {
-            return with((object) $result)->name;
+            return ((object) $result)->name;
         }, $results);
     }
 }

--- a/src/Illuminate/Foundation/Bootstrap/LoadEnvironmentVariables.php
+++ b/src/Illuminate/Foundation/Bootstrap/LoadEnvironmentVariables.php
@@ -38,7 +38,7 @@ class LoadEnvironmentVariables
      */
     protected function checkForSpecificEnvironmentFile($app)
     {
-        if (php_sapi_name() == 'cli' && with($input = new ArgvInput)->hasParameterOption('--env')) {
+        if (php_sapi_name() == 'cli' && ($input = new ArgvInput)->hasParameterOption('--env')) {
             $this->setEnvironmentFilePath(
                 $app, $app->environmentFile().'.'.$input->getParameterOption('--env')
             );

--- a/src/Illuminate/Mail/Markdown.php
+++ b/src/Illuminate/Mail/Markdown.php
@@ -61,7 +61,7 @@ class Markdown
             'mail', $this->htmlComponentPaths()
         )->make($view, $data)->render();
 
-        return new HtmlString(with($inliner ?: new CssToInlineStyles)->convert(
+        return new HtmlString(($inliner ?: new CssToInlineStyles)->convert(
             $contents, $this->view->make('mail::themes.'.$this->theme)->render()
         ));
     }

--- a/src/Illuminate/Queue/Jobs/Job.php
+++ b/src/Illuminate/Queue/Jobs/Job.php
@@ -66,7 +66,7 @@ abstract class Job
 
         list($class, $method) = JobName::parse($payload['job']);
 
-        with($this->instance = $this->resolve($class))->{$method}($this, $payload['data']);
+        ($this->instance = $this->resolve($class))->{$method}($this, $payload['data']);
     }
 
     /**

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -106,7 +106,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
             return;
         }
 
-        $values = with(isset($key) ? $this->pluck($key) : $this)
+        $values = (isset($key) ? $this->pluck($key) : $this)
                     ->sort()->values();
 
         $middle = (int) ($count / 2);

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -924,16 +924,3 @@ if (! function_exists('windows_os')) {
         return strtolower(substr(PHP_OS, 0, 3)) === 'win';
     }
 }
-
-if (! function_exists('with')) {
-    /**
-     * Return the given object. Useful for chaining.
-     *
-     * @param  mixed  $object
-     * @return mixed
-     */
-    function with($object)
-    {
-        return $object;
-    }
-}

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -924,3 +924,16 @@ if (! function_exists('windows_os')) {
         return strtolower(substr(PHP_OS, 0, 3)) === 'win';
     }
 }
+
+if (! function_exists('with')) {
+    /**
+     * Return the given object. Useful for chaining.
+     *
+     * @param  mixed  $object
+     * @return mixed
+     */
+    function with($object)
+    {
+        return $object;
+    }
+}


### PR DESCRIPTION
Now that Laravel 5.5 requires PHP 7 the usage of `with()` becomes unnecessary.