### PR TITLE
[5.4] Resolved rollback not compatible with strings

### DIFF
--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -228,11 +228,11 @@ class Migrator
      * Rollback the given migrations.
      *
      * @param  array  $migrations
-     * @param  array  $paths
+     * @param  array|string  $paths
      * @param  array  $options
      * @return array
      */
-    protected function rollbackMigrations(array $migrations, array $paths, array $options)
+    protected function rollbackMigrations(array $migrations, $paths, array $options)
     {
         $rolledBack = [];
 


### PR DESCRIPTION
`rollbackMigrations` is called from `rollback` and passes `$paths`, which can be a `string` or an `array`. However, `rollbackMigrations` only accepts an `array`. It's only logical that it accepts both, as the method that passes the `$paths` variable accepts both too.