### PR TITLE
[5.4] Add setKeyType() method to Eloquent abstract Model

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1105,7 +1105,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     }
 
     /**
-     * Get the auto incrementing key type.
+     * Get the auto-incrementing key type.
      *
      * @return string
      */
@@ -1115,9 +1115,9 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     }
 
     /**
-     * Sets the data type for the primary key.
+     * Set the data type for the primary key.
      *
-     * @param string $type
+     * @param  string  $type
      * @return $this
      */
     public function setKeyType($type)

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1115,6 +1115,19 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     }
 
     /**
+     * Sets the data type for the primary key.
+     *
+     * @param string $type
+     * @return $this
+     */
+    public function setKeyType($type)
+    {
+        $this->keyType = $type;
+
+        return $this;
+    }
+
+    /**
      * Get the value indicating whether the IDs are incrementing.
      *
      * @return bool


### PR DESCRIPTION
The Eloquent Model class has various public methods to set the protected properties used to match characteristics of the underlying table, such as table name, primary key and primary key type.  Eloquent documentation states to overwrite these protected properties in classes that extends Model.  However, there are public methods provided to overwrite these values during runtime which are extremely useful if you have Eloquent Models that need to operate on multiple tables.  There is setTable and setKeyName and setIncrementing, however, there is no setKeyType method to change the primary key type.