### PR TITLE
[5.5] Fix exception reporting for new feature

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -60,12 +60,12 @@ class Handler implements ExceptionHandlerContract
      */
     public function report(Exception $e)
     {
-        if (method_exists($e, 'report')) {
-            return $e->report();
-        }
-
         if ($this->shouldntReport($e)) {
             return;
+        }
+
+        if (method_exists($e, 'report')) {
+            return $e->report();
         }
 
         try {


### PR DESCRIPTION
With the new ability for exceptions to have their own report & render functions - they still should honor the `dontReport` list?

Currently they will still report themselves, even if we told them not to.