### PR TITLE
[5.4] Add columnize() method to Collection

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1311,7 +1311,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      * e.g. new Collection([1, 2, 3, 4, 5, 6)->columnize(4);
      *      => [[1, 2], [3, 4], [5], [6]]
      *
-     * @param  mixed ...$items
+     * @param  int ...$columns
      * @return static
      */
     public function columnize($columns)

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1306,6 +1306,32 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
+     * Split the collection into columns of equal length.
+     *
+     * e.g. new Collection([1, 2, 3, 4, 5, 6)->columnize(4);
+     *      => [[1, 2], [3, 4], [5], [6]]
+     *
+     * @param  mixed ...$items
+     * @return static
+     */
+    public function columnize($columns)
+    {
+        $listLength = $this->count();
+        $columnLength = floor($listLength / $columns);
+        $columnRemainder = $listLength % $columns;
+        $partitions = [];
+        $mark = 0;
+
+        for ($partition = 0; $partition < $columns; $partition++) {
+            $increment = ($partition < $columnRemainder) ? $columnLength + 1 : $columnLength;
+            $partitions[$partition] = $this->slice($mark, $increment);
+            $mark += $increment;
+        }
+
+        return new static($partitions);
+    }
+
+    /**
      * Get the collection of items as a plain array.
      *
      * @return array

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -405,6 +405,18 @@ class SupportCollectionTest extends TestCase
         })->values()->all());
     }
 
+     public function testColumnize()
+     {
+        $c = new Collection([1, 2, 3, 4]);
+        $this->assertEquals([[0 => 1, 1 => 2], [2 => 3, 3 => 4]], $c->columnize(2)->toArray());
+
+        $c = new Collection([1, 2, 3, 4, 5]);
+        $this->assertEquals([[0 => 1, 1 => 2, 2 => 3], [3 => 4, 4 => 5]], $c->columnize(2)->toArray());
+
+        $c = new Collection([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
+        $this->assertEquals([[0 => 1, 1 => 2, 2 => 3], [3 => 4, 4 => 5, 5 => 6], [6 => 7, 7 => 8, 8 => 9], [9 => 10, 10 => 11]], $c->columnize(4)->toArray());
+     }
+
     public function testFlatten()
     {
         // Flat arrays are unaffected

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -405,8 +405,8 @@ class SupportCollectionTest extends TestCase
         })->values()->all());
     }
 
-     public function testColumnize()
-     {
+    public function testColumnize()
+    {
         $c = new Collection([1, 2, 3, 4]);
         $this->assertEquals([[0 => 1, 1 => 2], [2 => 3, 3 => 4]], $c->columnize(2)->toArray());
 
@@ -415,7 +415,7 @@ class SupportCollectionTest extends TestCase
 
         $c = new Collection([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
         $this->assertEquals([[0 => 1, 1 => 2, 2 => 3], [3 => 4, 4 => 5, 5 => 6], [6 => 7, 7 => 8, 8 => 9], [9 => 10, 10 => 11]], $c->columnize(4)->toArray());
-     }
+    }
 
     public function testFlatten()
     {


### PR DESCRIPTION
We have this setup as a Collection macro in the majority of our projects so thought I'd see if it would be useful to add to the core.

This differs from the `chunk()` method given that you have to pass the number of items you want in each "column", whereas, more often than not we don't care about the number of items in each column. We want to specify the number of columns, and the items are split equally over those columns.

Say you have 18 items and you want to output 4 columns.

```php

$collection = collect([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18]);

dd($collection->columnize(4)->toArray());

/*
array:4 [
  0 => array:5 [
    0 => 1
    1 => 2
    2 => 3
    3 => 4
    4 => 5
  ]
  1 => array:5 [
    5 => 6
    6 => 7
    7 => 8
    8 => 9
    9 => 10
  ]
  2 => array:4 [
    10 => 11
    11 => 12
    12 => 13
    13 => 14
  ]
  3 => array:4 [
    14 => 15
    15 => 16
    16 => 17
    17 => 18
  ]
]
*/
```