### PR TITLE
[5.4] Wrap error message in array

### DIFF
--- a/src/Illuminate/Foundation/Auth/AuthenticatesUsers.php
+++ b/src/Illuminate/Foundation/Auth/AuthenticatesUsers.php
@@ -123,7 +123,7 @@ trait AuthenticatesUsers
      */
     protected function sendFailedLoginResponse(Request $request)
     {
-        $errors = [$this->username() => trans('auth.failed')];
+        $errors = [$this->username() => [trans('auth.failed')]];
 
         if ($request->expectsJson()) {
             return response()->json($errors, 422);


### PR DESCRIPTION
I think the returned error message for a failed login response should be wrapped in an array like the regular validation error messages. Could not find an according test - so no tests provided - sorry.