### PR TITLE
[5.4] PSR-2 fix

### DIFF
--- a/src/Illuminate/Foundation/Auth/AuthenticatesUsers.php
+++ b/src/Illuminate/Foundation/Auth/AuthenticatesUsers.php
@@ -72,7 +72,8 @@ trait AuthenticatesUsers
     protected function attemptLogin(Request $request)
     {
         return $this->guard()->attempt(
-            $this->credentials($request), $request->has('remember')
+            $this->credentials($request),
+            $request->has('remember')
         );
     }
 


### PR DESCRIPTION
only one argument is allowed per line in a multi-line function call