### PR TITLE
[5.5] Allow passing keys to `Request::all()` to behave like old `Request::only()`

### DIFF
--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -117,9 +117,21 @@ trait InteractsWithInput
      *
      * @return array
      */
-    public function all()
+    public function all($keys = null)
     {
-        return array_replace_recursive($this->input(), $this->allFiles());
+        $input = array_replace_recursive($this->input(), $this->allFiles());
+
+        if (! $keys) {
+            return $input;
+        }
+
+        $results = [];
+
+        foreach (is_array($keys) ? $keys : func_get_args() as $key) {
+            Arr::set($results, $key, Arr::get($input, $key));
+        }
+
+        return $results;
     }
 
     /**

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -243,6 +243,21 @@ class HttpRequestTest extends TestCase
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\File\UploadedFile', $request['file']);
     }
 
+    public function testAllMethod()
+    {
+        $request = Request::create('/', 'GET', ['name' => 'Taylor', 'age' => null]);
+        $this->assertEquals(['name' => 'Taylor', 'age' => null, 'email' => null], $request->all('name', 'age', 'email'));
+        $this->assertEquals(['name' => 'Taylor'], $request->all('name'));
+        $this->assertEquals(['name' => 'Taylor', 'age' => null], $request->all());
+
+        $request = Request::create('/', 'GET', ['developer' => ['name' => 'Taylor', 'age' => null]]);
+        $this->assertEquals(['developer' => ['name' => 'Taylor', 'skills' => null]], $request->all('developer.name', 'developer.skills'));
+        $this->assertEquals(['developer' => ['name' => 'Taylor', 'skills' => null]], $request->all(['developer.name', 'developer.skills']));
+        $this->assertEquals(['developer' => ['age' => null]], $request->all('developer.age'));
+        $this->assertEquals(['developer' => ['skills' => null]], $request->all('developer.skills'));
+        $this->assertEquals(['developer' => ['name' => 'Taylor', 'age' => null]], $request->all());
+    }
+
     public function testOnlyMethod()
     {
         $request = Request::create('/', 'GET', ['name' => 'Taylor', 'age' => null]);


### PR DESCRIPTION
This will make `Request::all('key1', 'key2')` return the two keys only and even if a key wasn't present it'll present it with value `null`.