### PR TITLE
Prevent email and password being identical

### DIFF
--- a/src/Illuminate/Foundation/Auth/ResetsPasswords.php
+++ b/src/Illuminate/Foundation/Auth/ResetsPasswords.php
@@ -64,7 +64,7 @@ trait ResetsPasswords
         return [
             'token' => 'required',
             'email' => 'required|email',
-            'password' => 'required|confirmed|min:6',
+            'password' => 'required|min:6|confirmed|different:email',
         ];
     }
 


### PR DESCRIPTION
Don't allow users to reset their password to their email address. It's a fast check and raises awareness.

See https://github.com/laravel/laravel/pull/4200.