### PR TITLE
[5.4] Support setting an Eloquent model as an attribute

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -527,10 +527,6 @@ trait HasAttributes
             $value = $this->fromDateTime($value);
         }
 
-        if ($value && $value instanceof Model) {
-            $value = $value->getKey();
-        }
-
         if ($this->isJsonCastable($key) && ! is_null($value)) {
             $value = $this->castAttributeAsJson($key, $value);
         }
@@ -540,6 +536,10 @@ trait HasAttributes
         // attribute in the array's value in the case of deeply nested items.
         if (Str::contains($key, '->')) {
             return $this->fillJsonAttribute($key, $value);
+        }
+
+        if ($value && $value instanceof Model) {
+            $value = $value->getKey();
         }
 
         $this->attributes[$key] = $value;

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -7,6 +7,7 @@ use LogicException;
 use DateTimeInterface;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Collection as BaseCollection;
@@ -524,6 +525,10 @@ trait HasAttributes
         // the connection grammar's date format. We will auto set the values.
         elseif ($value && $this->isDateAttribute($key)) {
             $value = $this->fromDateTime($value);
+        }
+
+        if ($value && $value instanceof Model) {
+            $value = $value->getKey();
         }
 
         if ($this->isJsonCastable($key) && ! is_null($value)) {

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1603,6 +1603,18 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertFalse($result);
     }
 
+    public function testSettingModelAsAttribute()
+    {
+        $model = new EloquentModelStub;
+        $model->id = 1;
+
+        $association = new EloquentModelStub;
+        $association->id = 2;
+
+        $model->association_id = $association;
+        $this->assertEquals($association->id, $model->association_id);
+    }
+
     protected function addMockConnection($model)
     {
         $model->setConnectionResolver($resolver = m::mock('Illuminate\Database\ConnectionResolverInterface'));


### PR DESCRIPTION
This just adds a little bit of "syntax sugar" in a way, that when setting an Eloquent model on an attribute it automatically assigns the attribute as the primary key. It's subtle, but it just avoids the repetitive `->id` or `->getKey()`

```
$user = App\User::first();

$post = new App\Post(['user_id' => $user]);

$post->user_id = $user;

$post->save();
```