### PR TITLE
Allow access to the result in mapWithKeys

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -670,7 +670,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
         $result = [];
 
         foreach ($this->items as $key => $value) {
-            $assoc = $callback($value, $key);
+            $assoc = $callback($value, $key, $result);
 
             foreach ($assoc as $mapKey => $mapValue) {
                 $result[$mapKey] = $mapValue;

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1034,6 +1034,32 @@ class SupportCollectionTest extends TestCase
         );
     }
 
+    public function testMapWithKeysResult()
+    {
+        $data = new Collection([
+            ['name' => 'itemA', 'value' => 1],
+            ['name' => 'itemB', 'value' => 0],
+            ['name' => 'itemC', 'value' => 'D'],
+            ['name' => 'itemC', 'value' => 'E'],
+            ['name' => 'itemC', 'value' => 'F'],
+        ]);
+        $data = $data->mapWithKeys(function ($value, $key, $result) {
+            if ($current = data_get($result, $value['name'])) {
+                if (! is_array($current)) {
+                    $current = [$current];
+                }
+
+                $current[] = $value['value'];
+            }
+
+            return [$value['name'] => $current ?: $value['value']];
+        });
+        $this->assertEquals(
+            ['itemA' => 1, 'itemB' => 0, 'itemC' => ['D', 'E', 'F']],
+            $data->all()
+        );
+    }
+
     public function testMapWithKeysIntegerKeys()
     {
         $data = new Collection([


### PR DESCRIPTION
This change will allow us to, for instance, create arrays of arrays:

    $filter = [
        ['name' => 'itemA', 'value' => 1],
        ['name' => 'itemB', 'value' => 0],
        ['name' => 'itemC', 'value' => 'D'],
        ['name' => 'itemC', 'value' => 'E'],
        ['name' => 'itemC', 'value' => 'F'],
    ];

    $filter = collect($filter)->mapWithKeys(function($value, $key, $result) {
        if ($current = data_get($result, $value['name'])) {
            if (! is_array($current)) {
                $current = [$current];
            }

            $current[] = $value['value'];
        }

        return [$value['name'] => $current ?: $value['value']];
    });

Resulting in 

![image](https://cloud.githubusercontent.com/assets/3182864/23096748/0f39502e-f60a-11e6-80ed-76d6c99044b4.png)
