### PR TITLE
Validation correction

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -230,7 +230,7 @@ trait ValidatesAttributes
      */
     protected function validateAlpha($attribute, $value)
     {
-        return is_string($value) && preg_match('/^[\pL\pM]+$/u', $value);
+        return is_string($value) && preg_match('/\A[\pL\pM]+\z/u', $value);
     }
 
     /**
@@ -246,7 +246,7 @@ trait ValidatesAttributes
             return false;
         }
 
-        return preg_match('/^[\pL\pM\pN_-]+$/u', $value) > 0;
+        return preg_match('/\A[\pL\pM\pN_-]+\z/u', $value) > 0;
     }
 
     /**
@@ -262,7 +262,7 @@ trait ValidatesAttributes
             return false;
         }
 
-        return preg_match('/^[\pL\pM\pN]+$/u', $value) > 0;
+        return preg_match('/\A[\pL\pM\pN]+\z/u', $value) > 0;
     }
 
     /**

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -2100,7 +2100,7 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['x' => 'नमस्कार'], ['x' => 'AlphaNum']);
         $this->assertTrue($v->passes());
 
-        $v = new Validator($trans, ['x' => "abc\n"], ['x' => 'Alpha']);
+        $v = new Validator($trans, ['x' => "abc\n"], ['x' => 'AlphaNum']);
         $this->assertFalse($v->passes());
     }
 
@@ -2119,7 +2119,7 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['x' => '٧٨٩'], ['x' => 'AlphaDash']); // eastern arabic numerals
         $this->assertTrue($v->passes());
 
-        $v = new Validator($trans, ['x' => "abc\n"], ['x' => 'Alpha']);
+        $v = new Validator($trans, ['x' => "abc\n"], ['x' => 'AlphaDash']);
         $this->assertFalse($v->passes());
     }
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -2077,6 +2077,9 @@ class ValidationValidatorTest extends TestCase
 
         $v = new Validator($trans, ['x' => 'abc123'], ['x' => 'Alpha']);
         $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['x' => "abc\n"], ['x' => 'Alpha']);
+        $this->assertFalse($v->passes());
     }
 
     public function testValidateAlphaNum()
@@ -2096,6 +2099,9 @@ class ValidationValidatorTest extends TestCase
 
         $v = new Validator($trans, ['x' => 'नमस्कार'], ['x' => 'AlphaNum']);
         $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => "abc\n"], ['x' => 'Alpha']);
+        $this->assertFalse($v->passes());
     }
 
     public function testValidateAlphaDash()
@@ -2112,6 +2118,9 @@ class ValidationValidatorTest extends TestCase
 
         $v = new Validator($trans, ['x' => '٧٨٩'], ['x' => 'AlphaDash']); // eastern arabic numerals
         $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => "abc\n"], ['x' => 'Alpha']);
+        $this->assertFalse($v->passes());
     }
 
     public function testValidateTimezone()


### PR DESCRIPTION
I've had an issue with Laravels validators, namely alpha, alphaDash and alphaNum. When I pass the validator a string that ends with a new line, the validation passes even tho a new line is not really a letter :) Here is the code example (correct me if 'm wrong, but in my opinion this should not be valid):

`
$validator = \Validator::make(['x'=>"abc\n"],['x'=>'alpha'])->validate();
`

So I've added really simple corrections to these three alpha-based validators... there might be other places where this could also be changed. Hope you acknowledge this, since I kinda don't wanna use custom validations for this :)

Cheers