### PR TITLE
[5.4] Support queued jobs with unpersisted models

### DIFF
--- a/src/Illuminate/Queue/SerializesAndRestoresModelIdentifiers.php
+++ b/src/Illuminate/Queue/SerializesAndRestoresModelIdentifiers.php
@@ -21,7 +21,7 @@ trait SerializesAndRestoresModelIdentifiers
             return new ModelIdentifier($value->getQueueableClass(), $value->getQueueableIds());
         }
 
-        if ($value instanceof QueueableEntity && !empty($value->getQueueableId())) {
+        if ($value instanceof QueueableEntity && ! empty($value->getQueueableId())) {
             return new ModelIdentifier(get_class($value), $value->getQueueableId());
         }
 

--- a/src/Illuminate/Queue/SerializesAndRestoresModelIdentifiers.php
+++ b/src/Illuminate/Queue/SerializesAndRestoresModelIdentifiers.php
@@ -21,7 +21,7 @@ trait SerializesAndRestoresModelIdentifiers
             return new ModelIdentifier($value->getQueueableClass(), $value->getQueueableIds());
         }
 
-        if ($value instanceof QueueableEntity) {
+        if ($value instanceof QueueableEntity && !empty($value->getQueueableId())) {
             return new ModelIdentifier(get_class($value), $value->getQueueableId());
         }
 

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1026,7 +1026,7 @@ class Validator implements ValidatorContract
     {
         $callback = $this->extensions[$rule];
 
-        if ($callback instanceof Closure || is_array($callback)) {
+        if (is_callable($callback)) {
             return call_user_func_array($callback, $parameters);
         } elseif (is_string($callback)) {
             return $this->callClassBasedExtension($callback, $parameters);

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1026,7 +1026,7 @@ class Validator implements ValidatorContract
     {
         $callback = $this->extensions[$rule];
 
-        if ($callback instanceof Closure) {
+        if ($callback instanceof Closure || is_array($callback)) {
             return call_user_func_array($callback, $parameters);
         } elseif (is_string($callback)) {
             return $this->callClassBasedExtension($callback, $parameters);


### PR DESCRIPTION
Currently, if you try to send an unpersisted Eloquent model to a queued Job, the job will fail because the model doesn't have an identifier, which breaks the (un)serialization strategy. This was identified as a non-bug in issue #14526, but it's useful behavior to support and requires only a very minor change.