### PR TITLE
[5.5] Return validation message as array on failed login response

### DIFF
--- a/src/Illuminate/Foundation/Auth/AuthenticatesUsers.php
+++ b/src/Illuminate/Foundation/Auth/AuthenticatesUsers.php
@@ -123,7 +123,7 @@ trait AuthenticatesUsers
      */
     protected function sendFailedLoginResponse(Request $request)
     {
-        $errors = [$this->username() => trans('auth.failed')];
+        $errors = [$this->username() => [trans('auth.failed')]];
 
         if ($request->expectsJson()) {
             return response()->json($errors, 422);


### PR DESCRIPTION
All error messages from the Validator are wrapped in arrays. The failed login error message comes as string. To be consistent it should be an array, too.

