### PR TITLE
add destruct method to Model.php

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -145,6 +145,13 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         $this->fill($attributes);
     }
 
+    public function __destruct()
+    {
+        unset($this->attributes);
+        unset($this->original);
+        unset($this->relations);
+    }
+
     /**
      * Check if the model needs to be booted and if so, do it.
      *


### PR DESCRIPTION
Unsetting these properties helps solving "zend_mm_heap corrupted" problems.

See http://bugs.php.net/bug.php?id=40479

**This is mainly a PHP problem, but the way Eloquent relations work contributes to this problem.**

How to reproduce this problem ?
========================
In Laravel framework, when two models has relations like this:

```
class User extends Model
{
    /**
     * Get the phone record associated with the user.
     */
    public function phone()
    {
        return $this->hasOne('App\Phone');
    }
}
```
```
class Phone extends Model
{
    /**
     * Get the user that owns the phone.
     */
    public function user()
    {
        return $this->belongsTo('App\User');
    }
}
```
When relations are both loaded, you have
```
$user->phone = $phone;
```
and
```
$phone->user = $user;
```
Each of objects $user and $phone has properties referring to the other.

The PHP engine has number count of refered objects. While $user is refered by $phone and $phone is refered by $user, the number count of $user and $phone cannot by reduced to zero. Thus when the PHP script is completed, the memory for $user and $phone are not released. The memory uasge then increase request by request, until the framework crashes.

I met the problem in my production system, I tracked the memory usages and found this is a solution.

Solution:
=======
>I then decided to try cleaning up the code I had written by using unset() to destroy the object after it had been finished with. All of the records were then inserted without any problems.

>I would advise anyone receiving this error to check that variables and objects are being destroyed with unset, because if you think about it the error is telling you that the zend memory managers heap is corrupted.
