### PR TITLE
[5.4] Add more information to migrations

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
@@ -64,17 +64,12 @@ class MigrateCommand extends BaseCommand
         // Next, we will check to see if a path option has been defined. If it has
         // we will use the path relative to the root of this installation folder
         // so that migrations may be run for any path within the applications.
+
         $this->migrator->run($this->getMigrationPaths(), [
             'pretend' => $this->option('pretend'),
-            'step' => $this->option('step'),
-        ]);
+            'step'    => $this->option('step'),
+        ], $this->output);
 
-        // Once the migrator has run we will grab the note output and send it out to
-        // the console screen, since the migrator itself functions without having
-        // any instances of the OutputInterface contract passed into the class.
-        foreach ($this->migrator->getNotes() as $note) {
-            $this->output->writeln($note);
-        }
 
         // Finally, if the "seed" option has been given, we will re-run the database
         // seed task to re-populate the database, which is convenient when adding

--- a/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
@@ -68,7 +68,7 @@ class MigrateCommand extends BaseCommand
         $this->migrator->run($this->getMigrationPaths(), [
             'pretend' => $this->option('pretend'),
             'step'    => $this->option('step'),
-        ], $this->output);
+        ], $this->getOutput());
 
 
         // Finally, if the "seed" option has been given, we will re-run the database

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -3,12 +3,12 @@
 namespace Illuminate\Database\Migrations;
 
 use Carbon\Carbon;
-use Illuminate\Console\OutputStyle;
 use Illuminate\Database\ConnectionResolverInterface as Resolver;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
+use Symfony\Component\Console\Output\OutputInterface;
 
 class Migrator
 {
@@ -76,10 +76,10 @@ class Migrator
      *
      * @param  array|string $paths
      * @param  array $options
-     * @param  OutputStyle $outputStyle
+     * @param  OutputInterface $output
      * @return array
      */
-    public function run($paths = [], array $options = [], OutputStyle $outputStyle = NULL)
+    public function run($paths = [], array $options = [], OutputInterface $output = NULL)
     {
         $this->notes = [];
 
@@ -95,7 +95,7 @@ class Migrator
         // Once we have all these migrations that are outstanding we are ready to run
         // we will go ahead and run them "up". This will execute each migration as
         // an operation against a database. Then we'll return this list of them.
-        $this->runPending($migrations, $options, $outputStyle);
+        $this->runPending($migrations, $options, $output);
 
         return $migrations;
     }
@@ -120,10 +120,10 @@ class Migrator
      *
      * @param  array $migrations
      * @param  array $options
-     * @param  OutputStyle $outputStyle
+     * @param  OutputInterface $output
      * @return void
      */
-    public function runPending(array $migrations, array $options = [], OutputStyle $outputStyle = NULL)
+    public function runPending(array $migrations, array $options = [], OutputInterface $output = NULL)
     {
         // First we will just make sure that there are any migrations to run. If there
         // aren't, we will just make a note of it to the developer so they're aware
@@ -147,16 +147,16 @@ class Migrator
         // migrations "up" so the changes are made to the databases. We'll then log
         // that the migration was run so we don't repeat it next time we execute.
         foreach ($migrations as $file) {
-            if (!is_null($outputStyle)){
-                $outputStyle->write('<info>Running:</info> ' . $this->getMigrationName($file) . '...');
+            if (!is_null($output)){
+                $output->write('<info>Running:</info> ' . $this->getMigrationName($file) . '...');
             }
 
             $now = Carbon::now();
             $this->runUp($file, $batch, $pretend);
             $difference = Carbon::now()->diffInSeconds($now);
 
-            if (!is_null($outputStyle)){
-                $outputStyle->writeln("Done! <comment>({$difference}s)</comment>");
+            if (!is_null($output)){
+                $output->writeln("Done! <comment>({$difference}s)</comment>");
             }
 
             if ($step) {

--- a/tests/Database/DatabaseMigrationMigrateCommandTest.php
+++ b/tests/Database/DatabaseMigrationMigrateCommandTest.php
@@ -22,8 +22,7 @@ class DatabaseMigrationMigrateCommandTest extends TestCase
         $command->setLaravel($app);
         $migrator->shouldReceive('paths')->once()->andReturn([]);
         $migrator->shouldReceive('setConnection')->once()->with(null);
-        $migrator->shouldReceive('run')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => false, 'step' => false]);
-        $migrator->shouldReceive('getNotes')->andReturn([]);
+        $migrator->shouldReceive('run')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => false, 'step' => false], \Mockery::type('\Symfony\Component\Console\Output\OutputInterface'));
         $migrator->shouldReceive('repositoryExists')->once()->andReturn(true);
 
         $this->runCommand($command);
@@ -38,8 +37,7 @@ class DatabaseMigrationMigrateCommandTest extends TestCase
         $command->setLaravel($app);
         $migrator->shouldReceive('paths')->once()->andReturn([]);
         $migrator->shouldReceive('setConnection')->once()->with(null);
-        $migrator->shouldReceive('run')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => false, 'step' => false]);
-        $migrator->shouldReceive('getNotes')->andReturn([]);
+        $migrator->shouldReceive('run')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => false, 'step' => false], \Mockery::type('\Symfony\Component\Console\Output\OutputInterface'));
         $migrator->shouldReceive('repositoryExists')->once()->andReturn(false);
         $command->expects($this->once())->method('call')->with($this->equalTo('migrate:install'), $this->equalTo(['--database' => null]));
 
