### PR TITLE
Makes buildView() public

### DIFF
--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -179,7 +179,7 @@ class Mailable implements MailableContract, Renderable
      *
      * @return array|string
      */
-    protected function buildView()
+    public function buildView()
     {
         if (isset($this->markdown)) {
             return $this->buildMarkdownView();


### PR DESCRIPTION
When this is protected, I cannot build the view from an external class. I'm currently using this as a means to preview an email before it gets sent.