### PR TITLE
[5.4] Add PHPUnit failures to MocksApplicationServices

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MocksApplicationServices.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MocksApplicationServices.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Foundation\Testing\Concerns;
 
 use Mockery;
-use Exception;
 use Illuminate\Contracts\Bus\Dispatcher as BusDispatcherContract;
 use Illuminate\Contracts\Events\Dispatcher as EventsDispatcherContract;
 use Illuminate\Contracts\Notifications\Dispatcher as NotificationDispatcher;

--- a/src/Illuminate/Foundation/Testing/Concerns/MocksApplicationServices.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MocksApplicationServices.php
@@ -57,11 +57,10 @@ trait MocksApplicationServices
         $this->beforeApplicationDestroyed(function () use ($events) {
             $fired = $this->getFiredEvents($events);
 
-            if ($eventsNotFired = array_diff($events, $fired)) {
-                throw new Exception(
-                    'These expected events were not fired: ['.implode(', ', $eventsNotFired).']'
-                );
-            }
+            $this->assertEmpty(
+                $eventsNotFired = array_diff($events, $fired),
+                'These expected events were not fired: ['.implode(', ', $eventsNotFired).']'
+            );
         });
 
         return $this;
@@ -82,11 +81,10 @@ trait MocksApplicationServices
         $this->withoutEvents();
 
         $this->beforeApplicationDestroyed(function () use ($events) {
-            if ($fired = $this->getFiredEvents($events)) {
-                throw new Exception(
-                    'These unexpected events were fired: ['.implode(', ', $fired).']'
-                );
-            }
+            $this->assertEmpty(
+                $fired = $this->getFiredEvents($events),
+                'These unexpected events were fired: ['.implode(', ', $fired).']'
+            );
         });
 
         return $this;
@@ -138,11 +136,10 @@ trait MocksApplicationServices
         $this->beforeApplicationDestroyed(function () use ($jobs) {
             $dispatched = $this->getDispatchedJobs($jobs);
 
-            if ($jobsNotDispatched = array_diff($jobs, $dispatched)) {
-                throw new Exception(
-                    'These expected jobs were not dispatched: ['.implode(', ', $jobsNotDispatched).']'
-                );
-            }
+            $this->assertEmpty(
+                $jobsNotDispatched = array_diff($jobs, $dispatched),
+                'These expected jobs were not dispatched: ['.implode(', ', $jobsNotDispatched).']'
+            );
         });
 
         return $this;
@@ -163,11 +160,10 @@ trait MocksApplicationServices
         $this->withoutJobs();
 
         $this->beforeApplicationDestroyed(function () use ($jobs) {
-            if ($dispatched = $this->getDispatchedJobs($jobs)) {
-                throw new Exception(
-                    'These unexpected jobs were dispatched: ['.implode(', ', $dispatched).']'
-                );
-            }
+            $this->assertEmpty(
+                $dispatched = $this->getDispatchedJobs($jobs),
+                'These unexpected jobs were dispatched: ['.implode(', ', $dispatched).']'
+            );
         });
 
         return $this;
@@ -280,9 +276,7 @@ trait MocksApplicationServices
                 }
             }
 
-            throw new Exception(
-                'The following expected notification were not dispatched: ['.$notification.']'
-            );
+            $this->fail('The following expected notification were not dispatched: ['.$notification.']');
         });
 
         return $this;


### PR DESCRIPTION
By throwing an exception for failed assertions, tests that only expect events or dispatched jobs will be considered risky under PHPUnit's `--report-useless-tests`.

This PR replaces the exceptions with PHPUnit assertions for PHPUnit knows that an assertion **did** take place.