### PR TITLE
Adds feature to allow auto-managing datetime fields when storing and when displaying the value

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1186,6 +1186,6 @@ trait HasAttributes
      */
     protected function getFallBackOutFormat()
     {
-        return config('app.fallback_out_format') ?: 'd/m/Y H:i A';
+        return config('app.fallback_out_format') ?: 'm/d/Y H:i A';
     }
 }

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1092,10 +1092,9 @@ trait HasAttributes
      */
     protected function getFieldToFormat($key)
     {
-        foreach($this->getFixedFormattedFields() as $field)
-        {
-            if($field['key'] == $key)
-            {
+        foreach($this->getFixedFormattedFields() as $field) {
+            
+            if($field['key'] == $key) {
                 return $field;
             }
         }
@@ -1104,7 +1103,7 @@ trait HasAttributes
     }
 
     /**
-     * Get the fields to auto format.
+     * Get the fields that should be auto formatted.
      *
      * @return array
      */
@@ -1114,22 +1113,17 @@ trait HasAttributes
         {
             $this->fixedFormattedFields = [];
 
-            if( property_exists($this, 'formattedDates') && is_array($this->formattedDates))
-            {
+            if( property_exists($this, 'formattedDates') && is_array($this->formattedDates)) {
+                
                 foreach($this->formattedDates as $field)
                 {
-                    if(!is_array($field))
-                    {
+                    if(!is_array($field)) {
                         $this->fixedFormattedFields[] = $this->getFixedFormattedField($field);
                         continue;
                     }
 
-                    if(isset($field['key']))
-                    {
-                        $inFormat = isset($field['in_format']) ? $field['in_format'] : null;
-                        $outFormat = isset($field['out_format']) ? $field['out_format'] : null;
-
-                        $this->fixedFormattedFields[] = $this->getFixedFormattedField($field['key'], $inFormat, $outFormat);
+                    if( !is_null($fixed = $this->getFixedFormattedFieldFromArray($field))  ) {
+                        $this->fixedFormattedFields[] = $fixed;
                     }
                 }
             }
@@ -1139,7 +1133,26 @@ trait HasAttributes
     }
 
     /**
-     * Get get a standard format for the fields to auto format.
+     * Get a standard format field from a giving array.
+     *
+     * @param  array  $field
+     * @return array|null
+     */
+    protected function getFixedFormattedFieldFromArray(array $field)
+    {
+        if(isset($field['key']))
+        {
+            $inFormat = isset($field['in_format']) ? $field['in_format'] : null;
+            $outFormat = isset($field['out_format']) ? $field['out_format'] : null;
+
+            return $this->getFixedFormattedField($field['key'], $inFormat, $outFormat);
+        }
+
+        return null;
+    }
+
+    /**
+     * Get a standard format for an auto formatted field.
      *
      * @param  string  $key
      * @param  string $inFormat
@@ -1151,8 +1164,28 @@ trait HasAttributes
         return 
         [   
             'key' => $key,
-            'in_format' => is_null($inFormat) ? config('app.fallback_in_format') : $inFormat,
-            'out_format' => is_null($outFormat) ? config('app.fallback_out_format') : $outFormat
+            'in_format' => is_null($inFormat) ? $this->getFallBackInFormat() : $inFormat,
+            'out_format' => is_null($outFormat) ? $this->getFallBackOutFormat() : $outFormat
         ];
+    }
+
+    /**
+     * Get a standard datetime format for input.
+     *
+     * @return string
+     */
+    protected function getFallBackInFormat()
+    {
+        return config('app.fallback_in_format') ?: 'Y-m-d H:i:s';
+    }
+
+    /**
+     * Get a standard datetime format for output.
+     *
+     * @return string
+     */
+    protected function getFallBackOutFormat()
+    {
+        return config('app.fallback_out_format') ?: 'd/m/Y H:i A';
     }
 }

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -336,8 +336,7 @@ trait HasAttributes
 
         // If the attribute exists within the formattedDated array, we will convert it to
         // we will format it before outputting it.
-        if( ($field = $this->getFieldToFormat($key)) != null)
-        {
+        if (($field = $this->getFieldToFormat($key)) != null) {
             return date($field['out_format'], strtotime($this->getAttributeFromArray($key)));
         }
 
@@ -529,8 +528,7 @@ trait HasAttributes
         // First we will check for the presence of a mutator for the set operation
         // which simply lets the developers assign some datetime properties and
         // we'll auto convert a string to a proper formatted datetime string.
-        if( ($field = $this->getFieldToFormat($key)) != null)
-        {
+        if (($field = $this->getFieldToFormat($key)) != null) {
             $value = date($field['in_format'], strtotime($value));
         }
         // Second we will check for the presence of a mutator for the set operation
@@ -1092,9 +1090,9 @@ trait HasAttributes
      */
     protected function getFieldToFormat($key)
     {
-        foreach($this->getFixedFormattedFields() as $field) {
+        foreach ($this->getFixedFormattedFields() as $field) {
             
-            if($field['key'] == $key) {
+            if ($field['key'] == $key) {
                 return $field;
             }
         }
@@ -1109,20 +1107,19 @@ trait HasAttributes
      */
     protected function getFixedFormattedFields()
     {
-        if( is_null($this->fixedFormattedFields))
-        {
+        if (is_null($this->fixedFormattedFields)) {
             $this->fixedFormattedFields = [];
 
-            if( property_exists($this, 'formattedDates') && is_array($this->formattedDates)) {
+            if (property_exists($this, 'formattedDates') && is_array($this->formattedDates)) {
                 
-                foreach($this->formattedDates as $field)
-                {
-                    if(!is_array($field)) {
+                foreach ($this->formattedDates as $field) {
+
+                    if (! is_array($field)) {
                         $this->fixedFormattedFields[] = $this->getFixedFormattedField($field);
                         continue;
                     }
 
-                    if( !is_null($fixed = $this->getFixedFormattedFieldFromArray($field))  ) {
+                    if (! is_null($fixed = $this->getFixedFormattedFieldFromArray($field))) {
                         $this->fixedFormattedFields[] = $fixed;
                     }
                 }
@@ -1140,8 +1137,8 @@ trait HasAttributes
      */
     protected function getFixedFormattedFieldFromArray(array $field)
     {
-        if(isset($field['key']))
-        {
+        if (isset($field['key'])) {
+
             $inFormat = isset($field['in_format']) ? $field['in_format'] : null;
             $outFormat = isset($field['out_format']) ? $field['out_format'] : null;
 
@@ -1165,7 +1162,7 @@ trait HasAttributes
         [   
             'key' => $key,
             'in_format' => is_null($inFormat) ? $this->getFallBackInFormat() : $inFormat,
-            'out_format' => is_null($outFormat) ? $this->getFallBackOutFormat() : $outFormat
+            'out_format' => is_null($outFormat) ? $this->getFallBackOutFormat() : $outFormat,
         ];
     }
 


### PR DESCRIPTION
Managing datetime field can be easily done by adding Accessor and Mutator into eloquent model. However, if you have multiple datetime fields it can lead more work. Or if you're new to Laravel, Accessor and Mutator may not be the first thing to think off.

Managing datetime field is now easier than ever. You can do so by listing the property names that you want Eloquent to manage for you like so
```
   /**
     * Datetime attributes that should be auto formatted.
     *
     * @var array
     */
    protected $formattedDates = ['approved_at','uploaded_at'];

```

Moreover, you can even change the display format for only one field like so

   /**
     * Datetime attributes that should be auto formatted.
     *
     * @var array
     */
    protected $formattedDates = [
                                                    'approved_at',
                                                     [
                                                           'key' => 'uploaded_at',
                                                           'out_format' => 'H:i A'
                                                     ]
                                                   ];

The default format can easily be set in the config/app.php file using the following config
```
    /*
    |--------------------------------------------------------------------------
    | Application Fallback In Datetime Format
    |--------------------------------------------------------------------------
    |
    | The fallback in datetime format determines the default format to use when
    | storing a datetime auto-formatted field value in the databases.
    |
    */

    'fallback_in_format' => 'Y-m-d H:i:s',

    /*
    |--------------------------------------------------------------------------
    | Application Fallback Out Datetime Format
    |--------------------------------------------------------------------------
    |
    | The fallback out datetime format determines the default format to use when 
    | displaying a datetime value from the database.
    | You may override this format for each field using the $formattedDates
    | in eloquent model model.
    |
    */

    'fallback_out_format' => 'm/d/Y H:i A',
```
