### PR TITLE
[5.4] If a route::group namespace begins with `\` then reset

### DIFF
--- a/src/Illuminate/Routing/RouteGroup.php
+++ b/src/Illuminate/Routing/RouteGroup.php
@@ -43,6 +43,7 @@ class RouteGroup
             if (substr($new['namespace'], 0, 1) == '\\') {
                 return trim($new['namespace'], '\\');
             }
+            
             return isset($old['namespace'])
                     ? trim($old['namespace'], '\\').'\\'.trim($new['namespace'], '\\')
                     : trim($new['namespace'], '\\');

--- a/src/Illuminate/Routing/RouteGroup.php
+++ b/src/Illuminate/Routing/RouteGroup.php
@@ -40,7 +40,7 @@ class RouteGroup
     protected static function formatNamespace($new, $old)
     {
         if (isset($new['namespace'])) {
-            if(substr($new['namespace'],0, 1) == '\\'){
+            if (substr($new['namespace'], 0, 1) == '\\') {
                 return trim($new['namespace'], '\\');
             }
             return isset($old['namespace'])

--- a/src/Illuminate/Routing/RouteGroup.php
+++ b/src/Illuminate/Routing/RouteGroup.php
@@ -40,6 +40,9 @@ class RouteGroup
     protected static function formatNamespace($new, $old)
     {
         if (isset($new['namespace'])) {
+            if(substr($new['namespace'],0, 1) == '\\'){
+                return trim($new['namespace'], '\\');
+            }
             return isset($old['namespace'])
                     ? trim($old['namespace'], '\\').'\\'.trim($new['namespace'], '\\')
                     : trim($new['namespace'], '\\');


### PR DESCRIPTION
If a route::group namespace begins with `\` then reset