### PR TITLE
[5.4] fixes #18854 - route parameter binding

### DIFF
--- a/src/Illuminate/Routing/RouteParameterBinder.php
+++ b/src/Illuminate/Routing/RouteParameterBinder.php
@@ -57,7 +57,8 @@ class RouteParameterBinder
      */
     protected function bindPathParameters($request)
     {
-        preg_match($this->route->compiled->getRegex(), '/'.$request->decodedPath(), $matches);
+        $path = '/'.ltrim($request->decodedPath(), '/');
+        preg_match($this->route->compiled->getRegex(), $path, $matches);
 
         return $this->matchToKeys(array_slice($matches, 1));
     }

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -452,6 +452,28 @@ class RoutingRouteTest extends TestCase
         $this->assertInstanceOf('Illuminate\Tests\Routing\RoutingTestTeamModel', $values[3]);
     }
 
+    public function testLeadingParamDoesntReceiveForwardSlashOnEmptyPath()
+    {
+        $router = $this->getRouter();
+        $outer_one = 'abc1234'; // a string that is not one we're testing
+        $router->get('{one?}', [
+            'uses' => function ($one = null) use (&$outer_one) {
+                $outer_one = $one;
+
+                return $one;
+            },
+            'where' => ['one' => '(.+)'],
+        ]);
+
+        $this->assertEquals('', $router->dispatch(Request::create(''))->getContent());
+        $this->assertNull($outer_one);
+        // Expects: '' ($one === null)
+        // Actual: '/' ($one === '/')
+
+        $this->assertEquals('foo', $router->dispatch(Request::create('/foo', 'GET'))->getContent());
+        $this->assertEquals('foo/bar/baz', $router->dispatch(Request::create('/foo/bar/baz', 'GET'))->getContent());
+    }
+
     /**
      * @expectedException \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
      */


### PR DESCRIPTION
Fixes #18854 by trimming any additional forward slashes off the front of the requested path before prepending a single forward slash and matching bound parameters on the request path.