### PR TITLE
[5.4] Get Swift_Message instance by using createMessage method.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "laravel/framework",
+    "name": "s-ichikawa/framework",
     "description": "The Laravel Framework.",
     "keywords": ["framework", "laravel"],
     "license": "MIT",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "s-ichikawa/framework",
+    "name": "laravel/framework",
     "description": "The Laravel Framework.",
     "keywords": ["framework", "laravel"],
     "license": "MIT",

--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -401,7 +401,7 @@ class Mailer implements MailerContract, MailQueueContract
      */
     protected function createMessage()
     {
-        $message = new Message(new Swift_Message);
+        $message = new Message($this->swift->createMessage('message'));
 
         // If a global from address has been specified we will set it on every message
         // instances so the developer does not have to repeat themselves every time

--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Mail;
 
 use Swift_Mailer;
-use Swift_Message;
 use Illuminate\Support\Arr;
 use InvalidArgumentException;
 use Illuminate\Contracts\View\Factory;

--- a/tests/Mail/MailMailerTest.php
+++ b/tests/Mail/MailMailerTest.php
@@ -140,6 +140,7 @@ class MailMailerTest extends TestCase
     public function setSwiftMailer($mailer)
     {
         $swift = m::mock('Swift_Mailer');
+        $swift->shouldReceive('createMessage')->andReturn(new \Swift_Message);
         $swift->shouldReceive('getTransport')->andReturn($transport = m::mock('Swift_Transport'));
         $transport->shouldReceive('stop');
         $mailer->setSwiftMailer($swift);
@@ -166,5 +167,10 @@ class FailingSwiftMailerStub
         $transport->shouldReceive('stop');
 
         return $transport;
+    }
+
+    public function createMessage()
+    {
+        return new \Swift_Message();
     }
 }


### PR DESCRIPTION
This Pull Request will be able to assign custom Message instance that inherited Swift_Message to send() in Transport class.
```
Swift_DependencyContainer::getInstance()
->register('message.message')
->asNewInstanceOf(CustomMessage::class);
```

Transport classes by using API are able to improve post any parameter such as tracking parameter via custom Message.