### PR TITLE
[5.4] Add support for nested relationships in relationLoaded()

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -36,6 +36,47 @@ class Collection extends BaseCollection implements QueueableCollection
     }
 
     /**
+     * Determine if the given relation is loaded on collection models.
+     *
+     * @param  string  $key
+     * @return bool
+     */
+    public function relationLoaded($key)
+    {
+        // If collection is empty relations are still loaded, but nothing was found
+        if ($this->isEmpty()) {
+            return true;
+        }
+
+        // Get first model
+        $first = $this->first();
+
+        // Check if this is a nested relationship
+        if (strpos($key, '.') === false) {
+            return $first->relationLoaded($key);
+        } else {
+            // Split first key from nested relations
+            $name = strstr($key, '.', true);
+            $nested = substr(strstr($key, '.'), 1);
+
+            // Check if relations are loaded
+            if (! $first->relationLoaded($name)) {
+                return false;
+            }
+
+            // Get all relationship models as new collection
+            $models = $this->pluck($name)->flatten()->unique();
+
+            // Pluck and flatten will return a base collection
+            // Cast collection back to Eloquent collection
+            $models = new static($models->items);
+
+            // Continue down nested relations
+            return $models->relationLoaded($nested);
+        }
+    }
+
+    /**
      * Load a set of relationships onto the collection.
      *
      * @param  mixed  $relations

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -48,19 +48,22 @@ class Collection extends BaseCollection implements QueueableCollection
             return true;
         }
 
-        // Get first model
-        $first = $this->first();
-
         // Check if this is a nested relationship
         if (strpos($key, '.') === false) {
-            return $first->relationLoaded($key);
+            return $this->every(function ($item) use ($key) {
+                return $item->relationLoaded($key);
+            });
         } else {
             // Split first key from nested relations
             $name = strstr($key, '.', true);
             $nested = substr(strstr($key, '.'), 1);
 
+            $relationLoaded = $this->every(function ($item) use ($name) {
+                return $item->relationLoaded($name);
+            });
+
             // Check if relations are loaded
-            if (! $first->relationLoaded($name)) {
+            if (! $relationLoaded) {
                 return false;
             }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -520,7 +520,32 @@ trait HasRelationships
      */
     public function relationLoaded($key)
     {
-        return array_key_exists($key, $this->relations);
+        // Check if this is a nested relationship
+        if (strpos($key, '.') === false) {
+            return array_key_exists($key, $this->relations);
+        } else {
+
+            // Split first key from nested relations
+            $name = strstr($key, '.', true);
+            $nested = substr(strstr($key, '.'), 1);
+
+            // Check if first relation is loaded
+            if (array_key_exists($name, $this->relations)) {
+
+                // Get existing relation
+                $relation = $this->{$name};
+
+                // If model is null relations are still loaded, but nothing was found
+                if (! $relation) {
+                    return true;
+                }
+
+                // Check nested relations
+                return $relation->relationLoaded($nested);
+            } else {
+                return false;
+            }
+        }
     }
 
     /**

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -147,6 +147,40 @@ class DatabaseEloquentCollectionTest extends TestCase
         $this->assertEquals(['results'], $c->all());
     }
 
+    public function testRelationLoadedMethod()
+    {
+        // Nested relationship of collections (i.e. many-to-many)
+        $nested = new TestEloquentCollectionModel;
+        $nested->setRelation('bar', []);
+        $model = new TestEloquentCollectionModel;
+        $model->setRelation('foo', new Collection([$nested]));
+        $c = new Collection([$model]);
+
+        $this->assertTrue($c->relationLoaded('foo.bar'));
+
+        // Nested relationship missing on one model
+        $monkeyWrench = new TestEloquentCollectionModel; // No nested relations
+        $model->setRelation('foo', new Collection([$nested, $monkeyWrench]));
+        $c2 = new Collection([$model]);
+
+        $this->assertFalse($c2->relationLoaded('foo.bar'));
+
+        // Nested ralationship with single model (i.e. one-to-many)
+        $modelTwo = new TestEloquentCollectionModel;
+        $modelTwo->setRelation('bar', []);
+        $model->setRelation('foo', $modelTwo);
+        $c3 = new Collection([$model]);
+
+        $this->assertTrue($c3->relationLoaded('foo.bar'));
+
+        // Empty collection on first level of nesting
+        // Relations should still be considered as loaded
+        $model->setRelation('foo', new Collection([]));
+        $c4 = new Collection([$model]);
+
+        $this->assertTrue($c4->relationLoaded('foo.bar'));
+    }
+
     public function testCollectionDictionaryReturnsModelKeys()
     {
         $one = m::mock('Illuminate\Database\Eloquent\Model');


### PR DESCRIPTION
* Added `relationLoaded()`function to `Illuminate\Database\Eloquent\Collection`
* Added support for nested relationships in `relationLoaded()` on `Illuminate\Database\Eloquent\Concerns\HasRelationships`

This will allows for checking nested relationships:
```php
if (! $post->relationLoaded('comments.author')) {
    $post->load('comments.author');
}
```

It also allows for checking relationships on Eloquent collections:
```php
if(! $comments->relationLoaded('post.tags')) {
    $comments->load('post.tags');
}
```

Partial fix for https://github.com/laravel/internals/issues/450.