### PR TITLE
[5.4] Ensure illuminate/contracts is required.

### DIFF
--- a/src/Illuminate/Translation/composer.json
+++ b/src/Illuminate/Translation/composer.json
@@ -15,6 +15,7 @@
     ],
     "require": {
         "php": ">=5.6.4",
+        "illuminate/contracts": "5.4.*",
         "illuminate/filesystem": "5.4.*",
         "illuminate/support": "5.4.*"
     },


### PR DESCRIPTION
Ensure `illuminate/contracts` is required, as `\Illuminate\Translation\Translator` implements `\Illuminate\Contracts\Translation\Translator`.