### PR TITLE
[5.0] Ambiguous column id error resolved with newQueryWithoutScopes()

### DIFF
--- a/src/Illuminate/Database/Eloquent/SoftDeletes.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletes.php
@@ -42,7 +42,7 @@ trait SoftDeletes {
 	{
 		if ($this->forceDeleting)
 		{
-			return $this->withTrashed()->where($this->getKeyName(), $this->getKey())->forceDelete();
+			return $this->newQueryWithoutScopes()->where($this->getKeyName(), $this->getKey())->forceDelete();
 		}
 
 		return $this->runSoftDelete();
@@ -55,7 +55,7 @@ trait SoftDeletes {
 	 */
 	protected function runSoftDelete()
 	{
-		$query = $this->newQuery()->where($this->getKeyName(), $this->getKey());
+		$query = $this->newQueryWithoutScopes()->where($this->getKeyName(), $this->getKey());
 
 		$this->{$this->getDeletedAtColumn()} = $time = $this->freshTimestamp();
 

--- a/tests/Database/DatabaseSoftDeletingTraitTest.php
+++ b/tests/Database/DatabaseSoftDeletingTraitTest.php
@@ -14,7 +14,7 @@ class DatabaseSoftDeletingTraitTest extends PHPUnit_Framework_TestCase {
 	{
 		$model = m::mock('DatabaseSoftDeletingTraitStub');
 		$model->shouldDeferMissing();
-		$model->shouldReceive('newQuery')->andReturn($query = m::mock('StdClass'));
+		$model->shouldReceive('newQueryWithoutScopes')->andReturn($query = m::mock('StdClass'));
 		$query->shouldReceive('where')->once()->with('id', 1)->andReturn($query);
 		$query->shouldReceive('update')->once()->with(['deleted_at' => 'date-time']);
 		$model->delete();


### PR DESCRIPTION
### Description:
Database generates 'ambiguous column id' error when I use joins in global scope for the model with SoftDeletes

### Steps To Reproduce:

1. Use SoftDeletes in the model whose primary key is 'id'
2. Write a global scope for the model and join to table who has a column named 'id'
3. Try to delete the model.

### Solution
Change `newQuery()` to `newQueryWithoutGlobalScopes()` in `performDeleteOnModel()` and `runSoftDelete()` functions of SoftDeletes.php like in newer versions of Laravel