### PR TITLE
[5.5] Add precision to dateTime and timestamp column types

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -734,22 +734,24 @@ class Blueprint
      * Create a new date-time column on the table.
      *
      * @param  string  $column
+     * @param  int     $precision
      * @return \Illuminate\Support\Fluent
      */
-    public function dateTime($column)
+    public function dateTime($column, $precision = 0)
     {
-        return $this->addColumn('dateTime', $column);
+        return $this->addColumn('dateTime', $column, compact('precision'));
     }
 
     /**
      * Create a new date-time column (with time zone) on the table.
      *
      * @param  string  $column
+     * @param  int     $precision
      * @return \Illuminate\Support\Fluent
      */
-    public function dateTimeTz($column)
+    public function dateTimeTz($column, $precision = 0)
     {
-        return $this->addColumn('dateTimeTz', $column);
+        return $this->addColumn('dateTimeTz', $column, compact('precision'));
     }
 
     /**
@@ -778,22 +780,24 @@ class Blueprint
      * Create a new timestamp column on the table.
      *
      * @param  string  $column
+     * @param  int     $precision
      * @return \Illuminate\Support\Fluent
      */
-    public function timestamp($column)
+    public function timestamp($column, $precision = 0)
     {
-        return $this->addColumn('timestamp', $column);
+        return $this->addColumn('timestamp', $column, compact('precision'));
     }
 
     /**
      * Create a new timestamp (with time zone) column on the table.
      *
      * @param  string  $column
+     * @param  int     $precision
      * @return \Illuminate\Support\Fluent
      */
