### PR TITLE
[5.4] Fix: Str::replaceArray()

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -277,8 +277,26 @@ class Str
      */
     public static function replaceArray($search, array $replace, $subject)
     {
-        foreach ($replace as $value) {
-            $subject = static::replaceFirst($search, $value, $subject);
+        if ($search === '') {
+            return $subject;
+        }
+        $positions = [];
+        $offset = 0;
+        do {
+            $position = strpos($subject, $search, $offset);
+            if ($position === false) {
+                break;
+            }
+            $positions[] = $position;
+            $offset = $position + strlen($search);
+        } while (true);
+
+        array_splice($positions, count($replace));
+        array_splice($replace, count($positions));
+        $positions = array_reverse($positions);
+        $replace = array_reverse($replace);
+        foreach ($positions as $index => $position) {
+            $subject = substr_replace($subject, $replace[$index], $position, strlen($search));
         }
 
         return $subject;

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -169,10 +169,17 @@ class SupportStrTest extends TestCase
 
     public function testReplaceArray()
     {
+        $this->assertEquals('?/?/?', Str::replaceArray('', ['foo', 'bar', 'baz'], '?/?/?'));
         $this->assertEquals('foo/bar/baz', Str::replaceArray('?', ['foo', 'bar', 'baz'], '?/?/?'));
         $this->assertEquals('foo/bar/baz/?', Str::replaceArray('?', ['foo', 'bar', 'baz'], '?/?/?/?'));
         $this->assertEquals('foo/bar', Str::replaceArray('?', ['foo', 'bar', 'baz'], '?/?'));
         $this->assertEquals('?/?/?', Str::replaceArray('x', ['foo', 'bar', 'baz'], '?/?/?'));
+        $this->assertEquals('foo?/bar?/baz?', Str::replaceArray('?', ['foo?', 'bar?', 'baz?'], '?/?/?'));
+        $this->assertEquals('foo?/bar?/baz?/?', Str::replaceArray('?', ['foo?', 'bar?', 'baz?'], '?/?/?/?'));
+        $this->assertEquals('foo?/bar?', Str::replaceArray('?', ['foo?', 'bar?', 'baz?'], '?/?'));
+        $this->assertEquals('foo??/bar??/baz??', Str::replaceArray('??', ['foo??', 'bar??', 'baz??'], '??/??/??'));
+        $this->assertEquals('foo?bar?baz?', Str::replaceArray('?', ['foo?', 'bar?', 'baz?'], '???'));
+        $this->assertEquals('foo??bar??baz??', Str::replaceArray('??', ['foo??', 'bar??', 'baz??'], '??????'));
     }
 
     public function testReplaceFirst()


### PR DESCRIPTION
In old implementation, `Str::replaceArray('?', ['foo?', 'bar?', 'baz?'], '?/?/?')` would return `foobarbaz?/?/?`, that obviously not what we want.