### PR TITLE
[5.4] Fix issue with case in authorizeResource

### DIFF
--- a/src/Illuminate/Foundation/Auth/Access/AuthorizesRequests.php
+++ b/src/Illuminate/Foundation/Auth/Access/AuthorizesRequests.php
@@ -81,7 +81,7 @@ trait AuthorizesRequests
      */
     public function authorizeResource($model, $parameter = null, array $options = [], $request = null)
     {
-        $parameter = $parameter ?: strtolower(class_basename($model));
+        $parameter = $parameter ?: lcfirst(class_basename($model));
 
         $middleware = [];
 


### PR DESCRIPTION
Should fix issue #18432 
Will add some tests this evening.

## Problem:
When using the "authorizeResource" method, by default, the method derives the parameter name from the passed model if it is not given as the secoond parameter. However, "strtolower" is used. If the model name contains multiple words, ie. "ProductionOrder", then the parameter becomes "productionorder", which will not work. We need "productionOrder".
So, currently, authorizeResource will always return false, unless the second parameter is provided as "productionOrder".

## Solution:
Simply change the following line:
```
$parameter = $parameter ?: strtolower(class_basename($model));
```
to
```
$parameter = $parameter ?: lcfirst(class_basename($model));
```
