### PR TITLE
[5.4] Allow Slack Notifications to use image urls

### DIFF
--- a/src/Illuminate/Notifications/Channels/SlackWebhookChannel.php
+++ b/src/Illuminate/Notifications/Channels/SlackWebhookChannel.php
@@ -57,6 +57,7 @@ class SlackWebhookChannel
         $optionalFields = array_filter([
             'username' => data_get($message, 'username'),
             'icon_emoji' => data_get($message, 'icon'),
+            'icon_url' => data_get($message, 'image'),
             'channel' => data_get($message, 'channel'),
         ]);
 

--- a/src/Illuminate/Notifications/Messages/SlackMessage.php
+++ b/src/Illuminate/Notifications/Messages/SlackMessage.php
@@ -21,11 +21,18 @@ class SlackMessage
     public $username;
 
     /**
-     * The user icon for the message.
+     * The user emoji icon for the message.
      *
      * @var string|null
      */
     public $icon;
+
+    /**
+     * The user image icon for the message.
+     *
+     * @var string|null
+     */
+    public $image;
 
     /**
      * The channel to send the message on.
@@ -92,7 +99,7 @@ class SlackMessage
     }
 
     /**
-     * Set a custom user icon for the Slack message.
+     * Set a custom username and optional emoji icon for the Slack message.
      *
      * @param  string  $username
      * @param  string|null  $icon
@@ -105,6 +112,19 @@ class SlackMessage
         if (! is_null($icon)) {
             $this->icon = $icon;
         }
+
+        return $this;
+    }
+
+    /**
+     * Set a custom image icon the message should use.
+     *
+     * @param  string $channel
+     * @return $this
+     */
+    public function image($image)
+    {
+        $this->image = $image;
 
         return $this;
     }

--- a/tests/Notifications/NotificationSlackChannelTest.php
+++ b/tests/Notifications/NotificationSlackChannelTest.php
@@ -65,6 +65,40 @@ class NotificationSlackChannelTest extends TestCase
         );
     }
 
+    public function testCorrectPayloadIsSentToSlackWithImageIcon()
+    {
+        $this->validatePayload(
+            new NotificationSlackChannelTestNotificationWithImageIcon,
+            [
+                'json' => [
+                    'username' => 'Ghostbot',
+                    'icon_url' => 'http://example.com/image.png',
+                    'channel' => '#ghost-talk',
+                    'text' => 'Content',
+                    'attachments' => [
+                        [
+                            'title' => 'Laravel',
+                            'title_link' => 'https://laravel.com',
+                            'text' => 'Attachment Content',
+                            'fallback' => 'Attachment Fallback',
+                            'fields' => [
+                                [
+                                    'title' => 'Project',
+                                    'value' => 'Laravel',
+                                    'short' => true,
+                                ],
+                            ],
+                            'mrkdwn_in' => ['text'],
+                            'footer' => 'Laravel',
+                            'footer_icon' => 'https://laravel.com/fake.png',
+                            'ts' => 1234567890,
+                        ],
+                    ],
+                ],
+            ]
+        );
+    }
+
     public function testCorrectPayloadWithoutOptionalFieldsIsSentToSlack()
     {
         $this->validatePayload(
@@ -139,6 +173,32 @@ class NotificationSlackChannelTestNotification extends Notification
     {
         return (new SlackMessage)
                     ->from('Ghostbot', ':ghost:')
+                    ->to('#ghost-talk')
+                    ->content('Content')
+                    ->attachment(function ($attachment) {
+                        $timestamp = Mockery::mock('Carbon\Carbon');
+                        $timestamp->shouldReceive('getTimestamp')->andReturn(1234567890);
+                        $attachment->title('Laravel', 'https://laravel.com')
+                                   ->content('Attachment Content')
+                                   ->fallback('Attachment Fallback')
+                                   ->fields([
+                                        'Project' => 'Laravel',
+                                    ])
+                                    ->footer('Laravel')
+                                    ->footerIcon('https://laravel.com/fake.png')
+                                    ->markdown(['text'])
+                                    ->timestamp($timestamp);
+                    });
+    }
+}
+
+class NotificationSlackChannelTestNotificationWithImageIcon extends Notification
+{
+    public function toSlack($notifiable)
+    {
+        return (new SlackMessage)
+                    ->from('Ghostbot')
+                    ->image('http://example.com/image.png')
                     ->to('#ghost-talk')
                     ->content('Content')
                     ->attachment(function ($attachment) {


### PR DESCRIPTION
Currently the Laravel Notification channel for Slack seems to only support the 'icon_emoji'.

However Slack webhooks also allow you to provide an image URL - allowing you to use your own custom logo when sending a Slack notification - which is probably better for most Laravel Apps so they can include their logo?

This PR is fully BC. You can set a logo URL instead of an emoji:

```
public function toSlack($notifiable)
{
    return (new SlackMessage)
                ->from('My App')
                ->image('https://example.com/my-image.png')  
                ->content('This will be display my-image.png next to this alert on Slack');
}
```

p.s. I've tested this against the Slack API. If someone sets both an icon emoji and an icon image - Slack just uses the emoji with no complaints.