### PR TITLE
[5.4] Added exception error when bootstrap/cache directory is not writable

### DIFF
--- a/src/Illuminate/Foundation/ProviderRepository.php
+++ b/src/Illuminate/Foundation/ProviderRepository.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Foundation;
 
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\Contracts\Filesystem\FileNotFoundException;
 use Illuminate\Contracts\Foundation\Application as ApplicationContract;
 
 class ProviderRepository
@@ -180,9 +181,14 @@ class ProviderRepository
      *
      * @param  array  $manifest
      * @return array
+     * @throws FileNotFoundException
      */
     public function writeManifest($manifest)
     {
+        if (! is_writable(dirname($this->manifestPath))) {
+            throw new FileNotFoundException('The bootstrap/cache directory must be present and writable.');
+        }
+
         $this->files->put(
             $this->manifestPath, '<?php return '.var_export($manifest, true).';'
         );


### PR DESCRIPTION
This is to fix an annoying issue related to: https://github.com/laravel/framework/issues/17969 where a generic error is thrown if the bootstrap/cache directory is not present or writable.