### PR TITLE
[5.4] Output migration name before starting a migration or rollback

### DIFF
--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -172,7 +172,7 @@ class Migrator
             return $this->pretendToRun($migration, 'up');
         }
         
-        $this->note("<info>Migrating:</info> {$file}");
+        $this->note("<info>Migrating:</info> {$name}");
 
         $this->runMigration($migration, 'up');
 
@@ -319,7 +319,7 @@ class Migrator
             $name = $this->getMigrationName($file)
         );
         
-        $this->note("<info>Rolling back:</info> {$file}");
+        $this->note("<info>Rolling back:</info> {$name}");
 
         if ($pretend) {
             return $this->pretendToRun($instance, 'down');

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -171,6 +171,8 @@ class Migrator
         if ($pretend) {
             return $this->pretendToRun($migration, 'up');
         }
+        
+        $this->note("<info>Migrating:</info> {$file}");
 
         $this->runMigration($migration, 'up');
 
@@ -316,6 +318,8 @@ class Migrator
         $instance = $this->resolve(
             $name = $this->getMigrationName($file)
         );
+        
+        $this->note("<info>Rolling back:</info> {$file}");
 
         if ($pretend) {
             return $this->pretendToRun($instance, 'down');


### PR DESCRIPTION
Laravel shows the migration name as output when an UP or DOWN has finished, but does not show any output before starting either.

It would be useful to see the migration name before it starts,  in the runUp and runDown methods.

I spent some time today trying to figure out why my simple migration was just hanging -- rebooting my VM and such, when it was actually a 10+ minute long migration a teammate had slipped in that was running before mine. Since there is no output until finished, I thought something was hanging as the cursor just sat below the command prompt with no indication of anything happening.

It would have been useful to know that it was busy running THAT migration.

 For language, I’m propose this in this pull request:

```
$this->note("<info>Rolling back:</info> {$file}");
$this->note("<info>Migrating:</info> {$file}");
```

(to matched the ‘Rolled Back: ‘ and ‘Migrated: ' messages that are show on completion.)