### PR TITLE
[5.5] Add Blade filters

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -4,6 +4,7 @@ namespace Illuminate\View\Compilers;
 
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
+use InvalidArgumentException;
 
 class BladeCompiler extends Compiler implements CompilerInterface
 {
@@ -35,6 +36,13 @@ class BladeCompiler extends Compiler implements CompilerInterface
      * @var array
      */
     protected $customDirectives = [];
+
+    /**
+     * All filters, including custom filters.
+     *
+     * @var array
+     */
+    protected $filters = [];
 
     /**
      * The file currently being compiled.
@@ -365,6 +373,44 @@ class BladeCompiler extends Compiler implements CompilerInterface
     public function getCustomDirectives()
     {
         return $this->customDirectives;
+    }
+
+    /**
+     * Register a handler for a filter.
+     *
+     * @param  string  $name
+     * @param  callable  $handler
+     * @return void
+     */
+    public function filter($name, callable $handler)
+    {
+        $this->filters[$name] = $handler;
+    }
+
+    /**
+     * Get the list of filters.
+     *
+     * @return array
+     */
+    public function getFilters()
+    {
+        return $this->filters;
+    }
+
+    /**
+     * Call the given filter with the given value.
+     *
+     * @param  string  $name
+     * @param  string|null  $value
+     * @return string
+     */
+    protected function callFilter($name, $value)
+    {
+        if (! isset($this->filters[$name])) {
+            throw new InvalidArgumentException("Filter [$name] does not exist.");
+        }
+
+        return call_user_func($this->filters[$name], trim($value));
     }
 
     /**

--- a/tests/View/Blade/BladeFilterTest.php
+++ b/tests/View/Blade/BladeFilterTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Illuminate\Tests\Blade;
+
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+use Illuminate\View\Compilers\BladeCompiler;
+
+class BladeFilterTest extends TestCase
+{
+    public function tearDown()
+    {
+        m::close();
+    }
+
+    public function testAddFilter()
+    {
+        $compiler = new BladeCompiler($this->getFiles(), __DIR__);
+        $this->assertCount(0, $compiler->getFilters());
+
+        $compiler->filter('arbitrary', function ($expression) {
+            return "arbitrary({$expression})";
+        });
+
+        $this->assertCount(1, $compiler->getFilters());
+        $this->assertArrayHasKey('arbitrary', $compiler->getFilters());
+    }
+
+    public function testCompileFilter()
+    {
+        $compiler = new BladeCompiler($this->getFiles(), __DIR__);
+        $compiler->filter('upperCase', function ($expression) {
+            return "strtoupper({$expression})";
+        });
+
+        $this->assertEquals('<?php echo e(strtoupper($foo)); ?>', $compiler->compileString('{{ $foo | upperCase }}'));
+    }
+
+    public function testCompileNestedFilters()
+    {
+        $compiler = new BladeCompiler($this->getFiles(), __DIR__);
+        $compiler->filter('upperCase', function ($expression) {
+            return "strtoupper({$expression})";
+        });
+        $compiler->filter('trim', function ($expression) {
+            return "trim({$expression})";
+        });
+
+        $this->assertEquals(
+            '<?php echo e(trim(strtoupper($foo))); ?>',
+            $compiler->compileString('{{ $foo | upperCase | trim }}')
+        );
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     * @expectedExceptionMessage Filter [non-existing-filter-name] does not exist.
+     */
+    public function testTryToCompileNotExistingFilter()
+    {
+        $compiler = new BladeCompiler($this->getFiles(), __DIR__);
+
+        $compiler->compileString('{{ $foo | non-existing-filter-name }}');
+    }
+
+    protected function getFiles()
+    {
+        return m::mock('Illuminate\Filesystem\Filesystem');
+    }
+}


### PR DESCRIPTION
Well, this is my first PR to Laravel, hope you enjoy it ;).

# Blade filters
This PR adds Blade filters. Let's first show an example:
```blade
{{ $foo | upperCase | reverse }}
```
You might already recognize this from other template languages (and Vue, for instance, has this feature as well). Assuming `$foo = 'Hello'`, the result of this example would be `OLLEH`.

Blade filters are meant for little transformations of the representation of a value. They allow developers to easily format a certain value in a consistent, possibly application specific, way. Think for instance about formatting an amount of money in a consistent way throughout the application (`{{ $amount | euro }}` could for instance output `&euro; 4.445,50`). 

So, what value do Blade filters have over Blade directives?
1. Blade filters can be nested. Using the first example: It is not possible to do `@reverse(@upperCase($foo))` (due to the way Blade filters have to be defined). Also, when you need to nest more directives than 2 (or maybe even 1), it becomes hard to read. The Blade filter syntax (`{{ $foo | upperCase | reverse }}`) _does_ allow nesting (actually it's more like stacking) of these formatting functions and it keeps it readable as well. You can just read it as piping `$foo` through upperCase and then through reverse.
2. Blade filters do not break the flow. This is more personal, but in my opinion, when we have, for instance, a table row like below, the @datetime directive really breaks the 'visual' flow of the code.
```blade
<tr>
	<td>{{ $post->id }}</td>
	<td>{{ $post->title }}</td>
	<td>{{ $post->author->name }}</td>
	<td>@datetime($post->created_at)</td>
</tr>
```

Note that there is a slight backwards incompatibility. `|` is of course also a bitwise OR. If someone currently has `{{ 5 | 2 }}` in a template (giving 7 as output), this would now throw an exception saying that filter '2' does not exist. However, I think that it is not very likely (and also is not a very good idea) that people actually do bitwise ORs in their Blade templates. This incompatibility is part of the reason why I did not submit this PR to the 5.4 branch.

## How to define a Blade filter
Blade filters can be added in a similar way as directives by putting the following code in a service provider:
```php
Blade::filter('upperCase', function ($value) {
    return "strtoupper($value)";
}
```
or
```php
Blade::filter('euro', function ($value) {
    return "'&euro ' . number_format($value / 100, 2, ',', '.')";
}
```

Personally, I would have preferred it if the function did not have to return a string version of how we would like the compiled output to look like, but more something like this:
```php
Blade::filter('upperCase', function ($value) {
    return strtoupper($value);
}
```
However, this means the strtoupper function can not be embedded in the template at compile time, but the anonymous function belonging to the filter should be executed at run time (in the compiled template that would be (simplified): `<?php echo e(Blade::callFilter('upperCase', $foo)); ?>`).  Since, this way kind of breaks the spirit of Blade compilation, I've chosen to go with the first option. If the second option is preferred, I'm more than happy to make that change, since it would make it a lot easier for developers to define filters.

## Future
It would be cool to add some default filters in the future (for basic stuff like upcasing, capitalization, pluralizing etc.). I did not want to include them in this PR yet.

Another extension would be adding the ability to add parameters. The only thing to keep in mind here is, that Blade filters are mostly meant for easy and small functions primarily focused on transforming some piece of data to a (slightly) different format.

Finally, simple array operations could be added. Think about `{{ $users | first | upperCase }}` for example. It is actually already possible to accomplish this with the current implementation.


Sorry that you had to go through this wall of text, but I hope you like feature. In case you have any questions or concerns, I'm happy to answer them.