### PR TITLE
[5.4] Add "size" method for initializing collections

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1075,6 +1075,17 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
+     * Generate a collection instance with n number of null values.
+     *
+     * @param  int  $size
+     * @return mixed
+     */
+    public static function size($size)
+    {
+        return static::make(range(1, $size))->map(function () {});
+    }
+
+    /**
      * Slice the underlying collection array.
      *
      * @param  int  $offset

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -955,6 +955,16 @@ class SupportCollectionTest extends TestCase
         $this->assertTrue($negative->isEmpty());
     }
 
+    public function testSizeMethod()
+    {
+        $one = Collection::size(1);
+
+        $three = Collection::size(3);
+
+        $this->assertEquals([null], $one->all());
+        $this->assertEquals([null, null, null], $three->all());
+    }
+
     public function testConstructMakeFromObject()
     {
         $object = new stdClass();


### PR DESCRIPTION
Similar to #18608, this method can be used to initialize a collection of a specific length for further manipulation down the pipeline.

```php
$arrayOfFiveSomethings = Collection::size(5)->map(function () {
  return $something;
})
```