### PR TITLE
[5.5] Added UUID validation rule

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -7,6 +7,7 @@ use Countable;
 use Exception;
 use Throwable;
 use DateTimeZone;
+use Ramsey\Uuid\Uuid;
 use DateTimeInterface;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
@@ -14,7 +15,6 @@ use InvalidArgumentException;
 use Illuminate\Validation\Rules\Exists;
 use Illuminate\Validation\Rules\Unique;
 use Illuminate\Validation\ValidationData;
-use Ramsey\Uuid\Uuid;
 use Symfony\Component\HttpFoundation\File\File;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 
@@ -1322,7 +1322,7 @@ trait ValidatesAttributes
     /**
      * Validate that an attribute is a valid UUID.
      *
-     * @param string  $attibute
+     * @param string  $attribute
      * @param mixed   $value
      * @return bool
      */

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -14,6 +14,7 @@ use InvalidArgumentException;
 use Illuminate\Validation\Rules\Exists;
 use Illuminate\Validation\Rules\Unique;
 use Illuminate\Validation\ValidationData;
+use Ramsey\Uuid\Uuid;
 use Symfony\Component\HttpFoundation\File\File;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 
@@ -1316,6 +1317,18 @@ trait ValidatesAttributes
         $~ixu';
 
         return preg_match($pattern, $value) > 0;
+    }
+
+    /**
+     * Validate that an attribute is a valid UUID.
+     *
+     * @param string  $attibute
+     * @param mixed   $value
+     * @return bool
+     */
+    protected function validateUuid($attribute, $value)
+    {
+        return Uuid::isValid($value);
     }
 
     /**

--- a/src/Illuminate/Validation/composer.json
+++ b/src/Illuminate/Validation/composer.json
@@ -19,6 +19,7 @@
         "illuminate/contracts": "5.5.*",
         "illuminate/support": "5.5.*",
         "illuminate/translation": "5.5.*",
+        "ramsey/uuid": "~3.0",
         "symfony/http-foundation": "~3.2"
     },
     "autoload": {

--- a/src/Illuminate/Validation/composer.json
+++ b/src/Illuminate/Validation/composer.json
@@ -19,7 +19,6 @@
         "illuminate/contracts": "5.5.*",
         "illuminate/support": "5.5.*",
         "illuminate/translation": "5.5.*",
-        "ramsey/uuid": "~3.0",
         "symfony/http-foundation": "~3.2"
     },
     "autoload": {
@@ -33,7 +32,8 @@
         }
     },
     "suggest": {
-        "illuminate/database": "Required to use the database presence verifier (5.5.*)."
+        "illuminate/database": "Required to use the database presence verifier (5.5.*).",
+        "ramsey/uuid": "Required to use the UUID validation rule"
     },
     "config": {
         "sort-packages": true

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1837,6 +1837,16 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->passes());
     }
 
+    public function testValidateUuid()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['x' => 'aslsdlks'], ['x' => 'Uuid']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['x' => 'fa47c0e9-2fc8-4c58-a8c5-bd53684706e1'], ['x' => 'Uuid']);
+        $this->assertTrue($v->passes());
+    }
+
     public function testValidateImage()
     {
         $trans = $this->getIlluminateArrayTranslator();


### PR DESCRIPTION
Hi there,

I've added a validation rule to check for a valid UUID. It's very common nowadays to use UUIDs as unique identifiers and it's looks very handy to me to have common validation support for this in the Laravel framework. 
The [ramsey/uuid](https://github.com/ramsey/uuid) library is already a dependency of the Laravel framework so I've added it as extra dependency to the subtree split. You can even think of adding it to the "suggested" packages so you have to install it yourself when using the validation component as standalone.