### PR TITLE
[5.4] Call getKey() if instance of factory model

### DIFF
--- a/src/Illuminate/Database/Eloquent/FactoryBuilder.php
+++ b/src/Illuminate/Database/Eloquent/FactoryBuilder.php
@@ -236,6 +236,9 @@ class FactoryBuilder
         foreach ($attributes as &$attribute) {
             $attribute = $attribute instanceof Closure
                             ? $attribute($attributes) : $attribute;
+
+            $attribute = $attribute instanceof Model
+                            ? $attribute->getKey() : $attribute;
         }
 
         return $attributes;


### PR DESCRIPTION
I've seen a few examples where a closure is used in a factory definition to build up a related model, and then return that new model's ID. Here's an example of how a `Post` factory might generate it's `User` association.

```
$factory->define(App\Post::class, function (Faker\Generator $faker) {
    return [
        'user_id' => function() {
            return factory(App\User::class)->create()->id;
        }
   ];
});
```

Getting the `id` attribute from the new model doesn't really look quite right, so I'm proposing we call `getKey()` on the result of the `Closure` if it's an Eloquent model. Would just make it a tad cleaner to write.

```
$factory->define(App\Post::class, function (Faker\Generator $faker) {
    return [
        'user_id' => function() {
            return factory(App\User::class)->create();
        }
   ];
});
```