### PR TITLE
[5.5] Use coalesce instead of ternary operator

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -112,8 +112,7 @@ class Handler implements ExceptionHandlerContract
     {
         return array_filter([
             'userId' => Auth::id(),
-            'email' => Auth::check() && isset(Auth::user()->email)
-                        ? Auth::user()->email : null,
+            'email' => Auth::user()->email ?? null,
         ]);
     }
 


### PR DESCRIPTION
Since v5.5 is PHP7+, we can make this shorter.