### PR TITLE
[5.5] [WIP] Allow custom string passwords in Encrypter class

### DIFF
--- a/src/Illuminate/Contracts/Encryption/Encrypter.php
+++ b/src/Illuminate/Contracts/Encryption/Encrypter.php
@@ -9,16 +9,18 @@ interface Encrypter
      *
      * @param  string  $value
      * @param  bool  $serialize
+     * @param  string  $key
      * @return string
      */
-    public function encrypt($value, $serialize = true);
+    public function encrypt($value, $serialize = true, $key = null);
 
     /**
      * Decrypt the given value.
      *
      * @param  string  $payload
      * @param  bool  $unserialize
+     * @param  string  $key
      * @return string
      */
-    public function decrypt($payload, $unserialize = true);
+    public function decrypt($payload, $unserialize = true, $key = null);
 }

--- a/src/Illuminate/Encryption/Encrypter.php
+++ b/src/Illuminate/Encryption/Encrypter.php
@@ -113,7 +113,7 @@ class Encrypter implements EncrypterContract
     {
         $iterations = 1000;
         $salt = $this->key;
-      	$key = hash_pbkdf2('sha256', $password, $salt, $iterations, 32);
+        $key = hash_pbkdf2('sha256', $password, $salt, $iterations, 32);
         return $this->encrypt($value, $serialize, $key);
     }
 
@@ -157,7 +157,7 @@ class Encrypter implements EncrypterContract
 		if (! is_null($key)) {
 			$iterations = 1000;
 			$salt = $this->key;
-			$key = hash_pbkdf2('sha256', $key, $salt, $iterations, 32);
+            $key = hash_pbkdf2('sha256', $key, $salt, $iterations, 32);
 		}
 
 		$payload = $this->getJsonPayload($payload);

--- a/src/Illuminate/Encryption/Encrypter.php
+++ b/src/Illuminate/Encryption/Encrypter.php
@@ -114,6 +114,7 @@ class Encrypter implements EncrypterContract
         $iterations = 1000;
         $salt = $this->key;
         $key = hash_pbkdf2('sha256', $password, $salt, $iterations, 32);
+
         return $this->encrypt($value, $serialize, $key);
     }
 
