### PR TITLE
[5.4] Make SessionGuard Macroable

### DIFF
--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -5,6 +5,7 @@ namespace Illuminate\Auth;
 use RuntimeException;
 use Illuminate\Support\Str;
 use Illuminate\Http\Response;
+use Illuminate\Support\Traits\Macroable;
 use Illuminate\Contracts\Session\Session;
 use Illuminate\Contracts\Auth\UserProvider;
 use Illuminate\Contracts\Events\Dispatcher;
@@ -16,7 +17,7 @@ use Illuminate\Contracts\Auth\Authenticatable as AuthenticatableContract;
 
 class SessionGuard implements StatefulGuard, SupportsBasicAuth
 {
-    use GuardHelpers;
+    use GuardHelpers, Macroable;
 
     /**
      * The name of the Guard. Typically "session".

--- a/tests/Auth/AuthGuardTest.php
+++ b/tests/Auth/AuthGuardTest.php
@@ -111,6 +111,19 @@ class AuthGuardTest extends TestCase
         $mock->login($user);
     }
 
+    public function testSessionGuardIsMacroable()
+    {
+        $guard = $this->getGuard();
+
+        $guard->macro('foo', function () {
+            return 'bar';
+        });
+
+        $this->assertEquals(
+            'bar', $guard->foo()
+        );
+    }
+
     public function testLoginFiresLoginAndAuthenticatedEvents()
     {
         list($session, $provider, $request, $cookie) = $this->getMocks();


### PR DESCRIPTION
I often find it convenient to shortcut code like:
```php
auth()->user()->company
```
By adding "Macroable" to the SessionGuard, we open up possibilities for things like:
```php
auth()->company
```
