### PR TITLE
[5.5] Ensure uncaught exceptions are returned in JSON if required

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -6,6 +6,7 @@ use Exception;
 use Psr\Log\LoggerInterface;
 use Illuminate\Http\Response;
 use Illuminate\Routing\Router;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Auth\AuthenticationException;
@@ -212,7 +213,7 @@ class Handler implements ExceptionHandlerContract
      *
      * @param  \Illuminate\Http\Request  $request
      * @param  \Exception $e
-     * @return \Symfony\Component\HttpFoundation\Response
+     * @return \Illuminate\Http\JsonResponse
      */
     protected function prepareJsonResponse($request, Exception $e)
     {
@@ -233,9 +234,7 @@ class Handler implements ExceptionHandlerContract
             ];
         }
 
-        return response(json_encode($response, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES), $status, array_merge($headers, [
-            'Content-Type' => 'application/json',
-        ]));
+        return new JsonResponse($response, $status, $headers, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
     }
 
     /**

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -226,7 +226,9 @@ class Handler implements ExceptionHandlerContract
                 'trace' => $e->getTrace(),
             ];
         } else {
-            $response['message'] = $this->isHttpException($e) ? $e->getMessage() : 'Server Error';
+            $response = [
+                'message' => $this->isHttpException($e) ? $e->getMessage() : 'Server Error',
+            ];
         }
 
         return response(json_encode($response, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES), $status, array_merge($headers, [

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -139,7 +139,9 @@ class Handler implements ExceptionHandlerContract
             return $this->convertValidationExceptionToResponse($e, $request);
         }
 
-        return $request->expectsJson() ? $this->prepareJsonResponse($request, $e) : $this->prepareResponse($request, $e);
+        return $request->expectsJson()
+                        ? $this->prepareJsonResponse($request, $e)
+                        : $this->prepareResponse($request, $e);
     }
 
     /**

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -219,10 +219,12 @@ class Handler implements ExceptionHandlerContract
         $headers = $this->isHttpException($e) ? $e->getHeaders() : [];
 
         if (config('app.debug')) {
-            $response['message'] = $e->getMessage();
-            $response['file'] = $e->getFile();
-            $response['line'] = $e->getLine();
-            $response['trace'] = $e->getTrace();
+            $response = [
+                'message' => $e->getMessage(),
+                'file' => $e->getFile(),
+                'line' => $e->getLine(),
+                'trace' => $e->getTrace(),
+            ];
         } else {
             $response['message'] = $this->isHttpException($e) ? $e->getMessage() : 'Server Error';
         }

--- a/tests/Foundation/FoundationExceptionsHandlerTest.php
+++ b/tests/Foundation/FoundationExceptionsHandlerTest.php
@@ -6,7 +6,6 @@ use Exception;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Container\Container;
-use Illuminate\Foundation\Application;
 use Illuminate\Config\Repository as Config;
 use Illuminate\Foundation\Exceptions\Handler;
 
@@ -87,5 +86,4 @@ class FoundationExceptionsHandlerTest extends TestCase
         $this->assertNotContains('"line"', $response);
         $this->assertNotContains('"trace"', $response);
     }
-
 }

--- a/tests/Foundation/FoundationExceptionsHandlerTest.php
+++ b/tests/Foundation/FoundationExceptionsHandlerTest.php
@@ -18,7 +18,7 @@ class FoundationExceptionsHandlerTest extends TestCase
 
     protected $handler;
 
-    protected $rquest;
+    protected $request;
 
     public function setUp()
     {

--- a/tests/Foundation/FoundationExceptionsHandlerTest.php
+++ b/tests/Foundation/FoundationExceptionsHandlerTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Illuminate\Tests\Foundation;
+
+use Exception;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+use Illuminate\Container\Container;
+use Illuminate\Foundation\Application;
+use Illuminate\Config\Repository as Config;
+use Illuminate\Foundation\Exceptions\Handler;
+
+class FoundationExceptionsHandlerTest extends TestCase
+{
+    protected $config;
+
+    protected $container;
+
+    protected $handler;
+
+    protected $rquest;
+
+    public function setUp()
+    {
+        $this->config = m::mock(Config::class);
+
+        $this->request = m::mock('StdClass');
+
+        $this->container = Container::setInstance(new Container);
+
+        $this->container->singleton('config', function () {
+            return $this->config;
+        });
+
+        $this->container->singleton('Illuminate\Contracts\Routing\ResponseFactory', function () {
+            return new \Illuminate\Routing\ResponseFactory(
+                m::mock(\Illuminate\Contracts\View\Factory::class),
+                m::mock(\Illuminate\Routing\Redirector::class)
+            );
+        });
+
+        $this->handler = new Handler($this->container);
+    }
+
+    public function tearDown()
+    {
+        m::close();
+    }
+
+    public function testReturnsHtmlPageWithStackTraceWhenHtmlRequestAndDebugTrue()
+    {
+        $this->config->shouldReceive('get')->with('app.debug', null)->twice()->andReturn(true);
+        $this->request->shouldReceive('expectsJson')->once()->andReturn(false);
+
+        $response = $this->handler->render($this->request, new Exception('My custom error message'))->getContent();
+
+        $this->assertContains('<!DOCTYPE html>', $response);
+        $this->assertContains('<h1>Whoops, looks like something went wrong.</h1>', $response);
+        $this->assertContains('My custom error message', $response);
+        $this->assertContains('::main()', $response);
+    }
+
+    public function testReturnsJsonWithStackTraceWhenAjaxRequestAndDebugTrue()
+    {
+        $this->config->shouldReceive('get')->with('app.debug', null)->once()->andReturn(true);
+        $this->request->shouldReceive('expectsJson')->once()->andReturn(true);
+
+        $response = $this->handler->render($this->request, new Exception('My custom error message'))->getContent();
+
+        $this->assertNotContains('<!DOCTYPE html>', $response);
+        $this->assertContains('"message": "My custom error message"', $response);
+        $this->assertContains('"file"', $response);
+        $this->assertContains('"line"', $response);
+        $this->assertContains('"trace"', $response);
+    }
+
+    public function testReturnsJsonWithoutStackTraceWhenAjaxRequestAndDebugFalse()
+    {
+        $this->config->shouldReceive('get')->with('app.debug', null)->once()->andReturn(false);
+        $this->request->shouldReceive('expectsJson')->once()->andReturn(true);
+
+        $response = $this->handler->render($this->request, new Exception('This error message should not be visible'))->getContent();
+
+        $this->assertContains('"message": "Server Error"', $response);
+        $this->assertNotContains('<!DOCTYPE html>', $response);
+        $this->assertNotContains('"file"', $response);
+        $this->assertNotContains('"line"', $response);
+        $this->assertNotContains('"trace"', $response);
+    }
+
+}


### PR DESCRIPTION
The current framework behavior is to return full html in uncaught exceptions (such as a 500 internal error). 

In `5.5/master` there are already some changes which will forcibly return JSON if `expectsJSON()` is `true` - but only if `app.debug = true`.

I propose that if `expectsJSON()` is `true` - then we should always be returning JSON regardless of the debug setting.

