### PR TITLE
[5.5] Arr::merge

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -192,6 +192,31 @@ class Arr
     }
 
     /**
+     * @param  \ArrayAccess|array  $first
+     * @param  \ArrayAccess|array  ...$rest
+     * @return array
+     */
+    public static function merge($first, ...$rest)
+    {
+        return array_reduce($rest, function ($result, $item) {
+            $item = $item instanceof Collection ? $item->all() : $item;
+
+            foreach ($item as $key => $value) {
+                if (static::exists($result, $key) &&
+                    static::accessible($result[$key]) &&
+                    static::accessible($value)
+                ) {
+                    $result[$key] = static::merge($result[$key], $value);
+                } else {
+                    $result[$key] = $value;
+                }
+            }
+
+            return $result;
+        }, $first instanceof Collection ? $first->all() : $first);
+    }
+
+    /**
      * Remove one or many array items from a given array using "dot" notation.
      *
      * @param  array  $array

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -160,6 +160,25 @@ class SupportArrTest extends TestCase
         $this->assertEquals(['#foo', '#bar', ['#baz'], '#zap'], Arr::flatten($array, 2));
     }
 
+    public function testMerge()
+    {
+        $one = ['a' => 'foo', 'b' => 'bar'];
+        $two = ['b' => 'BAR', 'c' => ['c1' => 'baz1', 'c2' => 'baz2']];
+        $three = ['a' => 'FOO', 'c' => ['c1' => 'BAZ1']];
+
+        // Replace or insert
+        $expected = ['a' => 'foo', 'b' => 'BAR', 'c' => ['c1' => 'baz1', 'c2' => 'baz2']];
+        $this->assertEquals($expected, Arr::merge($one, $two));
+
+        // Replace root level as well as nested
+        $expected = ['a' => 'FOO', 'b' => 'BAR', 'c' => ['c1' => 'BAZ1', 'c2' => 'baz2']];
+        $this->assertEquals($expected, Arr::merge($one, $two, $three));
+
+        // Accept Collections
+        $expected = ['a' => 'FOO', 'b' => 'BAR', 'c' => ['c1' => 'BAZ1', 'c2' => 'baz2']];
+        $this->assertEquals($expected, Arr::merge(new Collection($one), $two, new Collection($three)));
+    }
+
     public function testGet()
     {
         $array = ['products.desk' => ['price' => 100]];


### PR DESCRIPTION
Sort of a recursive (multilevel) `array_merge`. I use it all the time for overriding config arrays. Typically I macro it, but it's probably a nice function to provide out of the box.

Example:

```
$one = [
    'foo' => 'something',
    'bar' => [
        'a' => 1,
        'b' => 2,
    ],
];

$two = [
    'foo' => 'something else',
    'bar' => [        
        'b' => 3,
    ],
    'baz' => 'another',
];

Arr::merge($one, $two);

/*

[
    'foo' => 'something else',
    'bar' => [        
        'a' => 1,
        'b' => 3,
    ],
    'baz' => 'another',
];

*/