### PR TITLE
[5.4] Fixed Integer|Int rules on validator not accepting octals and hexadec…

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -819,7 +819,7 @@ trait ValidatesAttributes
      */
     protected function validateInteger($attribute, $value)
     {
-        return filter_var($value, FILTER_VALIDATE_INT) !== false;
+        return filter_var($value, FILTER_VALIDATE_INT, FILTER_FLAG_ALLOW_OCTAL | FILTER_FLAG_ALLOW_HEX) !== false;
     }
 
     /**

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1142,6 +1142,12 @@ class ValidationValidatorTest extends TestCase
 
         $v = new Validator($trans, ['foo' => '1'], ['foo' => 'Integer']);
         $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => '020'], ['foo' => 'Integer']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => '0x25'], ['foo' => 'Integer']);
+        $this->assertTrue($v->passes());
     }
 
     public function testValidateInt()
@@ -1157,6 +1163,12 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['foo' => '1'], ['foo' => 'Int']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => '020'], ['foo' => 'Int']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => '0x25'], ['foo' => 'Int']);
         $this->assertTrue($v->passes());
     }
 


### PR DESCRIPTION
PR to fix the related issue:

https://github.com/laravel/framework/issues/18560