### PR TITLE
[5.4] Attempt to simplify validation with an edge case

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -417,7 +417,7 @@ class Validator implements ValidatorContract
     {
         return $this->presentOrRuleIsImplicit($rule, $attribute, $value) &&
                $this->passesOptionalCheck($attribute) &&
-               $this->isNotNullIfMarkedAsNullable($attribute, $value) &&
+               $this->isNotNullIfMarkedAsNullable($rule, $attribute, $value) &&
                $this->hasNotFailedPreviousRuleIfPresenceRule($rule, $attribute);
     }
 
@@ -470,13 +470,16 @@ class Validator implements ValidatorContract
     /**
      * Determine if the attribute fails the nullable check.
      *
+     * @param  string  $rule
      * @param  string  $attribute
      * @param  mixed  $value
      * @return bool
      */
-    protected function isNotNullIfMarkedAsNullable($attribute, $value)
+    protected function isNotNullIfMarkedAsNullable($rule, $attribute, $value)
     {
-        if (! $this->hasRule($attribute, ['Nullable'])) {
+        if (in_array($rule, $this->implicitRules) ||
+            ! $this->hasRule($attribute, ['Nullable']))
+        {
             return true;
         }
 

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -417,7 +417,7 @@ class Validator implements ValidatorContract
     {
         return $this->presentOrRuleIsImplicit($rule, $attribute, $value) &&
                $this->passesOptionalCheck($attribute) &&
-               $this->isNotNullIfMarkedAsNullable($rule, $attribute, $value) &&
+               $this->isNotNullIfMarkedAsNullable($rule, $attribute) &&
                $this->hasNotFailedPreviousRuleIfPresenceRule($rule, $attribute);
     }
 
@@ -476,8 +476,7 @@ class Validator implements ValidatorContract
      */
     protected function isNotNullIfMarkedAsNullable($rule, $attribute)
     {
-        if (in_array($rule, $this->implicitRules) || ! $this->hasRule($attribute, ['Nullable']))
-        {
+        if (in_array($rule, $this->implicitRules) || ! $this->hasRule($attribute, ['Nullable'])) {
             return true;
         }
 

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -472,10 +472,9 @@ class Validator implements ValidatorContract
      *
      * @param  string  $rule
      * @param  string  $attribute
-     * @param  mixed  $value
      * @return bool
      */
-    protected function isNotNullIfMarkedAsNullable($rule, $attribute, $value)
+    protected function isNotNullIfMarkedAsNullable($rule, $attribute)
     {
         if (in_array($rule, $this->implicitRules) || ! $this->hasRule($attribute, ['Nullable']))
         {

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -477,8 +477,7 @@ class Validator implements ValidatorContract
      */
     protected function isNotNullIfMarkedAsNullable($rule, $attribute, $value)
     {
-        if (in_array($rule, $this->implicitRules) ||
-            ! $this->hasRule($attribute, ['Nullable']))
+        if (in_array($rule, $this->implicitRules) || ! $this->hasRule($attribute, ['Nullable']))
         {
             return true;
         }

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -177,6 +177,37 @@ class ValidationValidatorTest extends TestCase
         $this->assertEquals('validation.boolean', $v->messages()->get('b')[0]);
     }
 
+    public function testNullableMakesNoDifferenceIfImplicitRuleExists()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+
+        $v = new Validator($trans, [
+            'x' => null, 'y' => null,
+        ], [
+            'x' => 'nullable|required_with:y|integer',
+            'y' => 'nullable|required_with:x|integer',
+        ]);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, [
+            'x' => 'value', 'y' => null,
+        ], [
+            'x' => 'nullable|required_with:y|integer',
+            'y' => 'nullable|required_with:x|integer',
+        ]);
+        $this->assertTrue($v->fails());
+        $this->assertEquals('validation.integer', $v->messages()->get('x')[0]);
+
+        $v = new Validator($trans, [
+            'x' => 123, 'y' => null,
+        ], [
+            'x' => 'nullable|required_with:y|integer',
+            'y' => 'nullable|required_with:x|integer',
+        ]);
+        $this->assertTrue($v->fails());
+        $this->assertEquals('validation.required_with', $v->messages()->get('y')[0]);
+    }
+
     public function testProperLanguageLineIsSet()
     {
         $trans = $this->getIlluminateArrayTranslator();


### PR DESCRIPTION
This PR attempts to solve the issue with using `required_*` rules while the `ConvertEmptyStringToNull` middleware is applied.

Given the following data & rules:

```php
validator(
    [
        'address_one' => null,
        'address_two' => null,
    ],
    [
        'address_one' => ['nullable','required_with:address_two', 'min:6'],
        'address_two' => ['nullable','required_with:address_one', 'min:6'],
    ]
);
```

With this PR, using nullable won't skip the `required_with` validation if the value is null and will still fail, this solves the case when you accept null as a value for all rules but rules that imply the field is required.