### PR TITLE
[5.4] Switch to using namespaced PHPUnit classes

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/BusFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/BusFake.php
@@ -3,7 +3,7 @@
 namespace Illuminate\Support\Testing\Fakes;
 
 use Illuminate\Contracts\Bus\Dispatcher;
-use PHPUnit_Framework_Assert as PHPUnit;
+use PHPUnit\Framework\Assert as PHPUnit;
 
 class BusFake implements Dispatcher
 {

--- a/src/Illuminate/Support/Testing/Fakes/EventFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/EventFake.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\Support\Testing\Fakes;
 
-use PHPUnit_Framework_Assert as PHPUnit;
+use PHPUnit\Framework\Assert as PHPUnit;
 use Illuminate\Contracts\Events\Dispatcher;
 
 class EventFake implements Dispatcher

--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -4,7 +4,7 @@ namespace Illuminate\Support\Testing\Fakes;
 
 use Illuminate\Contracts\Mail\Mailer;
 use Illuminate\Contracts\Mail\Mailable;
-use PHPUnit_Framework_Assert as PHPUnit;
+use PHPUnit\Framework\Assert as PHPUnit;
 
 class MailFake implements Mailer
 {

--- a/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
@@ -4,7 +4,7 @@ namespace Illuminate\Support\Testing\Fakes;
 
 use Ramsey\Uuid\Uuid;
 use Illuminate\Support\Collection;
-use PHPUnit_Framework_Assert as PHPUnit;
+use PHPUnit\Framework\Assert as PHPUnit;
 use Illuminate\Contracts\Notifications\Factory as NotificationFactory;
 
 class NotificationFake implements NotificationFactory

--- a/src/Illuminate/Support/Testing/Fakes/QueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/QueueFake.php
@@ -4,7 +4,7 @@ namespace Illuminate\Support\Testing\Fakes;
 
 use Illuminate\Queue\QueueManager;
 use Illuminate\Contracts\Queue\Queue;
-use PHPUnit_Framework_Assert as PHPUnit;
+use PHPUnit\Framework\Assert as PHPUnit;
 
 class QueueFake extends QueueManager implements Queue
 {


### PR DESCRIPTION
We're already using it in:

https://github.com/laravel/framework/blob/95ff4d55c0032bec6cd842892975b04ed4fc33f4/src/Illuminate/Foundation/Testing/TestResponse.php#L11

and

https://github.com/laravel/framework/blob/acd66fef646fd5f7ca54380d55bc8e2e2cbe64b6/src/Illuminate/Filesystem/FilesystemAdapter.php#L12