### PR TITLE
User should be redirected to intended page on register

### DIFF
--- a/src/Illuminate/Foundation/Auth/RegistersUsers.php
+++ b/src/Illuminate/Foundation/Auth/RegistersUsers.php
@@ -35,7 +35,7 @@ trait RegistersUsers
         $this->guard()->login($user);
 
         return $this->registered($request, $user)
-                        ?: redirect($this->redirectPath());
+                        ?: redirect()->intended($this->redirectPath());
     }
 
     /**


### PR DESCRIPTION
Currently AuthenticatesUsers will redirect a user to an "intended" private page if access attempted prior to logging in. RegistersUsers should work the same. Whether a user has an account already or needs to register, they should still both go back to the intended page. Currently RegistersUsers only goes to the user dashboard (or whatever is triggered by RedirectsUsers).