### PR TITLE
Mismatched type-hints between Registrar and Router

### DIFF
--- a/src/Illuminate/Contracts/Routing/Registrar.php
+++ b/src/Illuminate/Contracts/Routing/Registrar.php
@@ -9,7 +9,7 @@ interface Registrar
      *
      * @param  string  $uri
      * @param  \Closure|array|string  $action
-     * @return void
+     * @return \Illuminate\Routing\Route
      */
     public function get($uri, $action);
 
@@ -18,7 +18,7 @@ interface Registrar
      *
      * @param  string  $uri
      * @param  \Closure|array|string  $action
-     * @return void
+     * @return \Illuminate\Routing\Route
      */
     public function post($uri, $action);
 
@@ -27,7 +27,7 @@ interface Registrar
      *
      * @param  string  $uri
      * @param  \Closure|array|string  $action
-     * @return void
+     * @return \Illuminate\Routing\Route
      */
     public function put($uri, $action);
 
@@ -36,7 +36,7 @@ interface Registrar
      *
      * @param  string  $uri
      * @param  \Closure|array|string  $action
-     * @return void
+     * @return \Illuminate\Routing\Route
      */
     public function delete($uri, $action);
 
@@ -45,7 +45,7 @@ interface Registrar
      *
      * @param  string  $uri
      * @param  \Closure|array|string  $action
-     * @return void
+     * @return \Illuminate\Routing\Route
      */
     public function patch($uri, $action);
 
@@ -54,7 +54,7 @@ interface Registrar
      *
      * @param  string  $uri
      * @param  \Closure|array|string  $action
-     * @return void
+     * @return \Illuminate\Routing\Route
      */
     public function options($uri, $action);
 
@@ -64,7 +64,7 @@ interface Registrar
      * @param  array|string  $methods
      * @param  string  $uri
      * @param  \Closure|array|string  $action
-     * @return void
+     * @return \Illuminate\Routing\Route
      */
     public function match($methods, $uri, $action);
 


### PR DESCRIPTION
Other methods in this interface already type-hint against `\Illuminate\Routing\Route`, so this is just alignment with implementation, and only doc-block affected so no BC.