### PR TITLE
[5.4] Set connection on model factory

### DIFF
--- a/src/Illuminate/Database/Eloquent/FactoryBuilder.php
+++ b/src/Illuminate/Database/Eloquent/FactoryBuilder.php
@@ -103,6 +103,19 @@ class FactoryBuilder
     }
 
     /**
+     * Create a model and persist it in the database if requested.
+     *
+     * @param  array  $attributes
+     * @return \Closure
+     */
+    public function lazy(array $attributes = [])
+    {
+        return function () use ($attributes) {
+            return $this->create($attributes);
+        };
+    }
+
+    /**
      * Create a collection of models and persist them to the database.
      *
      * @param  array  $attributes

--- a/src/Illuminate/Database/Eloquent/FactoryBuilder.php
+++ b/src/Illuminate/Database/Eloquent/FactoryBuilder.php
@@ -103,19 +103,6 @@ class FactoryBuilder
     }
 
     /**
-     * Create a model and persist it in the database if requested.
-     *
-     * @param  array  $attributes
-     * @return \Closure
-     */
-    public function lazy(array $attributes = [])
-    {
-        return function () use ($attributes) {
-            return $this->create($attributes);
-        };
-    }
-
-    /**
      * Create a collection of models and persist them to the database.
      *
      * @param  array  $attributes
@@ -126,9 +113,15 @@ class FactoryBuilder
         $results = $this->make($attributes);
 
         if ($results instanceof Model) {
+            $results->setConnection($results->query()->getConnection()->getName());
+
             $results->save();
         } else {
-            $results->each->save();
+            $results->each(function ($model) {
+                $model->setConnection($model->query()->getConnection()->getName());
+
+                $model->save();
+            });
         }
 
         return $results;


### PR DESCRIPTION
In https://github.com/laravel/framework/pull/18769 we set the Model connection while retrieving it, we did that to fix the failing test @adamwathan shows in https://github.com/laravel/framework/pull/18760/files#diff-2b6eae4ede78d520041c54df36afb408R1064

However when you create a model via `factory()` the connection is not set on the created model, so using `->is()` to compare the model you just created and a model retrieved from the DB will fail since the one created by `factory()` has `$connection = null`.

This PR sets the connection while creating the model using `factory()`.