### PR TITLE
[5.5] Better cli detection for phpdbg

### DIFF
--- a/src/Illuminate/Foundation/Bootstrap/LoadEnvironmentVariables.php
+++ b/src/Illuminate/Foundation/Bootstrap/LoadEnvironmentVariables.php
@@ -38,7 +38,7 @@ class LoadEnvironmentVariables
      */
     protected function checkForSpecificEnvironmentFile($app)
     {
-        if (php_sapi_name() == 'cli' && ($input = new ArgvInput)->hasParameterOption('--env')) {
+        if ($app->runningInConsole() && ($input = new ArgvInput)->hasParameterOption('--env')) {
             $this->setEnvironmentFilePath(
                 $app, $app->environmentFile().'.'.$input->getParameterOption('--env')
             );

--- a/src/Illuminate/Support/Debug/Dumper.php
+++ b/src/Illuminate/Support/Debug/Dumper.php
@@ -16,7 +16,7 @@ class Dumper
     public function dump($value)
     {
         if (class_exists(CliDumper::class)) {
-            $dumper = 'cli' === PHP_SAPI ? new CliDumper : new HtmlDumper;
+            $dumper = in_array(PHP_SAPI, ['cli', 'phpdbg']) ? new CliDumper : new HtmlDumper;
 
             $dumper->dump((new VarCloner)->cloneVar($value));
         } else {


### PR DESCRIPTION
[Illuminate\Foundation\Application::runningInConsole()](https://github.com/laravel/framework/blob/master/src/Illuminate/Foundation/Application.php#L526) already checks to see if the current script is being run from `cli` or `phpdbg`, but there were a few other places in the application where only `cli` was being checked.

The primary need for this fix is that the Dumper class, used by `dd` would dump html output when running under `phpdbg`