### PR TITLE
[5.5] Bootable Testing Traits ( Cleaner / Breaking )

### DIFF
--- a/src/Illuminate/Foundation/Testing/DatabaseMigrations.php
+++ b/src/Illuminate/Foundation/Testing/DatabaseMigrations.php
@@ -11,7 +11,7 @@ trait DatabaseMigrations
      *
      * @return void
      */
-    public function runDatabaseMigrations()
+    public function setUpRunDatabaseMigrations()
     {
         $this->artisan('migrate');
 

--- a/src/Illuminate/Foundation/Testing/DatabaseTransactions.php
+++ b/src/Illuminate/Foundation/Testing/DatabaseTransactions.php
@@ -9,7 +9,7 @@ trait DatabaseTransactions
      *
      * @return void
      */
-    public function beginDatabaseTransaction()
+    public function setUpBeginDatabaseTransaction()
     {
         $database = $this->app->make('db');
 

--- a/src/Illuminate/Foundation/Testing/WithoutEvents.php
+++ b/src/Illuminate/Foundation/Testing/WithoutEvents.php
@@ -11,7 +11,7 @@ trait WithoutEvents
      *
      * @throws \Exception
      */
-    public function disableEventsForAllTests()
+    public function setUpDisableEventsForAllTests()
     {
         if (method_exists($this, 'withoutEvents')) {
             $this->withoutEvents();

--- a/src/Illuminate/Foundation/Testing/WithoutMiddleware.php
+++ b/src/Illuminate/Foundation/Testing/WithoutMiddleware.php
@@ -11,7 +11,7 @@ trait WithoutMiddleware
      *
      * @throws \Exception
      */
-    public function disableMiddlewareForAllTests()
+    public function setUpDisableMiddlewareForAllTests()
     {
         if (method_exists($this, 'withoutMiddleware')) {
             $this->withoutMiddleware();


### PR DESCRIPTION
Uses the same principle that Eloquent Models use to boot traits. This allows user defined traits to hook into both the `setUp` and `tearDown` methods by defining methods prefixed with `setUp` and `tearDown` respectively.

This is a breaking change that needs to be coordinated with the [sister pull request for Laravel Browser Kit Testing](https://github.com/laravel/browser-kit-testing/pull/18)

A Non-breaking implementation has been submitted as an alternate here: https://github.com/laravel/framework/pull/18408