### PR TITLE
[5.5] Fluent resource options

### DIFF
--- a/src/Illuminate/Contracts/Routing/Registrar.php
+++ b/src/Illuminate/Contracts/Routing/Registrar.php
@@ -74,7 +74,7 @@ interface Registrar
      * @param  string  $name
      * @param  string  $controller
      * @param  array   $options
-     * @return void
+     * @return \Illuminate\Routing\PendingResourceRegistration
      */
     public function resource($name, $controller, array $options = []);
 

--- a/src/Illuminate/Routing/PendingResourceRegistration.php
+++ b/src/Illuminate/Routing/PendingResourceRegistration.php
@@ -72,19 +72,87 @@ class PendingResourceRegistration
      * Set the methods the controller should apply to.
      *
      * @param  array|string|dynamic  $methods
+     * @return \Illuminate\Routing\PendingResourceRegistration
      */
     public function only($methods)
     {
         $this->options['only'] = is_array($methods) ? $methods : func_get_args();
+
+        return $this;
     }
 
     /**
      * Set the methods the controller should exclude.
      *
      * @param  array|string|dynamic  $methods
+     * @return \Illuminate\Routing\PendingResourceRegistration
      */
     public function except($methods)
     {
         $this->options['except'] = is_array($methods) ? $methods : func_get_args();
+
+        return $this;
+    }
+
+    /**
+     * Set the route names for controller actions.
+     *
+     * @param  array  $names
+     * @return \Illuminate\Routing\PendingResourceRegistration
+     */
+    public function names(array $names)
+    {
+        $this->options['names'] = $names;
+
+        return $this;
+    }
+
+    /**
+     * Set the methods the controller should exclude.
+     *
+     * @param  string  $method
+     * @param  string  $name
+     * @return \Illuminate\Routing\PendingResourceRegistration
+     */
+    public function name($method, $name)
+    {
+        if (! isset($this->options['names'])) {
+            $this->options['names'] = [];
+        }
+
+        $this->options['names'][$method] = $name;
+
+        return $this;
+    }
+
+    /**
+     * Override the route parameter names.
+     *
+     * @param  array  $parameters
+     * @return \Illuminate\Routing\PendingResourceRegistration
+     */
+    public function parameters(array $parameters)
+    {
+        $this->options['parameters'] = $parameters;
+
+        return $this;
+    }
+
+    /**
+     * Override the route parameter name.
+     *
+     * @param  string  $previous
+     * @param  string  $new
+     * @return \Illuminate\Routing\PendingResourceRegistration
+     */
+    public function parameter($previous, $new)
+    {
+        if (! isset($this->options['parameters'])) {
+            $this->options['parameters'] = [];
+        }
+
+        $this->options['parameters'][$previous] = $new;
+
+        return $this;
     }
 }

--- a/src/Illuminate/Routing/PendingResourceRegistration.php
+++ b/src/Illuminate/Routing/PendingResourceRegistration.php
@@ -147,4 +147,17 @@ class PendingResourceRegistration
 
         return $this;
     }
+
+    /**
+     * Set a middleware to the resource.
+     *
+     * @param  mixed  $middleware
+     * @return \Illuminate\Routing\PendingResourceRegistration
+     */
+    public function middleware($middleware)
+    {
+        $this->options['middleware'] = $middleware;
+
+        return $this;
+    }
 }

--- a/src/Illuminate/Routing/PendingResourceRegistration.php
+++ b/src/Illuminate/Routing/PendingResourceRegistration.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Illuminate\Routing;
+
+class PendingResourceRegistration
+{
+    /**
+     * The resource name.
+     *
+     * @var string
+     */
+    protected $name;
+
+    /**
+     * The resource controller.
+     *
+     * @var string
+     */
+    protected $controller;
+
+    /**
+     * The resource options.
+     *
+     * @var string
+     */
+    protected $options = [];
+
+    /**
+     * The resource registrar.
+     *
+     * @var \Illuminate\Routing\ResourceRegistrar
+     */
+    protected $registrar;
+
+    /**
+     * Create a new pending resource registration instance.
+     *
+     * @param  \Illuminate\Routing\ResourceRegistrar  $registrar
+     * @return void
+     */
+    public function __construct(ResourceRegistrar $registrar)
+    {
+        $this->registrar = $registrar;
+    }
+
+    /**
+     * Handle the object's destruction.
+     *
+     * @return void
+     */
+    public function __destruct()
+    {
+        $this->registrar->register($this->name, $this->controller, $this->options);
+    }
+
+    /**
+     * The name, controller and options to use when ready to register.
+     *
+     * @param  string  $name
+     * @param  string  $controller
+     * @param  array   $options
+     * @return void
+     */
+    public function remember($name, $controller, array $options)
+    {
+        $this->name = $name;
+        $this->controller = $controller;
+        $this->options = $options;
+    }
+
+    /**
+     * Set the methods the controller should apply to.
+     *
+     * @param  array|string|dynamic  $methods
+     */
+    public function only($methods)
+    {
+        $this->options['only'] = is_array($methods) ? $methods : func_get_args();
+    }
+
+    /**
+     * Set the methods the controller should exclude.
+     *
+     * @param  array|string|dynamic  $methods
+     */
+    public function except($methods)
+    {
+        $this->options['except'] = is_array($methods) ? $methods : func_get_args();
+    }
+}

