### PR TITLE
[5.4] Fix validating array of input type file

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -368,7 +368,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
             }
 
             if (empty($files[$key])) {
-                unset($files[$key]);
+                $files[$key] = [];
             }
         }
 

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -480,7 +480,7 @@ class HttpRequestTest extends TestCase
 
         $request = Request::createFromBase($baseRequest);
 
-         array_map(function ($file) {
+        array_map(function ($file) {
             $this->assertEmpty($file[0]);
         }, $request->files->all());
     }

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -467,13 +467,22 @@ class HttpRequestTest extends TestCase
                 'error' => [4],
                 'size' => [0],
             ],
+            'file2' => [
+                'name' => [null],
+                'type' => [''],
+                'tmp_name' => [''],
+                'error' => [4],
+                'size' => [0],
+            ],
         ];
 
         $baseRequest = SymfonyRequest::create('/?boom=breeze', 'GET', ['foo' => ['bar' => 'baz']], [], $invalidFiles);
 
         $request = Request::createFromBase($baseRequest);
 
-        $this->assertEmpty($request->files->all());
+         array_map(function ($file) {
+            $this->assertEmpty($file[0]);
+        }, $request->files->all());
     }
 
     public function testOldMethodCallsSession()


### PR DESCRIPTION
`   <form method="post" action="{{ route('test.store') }}" enctype="multipart/form-data">
                                            {{csrf_field()}}
                                            <input type="file" name="profile[ar]">
                                            <input type="file" name="profile[en]">
                                            <input type="submit" value="create">
                                            </form>`

then if we tried this in a request file or with validate method , 
**[ 'profile.*' => 'required|image']**

the validation will pass on submit because of :-

**filterFiles** method removes the null elements, so in **Validation/Validation.php** **constructor**  if we made **dd($data)** we will find that our files elements aren't presented in the data array , so in **addRules** method if we made **dd($response)** we will find our **rules attribute** and **implicitAttributes** are empty .

so finally in **Http/Request.php passes()** method , the two **loops on $this->rules , and on $this->after** will not be executed unless there's another attributes other than files attributes . 

and the array validation with files upload will always pass .

try the same above steps after , initializing the **$files[$key]** with empty array .

note :- it should be initialized as array , so that it doesn't break **Symfony FileBag.php the set($key, $value) method** and throws an exception ,for in case we mixed , array file validation , with single file validation like that :-
 **['profile.*' => 'required|image',
 'single' => 'required|image' ]**

this pull request will fix this problem  :-
**['profile.ar'  => 'required|image',
'profile.en' => 'required|image']**
as it will be pain for writing all upload files like that .