### PR TITLE
[5.4] Adding tinyIncrements database schema method

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -406,6 +406,17 @@ class Blueprint
     }
 
     /**
+     * Create a new auto-incrementing tiny integer (1-byte) column on the table.
+     *
+     * @param  string  $column
+     * @return \Illuminate\Support\Fluent
+     */
+    public function tinyIncrements($column)
+    {
+        return $this->unsignedTinyInteger($column, true);
+    }
+
+    /**
      * Create a new auto-incrementing small integer (2-byte) column on the table.
      *
      * @param  string  $column


### PR DESCRIPTION
I have just met this problem, there is every size of increments, except `tinyIncrements`, which can be useful for smaller datasets, like currencies (<200 exists).