### PR TITLE
[5.4] Support string of model name in factory

### DIFF
--- a/src/Illuminate/Database/Eloquent/FactoryBuilder.php
+++ b/src/Illuminate/Database/Eloquent/FactoryBuilder.php
@@ -176,7 +176,7 @@ class FactoryBuilder
             $this->faker, $attributes
         );
 
-        return $this->callClosureAttributes(
+        return $this->callDynamicAttributes(
             array_merge($this->applyStates($definition, $attributes), $attributes)
         );
     }
@@ -226,16 +226,20 @@ class FactoryBuilder
     }
 
     /**
-     * Evaluate any Closure attributes on the attribute array.
+     * Evaluate any dynamic attributes on the attribute array.
      *
      * @param  array  $attributes
      * @return array
      */
-    protected function callClosureAttributes(array $attributes)
+    protected function callDynamicAttributes(array $attributes)
     {
         foreach ($attributes as &$attribute) {
             $attribute = $attribute instanceof Closure
                             ? $attribute($attributes) : $attribute;
+
+            if (is_string($attribute) && class_exists($attribute)) {
+                $attribute = factory($attribute)->create();
+            }
 
             $attribute = $attribute instanceof Model
                             ? $attribute->getKey() : $attribute;


### PR DESCRIPTION
This sort of builds on the PR from last night (#18499), after sleeping on it I had another idea for how improve it a little bit more. If an attribute is a string that represents a class that exists, the factory could automatically build that relation as well. Using the same example, we could replace a closure like this:

```
$factory->define(App\Post::class, function (Faker\Generator $faker) {
    return [
        'user_id' => function() {
            return factory(App\User::class)->create();
        }
   ];
});
```

With something much simpler like this:

```
$factory->define(App\Post::class, function (Faker\Generator $faker) {
    return [
        'user_id' => App\User::class
   ];
});
```

Granted, it doesn't give you the ability to use factory states, but I think it's fair to use a closure if you want that sort of control. For the most common use-case where you just want an association to exist this will get the job done.