### PR TITLE
[5.5] Filesystem files() to return similar structured arrays as allFiles()

### DIFF
--- a/CHANGELOG-5.5.md
+++ b/CHANGELOG-5.5.md
@@ -53,6 +53,9 @@
 ### Events
 - ⚠️ Removed calling queue method on handlers ([0360cb1](https://github.com/laravel/framework/commit/0360cb1c6b71ec89d406517b19d1508511e98fb5), [ec96979](https://github.com/laravel/framework/commit/ec969797878f2c731034455af2397110732d14c4), [d9be4bf](https://github.com/laravel/framework/commit/d9be4bfe0367a8e07eed4931bdabf135292abb1b))
 
+### Filesystem
+- ⚠️ Made `Storage::files()` work like `Storage::allFiles()` ([#18874](https://github.com/laravel/framework/pull/18874))
+
 ### Helpers
 - Added `throw_if()` and `throw_unless()` helpers ([18bb4df](https://github.com/laravel/framework/commit/18bb4dfc77c7c289e9b40c4096816ebeff1cd843))
 - Added `dispatch_now()` helper function ([#18668](https://github.com/laravel/framework/pull/18668), [61f2e7b](https://github.com/laravel/framework/commit/61f2e7b4106f8eb0b79603d9792426f7c6a6d273))

--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -372,20 +372,9 @@ class Filesystem
      * @param  string  $directory
      * @return array
      */
-    public function files($directory)
+    public function files($directory, $hidden = false)
     {
-        $glob = glob($directory.'/*');
-
-        if ($glob === false) {
-            return [];
-        }
-
-        // To get the appropriate files, we'll simply glob the directory and filter
-        // out any "files" that are not truly files so we do not end up with any
-        // directories in our list, but only true files within the directory.
-        return array_filter($glob, function ($file) {
-            return filetype($file) == 'file';
-        });
+        return iterator_to_array(Finder::create()->files()->ignoreDotFiles(! $hidden)->in($directory)->depth(0), false);
     }
 
     /**

--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -370,23 +370,30 @@ class Filesystem
      * Get an array of all files in a directory.
      *
      * @param  string  $directory
+     * @param  bool  $ignoreDotFiles
      * @return array
      */
-    public function files($directory, $hidden = false)
+    public function files($directory, $ignoreDotFiles = false)
     {
-        return iterator_to_array(Finder::create()->files()->ignoreDotFiles(! $hidden)->in($directory)->depth(0), false);
+        return iterator_to_array(
+            Finder::create()->files()->ignoreDotFiles(! $ignoreDotFiles)->in($directory)->depth(0),
+            false
+        );
     }
 
     /**
      * Get all of the files from the given directory (recursive).
      *
      * @param  string  $directory
-     * @param  bool  $hidden
+     * @param  bool  $ignoreDotFiles
      * @return array
      */
-    public function allFiles($directory, $hidden = false)
+    public function allFiles($directory, $ignoreDotFiles = false)
     {
-        return iterator_to_array(Finder::create()->files()->ignoreDotFiles(! $hidden)->in($directory), false);
+        return iterator_to_array(
+            Finder::create()->files()->ignoreDotFiles(! $ignoreDotFiles)->in($directory),
+            false
+        );
     }
 
     /**

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -414,4 +414,28 @@ class FilesystemTest extends TestCase
         $this->assertTrue($filesystem->isFile($this->tempDir.'/foo/foo.txt'));
         $this->assertFalse($filesystem->isFile($this->tempDir.'./foo'));
     }
+
+    public function testFilesMethodReturnsFileInfoObjects()
+    {
+        mkdir($this->tempDir.'/foo');
+        file_put_contents($this->tempDir.'/foo/1.txt', '1');
+        file_put_contents($this->tempDir.'/foo/2.txt', '2');
+        mkdir($this->tempDir.'/foo/bar');
+        $files = new Filesystem();
+        foreach ($files->files($this->tempDir.'/foo') as $file) {
+            $this->assertInstanceOf(\SplFileInfo::class, $file);
+        }
+        unset($files);
+    }
+
+    public function testAllFilesReturnsFileInfoObjects()
+    {
+        file_put_contents($this->tempDir.'/foo.txt', 'foo');
+        file_put_contents($this->tempDir.'/bar.txt', 'bar');
+        $files = new Filesystem();
+        $allFiles = [];
+        foreach ($files->allFiles($this->tempDir) as $file) {
+            $this->assertInstanceOf(\SplFileInfo::class, $file);
+        }
+    }
 }


### PR DESCRIPTION
I did some work using the Filesystem the other day, and quickly started with the allFiles method, then realized that I needed only the files in the given directory. So I switched the call from allFiles to files, ran my test and something broke. Digging into it, I found that both files and allFiles return an array, but allFiles returns an array of SplFileInfo objects, where files returns an array of strings.

This seemed a little weird, and I thought it might be convenient if both functions had similar return array values. If you parse the string from files, then I think switching to allFiles will still work because SplFileInfo has __toString() implemented. But if you use any method on the SplFileInfo object that allFiles returns, then switching to files from allFiles will break. Which is why this change is being proposed.

Here is a gist that shows the difference in the arrays: https://gist.github.com/ahuggins/21d1af3c1e274cfa305d8220fb5303f2

A side benefit of this is that the api of the files and allFiles methods would be the same...how allFiles handles hidden files, would be the same as files with this PR.

** Was closed against 5.4, so submitting to master (5.5)