### PR TITLE
[5.4] Allow boolean keys for Collection::groupBy method

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -546,6 +546,10 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
             }
 
             foreach ($groupKeys as $groupKey) {
+                if (is_bool($groupKey)) {
+                    $groupKey = (int) $groupKey;
+                }
+
                 if (! array_key_exists($groupKey, $results)) {
                     $results[$groupKey] = new static;
                 }


### PR DESCRIPTION
The following PR adds support for boolean keys when used in ``groupBy`` method of ``\lluminate\Support\Collection``. Related to #18672 issue.