### PR TITLE
[5.4] Allow getActualClassNameForMorph() used by createModelByType() to be overridden

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -147,7 +147,7 @@ class MorphTo extends BelongsTo
      */
     public function createModelByType($type)
     {
-        $class = Model::getActualClassNameForMorph($type);
+        $class = static::getActualClassNameForMorph($type);
 
         return new $class;
     }


### PR DESCRIPTION
Refer to #18058.