### PR TITLE
[5.5] Allow Default Value for Command Array Input.

### DIFF
--- a/src/Illuminate/Console/Parser.php
+++ b/src/Illuminate/Console/Parser.php
@@ -89,7 +89,7 @@ class Parser
                 return new InputArgument(trim($token, '*'), InputArgument::IS_ARRAY | InputArgument::REQUIRED, $description);
             case Str::endsWith($token, '?'):
                 return new InputArgument(trim($token, '?'), InputArgument::OPTIONAL, $description);
-            case preg_match('/(.+)\*\=(.+)/', $token, $matches):
+            case preg_match('/(.+)\=\*(.+)/', $token, $matches):
                 return new InputArgument($matches[1], InputArgument::IS_ARRAY, $description, preg_split('/,\s?/', $matches[2]));
             case preg_match('/(.+)\=(.+)/', $token, $matches):
                 return new InputArgument($matches[1], InputArgument::OPTIONAL, $description, $matches[2]);
@@ -122,8 +122,8 @@ class Parser
                 return new InputOption(trim($token, '='), $shortcut, InputOption::VALUE_OPTIONAL, $description);
             case Str::endsWith($token, '=*'):
                 return new InputOption(trim($token, '=*'), $shortcut, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, $description);
-            case preg_match('/(.+)\*\=(.+)/', $token, $matches):
-                return new InputOption($matches[1], $shortcut, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, $description, $matches[2]);
+            case preg_match('/(.+)\=\*(.+)/', $token, $matches):
+                return new InputOption($matches[1], $shortcut, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, $description, preg_split('/,\s?/', $matches[2]));
             case preg_match('/(.+)\=(.+)/', $token, $matches):
                 return new InputOption($matches[1], $shortcut, InputOption::VALUE_OPTIONAL, $description, $matches[2]);
             default:

--- a/src/Illuminate/Console/Parser.php
+++ b/src/Illuminate/Console/Parser.php
@@ -89,6 +89,8 @@ class Parser
                 return new InputArgument(trim($token, '*'), InputArgument::IS_ARRAY | InputArgument::REQUIRED, $description);
             case Str::endsWith($token, '?'):
                 return new InputArgument(trim($token, '?'), InputArgument::OPTIONAL, $description);
+            case preg_match('/(.+)\*\=(.+)/', $token, $matches):
+                return new InputArgument($matches[1], InputArgument::IS_ARRAY, $description, preg_split('/,\s?/', $matches[2]));
             case preg_match('/(.+)\=(.+)/', $token, $matches):
                 return new InputArgument($matches[1], InputArgument::OPTIONAL, $description, $matches[2]);
             default:
@@ -120,6 +122,8 @@ class Parser
                 return new InputOption(trim($token, '='), $shortcut, InputOption::VALUE_OPTIONAL, $description);
             case Str::endsWith($token, '=*'):
                 return new InputOption(trim($token, '=*'), $shortcut, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, $description);
+            case preg_match('/(.+)\*\=(.+)/', $token, $matches):
+                return new InputOption($matches[1], $shortcut, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, $description, $matches[2]);
             case preg_match('/(.+)\=(.+)/', $token, $matches):
                 return new InputOption($matches[1], $shortcut, InputOption::VALUE_OPTIONAL, $description, $matches[2]);
             default:

--- a/tests/Console/ConsoleParserTest.php
+++ b/tests/Console/ConsoleParserTest.php
@@ -107,18 +107,18 @@ class ConsoleParserTest extends TestCase
         $this->assertTrue($results[2][0]->acceptValue());
         $this->assertTrue($results[2][0]->isArray());
     }
-    
+
     public function testDefaultValueParsing()
     {
         $results = Parser::parse('command:name {argument=defaultArgumentValue} {--option=defaultOptionValue}');
-        
+
         $this->assertFalse($results[1][0]->isRequired());
         $this->assertEquals('defaultArgumentValue', $results[1][0]->getDefault());
         $this->assertTrue($results[2][0]->acceptValue());
         $this->assertEquals('defaultOptionValue', $results[2][0]->getDefault());
-        
+
         $results = Parser::parse('command:name {argument=*defaultArgumentValue1,defaultArgumentValue2} {--option=*defaultOptionValue1,defaultOptionValue2}');
-        
+
         $this->assertTrue($results[1][0]->isArray());
         $this->assertFalse($results[1][0]->isRequired());
         $this->assertEquals(['defaultArgumentValue1', 'defaultArgumentValue2'], $results[1][0]->getDefault());

--- a/tests/Console/ConsoleParserTest.php
+++ b/tests/Console/ConsoleParserTest.php
@@ -107,4 +107,23 @@ class ConsoleParserTest extends TestCase
         $this->assertTrue($results[2][0]->acceptValue());
         $this->assertTrue($results[2][0]->isArray());
     }
+    
+    public function testDefaultValueParsing()
+    {
+        $results = Parser::parse('command:name {argument=defaultArgumentValue} {--option=defaultOptionValue}');
+        
+        $this->assertFalse($results[1][0]->isRequired());
+        $this->assertEquals('defaultArgumentValue', $results[1][0]->getDefault());
+        $this->assertTrue($results[2][0]->acceptValue());
+        $this->assertEquals('defaultOptionValue', $results[2][0]->getDefault());
+        
+        $results = Parser::parse('command:name {argument=*defaultArgumentValue1,defaultArgumentValue2} {--option=*defaultOptionValue1,defaultOptionValue2}');
+        
+        $this->assertTrue($results[1][0]->isArray());
+        $this->assertFalse($results[1][0]->isRequired());
+        $this->assertEquals(['defaultArgumentValue1', 'defaultArgumentValue2'], $results[1][0]->getDefault());
+        $this->assertTrue($results[2][0]->acceptValue());
+        $this->assertTrue($results[2][0]->isArray());
+        $this->assertEquals(['defaultOptionValue1', 'defaultOptionValue2'], $results[2][0]->getDefault());
+    }
 }


### PR DESCRIPTION
This PR allows console command signature to define input array with default value.

Signature would be as follows:

 - `command:name {argument=*default} {--option=*default}`
 - `command:name {argument=*default1,default2} {--option=*default1,default2}`