### PR TITLE
[5.4] Set connection while retrieving models

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -225,7 +225,9 @@ class Builder
      */
     public function hydrate(array $items)
     {
-        $instance = $this->model->newInstance();
+        $instance = $this->model->newInstance()->setConnection(
+            $this->query->getConnection()->getName()
+        );
 
         return $instance->newCollection(array_map(function ($item) use ($instance) {
             return $instance->newFromBuilder($item);
@@ -459,8 +461,7 @@ class Builder
     public function getModels($columns = ['*'])
     {
         return $this->model->hydrate(
-            $this->query->get($columns)->all(),
-            $this->model->getConnectionName()
+            $this->query->get($columns)->all()
         )->all();
     }
 

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -386,11 +386,10 @@ class DatabaseEloquentBuilderTest extends TestCase
         $records[] = ['name' => 'taylor', 'age' => 26];
         $records[] = ['name' => 'dayle', 'age' => 28];
         $builder->getQuery()->shouldReceive('get')->once()->with(['foo'])->andReturn(new BaseCollection($records));
-        $model = m::mock('Illuminate\Database\Eloquent\Model[getTable,getConnectionName,hydrate]');
+        $model = m::mock('Illuminate\Database\Eloquent\Model[getTable,hydrate]');
         $model->shouldReceive('getTable')->once()->andReturn('foo_table');
         $builder->setModel($model);
-        $model->shouldReceive('getConnectionName')->once()->andReturn('foo_connection');
-        $model->shouldReceive('hydrate')->once()->with($records, 'foo_connection')->andReturn(new Collection(['hydrated']));
+        $model->shouldReceive('hydrate')->once()->with($records)->andReturn(new Collection(['hydrated']));
         $models = $builder->getModels(['foo']);
 
         $this->assertEquals($models, ['hydrated']);

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -1061,6 +1061,14 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertEquals('Jule Doe', $johnWithFriends->friends->find(4)->pivot->friend->name);
     }
 
+    public function testIsAfterRetrievingTheSameModel()
+    {
+        $saved = EloquentTestUser::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']);
+        $retrieved = EloquentTestUser::find(1);
+
+        $this->assertTrue($saved->is($retrieved));
+    }
+
     /**
      * Helpers...
      */


### PR DESCRIPTION
In https://github.com/laravel/framework/pull/17395 we moved the model's `create()` and `forceCreate()` methods to the `Builder` to allow something like `User::on('myCustomConnection')->create();`, before that creating a model on a different collection was a bit hacky.

After that it was pretty obvious that `hydrate()` and `fromQuery()` can be moved to the builder instance as well, since we won't have to pass that $connection argument and we just get it from the Builder instance, that's when https://github.com/laravel/framework/commit/1ae29d9d83a0345e44437237d1c492532b5bcde0 was committed.

However in that commit we removed the argument but forgot to pass the connection name from the Builder instance, leaving the connection as `null` when we retrieve a model.

In this PR we simply set the connection using `$this->query->getConnection()->getName()`, just like we do in `create()` and `forceCreate()`.

This will solve the failing test in https://github.com/laravel/framework/pull/18760 without having to re-introduce the `$connection` argument to the `hydrate()` method.