### PR TITLE
[5.4] Attempt to fix container bug

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -587,6 +587,7 @@ class Container implements ArrayAccess, ContainerContract
         // so the developer can keep using the same objects instance every time.
         if (isset($this->instances[$abstract]) && ! $needsContextualBuild) {
             array_pop($this->with);
+
             return $this->instances[$abstract];
         }
 

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -576,8 +576,6 @@ class Container implements ArrayAccess, ContainerContract
      */
     protected function resolve($abstract, $parameters = [])
     {
-        $this->with[] = $parameters;
-
         $needsContextualBuild = ! empty($parameters) || ! is_null(
             $this->getContextualConcrete($abstract = $this->getAlias($abstract))
         );
@@ -586,10 +584,10 @@ class Container implements ArrayAccess, ContainerContract
         // just return an existing instance instead of instantiating new instances
         // so the developer can keep using the same objects instance every time.
         if (isset($this->instances[$abstract]) && ! $needsContextualBuild) {
-            array_pop($this->with);
-
             return $this->instances[$abstract];
         }
+
+        $this->with[] = $parameters;
 
         $concrete = $this->getConcrete($abstract);
 

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -586,6 +586,7 @@ class Container implements ArrayAccess, ContainerContract
         // just return an existing instance instead of instantiating new instances
         // so the developer can keep using the same objects instance every time.
         if (isset($this->instances[$abstract]) && ! $needsContextualBuild) {
+            array_pop($this->with);
             return $this->instances[$abstract];
         }
 


### PR DESCRIPTION
This is an attempt to fix the bug introduced in 5.4.16 as described in https://github.com/laravel/framework/issues/18806

From my testing - it looks when resolving a singleton, the collection never pops the `$this->make[]` array - resulting in additional new arrays being constantly added to the existing array every time a call to `resolve()` occurs. Because these new arrays are never released when resolving a singleton - it results in the run away memory usage.

This is particularly noticeable in an Eloquent object, where calls that include date attribute casting can easily result in thousands of calls to `resolve()` - which keeps adding arrays to `$this->make[]`, and never pops them off when finished.

My testing shows memory returns to the same as `5.4.15` with this PR.

My major concern; is there another effect on the container this PR might have that I'm not considering? Especially for the `makeWith()` functions?

I ran through the container code - and I dont believe `$this->with` is ever touched until after the container confirms it is not resolving something that is already resolved as a singleton. So by moving it down until after the singleton test, we remove the increased memory usage...