### PR TITLE
Add row format

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -65,7 +65,12 @@ class MySqlGrammar extends Grammar
         $sql = $this->compileCreateEncoding(
             $sql, $connection, $blueprint
         );
-
+        
+        // Then, we can add the row format option to the SQL for the table.
+        $sql = $this->compileCreateRowFormat(
+            $sql, $connection, $blueprint
+        );
+        
         // Finally, we will append the engine configuration onto this SQL statement as
         // the final thing we do before returning this finished SQL. Once this gets
         // added the query will be ready to execute against the real connections.
@@ -123,6 +128,25 @@ class MySqlGrammar extends Grammar
     }
 
     /**
+     * Append the row format specifications to a command.
+     *
+     * @param  string  $sql
+     * @param  \Illuminate\Database\Connection  $connection
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @return string
+     */
+    protected function compileCreateRowFormat($sql, Connection $connection, Blueprint $blueprint)
+    {
+        if (isset($blueprint->rowFormat)) {
+            return $sql.' row_format = '.$blueprint->rowFormat;
+        } elseif (! is_null($rowFormat = $connection->getConfig('row_format'))) {
+            return $sql.' row_format = '.$rowFormat;
+        }
+
+        return $sql;
+    }
+    
+    /**
      * Append the engine specifications to a command.
      *
      * @param  string  $sql
@@ -140,7 +164,7 @@ class MySqlGrammar extends Grammar
 
         return $sql;
     }
-
+    
     /**
      * Compile an add column command.
      *


### PR DESCRIPTION
I have a same issue with #17530 and already read the laravel doc about [Index Lengths & MySQL / MariaDB](https://laravel.com/docs/5.4/migrations#indexes).

My problem is my server running MySQL 5.6 and I can't upgrade it to 5.7.

According the article [Using Innodb_large_prefix to Avoid ERROR 1071](http://mechanics.flite.com/blog/2014/07/29/using-innodb-large-prefix-to-avoid-error-1071/), MySQL doc [Specifying the Row Format for a Table on 5.6](https://dev.mysql.com/doc/refman/5.6/en/innodb-row-format-specification.html) and [Specifying the Row Format for a Table on 5.7](https://dev.mysql.com/doc/refman/5.7/en/innodb-row-format-specification.html), l learn that 5.7 has a global variable called `innodb_default_row_format` which 5.6 doesn't. So we need explicitly manually add `row_format=dynamic` or `row_format=compressed` to each table.

I modify `src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php`, then add `row_format` to `config/database.php` 

```
'mysql' => [
            ...
            'charset' => 'utf8mb4',
            'collation' => 'utf8mb4_unicode_ci',
            'prefix' => '',
            'strict' => true,
            'engine' => null,
            'row_format'=>'dynamic', // add row_format here
        ],
```

Finally, run `php artisan migrate` again, it works well now!