### PR TITLE
[5.4] Add the lazy method to replace the closure use in model factories

### DIFF
--- a/src/Illuminate/Database/Eloquent/FactoryBuilder.php
+++ b/src/Illuminate/Database/Eloquent/FactoryBuilder.php
@@ -103,6 +103,19 @@ class FactoryBuilder
     }
 
     /**
+     * Create a model and persist it in the database if requested.
+     *
+     * @param  array  $attributes
+     * @return \Closure
+     */
+    public function lazy(array $attributes = [])
+    {
+        return function () use ($attributes) {
+            return $this->create($attributes);
+        };
+    }
+
+    /**
      * Create a collection of models and persist them to the database.
      *
      * @param  array  $attributes


### PR DESCRIPTION
Following: https://github.com/laravel/framework/pull/18499

I added the lazy method to delay the creation of models in the database in a more eloquent way:

```
$factory->define(App\Post::class, function (Faker\Generator $faker) {
    return [
        'user_id' => function() {
            return factory(App\User::class)->create();
        }
   ];
});
```

```
$factory->define(App\Post::class, function (Faker\Generator $faker) {
    return [
        'user_id' => factory(App\User::class)->lazy()
   ];
});
```

What do you think?