### PR TITLE
[5.4] call a finished() method on a queued job after it is handled or failed

### DIFF
--- a/src/Illuminate/Queue/CallQueuedHandler.php
+++ b/src/Illuminate/Queue/CallQueuedHandler.php
@@ -98,4 +98,19 @@ class CallQueuedHandler
             $command->failed($e);
         }
     }
+
+    /**
+     * Call the finished method on the job instance.
+     *
+     * @param  array  $data
+     * @return void
+     */
+    public function finished(array $data)
+    {
+        $command = unserialize($data['command']);
+
+        if (method_exists($command, 'finished')) {
+            $command->finished();
+        }
+    }
 }

--- a/src/Illuminate/Queue/FailingJob.php
+++ b/src/Illuminate/Queue/FailingJob.php
@@ -31,6 +31,8 @@ class FailingJob
             $job->delete();
 
             $job->failed($e);
+
+            $job->finished();
         } finally {
             static::events()->fire(new JobFailed(
                 $connectionName, $job, $e ?: new ManuallyFailedException

--- a/src/Illuminate/Queue/Jobs/Job.php
+++ b/src/Illuminate/Queue/Jobs/Job.php
@@ -160,6 +160,22 @@ abstract class Job
     }
 
     /**
+     * Signal that the job is finished.
+     *
+     * @return void
+     */
+    public function finished()
+    {
+        $payload = $this->payload();
+
+        list($class, $method) = JobName::parse($payload['job']);
+
+        if (method_exists($this->instance = $this->resolve($class), 'finished')) {
+            $this->instance->finished($payload['data']);
+        }
+    }
+
+    /**
      * Resolve the given class.
      *
      * @param  string  $class

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -291,6 +291,8 @@ class Worker
             $job->fire();
 
             $this->raiseAfterJobEvent($connectionName, $job);
+
+            $job->finished();
         } catch (Exception $e) {
             $this->handleJobException($connectionName, $job, $options, $e);
         } catch (Throwable $e) {

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -256,6 +256,7 @@ class WorkerFakeJob
     public $fired = false;
     public $callback;
     public $deleted = false;
+    public $finished = false;
     public $releaseAfter;
     public $maxTries;
     public $attempts = 0;
@@ -312,6 +313,11 @@ class WorkerFakeJob
     public function failed($e)
     {
         $this->failedWith = $e;
+    }
+
+    public function finished()
+    {
+        $this->finished = true;
     }
 
     public function setConnectionName($name)


### PR DESCRIPTION
This PR adds the functionality of defining a `finished()` method on a queued job that'll be called after the job finishes processing or after failing.