### PR TITLE
[5.5] session cookie secure flag by default for https connections

### DIFF
--- a/src/Illuminate/Session/Middleware/StartSession.php
+++ b/src/Illuminate/Session/Middleware/StartSession.php
@@ -69,7 +69,7 @@ class StartSession
         if ($this->sessionConfigured()) {
             $this->storeCurrentUrl($request, $session);
 
-            $this->addCookieToResponse($response, $session);
+            $this->addCookieToResponse($request, $response, $session);
         }
 
         return $response;
@@ -163,11 +163,12 @@ class StartSession
     /**
      * Add the session cookie to the application response.
      *
+     * @param  \Illuminate\Http\Request  $request
      * @param  \Symfony\Component\HttpFoundation\Response  $response
      * @param  \Illuminate\Contracts\Session\Session  $session
      * @return void
      */
-    protected function addCookieToResponse(Response $response, Session $session)
+    protected function addCookieToResponse(Request $request, Response $response, Session $session)
     {
         if ($this->usingCookieSessions()) {
             $this->manager->driver()->save();
@@ -176,7 +177,7 @@ class StartSession
         if ($this->sessionIsPersistent($config = $this->manager->getSessionConfig())) {
             $response->headers->setCookie(new Cookie(
                 $session->getName(), $session->getId(), $this->getCookieExpirationDate(),
-                $config['path'], $config['domain'], Arr::get($config, 'secure', false),
+                $config['path'], $config['domain'], Arr::get($config, 'secure', $request->secure()),
                 Arr::get($config, 'http_only', true)
             ));
         }


### PR DESCRIPTION
> The secure flag is an option that can be set by the application server when sending a new cookie to the user within an HTTP Response. The purpose of the secure flag is to prevent cookies from being observed by unauthorized parties due to the transmission of a the cookie in clear text.
[OWASP](https://www.owasp.org/index.php/SecureFlag)

in both [StartSession](https://github.com/laravel/framework/blob/5.4/src/Illuminate/Session/Middleware/StartSession.php#L179) middleware and [session config](https://github.com/laravel/laravel/blob/master/config/session.php#L164), it's `false` by default.

I hope we can make the session cookie "secure by default" if request is using HTTS.

What do you think @themsaid?  