### PR TITLE
[5.4] Fix mail theme body color

### DIFF
--- a/src/Illuminate/Mail/resources/views/html/themes/default.css
+++ b/src/Illuminate/Mail/resources/views/html/themes/default.css
@@ -6,7 +6,7 @@ body, body *:not(html):not(style):not(br):not(tr):not(code) {
 }
 
 body {
-    background-color: #F2F4F6;
+    background-color: #f5f8fa;
     color: #74787E;
     height: 100%;
     line-height: 1.4;


### PR DESCRIPTION
For whatever reason the `body` background color was slightly different from `.wrapper`.