### PR TITLE
Adds the ability to force a new connection to Redis

### DIFF
--- a/src/Illuminate/Redis/RedisManager.php
+++ b/src/Illuminate/Redis/RedisManager.php
@@ -47,11 +47,11 @@ class RedisManager implements Factory
      * @param  string|null  $name
      * @return \Illuminate\Redis\Connections\Connection
      */
-    public function connection($name = null)
+    public function connection($name = null, $forceNew = false)
     {
         $name = $name ?: 'default';
 
-        if (isset($this->connections[$name])) {
+        if (isset($this->connections[$name]) && $forceNew == false) {
             return $this->connections[$name];
         }
 


### PR DESCRIPTION
When using Redis' SUBSCRIBE the recommendation is to open a second connection for any key modification you need to do. E.g. Laravel does not currently allow you to modify keys why subscribed, causing the following to error,

```
Redis::subscribe('queue-notifications', function ($msg) {
  $job = Redis::rpoplpush('queue-jobs', 'working-jobs');
});
```

The exact error is,

```
ERR only (P)SUBSCRIBE / (P)UNSUBSCRIBE / PING / QUIT allowed in this context
```

This PR allows you to work around this by forcing a new connection to Redis, when necessary,

```
Redis::subscribe('queue-notifications', function ($msg) {
  $redis = Redis::connection(null, true);
  $job = $redis->rpoplpush('queue-jobs', 'working-jobs');
});
```

The need for a second connection is also stated here,

http://stackoverflow.com/questions/22668244/should-i-use-separate-connections-for-pub-and-sub-with-redis

Note, this could probably be more expressive with `Redis::newConnection()` but I wanted to start here.