### PR TITLE
[5.4] Console alert box

### DIFF
--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -434,6 +434,19 @@ class Command extends SymfonyCommand
     }
 
     /**
+     * Write a string in an alert box.
+     *
+     * @param  string  $string
+     * @return void
+     */
+    public function alert($string)
+    {
+        $this->comment(str_repeat('*', strlen($string) + 12));
+        $this->comment('*     '.$string.'     *');
+        $this->comment(str_repeat('*', strlen($string) + 12));
+    }
+
+    /**
      * Write a string as question output.
      *
      * @param  string  $string

--- a/src/Illuminate/Console/ConfirmableTrait.php
+++ b/src/Illuminate/Console/ConfirmableTrait.php
@@ -26,9 +26,7 @@ trait ConfirmableTrait
                 return true;
             }
 
-            $this->comment(str_repeat('*', strlen($warning) + 12));
-            $this->comment('*     '.$warning.'     *');
-            $this->comment(str_repeat('*', strlen($warning) + 12));
+            $this->alert($warning);
             $this->output->writeln('');
 
             $confirmed = $this->confirm('Do you really wish to run this command?');


### PR DESCRIPTION
This PR introduces `alert()` method into `Illuminate/Console/Command` class.

It extracts the _alert-style box_ from `Illuminate/Console/ConfirmableTrait` and makes it available to everybody alongside with standard console output formatting methods.

🌵 