### PR TITLE
[5.4] Simplify new notifications channels creation and registration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
 /vendor
 composer.phar
 composer.lock
-.php_cs.cache
 .DS_Store
+.php_cs.cache
 Thumbs.db
 /phpunit.xml
+/.idea

--- a/src/Illuminate/Contracts/Notifications/Channels/Dispatcher.php
+++ b/src/Illuminate/Contracts/Notifications/Channels/Dispatcher.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Illuminate\Contracts\Notifications\Channels;
+
+use Illuminate\Notifications\Notification;
+
+interface Dispatcher
+{
+    /**
+     * Send the given notification.
+     *
+     * @param  $notifiable
+     * @param  \Illuminate\Notifications\Notification $notification
+     * @return mixed
+     */
+    public function send($notifiable, Notification $notification);
+}

--- a/src/Illuminate/Contracts/Notifications/Channels/Factory.php
+++ b/src/Illuminate/Contracts/Notifications/Channels/Factory.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Illuminate\Contracts\Notifications\Channels;
+
+interface Factory
+{
+    /**
+     * Check for the driver capacity.
+     *
+     * @param  string  $driver
+     * @return bool
+     */
+    public static function canHandleNotification($driver);
+
+    /**
+     * Create a new driver instance.
+     *
+     * @param  $driver
+     * @return \Illuminate\Contracts\Notifications\Channels\Dispatcher
+     */
+    public static function createDriver($driver);
+}

--- a/src/Illuminate/Foundation/Notifications/Channels/DefaultChannel.php
+++ b/src/Illuminate/Foundation/Notifications/Channels/DefaultChannel.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Illuminate\Foundation\Notifications\Channels;
+
+use Illuminate\Support\Str;
+use Illuminate\Notifications\Channels\MailChannel;
+use Illuminate\Notifications\Channels\NexmoSmsChannel;
+use Illuminate\Notifications\Channels\DatabaseChannel;
+use Illuminate\Notifications\Channels\BroadcastChannel;
+use Illuminate\Contracts\Notifications\Channels\Factory;
+use Illuminate\Notifications\Channels\SlackWebhookChannel;
+
+class DefaultChannel implements Factory
+{
+    /**
+     * Check for the driver capacity.
+     *
+     * @param  string $driver
+     * @return bool
+     */
+    public static function canHandleNotification($driver)
+    {
+        return in_array($driver, ['mail', 'nexmo', 'database', 'slack', 'broadcast']);
+    }
+
+    /**
+     * Create a new driver instance.
+     *
+     * @param  $driver
+     * @return \Illuminate\Contracts\Notifications\Channels\Dispatcher
+     */
+    public static function createDriver($driver)
+    {
+        if(! static::canHandleNotification($driver)) {
+            return null;
+        }
+
+        $method = 'create'.Str::studly($driver).'Driver';
+
+        if (method_exists($factory = new static, $method)) {
+            $channel = $factory->$method($driver);
+        }
+
+        return $channel ?: null;
+    }
+
+    /**
+     * Create an instance of the database driver.
+     *
+     * @param  $driver
+     * @return \Illuminate\Contracts\Notifications\Channels\Dispatcher
+     */
+    protected function createDatabaseDriver($driver)
+    {
+        return DatabaseChannel::createDriver($driver);
+    }
+
+    /**
+     * Create an instance of the broadcast driver.
+     *
+     * @param  $driver
+     * @return \Illuminate\Contracts\Notifications\Channels\Dispatcher
+     */
+    protected function createBroadcastDriver($driver)
+    {
+        return BroadcastChannel::createDriver($driver);
+    }
+
+    /**
+     * Create an instance of the mail driver.
+     *
+     * @param  $driver
+     * @return \Illuminate\Contracts\Notifications\Channels\Dispatcher
+     */
+    protected function createMailDriver($driver)
+    {
+        return MailChannel::createDriver($driver);
+    }
+
+    /**
+     * Create an instance of the Nexmo driver.
+     *
+     * @param  $driver
+     * @return \Illuminate\Contracts\Notifications\Channels\Dispatcher
+     */
+    protected function createNexmoDriver($driver)
+    {
+        return NexmoSmsChannel::createDriver($driver);
+    }
+
+    /**
+     * Create an instance of the Slack driver.
+     *
+     * @param  $driver
+     * @return \Illuminate\Contracts\Notifications\Channels\Dispatcher
+     */
+    protected function createSlackDriver($driver)
+    {
+        return SlackWebhookChannel::createDriver($driver);
+    }
+
+}

