### PR TITLE
[5.4] Random optional strict mode

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -941,17 +941,18 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      * Get one or more items randomly from the collection.
      *
      * @param  int|null  $amount
+     * @param  bool $strict
      * @return mixed
      *
      * @throws \InvalidArgumentException
      */
-    public function random($amount = 1)
+    public function random($amount = 1, $strict = true)
     {
-        if ($amount > ($count = $this->count())) {
+        if ($amount > ($count = $this->count()) && $strict) {
             throw new InvalidArgumentException("You requested {$amount} items, but there are only {$count} items in the collection.");
         }
 
-        $keys = array_rand($this->items, $amount);
+        $keys = array_rand($this->items, $amount < $count ? $amount : $count);
 
         if (count(func_get_args()) == 0) {
             return $this->items[$keys];

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -870,6 +870,15 @@ class SupportCollectionTest extends TestCase
         (new Collection)->random();
     }
 
+    public function testRandomWithoutStrictReturnTotalIfLessThanAmout()
+    {
+        $data = new Collection([1, 2, 3]);
+
+        $random = $data->random(4, false);
+        $this->assertInstanceOf(Collection::class, $random);
+        $this->assertCount(3, $random);
+    }
+
     public function testTakeLast()
     {
         $data = new Collection(['taylor', 'dayle', 'shawn']);


### PR DESCRIPTION
In this PR , collection ```random()``` method would have optionally strict mode so if I don't know the count of the array but I just need to get 4 items from it, I don't have to check the ```count``` first.

**summary** :

```
$array = collect([1,2,3])->random(4,false); // [1,2,3]
```

instead of 
```
$array = collect([1,2,3]);
if($array->count() > 4){
    $array = $array->random(4);
}
```
