### PR TITLE
[5.5] Eloquent object casting

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -540,7 +540,7 @@ trait HasAttributes
             return $this->classCastCache[$key];
         } else {
             return $this->classCastCache[$key] = forward_static_call(
-                [$this->getCasts()[$key], 'fromModelAttributes'], $this, $this->attributes
+                [$this->getCasts()[$key], 'fromModelAttributes'], $this->attributes, $key, $this
             );
         }
     }
@@ -571,7 +571,8 @@ trait HasAttributes
     {
         foreach ($this->classCastCache as $key => $value) {
             $this->attributes = array_merge(
-                $this->attributes, $value->toModelAttributes($this, $this->attributes)
+                $this->attributes,
+                $value->toModelAttributes($this->attributes, $key, $this)
             );
         }
     }
@@ -646,7 +647,7 @@ trait HasAttributes
                 function () {
                     return null;
                 },
-                $this->castToClass($key)->toModelAttributes($this)
+                $this->castToClass($key)->toModelAttributes($this->attributes, $key, $this)
             ));
 
             unset($this->classCastCache[$key]);

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -923,7 +923,10 @@ trait HasAttributes
     public function hasCast($key, $types = null)
     {
         if (array_key_exists($key, $this->getCasts())) {
-            return $types ? in_array($this->getCastType($key), (array) $types, true) : true;
+            $cast = $this->getCastType($key);
+            $cast = strstr($cast, ':', true) ?: $cast;
+
+            return $types ? in_array($cast, (array) $types, true) : true;
         }
 
         return false;

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -489,7 +489,7 @@ trait HasAttributes
     {
         $castType = $this->getCastType($key);
 
-        if (is_null($value) && in_array($castType, static::$primitiveCastTypes)) {
+        if (is_null($value)) {
             return $value;
         }
 
@@ -569,11 +569,14 @@ trait HasAttributes
      */
     protected function mergeAttributesFromClassCasts()
     {
-        foreach ($this->classCastCache as $key => $value) {
-            $this->attributes = array_merge(
-                $this->attributes,
-                $value->toModelAttributes($this->attributes, $key, $this)
-            );
+        foreach ($this->getCasts() as $attribute => $cast) {
+            if ($this->isClassCastable($attribute)) {
+                $this->attributes = array_merge(
+                    $this->attributes,
+                    $this->castToClass($attribute)
+                         ->toModelAttributes($this->attributes, $attribute, $this)
+                );
+            }
         }
     }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -574,9 +574,9 @@ trait HasAttributes
                 $attributeCount = count($attributes);
                 $object = $this->castToClass($attribute);
 
-                $castedAttributes = method_exists($object, '__toString')
-                    ? (string) $object
-                    : $this->{'castFrom'.Str::studly($type)}($object);
+                $castedAttributes = method_exists($this, 'castFrom'.Str::studly($type))
+                    ? $this->{'castFrom'.Str::studly($type)}($object)
+                    : $object->__toString();
 
                 if ($attributeCount !== count($castedAttributes)) {
                     throw new LogicException("Class cast {$attribute} must return {$attributeCount} attributes");

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -966,7 +966,7 @@ trait HasAttributes
 
         return [
             strstr($cast, ':', true),
-            explode(',', ltrim(strstr($cast, ':'), ':'))
+            explode(',', ltrim(strstr($cast, ':'), ':')),
         ];
     }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -538,9 +538,7 @@ trait HasAttributes
             $parameters = [$this->attributes[$key] ?? null];
         }
 
-        return $this->classCastCache[$key] = forward_static_call(
-            [$this, 'castTo'.Str::studly($cast)], ...$parameters
-        );
+        return $this->classCastCache[$key] = $this->{'castTo'.Str::studly($type)}(...$parameters);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -579,7 +579,7 @@ trait HasAttributes
                     : $object->__toString();
 
                 if ($attributeCount !== count($castedAttributes)) {
-                    throw new LogicException("Class cast {$attribute} must return {$attributeCount} attributes");
+                    throw new LogicException("Class cast {$attribute} must return {$attributeCount} attribute(s)");
                 }
 
                 $this->attributes = array_merge(

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -528,7 +528,7 @@ trait HasAttributes
             return $this->classCastCache[$key];
         }
 
-        [$cast, $attributes] = $this->getClassCast($key);
+        [$type, $attributes] = $this->getClassCast($key);
 
         if ($attributes) {
             $parameters = array_map(function ($key) {
@@ -573,10 +573,10 @@ trait HasAttributes
     {
         foreach ($this->getCasts() as $attribute => $cast) {
             if ($this->isClassCastable($attribute)) {
-                [$cast, $attributes] = $this->getClassCast($attribute);
+                [$type, $attributes] = $this->getClassCast($attribute);
 
                 $casted = array_filter((array) call_user_func(
-                    [$this, 'castFrom'. Str::studly($cast)],
+                    [$this, 'castFrom'. Str::studly($type)],
                     $this->castToClass($attribute)
                 ));
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -43,6 +43,13 @@ trait HasAttributes
     protected $casts = [];
 
     /**
+     * The attributes that have been cast to classes.
+     *
+     * @var array
+     */
+    protected $classCastCache = [];
+
+    /**
      * The attributes that should be mutated to dates.
      *
      * @var array
@@ -76,6 +83,16 @@ trait HasAttributes
      * @var array
      */
     protected static $mutatorCache = [];
+
+    /**
+     * All of the valid primitive cast types.
+     *
+     * @var array
+     */
+    protected static $primitiveCastTypes = [
+        'int', 'integer', 'real', 'float', 'double', 'string', 'bool', 'boolean',
+        'object', 'array', 'json', 'collection', 'date', 'datetime', 'timestamp',
+    ];
 
     /**
      * Convert the model's attributes to an array.
@@ -175,6 +192,10 @@ trait HasAttributes
                 continue;
             }
 
+            if ($this->isClassCastable($key)) {
+                continue;
+            }
+
             // Here we will cast the attribute. Then, if the cast is a date or datetime cast
             // then we will serialize the date for the array. This will convert the dates
             // to strings based on the date format specified for these Eloquent models.
@@ -201,7 +222,7 @@ trait HasAttributes
      */
     protected function getArrayableAttributes()
     {
-        return $this->getArrayableItems($this->attributes);
+        return $this->getArrayableItems($this->getAttributes());
     }
 
     /**
@@ -308,8 +329,7 @@ trait HasAttributes
         // If the attribute exists in the attribute array or has a "get" mutator we will
         // get the attribute's value. Otherwise, we will proceed as if the developers
         // are asking for a relationship's value. This covers both types of values.
-        if (array_key_exists($key, $this->attributes) ||
-            $this->hasGetMutator($key)) {
+        if (array_key_exists($key, $this->attributes) || $this->hasGetMutator($key) || $this->isClassCastable($key)) {
             return $this->getAttributeValue($key);
         }
 
@@ -366,8 +386,10 @@ trait HasAttributes
      */
     protected function getAttributeFromArray($key)
     {
-        if (isset($this->attributes[$key])) {
-            return $this->attributes[$key];
+        $attributes = $this->getAttributes();
+
+        if (isset($attributes[$key])) {
+            return $attributes[$key];
         }
     }
 
@@ -447,7 +469,11 @@ trait HasAttributes
      */
     protected function mutateAttributeForArray($key, $value)
     {
-        $value = $this->mutateAttribute($key, $value);
+        if ($this->isClassCastable($key)) {
+            $value = $this->castToClass($key);
+        } else {
+            $value = $this->mutateAttribute($key, $value);
+        }
 
         return $value instanceof Arrayable ? $value->toArray() : $value;
     }
@@ -461,11 +487,13 @@ trait HasAttributes
      */
     protected function castAttribute($key, $value)
     {
-        if (is_null($value)) {
+        $castType = $this->getCastType($key);
+
+        if (is_null($value) && in_array($castType, static::$primitiveCastTypes)) {
             return $value;
         }
 
-        switch ($this->getCastType($key)) {
+        switch ($castType) {
             case 'int':
             case 'integer':
                 return (int) $value;
@@ -491,8 +519,60 @@ trait HasAttributes
                 return $this->asDateTime($value);
             case 'timestamp':
                 return $this->asTimestamp($value);
-            default:
-                return $value;
+        }
+
+        if ($this->isClassCastable($key)) {
+            return $this->castToClass($key);
+        }
+
+        return $value;
+    }
+
+    /**
+     * Cast the given attribute to a class.
+     *
+     * @param  string  $key
+     * @return mixed
+     */
+    protected function castToClass($key)
+    {
+        if (isset($this->classCastCache[$key])) {
+            return $this->classCastCache[$key];
+        } else {
+            return $this->classCastCache[$key] = forward_static_call(
+                [$this->getCasts()[$key], 'fromModelAttributes'], $this, $this->attributes
+            );
+        }
+    }
+
+    /**
+     * Determine whether a value is JSON castable for inbound manipulation.
+     *
+     * @param  string  $key
+     * @return bool
+     */
+    protected function isClassCastable($key)
+    {
+        if (! array_key_exists($key, $this->getCasts())) {
+            return false;
+        }
+
+        $class = $this->getCasts()[$key];
+
+        return class_exists($class) && ! in_array($class, static::$primitiveCastTypes);
+    }
+
+    /**
+     * Merge the cast class attributes back into the model.
+     *
+     * @return void
+     */
+    protected function mergeAttributesFromClassCasts()
+    {
+        foreach ($this->classCastCache as $key => $value) {
+            $this->attributes = array_merge(
+                $this->attributes, $value->toModelAttributes($this, $this->attributes)
+            );
         }
     }
 
@@ -543,9 +623,36 @@ trait HasAttributes
             return $this->fillJsonAttribute($key, $value);
         }
 
-        $this->attributes[$key] = $value;
+        if ($this->isClassCastable($key)) {
+            $this->setClassCastableAttribute($key, $value);
+        } else {
+            $this->attributes[$key] = $value;
+        }
 
         return $this;
+    }
+
+    /**
+     * Set the value of a class castable attribute.
+     *
+     * @param  string  $key
+     * @param  mixed  $value
+     * @return void
+     */
+    protected function setClassCastableAttribute($key, $value)
+    {
+        if (is_null($value)) {
+            $this->attributes = array_merge($this->attributes, array_map(
+                function () {
+                    return null;
+                },
+                $this->castToClass($key)->toModelAttributes($this)
+            ));
+
+            unset($this->classCastCache[$key]);
+        } else {
+            $this->classCastCache[$key] = $value;
+        }
     }
 
     /**
@@ -856,6 +963,8 @@ trait HasAttributes
      */
     public function getAttributes()
     {
+        $this->mergeAttributesFromClassCasts();
+
         return $this->attributes;
     }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -655,7 +655,7 @@ trait HasAttributes
 
             $this->attributes = array_merge(
                 $this->attributes,
-                array_fill_keys(array_keys(array_flip((array) $attributes)), null)
+                array_fill_keys((array) $attributes, null)
             );
 
             unset($this->classCastCache[$key]);

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -528,7 +528,7 @@ trait HasAttributes
             return $this->classCastCache[$key];
         }
 
-        [$type, $attributes] = $this->getClassCast($key);
+        list($type, $attributes) = $this->getClassCast($key);
 
         if ($attributes) {
             $parameters = array_map(function ($key) {
@@ -569,7 +569,7 @@ trait HasAttributes
     {
         foreach ($this->getCasts() as $attribute => $cast) {
             if ($this->isClassCastable($attribute)) {
-                [$type, $attributes] = $this->getClassCast($attribute);
+                list($type, $attributes) = $this->getClassCast($attribute);
 
                 $attributeCount = count($attributes);
                 $object = $this->castToClass($attribute);
@@ -655,7 +655,7 @@ trait HasAttributes
     protected function setClassCastableAttribute($key, $value)
     {
         if (is_null($value)) {
-            [$cast, $attributes] = $this->getClassCast($key);
+            list($cast, $attributes) = $this->getClassCast($key);
 
             $this->attributes = array_merge(
                 $this->attributes,

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -497,6 +497,8 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public function save(array $options = [])
     {
+        $this->mergeAttributesFromClassCasts();
+
         $query = $this->newQueryWithoutScopes();
 
         // If the "saving" event returns false we'll bail out of the save and return
@@ -728,6 +730,8 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public function delete()
     {
+        $this->mergeAttributesFromClassCasts();
+
         if (is_null($this->getKeyName())) {
             throw new Exception('No primary key defined on model.');
         }
@@ -1393,6 +1397,18 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     {
         return $this->toJson();
     }
+
+     /**
+      * Prepare the object for serialization.
+      *
+      * @return array
+      */
+     public function __sleep()
+     {
+         $this->mergeAttributesFromClassCasts();
+
+         return array_keys(get_object_vars($this));
+     }
 
     /**
      * When a model is being unserialized, check if it needs to be booted.


### PR DESCRIPTION
Re-implementation of #13706 after a long discussion with @adamwathan and @JosephSilber.

```php
$user = User::create([
    'name' => 'Taylor',
    'token' => new Secret('Adam123'),
]);

$user->token; // Secret instance
$user->token->secret; // "Adam123"

$user->price = (new Money(10))->setCurrency('BTC');

$user->price; // Money instance
$user->price->amount; // "10"
$user->toArray()['price']; // "10"
$user->currency; // "BTC"
```

Example classes are in the next comment below. 