### PR TITLE
[5.4] Fix overwriting of routes

### DIFF
--- a/src/Illuminate/Foundation/Console/RouteCacheCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteCacheCommand.php
@@ -58,6 +58,9 @@ class RouteCacheCommand extends Command
             return $this->error("Your application doesn't have any routes.");
         }
 
+        $routes->refreshNameLookups();
+        $routes->refreshActionLookups();
+
         foreach ($routes as $route) {
             $route->prepareForSerialization();
         }

--- a/src/Illuminate/Foundation/Support/Providers/RouteServiceProvider.php
+++ b/src/Illuminate/Foundation/Support/Providers/RouteServiceProvider.php
@@ -31,6 +31,7 @@ class RouteServiceProvider extends ServiceProvider
 
             $this->app->booted(function () {
                 $this->app['router']->getRoutes()->refreshNameLookups();
+                $this->app['router']->getRoutes()->refreshActionLookups();
             });
         }
     }

--- a/src/Illuminate/Routing/RouteCollection.php
+++ b/src/Illuminate/Routing/RouteCollection.php
@@ -113,7 +113,7 @@ class RouteCollection implements Countable, IteratorAggregate
     /**
      * Refresh the name look-up table.
      *
-     * This is done in case any names are fluently defined.
+     * This is done in case any names are fluently defined or if routes are overwritten.
      *
      * @return void
      */
@@ -124,6 +124,25 @@ class RouteCollection implements Countable, IteratorAggregate
         foreach ($this->allRoutes as $route) {
             if ($route->getName()) {
                 $this->nameList[$route->getName()] = $route;
+            }
+        }
+    }
+
+    /**
+     * Refresh the action look-up table.
+     *
+     * This is done in case any actions are fluently defined or if routes are overwritten.
+     *
+     * @return void
+     */
+    public function refreshActionLookups()
+    {
+        $this->actionList = [];
+
+        foreach ($this->allRoutes as $route) {
+            $action = $route->getAction();
+            if (isset($action['controller'])) {
+                $this->addToActionList($action, $route);
             }
         }
     }

--- a/tests/Routing/RouteCollectionTest.php
+++ b/tests/Routing/RouteCollectionTest.php
@@ -166,7 +166,6 @@ class RouteCollectionTest extends TestCase
         $this->assertEquals($allRoutes, $this->routeCollection->getRoutes());
     }
 
-
     public function testRouteCollectionCleansUpOverwrittenRoutes()
     {
         // Create two routes with the same path and method.
@@ -192,8 +191,5 @@ class RouteCollectionTest extends TestCase
         // The lookups of $routeB are still there.
         $this->assertEquals($routeB, $this->routeCollection->getByName('overwrittenRouteA'));
         $this->assertEquals($routeB, $this->routeCollection->getByAction('OverwrittenView@view'));
-
     }
-
-
 }

--- a/tests/Routing/RouteCollectionTest.php
+++ b/tests/Routing/RouteCollectionTest.php
@@ -165,4 +165,35 @@ class RouteCollectionTest extends TestCase
         ];
         $this->assertEquals($allRoutes, $this->routeCollection->getRoutes());
     }
+
+
+    public function testRouteCollectionCleansUpOverwrittenRoutes()
+    {
+        // Create two routes with the same path and method.
+        $routeA = new Route('GET', 'product', ['controller' => 'View@view', 'as' => 'routeA']);
+        $routeB = new Route('GET', 'product', ['controller' => 'OverwrittenView@view', 'as' => 'overwrittenRouteA']);
+
+        $this->routeCollection->add($routeA);
+        $this->routeCollection->add($routeB);
+
+        // Check if the lookups of $routeA and $routeB are there.
+        $this->assertEquals($routeA, $this->routeCollection->getByName('routeA'));
+        $this->assertEquals($routeA, $this->routeCollection->getByAction('View@view'));
+        $this->assertEquals($routeB, $this->routeCollection->getByName('overwrittenRouteA'));
+        $this->assertEquals($routeB, $this->routeCollection->getByAction('OverwrittenView@view'));
+
+        // Rebuild the lookup arrays.
+        $this->routeCollection->refreshNameLookups();
+        $this->routeCollection->refreshActionLookups();
+
+        // The lookups of $routeA should not be there anymore, because they are no longer valid.
+        $this->assertNull($this->routeCollection->getByName('routeA'));
+        $this->assertNull($this->routeCollection->getByAction('View@view'));
+        // The lookups of $routeB are still there.
+        $this->assertEquals($routeB, $this->routeCollection->getByName('overwrittenRouteA'));
+        $this->assertEquals($routeB, $this->routeCollection->getByAction('OverwrittenView@view'));
+
+    }
+
+
 }


### PR DESCRIPTION
### Background
Currently, two routes with the same path and method are breaking the route cache. A routes file containing the following routes
```php
Route::get('home', 'HomeController@index');
Route::get('home', 'NewHomeController@index');
```
will break the `artisan route:cache` command with the following exception:
```
exception 'Exception' with message 'Serialization of 'Closure' is not allowed' in ..\vendor\laravel\framework\src\Illuminate\Foundation\Console\RouteCacheCommand.php:95
```
This is a problem if you want to overwrite routes from a vendor package (for example Spark). Also see: #7452

### The underlaying problem

Adding the second route to the `RouteCollection` overwrites the first route of `$routes` and `$allRoutes`. However, the old route is still in the action look-up table `$actionList` (and in `$nameList`, if the route has a name). 
The `RouteCacheCommand` iterates over `$routes` of `RouteCollection` and serializes all routes. It cannot serialize the first, old route because it is not in `$routes` anymore. This causes the exception.

### Solution

The clean solution is to to keep the `$actionList` and `$nameList` always up to date and avoid keeping outdated routes. There is already a method `refreshNameLookups()` to refresh the name look-up table. I added the same method for the action look-up table (`refreshActionLookups()`). I changed the `RouteCacheCommand` to use these methods.
