### PR TITLE
[5.4] Make migration pre and post status message equal in length

### DIFF
--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -332,7 +332,7 @@ class Migrator
         // by the application then will be able to fire by any later operation.
         $this->repository->delete($migration);
 
-        $this->note("<info>Rolled back:</info> {$name}");
+        $this->note("<info>Rolled back:</info>  {$name}");
     }
 
     /**

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -181,7 +181,7 @@ class Migrator
         // in the application. A migration repository keeps the migrate order.
         $this->repository->log($name, $batch);
 
-        $this->note("<info>Migrated:</info> {$name}");
+        $this->note("<info>Migrated:</info>  {$name}");
     }
 
     /**


### PR DESCRIPTION
`Migrating` is of length 9
`Migrated` is of length 8

I propose to add one space so the names of the actual migrations share the same indentation.
(in other words, make it easier to read over them)

before and after images:

![screen shot 2017-03-28 at 16 15 36](https://cloud.githubusercontent.com/assets/3179271/24409914/e948ce5e-13d1-11e7-898f-bb2b260cb485.png)
![screen shot 2017-03-28 at 16 16 13](https://cloud.githubusercontent.com/assets/3179271/24409948/fdd0e6d6-13d1-11e7-9aeb-3cc6bfed820a.png)
