### PR TITLE
[5.4] Prevent mail sending from a listener to the MessageSending event

### DIFF
--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -428,8 +428,8 @@ class Mailer implements MailerContract, MailQueueContract
      */
     protected function sendSwiftMessage($message)
     {
-        if ($this->events) {
-            $this->events->dispatch(new Events\MessageSending($message));
+        if (! $this->shouldSendMessage($message)) {
+            return;
         }
 
         try {
@@ -437,6 +437,23 @@ class Mailer implements MailerContract, MailQueueContract
         } finally {
             $this->forceReconnection();
         }
+    }
+
+    /**
+     * Determines if the message can be sent.
+     *
+     * @param  \Swift_Message  $message
+     * @return bool
+     */
+    protected function shouldSendMessage($message)
+    {
+        if (! $this->events) {
+            return true;
+        }
+
+        return $this->events->until(
+            new Events\MessageSending($message)
+        ) !== false;
     }
 
     /**


### PR DESCRIPTION
While sending a notification, if you return false in the handle method of a listener to the `NotificationSending` event the notification isn't sent, this PR adds the same functionality to the mail sending process, if one of the listeners of `MessageSending` returned false the mail is never sent.