### PR TITLE
[5.4] Allow providing a user-defined default namespace for all make commands

### DIFF
--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -102,7 +102,7 @@ abstract class GeneratorCommand extends Command
     protected function getFinalNamespace($rootNamespace)
     {
         $userNamespace = config('generators.namespaces.'.str_slug($this->type), null);
-        if ( !is_null($userNamespace)) {
+        if (! is_null($userNamespace)) {
             return $rootNamespace.$userNamespace;
         }
 

--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -101,7 +101,7 @@ abstract class GeneratorCommand extends Command
      */
     protected function getFinalNamespace($rootNamespace)
     {
-        $userNamespace = config('generators.namespaces.'.str_slug($this->type), null);
+        $userNamespace = $this->laravel['config']->get('generators.namespaces.'.Str::slug($this->type), null);
         if (! is_null($userNamespace)) {
             return $rootNamespace.$userNamespace;
         }

--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -89,8 +89,24 @@ abstract class GeneratorCommand extends Command
         $name = str_replace('/', '\\', $name);
 
         return $this->qualifyClass(
-            $this->getDefaultNamespace(trim($rootNamespace, '\\')).'\\'.$name
+            $this->getFinalNamespace(trim($rootNamespace, '\\')).'\\'.$name
         );
+    }
+
+    /**
+     * Get the final namespace for the class.
+     *
+     * @param  string  $rootNamespace
+     * @return string
+     */
+    protected function getFinalNamespace($rootNamespace)
+    {
+        $userNamespace = config('generators.namespaces.'.str_slug($this->type), null);
+        if ( !is_null($userNamespace)) {
+            return $rootNamespace . $userNamespace;
+        }
+
+        return $this->getDefaultNamespace($rootNamespace);
     }
 
     /**

--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -103,7 +103,7 @@ abstract class GeneratorCommand extends Command
     {
         $userNamespace = config('generators.namespaces.'.str_slug($this->type), null);
         if ( !is_null($userNamespace)) {
-            return $rootNamespace . $userNamespace;
+            return $rootNamespace.$userNamespace;
         }
 
         return $this->getDefaultNamespace($rootNamespace);


### PR DESCRIPTION
This PR references a [discussion on Laravel Internals](https://github.com/laravel/internals/issues/447) where it seems that lots of people would love to be able to change the default namespaces for some generator commands.

For example, it is common for many to store their models inside the namespace `App\Models`.

The default behaviour is kept when no `config/generators.php` file is specified (to keep BC). If such a file is created and if the proper value is inserted (based on the `$type` member of the command class), that will be used as the default namespace.

Below is a sample configuration file which will only specify a different default namespace for the models (but any type could be changed too).


```php
<?php

return [

    /*
    |--------------------------------------------------------------------------
    | Default namespaces for the classes generated via the make command
    |--------------------------------------------------------------------------
    |
    | You can change the default namespaces for the classes generated by the
    | make commands. All namespaces here will be relative to the root
    | application namespace and should start with a '\'.
    */

    'namespaces' => [
        'model' => '\Models',
    ],

];
```