### PR TITLE
[5.4] Database Factory includes non-php files

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factory.php
@@ -199,6 +199,10 @@ class Factory implements ArrayAccess
 
         if (is_dir($path)) {
             foreach (Finder::create()->files()->in($path) as $file) {
+                if(pathinfo($file->getRealPath(), PATHINFO_EXTENSION) !== 'php') {
+                    continue;
+                }
+
                 require $file->getRealPath();
             }
         }

--- a/src/Illuminate/Database/Eloquent/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factory.php
@@ -198,11 +198,7 @@ class Factory implements ArrayAccess
         $factory = $this;
 
         if (is_dir($path)) {
-            foreach (Finder::create()->files()->in($path) as $file) {
-                if(pathinfo($file->getRealPath(), PATHINFO_EXTENSION) !== 'php') {
-                    continue;
-                }
-
+            foreach (Finder::create()->files()->name('*.php')->in($path) as $file) {
                 require $file->getRealPath();
             }
         }


### PR DESCRIPTION
When using a editor like emacs that creates eg. 'UserSeeder.php~' files, those files will get included as well as the correct 'UserSeeder.php' file.

This causes 'UserSeeder.php' to get overwritten with the 'UserSeeder.php~', which can cause a lot of confusion. 