### PR TITLE
[5.4] Disallow access to protected properties via array access

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -287,6 +287,28 @@ trait HasAttributes
     }
 
     /**
+     * Determine if an attribute exists.
+     *
+     * @param  string  $key
+     * @return bool
+     */
+    public function hasAttribute($key)
+    {
+        return ! is_null($this->getAttribute($key));
+    }
+
+    /**
+     * Unset an attribute on the model.
+     *
+     * @param  string  $key
+     * @return void
+     */
+    public function unsetAttribute($key)
+    {
+        unset($this->attributes[$key], $this->relations[$key]);
+    }
+
+    /**
      * Get an attribute from the model.
      *
      * @param  string  $key

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -298,17 +298,6 @@ trait HasAttributes
     }
 
     /**
-     * Unset an attribute on the model.
-     *
-     * @param  string  $key
-     * @return void
-     */
-    public function unsetAttribute($key)
-    {
-        unset($this->attributes[$key], $this->relations[$key]);
-    }
-
-    /**
      * Get an attribute from the model.
      *
      * @param  string  $key

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1254,7 +1254,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public function offsetExists($offset)
     {
-        return isset($this->$offset);
+        return $this->hasAttribute($offset);
     }
 
     /**
@@ -1265,7 +1265,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public function offsetGet($offset)
     {
-        return $this->$offset;
+        return $this->getAttribute($offset);
     }
 
     /**
@@ -1277,7 +1277,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public function offsetSet($offset, $value)
     {
-        $this->$offset = $value;
+        $this->setAttribute($offset, $value);
     }
 
     /**
@@ -1288,7 +1288,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public function offsetUnset($offset)
     {
-        unset($this->$offset);
+        $this->unsetAttribute($offset);
     }
 
     /**
@@ -1299,7 +1299,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public function __isset($key)
     {
-        return ! is_null($this->getAttribute($key));
+        return $this->hasAttribute($key);
     }
 
     /**
@@ -1310,7 +1310,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public function __unset($key)
     {
-        unset($this->attributes[$key], $this->relations[$key]);
+        $this->unsetAttribute($key);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1288,7 +1288,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public function offsetUnset($offset)
     {
-        $this->unsetAttribute($offset);
+        unset($this->attributes[$offset], $this->relations[$offset]);
     }
 
     /**
@@ -1310,7 +1310,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public function __unset($key)
     {
-        $this->unsetAttribute($key);
+        $this->offsetUnset($key);
     }
 
     /**

--- a/src/Illuminate/Support/Fluent.php
+++ b/src/Illuminate/Support/Fluent.php
@@ -69,17 +69,6 @@ class Fluent implements ArrayAccess, Arrayable, Jsonable, JsonSerializable
     }
 
     /**
-     * Unset an attribute.
-     *
-     * @param  string  $key
-     * @return void
-     */
-    public function unset($key)
-    {
-        unset($this->attributes[$key]);
-    }
-
-    /**
      * Get the attributes from the container.
      *
      * @return array
@@ -162,7 +151,7 @@ class Fluent implements ArrayAccess, Arrayable, Jsonable, JsonSerializable
      */
     public function offsetUnset($offset)
     {
-        $this->unset($offset);
+        unset($this->attributes[$offset]);
     }
 
     /**
@@ -221,6 +210,6 @@ class Fluent implements ArrayAccess, Arrayable, Jsonable, JsonSerializable
      */
     public function __unset($key)
     {
-        $this->unset($key);
+        $this->offsetUnset($key);
     }
 }

--- a/src/Illuminate/Support/Fluent.php
+++ b/src/Illuminate/Support/Fluent.php
@@ -46,6 +46,40 @@ class Fluent implements ArrayAccess, Arrayable, Jsonable, JsonSerializable
     }
 
     /**
+     * Set the value of an attribute.
+     *
+     * @param  string  $key
+     * @param  mixed   $value
+     * @return void
+     */
+    public function set($key, $value)
+    {
+        $this->attributes[$key] = $value;
+    }
+
+    /**
+     * Determine if an attribute exists.
+     *
+     * @param  string  $key
+     * @return bool
+     */
+    public function has($key)
+    {
+        return isset($this->attributes[$key]);
+    }
+
+    /**
+     * Unset an attribute.
+     *
+     * @param  string  $key
+     * @return void
+     */
+    public function unset($key)
+    {
+        unset($this->attributes[$key]);
+    }
+
+    /**
      * Get the attributes from the container.
      *
      * @return array
@@ -94,7 +128,7 @@ class Fluent implements ArrayAccess, Arrayable, Jsonable, JsonSerializable
      */
     public function offsetExists($offset)
     {
-        return isset($this->{$offset});
+        return $this->has($offset);
     }
 
     /**
@@ -105,7 +139,7 @@ class Fluent implements ArrayAccess, Arrayable, Jsonable, JsonSerializable
      */
     public function offsetGet($offset)
     {
-        return $this->{$offset};
+        return $this->get($offset);
     }
 
     /**
@@ -117,7 +151,7 @@ class Fluent implements ArrayAccess, Arrayable, Jsonable, JsonSerializable
      */
     public function offsetSet($offset, $value)
     {
-        $this->{$offset} = $value;
+        $this->set($offset, $value);
     }
 
     /**
@@ -128,7 +162,7 @@ class Fluent implements ArrayAccess, Arrayable, Jsonable, JsonSerializable
      */
     public function offsetUnset($offset)
     {
-        unset($this->{$offset});
+        $this->unset($offset);
     }
 
     /**
@@ -140,7 +174,7 @@ class Fluent implements ArrayAccess, Arrayable, Jsonable, JsonSerializable
      */
     public function __call($method, $parameters)
     {
-        $this->attributes[$method] = count($parameters) > 0 ? $parameters[0] : true;
+        $this->set($method, count($parameters) > 0 ? $parameters[0] : true);
 
         return $this;
     }
