### PR TITLE
Added ability to use Redis Sentinel configuration

### DIFF
--- a/src/Illuminate/Redis/Connectors/PredisConnector.php
+++ b/src/Illuminate/Redis/Connectors/PredisConnector.php
@@ -21,7 +21,7 @@ class PredisConnector
         $completeOpts = array_merge(
             ['timeout' => 10.0], $options, Arr::pull($config, 'options', [])
         );
-        
+
         return new PredisConnection(new Client($config, $completeOpts));
     }
 

--- a/src/Illuminate/Redis/Connectors/PredisConnector.php
+++ b/src/Illuminate/Redis/Connectors/PredisConnector.php
@@ -21,6 +21,7 @@ class PredisConnector
         $completeOpts = array_merge(
             ['timeout' => 10.0], $options, Arr::pull($config, 'options', [])
         );
+        
         return new PredisConnection(new Client($config, $completeOpts));
     }
 

--- a/src/Illuminate/Redis/Connectors/PredisConnector.php
+++ b/src/Illuminate/Redis/Connectors/PredisConnector.php
@@ -18,9 +18,10 @@ class PredisConnector
      */
     public function connect(array $config, array $options)
     {
-        return new PredisConnection(new Client($config, array_merge(
+        $completeOpts = array_merge(
             ['timeout' => 10.0], $options, Arr::pull($config, 'options', [])
-        )));
+        );
+        return new PredisConnection(new Client($config, $completeOpts));
     }
 
     /**


### PR DESCRIPTION
These changes make it possible to use Redis Sentinel with Laravel/Lumen and Predis, configuration example:
```
return [
   // ...
    'redis' => [
        'client' => 'predis',
        'sentinel' => [
            'tcp://10.24.5.136:26379?timeout=0.100',
            'tcp://10.24.5.137:26379?timeout=0.100',
            'tcp://10.24.5.138:26379?timeout=0.100',
            'options' => [
                'replication' => 'sentinel',
                'service' => env('REDIS_SENTINEL_SERVICE', 'mymaster'),
                'parameters' => [
                    'password' => env('REDIS_PASSWORD', null),
                    'database' => 0,
                ],
            ],
        ],
    ],
];
```
It's very important to call Arr::pull($config, 'options', []) before passing it to Client.