### PR TITLE
[5.5] Remove now unneeded set of mb_internal_encoding

### DIFF
--- a/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php
+++ b/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php
@@ -46,8 +46,6 @@ class LoadConfiguration
         });
 
         date_default_timezone_set($config->get('app.timezone', 'UTC'));
-
-        mb_internal_encoding('UTF-8');
     }
 
     /**


### PR DESCRIPTION
Follow-up to #6891.

I did some tests on PHP 5.6, and `mb_internal_encoding()` appears to give 'UTF-8' by default. Even if `default_charset` INI setting has been set to a different charset.

So the only way to have a different charset is to call `mb_internal_encoding('other charset')` beforehand.