### PR TITLE
[5.4] Add App\User to Guard::user() possible return values

### DIFF
--- a/src/Illuminate/Auth/RequestGuard.php
+++ b/src/Illuminate/Auth/RequestGuard.php
@@ -37,9 +37,7 @@ class RequestGuard implements Guard
     }
 
     /**
-     * Get the currently authenticated user.
-     *
-     * @return \Illuminate\Contracts\Auth\Authenticatable|null
+     * {@inheritdoc}
      */
     public function user()
     {

--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -104,9 +104,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
     }
 
     /**
-     * Get the currently authenticated user.
-     *
-     * @return \Illuminate\Contracts\Auth\Authenticatable|null
+     * {@inheritdoc}
      */
     public function user()
     {

--- a/src/Illuminate/Auth/TokenGuard.php
+++ b/src/Illuminate/Auth/TokenGuard.php
@@ -47,9 +47,7 @@ class TokenGuard implements Guard
     }
 
     /**
-     * Get the currently authenticated user.
-     *
-     * @return \Illuminate\Contracts\Auth\Authenticatable|null
+     * {@inheritdoc}
      */
     public function user()
     {

--- a/src/Illuminate/Contracts/Auth/Guard.php
+++ b/src/Illuminate/Contracts/Auth/Guard.php
@@ -21,7 +21,7 @@ interface Guard
     /**
      * Get the currently authenticated user.
      *
-     * @return \Illuminate\Contracts\Auth\Authenticatable|null
+     * @return \Illuminate\Contracts\Auth\Authenticatable|\App\User|null
      */
     public function user();
 


### PR DESCRIPTION
I personally almost always stick with the default App\User model and this provides autocompletion for custom methods defined on it in IDEs like PhpStorm. 

![image](https://cloud.githubusercontent.com/assets/13980973/24788288/f3d8ecd0-1b6c-11e7-9d75-c601376f5df7.png)

For those who choose to change the default location of User model it will make no difference.