### PR TITLE
[5.4] Don't call method cleanParameterBag() twice for json request

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/TransformsRequest.php
+++ b/src/Illuminate/Foundation/Http/Middleware/TransformsRequest.php
@@ -40,10 +40,10 @@ class TransformsRequest
     {
         $this->cleanParameterBag($request->query);
 
-        $this->cleanParameterBag($request->request);
-
         if ($request->isJson()) {
             $this->cleanParameterBag($request->json());
+        } else {
+            $this->cleanParameterBag($request->request);
         }
     }
 


### PR DESCRIPTION
Fix for bug I found in TransformsRequest middleware. Currently for json request it is calling method cleanParameterBag 2x so method transform() is executed 2x. The result is malformed data (transformed twice).