### PR TITLE
[5.4] Fix bug of Eloquent\Builder::implode() returns the builder self

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -69,7 +69,7 @@ class Builder
      */
     protected $passthru = [
         'insert', 'insertGetId', 'getBindings', 'toSql',
-        'exists', 'count', 'min', 'max', 'avg', 'sum', 'getConnection',
+        'exists', 'count', 'min', 'max', 'avg', 'sum', 'getConnection', 'implode',
     ];
 
     /**


### PR DESCRIPTION
### Bug
```php
SomeModel::implode('the_field');                        // returns a instance of Eloquent\Builder
$modelObject->someRelationship()->implode('the_field'); // returns a instance of Eloquent\Builder
(new Eloquent\Builder)->implode('the_field');           // returns a instance of relation class
```
### Fixing
Add "implode" to Eloquent\Builder::$passthru