### PR TITLE
[5.4] Add any() method to ViewErrorBag

### DIFF
--- a/src/Illuminate/Support/ViewErrorBag.php
+++ b/src/Illuminate/Support/ViewErrorBag.php
@@ -71,6 +71,16 @@ class ViewErrorBag implements Countable
     }
 
     /**
+     * Determine if the default message bag has any messages.
+     *
+     * @return bool
+     */
+    public function any()
+    {
+        return $this->count() > 0;
+    }
+
+    /**
      * Dynamically call methods on the default bag.
      *
      * @param  string  $method


### PR DESCRIPTION
This PR introduces new `any()` method to `ViewErrorBag` class.

This method can be used in views to determine whether the bag contains any errors. Please consider following:

```blade
@if ($errors->count() > 0)

// vs

@if ($errors->any())
```

The name `any()` aligns nicely with `Illuminate\Support\MessageBag::any()`.

🌵 