### PR TITLE
[5.4] Have rate limiter set correct counter

### DIFF
--- a/src/Illuminate/Cache/RateLimiter.php
+++ b/src/Illuminate/Cache/RateLimiter.php
@@ -73,7 +73,7 @@ class RateLimiter
      */
     public function hit($key, $decayMinutes = 1)
     {
-        $this->cache->add($key, 1, $decayMinutes);
+        $this->cache->add($key, 0, $decayMinutes);
 
         return (int) $this->cache->increment($key);
     }

--- a/tests/Cache/CacheRateLimiterTest.php
+++ b/tests/Cache/CacheRateLimiterTest.php
@@ -39,11 +39,12 @@ class CacheRateLimiterTest extends TestCase
     public function testHitProperlyIncrementsAttemptCount()
     {
         $cache = m::mock(Cache::class);
-        $cache->shouldReceive('add')->once()->with('key', 1, 1);
+        $cache->shouldReceive('add')->once()->with('key', 0, 1);
         $cache->shouldReceive('increment')->once()->with('key');
         $rateLimiter = new RateLimiter($cache);
 
         $rateLimiter->hit('key', 1);
+        $this->assertEquals(1, $rateLimiter->attempts('key'));
     }
 
     public function testClearClearsTheCacheKeys()

--- a/tests/Cache/CacheRateLimiterTest.php
+++ b/tests/Cache/CacheRateLimiterTest.php
@@ -44,7 +44,6 @@ class CacheRateLimiterTest extends TestCase
         $rateLimiter = new RateLimiter($cache);
 
         $rateLimiter->hit('key', 1);
-        $this->assertEquals(1, $rateLimiter->attempts('key'));
     }
 
     public function testClearClearsTheCacheKeys()


### PR DESCRIPTION
This fixes a very small bug in the rate limiter.

Currently the code for the first hit sets the count to `1` if the key does not exist, then increments it to `2`.

This sets the initial count to `0`, then increments to `1` for the first hit.