### PR TITLE
[5.4] Always use stdClass with proper casing

### DIFF
--- a/src/Illuminate/Queue/Console/RetryCommand.php
+++ b/src/Illuminate/Queue/Console/RetryCommand.php
@@ -63,7 +63,7 @@ class RetryCommand extends Command
     /**
      * Retry the queue job.
      *
-     * @param  stdClass  $job
+     * @param  \stdClass  $job
      * @return void
      */
     protected function retryJob($job)

--- a/src/Illuminate/Queue/Jobs/DatabaseJob.php
+++ b/src/Illuminate/Queue/Jobs/DatabaseJob.php
@@ -18,7 +18,7 @@ class DatabaseJob extends Job implements JobContract
     /**
      * The database job payload.
      *
-     * @var \StdClass
+     * @var \stdClass
      */
     protected $job;
 
@@ -27,7 +27,7 @@ class DatabaseJob extends Job implements JobContract
      *
      * @param  \Illuminate\Container\Container  $container
      * @param  \Illuminate\Queue\DatabaseQueue  $database
-     * @param  \StdClass  $job
+     * @param  \stdClass  $job
      * @param  string  $connectionName
      * @param  string  $queue
      * @return void

--- a/src/Illuminate/Queue/Jobs/DatabaseJobRecord.php
+++ b/src/Illuminate/Queue/Jobs/DatabaseJobRecord.php
@@ -11,14 +11,14 @@ class DatabaseJobRecord
     /**
      * The underlying job record.
      *
-     * @var \StdClass
+     * @var \stdClass
      */
     protected $record;
 
     /**
      * Create a new job record instance.
      *
-     * @param  \StdClass  $record
+     * @param  \stdClass  $record
      * @return void
      */
     public function __construct($record)

--- a/src/Illuminate/Session/DatabaseSessionHandler.php
+++ b/src/Illuminate/Session/DatabaseSessionHandler.php
@@ -103,7 +103,7 @@ class DatabaseSessionHandler implements SessionHandlerInterface, ExistenceAwareI
     /**
      * Determine if the session is expired.
      *
-     * @param  \StdClass  $session
+     * @param  \stdClass  $session
      * @return bool
      */
     protected function expired($session)

--- a/src/Illuminate/Validation/ValidationRuleParser.php
+++ b/src/Illuminate/Validation/ValidationRuleParser.php
@@ -38,7 +38,7 @@ class ValidationRuleParser
      * Parse the human-friendly rules into a full rules array for the validator.
      *
      * @param  array  $rules
-     * @return \StdClass
+     * @return \stdClass
      */
     public function explode($rules)
     {

--- a/src/Illuminate/View/Concerns/ManagesLoops.php
+++ b/src/Illuminate/View/Concerns/ManagesLoops.php
@@ -69,7 +69,7 @@ trait ManagesLoops
     /**
      * Get an instance of the last loop in the stack.
      *
-     * @return \StdClass|null
+     * @return \stdClass|null
      */
     public function getLastLoop()
     {


### PR DESCRIPTION
Always use stdClass with proper casing
