### PR TITLE
[5.4] Preserve route parameters name

### DIFF
--- a/src/Illuminate/Routing/RouteDependencyResolverTrait.php
+++ b/src/Illuminate/Routing/RouteDependencyResolverTrait.php
@@ -51,9 +51,9 @@ trait RouteDependencyResolverTrait
             if (! is_null($instance)) {
                 $instanceCount++;
 
-                $results[] = $instance;
+                $results[$parameter->getName()] = $instance;
             } else {
-                $results[] = isset($values[$key - $instanceCount])
+                $results[$parameter->getName()] = isset($values[$key - $instanceCount])
                     ? $values[$key - $instanceCount] : $parameter->getDefaultValue();
             }
         }


### PR DESCRIPTION
As reported in: https://github.com/laravel/framework/issues/18593

This PR ensures that the parameter keys are preserved so that if you override `Illuminate\Routing\Controller@callAction` in your controller the `$parameters` is an associative array,

```
public function callAction($method, $parameters)
{
    return call_user_func_array([$this, $method], $parameters);
}
```

This behaviour was broken in https://github.com/laravel/framework/pull/17973, this PR should get back the original behaviour.