### PR TITLE
[5.4] Add "range" method to collections

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -992,7 +992,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
             $start = 1;
         }
 
-        return new static(range($start, $end));
+        return static::make(range($start, $end));
     }
 
     /**

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -979,6 +979,23 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
+     * Create a new collection instance containing an incrementing range of values.
+     *
+     * @param  int  $start
+     * @param  int|null  $end
+     * @return mixed
+     */
+    public static function range($start, $end = null)
+    {
+        if ($end === null) {
+            $end = $start;
+            $start = 1;
+        }
+
+        return new static(range($start, $end));
+    }
+
+    /**
      * Reduce the collection to a single value.
      *
      * @param  callable  $callback

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -955,6 +955,16 @@ class SupportCollectionTest extends TestCase
         $this->assertTrue($negative->isEmpty());
     }
 
+    public function testRangeMethod()
+    {
+        $fullRange = Collection::range(1, 3);
+
+        $endRange = Collection::range(3);
+
+        $this->assertSame([1, 2, 3], $fullRange->all());
+        $this->assertSame([1, 2, 3], $endRange->all());
+    }
+
     public function testConstructMakeFromObject()
     {
         $object = new stdClass();
@@ -1957,16 +1967,6 @@ class SupportCollectionTest extends TestCase
         });
 
         $this->assertSame(['michael', 'tom', 'taylor'], $collection->toArray());
-    }
-
-    public function testRange()
-    {
-        $fullRange = Collection::range(1, 3);
-
-        $endRange = Collection::range(3);
-
-        $this->assertSame([1, 2, 3], $fullRange->all());
-        $this->assertSame([1, 2, 3], $endRange->all());
     }
 }
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1958,6 +1958,16 @@ class SupportCollectionTest extends TestCase
 
         $this->assertSame(['michael', 'tom', 'taylor'], $collection->toArray());
     }
+
+    public function testRange()
+    {
+        $fullRange = Collection::range(1, 3);
+
+        $endRange = Collection::range(3);
+
+        $this->assertSame([1, 2, 3], $fullRange->all());
+        $this->assertSame([1, 2, 3], $endRange->all());
+    }
 }
 
 class TestSupportCollectionHigherOrderItem


### PR DESCRIPTION
This came out of a recent conversation with Adam Wathan. This can be handy for initializing collections of a specific length and manipulating from there.

```php
$this->assertEquals(range(1, 5), Collection::range(5)->all()); // returns true
$this->assertEquals(range(1, 5), Collection::range(1, 5)->all()); // returns true
```