### PR TITLE
[5.4] Pickup when function from support collection to whenable trait

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Str;
 use InvalidArgumentException;
 use Illuminate\Support\Collection;
 use Illuminate\Pagination\Paginator;
+use Illuminate\Support\Traits\Whenable;
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\ConnectionInterface;
@@ -22,6 +23,8 @@ class Builder
     use Macroable {
         __call as macroCall;
     }
+
+    use Whenable;
 
     /**
      * The database connection instance.
@@ -455,27 +458,6 @@ class Builder
         $this->joins[] = new JoinClause($this, 'cross', $table);
 
         return $this;
-    }
-
-    /**
-     * Apply the callback's query changes if the given "value" is true.
-     *
-     * @param  bool  $value
-     * @param  \Closure  $callback
-     * @param  \Closure  $default
-     * @return \Illuminate\Database\Query\Builder
-     */
-    public function when($value, $callback, $default = null)
-    {
-        $builder = $this;
-
-        if ($value) {
-            $builder = call_user_func($callback, $builder);
-        } elseif ($default) {
-            $builder = call_user_func($default, $builder);
-        }
-
-        return $builder;
     }
 
     /**

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -11,13 +11,14 @@ use CachingIterator;
 use JsonSerializable;
 use IteratorAggregate;
 use InvalidArgumentException;
+use Illuminate\Support\Traits\Whenable;
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Contracts\Support\Arrayable;
 
 class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate, Jsonable, JsonSerializable
 {
-    use Macroable;
+    use Macroable, Whenable;
 
     /**
      * The items contained in the collection.
@@ -306,25 +307,6 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
         }
 
         return new static(array_filter($this->items));
-    }
-
-    /**
-     * Apply the callback if the value is truthy.
-     *
-     * @param  bool  $value
-     * @param  callable  $callback
-     * @param  callable  $default
-     * @return mixed
-     */
-    public function when($value, callable $callback, callable $default = null)
-    {
-        if ($value) {
-            return $callback($this);
-        } elseif ($default) {
-            return $default($this);
-        }
-
-        return $this;
     }
 
     /**

--- a/src/Illuminate/Support/Traits/Whenable.php
+++ b/src/Illuminate/Support/Traits/Whenable.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Illuminate\Support\Traits;
+
+trait Whenable
+{
+    /**
+     * Apply the callback if the value is truthy.
+     *
+     * @param  bool  $value
+     * @param  callable  $callback
+     * @param  callable  $default
+     * @return mixed
+     */
+    public function when($value, callable $callback, callable $default = null)
+    {
+        if ($value) {
+            return $callback($this);
+        } elseif ($default) {
+            return $default($this);
+        }
+
+        return $this;
+    }
+}

--- a/tests/Support/SupportWhenableTest.php
+++ b/tests/Support/SupportWhenableTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Illuminate\Tests\Support;
+
+use PHPUnit\Framework\TestCase;
+use Illuminate\Support\Traits\Whenable;
+
+class SupportWhenableTest extends TestCase
+{
+    use Whenable;
+
+    public function testNotApplyGivenCallbackWhenFalse()
+    {
+        $result = $this->when(false, function ($self) {
+            return 'Whenable';
+        });
+
+        $this->assertEquals($result, $this);
+    }
+
+    public function testNotApplyCallbackWhenTrue()
+    {
+        $result = $this->when(true, function ($self) {
+            return 'Whenable';
+        });
+
+        $this->assertEquals($result, 'Whenable');
+    }
+
+    public function testApplyDefaultCallbackWhenFalse()
+    {
+        $method = __METHOD__;
+
+        $result = $this->when(false, function ($self) {
+            return 'Whenable';
+        }, function ($self) use ($method) {
+            return $self->callDefault($method);
+        });
+
+        $this->assertEquals($result, $method . '!');
+    }
+
+    public function callDefault($message)
+    {
+        return $message . '!';
+    }
+}

--- a/tests/Support/SupportWhenableTest.php
+++ b/tests/Support/SupportWhenableTest.php
@@ -37,11 +37,11 @@ class SupportWhenableTest extends TestCase
             return $self->callDefault($method);
         });
 
-        $this->assertEquals($result, $method . '!');
+        $this->assertEquals($result, $method.'!');
     }
 
     public function callDefault($message)
     {
-        return $message . '!';
+        return $message.'!';
     }
 }


### PR DESCRIPTION
Pickup when function from support collection

```php
<?php

namespace Illuminate\Support\Traits;

trait Whenable
{
    /**
     * Apply the callback if the value is truthy.
     *
     * @param  bool  $value
     * @param  callable  $callback
     * @param  callable  $default
     * @return mixed
     */
    public function when($value, callable $callback, callable $default = null)
    {
        if ($value) {
            return $callback($this);
        } elseif ($default) {
            return $default($this);
        }
        return $this;
    }
}
```

Reuse in [Support Collection](https://github.com/RryLee/framework/blob/d7fad246c25d60ea5335a31ade249efefb8e77bc/src/Illuminate/Support/Collection.php#L21) and [Query/Builder](https://github.com/RryLee/framework/blob/d7fad246c25d60ea5335a31ade249efefb8e77bc/src/Illuminate/Database/Query/Builder.php#L27)


🍻 