### PR TITLE
[5.4] Storing SparkPost Transmission-ID in the headers after sending

### DIFF
--- a/src/Illuminate/Mail/Transport/SparkPostTransport.php
+++ b/src/Illuminate/Mail/Transport/SparkPostTransport.php
@@ -54,7 +54,7 @@ class SparkPostTransport extends Transport
 
         $message->setBcc([]);
 
-        $this->client->post('https://api.sparkpost.com/api/v1/transmissions', [
+        $response = $this->client->post('https://api.sparkpost.com/api/v1/transmissions', [
             'headers' => [
                 'Authorization' => $this->key,
             ],
@@ -65,6 +65,8 @@ class SparkPostTransport extends Transport
                 ],
             ], $this->options),
         ]);
+
+        $message->getHeaders()->addTextHeader('X-SparkPost-Transmission-ID', $this->getTransmissionId($response));
 
         $this->sendPerformed($message);
 
@@ -96,6 +98,19 @@ class SparkPostTransport extends Transport
         }
 
         return $recipients;
+    }
+
+    /**
+     * Get the transmission ID from the response.
+     *
+     * @param \GuzzleHttp\Psr7\Response $response
+     * @return string
+     */
+    protected function getTransmissionId($response)
+    {
+        $result = json_decode($response->getBody()->getContents());
+
+        return object_get($result, 'results.id');
     }
 
     /**


### PR DESCRIPTION
Issue https://github.com/laravel/framework/issues/18581 - this update stores the transmission ID from SparkPost into the X-SparkPost-Transmission-ID header so that sendPerformed() can reference it. Just like this previous PR https://github.com/laravel/framework/pull/16366 did for Amazon SES.