### PR TITLE
[5.4] Add kebab case to Str with kebab_case helper

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -133,6 +133,17 @@ class Str
     }
 
     /**
+     * Convert a string to kebab case.
+     *
+     * @param  string  $value
+     * @return string
+     */
+    public static function kebab($value)
+    {
+        return static::snake($value, '-');
+    }
+
+    /**
      * Return the length of the given string.
      *
      * @param  string  $value

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -560,6 +560,19 @@ if (! function_exists('head')) {
     }
 }
 
+if (! function_exists('kebab_case')) {
+    /**
+     * Convert a string to kebab case.
+     *
+     * @param  string  $value
+     * @return string
+     */
+    function kebab_case($value)
+    {
+        return Str::kebab($value);
+    }
+}
+
 if (! function_exists('last')) {
     /**
      * Get the last element from an array.

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -123,6 +123,11 @@ class SupportStrTest extends TestCase
         $this->assertTrue(Str::is($patternObject, $valueObject));
     }
 
+    public function testKebab()
+    {
+        $this->assertEquals('laravel-php-framework', Str::kebab('LaravelPhpFramework'));
+    }
+
     public function testLower()
     {
         $this->assertEquals('foo bar baz', Str::lower('FOO BAR BAZ'));


### PR DESCRIPTION
It seems to be a convention to "kebab-case" blade view names. Therefore, a kebab method would be helpful for instances such as the following:

I want to "polymorphically" change views based on different notification types.
```php
<a href="#">
    @include('notifications.' . snake_case(class_basename($notification->type), '-'))
</a>
```

Could become:

```php
<a href="#">
    @include('notifications.' . kebab_case(class_basename($notification->type)))
</a>
```

Thanks for the hard work and time put into reviewing PRs like these.
