### PR TITLE
Fix in Broadcast::routes() controller's class path

### DIFF
--- a/src/Illuminate/Broadcasting/BroadcastManager.php
+++ b/src/Illuminate/Broadcasting/BroadcastManager.php
@@ -63,7 +63,7 @@ class BroadcastManager implements FactoryContract
         $attributes = $attributes ?: ['middleware' => ['web']];
 
         $this->app['router']->group($attributes, function ($router) {
-            $router->post('/broadcasting/auth', BroadcastController::class.'@authenticate');
+            $router->post('/broadcasting/auth', '\Illuminate\Broadcasting\BroadcastController@authenticate');
         });
     }
 


### PR DESCRIPTION
I got this error while using laravel echo server.
The route `/broadcasting/auth`  returns `Class App\Http\Controllers\Illuminate\Broadcasting\BroadcastController does not exist`
It works when pointing to the full BroadcastController's class path