### PR TITLE
[5.4] Fix bug with delete reset token

### DIFF
--- a/src/Illuminate/Auth/Passwords/PasswordBroker.php
+++ b/src/Illuminate/Auth/Passwords/PasswordBroker.php
@@ -208,14 +208,14 @@ class PasswordBroker implements PasswordBrokerContract
     }
 
     /**
-     * Delete the given password reset token.
+     * Delete password reset tokens of the given user.
      *
-     * @param  string  $token
+     * @param  \Illuminate\Contracts\Auth\CanResetPassword $user
      * @return void
      */
-    public function deleteToken($token)
+    public function deleteToken(CanResetPasswordContract $user)
     {
-        $this->tokens->delete($token);
+        $this->tokens->delete($user);
     }
 
     /**


### PR DESCRIPTION
In commit c454c87, reset token will be hashed first before saving to the database. So it is not possible to delete the entry based on the public token sent to the user. Similar issue: #17524