### PR TITLE
[5.4] Convert object rules to string only once.

### DIFF
--- a/src/Illuminate/Validation/ValidationRuleParser.php
+++ b/src/Illuminate/Validation/ValidationRuleParser.php
@@ -82,9 +82,9 @@ class ValidationRuleParser
         if (is_string($rule)) {
             return explode('|', $rule);
         } elseif (is_object($rule)) {
-            return [$rule];
+            return [strval($rule)];
         } else {
-            return $rule;
+            return array_map('strval', $rule);
         }
     }
 

--- a/src/Illuminate/Validation/ValidationRuleParser.php
+++ b/src/Illuminate/Validation/ValidationRuleParser.php
@@ -4,6 +4,8 @@ namespace Illuminate\Validation;
 
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
+use Illuminate\Validation\Rules\Exists;
+use Illuminate\Validation\Rules\Unique;
 
 class ValidationRuleParser
 {
@@ -82,10 +84,29 @@ class ValidationRuleParser
         if (is_string($rule)) {
             return explode('|', $rule);
         } elseif (is_object($rule)) {
-            return [strval($rule)];
+            return [$this->prepareRule($rule)];
         } else {
-            return array_map('strval', $rule);
+            return array_map([$this, 'prepareRule'], $rule);
         }
+    }
+
+    /**
+     * Prepare the given rule for the Validator.
+     *
+     * @param  mixed  $rule
+     * @return mixed
+     */
+    protected function prepareRule($rule)
+    {
+        if (
+            ! is_object($rule) ||
+            ($rule instanceof Exists && $rule->queryCallbacks()) ||
+            ($rule instanceof Unique && $rule->queryCallbacks())
+        ) {
+            return $rule;
+        }
+
+        return strval($rule);
     }
 
     /**


### PR DESCRIPTION
Currently if you have this rule definition `'required|'.Rule::in([1,2])`, __toString of `Illuminate\Validation\Rules\In` will be called only once, however in the following two cases the method will be called over 20 times in the second case and 8 times in the first case.

- `Rule::in([1,2])`
- `['required', Rule::in([1,2])]`

This PR converts these object rules to string once in the parser so that we don't have to do it again.