### PR TITLE
[5.4] Add `markTestIncomplete` to test stubs

### DIFF
--- a/src/Illuminate/Foundation/Console/stubs/test.stub
+++ b/src/Illuminate/Foundation/Console/stubs/test.stub
@@ -16,6 +16,7 @@ class DummyClass extends TestCase
      */
     public function testExample()
     {
+        $this->markTestIncomplete('Incomplete feature test at '.self::class);
         $this->assertTrue(true);
     }
 }

--- a/src/Illuminate/Foundation/Console/stubs/unit-test.stub
+++ b/src/Illuminate/Foundation/Console/stubs/unit-test.stub
@@ -15,6 +15,7 @@ class DummyClass extends TestCase
      */
     public function testExample()
     {
+        $this->markTestIncomplete('Incomplete unit test at '.self::class);
         $this->assertTrue(true);
     }
 }


### PR DESCRIPTION
If you scaffold several tests  just to build structure without implementing them it would be good to mark them incomplete automatically.