### PR TITLE
[5.4] Convert zRangeByScore syntax for PhpRedis

### DIFF
--- a/src/Illuminate/Redis/Connections/PhpRedisConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisConnection.php
@@ -190,8 +190,16 @@ class PhpRedisConnection extends Connection
      */
     public function __call($method, $parameters)
     {
+        $method = strtolower($method);
+
         if ($method == 'eval') {
             return $this->proxyToEval($parameters);
+        }
+
+        if ($method == 'zrangebyscore' || $method == 'zrevrangebyscore') {
+            $parameters = array_map(function ($parameter) {
+                return is_array($parameter) ? array_change_key_case($parameter) : $parameter;
+            }, $parameters);
         }
 
         return parent::__call($method, $parameters);


### PR DESCRIPTION
This converts Predis':
```php
['WITHSCORES' => true, 'LIMIT' => [$offset, $count]
```

To PhpRedis:

```php
['withscores' => true, 'limit' => [$offset, $count]
```