### PR TITLE
[5.4] some cleanup and tiny refactor

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -430,15 +430,13 @@ class Str
      */
     public static function studly($value)
     {
-        $key = $value;
-
-        if (isset(static::$studlyCache[$key])) {
-            return static::$studlyCache[$key];
+        if (isset(static::$studlyCache[$value])) {
+            return static::$studlyCache[$value];
         }
 
         $value = ucwords(str_replace(['-', '_'], ' ', $value));
 
-        return static::$studlyCache[$key] = str_replace(' ', '', $value);
+        return static::$studlyCache[$value] = str_replace(' ', '', $value);
     }
 
     /**

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -529,8 +529,8 @@ class SupportArrTest extends TestCase
         $array = ['a'];
         $object = new stdClass;
         $object->value = 'a';
-        $this->assertEquals(['a'], array_wrap($string));
-        $this->assertEquals($array, array_wrap($array));
-        $this->assertEquals([$object], array_wrap($object));
+        $this->assertEquals(['a'], Arr::wrap($string));
+        $this->assertEquals($array, Arr::wrap($array));
+        $this->assertEquals([$object], Arr::wrap($object));
     }
 }

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -86,9 +86,7 @@ class ViewBladeCompilerTest extends TestCase
 
         $this->assertEquals('<?php echo e($name); ?>', $compiler->compileString('{{{ $name }}}'));
         $this->assertEquals('<?php echo $name; ?>', $compiler->compileString('{{ $name }}'));
-        $this->assertEquals('<?php echo $name; ?>', $compiler->compileString('{{
-            $name
-        }}'));
+        $this->assertEquals('<?php echo $name; ?>', $compiler->compileString('{{ $name }}'));
     }
 
     protected function getFiles()


### PR DESCRIPTION
Str::studly() and all the rest in that helper class still passing the tests:

![teststrstudly](https://cloud.githubusercontent.com/assets/16985712/24458831/5e2bf1c4-149a-11e7-8e22-877c7753a742.jpg)

there was probably a readability concerns creating another copy of the argument $value. well, in Str::camel() $value is used also as a key, so I though it would make sense to keep that naming convention.
