### PR TITLE
[5.4] Check if model persisted before using primary key

### DIFF
--- a/src/Illuminate/Database/Eloquent/FactoryBuilder.php
+++ b/src/Illuminate/Database/Eloquent/FactoryBuilder.php
@@ -250,7 +250,7 @@ class FactoryBuilder
             $attribute = $attribute instanceof Closure
                             ? $attribute($attributes) : $attribute;
 
-            $attribute = $attribute instanceof Model
+            $attribute = ($attribute instanceof Model && $attribute->exists)
                             ? $attribute->getKey() : $attribute;
         }
 


### PR DESCRIPTION
Before using the primary key of an Eloquent model that is passed to a factory, it will first check to see if the model has actually been persisted to the database. Only then will it prefer to use the model's primary key, otherwise falling back to the raw value.

This follows up on #18499 with an issue reported on the PR.