### PR TITLE
[5.4] Correct implementation of SqsQueue::size

### DIFF
--- a/src/Illuminate/Queue/SqsQueue.php
+++ b/src/Illuminate/Queue/SqsQueue.php
@@ -52,9 +52,14 @@ class SqsQueue extends Queue implements QueueContract
      */
     public function size($queue = null)
     {
-        return (int) $this->sqs->getQueueAttributes([
+        $response = $this->sqs->getQueueAttributes([
             'QueueUrl' => $this->getQueue($queue),
-        ])->get('ApproximateNumberOfMessages');
+            'AttributeNames' => ['ApproximateNumberOfMessages'],
+        ]);
+
+        $attributes = $response->get('Attributes');
+
+        return (int) $attributes['ApproximateNumberOfMessages'];
     }
 
     /**

--- a/tests/Queue/QueueSqsJobTest.php
+++ b/tests/Queue/QueueSqsJobTest.php
@@ -19,7 +19,7 @@ class QueueSqsJobTest extends TestCase
         $this->releaseDelay = 0;
 
         // This is how the modified getQueue builds the queueUrl
-        $this->queueUrl = $this->baseUrl . '/' . $this->account . '/' . $this->queueName;
+        $this->queueUrl = $this->baseUrl.'/'.$this->account.'/'.$this->queueName;
 
         // Get a mock of the SqsClient
         $this->mockedSqsClient = $this->getMockBuilder('Aws\Sqs\SqsClient')

--- a/tests/Queue/QueueSqsJobTest.php
+++ b/tests/Queue/QueueSqsJobTest.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Tests\Queue;
 
 use Mockery as m;
-use Aws\Sqs\SqsClient;
 use PHPUnit\Framework\TestCase;
 
 class QueueSqsJobTest extends TestCase
@@ -20,7 +19,7 @@ class QueueSqsJobTest extends TestCase
         $this->releaseDelay = 0;
 
         // This is how the modified getQueue builds the queueUrl
-        $this->queueUrl = $this->baseUrl.'/'.$this->account.'/'.$this->queueName;
+        $this->queueUrl = $this->baseUrl . '/' . $this->account . '/' . $this->queueName;
 
         // Get a mock of the SqsClient
         $this->mockedSqsClient = $this->getMockBuilder('Aws\Sqs\SqsClient')
@@ -37,11 +36,13 @@ class QueueSqsJobTest extends TestCase
         $this->mockedMessageId = 'e3cd03ee-59a3-4ad8-b0aa-ee2e3808ac81';
         $this->mockedReceiptHandle = '0NNAq8PwvXuWv5gMtS9DJ8qEdyiUwbAjpp45w2m6M4SJ1Y+PxCh7R930NRB8ylSacEmoSnW18bgd4nK\/O6ctE+VFVul4eD23mA07vVoSnPI4F\/voI1eNCp6Iax0ktGmhlNVzBwaZHEr91BRtqTRM3QKd2ASF8u+IQaSwyl\/DGK+P1+dqUOodvOVtExJwdyDLy1glZVgm85Yw9Jf5yZEEErqRwzYz\/qSigdvW4sm2l7e4phRol\/+IjMtovOyH\/ukueYdlVbQ4OshQLENhUKe7RNN5i6bE\/e5x9bnPhfj2gbM';
 
-        $this->mockedJobData = ['Body' => $this->mockedPayload,
-                         'MD5OfBody' => md5($this->mockedPayload),
-                         'ReceiptHandle' => $this->mockedReceiptHandle,
-                         'MessageId' => $this->mockedMessageId,
-                         'Attributes' => ['ApproximateReceiveCount' => 1], ];
+        $this->mockedJobData = [
+            'Body' => $this->mockedPayload,
+            'MD5OfBody' => md5($this->mockedPayload),
+            'ReceiptHandle' => $this->mockedReceiptHandle,
+            'MessageId' => $this->mockedMessageId,
+            'Attributes' => ['ApproximateReceiveCount' => 1],
+        ];
     }
 
     public function tearDown()

--- a/tests/Queue/QueueSqsQueueTest.php
+++ b/tests/Queue/QueueSqsQueueTest.php
@@ -4,7 +4,6 @@ namespace Illuminate\Tests\Queue;
 
 use Aws\Result;
 use Mockery as m;
-use Aws\Sqs\SqsClient;
 use PHPUnit\Framework\TestCase;
 
 class QueueSqsQueueTest extends TestCase
@@ -16,7 +15,6 @@ class QueueSqsQueueTest extends TestCase
 
     public function setUp()
     {
-
         // Use Mockery to mock the SqsClient
         $this->sqs = m::mock('Aws\Sqs\SqsClient');
 
@@ -25,8 +23,8 @@ class QueueSqsQueueTest extends TestCase
         $this->baseUrl = 'https://sqs.someregion.amazonaws.com';
 
         // This is how the modified getQueue builds the queueUrl
-        $this->prefix = $this->baseUrl.'/'.$this->account.'/';
-        $this->queueUrl = $this->prefix.$this->queueName;
+        $this->prefix = $this->baseUrl . '/' . $this->account . '/';
+        $this->queueUrl = $this->prefix . $this->queueName;
 
         $this->mockedJob = 'foo';
         $this->mockedData = ['data'];
@@ -35,17 +33,24 @@ class QueueSqsQueueTest extends TestCase
         $this->mockedMessageId = 'e3cd03ee-59a3-4ad8-b0aa-ee2e3808ac81';
         $this->mockedReceiptHandle = '0NNAq8PwvXuWv5gMtS9DJ8qEdyiUwbAjpp45w2m6M4SJ1Y+PxCh7R930NRB8ylSacEmoSnW18bgd4nK\/O6ctE+VFVul4eD23mA07vVoSnPI4F\/voI1eNCp6Iax0ktGmhlNVzBwaZHEr91BRtqTRM3QKd2ASF8u+IQaSwyl\/DGK+P1+dqUOodvOVtExJwdyDLy1glZVgm85Yw9Jf5yZEEErqRwzYz\/qSigdvW4sm2l7e4phRol\/+IjMtovOyH\/ukueYdlVbQ4OshQLENhUKe7RNN5i6bE\/e5x9bnPhfj2gbM';
 
-        $this->mockedSendMessageResponseModel = new Result(['Body' => $this->mockedPayload,
-                                          'MD5OfBody' => md5($this->mockedPayload),
-                                          'ReceiptHandle' => $this->mockedReceiptHandle,
-                                          'MessageId' => $this->mockedMessageId,
-                                          'Attributes' => ['ApproximateReceiveCount' => 1], ]);
+        $this->mockedSendMessageResponseModel = new Result([
+            'Body' => $this->mockedPayload,
+            'MD5OfBody' => md5($this->mockedPayload),
+            'ReceiptHandle' => $this->mockedReceiptHandle,
+            'MessageId' => $this->mockedMessageId,
+            'Attributes' => ['ApproximateReceiveCount' => 1],
+        ]);
 
-        $this->mockedReceiveMessageResponseModel = new Result(['Messages' => [0 => [
-                                                'Body' => $this->mockedPayload,
-                                                     'MD5OfBody' => md5($this->mockedPayload),
-                                                      'ReceiptHandle' => $this->mockedReceiptHandle,
-                                                     'MessageId' => $this->mockedMessageId, ]]]);
+        $this->mockedReceiveMessageResponseModel = new Result([
+            'Messages' => [
+                0 => [
+                    'Body' => $this->mockedPayload,
+                    'MD5OfBody' => md5($this->mockedPayload),
+                    'ReceiptHandle' => $this->mockedReceiptHandle,
+                    'MessageId' => $this->mockedMessageId,
+                ],
+            ],
+        ]);
     }
 
     public function testPopProperlyPopsJobOffOfSqs()
@@ -95,7 +100,7 @@ class QueueSqsQueueTest extends TestCase
     {
         $queue = new \Illuminate\Queue\SqsQueue($this->sqs, $this->queueName, $this->prefix);
         $this->assertEquals($this->queueUrl, $queue->getQueue(null));
-        $queueUrl = $this->baseUrl.'/'.$this->account.'/test';
+        $queueUrl = $this->baseUrl . '/' . $this->account . '/test';
         $this->assertEquals($queueUrl, $queue->getQueue('test'));
     }
 
@@ -103,7 +108,7 @@ class QueueSqsQueueTest extends TestCase
     {
         $queue = new \Illuminate\Queue\SqsQueue($this->sqs, $this->queueUrl);
         $this->assertEquals($this->queueUrl, $queue->getQueue(null));
-        $queueUrl = $this->baseUrl.'/'.$this->account.'/test';
+        $queueUrl = $this->baseUrl . '/' . $this->account . '/test';
         $this->assertEquals($queueUrl, $queue->getQueue($queueUrl));
     }
 }

--- a/tests/Queue/QueueSqsQueueTest.php
+++ b/tests/Queue/QueueSqsQueueTest.php
@@ -23,8 +23,8 @@ class QueueSqsQueueTest extends TestCase
         $this->baseUrl = 'https://sqs.someregion.amazonaws.com';
 
         // This is how the modified getQueue builds the queueUrl
-        $this->prefix = $this->baseUrl . '/' . $this->account . '/';
-        $this->queueUrl = $this->prefix . $this->queueName;
+        $this->prefix = $this->baseUrl.'/'.$this->account.'/';
+        $this->queueUrl = $this->prefix.$this->queueName;
 
         $this->mockedJob = 'foo';
         $this->mockedData = ['data'];
@@ -115,7 +115,7 @@ class QueueSqsQueueTest extends TestCase
     {
         $queue = new \Illuminate\Queue\SqsQueue($this->sqs, $this->queueName, $this->prefix);
         $this->assertEquals($this->queueUrl, $queue->getQueue(null));
-        $queueUrl = $this->baseUrl . '/' . $this->account . '/test';
+        $queueUrl = $this->baseUrl.'/'.$this->account.'/test';
         $this->assertEquals($queueUrl, $queue->getQueue('test'));
     }
 
@@ -123,7 +123,7 @@ class QueueSqsQueueTest extends TestCase
     {
         $queue = new \Illuminate\Queue\SqsQueue($this->sqs, $this->queueUrl);
         $this->assertEquals($this->queueUrl, $queue->getQueue(null));
-        $queueUrl = $this->baseUrl . '/' . $this->account . '/test';
+        $queueUrl = $this->baseUrl.'/'.$this->account.'/test';
         $this->assertEquals($queueUrl, $queue->getQueue($queueUrl));
     }
 }


### PR DESCRIPTION
The `size` method for SqsQueue driver was missing the `AttributeNames` parameter and was reading the result from a wrong place. This PR fixes this.

See http://docs.aws.amazon.com/aws-sdk-php/v2/api/class-Aws.Sqs.SqsClient.html#_getQueueAttributes.

The only thing that I'm not entirely sure of is whether should an exception be thrown if `$attributes['ApproximateNumberOfMessages']` is not set. However, my tests show that the command itself will throw an exception if requests cannot be fulfilled for any reason.