### PR TITLE
[5.4] Allow routes to match one or many subdomains

### DIFF
--- a/CHANGELOG-5.4.md
+++ b/CHANGELOG-5.4.md
@@ -4,6 +4,7 @@
 
 ### Added
 - Added `Str::kebab()` and `kebab_case()` helper ([#18084](https://github.com/laravel/framework/pull/18084))
+- Routes can now be restricted to a subdomain ([#18126](https://github.com/laravel/framework/pull/18126))
 
 ### Changed
 - Create `TestResponse` using composition instead of inheritance ([#18089](https://github.com/laravel/framework/pull/18089))

--- a/CHANGELOG-5.4.md
+++ b/CHANGELOG-5.4.md
@@ -4,7 +4,6 @@
 
 ### Added
 - Added `Str::kebab()` and `kebab_case()` helper ([#18084](https://github.com/laravel/framework/pull/18084))
-- Routes can now be restricted to a subdomain ([#18126](https://github.com/laravel/framework/pull/18126))
 
 ### Changed
 - Create `TestResponse` using composition instead of inheritance ([#18089](https://github.com/laravel/framework/pull/18089))

--- a/src/Illuminate/Routing/Matching/SubdomainValidator.php
+++ b/src/Illuminate/Routing/Matching/SubdomainValidator.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Illuminate\Routing\Matching;
+
+use Illuminate\Http\Request;
+use Illuminate\Routing\Route;
+
+class SubdomainValidator implements ValidatorInterface
+{
+    /**
+     * Validate a given rule against a route and request.
+     *
+     * @param  \Illuminate\Routing\Route  $route
+     * @param  \Illuminate\Http\Request  $request
+     * @return bool
+     */
+    public function matches(Route $route, Request $request)
+    {
+        if (is_null($route->subdomain())) {
+            return true;
+        }
+
+        $subdomains = implode('|', $route->subdomain());
+        $regex = "/^$subdomains\..*/i";
+
+        return preg_match($regex, $request->getHost());
+    }
+}

--- a/src/Illuminate/Routing/Matching/SubdomainValidator.php
+++ b/src/Illuminate/Routing/Matching/SubdomainValidator.php
@@ -20,8 +20,8 @@ class SubdomainValidator implements ValidatorInterface
             return true;
         }
 
-        $subdomains = implode('|', $route->subdomain());
-        $regex = "/^$subdomains\..*/i";
+        $subdomains = implode('\.|', $route->subdomain());
+        $regex = "/^($subdomains).*/i";
 
         return preg_match($regex, $request->getHost());
     }

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Routing;
 
 use Closure;
-use Illuminate\Routing\Matching\SubdomainValidator;
 use LogicException;
 use ReflectionFunction;
 use Illuminate\Support\Arr;
@@ -14,6 +13,7 @@ use Illuminate\Routing\Matching\UriValidator;
 use Illuminate\Routing\Matching\HostValidator;
 use Illuminate\Routing\Matching\MethodValidator;
 use Illuminate\Routing\Matching\SchemeValidator;
+use Illuminate\Routing\Matching\SubdomainValidator;
 use Illuminate\Http\Exceptions\HttpResponseException;
 
 class Route
@@ -541,7 +541,7 @@ class Route
      */
     public function subdomain()
     {
-        if (!isset($this->action['subdomain'])) {
+        if (! isset($this->action['subdomain'])) {
             return null;
         }
 

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Routing;
 
 use Closure;
+use Illuminate\Routing\Matching\SubdomainValidator;
 use LogicException;
 use ReflectionFunction;
 use Illuminate\Support\Arr;
@@ -534,6 +535,20 @@ class Route
     }
 
     /**
+     * Get the domain defined for the route.
+     *
+     * @return array|null
+     */
+    public function subdomain()
+    {
+        if (!isset($this->action['subdomain'])) {
+            return null;
+        }
+
+        return is_array($this->action['subdomain']) ? $this->action['subdomain'] : [$this->action['subdomain']];
+    }
+
+    /**
      * Get the prefix of the route instance.
      *
      * @return string
@@ -752,8 +767,11 @@ class Route
         // validator implementations. We will spin through each one making sure it
         // passes and then we will know if the route as a whole matches request.
         return static::$validators = [
-            new UriValidator, new MethodValidator,
-            new SchemeValidator, new HostValidator,
+            new SubdomainValidator,
+            new UriValidator,
+            new MethodValidator,
+            new SchemeValidator,
+            new HostValidator,
         ];
     }
 

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -545,7 +545,7 @@ class Route
             return null;
         }
 
-        return is_array($this->action['subdomain']) ? $this->action['subdomain'] : [$this->action['subdomain']];
+        return (array) $this->action['subdomain'];
     }
 
     /**

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -541,11 +541,7 @@ class Route
      */
     public function subdomain()
     {
-        if (! isset($this->action['subdomain'])) {
-            return null;
-        }
-
-        return (array) $this->action['subdomain'];
+        return isset($this->action['subdomain']) ? (array) $this->action['subdomain'] : null;
     }
 
     /**

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -529,8 +529,8 @@ class RoutingRouteTest extends TestCase
         }]);
         $this->assertTrue($route->matches($request));
 
-        $request = Request::create('http://api.foo.com/bar', 'GET');
-        $route = new Route('GET', 'bar', ['subdomain' => ['api', 'backend'], function () {
+        $request = Request::create('http://api.v2.foo.co.uk/bar', 'GET');
+        $route = new Route('GET', 'bar', ['subdomain' => ['api.v2', 'backend'], function () {
         }]);
         $this->assertTrue($route->matches($request));
 
@@ -539,8 +539,8 @@ class RoutingRouteTest extends TestCase
         }]);
         $this->assertFalse($route->matches($request));
 
-        $request = Request::create('http://www.foo.com/bar', 'GET');
-        $route = new Route('GET', 'bar', ['subdomain' => ['api', 'backend'], function () {
+        $request = Request::create('http://api.v1.foo.co.uk/bar', 'GET');
+        $route = new Route('GET', 'bar', ['subdomain' => ['api.v2', 'api.latest'], function () {
         }]);
         $this->assertFalse($route->matches($request));
     }

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -526,25 +526,21 @@ class RoutingRouteTest extends TestCase
          */
         $request = Request::create('http://api.foo.com/bar', 'GET');
         $route = new Route('GET', 'bar', ['subdomain' => 'api', function () {
-
         }]);
         $this->assertTrue($route->matches($request));
 
         $request = Request::create('http://api.foo.com/bar', 'GET');
         $route = new Route('GET', 'bar', ['subdomain' => ['api', 'backend'], function () {
-
         }]);
         $this->assertTrue($route->matches($request));
 
         $request = Request::create('http://api.foo.com/bar', 'GET');
         $route = new Route('GET', 'bar', ['subdomain' => 'backend', function () {
-
         }]);
         $this->assertFalse($route->matches($request));
 
         $request = Request::create('http://www.foo.com/bar', 'GET');
         $route = new Route('GET', 'bar', ['subdomain' => ['api', 'backend'], function () {
-
         }]);
         $this->assertFalse($route->matches($request));
     }


### PR DESCRIPTION
Hi!

In relation with [laravel/internals Allows routes to match a subdomain #367](https://github.com/laravel/internals/issues/367).

You can now:
```php
// Will match admin.youdomain.com
Route::get('/', ['subdomain' => 'admin', 'uses' => 'AdminController@index']);
```

Or:
```php
Route::group(['subdomain' => ['backend', 'admin']], function($router) {
    $router->get('/', 'AdminController@index');
});
```

If accepted, I can update the doc.