### PR TITLE
[5.4] Adds the `runningInConsole` method to the Foundation Application Contract

### DIFF
--- a/src/Illuminate/Contracts/Foundation/Application.php
+++ b/src/Illuminate/Contracts/Foundation/Application.php
@@ -28,6 +28,13 @@ interface Application extends Container
     public function environment();
 
     /**
+     * Determine if we are running in the console.
+     *
+     * @return bool
+     */
+    public function runningInConsole();
+
+    /**
      * Determine if the application is currently down for maintenance.
      *
      * @return bool

--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -9,7 +9,7 @@ abstract class ServiceProvider
     /**
      * The application instance.
      *
-     * @var \Illuminate\Foundation\Application
+     * @var \Illuminate\Contracts\Foundation\Application
      */
     protected $app;
 
@@ -37,7 +37,7 @@ abstract class ServiceProvider
     /**
      * Create a new service provider instance.
      *
-     * @param  \Illuminate\Foundation\Application  $app
+     * @param  \Illuminate\Contracts\Foundation\Application  $app
      * @return void
      */
     public function __construct($app)


### PR DESCRIPTION
This reverts the changes in #18248 in favour of adding the missing method to the foundation application contract. 

Since the `illuminate\support` dependency does not provide the `Illuminate/Foundation/Application` implementation, but does provide the `Illuminate/Contracts/Foundation/Application`, it makes more sense to add the missing `runningInConsole` method to the interface.