--- a/src/Illuminate/Foundation/Support/Notifications/NotificationChannel.php
+++ b/src/Illuminate/Foundation/Support/Notifications/NotificationChannel.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Illuminate\Foundation\Support\Notifications;
+
+use Illuminate\Contracts\Notifications\Channels\Dispatcher;
+use Illuminate\Contracts\Notifications\Channels\Factory;
+
+/**
+ * Class NotificationChannel
+ */
+abstract class NotificationChannel implements Factory, Dispatcher {}

--- a/src/Illuminate/Foundation/Support/Providers/AppServiceProvider.php
+++ b/src/Illuminate/Foundation/Support/Providers/AppServiceProvider.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Illuminate\Foundation\Support\Providers;
+
+use Illuminate\Notifications\ChannelManager;
+use Illuminate\Support\ServiceProvider;
+
+class AppServiceProvider extends ServiceProvider
+{
+    /**
+     * Notifications channels list.
+     *
+     * @var array
+     */
+    protected $notificationsChannels = [];
+
+    /**
+     * Boot the application services.
+     *
+     * @return void
+     */
+    public function boot()
+    {
+        $this->registerNotificationsChannels();
+    }
+
+    /**
+     * Register Notifications channels.
+     *
+     * @return void
+     */
+    public function registerNotificationsChannels()
+    {
+        if(empty($this->notificationsChannels))
+            return;
+
+        $manager = $this->app->make(ChannelManager::class);
+
+        foreach ($this->notificationsChannels as $channel) {
+            if (class_exists($channel)) {
+                $manager->register($channel);
+            }
+        }
+    }
+}

--- a/src/Illuminate/Notifications/Channels/BroadcastChannel.php
+++ b/src/Illuminate/Notifications/Channels/BroadcastChannel.php
@@ -3,12 +3,15 @@
 namespace Illuminate\Notifications\Channels;
 
 use RuntimeException;
+use Illuminate\Container\Container;
 use Illuminate\Notifications\Notification;
-use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Notifications\Messages\BroadcastMessage;
+use Illuminate\Contracts\Notifications\Channels\Factory;
+use Illuminate\Contracts\Notifications\Channels\Dispatcher;
+use Illuminate\Contracts\Events\Dispatcher as EventDispatcher;
 use Illuminate\Notifications\Events\BroadcastNotificationCreated;
 
-class BroadcastChannel
+class BroadcastChannel implements Factory, Dispatcher
 {
     /**
      * The event dispatcher.
@@ -23,7 +26,7 @@ class BroadcastChannel
      * @param  \Illuminate\Contracts\Events\Dispatcher  $events
      * @return void
      */
-    public function __construct(Dispatcher $events)
+    public function __construct(EventDispatcher $events)
     {
         $this->events = $events;
     }
@@ -73,5 +76,29 @@ class BroadcastChannel
         throw new RuntimeException(
             'Notification is missing toArray method.'
         );
+    }
+
+    /**
+     * Check for the driver capacity.
+     *
+     * @param  string  $driver
+     * @return bool
+     */
+    public static function canHandleNotification($driver)
+    {
+        return in_array($driver, ['broadcast']);
+    }
+
+    /**
+     * Create a new driver instance.
+     *
+     * @param  $driver
+     * @return \Illuminate\Contracts\Notifications\Channels\Dispatcher
+     */
+    public static function createDriver($driver)
+    {
+        return static::canHandleNotification($driver)
+            ? Container::getInstance()->make(BroadcastChannel::class)
+            : null;
     }
 }

--- a/src/Illuminate/Notifications/Channels/DatabaseChannel.php
+++ b/src/Illuminate/Notifications/Channels/DatabaseChannel.php
@@ -3,9 +3,12 @@
 namespace Illuminate\Notifications\Channels;
 
 use RuntimeException;
+use Illuminate\Container\Container;
 use Illuminate\Notifications\Notification;
+use Illuminate\Contracts\Notifications\Channels\Factory;
+use Illuminate\Contracts\Notifications\Channels\Dispatcher;
 
