### PR TITLE
[5.5] Refactor Illuminate\Database\Connection

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -16,9 +16,8 @@ use Doctrine\DBAL\Connection as DoctrineConnection;
 use Illuminate\Database\Query\Processors\Processor;
 use Illuminate\Database\Query\Builder as QueryBuilder;
 use Illuminate\Database\Schema\Builder as SchemaBuilder;
-use Illuminate\Database\Query\Grammars\Grammar as QueryGrammar;
 
-class Connection implements ConnectionInterface
+abstract class Connection implements ConnectionInterface
 {
     use DetectsDeadlocks,
         DetectsLostConnections,
@@ -188,10 +187,7 @@ class Connection implements ConnectionInterface
      *
      * @return \Illuminate\Database\Query\Grammars\Grammar
      */
-    protected function getDefaultQueryGrammar()
-    {
-        return new QueryGrammar;
-    }
+    abstract protected function getDefaultQueryGrammar();
 
     /**
      * Set the schema grammar to the default implementation.
@@ -208,10 +204,7 @@ class Connection implements ConnectionInterface
      *
      * @return \Illuminate\Database\Schema\Grammars\Grammar
      */
-    protected function getDefaultSchemaGrammar()
-    {
-        //
-    }
+    abstract protected function getDefaultSchemaGrammar();
 
     /**
      * Set the query post processor to the default implementation.
@@ -228,10 +221,7 @@ class Connection implements ConnectionInterface
      *
      * @return \Illuminate\Database\Query\Processors\Processor
      */
-    protected function getDefaultPostProcessor()
-    {
-        return new Processor;
-    }
+    abstract protected function getDefaultPostProcessor();
 
     /**
      * Get a schema builder instance for the connection.
@@ -842,6 +832,13 @@ class Connection implements ConnectionInterface
 
         return $schema->listTableDetails($table)->getColumn($column);
     }
+
+    /**
+     * Get the Doctrine DBAL driver.
+     *
+     * @return \Doctrine\DBAL\Driver\Driver
+     */
+    abstract protected function getDoctrineDriver();
 
     /**
      * Get the Doctrine DBAL schema manager for the connection.

--- a/tests/Database/DatabaseConnectionTest.php
+++ b/tests/Database/DatabaseConnectionTest.php
@@ -265,7 +265,7 @@ class DatabaseConnectionTest extends TestCase
         $pdo->shouldReceive('prepare')->once()->andReturn($statement);
         $statement->shouldReceive('execute')->once()->andThrow(new \PDOException('server has gone away'));
 
-        $connection = new \Illuminate\Database\Connection($pdo);
+        $connection = $this->getMockConnection([], $pdo);
         $connection->beginTransaction();
         $connection->statement('foo');
     }
@@ -280,7 +280,7 @@ class DatabaseConnectionTest extends TestCase
 
         $pdo->shouldReceive('prepare')->twice()->andReturn($statement);
 
-        $connection = new \Illuminate\Database\Connection($pdo);
+        $connection = $this->getMockConnection([], $pdo);
 
         $called = false;
 
@@ -379,7 +379,7 @@ class DatabaseConnectionTest extends TestCase
     protected function getMockConnection($methods = [], $pdo = null)
     {
         $pdo = $pdo ?: new DatabaseConnectionTestMockPDO;
-        $defaults = ['getDefaultQueryGrammar', 'getDefaultPostProcessor', 'getDefaultSchemaGrammar'];
+        $defaults = ['getDefaultQueryGrammar', 'getDefaultPostProcessor', 'getDefaultSchemaGrammar', 'getDoctrineDriver'];
         $connection = $this->getMockBuilder('Illuminate\Database\Connection')->setMethods(array_merge($defaults, $methods))->setConstructorArgs([$pdo])->getMock();
         $connection->enableQueryLog();
 


### PR DESCRIPTION
Whilst working on a different new feature for 5.5 (outside the scope of this PR) - I've run into something that I feel should be refactored.

Currently `\Illuminate\Database\Connection` is a normal class. I propose it should be an `abstract` class. There are a few reasons for this;

1. `Connection` calls `$this->getDoctrineDriver()` throughout. Except there is actually no `getDoctrineDriver()` function within the `Connection` class. The function *only* exists on the classes that currently extend `Connection` (such as `MySqlConnection`)

2. `Connection` implements some functions - but actually leaves them blank for other classes to extend on - such as 

```
protected function getDefaultSchemaGrammar()
{
    //
}
```

3. All four database connections (`MySqlConnection`, `PostgresConnection`, `SQLiteConnection`, `SqlServerConnection`) currently extend `Connection` and implement:

```
getDefaultQueryGrammar()
getDefaultSchemaGrammar()
getDefaultPostProcessor()
getDoctrineDriver()
```

4. When would you ever want a `Connection` and not the actual driver (such as `MySqlConnection`)? Given the base `Connection` might not have the correct QueryGrammer etc (because you are using the wrong class) - it seems risky to use it?

I tried changing the `Connection` class to `abstract` and running the framework unit tests to see what happens. Only 2 tests break:

```
DatabaseConnectionTest.php:283:
Illuminate\Tests\Database\DatabaseConnectionTest::testOnLostConnectionPDOIsSwappedOutsideTransaction
Error: Cannot instantiate abstract class Illuminate\Database\Connection
```

```
Illuminate\Tests\Database\DatabaseConnectionTest::testOnLostConnectionPDOIsNotSwappedWithinATransaction
Failed asserting that exception of type "Error" matches expected exception "\Illuminate\Database\QueryException". Message was: "Cannot instantiate abstract class Illuminate\Database\Connection" at
DatabaseConnectionTest.php:268
```

I had a look at those 2 tests. The code that fails is: 

`$connection = new \Illuminate\Database\Connection($pdo);`

I'm not sure why they are trying to `new` up a `Connection` rather than using the mock that the other tests use? Looking at all the other tests in that suite - they all use:

`$connection = $this->getMockConnection([], $pdo);`

Changing the 2 instances of this makes all framework tests pass green across the board. But is that hiding an error - or is that allowed?

I apologise in advance if I've missed something that would prevent this from happening. Apart from the two tests, everything else seems to work with the change. But I appreciate there are possibly scenarios I have not thought of.