### PR TITLE
[5.3] Fix array multi file upload

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithPages.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithPages.php
@@ -702,9 +702,7 @@ trait InteractsWithPages
         $names = array_keys($files);
 
         $files = array_map(function (array $file, $name) use ($uploads) {
-            return isset($uploads[$name])
-                        ? $this->getUploadedFileForTesting($file, $uploads, $name)
-                        : $file;
+            return $this->getUploadedFileForTesting($file, $uploads, $name);
         }, $files, $names);
 
         $uploads = array_combine($names, $files);
@@ -752,8 +750,10 @@ trait InteractsWithPages
      */
     protected function getUploadedFileForTesting($file, $uploads, $name)
     {
+        $originalName = isset( $uploads[$name] ) ? basename($uploads[$name]) :  $file['name'];
+
         return new UploadedFile(
-            $file['tmp_name'], basename($uploads[$name]), $file['type'], $file['size'], $file['error'], true
+            $file['tmp_name'], $originalName, $file['type'], $file['size'], $file['error'], true
         );
     }
 }

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithPages.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithPages.php
@@ -750,6 +750,9 @@ trait InteractsWithPages
      */
     protected function getUploadedFileForTesting($file, $uploads, $name)
     {
+        // if file is empty return $file
+        if( $file['error'] == UPLOAD_ERR_NO_FILE ) { return; }
+
         $originalName = isset( $uploads[$name] ) ? basename($uploads[$name]) :  $file['name'];
 
         return new UploadedFile(


### PR DESCRIPTION
Fixed an issue when testing multiple files with a form element like

```html
<input type="file" name="files[]" multiple="multiple"></input>
```

using

```php
// attach file to multiple file element and submit
$this->visit( route( 'page.form' ) )
            ->attach( [$pathToFile] , 'images[]')
            ->press('Submit')
            ->seePageIs( route('page') );
```

An error was thrown because the `Form::getFile()` method returned an array representing the file which never got converted to a `UploadFile`.

The fix converts all files to an instance of `UploadFile` with the test attribute set to true, unless the array returned by `Form::getFile()` has `UPLOAD_ERR_NO_FILE` as its error.