@@ -154,13 +155,13 @@ class Encrypter implements EncrypterContract
     public function decrypt($payload, $unserialize = true, $key = null)
     {
 
-		if (! is_null($key)) {
-			$iterations = 1000;
-			$salt = $this->key;
+        if (! is_null($key)) {
+            $iterations = 1000;
+            $salt = $this->key;
             $key = hash_pbkdf2('sha256', $key, $salt, $iterations, 32);
-		}
+        }
 
-		$payload = $this->getJsonPayload($payload);
+        $payload = $this->getJsonPayload($payload);
         $iv = base64_decode($payload['iv']);
 
         // Here we will decrypt the value. If we are able to successfully decrypt it

--- a/src/Illuminate/Encryption/Encrypter.php
+++ b/src/Illuminate/Encryption/Encrypter.php
@@ -154,7 +154,6 @@ class Encrypter implements EncrypterContract
      */
     public function decrypt($payload, $unserialize = true, $key = null)
     {
-
         if (! is_null($key)) {
             $iterations = 1000;
             $salt = $this->key;

--- a/tests/Encryption/EncrypterTest.php
+++ b/tests/Encryption/EncrypterTest.php
@@ -1,105 +1,241 @@
 <?php
 
-namespace Illuminate\Tests\Encryption;
+namespace Illuminate\Encryption;
 
-use PHPUnit\Framework\TestCase;
-use Illuminate\Encryption\Encrypter;
+use RuntimeException;
+use Illuminate\Contracts\Encryption\DecryptException;
+use Illuminate\Contracts\Encryption\EncryptException;
+use Illuminate\Contracts\Encryption\Encrypter as EncrypterContract;
 
-class EncrypterTest extends TestCase
+class Encrypter implements EncrypterContract
 {
-    public function testEncryption()
-    {
-        $e = new Encrypter(str_repeat('a', 16));
-        $encrypted = $e->encrypt('foo');
-        $this->assertNotEquals('foo', $encrypted);
-        $this->assertEquals('foo', $e->decrypt($encrypted));
-    }
+    /**
+     * The encryption key.
+     *
+     * @var string
+     */
+    protected $key;
 
-    public function testRawStringEncryption()
-    {
-        $e = new Encrypter(str_repeat('a', 16));
-        $encrypted = $e->encryptString('foo');
-        $this->assertNotEquals('foo', $encrypted);
-        $this->assertEquals('foo', $e->decryptString($encrypted));
-    }
+    /**
+     * The algorithm used for encryption.
+     *
+     * @var string
+     */
+    protected $cipher;
 
-    public function testEncryptionUsingBase64EncodedKey()
+    /**
+     * Create a new encrypter instance.
+     *
+     * @param  string  $key
+     * @param  string  $cipher
+     * @return void
+     *
+     * @throws \RuntimeException
+     */
+    public function __construct($key, $cipher = 'AES-128-CBC')
     {
-        $e = new Encrypter(random_bytes(16));
-        $encrypted = $e->encrypt('foo');
-        $this->assertNotEquals('foo', $encrypted);
-        $this->assertEquals('foo', $e->decrypt($encrypted));
-    }
+        $key = (string) $key;
 
-    public function testWithCustomCipher()
-    {
-        $e = new Encrypter(str_repeat('b', 32), 'AES-256-CBC');
-        $encrypted = $e->encrypt('bar');
-        $this->assertNotEquals('bar', $encrypted);
-        $this->assertEquals('bar', $e->decrypt($encrypted));
-
-        $e = new Encrypter(random_bytes(32), 'AES-256-CBC');
-        $encrypted = $e->encrypt('foo');
-        $this->assertNotEquals('foo', $encrypted);
-        $this->assertEquals('foo', $e->decrypt($encrypted));
+        if (static::supported($key, $cipher)) {
+            $this->key = $key;
+            $this->cipher = $cipher;
+        } else {
+            throw new RuntimeException('The only supported ciphers are AES-128-CBC and AES-256-CBC with the correct key lengths.');
+        }
     }
 
     /**
-     * @expectedException RuntimeException
-     * @expectedExceptionMessage The only supported ciphers are AES-128-CBC and AES-256-CBC with the correct key lengths.
+     * Determine if the given key and cipher combination is valid.
+     *
+     * @param  string  $key
+     * @param  string  $cipher
+     * @return bool
      */
-    public function testDoNoAllowLongerKey()
+    public static function supported($key, $cipher)
     {
-        new Encrypter(str_repeat('z', 32));
+        $length = mb_strlen($key, '8bit');
+
+        return ($cipher === 'AES-128-CBC' && $length === 16) ||
+               ($cipher === 'AES-256-CBC' && $length === 32);
     }
 
     /**
-     * @expectedException RuntimeException
-     * @expectedExceptionMessage The only supported ciphers are AES-128-CBC and AES-256-CBC with the correct key lengths.
+     * Encrypt the given value.
+     *
+     * @param  mixed  $value
+     * @param  bool  $serialize
+     * @return string
+     *
+     * @throws \Illuminate\Contracts\Encryption\EncryptException
      */
-    public function testWithBadKeyLength()
+    public function encrypt($value, $serialize = true)
     {
-        new Encrypter(str_repeat('a', 5));
+        $iv = random_bytes(16);
+
+        // First we will encrypt the value using OpenSSL. After this is encrypted we
+        // will proceed to calculating a MAC for the encrypted value so that this
+        // value can be verified later as not having been changed by the users.
+        $value = \openssl_encrypt(
+            $serialize ? serialize($value) : $value,
+            $this->cipher, $this->key, 0, $iv
+        );
+
+        if ($value === false) {
+            throw new EncryptException('Could not encrypt the data.');
+        }
+
+        // Once we have the encrypted value we will go ahead base64_encode the input
+        // vector and create the MAC for the encrypted value so we can verify its
+        // authenticity. Then, we'll JSON encode the data in a "payload" array.
+        $mac = $this->hash($iv = base64_encode($iv), $value);
+
+        $json = json_encode(compact('iv', 'value', 'mac'));
+
+        if (! is_string($json)) {
+            throw new EncryptException('Could not encrypt the data.');
+        }
+
+        return base64_encode($json);
     }
 
     /**
-     * @expectedException RuntimeException
-     * @expectedExceptionMessage The only supported ciphers are AES-128-CBC and AES-256-CBC with the correct key lengths.
+     * Encrypt a string without serialization.
+     *
+     * @param  string  $value
+     * @return string
      */
-    public function testWithBadKeyLengthAlternativeCipher()
+    public function encryptString($value)
     {
-        new Encrypter(str_repeat('a', 16), 'AES-256-CFB8');
+        return $this->encrypt($value, false);
     }
 
     /**
-     * @expectedException RuntimeException
-     * @expectedExceptionMessage The only supported ciphers are AES-128-CBC and AES-256-CBC with the correct key lengths.
+     * Decrypt the given value.
+     *
+     * @param  mixed  $payload
+     * @param  bool  $unserialize
+     * @return string
+     *
+     * @throws \Illuminate\Contracts\Encryption\DecryptException
      */
-    public function testWithUnsupportedCipher()
+    public function decrypt($payload, $unserialize = true)
     {
-        new Encrypter(str_repeat('c', 16), 'AES-256-CFB8');
+        $payload = $this->getJsonPayload($payload);
+
+        $iv = base64_decode($payload['iv']);
+
+        // Here we will decrypt the value. If we are able to successfully decrypt it
+        // we will then unserialize it and return it out to the caller. If we are
+        // unable to decrypt this value we will throw out an exception message.
+        $decrypted = \openssl_decrypt(
+            $payload['value'], $this->cipher, $this->key, 0, $iv
+        );
+
+        if ($decrypted === false) {
+            throw new DecryptException('Could not decrypt the data.');
+        }
+
+        return $unserialize ? unserialize($decrypted) : $decrypted;
     }
 
     /**
-     * @expectedException Illuminate\Contracts\Encryption\DecryptException
-     * @expectedExceptionMessage The payload is invalid.
+     * Decrypt the given string without unserialization.
+     *
+     * @param  string  $payload
+     * @return string
      */
-    public function testExceptionThrownWhenPayloadIsInvalid()
+    public function decryptString($payload)
     {
-        $e = new Encrypter(str_repeat('a', 16));
-        $payload = $e->encrypt('foo');
-        $payload = str_shuffle($payload);
-        $e->decrypt($payload);
+        return $this->decrypt($payload, false);
     }
 
     /**
-     * @expectedException Illuminate\Contracts\Encryption\DecryptException
-     * @expectedExceptionMessage The MAC is invalid.
+     * Create a MAC for the given value.
+     *
+     * @param  string  $iv
+     * @param  mixed  $value
+     * @return string
      */
-    public function testExceptionThrownWithDifferentKey()
+    protected function hash($iv, $value)
     {
-        $a = new Encrypter(str_repeat('a', 16));
-        $b = new Encrypter(str_repeat('b', 16));
-        $b->decrypt($a->encrypt('baz'));
+        return hash_hmac('sha256', $iv.$value, $this->key);
+    }
+
+    /**
+     * Get the JSON array from the given payload.
+     *
+     * @param  string  $payload
+     * @return array
+     *
+     * @throws \Illuminate\Contracts\Encryption\DecryptException
+     */
+    protected function getJsonPayload($payload)
+    {
+        $payload = json_decode(base64_decode($payload), true);
+
+        // If the payload is not valid JSON or does not have the proper keys set we will
+        // assume it is invalid and bail out of the routine since we will not be able
+        // to decrypt the given value. We'll also check the MAC for this encryption.
+        if (! $this->validPayload($payload)) {
+            throw new DecryptException('The payload is invalid.');
+        }
+
+        if (! $this->validMac($payload)) {
+            throw new DecryptException('The MAC is invalid.');
+        }
+
+        return $payload;
+    }
+
+    /**
+     * Verify that the encryption payload is valid.
+     *
+     * @param  mixed  $payload
+     * @return bool
+     */
+    protected function validPayload($payload)
+    {
+        return is_array($payload) && isset(
+            $payload['iv'], $payload['value'], $payload['mac']
+        );
+    }
+
+    /**
+     * Determine if the MAC for the given payload is valid.
+     *
+     * @param  array  $payload
+     * @return bool
+     */
+    protected function validMac(array $payload)
+    {
+        $calculated = $this->calculateMac($payload, $bytes = random_bytes(16));
+
+        return hash_equals(
+            hash_hmac('sha256', $payload['mac'], $bytes, true), $calculated
+        );
+    }
+
+    /**
+     * Calculate the hash of the given payload.
+     *
+     * @param  array  $payload
+     * @param  string  $bytes
+     * @return string
+     */
+    protected function calculateMac($payload, $bytes)
+    {
+        return hash_hmac(
+            'sha256', $this->hash($payload['iv'], $payload['value']), $bytes, true
+        );
+    }
+
+    /**
+     * Get the encryption key.
+     *
+     * @return string
+     */
+    public function getKey()
+    {
+        return $this->key;
     }
 }

--- a/tests/Encryption/EncrypterTest.php
+++ b/tests/Encryption/EncrypterTest.php
@@ -1,241 +1,121 @@
 <?php
 
-namespace Illuminate\Encryption;
+namespace Illuminate\Tests\Encryption;
 
-use RuntimeException;
-use Illuminate\Contracts\Encryption\DecryptException;
-use Illuminate\Contracts\Encryption\EncryptException;
-use Illuminate\Contracts\Encryption\Encrypter as EncrypterContract;
+use PHPUnit\Framework\TestCase;
+use Illuminate\Encryption\Encrypter;
 
-class Encrypter implements EncrypterContract
+class EncrypterTest extends TestCase
 {
-    /**
-     * The encryption key.
-     *
-     * @var string
-     */
-    protected $key;
-
-    /**
-     * The algorithm used for encryption.
-     *
-     * @var string
-     */
-    protected $cipher;
-
-    /**
-     * Create a new encrypter instance.
-     *
-     * @param  string  $key
-     * @param  string  $cipher
-     * @return void
-     *
-     * @throws \RuntimeException
-     */
-    public function __construct($key, $cipher = 'AES-128-CBC')
+    public function testEncryption()
     {
-        $key = (string) $key;
+        $e = new Encrypter(str_repeat('a', 16));
+        $encrypted = $e->encrypt('foo');
+        $this->assertNotEquals('foo', $encrypted);
+        $this->assertEquals('foo', $e->decrypt($encrypted));
+    }
 
-        if (static::supported($key, $cipher)) {
-            $this->key = $key;
-            $this->cipher = $cipher;
-        } else {
-            throw new RuntimeException('The only supported ciphers are AES-128-CBC and AES-256-CBC with the correct key lengths.');
-        }
+	public function testEncryptionWithPassword()
+	{
+		$e = new Encrypter(str_repeat('a', 16));
+		$encrypted = $e->encryptWithPassword('foo', true, 'bar');
+		$this->assertNotEquals('foo', $encrypted);
+		$this->assertSame('foo', $e->decrypt($encrypted, true, 'bar'));
+	}
+
+    public function testRawStringEncryption()
+    {
+        $e = new Encrypter(str_repeat('a', 16));
+        $encrypted = $e->encryptString('foo');
+        $this->assertNotEquals('foo', $encrypted);
+        $this->assertEquals('foo', $e->decryptString($encrypted));
+    }
+
+    public function testRawStringEncryptionWithPassword()
+    {
+        $e = new Encrypter(str_repeat('a', 16));
+        $encrypted = $e->encryptStringWithPassword('foo', 'bar');
+        $this->assertNotEquals('foo', $encrypted);
+        $this->assertEquals('foo', $e->decryptString($encrypted, 'bar'));
+    }
+
+    public function testEncryptionUsingBase64EncodedKey()
+    {
+        $e = new Encrypter(random_bytes(16));
+        $encrypted = $e->encrypt('foo');
+        $this->assertNotEquals('foo', $encrypted);
+        $this->assertEquals('foo', $e->decrypt($encrypted));
+    }
+
+    public function testWithCustomCipher()
+    {
+        $e = new Encrypter(str_repeat('b', 32), 'AES-256-CBC');
+        $encrypted = $e->encrypt('bar');
+        $this->assertNotEquals('bar', $encrypted);
+        $this->assertEquals('bar', $e->decrypt($encrypted));
+
+        $e = new Encrypter(random_bytes(32), 'AES-256-CBC');
+        $encrypted = $e->encrypt('foo');
+        $this->assertNotEquals('foo', $encrypted);
+        $this->assertEquals('foo', $e->decrypt($encrypted));
     }
 
     /**
-     * Determine if the given key and cipher combination is valid.
-     *
-     * @param  string  $key
-     * @param  string  $cipher
-     * @return bool
+     * @expectedException RuntimeException
+     * @expectedExceptionMessage The only supported ciphers are AES-128-CBC and AES-256-CBC with the correct key lengths.
      */
-    public static function supported($key, $cipher)
+    public function testDoNoAllowLongerKey()
     {
-        $length = mb_strlen($key, '8bit');
-
-        return ($cipher === 'AES-128-CBC' && $length === 16) ||
-               ($cipher === 'AES-256-CBC' && $length === 32);
+        new Encrypter(str_repeat('z', 32));
     }
 
     /**
-     * Encrypt the given value.
-     *
-     * @param  mixed  $value
-     * @param  bool  $serialize
-     * @return string
-     *
-     * @throws \Illuminate\Contracts\Encryption\EncryptException
+     * @expectedException RuntimeException
+     * @expectedExceptionMessage The only supported ciphers are AES-128-CBC and AES-256-CBC with the correct key lengths.
      */
-    public function encrypt($value, $serialize = true)
+    public function testWithBadKeyLength()
     {
-        $iv = random_bytes(16);
-
-        // First we will encrypt the value using OpenSSL. After this is encrypted we
-        // will proceed to calculating a MAC for the encrypted value so that this
-        // value can be verified later as not having been changed by the users.
-        $value = \openssl_encrypt(
-            $serialize ? serialize($value) : $value,
-            $this->cipher, $this->key, 0, $iv
-        );
-
-        if ($value === false) {
-            throw new EncryptException('Could not encrypt the data.');
-        }
-
-        // Once we have the encrypted value we will go ahead base64_encode the input
-        // vector and create the MAC for the encrypted value so we can verify its
-        // authenticity. Then, we'll JSON encode the data in a "payload" array.
-        $mac = $this->hash($iv = base64_encode($iv), $value);
-
-        $json = json_encode(compact('iv', 'value', 'mac'));
-
-        if (! is_string($json)) {
-            throw new EncryptException('Could not encrypt the data.');
-        }
-
-        return base64_encode($json);
+        new Encrypter(str_repeat('a', 5));
     }
 
     /**
-     * Encrypt a string without serialization.
-     *
-     * @param  string  $value
-     * @return string
+     * @expectedException RuntimeException
+     * @expectedExceptionMessage The only supported ciphers are AES-128-CBC and AES-256-CBC with the correct key lengths.
      */
-    public function encryptString($value)
+    public function testWithBadKeyLengthAlternativeCipher()
     {
-        return $this->encrypt($value, false);
+        new Encrypter(str_repeat('a', 16), 'AES-256-CFB8');
     }
 
     /**
-     * Decrypt the given value.
-     *
-     * @param  mixed  $payload
-     * @param  bool  $unserialize
-     * @return string
-     *
-     * @throws \Illuminate\Contracts\Encryption\DecryptException
+     * @expectedException RuntimeException
+     * @expectedExceptionMessage The only supported ciphers are AES-128-CBC and AES-256-CBC with the correct key lengths.
      */
-    public function decrypt($payload, $unserialize = true)
+    public function testWithUnsupportedCipher()
     {
-        $payload = $this->getJsonPayload($payload);
-
-        $iv = base64_decode($payload['iv']);
-
-        // Here we will decrypt the value. If we are able to successfully decrypt it
-        // we will then unserialize it and return it out to the caller. If we are
-        // unable to decrypt this value we will throw out an exception message.
-        $decrypted = \openssl_decrypt(
-            $payload['value'], $this->cipher, $this->key, 0, $iv
-        );
-
-        if ($decrypted === false) {
-            throw new DecryptException('Could not decrypt the data.');
-        }
-
-        return $unserialize ? unserialize($decrypted) : $decrypted;
+        new Encrypter(str_repeat('c', 16), 'AES-256-CFB8');
     }
 
     /**
-     * Decrypt the given string without unserialization.
-     *
-     * @param  string  $payload
-     * @return string
+     * @expectedException Illuminate\Contracts\Encryption\DecryptException
+     * @expectedExceptionMessage The payload is invalid.
      */
-    public function decryptString($payload)
+    public function testExceptionThrownWhenPayloadIsInvalid()
     {
-        return $this->decrypt($payload, false);
+        $e = new Encrypter(str_repeat('a', 16));
+        $payload = $e->encrypt('foo');
+        $payload = str_shuffle($payload);
+        $e->decrypt($payload);
     }
 
     /**
-     * Create a MAC for the given value.
-     *
-     * @param  string  $iv
-     * @param  mixed  $value
-     * @return string
+     * @expectedException Illuminate\Contracts\Encryption\DecryptException
+     * @expectedExceptionMessage The MAC is invalid.
      */
-    protected function hash($iv, $value)
+    public function testExceptionThrownWithDifferentKey()
     {
-        return hash_hmac('sha256', $iv.$value, $this->key);
-    }
-
-    /**
-     * Get the JSON array from the given payload.
-     *
-     * @param  string  $payload
-     * @return array
-     *
-     * @throws \Illuminate\Contracts\Encryption\DecryptException
-     */
-    protected function getJsonPayload($payload)
-    {
-        $payload = json_decode(base64_decode($payload), true);
-
-        // If the payload is not valid JSON or does not have the proper keys set we will
-        // assume it is invalid and bail out of the routine since we will not be able
-        // to decrypt the given value. We'll also check the MAC for this encryption.
-        if (! $this->validPayload($payload)) {
-            throw new DecryptException('The payload is invalid.');
-        }
-
-        if (! $this->validMac($payload)) {
-            throw new DecryptException('The MAC is invalid.');
-        }
-
-        return $payload;
-    }
-
-    /**
-     * Verify that the encryption payload is valid.
-     *
-     * @param  mixed  $payload
-     * @return bool
-     */
-    protected function validPayload($payload)
-    {
-        return is_array($payload) && isset(
-            $payload['iv'], $payload['value'], $payload['mac']
-        );
-    }
-
-    /**
-     * Determine if the MAC for the given payload is valid.
-     *
-     * @param  array  $payload
-     * @return bool
-     */
-    protected function validMac(array $payload)
-    {
-        $calculated = $this->calculateMac($payload, $bytes = random_bytes(16));
-
-        return hash_equals(
-            hash_hmac('sha256', $payload['mac'], $bytes, true), $calculated
-        );
-    }
-
-    /**
-     * Calculate the hash of the given payload.
-     *
-     * @param  array  $payload
-     * @param  string  $bytes
-     * @return string
-     */
-    protected function calculateMac($payload, $bytes)
-    {
-        return hash_hmac(
-            'sha256', $this->hash($payload['iv'], $payload['value']), $bytes, true
-        );
-    }
-
-    /**
-     * Get the encryption key.
-     *
-     * @return string
-     */
-    public function getKey()
-    {
-        return $this->key;
+        $a = new Encrypter(str_repeat('a', 16));
+        $b = new Encrypter(str_repeat('b', 16));
+        $b->decrypt($a->encrypt('baz'));
     }
 }

--- a/tests/Encryption/EncrypterTest.php
+++ b/tests/Encryption/EncrypterTest.php
@@ -15,13 +15,13 @@ class EncrypterTest extends TestCase
         $this->assertEquals('foo', $e->decrypt($encrypted));
     }
 
-	public function testEncryptionWithPassword()
-	{
-		$e = new Encrypter(str_repeat('a', 16));
-		$encrypted = $e->encryptWithPassword('foo', true, 'bar');
-		$this->assertNotEquals('foo', $encrypted);
-		$this->assertSame('foo', $e->decrypt($encrypted, true, 'bar'));
-	}
+    public function testEncryptionWithPassword()
+    {
+        $e = new Encrypter(str_repeat('a', 16));
+        $encrypted = $e->encryptWithPassword('foo', true, 'bar');
+        $this->assertNotEquals('foo', $encrypted);
+        $this->assertSame('foo', $e->decrypt($encrypted, true, 'bar'));
+    }
 
     public function testRawStringEncryption()
     {


### PR DESCRIPTION
My last request was closed with comment: "No need for any of this. All you need to do is:

> $encrypter = new Encrypter('key', 'cipher');"

The goal is to allow custom passwords when encrypting data, the code I provided allows for this by converting a password string into an acceptable key to match with the cipher. e.g.

`        $iterations = 1000;
        $salt = $this->key;
        $key = hash_pbkdf2('sha256', $password, $salt, $iterations, 32);
`

As suggested, if I were to instantiate the Encrypter class with a string password that doesn't match the cipher, then an exception is raised.

`$string` = 'secret message';`
`$pass = 'swordfish';`

`$encrypter = new Encrypter($pass, 'AES-128-CBC');`

`The only supported ciphers are AES-128-CBC and AES-256-CBC with the correct key lengths.`

Please reconsider or provide a better explanation.
