### PR TITLE
[5.4] Add unsetUser to the auth guard

### DIFF
--- a/src/Illuminate/Auth/GuardHelpers.php
+++ b/src/Illuminate/Auth/GuardHelpers.php
@@ -83,4 +83,16 @@ trait GuardHelpers
 
         return $this;
     }
+
+    /**
+     * Unset the current user.
+     *
+     * @return $this
+     */
+    public function unsetUser()
+    {
+        $this->user = null;
+
+        return $this;
+    }
 }

--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -750,6 +750,22 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
     }
 
     /**
+     * Unset the current user.
+     *
+     * @return $this
+     */
+    public function unsetUser()
+    {
+        $this->user = null;
+
+        $this->loggedOut = true;
+
+        $this->fireAuthenticatedEvent(null);
+
+        return $this;
+    }
+
+    /**
      * Get the current request instance.
      *
      * @return \Symfony\Component\HttpFoundation\Request

--- a/src/Illuminate/Contracts/Auth/Guard.php
+++ b/src/Illuminate/Contracts/Auth/Guard.php
@@ -47,4 +47,11 @@ interface Guard
      * @return void
      */
     public function setUser(Authenticatable $user);
+
+    /**
+     * Unset the current user.
+     *
+     * @return void
+     */
+    public function unsetUser();
 }

--- a/tests/Auth/AuthGuardTest.php
+++ b/tests/Auth/AuthGuardTest.php
@@ -182,6 +182,18 @@ class AuthGuardTest extends TestCase
         $this->assertTrue($mock->guest());
     }
 
+    public function testIsAuthedReturnsFalseWhenUserIsUnset()
+    {
+        $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');
+        $mock = $this->getGuard();
+        $mock->setUser($user);
+        $this->assertTrue($mock->check());
+        $this->assertFalse($mock->guest());
+        $mock->unsetUser();
+        $this->assertFalse($mock->check());
+        $this->assertTrue($mock->guest());
+    }
+
     public function testUserMethodReturnsCachedUser()
     {
         $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');


### PR DESCRIPTION
This works well with testing a mix of authenticated and
unauthenticated users.

Future ideas:
* add and fire an unauthenticated event
* add stopActingAs