### PR TITLE
[5.5] Queue ResetPassword notification

### DIFF
--- a/src/Illuminate/Auth/Notifications/ResetPassword.php
+++ b/src/Illuminate/Auth/Notifications/ResetPassword.php
@@ -2,11 +2,15 @@
 
 namespace Illuminate\Auth\Notifications;
 
+use Illuminate\Bus\Queueable;
 use Illuminate\Notifications\Notification;
+use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
 
-class ResetPassword extends Notification
+class ResetPassword extends Notification implements ShouldQueue
 {
+    use Queueable;
+
     /**
      * The password reset token.
      *


### PR DESCRIPTION
I think it's fairly reasonable assumption that all sent emails are queued when app is utilizing job queues.

While even now it's easy to make reset password email queueable, it's a bit tedious in a sense that you need to override `sendPasswordResetNotification` on a `User` model and than extend default `ResetPassword` notification to implement an interface. This isn't something I wish to bother with when scaffolding default authentication.

With `sync` driver it makes no difference whether the queue and workers are configured or not for this to work so this should be a safe change.

