### PR TITLE
[5.4] test when() method with return statement

### DIFF
--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -147,6 +147,23 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals('select * from "users" where "email" = ?', $builder->toSql());
     }
 
+    public function testWhenCallbackWithReturn()
+    {
+        $callback = function ($query, $condition) {
+            $this->assertTrue($condition);
+
+            return $query->where('id', '=', 1);
+        };
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->when(true, $callback)->where('email', 'foo');
+        $this->assertEquals('select * from "users" where "id" = ? and "email" = ?', $builder->toSql());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->when(false, $callback)->where('email', 'foo');
+        $this->assertEquals('select * from "users" where "email" = ?', $builder->toSql());
+    }
+
     public function testWhenCallbackWithDefault()
     {
         $callback = function ($query, $condition) {


### PR DESCRIPTION
#18422 removed the need for a `return` statement on the when() method, but it also removed the tests for it. 

This adds a specific test so we can make sure that behavior still works.