### PR TITLE
Adding "mapAllWithKeys" method to Collection

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -727,6 +727,29 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
         return new static($result);
     }
 
+	/**
+	 * Map over the collection values and create a new one where the $index key of each item is
+	 * the final item index, And the value is an array of arrays, So the ones with the same
+	 * indexes, wouldnt be lost.
+	 *
+	 * Useful when doing multiple searches through database for rows with the columns such as "Date" or ... equal to a value...
+	 * This way we only use one query, and get the value with Collection get("index"), or plain php $array["index"].
+	 *
+	 *
+	 * @param  string  $index
+	 * @return static
+	 */
+	public function mapAllWithKeys( $index )
+	{
+		$result = [];
+
+		foreach ($this->items as $key => $value) {
+			$result[ $value[$index] ][] = $value;
+		}
+
+		return new static($result);
+	}
+
     /**
      * Map a collection and flatten the result by a single level.
      *


### PR DESCRIPTION
I was creating a calendar with Laravel and I came across the method **mapWithKeys**, what I wanted to do was searching for events in every day, now obviously I couldnt make a search query for every day to search for events, and using **mapWithKeys**, I would get one item in each day, which isn`t useful because a day can have multiple events.
But with this **mapAllWithKeys** method, i was able to gather all rows of my table, and save it to an array where key is the column`s date, and value is an array of rows which their date column equals to $date ( the index ).
So now, all I have to do to find each day`s events, Is to use PHP isset( $array[ "today-date" ], or Collection::has("today-date") and then get them.