### PR TITLE
[5.4] add default param to collection's when() method

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -313,6 +313,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      *
      * @param  bool  $value
      * @param  callable  $callback
+     * @param  callable  $default
      * @return mixed
      */
     public function when($value, callable $callback, callable $default = null)

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -315,10 +315,12 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      * @param  callable  $callback
      * @return mixed
      */
-    public function when($value, callable $callback)
+    public function when($value, callable $callback, callable $default = null)
     {
         if ($value) {
             return $callback($this);
+        } elseif ($default) {
+            return $default($this);
         }
 
         return $this;

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1914,6 +1914,20 @@ class SupportCollectionTest extends TestCase
 
         $this->assertSame(['michael', 'tom'], $collection->toArray());
     }
+    
+    public function testWhenDefault()
+    {
+        $collection = new Collection(['michael', 'tom']);
+
+        $collection->when(false, function ($collection) {
+            return $collection->push('adam');
+        }, function ($collection) {
+            return $collection->push('taylor');
+        });
+
+        $this->assertSame(['michael', 'tom', 'taylor'], $collection->toArray());
+    }
+   
 }
 
 class TestSupportCollectionHigherOrderItem

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1914,7 +1914,7 @@ class SupportCollectionTest extends TestCase
 
         $this->assertSame(['michael', 'tom'], $collection->toArray());
     }
-    
+
     public function testWhenDefault()
     {
         $collection = new Collection(['michael', 'tom']);
@@ -1927,7 +1927,6 @@ class SupportCollectionTest extends TestCase
 
         $this->assertSame(['michael', 'tom', 'taylor'], $collection->toArray());
     }
-   
 }
 
 class TestSupportCollectionHigherOrderItem


### PR DESCRIPTION
This brings the changes made in #17917 up to date with my original changes to the eloquent query builder made in #15428