@@ -54,8 +52,7 @@ class DatabaseMigrationMigrateCommandTest extends TestCase
         $command->setLaravel($app);
         $migrator->shouldReceive('paths')->once()->andReturn([]);
         $migrator->shouldReceive('setConnection')->once()->with(null);
-        $migrator->shouldReceive('run')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => true, 'step' => false]);
-        $migrator->shouldReceive('getNotes')->andReturn([]);
+        $migrator->shouldReceive('run')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => true, 'step' => false], \Mockery::type('\Symfony\Component\Console\Output\OutputInterface'));
         $migrator->shouldReceive('repositoryExists')->once()->andReturn(true);
 
         $this->runCommand($command, ['--pretend' => true]);
@@ -69,8 +66,7 @@ class DatabaseMigrationMigrateCommandTest extends TestCase
         $command->setLaravel($app);
         $migrator->shouldReceive('paths')->once()->andReturn([]);
         $migrator->shouldReceive('setConnection')->once()->with('foo');
-        $migrator->shouldReceive('run')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => false, 'step' => false]);
-        $migrator->shouldReceive('getNotes')->andReturn([]);
+        $migrator->shouldReceive('run')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => false, 'step' => false], \Mockery::type('\Symfony\Component\Console\Output\OutputInterface'));
         $migrator->shouldReceive('repositoryExists')->once()->andReturn(true);
 
         $this->runCommand($command, ['--database' => 'foo']);
@@ -84,8 +80,7 @@ class DatabaseMigrationMigrateCommandTest extends TestCase
         $command->setLaravel($app);
         $migrator->shouldReceive('paths')->once()->andReturn([]);
         $migrator->shouldReceive('setConnection')->once()->with(null);
-        $migrator->shouldReceive('run')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => false, 'step' => true]);
-        $migrator->shouldReceive('getNotes')->andReturn([]);
+        $migrator->shouldReceive('run')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => false, 'step' => true], \Mockery::type('\Symfony\Component\Console\Output\OutputInterface'));
         $migrator->shouldReceive('repositoryExists')->once()->andReturn(true);
 
         $this->runCommand($command, ['--step' => true]);


### PR DESCRIPTION
When running a number of migrations it will give information on which migration is currently running and when the migration is finished it will say how many seconds it took to run. https://github.com/laravel/internals/issues/436

```
Running: 2014_10_12_000000_create_users_table...Done! (2s)
Running: 2014_10_12_100000_create_password_resets_table...Done! (0s)
``` 