### PR TITLE
[5.4] Replace duplicated method with result

### DIFF
--- a/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php
+++ b/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php
@@ -66,7 +66,7 @@ class LoadConfiguration
             throw new Exception('Unable to load the "app" configuration file.');
         }
 
-        foreach ($this->getConfigurationFiles($app) as $key => $path) {
+        foreach ($files as $key => $path) {
             $repository->set($key, require $path);
         }
     }


### PR DESCRIPTION
In the loadConfigurationFiles method, on the first line, the getConfigurationFiles method is called and set to $files. A couple of lines down, instead of using the $files that were found, the getConfigurationFiles method is called again. I can't see where this would cause any problems, and might actually speed things up a little down at the nano-level. Code below:
```
    protected function loadConfigurationFiles(Application $app, RepositoryContract $repository)
    {
        $files = $this->getConfigurationFiles($app);  // FIRST CALL
        if (! isset($files['app'])) {
            throw new Exception('Unable to load the "app" configuration file.');
        }
        foreach ($this->getConfigurationFiles($app) as $key => $path) {  // SECOND CALL
            $repository->set($key, require $path);
        }
    }

```
See the duplication via comments.
Is it possible that something can actually change in the config files between the time it takes to check for the 'app' key in $files? Doesn't seem so.

This PR simply replaces the second call to this method with the results of the first, which is $files.

Thanks! Clay