### PR TITLE
[5.4] Fix image dimension ratio check

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -478,7 +478,7 @@ trait ValidatesAttributes
             [1, 1], array_filter(sscanf($parameters['ratio'], '%f/%d'))
         );
 
-        return $numerator / $denominator !== $width / $height;
+        return $numerator / $denominator != $width / $height;
     }
 
     /**


### PR DESCRIPTION
Fix image ratio check :
Fail case with an image of dimension 400x400 and validator rule like :
```
dimensions:ratio=1
or
dimensions:ratio=1/1
```
Give in `failsRatioCheck`:
```php
$numerator = 1.0; // Float
$denominator = 1; // Int
$numerator / $denominator; // Give a float

$width = 400; // Int from failsRatioCheck args
$height = 400; // Int from failsRatioCheck args
$width / $height // Give a int

return $numerator / $denominator !== $width / $height // Give true for (1.0 / 1 !== 400 / 400)
```