### PR TITLE
[5.4] Improve the dd helper function

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -508,9 +508,16 @@ if (! function_exists('dd')) {
      */
     function dd()
     {
-        array_map(function ($x) {
-            (new Dumper)->dump($x);
-        }, func_get_args());
+        $caller = debug_backtrace()[0];
+        $caller = $caller['function'].':'.$caller['line'];
+
+        if (config('app.debug')) {
+            array_map(function ($x) {
+                (new Dumper)->dump($x);
+            }, array_merge(["Executed in $caller"], func_get_args()));
+        } else {
+            logger()->warning("Attempted to use dd outside debug mode in $caller", func_get_args());
+        }
 
         die(1);
     }


### PR DESCRIPTION
This PR does two things:

1. If `app.debug` is set to false (which will be default in production), a warning is logged with a message and the calling file and line, adding the supposed `dd` output to the logging context.
2. Display the calling file and line in the start of the regular output, making it easier to know where your `dd` was called from, in case you accidentally left it in there