### PR TITLE
[5.4] d() function instead of killing the script

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -499,6 +499,21 @@ if (! function_exists('data_set')) {
     }
 }
 
+if (! function_exists('d')) {
+    /**
+     * Dump the passed variables.
+     *
+     * @param  mixed
+     * @return void
+     */
+    function d()
+    {
+        array_map(function ($x) {
+            (new Dumper)->dump($x);
+        }, func_get_args());
+    }
+}
+
 if (! function_exists('dd')) {
     /**
      * Dump the passed variables and end the script.


### PR DESCRIPTION
just like var_dump but with the same syntax highlighting in the console of dd(), in some senarios we might be interested in all of the output.
say you want to debug a function which is being called few times.

alternative would be to add somekind of flag dd(yourarguments, false / true); // if you dont want to kill the script