### PR TITLE
[5.4][WIP] Add an or pipe

### DIFF
--- a/src/Illuminate/Pipeline/NonClosureResponseException.php
+++ b/src/Illuminate/Pipeline/NonClosureResponseException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Illuminate\Pipeline;
+
+use Exception;
+
+class NonClosureResponseException extends Exception
+{
+    //
+}

--- a/src/Illuminate/Pipeline/OrPipe.php
+++ b/src/Illuminate/Pipeline/OrPipe.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Illuminate\Pipeline;
+
+use Closure;
+use Exception;
+use Illuminate\Contracts\Container\Container;
+
+class OrPipe
+{
+    /**
+     * The container implementation.
+     *
+     * @var \Illuminate\Contracts\Container\Container
+     */
+    protected $container;
+
+    /**
+     * The method to call on each pipe.
+     *
+     * @var string
+     */
+    protected $method = 'handle';
+
+    /**
+     * OrPipe constructor.
+     *
+     * @param  \Illuminate\Contracts\Container\Container  $container
+     * @param  string  $method
+     */
+    public function __construct(Container $container, $method)
+    {
+        $this->container = $container;
+        $this->method = $method;
+    }
+
+    /**
+     * Handle an or pipe.
+     *
+     * @param  mixed  $passable
+     * @param  \Closure  $stack
+     * @param  array  $pipes
+     *
+     * @return mixed
+     * @throws \Exception
+     */
+    public function handle($passable, $stack, array $pipes)
+    {
+        foreach ($pipes as $index => $pipe) {
+            list($name, $parameters) = $pipe;
+            $parameters = array_merge([$passable, $stack], $parameters);
+
+            $pipe = $this->container->make($name);
+
+            try {
+                $result = method_exists($pipe, $this->method)
+                    ? $pipe->{$this->method}(...$parameters)
+                    : $pipe(...$parameters);
+
+                if (! ($result instanceof Closure || $index === count($pipes) - 1)) {
+                    continue;
+                }
+
+                return $result;
+            } catch (Exception $e) {
+                // If this is the final pipe that we are running,
+                // allow the exception to bubble up, and allow
+                // the application to handle it as any pipe.
+                if ($index === count($pipes) - 1) {
+                    throw $e;
+                }
+
+                continue;
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR will add an "or" pipe, allowing users to declare middlewares where only one must pass. One such example is when you have different types of authentication;  you might have a service that allows for either token auth or session auth (or something like system auth to allow internal services to communicate), but still want to make the same endpoints available to avoid making new routes just to use another middleware. This PR aims to solve that by allowing users to declare their middleware as follows:

```
$router->get('/home',['middleware' =>['auth.jwt||auth.session'], ...]);
```
This will be treated by an `OrPipe`, that will first run the JWT auth middleware, and if that fails (where failure is regarded, at the moment, as returning a non-closure or throwing an exception), run the next one. If none of the pipes pass, the result of the last pipe will be returned (or thrown if it's an exception).

This is a work in progress and I would like to hear some opinions on this before finishing it up.