### PR TITLE
[5.4] Change property name in Pivot class

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Pivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Pivot.php
@@ -12,7 +12,7 @@ class Pivot extends Model
      *
      * @var \Illuminate\Database\Eloquent\Model
      */
-    protected $parent;
+    protected $pivotParent;
 
     /**
      * The name of the foreign key column.
@@ -59,7 +59,7 @@ class Pivot extends Model
         // We store off the parent instance so we will access the timestamp column names
         // for the model, since the pivot model timestamps aren't easily configurable
         // from the developer's point of view. We can use the parents to get these.
-        $this->parent = $parent;
+        $this->pivotParent = $parent;
 
         $this->exists = $exists;
 
@@ -183,7 +183,7 @@ class Pivot extends Model
      */
     public function getCreatedAtColumn()
     {
-        return $this->parent->getCreatedAtColumn();
+        return $this->pivotParent->getCreatedAtColumn();
     }
 
     /**
@@ -193,6 +193,6 @@ class Pivot extends Model
      */
     public function getUpdatedAtColumn()
     {
-        return $this->parent->getUpdatedAtColumn();
+        return $this->pivotParent->getUpdatedAtColumn();
     }
 }


### PR DESCRIPTION
Make it possible to use ‘parent’ as a relation in a custom pivot model. 

In the current version one can not refer to `$this->parent`from within the class to access the 'parent' relation:

```php
class EmployeeHierarchy extends Pivot
{
    /**
     * The parent model of the relationship.
     *
     * @var \Illuminate\Database\Eloquent\Model
     */
    protected $parent;

    public function child()
    {
        return $this->belongsTo(Employee::class);
    }

    public function parent()
    {
        return $this->belongsTo(Employee::class);
    }

    public function doSomethingWithParent()
    {
        // accesses the property instead of the relation
        $this->parent->foo();
    }
}
```

Changing the property name to 'pivotParent' (unlikely to be used as a relation name) would solve this. Another suggestion would be 'relationParent'. More suggestions welcome of course. 