### PR TITLE
[5.4] Add support for multiple --path to migrate:reset

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/BaseCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/BaseCommand.php
@@ -17,7 +17,12 @@ class BaseCommand extends Command
         // use the path relative to the root of the installation folder so our database
         // migrations may be run for any customized path from within the application.
         if ($this->input->hasOption('path') && $this->option('path')) {
-            return [$this->laravel->basePath().'/'.$this->option('path')];
+            $paths = [];
+            foreach ($this->option('path') as $path) {
+                $paths[] = $this->laravel->basePath().'/'.$path;
+            }
+
+            return $paths;
         }
 
         return array_merge(

--- a/src/Illuminate/Database/Console/Migrations/BaseCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/BaseCommand.php
@@ -18,7 +18,7 @@ class BaseCommand extends Command
         // migrations may be run for any customized path from within the application.
         if ($this->input->hasOption('path') && $this->option('path')) {
             $paths = [];
-            foreach ($this->option('path') as $path) {
+            foreach ((array) $this->option('path') as $path) {
                 $paths[] = $this->laravel->basePath().'/'.$path;
             }
 

--- a/src/Illuminate/Database/Console/Migrations/ResetCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/ResetCommand.php
@@ -88,7 +88,7 @@ class ResetCommand extends BaseCommand
 
             ['force', null, InputOption::VALUE_NONE, 'Force the operation to run when in production.'],
 
-            ['path', null, InputOption::VALUE_OPTIONAL, 'The path of migrations files to be executed.'],
+            ['path', null, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'The path(s) of migrations files to be executed.'],
 
             ['pretend', null, InputOption::VALUE_NONE, 'Dump the SQL queries that would be run.'],
         ];


### PR DESCRIPTION
It's required for `migrate:reset` if you run migrations from different paths:
```
./artisan migrate
./artisan migrate --path database/migrations/foodir1
./artisan migrate --path database/migrations/bardir2
```

`./artisan migrate:reset` will fail with something like this:
```
[ErrorException]
Undefined index: 2016_10_11_153917_some_migration_from_foodir1_or_bardir2
```

At the same time next code will work (with mine changes):
```
./artisan migrate:reset --path database/migrations --path database/migrations/foodir1 --path database/migrations/bardir2
```