### PR TITLE
[5.5] Belongs to many related local key

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -290,7 +290,7 @@ trait HasRelationships
      * @param  string  $relation
      * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
      */
-    public function belongsToMany($related, $table = null, $foreignKey = null, $relatedKey = null, $localKey = null, $relation = null)
+    public function belongsToMany($related, $table = null, $foreignKey = null, $relatedKey = null, $parentKey = null, $localKey = null, $relation = null)
     {
         // If no relationship name was passed, we will pull backtraces to get the
         // name of the calling function. We will use that function name as the
@@ -317,7 +317,8 @@ trait HasRelationships
 
         return new BelongsToMany(
             $instance->newQuery(), $this, $table, $foreignKey,
-            $relatedKey, $localKey ?: $this->getKeyName(), $relation
+            $relatedKey, $parentKey ?: $this->getKeyName(), $localKey ?: $instance->getKeyName(),
+            $relation
         );
     }
 

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -39,6 +39,13 @@ class BelongsToMany extends Relation
      *
      * @var string
      */
+    protected $parentKey;
+
+    /**
+     * The local key of the related model.
+     *
+     * @var string
+     */
     protected $localKey;
 
     /**
@@ -106,12 +113,14 @@ class BelongsToMany extends Relation
      * @param  string  $foreignKey
      * @param  string  $relatedKey
      * @param  string  $localKey
+     * @param  string  $parentKey
      * @param  string  $relationName
      * @return void
      */
