### PR TITLE
[5.4] Fix bug when using select() and paginate() in BelongsToMany relations

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -477,8 +477,6 @@ class BelongsToMany extends Relation
         // First we'll add the proper select columns onto the query so it is run with
         // the proper columns. Then, we will get the results and hydrate out pivot
         // models with the result of those columns as a separate model relation.
-        $columns = $this->query->getQuery()->columns ? [] : $columns;
-
         $builder = $this->query->applyScopes();
 
         $models = $builder->addSelect(
@@ -505,6 +503,8 @@ class BelongsToMany extends Relation
      */
     protected function shouldSelect(array $columns = ['*'])
     {
+        $columns = $this->query->getQuery()->columns ? [] : $columns;
+
         if ($columns == ['*']) {
             $columns = [$this->related->getTable().'.*'];
         }

--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -331,8 +331,6 @@ class HasManyThrough extends Relation
         // First we'll add the proper select columns onto the query so it is run with
         // the proper columns. Then, we will get the results and hydrate out pivot
         // models with the result of those columns as a separate model relation.
-        $columns = $this->query->getQuery()->columns ? [] : $columns;
-
         $builder = $this->query->applyScopes();
 
         $models = $builder->addSelect(
@@ -389,6 +387,8 @@ class HasManyThrough extends Relation
      */
     protected function shouldSelect(array $columns = ['*'])
     {
+        $columns = $this->query->getQuery()->columns ? [] : $columns;
+
         if ($columns == ['*']) {
             $columns = [$this->related->getTable().'.*'];
         }


### PR DESCRIPTION
### Bug: 
Currently when you use `paginate()` / `simplePaginate()` / `chunk()` method in `BelongsToMany` / `HasManyThrough` Relation, and you chain `select()` method in your query builder, your `select()` method won't take effect at all.

### Example:
Say you have two models: Post and Tag. They are in many-to-many relation.
Post:
 - id
 - title
 - body

Tag:
 - id
 - name
 - description

and the pivot table.

When you do something like:
`$tags = Post::find(1)->tags()->select('name')->get();`  work well
`$tags = Post::find(1)->tags()->get('name');`  work well

`$tags = Post::find(1)->tags()->paginate(15, ['name']);`  work well
`$tags = Post::find(1)->tags()->select('name')->paginate();`  **select() method will fail and the query will give you all 3 columns in the tags table.**
Same problem in simplePaginate() and chunk().

### Reasons:

`BelongsToMany` and `HasManyThrough` class rewrite these methods to deal with the pivot table:
`get()` / `paginate()` / `simplePaginate()` / `chunk()`.

The rewrited `get()` method has something like:
`$columns = $this->query->getQuery()->columns ? [] : $columns;`

But the latter three methods don't have such a statement, **so the columns selected previously by select() method will get flushed by a default '*'.**