### PR TITLE
Only return query builder when the result is null for callScope().

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -945,7 +945,7 @@ class Builder
         // query as their own isolated nested where statement and avoid issues.
         $originalWhereCount = count($query->wheres);
 
-        $result = $scope(...array_values($parameters)) ?: $this;
+        $result = $scope(...array_values($parameters)) ?? $this;
 
         if (count($query->wheres) > $originalWhereCount) {
             $this->addNewWheresWithinGroup($query, $originalWhereCount);


### PR DESCRIPTION
Follow up for PR #18842.

**Adrian Brown:**

> The way the `callScope()` function is implemented is to return the query builder on `null`, `0`, or `false` (loose comparison) for the result.
>
> This change will have the `callScope()` method on the query builder only return `$this` if the `$result` is `null` only.
>
> In my application, I created a query scope that performs the query, evaluates the results and returns a boolean. I was expecting false when a query builder was returned.

**Taylor Otwell:**

> This will need to be sent to 5.5 (master branch) since it's a breaking change.
