### PR TITLE
[5.4] add tap to query builder

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -479,6 +479,16 @@ class Builder
     }
 
     /**
+     * Pass the query to a given callback
+     * 
+     * @param  \Closure  $callback
+     * @return \Illuminate\Database\Query\Builder
+     */
+    public function tap($callback) {
+        return $this->when(true, $callback);
+    }
+
+    /**
      * Merge an array of where clauses and bindings.
      *
      * @param  array  $wheres

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -480,7 +480,7 @@ class Builder
 
     /**
      * Pass the query to a given callback.
-     * 
+     *
      * @param  \Closure  $callback
      * @return \Illuminate\Database\Query\Builder
      */

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -479,12 +479,13 @@ class Builder
     }
 
     /**
-     * Pass the query to a given callback
+     * Pass the query to a given callback.
      * 
      * @param  \Closure  $callback
      * @return \Illuminate\Database\Query\Builder
      */
-    public function tap($callback) {
+    public function tap($callback)
+    {
         return $this->when(true, $callback);
     }
 

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -166,6 +166,17 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => 2, 1 => 'foo'], $builder->getBindings());
     }
 
+    public function testTapCallback()
+    {
+        $callback = function ($query) {
+            return $query->where('id', '=', 1);
+        };
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->tap($callback)->where('email', 'foo');
+        $this->assertEquals('select * from "users" where "id" = ? and "email" = ?', $builder->toSql());
+    }
+
     public function testBasicWheres()
     {
         $builder = $this->getBuilder();


### PR DESCRIPTION
I've run into a few situations lately (mainly parsing filters from query strings) where I ended up using when(1, $callback).

To make this a bit cleaner, I added a tap method to query builder to mimic the behavior found in collections. 