### PR TITLE
[5.4] AliasLoader docblock and code

### DIFF
--- a/src/Illuminate/Foundation/AliasLoader.php
+++ b/src/Illuminate/Foundation/AliasLoader.php
@@ -84,13 +84,11 @@ class AliasLoader
      * Load a real-time facade for the given alias.
      *
      * @param  string  $alias
-     * @return bool
+     * @return void
      */
     protected function loadFacade($alias)
     {
-        tap($this->ensureFacadeExists($alias), function ($path) {
-            require $path;
-        });
+        require $this->ensureFacadeExists($alias);
     }
 
     /**


### PR DESCRIPTION
This method doesn't return and the use of `tap` here is unneeded.