### PR TITLE
[5.5] Ability to prevent mail from sending

### DIFF
--- a/src/Illuminate/Mail/Transport/ArrayTransport.php
+++ b/src/Illuminate/Mail/Transport/ArrayTransport.php
@@ -31,6 +31,10 @@ class ArrayTransport extends Transport
     {
         $this->beforeSendPerformed($message);
 
+        if($this->beforeSendEvent->bubbleCancelled()) {
+            return 0;
+        }
+
         $this->messages[] = $message;
 
         return $this->numberOfRecipients($message);

--- a/src/Illuminate/Mail/Transport/LogTransport.php
+++ b/src/Illuminate/Mail/Transport/LogTransport.php
@@ -33,6 +33,10 @@ class LogTransport extends Transport
     {
         $this->beforeSendPerformed($message);
 
+        if($this->beforeSendEvent->bubbleCancelled()) {
+            return 0;
+        }
+
         $this->logger->debug($this->getMimeEntityString($message));
 
         $this->sendPerformed($message);

--- a/src/Illuminate/Mail/Transport/MailgunTransport.php
+++ b/src/Illuminate/Mail/Transport/MailgunTransport.php
@@ -57,6 +57,10 @@ class MailgunTransport extends Transport
     {
         $this->beforeSendPerformed($message);
 
+        if($this->beforeSendEvent->bubbleCancelled()) {
+            return 0;
+        }
+
         $to = $this->getTo($message);
 
         $message->setBcc([]);

--- a/src/Illuminate/Mail/Transport/MandrillTransport.php
+++ b/src/Illuminate/Mail/Transport/MandrillTransport.php
@@ -41,6 +41,10 @@ class MandrillTransport extends Transport
     {
         $this->beforeSendPerformed($message);
 
+        if($this->beforeSendEvent->bubbleCancelled()) {
+            return 0;
+        }
+
         $this->client->post('https://mandrillapp.com/api/1.0/messages/send-raw.json', [
             'form_params' => [
                 'key' => $this->key,

--- a/src/Illuminate/Mail/Transport/SesTransport.php
+++ b/src/Illuminate/Mail/Transport/SesTransport.php
@@ -32,6 +32,10 @@ class SesTransport extends Transport
     {
         $this->beforeSendPerformed($message);
 
+        if($this->beforeSendEvent->bubbleCancelled()) {
+            return 0;
+        }
+
         $headers = $message->getHeaders();
 
         $headers->addTextHeader('X-SES-Message-ID', $this->ses->sendRawEmail([

--- a/src/Illuminate/Mail/Transport/SparkPostTransport.php
+++ b/src/Illuminate/Mail/Transport/SparkPostTransport.php
@@ -50,6 +50,10 @@ class SparkPostTransport extends Transport
     {
         $this->beforeSendPerformed($message);
 
+        if($this->beforeSendEvent->bubbleCancelled()) {
+            return 0;
+        }
+
         $recipients = $this->getRecipients($message);
 
         $message->setBcc([]);

--- a/src/Illuminate/Mail/Transport/Transport.php
+++ b/src/Illuminate/Mail/Transport/Transport.php
@@ -17,6 +17,11 @@ abstract class Transport implements Swift_Transport
     public $plugins = [];
 
     /**
+     * @var Swift_Events_SendEvent
+     */
+    protected $beforeSendEvent;
+
+    /**
      * {@inheritdoc}
      */
     public function isStarted()
@@ -59,11 +64,11 @@ abstract class Transport implements Swift_Transport
      */
     protected function beforeSendPerformed(Swift_Mime_Message $message)
     {
-        $event = new Swift_Events_SendEvent($this, $message);
+        $this->beforeSendEvent = new Swift_Events_SendEvent($this, $message);
 
         foreach ($this->plugins as $plugin) {
             if (method_exists($plugin, 'beforeSendPerformed')) {
-                $plugin->beforeSendPerformed($event);
+                $plugin->beforeSendPerformed($this->beforeSendEvent);
             }
         }
     }


### PR DESCRIPTION
This PR adds the ability to prevent mail from sending. This can be done by registering a plugin with swift mailer.

Example:

```php
class BlacklistListener implements Swift_Events_SendListener {

    /**
     * Invoked immediately after the Message is sent.
     *
     * @param Swift_Events_SendEvent $evt
     */
    public function sendPerformed (Swift_Events_SendEvent $evt)
    {
        // 
    }

    /**
     * Invoked immediately before the Message is sent.
     *
     * @param Swift_Events_SendEvent $evt
     */
    public function beforeSendPerformed (Swift_Events_SendEvent $evt)
    {
        ...

        if($user->isBlacklisted()) {
            $evt->cancelBubble();
        }
    }
}
```

This is based on [Swift Mailer's smtp transport](https://github.com/swiftmailer/swiftmailer/blob/5.x/lib/classes/Swift/Transport/AbstractSmtpTransport.php#L156). This method, therefore, already works for the smtp driver.

## Why?

I maintain a central database of domains and email addresses that should be blacklisted from emails. This helps prevent me from accidentally emailing a user that has asked to unsubscribe from my emails. 

It could be argued one should simply check the email address beforehand. This solution is less than ideal as there are numerous places across the codebase where mail is sent from. This acts as a catch all. 

Further, I am sure there are other potential uses for this.