### PR TITLE
[5.4] Allow Validator extension to use array-style callable

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1026,7 +1026,7 @@ class Validator implements ValidatorContract
     {
         $callback = $this->extensions[$rule];
 
-        if ($callback instanceof Closure || is_array($callback)) {
+        if (is_callable($callback)) {
             return call_user_func_array($callback, $parameters);
         } elseif (is_string($callback)) {
             return $this->callClassBasedExtension($callback, $parameters);

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1026,7 +1026,7 @@ class Validator implements ValidatorContract
     {
         $callback = $this->extensions[$rule];
 
-        if ($callback instanceof Closure) {
+        if ($callback instanceof Closure || is_array($callback)) {
             return call_user_func_array($callback, $parameters);
         } elseif (is_string($callback)) {
             return $this->callClassBasedExtension($callback, $parameters);


### PR DESCRIPTION
Currently, a validator extension can be either a Closure or a string denoting a class and method. For complex validation scenarios, however, it's useful to be able to pass an object and method in the array-style callable format (i.e. [$object, $method] instead of "$class@$method").