### PR TITLE
[5.4] Add replaceDimensions for validator messages

### DIFF
--- a/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
@@ -355,4 +355,25 @@ trait ReplacesAttributes
     {
         return $this->replaceBefore($message, $attribute, $rule, $parameters);
     }
+
+    /**
+     * Replace all place-holders for the dimensions rule.
+     *
+     * @param  string  $message
+     * @param  string  $attribute
+     * @param  string  $rule
+     * @param  array   $parameters
+     * @return string
+     */
+    protected function replaceDimensions($message, $attribute, $rule, $parameters)
+    {
+        $nesteds = $this->parseNamedParameters($parameters);
+        if (is_array($nesteds)) {
+            foreach ($nesteds as $key => $value) {
+                $message = str_replace(':'.$key, $value, $message);
+            }
+        }
+
+        return $message;
+    }
 }

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -215,6 +215,26 @@ class ValidationValidatorTest extends TestCase
         $this->assertEquals('replaced!', $v->messages()->first('name'));
     }
 
+    public function testNestedAttributesAreReplacedInDimensions()
+    {
+        // Knowing that demo image.gif has width = 3 and height = 2
+        $uploadedFile = new \Symfony\Component\HttpFoundation\File\UploadedFile(__DIR__.'/fixtures/image.gif', '', null, null, null, true);
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $trans->addLines(['validation.dimensions' => ':min_width :max_height :ratio'], 'en');
+        $v = new Validator($trans, ['x' => $uploadedFile], ['x' => 'dimensions:min_width=10,max_height=20,ratio=1']);
+        $v->messages()->setFormat(':message');
+        $this->assertTrue($v->fails());
+        $this->assertEquals('10 20 1', $v->messages()->first('x'));
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $trans->addLines(['validation.dimensions' => ':width :height :ratio'], 'en');
+        $v = new Validator($trans, ['x' => $uploadedFile], ['x' => 'dimensions:min_width=10,max_height=20,ratio=1']);
+        $v->messages()->setFormat(':message');
+        $this->assertTrue($v->fails());
+        $this->assertEquals(':width :height 1', $v->messages()->first('x'));
+    }
+
     public function testAttributeNamesAreReplaced()
     {
         $trans = $this->getIlluminateArrayTranslator();


### PR DESCRIPTION
Add `replaceDimensions` for allowing the uses of nested arguments in validator messages.

Ex:
```
The image is to small (Minimum :min_width x :min_height)
```