### PR TITLE
[5.5] Add prompt to vendor:publish to specify which provider/tag to publish

### DIFF
--- a/src/Illuminate/Foundation/Console/VendorPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/VendorPublishCommand.php
@@ -24,6 +24,7 @@ class VendorPublishCommand extends Command
      * @var string
      */
     protected $signature = 'vendor:publish {--force : Overwrite any existing files.}
+                    {--all : Publish assets for all service providers without prompt.}
                     {--provider= : The service provider that has assets you want to publish.}
                     {--tag=* : One or many tags that have assets you want to publish.}';
 
@@ -77,6 +78,27 @@ class VendorPublishCommand extends Command
     }
 
     /**
+     * Determine the provider to publish.
+     *
+     * @return mixed
+     */
+    protected function providerToPublish()
+    {
+        if ($this->option('all')) {
+            return null;
+        }
+
+        if ($this->option('provider')) {
+            return $this->option('provider');
+        }
+
+        return $this->choice(
+            "Which package's files would you like to publish?",
+            ServiceProvider::providersAvailableToPublish()
+        );
+    }
+
+    /**
      * Get all of the paths to publish.
      *
      * @param  string  $tag
@@ -85,7 +107,7 @@ class VendorPublishCommand extends Command
     protected function pathsToPublish($tag)
     {
         return ServiceProvider::pathsToPublish(
-            $this->option('provider'), $tag
+            $this->providerToPublish(), $tag
         );
     }
 

--- a/src/Illuminate/Foundation/Console/VendorPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/VendorPublishCommand.php
@@ -92,10 +92,15 @@ class VendorPublishCommand extends Command
             return $this->option('provider');
         }
 
-        return $this->choice(
+        $choice = $this->choice(
             "Which package's files would you like to publish?",
-            ServiceProvider::providersAvailableToPublish()
+            array_merge(
+                [$all = '<comment>Publish files from all packages listed below</comment>'],
+                ServiceProvider::providersAvailableToPublish()
+            )
         );
+
+        return $choice == $all ? null : $choice;
     }
 
     /**

--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -165,6 +165,16 @@ abstract class ServiceProvider
     }
 
     /**
+     * Get the service providers available for publishing.
+     *
+     * @return array
+     */
+    public static function providersAvailableToPublish()
+    {
+        return array_keys(static::$publishes);
+    }
+
+    /**
      * Get the paths to publish.
      *
      * @param  string  $provider

--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -169,9 +169,19 @@ abstract class ServiceProvider
      *
      * @return array
      */
-    public static function providersAvailableToPublish()
+    public static function publishableProviders()
     {
         return array_keys(static::$publishes);
+    }
+
+    /**
+     * Get the groups available for publishing.
+     *
+     * @return array
+     */
+    public static function publishableGroups()
+    {
+        return array_keys(static::$publishGroups);
     }
 
     /**

--- a/tests/Support/SupportServiceProviderTest.php
+++ b/tests/Support/SupportServiceProviderTest.php
@@ -22,6 +22,16 @@ class SupportServiceProviderTest extends TestCase
         m::close();
     }
 
+    public function testGetAvailableServiceProvidersToPublish()
+    {
+        $availableToPublish = ServiceProvider::providersAvailableToPublish();
+        $expected = [
+            'Illuminate\Tests\Support\ServiceProviderForTestingOne',
+            'Illuminate\Tests\Support\ServiceProviderForTestingTwo',
+        ];
+        $this->assertEquals($expected, $availableToPublish, 'Publishable service providers do not return expected set of providers.');
+    }
+
     public function testSimpleAssetsArePublishedCorrectly()
     {
         $toPublish = ServiceProvider::pathsToPublish('Illuminate\Tests\Support\ServiceProviderForTestingOne');

--- a/tests/Support/SupportServiceProviderTest.php
+++ b/tests/Support/SupportServiceProviderTest.php
@@ -22,14 +22,20 @@ class SupportServiceProviderTest extends TestCase
         m::close();
     }
 
-    public function testGetAvailableServiceProvidersToPublish()
+    public function testPublishableServiceProviders()
     {
-        $availableToPublish = ServiceProvider::providersAvailableToPublish();
+        $toPublish = ServiceProvider::publishableProviders();
         $expected = [
             'Illuminate\Tests\Support\ServiceProviderForTestingOne',
             'Illuminate\Tests\Support\ServiceProviderForTestingTwo',
         ];
-        $this->assertEquals($expected, $availableToPublish, 'Publishable service providers do not return expected set of providers.');
+        $this->assertEquals($expected, $toPublish, 'Publishable service providers do not return expected set of providers.');
+    }
+
+    public function testPublishableGroups()
+    {
+        $toPublish = ServiceProvider::publishableGroups();
+        $this->assertEquals(['some_tag'], $toPublish, 'Publishable groups do not return expected set of groups.');
     }
 
     public function testSimpleAssetsArePublishedCorrectly()


### PR DESCRIPTION
By default, `artisan vendor:publish` will publish everything it can find. Passing the `--provider` flag is the way around this but you have to lookup the package's service provider class name along with its namespace (long and inconsistent naming across packages).

This pull request adds a prompt to allow the user to specify the package for which they want to publish files.

Prompt can be avoided by using the `--all` flag or by continuing to pass a `--provider`.

*Edit: Updated screen capture gif below*
![laravel-vendor-publish4](https://cloud.githubusercontent.com/assets/271432/23688497/f0b690cc-0382-11e7-901c-b3b13a365e24.gif)