### PR TITLE
[5.4] Simplify the command to generate resource controllers from make:model

### DIFF
--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -44,7 +44,7 @@ class ModelMakeCommand extends GeneratorCommand
             $this->createMigration();
         }
 
-        if ($this->option('controller')) {
+        if ($this->option('controller') || $this->option('resource')) {
             $this->createController();
         }
     }


### PR DESCRIPTION
This PR allows:

`php artisan make:model Something --resource` 

To generate a resource controller bind to a model, specifying both controller and resource options is no longer necessary: 

`php artisan make:model Something --controller --resource`

