### PR TITLE
[5.4] while doing 'npm run hot', do not require existence of the manifest file for 'mix()'

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -562,8 +562,16 @@ if (! function_exists('mix')) {
     {
         static $manifest;
 
+        if (! starts_with($path, '/')) {
+            $path = "/{$path}";
+        }
+
         if ($manifestDirectory && ! starts_with($manifestDirectory, '/')) {
             $manifestDirectory = "/{$manifestDirectory}";
+        }
+
+        if (file_exists(public_path($manifestDirectory.'/hot'))) {
+            return new HtmlString("http://localhost:8080{$path}");
         }
 
         if (! $manifest) {
@@ -574,10 +582,6 @@ if (! function_exists('mix')) {
             $manifest = json_decode(file_get_contents($manifestPath), true);
         }
 
-        if (! starts_with($path, '/')) {
-            $path = "/{$path}";
-        }
-
         if (! array_key_exists($path, $manifest)) {
             throw new Exception(
                 "Unable to locate Mix file: {$path}. Please check your ".
@@ -585,9 +589,7 @@ if (! function_exists('mix')) {
             );
         }
 
-        return file_exists(public_path($manifestDirectory.'/hot'))
-                    ? new HtmlString("http://localhost:8080{$manifest[$path]}")
-                    : new HtmlString($manifestDirectory.$manifest[$path]);
+        return new HtmlString($manifestDirectory.$manifest[$path]);
     }
 }
 


### PR DESCRIPTION
With tested versions of `laravel-mix`, the manifest file isn't generated when running `npm run hot`. This makes it so you need to run `npm run dev`, for example, before running `npm run hot` either on first run or every time a new file should exist.