### PR TITLE
[5.4] Make consistent the disuse of helper functions within ServiceProviders

### DIFF
--- a/src/Illuminate/Database/DatabaseServiceProvider.php
+++ b/src/Illuminate/Database/DatabaseServiceProvider.php
@@ -80,7 +80,7 @@ class DatabaseServiceProvider extends ServiceProvider
 
         $this->app->singleton(EloquentFactory::class, function ($app) {
             return EloquentFactory::construct(
-                $app->make(FakerGenerator::class), database_path('factories')
+                $app->make(FakerGenerator::class), $this->app->databasePath('factories')
             );
         });
     }

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -294,41 +294,45 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     /**
      * Get the path to the application "app" directory.
      *
+     * @param string $path
      * @return string
      */
-    public function path()
+    public function path($path = '')
     {
-        return $this->basePath.DIRECTORY_SEPARATOR.'app';
+        return $this->basePath.DIRECTORY_SEPARATOR.'app'.($path ? DIRECTORY_SEPARATOR.$path : $path);
     }
 
     /**
      * Get the base path of the Laravel installation.
      *
+     * @param string $path
      * @return string
      */
-    public function basePath()
+    public function basePath($path = '')
     {
-        return $this->basePath;
+        return $this->basePath.($path ? DIRECTORY_SEPARATOR.$path : $path);
     }
 
     /**
      * Get the path to the bootstrap directory.
      *
+     * @param string $path
      * @return string
      */
-    public function bootstrapPath()
+    public function bootstrapPath($path = '')
     {
-        return $this->basePath.DIRECTORY_SEPARATOR.'bootstrap';
+        return $this->basePath.DIRECTORY_SEPARATOR.'bootstrap'.($path ? DIRECTORY_SEPARATOR.$path : $path);
     }
 
     /**
      * Get the path to the application configuration files.
      *
+     * @param string $path
      * @return string
      */
-    public function configPath()
+    public function configPath($path = '')
     {
-        return $this->basePath.DIRECTORY_SEPARATOR.'config';
+        return $this->basePath.DIRECTORY_SEPARATOR.'config'.($path ? DIRECTORY_SEPARATOR.$path : $path);
     }
 
     /**

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -334,11 +334,13 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     /**
      * Get the path to the database directory.
      *
+     * @param string $path
      * @return string
      */
-    public function databasePath()
+    public function databasePath($path = '')
     {
-        return $this->databasePath ?: $this->basePath.DIRECTORY_SEPARATOR.'database';
+        $basePath = $this->databasePath ?: $this->basePath.DIRECTORY_SEPARATOR.'database';
+        return $basePath.($path ? DIRECTORY_SEPARATOR.$path : $path);
     }
 
     /**

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -343,9 +343,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
      */
     public function databasePath($path = '')
     {
-        $databasePath = $this->databasePath ?: $this->basePath.DIRECTORY_SEPARATOR.'database';
-        
-        return $databasePath.($path ? DIRECTORY_SEPARATOR.$path : $path);
+        return ($this->databasePath ?: $this->basePath.DIRECTORY_SEPARATOR.'database').($path ? DIRECTORY_SEPARATOR.$path : $path);
     }
 
     /**

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -294,7 +294,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     /**
      * Get the path to the application "app" directory.
      *
-     * @param string $path
+     * @param string $path Optionally, a path to append to the app path
      * @return string
      */
     public function path($path = '')
@@ -305,7 +305,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     /**
      * Get the base path of the Laravel installation.
      *
-     * @param string $path
+     * @param string $path Optionally, a path to append to the base path
      * @return string
      */
     public function basePath($path = '')
@@ -316,7 +316,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     /**
      * Get the path to the bootstrap directory.
      *
-     * @param string $path
+     * @param string $path Optionally, a path to append to the bootstrap path
      * @return string
      */
     public function bootstrapPath($path = '')
@@ -327,7 +327,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     /**
      * Get the path to the application configuration files.
      *
-     * @param string $path
+     * @param string $path Optionally, a path to append to the config path
      * @return string
      */
     public function configPath($path = '')
@@ -338,7 +338,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     /**
      * Get the path to the database directory.
      *
-     * @param string $path
+     * @param string $path Optionally, a path to append to the database path
      * @return string
      */
     public function databasePath($path = '')

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -339,8 +339,8 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
      */
     public function databasePath($path = '')
     {
-        $basePath = $this->databasePath ?: $this->basePath.DIRECTORY_SEPARATOR.'database';
-        return $basePath.($path ? DIRECTORY_SEPARATOR.$path : $path);
+        $databasePath = $this->databasePath ?: $this->basePath.DIRECTORY_SEPARATOR.'database';
+        return $databasePath.($path ? DIRECTORY_SEPARATOR.$path : $path);
     }
 
     /**

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -344,6 +344,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     public function databasePath($path = '')
     {
         $databasePath = $this->databasePath ?: $this->basePath.DIRECTORY_SEPARATOR.'database';
+        
         return $databasePath.($path ? DIRECTORY_SEPARATOR.$path : $path);
     }
 

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -346,7 +346,7 @@ if (! function_exists('database_path')) {
      */
     function database_path($path = '')
     {
-        return app()->databasePath().($path ? DIRECTORY_SEPARATOR.$path : $path);
+        return app()->databasePath($path);
     }
 }
 

--- a/src/Illuminate/Notifications/NotificationServiceProvider.php
+++ b/src/Illuminate/Notifications/NotificationServiceProvider.php
@@ -19,7 +19,7 @@ class NotificationServiceProvider extends ServiceProvider
 
         if ($this->app->runningInConsole()) {
             $this->publishes([
-                __DIR__.'/resources/views' => resource_path('views/vendor/notifications'),
+                __DIR__.'/resources/views' => $this->app->resourcePath('views/vendor/notifications'),
             ], 'laravel-notifications');
         }
     }

--- a/src/Illuminate/Pagination/PaginationServiceProvider.php
+++ b/src/Illuminate/Pagination/PaginationServiceProvider.php
@@ -17,7 +17,7 @@ class PaginationServiceProvider extends ServiceProvider
 
         if ($this->app->runningInConsole()) {
             $this->publishes([
-                __DIR__.'/resources/views' => resource_path('views/vendor/pagination'),
+                __DIR__.'/resources/views' => $this->app->resourcePath('views/vendor/pagination'),
             ], 'laravel-pagination');
         }
     }


### PR DESCRIPTION
Following on #18506, this branch further refactors `DatabaseServiceProvider`, `NotificationServiceProvider`, and `PaginationServiceProvider`, and updates the signatures of `Application::databasePath()`, `Application::configPath()`, `Application::bootstrapPath()`, and `Application::basePath()` to support a `$path` argument, making consistent the path accessing part of `Application`'s API.

Thank you for your consideration.