### PR TITLE
[5.5] Mailer

### DIFF
--- a/src/Illuminate/Contracts/Mail/MailQueue.php
+++ b/src/Illuminate/Contracts/Mail/MailQueue.php
@@ -7,23 +7,19 @@ interface MailQueue
     /**
      * Queue a new e-mail message for sending.
      *
-     * @param  string|array  $view
-     * @param  array   $data
-     * @param  \Closure|string  $callback
+     * @param  string|array|MailableContract  $view
      * @param  string  $queue
      * @return mixed
      */
-    public function queue($view, array $data, $callback, $queue = null);
+    public function queue($view, $queue = null);
 
     /**
      * Queue a new e-mail message for sending after (n) seconds.
      *
-     * @param  int  $delay
-     * @param  string|array  $view
-     * @param  array  $data
-     * @param  \Closure|string  $callback
+     * @param  \DateTime|int  $delay
+     * @param  string|array|MailableContract  $view
      * @param  string  $queue
      * @return mixed
      */
-    public function later($delay, $view, array $data, $callback, $queue = null);
+    public function later($delay, $view, $queue = null);
 }

--- a/src/Illuminate/Contracts/Mail/Mailer.php
+++ b/src/Illuminate/Contracts/Mail/Mailer.php
@@ -16,7 +16,7 @@ interface Mailer
     /**
      * Send a new message using a view.
      *
-     * @param  string|array  $view
+     * @param  string|array|MailableContract  $view
      * @param  array  $data
      * @param  \Closure|string  $callback
      * @return void

--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -193,7 +193,7 @@ class Mailer implements MailerContract, MailQueueContract
     /**
      * Send a new message using a view.
      *
-     * @param  string|array  $view
+     * @param  string|array|MailableContract  $view
      * @param  array  $data
      * @param  \Closure|string  $callback
      * @return void
@@ -334,19 +334,17 @@ class Mailer implements MailerContract, MailQueueContract
     /**
      * Queue a new e-mail message for sending.
      *
-     * @param  string|array  $view
-     * @param  array  $data
-     * @param  \Closure|string  $callback
+     * @param  string|array|MailableContract  $view
      * @param  string|null  $queue
      * @return mixed
      */
-    public function queue($view, array $data = [], $callback = null, $queue = null)
+    public function queue($view, $queue = null)
     {
         if (! $view instanceof MailableContract) {
             throw new InvalidArgumentException('Only mailables may be queued.');
         }
 
-        return $view->queue($this->queue);
+        return $view->queue(is_null($queue) ? $this->queue : $queue);
     }
 
     /**
@@ -354,13 +352,11 @@ class Mailer implements MailerContract, MailQueueContract
      *
      * @param  string  $queue
      * @param  string|array  $view
-     * @param  array  $data
-     * @param  \Closure|string  $callback
      * @return mixed
      */
-    public function onQueue($queue, $view, array $data, $callback)
+    public function onQueue($queue, $view)
     {
-        return $this->queue($view, $data, $callback, $queue);
+        return $this->queue($view, $queue);
     }
 
     /**
@@ -370,47 +366,41 @@ class Mailer implements MailerContract, MailQueueContract
      *
      * @param  string  $queue
      * @param  string|array  $view
-     * @param  array  $data
-     * @param  \Closure|string  $callback
      * @return mixed
      */
-    public function queueOn($queue, $view, array $data, $callback)
+    public function queueOn($queue, $view)
     {
-        return $this->onQueue($queue, $view, $data, $callback);
+        return $this->onQueue($queue, $view);
     }
 
     /**
      * Queue a new e-mail message for sending after (n) seconds.
      *
-     * @param  int  $delay
-     * @param  string|array  $view
-     * @param  array  $data
-     * @param  \Closure|string  $callback
+     * @param  \DateTime|int  $delay
+     * @param  string|array|MailableContract  $view
      * @param  string|null  $queue
      * @return mixed
      */
-    public function later($delay, $view, array $data = [], $callback = null, $queue = null)
+    public function later($delay, $view, $queue = null)
     {
         if (! $view instanceof MailableContract) {
             throw new InvalidArgumentException('Only mailables may be queued.');
         }
 
-        return $view->later($delay, $this->queue);
+        return $view->later($delay, is_null($queue) ? $this->queue : $queue);
     }
 
     /**
      * Queue a new e-mail message for sending after (n) seconds on the given queue.
      *
      * @param  string  $queue
-     * @param  int  $delay
+     * @param  \DateTime|int  $delay
      * @param  string|array  $view
-     * @param  array  $data
-     * @param  \Closure|string  $callback
      * @return mixed
      */
-    public function laterOn($queue, $delay, $view, array $data, $callback)
+    public function laterOn($queue, $delay, $view)
     {
-        return $this->later($delay, $view, $data, $callback, $queue);
+        return $this->later($delay, $view, $queue);
     }
 
     /**


### PR DESCRIPTION
- Remove unused parameters
This is sent to 5.5 because contract(s) are updated.

Some changes (Docblocks) can be applied to 5.4 and 5.3.
Should I create and send a separate PR?