### PR TITLE
[5.5] Http: let withHeaders also accept an HeaderBag

### DIFF
--- a/src/Illuminate/Http/ResponseTrait.php
+++ b/src/Illuminate/Http/ResponseTrait.php
@@ -3,7 +3,9 @@
 namespace Illuminate\Http;
 
 use Exception;
+use Symfony\Component\HttpFoundation\HeaderBag;
 use Illuminate\Http\Exceptions\HttpResponseException;
+
 
 trait ResponseTrait
 {
@@ -69,11 +71,15 @@ trait ResponseTrait
     /**
      * Add an array of headers to the response.
      *
-     * @param  array  $headers
+     * @param  \Symfony\Component\HttpFoundation\HeaderBag|array  $headers
      * @return $this
      */
-    public function withHeaders(array $headers)
+    public function withHeaders($headers)
     {
+        if ($headers instanceof HeaderBag) {
+            $headers = $headers->all();
+        }
+
         foreach ($headers as $key => $value) {
             $this->headers->set($key, $value);
         }

--- a/tests/Http/HttpResponseTest.php
+++ b/tests/Http/HttpResponseTest.php
@@ -142,6 +142,26 @@ class HttpResponseTest extends TestCase
         $response->withErrors($provider);
     }
 
+    public function testWithHeaders()
+    {
+        $response = new \Illuminate\Http\Response(null, 200, ['foo' => 'bar']);
+        $this->assertSame('bar', $response->headers->get('foo'));
+
+        $response->withHeaders(['foo' => 'BAR', 'bar' => 'baz']);
+        $this->assertSame('BAR', $response->headers->get('foo'));
+        $this->assertSame('baz', $response->headers->get('bar'));
+
+        $responseMessageBag = new \Symfony\Component\HttpFoundation\ResponseHeaderBag(['bar' => 'BAZ', 'titi' => 'toto']);
+        $response->withHeaders($responseMessageBag);
+        $this->assertSame('BAZ', $response->headers->get('bar'));
+        $this->assertSame('toto', $response->headers->get('titi'));
+
+        $headerBag = new \Symfony\Component\HttpFoundation\HeaderBag(['bar' => 'BAAA', 'titi' => 'TATA']);
+        $response->withHeaders($headerBag);
+        $this->assertSame('BAAA', $response->headers->get('bar'));
+        $this->assertSame('TATA', $response->headers->get('titi'));
+    }
+
     public function testMagicCall()
     {
         $response = new RedirectResponse('foo.bar');


### PR DESCRIPTION
Let withHeaders also accept an HeaderBag.
Also add some tests for `\Illuminate\Http\ResponseTrait::withHeaders`

---

For some reasons CIs seem to be stuck.