-    public function timestampTz($column)
+    public function timestampTz($column, $precision = 0)
     {
-        return $this->addColumn('timestampTz', $column);
+        return $this->addColumn('timestampTz', $column, compact('precision'));
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -803,13 +803,14 @@ class Blueprint
     /**
      * Add nullable creation and update timestamps to the table.
      *
+     * @param  int     $precision
      * @return void
      */
-    public function timestamps()
+    public function timestamps($precision = 0)
     {
-        $this->timestamp('created_at')->nullable();
+        $this->timestamp('created_at', $precision)->nullable();
 
-        $this->timestamp('updated_at')->nullable();
+        $this->timestamp('updated_at', $precision)->nullable();
     }
 
     /**
@@ -817,43 +818,47 @@ class Blueprint
      *
      * Alias for self::timestamps().
      *
+     * @param  int     $precision
      * @return void
      */
-    public function nullableTimestamps()
+    public function nullableTimestamps($precision = 0)
     {
-        $this->timestamps();
+        $this->timestamps($precision);
     }
 
     /**
      * Add creation and update timestampTz columns to the table.
      *
+     * @param  int     $precision
      * @return void
      */
-    public function timestampsTz()
+    public function timestampsTz($precision = 0)
     {
-        $this->timestampTz('created_at')->nullable();
+        $this->timestampTz('created_at', $precision)->nullable();
 
-        $this->timestampTz('updated_at')->nullable();
+        $this->timestampTz('updated_at', $precision)->nullable();
     }
 
     /**
      * Add a "deleted at" timestamp for the table.
      *
+     * @param  int     $precision
      * @return \Illuminate\Support\Fluent
      */
-    public function softDeletes()
+    public function softDeletes($precision = 0)
     {
-        return $this->timestamp('deleted_at')->nullable();
+        return $this->timestamp('deleted_at', $precision)->nullable();
     }
 
     /**
      * Add a "deleted at" timestampTz for the table.
      *
+     * @param  int     $precision
      * @return \Illuminate\Support\Fluent
      */
-    public function softDeletesTz()
+    public function softDeletesTz($precision = 0)
     {
-        return $this->timestampTz('deleted_at')->nullable();
+        return $this->timestampTz('deleted_at', $precision)->nullable();
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -593,7 +593,7 @@ class MySqlGrammar extends Grammar
     protected function typeTimestamp(Fluent $column)
     {
         if ($column->useCurrent) {
-            return "timestamp($column->precision) default CURRENT_TIMESTAMP($column->precision)";
+            return "timestamp($column->precision) default CURRENT_TIMESTAMP";
         }
 
         return "timestamp($column->precision)";
@@ -608,7 +608,7 @@ class MySqlGrammar extends Grammar
     protected function typeTimestampTz(Fluent $column)
     {
         if ($column->useCurrent) {
-            return "timestamp($column->precision) default CURRENT_TIMESTAMP($column->precision)";
+            return "timestamp($column->precision) default CURRENT_TIMESTAMP";
         }
 
         return "timestamp($column->precision)";

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -548,7 +548,7 @@ class MySqlGrammar extends Grammar
      */
     protected function typeDateTime(Fluent $column)
     {
-        return 'datetime';
+        return "datetime($column->precision)";
     }
 
     /**
@@ -559,7 +559,7 @@ class MySqlGrammar extends Grammar
      */
     protected function typeDateTimeTz(Fluent $column)
     {
-        return 'datetime';
+        return "datetime($column->precision)";
     }
 
     /**
@@ -593,10 +593,10 @@ class MySqlGrammar extends Grammar
     protected function typeTimestamp(Fluent $column)
     {
         if ($column->useCurrent) {
-            return 'timestamp default CURRENT_TIMESTAMP';
+            return "timestamp($column->precision) default CURRENT_TIMESTAMP($column->precision)";
         }
 
-        return 'timestamp';
+        return "timestamp($column->precision)";
     }
 
     /**
@@ -608,10 +608,10 @@ class MySqlGrammar extends Grammar
     protected function typeTimestampTz(Fluent $column)
     {
         if ($column->useCurrent) {
-            return 'timestamp default CURRENT_TIMESTAMP';
+            return "timestamp($column->precision) default CURRENT_TIMESTAMP($column->precision)";
         }
 
-        return 'timestamp';
+        return "timestamp($column->precision)";
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -496,7 +496,7 @@ class PostgresGrammar extends Grammar
      */
     protected function typeDateTime(Fluent $column)
     {
-        return 'timestamp(0) without time zone';
+        return "timestamp($column->precision) without time zone";
     }
 
     /**
@@ -507,7 +507,7 @@ class PostgresGrammar extends Grammar
      */
     protected function typeDateTimeTz(Fluent $column)
     {
-        return 'timestamp(0) with time zone';
+        return "timestamp($column->precision) with time zone";
     }
 
     /**
@@ -541,10 +541,10 @@ class PostgresGrammar extends Grammar
     protected function typeTimestamp(Fluent $column)
     {
         if ($column->useCurrent) {
-            return 'timestamp(0) without time zone default CURRENT_TIMESTAMP(0)';
+            return "timestamp($column->precision) without time zone default CURRENT_TIMESTAMP($column->precision)";
         }
 
-        return 'timestamp(0) without time zone';
+        return "timestamp($column->precision) without time zone";
     }
 
     /**
@@ -556,10 +556,10 @@ class PostgresGrammar extends Grammar
     protected function typeTimestampTz(Fluent $column)
     {
         if ($column->useCurrent) {
-            return 'timestamp(0) with time zone default CURRENT_TIMESTAMP(0)';
+            return "timestamp($column->precision) with time zone default CURRENT_TIMESTAMP($column->precision)";
         }
 
-        return 'timestamp(0) with time zone';
+        return "timestamp($column->precision) with time zone";
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -468,7 +468,7 @@ class SqlServerGrammar extends Grammar
      */
     protected function typeDateTime(Fluent $column)
     {
-        return 'datetime';
+        return "datetime($column->precision)";
     }
 
     /**
@@ -479,7 +479,7 @@ class SqlServerGrammar extends Grammar
      */
     protected function typeDateTimeTz(Fluent $column)
     {
-        return 'datetimeoffset(0)';
+        return "datetimeoffset($column->precision)";
     }
 
     /**
@@ -513,10 +513,10 @@ class SqlServerGrammar extends Grammar
     protected function typeTimestamp(Fluent $column)
     {
         if ($column->useCurrent) {
-            return 'datetime default CURRENT_TIMESTAMP';
+            return "datetime($column->precision) default CURRENT_TIMESTAMP";
         }
 
-        return 'datetime';
+        return "datetime($column->precision)";
     }
 
     /**
@@ -530,10 +530,10 @@ class SqlServerGrammar extends Grammar
     protected function typeTimestampTz(Fluent $column)
     {
         if ($column->useCurrent) {
-            return 'datetimeoffset(0) default CURRENT_TIMESTAMP';
+            return "datetimeoffset($column->precision) default CURRENT_TIMESTAMP";
         }
 
-        return 'datetimeoffset(0)';
+        return "datetimeoffset($column->precision)";
     }
 
     /**

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -586,7 +586,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('alter table `users` add `foo` datetime not null', $statements[0]);
+        $this->assertEquals('alter table `users` add `foo` datetime(0) not null', $statements[0]);
     }
 
     public function testAddingDateTimeTz()
@@ -596,7 +596,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('alter table `users` add `foo` datetime not null', $statements[0]);
+        $this->assertEquals('alter table `users` add `foo` datetime(0) not null', $statements[0]);
     }
 
     public function testAddingTime()
@@ -626,7 +626,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('alter table `users` add `foo` timestamp not null', $statements[0]);
+        $this->assertEquals('alter table `users` add `foo` timestamp(0) not null', $statements[0]);
     }
 
     public function testAddingTimeStampWithDefault()
@@ -636,7 +636,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('alter table `users` add `foo` timestamp not null default \'2015-07-22 11:43:17\'', $statements[0]);
+        $this->assertEquals('alter table `users` add `foo` timestamp(0) not null default \'2015-07-22 11:43:17\'', $statements[0]);
     }
 
     public function testAddingTimeStampTz()
@@ -646,7 +646,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('alter table `users` add `foo` timestamp not null', $statements[0]);
+        $this->assertEquals('alter table `users` add `foo` timestamp(0) not null', $statements[0]);
     }
 
     public function testAddingTimeStampTzWithDefault()
@@ -656,7 +656,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('alter table `users` add `foo` timestamp not null default \'2015-07-22 11:43:17\'', $statements[0]);
+        $this->assertEquals('alter table `users` add `foo` timestamp(0) not null default \'2015-07-22 11:43:17\'', $statements[0]);
     }
 
     public function testAddingTimeStamps()
@@ -666,7 +666,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('alter table `users` add `created_at` timestamp null, add `updated_at` timestamp null', $statements[0]);
+        $this->assertEquals('alter table `users` add `created_at` timestamp(0) null, add `updated_at` timestamp(0) null', $statements[0]);
     }
 
     public function testAddingTimeStampsTz()
@@ -676,7 +676,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('alter table `users` add `created_at` timestamp null, add `updated_at` timestamp null', $statements[0]);
+        $this->assertEquals('alter table `users` add `created_at` timestamp(0) null, add `updated_at` timestamp(0) null', $statements[0]);
     }
 
     public function testAddingRememberToken()

--- a/tests/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintTest.php
@@ -64,7 +64,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
         $connection = m::mock('Illuminate\Database\Connection');
 
         $blueprint = clone $base;
-        $this->assertEquals(['alter table `users` add `created` timestamp(0) default CURRENT_TIMESTAMP(0) not null'], $blueprint->toSql($connection, new MySqlGrammar));
+        $this->assertEquals(['alter table `users` add `created` timestamp(0) default CURRENT_TIMESTAMP not null'], $blueprint->toSql($connection, new MySqlGrammar));
 
         $blueprint = clone $base;
         $this->assertEquals(['alter table "users" add column "created" timestamp(0) without time zone default CURRENT_TIMESTAMP(0) not null'], $blueprint->toSql($connection, new PostgresGrammar));

--- a/tests/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintTest.php
@@ -64,7 +64,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
         $connection = m::mock('Illuminate\Database\Connection');
 
         $blueprint = clone $base;
-        $this->assertEquals(['alter table `users` add `created` timestamp default CURRENT_TIMESTAMP not null'], $blueprint->toSql($connection, new MySqlGrammar));
+        $this->assertEquals(['alter table `users` add `created` timestamp(0) default CURRENT_TIMESTAMP(0) not null'], $blueprint->toSql($connection, new MySqlGrammar));
 
         $blueprint = clone $base;
         $this->assertEquals(['alter table "users" add column "created" timestamp(0) without time zone default CURRENT_TIMESTAMP(0) not null'], $blueprint->toSql($connection, new PostgresGrammar));
@@ -73,6 +73,6 @@ class DatabaseSchemaBlueprintTest extends TestCase
         $this->assertEquals(['alter table "users" add column "created" datetime default CURRENT_TIMESTAMP not null'], $blueprint->toSql($connection, new SQLiteGrammar));
 
         $blueprint = clone $base;
-        $this->assertEquals(['alter table "users" add "created" datetime default CURRENT_TIMESTAMP not null'], $blueprint->toSql($connection, new SqlServerGrammar));
+        $this->assertEquals(['alter table "users" add "created" datetime(0) default CURRENT_TIMESTAMP not null'], $blueprint->toSql($connection, new SqlServerGrammar));
     }
 }

--- a/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
@@ -446,7 +446,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('alter table "users" add "foo" datetime not null', $statements[0]);
+        $this->assertEquals('alter table "users" add "foo" datetime(0) not null', $statements[0]);
     }
 
     public function testAddingDateTimeTz()
@@ -486,7 +486,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('alter table "users" add "foo" datetime not null', $statements[0]);
+        $this->assertEquals('alter table "users" add "foo" datetime(0) not null', $statements[0]);
     }
 
     public function testAddingTimeStampTz()
@@ -506,7 +506,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('alter table "users" add "created_at" datetime null, "updated_at" datetime null', $statements[0]);
+        $this->assertEquals('alter table "users" add "created_at" datetime(0) null, "updated_at" datetime(0) null', $statements[0]);
     }
 
     public function testAddingTimeStampsTz()


### PR DESCRIPTION
Regarding to issues like #3506 and #11239 I would like to propose a grammar change which allows to set the precision of dateTime and timestamp fields.

- MySQL fully supported
- PostgreSQL fully supported
- SQLite has no date time
- MSSQL unfortunately I can't test it.

The maximum granularity of the fractional seconds depends on the RDMS.