### PR TITLE
Unable to create new records.

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -486,6 +486,14 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     {
         $query = $this->newQueryWithoutScopes();
 
+        // If new save is required without instantizing the new class.
+        // $options = "create" || "update"
+        if (isset($options['create']))
+            if ($options['create'] && $this -> exists ) {
+                $this->attributes[(string)$this->primaryKey]++;
+                $this->exists = false;
+            }
+
         // If the "saving" event returns false we'll bail out of the save and return
         // false, indicating that the save failed. This provides a chance for any
         // listeners to cancel save operations if validations fail or whatever.

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -488,7 +488,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 
         // If new save is required without instantizing the new class.
         // $options["create"] is boolean; true means create a new record without updating previous.
-        // false or not set means update the same record without updating a new one.
+        // false or not set means update the same record without creating a new one.
         if (isset($options['create']))
             if ($options['create'] && $this -> exists ) {
                 $this->attributes[(string)$this->primaryKey]++;

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -486,6 +486,15 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     {
         $query = $this->newQueryWithoutScopes();
 
+        // If new save is required without instantizing the new class.
+        // $options["create"] is boolean; true means create a new record without updating previous.
+        // false or not set means update the same record without updating a new one.
+        if (isset($options['create']))
+            if ($options['create'] && $this -> exists ) {
+                $this->attributes[(string)$this->primaryKey]++;
+                $this->exists = false;
+            }
+
         // If the "saving" event returns false we'll bail out of the save and return
         // false, indicating that the save failed. This provides a chance for any
         // listeners to cancel save operations if validations fail or whatever.

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -489,11 +489,12 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         // If new save is required without instantizing the new class.
         // $options["create"] is boolean; true means create a new record without updating previous.
         // false or not set means update the same record without creating a new one.
-        if (isset($options['create']))
-            if ($options['create'] && $this -> exists ) {
-                $this->attributes[(string)$this->primaryKey]++;
+        if (isset($options['create'])) {
+            if ($options['create'] && $this->exists) {
+                $this->attributes[(string) $this->primaryKey]++;
                 $this->exists = false;
             }
+        }
 
         // If the "saving" event returns false we'll bail out of the save and return
         // false, indicating that the save failed. This provides a chance for any


### PR DESCRIPTION
- Laravel Version: 5.4.12
- PHP Version: 5.6.25
- Database Driver & Version: MySQL 5.6.31

### Description:
Currently, it is featured that you cannot create a new record unless you create a new instance of the model. So if you would like to create the class once and use it again and again to create new records, it is not possible, since it updates the old records based on the ID present in the model object itself. 


### Steps To Reproduce:
```php
<?php

/**
 * Created by PhpStorm.
 * User: Gary
 * Date: 19/02/17
 * Time: 9:11 AM
 */

namespace  App\Repositories\SHRD;

use App\Models\FormResponse;

class formResonsesData {
    private $modelPipeline = null;

    function __construct(FormResponse $formResponse) {
        $this -> modelPipeline = $formResponse;
    }

    function getCounts() {
        return $this -> modelPipeline -> all() -> count();
    }

    function insertResponseData ($responseArray) {
        $failedInsertions = false;
        foreach ($responseArray as $resonseSubmission) {
            $modelPipeline = $this -> modelPipeline;
            $modelPipeline -> email_address =  $resonseSubmission -> hidden -> email;
            foreach ($resonseSubmission -> answers as $item => $value) {
                $modelPipeline [(string)$item] = $value;
            }
            $failedInsertions = $failedInsertions && $modelPipeline -> save();
        }
        return !$failedInsertions;
    }
}
```


Issue #17999  referenced, 