### PR TITLE
[5.4] Update HasRelations::morphInstanceTo()

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -176,7 +176,7 @@ trait HasRelationships
     protected function morphInstanceTo($target, $name, $type, $id)
     {
         $instance = $this->newRelatedInstance(
-            Model::getActualClassNameForMorph($target)
+            static::getActualClassNameForMorph($target)
         );
 
         return new MorphTo(


### PR DESCRIPTION
I changed this line so that the static method getActualClassNameForMorph can be overridden.
In my case, the morph relationship is idetified by integers, so I rewrote the static method getActualClassNameForMorph.
