### PR TITLE
[5.4] Allow setting a factory's attribute to a factory instance

### DIFF
--- a/src/Illuminate/Database/Eloquent/FactoryBuilder.php
+++ b/src/Illuminate/Database/Eloquent/FactoryBuilder.php
@@ -204,7 +204,7 @@ class FactoryBuilder
             $this->faker, $attributes
         );
 
-        return $this->callClosureAttributes(
+        return $this->expandAttributes(
             array_merge($this->applyStates($definition, $attributes), $attributes)
         );
     }
@@ -254,19 +254,21 @@ class FactoryBuilder
     }
 
     /**
-     * Evaluate any Closure attributes on the attribute array.
+     * Expand all attributes to their underlying values.
      *
      * @param  array  $attributes
      * @return array
      */
-    protected function callClosureAttributes(array $attributes)
+    protected function expandAttributes(array $attributes)
     {
         foreach ($attributes as &$attribute) {
-            $attribute = $attribute instanceof Closure
-                            ? $attribute($attributes) : $attribute;
-
-            $attribute = $attribute instanceof Model
-                            ? $attribute->getKey() : $attribute;
+            if ($attribute instanceof Closure) {
+                $attribute = $attribute($attributes);
+            } elseif ($attribute instanceof static) {
+                $attribute = $attribute->create()->getKey();
+            } elseif ($attribute instanceof Model) {
+                $attribute = $attribute->getKey();
+            }
         }
 
         return $attributes;


### PR DESCRIPTION
The factory will then create the model and use its primary key.

---

This is the same as #18869, but without removing the `lazy` method.