### PR TITLE
[5.4] allow custom 'confirmed' field

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -313,11 +313,14 @@ trait ValidatesAttributes
      *
      * @param  string  $attribute
      * @param  mixed   $value
+     * @param  array   $parameters
      * @return bool
      */
-    protected function validateConfirmed($attribute, $value)
+    protected function validateConfirmed($attribute, $value, $parameters)
     {
-        return $this->validateSame($attribute, $value, [$attribute.'_confirmation']);
+        $confirmedField = (isset($parameters[0])) ? $parameters[0] : $attribute.'_confirmation';
+
+        return $this->validateSame($attribute, $value, [$confirmedField]);
     }
 
     /**

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -904,6 +904,15 @@ class ValidationValidatorTest extends TestCase
 
         $v = new Validator($trans, ['password' => '1e2', 'password_confirmation' => '100'], ['password' => 'Confirmed']);
         $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['password' => 'foo', 'password_confirmation' => 'foo'], ['password' => 'Confirmed:confirm_password']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['password' => 'foo', 'confirm_password' => 'bar'], ['password' => 'Confirmed:confirm_password']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['password' => 'foo', 'confirm_password' => 'foo'], ['password' => 'Confirmed:confirm_password']);
+        $this->assertTrue($v->passes());
     }
 
     public function testValidateSame()


### PR DESCRIPTION
currently we force the user to use an input with the same name with
‘_confirmation’ appended.  this update gives the user the option to
pass in a custom field name to confirm against.