### PR TITLE
[5.4] Fix validating present with nullable

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -480,7 +480,7 @@ class Validator implements ValidatorContract
             return true;
         }
 
-        return ! is_null($value);
+        return ! is_null(Arr::get($this->data, $attribute, 0));
     }
 
     /**

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -549,6 +549,12 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, [], ['name' => 'present']);
         $this->assertFalse($v->passes());
 
+        $v = new Validator($trans, [], ['name' => 'present|nullable']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['name' => null], ['name' => 'present|nullable']);
+        $this->assertTrue($v->passes());
+
         $v = new Validator($trans, ['name' => ''], ['name' => 'present']);
         $this->assertTrue($v->passes());
 


### PR DESCRIPTION
Having `nullable|present`, we use `Arr::get()` to find the value of the field to check if its nullable, if the field is not present Arr::get() defaults to `null` which causes the validator to consider the attributes as not validatable since it's `null` and null is ok.