### PR TITLE
[5.3] Use configured view paths for vendor views

### DIFF
--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -68,8 +68,11 @@ abstract class ServiceProvider
      */
     protected function loadViewsFrom($path, $namespace)
     {
-        if (is_dir($appPath = $this->app->resourcePath().'/views/vendor/'.$namespace)) {
-            $this->app['view']->addNamespace($namespace, $appPath);
+        $viewPaths = $this->app['config']->get('view.paths', [$this->app->resourcePath().'/views']);
+        foreach ($viewPaths as $viewPath) {
+            if (is_dir($appPath = rtrim($viewPath, '/').'/vendor/'.$namespace)) {
+                $this->app['view']->addNamespace($namespace, $appPath);
+            }
         }
 
         $this->app['view']->addNamespace($namespace, $path);


### PR DESCRIPTION
Currently all service providers look in `resources/views/vendor/[namespace]` for custom views. If you've configured a different location for views, this fails (I prefer my views in `views/`). This PR checks all configured paths in `config('view.paths')` and looks for `vendor/[namespace]` in each.