### PR TITLE
[5.4] method tableForeign for Blueprint

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -401,7 +401,7 @@ class Blueprint
      * @param  string  $name
      * @return \Illuminate\Support\Fluent
      */
-    public function fastForeign($table, $name = null){
+    public function tableForeign($table, $name = null){
 
         $column_name = substr($table, 0, -1) . "_id";
 

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -403,9 +403,7 @@ class Blueprint
      */
     public function tableForeign($table, $name = null)
     {
-
         $column_name = substr($table, 0, -1).'_id';
-
         $column = $this->integer($column_name)->unsigned();
         $this->foreign($column_name, $name)->references('id')->on($table);
 

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -393,7 +393,7 @@ class Blueprint
     {
         return $this->indexCommand('foreign', $columns, $name);
     }
-    
+
     /**
      * Specify a table to create a standard foreign key for the table.
      *
@@ -401,9 +401,10 @@ class Blueprint
      * @param  string  $name
      * @return \Illuminate\Support\Fluent
      */
-    public function tableForeign($table, $name = null){
+    public function tableForeign($table, $name = null)
+    {
 
-        $column_name = substr($table, 0, -1) . "_id";
+        $column_name = substr($table, 0, -1).'_id';
 
         $column = $this->integer($column_name)->unsigned();
         $this->foreign($column_name, $name)->references('id')->on($table);

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -393,6 +393,23 @@ class Blueprint
     {
         return $this->indexCommand('foreign', $columns, $name);
     }
+    
+    /**
+     * Specify a table to create a standard foreign key for the table.
+     *
+     * @param  string  $table
+     * @param  string  $name
+     * @return \Illuminate\Support\Fluent
+     */
+    public function fastForeign($table, $name = null){
+
+        $column_name = substr($table, 0, -1) . "_id";
+
+        $column = $this->integer($column_name)->unsigned();
+        $this->foreign($column_name, $name)->references('id')->on($table);
+
+        return $column;
+    }
 
     /**
      * Create a new auto-incrementing integer (4-byte) column on the table.


### PR DESCRIPTION
This method creates a standard foreign key passing the name of the table and the foreign key name if required, this method returns the created column.