### PR TITLE
[5.5] Possibility to specify default user provider and passing user provider in RequestGuard callback

### DIFF
--- a/src/Illuminate/Auth/AuthManager.php
+++ b/src/Illuminate/Auth/AuthManager.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Auth;
 
 use Closure;
+use Illuminate\Support\Arr;
 use InvalidArgumentException;
 use Illuminate\Contracts\Auth\Factory as FactoryContract;
 
@@ -120,7 +121,7 @@ class AuthManager implements FactoryContract
      */
     public function createSessionDriver($name, $config)
     {
-        $provider = $this->createUserProvider($config['provider']);
+        $provider = $this->createUserProvider(Arr::get($config, 'provider'));
 
         $guard = new SessionGuard($name, $provider, $this->app['session.store']);
 
@@ -155,7 +156,7 @@ class AuthManager implements FactoryContract
         // that takes an API token field from the request and matches it to the
         // user in the database or another persistence layer where users are.
         $guard = new TokenGuard(
-            $this->createUserProvider($config['provider']),
+            $this->createUserProvider(Arr::get($config, 'provider')),
             $this->app['request']
         );
 
@@ -223,7 +224,7 @@ class AuthManager implements FactoryContract
     public function viaRequest($driver, callable $callback)
     {
         return $this->extend($driver, function () use ($callback) {
-            $guard = new RequestGuard($callback, $this->app['request']);
+            $guard = new RequestGuard($callback, $this->app['request'], $this->createUserProvider());
 
             $this->app->refresh('request', $guard, 'setRequest');
 

--- a/src/Illuminate/Auth/GuardHelpers.php
+++ b/src/Illuminate/Auth/GuardHelpers.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Auth;
 
+use Illuminate\Contracts\Auth\UserProvider;
 use Illuminate\Contracts\Auth\Authenticatable as AuthenticatableContract;
 
 /**
@@ -82,5 +83,26 @@ trait GuardHelpers
         $this->user = $user;
 
         return $this;
+    }
+
+    /**
+     * Get the user provider used by the guard.
+     *
+     * @return \Illuminate\Contracts\Auth\UserProvider
+     */
+    public function getProvider()
+    {
+        return $this->provider;
+    }
+
+    /**
+     * Set the user provider used by the guard.
+     *
+     * @param  \Illuminate\Contracts\Auth\UserProvider  $provider
+     * @return void
+     */
+    public function setProvider(UserProvider $provider)
+    {
+        $this->provider = $provider;
     }
 }

--- a/src/Illuminate/Auth/Passwords/PasswordBrokerManager.php
+++ b/src/Illuminate/Auth/Passwords/PasswordBrokerManager.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Auth\Passwords;
 
+use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
 use Illuminate\Contracts\Auth\PasswordBrokerFactory as FactoryContract;
@@ -69,7 +70,7 @@ class PasswordBrokerManager implements FactoryContract
         // aggregate service of sorts providing a convenient interface for resets.
         return new PasswordBroker(
             $this->createTokenRepository($config),
-            $this->app['auth']->createUserProvider($config['provider'])
+            $this->app['auth']->createUserProvider(Arr::get($config, 'provider'))
         );
     }
 

--- a/src/Illuminate/Auth/RequestGuard.php
+++ b/src/Illuminate/Auth/RequestGuard.php
@@ -4,6 +4,7 @@ namespace Illuminate\Auth;
 
 use Illuminate\Http\Request;
 use Illuminate\Contracts\Auth\Guard;
+use Illuminate\Contracts\Auth\UserProvider;
 
 class RequestGuard implements Guard
 {
@@ -28,12 +29,14 @@ class RequestGuard implements Guard
      *
      * @param  callable  $callback
      * @param  \Illuminate\Http\Request  $request
+     * @param  \Illuminate\Contracts\Auth\UserProvider $provider
      * @return void
      */
-    public function __construct(callable $callback, Request $request)
+    public function __construct(callable $callback, Request $request, UserProvider $provider)
     {
         $this->request = $request;
         $this->callback = $callback;
+        $this->provider = $provider;
     }
 
     /**
@@ -51,7 +54,7 @@ class RequestGuard implements Guard
         }
 
         return $this->user = call_user_func(
-            $this->callback, $this->request
+            $this->callback, $this->request, $this->getProvider()
         );
     }
 
@@ -64,7 +67,7 @@ class RequestGuard implements Guard
     public function validate(array $credentials = [])
     {
         return ! is_null((new static(
-            $this->callback, $credentials['request']
+            $this->callback, $credentials['request'], $this->getProvider()
         ))->user());
     }
 

--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -703,27 +703,6 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
     }
 
     /**
-     * Get the user provider used by the guard.
-     *
-     * @return \Illuminate\Contracts\Auth\UserProvider
-     */
-    public function getProvider()
-    {
-        return $this->provider;
-    }
-
-    /**
-     * Set the user provider used by the guard.
-     *
-     * @param  \Illuminate\Contracts\Auth\UserProvider  $provider
-     * @return void
-     */
-    public function setProvider(UserProvider $provider)
-    {
-        $this->provider = $provider;
-    }
-
-    /**
      * Return the currently cached user.
      *
      * @return \Illuminate\Contracts\Auth\Authenticatable|null

--- a/tests/Auth/AuthenticateMiddlewareTest.php
+++ b/tests/Auth/AuthenticateMiddlewareTest.php
@@ -9,6 +9,7 @@ use PHPUnit\Framework\TestCase;
 use Illuminate\Auth\AuthManager;
 use Illuminate\Auth\RequestGuard;
 use Illuminate\Container\Container;
+use Illuminate\Auth\EloquentUserProvider;
 use Illuminate\Config\Repository as Config;
 use Illuminate\Auth\AuthenticationException;
 use Illuminate\Auth\Middleware\Authenticate;
@@ -166,7 +167,7 @@ class AuthenticateMiddlewareTest extends TestCase
     {
         return new RequestGuard(function () use ($authenticated) {
             return $authenticated ? new stdClass : null;
-        }, m::mock(Request::class));
+        }, m::mock(Request::class), m::mock(EloquentUserProvider::class));
     }
 
     /**


### PR DESCRIPTION
Some small refactoring.
1. Move getters and setters for user provider from `Illuminate\Auth\SessionGuard` to `Illuminate\Auth\GuardHelpers`.
2. Possibility to specify default user provider in config
3. Pass default user provider in RequestGuard callback