### PR TITLE
[5.4] Handle missing or malformed config/app.php file

### DIFF
--- a/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php
+++ b/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php
@@ -62,7 +62,7 @@ class LoadConfiguration
         $files = $this->getConfigurationFiles($app);
 
         if (! isset($files['app'])) {
-            throw new \Exception('Unable not load the config/app.php file.');
+            throw new \Exception('Unable to load the config/app.php file.');
         }
 
         foreach ($this->getConfigurationFiles($app) as $key => $path) {

--- a/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php
+++ b/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php
@@ -59,6 +59,12 @@ class LoadConfiguration
      */
     protected function loadConfigurationFiles(Application $app, RepositoryContract $repository)
     {
+        $files = $this->getConfigurationFiles($app);
+
+        if (! isset($files['app'])) {
+            throw new \Exception('Unable not load the config/app.php file.');
+        }
+
         foreach ($this->getConfigurationFiles($app) as $key => $path) {
             $repository->set($key, require $path);
         }

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -208,7 +208,7 @@ class Handler implements ExceptionHandlerContract
     {
         $e = FlattenException::create($e);
 
-        $handler = new SymfonyExceptionHandler(config('app.debug'));
+        $handler = new SymfonyExceptionHandler(config('app.debug', true));
 
         return SymfonyResponse::create($handler->getHtml($e), $e->getStatusCode(), $e->getHeaders());
     }

--- a/src/Illuminate/Log/LogServiceProvider.php
+++ b/src/Illuminate/Log/LogServiceProvider.php
@@ -118,7 +118,7 @@ class LogServiceProvider extends ServiceProvider
     protected function handler()
     {
         if ($this->app->bound('config')) {
-            return $this->app->make('config')->get('app.log');
+            return $this->app->make('config')->get('app.log', 'single');
         }
 
         return 'single';


### PR DESCRIPTION
In case the `config/app.php` file was missing or corrupted you get a `PHP Fatal error:  Maximum function nesting level of 'x' reached`, this is because `LogServiceProvider::configureHandler()` will call itself recursively since it has `$this->{'configure'.ucfirst($this->handler()).'Handler'}($log);`

In case the app.php file couldn't be loaded `$this->handler()` will return `null`, causing the method to call itself.

In this PR I'm throwing an exception in case the `app.php` configuration file wasn't found, and if it was found but malformed I made sure Laravel can boot without it and be able to render the exception & log it.