### PR TITLE
[5.4] Add assertion to MailFake (check for no mailables were sent)

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -54,7 +54,7 @@ class MailFake implements Mailer
     {
         PHPUnit::assertEmpty(
             $this->mailables,
-            "Some mailables (".count($this->mailables).") were sent."
+            'Some mailables ('.count($this->mailables).') were sent.'
         );
     }
 

--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -46,6 +46,19 @@ class MailFake implements Mailer
     }
 
     /**
+     * Determine if no mailable was sent.
+     *
+     * @return void
+     */
+    public function assertNilSent()
+    {
+        PHPUnit::assertEmpty(
+            $this->mailables,
+            "Some mailables (".count($this->mailables).") were sent."
+        );
+    }
+
+    /**
      * Get all of the mailables matching a truth-test callback.
      *
      * @param  string  $mailable

--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -31,7 +31,7 @@ class MailFake implements Mailer
     }
 
     /**
-     * Determine if a mailable was sent based on a truth-test callback.
+     * Determine if a mailable was not sent based on a truth-test callback.
      *
      * @param  string  $mailable
      * @param  callable|null  $callback


### PR DESCRIPTION
I find it useful to be able to check if no mailables were sent at all.

This assertion sorts it out (it **may** need new name).

---

Another solution is to make `$mailables` public so its possible to test for empty array from test itself.