### PR TITLE
[5.4] Fix Pagination overflow with page bigger than last page

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1725,6 +1725,15 @@ class Builder
 
         $total = $this->getCountForPagination($columns);
 
+        /**
+         * We want to avoid having an overflow of pages
+         * If the page asked is bigger than the last page,
+         * return the last page
+         */
+        if(($page * $perPage) > $total) {
+            $page = ceil($total / $perPage);
+        }
+
         $results = $total ? $this->forPage($page, $perPage)->get($columns) : collect();
 
         return new LengthAwarePaginator($results, $total, $perPage, $page, [

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1725,12 +1725,12 @@ class Builder
 
         $total = $this->getCountForPagination($columns);
 
-        /**
+        /*
          * We want to avoid having an overflow of pages
          * If the page asked is bigger than the last page,
          * return the last page
          */
-        if(($page * $perPage) > $total) {
+        if (($page * $perPage) > $total) {
             $page = ceil($total / $perPage);
         }
 


### PR DESCRIPTION
When the user give a page to the paginator that is bigger than the last page, it can trigger a SQL exception where the offset is negative or bigger than the number of records in the table.