### PR TITLE
[5.5] Route: simplify RouteCollection.

### DIFF
--- a/src/Illuminate/Foundation/Support/Providers/RouteServiceProvider.php
+++ b/src/Illuminate/Foundation/Support/Providers/RouteServiceProvider.php
@@ -28,10 +28,6 @@ class RouteServiceProvider extends ServiceProvider
             $this->loadCachedRoutes();
         } else {
             $this->loadRoutes();
-
-            $this->app->booted(function () {
-                $this->app['router']->getRoutes()->refreshNameLookups();
-            });
         }
     }
 

--- a/tests/Routing/RouteCollectionTest.php
+++ b/tests/Routing/RouteCollectionTest.php
@@ -121,7 +121,7 @@ class RouteCollectionTest extends TestCase
         $this->assertCount(2, $this->routeCollection);
     }
 
-    public function testRouteCollectionCanRefreshNameLookups()
+    public function testRouteCollectionDoesNotNeedToRefreshNameLookups()
     {
         $routeIndex = new Route('GET', 'foo/index', [
             'uses' => 'FooController@index',
@@ -132,12 +132,6 @@ class RouteCollectionTest extends TestCase
 
         // The route name is set by calling \Illuminate\Routing\Route::name()
         $this->routeCollection->add($routeIndex)->name('route_name');
-
-        // No route is found. This is normal, as no refresh as been done.
-        $this->assertNull($this->routeCollection->getByName('route_name'));
-
-        // After the refresh, the name will be properly set to the route.
-        $this->routeCollection->refreshNameLookups();
         $this->assertEquals($routeIndex, $this->routeCollection->getByName('route_name'));
     }
 

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -170,7 +170,6 @@ class RoutingUrlGeneratorTest extends TestCase
         $route = new Route(['GET'], 'foo/bar', []);
         $route->name('foo');
         $routes->add($route);
-        $routes->refreshNameLookups();
 
         $this->assertEquals('http://www.foo.com/foo/bar', $url->route('foo'));
     }


### PR DESCRIPTION
Simplify `RouteCollection` using only one collection for the route storage.
There is no need to handle `$allRoutes`, `$nameList` and `$actionList` anymore.

---

This also makes the lookup refresh useless, as it's not necessary anymore.

---

**Note:**
the Travis build is failing because of another reason, related to `orchestra/testbench`, as in #18229, #18313 , #18400 & #18403 