### PR TITLE
[5.4] Add constructed event to eloquent model

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -143,6 +143,8 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         $this->syncOriginal();
 
         $this->fill($attributes);
+
+        $this->fireModelEvent('constructed', false);
     }
 
     /**


### PR DESCRIPTION
The purpose of this PR is to make it more convenient to make attributes visible/hidden/append in subclasses or traits.

For example, we have a `User` model with `protected $appends = ['full_name']`, and there is a subclass named `Student` which extends the `User` model, we need `Student` to have `protected $appends = ['full_name', 'last_class']`, if we hard code the `$appends` attribute in `Student` class and one day we add one more append `birthday` to the `User` class, we have to add that to `Student`'s `$appends` too. It's a nightmare if we have many subclass or we change the `User`'s `$appends` frequently.

With this PR, we can override the `boot` method in `Student` like this

```
protected function boot() {
    parent::boot();
    static::registerModelEvent('constructed', function($model) {
        $model->append('last_class');
    });
}
```