### PR TITLE
Use namespaces in migrations

### DIFF
--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -165,7 +165,8 @@ class Migrator
         // migration file name. Once we have the instances we can run the actual
         // command such as "up" or "down", or we can just simulate the action.
         $migration = $this->resolve(
-            $name = $this->getMigrationName($file)
+            $name = $this->getMigrationName($file),
+            $file
         );
 
         if ($pretend) {
@@ -404,9 +405,16 @@ class Migrator
      * @param  string  $file
      * @return object
      */
-    public function resolve($file)
+    public function resolve($file, $path)
     {
-        $class = Str::studly(implode('_', array_slice(explode('_', $file), 4)));
+        $namespace = '';
+
+        if (preg_match('#^namespace\s+(.+?);$#sm', $this->files->sharedGet($path), $m)) {
+            $namespace = $m[1];
+        }
+
+        $class = ($namespace ? $namespace . '\\' : '')
+            . Str::studly(implode('_', array_slice(explode('_', $file), 4)));
 
         return new $class;
     }

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -405,7 +405,7 @@ class Migrator
      * @param  string  $file
      * @return object
      */
-    public function resolve($file, $path)
+    public function resolve($file, $path = "")
     {
         $class = Str::studly(implode('_', array_slice(explode('_', $file), 4)));
 

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -410,7 +410,7 @@ class Migrator
         $class = Str::studly(implode('_', array_slice(explode('_', $file), 4)));
 
         if (preg_match('#^namespace\s+(.+?);$#sm', $this->files->sharedGet($path), $m)) {
-            $class = $m[1] . '\\' . $class;
+            $class = $m[1].'\\'.$class;
         }
 
         return new $class;

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -405,7 +405,7 @@ class Migrator
      * @param  string  $file
      * @return object
      */
-    public function resolve($file, $path="")
+    public function resolve($file, $path = '')
     {
         $class = Str::studly(implode('_', array_slice(explode('_', $file), 4)));
 

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -405,7 +405,7 @@ class Migrator
      * @param  string  $file
      * @return object
      */
-    public function resolve($file, $path = "")
+    public function resolve($file, $path="")
     {
         $class = Str::studly(implode('_', array_slice(explode('_', $file), 4)));
 

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -407,14 +407,11 @@ class Migrator
      */
     public function resolve($file, $path)
     {
-        $namespace = '';
+        $class = Str::studly(implode('_', array_slice(explode('_', $file), 4)));
 
         if (preg_match('#^namespace\s+(.+?);$#sm', $this->files->sharedGet($path), $m)) {
-            $namespace = $m[1];
+            $class = $m[1] . '\\' . $class;
         }
-
-        $class = ($namespace ? $namespace . '\\' : '')
-            . Str::studly(implode('_', array_slice(explode('_', $file), 4)));
 
         return new $class;
     }


### PR DESCRIPTION
Now you can use namespaces in migrations for exclusion classname conflicts.