### PR TITLE
[5.3] Require at least league/flysystem:1.0.35

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "classpreloader/classpreloader": "~3.0",
         "doctrine/inflector": "~1.0",
         "jeremeamia/superclosure": "~2.2",
-        "league/flysystem": "~1.0",
+        "league/flysystem": "~1.0.35",
         "monolog/monolog": "~1.11",
         "mtdowling/cron-expression": "~1.0",
         "nesbot/carbon": "~1.20",


### PR DESCRIPTION
`Illuminate/Filesystem/FilesystemManager` requires that the const `DISALLOW_LINKS` in `League\Flysystem\Adapter\Local`, which first exists from version `1.0.35`.