### PR TITLE
[5.4] use Illuminate\Contracts\Auth\Authenticatable contract to get the user password

### DIFF
--- a/src/Illuminate/Session/Middleware/AuthenticateSession.php
+++ b/src/Illuminate/Session/Middleware/AuthenticateSession.php
@@ -47,7 +47,7 @@ class AuthenticateSession
             $this->storePasswordHashInSession($request);
         }
 
-        if ($request->session()->get('password_hash') !== $request->user()->password) {
+        if ($request->session()->get('password_hash') !== $request->user()->getAuthPassword()) {
             $this->logout($request);
         }
 
@@ -69,7 +69,7 @@ class AuthenticateSession
         }
 
         $request->session()->put([
-            'password_hash' => $request->user()->password,
+            'password_hash' => $request->user()->getAuthPassword(),
         ]);
     }
 


### PR DESCRIPTION
the `AuthenticateSession` does not follow the `Illuminate\Contracts\Auth\Authenticatable` contract when getting the user password.

* changed from field access to getAuthPassword() method