### PR TITLE
[5.4] fix an issue with slots when content is null

### DIFF
--- a/src/Illuminate/View/Concerns/ManagesComponents.php
+++ b/src/Illuminate/View/Concerns/ManagesComponents.php
@@ -88,7 +88,7 @@ trait ManagesComponents
      */
     public function slot($name, $content = null)
     {
-        if ($content !== null) {
+        if (count(func_get_args()) == 2) {
             $this->slots[$this->currentComponent()][$name] = $content;
         } else {
             if (ob_start()) {


### PR DESCRIPTION
In reference to https://github.com/laravel/framework/issues/18234

if you do `@slot('name', $variable)` while `$variable` the code in `else` will be executed and output  buffering will start causing the blade rendering to break.