### PR TITLE
[5.4] Remove unused "deleteToken" method

### DIFF
--- a/src/Illuminate/Auth/Passwords/PasswordBroker.php
+++ b/src/Illuminate/Auth/Passwords/PasswordBroker.php
@@ -208,17 +208,6 @@ class PasswordBroker implements PasswordBrokerContract
     }
 
     /**
-     * Delete the given password reset token.
-     *
-     * @param  string  $token
-     * @return void
-     */
-    public function deleteToken($token)
-    {
-        $this->tokens->delete($token);
-    }
-
-    /**
      * Validate the given password reset token.
      *
      * @param  CanResetPasswordContract $user


### PR DESCRIPTION
According to #17524: in commit c454c87, reset token will be hashed first before saving to the database. So it is not possible to delete the entry based on the public token sent to the user. Accordingly the `deleteToken` method can't be used this way, instead `$this->tokens->delete($user);` has to be used, which accepts user instance anyway.