### PR TITLE
[5.5] [WIP] Transformable Responses

### DIFF
--- a/src/Illuminate/Contracts/Support/Transformable.php
+++ b/src/Illuminate/Contracts/Support/Transformable.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Illuminate\Contracts\Support;
+
+interface Transformable
+{
+    /**
+     * Get data to apply transformations.
+     *
+     * @return array
+     */
+    public function getTransformableData();
+}

--- a/src/Illuminate/Http/TransformableResponse.php
+++ b/src/Illuminate/Http/TransformableResponse.php
@@ -7,8 +7,9 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Validation\ValidationData;
 use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Contracts\Support\Transformable;
 
-abstract class TransformableResponse extends JsonResponse
+class TransformableResponse extends JsonResponse
 {
     /**
      * Constructor.
@@ -22,12 +23,40 @@ abstract class TransformableResponse extends JsonResponse
     public function __construct($data = null, $status = 200, $headers = [], $options = 0)
     {
         if (is_array($data)) {
-            $data = $this->transform($data);
+            $transformedData = $this->transform($data);
+        } elseif ($data instanceof Transformable) {
+            $transformedData = $this->transform($this->getTransformableData());
+        } elseif ($data instanceof Collection) {
+            $transformedData = $this->handleCollectionTransformation($data);
         } elseif ($data instanceof Arrayable) {
-            $data = $this->transform($data->toArray());
+            $transformedData = $this->transform($data->toArray());
         }
 
-        parent::__construct($data, $status, $headers, $options);
+        parent::__construct($transformedData, $status, $headers, $options);
+
+        $this->original = $data;
+    }
+
+    /**
+     * Handle how a collection will be transformed.
+     *
+     * @param  Collection  $data
+     * @return mixed
+     */
+    protected function handleCollectionTransformation(Collection $data)
+    {
+        return $this->transform(
+            $data->map(function ($item) {
+                if ($item instanceof Transformable) {
+                    return $item->getTransformableData();
+                } elseif ($item instanceof Arrayable) {
+                    return $item->toArray();
+                }
+
+                return $item;
+            })
+            ->toArray()
+        );
     }
 
     /**
@@ -36,13 +65,264 @@ abstract class TransformableResponse extends JsonResponse
      * @param  array  $data
      * @return array
      */
-    public function transform(array $data)
+    protected function transform(array $data)
     {
-        $rules = $this->resolveArrayVisibilityRules($data, $this->visibilityRules());
+        if (! empty($data) && method_exists($this, 'visibilityRules')) {
+            $data = $this->applyVisibilityRules(
+                $data,
+                $this->visibilityRules()
+            );
+        }
 
-        $data = $this->applyVisibilityRules($data, $rules);
+        if (! empty($data) && method_exists($this, 'castingRules')) {
+            $data = $this->applyCastingRules(
+                $data,
+                $this->castingRules()
+            );
+        }
+
+        if (! empty($data) && method_exists($this, 'mutationRules')) {
+            $data = $this->applyMutationRules(
+                $data,
+                $this->mutationRules()
+            );
+        }
+
+        if (! empty($data) && method_exists($this, 'renamingRules')) {
+            $data = $this->applyRenamingRules(
+                $data,
+                $this->renamingRules()
+            );
+        }
 
         return $data;
+    }
+
+    /**
+     * Apply visibility rules to given data.
+     *
+     * @param  array  $data
+     * @param  array  $rules
+     * @return array
+     */
+    protected function applyVisibilityRules(array $data, array $rules)
+    {
+        if (empty($rules = $this->resolveWildcardRules($data, $rules))) {
+            return $data;
+        }
+
+        $data = $this->performShowFields($data, $rules);
+        $data = $this->performHideFields($data, $rules);
+
+        return $data;
+    }
+
+    /**
+     * Apply rules over the fields that must be displayed.
+     *
+     * @param  array  $data
+     * @param  array  $rules
+     * @return array
+     */
+    protected function performShowFields(array $data, array $rules)
+    {
+        if (empty($applicableRules = array_filter($rules))) {
+            return $data;
+        }
+
+        return array_reduce(array_keys($applicableRules),
+            function ($transformedData, $attribute) use ($data) {
+                if ($value = Arr::get($data, $attribute)) {
+                    Arr::set($transformedData, $attribute, $value);
+                }
+
+                return $transformedData;
+            },
+        []);
+    }
+
+    /**
+     * Apply rules over the fields that must be hidden.
+     *
+     * @param  array  $data
+     * @param  array  $rules
+     * @return array
+     */
+    protected function performHideFields(array $data, array $rules)
+    {
+        $applicableRules = array_filter($rules, function ($rule) {
+            return ! $rule;
+        });
+
+        return array_reduce(array_keys($applicableRules),
+            function ($transformedData, $rule) {
+                Arr::forget($transformedData, $rule);
+
+                return $transformedData;
+            },
+        $data);
+    }
+
+    /**
+     * Apply casting rules to given data.
+     *
+     * @param  array  $data
+     * @param  array  $rules
+     * @return array
+     */
+    protected function applyCastingRules(array $data, array $rules)
+    {
+        if (empty($rules = $this->resolveWildcardRules($data, $rules))) {
+            return $data;
+        }
+
+        return array_reduce(array_keys($rules),
+            function ($data, $rule) use ($rules) {
+                if (Arr::has($data, $rule)) {
+                    $value = $this->performCasting(
+                        Arr::get($rules, $rule),
+                        Arr::get($data, $rule)
+                    );
+
+                    Arr::set($data, $rule, $value);
+                }
+
+                return $data;
+            },
+        $data);
+    }
+
+    /**
+     * Performs casting to given value based on given type.
+     *
+     * @param  string  $type
+     * @param  mixed  $value
+     * @return mixed
+     */
+    protected function performCasting($type, $value)
+    {
+        switch ($type) {
+            case 'int':
+            case 'integer':
+                return (int) $value;
+            case 'real':
+            case 'float':
+            case 'double':
+                return (float) $value;
+            case 'string':
+                return (string) $value;
+            case 'bool':
+            case 'boolean':
+                return (bool) $value;
+            default:
+                return $value;
+        }
+    }
+
+    /**
+     * Apply mutation rules to given value.
+     *
+     * @param  array  $data
+     * @param  array  $rules
+     * @return mixed
+     */
+    public function applyMutationRules(array $data, array $rules)
+    {
+        if (empty($rules = $this->resolveWildcardRules($data, $rules))) {
+            return $data;
+        }
+
+        return array_reduce(array_keys($rules),
+            function ($data, $rule) use ($rules) {
+                if (Arr::has($data, $rule)) {
+                    $value = $this->performMutations(
+                        Arr::get($rules, $rule),
+                        Arr::get($data, $rule)
+                    );
+
+                    Arr::set($data, $rule, $value);
+                }
+
+                return $data;
+            },
+        $data);
+    }
+
+    /**
+     * Performs given mutators in given value.
+     *
+     * @param  string  $mutators
+     * @param  mixed  $value
+     * @throws Exception
+     * @return mixed
+     */
+    public function performMutations($mutators, $value)
+    {
+        $mutators = explode('|', $mutators);
+
+        return array_reduce($mutators, function ($value, $mutator) {
+            $method = 'mutator'.Str::studly($mutator);
+
+            if (! method_exists($this, $method)) {
+                $class = static::class;
+
+                throw new Exception("No mutator [$method] defined in [$class]");
+            }
+
+            return $this->$method($value);
+        }, $value);
+    }
+
+    /**
+     * Apply renaming rules for given attribute.
+     *
+     * @param  array  $data
+     * @param  array  $rules
+     * @return array
+     */
+    protected function applyRenamingRules(array $data, array $rules)
+    {
+        if (empty($rules = $this->resolveWildcardRules($data, $rules))) {
+            return $data;
+        }
+
+        uksort($rules, function ($a, $b) {
+            return count(explode('.', $a)) < count(explode('.', $b));
+        });
+
+        $resultData = $this->performRenaming($data, $rules);
+
+        return array_reduce(array_keys($resultData),
+            function ($data, $attribute) use ($resultData) {
+                Arr::set($data, $attribute, $resultData[$attribute]);
+
+                return $data;
+            },
+        []);
+    }
+
+    /**
+     * Performs renaming mutators in given data.
+     *
+     * @param  array  $data
+     * @param  array  $rules
+     * @return array
+     */
+    protected function performRenaming(array $data, array $rules)
+    {
+        $resultData = array_reduce(array_keys($rules),
+            function ($encodedData, $rule) use ($rules) {
+                $replace = preg_replace(
+                    '/(\w|\s|\-)+$/',
+                    $rules[$rule],
+                    $rule
+                );
+
+                return str_replace('"'.$rule, '"'.$replace, $encodedData);
+            },
+        json_encode(Arr::dot($data)));
+
+        return json_decode($resultData, true);
     }
 
     /**
@@ -52,7 +332,7 @@ abstract class TransformableResponse extends JsonResponse
      * @param  array  $rules
      * @return array
      */
-    protected function resolveArrayVisibilityRules(array $data, array $rules)
+    protected function resolveWildcardRules(array $data, array $rules)
     {
         return array_reduce(array_keys($rules),
             function ($parsedRules, $rule) use ($data, $rules) {
@@ -63,7 +343,7 @@ abstract class TransformableResponse extends JsonResponse
 
                     return array_merge(
                         $parsedRules,
-                        $this->sanitizeArrayGatheredRules(
+                        $this->sanitizeWildcardGatheredRules(
                             $rule,
                             $gatheredRules,
                             $rules[$rule]
@@ -85,7 +365,7 @@ abstract class TransformableResponse extends JsonResponse
      * @param  bool  $valueForValidOnes
      * @return array
      */
-    protected function sanitizeArrayGatheredRules($rule, array $gatheredRules, $valueForValidOnes)
+    protected function sanitizeWildcardGatheredRules($rule, array $gatheredRules, $valueForValidOnes)
     {
         $pattern = '/'.str_replace('.*.', '\.([0-9])+\.', $rule).'/';
 
@@ -99,235 +379,4 @@ abstract class TransformableResponse extends JsonResponse
             },
         []);
     }
-
-    /**
-     * Apply visibility rules to given data.
-     *
-     * @param  array  $rules
-     * @return array
-     */
-    protected function applyVisibilityRules(array $data, array $rules)
-    {
-        if (empty($rules)) {
-            return $data;
-        }
-
-        $data = $this->showFields($data, $rules);
-        $data = $this->hideFields($data, $rules);
-
-        return $data;
-    }
-
-    /**
-     * Apply rules over the fields that must be displayed.
-     *
-     * @param  array  $data
-     * @param  array  $rules
-     * @return array
-     */
-    protected function showFields(array $data, array $rules)
-    {
-        $applicableRules = array_filter($rules);
-
-        if (empty($applicableRules)) {
-            return $data;
-        }
-
-        return array_reduce(array_keys($applicableRules),
-            function ($transformedData, $attribute) use ($data) {
-                if ($value = Arr::get($data, $attribute)) {
-                    Arr::set(
-                        $transformedData,
-                        $this->applyRenamingRules($attribute),
-                        $this->applyMutationRules(
-                            $attribute,
-                            $this->applyCastingRules($attribute, $value)
-                        )
-                    );
-                }
-
-                return $transformedData;
-            },
-        []);
-    }
-
-    /**
-     * Apply rules over the fields that must be hidden.
-     *
-     * @param  array  $data
-     * @param  array  $rules
-     * @return array
-     */
-    protected function hideFields(array $data, array $rules)
-    {
-        $applicableRules = array_filter($rules, function ($rule) {
-            return ! $rule;
-        });
-
-        if (empty($applicableRules)) {
-            return $data;
-        }
-
-        return array_reduce(array_keys($applicableRules),
-            function ($transformedData, $rule) {
-                Arr::forget($transformedData, $rule);
-
-                return $transformedData;
-            },
-        $data);
-    }
-
-    /**
-     * Apply casting rules to given value.
-     *
-     * @param  string  $attribute
-     * @param  mixed  $value
-     * @return mixed
-     */
-    protected function applyCastingRules($attribute, $value)
-    {
-        switch ($this->getCastType($attribute)) {
-            case 'int':
-            case 'integer':
-                return (int) $value;
-            case 'real':
-            case 'float':
-            case 'double':
-                return (float) $value;
-            case 'string':
-                return (string) $value;
-            case 'bool':
-            case 'boolean':
-                return (bool) $value;
-            default:
-                return $value;
-        }
-    }
-
-    /**
-     * Get casting rule for given attribute.
-     *
-     * @param  string  $attribute
-     * @return bool|null
-     */
-    protected function getCastType($attribute)
-    {
-        if (! $castings = $this->castingRules()) {
-            return;
-        }
-
-        if (array_key_exists($attribute, $castings)) {
-            return $castings[$attribute];
-        }
-
-        $pattern = preg_replace('/\.([0-9])+\./', '.*.', $attribute);
-
-        if (array_key_exists($pattern, $castings)) {
-            return $castings[$pattern];
-        }
-
-        return null;
-    }
-
-    /**
-     * Apply renaming rules for given attribute.
-     *
-     * @param  string  $attribute
-     * @return string
-     */
-    protected function applyRenamingRules($attribute)
-    {
-        if (! $renamings = $this->renamingRules()) {
-            return $attribute;
-        }
-
-        if (array_key_exists($attribute, $renamings)) {
-            return $renamings[$attribute];
-        }
-
-        $pattern = preg_replace('/\.([0-9])+\./', '.*.', $attribute);
-
-        if (array_key_exists($pattern, $renamings)) {
-            return preg_replace('/(\w|\s|\-)+$/', $renamings[$pattern], $attribute);
-        }
-
-        return $attribute;
-    }
-
-    /**
-     * Apply mutation rules to given value.
-     *
-     * @param  string  $attribute
-     * @param  mixed  $value
-     * @return mixed
-     */
-    public function applyMutationRules($attribute, $value)
-    {
-        $mutations = $this->mutationRules();
-
-        if (array_key_exists($attribute, $mutations)) {
-            return $this->executeMutators($value, $mutations[$attribute]);
-        }
-
-        $pattern = preg_replace('/\.([0-9])+\./', '.*.', $attribute);
-
-        if (array_key_exists($pattern, $mutations)) {
-            return $this->executeMutators($value, $mutations[$pattern]);
-        }
-
-        return $value;
-    }
-
-    /**
-     * Execute mutators in given value.
-     *
-     * @param  mixed  $value
-     * @param  string  $mutators
-     * @throws Exception
-     * @return mixed
-     */
-    public function executeMutators($value, $mutators)
-    {
-        $mutators = explode('|', $mutators);
-
-        return array_reduce($mutators, function ($value, $mutator) {
-            $method = 'mutator'.Str::studly($mutator);
-
-            if (! method_exists($this, $method)) {
-                $classname = static::class;
-
-                throw new Exception("There is no mutator [$method] declared in [$classname].");
-            }
-
-            return $this->$method($value);
-        }, $value);
-    }
-
-    /**
-     * Set visibility rules to apply to current response.
-     *
-     * @return array
-     */
-    abstract public function visibilityRules();
-
-    /**
-     * Set casting rules to apply to current response.
-     *
-     * @return array
-     */
-    abstract public function castingRules();
-
-    /**
-     * Set renaming rules to apply to current response.
-     *
-     * @return array
-     */
-    abstract public function renamingRules();
-
-    /**
-     * Set mutation rules to apply to current response.
-     *
-     * @return array
-     */
-    abstract public function mutationRules();
 }

--- a/src/Illuminate/Http/TransformableResponse.php
+++ b/src/Illuminate/Http/TransformableResponse.php
@@ -1,0 +1,179 @@
+<?php
+
+namespace Illuminate\Http;
+
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
+use Illuminate\Validation\ValidationData;
+use Illuminate\Contracts\Support\Arrayable;
+
+abstract class TransformableResponse extends JsonResponse
+{
+    /**
+     * Constructor.
+     *
+     * @param  mixed  $data
+     * @param  int    $status
+     * @param  array  $headers
+     * @param  int    $options
+     */
+    public function __construct($data = null, $status = 200, $headers = [], $options = 0)
+    {
+        if (is_array($data)) {
+            $data = $this->transform($data);
+        } elseif ($data instanceof Arrayable) {
+            $data = $this->transform($data->toArray());
+        }
+
+        parent::__construct($data, $status, $headers, $options);
+    }
+    
+    /**
+     * Transforms the response data.
+     *
+     * @param  array  $data
+     * @return array
+     */
+    public function transform(array $data)
+    {
+        $rules = $this->resolveArrayRules($data, $this->rules());
+
+        return $this->applyRules($data, $rules);
+    }
+    
+    /**
+     * Resolve array rules generating a new rule for every item in the array
+     * spcified with the '*' symbol.
+     *
+     * Example: posts.*.comments.*.title => posts.0.comments.0.title
+     *
+     * @param  array  $data
+     * @param  array  $rules
+     * @return array
+     */
+    protected function resolveArrayRules(array $data, array $rules)
+    {
+        return array_reduce(array_keys($rules), function ($parsedRules, $rule) use ($data, $rules) {
+            if (Str::contains($rule, '*')) {
+                $gatheredRules = array_keys(
+                    ValidationData::initializeAndGatherData($rule, $data)
+                );
+                
+                return array_merge(
+                    $parsedRules,
+                    $this->sanitizeArrayGatheredRules($rule, $gatheredRules, $rules[$rule])
+                );
+            }
+            
+            $parsedRules[$rule] = $rules[$rule];
+            
+            return $parsedRules;
+        }, []);
+    }
+    
+    /**
+     * Sanitize gathered array rules removing those that don't appear into
+     * orginal rules.
+     *
+     * @param  string   $rule
+     * @param  array    $gatheredRules
+     * @param  boolean  $valueForValidOnes
+     * @return array
+     */
+    protected function sanitizeArrayGatheredRules($rule, array $gatheredRules, $valueForValidOnes)
+    {
+        $pattern = '/' . str_replace('.*.', '\.([0-9])+\.', $rule) . '/';
+        
+        return array_reduce($gatheredRules,
+            function ($validRules, $rule) use ($pattern, $valueForValidOnes) {
+                preg_match($pattern, $rule, $matches);
+                
+                if ($matches) {
+                    $validRules[$matches[0]] = $valueForValidOnes;
+                }
+                
+                return $validRules;
+            },
+        []);
+    }
+    
+    /**
+     * Apply rules to the initial given data.
+     *
+     * @param  array  $rules
+     * @return array
+     */
+    protected function applyRules(array $data, array $rules)
+    {
+        if (empty($rules)) {
+            return $data;
+        }
+
+        $data = $this->applyRulesToShowFields($data, $rules);
+        $data = $this->applyRulesToHideFields($data, $rules);
+
+        return $data;
+    }
+    
+    /**
+     * Apply rules over the fields that must be displayed.
+     *
+     * @param  array  $data
+     * @param  array  $rules
+     * @return array
+     */
+    protected function applyRulesToShowFields(array $data, array $rules)
+    {
+        $applicableRules = array_filter($rules);
+
+        if (empty($applicableRules)) {
+            return $data;
+        }
+
+        return array_reduce(array_keys($applicableRules),
+            function ($transformedData, $rule) use ($data) {
+                if ($value = Arr::get($data, $rule)) {
+                    Arr::set($transformedData, $rule, $value);
+                }
+                
+                return $transformedData;
+            },
+        []);
+    }
+    
+    /**
+     * Apply rules over the fields that must be hidden.
+     *
+     * @param  array  $data
+     * @param  array  $rules
+     * @return array
+     */
+    protected function applyRulesToHideFields(array $data, array $rules)
+    {
+        $applicableRules = array_filter($rules, function ($rule) {
+            return !$rule;
+        });
+
+        if (empty($applicableRules)) {
+            return $data;
+        }
+        
+        return array_reduce(array_keys($applicableRules),
+            function ($transformedData, $rule) {
+                if (Arr::has($transformedData, $rule)) {
+                    Arr::forget($transformedData, $rule);
+                }
+                
+                return $transformedData;
+            },
+        $data);
+    }
+    
+    /**
+     * Define the rules that will apply to this transformer
+     * response.
+     *
+     * @return array
+     */
+    abstract public function rules();
+}

--- a/src/Illuminate/Http/TransformableResponse.php
+++ b/src/Illuminate/Http/TransformableResponse.php
@@ -27,102 +27,104 @@ abstract class TransformableResponse extends JsonResponse
 
         parent::__construct($data, $status, $headers, $options);
     }
-
+    
     /**
      * Transforms the response data.
      *
-     * @param  array  $data
+     * @param  array $data
      * @return array
      */
     public function transform(array $data)
     {
-        $rules = $this->resolveArrayRules($data, $this->rules());
+        $rules = $this->resolveArrayVisibilityRules($data, $this->visibilityRules());
 
-        return $this->applyRules($data, $rules);
+        $data = $this->applyVisibilityRules($data, $rules);
+
+        return $data;
     }
-
+    
     /**
      * Resolve array rules generating a new rule for every item in the array
      * spcified with the '*' symbol.
      *
      * Example: posts.*.comments.*.title => posts.0.comments.0.title
      *
-     * @param  array  $data
-     * @param  array  $rules
+     * @param  array $data
+     * @param  array $rules
      * @return array
      */
-    protected function resolveArrayRules(array $data, array $rules)
+    protected function resolveArrayVisibilityRules(array $data, array $rules)
     {
         return array_reduce(array_keys($rules), function ($parsedRules, $rule) use ($data, $rules) {
             if (Str::contains($rule, '*')) {
                 $gatheredRules = array_keys(
                     ValidationData::initializeAndGatherData($rule, $data)
                 );
-
+                
                 return array_merge(
                     $parsedRules,
                     $this->sanitizeArrayGatheredRules($rule, $gatheredRules, $rules[$rule])
                 );
             }
-
+            
             $parsedRules[$rule] = $rules[$rule];
-
+            
             return $parsedRules;
         }, []);
     }
-
+    
     /**
      * Sanitize gathered array rules removing those that don't appear into
      * orginal rules.
      *
-     * @param  string   $rule
-     * @param  array    $gatheredRules
-     * @param  bool  $valueForValidOnes
+     * @param  string $rule
+     * @param  array $gatheredRules
+     * @param  boolean $valueForValidOnes
      * @return array
      */
     protected function sanitizeArrayGatheredRules($rule, array $gatheredRules, $valueForValidOnes)
     {
-        $pattern = '/'.str_replace('.*.', '\.([0-9])+\.', $rule).'/';
-
+        $pattern = '/' . str_replace('.*.', '\.([0-9])+\.', $rule) . '/';
+        
         return array_reduce($gatheredRules,
             function ($validRules, $rule) use ($pattern, $valueForValidOnes) {
                 preg_match($pattern, $rule, $matches);
-
+                
                 if ($matches) {
                     $validRules[$matches[0]] = $valueForValidOnes;
                 }
-
+                
                 return $validRules;
             },
         []);
     }
-
+    
     /**
-     * Apply rules to the initial given data.
+     * Apply visbility rules to given data.
      *
-     * @param  array  $rules
+     * @param  array $rules
      * @return array
      */
-    protected function applyRules(array $data, array $rules)
+    protected function applyVisibilityRules(array $data, array $rules)
     {
         if (empty($rules)) {
             return $data;
         }
 
-        $data = $this->applyRulesToShowFields($data, $rules);
-        $data = $this->applyRulesToHideFields($data, $rules);
+        $data = $this->showFields($data, $rules);
+        $data = $this->hideFields($data, $rules);
 
         return $data;
     }
-
+    
     /**
      * Apply rules over the fields that must be displayed.
      *
-     * @param  array  $data
-     * @param  array  $rules
+     * @param  array $data
+     * @param  array $rules
      * @return array
      */
-    protected function applyRulesToShowFields(array $data, array $rules)
+    protected function showFields(array $data, array $rules)
     {
         $applicableRules = array_filter($rules);
 
@@ -131,49 +133,201 @@ abstract class TransformableResponse extends JsonResponse
         }
 
         return array_reduce(array_keys($applicableRules),
-            function ($transformedData, $rule) use ($data) {
-                if ($value = Arr::get($data, $rule)) {
-                    Arr::set($transformedData, $rule, $value);
+            function ($transformedData, $attribute) use ($data) {
+                if ($value = Arr::get($data, $attribute)) {
+                    Arr::set(
+                        $transformedData,
+                        $this->applyRenamingRules($attribute),
+                        $this->applyMutationRules(
+                            $attribute,
+                            $this->applyCastingRules($attribute, $value)
+                        )
+                    );
                 }
-
+                
                 return $transformedData;
             },
         []);
     }
-
+    
     /**
      * Apply rules over the fields that must be hidden.
      *
-     * @param  array  $data
-     * @param  array  $rules
+     * @param  array $data
+     * @param  array $rules
      * @return array
      */
-    protected function applyRulesToHideFields(array $data, array $rules)
+    protected function hideFields(array $data, array $rules)
     {
         $applicableRules = array_filter($rules, function ($rule) {
-            return ! $rule;
+            return !$rule;
         });
 
         if (empty($applicableRules)) {
             return $data;
         }
-
+        
         return array_reduce(array_keys($applicableRules),
             function ($transformedData, $rule) {
                 if (Arr::has($transformedData, $rule)) {
                     Arr::forget($transformedData, $rule);
                 }
-
+                
                 return $transformedData;
             },
         $data);
     }
-
+    
     /**
-     * Define the rules that will apply to this transformer
-     * response.
+     * Apply casting rules to given value.
+     *
+     * @param  string $attribute
+     * @param  mixed $value
+     * @return mixed
+     */
+    protected function applyCastingRules($attribute, $value)
+    {
+        switch ($this->getCastType($attribute)) {
+            case 'int':
+            case 'integer':
+                return (int) $value;
+            case 'real':
+            case 'float':
+            case 'double':
+                return (float) $value;
+            case 'string':
+                return (string) $value;
+            case 'bool':
+            case 'boolean':
+                return (bool) $value;
+            default:
+                return $value;
+        }
+    }
+    
+    /**
+     * Get casting rule for given attribute.
+     *
+     * @param  string  $attribute
+     * @return boolean
+     */
+    protected function getCastType($attribute)
+    {
+        if (!$castings = $this->castingRules()) {
+            return null;
+        }
+        
+        if (array_key_exists($attribute, $castings)) {
+            return $castings[$attribute];
+        }
+        
+        $pattern = preg_replace('/\.([0-9])+\./', '.*.', $attribute);
+        
+        if (array_key_exists($pattern, $castings)) {
+            return $castings[$pattern];
+        }
+        
+        return null;
+    }
+    
+    /**
+     * Apply renaming rules for given attribute.
+     *
+     * @param  string  $attribute
+     * @return string
+     */
+    protected function applyRenamingRules($attribute)
+    {
+        if (!$renamings = $this->renamingRules()) {
+            return $attribute;
+        }
+
+        if (array_key_exists($attribute, $renamings)) {
+            return $renamings[$attribute];
+        }
+        
+        $pattern = preg_replace('/\.([0-9])+\./', '.*.', $attribute);
+
+        if (array_key_exists($pattern, $renamings)) {
+            return preg_replace('/(\w|\s|\-)+$/', $renamings[$pattern], $attribute);
+        }
+        
+        return $attribute;
+    }
+    
+    /**
+     * Apply mutation rules to given value.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @return mixed
+     */
+    public function applyMutationRules($attribute, $value)
+    {
+        $mutations = $this->mutationRules();
+        
+        if (array_key_exists($attribute, $mutations)) {
+            return $this->executeMutators($value, $mutations[$attribute]);
+        }
+        
+        $pattern = preg_replace('/\.([0-9])+\./', '.*.', $attribute);
+
+        if (array_key_exists($pattern, $mutations)) {
+            return $this->executeMutators($value, $mutations[$pattern]);
+        }
+        
+        return $value;
+    }
+    
+    /**
+     * Execute mutators in given value.
+     *
+     * @param  mixed  $value
+     * @param  string  $mutators
+     * @return mixed
+     */
+    public function executeMutators($value, $mutators)
+    {
+        $mutators = explode('|', $mutators);
+        
+        return array_reduce($mutators, function ($value, $mutator) {
+            $method = 'mutator'.Str::studly($mutator);
+            
+            if (!method_exists($this, $method)) {
+                $classname = static::class;
+                
+                throw new \Exception("There is no mutator [$method] declared in [$classname].");
+            }
+            
+            return $this->$method($value);
+        }, $value);
+    }
+    
+    /**
+     * Set visibility rules to apply to current response.
      *
      * @return array
      */
-    abstract public function rules();
+    abstract public function visibilityRules();
+    
+    /**
+     * Set casting rules to apply to current response.
+     *
+     * @return array
+     */
+    abstract public function castingRules();
+    
+    /**
+     * Set renaming rules to apply to current response.
+     *
+     * @return array
+     */
+    abstract public function renamingRules();
+    
+    /**
+     * Set mutation rules to apply to current response.
+     *
+     * @return array
+     */
+    abstract public function mutationRules();
 }

--- a/src/Illuminate/Http/TransformableResponse.php
+++ b/src/Illuminate/Http/TransformableResponse.php
@@ -40,7 +40,7 @@ class TransformableResponse extends JsonResponse
     /**
      * Handle how a collection will be transformed.
      *
-     * @param  Collection  $data
+     * @param  \Illuminate\Support\Collection  $data
      * @return mixed
      */
     protected function handleCollectionTransformation(Collection $data)

--- a/src/Illuminate/Http/TransformableResponse.php
+++ b/src/Illuminate/Http/TransformableResponse.php
@@ -27,7 +27,7 @@ abstract class TransformableResponse extends JsonResponse
 
         parent::__construct($data, $status, $headers, $options);
     }
-    
+
     /**
      * Transforms the response data.
      *
@@ -40,7 +40,7 @@ abstract class TransformableResponse extends JsonResponse
 
         return $this->applyRules($data, $rules);
     }
-    
+
     /**
      * Resolve array rules generating a new rule for every item in the array
      * spcified with the '*' symbol.
@@ -58,45 +58,45 @@ abstract class TransformableResponse extends JsonResponse
                 $gatheredRules = array_keys(
                     ValidationData::initializeAndGatherData($rule, $data)
                 );
-                
+
                 return array_merge(
                     $parsedRules,
                     $this->sanitizeArrayGatheredRules($rule, $gatheredRules, $rules[$rule])
                 );
             }
-            
+
             $parsedRules[$rule] = $rules[$rule];
-            
+
             return $parsedRules;
         }, []);
     }
-    
+
     /**
      * Sanitize gathered array rules removing those that don't appear into
      * orginal rules.
      *
      * @param  string   $rule
      * @param  array    $gatheredRules
-     * @param  boolean  $valueForValidOnes
+     * @param  bool  $valueForValidOnes
      * @return array
      */
     protected function sanitizeArrayGatheredRules($rule, array $gatheredRules, $valueForValidOnes)
     {
-        $pattern = '/' . str_replace('.*.', '\.([0-9])+\.', $rule) . '/';
-        
+        $pattern = '/'.str_replace('.*.', '\.([0-9])+\.', $rule).'/';
+
         return array_reduce($gatheredRules,
             function ($validRules, $rule) use ($pattern, $valueForValidOnes) {
                 preg_match($pattern, $rule, $matches);
-                
+
                 if ($matches) {
                     $validRules[$matches[0]] = $valueForValidOnes;
                 }
-                
+
                 return $validRules;
             },
         []);
     }
-    
+
     /**
      * Apply rules to the initial given data.
      *
@@ -114,7 +114,7 @@ abstract class TransformableResponse extends JsonResponse
 
         return $data;
     }
-    
+
     /**
      * Apply rules over the fields that must be displayed.
      *
@@ -135,12 +135,12 @@ abstract class TransformableResponse extends JsonResponse
                 if ($value = Arr::get($data, $rule)) {
                     Arr::set($transformedData, $rule, $value);
                 }
-                
+
                 return $transformedData;
             },
         []);
     }
-    
+
     /**
      * Apply rules over the fields that must be hidden.
      *
@@ -151,24 +151,24 @@ abstract class TransformableResponse extends JsonResponse
     protected function applyRulesToHideFields(array $data, array $rules)
     {
         $applicableRules = array_filter($rules, function ($rule) {
-            return !$rule;
+            return ! $rule;
         });
 
         if (empty($applicableRules)) {
             return $data;
         }
-        
+
         return array_reduce(array_keys($applicableRules),
             function ($transformedData, $rule) {
                 if (Arr::has($transformedData, $rule)) {
                     Arr::forget($transformedData, $rule);
                 }
-                
+
                 return $transformedData;
             },
         $data);
     }
-    
+
     /**
      * Define the rules that will apply to this transformer
      * response.

--- a/src/Illuminate/Http/TransformableResponse.php
+++ b/src/Illuminate/Http/TransformableResponse.php
@@ -253,8 +253,9 @@ class TransformableResponse extends JsonResponse
      *
      * @param  string  $mutators
      * @param  mixed  $value
-     * @throws Exception
      * @return mixed
+     *
+     * @throws \Exception
      */
     public function performMutations($mutators, $value)
     {

--- a/src/Illuminate/Http/TransformableResponse.php
+++ b/src/Illuminate/Http/TransformableResponse.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Http;
 
+use Exception;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Validation\ValidationData;
@@ -77,7 +78,7 @@ abstract class TransformableResponse extends JsonResponse
     }
 
     /**
-     * Sanitize rules removing those that don't appear into orginal rules.
+     * Sanitize rules removing those that don't appear into original rules.
      *
      * @param  string  $rule
      * @param  array  $gatheredRules
@@ -90,10 +91,8 @@ abstract class TransformableResponse extends JsonResponse
 
         return array_reduce($gatheredRules,
             function ($validRules, $rule) use ($pattern, $valueForValidOnes) {
-                preg_match($pattern, $rule, $matches);
-
-                if ($matches) {
-                    $validRules[$matches[0]] = $valueForValidOnes;
+                if (preg_match($pattern, $rule)) {
+                    $validRules[$rule] = $valueForValidOnes;
                 }
 
                 return $validRules;
@@ -102,7 +101,7 @@ abstract class TransformableResponse extends JsonResponse
     }
 
     /**
-     * Apply visbility rules to given data.
+     * Apply visibility rules to given data.
      *
      * @param  array  $rules
      * @return array
@@ -171,9 +170,7 @@ abstract class TransformableResponse extends JsonResponse
 
         return array_reduce(array_keys($applicableRules),
             function ($transformedData, $rule) {
-                if (Arr::has($transformedData, $rule)) {
-                    Arr::forget($transformedData, $rule);
-                }
+                Arr::forget($transformedData, $rule);
 
                 return $transformedData;
             },
@@ -286,6 +283,7 @@ abstract class TransformableResponse extends JsonResponse
      *
      * @param  mixed  $value
      * @param  string  $mutators
+     * @throws Exception
      * @return mixed
      */
     public function executeMutators($value, $mutators)
@@ -298,7 +296,7 @@ abstract class TransformableResponse extends JsonResponse
             if (! method_exists($this, $method)) {
                 $classname = static::class;
 
-                throw new \Exception("There is no mutator [$method] declared in [$classname].");
+                throw new Exception("There is no mutator [$method] declared in [$classname].");
             }
 
             return $this->$method($value);


### PR DESCRIPTION
### Why ?

The purpose of this pull request is to give **Laravel** better flexibility when responding to API requests.

I have created a new `TransformableResponse` class that allows to define a few rulesets for transform the response in multiple forms that will be passed to the client.

Its design is highly inspired in `FormRequests` classes. If we can define `Requests` individually, _why don't extend this behaviour to responses_?

### What is included in this PR ?

First of all, I suggest to store our `Response` classes inside `app/Http/Responses` folder(A nice artisan command will be included out of the box). Once said this ...

#### Class structure

```php
class GetTestsResponse extends TransformableResponse
{
    /**
     * Set visibility rules to apply to current response.
     *
     * @return array
     */
    public function visibilityRules()
    {
        return [];
    }
    
   /**
     * Set casting rules to apply to current response.
     *
     * @return array
     */
    public function castingRules()
    {
        return [];
    }

    /**
     * Set mutation rules to apply to current response.
     *
     * @return array
     */
    public function mutationRules()
    {
        return [];
    }
    
    /**
     * Set renaming rules to apply to current response.
     *
     * @return array
     */
    public function renamingRules()
    {
        return [];
    }
}
```

#### Dummy Data

We will use this dummy data for demo purposes:

```php
[
  'id' => '1',
  'name' => 'Name #1',
  'surname' => 'Surname #1',
  'posts' => [
      [
          'id' => '1',
          'title' => 'Post #1',
          'comments' => [
              [
                  'id' => '1',
                  'title' => 'Comment #1-1'
              ]
          ]
      ],
      [
          'id' => '2',
          'title' => 'Post #2',
          'comments' => [
              [
                  'id' => '1',
                  'title' => 'Comment #2-1'
              ]
          ]
      ]
  ]
]
```


#### Defining visibility rules

This ruleset define what fields will be present once the response is emitted. It's the **first** ruleset to be executed.

```php
   /**
     * Set visibility rules to apply to current response.
     *
     * @return array
     */
    public function visibilityRules()
    {
        return [
            'id' => true,
            'name' => true,
            'posts.*.id' => true,
            'posts.*.comments.*.id' => true
        ];
    }
```

This will be the resultant response:

```json
{
   "id":"1",
   "name":"Name #1",
   "posts":[
      {
         "id":"1",
         "comments":[
            {
               "id":"1"
            }
         ]
      },
      {
         "id":"2",
         "comments":[
            {
               "id":"1"
            }
         ]
      }
   ]
}
```

##### How does this work ?

As you can see in the rules section you define which attributes should be visible and which attributes should be hidden. So:

1. Fields checked as **true** will be evaluated first. If none, **all** will be visible by **default**.
2. Fields checked as **false** will be hidden using the data passed from the previous process.

Easy.

#### Defining casting rules

This ruleset define which fields should be casted. Valid casting values are: `int, integer, real, float, double, string, bool, boolean`. It's the **second** ruleset to be executed.

```php
    /**
     * Set casting rules to apply to current response.
     *
     * @return array
     */
    public function castingRules()
    {
        return [
            'id' => 'int',
            'posts.*.id' => 'int',
            'posts.*.comments.*.id' => 'int'
        ];
    }
```

This will be the resultant response (chained from first ruleset):

```json
{
   "id":1,
   "name":"Name #1",
   "posts":[
      {
         "id":1,
         "comments":[
            {
               "id":1
            }
         ]
      },
      {
         "id":2,
         "comments":[
            {
               "id":1
            }
         ]
      }
   ]
}
```

#### Defining mutation rules

This ruleset define how the data should be mutated. You can define your own mutators in the own class, just prefix the name of your method with the word `mutator`. If you want to reuse mutators you always can inherit from a parent class 👍 . It's the **third** ruleset to be executed.

```php
    /**
     * Set mutation rules to apply to current response.
     *
     * @return array
     */
    public function mutationRules()
    {
        return [
            'id' => 'double|uppercase',
            'name' => 'uppercase',
            'posts.*.id' => 'double',
            'posts.*.comments.*.id' => 'double'
        ];
    }

    public function mutatorDouble($value)
    {
        return $value * 2;
    }
    
    public function mutatorUppercase($value)
    {
        return strtoupper($value);
    }
```

This will be the resultant response (chained from first and second ruleset):

```json
{
   "id":"2",
   "name":"NAME #1",
   "posts":[
      {
         "id":2,
         "comments":[
            {
               "id":2
            }
         ]
      },
      {
         "id":4,
         "comments":[
            {
               "id":2
            }
         ]
      }
   ]
}
```

#### Defining renaming rules

This ruleset define how the keys of your data should be renamed. It's the **forth** ruleset to be executed.

```php
    /**
     * Set renaming rules to apply to current response.
     *
     * @return array
     */
    public function renamingRules()
    {
        return [
            'id' => 'user_id',
            'posts.*.id' => 'post_id',
            'posts.*.comments.*.id' => 'comment_id'
        ];
    }
```

This will be the resultant response (chained from first, second and third ruleset):

```json
{
   "user_id":"2",
   "name":"NAME #1",
   "posts":[
      {
         "post_id":2,
         "comments":[
            {
               "comment_id":2
            }
         ]
      },
      {
         "post_id":4,
         "comments":[
            {
               "comment_id":2
            }
         ]
      }
   ]
}
```

#### How this feature will be used ?

Simple. Look at this controller method:

```php
    public function index()
    {
        $users = User::all(); // Our dummy data
        
        return new GetTestsResponse($users, 200, []); // status and headers are optional
    }
```

### Why is a WIP ?

There are a few things to be covered before merge this PR, but first I want to check if this is useful for the Laravel community.

**TODO**:
* `php artisan make:response MyCustomResponse` command.
* Tests to cover this PR.

Any idea ? Any feedback ? Let me know what you all think!

Thanks !