### PR TITLE
[5.4] Fixes phpdocs on abstract ServiceProvider class

### DIFF
--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -9,7 +9,7 @@ abstract class ServiceProvider
     /**
      * The application instance.
      *
-     * @var \Illuminate\Contracts\Foundation\Application
+     * @var \Illuminate\Foundation\Application
      */
     protected $app;
 
@@ -37,7 +37,7 @@ abstract class ServiceProvider
     /**
      * Create a new service provider instance.
      *
-     * @param  \Illuminate\Contracts\Foundation\Application  $app
+     * @param  \Illuminate\Foundation\Application  $app
      * @return void
      */
     public function __construct($app)


### PR DESCRIPTION
Currently the interface/contract _Application_ is specified on the following code:

```
abstract class ServiceProvider
{
    /**
     * The application instance.
     *
     * @var \Illuminate\Contracts\Foundation\Application
     */
    protected $app;
```

**Problem:**: There are service providers that assume that the `$app` implementation have the method `runningInConsole`. For example the MailServiceProvider on the method:

```
 /**
     * Register the Markdown renderer instance.
     *
     * @return void
     */
    protected function registerMarkdownRenderer()
    {
        if ($this->app->runningInConsole()) {
```

Since runningInConsole do not exist on the contract, I propose is just specify on the php docs that service providers are instantiated with instance of Illuminate\Foundation\Application.