### PR TITLE
[5.4] Prevent DB::unprepared() causes application crash when executing resultset statements.

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -490,7 +490,9 @@ class Connection implements ConnectionInterface
                 return true;
             }
 
-            return (bool) $this->getPdo()->exec($query);
+            $statement = $this->getPdo()->query($query);
+
+            return (bool) $statement->rowCount();
         });
     }
 


### PR DESCRIPTION
Based on issue #18390 

PDO::exec() does not fetch result for queries that produce result sets, e.g. SELECT. So, the next query will crash the application.
Solution:
Use PDO::query() that implicitly fetch result to prevent application failure, but this may lead to OOM when doing SELECTS with big results.

Overview:
According the [manual](http://php.net/manual/en/pdo.exec.php) we should not use this method for executing SELECT (ALTER etc.) statements. Because this statements produce result sets and PDO::exec() do not fetch them, so next query will lead the error.

```
DB::unprepared('SELECT NOW();'); // ok
DB::unprepared('SELECT NOW();'); // second will fail
DB::getPdo()->query("SELECT NOW();"); // this also will fail
```

So, variants:
- Do not modify this method and use it only with statements, that do not produce result sets. Also mention about that restrictions in comments, for example.
- Modify this method so that application does not crash. (this pr) Plus we can allow SELECTS. Current mysql PDO implementation may return number of selected rows for SELECT that also will be cast to boolean, but i don't know about other db drivers. But results for ALTER for example will be unexpected.
- We can change method so it returns PDOStatement, but we also should change Interface in this case. On the other hand programmer can execute any statement.
- Specify method responsibilities more detail.