### PR TITLE
[5.4] [WIP] Allow logging of events

### DIFF
--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -43,6 +43,13 @@ class Dispatcher implements DispatcherContract
     protected $queueResolver;
 
     /**
+     * All of the events fired since enabling event logging.
+     *
+     * @var array
+     */
+    protected $eventLog = [];
+
+    /**
      * Create a new event dispatcher instance.
      *
      * @param  \Illuminate\Contracts\Container\Container|null  $container
@@ -545,5 +552,27 @@ class Dispatcher implements DispatcherContract
         $this->queueResolver = $resolver;
 
         return $this;
+    }
+
+    /**
+     * Enable logging of events.
+     *
+     * @return void
+     */
+    public function enableEventLog()
+    {
+        $this->listen('*', function ($event) {
+            array_push($this->eventLog, $event);
+        });
+    }
+
+    /**
+     * Get the event log.
+     *
+     * @return array
+     */
+    public function getEventLog()
+    {
+        return $this->eventLog;
     }
 }

--- a/tests/Events/EventsDispatcherTest.php
+++ b/tests/Events/EventsDispatcherTest.php
@@ -239,6 +239,15 @@ class EventsDispatcherTest extends TestCase
         $this->assertSame('fooo', $_SERVER['__event.test1']);
         $this->assertSame('baar', $_SERVER['__event.test2']);
     }
+
+    public function testCanLogEvents()
+    {
+        $d = new Dispatcher;
+        $d->enableEventLog();
+        $d->fire(new ExampleEvent);
+
+        $this->assertEquals(['Illuminate\Tests\Events\ExampleEvent'], $d->getEventLog());
+    }
 }
 
 class TestDispatcherQueuedHandler implements \Illuminate\Contracts\Queue\ShouldQueue


### PR DESCRIPTION
As proposed in [this internals issue](https://github.com/laravel/internals/issues/530). This introduces a couple new methods to the event dispatcher to allow logging of events.

```php
Event::enableEventLog();
Event::getEventLog();
```

Ideally I'd prefer it if the logging functionality could be disabled.

```php
Event::disableEventLog();
```

However, I can't figure out how to do this without side affects. Any suggestions?