### PR TITLE
Fire event when a singleton is resolved

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -553,6 +553,7 @@ class Container implements ArrayAccess, ContainerContract
         // just return an existing instance instead of instantiating new instances
         // so the developer can keep using the same objects instance every time.
         if (isset($this->instances[$abstract]) && ! $needsContextualBuild) {
+            $this->fireResolvingCallbacks($abstract, $this->instances[$abstract]);
             return $this->instances[$abstract];
         }
 

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -554,6 +554,7 @@ class Container implements ArrayAccess, ContainerContract
         // so the developer can keep using the same objects instance every time.
         if (isset($this->instances[$abstract]) && ! $needsContextualBuild) {
             $this->fireResolvingCallbacks($abstract, $this->instances[$abstract]);
+
             return $this->instances[$abstract];
         }
 


### PR DESCRIPTION
`fireResolvingCallbacks` is not being called when:

- I have already *resolved* a `singleton` (i.e.: it is only fired the first time)
- I *resolve* an `instance`

Is it intended to work like this?