### PR TITLE
[5.4] Dispatch Illuminate\Mail\Events\MessageSent event

### DIFF
--- a/src/Illuminate/Mail/Events/MessageSent.php
+++ b/src/Illuminate/Mail/Events/MessageSent.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Illuminate\Mail\Events;
+
+class MessageSent
+{
+    /**
+     * The Swift message instance.
+     *
+     * @var \Swift_Message
+     */
+    public $message;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  \Swift_Message  $message
+     * @return void
+     */
+    public function __construct($message)
+    {
+        $this->message = $message;
+    }
+}

--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -206,6 +206,8 @@ class Mailer implements MailerContract, MailQueueContract
         }
 
         $this->sendSwiftMessage($message->getSwiftMessage());
+
+        $this->events->dispatch(new Events\MessageSent($message->getSwiftMessage()));
     }
 
     /**

--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -207,7 +207,9 @@ class Mailer implements MailerContract, MailQueueContract
 
         $this->sendSwiftMessage($message->getSwiftMessage());
 
-        $this->events->dispatch(new Events\MessageSent($message->getSwiftMessage()));
+        if ($this->events) {
+            $this->events->dispatch(new Events\MessageSent($message->getSwiftMessage()));
+        }
     }
 
     /**


### PR DESCRIPTION
Related to proposal https://github.com/laravel/internals/issues/505. This PR dispatches a new `Illuminate\Mail\Events\MessageSent` event AFTER the message is actually sent (to the contrary of `MessageSending` which is dispatched BEFORE the message is sent).

Pros:
- `MessageSent` is dispatched only if the message is successfully sent. It is not dispatched if the message isn't successfully sent (ie the Mailer throws an exception).
- The `$message` variable contains the message id (SES) / transmission id (SparkPost) that's set into the swift message's headers after the message is sent.

I think the use case in the example from the official doc is a bit clumsy (https://laravel.com/docs/5.4/mail#events), because the listener for logging the message is executed whether the email is actually sent or not. There could be an error while actually sending the email (ex: network issue, temporary API error from Mandrill / SparkPost etc...) and `MessageSending` would still be triggered. `MessageSent` would be a better fit for this use case, because when it's triggered it's guaranteed the message was actually sent.