### PR TITLE
Add failing test for is() method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -244,7 +244,8 @@ class Builder
         $instance = $this->model->newInstance();
 
         return $this->hydrate(
-            $instance->getConnection()->select($query, $bindings)
+            $instance->getConnection()->select($query, $bindings),
+            $this->query->getConnection()->getName()
         );
     }
 

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -223,9 +223,9 @@ class Builder
      * @param  array  $items
      * @return \Illuminate\Database\Eloquent\Collection
      */
-    public function hydrate(array $items)
+    public function hydrate(array $items, $connection = null)
     {
-        $instance = $this->model->newInstance();
+        $instance = $this->model->newInstance()->setConnection($connection);
 
         return $instance->newCollection(array_map(function ($item) use ($instance) {
             return $instance->newFromBuilder($item);
@@ -460,7 +460,7 @@ class Builder
     {
         return $this->model->hydrate(
             $this->query->get($columns)->all(),
-            $this->model->getConnectionName()
+            $this->query->getConnection()->getName()
         )->all();
     }
 

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -1061,6 +1061,14 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertEquals('Jule Doe', $johnWithFriends->friends->find(4)->pivot->friend->name);
     }
 
+    public function testIsAfterRetrievingTheSameModel()
+    {
+        $saved = EloquentTestUser::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']);
+        $retrieved = EloquentTestUser::find(1);
+
+        $this->assertTrue($saved->is($retrieved));
+    }
+
     /**
      * Helpers...
      */


### PR DESCRIPTION
For some reason, retrieving a model from the database isn't setting it's connection name, so if you create a model, retrieve it, and use `is()` to find out if it's the same model, it fails.