### PR TITLE
[5.5] Increase default max log files from 5 to 30

### DIFF
--- a/src/Illuminate/Log/LogServiceProvider.php
+++ b/src/Illuminate/Log/LogServiceProvider.php
@@ -146,7 +146,7 @@ class LogServiceProvider extends ServiceProvider
     protected function maxFiles()
     {
         if ($this->app->bound('config')) {
-            return $this->app->make('config')->get('app.log_max_files', 5);
+            return $this->app->make('config')->get('app.log_max_files', 30);
         }
 
         return 0;


### PR DESCRIPTION
5 days is really short. Keeping a bit more won't hurt.

Will avoid the following scenario:
– Client: Remember that bug from last week?
– Developer: Oh sh-