### PR TITLE
[5.5] Bug fix for emailOutputTo when passed a string

### DIFF
--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -353,7 +353,7 @@ class Event
     /**
      * E-mail the results of the scheduled operation.
      *
-     * @param  array|mixed  $addresses
+     * @param  array|string  $addresses
      * @param  bool  $onlyIfOutputExists
      * @return $this
      *
@@ -363,7 +363,7 @@ class Event
     {
         $this->ensureOutputIsBeingCapturedForEmail();
 
-        $addresses = is_array($addresses) ? $addresses : func_get_args();
+        $addresses = is_array($addresses) ? $addresses : [$addresses];
 
         return $this->then(function (Mailer $mailer) use ($addresses, $onlyIfOutputExists) {
             $this->emailOutput($mailer, $addresses, $onlyIfOutputExists);


### PR DESCRIPTION
The docs illustrate the method `emailOutputTo` to be used like this: `emailOutputTo('foo@example.com')`.

However, the method does not handle the string as it should, because it puts both the string and second parameter in an array. That second parameter is `false` by default, which I guess is being filtered out by further processing, but if the second parameter happens to be true, the array will include both the string and `true`. This results in the mailer trying to send an email to `1` (cast somewhere from `true` I suppose).
Which in turns causes: `Swift_RfcComplianceException: Address in mailbox given [1] does not comply with RFC 2822, 3.6.2.`

That second parameter isn't mentioned in the documentation, but is in the code documentation.

Disclaimer: first pull request ever, be merciful.

To avoid this, without this fix, the method would need to be used like this: `emailOutputTo(['foo@example.com'], true)` instead of `emailOutputTo('foo@example.com', true)`.