### PR TITLE
[5.4] Add constructed event to eloquent model

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -143,6 +143,8 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         $this->syncOriginal();
 
         $this->fill($attributes);
+
+        $this->fireModelEvent('constructed', false);
     }
 
     /**

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -11,6 +11,7 @@ use LogicException;
 use ReflectionClass;
 use DateTimeImmutable;
 use DateTimeInterface;
+use Mockery\Matcher\Type;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
@@ -405,6 +406,7 @@ class DatabaseEloquentModelTest extends TestCase
         $events->shouldReceive('until')->once()->with('eloquent.creating: '.get_class($model), $model)->andReturn(true);
         $events->shouldReceive('fire')->once()->with('eloquent.created: '.get_class($model), $model);
         $events->shouldReceive('fire')->once()->with('eloquent.saved: '.get_class($model), $model);
+        $events->shouldReceive('fire')->once()->with('eloquent.constructed: '.get_class($model), new Type(get_class($model)));
 
         $model->name = 'taylor';
         $model->exists = false;
@@ -1173,6 +1175,7 @@ class DatabaseEloquentModelTest extends TestCase
     public function testModelObserversCanBeAttachedToModels()
     {
         EloquentModelStub::setEventDispatcher($events = m::mock('Illuminate\Contracts\Events\Dispatcher'));
+        $events->shouldReceive('fire')->times(2)->with('eloquent.constructed: Illuminate\Tests\Database\EloquentModelStub', new Type(EloquentModelStub::class));
         $events->shouldReceive('listen')->once()->with('eloquent.creating: Illuminate\Tests\Database\EloquentModelStub', 'Illuminate\Tests\Database\EloquentTestObserverStub@creating');
         $events->shouldReceive('listen')->once()->with('eloquent.saved: Illuminate\Tests\Database\EloquentModelStub', 'Illuminate\Tests\Database\EloquentTestObserverStub@saved');
         $events->shouldReceive('forget');
@@ -1183,6 +1186,7 @@ class DatabaseEloquentModelTest extends TestCase
     public function testModelObserversCanBeAttachedToModelsWithString()
     {
         EloquentModelStub::setEventDispatcher($events = m::mock('Illuminate\Contracts\Events\Dispatcher'));
+        $events->shouldReceive('fire')->times(2)->with('eloquent.constructed: Illuminate\Tests\Database\EloquentModelStub', new Type(EloquentModelStub::class));
         $events->shouldReceive('listen')->once()->with('eloquent.creating: Illuminate\Tests\Database\EloquentModelStub', 'Illuminate\Tests\Database\EloquentTestObserverStub@creating');
         $events->shouldReceive('listen')->once()->with('eloquent.saved: Illuminate\Tests\Database\EloquentModelStub', 'Illuminate\Tests\Database\EloquentTestObserverStub@saved');
         $events->shouldReceive('forget');


### PR DESCRIPTION
The purpose of this PR is to make it more convenient to make attributes visible/hidden/append in subclasses or traits.

For example, we have a `User` model with `protected $appends = ['full_name']`, and there is a subclass named `Student` which extends the `User` model, we need `Student` to have `protected $appends = ['full_name', 'last_lesson']`, if we hard code the `$appends` attribute in `Student` class and one day we add one more append `birthday` to the `User` class, we have to add that to `Student::$appends` too. It's a nightmare if we have many subclasses or we change the `User::$appends` frequently.

With this PR, we can override the `boot` method in `Student` like this

```
protected function boot() {
    parent::boot();
    static::registerModelEvent('constructed', function($model) {
        $model->append('last_lesson');
    });
}
```
