### PR TITLE
[5.4] option to add a queue 'prefix' to all tube names

### DIFF
--- a/src/Illuminate/Contracts/Queue/Queue.php
+++ b/src/Illuminate/Contracts/Queue/Queue.php
@@ -96,19 +96,4 @@ interface Queue
      * @return $this
      */
     public function setConnectionName($name);
-
-    /**
-     * Set the queue prefix.
-     *
-     * @param  string  $prefix
-     * @return $this
-     */
-    public function setQueuePrefix($prefix = null);
-
-    /**
-     * Get the queue prefix.
-     *
-     * @return string
-     */
-    public function getQueuePrefix();
 }

--- a/src/Illuminate/Contracts/Queue/Queue.php
+++ b/src/Illuminate/Contracts/Queue/Queue.php
@@ -96,4 +96,19 @@ interface Queue
      * @return $this
      */
     public function setConnectionName($name);
+
+    /**
+     * Set the queue prefix.
+     *
+     * @param  string  $prefix
+     * @return $this
+     */
+    public function setQueuePrefix($prefix = null);
+
+    /**
+     * Get the queue prefix.
+     *
+     * @return string
+     */
+    public function getQueuePrefix();
 }

--- a/src/Illuminate/Queue/BeanstalkdQueue.php
+++ b/src/Illuminate/Queue/BeanstalkdQueue.php
@@ -148,7 +148,7 @@ class BeanstalkdQueue extends Queue implements QueueContract
      */
     public function getQueue($queue)
     {
-        return $queue ?: $this->default;
+        return $this->getQueuePrefix().($queue ?: $this->default);
     }
 
     /**

--- a/src/Illuminate/Queue/Console/ListenCommand.php
+++ b/src/Illuminate/Queue/Console/ListenCommand.php
@@ -83,7 +83,7 @@ class ListenCommand extends Command
             "queue.connections.{$connection}.queue", 'default'
         );
 
-        return $this->laravel['config']->get('queue.prefix', null) . $queue;
+        return $this->laravel['config']->get('queue.prefix', null).$queue;
     }
 
     /**

--- a/src/Illuminate/Queue/Console/ListenCommand.php
+++ b/src/Illuminate/Queue/Console/ListenCommand.php
@@ -79,9 +79,11 @@ class ListenCommand extends Command
     {
         $connection = $connection ?: $this->laravel['config']['queue.default'];
 
-        return $this->input->getOption('queue') ?: $this->laravel['config']->get(
+        $queue = $this->input->getOption('queue') ?: $this->laravel['config']->get(
             "queue.connections.{$connection}.queue", 'default'
         );
+
+        return $this->laravel['config']->get('queue.prefix', null) . $queue;
     }
 
     /**

--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -200,7 +200,7 @@ class WorkCommand extends Command
             "queue.connections.{$connection}.queue", 'default'
         );
 
-        return $this->laravel['config']->get('queue.prefix', null) . $queue;
+        return $this->laravel['config']->get('queue.prefix', null).$queue;
     }
 
     /**

--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -196,9 +196,11 @@ class WorkCommand extends Command
      */
     protected function getQueue($connection)
     {
-        return $this->option('queue') ?: $this->laravel['config']->get(
+        $queue = $this->option('queue') ?: $this->laravel['config']->get(
             "queue.connections.{$connection}.queue", 'default'
         );
+
+        return $this->laravel['config']->get('queue.prefix', null) . $queue;
     }
 
     /**

--- a/src/Illuminate/Queue/DatabaseQueue.php
+++ b/src/Illuminate/Queue/DatabaseQueue.php
@@ -308,7 +308,7 @@ class DatabaseQueue extends Queue implements QueueContract
      */
     protected function getQueue($queue)
     {
-        return $queue ?: $this->default;
+        return $this->getQueuePrefix().($queue ?: $this->default);
     }
 
     /**

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -30,6 +30,13 @@ abstract class Queue
     protected $connectionName;
 
     /**
+     * The queue prefix.
+     *
+     * @var string
+     */
+    protected $queuePrefix;
+
+    /**
      * Push a new job onto the queue.
      *
      * @param  string  $queue
@@ -187,5 +194,28 @@ abstract class Queue
     public function setContainer(Container $container)
     {
         $this->container = $container;
+    }
+
+    /**
+     * Set the queue prefix.
+     *
+     * @param  string  $prefix
+     * @return $this
+     */
+    public function setQueuePrefix($prefix = null)
+    {
+        $this->queuePrefix = $prefix;
+
+        return $this;
+    }
+
+    /**
+     * Get the queue prefix.
+     *
+     * @return string
+     */
+    public function getQueuePrefix()
+    {
+        return $this->queuePrefix;
     }
 }

--- a/src/Illuminate/Queue/QueueManager.php
+++ b/src/Illuminate/Queue/QueueManager.php
@@ -152,7 +152,8 @@ class QueueManager implements FactoryContract, MonitorContract
 
         return $this->getConnector($config['driver'])
                         ->connect($config)
