### PR TITLE
[5.4] Add context to the assert json test response method

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -201,7 +201,16 @@ class TestResponse
      */
     public function assertJson(array $data)
     {
-        PHPUnit::assertArraySubset($data, $this->decodeResponseJson());
+        $options = JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES;
+        $expected = json_encode($data, $options);
+        $actual = json_encode($this->decodeResponseJson(), $options);
+
+        $message = 'Unable to find JSON subset: '.PHP_EOL.PHP_EOL.
+            "[{$expected}]".PHP_EOL.PHP_EOL.
+            'within'.PHP_EOL.PHP_EOL.
+            "[{$actual}].".PHP_EOL.PHP_EOL;
+
+        PHPUnit::assertArraySubset($data, $this->decodeResponseJson(), $strict = false, $message);
 
         return $this;
     }


### PR DESCRIPTION
The issue with the current `assertJson` method is that it only gives the expected value in the test failure output. 

Any thoughts on this new output? 

### New test failure output:

```
Unable to find JSON subset:

{
     'message' => 'Successfully updated post.'
}

within

{
    "title": [
        "The title field is required."
    ]
}.


Failed asserting that an array has the subset Array &0 (
    'message' => 'Successfully updated post.'
).
```

### Current test failure output:

```
Failed asserting that an array has the subset Array &0 (
    'message' => 'Successfully updated post.'
).
``` 