### PR TITLE
[5.5] Support multiple values in some has() methods

### DIFF
--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -79,12 +79,20 @@ class Gate implements GateContract
     /**
      * Determine if a given ability has been defined.
      *
-     * @param  string  $ability
+     * @param  string|array  $ability
      * @return bool
      */
     public function has($ability)
     {
-        return isset($this->abilities[$ability]);
+        $abilities = is_array($ability) ? $ability : func_get_args();
+
+        foreach ($abilities as $ability) {
+            if (! isset($this->abilities[$ability])) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /**

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -915,7 +915,15 @@ class Router implements RegistrarContract, BindingRegistrar
      */
     public function has($name)
     {
-        return $this->routes->hasNamedRoute($name);
+        $names = is_array($name) ? $name : func_get_args();
+
+        foreach ($names as $value) {
+            if (! $this->routes->hasNamedRoute($value)) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /**

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -593,7 +593,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     public function has($key)
     {
         $keys = is_array($key) ? $key : func_get_args();
-        
+
         foreach ($keys as $value) {
             if (! $this->offsetExists($value)) {
                 return false;

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -592,7 +592,15 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      */
     public function has($key)
     {
-        return $this->offsetExists($key);
+        $keys = is_array($key) ? $key : func_get_args();
+        
+        foreach ($keys as $value) {
+            if (! $this->offsetExists($value)) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /**


### PR DESCRIPTION
This PR gives the ability to pass an array of keys or multiple arguments for the following methods:

- `Gate::has()`
- `Router::has()`
- `Collection::has()`

The methods will return true only if all keys are present.