### PR TITLE
[5.4] Create a static "times" method on the collection

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -59,6 +59,22 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
+     * Create a new collection by invoking the callback a given amount of times.
+     *
+     * @param  int  $amount
+     * @param  callable  $callback
+     * @return static
+     */
+    public static function times($amount, callable $callback)
+    {
+        if ($amount < 1) {
+            return new static;
+        }
+
+        return (new static(range(1, $amount)))->map($callback);
+    }
+
+    /**
      * Get all of the items in the collection.
      *
      * @return array

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -936,6 +936,25 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(['foo' => 'bar'], $collection->all());
     }
 
+    public function testTimesMethod()
+    {
+        $two = Collection::times(2, function ($number) {
+            return 'slug-'.$number;
+        });
+
+        $zero = Collection::times(0, function ($number) {
+            return 'slug-'.$number;
+        });
+
+        $negative = Collection::times(-4, function ($number) {
+            return 'slug-'.$number;
+        });
+
+        $this->assertEquals(['slug-1', 'slug-2'], $two->all());
+        $this->assertTrue($zero->isEmpty());
+        $this->assertTrue($negative->isEmpty());
+    }
+
     public function testConstructMakeFromObject()
     {
         $object = new stdClass();


### PR DESCRIPTION
This is extremely useful to whip up a quick list of stuff, whether in a test or in production:

```php
$slugs = Collection::times(5, function ($number) {
    return 'slug-'.$number;
});

// ['slug-1', 'slug-2', 'slug-3', 'slug-4', 'slug-5'];
```

You can also use it with factories, for example if you want sequential numbers:

```php
$products = Collection::times(5, function ($number) {
    return factory(Product::class)->create(['name' => 'Product #'.$number]);
});
```