### PR TITLE
[5.5] Don't fail if no file to email

### DIFF
--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -405,15 +405,15 @@ class Event
      */
     protected function emailOutput(Mailer $mailer, $addresses, $onlyIfOutputExists = false)
     {
-         try {
+        try {
             $text = file_get_contents($this->output);
-         } catch (Exception $e) {
+        } catch (Exception $e) {
             // "Only If Output Exists" should not care that a file might not exist
             // Keep existing behavior and rethrow exception for regular cases
             if (! $onlyIfOutputExists) {
-                 throw $e;  // rethrow it
+                throw $e;  // rethrow it
             }
-         }
+        }
 
         if ($onlyIfOutputExists && empty($text)) {
             return;

--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -405,7 +405,15 @@ class Event
      */
     protected function emailOutput(Mailer $mailer, $addresses, $onlyIfOutputExists = false)
     {
-        $text = file_get_contents($this->output);
+        try {
+            $text = file_get_contents($this->output);
+        } catch (Exception $e) {
+           // "Only If Output Exists" should not care that a file might not exist
+           // Keep existing behavior and rethrow exception for regular cases
+            if (!$onlyIfOutputExists) {
+                throw $e;  // rethrow it
+            }
+        }
 
         if ($onlyIfOutputExists && empty($text)) {
             return;

--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -405,15 +405,15 @@ class Event
      */
     protected function emailOutput(Mailer $mailer, $addresses, $onlyIfOutputExists = false)
     {
-        try {
+         try {
             $text = file_get_contents($this->output);
-        } catch (Exception $e) {
-           // "Only If Output Exists" should not care that a file might not exist
-           // Keep existing behavior and rethrow exception for regular cases
-            if (!$onlyIfOutputExists) {
-                throw $e;  // rethrow it
+         } catch (Exception $e) {
+            // "Only If Output Exists" should not care that a file might not exist
+            // Keep existing behavior and rethrow exception for regular cases
+            if (! $onlyIfOutputExists) {
+                 throw $e;  // rethrow it
             }
-        }
+         }
 
         if ($onlyIfOutputExists && empty($text)) {
             return;


### PR DESCRIPTION
Avoid failing because we can't open the file to email.

This prevents the following error:
```
[2017-03-07 20:44:56] production.ERROR: ErrorException: file_get_contents(/web/LaravelLogs/check-approved-2017-03-07T13:44:55-07:00.
log): failed to open stream: No such file or directory in /web/vendor/laravel/framework/src/Illuminate/Console/Scheduling/Event.php:408
```

To replicate the error, delete the zero length file in the $schedule method chain's `->after(function())`.