### PR TITLE
[5.5] [WIP] Eloquent object casting

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -534,7 +534,7 @@ trait HasAttributes
             return $this->classCastCache[$key];
         } else {
             return $this->classCastCache[$key] = forward_static_call(
-                [$this->getCasts()[$key], 'fromModelAttributes'], $this, $this->attributes
+                [$this->getCasts()[$key], 'fromModelAttributes'], $this->attributes, $key, $this
             );
         }
     }
@@ -565,7 +565,8 @@ trait HasAttributes
     {
         foreach ($this->classCastCache as $key => $value) {
             $this->attributes = array_merge(
-                $this->attributes, $value->toModelAttributes($this, $this->attributes)
+                $this->attributes,
+                $value->toModelAttributes($this->attributes, $key, $this)
             );
         }
     }
@@ -640,7 +641,7 @@ trait HasAttributes
                 function () {
                     return null;
                 },
-                $this->castToClass($key)->toModelAttributes($this)
+                $this->castToClass($key)->toModelAttributes($this->attributes, $key, $this)
             ));
 
             unset($this->classCastCache[$key]);

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -484,6 +484,8 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public function save(array $options = [])
     {
+        $this->mergeAttributesFromClassCasts();
+
         $query = $this->newQueryWithoutScopes();
 
         // If the "saving" event returns false we'll bail out of the save and return
@@ -714,6 +716,8 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public function delete()
     {
+        $this->mergeAttributesFromClassCasts();
+
         if (is_null($this->getKeyName())) {
             throw new Exception('No primary key defined on model.');
         }
@@ -1337,6 +1341,18 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     {
         return $this->toJson();
     }
+
+     /**
+      * Prepare the object for serialization.
+      *
+      * @return array
+      */
+     public function __sleep()
+     {
+         $this->mergeAttributesFromClassCasts();
+
+         return array_keys(get_object_vars($this));
+     }
 
     /**
      * When a model is being unserialized, check if it needs to be booted.

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -1319,7 +1319,7 @@ class EloquentTestAddressValueObject implements Arrayable
         $this->lineTwo = $lineTwo;
     }
 
-    public static function fromModelAttributes($model, $attributes)
+    public static function fromModelAttributes($attributes)
     {
         return new static($attributes['line_one'], $attributes['line_two']);
     }


### PR DESCRIPTION
This is a direct port Taylor's PR (#13706). Related "Internals" discussion is: https://github.com/laravel/internals/issues/9.

Object casting solves often requested features like:
- encrypted model attributes (#16457, #16443)
- store encoded images (#16450)
- value objects (#16305, #16460, #13315)
- better JSON attribute handling
- logic for custom field types, like: `polygon`, `enum`, `cidr`, `macaddr`

Objects need to implement two methods (*all 3 parameters are optional*):

```php
class Foobar
{
    public static function fromModelAttributes($attributes, $key, $model);

    public function toModelAttributes($attributes, $key, $model);
}
```

The method signatures are slightly different to #13706, because this PR passes the attribute key to both methods, in order to make objects reusable (so attribute keys don't have to be hard coded).

Objects can be set/updated as usual:
```php
$user = User::create([
    'name' => 'Taylor',
    'token' => new Token('larav3l-secr3t')
]);

$user->update([
    'token' => new Token('adam123')
]);

// set object properties
$user->address->line1 = 'Infinite Loop 1';
$user->address->city = 'Cupertino';
$user->address->zip = '95014';
$user->address->region = 'CA';
$user->save();

// set entire object
$user->address = new Address('19111 Pruneridge Avenue', null, 'Cupertino', 'CA', '95014', null);
$user->save();

// unset an object
$user->address = null;
$user->save();
echo $user->address->line1; // null
```

This however does __not__ work:

```php
$user->token = 'larav3l-secr3t';
$user->save();
```

You may of course add methods to objects:

```php
$user->address->validate(); // bool
```

### `User.php`

```php
<?php

class User extends Model
{
    protected $guarded = [];

    protected $casts = [
        'address' => Address::class,
        'token' => Token::class,
        'meta' => Json::class,
    ];
}
```

### `Token.php`

The token example touches a single model attributes and acts as a accessor/mutator.

```php
<?php

class Token
{
    public $token;

    public function __construct($token)
    {
        $this->token = $token;
    }

    public static function fromModelAttributes($attributes, $key)
    {
        return new static(
            empty($attributes[$key]) ? null : decrypt($attributes[$key])
        );
    }

    public function toModelAttributes($attributes, $key)
    {
        return [
            $key => encrypt($this->token),
        ];
    }
}
```

### `Address.php`

The address example touches multiple model attributes and has a `validate()` method for extra functionality.

```php
<?php

class Address
{
    public $line1, $line2, $city, $region, $zip, $country;

    public function __construct(...$address)
    {
        [$this->line1, $this->line2, $this->city, $this->region, $this->zip, $this->country] = $address;
    }

    public function validate()
    {
        return Validator::make($this->toModelAttributes(), [
            'line1' => 'required',
            'city' => 'required',
            'zip' => 'required',
            'country' => 'required',
        ])->passes();
    }

    public static function fromModelAttributes($attributes, $key)
    {
        $address = array_map(function ($key) use ($attributes) {
            return $attributes[$key] ?? null;
        }, ['line1', 'price', 'city', 'region', 'zip', 'country']);

        return new static(...$address);
    }

    public function toModelAttributes()
    {
        return get_object_vars($this);
    }
}
```

### `Json.php`

The JSON example acts as a little helper to make it easier work with nested JSON data.

```php
<?php

namespace App;

class Json
{
    public $json;

    public function __construct($json = null)
    {
        $this->json = is_array($json) ? json_decode(json_encode($json)) : $json;
    }

    public static function fromModelAttributes($attributes, $key)
    {
        return new static(
            empty($attributes[$key]) ? null : json_decode($attributes[$key])
        );
    }

    public function toModelAttributes($attributes, $key)
    {
        return [
            $key => json_encode($this->json),
        ];
    }

    public function __get($name)
    {
        return $this->json->{$name};
    }

    public function __set($name, $value)
    {
        if (is_null($this->json)) {
            $this->json = (object) [];
        }

        if (is_array($value)) {
            $value = (object) $value;
        }

        $this->json->{$name} = $value;
    }
}
```