-class DatabaseChannel
+class DatabaseChannel implements Factory, Dispatcher
 {
     /**
      * Send the given notification.
@@ -47,5 +50,29 @@ class DatabaseChannel
         throw new RuntimeException(
             'Notification is missing toDatabase / toArray method.'
         );
+    }
+
+    /**
+     * Check for the driver capacity.
+     *
+     * @param  string  $driver
+     * @return bool
+     */
+    public static function canHandleNotification($driver)
+    {
+        return in_array($driver, ['database']);
+    }
+
+    /**
+     * Create a new driver instance.
+     *
+     * @param  $driver
+     * @return \Illuminate\Contracts\Notifications\Channels\Dispatcher
+     */
+    public static function createDriver($driver)
+    {
+        return static::canHandleNotification($driver)
+            ? Container::getInstance()->make(DatabaseChannel::class)
+            : null;
     }
 }

--- a/src/Illuminate/Notifications/Channels/SlackWebhookChannel.php
+++ b/src/Illuminate/Notifications/Channels/SlackWebhookChannel.php
@@ -6,9 +6,11 @@ use GuzzleHttp\Client as HttpClient;
 use Illuminate\Notifications\Notification;
 use Illuminate\Notifications\Messages\SlackMessage;
 use Illuminate\Notifications\Messages\SlackAttachment;
+use Illuminate\Contracts\Notifications\Channels\Factory;
+use Illuminate\Contracts\Notifications\Channels\Dispatcher;
 use Illuminate\Notifications\Messages\SlackAttachmentField;
 
-class SlackWebhookChannel
+class SlackWebhookChannel implements Factory, Dispatcher
 {
     /**
      * The HTTP client instance.
@@ -108,5 +110,27 @@ class SlackWebhookChannel
 
             return ['title' => $key, 'value' => $value, 'short' => true];
         })->values()->all();
+    }
+
+    /**
+     * Check for the driver capacity.
+     *
+     * @param  string  $driver
+     * @return bool
+     */
+    public static function canHandleNotification($driver)
+    {
+        return in_array($driver, ['slack']);
+    }
+
+    /**
+     * Create a new driver instance.
+     *
+     * @param  $driver
+     * @return \Illuminate\Contracts\Notifications\Channels\Dispatcher
+     */
+    public static function createDriver($driver)
+    {
+        return static::canHandleNotification($driver) ? new static(new HttpClient) : null;
     }
 }

