### PR TITLE
[5.4] Add a "getDot" method to Collections

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -123,7 +123,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
         }
 
         $values = with(isset($key) ? $this->pluck($key) : $this)
-                    ->sort()->values();
+            ->sort()->values();
 
         $middle = (int) ($count / 2);
 
@@ -523,6 +523,19 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
         }
 
         return value($default);
+    }
+
+    /**
+     * Get an item from the collection by dotted key.
+     *
+     * @param mixed $key
+     * @param mixed $default
+     *
+     * @return mixed
+     */
+    public function getDot($key, $default = null)
+    {
+        return Arr::get($this->items, $key, $default);
     }
 
     /**
@@ -1165,7 +1178,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
         }
 
         $descending ? arsort($results, $options)
-                    : asort($results, $options);
+            : asort($results, $options);
 
         // Once we have sorted all of the keys in the array, we will loop through them
         // and grab the corresponding model so we can set the underlying items list


### PR DESCRIPTION
Get an item from the collection by dotted key.
Example:
$d = collect(['a' => ['b' => ['c' => 'hello']]]);
echo $d->getDot('a.b.c');
// hello