### PR TITLE
[5.4] Add the ability to create model factory classes.

### DIFF
--- a/src/Illuminate/Database/Eloquent/FactoryClass.php
+++ b/src/Illuminate/Database/Eloquent/FactoryClass.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Illuminate\Database\Eloquent;
+
+use Exception;
+use Faker\Generator as Faker;
+
+abstract class FactoryClass
+{
+    /**
+     * The Faker instance.
+     *
+     * @var \Faker\Generator
+     */
+    protected $faker;
+
+    /**
+     * The Eloquent model associated to this factory class.
+     *
+     * @var string
+     */
+    protected $model;
+
+    /**
+     * Create a new factory class instance.
+     *
+     * @param  \Faker\Generator  $faker
+     * @return void
+     */
+    public function __construct()
+    {
+        $this->faker = app(Faker::class);
+    }
+
+    /**
+     * Return the basic data for this model factory.
+     *
+     * @return array
+     */
+    abstract public function data();
+
+    /**
+     * Return the Eloquent model associated to this factory class.
+     *
+     * @return string
+     *
+     * @throws Exception
+     */
+    public function model()
+    {
+        if (! $this->model) {
+            throw new Exception(
+                'Please define the $model property in the '.get_class($this).' class'
+            );
+        }
+
+        return $this->model;
+    }
+
+    /**
+     * Proxy to get the Faker data.
+     *
+     * @param $var
+     * @return mixed
+     */
+    public function __get($var)
+    {
+        return $this->faker->$var;
+    }
+
+    /**
+     * Proxy to call the Faker methods.
+     *
+     * @param  string  $method
+     * @param  array  $attributes
+     * @return mixed
+     */
+    public function __call($method, array $attributes = [])
+    {
+        return $this->faker->$method(...$attributes);
+    }
+
+    /**
+     * Create and return a new factory class builder.
+     *
+     * @param  string  $method
+     * @param  array  $attributes
+     * @return \Illuminate\Database\Eloquent\FactoryClassBuilder
+     */
+    public static function __callStatic($method, array $attributes = [])
+    {
+        return (new FactoryClassBuilder(new static))->$method(...$attributes);
+    }
+}

--- a/src/Illuminate/Database/Eloquent/FactoryClassBuilder.php
+++ b/src/Illuminate/Database/Eloquent/FactoryClassBuilder.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Illuminate\Database\Eloquent;
+
+use InvalidArgumentException;
+
+class FactoryClassBuilder extends FactoryBuilder
+{
+    /**
+     * The factory class linked to this builder.
+     *
+     * @var \Illuminate\Database\Eloquent\FactoryClass
+     */
+    protected $factoryClass;
+
+    /**
+     * Create an new builder instance.
+     *
+     * @param  \Illuminate\Database\Eloquent\FactoryClass  $factoryClass
+     * @return void
+     */
+    public function __construct(FactoryClass $factoryClass)
+    {
+        $this->factoryClass = $factoryClass;
+        $this->class = $factoryClass->model();
+    }
+
+    /**
+     * Get a raw attributes array for the model.
+     *
+     * @param  array  $attributes
+     * @return mixed
+     */
+    protected function getRawAttributes(array $attributes = [])
+    {
+        return $this->callClosureAttributes(
+            array_merge(
+                $this->applyStates($this->factoryClass->data($attributes), $attributes),
+                $attributes
+            )
+        );
+    }
+
+    /**
+     * Make an instance of the model with the given attributes.
+     *
+     * @param  array  $attributes
+     * @return \Illuminate\Database\Eloquent\Model
+     */
+    protected function makeInstance(array $attributes = [])
+    {
+        return Model::unguarded(function () use ($attributes) {
+            return new $this->class(
+                $this->getRawAttributes($attributes)
+            );
+        });
+    }
+
+    /**
+     * Apply the active states to the model definition array.
+     *
+     * @param  array  $definition
+     * @param  array  $attributes
+     * @return array
+     */
+    protected function applyStates(array $definition, array $attributes = [])
+    {
+        foreach ($this->activeStates as $state) {
+            $stateMethod = 'state'.ucfirst($state);
+
+            if (! method_exists($this->factoryClass, $stateMethod)) {
+                throw new InvalidArgumentException(
+                    "The state method [{$stateMethod}] was not found in the class "
+                    .get_class($this->factoryClass)
+                );
+            }
+
+            $definition = array_merge($definition, $this->factoryClass->$stateMethod($attributes));
+        }
+
+        return $definition;
+    }
+}


### PR DESCRIPTION
I've been playing with the idea of using classes to define model factories instead of closures, so this:

```
<?php

$factory->define(\App\User::class, function (Faker\Generator $faker) {
    return [
        'name' => $faker->name,
        'email' => $faker->unique()->safeEmail,
        'remember_token' => str_random(10),
    ];
});

$factory->state(App\User::class, 'delinquent', function (Faker\Generator $faker) {
    return ['account_status' => 'delinquent'];
});
```

Could be defined like this:

```
<?php

class UserFactory extends Factory
{
    protected $model = 'App\User'; // or protected $model = \App\User::class

    public function data()
    {
        return [
            'name' => $this->name,
            'email' => $this->unique()->safeEmail,
            'remember_token' => str_random(10),
        ];
    }

    public function stateDelinquent()
    {
        return ['account_status' => 'delinquent'];
    }
}
```

(`Factory` is an alias of `Illuminate\Database\Eloquent\FactoryClass`).

It is a little bit more of code (I know) but the classes can be generated with a simple artisan command (I can commit the command later):

`php artisan make:factory PostFactory` or:

`php artisan make:model Post -f`

On the other hand I think the tests will look cleaner since this:

`factory(\App\Post::class)->create()`

Now becomes:

`PostFactory::create()`

Or:

`factory(\App\Post::class)->times(5)->create()`

Now becomes:

`PostFactory::times(5)->create()`

By using classes for each factory it is now possible to define common states or having a factory class extend from another in a more OO way.

The current factories are of course still in place (I didn't touch the current classes).