### PR TITLE
[5.4] Simplify method

### DIFF
--- a/src/Illuminate/Support/MessageBag.php
+++ b/src/Illuminate/Support/MessageBag.php
@@ -236,7 +236,7 @@ class MessageBag implements Arrayable, Countable, Jsonable, JsonSerializable, Me
      */
     protected function transform($messages, $format, $messageKey)
     {
-        return collect($messages)
+        return collect((array) $messages)
             ->map(function ($message) use ($messageKey, $format) {
                 // We will simply spin through the given messages and transform each one
                 // replacing the :message place holder with the real message allowing

--- a/src/Illuminate/Support/MessageBag.php
+++ b/src/Illuminate/Support/MessageBag.php
@@ -236,18 +236,14 @@ class MessageBag implements Arrayable, Countable, Jsonable, JsonSerializable, Me
      */
     protected function transform($messages, $format, $messageKey)
     {
-        $messages = (array) $messages;
-
-        // We will simply spin through the given messages and transform each one
-        // replacing the :message place holder with the real message allowing
-        // the messages to be easily formatted to each developer's desires.
-        $replace = [':message', ':key'];
-
-        foreach ($messages as &$message) {
-            $message = str_replace($replace, [$message, $messageKey], $format);
-        }
-
-        return $messages;
+        return collect($messages)
+            ->map(function ($message) use ($messageKey, $format) {
+                // We will simply spin through the given messages and transform each one
+                // replacing the :message place holder with the real message allowing
+                // the messages to be easily formatted to each developer's desires.
+                return str_replace([':message', ':key'], [$message, $messageKey], $format);
+            })
+            ->toArray();
     }
 
     /**

--- a/src/Illuminate/Support/MessageBag.php
+++ b/src/Illuminate/Support/MessageBag.php
@@ -242,8 +242,7 @@ class MessageBag implements Arrayable, Countable, Jsonable, JsonSerializable, Me
                 // replacing the :message place holder with the real message allowing
                 // the messages to be easily formatted to each developer's desires.
                 return str_replace([':message', ':key'], [$message, $messageKey], $format);
-            })
-            ->toArray();
+            })->all();
     }
 
     /**

--- a/src/Illuminate/Support/MessageBag.php
+++ b/src/Illuminate/Support/MessageBag.php
@@ -237,7 +237,7 @@ class MessageBag implements Arrayable, Countable, Jsonable, JsonSerializable, Me
     protected function transform($messages, $format, $messageKey)
     {
         return collect((array) $messages)
-            ->map(function ($message) use ($messageKey, $format) {
+            ->map(function ($message) use ($format, $messageKey) {
                 // We will simply spin through the given messages and transform each one
                 // replacing the :message place holder with the real message allowing
                 // the messages to be easily formatted to each developer's desires.


### PR DESCRIPTION
This PR simplifies `Illuminate\Support\MessageBag::transform()` method. It makes use of a collection instead of using an array with `&` variable reference operator.

🌵 