### PR TITLE
[5.4] Added check not to retry non-existing jobs for clarity

### DIFF
--- a/src/Illuminate/Queue/Console/RetryCommand.php
+++ b/src/Illuminate/Queue/Console/RetryCommand.php
@@ -30,11 +30,17 @@ class RetryCommand extends Command
     public function fire()
     {
         foreach ($this->getJobIds() as $id) {
-            $this->retryJob($id);
+            $job = $this->getJob($id);
 
-            $this->info("The failed job [{$id}] has been pushed back onto the queue!");
+            if (is_null($job)) {
+                $this->error("No failed job matches the given ID [{$id}].");
+            } else {
+                $this->retryJob($job);
 
-            $this->laravel['queue.failer']->forget($id);
+                $this->info("The failed job [{$id}] has been pushed back onto the queue!");
+
+                $this->laravel['queue.failer']->forget($id);
+            }
         }
     }
 
@@ -55,21 +61,25 @@ class RetryCommand extends Command
     }
 
     /**
-     * Retry the queue job with the given ID.
-     *
+     * Get the job instance.
      * @param  string  $id
+     * @return stdClass
+     */
+    protected function getJob($id)
+    {
+        return $this->laravel['queue.failer']->find($id);
+    }
+
+    /**
+     * Retry the queue job.
+     *
+     * @param  stdClass  $job
      * @return void
      */
-    protected function retryJob($id)
+    protected function retryJob($job)
     {
-        if (is_null($failed = $this->laravel['queue.failer']->find($id))) {
-            return $this->error("No failed job matches the given ID [{$id}].");
-        }
-
-        $failed = (object) $failed;
-
-        $this->laravel['queue']->connection($failed->connection)->pushRaw(
-            $this->resetAttempts($failed->payload), $failed->queue
+        $this->laravel['queue']->connection($job->connection)->pushRaw(
+            $this->resetAttempts($job->payload), $job->queue
         );
     }
 


### PR DESCRIPTION
Currently if you try to requeue non-existing jobs with artisan queue:retry it shows the error message and the info that the job has been requeued.

```shell
[root@server www]$ php artisan queue:retry foobar
No failed job matches the given ID [foobar].
The failed job [foobar] has been pushed back onto the queue!
```

This pull request changes the logic so the job is not retried if the id does not even exist and only shows the proper error message.

```shell
vagrant@homestead:~/Code/foobar$ php artisan queue:retry foo bar 9561
No failed job matches the given ID [foo].
No failed job matches the given ID [bar].
The failed job [9561] has been pushed back onto the queue!
```
