### PR TITLE
[5.5] Add date rule generator class

### DIFF
--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -64,4 +64,17 @@ class Rule
     {
         return new Rules\Unique($table, $column);
     }
+
+    /**
+     * Get a date constraint builder instance.
+     *
+     * @param string $type
+     * @param string|\DateTime $date
+     * @throws \InvalidArgumentException
+     * @return \Illuminate\Validation\Rules\Date
+     */
+    public static function date($type = 'date', $date = '')
+    {
+        return new Rules\Date($type, $date);
+    }
 }

--- a/src/Illuminate/Validation/Rules/Date.php
+++ b/src/Illuminate/Validation/Rules/Date.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace Illuminate\Validation\Rules;
+
+use DateTimeInterface;
+use InvalidArgumentException;
+
+class Date
+{
+    /** @var string $type The type of the rule to apply. */
+    protected $type;
+
+    /** @var string $date The date or field name to compare the type against. */
+    protected $date;
+
+    /** @var array allowedTypes The allowed types of the rule. */
+    const ALLOWEDTYPES = [
+        'date',
+        'after',
+        'after_or_equal',
+        'before',
+        'before_or_equal',
+    ];
+
+    /**
+     * Create a new date rule instance.
+     *
+     * @param string $type
+     * @param string|\DateTimeInterface $date
+     * @throws \InvalidArgumentException
+     * @return void
+     */
+    public function __construct($type = 'date', $date = '')
+    {
+        $this->type($type);
+        $this->date($date);
+    }
+
+    /**
+     * Set the type of the rule manually.
+     *
+     * @param string $value
+     * @throws \InvalidArgumentException
+     * @return $this
+     */
+    public function type($value)
+    {
+        if (! in_array($value, self::ALLOWEDTYPES)) {
+            throw new InvalidArgumentException();
+        }
+
+        $this->type = $value;
+
+        return $this;
+    }
+
+    /**
+     * Set the date or field to compare the submitted value against.
+     *
+     * @param string|\DateTimeInterface $value
+     * @return $this
+     */
+    public function date($value)
+    {
+        if ($value instanceof DateTimeInterface) {
+            $this->date = $value->format('Y-m-d');
+
+            return $this;
+        }
+
+        $this->date = $value;
+
+        return $this;
+    }
+
+    /**
+     * Set the type to "after".
+     *
+     * @return $this
+     */
+    public function after()
+    {
+        $this->type('after');
+
+        return $this;
+    }
+
+    /**
+     * Set the type to "after_or_equal".
+     *
+     * @return $this
+     */
+    public function afterOrEqual()
+    {
+        $this->type('after_or_equal');
+
+        return $this;
+    }
+
+    /**
+     * Set the type to "before".
+     *
+     * @return $this
+     */
+    public function before()
+    {
+        $this->type('before');
+
+        return $this;
+    }
+
+    /**
+     * Set the type to "before_or_equal".
+     *
+     * @return $this
+     */
+    public function beforeOrEqual()
+    {
+        $this->type('before_or_equal');
+
+        return $this;
+    }
+
+    /**
+     * Convert the rule to a validation string.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        $extra = '';
+        if ($this->type !== 'date' && $this->date !== '') {
+            $extra = '|'.$this->type.':'.$this->date;
+        }
+
+        return 'date'.$extra;
+    }
+}

--- a/tests/Validation/ValidationDateRuleRest.php
+++ b/tests/Validation/ValidationDateRuleRest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Illuminate\Tests\Validation;
+
+use PHPUnit\Framework\TestCase;
+use Illuminate\Validation\Rules\Date;
+
+class ValidationDateRuleRest extends TestCase
+{
+    public function testDate()
+    {
+        $rule = new Date();
+        $this->assertEquals('date', (string) $rule);
+
+        $rule = new Date('date');
+        $this->assertEquals('date', (string) $rule);
+    }
+
+    public function testAfter()
+    {
+        $rule = (new Date('after'))->date('today');
+        $this->assertEquals('date|after:today', (string) $rule);
+
+        $rule = (new Date())->after()->date('tomorrow');
+        $this->assertEquals('date|after:tomorrow', (string) $rule);
+
+        $rule = new Date('after', 'today');
+        $this->assertEquals('date|after:today', (string) $rule);
+    }
+
+    public function testAfterOrEqual()
+    {
+        $rule = (new Date('after_or_equal'))->date('today');
+        $this->assertEquals('date|after_or_equal:today', (string) $rule);
+
+        $rule = (new Date())->afterOrEqual()->date('tomorrow');
+        $this->assertEquals('date|after_or_equal:tomorrow', (string) $rule);
+
+        $rule = new Date('after_or_equal', 'today');
+        $this->assertEquals('date|after_or_equal:today', (string) $rule);
+    }
+
+    public function testBefore()
+    {
+        $rule = (new Date('before'))->date('today');
+        $this->assertEquals('date|before:today', (string) $rule);
+
+        $rule = (new Date())->before()->date('tomorrow');
+        $this->assertEquals('date|before:tomorrow', (string) $rule);
+
+        $rule = new Date('before', 'today');
+        $this->assertEquals('date|before:today', (string) $rule);
+    }
+
+    public function testBeforeOrEqual()
+    {
+        $rule = (new Date('before_or_equal'))->date('today');
+        $this->assertEquals('date|before_or_equal:today', (string) $rule);
+
+        $rule = (new Date())->beforeOrEqual()->date('tomorrow');
+        $this->assertEquals('date|before_or_equal:tomorrow', (string) $rule);
+
+        $rule = new Date('before_or_equal', 'today');
+        $this->assertEquals('date|before_or_equal:today', (string) $rule);
+    }
+
+    public function testRejectionOfInvalidTypes()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        new Date('nonexistant');
+    }
+}


### PR DESCRIPTION
This adds a new validation generator class for the date rules (except for `date_format` which doesn't fit with this class at all.) It allows developers to make date comparison rules using the object system.

For example: `(new Date())->after()->date('start_date');` to create create `date|after:start_date` for the validator.

If simply `new Date()` is used then it just checks that a valid date is provided.

When setting the date a developer may provide a `DateTime` instance of any kind, which gets formatted into a string for the validator `Y-m-d` format. This allows using Carbon instances for example to set the date easily.