### PR TITLE
[5.4] Use hash tag for Redis queue names

### DIFF
--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -256,7 +256,7 @@ class RedisQueue extends Queue implements QueueContract
      */
     protected function getQueue($queue)
     {
-        return 'queues:'.($queue ?: $this->default);
+        return 'queues:{'.($queue ?: $this->default).'}';
     }
 
     /**


### PR DESCRIPTION
This fixes https://github.com/laravel/framework/issues/18527.

However this is kind of a breaking change if the Redis queue is not empty when upgrading to the next minor point release.

To prevent this we can either target v5.5, or we could only add the hash tag if the connection is a cluster. Feedback appreciated.