### PR TITLE
[5.4] Ability to remove middlewares for specific route

### DIFF
--- a/src/Illuminate/Routing/MiddlewareNameResolver.php
+++ b/src/Illuminate/Routing/MiddlewareNameResolver.php
@@ -66,7 +66,7 @@ class MiddlewareNameResolver
             // reference other groups without needing to repeat all their middlewares.
             if (isset($middlewareGroups[$middleware])) {
                 $results = array_merge($results, static::parseMiddlewareGroup(
-                    $middleware, $map, $middlewareGroups
+                    $middleware, $map, $middlewareGroups, $disabledMiddlewares
                 ));
 
                 continue;

--- a/src/Illuminate/Routing/MiddlewareNameResolver.php
+++ b/src/Illuminate/Routing/MiddlewareNameResolver.php
@@ -31,7 +31,7 @@ class MiddlewareNameResolver
         // set of middleware under single keys that can be conveniently referenced.
         } elseif (isset($middlewareGroups[$name])) {
             return static::parseMiddlewareGroup(
-                $name, $map, $middlewareGroups
+                $name, $map, $middlewareGroups, $disabledMiddlewares
             );
 
         // Finally, when the middleware is simply a string mapped to a class name the
@@ -53,11 +53,14 @@ class MiddlewareNameResolver
      * @param  array  $middlewareGroups
      * @return array
      */
-    protected static function parseMiddlewareGroup($name, $map, $middlewareGroups)
+    protected static function parseMiddlewareGroup($name, $map, $middlewareGroups, $disabledMiddlewares)
     {
         $results = [];
 
         foreach ($middlewareGroups[$name] as $middleware) {
+            if (in_array($middleware, $disabledMiddlewares)) {
+                continue;
+            }
             // If the middleware is another middleware group we will pull in the group and
             // merge its middleware into the results. This allows groups to conveniently
             // reference other groups without needing to repeat all their middlewares.

--- a/src/Illuminate/Routing/MiddlewareNameResolver.php
+++ b/src/Illuminate/Routing/MiddlewareNameResolver.php
@@ -12,6 +12,7 @@ class MiddlewareNameResolver
      * @param  string  $name
      * @param  array  $map
      * @param  array  $middlewareGroups
+     * @param  array  $disabledMiddlewares
      * @return string|array
      */
     public static function resolve($name, $map, $middlewareGroups, $disabledMiddlewares)
@@ -51,6 +52,7 @@ class MiddlewareNameResolver
      * @param  string  $name
      * @param  array  $map
      * @param  array  $middlewareGroups
+     * @param  array  $disabledMiddlewares
      * @return array
      */
     protected static function parseMiddlewareGroup($name, $map, $middlewareGroups, $disabledMiddlewares)

--- a/src/Illuminate/Routing/MiddlewareNameResolver.php
+++ b/src/Illuminate/Routing/MiddlewareNameResolver.php
@@ -14,13 +14,15 @@ class MiddlewareNameResolver
      * @param  array  $middlewareGroups
      * @return string|array
      */
-    public static function resolve($name, $map, $middlewareGroups)
+    public static function resolve($name, $map, $middlewareGroups, $disabledMiddlewares)
     {
         // When the middleware is simply a Closure, we will return this Closure instance
         // directly so that Closures can be registered as middleware inline, which is
         // convenient on occasions when the developers are experimenting with them.
         if ($name instanceof Closure) {
             return $name;
+        } elseif (in_array($name, $disabledMiddlewares)) {
+            return [];
         } elseif (isset($map[$name]) && $map[$name] instanceof Closure) {
             return $map[$name];
 

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -711,7 +711,7 @@ class Route
     /**
      * Get or set the middlewares attached to the route.
      *
-     * @param  array|string|null $middleware
+     * @param  array|string $middleware
      * @return $this|array
      */
     public function middleware($middleware = null)
@@ -734,22 +734,22 @@ class Route
     /**
      * Remove the given middlewares from the route. If no middleware is passed, all middlewares will be removed.
      *
-     * @param null $middleware
+     * @param array|string $middleware
      * @return $this
      */
     public function withoutMiddleware($middleware = null)
     {
         if (is_null($middleware)) {
             $this->action['middleware'] = [];
-        } else {
-            if (is_string($middleware)) {
-                $middleware = func_get_args();
-            }
 
-            $this->action['bypass'] = array_merge(
-                (array) Arr::get($this->action, 'bypass', []), $middleware
-            );
+            return $this;
         }
+
+        $middleware = is_array($middleware) ? $middleware : func_get_args();
+
+        $this->action['bypass'] = array_merge(
+            (array) Arr::get($this->action, 'bypass', []), $middleware
+        );
 
         return $this;
     }

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -699,6 +699,15 @@ class Route
     }
 
     /**
+     * Return all disabled middlewares.
+     *
+     * @return array
+     */
+    public function gatherDisabledMiddlewares() {
+        return (array) Arr::get($this->action, 'bypass', []);
+    }
+
+    /**
      * Get or set the middlewares attached to the route.
      *
      * @param  array|string|null $middleware
@@ -718,6 +727,29 @@ class Route
             (array) Arr::get($this->action, 'middleware', []), $middleware
         );
 
+        return $this;
+    }
+
+    /**
+     * Remove the given middlewares from the route. If no middleware is passed, all middlewares will be removed.
+     *
+     * @param null $middleware
+     * @return $this
+     */
+    public function withoutMiddleware($middleware = null) 
+    {
+        if (is_null($middleware)) {
+            $this->action['middleware'] = [];
+        } else {
+            if (is_string($middleware)) {
+                $middleware = func_get_args();
+            }
+        
+            $this->action['bypass'] = array_merge(
+                (array) Arr::get($this->action, 'bypass', []), $middleware
+            );
+        }
+        
         return $this;
     }
 

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -703,7 +703,8 @@ class Route
      *
      * @return array
      */
-    public function gatherDisabledMiddlewares() {
+    public function gatherDisabledMiddlewares()
+    {
         return (array) Arr::get($this->action, 'bypass', []);
     }
 
@@ -736,7 +737,7 @@ class Route
      * @param null $middleware
      * @return $this
      */
-    public function withoutMiddleware($middleware = null) 
+    public function withoutMiddleware($middleware = null)
     {
         if (is_null($middleware)) {
             $this->action['middleware'] = [];
@@ -744,12 +745,12 @@ class Route
             if (is_string($middleware)) {
                 $middleware = func_get_args();
             }
-        
+
             $this->action['bypass'] = array_merge(
                 (array) Arr::get($this->action, 'bypass', []), $middleware
             );
         }
-        
+
         return $this;
     }
 

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -569,8 +569,8 @@ class Router implements RegistrarContract, BindingRegistrar
      */
     public function gatherRouteMiddleware(Route $route)
     {
-        $middleware = collect($route->gatherMiddleware())->map(function ($name) {
-            return (array) MiddlewareNameResolver::resolve($name, $this->middleware, $this->middlewareGroups);
+        $middleware = collect($route->gatherMiddleware())->map(function ($name) use ($route) {
+            return (array) MiddlewareNameResolver::resolve($name, $this->middleware, $this->middlewareGroups, $route->gatherDisabledMiddlewares());
         })->flatten();
 
         return $this->sortMiddleware($middleware);

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -261,6 +261,23 @@ class RoutingRouteTest extends TestCase
         unset($_SERVER['__middleware.group']);
     }
 
+    public function testWithoutMiddlewareGroups()
+    {
+        unset($_SERVER['__middleware.group']);
+        $router = $this->getRouter();
+        $router->get('foo/bar', ['middleware' => 'web', function () {
+            return 'hello';
+        }])->withoutMiddleware('two:taylor');
+
+        $router->aliasMiddleware('two', 'Illuminate\Tests\Routing\RoutingTestMiddlewareGroupTwo');
+        $router->middlewareGroup('web', ['Illuminate\Tests\Routing\RoutingTestMiddlewareGroupOne', 'two:taylor']);
+
+        $this->assertEquals('hello', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
+        $this->assertTrue($_SERVER['__middleware.group']);
+
+        unset($_SERVER['__middleware.group']);
+    }
+
     public function testMiddlewareGroupsCanReferenceOtherGroups()
     {
         unset($_SERVER['__middleware.group']);

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -175,6 +175,18 @@ class RoutingRouteTest extends TestCase
         $this->assertEquals('caught', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
     }
 
+    public function testDisableMiddleware()
+    {
+        $router = $this->getRouter();
+        $router->get('foo/bar', ['middleware' => 'foo', function () {
+            return 'hello';
+        }])->withoutMiddleware('foo');
+        $router->aliasMiddleware('foo', function ($request, $next) {
+            return 'caught';
+        });
+        $this->assertEquals('hello', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
+    }
+
     public function testControllerClosureMiddleware()
     {
         $router = $this->getRouter();


### PR DESCRIPTION
This allows us to remove middleware from a very specific route without having to rely on RouteServiceProvider to create a whole new Router environment for a single route.

```
Route::get('/health', 'ClosuresController@health')->withoutMiddleware();
```

I decided not to put too much effort into it to get a feedback before moving with a more interesting approach where we can remove just a single middleware. The following snippet would be the next step.

```
Route::get('/health', 'ClosuresController@health')->withoutMiddleware(\App\Http\Middleware\VerifyCsrfToken::class);
```