### PR TITLE
[5.4] Add getActionMethod to Route class

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -646,7 +646,7 @@ class Route
     {
         return isset($this->action['controller']) ? $this->action['controller'] : 'Closure';
     }
-    
+
     /**
      * Get only the method name of the route action.
      *

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -648,7 +648,7 @@ class Route
     }
 
     /**
-     * Get only the method name of the route action.
+     * Get the method name of the route action.
      *
      * @return string
      */

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -646,6 +646,16 @@ class Route
     {
         return isset($this->action['controller']) ? $this->action['controller'] : 'Closure';
     }
+    
+    /**
+     * Get only the method name of the route action.
+     *
+     * @return string
+     */
+    public function getActionMethod()
+    {
+        return array_last(explode('@', $this->getActionName()));
+    }
 
     /**
      * Get the action array for the route.


### PR DESCRIPTION
With the 'getActionName' we'd get the full namespace of the Controller plus the method that is called inside it. This function returns only the name of the method that is called inside the Controller.
I'm assuming that this is useful only for those who have Route actions in the form Controller@method, otherwise 'Closure' is always returned from both methods.

This would be nice to have, at least for my use case:

I'll have several App\Http\Requests\<ControllerName>Request classes (one for each Controller where Form Request Validation is needed) that extend from a base App\Http\Requests\Request.

On the child classes I'll have methods with the same name of the Controller methods. Example: if the Controller as a 'store' method, I'll have a 'store' method on my Request that returns the rules needed for that validation.

On the base class, I'll have the usual 'rules' method that would do the following:

```
if (method_exists($this, $this->route()->getActionMethod())) {
  return $this->{$action}();
}
return [];
```

I'm not sure if this is really usefull or not, but I thought I should share it anyway.