### PR TITLE
Add `$strict` to `has()` so a user can decide if they want it to chec…

### DIFF
--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -91,7 +91,7 @@ trait InteractsWithInput
         $keys = is_array($key) ? $key : func_get_args();
 
         foreach ($keys as $value) {
-            if ($this->isEmptyString($value) && !$strict) {
+            if ($this->isEmptyString($value) && ! $strict) {
                 return false;
             }
         }

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -80,17 +80,18 @@ trait InteractsWithInput
     }
 
     /**
-     * Determine if the request contains a non-empty value for an input item.
+     * Determine if the request contains a value for an input item.
      *
      * @param  string|array  $key
+     * @param  bool          $strict
      * @return bool
      */
-    public function has($key)
+    public function has($key, $strict = false)
     {
         $keys = is_array($key) ? $key : func_get_args();
 
         foreach ($keys as $value) {
-            if ($this->isEmptyString($value)) {
+            if ($this->isEmptyString($value) && !$strict) {
                 return false;
             }
         }

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -91,7 +91,7 @@ trait InteractsWithInput
         $keys = is_array($key) ? $key : func_get_args();
 
         foreach ($keys as $value) {
-            if ($this->isEmptyString($value) && ! $strict) {
+            if ($this->isEmptyString($value) && $strict === false) {
                 return false;
             }
         }


### PR DESCRIPTION
Add strict mode so a user can decide if they want to check for empty strings or not, sometimes you might want an empty string to deliberately set a value to null. Example: Someone updates a post with an empty description.