### PR TITLE
[5.4] Allow route key manipulation on model binding

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1181,6 +1181,16 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     }
 
     /**
+     * Parse the route key value before query the model.
+     *
+     * @return mixed
+     */
+    public function parseRouteKey($key)
+    {
+        return $key;
+    }
+
+    /**
      * Get the route key for the model.
      *
      * @return string

--- a/src/Illuminate/Routing/ImplicitRouteBinding.php
+++ b/src/Illuminate/Routing/ImplicitRouteBinding.php
@@ -31,7 +31,7 @@ class ImplicitRouteBinding
             $model = $container->make($parameter->getClass()->name);
 
             $route->setParameter($parameterName, $model->where(
-                $model->getRouteKeyName(), $parameterValue
+                $model->getRouteKeyName(), $model->parseRouteKey($parameterValue)
             )->firstOrFail());
         }
     }

--- a/src/Illuminate/Routing/RouteBinding.php
+++ b/src/Illuminate/Routing/RouteBinding.php
@@ -65,7 +65,7 @@ class RouteBinding
             // throw a not found exception otherwise we will return the instance.
             $instance = $container->make($class);
 
-            if ($model = $instance->where($instance->getRouteKeyName(), $value)->first()) {
+            if ($model = $instance->where($instance->getRouteKeyName(), $instance->parseRouteKey($value))->first()) {
                 return $model;
             }
 

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -1450,6 +1450,11 @@ class RouteModelBindingStub
         return 'id';
     }
 
+    public function parseRouteKey($key)
+    {
+        return $key;
+    }
+
     public function where($key, $value)
     {
         $this->value = $value;
@@ -1468,6 +1473,11 @@ class RouteModelBindingNullStub
     public function getRouteKeyName()
     {
         return 'id';
+    }
+
+    public function parseRouteKey($key)
+    {
+        return $key;
     }
 
     public function where($key, $value)


### PR DESCRIPTION
Allow any manipulation/transformation on the route key before query the model on implicit model binding.

This is especially useful when using hash ids in the url, so you can convert the hash back to the id before trying to find the model.