### PR TITLE
[5.4] Make sure support is not required.

### DIFF
--- a/src/Illuminate/Container/BoundMethod.php
+++ b/src/Illuminate/Container/BoundMethod.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Container;
 
+use Closure;
 use ReflectionMethod;
 use ReflectionFunction;
 use InvalidArgumentException;
@@ -71,7 +72,7 @@ class BoundMethod
     protected static function callBoundMethod($container, $callback, $default)
     {
         if (! is_array($callback)) {
-            return value($default);
+            return $default instanceof Closure ? $default() : $default;
         }
 
         // Here we need to turn the array callable into a Class@method string we can use to
@@ -83,7 +84,7 @@ class BoundMethod
             return $container->callMethodBinding($method, $callback[0]);
         }
 
-        return value($default);
+        return $default instanceof Closure ? $default() : $default;
     }
 
     /**


### PR DESCRIPTION
`value()` helper is part of `illuminate/support` package.

---

This PR ensures that `illuminate/container` really does not require `illuminate/support`.