### PR TITLE
[5.4] Extra check for CLI mode

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -525,7 +525,9 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
      */
     public function runningInConsole()
     {
-        return php_sapi_name() == 'cli' || php_sapi_name() == 'phpdbg';
+        return php_sapi_name() == 'cli' ||
+            php_sapi_name() == 'phpdbg' ||
+            (php_sapi_name() == 'cgi-fcgi' && array_key_exists('SHELL', $_SERVER));
     }
 
     /**


### PR DESCRIPTION
Added check for cgi-fcgi and shell existence within the $_SERVER variable.
This is needed for servers running cpanel + centos 7 + php multi version