### PR TITLE
[5.4] Optimize performance for Arr::isAssoc

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -320,9 +320,7 @@ class Arr
      */
     public static function isAssoc(array $array)
     {
-        $keys = array_keys($array);
-
-        return array_keys($keys) !== $keys;
+		return (array_values($array) !== $array);
     }
 
     /**

--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -320,7 +320,7 @@ class Arr
      */
     public static function isAssoc(array $array)
     {
-		return (array_values($array) !== $array);
+        return array_values($array) !== $array;
     }
 
     /**


### PR DESCRIPTION
Same functionality as the old `isAssoc`, but uses `array_values` for checking instead of `array_keys`, for better performance. 

Gist with benchmark of different methods for checking if array is associative.
https://gist.github.com/Thinkscape/1965669
