### PR TITLE
[5.4] Allow Artisan::queue() to accept --queue options.

### DIFF
--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -230,8 +230,11 @@ class Kernel implements KernelContract
      */
     public function queue($command, array $parameters = [])
     {
+        $queue = isset($parameters['--queue']) ? $parameters['--queue'] : null;
+        unset($parameters['--queue']);
+
         $this->app[QueueContract::class]->push(
-            new QueuedCommand(func_get_args())
+            new QueuedCommand([$command, $parameters]), '', $queue
         );
     }
 


### PR DESCRIPTION
This allow artisan command to be queued on specific tube instead of
using the "default" tube.

```php
Artisan::queue('send-email', ['--queue' => 'notifications']);
```

Signed-off-by: crynobone <crynobone@gmail.com>