### PR TITLE
[5.4] Allow disabling of specific middleware in tests

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -2,9 +2,9 @@
 
 namespace Illuminate\Foundation\Testing\Concerns;
 
-use Illuminate\Http\Testing\NullMiddleware;
 use Illuminate\Support\Str;
 use Illuminate\Http\Request;
+use Illuminate\Http\Testing\NullMiddleware;
 use Illuminate\Foundation\Testing\TestResponse;
 use Illuminate\Contracts\Http\Kernel as HttpKernel;
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;

--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Foundation\Testing\Concerns;
 
+use Illuminate\Http\Testing\NullMiddleware;
 use Illuminate\Support\Str;
 use Illuminate\Http\Request;
 use Illuminate\Foundation\Testing\TestResponse;
@@ -34,11 +35,20 @@ trait MakesHttpRequests
     /**
      * Disable middleware for the test.
      *
+     * @param  array  $middleware
      * @return $this
      */
-    public function withoutMiddleware()
+    public function withoutMiddleware(array $middleware = [])
     {
-        $this->app->instance('middleware.disable', true);
+        if (empty($middleware)) {
+            $this->app->instance('middleware.disable', true);
+
+            return $this;
+        }
+
+        foreach ($middleware as $abstract) {
+            $this->app->instance($abstract, new NullMiddleware);
+        }
 
         return $this;
     }

--- a/src/Illuminate/Http/Testing/NullMiddleware.php
+++ b/src/Illuminate/Http/Testing/NullMiddleware.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Illuminate\Http\Testing;
+
+use Closure;
+
+class NullMiddleware
+{
+    public function handle($request, Closure $next)
+    {
+        return $next($request);
+    }
+}


### PR DESCRIPTION
`withoutMiddleware` is useful in tests, however, because implicit bindings are resolved in middleware, disabling all middleware classes is not ideal (as mentioned in [this issue](https://github.com/laravel/internals/issues/506)). Therefore, this PR allows you to disable specific middleware classes.

```php
$this->withoutMiddleware([
    \Illuminate\Auth\Middleware\Authenticate::class,
    \App\Http\Middleware\VerifyCsrfToken::class,
]);
```

This shouldn't break backward compatibility, because if the array is empty then all middleware is disabled.

I attempted to write a test for this, however, the framework's test suite was a bit daunting for me. Is there anybody around that can help me write a test case for it?