### PR TITLE
[5.4] Why do service providers depend on helper functions?

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -404,11 +404,12 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     /**
      * Get the path to the resources directory.
      *
+     * @param  string  $path
      * @return string
      */
-    public function resourcePath()
+    public function resourcePath($path = '')
     {
-        return $this->basePath.DIRECTORY_SEPARATOR.'resources';
+        return $this->basePath.DIRECTORY_SEPARATOR.'resources'.($path ? DIRECTORY_SEPARATOR.$path : $path);
     }
 
     /**

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -702,7 +702,7 @@ if (! function_exists('resource_path')) {
      */
     function resource_path($path = '')
     {
-        return app()->resourcePath().($path ? DIRECTORY_SEPARATOR.$path : $path);
+        return app()->resourcePath($path);
     }
 }
 

--- a/src/Illuminate/Mail/MailServiceProvider.php
+++ b/src/Illuminate/Mail/MailServiceProvider.php
@@ -117,7 +117,7 @@ class MailServiceProvider extends ServiceProvider
     {
         if ($this->app->runningInConsole()) {
             $this->publishes([
-                __DIR__.'/resources/views' => resource_path('views/vendor/mail'),
+                __DIR__.'/resources/views' => $this->app->resourcePath('views/vendor/mail'),
             ], 'laravel-mail');
         }
 


### PR DESCRIPTION
Dear Taylor and amazing Laravel community;

I'm working on some projects in which it is not possible to rely on core helper functions. The reason for this isn't trivial to explain, but I'll try to be concise. The codebase incorporates more than one Laravel-based application such that it is not possible to use `Container::getInstance()`, since more than one instance of the Container may exist in a single request. 

Because of this constraint, it is also not possible to use the global helper functions, all of which rely on `Container::getInstance()` for accessing what would normally be the only container in the request. 

The simple change I am requesting is that service providers, already having in `ServiceProvider::$app` the instance of `Container` that represents their relationship to the application in which they are configured and installed, should use that instance for accessing the `Container`'s contents instead of invoking helper functions.

The specific case I have highlighted below focuses on `Illuminate\Mail\MailServiceProvider`, but I believe there are other examples, including `Illuminate\Database\DatabaseServiceProvider`,  `Illuminate\Pagination\PaginationServiceProvider`, and `Illuminate\Scout\ScoutServiceProvider`. 

In addition to ending the practice of using helper functions within service providers, I would like to recommend that the usefulness of being able to pass a subpath argument to `resource_path($path='')` be refactored into the aliased function `Illuminate\Foundation\Application::resourcePath()` such that this convenience can continue even without the helper function in play.

Thank you for your consideration.

Sincerely,

Aaron