### PR TITLE
[5.5] Extend queue-worker with process-forking option

### DIFF
--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -27,7 +27,8 @@ class WorkCommand extends Command
                             {--memory=128 : The memory limit in megabytes}
                             {--sleep=3 : Number of seconds to sleep when no job is available}
                             {--timeout=60 : The number of seconds a child process can run}
-                            {--tries=0 : Number of times to attempt a job before logging it failed}';
+                            {--tries=0 : Number of times to attempt a job before logging it failed}
+                            {--fork : Execute jobs in a forked process}';
 
     /**
      * The console command description.
@@ -111,7 +112,8 @@ class WorkCommand extends Command
         return new WorkerOptions(
             $this->option('delay'), $this->option('memory'),
             $this->option('timeout'), $this->option('sleep'),
-            $this->option('tries'), $this->option('force')
+            $this->option('tries'), $this->option('force'),
+            $this->option('fork')
         );
     }
 

--- a/src/Illuminate/Queue/WorkerOptions.php
+++ b/src/Illuminate/Queue/WorkerOptions.php
@@ -47,6 +47,13 @@ class WorkerOptions
     public $force;
 
     /**
+     * Indicates if the worker should execute jobs in a forked process.
+     *
+     * @var bool
+     */
+    public $fork;
+
+    /**
      * Create a new worker options instance.
      *
      * @param  int  $delay
@@ -56,8 +63,9 @@ class WorkerOptions
      * @param  int  $maxTries
      * @param  bool  $force
      */
-    public function __construct($delay = 0, $memory = 128, $timeout = 60, $sleep = 3, $maxTries = 0, $force = false)
+    public function __construct($delay = 0, $memory = 128, $timeout = 60, $sleep = 3, $maxTries = 0, $force = false, $fork = false)
     {
+        $this->fork = $fork;
         $this->delay = $delay;
         $this->sleep = $sleep;
         $this->force = $force;


### PR DESCRIPTION
This is a simple (and incomplete) attempt to solve #16694, by introducing an opt-in process-forking to queue-workers.

This commit solves the (very simple) use-case described in #16694.

If I could make this work with all use-cases (timeouts, exceptions, memory-limits, ...) and keep the overhead to the existing `Queue\Worker` minimal, would you be willing to merge this?

Thanks for your feedback!