### PR TITLE
[5.4] DatabaseManager::purge with no argument

### DIFF
--- a/src/Illuminate/Database/DatabaseManager.php
+++ b/src/Illuminate/Database/DatabaseManager.php
@@ -194,7 +194,7 @@ class DatabaseManager implements ConnectionResolverInterface
      */
     public function purge($name = null)
     {
-    	$name = $name ?: $this->getDefaultConnection();
+        $name = $name ?: $this->getDefaultConnection();
 
         $this->disconnect($name);
 

--- a/src/Illuminate/Database/DatabaseManager.php
+++ b/src/Illuminate/Database/DatabaseManager.php
@@ -194,6 +194,8 @@ class DatabaseManager implements ConnectionResolverInterface
      */
     public function purge($name = null)
     {
+    	$name = $name ?: $this->getDefaultConnection();
+
         $this->disconnect($name);
 
         unset($this->connections[$name]);


### PR DESCRIPTION
Previously, if no argument was passed, `unset($this->connections[null])` was executed, whereas the key for default connection is obviously not `null`. I haven't found any tests for DatabaseManager, that's why I haven't created a test for this fix.