### PR TITLE
[5.4] Pass the condition value to "when"

### DIFF
--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -84,9 +84,9 @@ trait BuildsQueries
         $builder = $this;
 
         if ($value) {
-            $builder = $callback($builder);
+            $builder = $callback($builder, $value);
         } elseif ($default) {
-            $builder = $default($builder);
+            $builder = $default($builder, $value);
         }
 
         return $builder;

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -132,7 +132,9 @@ class DatabaseQueryBuilderTest extends TestCase
 
     public function testWhenCallback()
     {
-        $callback = function ($query) {
+        $callback = function ($query, $condition) {
+            $this->assertTrue($condition);
+
             return $query->where('id', '=', 1);
         };
 
@@ -147,21 +149,25 @@ class DatabaseQueryBuilderTest extends TestCase
 
     public function testWhenCallbackWithDefault()
     {
-        $callback = function ($query) {
+        $callback = function ($query, $condition) {
+            $this->assertEquals($condition, 'truthy');
+
             return $query->where('id', '=', 1);
         };
 
-        $default = function ($query) {
+        $default = function ($query, $condition) {
+            $this->assertEquals($condition, 0);
+
             return $query->where('id', '=', 2);
         };
 
         $builder = $this->getBuilder();
-        $builder->select('*')->from('users')->when(true, $callback, $default)->where('email', 'foo');
+        $builder->select('*')->from('users')->when('truthy', $callback, $default)->where('email', 'foo');
         $this->assertEquals('select * from "users" where "id" = ? and "email" = ?', $builder->toSql());
         $this->assertEquals([0 => 1, 1 => 'foo'], $builder->getBindings());
 
         $builder = $this->getBuilder();
-        $builder->select('*')->from('users')->when(false, $callback, $default)->where('email', 'foo');
+        $builder->select('*')->from('users')->when(0, $callback, $default)->where('email', 'foo');
         $this->assertEquals('select * from "users" where "id" = ? and "email" = ?', $builder->toSql());
         $this->assertEquals([0 => 2, 1 => 'foo'], $builder->getBindings());
     }


### PR DESCRIPTION
So that this:

```php
$role = $request->input('role');

$users = User::when($role, function ($query) use ($role) {
    return $query->where('role_id', $role);
})->get();
```

becomes this:

```php
$users = User::when($request->input('role'), function ($query, $role) {
    return $query->where('role_id', $role);
})->get();
```