### PR TITLE
[5.4] Always put Mailable on queue if ShouldQueue contract exists

### DIFF
--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Arr;
 use InvalidArgumentException;
 use Illuminate\Support\HtmlString;
 use Illuminate\Contracts\View\Factory;
+use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Mail\Mailer as MailerContract;
 use Illuminate\Contracts\Queue\Factory as QueueContract;
@@ -181,6 +182,10 @@ class Mailer implements MailerContract, MailQueueContract
     public function send($view, array $data = [], $callback = null)
     {
         if ($view instanceof MailableContract) {
+            if($view instanceof ShouldQueue) {
+                return $view->queue($this->queue);
+            }
+
             return $view->send($this);
         }
 

--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -8,8 +8,8 @@ use Illuminate\Support\Arr;
 use InvalidArgumentException;
 use Illuminate\Support\HtmlString;
 use Illuminate\Contracts\View\Factory;
-use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Contracts\Mail\Mailer as MailerContract;
 use Illuminate\Contracts\Queue\Factory as QueueContract;
 use Illuminate\Contracts\Mail\Mailable as MailableContract;
@@ -182,7 +182,7 @@ class Mailer implements MailerContract, MailQueueContract
     public function send($view, array $data = [], $callback = null)
     {
         if ($view instanceof MailableContract) {
-            if($view instanceof ShouldQueue) {
+            if ($view instanceof ShouldQueue) {
                 return $view->queue($this->queue);
             }
 


### PR DESCRIPTION
Documentation says:

> If you have mailable classes that you want to always be queued, you may implement the `ShouldQueue` contract on the class. Now, even if you call the send method when mailing, the mailable will still be queued.

With this change, even if I use the `send()` method, will be queued, because the `ShouldQueue` interface was implemented:

```php
class OrderShipped extends Mailable implements ShouldQueue
{
    use Queueable, SerializesModels;

    // todo
}
```

Then:

```php
Mail::send(new OrderShipped()); // Will be queued
Mail::queue(new OrderShipped()); // Will be queued
```

@taylorotwell Is this makes sense for you?