### PR TITLE
[5.4] Use composition to create TestResponses instead of inheritance

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -36,33 +36,6 @@ class TestResponse
     }
 
     /**
-     * Dynamically access base response parameters.
-     *
-     * @param  string  $key
-     * @return mixed
-     */
-    public function __get($key)
-    {
-        return $this->baseResponse->{$key};
-    }
-
-    /**
-     * Handle dynamic calls into macros or pass missing methods to the base response.
-     *
-     * @param  string  $method
-     * @param  array   $parameters
-     * @return mixed
-     */
-    public function __call($method, $args)
-    {
-        if (static::hasMacro($method)) {
-            return $this->macroCall($method, $args);
-        }
-
-        return $this->baseResponse->{$method}(...$args);
-    }
-
-    /**
      * Create a new TestResponse from another response.
      *
      * @param  \Illuminate\Http\Response  $response
@@ -535,5 +508,32 @@ class TestResponse
         }
 
         dd($content);
+    }
+
+    /**
+     * Dynamically access base response parameters.
+     *
+     * @param  string  $key
+     * @return mixed
+     */
+    public function __get($key)
+    {
+        return $this->baseResponse->{$key};
+    }
+
+    /**
+     * Handle dynamic calls into macros or pass missing methods to the base response.
+     *
+     * @param  string  $method
+     * @param  array   $parameters
+     * @return mixed
+     */
+    public function __call($method, $args)
+    {
+        if (static::hasMacro($method)) {
+            return $this->macroCall($method, $args);
+        }
+
+        return $this->baseResponse->{$method}(...$args);
     }
 }

--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -11,33 +11,66 @@ use Illuminate\Support\Traits\Macroable;
 use PHPUnit\Framework\Assert as PHPUnit;
 use Symfony\Component\HttpFoundation\Cookie;
 
