### PR TITLE
[5.4] trim spaces while collecting section name

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesLayouts.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesLayouts.php
@@ -38,7 +38,7 @@ trait CompilesLayouts
      */
     protected function compileSection($expression)
     {
-        $this->lastSection = trim($expression, "()'\"");
+        $this->lastSection = trim($expression, "()'\" ");
 
         return "<?php \$__env->startSection{$expression}; ?>";
     }


### PR DESCRIPTION
Currently using spaces in a section declaration causes the parent placeholder to be different than the section name `@section([ ]"parts"[ ])`, this PR trims the spaces around the section name for proper placeholder creation.