### PR TITLE
[5.4] Fix issue in php5.6.10+ when generate fake images for testing

### DIFF
--- a/src/Illuminate/Http/Testing/FileFactory.php
+++ b/src/Illuminate/Http/Testing/FileFactory.php
@@ -41,7 +41,9 @@ class FileFactory
     protected function generateImage($width, $height)
     {
         return tap(tmpfile(), function ($temp) use ($width, $height) {
-            imagepng(imagecreatetruecolor($width, $height), $temp);
+            ob_start();
+            imagepng(imagecreatetruecolor($width, $height));
+            fwrite($temp, ob_get_clean());
         });
     }
 }


### PR DESCRIPTION
When try to use the fake files for testing feature get an error like:

```
ErrorException: stream_get_meta_data(): 1791 is not a valid stream resource
```

See https://github.com/laravel/framework/issues/18268#issuecomment-285311453