### PR TITLE
Update Factory.php

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factory.php
@@ -199,7 +199,7 @@ class Factory implements ArrayAccess
 
         if (is_dir($path)) {
             foreach (Finder::create()->files()->name('*.php')->in($path) as $file) {
-                require $file->getRealPath();
+                require_once $file->getRealPath();
             }
         }
 


### PR DESCRIPTION
Update Factory.php, load method
use require_once to make sure the files are getting loaded only once

Currently we have an issue, where DatabaseSeeder Class is loading twice, here is the stack trace after which we are getting re declare error. Please note that we have moved the Database seeder to other location, and overrided databasePath in application. PHP 24 step already included DatabaseSeeder class, line 32 tried to require it once again.

PHP Stack trace:
PHP   1. {main}() /home/tiko/lumen/artisan:0
PHP   2. Laravel\Lumen\Console\Kernel->handle() /home/tiko/lumen/artisan:35
PHP   3. Symfony\Component\Console\Application->run() /home/tiko/lumen/vendor/laravel/lumen-framework/src/Console/Kernel.php:84
PHP   4. Symfony\Component\Console\Application->doRun() /home/tiko/lumen/vendor/symfony/console/Application.php:120
PHP   5. Symfony\Component\Console\Application->doRunCommand() /home/tiko/lumen/vendor/symfony/console/Application.php:189
PHP   6. Illuminate\Console\Command->run() /home/tiko/lumen/vendor/symfony/console/Application.php:826
PHP   7. Symfony\Component\Console\Command\Command->run() /home/tiko/lumen/vendor/illuminate/console/Command.php:167
PHP   8. Illuminate\Console\Command->execute() /home/tiko/lumen/vendor/symfony/console/Command/Command.php:265
PHP   9. Illuminate\Container\Container->call() /home/tiko/lumen/vendor/illuminate/console/Command.php:182
PHP  10. Illuminate\Container\BoundMethod::call() /home/tiko/lumen/vendor/illuminate/container/Container.php:531
PHP  11. Illuminate\Container\BoundMethod::callBoundMethod() /home/tiko/lumen/vendor/illuminate/container/BoundMethod.php:31
PHP  12. Illuminate\Container\BoundMethod::Illuminate\Container\{closure}() /home/tiko/lumen/vendor/illuminate/container/BoundMethod.php:87
PHP  13. call_user_func_array:{/home/tiko/lumen/vendor/illuminate/container/BoundMethod.php:29}() /home/tiko/lumen/vendor/illuminate/container/BoundMethod.php:29
PHP  14. Illuminate\Database\Console\Seeds\SeedCommand->fire() /home/tiko/lumen/vendor/illuminate/container/BoundMethod.php:29
PHP  15. Illuminate\Database\Eloquent\Model::unguarded() /home/tiko/lumen/vendor/illuminate/database/Console/Seeds/SeedCommand.php:64
PHP  16. Illuminate\Database\Console\Seeds\SeedCommand->Illuminate\Database\Console\Seeds\{closure}() /home/tiko/lumen/vendor/illuminate/database/Eloquent/Concerns/GuardsAttributes.php:122
PHP  17. Illuminate\Database\Seeder->__invoke() /home/tiko/lumen/vendor/illuminate/database/Console/Seeds/SeedCommand.php:63
PHP  18. Illuminate\Container\Container->call() /home/tiko/lumen/vendor/illuminate/database/Seeder.php:103
PHP  19. Illuminate\Container\BoundMethod::call() /home/tiko/lumen/vendor/illuminate/container/Container.php:531
PHP  20. Illuminate\Container\BoundMethod::callBoundMethod() /home/tiko/lumen/vendor/illuminate/container/BoundMethod.php:31
PHP  21. Illuminate\Container\BoundMethod::Illuminate\Container\{closure}() /home/tiko/lumen/vendor/illuminate/container/BoundMethod.php:87
PHP  22. call_user_func_array:{/home/tiko/lumen/vendor/illuminate/container/BoundMethod.php:29}() /home/tiko/lumen/vendor/illuminate/container/BoundMethod.php:29
PHP  23. DatabaseSeeder->run() /home/tiko/lumen/vendor/illuminate/container/BoundMethod.php:29
PHP  24. factory() /home/tiko/lumen/ucraft/Database/seeds/DatabaseSeeder.php:33
PHP  25. app() /home/tiko/lumen/vendor/laravel/lumen-framework/src/helpers.php:199
PHP  26. Laravel\Lumen\Application->make() /home/tiko/lumen/vendor/laravel/lumen-framework/src/helpers.php:38
PHP  27. Illuminate\Container\Container->make() /home/tiko/lumen/vendor/laravel/lumen-framework/src/Application.php:208
PHP  28. Illuminate\Container\Container->resolve() /home/tiko/lumen/vendor/illuminate/container/Container.php:567
PHP  29. Illuminate\Container\Container->build() /home/tiko/lumen/vendor/illuminate/container/Container.php:598
PHP  30. Illuminate\Database\DatabaseServiceProvider->Illuminate\Database\{closure}() /home/tiko/lumen/vendor/illuminate/container/Container.php:716
PHP  31. Illuminate\Database\Eloquent\Factory::construct() /home/tiko/lumen/vendor/illuminate/database/DatabaseServiceProvider.php:83
PHP  32. Illuminate\Database\Eloquent\Factory->load() /home/tiko/lumen/vendor/illuminate/database/Eloquent/Factory.php:54