### PR TITLE
[5.4] Take `getAuthIdentifierName` into account when retrieving users by ID.

### DIFF
--- a/src/Illuminate/Auth/EloquentUserProvider.php
+++ b/src/Illuminate/Auth/EloquentUserProvider.php
@@ -44,7 +44,11 @@ class EloquentUserProvider implements UserProvider
      */
     public function retrieveById($identifier)
     {
-        return $this->createModel()->newQuery()->find($identifier);
+        $model = $this->createModel();
+
+        return $model->newQuery()
+            ->where($model->getAuthIdentifierName(), $identifier)
+            ->first();
     }
 
     /**

--- a/tests/Auth/AuthEloquentUserProviderTest.php
+++ b/tests/Auth/AuthEloquentUserProviderTest.php
@@ -18,7 +18,9 @@ class AuthEloquentUserProviderTest extends TestCase
         $provider = $this->getProviderMock();
         $mock = m::mock('stdClass');
         $mock->shouldReceive('newQuery')->once()->andReturn($mock);
-        $mock->shouldReceive('find')->once()->with(1)->andReturn('bar');
+        $mock->shouldReceive('getAuthIdentifierName')->once()->andReturn('id');
+        $mock->shouldReceive('where')->once()->with('id', 1)->andReturn($mock);
+        $mock->shouldReceive('first')->once()->andReturn('bar');
         $provider->expects($this->once())->method('createModel')->will($this->returnValue($mock));
         $user = $provider->retrieveById(1);
 


### PR DESCRIPTION
The `retrieveById` method on the Eloquent user provider doesn't take into account custom auth identifiers [like the `retrieveByToken` method does](https://git.io/vSxYN). When using a different column for authentication than internal relationships, this causes unexpected behavior.

This pull request updates the `retrieveById` method to query against the column specified in `getAuthIdentifierName` as well. This should not be a breaking change since that method in the `Authenticatable` trait [defaults to the primary key](https://git.io/vSpLm).

References #10292.