### PR TITLE
[5.4] Add assertSeeText() and assertDontSeeText() to TestResponse

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -198,6 +198,19 @@ class TestResponse
     }
 
     /**
+     * Assert that the given string is contained within the response text.
+     *
+     * @param  string  $value
+     * @return $this
+     */
+    public function assertSeeText($value)
+    {
+        PHPUnit::assertContains($value, strip_tags($this->getContent()));
+
+        return $this;
+    }
+
+    /**
      * Assert that the given string is not contained within the response.
      *
      * @param  string  $value
@@ -206,6 +219,19 @@ class TestResponse
     public function assertDontSee($value)
     {
         PHPUnit::assertNotContains($value, $this->getContent());
+
+        return $this;
+    }
+
+    /**
+     * Assert that the given string is not contained within the response text.
+     *
+     * @param  string  $value
+     * @return $this
+     */
+    public function assertDontSeeText($value)
+    {
+        PHPUnit::assertNotContains($value, strip_tags($this->getContent()));
 
         return $this;
     }

--- a/tests/Foundation/FoundationTestResponseTest.php
+++ b/tests/Foundation/FoundationTestResponseTest.php
@@ -26,6 +26,19 @@ class FoundationTestResponseTest extends TestCase
         $response->assertViewHas('foo');
     }
 
+    public function testAssertSeeText()
+    {
+        $baseResponse = tap(new Response, function ($response) {
+            $response->setContent(\Mockery::mock(View::class, [
+                'render' => 'foo<strong>bar</strong>'
+            ]));
+        });
+
+        $response = TestResponse::fromBaseResponse($baseResponse);
+
+        $response->assertSeeText('foobar');
+    }
+
     public function testAssertJsonWithArray()
     {
         $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableSingleResourceStub));

--- a/tests/Foundation/FoundationTestResponseTest.php
+++ b/tests/Foundation/FoundationTestResponseTest.php
@@ -30,7 +30,7 @@ class FoundationTestResponseTest extends TestCase
     {
         $baseResponse = tap(new Response, function ($response) {
             $response->setContent(\Mockery::mock(View::class, [
-                'render' => 'foo<strong>bar</strong>'
+                'render' => 'foo<strong>bar</strong>',
             ]));
         });
 


### PR DESCRIPTION
This pull request adds two new assertions to the TestResponse class: `assertSeeText()` and `assertDontSeeText()`.

**Motivation**

These assertions are really helpful when asserting against HTML responses, as visual design of the page shouldn't make a test pass or fail. Given the following HTML:

```html
<strong>Views:</strong> 2
```

I would currently test this using the following assertion:

```php
$response->assertSee('<strong>Views:</strong> 2');
```

But whenever a designer thinks it would look better if it was also italic, or add some extra CSS classes, my test would break. All I really care about is that the views are shown on the page. The `assertSeeText()` assertion solves this issue:

```php
$response->assertSeeText('Views: 2');
```