### PR TITLE
[5.4] extend QueueManager on fake queue

### DIFF
--- a/src/Illuminate/Support/Facades/Queue.php
+++ b/src/Illuminate/Support/Facades/Queue.php
@@ -17,7 +17,7 @@ class Queue extends Facade
      */
     public static function fake()
     {
-        static::swap(new QueueFake);
+        static::swap(new QueueFake(static::getFacadeApplication()));
     }
 
     /**

--- a/src/Illuminate/Support/Testing/Fakes/QueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/QueueFake.php
@@ -2,10 +2,11 @@
 
 namespace Illuminate\Support\Testing\Fakes;
 
+use Illuminate\Queue\QueueManager;
 use Illuminate\Contracts\Queue\Queue;
 use PHPUnit_Framework_Assert as PHPUnit;
 
-class QueueFake implements Queue
+class QueueFake extends QueueManager implements Queue
 {
     /**
      * All of the jobs that have been pushed.


### PR DESCRIPTION
QueueFake needs to extend QueueManager or running artisan commands while testing won't work.

This is because in ArtisanServiceProvider, while registering the queue:work command the container resolves an instance of Worker which requires the QueueManager as a dependency, but since `queue` is swapped with `QueueFake` we get an error:

```
TypeError: Argument 1 passed to Illuminate\Queue\Worker::__construct() must be an instance of Illuminate\Queue\QueueManager, instance of Illuminate\Support\Testing\Fakes\QueueFake given, called in /Users/mac/sites/laravel-src/laravelcurrent/src/Illuminate/Queue/QueueServiceProvider.php on line 172

/Users/mac/sites/laravel-src/laravelcurrent/src/Illuminate/Queue/Worker.php:64
/Users/mac/sites/laravel-src/laravelcurrent/src/Illuminate/Queue/QueueServiceProvider.php:172
/Users/mac/sites/laravel-src/laravelcurrent/src/Illuminate/Container/Container.php:716
/Users/mac/sites/laravel-src/laravelcurrent/src/Illuminate/Container/Container.php:598
/Users/mac/sites/laravel-src/laravelcurrent/src/Illuminate/Container/Container.php:567
/Users/mac/sites/laravel-src/laravelcurrent/src/Illuminate/Foundation/Application.php:708
/Users/mac/sites/laravel-src/laravelcurrent/src/Illuminate/Container/Container.php:1139
/Users/mac/sites/laravel-src/laravelcurrent/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php:632
```