### PR TITLE
[5.3] Add a new parameter to the pagination.

### DIFF
--- a/src/Illuminate/Pagination/UrlWindow.php
+++ b/src/Illuminate/Pagination/UrlWindow.php
@@ -116,7 +116,7 @@ class UrlWindow
     protected function getSliderTooCloseToBeginning($window, $onEachEdge)
     {
         return [
-            'first'  => $this->paginator->getUrlRange(1, $window + $onEachEdge),
+            'first'  => $this->paginator->getUrlRange(1, $window + $onEachEdge + 1),
             'slider' => null,
             'last'   => $this->getFinish($onEachEdge),
         ];
@@ -132,7 +132,7 @@ class UrlWindow
     protected function getSliderTooCloseToEnding($window, $onEachEdge)
     {
         $last = $this->paginator->getUrlRange(
-            $this->lastPage() + 1 - $window - $onEachEdge,
+            $this->lastPage() - $window - $onEachEdge,
             $this->lastPage()
         );
 


### PR DESCRIPTION
The number of links at the beginning and the end of the link list can now be set with the $onEachEdge parameter, which is passed to the UrlWindow::make() and UrlWindow::get() methods.
The default value is 2, and it can be set to 0.