### PR TITLE
[5.4] Problem in paginate with distinct and joins

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -774,7 +774,7 @@ class Builder
 
         $perPage = $perPage ?: $this->model->getPerPage();
 
-        $results = ($total = $this->toBase()->getCountForPagination())
+        $results = ($total = $this->toBase()->getCountForPagination($columns))
                                     ? $this->forPage($page, $perPage)->get($columns)
                                     : $this->model->newCollection();
 


### PR DESCRIPTION
When using the distinct(), join() and paginate() methods the total with pagination is different from the total without pagination. The solution is to put the distinct field in the paginate method, for example paginate (10, ['events.id']), but the getCountForPagination function does not pass this parameter to get the total correct value.