### PR TITLE
[5.4] Proper float comparison in ratio validation

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -478,7 +478,7 @@ trait ValidatesAttributes
             [1, 1], array_filter(sscanf($parameters['ratio'], '%f/%d'))
         );
 
-        return $numerator / $denominator != $width / $height;
+        return abs($numerator / $denominator - $width / $height) > 0.000001;
     }
 
     /**


### PR DESCRIPTION
Spotted this while reading #17943.

One does not simply directly compare floats for equality.
There are countless articles about this, and a [big warning here](http://www.php.net/manual/en/language.types.float.php).

5-digit precision is needed to detect a 1px mismatch in a 122880x69120 [128K image](https://en.wikipedia.org/wiki/Image_resolution#Resolution_in_various_media).
I chose 6-digit precision, it costs nothing more and it adds a safety margin.

Maybe this change would have to be backported as well.
ping @themsaid