### PR TITLE
[5.4] Throw an OutOfPaginationRangeException on pages out of range

### DIFF
--- a/CHANGELOG-5.4.md
+++ b/CHANGELOG-5.4.md
@@ -1,5 +1,23 @@
 # Release Notes for 5.4.x
 
+## v5.4.19 (2017-04-16)
+
+### Added
+- Added ability to send `link_names` parameter in Slack notification ([#18765](https://github.com/laravel/framework/pull/18765))
+- Added `Mailable::hasFrom()` method ([#18790](https://github.com/laravel/framework/pull/18790))
+
+### Changed
+- Made `Mailer` macroable ([#18763](https://github.com/laravel/framework/pull/18763))
+- Made `SessionGuard` macroable ([#18796](https://github.com/laravel/framework/pull/18796))
+- Improved queue worker output ([#18773](https://github.com/laravel/framework/pull/18773))
+- Added `newModelInstance()` method to Eloquent Builder ([#18775](https://github.com/laravel/framework/pull/18775))
+- Use assertions instead of exceptions in `MocksApplicationServices` ([#18774](https://github.com/laravel/framework/pull/18774))
+
+### Fixed
+- Fixed memory issue in `Container` ([#18812](https://github.com/laravel/framework/pull/18812))
+- Set database connection while retrieving models ([#18769](https://github.com/laravel/framework/pull/18769))
+
+
 ## v5.4.18 (2017-04-10)
 
 ### Added

--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -5,6 +5,7 @@ namespace Illuminate\Auth;
 use RuntimeException;
 use Illuminate\Support\Str;
 use Illuminate\Http\Response;
+use Illuminate\Support\Traits\Macroable;
 use Illuminate\Contracts\Session\Session;
 use Illuminate\Contracts\Auth\UserProvider;
 use Illuminate\Contracts\Events\Dispatcher;
@@ -16,7 +17,7 @@ use Illuminate\Contracts\Auth\Authenticatable as AuthenticatableContract;
 
 class SessionGuard implements StatefulGuard, SupportsBasicAuth
 {
-    use GuardHelpers;
+    use GuardHelpers, Macroable;
 
     /**
      * The name of the Guard. Typically "session".

--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -156,7 +156,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
     /**
      * Pull a user from the repository by its "remember me" cookie token.
      *
-     * @param  string  $recaller
+     * @param  \Illuminate\Auth\Recaller  $recaller
      * @return mixed
      */
     protected function userFromRecaller($recaller)

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -576,8 +576,6 @@ class Container implements ArrayAccess, ContainerContract
      */
     protected function resolve($abstract, $parameters = [])
     {
-        $this->with[] = $parameters;
-
         $needsContextualBuild = ! empty($parameters) || ! is_null(
             $this->getContextualConcrete($abstract = $this->getAlias($abstract))
         );
@@ -588,6 +586,8 @@ class Container implements ArrayAccess, ContainerContract
         if (isset($this->instances[$abstract]) && ! $needsContextualBuild) {
             return $this->instances[$abstract];
         }
+
+        $this->with[] = $parameters;
 
         $concrete = $this->getConcrete($abstract);
 

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -28,7 +28,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
      *
      * @var string
      */
-    const VERSION = '5.4.18';
+    const VERSION = '5.4.19';
 
     /**
      * The base path for the Laravel installation.

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Foundation\Exceptions;
 
 use Exception;
-use Illuminate\Pagination\OutOfPaginationRangeException;
 use Psr\Log\LoggerInterface;
 use Illuminate\Http\Response;
 use Illuminate\Http\RedirectResponse;
@@ -14,6 +13,7 @@ use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Http\Exceptions\HttpResponseException;
 use Symfony\Component\Debug\Exception\FlattenException;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Pagination\OutOfPaginationRangeException;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\Console\Application as ConsoleApplication;
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Foundation\Exceptions;
 
 use Exception;
+use Illuminate\Pagination\OutOfPaginationRangeException;
 use Psr\Log\LoggerInterface;
 use Illuminate\Http\Response;
 use Illuminate\Http\RedirectResponse;
@@ -128,6 +129,8 @@ class Handler implements ExceptionHandlerContract
     protected function prepareException(Exception $e)
     {
         if ($e instanceof ModelNotFoundException) {
+            $e = new NotFoundHttpException($e->getMessage(), $e);
+        } elseif ($e instanceof OutOfPaginationRangeException) {
             $e = new NotFoundHttpException($e->getMessage(), $e);
         } elseif ($e instanceof AuthorizationException) {
             $e = new HttpException(403, $e->getMessage());

--- a/src/Illuminate/Mail/resources/views/html/message.blade.php
+++ b/src/Illuminate/Mail/resources/views/html/message.blade.php
@@ -10,13 +10,13 @@
     {{ $slot }}
 
     {{-- Subcopy --}}
-    @if (isset($subcopy))
+    @isset($subcopy)
         @slot('subcopy')
             @component('mail::subcopy')
                 {{ $subcopy }}
             @endcomponent
         @endslot
-    @endif
+    @endisset
 
     {{-- Footer --}}
     @slot('footer')

--- a/src/Illuminate/Mail/resources/views/markdown/layout.blade.php
+++ b/src/Illuminate/Mail/resources/views/markdown/layout.blade.php
@@ -1,9 +1,9 @@
 {!! strip_tags($header) !!}
 
 {!! strip_tags($slot) !!}
-@if (isset($subcopy))
+@isset($subcopy)
 
 {!! strip_tags($subcopy) !!}
-@endif
+@endisset
 
 {!! strip_tags($footer) !!}

--- a/src/Illuminate/Mail/resources/views/markdown/message.blade.php
+++ b/src/Illuminate/Mail/resources/views/markdown/message.blade.php
@@ -10,13 +10,13 @@
     {{ $slot }}
 
     {{-- Subcopy --}}
-    @if (isset($subcopy))
+    @isset($subcopy)
         @slot('subcopy')
             @component('mail::subcopy')
                 {{ $subcopy }}
             @endcomponent
         @endslot
-    @endif
+    @endisset
 
     {{-- Footer --}}
     @slot('footer')

--- a/src/Illuminate/Notifications/resources/views/email.blade.php
+++ b/src/Illuminate/Notifications/resources/views/email.blade.php
@@ -17,7 +17,7 @@
 @endforeach
 
 {{-- Action Button --}}
-@if (isset($actionText))
+@isset($actionText)
 <?php
     switch ($level) {
         case 'success':
@@ -33,7 +33,7 @@
 @component('mail::button', ['url' => $actionUrl, 'color' => $color])
 {{ $actionText }}
 @endcomponent
-@endif
+@endisset
 
 {{-- Outro Lines --}}
 @foreach ($outroLines as $line)
@@ -49,10 +49,10 @@ Regards,<br>{{ config('app.name') }}
 @endif
 
 <!-- Subcopy -->
-@if (isset($actionText))
+@isset($actionText)
 @component('mail::subcopy')
 If you’re having trouble clicking the "{{ $actionText }}" button, copy and paste the URL below
 into your web browser: [{{ $actionUrl }}]({{ $actionUrl }})
 @endcomponent
-@endif
+@endisset
 @endcomponent

--- a/src/Illuminate/Pagination/OutOfPaginationRangeException.php
+++ b/src/Illuminate/Pagination/OutOfPaginationRangeException.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Illuminate\Pagination;
+
+use RuntimeException;
+
+class OutOfPaginationRangeException extends RuntimeException
+{
+    /**
+     * Set the current page being queried.
+     *
+     * @param  int  $page
+     * @return $this
+     */
+    public function setPage($page)
+    {
+        $this->message = "No results found for page $page";
+
+        return $this;
+    }
+}

--- a/tests/Auth/AuthGuardTest.php
+++ b/tests/Auth/AuthGuardTest.php
@@ -111,6 +111,19 @@ class AuthGuardTest extends TestCase
         $mock->login($user);
     }
 
+    public function testSessionGuardIsMacroable()
+    {
+        $guard = $this->getGuard();
+
+        $guard->macro('foo', function () {
+            return 'bar';
+        });
+
+        $this->assertEquals(
+            'bar', $guard->foo()
+        );
+    }
+
     public function testLoginFiresLoginAndAuthenticatedEvents()
     {
         list($session, $provider, $request, $cookie) = $this->getMocks();


### PR DESCRIPTION
When you paginate results and request a page that's out of pagination range laravel currently shows a page with no results, this PR will throw an `OutOfPaginationRangeException` and adjusts the handler to render this exception as a `NotFoundHttpException`.

This will return a 404 response instead of 200 for pages that are out of range.

For more details on why such change can be useful you can refer to: https://support.google.com/webmasters/answer/181708?hl=en