### PR TITLE
[5.4] Make PhpRedis connection more compatible with Predis (pipeline, ...)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ services:
 before_install:
   - if [[ $TRAVIS_PHP_VERSION != 7.1 ]] ; then phpenv config-rm xdebug.ini; fi
   - echo "extension = memcached.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
-  - echo "extension = redis.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
+  - pecl install -f redis
   - travis_retry composer self-update
 
 install:

--- a/src/Illuminate/Redis/Connections/PhpRedisConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisConnection.php
@@ -111,7 +111,7 @@ class PhpRedisConnection extends Connection
     }
 
     /**
-     * Execute commands in a pipeline
+     * Execute commands in a pipeline.
      *
      * @param  callable  $callback
      * @return array|\Redis
@@ -126,7 +126,7 @@ class PhpRedisConnection extends Connection
     }
 
     /**
-     * Execute commands in a transaction
+     * Execute commands in a transaction.
      *
      * @param  callable  $callback
      * @return array|\Redis
@@ -141,14 +141,14 @@ class PhpRedisConnection extends Connection
     }
 
     /**
-     * Execute a raw command
+     * Execute a raw command.
      *
      * @param  array  $parameters
      * @return mixed
      */
     public function executeRaw(array $parameters)
     {
-        return $this->command("rawCommand", $parameters);
+        return $this->command('rawCommand', $parameters);
     }
 
     /**

--- a/src/Illuminate/Redis/Connections/PhpRedisConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisConnection.php
@@ -111,6 +111,47 @@ class PhpRedisConnection extends Connection
     }
 
     /**
+     * Execute commands in a pipeline
+     *
+     * @param  callable  $callback
+     * @return array|\Redis
+     */
+    public function pipeline(callable $callback = null)
+    {
+        $pipeline = $this->client()->pipeline();
+
+        return is_null($callback)
+            ? $pipeline
+            : tap($pipeline, $callback)->exec();
+    }
+
+    /**
+     * Execute commands in a transaction
+     *
+     * @param  callable  $callback
+     * @return array|\Redis
+     */
+    public function transaction(callable $callback = null)
+    {
+        $transaction = $this->client()->multi();
+
+        return is_null($callback)
+            ? $transaction
+            : tap($transaction, $callback)->exec();
+    }
+
+    /**
+     * Execute a raw command
+     *
+     * @param  array  $parameters
+     * @return mixed
+     */
+    public function executeRaw(array $parameters)
+    {
+        return $this->command("rawCommand", $parameters);
+    }
+
+    /**
      * Evaluate a LUA script serverside, from the SHA1 hash of the script instead of the script itself.
      *
      * @param  string  $script

--- a/tests/Redis/Connections/PhpRedisConnectionTest.php
+++ b/tests/Redis/Connections/PhpRedisConnectionTest.php
@@ -2,8 +2,8 @@
 
 namespace Illuminate\Tests\Redis\Connections;
 
-use Illuminate\Tests\Redis\InteractsWithRedis;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Tests\Redis\InteractsWithRedis;
 
 class PhpRedisConnectionTest extends TestCase
 {
@@ -14,7 +14,7 @@ class PhpRedisConnectionTest extends TestCase
         parent::setUp();
         $this->setUpRedis();
 
-        if(! isset($this->redis['phpredis'])) {
+        if (! isset($this->redis['phpredis'])) {
             $this->markTestSkipped('PhpRedis should be enabled to run the tests');
         }
     }
@@ -33,7 +33,7 @@ class PhpRedisConnectionTest extends TestCase
             $pipe->set('test:pipeline:2', 2);
             $pipe->get('test:pipeline:2');
         });
-        
+
         $this->assertCount(4, $result);
         $this->assertEquals(1, $result[1]);
         $this->assertEquals(2, $result[3]);

--- a/tests/Redis/Connections/PhpRedisConnectionTest.php
+++ b/tests/Redis/Connections/PhpRedisConnectionTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Illuminate\Tests\Redis\Connections;
+
+use Illuminate\Tests\Redis\InteractsWithRedis;
+use PHPUnit\Framework\TestCase;
+
+class PhpRedisConnectionTest extends TestCase
+{
+    use InteractsWithRedis;
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->setUpRedis();
+
+        if(! isset($this->redis['phpredis'])) {
+            $this->markTestSkipped('PhpRedis should be enabled to run the tests');
+        }
+    }
+
+    public function tearDown()
+    {
+        parent::tearDown();
+        $this->tearDownRedis();
+    }
+
+    public function testPhpRedisPipeline()
+    {
+        $result = $this->redis['phpredis']->connection()->pipeline(function ($pipe) {
+            $pipe->set('test:pipeline:1', 1);
+            $pipe->get('test:pipeline:1');
+            $pipe->set('test:pipeline:2', 2);
+            $pipe->get('test:pipeline:2');
+        });
+        
+        $this->assertCount(4, $result);
+        $this->assertEquals(1, $result[1]);
+        $this->assertEquals(2, $result[3]);
+    }
+
+    public function testPhpRedisTransaction()
+    {
+        $result = $this->redis['phpredis']->connection()->transaction(function ($pipe) {
+            $pipe->set('test:transaction:1', 1);
+            $pipe->get('test:transaction:1');
+            $pipe->set('test:transaction:2', 2);
+            $pipe->get('test:transaction:2');
+        });
+
+        $this->assertCount(4, $result);
+        $this->assertEquals(1, $result[1]);
+        $this->assertEquals(2, $result[3]);
+    }
+
+    public function testPhpRedisExecuteRaw()
+    {
+        $this->redis['phpredis']->connection()->set('test:raw:1', 1);
+
+        $this->assertEquals(
+            1, $this->redis['phpredis']->connection()->executeRaw(['GET', 'test:raw:1'])
+        );
+    }
+}


### PR DESCRIPTION
This PR makes PhpRedis connection more compatible with Predis. It allows you to use closure for `pipeline` or `transaction`. Also for raw commands, it adds `executeRaw`, same as Predis library.

#### 1. Pipeline:

```php
$result = Redis::pipeline(function ($pipe) {
   $pipe->set('test:pipeline:1', 1);
   $pipe->get('test:pipeline:1');
   $pipe->set('test:pipeline:2', 2);
   $pipe->get('test:pipeline:2');
});

dump($result);
```

```php
array:4 [
  0 => true
  1 => "1"
  2 => true
  3 => "2"
]
```

PhpRedis docs: https://github.com/phpredis/phpredis#multi-exec-discard
Predis docs: https://github.com/nrk/predis#command-pipelines

#### 2. Transaction:

```php
$result = Redis::transaction(function ($pipe) {
   $pipe->set('test:transaction:1', 1);
   $pipe->get('test:transaction:1');
   $pipe->set('test:transaction:2', 2);
   $pipe->get('test:transaction:2');
});

dump($result);
```

```php
array:4 [
  0 => true
  1 => "1"
  2 => true
  3 => "2"
]
```

PhpRedis docs: https://github.com/phpredis/phpredis#multi-exec-discard
Predis docs: https://github.com/nrk/predis#transactions

#### 3. Raw Commands

*Predis Style:*

```php
Redis::set('test:raw', 1);
Redis::executeRaw(['GET', 'test:raw']);
```

*PhpRedis Style:*

```php
Redis::set('test:raw', 1);
Redis::rawCommand('GET', 'test:raw');
```

PhpRedis docs: https://github.com/phpredis/phpredis#rawcommand
Predis docs: https://github.com/nrk/predis#adding-new-commands

-----

Also I added 3 tests for these methods.