### PR TITLE
[5.5] Show class and method name on invalid relationship LogicException

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -400,8 +400,8 @@ trait HasAttributes
         $relation = $this->$method();
 
         if (! $relation instanceof Relation) {
-            throw new LogicException('Relationship method must return an object of type '
-                .'Illuminate\Database\Eloquent\Relations\Relation');
+            throw new LogicException($method.' relationship method must return an object of type '
+                .Relation::class);
         }
 
         return tap($relation->getResults(), function ($results) use ($method) {

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -400,7 +400,7 @@ trait HasAttributes
         $relation = $this->$method();
 
         if (! $relation instanceof Relation) {
-            throw new LogicException($method.' relationship method must return an object of type '
+            throw new LogicException(get_class($this).'::'.$method.' relationship method must return an object of type '
                 .Relation::class);
         }
 

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1275,7 +1275,7 @@ class DatabaseEloquentModelTest extends TestCase
 
     /**
      * @expectedException LogicException
-     * @expectedExceptionMessage incorrectRelationStub relationship method must return an object of type Illuminate\Database\Eloquent\Relations\Relation
+     * @expectedExceptionMessage Illuminate\Tests\Database\EloquentModelStub::incorrectRelationStub relationship method must return an object of type Illuminate\Database\Eloquent\Relations\Relation
      */
     public function testGetModelAttributeMethodThrowsExceptionIfNotRelation()
     {

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1275,6 +1275,7 @@ class DatabaseEloquentModelTest extends TestCase
 
     /**
      * @expectedException LogicException
+     * @expectedExceptionMessage incorrectRelationStub relationship method must return an object of type Illuminate\Database\Eloquent\Relations\Relation
      */
     public function testGetModelAttributeMethodThrowsExceptionIfNotRelation()
     {


### PR DESCRIPTION
Someone mentioned on Larachat that it'd be cool to show the class and the wrong relationship method on the exception message. I think it would be cool too, I'm just not sure if the verbiage I used is okay.  

