### PR TITLE
[5.4] add ability to create nested model controllers

### DIFF
--- a/src/Illuminate/Routing/Console/ControllerMakeCommand.php
+++ b/src/Illuminate/Routing/Console/ControllerMakeCommand.php
@@ -37,7 +37,9 @@ class ControllerMakeCommand extends GeneratorCommand
      */
     protected function getStub()
     {
-        if ($this->option('model')) {
+        if ($this->option('parent')) {
+            return __DIR__.'/stubs/controller.nested.stub';
+        } elseif ($this->option('model')) {
             return __DIR__.'/stubs/controller.model.stub';
         } elseif ($this->option('resource')) {
             return __DIR__.'/stubs/controller.stub';
@@ -71,6 +73,22 @@ class ControllerMakeCommand extends GeneratorCommand
 
         $replace = [];
 
+        if ($this->option('parent')) {
+            $parentModelClass = $this->parseModel($this->option('parent'));
+
+            if (! class_exists($parentModelClass)) {
+                if ($this->confirm("A {$parentModelClass} model does not exist. Do you want to generate it?", true)) {
+                    $this->call('make:model', ['name' => $parentModelClass]);
+                }
+            }
+
+            $replace = [
+                'ParentDummyFullModelClass' => $parentModelClass,
+                'ParentDummyModelClass' => class_basename($parentModelClass),
+                'ParentDummyModelVariable' => lcfirst(class_basename($parentModelClass)),
+            ];
+        }
+
         if ($this->option('model')) {
             $modelClass = $this->parseModel($this->option('model'));
 
@@ -80,11 +98,11 @@ class ControllerMakeCommand extends GeneratorCommand
                 }
             }
 
-            $replace = [
+            $replace = array_merge($replace, [
                 'DummyFullModelClass' => $modelClass,
                 'DummyModelClass' => class_basename($modelClass),
                 'DummyModelVariable' => lcfirst(class_basename($modelClass)),
-            ];
+            ]);
         }
 
         $replace["use {$controllerNamespace}\Controller;\n"] = '';
@@ -126,6 +144,8 @@ class ControllerMakeCommand extends GeneratorCommand
             ['model', 'm', InputOption::VALUE_OPTIONAL, 'Generate a resource controller for the given model.'],
 
             ['resource', 'r', InputOption::VALUE_NONE, 'Generate a resource controller class.'],
+
+            ['parent', 'p', InputOption::VALUE_OPTIONAL, 'Generate a nested resource controller class.'],
         ];
     }
 }

--- a/src/Illuminate/Routing/Console/stubs/controller.nested.stub
+++ b/src/Illuminate/Routing/Console/stubs/controller.nested.stub
@@ -1,0 +1,94 @@
+<?php
+
+namespace DummyNamespace;
+
+use DummyFullModelClass;
+use Illuminate\Http\Request;
+use ParentDummyFullModelClass;
+use DummyRootNamespaceHttp\Controllers\Controller;
+
+class DummyClass extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     *
+     * @param  \ParentDummyFullModelClass  $ParentDummyModelVariable
+     * @return \Illuminate\Http\Response
+     */
+    public function index(ParentDummyModelClass $ParentDummyModelVariable)
+    {
+        //
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     *
+     * @param  \ParentDummyFullModelClass  $ParentDummyModelVariable
+     * @return \Illuminate\Http\Response
+     */
+    public function create(ParentDummyModelClass $ParentDummyModelVariable)
+    {
+        //
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \ParentDummyFullModelClass  $ParentDummyModelVariable
+     * @return \Illuminate\Http\Response
+     */
+    public function store(Request $request, ParentDummyModelClass $ParentDummyModelVariable)
+    {
+        //
+    }
+
+    /**
+     * Display the specified resource.
+     *
+     * @param  \ParentDummyFullModelClass  $ParentDummyModelVariable
+     * @param  \DummyFullModelClass  $DummyModelVariable
+     * @return \Illuminate\Http\Response
+     */
+    public function show(ParentDummyModelClass $ParentDummyModelVariable, DummyModelClass $DummyModelVariable)
+    {
+        //
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     *
+     * @param  \ParentDummyFullModelClass  $ParentDummyModelVariable
+     * @param  \DummyFullModelClass  $DummyModelVariable
+     * @return \Illuminate\Http\Response
+     */
+    public function edit(ParentDummyModelClass $ParentDummyModelVariable, DummyModelClass $DummyModelVariable)
+    {
+        //
+    }
+
+    /**
+     * Update the specified resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \ParentDummyFullModelClass  $ParentDummyModelVariable
+     * @param  \DummyFullModelClass  $DummyModelVariable
+     * @return \Illuminate\Http\Response
+     */
+    public function update(Request $request, ParentDummyModelClass $ParentDummyModelVariable, DummyModelClass $DummyModelVariable)
+    {
+        //
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     *
+     * @param  \ParentDummyFullModelClass  $ParentDummyModelVariable
+     * @param  \DummyFullModelClass  $DummyModelVariable
+     * @return \Illuminate\Http\Response
+     */
+    public function destroy(ParentDummyModelClass $ParentDummyModelVariable, DummyModelClass $DummyModelVariable)
+    {
+        //
+    }
+}


### PR DESCRIPTION
when we have polymorphic relationships, we often have nested routes and controllers. for example, we have the following models: `Client`, `Department`, `Document`.  `Client`s and `Department`s can have multiple `Document`s, so `Document`s are polymorphic to their owners.

In this situation we could have 2 controllers: `ClientDocumentController` and `DepartmentDocumentController` and the following routes:

```php
Route::resource('clients.documents', 'ClientDocumentController');
Route::resource('departments.documents', 'DepartmentDocumentController');
```

`make:controller` is great for generating single model resource controllers but doesn't help with these nested relationships. this PR adds the ability to quickly generate these nested controllers by passing a 'parent' flag with the command.

```php
art make:controller ClientDocumentController --resource=App/Document --parent=App/Client
```