### PR TITLE
[5.1] Fix sum with no results

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1690,7 +1690,9 @@ class Builder
      */
     public function sum($column)
     {
-        return $this->aggregate(__FUNCTION__, [$column]);
+        $result = $this->aggregate(__FUNCTION__, [$column]);
+
+        return $result ?: 0;
     }
 
     /**


### PR DESCRIPTION
For ticket #14793, this code was removed to use the numericAggregate function. When it was reverted on ticket #14994 it only replaced sum with returning aggregate even though prior to the initial change this code checked result and returned 0 in case the result was null.

This is just reverting back to how the code was prior to being changed to use numericAggregate so that it will return 0 if there is no results returned.