### PR TITLE
[5.4] RateLimiter bug fixes

### DIFF
--- a/src/Illuminate/Cache/RateLimiter.php
+++ b/src/Illuminate/Cache/RateLimiter.php
@@ -39,7 +39,7 @@ class RateLimiter
             return true;
         }
 
-        if ($this->attempts($key) > $maxAttempts) {
+        if ($this->attempts($key) >= $maxAttempts) {
             $this->lockout($key, $decayMinutes);
 
             $this->resetAttempts($key);
@@ -73,7 +73,7 @@ class RateLimiter
      */
     public function hit($key, $decayMinutes = 1)
     {
-        $this->cache->add($key, 1, $decayMinutes);
+        $this->cache->add($key, 0, $decayMinutes);
 
         return (int) $this->cache->increment($key);
     }
@@ -111,7 +111,7 @@ class RateLimiter
     {
         $attempts = $this->attempts($key);
 
-        return $attempts === 0 ? $maxAttempts : $maxAttempts - $attempts + 1;
+        return $maxAttempts - $attempts;
     }
 
     /**

--- a/tests/Cache/CacheRateLimiterTest.php
+++ b/tests/Cache/CacheRateLimiterTest.php
@@ -39,11 +39,20 @@ class CacheRateLimiterTest extends TestCase
     public function testHitProperlyIncrementsAttemptCount()
     {
         $cache = m::mock(Cache::class);
-        $cache->shouldReceive('add')->once()->with('key', 1, 1);
+        $cache->shouldReceive('add')->once()->with('key', 0, 1);
         $cache->shouldReceive('increment')->once()->with('key');
         $rateLimiter = new RateLimiter($cache);
 
         $rateLimiter->hit('key', 1);
+    }
+
+    public function testRetriesLeftReturnsCorrectCount()
+    {
+        $cache = m::mock(Cache::class);
+        $cache->shouldReceive('get')->once()->with('key', 0)->andReturn(3);
+        $rateLimiter = new RateLimiter($cache);
+
+        $this->assertEquals(2, $rateLimiter->retriesLeft('key', 5));
     }
 
     public function testClearClearsTheCacheKeys()


### PR DESCRIPTION
There are 3x simultaneous bugs in the current RateLimiter. They currently cancel each other out so as whole the class is working - but individually none of the functions work as intended:

1. `tooManyAttempts()`
Currently if you have `5` attempts in the cache, and a `$maxAttempts` of `5` - this function returns `false`, when it should be `true`.

The reason this was not noticed until now is:

2. `hit()`
Sets the initial count to `1`, then immediately increments it to `2`. So the number of attempts is actually artificially increased by one.

The reason that might never have been noticed until now is:

3. `retriesLeft()`

Currently the function does this:

```
return $attempts === 0 ? $maxAttempts : $maxAttempts - $attempts + 1;
```

Which you can see is actually artificially inflating the retriesLeft by 1. The reason is because, if you had the initial `hit()` wrong - the retriesLeft was also wrong. This PR reduces that code to just

```
return $maxAttempts - $attempts;
```

Because you dont need to adjust `$attempts` anymore - you can take it "as is".

This PR fixes all 3 bugs, yet *should* preserve the current behavior.

I've added an additional test for `retiresLeft()` to help prevent regressions.