### PR TITLE
[5.4] Change Eloquent Builder docblock to return object rather than $this

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -168,7 +168,7 @@ class Builder
      * @param  bool  $value
      * @param  \Closure  $callback
      * @param  \Closure  $default
-     * @return $this
+     * @return \Illuminate\Database\Eloquent\Builder
      */
     public function when($value, $callback, $default = null)
     {
@@ -187,7 +187,7 @@ class Builder
      * Add a where clause on the primary key to the query.
      *
      * @param  mixed  $id
-     * @return $this
+     * @return \Illuminate\Database\Eloquent\Builder
      */
     public function whereKey($id)
     {
@@ -207,7 +207,7 @@ class Builder
      * @param  string  $operator
      * @param  mixed   $value
      * @param  string  $boolean
-     * @return $this
+     * @return \Illuminate\Database\Eloquent\Builder
      */
     public function where($column, $operator = null, $value = null, $boolean = 'and')
     {


### PR DESCRIPTION
In smart IDEs (like PHPStorm) - this was causing the IDE not to know
what $this was due to the docblock. By updating it to show the object
that is being returned - this problem goes away.