### PR TITLE
[5.5] Allow disabling of specific middleware in tests

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -46,7 +46,8 @@ trait MakesHttpRequests
         }
 
         $nullMiddleware = new class {
-            public function handle($request, $next) {
+            public function handle($request, $next)
+            {
                 return $next($request);
             }
         };

--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Foundation\Testing\Concerns;
 
+use Illuminate\Http\Testing\NullMiddleware;
 use Illuminate\Support\Str;
 use Illuminate\Http\Request;
 use Illuminate\Foundation\Testing\TestResponse;
@@ -34,11 +35,26 @@ trait MakesHttpRequests
     /**
      * Disable middleware for the test.
      *
+     * @param  string|array  $middleware
      * @return $this
      */
-    public function withoutMiddleware()
+    public function withoutMiddleware($middleware = null)
     {
-        $this->app->instance('middleware.disable', true);
+        if (is_null($middleware)) {
+            $this->app->instance('middleware.disable', true);
+
+            return $this;
+        }
+
+        $nullMiddleware = new class {
+            public function handle($request, $next) {
+                return $next($request);
+            }
+        };
+
+        foreach ((array) $middleware as $abstract) {
+            $this->app->instance($abstract, $nullMiddleware);
+        }
 
         return $this;
     }

--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Foundation\Testing\Concerns;
 
-use Illuminate\Http\Testing\NullMiddleware;
 use Illuminate\Support\Str;
 use Illuminate\Http\Request;
 use Illuminate\Foundation\Testing\TestResponse;


### PR DESCRIPTION
`withoutMiddleware` is useful in tests, however, because implicit bindings are resolved in middleware, disabling all middleware classes is not ideal (as mentioned in [this issue](https://github.com/laravel/internals/issues/506)). Therefore, this PR allows you to disable specific middleware classes.

```php
$this->withoutMiddleware([
    \Illuminate\Auth\Middleware\Authenticate::class,
    \App\Http\Middleware\VerifyCsrfToken::class,
]);

$this->withoutMiddleware(ExampleMiddleware::class);
```