### PR TITLE
[5.4] Added PostgreSQL REAL data type

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -393,7 +393,7 @@ class PostgresGrammar extends Grammar
      */
     protected function typeReal(Fluent $column)
     {
-        return 'real precision';
+        return 'real';
     }
     
     /**

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -386,6 +386,17 @@ class PostgresGrammar extends Grammar
     }
 
     /**
+     * Create the column definition for a real type.
+     *
+     * @param  \Illuminate\Support\Fluent  $column
+     * @return string
+     */
+    protected function typeReal(Fluent $column)
+    {
+        return 'real precision';
+    }
+    
+    /**
      * Create the column definition for a decimal type.
      *
      * @param  \Illuminate\Support\Fluent  $column


### PR DESCRIPTION
Adds support for PostgresSQL's REAL data type.

That way you can have real columns in your schema:

$table->addColumn('real', $column);