--- a/tests/Notifications/NotificationDefaultChannelTest.php
+++ b/tests/Notifications/NotificationDefaultChannelTest.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Nexmo;
+
+use Nexmo\Client\Credentials\Basic as NexmoCredentials;
+
+class Client { public function __construct(NexmoCredentials $credentials) {} }
+
+namespace Nexmo\Client\Credentials;
+
+class Basic { public function __construct($key, $secret) {} }
+
+namespace Illuminate\Tests\Notifications;
+
+use Mockery;
+use PHPUnit\Framework\TestCase;
+use Illuminate\Container\Container;
+use GuzzleHttp\Client as HttpClient;
+use Illuminate\Contracts\Mail\Mailer;
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Notifications\Channels\MailChannel;
+use Illuminate\Foundation\Notifications\Channels\DefaultChannel;
+
+class NotificationDefaultChannelTest extends TestCase
+{
+    public function tearDown()
+    {
+        Mockery::close();
+    }
+
+    public function testDefaultChannelCreateMailDriver()
+    {
+        $this->assertTrue(DefaultChannel::canHandleNotification('mail'));
+
+        $container = new Container;
+        $container->instance(Mailer::class, $mailer = Mockery::mock('Illuminate\Contracts\Mail\Mailer'));
+        $container->instance(MailChannel::class, $mailChannel = Mockery::spy($container->make(MailChannel::class)));
+        Container::setInstance($container);
+
+        $driver = DefaultChannel::createDriver('mail');
+        $mailChannel->shouldHaveReceived('setMarkdownResolver')->with(Mockery::type('Closure'));
+
+        $this->assertInstanceOf('\Illuminate\Notifications\Channels\MailChannel', $driver);
+        $this->assertInstanceOf('\Illuminate\Contracts\Notifications\Channels\Dispatcher', $driver);
+    }
+
+    public function testDefaultChannelCreateBroadcastDriver()
+    {
+        $this->assertTrue(DefaultChannel::canHandleNotification('broadcast'));
+
+        $container = new Container;
+        $container->instance(Dispatcher::class, $events = Mockery::mock('Illuminate\Contracts\Events\Dispatcher'));
+        Container::setInstance($container);
+        $driver = DefaultChannel::createDriver('broadcast');
+
+        $this->assertInstanceOf('\Illuminate\Notifications\Channels\BroadcastChannel', $driver);
+        $this->assertInstanceOf('\Illuminate\Contracts\Notifications\Channels\Dispatcher', $driver);
+    }
+
+    public function testDefaultChannelCreateDatabaseDriver()
+    {
+        $this->assertTrue(DefaultChannel::canHandleNotification('database'));
+
+        $driver = DefaultChannel::createDriver('database');
+
+        $this->assertInstanceOf('\Illuminate\Notifications\Channels\DatabaseChannel', $driver);
+        $this->assertInstanceOf('\Illuminate\Contracts\Notifications\Channels\Dispatcher', $driver);
+    }
+
+    public function testDefaultChannelCreateSlackDriver()
+    {
+        $this->assertTrue(DefaultChannel::canHandleNotification('slack'));
+
+        $container = new Container;
+        $container->instance(HttpClient::class, $http = Mockery::mock('GuzzleHttp\Client'));
+        Container::setInstance($container);
+
+        $driver = DefaultChannel::createDriver('slack');
+
+        $this->assertInstanceOf('\Illuminate\Notifications\Channels\SlackWebhookChannel', $driver);
+        $this->assertInstanceOf('\Illuminate\Contracts\Notifications\Channels\Dispatcher', $driver);
+    }
+
+    public function testDefaultChannelCreateNexmoDriver()
+    {
+        $this->assertTrue(DefaultChannel::canHandleNotification('nexmo'));
+
+        $container = new Container;
+        $container->instance('config', ['services.nexmo.key' => null, 'services.nexmo.secret' => null, 'services.nexmo.sms_from' => null]);
+        Container::setInstance($container);
+
+        $driver = DefaultChannel::createDriver('nexmo');
+
+        $this->assertInstanceOf('\Illuminate\Notifications\Channels\NexmoSmsChannel', $driver);
+        $this->assertInstanceOf('\Illuminate\Contracts\Notifications\Channels\Dispatcher', $driver);
+    }
+
+    public function testDefaultChannelDriverNotSuppported()
+    {
+        $this->assertFalse(DefaultChannel::canHandleNotification('notSupported'));
+        $this->assertNull(DefaultChannel::createDriver('notSupported'));
+    }
+}


### PR DESCRIPTION
What if creating an new notification channel Package for laravel is just a matter of implementing 3 methods from an abstract class ? like this :
```php
<?php

namespace App\Notifications\Channels;

use Illuminate\Foundation\Support\Notifications\NotificationChannel;

class SomeServiceChannel extends NotificationChannel
{
    /**
     * Send the given notification.
     *
     * @param  mixed  $notifiable
     * @param  \Illuminate\Notifications\Notification  $notification
     * @return mixed
     */
    public function send($notifiable, Notification $notification)
    {
        //
    }

    /**
     * Check for the driver capacity.
     *
     * @param  string  $driver
     * @return bool
     */
    public static function canHandleNotification($driver)
    {
        return in_array($driver, ['service_hook_name']);
    }

    /**
     * Create a new driver instance.
     *
     * @param  $driver
     * @return \Illuminate\Contracts\Notifications\Channels\Dispatcher
     */
    public static function createDriver($driver)
    {
        return static::canHandleNotification($driver) ? new static : null;
    }
}
```
and then simply declare your channel through `$notificationsChannels` property in the `AppServiceProvider`
 
```php
   /**
     * Notifications channels list.
     *
     * @var array
     */
    protected $notificationsChannels = [
        \Illuminate\Foundation\Notifications\Channels\DefaultChannel,
        \App\Notifications\Channels\SomeServiceChannel 
    ];
```
I find this easier to create and maintain, plus it allows you to only declared channels based on the need of your application, and the PR  is fully backward compatible.
