### PR TITLE
[5.4] Bring back an old behaviour in resolving controller method dependencies

### DIFF
--- a/src/Illuminate/Routing/RouteDependencyResolverTrait.php
+++ b/src/Illuminate/Routing/RouteDependencyResolverTrait.php
@@ -37,8 +37,6 @@ trait RouteDependencyResolverTrait
      */
     public function resolveMethodDependencies(array $parameters, ReflectionFunctionAbstract $reflector)
     {
-        $results = [];
-
         $instanceCount = 0;
 
         $values = array_values($parameters);
@@ -49,16 +47,15 @@ trait RouteDependencyResolverTrait
             );
 
             if (! is_null($instance)) {
-                $instanceCount++;
+                $instanceCount ++;
 
-                $results[$parameter->getName()] = $instance;
-            } else {
-                $results[$parameter->getName()] = isset($values[$key - $instanceCount])
-                    ? $values[$key - $instanceCount] : $parameter->getDefaultValue();
+                $this->spliceIntoParameters($parameters, $key, $instance);
+            } elseif (! isset($values[$key - $instanceCount])) {
+                $this->spliceIntoParameters($parameters, $key, $parameter->getDefaultValue());
             }
         }
 
-        return $results;
+        return $parameters;
     }
 
     /**
@@ -92,5 +89,20 @@ trait RouteDependencyResolverTrait
         return ! is_null(Arr::first($parameters, function ($value) use ($class) {
             return $value instanceof $class;
         }));
+    }
+
+    /**
+     * Splice the given value into the parameter list.
+     *
+     * @param  array  $parameters
+     * @param  string  $offset
+     * @param  mixed  $value
+     * @return void
+     */
+    protected function spliceIntoParameters(array &$parameters, $offset, $value)
+    {
+        array_splice(
+            $parameters, $offset, 0, [$value]
+        );
     }
 }

--- a/src/Illuminate/Routing/RouteDependencyResolverTrait.php
+++ b/src/Illuminate/Routing/RouteDependencyResolverTrait.php
@@ -50,7 +50,8 @@ trait RouteDependencyResolverTrait
                 $instanceCount++;
 
                 $this->spliceIntoParameters($parameters, $key, $instance);
-            } elseif (! isset($values[$key - $instanceCount])) {
+            } elseif (! isset($values[$key - $instanceCount]) &&
+                      $parameter->isDefaultValueAvailable()) {
                 $this->spliceIntoParameters($parameters, $key, $parameter->getDefaultValue());
             }
         }

--- a/src/Illuminate/Routing/RouteDependencyResolverTrait.php
+++ b/src/Illuminate/Routing/RouteDependencyResolverTrait.php
@@ -47,7 +47,7 @@ trait RouteDependencyResolverTrait
             );
 
             if (! is_null($instance)) {
-                $instanceCount ++;
+                $instanceCount++;
 
                 $this->spliceIntoParameters($parameters, $key, $instance);
             } elseif (! isset($values[$key - $instanceCount])) {

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -313,7 +313,7 @@ class RoutingRouteTest extends TestCase
     {
         unset($_SERVER['__test.route_inject']);
         $router = $this->getRouter();
-        $router->get('foo/{var}/{bar?}/{baz?}', function (stdClass $foo, $var, $bar = 'test', stdClass $baz = null) {
+        $router->get('foo/{var}/{bar?}/{baz?}', function (stdClass $foo, $var, $bar = 'test') {
             $_SERVER['__test.route_inject'] = func_get_args();
 
             return 'hello';
@@ -322,7 +322,6 @@ class RoutingRouteTest extends TestCase
         $this->assertInstanceOf('stdClass', $_SERVER['__test.route_inject'][0]);
         $this->assertEquals('bar', $_SERVER['__test.route_inject'][1]);
         $this->assertEquals('test', $_SERVER['__test.route_inject'][2]);
-        $this->assertInstanceOf('stdClass', $_SERVER['__test.route_inject'][3]);
         $this->assertArrayHasKey(3, $_SERVER['__test.route_inject']);
         unset($_SERVER['__test.route_inject']);
     }

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -418,7 +418,8 @@ class RoutingRouteTest extends TestCase
         $this->assertEquals('foo', $router->dispatch(Request::create('foo', 'GET'))->getContent());
     }
 
-    public function testControllerCallActionMethodParameters(){
+    public function testControllerCallActionMethodParameters()
+    {
         $router = $this->getRouter();
 
         // Has one argument but receives two

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -442,8 +442,6 @@ class RoutingRouteTest extends TestCase
             'middleware' => SubstituteBindings::class,
             'uses' => 'Illuminate\Tests\Routing\RouteTestAnotherControllerWithParameterStub@withModels',
         ]);
-        $router->model('bar', 'Illuminate\Tests\Routing\RoutingTestUserModel');
-        $router->model('baz', 'Illuminate\Tests\Routing\RoutingTestTeamModel');
         $router->dispatch(Request::create($str.'/1', 'GET'));
 
         $values = array_values($_SERVER['__test.controller_callAction_parameters']);

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -440,7 +440,7 @@ class RoutingRouteTest extends TestCase
         unset($_SERVER['__test.controller_callAction_parameters']);
         $router->get(($str = str_random()).'/{user}/{defaultNull?}/{team?}', [
             'middleware' => SubstituteBindings::class,
-            'uses' => 'Illuminate\Tests\Routing\RouteTestAnotherControllerWithParameterStub@withModels'
+            'uses' => 'Illuminate\Tests\Routing\RouteTestAnotherControllerWithParameterStub@withModels',
         ]);
         $router->model('bar', 'Illuminate\Tests\Routing\RoutingTestUserModel');
         $router->model('baz', 'Illuminate\Tests\Routing\RoutingTestTeamModel');

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -322,7 +322,6 @@ class RoutingRouteTest extends TestCase
         $this->assertInstanceOf('stdClass', $_SERVER['__test.route_inject'][0]);
         $this->assertEquals('bar', $_SERVER['__test.route_inject'][1]);
         $this->assertEquals('test', $_SERVER['__test.route_inject'][2]);
-        $this->assertArrayHasKey(3, $_SERVER['__test.route_inject']);
         unset($_SERVER['__test.route_inject']);
     }
 


### PR DESCRIPTION
This PR will handle the breaking changes reported in https://github.com/laravel/framework/issues/18593 while keeping the fix in https://github.com/laravel/framework/pull/17973