### PR TITLE
[5.5] Callable/Invokable Objects in Pipelines

### DIFF
--- a/src/Illuminate/Pipeline/Pipeline.php
+++ b/src/Illuminate/Pipeline/Pipeline.php
@@ -124,7 +124,7 @@ class Pipeline implements PipelineContract
     {
         return function ($stack, $pipe) {
             return function ($passable) use ($stack, $pipe) {
-                if ($pipe instanceof Closure) {
+                if (is_callable($pipe)) {
                     // If the pipe is an instance of a Closure, we will just call it directly but
                     // otherwise we'll resolve the pipes out of the container and call it with
                     // the appropriate method and arguments, returning the results back out.

--- a/src/Illuminate/Pipeline/Pipeline.php
+++ b/src/Illuminate/Pipeline/Pipeline.php
@@ -145,7 +145,7 @@ class Pipeline implements PipelineContract
                     $parameters = [$passable, $stack];
                 }
 
-                return $pipe->{$this->method}(...$parameters);
+                return method_exists($pipe, $this->method) ? $pipe->{$this->method}(...$parameters) : $pipe(...$parameters);
             };
         };
     }

--- a/tests/Pipeline/PipelineTest.php
+++ b/tests/Pipeline/PipelineTest.php
@@ -84,6 +84,24 @@ class PipelineTest extends TestCase
 
         unset($_SERVER['__test.pipe.one']);
     }
+
+    public function testPipelineUsageWithInvokableClass()
+    {
+        $result = (new Pipeline(new \Illuminate\Container\Container))
+            ->send('foo')
+            ->through([PipelineTestPipeTwo::class])
+            ->then(
+                function ($piped) {
+                    return $piped;
+                }
+            );
+
+        $this->assertEquals('foo', $result);
+        $this->assertEquals('foo', $_SERVER['__test.pipe.one']);
+
+        unset($_SERVER['__test.pipe.one']);
+    }
+
     public function testPipelineUsageWithParameters()
     {
         $parameters = ['one', 'two'];

--- a/tests/Pipeline/PipelineTest.php
+++ b/tests/Pipeline/PipelineTest.php
@@ -45,6 +45,45 @@ class PipelineTest extends TestCase
         unset($_SERVER['__test.pipe.one']);
     }
 
+    public function testPipelineUsageWithInvokableObjects()
+    {
+        $result = (new Pipeline(new \Illuminate\Container\Container))
+            ->send('foo')
+            ->through([new PipelineTestPipeTwo])
+            ->then(
+                function ($piped) {
+                    return $piped;
+                }
+            );
+
+        $this->assertEquals('foo', $result);
+        $this->assertEquals('foo', $_SERVER['__test.pipe.one']);
+
+        unset($_SERVER['__test.pipe.one']);
+    }
+
+    public function testPipelineUsageWithCallable()
+    {
+        $function = function ($piped, $next) {
+            $_SERVER['__test.pipe.one'] = 'foo';
+
+            return $next($piped);
+        };
+
+        $result = (new Pipeline(new \Illuminate\Container\Container))
+            ->send('foo')
+            ->through([$function])
+            ->then(
+                function ($piped) {
+                    return $piped;
+                }
+            );
+
+        $this->assertEquals('foo', $result);
+        $this->assertEquals('foo', $_SERVER['__test.pipe.one']);
+
+        unset($_SERVER['__test.pipe.one']);
+    }
     public function testPipelineUsageWithParameters()
     {
         $parameters = ['one', 'two'];
@@ -98,6 +137,16 @@ class PipelineTestPipeOne
 
     public function differentMethod($piped, $next)
     {
+        return $next($piped);
+    }
+}
+
+class PipelineTestPipeTwo
+{
+    public function __invoke($piped, $next)
+    {
+        $_SERVER['__test.pipe.one'] = $piped;
+
         return $next($piped);
     }
 }


### PR DESCRIPTION
This will allow objects/classes with `__invoke` rather than `handle` to be executed, and also allows for closure or other callable types (i.e. `[$object, 'doSomething']`)