### PR TITLE
Allow depending on either v1 or v2 of random_compat

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "monolog/monolog": "~1.11",
         "mtdowling/cron-expression": "~1.0",
         "nesbot/carbon": "~1.19",
-        "paragonie/random_compat": "~1.4",
+        "paragonie/random_compat": "~1.4|~2.0",
         "psy/psysh": "0.7.*",
         "swiftmailer/swiftmailer": "~5.1",
         "symfony/console": "2.7.*",


### PR DESCRIPTION
Projects that use random_compat v1 are not compatible with laravel 5.1. So, composer selects laravel/framework v5.1.19 when random_compat was not included at all. Since random_compat v1 and v2 are functionally same, it should allow composer decide which version to install based on what other projects use.