### PR TITLE
[5.4] Optimize UrlGenerator->isValidUrl()

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -444,7 +444,7 @@ class UrlGenerator implements UrlGeneratorContract
      */
     public function isValidUrl($path)
     {
-        if (! Str::startsWith($path, ['#', '//', 'mailto:', 'tel:', 'http://', 'https://'])) {
+        if (! preg_match('~^(#|//|https?://|mailto:|tel:)~', $path)) {
             return filter_var($path, FILTER_VALIDATE_URL) !== false;
         }
 


### PR DESCRIPTION
`UrlGenerator->to()` and `UrlGenerator->asset()` are quite slow. Investigating about this, I found out `UrlGenerator->validUrl()` was a bottleneck, taking by itself about half of the total execution time.

Then, I found out this method could be made significantly faster:

```php
$path = 'foobar';
$nb = 10000;

$t1 = microtime(true);
for ($i = $nb; $i--; ) {
    if (Str::startsWith($path, ['#', '//', 'mailto:', 'tel:', 'http://', 'https://'])) {}
}
$t2 = microtime(true);
for ($i = $nb; $i--; ) {
    if (preg_match('~^(#|//|https?://|mailto:|tel:)~', $path)) {}
}
$t3 = microtime(true);

echo $t2 - $t1, "\n", $t3 - $t2;
```

Before: 673 ms
After: 76 ms