### PR TITLE
[5.4] Make it possible to publish package routes

### DIFF
--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -63,12 +63,17 @@ abstract class ServiceProvider
      * Load the given routes file if routes are not already cached.
      *
      * @param  string  $path
+     * @param  string|null  $package
      * @return void
      */
-    protected function loadRoutesFrom($path)
+    protected function loadRoutesFrom($path, $package = null)
     {
         if (! $this->app->routesAreCached()) {
-            require $path;
+            if ($package && is_file($routePath = $this->app->basePath().'/routes/vendor/'.$package.'.php')) {
+                require $routePath;
+            } else {
+                require $path;
+            }
         }
     }
 


### PR DESCRIPTION
Adding a way to publish package routes.
This can be convenient where a package creates routes for your application, but you want to modify them a bit.

This is a small change which does not break anything, only adds possibilities.
The routes that the package will publish will be stored in `routes/vendor/{packagename}.php`

See https://github.com/laravel/docs/pull/3200 for docs changes