### PR TITLE
[5.4] Allow lang path to be an array

### DIFF
--- a/src/Illuminate/Translation/FileLoader.php
+++ b/src/Illuminate/Translation/FileLoader.php
@@ -108,10 +108,13 @@ class FileLoader implements LoaderInterface
      * @param  string  $group
      * @return array
      */
-    protected function loadPath($path, $locale, $group)
+    protected function loadPath($paths, $locale, $group)
     {
-        if ($this->files->exists($full = "{$path}/{$locale}/{$group}.php")) {
-            return $this->files->getRequire($full);
+        $paths = array_wrap($paths);
+        foreach ($paths as $path) {
+            if ($this->files->exists($full = "{$path}/{$locale}/{$group}.php")) {
+                return $this->files->getRequire($full);
+            }
         }
 
         return [];
@@ -124,10 +127,13 @@ class FileLoader implements LoaderInterface
      * @param  string  $locale
      * @return array
      */
-    protected function loadJsonPath($path, $locale)
+    protected function loadJsonPath($paths, $locale)
     {
-        if ($this->files->exists($full = "{$path}/{$locale}.json")) {
-            return json_decode($this->files->get($full), true);
+        $paths = array_wrap($paths);
+        foreach ($paths as $path) {
+            if ($this->files->exists($full = "{$path}/{$locale}.json")) {
+                return json_decode($this->files->get($full), true);
+            }
         }
 
         return [];

--- a/src/Illuminate/Translation/FileLoader.php
+++ b/src/Illuminate/Translation/FileLoader.php
@@ -14,11 +14,11 @@ class FileLoader implements LoaderInterface
     protected $files;
 
     /**
-     * The default path for the loader.
+     * The default paths for the loader.
      *
-     * @var string
+     * @var array
      */
-    protected $path;
+    protected $paths;
 
     /**
      * All of the namespace hints.
@@ -31,12 +31,12 @@ class FileLoader implements LoaderInterface
      * Create a new file loader instance.
      *
      * @param  \Illuminate\Filesystem\Filesystem  $files
-     * @param  string  $path
+     * @param  array  $paths
      * @return void
      */
-    public function __construct(Filesystem $files, $path)
+    public function __construct(Filesystem $files, $paths)
     {
-        $this->path = $path;
+        $this->paths = array_wrap($paths);
         $this->files = $files;
     }
 
@@ -51,11 +51,11 @@ class FileLoader implements LoaderInterface
     public function load($locale, $group, $namespace = null)
     {
         if ($group == '*' && $namespace == '*') {
-            return $this->loadJsonPath($this->path, $locale);
+            return $this->loadJsonPath($this->paths, $locale);
         }
 
         if (is_null($namespace) || $namespace == '*') {
-            return $this->loadPath($this->path, $locale, $group);
+            return $this->loadPath($this->paths, $locale, $group);
         }
 
         return $this->loadNamespaced($locale, $group, $namespace);
@@ -91,10 +91,12 @@ class FileLoader implements LoaderInterface
      */
     protected function loadNamespaceOverrides(array $lines, $locale, $group, $namespace)
     {
-        $file = "{$this->path}/vendor/{$namespace}/{$locale}/{$group}.php";
+        foreach ($this->paths as $path) {
+            $file = "{$path}/vendor/{$namespace}/{$locale}/{$group}.php";
 
-        if ($this->files->exists($file)) {
-            return array_replace_recursive($lines, $this->files->getRequire($file));
+            if ($this->files->exists($file)) {
+                return array_replace_recursive($lines, $this->files->getRequire($file));
+            }
         }
 
         return $lines;

--- a/src/Illuminate/Translation/FileLoader.php
+++ b/src/Illuminate/Translation/FileLoader.php
@@ -101,9 +101,9 @@ class FileLoader implements LoaderInterface
     }
 
     /**
-     * Load a locale from a given path.
+     * Load a locale from a given paths.
      *
-     * @param  string  $path
+     * @param  array  $paths
      * @param  string  $locale
      * @param  string  $group
      * @return array
@@ -121,9 +121,9 @@ class FileLoader implements LoaderInterface
     }
 
     /**
-     * Load a locale from the given JSON file path.
+     * Load a locale from the given JSON file paths.
      *
-     * @param  string  $path
+     * @param  array  $paths
      * @param  string  $locale
      * @return array
      */


### PR DESCRIPTION
My use case:

I'm working on a multi-tenant/multi-language website which needs to have
a global languages directory in `storage/lang` and a local (domain
specific) languages in the usual `resources/lang` directory.

The local domain specific messages overrides the global messages.

For now I just extend the `\Illuminate\Foundation\Application` and
override the `langPath()` method supplying an array of possible paths for
the `\Illuminate\Translation\FileLoader.php` to load.

However this can be further customized to allow for languages to be
loaded from a **paths** key in the `config/app.php` (or even a separate
`config/lang.php` file) just like the `config/view.php` has an array of
possible paths.