### PR TITLE
[5.4] Implement standalone if empty in a NB-Change-Way

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesLoops.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesLoops.php
@@ -42,7 +42,7 @@ trait CompilesLoops
      */
     protected function compileEmpty($expression)
     {
-        if($expression){
+        if ($expression) {
             return "<?php if(empty{$expression}): ?>";
         }
         $empty = '$__empty_'.$this->forElseCounter--;

--- a/src/Illuminate/View/Compilers/Concerns/CompilesLoops.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesLoops.php
@@ -69,6 +69,7 @@ trait CompilesLoops
     {
         return '<?php endif; ?>';
     }
+    
     /**
      * Compile the for statements into valid PHP.
      *

--- a/src/Illuminate/View/Compilers/Concerns/CompilesLoops.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesLoops.php
@@ -69,7 +69,7 @@ trait CompilesLoops
     {
         return '<?php endif; ?>';
     }
-    
+
     /**
      * Compile the for statements into valid PHP.
      *

--- a/src/Illuminate/View/Compilers/Concerns/CompilesLoops.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesLoops.php
@@ -35,12 +35,16 @@ trait CompilesLoops
     }
 
     /**
-     * Compile the for-else-empty statements into valid PHP.
+     * Compile the for-else-empty and empty statements into valid PHP.
      *
+     * @param  string  $expression
      * @return string
      */
-    protected function compileEmpty()
+    protected function compileEmpty($expression)
     {
+        if($expression){
+            return "<?php if(empty{$expression}): ?>";
+        }
         $empty = '$__empty_'.$this->forElseCounter--;
 
         return "<?php endforeach; \$__env->popLoop(); \$loop = \$__env->getLastLoop(); if ({$empty}): ?>";
@@ -56,6 +60,15 @@ trait CompilesLoops
         return '<?php endif; ?>';
     }
 
+    /**
+     * Compile the end-empty statements into valid PHP.
+     *
+     * @return string
+     */
+    protected function compileEndEmpty()
+    {
+        return '<?php endif; ?>';
+    }
     /**
      * Compile the for statements into valid PHP.
      *

--- a/src/Illuminate/View/Compilers/Concerns/CompilesLoops.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesLoops.php
@@ -45,6 +45,7 @@ trait CompilesLoops
         if ($expression) {
             return "<?php if(empty{$expression}): ?>";
         }
+
         $empty = '$__empty_'.$this->forElseCounter--;
 
         return "<?php endforeach; \$__env->popLoop(); \$loop = \$__env->getLastLoop(); if ({$empty}): ?>";

--- a/tests/View/Blade/BladeIfIEmptyStatementsTest.php
+++ b/tests/View/Blade/BladeIfIEmptyStatementsTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Illuminate\Tests\Blade;
+
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+use Illuminate\View\Compilers\BladeCompiler;
+
+class BladeIfEmptyStatementsTest extends TestCase
+{
+    public function tearDown()
+    {
+        m::close();
+    }
+
+    public function testIfStatementsAreCompiled()
+    {
+        $compiler = new BladeCompiler($this->getFiles(), __DIR__);
+        $string = '@empty ($test)
+breeze
+@endempty';
+        $expected = '<?php if(empty($test)): ?>
+breeze
+<?php endif; ?>';
+        $this->assertEquals($expected, $compiler->compileString($string));
+    }
+
+    protected function getFiles()
+    {
+        return m::mock('Illuminate\Filesystem\Filesystem');
+    }
+}


### PR DESCRIPTION
As addition of https://github.com/laravel/framework/pull/18425 it would be nice if the @empty statement can be used outside of an forelese.

This PR implements this in a Non Breaking Change way.

So you can use it with:
```blade
@empty($array)
This Array is Empty!
@endempty
```
instead of
```blade
@if(empty($array))
This Array is Empty!
@endif
```

This has no impact to the @forelse statement.