-    public function __construct(Builder $query, Model $parent, $table, $foreignKey, $relatedKey, $localKey, $relationName = null)
+    public function __construct(Builder $query, Model $parent, $table, $foreignKey, $relatedKey, $parentKey, $localKey, $relationName = null)
     {
         $this->table = $table;
+        $this->parentKey = $parentKey;
         $this->localKey = $localKey;
         $this->relatedKey = $relatedKey;
         $this->foreignKey = $foreignKey;
@@ -163,8 +172,10 @@ class BelongsToMany extends Relation
      */
     protected function addWhereConstraints()
     {
+        $parentKey = $this->parentKey;
+
         $this->query->where(
-            $this->getQualifiedForeignKeyName(), '=', $this->parent->getKey()
+            $this->getQualifiedForeignKeyName(), '=', $this->parent->$parentKey
         );
 
         return $this;

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -35,6 +35,13 @@ class BelongsToMany extends Relation
     protected $relatedKey;
 
     /**
+     * The local key of the parent model.
+     *
+     * @var string
+     */
+    protected $localKey;
+
+    /**
      * The "name" of the relationship.
      *
      * @var string

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -112,8 +112,8 @@ class BelongsToMany extends Relation
      * @param  string  $table
      * @param  string  $foreignKey
      * @param  string  $relatedKey
-     * @param  string  $localKey
      * @param  string  $parentKey
+     * @param  string  $localKey
      * @param  string  $relationName
      * @return void
      */

--- a/src/Illuminate/Database/Eloquent/Relations/MorphToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphToMany.php
@@ -41,6 +41,7 @@ class MorphToMany extends BelongsToMany
      * @param  string  $foreignKey
      * @param  string  $relatedKey
      * @param  string  $localKey
+     * @param  string  $parentKey
      * @param  string  $relationName
      * @param  bool  $inverse
      * @return void

--- a/src/Illuminate/Database/Eloquent/Relations/MorphToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphToMany.php
@@ -45,13 +45,13 @@ class MorphToMany extends BelongsToMany
      * @param  bool  $inverse
      * @return void
      */
-    public function __construct(Builder $query, Model $parent, $name, $table, $foreignKey, $relatedKey, $localKey, $relationName = null, $inverse = false)
+    public function __construct(Builder $query, Model $parent, $name, $table, $foreignKey, $relatedKey, $localKey, $parentKey, $relationName = null, $inverse = false)
     {
         $this->inverse = $inverse;
         $this->morphType = $name.'_type';
         $this->morphClass = $inverse ? $query->getModel()->getMorphClass() : $parent->getMorphClass();
 
-        parent::__construct($query, $parent, $table, $foreignKey, $relatedKey, $localKey, $relationName);
+        parent::__construct($query, $parent, $table, $foreignKey, $relatedKey, $localKey, $parentKey, $relationName);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/MorphToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphToMany.php
@@ -40,19 +40,19 @@ class MorphToMany extends BelongsToMany
      * @param  string  $table
      * @param  string  $foreignKey
      * @param  string  $relatedKey
-     * @param  string  $localKey
      * @param  string  $parentKey
+     * @param  string  $localKey
      * @param  string  $relationName
      * @param  bool  $inverse
      * @return void
      */
-    public function __construct(Builder $query, Model $parent, $name, $table, $foreignKey, $relatedKey, $localKey, $parentKey, $relationName = null, $inverse = false)
+    public function __construct(Builder $query, Model $parent, $name, $table, $foreignKey, $relatedKey, $parentKey, $localKey, $relationName = null, $inverse = false)
     {
         $this->inverse = $inverse;
         $this->morphType = $name.'_type';
         $this->morphClass = $inverse ? $query->getModel()->getMorphClass() : $parent->getMorphClass();
 
-        parent::__construct($query, $parent, $table, $foreignKey, $relatedKey, $localKey, $parentKey, $relationName);
+        parent::__construct($query, $parent, $table, $foreignKey, $relatedKey, $parentKey, $localKey, $relationName);
     }
 
     /**

--- a/tests/Database/DatabaseEloquentBelongsToManyTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyTest.php
@@ -703,7 +703,7 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
     {
         list($builder, $parent) = $this->getRelationArguments();
 
-        return new BelongsToMany($builder, $parent, 'user_role', 'user_id', 'role_id', 'id', 'relation_name');
+        return new BelongsToMany($builder, $parent, 'user_role', 'user_id', 'role_id', 'id', 'id', 'relation_name');
     }
 
     public function getRelationArguments()
@@ -712,6 +712,7 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
         $parent->shouldReceive('getKey')->andReturn(1);
         $parent->shouldReceive('getCreatedAtColumn')->andReturn('created_at');
         $parent->shouldReceive('getUpdatedAtColumn')->andReturn('updated_at');
+        $parent->shouldReceive('getAttribute')->with('id')->andReturn(1);
 
         $builder = m::mock('Illuminate\Database\Eloquent\Builder');
         $related = m::mock('Illuminate\Database\Eloquent\Model');
@@ -728,7 +729,7 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
         $builder->shouldReceive('join')->once()->with('user_role', 'roles.id', '=', 'user_role.role_id');
         $builder->shouldReceive('where')->once()->with('user_role.user_id', '=', 1);
 
-        return [$builder, $parent, 'user_role', 'user_id', 'role_id', 'id', 'relation_name'];
+        return [$builder, $parent, 'user_role', 'user_id', 'role_id', 'id', 'id', 'relation_name'];
     }
 }
 

--- a/tests/Database/DatabaseEloquentMorphToManyTest.php
+++ b/tests/Database/DatabaseEloquentMorphToManyTest.php
@@ -74,7 +74,7 @@ class DatabaseEloquentMorphToManyTest extends TestCase
     {
         list($builder, $parent) = $this->getRelationArguments();
 
-        return new MorphToMany($builder, $parent, 'taggable', 'taggables', 'taggable_id', 'tag_id', 'id');
+        return new MorphToMany($builder, $parent, 'taggable', 'taggables', 'taggable_id', 'tag_id', 'id', 'id');
     }
 
     public function getRelationArguments()
@@ -85,6 +85,7 @@ class DatabaseEloquentMorphToManyTest extends TestCase
         $parent->shouldReceive('getCreatedAtColumn')->andReturn('created_at');
         $parent->shouldReceive('getUpdatedAtColumn')->andReturn('updated_at');
         $parent->shouldReceive('getMorphClass')->andReturn(get_class($parent));
+        $parent->shouldReceive('getAttribute')->with('id')->andReturn(1);
 
         $builder = m::mock('Illuminate\Database\Eloquent\Builder');
         $related = m::mock('Illuminate\Database\Eloquent\Model');
@@ -98,7 +99,7 @@ class DatabaseEloquentMorphToManyTest extends TestCase
         $builder->shouldReceive('where')->once()->with('taggables.taggable_id', '=', 1);
         $builder->shouldReceive('where')->once()->with('taggables.taggable_type', get_class($parent));
 
-        return [$builder, $parent, 'taggable', 'taggables', 'taggable_id', 'tag_id', 'id', 'relation_name', false];
+        return [$builder, $parent, 'taggable', 'taggables', 'taggable_id', 'tag_id', 'id', 'id', 'relation_name', false];
     }
 }
 


### PR DESCRIPTION
Hi, I've added also the configurability of the "related" local key using BelongsToMany relationship.

Take this example

````
USERS
- id
- email

ROLES
- id
- code

ROLE_USER
- user_email
- role_code
````

With this PR we can define this relationship like this:
````php
class User
{
    public function roles() 
    {
         return $this->belongsToMany('App/Role', 'role_user', 'user_email', 'role_code', 'email', 'code');
    }
}
````
````php
class Role
{
    public function users() 
    {
         return $this->belongsToMany('App/User', 'role_user', 'role_code', 'user_email', 'code', 'email');
    }
}
````
PS sorry for this second PR, I should have done one.