### PR TITLE
[5.4] ENV variable override for container immutability

### DIFF
--- a/src/Illuminate/Foundation/Bootstrap/LoadEnvironmentVariables.php
+++ b/src/Illuminate/Foundation/Bootstrap/LoadEnvironmentVariables.php
@@ -24,7 +24,7 @@ class LoadEnvironmentVariables
         $this->checkForSpecificEnvironmentFile($app);
 
         try {
-            (new Dotenv($app->environmentPath(), $app->environmentFile()))->load();
+            (new Dotenv($app->environmentPath(), $app->environmentFile()))->overload();
         } catch (InvalidPathException $e) {
             //
         }


### PR DESCRIPTION
DotEnv package allows [overriding](https://github.com/vlucas/phpdotenv#immutability) .env file variables by ENV variables. 

In our kubernetes docker environment it would be useful to override the .env file variables with testing and production environmental variables i.s.o. building separate docker containers with different .env files. 

Change ->load() to ->overload() to allow overriding the .env file variables by ENV variables, if they are set.