### PR TITLE
[5.4] Don't require returning the query from "when"

### DIFF
--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -74,21 +74,19 @@ trait BuildsQueries
     /**
      * Apply the callback's query changes if the given "value" is true.
      *
-     * @param  bool  $value
+     * @param  mixed  $value
      * @param  \Closure  $callback
      * @param  \Closure  $default
      * @return mixed
      */
     public function when($value, $callback, $default = null)
     {
-        $builder = $this;
-
         if ($value) {
-            $builder = $callback($builder, $value);
+            return $callback($this, $value) ?: $this;
         } elseif ($default) {
-            $builder = $default($builder, $value);
+            return $default($this, $value) ?: $this;
         }
 
-        return $builder;
+        return $this;
     }
 }

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -135,7 +135,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $callback = function ($query, $condition) {
             $this->assertTrue($condition);
 
-            return $query->where('id', '=', 1);
+            $query->where('id', '=', 1);
         };
 
         $builder = $this->getBuilder();
@@ -152,13 +152,13 @@ class DatabaseQueryBuilderTest extends TestCase
         $callback = function ($query, $condition) {
             $this->assertEquals($condition, 'truthy');
 
-            return $query->where('id', '=', 1);
+            $query->where('id', '=', 1);
         };
 
         $default = function ($query, $condition) {
             $this->assertEquals($condition, 0);
 
-            return $query->where('id', '=', 2);
+            $query->where('id', '=', 2);
         };
 
         $builder = $this->getBuilder();


### PR DESCRIPTION
Instead of:

```php
User::when($role, function ($query, $role) {
    return $query->where('role', $role);
});
```

you now don't have to return it:

```php
User::when($role, function ($query, $role) {
    $query->where('role', $role);
});
```