### PR TITLE
[WIP] added password argument to encrypter

### DIFF
--- a/CHANGELOG-5.4.md
+++ b/CHANGELOG-5.4.md
@@ -1,11 +1,13 @@
 # Release Notes for 5.4.x
 
-## [Unreleased]
+## v5.4.13 (2017-02-22)
 
 ### Added
 - Add `$default` parameter to `Collection::when()` method ([#17941](https://github.com/laravel/framework/pull/17941))
 - Support `--resource` argument on `make:model` command ([#17955](https://github.com/laravel/framework/pull/17955))
 - Added `replaceDimensions()` for validator messages ([#17946](https://github.com/laravel/framework/pull/17946), [b219058](https://github.com/laravel/framework/commit/b219058063336dd9cc851349e287052d76bcc18e))
+- Allow Slack notifications to use image urls ([#18011](https://github.com/laravel/framework/pull/18011))
+- Added `@includeWhen($condition, $view, $data)` directive ([#18047](https://github.com/laravel/framework/pull/18047))
 
 ### Changed
 - Prevent Blade from compiling statements inside comments ([#17952](https://github.com/laravel/framework/pull/17952))
@@ -13,12 +15,18 @@
 - Use the pagination translation strings in paginator templates ([#18009](https://github.com/laravel/framework/pull/18009))
 - Use `getAuthPassword()` method in `AuthenticateSession` middleware ([#17965](https://github.com/laravel/framework/pull/17965))
 - Return `null` from `Gate::getPolicyFor()` if given class is not a string ([#17972](https://github.com/laravel/framework/pull/17972))
+- Add missing methods to the `Job` interface ([#18034](https://github.com/laravel/framework/pull/18034))
+- Improved PostgreSQL table existence check ([#18041](https://github.com/laravel/framework/pull/18041))
+- Allow `getActualClassNameForMorph()` used by `morphInstanceTo()` to be overridden ([#18058](https://github.com/laravel/framework/pull/18058))
 
 ### Fixed
 - Fixed `@lang` directive when used with JSON file ([#17919](https://github.com/laravel/framework/pull/17919), [2bd35c1](https://github.com/laravel/framework/commit/2bd35c13678faae68ee0bbe95d46b12f77357c98))
 - Improved image `dimensions` validation rule ([#17943](https://github.com/laravel/framework/pull/17943), [#17944](https://github.com/laravel/framework/pull/17944), [#17963](https://github.com/laravel/framework/pull/17963), [#17980](https://github.com/laravel/framework/pull/17980))
 - Fixed `$willBeAvailableAt` having the wrong time if using `$retryAfter` in `MaintenanceModeException` ([#17991](https://github.com/laravel/framework/pull/17991))
 - Trim spaces while collecting section name ([#18012](https://github.com/laravel/framework/pull/18012))
+- Fixed implementation of `SqsQueue::size()` ([#18037](https://github.com/laravel/framework/pull/18037))
+- Fixed bug in `PasswordBroker::deleteToken()` ([#18045](https://github.com/laravel/framework/pull/18045))
+- Fixed route parameters binding ([#17973](https://github.com/laravel/framework/pull/17973))
 
 
 ## v5.4.12 (2017-02-15)

--- a/src/Illuminate/Contracts/Encryption/Encrypter.php
+++ b/src/Illuminate/Contracts/Encryption/Encrypter.php
@@ -11,7 +11,7 @@ interface Encrypter
      * @param  bool  $serialize
      * @return string
      */
-    public function encrypt($value, $serialize = true);
+    public function encrypt($value, $serialize = true, $password = null);
 
     /**
      * Decrypt the given value.
@@ -20,5 +20,5 @@ interface Encrypter
      * @param  bool  $unserialize
      * @return string
      */
-    public function decrypt($payload, $unserialize = true);
+    public function decrypt($payload, $unserialize = true, $password = null);
 }

--- a/src/Illuminate/Encryption/Encrypter.php
+++ b/src/Illuminate/Encryption/Encrypter.php
@@ -116,7 +116,7 @@ class Encrypter implements EncrypterContract
         $key = hash_pbkdf2('sha256', $password, $salt, $iterations, 32);
 
         return $this->encrypt($value, $serialize, $key);
-	}
+    }
 
     /**
      * Encrypt a string without serialization.

--- a/src/Illuminate/Encryption/Encrypter.php
+++ b/src/Illuminate/Encryption/Encrypter.php
@@ -68,7 +68,7 @@ class Encrypter implements EncrypterContract
      *
      * @throws \Illuminate\Contracts\Encryption\EncryptException
      */
-    public function encrypt($value, $serialize = true)
+    public function encrypt($value, $serialize = true, $password = null)
     {
         $iv = random_bytes(16);
 
@@ -77,7 +77,7 @@ class Encrypter implements EncrypterContract
         // value can be verified later as not having been changed by the users.
         $value = \openssl_encrypt(
             $serialize ? serialize($value) : $value,
-            $this->cipher, $this->key, 0, $iv
+            $this->cipher, ($password) ? $password : $this->key, 0, $iv
         );
 
         if ($value === false) {
@@ -104,9 +104,9 @@ class Encrypter implements EncrypterContract
      * @param  string  $value
      * @return string
      */
-    public function encryptString($value)
+    public function encryptString($value, $password = null)
     {
-        return $this->encrypt($value, false);
+        return $this->encrypt($value, false, $password);
     }
 
     /**
@@ -118,7 +118,7 @@ class Encrypter implements EncrypterContract
      *
      * @throws \Illuminate\Contracts\Encryption\DecryptException
      */
-    public function decrypt($payload, $unserialize = true)
+    public function decrypt($payload, $unserialize = true, $password = null)
     {
         $payload = $this->getJsonPayload($payload);
 
@@ -128,7 +128,7 @@ class Encrypter implements EncrypterContract
         // we will then unserialize it and return it out to the caller. If we are
         // unable to decrypt this value we will throw out an exception message.
         $decrypted = \openssl_decrypt(
-            $payload['value'], $this->cipher, $this->key, 0, $iv
+            $payload['value'], $this->cipher, ($password) ? $password : $this->key, 0, $iv
         );
 
         if ($decrypted === false) {
@@ -144,9 +144,9 @@ class Encrypter implements EncrypterContract
      * @param  string  $payload
      * @return string
      */
-    public function decryptString($payload)
+    public function decryptString($payload, $password = null)
     {
-        return $this->decrypt($payload, false);
+        return $this->decrypt($payload, false, $password);
     }
 
     /**

--- a/src/Illuminate/Encryption/Encrypter.php
+++ b/src/Illuminate/Encryption/Encrypter.php
@@ -64,11 +64,12 @@ class Encrypter implements EncrypterContract
      *
      * @param  mixed  $value
      * @param  bool  $serialize
+     * @param  string  $key
      * @return string
      *
      * @throws \Illuminate\Contracts\Encryption\EncryptException
      */
-    public function encrypt($value, $serialize = true, $password = null)
+    public function encrypt($value, $serialize = true, $key = null)
     {
         $iv = random_bytes(16);
 
@@ -77,7 +78,7 @@ class Encrypter implements EncrypterContract
         // value can be verified later as not having been changed by the users.
         $value = \openssl_encrypt(
             $serialize ? serialize($value) : $value,
-            $this->cipher, ($password) ? $password : $this->key, 0, $iv
+            $this->cipher, !is_null($key) ? $key : $this->key, 0, $iv
         );
 
         if ($value === false) {
@@ -102,11 +103,12 @@ class Encrypter implements EncrypterContract
      * Encrypt a string without serialization.
      *
      * @param  string  $value
+     * @param  string  $key
      * @return string
      */
-    public function encryptString($value, $password = null)
+    public function encryptString($value, $key = null)
     {
-        return $this->encrypt($value, false, $password);
+        return $this->encrypt($value, false, $key);
     }
 
     /**
@@ -114,11 +116,12 @@ class Encrypter implements EncrypterContract
      *
      * @param  mixed  $payload
      * @param  bool  $unserialize
+     * @param  string  $password
      * @return string
      *
      * @throws \Illuminate\Contracts\Encryption\DecryptException
      */
-    public function decrypt($payload, $unserialize = true, $password = null)
+    public function decrypt($payload, $unserialize = true, $key = null)
     {
         $payload = $this->getJsonPayload($payload);
 
@@ -128,7 +131,7 @@ class Encrypter implements EncrypterContract
         // we will then unserialize it and return it out to the caller. If we are
         // unable to decrypt this value we will throw out an exception message.
         $decrypted = \openssl_decrypt(
-            $payload['value'], $this->cipher, ($password) ? $password : $this->key, 0, $iv
+            $payload['value'], $this->cipher, !is_null($key) ? $key : $this->key, 0, $iv
         );
 
         if ($decrypted === false) {
@@ -142,11 +145,12 @@ class Encrypter implements EncrypterContract
      * Decrypt the given string without unserialization.
      *
      * @param  string  $payload
+     * @param  string  $key
      * @return string
      */
-    public function decryptString($payload, $password = null)
+    public function decryptString($payload, $key = null)
     {
-        return $this->decrypt($payload, false, $password);
+        return $this->decrypt($payload, false, $key);
     }
 
     /**

--- a/src/Illuminate/Encryption/Encrypter.php
+++ b/src/Illuminate/Encryption/Encrypter.php
@@ -113,7 +113,7 @@ class Encrypter implements EncrypterContract
 	{
 		$iterations = 1000;
 		$salt = $this->key;
-		$key = hash_pbkdf2("sha256", $password, $salt, $iterations, 32);
+		$key = hash_pbkdf2('sha256', $password, $salt, $iterations, 32);
 
 		return $this->encrypt($value, $serialize, $key);
 	}

--- a/src/Illuminate/Encryption/Encrypter.php
+++ b/src/Illuminate/Encryption/Encrypter.php
@@ -110,12 +110,12 @@ class Encrypter implements EncrypterContract
      * @throws \Illuminate\Contracts\Encryption\EncryptException
      */
     public function encryptWithPassword($value, $serialize, $password)
-	{
-		$iterations = 1000;
-		$salt = $this->key;
-		$key = hash_pbkdf2('sha256', $password, $salt, $iterations, 32);
+    {
+        $iterations = 1000;
+        $salt = $this->key;
+        $key = hash_pbkdf2('sha256', $password, $salt, $iterations, 32);
 
-		return $this->encrypt($value, $serialize, $key);
+        return $this->encrypt($value, $serialize, $key);
 	}
 
     /**

--- a/src/Illuminate/Encryption/Encrypter.php
+++ b/src/Illuminate/Encryption/Encrypter.php
@@ -78,7 +78,7 @@ class Encrypter implements EncrypterContract
         // value can be verified later as not having been changed by the users.
         $value = \openssl_encrypt(
             $serialize ? serialize($value) : $value,
-            $this->cipher, !is_null($key) ? $key : $this->key, 0, $iv
+            $this->cipher, ! is_null($key) ? $key : $this->key, 0, $iv
         );
 
         if ($value === false) {
@@ -131,7 +131,7 @@ class Encrypter implements EncrypterContract
         // we will then unserialize it and return it out to the caller. If we are
         // unable to decrypt this value we will throw out an exception message.
         $decrypted = \openssl_decrypt(
-            $payload['value'], $this->cipher, !is_null($key) ? $key : $this->key, 0, $iv
+            $payload['value'], $this->cipher, ! is_null($key) ? $key : $this->key, 0, $iv
         );
 
         if ($decrypted === false) {

--- a/src/Illuminate/Encryption/Encrypter.php
+++ b/src/Illuminate/Encryption/Encrypter.php
@@ -109,7 +109,7 @@ class Encrypter implements EncrypterContract
      *
      * @throws \Illuminate\Contracts\Encryption\EncryptException
      */
-    public function encryptWithPassword($value, $serialize = true, $password)
+    public function encryptWithPassword($value, $serialize, $password)
 	{
 		$iterations = 1000;
 		$salt = $this->key;

--- a/src/Illuminate/Encryption/Encrypter.php
+++ b/src/Illuminate/Encryption/Encrypter.php
@@ -100,6 +100,25 @@ class Encrypter implements EncrypterContract
     }
 
     /**
+     * Encrypt the given value using a custom key.
+     *
+     * @param  mixed  $value
+     * @param  bool  $serialize
+     * @param  string  $key
+     * @return string
+     *
+     * @throws \Illuminate\Contracts\Encryption\EncryptException
+     */
+    public function encryptWithPassword($value, $serialize = true, $password)
+	{
+		$iterations = 1000;
+		$salt = $this->key;
+		$key = hash_pbkdf2("sha256", $password, $salt, $iterations, 32);
+
+		return $this->encrypt($value, $serialize, $key);
+	}
+
+    /**
      * Encrypt a string without serialization.
      *
      * @param  string  $value
@@ -109,6 +128,18 @@ class Encrypter implements EncrypterContract
     public function encryptString($value, $key = null)
     {
         return $this->encrypt($value, false, $key);
+    }
+
+    /**
+     * Encrypt a string without serialization, using a custom key.
+     *
+     * @param  string  $value
+     * @param  string  $key
+     * @return string
+     */
+    public function encryptStringWithPassword($value, $key)
+    {
+        return $this->encryptWithPassword($value, false, $key);
     }
 
     /**

--- a/src/Illuminate/Encryption/Encrypter.php
+++ b/src/Illuminate/Encryption/Encrypter.php
@@ -112,7 +112,7 @@ class Encrypter implements EncrypterContract
     public function encryptWithPassword($value, $serialize, $password)
     {
         $iterations = 1000;
-        $salt = $this->key;
+        $salt = 1;//$this->key;
         $key = hash_pbkdf2('sha256', $password, $salt, $iterations, 32);
 
         return $this->encrypt($value, $serialize, $key);

--- a/src/Illuminate/Encryption/Encrypter.php
+++ b/src/Illuminate/Encryption/Encrypter.php
@@ -112,9 +112,8 @@ class Encrypter implements EncrypterContract
     public function encryptWithPassword($value, $serialize, $password)
     {
         $iterations = 1000;
-        $salt = 1;//$this->key;
-        $key = hash_pbkdf2('sha256', $password, $salt, $iterations, 32);
-
+        $salt = $this->key;
+      	$key = hash_pbkdf2('sha256', $password, $salt, $iterations, 32);
         return $this->encrypt($value, $serialize, $key);
     }
 
@@ -125,9 +124,9 @@ class Encrypter implements EncrypterContract
      * @param  string  $key
      * @return string
      */
-    public function encryptString($value, $key = null)
+    public function encryptString($value, $password = null)
     {
-        return $this->encrypt($value, false, $key);
+        return $this->encrypt($value, false, $password);
     }
 
     /**
@@ -137,9 +136,9 @@ class Encrypter implements EncrypterContract
      * @param  string  $key
      * @return string
      */
-    public function encryptStringWithPassword($value, $key)
+    public function encryptStringWithPassword($value, $password)
     {
-        return $this->encryptWithPassword($value, false, $key);
+        return $this->encryptWithPassword($value, false, $password);
     }
 
     /**
@@ -154,8 +153,14 @@ class Encrypter implements EncrypterContract
      */
     public function decrypt($payload, $unserialize = true, $key = null)
     {
-        $payload = $this->getJsonPayload($payload);
 
+		if (! is_null($key)) {
+			$iterations = 1000;
+			$salt = $this->key;
+			$key = hash_pbkdf2('sha256', $key, $salt, $iterations, 32);
+		}
+
+		$payload = $this->getJsonPayload($payload);
         $iv = base64_decode($payload['iv']);
 
         // Here we will decrypt the value. If we are able to successfully decrypt it

--- a/tests/Encryption/EncrypterTest.php
+++ b/tests/Encryption/EncrypterTest.php
@@ -15,12 +15,28 @@ class EncrypterTest extends TestCase
         $this->assertEquals('foo', $e->decrypt($encrypted));
     }
 
+    public function testEncryptionWithPassword()
+    {
+        $e = new Encrypter(str_repeat('a', 16));
+        $encrypted = $e->encrypt('foo','bar');
+        $this->assertNotEquals('foo', $encrypted);
+        $this->assertEquals('foo', $e->decrypt($encrypted,'bar'));
+    }
+
     public function testRawStringEncryption()
     {
         $e = new Encrypter(str_repeat('a', 16));
         $encrypted = $e->encryptString('foo');
         $this->assertNotEquals('foo', $encrypted);
         $this->assertEquals('foo', $e->decryptString($encrypted));
+    }
+
+    public function testRawStringEncryptionWithPassword()
+    {
+        $e = new Encrypter(str_repeat('a', 16));
+        $encrypted = $e->encryptString('foo','bar');
+        $this->assertNotEquals('foo', $encrypted);
+        $this->assertEquals('foo', $e->decryptString($encrypted,'bar'));
     }
 
     public function testEncryptionUsingBase64EncodedKey()

--- a/tests/Encryption/EncrypterTest.php
+++ b/tests/Encryption/EncrypterTest.php
@@ -20,7 +20,7 @@ class EncrypterTest extends TestCase
         $e = new Encrypter(str_repeat('a', 16));
         $encrypted = $e->encrypt('foo','bar');
         $this->assertNotEquals('foo', $encrypted);
-        $this->assertEquals('foo', $e->decrypt($encrypted,'bar'));
+        $this->assertSame('foo', $e->decrypt($encrypted,'bar'));
     }
 
     public function testRawStringEncryption()
@@ -36,7 +36,7 @@ class EncrypterTest extends TestCase
         $e = new Encrypter(str_repeat('a', 16));
         $encrypted = $e->encryptString('foo','bar');
         $this->assertNotEquals('foo', $encrypted);
-        $this->assertEquals('foo', $e->decryptString($encrypted,'bar'));
+        $this->assertSame('foo', $e->decryptString($encrypted,'bar'));
     }
 
     public function testEncryptionUsingBase64EncodedKey()

--- a/tests/Encryption/EncrypterTest.php
+++ b/tests/Encryption/EncrypterTest.php
@@ -7,34 +7,38 @@ use Illuminate\Encryption\Encrypter;
 
 class EncrypterTest extends TestCase
 {
-    public function testEncryption()
-    {
-        $e = new Encrypter(str_repeat('a', 16));
-        $encrypted = $e->encrypt('foo');
-        $this->assertNotEquals('foo', $encrypted);
-        $this->assertEquals('foo', $e->decrypt($encrypted));
-    }
+	/*
+     *public function testEncryption()
+     *{
+     *    $e = new Encrypter(str_repeat('a', 16));
+     *    $encrypted = $e->encrypt('foo');
+     *    $this->assertNotEquals('foo', $encrypted);
+     *    $this->assertEquals('foo', $e->decrypt($encrypted));
+     *}
+	 */
 
-    public function testEncryptionWithPassword()
-    {
-        $e = new Encrypter(str_repeat('a', 16));
-        $encrypted = $e->encrypt('foo', 'bar');
-        $this->assertNotEquals('foo', $encrypted);
-        $this->assertSame('foo', $e->decrypt($encrypted, 'bar'));
-    }
-
-    public function testRawStringEncryption()
-    {
-        $e = new Encrypter(str_repeat('a', 16));
-        $encrypted = $e->encryptString('foo');
-        $this->assertNotEquals('foo', $encrypted);
-        $this->assertEquals('foo', $e->decryptString($encrypted));
-    }
+/*
+ *    public function testEncryptionWithPassword()
+ *    {
+ *        $e = new Encrypter(str_repeat('a', 16));
+ *        $encrypted = $e->encryptWithPassword('foo', true, 'bar');
+ *        $this->assertNotEquals('foo', $encrypted);
+ *        $this->assertSame('foo', $e->decrypt($encrypted, 'bar'));
+ *    }
+ *
+ *    public function testRawStringEncryption()
+ *    {
+ *        $e = new Encrypter(str_repeat('a', 16));
+ *        $encrypted = $e->encryptString('foo');
+ *        $this->assertNotEquals('foo', $encrypted);
+ *        $this->assertEquals('foo', $e->decryptString($encrypted));
+ *    }
+ */
 
     public function testRawStringEncryptionWithPassword()
     {
         $e = new Encrypter(str_repeat('a', 16));
-        $encrypted = $e->encryptString('foo', 'bar');
+        $encrypted = $e->encryptStringWithPassword('foo', false, 'bar');
         $this->assertNotEquals('foo', $encrypted);
         $this->assertSame('foo', $e->decryptString($encrypted, 'bar'));
     }

--- a/tests/Encryption/EncrypterTest.php
+++ b/tests/Encryption/EncrypterTest.php
@@ -18,9 +18,9 @@ class EncrypterTest extends TestCase
     public function testEncryptionWithPassword()
     {
         $e = new Encrypter(str_repeat('a', 16));
-        $encrypted = $e->encrypt('foo','bar');
+        $encrypted = $e->encrypt('foo', 'bar');
         $this->assertNotEquals('foo', $encrypted);
-        $this->assertSame('foo', $e->decrypt($encrypted,'bar'));
+        $this->assertSame('foo', $e->decrypt($encrypted, 'bar'));
     }
 
     public function testRawStringEncryption()
@@ -34,9 +34,9 @@ class EncrypterTest extends TestCase
     public function testRawStringEncryptionWithPassword()
     {
         $e = new Encrypter(str_repeat('a', 16));
-        $encrypted = $e->encryptString('foo','bar');
+        $encrypted = $e->encryptString('foo', 'bar');
         $this->assertNotEquals('foo', $encrypted);
-        $this->assertSame('foo', $e->decryptString($encrypted,'bar'));
+        $this->assertSame('foo', $e->decryptString($encrypted, 'bar'));
     }
 
     public function testEncryptionUsingBase64EncodedKey()

--- a/tests/Encryption/EncrypterTest.php
+++ b/tests/Encryption/EncrypterTest.php
@@ -7,62 +7,58 @@ use Illuminate\Encryption\Encrypter;
 
 class EncrypterTest extends TestCase
 {
-	/*
-     *public function testEncryption()
-     *{
-     *    $e = new Encrypter(str_repeat('a', 16));
-     *    $encrypted = $e->encrypt('foo');
-     *    $this->assertNotEquals('foo', $encrypted);
-     *    $this->assertEquals('foo', $e->decrypt($encrypted));
-     *}
-	 */
+	public function testEncryption()
+	{
+		$e = new Encrypter(str_repeat('a', 16));
+		$encrypted = $e->encrypt('foo');
+		$this->assertNotEquals('foo', $encrypted);
+		$this->assertEquals('foo', $e->decrypt($encrypted));
+	}
 
-/*
- *    public function testEncryptionWithPassword()
- *    {
- *        $e = new Encrypter(str_repeat('a', 16));
- *        $encrypted = $e->encryptWithPassword('foo', true, 'bar');
- *        $this->assertNotEquals('foo', $encrypted);
- *        $this->assertSame('foo', $e->decrypt($encrypted, 'bar'));
- *    }
- *
- *    public function testRawStringEncryption()
- *    {
- *        $e = new Encrypter(str_repeat('a', 16));
- *        $encrypted = $e->encryptString('foo');
- *        $this->assertNotEquals('foo', $encrypted);
- *        $this->assertEquals('foo', $e->decryptString($encrypted));
- *    }
- */
+	public function testEncryptionWithPassword()
+	{
+		$e = new Encrypter(str_repeat('a', 16));
+		$encrypted = $e->encryptWithPassword('foo', true, 'bar');
+		$this->assertNotEquals('foo', $encrypted);
+		$this->assertSame('foo', $e->decrypt($encrypted, true, 'bar'));
+	}
+
+	public function testRawStringEncryption()
+	{
+		$e = new Encrypter(str_repeat('a', 16));
+		$encrypted = $e->encryptString('foo');
+		$this->assertNotEquals('foo', $encrypted);
+		$this->assertEquals('foo', $e->decryptString($encrypted));
+	}
 
     public function testRawStringEncryptionWithPassword()
     {
         $e = new Encrypter(str_repeat('a', 16));
-        $encrypted = $e->encryptStringWithPassword('foo', false, 'bar');
+        $encrypted = $e->encryptStringWithPassword('foo', 'bar');
         $this->assertNotEquals('foo', $encrypted);
-        $this->assertSame('foo', $e->decryptString($encrypted, 'bar'));
+        $this->assertEquals('foo', $e->decryptString($encrypted, 'bar'));
     }
 
-    public function testEncryptionUsingBase64EncodedKey()
-    {
-        $e = new Encrypter(random_bytes(16));
-        $encrypted = $e->encrypt('foo');
-        $this->assertNotEquals('foo', $encrypted);
-        $this->assertEquals('foo', $e->decrypt($encrypted));
-    }
+	public function testEncryptionUsingBase64EncodedKey()
+	{
+		$e = new Encrypter(random_bytes(16));
+		$encrypted = $e->encrypt('foo');
+		$this->assertNotEquals('foo', $encrypted);
+		$this->assertEquals('foo', $e->decrypt($encrypted));
+	}
 
-    public function testWithCustomCipher()
-    {
-        $e = new Encrypter(str_repeat('b', 32), 'AES-256-CBC');
-        $encrypted = $e->encrypt('bar');
-        $this->assertNotEquals('bar', $encrypted);
-        $this->assertEquals('bar', $e->decrypt($encrypted));
+	public function testWithCustomCipher()
+	{
+		$e = new Encrypter(str_repeat('b', 32), 'AES-256-CBC');
+		$encrypted = $e->encrypt('bar');
+		$this->assertNotEquals('bar', $encrypted);
+		$this->assertEquals('bar', $e->decrypt($encrypted));
 
-        $e = new Encrypter(random_bytes(32), 'AES-256-CBC');
-        $encrypted = $e->encrypt('foo');
-        $this->assertNotEquals('foo', $encrypted);
-        $this->assertEquals('foo', $e->decrypt($encrypted));
-    }
+		$e = new Encrypter(random_bytes(32), 'AES-256-CBC');
+		$encrypted = $e->encrypt('foo');
+		$this->assertNotEquals('foo', $encrypted);
+		$this->assertEquals('foo', $e->decrypt($encrypted));
+	}
 
     /**
      * @expectedException RuntimeException

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -313,7 +313,7 @@ class RoutingRouteTest extends TestCase
     {
         unset($_SERVER['__test.route_inject']);
         $router = $this->getRouter();
-        $router->get('foo/{var}/{bar?}/{baz?}', function (stdClass $foo, $var, $bar = 'test', Request $baz = null) {
+        $router->get('foo/{var}/{bar?}/{baz?}', function (stdClass $foo, $var, $bar = 'test', stdClass $baz = null) {
             $_SERVER['__test.route_inject'] = func_get_args();
 
             return 'hello';
@@ -322,8 +322,8 @@ class RoutingRouteTest extends TestCase
         $this->assertInstanceOf('stdClass', $_SERVER['__test.route_inject'][0]);
         $this->assertEquals('bar', $_SERVER['__test.route_inject'][1]);
         $this->assertEquals('test', $_SERVER['__test.route_inject'][2]);
+        $this->assertInstanceOf('stdClass', $_SERVER['__test.route_inject'][3]);
         $this->assertArrayHasKey(3, $_SERVER['__test.route_inject']);
-        $this->assertInstanceOf('Illuminate\Http\Request', $_SERVER['__test.route_inject'][3]);
         unset($_SERVER['__test.route_inject']);
     }
 


### PR DESCRIPTION
I am building an application that requires user input password encrypted data. Currently Laravel defaults to using the APP_KEY as the encryption password. I added updates that will allow users to pass in a custom password string to the encrypt, encryptString, decrypt, and decryptString methods. If no password, the default APP_KEY will be used. This update will allow Laravel users to easily add custom passwords to their encrypted data. 

In an age of domestic surveillance and data warehousing, it is crucial that developers can easily access the encryption tools needed to provide users secure data.