@@ -165,7 +199,7 @@ class Fluent implements ArrayAccess, Arrayable, Jsonable, JsonSerializable
      */
     public function __set($key, $value)
     {
-        $this->attributes[$key] = $value;
+        $this->set($key, $value);
     }
 
     /**
@@ -176,7 +210,7 @@ class Fluent implements ArrayAccess, Arrayable, Jsonable, JsonSerializable
      */
     public function __isset($key)
     {
-        return isset($this->attributes[$key]);
+        return $this->has($key);
     }
 
     /**
@@ -187,6 +221,6 @@ class Fluent implements ArrayAccess, Arrayable, Jsonable, JsonSerializable
      */
     public function __unset($key)
     {
-        unset($this->attributes[$key]);
+        $this->unset($key);
     }
 }

--- a/src/Illuminate/Support/Fluent.php
+++ b/src/Illuminate/Support/Fluent.php
@@ -46,29 +46,6 @@ class Fluent implements ArrayAccess, Arrayable, Jsonable, JsonSerializable
     }
 
     /**
-     * Set the value of an attribute.
-     *
-     * @param  string  $key
-     * @param  mixed   $value
-     * @return void
-     */
-    public function set($key, $value)
-    {
-        $this->attributes[$key] = $value;
-    }
-
-    /**
-     * Determine if an attribute exists.
-     *
-     * @param  string  $key
-     * @return bool
-     */
-    public function has($key)
-    {
-        return isset($this->attributes[$key]);
-    }
-
-    /**
      * Get the attributes from the container.
      *
      * @return array
@@ -117,7 +94,7 @@ class Fluent implements ArrayAccess, Arrayable, Jsonable, JsonSerializable
      */
     public function offsetExists($offset)
     {
-        return $this->has($offset);
+        return isset($this->attributes[$offset]);
     }
 
     /**
@@ -140,7 +117,7 @@ class Fluent implements ArrayAccess, Arrayable, Jsonable, JsonSerializable
      */
     public function offsetSet($offset, $value)
     {
-        $this->set($offset, $value);
+        $this->attributes[$offset] = $value;
     }
 
     /**
@@ -163,7 +140,7 @@ class Fluent implements ArrayAccess, Arrayable, Jsonable, JsonSerializable
      */
     public function __call($method, $parameters)
     {
-        $this->set($method, count($parameters) > 0 ? $parameters[0] : true);
+        $this->offsetSet($method, count($parameters) > 0 ? $parameters[0] : true);
 
         return $this;
     }
@@ -188,7 +165,7 @@ class Fluent implements ArrayAccess, Arrayable, Jsonable, JsonSerializable
      */
     public function __set($key, $value)
     {
-        $this->set($key, $value);
+        $this->offsetSet($key, $value);
     }
 
     /**
@@ -199,7 +176,7 @@ class Fluent implements ArrayAccess, Arrayable, Jsonable, JsonSerializable
      */
     public function __isset($key)
     {
-        return $this->has($key);
+        return $this->offsetExists($key);
     }
 
     /**

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -98,6 +98,20 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEquals($hash, $model->password_hash);
     }
 
+    public function testArrayAccessToAttributes()
+    {
+        $model = new EloquentModelStub(['attributes' => 1, 'connection' => 2, 'table' => 3]);
+        unset($model['table']);
+
+        $this->assertTrue(isset($model['attributes']));
+        $this->assertEquals($model['attributes'], 1);
+        $this->assertTrue(isset($model['connection']));
+        $this->assertEquals($model['connection'], 2);
+        $this->assertFalse(isset($model['table']));
+        $this->assertEquals($model['table'], null);
+        $this->assertFalse(isset($model['with']));
+    }
+
     public function testNewInstanceReturnsNewInstanceWithAttributesSet()
     {
         $model = new EloquentModelStub;

--- a/tests/Support/SupportFluentTest.php
+++ b/tests/Support/SupportFluentTest.php
@@ -58,6 +58,20 @@ class SupportFluentTest extends TestCase
         $this->assertNull($fluent->foo);
     }
 
+    public function testArrayAccessToAttributes()
+    {
+        $fluent = new Fluent;
+
+        $fluent->attributes = 1;
+
+        $this->assertTrue(isset($fluent['attributes']));
+        $this->assertEquals($fluent['attributes'], 1);
+
+        $fluent->attributes();
+
+        $this->assertTrue($fluent['attributes']);
+    }
+
     public function testMagicMethodsCanBeUsedToSetAttributes()
     {
         $fluent = new Fluent;


### PR DESCRIPTION
This PR fixes an issue with the `offset*` methods referring to magic methods allowing to access and manipulate protected properties.

For example:

```php
$model['table']; // returns value of protected $table instead of $attributes['table']
```

Array access is also leveraged in other cases, for example in Collection methods, which use `data_get` to retrieve values:

```php
$collection->pluck('attributes'); // basically dumps models contents
```

Thanks to @arikal for finding this.