### PR TITLE
Group collections on multiple fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,3 @@ composer.lock
 .DS_Store
 Thumbs.db
 /phpunit.xml
-.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ composer.lock
 .DS_Store
 Thumbs.db
 /phpunit.xml
+.idea/

--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -527,4 +527,22 @@ class Arr
     {
         return ! is_array($value) ? [$value] : $value;
     }
+
+    /**
+     * Convert a nested array (array of arrays) to a nested collection (collection of collections).
+     *
+     * @param  array  $array
+     * @return Collection
+     */
+    public static function toNestedCollection(&$array)
+    {
+        if (is_array($array)) {
+            foreach ($array as &$subArray) {
+                $subArray = static::toNestedCollection($subArray);
+            }
+            return new Collection($array);
+        } else {
+            return $array;
+        }
+    }
 }

--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -540,6 +540,7 @@ class Arr
             foreach ($array as &$subArray) {
                 $subArray = static::toNestedCollection($subArray);
             }
+
             return new Collection($array);
         } else {
             return $array;

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -550,7 +550,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      */
     public function groupByMultiple($groupBy, $preserveKeys = false)
     {
-        if (!is_array($groupBy)) {
+        if (! is_array($groupBy)) {
             $groupBy = [$groupBy];
         }
 
@@ -580,7 +580,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
                 $currentLevel = $nextLevel;
                 $nextLevel = [];
             }
-            if ($preserveKeys && !is_null($key)) {
+            if ($preserveKeys && ! is_null($key)) {
                 foreach ($currentLevel as &$lastLevel) {
                     $lastLevel[$key] = $value;
                 }
@@ -1326,7 +1326,6 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
             $exists[] = $id;
         });
     }
-
 
     /**
      * Return only unique items from the collection array using strict comparison.

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -519,19 +519,25 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     public function groupBy($groupBy, $preserveKeys = false)
     {
         $groupBy = $this->valueRetriever($groupBy);
+
         $results = [];
+
         foreach ($this->items as $key => $value) {
             $groupKeys = $groupBy($value, $key);
+
             if (! is_array($groupKeys)) {
                 $groupKeys = [$groupKeys];
             }
+
             foreach ($groupKeys as $groupKey) {
                 if (! array_key_exists($groupKey, $results)) {
                     $results[$groupKey] = new static;
                 }
+
                 $results[$groupKey]->offsetSet($preserveKeys ? $key : null, $value);
             }
         }
+
         return new static($results);
     }
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1264,6 +1264,62 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals($expected_result, $resultM->toArray());
     }
 
+    public function testGroupByMultipleAttributes()
+    {
+        $data = new Collection([
+          [ "A" => "foo", "B" => "bar",    "C" => "baz",    "D" => "thud" ],
+          [ "A" => "foo", "B" => "garply", "C" => "corge",  "D" => "plugh" ],
+          [ "A" => "foo", "B" => "bar",    "C" => "corge",  "D" => "thud" ],
+          [ "A" => "foo", "B" => "bar",    "C" => "corge",  "D" => "waldo" ],
+          [ "A" => "qux", "B" => "garply", "C" => "xyzzy",  "D" => "fred" ],
+          [ "A" => "qux", "B" => "grault", "C" => "garply", "D" => "quuz" ]
+        ]);
+        $result = $data->groupByMultiple(["A", "B", "C", "D"]);
+        $expected = [
+          "foo" => [
+            "bar" => [
+              "baz" => [
+                "thud" => [
+                  [ "A" => "foo", "B" => "bar",    "C" => "baz",    "D" => "thud" ]
+                ]
+              ],
+              "corge" => [
+                "thud" => [
+                  [ "A" => "foo", "B" => "bar",    "C" => "corge",  "D" => "thud" ]
+                ],
+                "waldo" => [
+                  [ "A" => "foo", "B" => "bar",    "C" => "corge",  "D" => "waldo" ]
+                ]
+              ]
+            ],
+            "garply" => [
+              "corge" => [
+                "plugh" => [
+                  [ "A" => "foo", "B" => "garply", "C" => "corge",  "D" => "plugh" ]
+                ]
+              ]
+            ]
+          ],
+          "qux" => [
+            "garply" => [
+              "xyzzy" => [
+                "fred" => [
+                  [ "A" => "qux", "B" => "garply", "C" => "xyzzy",  "D" => "fred" ]
+                ]
+              ]
+            ],
+            "grault" => [
+              "garply" => [
+                "quuz" => [
+                  [ "A" => "qux", "B" => "grault", "C" => "garply", "D" => "quuz" ]
+                ]
+              ]
+            ]
+          ]
+        ];
+        $this->assertEquals($expected, $result->toArray());
+    }
+
     public function testKeyByAttribute()
     {
         $data = new Collection([['rating' => 1, 'name' => '1'], ['rating' => 2, 'name' => '2'], ['rating' => 3, 'name' => '3']]);

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1267,55 +1267,55 @@ class SupportCollectionTest extends TestCase
     public function testGroupByMultipleAttributes()
     {
         $data = new Collection([
-          [ "A" => "foo", "B" => "bar",    "C" => "baz",    "D" => "thud" ],
-          [ "A" => "foo", "B" => "garply", "C" => "corge",  "D" => "plugh" ],
-          [ "A" => "foo", "B" => "bar",    "C" => "corge",  "D" => "thud" ],
-          [ "A" => "foo", "B" => "bar",    "C" => "corge",  "D" => "waldo" ],
-          [ "A" => "qux", "B" => "garply", "C" => "xyzzy",  "D" => "fred" ],
-          [ "A" => "qux", "B" => "grault", "C" => "garply", "D" => "quuz" ]
+          ['A' => 'foo', 'B' => 'bar',    'C' => 'baz',    'D' => 'thud'],
+          ['A' => 'foo', 'B' => 'garply', 'C' => 'corge',  'D' => 'plugh'],
+          ['A' => 'foo', 'B' => 'bar',    'C' => 'corge',  'D' => 'thud'],
+          ['A' => 'foo', 'B' => 'bar',    'C' => 'corge',  'D' => 'waldo'],
+          ['A' => 'qux', 'B' => 'garply', 'C' => 'xyzzy',  'D' => 'fred'],
+          ['A' => 'qux', 'B' => 'grault', 'C' => 'garply', 'D' => 'quuz'],
         ]);
-        $result = $data->groupByMultiple(["A", "B", "C", "D"]);
+        $result = $data->groupByMultiple(['A', 'B', 'C', 'D']);
         $expected = [
-          "foo" => [
-            "bar" => [
-              "baz" => [
-                "thud" => [
-                  [ "A" => "foo", "B" => "bar",    "C" => "baz",    "D" => "thud" ]
-                ]
-              ],
-              "corge" => [
-                "thud" => [
-                  [ "A" => "foo", "B" => "bar",    "C" => "corge",  "D" => "thud" ]
+          'foo' => [
+            'bar' => [
+              'baz' => [
+                'thud' => [
+                  ['A' => 'foo', 'B' => 'bar',    'C' => 'baz',    'D' => 'thud'],
                 ],
-                "waldo" => [
-                  [ "A" => "foo", "B" => "bar",    "C" => "corge",  "D" => "waldo" ]
-                ]
-              ]
+              ],
+              'corge' => [
+                'thud' => [
+                  ['A' => 'foo', 'B' => 'bar',    'C' => 'corge',  'D' => 'thud'],
+                ],
+                'waldo' => [
+                  ['A' => 'foo', 'B' => 'bar',    'C' => 'corge',  'D' => 'waldo'],
+                ],
+              ],
             ],
-            "garply" => [
-              "corge" => [
-                "plugh" => [
-                  [ "A" => "foo", "B" => "garply", "C" => "corge",  "D" => "plugh" ]
-                ]
-              ]
-            ]
+            'garply' => [
+              'corge' => [
+                'plugh' => [
+                  ['A' => 'foo', 'B' => 'garply', 'C' => 'corge',  'D' => 'plugh'],
+                ],
+              ],
+            ],
           ],
-          "qux" => [
-            "garply" => [
-              "xyzzy" => [
-                "fred" => [
-                  [ "A" => "qux", "B" => "garply", "C" => "xyzzy",  "D" => "fred" ]
-                ]
-              ]
+          'qux' => [
+            'garply' => [
+              'xyzzy' => [
+                'fred' => [
+                  ['A' => 'qux', 'B' => 'garply', 'C' => 'xyzzy',  'D' => 'fred'],
+                ],
+              ],
             ],
-            "grault" => [
-              "garply" => [
-                "quuz" => [
-                  [ "A" => "qux", "B" => "grault", "C" => "garply", "D" => "quuz" ]
-                ]
-              ]
-            ]
-          ]
+            'grault' => [
+              'garply' => [
+                'quuz' => [
+                  ['A' => 'qux', 'B' => 'grault', 'C' => 'garply', 'D' => 'quuz'],
+                ],
+              ],
+            ],
+          ],
         ];
         $this->assertEquals($expected, $result->toArray());
     }
@@ -1328,7 +1328,7 @@ class SupportCollectionTest extends TestCase
           30 => ['rating' => 2, 'url' => 'b'],
           40 => ['rating' => 2, 'url' => 'a'],
           50 => ['rating' => 1, 'url' => 'b'],
-          60 => ['rating' => 3, 'url' => 'c']
+          60 => ['rating' => 3, 'url' => 'c'],
         ]);
 
         $result = $data->groupByMultiple(['rating', 'url'], true);
@@ -1337,25 +1337,25 @@ class SupportCollectionTest extends TestCase
           1 => [
             'a' => [
               10 => ['rating' => 1, 'url' => 'a'],
-              20 => ['rating' => 1, 'url' => 'a']
+              20 => ['rating' => 1, 'url' => 'a'],
             ],
             'b' => [
-              50 => ['rating' => 1, 'url' => 'b']
-            ]
+              50 => ['rating' => 1, 'url' => 'b'],
+            ],
           ],
           2 => [
             'a' => [
-              40 => ['rating' => 2, 'url' => 'a']
+              40 => ['rating' => 2, 'url' => 'a'],
             ],
             'b' => [
-              30 => ['rating' => 2, 'url' => 'b']
-            ]
+              30 => ['rating' => 2, 'url' => 'b'],
+            ],
           ],
           3 => [
             'c' => [
-              60 => ['rating' => 3, 'url' => 'c']
-            ]
-          ]
+              60 => ['rating' => 3, 'url' => 'c'],
+            ],
+          ],
         ];
 
         $this->assertEquals($expected, $result->toArray());
@@ -1367,7 +1367,7 @@ class SupportCollectionTest extends TestCase
           ['rating' => 1, 'url' => '1'],
           ['rating' => 1, 'url' => '1'],
           ['rating' => 2, 'url' => '2'],
-          ['rating' => 1, 'url' => '3']
+          ['rating' => 1, 'url' => '3'],
         ]);
 
         $callback1 = function ($item) {
@@ -1382,17 +1382,17 @@ class SupportCollectionTest extends TestCase
           1 => [
             1 => [
               ['rating' => 1, 'url' => '1'],
-              ['rating' => 1, 'url' => '1']
+              ['rating' => 1, 'url' => '1'],
             ],
             3 => [
-              ['rating' => 1, 'url' => '3']
-            ]
+              ['rating' => 1, 'url' => '3'],
+            ],
           ],
           2 => [
             2 => [
-              ['rating' => 2, 'url' => '2']
-            ]
-          ]
+              ['rating' => 2, 'url' => '2'],
+            ],
+          ],
         ];
         $this->assertEquals($expected, $result->toArray());
     }
@@ -1403,7 +1403,7 @@ class SupportCollectionTest extends TestCase
           10 => ['rating' => 1, 'url' => '1'],
           20 => ['rating' => 1, 'url' => '1'],
           30 => ['rating' => 2, 'url' => '2'],
-          40 => ['rating' => 1, 'url' => '3']
+          40 => ['rating' => 1, 'url' => '3'],
         ]);
 
         $callback1 = function ($item) {
@@ -1418,17 +1418,17 @@ class SupportCollectionTest extends TestCase
           1 => [
             1 => [
               10 => ['rating' => 1, 'url' => '1'],
-              20 => ['rating' => 1, 'url' => '1']
+              20 => ['rating' => 1, 'url' => '1'],
             ],
             3 => [
-              40 => ['rating' => 1, 'url' => '3']
-            ]
+              40 => ['rating' => 1, 'url' => '3'],
+            ],
           ],
           2 => [
             2 => [
-              30 => ['rating' => 2, 'url' => '2']
-            ]
-          ]
+              30 => ['rating' => 2, 'url' => '2'],
+            ],
+          ],
         ];
 
         $this->assertEquals($expected, $result->toArray());
@@ -1454,29 +1454,29 @@ class SupportCollectionTest extends TestCase
           'Role_1' => [
             'red' => [
               ['user' => 1, 'roles' => ['Role_1', 'Role_3'], 'teams' => ['red', 'blue']],
-              ['user' => 2, 'roles' => ['Role_1', 'Role_2'], 'teams' => ['red']]
+              ['user' => 2, 'roles' => ['Role_1', 'Role_2'], 'teams' => ['red']],
             ],
             'blue' => [
               ['user' => 1, 'roles' => ['Role_1', 'Role_3'], 'teams' => ['red', 'blue']],
-              ['user' => 3, 'roles' => ['Role_1'],           'teams' => ['yellow', 'blue']]
+              ['user' => 3, 'roles' => ['Role_1'],           'teams' => ['yellow', 'blue']],
             ],
             'yellow' => [
-              ['user' => 3, 'roles' => ['Role_1'],           'teams' => ['yellow', 'blue']]
-            ]
+              ['user' => 3, 'roles' => ['Role_1'],           'teams' => ['yellow', 'blue']],
+            ],
           ],
           'Role_2' => [
             'red' => [
-              ['user' => 2, 'roles' => ['Role_1', 'Role_2'], 'teams' => ['red']]
-            ]
+              ['user' => 2, 'roles' => ['Role_1', 'Role_2'], 'teams' => ['red']],
+            ],
           ],
           'Role_3' => [
             'red' => [
-              ['user' => 1, 'roles' => ['Role_1', 'Role_3'], 'teams' => ['red', 'blue']]
+              ['user' => 1, 'roles' => ['Role_1', 'Role_3'], 'teams' => ['red', 'blue']],
             ],
             'blue' => [
-              ['user' => 1, 'roles' => ['Role_1', 'Role_3'], 'teams' => ['red', 'blue']]
-            ]
-          ]
+              ['user' => 1, 'roles' => ['Role_1', 'Role_3'], 'teams' => ['red', 'blue']],
+            ],
+          ],
         ];
 
         $this->assertEquals($expected, $result->toArray());
@@ -1502,29 +1502,29 @@ class SupportCollectionTest extends TestCase
           'Role_1' => [
             'red' => [
               10 => ['user' => 1, 'roles' => ['Role_1', 'Role_3'], 'teams' => ['red', 'blue']],
-              20 => ['user' => 2, 'roles' => ['Role_1', 'Role_2'], 'teams' => ['red']]
+              20 => ['user' => 2, 'roles' => ['Role_1', 'Role_2'], 'teams' => ['red']],
             ],
             'blue' => [
               10 => ['user' => 1, 'roles' => ['Role_1', 'Role_3'], 'teams' => ['red', 'blue']],
-              30 => ['user' => 3, 'roles' => ['Role_1'],           'teams' => ['yellow', 'blue']]
+              30 => ['user' => 3, 'roles' => ['Role_1'],           'teams' => ['yellow', 'blue']],
             ],
             'yellow' => [
-              30 => ['user' => 3, 'roles' => ['Role_1'],           'teams' => ['yellow', 'blue']]
-            ]
+              30 => ['user' => 3, 'roles' => ['Role_1'],           'teams' => ['yellow', 'blue']],
+            ],
           ],
           'Role_2' => [
             'red' => [
-              20 => ['user' => 2, 'roles' => ['Role_1', 'Role_2'], 'teams' => ['red']]
-            ]
+              20 => ['user' => 2, 'roles' => ['Role_1', 'Role_2'], 'teams' => ['red']],
+            ],
           ],
           'Role_3' => [
             'red' => [
-              10 => ['user' => 1, 'roles' => ['Role_1', 'Role_3'], 'teams' => ['red', 'blue']]
+              10 => ['user' => 1, 'roles' => ['Role_1', 'Role_3'], 'teams' => ['red', 'blue']],
             ],
             'blue' => [
-              10 => ['user' => 1, 'roles' => ['Role_1', 'Role_3'], 'teams' => ['red', 'blue']]
-            ]
-          ]
+              10 => ['user' => 1, 'roles' => ['Role_1', 'Role_3'], 'teams' => ['red', 'blue']],
+            ],
+          ],
         ];
 
         $this->assertEquals($expected, $result->toArray());

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1320,6 +1320,47 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals($expected, $result->toArray());
     }
 
+    public function testGroupByMultipleAttributePreservingKeys()
+    {
+        $data = new Collection([
+          10 => ['rating' => 1, 'url' => 'a'],
+          20 => ['rating' => 1, 'url' => 'a'],
+          30 => ['rating' => 2, 'url' => 'b'],
+          40 => ['rating' => 2, 'url' => 'a'],
+          50 => ['rating' => 1, 'url' => 'b'],
+          60 => ['rating' => 3, 'url' => 'c']
+        ]);
+
+        $result = $data->groupByMultiple(['rating', 'url'], true);
+
+        $expected = [
+          1 => [
+            'a' => [
+              10 => ['rating' => 1, 'url' => 'a'],
+              20 => ['rating' => 1, 'url' => 'a']
+            ],
+            'b' => [
+              50 => ['rating' => 1, 'url' => 'b']
+            ]
+          ],
+          2 => [
+            'a' => [
+              40 => ['rating' => 2, 'url' => 'a']
+            ],
+            'b' => [
+              30 => ['rating' => 2, 'url' => 'b']
+            ]
+          ],
+          3 => [
+            'c' => [
+              60 => ['rating' => 3, 'url' => 'c']
+            ]
+          ]
+        ];
+
+        $this->assertEquals($expected, $result->toArray());
+    }
+
     public function testKeyByAttribute()
     {
         $data = new Collection([['rating' => 1, 'name' => '1'], ['rating' => 2, 'name' => '2'], ['rating' => 3, 'name' => '3']]);

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1361,6 +1361,42 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals($expected, $result->toArray());
     }
 
+    public function testGroupByMultipleClosureWhereItemsHaveSingleGroup()
+    {
+        $data = new Collection([
+          ['rating' => 1, 'url' => '1'],
+          ['rating' => 1, 'url' => '1'],
+          ['rating' => 2, 'url' => '2'],
+          ['rating' => 1, 'url' => '3']
+        ]);
+
+        $callback1 = function ($item) {
+            return $item['rating'];
+        };
+        $callback2 = function ($item) {
+            return $item['url'];
+        };
+        $result = $data->groupByMultiple([$callback1, $callback2]);
+
+        $expected = [
+          1 => [
+            1 => [
+              ['rating' => 1, 'url' => '1'],
+              ['rating' => 1, 'url' => '1']
+            ],
+            3 => [
+              ['rating' => 1, 'url' => '3']
+            ]
+          ],
+          2 => [
+            2 => [
+              ['rating' => 2, 'url' => '2']
+            ]
+          ]
+        ];
+        $this->assertEquals($expected, $result->toArray());
+    }
+
     public function testKeyByAttribute()
     {
         $data = new Collection([['rating' => 1, 'name' => '1'], ['rating' => 2, 'name' => '2'], ['rating' => 3, 'name' => '3']]);

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1397,6 +1397,43 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals($expected, $result->toArray());
     }
 
+    public function testGroupByMultipleClosureWhereItemsHaveSingleGroupPreservingKeys()
+    {
+        $data = new Collection([
+          10 => ['rating' => 1, 'url' => '1'],
+          20 => ['rating' => 1, 'url' => '1'],
+          30 => ['rating' => 2, 'url' => '2'],
+          40 => ['rating' => 1, 'url' => '3']
+        ]);
+
+        $callback1 = function ($item) {
+            return $item['rating'];
+        };
+        $callback2 = function ($item) {
+            return $item['url'];
+        };
+        $result = $data->groupByMultiple([$callback1, $callback2], true);
+
+        $expected = [
+          1 => [
+            1 => [
+              10 => ['rating' => 1, 'url' => '1'],
+              20 => ['rating' => 1, 'url' => '1']
+            ],
+            3 => [
+              40 => ['rating' => 1, 'url' => '3']
+            ]
+          ],
+          2 => [
+            2 => [
+              30 => ['rating' => 2, 'url' => '2']
+            ]
+          ]
+        ];
+
+        $this->assertEquals($expected, $result->toArray());
+    }
+
     public function testGroupByMultipleClosureWhereItemsHaveMultipleGroups()
     {
         $data = new Collection([
@@ -1438,6 +1475,54 @@ class SupportCollectionTest extends TestCase
             ],
             'blue' => [
               ['user' => 1, 'roles' => ['Role_1', 'Role_3'], 'teams' => ['red', 'blue']]
+            ]
+          ]
+        ];
+
+        $this->assertEquals($expected, $result->toArray());
+    }
+
+    public function testGroupByMultipleClosureWhereItemsHaveMultipleGroupsPreservingKeys()
+    {
+        $data = new Collection([
+          10 => ['user' => 1, 'roles' => ['Role_1', 'Role_3'], 'teams' => ['red', 'blue']],
+          20 => ['user' => 2, 'roles' => ['Role_1', 'Role_2'], 'teams' => ['red']],
+          30 => ['user' => 3, 'roles' => ['Role_1'], 'teams' => ['yellow', 'blue']],
+        ]);
+
+        $callback1 = function ($item) {
+            return $item['roles'];
+        };
+        $callback2 = function ($item) {
+            return $item['teams'];
+        };
+        $result = $data->groupByMultiple([$callback1, $callback2], true);
+
+        $expected = [
+          'Role_1' => [
+            'red' => [
+              10 => ['user' => 1, 'roles' => ['Role_1', 'Role_3'], 'teams' => ['red', 'blue']],
+              20 => ['user' => 2, 'roles' => ['Role_1', 'Role_2'], 'teams' => ['red']]
+            ],
+            'blue' => [
+              10 => ['user' => 1, 'roles' => ['Role_1', 'Role_3'], 'teams' => ['red', 'blue']],
+              30 => ['user' => 3, 'roles' => ['Role_1'],           'teams' => ['yellow', 'blue']]
+            ],
+            'yellow' => [
+              30 => ['user' => 3, 'roles' => ['Role_1'],           'teams' => ['yellow', 'blue']]
+            ]
+          ],
+          'Role_2' => [
+            'red' => [
+              20 => ['user' => 2, 'roles' => ['Role_1', 'Role_2'], 'teams' => ['red']]
+            ]
+          ],
+          'Role_3' => [
+            'red' => [
+              10 => ['user' => 1, 'roles' => ['Role_1', 'Role_3'], 'teams' => ['red', 'blue']]
+            ],
+            'blue' => [
+              10 => ['user' => 1, 'roles' => ['Role_1', 'Role_3'], 'teams' => ['red', 'blue']]
             ]
           ]
         ];

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1397,6 +1397,54 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals($expected, $result->toArray());
     }
 
+    public function testGroupByMultipleClosureWhereItemsHaveMultipleGroups()
+    {
+        $data = new Collection([
+          ['user' => 1, 'roles' => ['Role_1', 'Role_3'], 'teams' => ['red', 'blue']],
+          ['user' => 2, 'roles' => ['Role_1', 'Role_2'], 'teams' => ['red']],
+          ['user' => 3, 'roles' => ['Role_1'], 'teams' => ['yellow', 'blue']],
+        ]);
+
+        $callback1 = function ($item) {
+            return $item['roles'];
+        };
+        $callback2 = function ($item) {
+            return $item['teams'];
+        };
+        $result = $data->groupByMultiple([$callback1, $callback2]);
+
+        $expected = [
+          'Role_1' => [
+            'red' => [
+              ['user' => 1, 'roles' => ['Role_1', 'Role_3'], 'teams' => ['red', 'blue']],
+              ['user' => 2, 'roles' => ['Role_1', 'Role_2'], 'teams' => ['red']]
+            ],
+            'blue' => [
+              ['user' => 1, 'roles' => ['Role_1', 'Role_3'], 'teams' => ['red', 'blue']],
+              ['user' => 3, 'roles' => ['Role_1'],           'teams' => ['yellow', 'blue']]
+            ],
+            'yellow' => [
+              ['user' => 3, 'roles' => ['Role_1'],           'teams' => ['yellow', 'blue']]
+            ]
+          ],
+          'Role_2' => [
+            'red' => [
+              ['user' => 2, 'roles' => ['Role_1', 'Role_2'], 'teams' => ['red']]
+            ]
+          ],
+          'Role_3' => [
+            'red' => [
+              ['user' => 1, 'roles' => ['Role_1', 'Role_3'], 'teams' => ['red', 'blue']]
+            ],
+            'blue' => [
+              ['user' => 1, 'roles' => ['Role_1', 'Role_3'], 'teams' => ['red', 'blue']]
+            ]
+          ]
+        ];
+
+        $this->assertEquals($expected, $result->toArray());
+    }
+
     public function testKeyByAttribute()
     {
         $data = new Collection([['rating' => 1, 'name' => '1'], ['rating' => 2, 'name' => '2'], ['rating' => 3, 'name' => '3']]);

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1130,19 +1130,28 @@ class SupportCollectionTest extends TestCase
     public function testGroupByAttribute()
     {
         $data = new Collection([['rating' => 1, 'url' => '1'], ['rating' => 1, 'url' => '1'], ['rating' => 2, 'url' => '2']]);
+        $dataM = clone $data;
 
+        $expected = [1 => [['rating' => 1, 'url' => '1'], ['rating' => 1, 'url' => '1']], 2 => [['rating' => 2, 'url' => '2']]];
         $result = $data->groupBy('rating');
-        $this->assertEquals([1 => [['rating' => 1, 'url' => '1'], ['rating' => 1, 'url' => '1']], 2 => [['rating' => 2, 'url' => '2']]], $result->toArray());
+        $this->assertEquals($expected, $result->toArray());
+        $resultM = $dataM->groupByMultiple('rating');
+        $this->assertEquals($expected, $resultM->toArray());
 
+        $expected = [1 => [['rating' => 1, 'url' => '1'], ['rating' => 1, 'url' => '1']], 2 => [['rating' => 2, 'url' => '2']]];
         $result = $data->groupBy('url');
-        $this->assertEquals([1 => [['rating' => 1, 'url' => '1'], ['rating' => 1, 'url' => '1']], 2 => [['rating' => 2, 'url' => '2']]], $result->toArray());
+        $this->assertEquals($expected, $result->toArray());
+        $resultM = $dataM->groupByMultiple('url');
+        $this->assertEquals($expected, $resultM->toArray());
     }
 
     public function testGroupByAttributePreservingKeys()
     {
         $data = new Collection([10 => ['rating' => 1, 'url' => '1'],  20 => ['rating' => 1, 'url' => '1'],  30 => ['rating' => 2, 'url' => '2']]);
+        $dataM = clone $data;
 
         $result = $data->groupBy('rating', true);
+        $resultM = $dataM->groupByMultiple('rating', true);
 
         $expected_result = [
             1 => [10 => ['rating' => 1, 'url' => '1'], 20 => ['rating' => 1, 'url' => '1']],
@@ -1150,26 +1159,35 @@ class SupportCollectionTest extends TestCase
         ];
 
         $this->assertEquals($expected_result, $result->toArray());
+        $this->assertEquals($expected_result, $resultM->toArray());
     }
 
     public function testGroupByClosureWhereItemsHaveSingleGroup()
     {
         $data = new Collection([['rating' => 1, 'url' => '1'], ['rating' => 1, 'url' => '1'], ['rating' => 2, 'url' => '2']]);
+        $dataM = clone $data;
 
-        $result = $data->groupBy(function ($item) {
+        $callback = function ($item) {
             return $item['rating'];
-        });
+        };
+        $result = $data->groupBy($callback);
+        $resultM = $dataM->groupByMultiple($callback);
 
-        $this->assertEquals([1 => [['rating' => 1, 'url' => '1'], ['rating' => 1, 'url' => '1']], 2 => [['rating' => 2, 'url' => '2']]], $result->toArray());
+        $expected = [1 => [['rating' => 1, 'url' => '1'], ['rating' => 1, 'url' => '1']], 2 => [['rating' => 2, 'url' => '2']]];
+        $this->assertEquals($expected, $result->toArray());
+        $this->assertEquals($expected, $resultM->toArray());
     }
 
     public function testGroupByClosureWhereItemsHaveSingleGroupPreservingKeys()
     {
         $data = new Collection([10 => ['rating' => 1, 'url' => '1'], 20 => ['rating' => 1, 'url' => '1'], 30 => ['rating' => 2, 'url' => '2']]);
+        $dataM = clone $data;
 
-        $result = $data->groupBy(function ($item) {
+        $callback = function ($item) {
             return $item['rating'];
-        }, true);
+        };
+        $result = $data->groupBy($callback, true);
+        $resultM = $dataM->groupByMultiple($callback, true);
 
         $expected_result = [
             1 => [10 => ['rating' => 1, 'url' => '1'], 20 => ['rating' => 1, 'url' => '1']],
@@ -1177,6 +1195,7 @@ class SupportCollectionTest extends TestCase
         ];
 
         $this->assertEquals($expected_result, $result->toArray());
+        $this->assertEquals($expected_result, $resultM->toArray());
     }
 
     public function testGroupByClosureWhereItemsHaveMultipleGroups()
@@ -1186,10 +1205,13 @@ class SupportCollectionTest extends TestCase
             ['user' => 2, 'roles' => ['Role_1', 'Role_2']],
             ['user' => 3, 'roles' => ['Role_1']],
         ]);
+        $dataM = clone $data;
 
-        $result = $data->groupBy(function ($item) {
+        $callback = function ($item) {
             return $item['roles'];
-        });
+        };
+        $result = $data->groupBy($callback);
+        $resultM = $dataM->groupByMultiple($callback);
 
         $expected_result = [
             'Role_1' => [
@@ -1206,6 +1228,7 @@ class SupportCollectionTest extends TestCase
         ];
 
         $this->assertEquals($expected_result, $result->toArray());
+        $this->assertEquals($expected_result, $resultM->toArray());
     }
 
     public function testGroupByClosureWhereItemsHaveMultipleGroupsPreservingKeys()
@@ -1215,10 +1238,13 @@ class SupportCollectionTest extends TestCase
             20 => ['user' => 2, 'roles' => ['Role_1', 'Role_2']],
             30 => ['user' => 3, 'roles' => ['Role_1']],
         ]);
+        $dataM = clone $data;
 
-        $result = $data->groupBy(function ($item) {
+        $callback = function ($item) {
             return $item['roles'];
-        }, true);
+        };
+        $result = $data->groupBy($callback, true);
+        $resultM = $dataM->groupByMultiple($callback, true);
 
         $expected_result = [
             'Role_1' => [
@@ -1235,6 +1261,7 @@ class SupportCollectionTest extends TestCase
         ];
 
         $this->assertEquals($expected_result, $result->toArray());
+        $this->assertEquals($expected_result, $resultM->toArray());
     }
 
     public function testKeyByAttribute()


### PR DESCRIPTION
**Use case**
In the project I am working on I frequently need to create nested structures that are then converted to JSON. This involves some ugly boilerplate code that is needed each time, so my idea is to add a groupByMultiple function to Laravel's Collections that supports grouping multiple times into a nested structure. The new function will be similar to the existing groupBy function.

**Example:**

A | B | C | D
------------ | ------------- | ------------- | -------------
foo | bar | baz | thud
foo | garply | corge | plugh
foo | bar | corge | thud
foo | bar | corge | waldo
qux | garply | xyzzy | fred
qux | grault | garply | quuz

By calling myCollection->groupBy(['A', 'B', 'C', 'D']) the result would become:

* foo
  * bar
    * baz
      * thud [foo, bar, baz, thud]
    * corge
      * thud [foo, bar, corge, thud]
      * waldo [foo, bar, corge, waldo]
  * garply
    * corge
      * plugh [foo, garply, corge, plugh]
* qux
  * garply
    * xyzzy
      * fred [quz, garply, xyzzy, fred]
  * grault
    * garply
      * quuz [qux, grault, garply, quuz]

**Backwards compatibility**
Since this is a new function and does not change existing functions, it could be added to 5.4 because no backwards compatibility is broken. The new functionality cannot be integrated into the existing groupBy function, because the groupBy function signature is groupBy(callable|string $groupBy, bool $preserveKeys = false) and this conflicts with groupBy(callable|string|array $groupBy, bool $preserveKeys = false) because a callable can be an array ["Foo", "Bar"] where Foo::Bar() is a valid method.

**Cross compatibility**
The groupByMultiple function is somewhat compatible with groupBy in that it functions in the same way if you pass as first argument something that is not an array, so just like groupBy you can call it with a string or a closure. The function just puts the first argument in an array if it isn't one. If you try to pass a callable as an array, so ["Foo", "Bar"] where Foo::Bar() is a valid method, then of course the groupByMultiple function will just attempt to group on the key "Foo" first and "Bar" second; this is the main difference with groupBy(). Of course you can pass an array with a callable in it, so [["Foo", "Bar"]] or [["Foo", "Bar"], "Baz"] would work just fine.

**Code questions**
My implementation is heavily based on Laravel's groupBy function. Since I am not that familiar with Laravel's internal code I am very open to improvements. For example I have a few questions:
* I basically inlined the usage of offsetSet() because it was simpler. Is that okay?
* The original groupBy code directly creates a child collection because the nesting is always one level, but when you have arbitrary grouping levels this is not possible. To solve this I added a helper to Arr which recursively converts a (nested) array into a (nested) collection. I am not sure this is the right place though, perhaps add it to Collection itself? It could also be made private if you do not want it exposed.

**Tests**
* I modified all existing Collection groupBy unit tests to also call groupByMultiple with the same parameters, and they all pass. This ensures the "semi cross-compatibility".
* I also created new unit tests specific to groupByMultiple that are based on all the cases that the existing groupBy unit tests test. They also all pass.

**Performance**
* Do I need to test for performance "regressions" compared to groupBy?
* Is there a frequently used / standard benchmark for collection operations? 


Would love to hear feedback :)