### PR TITLE
Fix invalid migration class name (#18067)

### DIFF
--- a/src/Illuminate/Database/Migrations/MigrationCreator.php
+++ b/src/Illuminate/Database/Migrations/MigrationCreator.php
@@ -114,14 +114,14 @@ class MigrationCreator
      */
     protected function populateStub($name, $stub, $table)
     {
-        $stub = str_replace('DummyClass', $this->getClassName($name), $stub);
-
         // Here we will replace the table place-holders with the table specified by
         // the developer, which is useful for quickly creating a tables creation
         // or update migration from the console instead of typing it manually.
         if (! is_null($table)) {
             $stub = str_replace('DummyTable', $table, $stub);
         }
+
+       $stub = str_replace('DummyClass', $this->getClassName($name), $stub);
 
         return $stub;
     }

--- a/tests/Database/DatabaseMigrationCreatorTest.php
+++ b/tests/Database/DatabaseMigrationCreatorTest.php
@@ -50,6 +50,16 @@ class DatabaseMigrationCreatorTest extends TestCase
         $creator->create('create_bar', 'foo', 'baz', true);
     }
 
+    public function testTableCreationMigrationStoresMigrationFileDummyTableMigrationName()
+    {
+        $creator = $this->getCreator();
+        $creator->expects($this->any())->method('getDatePrefix')->will($this->returnValue('foo'));
+        $creator->getFilesystem()->shouldReceive('get')->once()->with($creator->stubPath().'/create.stub')->andReturn('DummyClass DummyTable');
+        $creator->getFilesystem()->shouldReceive('put')->once()->with('foo/foo_create_dummy_table.php', 'CreateDummyTable dummy');
+
+        $creator->create('create_dummy_table', 'foo', 'dummy', true);
+    }
+
     public function testTableUpdateMigrationWontCreateDuplicateClass()
     {
         $creator = $this->getCreator();


### PR DESCRIPTION
This will fix the bug whereby using make:migration with either the --create or --table flags generates the wrong class name if "dummy_table" appears anywhere in the migration name.