### PR TITLE
Use the built-in IP Address type if supported

### DIFF
--- a/src/Illuminate/Session/Console/stubs/database.stub
+++ b/src/Illuminate/Session/Console/stubs/database.stub
@@ -16,7 +16,7 @@ class CreateSessionsTable extends Migration
         Schema::create('sessions', function (Blueprint $table) {
             $table->string('id')->unique();
             $table->integer('user_id')->nullable();
-            $table->string('ip_address', 45)->nullable();
+            $table->ipAddress('ip_address')->nullable();
             $table->text('user_agent')->nullable();
             $table->text('payload');
             $table->integer('last_activity');


### PR DESCRIPTION
The ability to use the built-in IP Address type in databases that support it was added in f89c580353826fae429bc7c386a92e62a874a251 (v5.2.27). It probably should be used here instead of defaulting to a string. Any database that doesn't have this type built in will still fallback to a 45-character string field.