### PR TITLE
[5.4] Ensure Mailable view data is not overridden by order of operations

### DIFF
--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -520,7 +520,7 @@ class Mailable implements MailableContract
     public function markdown($view, array $data = [])
     {
         $this->markdown = $view;
-        $this->viewData = $data;
+        $this->viewData = array_merge($this->viewData, $data);
 
         return $this;
     }
@@ -535,7 +535,7 @@ class Mailable implements MailableContract
     public function view($view, array $data = [])
     {
         $this->view = $view;
-        $this->viewData = $data;
+        $this->viewData = array_merge($this->viewData, $data);
 
         return $this;
     }
@@ -550,7 +550,7 @@ class Mailable implements MailableContract
     public function text($textView, array $data = [])
     {
         $this->textView = $textView;
-        $this->viewData = $data;
+        $this->viewData = array_merge($this->viewData, $data);
 
         return $this;
     }

--- a/tests/Mail/MailMailableDataTest.php
+++ b/tests/Mail/MailMailableDataTest.php
@@ -5,7 +5,7 @@ namespace Illuminate\Tests\Mail;
 use Illuminate\Mail\Mailable;
 use PHPUnit\Framework\TestCase;
 
-class MailMailableTest extends TestCase
+class MailMailableDataTest extends TestCase
 {
     public function testMailableDataIsNotLost()
     {

--- a/tests/Mail/MailMailableDataTest.php
+++ b/tests/Mail/MailMailableDataTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Illuminate\Tests\Mail;
+
+use Illuminate\Mail\Mailable;
+use PHPUnit\Framework\TestCase;
+
+class MailMailableTest extends TestCase
+{
+    public function testMailableDataIsNotLost()
+    {
+        $testData = ['first_name' => 'James'];
+
+        $mailable = new MailableStub;
+        $mailable->build(function($m) use ($testData) {
+            $m->view('view', $testData);
+        });
+        $this->assertSame($testData, $mailable->buildViewData());
+
+        $mailable = new MailableStub;
+        $mailable->build(function($m) use ($testData) {
+            $m->view('view', $testData)
+              ->text('text-view');
+        });
+        $this->assertSame($testData, $mailable->buildViewData());
+    }
+}
+
+class MailableStub extends Mailable
+{
+    /**
+     * Build the message.
+     *
+     * @return $this
+     */
+    public function build($builder)
+    {
+        $builder($this);
+    }
+}

--- a/tests/Mail/MailMailableTest.php
+++ b/tests/Mail/MailMailableTest.php
@@ -84,7 +84,7 @@ class WelcomeMailableStub extends Mailable
     public function build()
     {
         $this->with('first_name', 'Taylor')
-            ->withLastName('Otwell');
+             ->withLastName('Otwell');
     }
 }
 


### PR DESCRIPTION
The `markdown()`, `view()` and `text()` methods on the `Mailable` class currently override the instances `viewData` field with their own data parameter (which defaults to an empty array).

This means if any of these methods are called after the `with()` method that the previous view data supplied in the call to `with()` is lost.

In the following case the view data is empty:

    public function build()
    {
        $this->view('sample-view')
             ->with([ 'data' => 'example' ])
             ->text('sample-view_plain');
    }

This pull request ensures the `viewData` is always merged with each subsequent call.

Unit tests are provided which exhibit the incorrect behaviour.