### PR TITLE
[5.4] Always use Carbon::setTestNow() in tests.

### DIFF
--- a/tests/Auth/AuthDatabaseTokenRepositoryTest.php
+++ b/tests/Auth/AuthDatabaseTokenRepositoryTest.php
@@ -3,14 +3,25 @@
 namespace Illuminate\Tests\Auth;
 
 use Mockery as m;
+use Carbon\Carbon;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Auth\Passwords\DatabaseTokenRepository;
 
 class AuthDatabaseTokenRepositoryTest extends TestCase
 {
+    public function setup()
+    {
+        parent::setup();
+
+        Carbon::setTestNow(Carbon::now());
+    }
+
     public function tearDown()
     {
+        parent::tearDown();
+
         m::close();
+        Carbon::setTestNow(null);
     }
 
     public function testCreateInsertsNewRecordIntoTable()
@@ -48,7 +59,7 @@ class AuthDatabaseTokenRepositoryTest extends TestCase
         $repo->getHasher()->shouldReceive('check')->with('token', 'hashed-token')->andReturn(true);
         $repo->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($query = m::mock('StdClass'));
         $query->shouldReceive('where')->once()->with('email', 'email')->andReturn($query);
-        $date = date('Y-m-d H:i:s', time() - 300000);
+        $date = Carbon::now()->subSeconds(300000)->toDateTimeString();
         $query->shouldReceive('first')->andReturn((object) ['created_at' => $date, 'token' => 'hashed-token']);
         $user = m::mock('Illuminate\Contracts\Auth\CanResetPassword');
         $user->shouldReceive('getEmailForPasswordReset')->andReturn('email');
@@ -62,7 +73,7 @@ class AuthDatabaseTokenRepositoryTest extends TestCase
         $repo->getHasher()->shouldReceive('check')->with('token', 'hashed-token')->andReturn(true);
         $repo->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($query = m::mock('StdClass'));
         $query->shouldReceive('where')->once()->with('email', 'email')->andReturn($query);
-        $date = date('Y-m-d H:i:s', time() - 600);
+        $date = Carbon::now()->subMinutes(10)->toDateTimeString();
         $query->shouldReceive('first')->andReturn((object) ['created_at' => $date, 'token' => 'hashed-token']);
         $user = m::mock('Illuminate\Contracts\Auth\CanResetPassword');
         $user->shouldReceive('getEmailForPasswordReset')->andReturn('email');
@@ -76,7 +87,7 @@ class AuthDatabaseTokenRepositoryTest extends TestCase
         $repo->getHasher()->shouldReceive('check')->with('wrong-token', 'hashed-token')->andReturn(false);
         $repo->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($query = m::mock('StdClass'));
         $query->shouldReceive('where')->once()->with('email', 'email')->andReturn($query);
-        $date = date('Y-m-d H:i:s', time() - 600);
+        $date = Carbon::now()->subMinutes(10)->toDateTimeString();
         $query->shouldReceive('first')->andReturn((object) ['created_at' => $date, 'token' => 'hashed-token']);
         $user = m::mock('Illuminate\Contracts\Auth\CanResetPassword');
         $user->shouldReceive('getEmailForPasswordReset')->andReturn('email');

--- a/tests/Cache/CacheFileStoreTest.php
+++ b/tests/Cache/CacheFileStoreTest.php
@@ -2,12 +2,27 @@
 
 namespace Illuminate\Tests\Cache;
 
+use Carbon\Carbon;
 use Illuminate\Cache\FileStore;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Contracts\Filesystem\FileNotFoundException;
 
 class CacheFileStoreTest extends TestCase
 {
+    public function setup()
+    {
+        parent::setup();
+
+        Carbon::setTestNow(Carbon::now());
+    }
+
+    public function tearDown()
+    {
+        parent::tearDown();
+
+        Carbon::setTestNow(null);
+    }
+
     public function testNullIsReturnedIfFileDoesntExist()
     {
         $files = $this->mockFilesystem();
@@ -85,7 +100,7 @@ class CacheFileStoreTest extends TestCase
     public function testIncrementDoesNotExtendCacheLife()
     {
         $files = $this->mockFilesystem();
-        $expiration = time() + 59;
+        $expiration = Carbon::now()->addSeconds(50)->getTimestamp();
         $initialValue = $expiration.serialize(1);
         $valueAfterIncrement = $expiration.serialize(2);
         $store = new FileStore($files, __DIR__);

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -6,6 +6,7 @@ use DateTime;
 use stdClass;
 use Exception;
 use Mockery as m;
+use Carbon\Carbon;
 use LogicException;
 use ReflectionClass;
 use DateTimeImmutable;
@@ -17,9 +18,19 @@ use Illuminate\Database\Eloquent\Relations\Relation;
 
 class DatabaseEloquentModelTest extends TestCase
 {
+    public function setup()
+    {
+        parent::setup();
+
+        Carbon::setTestNow(Carbon::now());
+    }
+
     public function tearDown()
     {
+        parent::tearDown();
+
         m::close();
+        Carbon::setTestNow(null);
 
         \Illuminate\Database\Eloquent\Model::unsetEventDispatcher();
         \Carbon\Carbon::resetToStringFormat();
@@ -292,7 +303,7 @@ class DatabaseEloquentModelTest extends TestCase
         $model->expects($this->any())->method('getDateFormat')->will($this->returnValue('Y-m-d H:i:s'));
         $model->setRawAttributes([
             'created_at' => '2012-12-04',
-            'updated_at' => time(),
+            'updated_at' => Carbon::now()->getTimestamp(),
         ]);
 
         $this->assertInstanceOf('Carbon\Carbon', $model->created_at);
@@ -339,7 +350,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertInstanceOf('Carbon\Carbon', $model->created_at);
 
         $model = new EloquentDateModelStub;
-        $model->created_at = time();
+        $model->created_at = Carbon::now()->getTimestamp();
         $this->assertInstanceOf('Carbon\Carbon', $model->created_at);
 
         $model = new EloquentDateModelStub;

--- a/tests/Queue/RedisQueueIntegrationTest.php
+++ b/tests/Queue/RedisQueueIntegrationTest.php
@@ -21,14 +21,14 @@ class RedisQueueIntegrationTest extends TestCase
 
     public function setUp()
     {
-        Carbon::setTestNow();
+        Carbon::setTestNow(Carbon::now());
         parent::setUp();
         $this->setUpRedis();
     }
 
     public function tearDown()
     {
-        Carbon::setTestNow(Carbon::now());
+        Carbon::setTestNow(null);
         parent::tearDown();
         $this->tearDownRedis();
         m::close();
@@ -78,10 +78,10 @@ class RedisQueueIntegrationTest extends TestCase
         $this->queue->push($job);
 
         // Pop and check it is popped correctly
-        $before = time();
+        $before = Carbon::now()->getTimestamp();
         /** @var RedisJob $redisJob */
         $redisJob = $this->queue->pop();
-        $after = time();
+        $after = Carbon::now()->getTimestamp();
 
         $this->assertEquals($job, unserialize(json_decode($redisJob->getRawBody())->data->command));
         $this->assertEquals(1, $redisJob->attempts());
@@ -112,9 +112,9 @@ class RedisQueueIntegrationTest extends TestCase
         $this->queue->later(-10, $job);
 
         // Pop and check it is popped correctly
-        $before = time();
+        $before = Carbon::now()->getTimestamp();
         $this->assertEquals($job, unserialize(json_decode($this->queue->pop()->getRawBody())->data->command));
-        $after = time();
+        $after = Carbon::now()->getTimestamp();
 
         // Check reserved queue
         $this->assertEquals(1, $this->redis[$driver]->connection()->zcard('queues:default:reserved'));
@@ -141,9 +141,9 @@ class RedisQueueIntegrationTest extends TestCase
         $this->queue->later(-10, $job);
 
         // Pop and check it is popped correctly
-        $before = time();
+        $before = Carbon::now()->getTimestamp();
         $this->assertEquals($job, unserialize(json_decode($this->queue->pop()->getRawBody())->data->command));
-        $after = time();
+        $after = Carbon::now()->getTimestamp();
 
         // Check reserved queue
         $this->assertEquals(1, $this->redis[$driver]->connection()->zcard('queues:default:reserved'));
@@ -168,18 +168,18 @@ class RedisQueueIntegrationTest extends TestCase
         // Make an expired reserved job
         $failed = new RedisQueueIntegrationTestJob(-20);
         $this->queue->push($failed);
-        $beforeFailPop = time();
+        $beforeFailPop = Carbon::now()->getTimestamp();
         $this->queue->pop();
-        $afterFailPop = time();
+        $afterFailPop = Carbon::now()->getTimestamp();
 
         // Push an item into queue
         $job = new RedisQueueIntegrationTestJob(10);
         $this->queue->push($job);
 
         // Pop and check it is popped correctly
-        $before = time();
+        $before = Carbon::now()->getTimestamp();
         $this->assertEquals($job, unserialize(json_decode($this->queue->pop()->getRawBody())->data->command));
-        $after = time();
+        $after = Carbon::now()->getTimestamp();
 
         // Check reserved queue
         $this->assertEquals(2, $this->redis[$driver]->connection()->zcard('queues:default:reserved'));
@@ -214,9 +214,9 @@ class RedisQueueIntegrationTest extends TestCase
         $this->queue->push($job);
 
         // Pop and check it is popped correctly
-        $before = time();
+        $before = Carbon::now()->getTimestamp();
         $this->assertEquals($job, unserialize(json_decode($this->queue->pop()->getRawBody())->data->command));
-        $after = time();
+        $after = Carbon::now()->getTimestamp();
 
         // Check reserved queue
         $this->assertEquals(1, $this->redis[$driver]->connection()->zcard('queues:default:reserved'));
@@ -244,9 +244,9 @@ class RedisQueueIntegrationTest extends TestCase
         //pop and release the job
         /** @var \Illuminate\Queue\Jobs\RedisJob $redisJob */
         $redisJob = $this->queue->pop();
-        $before = time();
+        $before = Carbon::now()->getTimestamp();
         $redisJob->release(1000);
-        $after = time();
+        $after = Carbon::now()->getTimestamp();
 
         //check the content of delayed queue
         $this->assertEquals(1, $this->redis[$driver]->connection()->zcard('queues:default:delayed'));


### PR DESCRIPTION
This allows to always use a relative time for each test; these tests should not fail anymore in case of slow execution.

---

This also fix `setup` and `tearDown` in `RedisQueueIntegrationTest`.