### PR TITLE
[5.4] Fix job release when job exceptions occur

### DIFF
--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -328,7 +328,9 @@ class Worker
             // If we catch an exception, we will attempt to release the job back onto the queue
             // so it is not lost entirely. This'll let the job be retried at a later time by
             // another listener (or this same one). We will re-throw this exception after.
-            if (! $job->isDeleted()) {
+            // Do not release the job back onto the queue if the job is either deleted, failed
+            // or if the job has already been released from the JobExceptionOccurred event listener.
+            if (! ($job->isReleased() || $job->isDeleted() || $job->hasFailed())) {
                 $job->release($options->delay);
             }
         }

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -257,9 +257,11 @@ class WorkerFakeJob
     public $callback;
     public $deleted = false;
     public $releaseAfter;
+    public $released = false;
     public $maxTries;
     public $attempts = 0;
     public $failedWith;
+    public $failed = false;
     public $connectionName;
 
     public function __construct($callback = null)
@@ -296,7 +298,14 @@ class WorkerFakeJob
 
     public function release($delay)
     {
+        $this->released = true;
+
         $this->releaseAfter = $delay;
+    }
+
+    public function isReleased()
+    {
+        return $this->released;
     }
 
     public function attempts()
@@ -306,12 +315,19 @@ class WorkerFakeJob
 
     public function markAsFailed()
     {
-        //
+        $this->failed = true;
     }
 
     public function failed($e)
     {
+        $this->markAsFailed();
+
         $this->failedWith = $e;
+    }
+
+    public function hasFailed()
+    {
+        return $this->failed;
     }
 
     public function setConnectionName($name)


### PR DESCRIPTION
Without this change the worker does not account for changes to the job state done in the JobExceptionOccurred event listener except for when the job was deleted. If there is a need to release the job back onto the queue with a different delay than the one set on the worker, that is not possible and the job would be released with the worker delay. If the job needs to be failed by the JobExceptionOccurred event listener that is not possible as well and will be ignored by the worker.

A job should not be released back onto the queue if the job has been handled in the JobExceptionOccurred event listener by failing, deleting or releasing it with a specific delay. The event listener should have full controller over what happens with the job for what concerns releasing, failing and deleting the job.