### PR TITLE
[5.4] Retrieve only validated inputs from FormRequest

### DIFF
--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -104,6 +104,16 @@ class FormRequest extends Request implements ValidatesWhenResolved
     }
 
     /**
+     * Get data that is validated by the form request rules.
+     *
+     * @return array
+     */
+    public function validatedInputs()
+    {
+        return $this->intersect(array_keys($this->rules()));
+    }
+
+    /**
      * Get data to be validated from the request.
      *
      * @return array

--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -110,7 +110,7 @@ class FormRequest extends Request implements ValidatesWhenResolved
      */
     public function validatedInputs()
     {
-        return $this->intersect(array_keys($this->rules()));
+        return $this->only(array_keys($this->rules()));
     }
 
     /**


### PR DESCRIPTION
This allows you to call `$this->validatedInputs()` on Form Request objects and only retrieve inputs that have rules associated with them, i.e. only validated rules.

Helps keep in check that you are validating all the input that goes into your models as well I find.

This is something I do in my form objects just to make things that little nicer. Thought it might be helpful to others....maybe?

Example:

in a `PostRequestForm` class set your rules as per normal:

```php
public function rules()
{
    return [
        'title' => 'required|string|max:30',
        'content' => 'required|string'
    ];
}
```

Then in your controller you can just call:

```php
public function store(PostRequestForm $form)
{
    Post::create($form->validatedInputs());
}
```

For pretty simple rules, this is great, but might not work so well for more complex rules such and open to suggestions for making it work well with these kind of rules.

```php
'users.*.email' => 'required|email'
```