### PR TITLE
[5.5] Verbose TokenMismatch Error

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Facades\Auth;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Auth\AuthenticationException;
 use Illuminate\Contracts\Container\Container;
+use Illuminate\Session\TokenMismatchException;
 use Illuminate\Validation\ValidationException;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Http\Exceptions\HttpResponseException;
@@ -156,6 +157,8 @@ class Handler implements ExceptionHandlerContract
             $e = new NotFoundHttpException($e->getMessage(), $e);
         } elseif ($e instanceof AuthorizationException) {
             $e = new HttpException(403, $e->getMessage());
+        } elseif ($e instanceof TokenMismatchException) {
+            $e = new HttpException(419, $e->getMessage());
         }
 
         return $e;

--- a/src/Illuminate/Foundation/Exceptions/views/419.blade.php
+++ b/src/Illuminate/Foundation/Exceptions/views/419.blade.php
@@ -1,0 +1,9 @@
+@extends('errors::layout')
+
+@section('title', 'Logged out')
+
+@section('message')
+    You have been logged out due to inactivity.
+    <br/><br/>
+    Please log in and try again.
+@stop

--- a/src/Illuminate/Foundation/Exceptions/views/419.blade.php
+++ b/src/Illuminate/Foundation/Exceptions/views/419.blade.php
@@ -3,7 +3,7 @@
 @section('title', 'Logged out')
 
 @section('message')
-    You have been logged out due to inactivity.
+    The page has expired due to inactivity.
     <br/><br/>
-    Please log in and try again.
+    Please refresh the page and try again.
 @stop


### PR DESCRIPTION
Currently when a user has a `TokenMismatch` due to an expired session - they get a "Whoops" page and the server throws a `500` error.

This is very very confusing to users. There is no indication of what the error was. And technically a `500` error implies an internal "server" error, when in fact it should be throwing some `4xx` error - as it is a client error.

This is an common issue faced by developers, such as [here](https://laravel.io/index.php/forum/03-27-2015-laravel-5-token-custom-error-page), [here](http://stackoverflow.com/q/29115184/1317935), [here](https://laracasts.com/discuss/channels/laravel/l5-properly-handle-tokenmismatchexception-when-logging-in?page=1), [here](https://laracasts.com/discuss/channels/general-discussion/how-to-deal-with-tokenmismatchexception?page=1), [here](https://grafxflow.co.uk/blog/laravel/redirect-laravel-tokenmismatchexception-error-page/) and [here](https://gist.github.com/jrmadsen67/bd0f9ad0ef1ed6bb594e).

This PR aims to improve the experience for users out of the box.

![beforeafter](https://cloud.githubusercontent.com/assets/1210658/24828876/17ef8e88-1c5f-11e7-95e2-dbb6aab61958.png)

It is now very obvious to all users what the problem is and how to fix it.

The other benefit is developers can now add their own `view/errors/419.blade.php` file to their application to specifically target this error message, and include a button there to send to login/dashboard etc as needed. I didnt want to automatically redirect etc - because everyone's routes will be different.

One point of discussion is about what is the most appropriate `4xx` header to throw. There is technically no status code for "session expired" in the RFC (as it is part of the application layer and not the HTTP layer).

I went with `419` - which is not part of the official RFC - but it is mentioned on some websites such as [here](https://blogs.dropbox.com/developers/2015/04/how-many-http-status-codes-should-your-api-use/), [here](http://stackoverflow.com/a/9539833/1317935) and [here](http://getstatuscode.com/419).

The alternative is use `400` - but that was a little too generic for me. We cant use `401`, because that is used for the HTTP Basic Auth. I thought about `408` - but I think that is more for socket connections.
