### PR TITLE
[5.5] Camel case variables that get shared with a view

### DIFF
--- a/src/Illuminate/View/View.php
+++ b/src/Illuminate/View/View.php
@@ -399,7 +399,7 @@ class View implements ArrayAccess, ViewContract
             throw new BadMethodCallException("Method [$method] does not exist on view.");
         }
 
-        return $this->with(Str::snake(substr($method, 4)), $parameters[0]);
+        return $this->with(Str::camel(substr($method, 4)), $parameters[0]);
     }
 
     /**


### PR DESCRIPTION
Variables throughout the framework all use camelCase. I think it would make sense to also default to camelCase when sharing variables with a view using a magic `with*` call.