### PR TITLE
[5.4] fixing weird behaviour of Connection method

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -957,11 +957,15 @@ class Connection implements ConnectionInterface
     /**
      * Get an option from the configuration options.
      *
-     * @param  string  $option
+     * @param  string|null  $option
      * @return mixed
      */
-    public function getConfig($option)
+    public function getConfig($option = null)
     {
+        if (empty($option)) {
+            return $this->config;
+        }
+
         return Arr::get($this->config, $option);
     }
 

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -962,10 +962,6 @@ class Connection implements ConnectionInterface
      */
     public function getConfig($option = null)
     {
-        if (empty($option)) {
-            return $this->config;
-        }
-
         return Arr::get($this->config, $option);
     }
 


### PR DESCRIPTION
The method ```getConfig()``` of connection class was working weirdly if you did pass null, you could still get the ```$this->config``` array, but some warnings would be thrown.
I add a default parameter and a check to avoid the error to be thrown.

PR added after speaking on twitter with @taylorotwell, was an honour sir :smile: 