### PR TITLE
[5.4] Support for image_url property within Slack attachments

### DIFF
--- a/src/Illuminate/Notifications/Channels/SlackWebhookChannel.php
+++ b/src/Illuminate/Notifications/Channels/SlackWebhookChannel.php
@@ -89,6 +89,7 @@ class SlackWebhookChannel
                 'footer' => $attachment->footer,
                 'footer_icon' => $attachment->footerIcon,
                 'ts' => $attachment->timestamp,
+                'image_url' => $attachment->imageUrl,
             ]);
         })->all();
     }

--- a/src/Illuminate/Notifications/Messages/SlackAttachment.php
+++ b/src/Illuminate/Notifications/Messages/SlackAttachment.php
@@ -77,6 +77,13 @@ class SlackAttachment
     public $timestamp;
 
     /**
+     * The attachment's image url.
+     *
+     * @var string
+     */
+    public $imageUrl;
+
+    /**
      * Set the title of the attachment.
      *
      * @param  string  $title
@@ -215,6 +222,20 @@ class SlackAttachment
     public function timestamp(Carbon $timestamp)
     {
         $this->timestamp = $timestamp->getTimestamp();
+
+        return $this;
+    }
+
+    /**
+     * Set the image url.
+     *
+     * @param  string $url
+     *
+     * @return $this
+     */
+    public function imageUrl($url)
+    {
+        $this->imageUrl = $url;
 
         return $this;
     }


### PR DESCRIPTION
This pull request adds support for the image_url property of Slack attachments to show images as Slack attachments. 

As described here:

https://api.slack.com/docs/message-attachments#attachment_structure

