### PR TITLE
dispatch() helper with resolving class from ioc container and arguments

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -367,11 +367,15 @@ if (! function_exists('dispatch')) {
     /**
      * Dispatch a job to its appropriate handler.
      *
-     * @param  mixed  $job
+     * @param  dynamic  job instance|job class name|job class name, job arguments
      * @return mixed
      */
-    function dispatch($job)
+    function dispatch($job, ...$args)
     {
+        if (is_string($job)) {
+            $job = app()->makeWith($job, $args);
+        }
+
         return app(Dispatcher::class)->dispatch($job);
     }
 }

--- a/tests/Foundation/FoundationHelpersTest.php
+++ b/tests/Foundation/FoundationHelpersTest.php
@@ -5,12 +5,32 @@ namespace Illuminate\Tests\Foundation;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Foundation\Application;
+use Illuminate\Contracts\Bus\Dispatcher;
 
 class FoundationHelpersTest extends TestCase
 {
     public function tearDown()
     {
         m::close();
+    }
+
+    public function testDispatch()
+    {
+        $app = new Application;
+        $app[Dispatcher::class] = $dipatcher = m::mock('StdClass');
+
+        // 1. dispatch(new Job)
+        $job = m::mock('JobName');
+        $dipatcher->shouldReceive('dispatch')->with($job);
+        dispatch($job);
+
+        // 1. dispatch(Job::class)
+        $dipatcher->shouldReceive('dispatch')->once()->with(m::type('StdClass'));
+        dispatch(\StdClass::class);
+
+        // 1. dispatch(Job::class, 'arg1', 'arg2')
+        $dipatcher->shouldReceive('dispatch')->once()->with(m::type('StdClass'));
+        dispatch(\StdClass::class, 'arg1', 'arg2');
     }
 
     public function testCache()


### PR DESCRIPTION
This allows you dispatch a job from anywhere with automatic class resolution. 

```php
dispatch(JobName::class, 'arg1', 'arg2');
```

i wrote basic test, but have no idea how to test job arguments.
all tests passing, backward compatibility should be ok.