### PR TITLE
[5.4] Let the request handle default values.

### DIFF
--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -185,6 +185,27 @@ trait InteractsWithInput
     }
 
     /**
+     * Intersect an array of items with the input data or fallback to default values.
+     *
+     * @param  array  $keys
+     * @return array
+     */
+    public function defaults($keys)
+    {
+        $defaults = [];
+
+        foreach ($keys as $key => $value) {
+            if (is_numeric($key)) {
+                list($key, $value) = [$value, null];
+            }
+
+            $defaults[$key] = $this->has($key) ? $this->get($key) : $value;
+        }
+
+        return $defaults;
+    }
+
+    /**
      * Retrieve a query string item from the request.
      *
      * @param  string  $key

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -267,6 +267,23 @@ class HttpRequestTest extends TestCase
         $this->assertEquals(['name' => 'Taylor'], $request->intersect('name', 'age', 'email'));
     }
 
+    public function testDefaultsMethod()
+    {
+        $request = Request::create('/', 'GET', [
+            'name' => 'Taylor',
+            'age' => null,
+        ]);
+        $this->assertSame([
+            'name' => 'Taylor',
+            'framework' => 'laravel',
+            'age' => 25,
+        ], $request->defaults([
+            'name',
+            'framework' => 'laravel',
+            'age' => 25,
+        ]));
+    }
+
     public function testQueryMethod()
     {
         $request = Request::create('/', 'GET', ['name' => 'Taylor']);


### PR DESCRIPTION
In many cases, I find myself getting the argument of a request and setting its default value, if not present.

---

This function lets the request handle default values easily.