### PR TITLE
[5.4] Add includeWhen directive

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesIncludes.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesIncludes.php
@@ -40,4 +40,23 @@ trait CompilesIncludes
 
         return "<?php if (\$__env->exists({$expression})) echo \$__env->make({$expression}, array_except(get_defined_vars(), array('__data', '__path')))->render(); ?>";
     }
+
+    /**
+     * Compile the include-when statements into valid PHP.
+     *
+     * @param string $expression
+     * @return string
+     */
+    protected function compileIncludeWhen($expression)
+    {
+        $expression = $this->stripParentheses($expression);
+
+        preg_match('/ *(.*), *(.*)$/is', $expression, $matches);
+
+        $when = trim($matches[1]);
+
+        $arguments = trim($matches[2]);
+
+        return "<?php if ({$when}) echo \$__env->make({$arguments}, array_except(get_defined_vars(), array('__data', '__path')))->render(); ?>";
+    }
 }

--- a/tests/View/Blade/BladeIncludeWhenTest.php
+++ b/tests/View/Blade/BladeIncludeWhenTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Illuminate\Tests\Blade;
+
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+use Illuminate\View\Compilers\BladeCompiler;
+
+class BladeIncludeWhenTest extends TestCase
+{
+    public function tearDown()
+    {
+        m::close();
+    }
+
+    public function testIncludeWhensAreCompiled()
+    {
+        $compiler = new BladeCompiler($this->getFiles(), __DIR__);
+        $this->assertEquals('<?php if (true) echo $__env->make(\'foo\', array_except(get_defined_vars(), array(\'__data\', \'__path\')))->render(); ?>', $compiler->compileString('@includeWhen(true, \'foo\')'));
+        $this->assertEquals('<?php if (true) echo $__env->make(name(foo), array_except(get_defined_vars(), array(\'__data\', \'__path\')))->render(); ?>', $compiler->compileString('@includeWhen(true, name(foo))'));
+    }
+
+    protected function getFiles()
+    {
+        return m::mock('Illuminate\Filesystem\Filesystem');
+    }
+}


### PR DESCRIPTION
This is a directive that shortens:

```blade
@if ($user->ownsPost($post)
@include('posts.edit-controls', ['post' => $post])
@endif
```

to...

```blade
@includeWhen($user->ownsPost($post), 'posts.edit-controls', ['post' => $post])
```