### PR TITLE
[5.5] Snake and Kebab handle lower case words as expected.

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -375,7 +375,7 @@ class Str
         }
 
         if (! ctype_lower($value)) {
-            $value = preg_replace('/\s+/u', '', $value);
+            $value = preg_replace('/\s+/u', '', ucwords($value));
 
             $value = static::lower(preg_replace('/(.)(?=[A-Z])/u', '$1'.$delimiter, $value));
         }

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -193,6 +193,8 @@ class SupportStrTest extends TestCase
         // ensure cache keys don't overlap
         $this->assertEquals('laravel__php__framework', Str::snake('LaravelPhpFramework', '__'));
         $this->assertEquals('laravel_php_framework_', Str::snake('LaravelPhpFramework_', '_'));
+        $this->assertEquals('laravel_php_framework', Str::snake('laravel php Framework'));
+        $this->assertEquals('laravel_php_frame_work', Str::snake('laravel php FrameWork'));
     }
 
     public function testStudly()


### PR DESCRIPTION
It seems like unexpected results to return "snaked" words only if those words or letters start with uppercase and to explicitly ignore a non-letter character followed by an letter.

Current behavior:

```
>>> \Illuminate\Support\Str::snake('Random words Here')
=> "randomwords_here"
>>> Illuminate\Support\Str::snake('Random wORDS  p     here')
=> "randomw_o_r_d_sphere"
```

Proposed change passes current unit tests and doesn't change existing behavior.