### PR TITLE
[5.5] FileSystem: Use `root` config key to generate local adapter URL.

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -4,7 +4,6 @@ namespace Illuminate\Filesystem;
 
 use RuntimeException;
 use Illuminate\Http\File;
-use Illuminate\Support\Str;
 use InvalidArgumentException;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Collection;
@@ -327,16 +326,7 @@ class FilesystemAdapter implements FilesystemContract, CloudFilesystemContract
             return trim($config->get('url'), '/').'/'.ltrim($path, '/');
         }
 
-        $path = '/storage/'.$path;
-
-        // If the path contains "storage/public", it probably means the developer is using
-        // the default disk to generate the path instead of the "public" disk like they
-        // are really supposed to use. We will remove the public from this path here.
-        if (Str::contains($path, '/storage/public/')) {
-            return Str::replaceFirst('/public/', '/', $path);
-        } else {
-            return $path;
-        }
+        return rtrim($config->get('root'), '/').'/'.ltrim($path, '/');
     }
 
     /**

--- a/src/Illuminate/Filesystem/FilesystemManager.php
+++ b/src/Illuminate/Filesystem/FilesystemManager.php
@@ -255,7 +255,7 @@ class FilesystemManager implements FactoryContract
      */
     protected function createFlysystem(AdapterInterface $adapter, array $config)
     {
-        $config = Arr::only($config, ['visibility', 'disable_asserts', 'url']);
+        $config = Arr::only($config, ['visibility', 'disable_asserts', 'url', 'root']);
 
         return new Flysystem($adapter, count($config) > 0 ? $config : null);
     }

--- a/tests/Filesystem/LocalFilesystemTest.php
+++ b/tests/Filesystem/LocalFilesystemTest.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Illuminate\Tests\Filesystem;
+
+use PHPUnit\Framework\TestCase;
+use Illuminate\Container\Container;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Config\Repository as Config;
+use Illuminate\Filesystem\FilesystemAdapter;
+use Illuminate\Filesystem\FilesystemManager;
+
+class LocalFilesystemTest extends TestCase
+{
+    protected $container;
+    private $tempDir;
+
+    public function setUp()
+    {
+        $this->tempDir = __DIR__.'/tmp';
+        mkdir($this->tempDir);
+
+        Container::setInstance($this->container = new Container);
+
+        $this->container->singleton('config', function () {
+            return new Config([
+                'filesystems' => [
+                    'default' => 'local',
+                    'disks' => [
+                        'local' => [
+                            'driver' => 'local',
+                            'root' => $this->tempDir,
+                        ],
+                    ],
+                ],
+            ]);
+        });
+
+        $this->container->singleton(FilesystemManager::class, function () {
+            return new FilesystemManager($this->container);
+        });
+    }
+
+    public function tearDown()
+    {
+        $files = new Filesystem();
+        $files->deleteDirectory($this->tempDir);
+    }
+
+    public function testLocalAdapter()
+    {
+        $adapter = $this->disk('local');
+
+        $this->assertInstanceOf(FilesystemAdapter::class, $adapter);
+        $this->assertTrue($adapter->getConfig()->has('root'));
+    }
+
+    public function providePaths()
+    {
+        return [
+            [null],
+            ['toto.txt'],
+            ['folder/folder/file.csv'],
+        ];
+    }
+
+    /**
+     * @dataProvider providePaths
+     */
+    public function testLocalUrlGenerationFromRoot($path)
+    {
+        $root = rtrim($this->tempDir).'/';
+        $adapter = $this->disk('local');
+
+        $this->assertEquals($root.$path, $adapter->url($path));
+    }
+
+    public function provideUrlAndPath()
+    {
+        return [
+            [null, 'toto.txt', '/toto.txt'],
+            [$this->tempDir.'/', 'toto.txt', $this->tempDir.'/toto.txt'],
+            ['/', 'folder/folder/file.csv', '/folder/folder/file.csv'],
+        ];
+    }
+
+    /**
+     * @dataProvider provideUrlAndPath
+     */
+    public function testLocalUrlGenerationFromUrl($url, $path, $result)
+    {
+        $this->container['config']->set('filesystems.disks.local.url', $url);
+
+        $adapter = $this->disk('local');
+        $this->assertEquals($result, $adapter->url($path));
+    }
+
+    private function disk($name)
+    {
+        return $this->container->make(FilesystemManager::class)->disk($name);
+    }
+}


### PR DESCRIPTION
This will help retrieving local disk paths using the `url` method. If the `url` configuration key is defined, it’s used to build path but if not, it’s the root key which is used instead.

I've added a unit test to validate `url` method behaviour 😄.

Related to issue #17847.