### PR TITLE
[5.4] Add ability to set queue parameters from within a queued listener

### DIFF
--- a/src/Illuminate/Events/CallQueuedListener.php
+++ b/src/Illuminate/Events/CallQueuedListener.php
@@ -33,6 +33,20 @@ class CallQueuedListener implements ShouldQueue
     public $data;
 
     /**
+     * The number of times the job may be attempted.
+     *
+     * @var int
+     */
+    public $tries;
+
+    /**
+     * The number of seconds the job can run before timing out.
+     *
+     * @var int
+     */
+    public $timeout;
+
+    /**
      * Create a new job instance.
      *
      * @param  string  $class

--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -452,13 +452,19 @@ class Dispatcher implements DispatcherContract
     {
         $listener = (new ReflectionClass($class))->newInstanceWithoutConstructor();
 
+        $job = new CallQueuedListener($class, $method, $arguments);
+
         $connection = isset($listener->connection) ? $listener->connection : null;
 
         $queue = isset($listener->queue) ? $listener->queue : null;
 
+        $job->tries = isset($listener->tries) ? $listener->tries : null;
+
+        $job->timeout = isset($listener->timeout) ? $listener->timeout : null;
+
         $this->resolveQueue()
                 ->connection($connection)
-                ->pushOn($queue, new CallQueuedListener($class, $method, $arguments));
+                ->pushOn($queue, $job);
     }
 
     /**

--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -462,9 +462,13 @@ class Dispatcher implements DispatcherContract
 
         $job->timeout = isset($listener->timeout) ? $listener->timeout : null;
 
-        $this->resolveQueue()
-                ->connection($connection)
-                ->pushOn($queue, $job);
+        $resolvedQueue = $this->resolveQueue()->connection($connection);
+
+        if (isset($listener->delay)) {
+            $resolvedQueue->laterOn($queue, $listener->delay, $job);
+        } else {
+            $resolvedQueue->pushOn($queue, $job);
+        }
     }
 
     /**


### PR DESCRIPTION
This PR allows setting the following queue parameters from within the listener:

```
class TestListener implements ShouldQueue
{
    public $connection = 'sqs';

    public $queue = 'listeners';

    public $tries = 10;

    public $timeout = 30;
    
    public $delay = 15;
}
```