### PR TITLE
[5.4] Add string parameter type for associating models

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
@@ -204,7 +204,7 @@ class BelongsTo extends Relation
     /**
      * Associate the model instance to the given parent.
      *
-     * @param  \Illuminate\Database\Eloquent\Model|int  $model
+     * @param  \Illuminate\Database\Eloquent\Model|int|string  $model
      * @return \Illuminate\Database\Eloquent\Model
      */
     public function associate($model)


### PR DESCRIPTION
Add string as documented allowed type for a model association for `BelongsTo` relationships. This allows static analysis tools to not throw errors when using UUIDs as the identifiers to models.