### PR TITLE
[5.4] Allow lowercase JSON keys with ucfirst

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -853,6 +853,21 @@ if (! function_exists('__')) {
     }
 }
 
+if (! function_exists('___')) {
+    /**
+     * Translate the given message and transforms the first letter to uppercase.
+     *
+     * @param  string  $key
+     * @param  array  $replace
+     * @param  string  $locale
+     * @return \Illuminate\Contracts\Translation\Translator|string
+     */
+    function ___($key = null, $replace = [], $locale = null)
+    {
+        return ucfirst(app('translator')->getFromJson($key, $replace, $locale));
+    }
+}
+
 if (! function_exists('url')) {
     /**
      * Generate a url for the application.


### PR DESCRIPTION
Enables the user to uppercase the first letter (for a title example), without having to provide upper & lowercase versions.
Also allows the user to keep lowercased JSON keys in the language file, but still force the text to be uppercased in relevant situations.