### PR TITLE
[5.4] Add when method to collections

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -309,6 +309,22 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
+     * Apply the callback if the value is truthy.
+     *
+     * @param  bool  $value
+     * @param  callable  $callback
+     * @return mixed
+     */
+    public function when($value, callable $callback)
+    {
+        if ($value) {
+            return $callback($this);
+        }
+
+        return $this;
+    }
+
+    /**
      * Filter items by the given key value pair.
      *
      * @param  string  $key

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1895,6 +1895,25 @@ class SupportCollectionTest extends TestCase
         $this->assertSame([1], $fromTap);
         $this->assertSame([1, 2, 3], $collection->toArray());
     }
+
+    public function testWhen()
+    {
+        $collection = new Collection(['michael', 'tom']);
+
+        $collection->when(true, function ($collection) {
+            return $collection->push('adam');
+        });
+
+        $this->assertSame(['michael', 'tom', 'adam'], $collection->toArray());
+
+        $collection = new Collection(['michael', 'tom']);
+
+        $collection->when(false, function ($collection) {
+            return $collection->push('adam');
+        });
+
+        $this->assertSame(['michael', 'tom'], $collection->toArray());
+    }
 }
 
 class TestSupportCollectionHigherOrderItem


### PR DESCRIPTION
Inspired by @tomschlick's [addition to Eloquent](https://github.com/laravel/framework/pull/12878), add a `when` method to the Collection class and help crush temporary variable assignment in your code.