### PR TITLE
[5.5] change how request only works and remove intersect

### DIFF
--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -148,7 +148,7 @@ trait InteractsWithInput
 
         $input = $this->all();
 
-        $placeholder = new stdClass();
+        $placeholder = new stdClass;
 
         foreach (is_array($keys) ? $keys : func_get_args() as $key) {
             $value = data_get($input, $key, $placeholder);

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -149,7 +149,7 @@ trait InteractsWithInput
 
         $input = $this->all();
 
-        $placeholder = '##'.str_random();
+        $placeholder = str_random();
 
         foreach ($keys as $key) {
             $value = data_get($input, $key, $placeholder);

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -145,7 +145,21 @@ trait InteractsWithInput
     {
         $keys = is_array($keys) ? $keys : func_get_args();
 
-        return array_intersect_key($this->all(), array_flip($keys));
+        $results = [];
+
+        $input = $this->all();
+
+        $placeholder = '##'.str_random();
+
+        foreach ($keys as $key) {
+            $value = data_get($input, $key, $placeholder);
+
+            if ($value != $placeholder) {
+                Arr::set($results, $key, $value);
+            }
+        }
+
+        return $results;
     }
 
     /**

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -143,18 +143,16 @@ trait InteractsWithInput
      */
     public function only($keys)
     {
-        $keys = is_array($keys) ? $keys : func_get_args();
-
         $results = [];
 
         $input = $this->all();
 
-        $placeholder = str_random();
+        $placeholder = new class {};
 
-        foreach ($keys as $key) {
+        foreach (is_array($keys) ? $keys : func_get_args() as $key) {
             $value = data_get($input, $key, $placeholder);
 
-            if ($value != $placeholder) {
+            if ($value !== $placeholder) {
                 Arr::set($results, $key, $value);
             }
         }

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Http\Concerns;
 
+use stdClass;
 use SplFileInfo;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
@@ -147,7 +148,7 @@ trait InteractsWithInput
 
         $input = $this->all();
 
-        $placeholder = new class {};
+        $placeholder = new stdClass();
 
         foreach (is_array($keys) ? $keys : func_get_args() as $key) {
             $value = data_get($input, $key, $placeholder);

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -145,15 +145,7 @@ trait InteractsWithInput
     {
         $keys = is_array($keys) ? $keys : func_get_args();
 
-        $results = [];
-
-        $input = $this->all();
-
-        foreach ($keys as $key) {
-            Arr::set($results, $key, data_get($input, $key));
-        }
-
-        return $results;
+        return array_intersect_key($this->all(), array_flip($keys));
     }
 
     /**
@@ -171,17 +163,6 @@ trait InteractsWithInput
         Arr::forget($results, $keys);
 
         return $results;
-    }
-
-    /**
-     * Intersect an array of items with the input data.
-     *
-     * @param  array|mixed  $keys
-     * @return array
-     */
-    public function intersect($keys)
-    {
-        return array_filter($this->only(is_array($keys) ? $keys : func_get_args()));
     }
 
     /**

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -246,8 +246,12 @@ class HttpRequestTest extends TestCase
     public function testOnlyMethod()
     {
         $request = Request::create('/', 'GET', ['name' => 'Taylor', 'age' => null]);
-
         $this->assertEquals(['name' => 'Taylor', 'age' => null], $request->only('name', 'age', 'email'));
+
+        $request = Request::create('/', 'GET', ['developer' => ['name' => 'Taylor', 'age' => null]]);
+        $this->assertEquals(['developer' => ['name' => 'Taylor']], $request->only('developer.name', 'developer.skills'));
+        $this->assertEquals(['developer' => ['age' => null]], $request->only('developer.age'));
+        $this->assertEquals([], $request->only('developer.skills'));
     }
 
     public function testExceptMethod()

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -245,13 +245,9 @@ class HttpRequestTest extends TestCase
 
     public function testOnlyMethod()
     {
-        $request = Request::create('/', 'GET', ['name' => 'Taylor', 'age' => 25]);
-        $this->assertEquals(['age' => 25], $request->only('age'));
-        $this->assertEquals(['name' => 'Taylor', 'age' => 25], $request->only('name', 'age'));
+        $request = Request::create('/', 'GET', ['name' => 'Taylor', 'age' => null]);
 
-        $request = Request::create('/', 'GET', ['developer' => ['name' => 'Taylor', 'age' => 25]]);
-        $this->assertEquals(['developer' => ['age' => 25]], $request->only('developer.age'));
-        $this->assertEquals(['developer' => ['name' => 'Taylor'], 'test' => null], $request->only('developer.name', 'test'));
+        $this->assertEquals(['name' => 'Taylor', 'age' => null], $request->only('name', 'age', 'email'));
     }
 
     public function testExceptMethod()
@@ -259,12 +255,6 @@ class HttpRequestTest extends TestCase
         $request = Request::create('/', 'GET', ['name' => 'Taylor', 'age' => 25]);
         $this->assertEquals(['name' => 'Taylor'], $request->except('age'));
         $this->assertEquals([], $request->except('age', 'name'));
-    }
-
-    public function testIntersectMethod()
-    {
-        $request = Request::create('/', 'GET', ['name' => 'Taylor', 'age' => null]);
-        $this->assertEquals(['name' => 'Taylor'], $request->intersect('name', 'age', 'email'));
     }
 
     public function testQueryMethod()


### PR DESCRIPTION
This will make `Request::only()` work like `Collection::only()`. Currently these two methods are inconsistent with each other. This will bring them into harmony so that they behave the same.

Given the following payload:

```
{
    "name": "",
    "category": null,
    "level": 0
}
```

Output of `request()->only('name', 'category', 'level', 'age')` will be:

```
[
    "name"=> "",
    "category"=> null,
    "level"=> 0
]
```

Prior to this PR, `age` would have been included in the array returned by `only`.