### PR TITLE
[5.5] remove redundant $queue parameter from createPayload

### DIFF
--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -76,14 +76,13 @@ abstract class Queue
      *
      * @param  string  $job
      * @param  mixed   $data
-     * @param  string  $queue
      * @return string
      *
      * @throws \Illuminate\Queue\InvalidPayloadException
      */
-    protected function createPayload($job, $data = '', $queue = null)
+    protected function createPayload($job, $data = '')
     {
-        $payload = json_encode($this->createPayloadArray($job, $data, $queue));
+        $payload = json_encode($this->createPayloadArray($job, $data));
 
         if (JSON_ERROR_NONE !== json_last_error()) {
             throw new InvalidPayloadException;
@@ -97,10 +96,9 @@ abstract class Queue
      *
      * @param  string  $job
      * @param  mixed   $data
-     * @param  string  $queue
      * @return array
      */
-    protected function createPayloadArray($job, $data = '', $queue = null)
+    protected function createPayloadArray($job, $data = '')
     {
         return is_object($job)
                     ? $this->createObjectPayload($job)

--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -134,12 +134,11 @@ class RedisQueue extends Queue implements QueueContract
      *
      * @param  string  $job
      * @param  mixed   $data
-     * @param  string  $queue
      * @return string
      */
-    protected function createPayloadArray($job, $data = '', $queue = null)
+    protected function createPayloadArray($job, $data = '')
     {
-        return array_merge(parent::createPayloadArray($job, $data, $queue), [
+        return array_merge(parent::createPayloadArray($job, $data), [
             'id' => $this->getRandomId(),
             'attempts' => 0,
         ]);

--- a/src/Illuminate/Queue/SyncQueue.php
+++ b/src/Illuminate/Queue/SyncQueue.php
@@ -34,7 +34,7 @@ class SyncQueue extends Queue implements QueueContract
      */
     public function push($job, $data = '', $queue = null)
     {
-        $queueJob = $this->resolveJob($this->createPayload($job, $data, $queue), $queue);
+        $queueJob = $this->resolveJob($this->createPayload($job, $data), $queue);
 
         try {
             $this->raiseBeforeJobEvent($queueJob);


### PR DESCRIPTION
I don't see any use in the current queue drivers. I don't think any custom driver really requires the queue name to be given to `createPayload` and `createPayloadArray` functions.