### PR TITLE
Pass a callable array as controller action

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -173,7 +173,7 @@ class Route
      */
     protected function isControllerAction()
     {
-        return is_string($this->action['uses']);
+        return is_string($this->action['uses']) || is_array($this->action['uses']);
     }
 
     /**
@@ -237,6 +237,10 @@ class Route
      */
     protected function parseControllerCallback()
     {
+        if (is_array($this->action['uses'])) {
+            return $this->action['uses'];
+        }
+
         return Str::parseCallback($this->action['uses']);
     }
 

--- a/src/Illuminate/Routing/RouteRegistrar.php
+++ b/src/Illuminate/Routing/RouteRegistrar.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Routing;
 
-use Closure;
 use BadMethodCallException;
 use InvalidArgumentException;
 
@@ -146,7 +145,7 @@ class RouteRegistrar
             return $this->attributes;
         }
 
-        if (is_string($action) || $action instanceof Closure) {
+        if (is_string($action) || is_callable($action)) {
             $action = ['uses' => $action];
         }
 

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -97,10 +97,29 @@ class RouteRegistrarTest extends TestCase
         $this->seeMiddleware('controller-middleware');
     }
 
+    public function testCanRegisterRouteWithCallableControllerAction()
+    {
+        $this->router->middleware('controller-middleware')
+                     ->get('users', [RouteRegistrarControllerStub::class, 'index']);
+
+        $this->seeResponse('controller', Request::create('users', 'GET'));
+        $this->seeMiddleware('controller-middleware');
+    }
+
     public function testCanRegisterRouteWithArrayAndControllerAction()
     {
         $this->router->middleware('controller-middleware')->put('users', [
             'uses' => 'Illuminate\Tests\Routing\RouteRegistrarControllerStub@index',
+        ]);
+
+        $this->seeResponse('controller', Request::create('users', 'PUT'));
+        $this->seeMiddleware('controller-middleware');
+    }
+
+    public function testCanRegisterRouteWithArrayAndCallableControllerAction()
+    {
+        $this->router->middleware('controller-middleware')->put('users', [
+            'uses' => [RouteRegistrarControllerStub::class, 'index'],
         ]);
 
         $this->seeResponse('controller', Request::create('users', 'PUT'));


### PR DESCRIPTION
Include the ability to define a route with callable controller action:
```php
Route::get('user/{id}', [UserController::class, 'show']);
```