--- a/src/Illuminate/Routing/PendingResourceRegistration.php
+++ b/src/Illuminate/Routing/PendingResourceRegistration.php
@@ -108,7 +108,7 @@ class PendingResourceRegistration
     }
 
     /**
-     * Set the methods the controller should exclude.
+     * Set the route name for controller action.
      *
      * @param  string  $method
      * @param  string  $name
@@ -116,10 +116,6 @@ class PendingResourceRegistration
      */
     public function name($method, $name)
     {
-        if (! isset($this->options['names'])) {
-            $this->options['names'] = [];
-        }
-
         $this->options['names'][$method] = $name;
 
         return $this;
@@ -147,10 +143,6 @@ class PendingResourceRegistration
      */
     public function parameter($previous, $new)
     {
-        if (! isset($this->options['parameters'])) {
-            $this->options['parameters'] = [];
-        }
-
         $this->options['parameters'][$previous] = $new;
 
         return $this;

--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -63,6 +63,22 @@ class ResourceRegistrar
     }
 
     /**
+     * Route a resource to a controller lazy.
+     *
+     * @param  string  $name
+     * @param  string  $controller
+     * @param  array   $options
+     * @return \Illuminate\Routing\PendingResourceRegistration
+     */
+    public function lazy($name, $controller, array $options = [])
+    {
+        $registrar = new PendingResourceRegistration($this);
+        $registrar->remember($name, $controller, $options);
+
+        return $registrar;
+    }
+
+    /**
      * Route a resource to a controller.
      *
      * @param  string  $name

--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -63,19 +63,19 @@ class ResourceRegistrar
     }
 
     /**
-     * Route a resource to a controller lazy.
+     * Create a new PendingResourceRegistration.
      *
      * @param  string  $name
      * @param  string  $controller
      * @param  array   $options
      * @return \Illuminate\Routing\PendingResourceRegistration
      */
-    public function lazy($name, $controller, array $options = [])
+    public function registration($name, $controller, array $options = [])
     {
-        $registrar = new PendingResourceRegistration($this);
-        $registrar->remember($name, $controller, $options);
+        $registration = new PendingResourceRegistration($this);
+        $registration->remember($name, $controller, $options);
 
-        return $registrar;
+        return $registration;
     }
 
     /**

--- a/src/Illuminate/Routing/RouteRegistrar.php
+++ b/src/Illuminate/Routing/RouteRegistrar.php
@@ -86,11 +86,11 @@ class RouteRegistrar
      * @param  string  $name
      * @param  string  $controller
      * @param  array  $options
-     * @return void
+     * @return \Illuminate\Routing\PendingResourceRegistration
      */
     public function resource($name, $controller, array $options = [])
     {
-        $this->router->resource($name, $controller, $this->attributes + $options);
+        return $this->router->resource($name, $controller, $this->attributes + $options);
     }
 
     /**

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -255,7 +255,7 @@ class Router implements RegistrarContract, BindingRegistrar
             $registrar = new ResourceRegistrar($this);
         }
 
-        return $registrar->lazy($name, $controller, $options);
+        return $registrar->registration($name, $controller, $options);
     }
 
     /**

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -245,7 +245,7 @@ class Router implements RegistrarContract, BindingRegistrar
      * @param  string  $name
      * @param  string  $controller
      * @param  array  $options
-     * @return void
+     * @return \Illuminate\Routing\PendingResourceRegistration
      */
     public function resource($name, $controller, array $options = [])
     {
@@ -255,7 +255,7 @@ class Router implements RegistrarContract, BindingRegistrar
             $registrar = new ResourceRegistrar($this);
         }
 
-        $registrar->register($name, $controller, $options);
+        return $registrar->lazy($name, $controller, $options);
     }
 
     /**

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Routing;
 
 use Mockery as m;
+use Illuminate\Support\Str;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Router;
 use PHPUnit\Framework\TestCase;
@@ -208,6 +209,37 @@ class RouteRegistrarTest extends TestCase
 
         $this->assertTrue($this->router->getRoutes()->hasNamedRoute('users.update'));
         $this->assertTrue($this->router->getRoutes()->hasNamedRoute('users.destroy'));
+    }
+
+    public function testCanNameRoutesOnRegisteredResource()
+    {
+        $this->router->resource('users', 'Illuminate\Tests\Routing\RouteRegistrarControllerStub')
+                     ->only('create', 'store')->names([
+                         'create' => 'user.build',
+                         'store' => 'user.save',
+                     ]);
+
+        $this->router->resource('posts', 'Illuminate\Tests\Routing\RouteRegistrarControllerStub')
+                    ->only('create', 'destroy')
+                    ->name('create', 'posts.make')
+                    ->name('destroy', 'posts.remove');
+
+        $this->assertTrue($this->router->getRoutes()->hasNamedRoute('user.build'));
+        $this->assertTrue($this->router->getRoutes()->hasNamedRoute('user.save'));
+        $this->assertTrue($this->router->getRoutes()->hasNamedRoute('posts.make'));
+        $this->assertTrue($this->router->getRoutes()->hasNamedRoute('posts.remove'));
+    }
+
+    public function testCanOverrideParametersOnRegisteredResource()
+    {
+        $this->router->resource('users', 'Illuminate\Tests\Routing\RouteRegistrarControllerStub')
+                     ->parameters(['users' => 'admin_user']);
+
+        $this->router->resource('posts', 'Illuminate\Tests\Routing\RouteRegistrarControllerStub')
+                     ->parameter('posts', 'topic');
+
+        $this->assertContains('admin_user', $this->router->getRoutes()->getByName('users.show')->uri);
+        $this->assertContains('topic', $this->router->getRoutes()->getByName('posts.show')->uri);
     }
 
     public function testCanSetRouteName()

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Tests\Routing;
 
 use Mockery as m;
-use Illuminate\Support\Str;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Router;
 use PHPUnit\Framework\TestCase;

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -187,6 +187,29 @@ class RouteRegistrarTest extends TestCase
         $this->seeMiddleware('resource-middleware');
     }
 
+    public function testCanLimitMethodsOnRegisteredResource()
+    {
+        $this->router->resource('users', 'Illuminate\Tests\Routing\RouteRegistrarControllerStub')
+                     ->only('index', 'show', 'destroy');
+
+        $this->assertCount(3, $this->router->getRoutes());
+
+        $this->assertTrue($this->router->getRoutes()->hasNamedRoute('users.index'));
+        $this->assertTrue($this->router->getRoutes()->hasNamedRoute('users.show'));
+        $this->assertTrue($this->router->getRoutes()->hasNamedRoute('users.destroy'));
+    }
+
+    public function testCanExcludeMethodsOnRegisteredResource()
+    {
+        $this->router->resource('users', 'Illuminate\Tests\Routing\RouteRegistrarControllerStub')
+                     ->except(['index', 'create', 'store', 'show', 'edit']);
+
+        $this->assertCount(2, $this->router->getRoutes());
+
+        $this->assertTrue($this->router->getRoutes()->hasNamedRoute('users.update'));
+        $this->assertTrue($this->router->getRoutes()->hasNamedRoute('users.destroy'));
+    }
+
     public function testCanSetRouteName()
     {
         $this->router->as('users.index')->get('users', function () {

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -241,6 +241,14 @@ class RouteRegistrarTest extends TestCase
         $this->assertContains('topic', $this->router->getRoutes()->getByName('posts.show')->uri);
     }
 
+    public function testCanSetMiddlewareOnRegisteredResource()
+    {
+        $this->router->resource('users', 'Illuminate\Tests\Routing\RouteRegistrarControllerStub')
+                     ->middleware('Illuminate\Tests\Routing\RouteRegistrarMiddlewareStub');
+
+        $this->seeMiddleware('Illuminate\Tests\Routing\RouteRegistrarMiddlewareStub');
+    }
+
     public function testCanSetRouteName()
     {
         $this->router->as('users.index')->get('users', function () {
@@ -310,4 +318,9 @@ class RouteRegistrarControllerStub
     {
         return 'deleted';
     }
+}
+
+class RouteRegistrarMiddlewareStub
+{
+
 }


### PR DESCRIPTION
Discussed in https://github.com/laravel/internals/issues/412
Previous PR https://github.com/laravel/framework/pull/18393

Allows defining resource options fluently.

https://laravel.com/docs/master/controllers#resource-controllers

<hr>

**Partial Resource Routes**
```php
Route::resource('users', 'UserController')->only('index', 'show')

Route::resource('comments', 'CommentController')->except([
    'index', 'create', 'edit'
]);
```

**Resource Middleware**

Not in docs?

```php
Route::resource('posts', 'PostController')->middleware(AuthMiddleware::class);
```

**Naming Resource Routes**
```php
Route::resource('persons', 'PersonController')->names([
    'create'  => 'persons.make',
    'destroy' => 'persons.delete',
]);

Route::resource('customers', 'CustomerController')->name('store', 'make');
```

**Naming Resource Route Parameters**
```php
Route::resource('users', 'UserController')->parameters([
    'users' => 'admin_users',
]);

Route::resource('profiles', 'ProfileController')->parameter('profiles', 'users');
```

<hr>

Method chaining is of course allowed.

```php
Route::resource('avatars', 'AvatarController')
     ->only('index', 'show')
     ->name('index', 'avatars.all');
```