### PR TITLE
[5.5] Create a new "splitBy" method on the collection

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1088,6 +1088,25 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
+     * Split a collection based on condition into groups.
+     *
+     * @param \Closure $callback
+     *
+     * @return static
+     */
+    public function splitBy($callback)
+    {
+        $results = $this->reduce(function ($results, $row) use ($callback) {
+            $index = $callback($row) ? 0 : 1;
+            $results[$index][] = $row;
+
+            return $results;
+        }, []);
+
+        return new static($results);
+    }
+
+    /**
      * Chunk the underlying collection array.
      *
      * @param  int  $size

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1812,12 +1812,16 @@ class SupportCollectionTest extends TestCase
                 ['name' => 'User 1', 'email' => 'user1@gmail.com'],
                 ['name' => 'Taylor Otwell', 'email' => 'taylor@laravel.com'],
             ]))->splitBy(function ($row) {
-                return strpos($row['email'], '@gmail') !== false ? true : false;
+                return strpos($row['email'], '@gmail') !== false;
             });
 
         $this->assertEquals([
             ['name' => 'User 1', 'email' => 'user1@gmail.com'],
         ], $collection[0]);
+
+        $this->assertEquals([
+            ['name' => 'Taylor Otwell', 'email' => 'taylor@laravel.com'],
+        ], $collection[1]);
     }
 
     public function testHigherOrderCollectionMap()

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1806,6 +1806,20 @@ class SupportCollectionTest extends TestCase
         );
     }
 
+    public function testSplitBy()
+    {
+        $collection = (new Collection([
+                ['name' => 'User 1', 'email' => 'user1@gmail.com'],
+                ['name' => 'Taylor Otwell', 'email' => 'taylor@laravel.com'],
+            ]))->splitBy(function ($row) {
+                return strpos($row['email'], '@gmail') !== false ? true : false;
+            });
+
+        $this->assertEquals([
+            ['name' => 'User 1', 'email' => 'user1@gmail.com'],
+        ], $collection[0]);
+    }
+
     public function testHigherOrderCollectionMap()
     {
         $person1 = (object) ['name' => 'Taylor'];


### PR DESCRIPTION
Creates a new ``` splitBy ``` method, to split all items in the collection based on a condition:

for example : 

``` php
$emails = collect([

        ["name" => "User 1" , "email" => "user1@laravel.com"],
        ["name" => "User 2" , "email" => "user2@gmail.com"],
        ["name" => "User 3" , "email" => "user3@laracasts.com"],
        ["name" => "User 4" , "email" => "user4@laravel.com"],

])->splitBy(function($row){
    return strpos($row['email'],'@laravel') !== false;
})
```

the result : 

```
array(
   [
        ["name" => "User 1" , "email" => "user1@laravel.com"],
        ["name" => "User 4" , "email" => "user4@laravel.com"],
    ],
    [
        ["name" => "User 2" , "email" => "user2@gmail.com"],
        ["name" => "User 3" , "email" => "user3@laracasts.com"],
    ]
);
```

This method will work like groupBy but based on value, so I might do splitBy and collapse to manipulate the collection of specific data before taking action on them instead of using filter then merge filtered and unfiltered to group them back together