### PR TITLE
[5.5] Adding SameSite to config/sessions

### DIFF
--- a/src/Illuminate/Cookie/CookieJar.php
+++ b/src/Illuminate/Cookie/CookieJar.php
@@ -158,7 +158,7 @@ class CookieJar implements JarContract
      * @param  string  $sameSite
      * @return array
      */
-    protected function getPathAndDomain($path, $domain, $secure = false, $sameSite)
+    protected function getPathAndDomain($path, $domain, $secure = false, $sameSite = null)
     {
         return [$path ?: $this->path, $domain ?: $this->domain, $secure ?: $this->secure, $sameSite ?: $this->sameSite];
     }
@@ -172,7 +172,7 @@ class CookieJar implements JarContract
      * @param  string  $sameSite
      * @return $this
      */
-    public function setDefaultPathAndDomain($path, $domain, $secure = false, $sameSite)
+    public function setDefaultPathAndDomain($path, $domain, $secure = false, $sameSite = null)
     {
         list($this->path, $this->domain, $this->secure, $this->sameSite) = [$path, $domain, $secure, $sameSite];
 

--- a/src/Illuminate/Cookie/CookieJar.php
+++ b/src/Illuminate/Cookie/CookieJar.php
@@ -31,6 +31,13 @@ class CookieJar implements JarContract
     protected $secure = false;
 
     /**
+     * The default SameSite option (if specified).
+     *
+     * @var string
+     */
+    protected $sameSite;
+
+    /**
      * All of the cookies queued for sending.
      *
      * @var array
@@ -53,7 +60,7 @@ class CookieJar implements JarContract
      */
     public function make($name, $value, $minutes = 0, $path = null, $domain = null, $secure = false, $httpOnly = true, $raw = false, $sameSite = null)
     {
-        list($path, $domain, $secure) = $this->getPathAndDomain($path, $domain, $secure);
+        list($path, $domain, $secure, $sameSite) = $this->getPathAndDomain($path, $domain, $secure, $sameSite);
 
         $time = ($minutes == 0) ? 0 : Carbon::now()->getTimestamp() + ($minutes * 60);
 
@@ -148,11 +155,12 @@ class CookieJar implements JarContract
      * @param  string  $path
      * @param  string  $domain
      * @param  bool    $secure
+     * @param  string  $sameSite
      * @return array
      */
-    protected function getPathAndDomain($path, $domain, $secure = false)
+    protected function getPathAndDomain($path, $domain, $secure = false, $sameSite)
     {
-        return [$path ?: $this->path, $domain ?: $this->domain, $secure ?: $this->secure];
+        return [$path ?: $this->path, $domain ?: $this->domain, $secure ?: $this->secure, $sameSite ?: $this->sameSite];
     }
 
     /**
@@ -161,11 +169,12 @@ class CookieJar implements JarContract
      * @param  string  $path
      * @param  string  $domain
      * @param  bool    $secure
+     * @param  string  $sameSite
      * @return $this
      */
-    public function setDefaultPathAndDomain($path, $domain, $secure = false)
+    public function setDefaultPathAndDomain($path, $domain, $secure = false, $sameSite)
     {
-        list($this->path, $this->domain, $this->secure) = [$path, $domain, $secure];
+        list($this->path, $this->domain, $this->secure, $this->sameSite) = [$path, $domain, $secure, $sameSite];
 
         return $this;
     }

--- a/src/Illuminate/Cookie/CookieServiceProvider.php
+++ b/src/Illuminate/Cookie/CookieServiceProvider.php
@@ -16,7 +16,7 @@ class CookieServiceProvider extends ServiceProvider
         $this->app->singleton('cookie', function ($app) {
             $config = $app->make('config')->get('session');
 
-            return (new CookieJar)->setDefaultPathAndDomain($config['path'], $config['domain'], $config['secure']);
+            return (new CookieJar)->setDefaultPathAndDomain($config['path'], $config['domain'], $config['secure'], $config['sameSite']);
         });
     }
 }

