### PR TITLE
[5.4] Revert overly broad return type

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -253,7 +253,7 @@ class Builder
      *
      * @param  mixed  $id
      * @param  array  $columns
-     * @return mixed
+     * @return \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Collection|static[]|static|null
      */
     public function find($id, $columns = ['*'])
     {


### PR DESCRIPTION
## Problem

A recent commit tried to simplify a return type on a method in the Eloquent Builder. To be fair the return type doc block was fairly long. But it was specific.

This new simplification had the unintended consequence of breaking code completion in a number of IDE's/code editors. eg

```php
User::find(1)-><'unable to continue with easy code completion/chaining from here'>
```

## Proposal 
It would be helpful to developers if this simplification could be reverted to allow the previous functionality to be restored and improve workflow.

## Disadvantages
Just a longer line in a doc block. Approx an extra 94 characters. There is a possibility that the actual line could be simplified a little, but the current type of `mixed` is too generic to be useful.

Thank you.