### PR TITLE
[5.4] Mind file uploads in nested array keys

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -304,6 +304,10 @@ trait MakesHttpRequests
 
                 unset($data[$key]);
             }
+
+            if (is_array($value)) {
+                $files[$key] = $this->extractFilesFromDataArray($value);
+            }
         }
 
         return $files;


### PR DESCRIPTION
In reference to https://github.com/laravel/framework/issues/18268

It handles the case when the uploaded files are in nested keys

```
$this->post('/', [
            'foo' => [
                'bar' => UploadedFile::fake()->image('image.gif')
            ]
]);
```