### PR TITLE
[5.4] Return the insertId of released jobs

### DIFF
--- a/src/Illuminate/Queue/Jobs/DatabaseJob.php
+++ b/src/Illuminate/Queue/Jobs/DatabaseJob.php
@@ -45,7 +45,7 @@ class DatabaseJob extends Job implements JobContract
      * Release the job back into the queue.
      *
      * @param  int  $delay
-     * @return void
+     * @return mixed
      */
     public function release($delay = 0)
     {
@@ -53,7 +53,7 @@ class DatabaseJob extends Job implements JobContract
 
         $this->delete();
 
-        $this->database->release($this->queue, $this->job, $delay);
+        return $this->database->release($this->queue, $this->job, $delay);
     }
 
     /**


### PR DESCRIPTION
The `InteractsWithQueue` trait returns the response from `$this->job->release($delay);` in it's `release()` and the `DatabaseQueue` class returns the inserted id from it's `release()` method.  This allows the inserted id to flow back to a job that manually calls `release()`.

My use case involves wanting to release a job back onto the queue without incrementing it's attempts count.  I would use this to manually query the `jobs` table and decrement the `attempts` after calling `release()`.

One issue I see with this proposal is that the `Job` contract describes the `release()` response as being `void`, which is violated by this change.