### PR TITLE
[5.4] Simplify method

### DIFF
--- a/src/Illuminate/Foundation/AliasLoader.php
+++ b/src/Illuminate/Foundation/AliasLoader.php
@@ -88,9 +88,7 @@ class AliasLoader
      */
     protected function loadFacade($alias)
     {
-        tap($this->ensureFacadeExists($alias), function ($path) {
-            require $path;
-        });
+        require $this->ensureFacadeExists($alias);
     }
 
     /**


### PR DESCRIPTION
This PR just removes an unnecessary call to `tap()` function.

I find it simpler to not use the `tap()` helper, as there is only one action performed.