### PR TITLE
[5.5] Default value to true in session's Store::flash

### DIFF
--- a/src/Illuminate/Session/Store.php
+++ b/src/Illuminate/Session/Store.php
@@ -337,7 +337,7 @@ class Store implements Session
      * @param  mixed   $value
      * @return void
      */
-    public function flash($key, $value)
+    public function flash($key, $value = true)
     {
         $this->put($key, $value);
 

--- a/tests/Session/SessionStoreTest.php
+++ b/tests/Session/SessionStoreTest.php
@@ -137,10 +137,12 @@ class SessionStoreTest extends TestCase
         $session = $this->getSession();
         $session->flash('foo', 'bar');
         $session->flash('bar', 0);
+        $session->flash('baz');
 
         $this->assertTrue($session->has('foo'));
         $this->assertEquals('bar', $session->get('foo'));
         $this->assertEquals(0, $session->get('bar'));
+        $this->assertTrue($session->get('baz'));
 
         $session->ageFlashData();
 


### PR DESCRIPTION
This would be useful for cases in which you don't care about the actual contents of the flash message. Looks cleaner that assigning an arbitrary value like `true`, `'success'` or `1`.

E.g. if you want to display a notification if settings have been saved, and do nothing otherwise.

```php
session()->flash('settings:saved')
```

```html
@if(session()->has('settings:saved'))
    <div class="alert">Saved!</div>
@endif
```