### PR TITLE
[5.4] Use setRawAttributes in Pivot constructor to avoid casting twice

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Pivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Pivot.php
@@ -53,7 +53,7 @@ class Pivot extends Model
         // many to many relationship that are defined by this developer's classes.
         $this->setConnection($parent->getConnectionName())
              ->setTable($table)
-             ->forceFill($attributes)
+             ->setRawAttributes($attributes)
              ->syncOriginal();
 
         // We store off the parent instance so we will access the timestamp column names


### PR DESCRIPTION
At present, the Pivot constructor uses `forceFill` to set the attributes of the pivot model, which uses `setAttribute` to set each property and ends up casting the data provided as a string given by the database to the relevant type. Most notably, for attributes that are set to be cast as a JSON castable type (array, object etc.) this results in a JSON encoded string from the database being JSON encoded again when it's being set in the Pivot model. Therefore, accessing such an attribute results in a JSON encoded string being returned rather than an array or stdClass object as expected.

This pull request changes `forceFill` to `setRawAttributes` so that casting is not carried out when setting the Pivot attributes.

#18135 

**Note:** This PR is causing 2 tests to fail. One which ensures mutators are called from the constructor of Pivot and another which ensures that a dummy date passed in has been mutated. My suggestion intentionally skips the mutators by using `setRawAttributes`, similar to when a Model is created, therefore I'm not sure what to do regarding this.