### PR TITLE
[5.4] Add named constructor helpers directly to Testing/File

### DIFF
--- a/src/Illuminate/Http/Testing/File.php
+++ b/src/Illuminate/Http/Testing/File.php
@@ -46,6 +46,31 @@ class File extends UploadedFile
     }
 
     /**
+     * Create a new fake file.
+     *
+     * @param  string  $name
+     * @param  int  $kilobytes
+     * @return \Illuminate\Http\Testing\File
+     */
+    public static function create($name, $kilobytes = 0)
+    {
+        return (new FileFactory)->create($name, $kilobytes);
+    }
+
+    /**
+     * Create a new fake image.
+     *
+     * @param  string  $name
+     * @param  int  $height
+     * @param  int  $height
+     * @return \Illuminate\Http\Testing\File
+     */
+    public static function image($name, $width = 10, $height = 10)
+    {
+        return (new FileFactory)->image($name, $width, $height);
+    }
+
+    /**
      * Set the "size" of the file in kilobytes.
      *
      * @param  int  $kilobytes

--- a/src/Illuminate/Http/Testing/File.php
+++ b/src/Illuminate/Http/Testing/File.php
@@ -61,7 +61,7 @@ class File extends UploadedFile
      * Create a new fake image.
      *
      * @param  string  $name
-     * @param  int  $height
+     * @param  int  $width
      * @param  int  $height
      * @return \Illuminate\Http\Testing\File
      */

--- a/src/Illuminate/Http/Testing/FileFactory.php
+++ b/src/Illuminate/Http/Testing/FileFactory.php
@@ -22,7 +22,7 @@ class FileFactory
      * Create a new fake image.
      *
      * @param  string  $name
-     * @param  int  $height
+     * @param  int  $width
      * @param  int  $height
      * @return \Illuminate\Http\Testing\File
      */

--- a/src/Illuminate/Http/Testing/FileFactory.php
+++ b/src/Illuminate/Http/Testing/FileFactory.php
@@ -11,7 +11,7 @@ class FileFactory
      * @param  int  $kilobytes
      * @return \Illuminate\Http\Testing\File
      */
-    public function create($name, $kilobytes)
+    public function create($name, $kilobytes = 0)
     {
         return tap(new File($name, tmpfile()), function ($file) use ($kilobytes) {
             $file->sizeToReport = $kilobytes * 1024;


### PR DESCRIPTION
Also set the default file size to 0, so you can omit that parameter when it's not important.