### PR TITLE
[5.4] Added ability to granularly set mailable tries & timeout

### DIFF
--- a/src/Illuminate/Mail/SendQueuedMailable.php
+++ b/src/Illuminate/Mail/SendQueuedMailable.php
@@ -23,6 +23,8 @@ class SendQueuedMailable
     public function __construct(MailableContract $mailable)
     {
         $this->mailable = $mailable;
+        $this->tries = property_exists($mailable, 'tries') ? $mailable->tries : null;
+        $this->timeout = property_exists($mailable, 'timeout') ? $mailable->timeout : null;
     }
 
     /**

--- a/src/Illuminate/Mail/SendQueuedMailable.php
+++ b/src/Illuminate/Mail/SendQueuedMailable.php
@@ -15,6 +15,20 @@ class SendQueuedMailable
     public $mailable;
 
     /**
+     * The number of times the job may be attempted.
+     *
+     * @var int
+     */
+    public $tries;
+
+    /**
+     * The number of seconds the job can run before timing out.
+     *
+     * @var int
+     */
+    public $timeout;
+
+    /**
      * Create a new job instance.
      *
      * @param  \Illuminate\Contracts\Mail\Mailable  $mailable


### PR DESCRIPTION
This will allow for something like:

```
class TestMail extends Mailable implements ShouldQueue
{
    use Queueable, SerializesModels;

    public $tries = 10;

    /**
     * Build the message.
     *
     * @return $this
     */
    public function build()
    {
        return $this->view('mail.newOrder');
    }
}
```