### PR TITLE
[5.4] Enable verbose mode for queue:work

### DIFF
--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -9,6 +9,7 @@ use Illuminate\Contracts\Queue\Job;
 use Illuminate\Queue\WorkerOptions;
 use Illuminate\Queue\Events\JobFailed;
 use Illuminate\Queue\Events\JobProcessed;
+use Symfony\Component\Console\Output\OutputInterface;
 
 class WorkCommand extends Command
 {
@@ -75,10 +76,14 @@ class WorkCommand extends Command
         $connection = $this->argument('connection')
                         ?: $this->laravel['config']['queue.default'];
 
+        $this->output->writeln("Using connection: {$connection}", OutputInterface::VERBOSITY_VERBOSE);
+
         // We need to get the right queue for the connection which is set in the queue
         // configuration file for the application. We will pull it based on the set
         // connection being run for the queue operation currently being executed.
         $queue = $this->getQueue($connection);
+
+        $this->output->writeln("Using queue: {$queue}", OutputInterface::VERBOSITY_VERBOSE);
 
         $this->runWorker(
             $connection, $queue
@@ -95,6 +100,7 @@ class WorkCommand extends Command
     protected function runWorker($connection, $queue)
     {
         $this->worker->setCache($this->laravel['cache']->driver());
+        $this->worker->setOutput($this->output);
 
         return $this->worker->{$this->option('once') ? 'runNextJob' : 'daemon'}(
             $connection, $queue, $this->gatherWorkerOptions()

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -260,7 +260,7 @@ class Worker
             foreach (explode(',', $queue) as $queue) {
                 if (! is_null($job = $connection->pop($queue))) {
                     $preview = str_limit(json_encode($job->payload(), 256));
-                    $this->output->writeln('Successfully fetched a job:' . PHP_EOL . $preview . PHP_EOL, OutputInterface::VERBOSITY_VERY_VERBOSE);
+                    $this->output->writeln('Successfully fetched a job:'.PHP_EOL.$preview.PHP_EOL, OutputInterface::VERBOSITY_VERY_VERBOSE);
 
                     return $job;
                 }
@@ -270,7 +270,7 @@ class Worker
         } catch (Exception $e) {
             $this->exceptions->report($e);
             $message = str_limit($e->getMessage(), 256);
-            $this->output->writeln('Error fetching a job:' . PHP_EOL . $message . PHP_EOL, OutputInterface::VERBOSITY_VERBOSE);
+            $this->output->writeln('Error fetching a job:'.PHP_EOL.$message.PHP_EOL, OutputInterface::VERBOSITY_VERBOSE);
         } catch (Throwable $e) {
             $this->exceptions->report(new FatalThrowableError($e));
         }

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -3,12 +3,12 @@
 namespace Illuminate\Queue;
 
 use Exception;
-use Symfony\Component\Console\Output\NullOutput;
-use Symfony\Component\Console\Output\OutputInterface;
 use Throwable;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Symfony\Component\Debug\Exception\FatalThrowableError;
+use Symfony\Component\Console\Output\NullOutput;
+use Symfony\Component\Console\Output\OutputInterface;
 use Illuminate\Contracts\Cache\Repository as CacheContract;
 
 class Worker
@@ -241,6 +241,8 @@ class Worker
         if ($job) {
             return $this->runJob($job, $connectionName, $options);
         }
+
+        $this->sleep($options->sleep);
     }
 
     /**

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -6,9 +6,9 @@ use Exception;
 use Throwable;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Debug\ExceptionHandler;
-use Symfony\Component\Debug\Exception\FatalThrowableError;
 use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Debug\Exception\FatalThrowableError;
 use Illuminate\Contracts\Cache\Repository as CacheContract;
 
 class Worker
@@ -260,7 +260,8 @@ class Worker
             foreach (explode(',', $queue) as $queue) {
                 if (! is_null($job = $connection->pop($queue))) {
                     $preview = str_limit(json_encode($job->payload(), 256));
-                    $this->output->writeln("Successfully fetched a job:\n{$preview}\n", OutputInterface::VERBOSITY_VERY_VERBOSE);
+                    $this->output->writeln('Successfully fetched a job:' . PHP_EOL . $preview . PHP_EOL, OutputInterface::VERBOSITY_VERY_VERBOSE);
+
                     return $job;
                 }
 
@@ -269,7 +270,7 @@ class Worker
         } catch (Exception $e) {
             $this->exceptions->report($e);
             $message = str_limit($e->getMessage(), 256);
-            $this->output->writeln("Error fetching a job:\n{$message}\n", OutputInterface::VERBOSITY_VERBOSE);
+            $this->output->writeln('Error fetching a job:' . PHP_EOL . $message . PHP_EOL, OutputInterface::VERBOSITY_VERBOSE);
         } catch (Throwable $e) {
             $this->exceptions->report(new FatalThrowableError($e));
         }

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -77,7 +77,7 @@ class QueueWorkerTest extends TestCase
         $this->exceptionHandler->shouldHaveReceived('report')->with($e);
     }
 
-    public function test_worker_does_sleep_when_queue_is_empty()
+    public function test_worker_sleeps_when_queue_is_empty()
     {
         $worker = $this->getWorker('default', ['queue' => []]);
         $worker->runNextJob('default', 'queue', $this->workerOptions(['sleep' => 5]));

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -77,11 +77,11 @@ class QueueWorkerTest extends TestCase
         $this->exceptionHandler->shouldHaveReceived('report')->with($e);
     }
 
-    public function test_worker_doesnt_sleep_when_queue_is_empty_in_once_mode()
+    public function test_worker_does_sleep_when_queue_is_empty()
     {
         $worker = $this->getWorker('default', ['queue' => []]);
         $worker->runNextJob('default', 'queue', $this->workerOptions(['sleep' => 5]));
-        $this->assertEquals(0, $worker->sleptFor);
+        $this->assertEquals(5, $worker->sleptFor);
     }
 
     public function test_job_is_released_on_exception()

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -77,11 +77,11 @@ class QueueWorkerTest extends TestCase
         $this->exceptionHandler->shouldHaveReceived('report')->with($e);
     }
 
-    public function test_worker_sleeps_when_queue_is_empty()
+    public function test_worker_doesnt_sleep_when_queue_is_empty_in_once_mode()
     {
         $worker = $this->getWorker('default', ['queue' => []]);
         $worker->runNextJob('default', 'queue', $this->workerOptions(['sleep' => 5]));
-        $this->assertEquals(5, $worker->sleptFor);
+        $this->assertEquals(0, $worker->sleptFor);
     }
 
     public function test_job_is_released_on_exception()


### PR DESCRIPTION
For months it bugged me that neither of the console verbose flags (-v/-vv/-vvv) work with queue:work command. As a result, developer has no idea 1) what queue is being used at the moment 2) does the queue actually work 3) did the application fetch a job off the queue or not 4) what's happening at any stage.

I've added some basic output, eg.:
Using connection: sqs
Using queue: XXX
Running worker in daemon mode
Trying to fetch a job...
The queue is empty
Sleeping for 3 seconds