### PR TITLE
[5.4] Make Mailer macroable

### DIFF
--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -6,6 +6,7 @@ use Swift_Mailer;
 use Illuminate\Support\Arr;
 use InvalidArgumentException;
 use Illuminate\Contracts\View\Factory;
+use Illuminate\Support\Traits\Macroable;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -16,6 +17,8 @@ use Illuminate\Contracts\Mail\MailQueue as MailQueueContract;
 
 class Mailer implements MailerContract, MailQueueContract
 {
+    use Macroable;
+
     /**
      * The view factory instance.
      *

--- a/tests/Mail/MailMailerTest.php
+++ b/tests/Mail/MailMailerTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Mail;
 
 use Mockery as m;
+use Illuminate\Mail\Mailer;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Support\HtmlString;
 
@@ -148,9 +149,22 @@ class MailMailerTest extends TestCase
         });
     }
 
+    public function testMacroable()
+    {
+        Mailer::macro('foo', function () {
+            return 'bar';
+        });
+
+        $mailer = $this->getMailer();
+
+        $this->assertEquals(
+            'bar', $mailer->foo()
+        );
+    }
+
     protected function getMailer($events = null)
     {
-        return new \Illuminate\Mail\Mailer(m::mock('Illuminate\Contracts\View\Factory'), m::mock('Swift_Mailer'), $events);
+        return new Mailer(m::mock('Illuminate\Contracts\View\Factory'), m::mock('Swift_Mailer'), $events);
     }
 
     public function setSwiftMailer($mailer)


### PR DESCRIPTION
Have a situation where it would be extremely useful to backport the new mail previewing functionality from 5.5, and this is by far the easiest way 😬 

Since it's a [fairly complex class to bootstrap](https://github.com/laravel/framework/blob/5.4/src/Illuminate/Mail/MailServiceProvider.php), binding my own implementation to replace the regular Mailer is more work than I'd like :/