### PR TITLE
[5.4] Wrong type of argument for formatRecordsList method in InteractsWithPivotTable trait.

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -93,7 +93,7 @@ trait InteractsWithPivotTable
         )->all();
 
         $detach = array_diff($current, array_keys(
-            $records = $this->formatRecordsList($this->parseIds($ids))
+            $records = $this->formatRecordsList((array) $this->parseIds($ids))
         ));
 
         // Next, we will take the differences of the currents and given IDs and detach


### PR DESCRIPTION
 When using `sync` method and passing only one eloquent model as first argument `Fatal error` is thrown, because `formatRecordsList` accepts only arrays, but result of `parseIds` method is not casted to type like in `toggle` method.