### PR TITLE
[WIP][5.4] Allow ::class when referencing a resource route action

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -245,7 +245,6 @@ class Router implements RegistrarContract, BindingRegistrar
     public function resource($name, $controller, array $options = [])
     {
         $controller = str_replace('App\Http\Controllers\\', '', $controller);
-        
         if ($this->container && $this->container->bound(ResourceRegistrar::class)) {
             $registrar = $this->container->make(ResourceRegistrar::class);
         } else {

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -244,6 +244,8 @@ class Router implements RegistrarContract, BindingRegistrar
      */
     public function resource($name, $controller, array $options = [])
     {
+        $controller = str_replace('App\Http\Controllers\\', '', $controller);
+        
         if ($this->container && $this->container->bound(ResourceRegistrar::class)) {
             $registrar = $this->container->make(ResourceRegistrar::class);
         } else {


### PR DESCRIPTION
When using resource routes it feels more natural to use
`Route::resource('foo', \App\Http\Controllers\FooController::class);`
instead of
`Route::resource('foo', 'FooController');`

This also benefits of IDE autocomplete functionality.