### PR TITLE
Added `js` extension to valid view file extensions

### DIFF
--- a/src/Illuminate/View/Factory.php
+++ b/src/Illuminate/View/Factory.php
@@ -64,6 +64,7 @@ class Factory implements FactoryContract
         'blade.php' => 'blade',
         'php' => 'php',
         'css' => 'file',
+        'js' => 'file',
     ];
 
     /**

--- a/src/Illuminate/View/FileViewFinder.php
+++ b/src/Illuminate/View/FileViewFinder.php
@@ -40,7 +40,7 @@ class FileViewFinder implements ViewFinderInterface
      *
      * @var array
      */
-    protected $extensions = ['blade.php', 'php', 'css'];
+    protected $extensions = ['blade.php', 'php', 'css', 'js'];
 
     /**
      * Create a new file view loader instance.


### PR DESCRIPTION
I was working on with the laravel-datatables package, and needed to do something like this.

```php
 /**
     * Get default builder parameters.
     *
     * @return array
     */
    protected function getBaseBuilderParameters()
    {
        return [
            'responsive' => [
                'details' => [
                    'type' => 'column',
                    'display' => view('clinicforce.datatables.details.display')->render(),
                    'renderer' => view('clinicforce.datatables.details.renderer')->render(),
                ]
        ];
    }
```
```js
function ( api, rowIdx, columns ) {
    var data = $.map( columns, function ( col, i ) {
        return col.hidden ?
            '<tr data-dt-row="'+col.rowIndex+'" data-dt-column="'+col.columnIndex+'">'+
                '<td>'+col.title+':'+'</td> '+
                '<td>'+col.data+'</td>'+
            '</tr>' :
            '';
    } ).join('');

    return data ?
        $('<table/>').addClass('table table-bordered table-hover responsive').append( data ) :
        false;
}
```

It was a real pain to code some js functionality just to be able to handle js stuff from backend.
First I saved the file below as `renderer.php` and changed the syntax. Then I was like, "Why would I change my syntax each time I want to edit this file?". I believe people also tried stuff like this.

It would help people to have a cleaner code.

Hope you accept the PR. 👍 