### PR TITLE
[5.4] Add markdown helper, refactor mailable markdown

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -917,3 +917,22 @@ if (! function_exists('view')) {
         return $factory->make($view, $data, $mergeData);
     }
 }
+
+if (! function_exists('markdown')) {
+    /**
+     * Parse a Markdown formatted string into HTML.
+     *
+     * @param  null|string  $input
+     * @return \Parsedown|\Illuminate\Support\HtmlString
+     */
+    function markdown($input = null)
+    {
+        $parsedown = app(Parsedown::class);
+
+        if (func_num_args() == 0) {
+            return $parsedown;
+        }
+
+        return new HtmlString($parsedown->text($input));
+    }
+}


### PR DESCRIPTION
Introduce a markdown helper that returns a Parsedown instance if no arguments are passed to it, otherwise return a `HtmlString` of the parsed Markdown input.

This simplifies the `Mail\Markdown::parse()` method to deferring to the helper, whilst allowing developers to easily parse Markdown elsewhere in their application as needed.