### PR TITLE
[5.4] Use fromRawAttributes when creating a newPivot

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -870,7 +870,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public function newPivot(Model $parent, array $attributes, $table, $exists, $using = null)
     {
-        return $using ? new $using($parent, $attributes, $table, $exists)
+        return $using ? $using::fromRawAttributes($parent, $attributes, $table, $exists)
                       : new Pivot($parent, $attributes, $table, $exists);
     }
 


### PR DESCRIPTION
Casting attributes stored as JSON don't work properly when using a pivot model and setting the `$casts` property.

In 5.2 fromRawAttributes method was added to manually resolve this issue. https://github.com/laravel/framework/pull/13294

When using the new "using" method, for example: `$this->belongsToMany(Team::class, 'user_teams', 'user_id', 'team_id')->using(UserTeamPivot::class)`, the JSON is still encoded twice. It would be great if this could be changed so the `fromRawAttributes` method is used.

```php
class UserTeamPivot extends Pivot
{
    protected $casts = ['permissions' => 'collection'];
}
```

```php
// App\User::find(1)->teams->first()
 App\Team {#1437
     id: 1,
     name: "Team Name",
     pivot: App\UserTeamPivot {#1436
       user_id: 1,
       team_id: 1,
       permissions: ""[\"create_campaign\"]"",
     },
   }
```

When using the `fromRawAttributes` method this is resolved.

```php
// App\User::find(1)->teams->first()
 App\Team {#1437
     id: 1,
     name: "Team Name",
     pivot: App\UserTeamPivot {#1436
       user_id: 1,
       team_id: 1,
       permissions: "["create_campaign"]",
     },
   }
```