### PR TITLE
[5.4] Checking if should cast value to int when finding by key

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -197,6 +197,10 @@ class Builder
             return $this;
         }
 
+        if ($this->model->incrementing) {
+            $id = (int) $id;
+        }
+
         return $this->where($this->model->getQualifiedKeyName(), '=', $id);
     }
 


### PR DESCRIPTION
Checking if the model primary key is an incremeting key, if so, do a cast to integer, avoiding exceptions with databases that don't make auto cast when sending an empty string as id.
This error was found when trying to use laravel\passport in a postgres database and accessing a route protected with auth:api middleware using a bearer token created with grant type client_credentials.
So calls like User::find('') in postgres would throw a exception `Illuminate\Database\QueryException with message 'SQLSTATE[22P02]: Invalid text representation: 7 ERROR:  invalid input syntax for integer: "" `.