### PR TITLE
Add ddd() helper function

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -516,6 +516,24 @@ if (! function_exists('dd')) {
     }
 }
 
+if (! function_exists('ddd')) {
+    /**
+     * Dump the location of the call call to ddd(), the passed variables, and end the script.
+     *
+     * For those who like to practice "dd() Driven Design", using this instead of dd() might help
+     * you find those pesky dumps which are left in the code during debugging
+     *
+     * @param  mixed
+     * @return void
+     */
+    function ddd(...$args)
+    {
+        $calledFrom = debug_backtrace()[0];
+
+        dd('Dump called at ' . $calledFrom['file'] . ':' . $calledFrom['line'], $args);
+    }
+}
+
 if (! function_exists('e')) {
     /**
      * Escape HTML special characters in a string.


### PR DESCRIPTION
ddd() is identical to dd() except that before dumping the given variables it dumps the code location of the call to ddd(). This way, if one uses ddd() instead of dd() it's easier to find dd calls which are left in the codebase without having to grep "dd(".