### PR TITLE
[5.4] Break long words in HTML emails

### DIFF
--- a/src/Illuminate/Mail/resources/views/html/themes/default.css
+++ b/src/Illuminate/Mail/resources/views/html/themes/default.css
@@ -13,6 +13,12 @@ body {
     margin: 0;
     width: 100% !important;
     -webkit-text-size-adjust: none;
+    -ms-word-break: break-all;
+    word-break: break-all;
+    word-break: break-word;
+    -webkit-hyphens: auto;
+    -moz-hyphens: auto;
+    hyphens: auto;
 }
 
 p,


### PR DESCRIPTION
Long words or links (like password reset tokens) break the email layout.

Code taken from: https://css-tricks.com/almanac/properties/w/word-break/