### PR TITLE
[5.4] Fixing Model Binding when you have a Route Binding with same name

### DIFF
--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -710,6 +710,17 @@ class RoutingRouteTest extends TestCase
         $this->assertEquals('12345', $router->dispatch(Request::create('foo-bar/12345', 'GET'))->getContent());
     }
 
+    /**
+     * @group shit
+     */
+    public function testModelBindingWithCompoundParameterNameAndRouteBinding()
+    {
+        $router = $this->getRouter();
+        $router->model('foo_bar', 'Illuminate\Tests\Routing\RoutingTestUserModel');
+        $router->resource('foo-bar', 'Illuminate\Tests\Routing\RouteTestResourceControllerWithModelParameter', ['middleware' => SubstituteBindings::class]);
+        $this->assertEquals('12345', $router->dispatch(Request::create('foo-bar/12345', 'GET'))->getContent());
+    }
+
     public function testModelBindingThroughIOC()
     {
         $container = new Container;


### PR DESCRIPTION
When you have a Route Binding with the same compound name of the Model Binding, it colides, for example:

````php
Route::model('foo_bar', FooBarModel::class);
Route::resource('foo-bar', FooBarController::class);

class FooBarController extends Controller {
    public function show(FooBarModel $fooBar) {
    }
}
````

This happens because at https://github.com/laravel/framework/blob/5.4/src/Illuminate/Routing/ImplicitRouteBinding.php#L21 the parameter is called `fooBar` and isn't found, but bellow at https://github.com/laravel/framework/blob/5.4/src/Illuminate/Routing/ImplicitRouteBinding.php#L27 it changes the parameter name to `foo_bar` and at https://github.com/laravel/framework/blob/5.4/src/Illuminate/Routing/ImplicitRouteBinding.php#L32 the parameter value is already a `FooBarModel`.

The use case is pretty specific, Route and Model Binding with same name AND compound name.

My PR fixes this problem.