### PR TITLE
[5.4] "trans" helper is not calling getFromJson method

### DIFF
--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -97,7 +97,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
      */
     public function trans($key, array $replace = [], $locale = null)
     {
-        return $this->get($key, $replace, $locale);
+        return $this->getFromJson($key, $replace, $locale);
     }
 
     /**


### PR DESCRIPTION
"trans" helper method is not using new json file translation. Therefore, when you called "trans" helper method, json "sentence translation" is not working. I am not sure that this was made intentionally. If I use "__" helper method, there is no problem. So that is the difference between the two. Since latest 5.4 documentation is not covering "trans" helper method on localization page, any recommandation to use either of them?