### PR TITLE
[5.4] Add a putAll() function to Collection

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -918,6 +918,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     {
         $source = $this->items;
         $destination = (array) $collection->getIterator();
+
         return new static(array_merge(array_values($source), array_values($destination)));
     }
 

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -909,6 +909,19 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
+     * Put a collection of items into the collection.
+     *
+     * @param $collection
+     * @return static
+     */
+    public function putAll($collection)
+    {
+        $source = $this->items;
+        $destination = (array) $collection->getIterator();
+        return new static(array_merge(array_values($source), array_values($destination)));
+    }
+
+    /**
      * Get one or more items randomly from the collection.
      *
      * @param  int|null  $amount

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -483,6 +483,12 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(['name' => 'World', 'id' => 1], $c->merge(new Collection(['name' => 'World', 'id' => 1]))->all());
     }
 
+    public function testPutAllCollection()
+    {
+        $c = new Collection([0 => 'foo', 1 => 'bar']);
+        $this->assertEquals([0 => 'foo', 1 => 'bar', 2 => 'foo', 3 => 'bar'], $c->putAll(new Collection([0 => 'foo', 1 => 'bar']))->all());
+    }
+
     public function testUnionNull()
     {
         $c = new Collection(['name' => 'Hello']);


### PR DESCRIPTION
I've added a function to Collection: `putAll($collection)`

The problem is that `Collection::merge` / `Collection::union` overrides every item in the original collection, which has the same index key ( for laravel Models, that means the primary key ).

Lets assume we have two collections of `Model_A` and `Model_B`

The database table could be something like:

**Model A**
```
| id | name    |
| 1  | 'foo'   |
| 2  | 'bar'   |
```
**Model B**
```
| id | name      |
| 1  | 'brown'   |
| 2  | 'fox'     |
```

Using `Collection::merge`

```
ModelA::take(2)->get()->merge(ModelB::take(2)->get())->all();
// [ 0 => 'foo', 1 => 'bar' ]
```

Using `Collection::putAll`

```
ModelA::take(2)->get()->putAll(ModelB::take(2)->get())->all();
// [ 0 => 'foo', 1 => 'bar', 2 => 'brown', 3 => 'fox']
```
