### PR TITLE
[5.5] Pretty default 404 and 500 error pages

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -169,11 +169,15 @@ class Handler implements ExceptionHandlerContract
      */
     protected function prepareResponse($request, Exception $e)
     {
-        if ($this->isHttpException($e)) {
-            return $this->toIlluminateResponse($this->renderHttpException($e), $e);
-        } else {
-            return $this->toIlluminateResponse($this->convertExceptionToResponse($e), $e);
+        if (! $this->isHttpException($e)) {
+            if (config('app.debug')) {
+                return $this->toIlluminateResponse($this->convertExceptionToResponse($e), $e);
+            }
+
+            $e = new HttpException(500, $e->getMessage());
         }
+
+        return $this->toIlluminateResponse($this->renderHttpException($e), $e);
     }
 
     /**


### PR DESCRIPTION
There is currently a nice pretty default 503 error page in the framework.

This includes similar pretty default 404 and 500 error pages (still can be easily overridden as required).


default 404 page before PR:

![image](https://cloud.githubusercontent.com/assets/1210658/24316515/61c8a3f2-10e6-11e7-8865-1be9c889e4fc.png)

default 404 page after PR:

![image](https://cloud.githubusercontent.com/assets/1210658/24316524/6d10980a-10e6-11e7-90ca-90f122525dfc.png)


and default 500 page before PR (when not in debug mode):

![image](https://cloud.githubusercontent.com/assets/1210658/24316535/99f6b228-10e6-11e7-9e7b-40a7b501c858.png)

default 500 page after PR (when not in debug mode):

![image](https://cloud.githubusercontent.com/assets/1210658/24316547/ba407e10-10e6-11e7-9c9b-d5750d176da1.png)
