### PR TITLE
[5.4] allow scheduling of queued jobs

### DIFF
--- a/src/Illuminate/Console/Scheduling/Schedule.php
+++ b/src/Illuminate/Console/Scheduling/Schedule.php
@@ -4,6 +4,7 @@ namespace Illuminate\Console\Scheduling;
 
 use Illuminate\Console\Application;
 use Illuminate\Container\Container;
+use Illuminate\Contracts\Queue\ShouldQueue;
 use Symfony\Component\Process\ProcessUtils;
 use Illuminate\Contracts\Cache\Repository as Cache;
 
@@ -46,6 +47,19 @@ class Schedule
         $this->events[] = $event = new CallbackEvent($this->cache, $callback, $parameters);
 
         return $event;
+    }
+
+    /**
+     * Add a new queued job callback event to the schedule.
+     *
+     * @param  \Illuminate\Contracts\Queue\ShouldQueue  $job
+     * @return \Illuminate\Console\Scheduling\Event
+     */
+    public function job(ShouldQueue $job)
+    {
+        return $this->call(function() use($job) {
+            dispatch($job);
+        })->name(get_class($job));
     }
 
     /**

--- a/src/Illuminate/Console/Scheduling/Schedule.php
+++ b/src/Illuminate/Console/Scheduling/Schedule.php
@@ -57,7 +57,7 @@ class Schedule
      */
     public function job(ShouldQueue $job)
     {
-        return $this->call(function() use($job) {
+        return $this->call(function () use($job) {
             dispatch($job);
         })->name(get_class($job));
     }

--- a/src/Illuminate/Console/Scheduling/Schedule.php
+++ b/src/Illuminate/Console/Scheduling/Schedule.php
@@ -57,7 +57,7 @@ class Schedule
      */
     public function job(ShouldQueue $job)
     {
-        return $this->call(function () use($job) {
+        return $this->call(function () use ($job) {
             dispatch($job);
         })->name(get_class($job));
     }


### PR DESCRIPTION
As proposed in laravel/internals#457, this simple addition allows us to schedule a job to be queued at a specific interval. 

This enables you do have something like this
```php
# /app/Console/Kernel.php

$schedule->job(new Heartbeat())->everyFiveMinutes();

```

In this example, you might be scheduling a heartbeat to be run from the queue workers themselves. This is something I currently do in production which ping's Envoyer's heartbeat endpoints to tell me if a queue is backed up for too long.

Right now, if you want to do this you have to either create a dedicated command per job you want to schedule, or use the `$schedule->call();` method passing in a closure which can be overly verbose for the Kernel file. This provides a clean abstraction to that.

