### PR TITLE
[5.4] Added helper to check for any notification that should not be dispatched.

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MocksApplicationServices.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MocksApplicationServices.php
@@ -287,4 +287,40 @@ trait MocksApplicationServices
 
         return $this;
     }
+
+    /**
+     * Specify a list of notifications that should not be dispatched for the given operation.
+     *
+     * These notifications will be mocked, so that handlers will not actually be executed.
+     *
+     * @param  array|string  $notifications
+     * @return $this
+     */
+    protected function doesntExpectNotifications($notifications)
+    {
+        $notifications = is_array($notifications) ? $notifications : func_get_args();
+
+        $this->withoutNotifications();
+
+        $this->beforeApplicationDestroyed(function () use ($notifications) {
+            if ($dispatched = $this->getDispatchedNotifications($notifications)) {
+                throw new Exception(
+                    'These unexpected notifications were dispatched: ['.implode(', ', $dispatched).']'
+                );
+            }
+        });
+
+        return $this;
+    }
+
+    /**
+     * Filter the given notifications against the dispatched notifications.
+     *
+     * @param  array  $notifications
+     * @return array
+     */
+    protected function getDispatchedNotifications(array $notifications)
+    {
+        return $this->getDispatched($notifications, array_map('get_class', array_pluck($this->dispatchedNotifications, 'instance')));
+    }
 }


### PR DESCRIPTION
Hi there,

I've added an helper method to check if any notification is not dispatched. This was already the case  for events and jobs, but with this PR you'll get this check also for notifications.

Cheers!