### PR TITLE
[5.4] Return errors in JSON

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -190,7 +190,11 @@ class Handler implements ExceptionHandlerContract
             resource_path('views/errors'),
             __DIR__.'/views',
         ]);
-
+        
+        if ($request->expectsJson()) {
+            return response()->json(['error' => $e->getMessage()], $status);
+        }
+        
         if (view()->exists("errors::{$status}")) {
             return response()->view("errors::{$status}", ['exception' => $e], $status, $e->getHeaders());
         } else {

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -190,11 +190,11 @@ class Handler implements ExceptionHandlerContract
             resource_path('views/errors'),
             __DIR__.'/views',
         ]);
-        
+
         if ($request->expectsJson()) {
             return response()->json(['error' => $e->getMessage()], $status);
         }
-        
+
         if (view()->exists("errors::{$status}")) {
             return response()->view("errors::{$status}", ['exception' => $e], $status, $e->getHeaders());
         } else {


### PR DESCRIPTION
Return all HTTP errors in JSON if the request expected json. Prevents redirects  + getting a bunch of HTML in API requests