### PR TITLE
[5.1] Return numeric from query builder sum

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1686,7 +1686,7 @@ class Builder
      * Retrieve the sum of the values of a given column.
      *
      * @param  string  $column
-     * @return mixed
+     * @return float|int
      */
     public function sum($column)
     {

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1690,7 +1690,7 @@ class Builder
      */
     public function sum($column)
     {
-        return $this->aggregate(__FUNCTION__, [$column]);
+        return $this->numericAggregate(__FUNCTION__, [$column]);
     }
 
     /**

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -883,7 +883,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase
             return $results;
         });
         $results = $builder->from('users')->sum('id');
-        $this->assertEquals(1, $results);
+        $this->assertSame(1, $results);
     }
 
     public function testSqlServerExists()


### PR DESCRIPTION
The `sum` function in the Query Builder should return a numeric value.

That is how it is on [5.4](https://github.com/laravel/framework/commit/17e336797c6669d64fa30132e32e017c8e4cda17).
And that is how it used to be on [5.1](https://github.com/laravel/framework/blob/092bea01c14f537d3097b4f2df3ddc339b11c29c/src/Illuminate/Database/Query/Builder.php#L1691) before it was [changed](https://github.com/laravel/framework/commit/73ee91b55ecc9f8cd027f983bb4b239cb4f2435d) (and [changed back](https://github.com/laravel/framework/commit/509bef6759766ce7c24d61df52171c89e9288fef), incorrectly)

This is related to issues #14793, and #14994