### PR TITLE
[5.5] Allow 500 custom error pages when not in debug mode

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -169,11 +169,15 @@ class Handler implements ExceptionHandlerContract
      */
     protected function prepareResponse($request, Exception $e)
     {
-        if ($this->isHttpException($e)) {
-            return $this->toIlluminateResponse($this->renderHttpException($e), $e);
-        } else {
+        if (! $this->isHttpException($e) && config('app.debug')) {
             return $this->toIlluminateResponse($this->convertExceptionToResponse($e), $e);
         }
+
+        if (! $this->isHttpException($e)) {
+           $e = new HttpException(500, $e->getMessage());
+        }
+
+        return $this->toIlluminateResponse($this->renderHttpException($e), $e);
     }
 
     /**

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -174,7 +174,7 @@ class Handler implements ExceptionHandlerContract
         }
 
         if (! $this->isHttpException($e)) {
-           $e = new HttpException(500, $e->getMessage());
+            $e = new HttpException(500, $e->getMessage());
         }
 
         return $this->toIlluminateResponse($this->renderHttpException($e), $e);


### PR DESCRIPTION
As discussed with @taylorotwell in PR https://github.com/laravel/docs/pull/3165

Currently, even with a `views/errors/500.blade.php` file, a non HttpException 500 error will still display a "whoops" page (with or without stack trace depending on env settings).

This PR changes behavior only when `APP_DEBUG=false`, to use a custom 500 error page if one is available. If no custom 500 page is available it will still display the same whoops error page (without a stack trace).

It solves issues such as https://github.com/laravel/framework/issues/17586, https://github.com/laravel/framework/issues/14137 & https://github.com/laravel/framework/issues/10466



With `APP_DEBUG=true` (even with a custom 500 page):
![debug_true](https://cloud.githubusercontent.com/assets/1210658/24317008/ff764d30-10ea-11e7-979e-a432e6b6e250.png)


With `APP_DEBUG=false` and a ***no*** defined custom 500 error page:
![debug_false1](https://cloud.githubusercontent.com/assets/1210658/24317010/029f7cf2-10eb-11e7-8fd3-615aaa538cf9.png)


With `APP_DEBUG=false` and a custom 500 error page:
![debug_false2](https://cloud.githubusercontent.com/assets/1210658/24317011/05708462-10eb-11e7-84b7-bf1c70263231.png)

