### PR TITLE
[5.4] Updated causedByDeadlock to catch Sqlite3 deadlock

### DIFF
--- a/src/Illuminate/Database/DetectsDeadlocks.php
+++ b/src/Illuminate/Database/DetectsDeadlocks.php
@@ -21,6 +21,8 @@ trait DetectsDeadlocks
             'Deadlock found when trying to get lock',
             'deadlock detected',
             'The database file is locked',
+            'database is locked',
+            'database table is locked',
             'A table in the database is locked',
             'has been chosen as the deadlock victim',
         ]);


### PR DESCRIPTION
Sqlite3's deadlock messages are "database is locked" (SQLITE_BUSY) and "database table is locked" (SQLITE_LOCKED)