### PR TITLE
[5.4] Add assertSuccessful(), tweak assertRedirect()

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -47,6 +47,21 @@ class TestResponse
     }
 
     /**
+     * Assert that the response has a successful status code.
+     *
+     * @return $this
+     */
+    public function assertSuccessful()
+    {
+        PHPUnit::assertTrue(
+            $this->isSuccessful(),
+            'Response status code ['.$this->getStatusCode().'] is not a successful status code.'
+        );
+
+        return $this;
+    }
+
+    /**
      * Assert that the response has the given status code.
      *
      * @param  int  $status
@@ -70,13 +85,15 @@ class TestResponse
      * @param  string  $uri
      * @return $this
      */
-    public function assertRedirect($uri)
+    public function assertRedirect($uri = null)
     {
         PHPUnit::assertTrue(
             $this->isRedirect(), 'Response status code ['.$this->getStatusCode().'] is not a redirect status code.'
         );
 
-        PHPUnit::assertEquals(app('url')->to($uri), $this->headers->get('Location'));
+        if (! is_null($uri)) {
+            PHPUnit::assertEquals(app('url')->to($uri), $this->headers->get('Location'));
+        }
 
         return $this;
     }


### PR DESCRIPTION
This adds `assertSuccessful()` which is similar to a helper that existed back in Laravel 5.3 and also makes a slight tweak to the functionality of `assertRedirect()` so it can be used more loosely.

`assertSuccessful()` just asserts that the status code is `2xx`, which is handy when you don't really care if the response is `OK`, `Created`, `No Content` etc.

`assertRedirect()`'s argument is now optional, and by calling it without an argument you simply assert that the response is a redirect, making no assertion on where it actually redirects to.