### PR TITLE
[5.4] Add getParentClass to Pivot relationship

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Pivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Pivot.php
@@ -195,4 +195,14 @@ class Pivot extends Model
     {
         return $this->parent->getUpdatedAtColumn();
     }
+
+    /**
+     * Get the parent model class.
+     *
+     * @return \Illuminate\Database\Eloquent\Model
+     */
+    public function getParentClass()
+    {
+        return $this->parent;
+    }
 }


### PR DESCRIPTION
When working with Pivots, it might be that you need to know which class was used as the parent relationship.