### PR TITLE
[5.4] Removes unwanted dependency of illuminate/mail

### DIFF
--- a/src/Illuminate/Mail/MailServiceProvider.php
+++ b/src/Illuminate/Mail/MailServiceProvider.php
@@ -122,9 +122,11 @@ class MailServiceProvider extends ServiceProvider
         }
 
         $this->app->singleton(Markdown::class, function () {
+            $config = $this->app->make('config');
+
             return new Markdown($this->app->make('view'), [
-                'theme' => config('mail.markdown.theme', 'default'),
-                'paths' => config('mail.markdown.paths', []),
+                'theme' => $config->get('mail.markdown.theme', 'default'),
+                'paths' => $config->get('mail.markdown.paths', []),
             ]);
         });
     }

--- a/src/Illuminate/Mail/MailServiceProvider.php
+++ b/src/Illuminate/Mail/MailServiceProvider.php
@@ -121,10 +121,10 @@ class MailServiceProvider extends ServiceProvider
             ], 'laravel-mail');
         }
 
-        $this->app->singleton(Markdown::class, function () {
-            $config = $this->app->make('config');
+        $this->app->singleton(Markdown::class, function ($app) {
+            $config = $app->make('config');
 
-            return new Markdown($this->app->make('view'), [
+            return new Markdown($app->make('view'), [
                 'theme' => $config->get('mail.markdown.theme', 'default'),
                 'paths' => $config->get('mail.markdown.paths', []),
             ]);

--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -9,7 +9,7 @@ abstract class ServiceProvider
     /**
      * The application instance.
      *
-     * @var \Illuminate\Contracts\Foundation\Application
+     * @var \Illuminate\Foundation\Application
      */
     protected $app;
 
@@ -37,7 +37,7 @@ abstract class ServiceProvider
     /**
      * Create a new service provider instance.
      *
-     * @param  \Illuminate\Contracts\Foundation\Application  $app
+     * @param  \Illuminate\Foundation\Application  $app
      * @return void
      */
     public function __construct($app)


### PR DESCRIPTION
On the `MailServiceProvider` the method `registerMarkdownRenderer` is using the helper function `config()` on the following code:

```
        $this->app->singleton(Markdown::class, function () {
            return new Markdown($this->app->make('view'), [
                'theme' => config('mail.markdown.theme', 'default'),
                'paths' => config('mail.markdown.paths', []),
            ]);
        });
```

**Problem:** On the composer.json of the package `illuminate/mail` the package `illuminate/foundation` **don't exists**. So the helper function `config()` also don't exists.

**Solucion:** Makes usage of the app container to get the markdown app config.