### PR TITLE
[5.4] Allow configuration of Faker locale through config

### DIFF
--- a/src/Illuminate/Database/DatabaseServiceProvider.php
+++ b/src/Illuminate/Database/DatabaseServiceProvider.php
@@ -74,8 +74,8 @@ class DatabaseServiceProvider extends ServiceProvider
      */
     protected function registerEloquentFactory()
     {
-        $this->app->singleton(FakerGenerator::class, function () {
-            return FakerFactory::create();
+        $this->app->singleton(FakerGenerator::class, function ($app) {
+            return FakerFactory::create($app['config']->get('app.faker_locale'));
         });
 
         $this->app->singleton(EloquentFactory::class, function ($app) {

--- a/src/Illuminate/Database/DatabaseServiceProvider.php
+++ b/src/Illuminate/Database/DatabaseServiceProvider.php
@@ -75,7 +75,7 @@ class DatabaseServiceProvider extends ServiceProvider
     protected function registerEloquentFactory()
     {
         $this->app->singleton(FakerGenerator::class, function ($app) {
-            return FakerFactory::create($app['config']->get('app.faker_locale'));
+            return FakerFactory::create($app['config']->get('app.faker_locale', 'en_US'));
         });
 
         $this->app->singleton(EloquentFactory::class, function ($app) {


### PR DESCRIPTION
As a followup to #17887, this grabs an adjustment to the Faker locale through the configuration. I went with `env` the first time as I thought it wouldn't matter much in development/test environments.

Here I'm using `app.faker_locale` as I'm not sure if any of the other standard configuration files are a better fit for this setting. Let me know if you would prefer a different name/location.

I'm happy to make the PR to `laravel/laravel` if this gets merged and you want it in the app boilerplate.