### PR TITLE
[5.4] Handle model instance in Authorize middleware

### DIFF
--- a/src/Illuminate/Auth/Middleware/Authorize.php
+++ b/src/Illuminate/Auth/Middleware/Authorize.php
@@ -4,6 +4,7 @@ namespace Illuminate\Auth\Middleware;
 
 use Closure;
 use Illuminate\Contracts\Auth\Access\Gate;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Contracts\Auth\Factory as Auth;
 
 class Authorize
@@ -70,7 +71,9 @@ class Authorize
         }
 
         return collect($models)->map(function ($model) use ($request) {
-            return $this->getModel($request, $model);
+            return $model instanceof Model
+                ?$model
+                :$this->getModel($request, $model);
         })->all();
     }
 

--- a/tests/Auth/AuthorizeMiddlewareTest.php
+++ b/tests/Auth/AuthorizeMiddlewareTest.php
@@ -187,6 +187,28 @@ class AuthorizeMiddlewareTest extends TestCase
         $this->assertEquals($response->content(), 'success');
     }
 
+    public function testModelInstanceAsParameter()
+    {
+        $instance = m::mock(\Illuminate\Database\Eloquent\Model::class);
+
+        $this->gate()->define('success', function ($user, $model) use ($instance) {
+            $this->assertSame($model, $instance);
+
+            return true;
+        });
+
+        $request = m::mock(Request::class);
+
+        $nextParam = null;
+
+        $next = function ($param) use (&$nextParam) {
+            $nextParam = $param;
+        };
+
+        (new Authorize($this->container->make(Auth::class), $this->gate()))
+            ->handle($request, $next, 'success', $instance);
+    }
+
     /**
      * Get the Gate instance from the container.
      *


### PR DESCRIPTION
Related to #17848 issue.

This will help extending Middleware capabilities by giving it directly the Model to check.

Implementation example :

```php
<?php

namespace App\Http\Middleware;

use Closure;
use Illuminate\Database\Eloquent\Model;
use Illuminate\Auth\Middleware\Authorize;

class AuthorizeCommand extends Authorize
{
    /**
     * Handle an incoming request.
     *
     * @param  \Illuminate\Http\Request  $request
     * @param  \Closure  $next
     * @return mixed
     */
    public function handle($request, Closure $next, $ability = null, ...$models)
    {
        if ((null !== $command = $request->route('command')) &&
            $command instanceof Model
        ) {
            return parent::handle($request, $next, 'access', $command);
        }

        return $next($request);
    }
}
```