### PR TITLE
[5.4] Feature/Bug: Allow ImplicitRouteBinding to match camelized method parameter names

### DIFF
--- a/src/Illuminate/Routing/ImplicitRouteBinding.php
+++ b/src/Illuminate/Routing/ImplicitRouteBinding.php
@@ -26,7 +26,7 @@ class ImplicitRouteBinding
                 $parameterName = array_key_exists($parameter->name, $parameters) ? $parameter->name : null;
 
                 // check if parameter name used was camelized in routed callback method
-                if (!$parameterName) {
+                if (! $parameterName) {
                     $snakeParamName = snake_case($parameter->name);
                     $parameterName = array_key_exists($snakeParamName, $parameters) ? $snakeParamName : null;
                 }

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -700,6 +700,13 @@ class RoutingRouteTest extends TestCase
         $this->assertEquals('tayloralt', $router->dispatch(Request::create('foo/TAYLOR', 'GET'))->getContent());
     }
 
+    public function testModelBindingWithCompoundParameterName()
+    {
+        $router = $this->getRouter();
+        $router->resource('foo-bar', 'Illuminate\Tests\Routing\RouteTestResourceControllerWithModelParameter', ['middleware' => SubstituteBindings::class]);
+        $this->assertEquals('12345', $router->dispatch(Request::create('foo-bar/12345', 'GET'))->getContent());
+    }
+
     public function testModelBindingThroughIOC()
     {
         $container = new Container;
@@ -1272,6 +1279,14 @@ class RouteTestControllerWithParameterStub extends Controller
     public function returnParameter($bar = '')
     {
         return $bar;
+    }
+}
+
+class RouteTestResourceControllerWithModelParameter extends Controller
+{
+    public function show(RoutingTestUserModel $fooBar)
+    {
+        return $fooBar->value;
     }
 }
 


### PR DESCRIPTION
Problem:
```php
Route::resource('foo-bar', 'FooBarController')
```

will not route implicitly bound model parameters to

```php
<?php
namespace App\Http\Controllers;

use App\Models\FooBar;

class FooBarController extends Controller
{
    public function show(FooBar $fooBar)
    {
        // ...
    }
    // ...
}
```
since ImplicitRouteBinding will not match the auto-generated `foo_bar` resource parameter name to the controller method name `$fooBar`.

The provided PR ensures this will work in a non-breaking way (original explicit matching remains priority matching, and only in the case of non-matching exact will the snake_case version of a method name be attempted to be matched.

(I feel this could qualify as a bug since my expectation is that camelized method parameter naming should work and Route::resource() doesn't allow for hinting a proper parameter name.)