### PR TITLE
[5.4] Add acessors back to queue worker

### DIFF
--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -568,4 +568,24 @@ class Worker
     {
         $this->cache = $cache;
     }
+
+    /**
+     * Get the queue manager instance.
+     *
+     * @return \Illuminate\Queue\QueueManager
+     */
+    public function getManager()
+    {
+        return $this->manager;
+    }
+    /**
+     * Set the queue manager instance.
+     *
+     * @param  \Illuminate\Queue\QueueManager  $manager
+     * @return void
+     */
+    public function setManager(QueueManager $manager)
+    {
+        $this->manager = $manager;
+    }
 }

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -578,6 +578,7 @@ class Worker
     {
         return $this->manager;
     }
+
     /**
      * Set the queue manager instance.
      *


### PR DESCRIPTION
As pointed out by @crlcu these acessors aren't used by the framework core however they are used on packages, like [this one](https://github.com/barryvdh/laravel-async-queue/blob/master/src/Console/AsyncCommand.php).

Commit that removed the acessors: https://github.com/laravel/framework/commit/712b99df85c7a9daf8fb9f0a9a34fa90cbe99f44