### PR TITLE
[5.4] Replaced nonexistent status() method by getStatusCode()

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -73,7 +73,7 @@ class TestResponse
     public function assertRedirect($uri)
     {
         PHPUnit::assertTrue(
-            $this->isRedirect(), 'Response status code ['.$this->status().'] is not a redirect status code.'
+            $this->isRedirect(), 'Response status code ['.$this->getStatusCode().'] is not a redirect status code.'
         );
 
         PHPUnit::assertEquals(app('url')->to($uri), $this->headers->get('Location'));


### PR DESCRIPTION
Fixed issue in ```assertRedirect``` method.