### PR TITLE
[5.4] Model event result prevents firing observable events

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
@@ -143,7 +143,7 @@ trait HasEvents
         }
 
         if (is_array($result)) {
-            $result = array_filter($result, function($response) {
+            $result = array_filter($result, function ($response) {
                 return ! is_null($response);
             });
         }

--- a/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
@@ -142,6 +142,12 @@ trait HasEvents
             return false;
         }
 
+        if (is_array($result)) {
+            $result = array_filter($result, function($response) {
+                return ! is_null($response);
+            });
+        }
+
         return ! empty($result) ? $result : static::$dispatcher->{$method}(
             "eloquent.{$event}: ".static::class, $this
         );


### PR DESCRIPTION
When a model uses the `$event` property as well as observable events (e.g., through a 3rd party package), sometimes event handling will stop before reaching the observables. This is because the model's event result is treated as "failed" in `Illuminate/Database/Eloquent/Concerns/HasEvents.php`, while it isn't:

```php
$result = $this->fireCustomModelEvent($event, $method);

// ...
// For example, one event listener running successfully 
// causes the $result variable to be array(0 => null)
// ...

return ! empty($result) ? $result : static::$dispatcher->{$method}(
    "eloquent.{$event}: ".static::class, $this
);
```

`Empty` evaluates the array containing `null` as false, preventing the dispatcher from firing any subsequent events. The code fragment in this PR strips out the null elements, causing empty to be true when model events were handled successfully.