### PR TITLE
add support for ID in snake case

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -377,6 +377,9 @@ class Str
         if (! ctype_lower($value)) {
             $value = preg_replace('/\s+/u', '', $value);
 
+            // handle IDs
+            $value = preg_replace('/([^A-Z])ID$/u', '$1Id', $value);
+
             $value = static::lower(preg_replace('/(.)(?=[A-Z])/u', '$1'.$delimiter, $value));
         }
 

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -193,6 +193,15 @@ class SupportStrTest extends TestCase
         // ensure cache keys don't overlap
         $this->assertEquals('laravel__php__framework', Str::snake('LaravelPhpFramework', '__'));
         $this->assertEquals('laravel_php_framework_', Str::snake('LaravelPhpFramework_', '_'));
+
+        // handle IDs
+        $this->assertEquals('user_id', Str::snake('UserID'));
+        $this->assertEquals('user_id', Str::snake('userId'));
+        $this->assertEquals('user_id', Str::snake('user_id'));
+        // ignored cases
+        $this->assertEquals('u_s_e_r_i_d', Str::snake('USERID'));
+        $this->assertEquals('u_i_d', Str::snake('UID'));
+        $this->assertEquals('use_r_i_d', Str::snake('useRID'));
     }
 
     public function testStudly()


### PR DESCRIPTION
Data from external sources often uses an all caps `ID` for an attribute name such as `UserID` or `imdbID` 

It would be handy to use `snake_case` to map these to the eloquent default `user_id`, but it's not so easy:

```php
echo snake_case('UserID'); // user_i_d
```

I understand this is the expected behavior given [the test][1]:

```php
$this->assertEquals('laravel_p_h_p_framework', Str::snake('LaravelPHPFramework'));
```

But I thought because this is such a common use case, it might be worth your consideration.

```php
echo snake_case('UserID'); // user_id
```

Thanks

[1]:https://github.com/laravel/framework/blob/5.4/tests/Support/SupportStrTest.php#L196
