### PR TITLE
[5.4] Adding Cookie SameSite support

### DIFF
--- a/src/Illuminate/Cookie/CookieJar.php
+++ b/src/Illuminate/Cookie/CookieJar.php
@@ -40,38 +40,42 @@ class CookieJar implements JarContract
     /**
      * Create a new cookie instance.
      *
-     * @param  string  $name
-     * @param  string  $value
-     * @param  int     $minutes
-     * @param  string  $path
-     * @param  string  $domain
-     * @param  bool    $secure
-     * @param  bool    $httpOnly
+     * @param  string       $name
+     * @param  string       $value
+     * @param  int          $minutes
+     * @param  string       $path
+     * @param  string       $domain
+     * @param  bool         $secure
+     * @param  bool         $httpOnly
+     * @param  bool         $raw
+     * @param  string|null  $sameSite
      * @return \Symfony\Component\HttpFoundation\Cookie
      */
-    public function make($name, $value, $minutes = 0, $path = null, $domain = null, $secure = false, $httpOnly = true)
+    public function make($name, $value, $minutes = 0, $path = null, $domain = null, $secure = false, $httpOnly = true, $raw = false, $sameSite = null)
     {
         list($path, $domain, $secure) = $this->getPathAndDomain($path, $domain, $secure);
 
         $time = ($minutes == 0) ? 0 : Carbon::now()->getTimestamp() + ($minutes * 60);
 
-        return new Cookie($name, $value, $time, $path, $domain, $secure, $httpOnly);
+        return new Cookie($name, $value, $time, $path, $domain, $secure, $httpOnly, $raw, $sameSite);
     }
 
     /**
      * Create a cookie that lasts "forever" (five years).
      *
-     * @param  string  $name
-     * @param  string  $value
-     * @param  string  $path
-     * @param  string  $domain
-     * @param  bool    $secure
-     * @param  bool    $httpOnly
+     * @param  string       $name
+     * @param  string       $value
+     * @param  string       $path
+     * @param  string       $domain
+     * @param  bool         $secure
+     * @param  bool         $httpOnly
+     * @param  bool         $raw
+     * @param  string|null  $sameSite
      * @return \Symfony\Component\HttpFoundation\Cookie
      */
-    public function forever($name, $value, $path = null, $domain = null, $secure = false, $httpOnly = true)
+    public function forever($name, $value, $path = null, $domain = null, $secure = false, $httpOnly = true, $raw = false, $sameSite = null)
     {
-        return $this->make($name, $value, 2628000, $path, $domain, $secure, $httpOnly);
+        return $this->make($name, $value, 2628000, $path, $domain, $secure, $httpOnly, $raw, $sameSite);
     }
 
     /**

--- a/tests/Cookie/CookieTest.php
+++ b/tests/Cookie/CookieTest.php
@@ -24,7 +24,7 @@ class CookieTest extends TestCase
         $this->assertTrue($c->isSecure());
         $this->assertEquals('/domain', $c->getDomain());
         $this->assertEquals('/path', $c->getPath());
-        $this->assertEquals('lax', $c2->getSameSite());
+        $this->assertEquals('lax', $c->getSameSite());
 
         $c2 = $cookie->forever('color', 'blue', '/path', '/domain', true, false, false, 'strict');
         $this->assertEquals('blue', $c2->getValue());

--- a/tests/Cookie/CookieTest.php
+++ b/tests/Cookie/CookieTest.php
@@ -18,19 +18,21 @@ class CookieTest extends TestCase
     {
         $cookie = $this->getCreator();
         $cookie->setDefaultPathAndDomain('foo', 'bar');
-        $c = $cookie->make('color', 'blue', 10, '/path', '/domain', true, false);
+        $c = $cookie->make('color', 'blue', 10, '/path', '/domain', true, false, false, 'lax');
         $this->assertEquals('blue', $c->getValue());
         $this->assertFalse($c->isHttpOnly());
         $this->assertTrue($c->isSecure());
         $this->assertEquals('/domain', $c->getDomain());
         $this->assertEquals('/path', $c->getPath());
+        $this->assertEquals('lax', $c2->getSameSite());
 
-        $c2 = $cookie->forever('color', 'blue', '/path', '/domain', true, false);
+        $c2 = $cookie->forever('color', 'blue', '/path', '/domain', true, false, false, 'strict');
         $this->assertEquals('blue', $c2->getValue());
         $this->assertFalse($c2->isHttpOnly());
         $this->assertTrue($c2->isSecure());
         $this->assertEquals('/domain', $c2->getDomain());
         $this->assertEquals('/path', $c2->getPath());
+        $this->assertEquals('strict', $c2->getSameSite());
 
         $c3 = $cookie->forget('color');
         $this->assertNull($c3->getValue());


### PR DESCRIPTION
This PR add's support for SameSite cookies, the accepted parameters are 'lax' and 'strict'.

This seems to be getting some attention since they may be an alternative to csrf tokens, still too early though...

Some links about it:
https://scotthelme.co.uk/csrf-is-dead/
http://caniuse.com/#search=SameSite