### PR TITLE
[5.4] Allow Slack Notifications to use Image Urls

### DIFF
--- a/src/Illuminate/Notifications/Channels/SlackWebhookChannel.php
+++ b/src/Illuminate/Notifications/Channels/SlackWebhookChannel.php
@@ -57,6 +57,7 @@ class SlackWebhookChannel
         $optionalFields = array_filter([
             'username' => data_get($message, 'username'),
             'icon_emoji' => data_get($message, 'icon'),
+            'icon_url' => data_get($message, 'logo'),
             'channel' => data_get($message, 'channel'),
         ]);
 

--- a/src/Illuminate/Notifications/Messages/SlackMessage.php
+++ b/src/Illuminate/Notifications/Messages/SlackMessage.php
@@ -99,7 +99,7 @@ class SlackMessage
     }
 
     /**
-     * Set a custom user icon for the Slack message.
+     * Set a custom username for the Slack message.
      *
      * @param  string  $username
      * @param  string|null  $icon
@@ -112,6 +112,19 @@ class SlackMessage
         if (! is_null($icon)) {
             $this->icon = $icon;
         }
+
+        return $this;
+    }
+    
+    /**
+     * Set a custom logo image for the Slack message.
+     *
+     * @param  string  $logo
+     * @return $this
+     */
+    public function logo($logo)
+    {
+        $this->logo = $logo;
 
         return $this;
     }

--- a/src/Illuminate/Notifications/Messages/SlackMessage.php
+++ b/src/Illuminate/Notifications/Messages/SlackMessage.php
@@ -99,7 +99,7 @@ class SlackMessage
     }
 
     /**
-     * Set a custom username for the Slack message.
+     * Set a custom username and optional emoji icon for the Slack message.
      *
      * @param  string  $username
      * @param  string|null  $icon
@@ -115,7 +115,7 @@ class SlackMessage
 
         return $this;
     }
-    
+
     /**
      * Set a custom logo image for the Slack message.
      *

--- a/src/Illuminate/Notifications/Messages/SlackMessage.php
+++ b/src/Illuminate/Notifications/Messages/SlackMessage.php
@@ -21,11 +21,18 @@ class SlackMessage
     public $username;
 
     /**
-     * The user icon for the message.
+     * The user emoji icon for the message.
      *
      * @var string|null
      */
     public $icon;
+
+    /**
+     * The user url logo for the message.
+     *
+     * @var string|null
+     */
+    public $logo;
 
     /**
      * The channel to send the message on.


### PR DESCRIPTION
Currently the Laravel Notification channel for Slack seems to only support the 'icon_emoji'.

However Slack webhooks also allow you to provide a URL - and you can use your own custom logo - which is probably better for most Laravel Apps?

This PR is fully BC. You can set a logo URL instead of an emoji:

```
$this->slack = new SlackMessage;
$this->slack->from('My App')
                 ->logo('https://my.app/my-logo.png');
```

p.s. I've tested this against the Slack API. If someone sets _both_ an emoji and an icon - slack just uses the emoji with no complaints.