-                        ->setConnectionName($name);
+                        ->setConnectionName($name)
+                        ->setQueuePrefix($this->getQueuePrefix());
     }
 
     /**
@@ -230,6 +231,16 @@ class QueueManager implements FactoryContract, MonitorContract
     public function setDefaultDriver($name)
     {
         $this->app['config']['queue.default'] = $name;
+    }
+
+    /**
+     * Get the name of the queue prefix.
+     *
+     * @return string
+     */
+    public function getQueuePrefix()
+    {
+        return isset($this->app['config']['queue.prefix']) ? $this->app['config']['queue.prefix'] : null;
     }
 
     /**

--- a/src/Illuminate/Queue/QueueManager.php
+++ b/src/Illuminate/Queue/QueueManager.php
@@ -240,7 +240,7 @@ class QueueManager implements FactoryContract, MonitorContract
      */
     public function getQueuePrefix()
     {
-        return isset($this->app['config']['queue.prefix']) ? $this->app['config']['queue.prefix'] : null;
+        return $this->app['config']->get('queue.prefix');
     }
 
     /**

--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -256,7 +256,7 @@ class RedisQueue extends Queue implements QueueContract
      */
     protected function getQueue($queue)
     {
-        return 'queues:'.($queue ?: $this->default);
+        return 'queues:'.$this->getQueuePrefix().($queue ?: $this->default);
     }
 
     /**

--- a/src/Illuminate/Queue/SqsQueue.php
+++ b/src/Illuminate/Queue/SqsQueue.php
@@ -137,7 +137,7 @@ class SqsQueue extends Queue implements QueueContract
      */
     public function getQueue($queue)
     {
-        $queue = $queue ?: $this->default;
+        $queue = $this->getQueuePrefix().($queue ?: $this->default);
 
         return filter_var($queue, FILTER_VALIDATE_URL) === false
                         ? rtrim($this->prefix, '/').'/'.$queue : $queue;

--- a/tests/Queue/QueueManagerTest.php
+++ b/tests/Queue/QueueManagerTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Queue;
 
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Config\Repository;
 use Illuminate\Queue\QueueManager;
 
 class QueueManagerTest extends TestCase
@@ -15,11 +16,13 @@ class QueueManagerTest extends TestCase
 
     public function testDefaultConnectionCanBeResolved()
     {
+        $config = new Repository([
+            'queue.default' => 'sync',
+            'queue.connections.sync' => ['driver' => 'sync'],
+        ]);
+
         $app = [
-            'config' => [
-                'queue.default' => 'sync',
-                'queue.connections.sync' => ['driver' => 'sync'],
-            ],
+            'config' => $config,
             'encrypter' => $encrypter = m::mock('Illuminate\Contracts\Encryption\Encrypter'),
         ];
 
@@ -39,11 +42,13 @@ class QueueManagerTest extends TestCase
 
     public function testOtherConnectionCanBeResolved()
     {
+        $config = new Repository([
+            'queue.default' => 'sync',
+            'queue.connections.foo' => ['driver' => 'bar'],
+        ]);
+
         $app = [
-            'config' => [
-                'queue.default' => 'sync',
-                'queue.connections.foo' => ['driver' => 'bar'],
-            ],
+            'config' => $config,
             'encrypter' => $encrypter = m::mock('Illuminate\Contracts\Encryption\Encrypter'),
         ];
 
@@ -63,10 +68,12 @@ class QueueManagerTest extends TestCase
 
     public function testNullConnectionCanBeResolved()
     {
+        $config = new Repository([
+            'queue.default' => 'null',
+        ]);
+
         $app = [
-            'config' => [
-                'queue.default' => 'null',
-            ],
+            'config' => $config,
             'encrypter' => $encrypter = m::mock('Illuminate\Contracts\Encryption\Encrypter'),
         ];
 

--- a/tests/Queue/QueueManagerTest.php
+++ b/tests/Queue/QueueManagerTest.php
@@ -27,6 +27,7 @@ class QueueManagerTest extends TestCase
         $connector = m::mock('StdClass');
         $queue = m::mock('StdClass');
         $queue->shouldReceive('setConnectionName')->once()->with('sync')->andReturnSelf();
+        $queue->shouldReceive('setQueuePrefix')->once()->with('')->andReturnSelf();
         $connector->shouldReceive('connect')->once()->with(['driver' => 'sync'])->andReturn($queue);
         $manager->addConnector('sync', function () use ($connector) {
             return $connector;
@@ -50,6 +51,7 @@ class QueueManagerTest extends TestCase
         $connector = m::mock('StdClass');
         $queue = m::mock('StdClass');
         $queue->shouldReceive('setConnectionName')->once()->with('foo')->andReturnSelf();
+        $queue->shouldReceive('setQueuePrefix')->once()->with('')->andReturnSelf();
         $connector->shouldReceive('connect')->once()->with(['driver' => 'bar'])->andReturn($queue);
         $manager->addConnector('bar', function () use ($connector) {
             return $connector;
@@ -72,6 +74,7 @@ class QueueManagerTest extends TestCase
         $connector = m::mock('StdClass');
         $queue = m::mock('StdClass');
         $queue->shouldReceive('setConnectionName')->once()->with('null')->andReturnSelf();
+        $queue->shouldReceive('setQueuePrefix')->once()->with('')->andReturnSelf();
         $connector->shouldReceive('connect')->once()->with(['driver' => 'null'])->andReturn($queue);
         $manager->addConnector('null', function () use ($connector) {
             return $connector;


### PR DESCRIPTION
if you have multiple sites on a server that use the same queue driver,
there is no way for your queue worker to distinguish which jobs belong
to its application, and which jobs belong to other applications. one
way around this is to use custom tube names. however this is difficult
to ensure custom naming, and doesn’t offer a consistent way to set
these.

by adding a queue prefix config option, we have one location to set our
value, which gets automatically applied when a job is added to the
queue, and when it is pulled off the queue.

all tests are passing, but I have not added any additional ones for this yet.

I believe this is fully backwards compatible, and will only take effect if the user adds a config variable.