### PR TITLE
Cannot connect to remote database in Postgres.

### DIFF
--- a/src/Illuminate/Database/Connectors/PostgresConnector.php
+++ b/src/Illuminate/Database/Connectors/PostgresConnector.php
@@ -82,7 +82,18 @@ class PostgresConnector extends Connector implements ConnectorInterface
         // need to establish the PDO connections and return them back for use.
         extract($config, EXTR_SKIP);
 
-        $host = isset($host) ? "host={$host};" : '';
+        $IP_PATTERN =
+            "/^([01]?\\d\\d?|2[0-4]\\d|25[0-5])\\.".
+            "([01]?\\d\\d?|2[0-4]\\d|25[0-5])\\.".
+            "([01]?\\d\\d?|2[0-4]\\d|25[0-5])\\.".
+            "([01]?\\d\\d?|2[0-4]\\d|25[0-5])$/";
+
+        if (isset($host)) {
+            $prefix = preg_match($IP_PATTERN, $host) ? "hostaddr" : "host";
+            $host = "{$prefix}={$host};";
+        } else {
+            $host = '';
+        }
 
         $dsn = "pgsql:{$host}dbname={$database}";
 


### PR DESCRIPTION
- Laravel Version: 5.3.30
- PHP Version: 7.0.10.0
- Database Driver & Version: PostgreSQL 9.3

### Description:
When we are connecting to remote database by IP address connection, laravel would use localhost despite given IP. And this is expected behaviour according to this https://www.postgresql.org/docs/current/static/libpq-connect.html#LIBPQ-CONNECT-HOSTADDR 

### Solution
Laravel should replace 'host' with 'hostaddr' for IP connections. As I have done in my fork.

### Steps To Reproduce:
Just specify db connection properties to remote postgres database. Laravel will ignore it and use localhost instead.