### PR TITLE
[5.4] Fix for error when pass an array as second argument to gate

### DIFF
--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -348,6 +348,10 @@ class Gate implements GateContract
             $class = get_class($class);
         }
 
+        if (! is_string($class)) {
+            return null;
+        }
+
         if (isset($this->policies[$class])) {
             return $this->resolvePolicy($this->policies[$class]);
         }


### PR DESCRIPTION
Hi, we have a problem with this [code.](https://github.com/laravel/framework/pull/15757/files) We have policy function that accepts an array, but we got an exception when we pass an array as second argument to ```Gate::allows```, because previously it checked for ```is_string``` before