### PR TITLE
[5.4] Offload writing .env file to DotEnvWriter package for key:generate

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,8 @@
         "symfony/routing": "~3.2",
         "symfony/var-dumper": "~3.2",
         "tijsverkoyen/css-to-inline-styles": "~2.2",
-        "vlucas/phpdotenv": "~2.2"
+        "vlucas/phpdotenv": "~2.2",
+        "oohology/dotenvwriter": "^1.2"
     },
     "replace": {
         "illuminate/auth": "self.version",

--- a/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
+++ b/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Foundation\Console;
 
+use DotEnvWriter\DotEnvWriter;
 use Illuminate\Console\Command;
 use Illuminate\Console\ConfirmableTrait;
 
@@ -89,22 +90,8 @@ class KeyGenerateCommand extends Command
      */
     protected function writeNewEnvironmentFileWith($key)
     {
-        file_put_contents($this->laravel->environmentFilePath(), preg_replace(
-            $this->keyReplacementPattern(),
-            'APP_KEY='.$key,
-            file_get_contents($this->laravel->environmentFilePath())
-        ));
-    }
-
-    /**
-     * Get a regex pattern that will match env APP_KEY with any random key.
-     *
-     * @return string
-     */
-    protected function keyReplacementPattern()
-    {
-        $escaped = preg_quote('='.$this->laravel['config']['app.key'], '/');
-
-        return "/^APP_KEY{$escaped}/m";
+        (new DotEnvWriter($this->laravel->environmentFilePath()))
+            ->set('APP_KEY', $key)
+            ->save();
     }
 }


### PR DESCRIPTION
This outsources the logic to write environment files to a separate package dedicated to that responsibility ([oohology/DotEnvWriter](https://packagist.org/packages/oohology/dotenvwriter)). This allows the `key:generate` command to write the APP_KEY to the .env file more reliably, while simplifying the KeyGenerateCommand class.

Currently, the pattern for matching an existing APP_KEY is very strict. If the .env file does not contain an exact match for Laravel's current app key in the expected format, the artisan command will fail to update the .env file. This package can handle multiple variations of the APP_KEY statement including quoted values and whitespace, as well as append a new APP_KEY if one is not present.