### PR TITLE
[5.5] Rename authentication assertions

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithAuthentication.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithAuthentication.php
@@ -13,7 +13,7 @@ trait InteractsWithAuthentication
      * @param  string|null  $driver
      * @return $this
      */
-    public function actingAs(UserContract $user, $driver = null)
+    public function loginAs(UserContract $user, $driver = null)
     {
         $this->be($user, $driver);
 
@@ -40,7 +40,7 @@ trait InteractsWithAuthentication
      * @param  string|null  $guard
      * @return $this
      */
-    public function seeIsAuthenticated($guard = null)
+    public function assertAuthentication($guard = null)
     {
         $this->assertTrue($this->isAuthenticated($guard), 'The user is not authenticated');
 
@@ -53,7 +53,7 @@ trait InteractsWithAuthentication
      * @param  string|null  $guard
      * @return $this
      */
-    public function dontSeeIsAuthenticated($guard = null)
+    public function assertGuest($guard = null)
     {
         $this->assertFalse($this->isAuthenticated($guard), 'The user is authenticated');
 
@@ -78,7 +78,7 @@ trait InteractsWithAuthentication
      * @param  string|null  $guard
      * @return $this
      */
-    public function seeIsAuthenticatedAs($user, $guard = null)
+    public function assertAuthenticatedAs($user, $guard = null)
     {
         $expected = $this->app->make('auth')->guard($guard)->user();
 
@@ -102,7 +102,7 @@ trait InteractsWithAuthentication
      * @param  string|null  $guard
      * @return $this
      */
-    public function seeCredentials(array $credentials, $guard = null)
+    public function assertCredentials(array $credentials, $guard = null)
     {
         $this->assertTrue(
             $this->hasCredentials($credentials, $guard), 'The given credentials are invalid.'
@@ -118,7 +118,7 @@ trait InteractsWithAuthentication
      * @param  string|null  $guard
      * @return $this
      */
-    public function dontSeeCredentials(array $credentials, $guard = null)
+    public function assertCredentialsMissing(array $credentials, $guard = null)
     {
         $this->assertFalse(
             $this->hasCredentials($credentials, $guard), 'The given credentials are valid.'

--- a/tests/Foundation/FoundationAuthenticationTest.php
+++ b/tests/Foundation/FoundationAuthenticationTest.php
@@ -54,27 +54,27 @@ class FoundationAuthenticationTest extends TestCase
         m::close();
     }
 
-    public function testSeeIsAuthenticated()
+    public function testAssertAuthentication()
     {
         $this->mockGuard()
             ->shouldReceive('check')
             ->once()
             ->andReturn(true);
 
-        $this->seeIsAuthenticated();
+        $this->assertAuthentication();
     }
 
-    public function testDontSeeIsAuthenticated()
+    public function testAssertGuest()
     {
         $this->mockGuard()
             ->shouldReceive('check')
             ->once()
             ->andReturn(false);
 
-        $this->dontSeeIsAuthenticated();
+        $this->assertGuest();
     }
 
-    public function testSeeIsAuthenticatedAs()
+    public function testAssertAuthenticatedAs()
     {
         $expected = m::mock(Authenticatable::class);
         $expected->shouldReceive('getAuthIdentifier')
@@ -89,7 +89,7 @@ class FoundationAuthenticationTest extends TestCase
         $user->shouldReceive('getAuthIdentifier')
             ->andReturn('1');
 
-        $this->seeIsAuthenticatedAs($user);
+        $this->assertAuthenticatedAs($user);
     }
 
     protected function setupProvider(array $credentials)
@@ -112,14 +112,14 @@ class FoundationAuthenticationTest extends TestCase
             ->andReturn($provider);
     }
 
-    public function testSeeCredentials()
+    public function testAssertCredentials()
     {
         $this->setupProvider($this->credentials);
 
-        $this->seeCredentials($this->credentials);
+        $this->assertCredentials($this->credentials);
     }
 
-    public function testDontSeeCredentials()
+    public function testAssertCredentialsMissing()
     {
         $credentials = [
             'email' => 'invalid',
@@ -128,6 +128,6 @@ class FoundationAuthenticationTest extends TestCase
 
         $this->setupProvider($credentials);
 
-        $this->dontSeeCredentials($credentials);
+        $this->assertCredentialsMissing($credentials);
     }
 }


### PR DESCRIPTION
In order to match all the other assertions with the `assert*` prefix.
