### PR TITLE
Add pairMap function to collection

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -673,6 +673,20 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
+     * Map a collection to adjacent pairs.
+     *
+     * @return static
+     */
+    public function pairMap()
+    {
+        $count = $this->count();
+        $firstSlice = $this->slice(0, $count - 1);
+        $secondSlice = $this->slice(1, $count - 1);
+
+        return $firstSlice->zip($secondSlice);
+    }
+
+    /**
      * Get the max value of a given key.
      *
      * @param  callable|string|null  $callback

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1088,6 +1088,19 @@ class SupportCollectionTest extends TestCase
         );
     }
 
+    public function testPairMap()
+    {
+        $data = new Collection([2, 3, 5, 6]);
+        $data = $data->pairMap();
+        $this->assertSame([[2,3], [3,5], [5,6]], $data->toArray());
+    }
+
+    public function testPairMapInsufficientElements()
+    {
+        $this->assertSame([], collect([])->pairMap()->toArray());
+        $this->assertSame([], collect([1])->pairMap()->toArray());
+    }
+
     public function testNth()
     {
         $data = new Collection([

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1092,7 +1092,7 @@ class SupportCollectionTest extends TestCase
     {
         $data = new Collection([2, 3, 5, 6]);
         $data = $data->pairMap();
-        $this->assertSame([[2,3], [3,5], [5,6]], $data->toArray());
+        $this->assertSame([[2, 3], [3, 5], [5, 6]], $data->toArray());
     }
 
     public function testPairMapInsufficientElements()


### PR DESCRIPTION
Adds a new collection function to map adjacent pairs like in [Java StreamEX](https://amaembo.github.io/streamex/javadoc/one/util/streamex/StreamEx.html#pairMap-java.util.function.BiFunction-)

It works as follows:
``` php
$collection = collect([2, 3, 5, 6]);

$collection->pairMap()->toArray();
// [[2,3], [3,5], [5,6]]
```

This is particularly useful to calculate the relative difference between elements:

``` php
$collection = collect([2, 3, 5, 6]);

$collection->pairMap()->map(function ($item) {
    return $item[1] - $item[0];
});

$collection->toArray();
// [1, 2, 1]
```