### PR TITLE
change so files and allFiles return similar structured arrays

### DIFF
--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -372,20 +372,9 @@ class Filesystem
      * @param  string  $directory
      * @return array
      */
-    public function files($directory)
+    public function files($directory, $hidden = false)
     {
-        $glob = glob($directory.'/*');
-
-        if ($glob === false) {
-            return [];
-        }
-
-        // To get the appropriate files, we'll simply glob the directory and filter
-        // out any "files" that are not truly files so we do not end up with any
-        // directories in our list, but only true files within the directory.
-        return array_filter($glob, function ($file) {
-            return filetype($file) == 'file';
-        });
+        return iterator_to_array(Finder::create()->files()->ignoreDotFiles(! $hidden)->in($directory)->depth(0), false);
     }
 
     /**


### PR DESCRIPTION
I did some work using the Filesystem the other day, and quickly started with the allFiles method, then realized that I needed only the files in the given directory. So I switched the call from allFiles to files, ran my test and something broke. Digging into it, I found that both files and allFiles return an array, but allFiles returns an array of SplFileInfo objects, where files returns an array of strings.

This seemed a little weird, and I thought it might be convenient if both functions had similar return array values. If you parse the string from files, then I think switching to allFiles will still work because SplFileInfo has __toString() implemented. But if you use any method on the SplFileInfo object that allFiles returns, then switching to files from allFiles will break. Which is why this change is being proposed.

Here is a gist that shows the difference in the arrays: https://gist.github.com/ahuggins/21d1af3c1e274cfa305d8220fb5303f2

A side benefit of this is that the api of the files and allFiles methods would be the same...how allFiles handles hidden files, would be the same as files with this PR.

** I also opened a PR against the Illuminate repo directly (https://github.com/illuminate/filesystem/pull/16), I guess I can delete that one though.