### PR TITLE
[5.4] Update dirty attributes when soft deleting Eloquent model.

### DIFF
--- a/src/Illuminate/Database/Eloquent/SoftDeletes.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletes.php
@@ -11,7 +11,6 @@ trait SoftDeletes
      */
     protected $forceDeleting = false;
 
-
     /**
      * Indicates if the model should also update dirty attributes in addition to soft deleting.
      *

--- a/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
@@ -158,6 +158,17 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
         $this->assertNull(SoftDeletesTestUser::find(2)->deleted_at);
     }
 
+    public function testDeleteWithUpdateSetsDirtyAttributes()
+    {
+        $this->createUsers();
+
+        $abigail = SoftDeletesTestUser::find(2);
+        $abigail->email = 'test@gmail.com';
+        $abigail->deleteWithUpdate();
+
+        $this->assertEquals('test@gmail.com', SoftDeletesTestUser::withTrashed()->find(2)->email);
+    }
+
     public function testForceDeleteActuallyDeletesRecords()
     {
         $this->createUsers();

--- a/tests/Database/DatabaseSoftDeletingTraitTest.php
+++ b/tests/Database/DatabaseSoftDeletingTraitTest.php
@@ -25,6 +25,17 @@ class DatabaseSoftDeletingTraitTest extends TestCase
         $this->assertInstanceOf('Carbon\Carbon', $model->deleted_at);
     }
 
+    public function testDeleteWithUpdateSetsDirtyAttributes()
+    {
+        $model = m::mock('Illuminate\Tests\Database\DatabaseSoftDeletingTraitStub');
+        $model->shouldDeferMissing();
+        // $model->shouldReceive('newQuery')->andReturn($query = m::mock('StdClass'));
+        $model->shouldReceive('newQueryWithoutScopes')->andReturn($query = m::mock('StdClass'));
+        $query->shouldReceive('where')->once()->with('id', 1)->andReturn($query);
+        $query->shouldReceive('update')->once()->with(['deleted_at' => 'date-time', 'dirty' => true]);
+        $model->deleteWithUpdate();
+    }
+
     public function testRestore()
     {
         $model = m::mock('Illuminate\Tests\Database\DatabaseSoftDeletingTraitStub');
@@ -92,5 +103,10 @@ class DatabaseSoftDeletingTraitStub
     public function fromDateTime()
     {
         return 'date-time';
+    }
+
+    public function getDirty()
+    {
+        return ['dirty' => true];
     }
 }


### PR DESCRIPTION
Add protected variable `updateDirtyOnDelete` to track if dirty attributes should be updated when deleting.
Add function `deleteWithUpdate()` to update dirty attributes when deleting.
Modify `runSoftDelete()` to update dirty attributes when `updateDirtyOnDelete == true`.
Update unit tests for new functionality.

With this change, one can make modifications to their model and call `deleteWithUpdate()` to persist any changes to the database.

Before:
```php
$model->deleted_by = $user->id;
$model->save();
$model->delete();
```

After:
```php
$model->deleted_by = $user->id;
$model->deleteWithUpdate();
```

The original `delete()` function will still behave the same way as before so no existing applications will break with this change. The only instance where this will cause a breaking change is if a class implementing the `SoftDeletes` trait has the following variable:
```php
protected $updateDirtyOnDelete = false;
```