### PR TITLE
[5.1] Backport Postgres multi-schema support

### DIFF
--- a/src/Illuminate/Database/Schema/PostgresBuilder.php
+++ b/src/Illuminate/Database/Schema/PostgresBuilder.php
@@ -16,6 +16,10 @@ class PostgresBuilder extends Builder
 
         $schema = $this->connection->getConfig('schema');
 
+        if (is_array($schema)) {
+            $schema = head($schema);
+        }
+
         $schema = $schema ? $schema : 'public';
 
         $table = $this->connection->getTablePrefix().$table;


### PR DESCRIPTION
This PR backports the fix in #15535 to the 5.1 branch by cherry picking f0266cbb0c5c5686ae5661c948fe39a21b6ab6be. I'm using a multi-schema `search_path`, but now my migrations are failing. This is the needed fix.