### PR TITLE
[5.4] Compile Blade comments first

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -49,9 +49,9 @@ class BladeCompiler extends Compiler implements CompilerInterface
      * @var array
      */
     protected $compilers = [
+        'Comments',
         'Extensions',
         'Statements',
-        'Comments',
         'Echos',
     ];
 

--- a/tests/View/Blade/BladeCommentsTest.php
+++ b/tests/View/Blade/BladeCommentsTest.php
@@ -28,6 +28,14 @@ this is a comment
         $this->assertEmpty($compiler->compileString($string));
     }
 
+    public function testBladeCodeInsideCommentsIsNotCompiled()
+    {
+        $compiler = new BladeCompiler($this->getFiles(), __DIR__);
+        $string = '{{-- @foreach() --}}';
+
+        $this->assertEmpty($compiler->compileString($string));
+    }
+
     protected function getFiles()
     {
         return m::mock('Illuminate\Filesystem\Filesystem');


### PR DESCRIPTION
In this way we prevent Blade from compiling code inside comments, like statements, etc.

This should fix: https://github.com/laravel/framework/issues/17813 and https://github.com/laravel/framework/issues/16688.

This solution is so simple that I'm afraid I might be missing something? 