### PR TITLE
[5.4] Update compileComments docblock 

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesComments.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesComments.php
@@ -5,7 +5,7 @@ namespace Illuminate\View\Compilers\Concerns;
 trait CompilesComments
 {
     /**
-     * Compile Blade comments into valid PHP.
+     * Compile Blade comments into an empty string.
      *
      * @param  string  $value
      * @return string


### PR DESCRIPTION
To reflect it compiles blade comments into empty strings