--- a/src/Illuminate/Cookie/Middleware/EncryptCookies.php
+++ b/src/Illuminate/Cookie/Middleware/EncryptCookies.php
@@ -146,7 +146,8 @@ class EncryptCookies
     {
         return new Cookie(
             $c->getName(), $value, $c->getExpiresTime(), $c->getPath(),
-            $c->getDomain(), $c->isSecure(), $c->isHttpOnly()
+            $c->getDomain(), $c->isSecure(), $c->isHttpOnly(), $c->isRaw(),
+            $c->getSameSite()
         );
     }
 

--- a/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
+++ b/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
@@ -156,7 +156,7 @@ class VerifyCsrfToken
         $response->headers->setCookie(
             new Cookie(
                 'XSRF-TOKEN', $request->session()->token(), Carbon::now()->getTimestamp() + 60 * $config['lifetime'],
-                $config['path'], $config['domain'], $config['secure'], false
+                $config['path'], $config['domain'], $config['secure'], false, false, $config['sameSite']
             )
         );
 

--- a/src/Illuminate/Session/Middleware/StartSession.php
+++ b/src/Illuminate/Session/Middleware/StartSession.php
@@ -177,7 +177,7 @@ class StartSession
             $response->headers->setCookie(new Cookie(
                 $session->getName(), $session->getId(), $this->getCookieExpirationDate(),
                 $config['path'], $config['domain'], Arr::get($config, 'secure', false),
-                Arr::get($config, 'http_only', true), false, $config['sameSite'],
+                Arr::get($config, 'http_only', true), false, $config['sameSite']
             ));
         }
     }

--- a/src/Illuminate/Session/Middleware/StartSession.php
+++ b/src/Illuminate/Session/Middleware/StartSession.php
@@ -177,7 +177,7 @@ class StartSession
             $response->headers->setCookie(new Cookie(
                 $session->getName(), $session->getId(), $this->getCookieExpirationDate(),
                 $config['path'], $config['domain'], Arr::get($config, 'secure', false),
-                Arr::get($config, 'http_only', true)
+                Arr::get($config, 'http_only', true), false, $config['sameSite'],
             ));
         }
     }

--- a/tests/Cookie/CookieTest.php
+++ b/tests/Cookie/CookieTest.php
@@ -44,7 +44,7 @@ class CookieTest extends TestCase
         $cookie = $this->getCreator();
         $cookie->setDefaultPathAndDomain('/path', '/domain', true, 'lax');
         $c = $cookie->make('color', 'blue');
-        $this->assertEquals('blue', $c->getValue());        
+        $this->assertEquals('blue', $c->getValue());
         $this->assertTrue($c->isSecure());
         $this->assertEquals('/domain', $c->getDomain());
         $this->assertEquals('/path', $c->getPath());

--- a/tests/Cookie/CookieTest.php
+++ b/tests/Cookie/CookieTest.php
@@ -42,13 +42,13 @@ class CookieTest extends TestCase
     public function testCookiesAreCreatedWithProperOptionsUsingDefaultPathAndDomain()
     {
         $cookie = $this->getCreator();
-        $cookie->setDefaultPathAndDomain('/path', '/domain');
-        $c = $cookie->make('color', 'blue', 10, null, null, true, false);
-        $this->assertEquals('blue', $c->getValue());
-        $this->assertFalse($c->isHttpOnly());
+        $cookie->setDefaultPathAndDomain('/path', '/domain', true, 'lax');
+        $c = $cookie->make('color', 'blue');
+        $this->assertEquals('blue', $c->getValue());        
         $this->assertTrue($c->isSecure());
         $this->assertEquals('/domain', $c->getDomain());
         $this->assertEquals('/path', $c->getPath());
+        $this->assertEquals('lax', $c->getSameSite());
     }
 
     public function testQueuedCookies()


### PR DESCRIPTION
This allow us to specify a default value for this option on the sessions config file...

We could rename the methods ``` setDefaultPathAndDomain ``` and ``` getPathAndDomain ``` to something else like ``` setDefaultOptions ``` and ``` getDefaultOptions ``` would it be a good idea?