### PR TITLE
[5.4] Updated Collection get method to use Arr helper class

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -518,11 +518,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      */
     public function get($key, $default = null)
     {
-        if ($this->offsetExists($key)) {
-            return $this->items[$key];
-        }
-
-        return value($default);
+        return Arr::get($this->items, $key, $default);
     }
 
     /**


### PR DESCRIPTION
This is to fix the issue outlined in issue #18589.