### PR TITLE
[5.5] Allow to compare model with 'null'

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -959,12 +959,13 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     /**
      * Determine if two models have the same ID and belong to the same table.
      *
-     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  \Illuminate\Database\Eloquent\Model|null  $model
      * @return bool
      */
-    public function is(Model $model)
+    public function is(?Model $model)
     {
-        return $this->getKey() === $model->getKey() &&
+        return $model !== null &&
+               $this->getKey() === $model->getKey() &&
                $this->getTable() === $model->getTable() &&
                $this->getConnectionName() === $model->getConnectionName();
     }

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1583,6 +1583,14 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertSame($scopes, $model->scopesCalled);
     }
 
+    public function testIsWithNull()
+    {
+        $firstInstance = new EloquentModelStub(['id' => 1]);
+        $secondInstance = null;
+
+        $this->assertFalse($firstInstance->is($secondInstance));
+    }
+
     public function testIsWithTheSameModelInstance()
     {
         $firstInstance = new EloquentModelStub(['id' => 1]);


### PR DESCRIPTION
This merge request will allow to compare models in situations like we have a user and an order may/may not have a person.

In pseudocode:
```
class Order extends Model
{
   public $manager = null;
}
```

```
public function myAction(Order $order)
{
    if (! Auth::user()->is($order->manager)) {
        throw new IllegalAccessException();
    }
}
```