-class TestResponse extends Response
+class TestResponse
 {
-    use Macroable;
+    use Macroable {
+        __call as macroCall;
+    }
 
     /**
-     * Convert the given response into a TestResponse.
+     * The reponse to delegate to.
+     *
+     * @var \Illuminate\Http\Response
+     */
+    public $baseResponse;
+
+    /**
+     * Create a new test response instance.
+     *
+     * @param  \Illuminate\Http\Response  $response
+     * @return void
+     */
+    public function __construct($response)
+    {
+        $this->baseResponse = $response;
+    }
+
+    /**
+     * Dynamically access base response parameters.
+     *
+     * @param  string  $key
+     * @return mixed
+     */
+    public function __get($key)
+    {
+        return $this->baseResponse->{$key};
+    }
+
+    /**
+     * Handle dynamic calls into macros or pass missing methods to the base response.
+     *
+     * @param  string  $method
+     * @param  array   $parameters
+     * @return mixed
+     */
+    public function __call($method, $args)
+    {
+        if (static::hasMacro($method)) {
+            return $this->macroCall($method, $args);
+        }
+
+        return $this->baseResponse->{$method}(...$args);
+    }
+
+    /**
+     * Create a new TestResponse from another response.
      *
      * @param  \Illuminate\Http\Response  $response
      * @return static
      */
     public static function fromBaseResponse($response)
     {
-        $testResponse = new static(
-            $response->getContent(), $response->getStatusCode()
-        );
-
-        $testResponse->headers = $response->headers;
-
-        if (isset($response->original)) {
-            $testResponse->original = $response->original;
-        }
-
-        if (isset($response->exception)) {
-            $testResponse->exception = $response->exception;
-        }
-
-        return $testResponse;
+        return new static($response);
     }
 
     /**

--- a/tests/Foundation/FoundationTestResponseTest.php
+++ b/tests/Foundation/FoundationTestResponseTest.php
@@ -90,7 +90,6 @@ class FoundationTestResponseTest extends TestCase
         $files->makeDirectory($tempDir, 0755, false, true);
         $files->put($tempDir.'/file.txt', 'Hello World');
 
-
         $response = TestResponse::fromBaseResponse(new BinaryFileResponse($tempDir.'/file.txt'));
 
         $this->assertEquals($tempDir.'/file.txt', $response->getFile()->getPathname());

--- a/tests/Foundation/FoundationTestResponseTest.php
+++ b/tests/Foundation/FoundationTestResponseTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Foundation;
 
 use JsonSerializable;
+use Illuminate\Http\Response;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Foundation\Testing\TestResponse;
 
@@ -10,7 +11,7 @@ class FoundationTestResponseTest extends TestCase
 {
     public function testAssertJsonWithArray()
     {
-        $response = new TestResponse(new JsonSerializableSingleResourceStub);
+        $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableSingleResourceStub));
 
         $resource = new JsonSerializableSingleResourceStub;
 
@@ -19,7 +20,7 @@ class FoundationTestResponseTest extends TestCase
 
     public function testAssertJsonWithMixed()
     {
-        $response = new TestResponse(new JsonSerializableMixedResourcesStub);
+        $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableMixedResourcesStub));
 
         $resource = new JsonSerializableMixedResourcesStub;
 
@@ -28,13 +29,13 @@ class FoundationTestResponseTest extends TestCase
 
     public function testAssertJsonFragment()
     {
-        $response = new TestResponse(new JsonSerializableSingleResourceStub);
+        $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableSingleResourceStub));
 
         $response->assertJsonFragment(['foo' => 'foo 0']);
 
         $response->assertJsonFragment(['foo' => 'foo 0', 'bar' => 'bar 0', 'foobar' => 'foobar 0']);
 
-        $response = new TestResponse(new JsonSerializableMixedResourcesStub);
+        $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableMixedResourcesStub));
 
         $response->assertJsonFragment(['foo' => 'bar']);
 
@@ -47,7 +48,7 @@ class FoundationTestResponseTest extends TestCase
 
     public function testAssertJsonStructure()
     {
-        $response = new TestResponse(new JsonSerializableMixedResourcesStub);
+        $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableMixedResourcesStub));
 
         // At root
         $response->assertJsonStructure(['foo']);
@@ -62,7 +63,7 @@ class FoundationTestResponseTest extends TestCase
         $response->assertJsonStructure(['baz' => ['*' => ['foo', 'bar' => ['foo', 'bar']]]]);
 
         // Wildcard (repeating structure) at root
-        $response = new TestResponse(new JsonSerializableSingleResourceStub);
+        $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableSingleResourceStub));
 
         $response->assertJsonStructure(['*' => ['foo', 'bar', 'foobar']]);
     }
@@ -73,7 +74,7 @@ class FoundationTestResponseTest extends TestCase
             return 'bar';
         });
 
-        $response = new TestResponse;
+        $response = TestResponse::fromBaseResponse(new Response);
 
         $this->assertEquals(
             'bar', $response->foo()

--- a/tests/Foundation/FoundationTestResponseTest.php
+++ b/tests/Foundation/FoundationTestResponseTest.php
@@ -5,7 +5,9 @@ namespace Illuminate\Tests\Foundation;
 use JsonSerializable;
 use Illuminate\Http\Response;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Filesystem\Filesystem;
 use Illuminate\Foundation\Testing\TestResponse;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
 
 class FoundationTestResponseTest extends TestCase
 {
@@ -79,6 +81,21 @@ class FoundationTestResponseTest extends TestCase
         $this->assertEquals(
             'bar', $response->foo()
         );
+    }
+
+    public function testCanBeCreatedFromBinaryFileResponses()
+    {
+        $files = new Filesystem();
+        $tempDir = __DIR__.'/tmp';
+        $files->makeDirectory($tempDir, 0755, false, true);
+        $files->put($tempDir.'/file.txt', 'Hello World');
+
+
+        $response = TestResponse::fromBaseResponse(new BinaryFileResponse($tempDir.'/file.txt'));
+
+        $this->assertEquals($tempDir.'/file.txt', $response->getFile()->getPathname());
+
+        $files->deleteDirectory($tempDir);
     }
 }
 


### PR DESCRIPTION
Fixes #18049 by allowing a TestResponse to be created from any type of response, instead of being coupled to responses that support `getContent()`.

The real underlying cause for that issue is that Symfony's `BinaryFileResponse` extends their base response, even though it's not actually substitutable. Inheritance is stupid 👍🏻

This does introduce one potential problem (although it seems unlikely...)

Since TestResponse no longer extends Response, it won't pass any `Response` type hints. I find it extremely unlikely that this will affect anyone, because it seems very odd to get the `$response` variable back as a result in a test, and then pass it into something that's type hinting the base response, but this change would break that code if it exists anywhere.

I've only implemented `__get` and `__call` here because again it seems odd that anyone would try to mutate a property the returned response, but can add that if there's some reasonable justification for it.

I've left the `$baseResponse` property public, so it would be trivial for end users to grab that directly and manipulate it themselves if needed for whatever reason.