### PR TITLE
Added support for multi-dimensional array on Arr::forget and Collection::except

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -226,6 +226,10 @@ class Arr
 
                 if (isset($array[$part]) && is_array($array[$part])) {
                     $array = &$array[$part];
+                } elseif ($part === '*') {
+                    foreach ($array as &$arr) {
+                        static::forget($arr, implode('.', $parts));
+                    }
                 } else {
                     continue 2;
                 }

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -521,5 +521,73 @@ class SupportArrTest extends TestCase
         $array = ['emails' => ['joe@example.com' => ['name' => 'Joe'], 'jane@localhost' => ['name' => 'Jane']]];
         Arr::forget($array, ['emails.joe@example.com', 'emails.jane@localhost']);
         $this->assertEquals(['emails' => ['joe@example.com' => ['name' => 'Joe']]], $array);
+
+        // Works with one level array using '*' dot syntax
+        $array = [
+            ['name' => 'John Doe', 'age' => 18, 'password' => '12345'],
+            ['name' => 'Jane Doe', 'age' => 22, 'password' => '54321'],
+            ['name' => 'Merry Doe', 'age' => 25],
+            ['age' => 22, 'password' => '54321'],
+            [],
+        ];
+        Arr::forget($array, ['*.password', '*.age']);
+        $this->assertEquals([
+            ['name' => 'John Doe'],
+            ['name' => 'Jane Doe'],
+            ['name' => 'Merry Doe'],
+            [],
+            [],
+        ], $array);
+
+        // Works in case of '*' as array key (Original behavior)
+        $array = ['name' => 'John Doe', '*' => 33];
+        Arr::forget($array, ['*']);
+        $this->assertEquals(['name' => 'John Doe'], $array);
+
+        // Works wit multi-dimensional array using '*' dot syntax
+        $array = [
+            [
+                ['name' => 'John Doe', 'age' => 18, 'password' => '12345'],
+                ['name' => 'Jane Doe', 'age' => 22, 'password' => '54321'],
+            ],
+        ];
+        Arr::forget($array, ['*.*.password']);
+        $this->assertEquals([
+            [
+                ['name' => 'John Doe', 'age' => 18],
+                ['name' => 'Jane Doe', 'age' => 22],
+            ],
+        ], $array);
+
+        // Works with nested multi-dimensional array using '*' dot syntax
+        $array = [
+            [
+                'users' => [
+                    ['name' => 'John Vieira', 'age' => 18, 'password' => '12345'],
+                    ['name' => 'Jane Vieira', 'age' => 22, 'password' => '54321'],
+                ],
+            ],
+            [
+                'users' => [
+                    ['name' => 'John Silva', 'age' => 18, 'password' => '12345'],
+                    ['name' => 'Okano William', 'age' => 22, 'password' => '54321'],
+                ],
+            ],
+        ];
+        Arr::forget($array, ['*.users.*.password']);
+        $this->assertEquals([
+            [
+                'users' => [
+                    ['name' => 'John Vieira', 'age' => 18],
+                    ['name' => 'Jane Vieira', 'age' => 22],
+                ],
+            ],
+            [
+                'users' => [
+                    ['name' => 'John Silva', 'age' => 18],
+                    ['name' => 'Okano William', 'age' => 22],
+                ],
+            ],
+        ], $array);
     }
 }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -792,6 +792,32 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(['first' => 'Taylor', 'email' => 'taylorotwell@gmail.com'], $data->except('last')->all());
     }
 
+    public function testMultidimensionalExcept()
+    {
+        $data = new Collection([
+            ['first' => 'Taylor', 'last' => 'Otwell', 'email' => 'taylorotwell@gmail.com'],
+            ['first' => 'Nielsen', 'last' => 'Martins', 'email' => 'nielsenfake@gmail.com'],
+        ]);
+
+        $this->assertEquals([
+            ['first' => 'Taylor'],
+            ['first' => 'Nielsen'],
+        ], $data->except(['*.last', '*.email', '*.missing'])->all());
+        $this->assertEquals([
+            ['first' => 'Taylor'],
+            ['first' => 'Nielsen'],
+        ], $data->except('*.last', '*.email', '*.missing')->all());
+
+        $this->assertEquals([
+            ['first' => 'Taylor', 'email' => 'taylorotwell@gmail.com'],
+            ['first' => 'Nielsen', 'email' => 'nielsenfake@gmail.com'],
+        ], $data->except(['*.last'])->all());
+        $this->assertEquals([
+            ['first' => 'Taylor', 'email' => 'taylorotwell@gmail.com'],
+            ['first' => 'Nielsen', 'email' => 'nielsenfake@gmail.com'],
+        ], $data->except('*.last')->all());
+    }
+
     public function testPluckWithArrayAndObjectValues()
     {
         $data = new Collection([(object) ['name' => 'taylor', 'email' => 'foo'], ['name' => 'dayle', 'email' => 'bar']]);


### PR DESCRIPTION
This PR is intended to solve the following related issue:

https://github.com/laravel/internals/issues/437
