### PR TITLE
[5.4] @lang directive is not working with json lang file

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesTranslations.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesTranslations.php
@@ -17,7 +17,7 @@ trait CompilesTranslations
         } elseif ($expression[1] === '[') {
             return "<?php \$__env->startTranslation{$expression}; ?>";
         } else {
-            return "<?php echo app('translator')->get{$expression}; ?>";
+            return "<?php echo app('translator')->getFromJson{$expression}; ?>";
         }
     }
 


### PR DESCRIPTION
@lang Blade directive is not working. This PR tries to adjust @lang directive with new "getFromJson" method. If json is not set then "get" method will be called as fallback.