### PR TITLE
[5.5] Fire before callbacks on closure-based scheduling events

### DIFF
--- a/src/Illuminate/Console/Scheduling/CallbackEvent.php
+++ b/src/Illuminate/Console/Scheduling/CallbackEvent.php
@@ -59,6 +59,8 @@ class CallbackEvent extends Event
             $this->mutex->create($this);
         }
 
+        parent::callBeforeCallbacks($container);
+
         try {
             $response = $container->call($this->callback, $this->parameters);
         } finally {


### PR DESCRIPTION
Pull request based on the comments in https://github.com/laravel/framework/issues/18851

I'm pretty sure this is safe and seems logical to support.