### PR TITLE
[5.4] Add missing method to Dispatcher contract

### DIFF
--- a/src/Illuminate/Contracts/Bus/Dispatcher.php
+++ b/src/Illuminate/Contracts/Bus/Dispatcher.php
@@ -28,4 +28,12 @@ interface Dispatcher
      * @return $this
      */
     public function pipeThrough(array $pipes);
+
+    /**
+     * Retrieve the handler for a command.
+     *
+     * @param  mixed  $command
+     * @return bool|mixed
+     */
+    public function getCommandHandler($command);
 }


### PR DESCRIPTION
I just discovered that a public method on the `Illuminate\Bus\Dispatcher` class isn't added to the `Illuminate\Contracts\Bus\Dispatcher` interface. Since we have our own implementation of the interface this was breaking when the method was called in the `Illuminate\Queue\CallQueuedHandler` class. See here: https://github.com/laravel/framework/blob/5.4/src/Illuminate/Queue/CallQueuedHandler.php#L59

Since it's public and used outside the scope of the Bus component it should be added to the interface, which this PR does. Upgrading to this will require people who are implementing the interface, to add the method. But since this PR actually adds the correct behavior and fixes the missing method, this is actually a bug fix and can be released as a patch release.