### PR TITLE
[5.4] Modify redirect with input to return empty if given empty array

### DIFF
--- a/src/Illuminate/Http/RedirectResponse.php
+++ b/src/Illuminate/Http/RedirectResponse.php
@@ -74,7 +74,7 @@ class RedirectResponse extends BaseRedirectResponse
     public function withInput(array $input = null)
     {
         $this->session->flashInput($this->removeFilesFromInput(
-            $input !== null ? $input : $this->request->input()
+            ! is_null($input) ? $input : $this->request->input()
         ));
 
         return $this;

--- a/src/Illuminate/Http/RedirectResponse.php
+++ b/src/Illuminate/Http/RedirectResponse.php
@@ -74,7 +74,7 @@ class RedirectResponse extends BaseRedirectResponse
     public function withInput(array $input = null)
     {
         $this->session->flashInput($this->removeFilesFromInput(
-            $input ?: $this->request->input()
+            $input !== null ? $input : $this->request->input()
         ));
 
         return $this;


### PR DESCRIPTION
This will make `withInput()` flash no input if an empty array is passed:

`->withInput([])` currently flashes all input because `[]` is evaluated as false.