### PR TITLE
[5.4] Add ability to send link_names parameter in Slack notification

### DIFF
--- a/src/Illuminate/Notifications/Channels/SlackWebhookChannel.php
+++ b/src/Illuminate/Notifications/Channels/SlackWebhookChannel.php
@@ -59,6 +59,7 @@ class SlackWebhookChannel
             'icon_emoji' => data_get($message, 'icon'),
             'icon_url' => data_get($message, 'image'),
             'channel' => data_get($message, 'channel'),
+            'link_names' => data_get($message, 'linkNames'),
         ]);
 
         return array_merge([

--- a/src/Illuminate/Notifications/Messages/SlackMessage.php
+++ b/src/Illuminate/Notifications/Messages/SlackMessage.php
@@ -49,6 +49,13 @@ class SlackMessage
     public $content;
 
     /**
+     * Linkify channel names and usernames.
+     *
+     * @var bool
+     */
+    public $linkNames = 0;
+
+    /**
      * The message's attachments.
      *
      * @var array
@@ -94,6 +101,18 @@ class SlackMessage
     public function error()
     {
         $this->level = 'error';
+
+        return $this;
+    }
+
+    /**
+     * Find and link channel names and usernames.
+     *
+     * @return $this
+     */
+    public function linkNames()
+    {
+        $this->linkNames = 1;
 
         return $this;
     }


### PR DESCRIPTION
By default, leave link_names off. Added a method to enable link_names.

Signed-off-by: Donnie La Curan <don.lacuran@gmail.com>