### PR TITLE
[5.4] Revert breaking changes in ControllerDispatcher::resolveMethodDependencies

### DIFF
--- a/src/Illuminate/Routing/RouteDependencyResolverTrait.php
+++ b/src/Illuminate/Routing/RouteDependencyResolverTrait.php
@@ -37,28 +37,19 @@ trait RouteDependencyResolverTrait
      */
     public function resolveMethodDependencies(array $parameters, ReflectionFunctionAbstract $reflector)
     {
-        $results = [];
-
-        $instanceCount = 0;
-
-        $values = array_values($parameters);
-
         foreach ($reflector->getParameters() as $key => $parameter) {
             $instance = $this->transformDependency(
                 $parameter, $parameters
             );
 
             if (! is_null($instance)) {
-                $instanceCount++;
-
-                $results[$parameter->getName()] = $instance;
-            } else {
-                $results[$parameter->getName()] = isset($values[$key - $instanceCount])
-                    ? $values[$key - $instanceCount] : $parameter->getDefaultValue();
+                array_splice(
+                    $parameters, $key, 0, [$instance]
+                );
             }
         }
 
-        return $results;
+        return $parameters;
     }
 
     /**

--- a/tests/Routing/ControllerDispatcherTest.php
+++ b/tests/Routing/ControllerDispatcherTest.php
@@ -97,5 +97,4 @@ class ControllerDispatcherTest extends TestCase
         $expected = [];
         $this->assertEquals($expected, $actual);
     }
-
 }

--- a/tests/Routing/ControllerDispatcherTest.php
+++ b/tests/Routing/ControllerDispatcherTest.php
@@ -2,10 +2,10 @@
 
 namespace Illuminate\Tests\Routing;
 
-use Illuminate\Container\Container;
-use PHPUnit\Framework\TestCase;
-use Illuminate\Routing\ControllerDispatcher;
 use ReflectionMethod;
+use PHPUnit\Framework\TestCase;
+use Illuminate\Container\Container;
+use Illuminate\Routing\ControllerDispatcher;
 
 class ControllerDispatcherTest extends TestCase
 {
@@ -22,32 +22,34 @@ class ControllerDispatcherTest extends TestCase
         $this->controllerDispatcher = new ControllerDispatcher($container);
     }
 
-    public function targetResolveMethodDependenciesKeepKeys($first) {
+    public function targetResolveMethodDependenciesKeepKeys($first)
+    {
     }
 
     public function testResolveMethodDependenciesKeepKeys()
     {
         $parameters = [
-            'first' => 'first-value'
+            'first' => 'first-value',
         ];
         $target = new ReflectionMethod(self::class, 'targetResolveMethodDependenciesKeepKeys');
 
         $actual = $this->controllerDispatcher->resolveMethodDependencies($parameters, $target);
 
         $expected = [
-            'first' => 'first-value'
+            'first' => 'first-value',
         ];
         $this->assertEquals($expected, $actual);
     }
 
-    public function targetResolveMethodDependenciesKeepsOrderOfKeysAndValues($first, $second) {
+    public function targetResolveMethodDependenciesKeepsOrderOfKeysAndValues($first, $second)
+    {
     }
 
     public function testResolveMethodDependenciesKeepsOrderOfKeysAndValues()
     {
         $parameters = [
             'second' => 'second-value',
-            'first' => 'first-value'
+            'first' => 'first-value',
         ];
         $target = new ReflectionMethod(self::class, 'targetResolveMethodDependenciesKeepsOrderOfKeysAndValues');
 
@@ -55,19 +57,20 @@ class ControllerDispatcherTest extends TestCase
 
         $expected = [
             'second' => 'second-value',
-            'first' => 'first-value'
+            'first' => 'first-value',
         ];
         $this->assertEquals($expected, $actual);
     }
 
-    public function targetResolveMethodDependenciesKeepsUnknownKeys($first) {
+    public function targetResolveMethodDependenciesKeepsUnknownKeys($first)
+    {
     }
 
     public function testResolveMethodDependenciesKeepsUnknownKeys()
     {
         $parameters = [
             'first' => 'first-value',
-            'unknown' => 'unknown'
+            'unknown' => 'unknown',
         ];
         $target = new ReflectionMethod(self::class, 'targetResolveMethodDependenciesKeepsUnknownKeys');
 
@@ -75,12 +78,13 @@ class ControllerDispatcherTest extends TestCase
 
         $expected = [
             'first' => 'first-value',
-            'unknown' => 'unknown'
+            'unknown' => 'unknown',
         ];
         $this->assertEquals($expected, $actual);
     }
 
-    public function targetResolveMethodDependenciesDoesNotCrashOnMissingKeys($first) {
+    public function targetResolveMethodDependenciesDoesNotCrashOnMissingKeys($first)
+    {
     }
 
     public function testResolveMethodDependenciesDoesNotCrashOnMissingKeys()

--- a/tests/Routing/ControllerDispatcherTest.php
+++ b/tests/Routing/ControllerDispatcherTest.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Illuminate\Tests\Routing;
+
+use Illuminate\Container\Container;
+use PHPUnit\Framework\TestCase;
+use Illuminate\Routing\ControllerDispatcher;
+use ReflectionMethod;
+
+class ControllerDispatcherTest extends TestCase
+{
+    /**
+     * @var \Illuminate\Routing\ControllerDispatcher
+     */
+    protected $controllerDispatcher;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $container = new Container();
+        $this->controllerDispatcher = new ControllerDispatcher($container);
+    }
+
+    public function targetResolveMethodDependenciesKeepKeys($first) {
+    }
+
+    public function testResolveMethodDependenciesKeepKeys()
+    {
+        $parameters = [
+            'first' => 'first-value'
+        ];
+        $target = new ReflectionMethod(self::class, 'targetResolveMethodDependenciesKeepKeys');
+
+        $actual = $this->controllerDispatcher->resolveMethodDependencies($parameters, $target);
+
+        $expected = [
+            'first' => 'first-value'
+        ];
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function targetResolveMethodDependenciesKeepsOrderOfKeysAndValues($first, $second) {
+    }
+
+    public function testResolveMethodDependenciesKeepsOrderOfKeysAndValues()
+    {
+        $parameters = [
+            'second' => 'second-value',
+            'first' => 'first-value'
+        ];
+        $target = new ReflectionMethod(self::class, 'targetResolveMethodDependenciesKeepsOrderOfKeysAndValues');
+
+        $actual = $this->controllerDispatcher->resolveMethodDependencies($parameters, $target);
+
+        $expected = [
+            'second' => 'second-value',
+            'first' => 'first-value'
+        ];
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function targetResolveMethodDependenciesKeepsUnknownKeys($first) {
+    }
+
+    public function testResolveMethodDependenciesKeepsUnknownKeys()
+    {
+        $parameters = [
+            'first' => 'first-value',
+            'unknown' => 'unknown'
+        ];
+        $target = new ReflectionMethod(self::class, 'targetResolveMethodDependenciesKeepsUnknownKeys');
+
+        $actual = $this->controllerDispatcher->resolveMethodDependencies($parameters, $target);
+
+        $expected = [
+            'first' => 'first-value',
+            'unknown' => 'unknown'
+        ];
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function targetResolveMethodDependenciesDoesNotCrashOnMissingKeys($first) {
+    }
+
+    public function testResolveMethodDependenciesDoesNotCrashOnMissingKeys()
+    {
+        $parameters = [];
+        $target = new ReflectionMethod(self::class, 'targetResolveMethodDependenciesDoesNotCrashOnMissingKeys');
+
+        $actual = $this->controllerDispatcher->resolveMethodDependencies($parameters, $target);
+
+        $expected = [];
+        $this->assertEquals($expected, $actual);
+    }
+
+}

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -314,7 +314,10 @@ class RoutingRouteTest extends TestCase
         unset($_SERVER['__test.route_inject']);
         $router = $this->getRouter();
         $router->get('foo/{var}/{bar?}/{baz?}', function (stdClass $foo, $var, $bar = 'test', stdClass $baz = null) {
-            $_SERVER['__test.route_inject'] = func_get_args();
+            // We build the array manually to ensure that we get the actual values in the method,
+            // and not the values that were originally sent to us; func_get_args() will only return
+            // the original values sent to us, not what the method received, including default values.
+            $_SERVER['__test.route_inject'] = [$foo, $var, $bar, $baz];
 
             return 'hello';
         });
@@ -322,7 +325,7 @@ class RoutingRouteTest extends TestCase
         $this->assertInstanceOf('stdClass', $_SERVER['__test.route_inject'][0]);
         $this->assertEquals('bar', $_SERVER['__test.route_inject'][1]);
         $this->assertEquals('test', $_SERVER['__test.route_inject'][2]);
-        $this->assertInstanceOf('stdClass', $_SERVER['__test.route_inject'][3]);
+        $this->assertNull($_SERVER['__test.route_inject'][3]);
         $this->assertArrayHasKey(3, $_SERVER['__test.route_inject']);
         unset($_SERVER['__test.route_inject']);
     }


### PR DESCRIPTION
This fixes all known (so far) breaking changes mentioned in issue https://github.com/laravel/framework/issues/18593. It also includes tests for these cases to avoid a regression in the future.

It has one change of existing behavior back to the 5.4.12 ways; a certain type will only be resolved once. One test introduced with the breaking 5.4.13 changes, testClassesAndVariablesCanBeInjectedIntoRoutes, has to be updated to reflect this: In this case it still works because the second parameter of type stdClass also has a default value, and the default value is passed into the method instead.

I believe that this is the correct behavior based on a comment in [RouteDependencyResolverTrait::transformDependency][1] and the way that pre-5.4.13 ensured that a specific type was only resolved once.

> If the parameter has a type-hinted class, we will check to see if it is already in
> the list of parameters. If it is we will just skip it as it is probably a model
> binding and we do not want to mess with those; otherwise, we resolve it here.

Assuming I understand this change correctly; this only affects people that uses the same interface twice (or more) in the same action signature. The test now fails because it has two parameters of the same type, and no model binding involved. I believe the test to be odd and have updated it to verify the null value instead.

[1]: https://github.com/laravel/framework/blob/707f32d32dce58232f7a860e0a1d62caf6f9dbfc/src/Illuminate/Routing/RouteDependencyResolverTrait.php#L67-L69