### PR TITLE
[5.4] Don’t require PhpRedis extension for tests

### DIFF
--- a/src/Illuminate/Redis/Connections/PhpRedisConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisConnection.php
@@ -182,6 +182,16 @@ class PhpRedisConnection extends Connection
     }
 
     /**
+     * Disconnects from the Redis instance.
+     *
+     * @return void
+     */
+    public function disconnect()
+    {
+        $this->client->close();
+    }
+
+    /**
      * Pass other method calls down to the underlying client.
      *
      * @param  string  $method


### PR DESCRIPTION
Followup on https://github.com/laravel/framework/pull/17882.