### PR TITLE
[5.4] Allow binding of decorator chains

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -1186,4 +1186,41 @@ class Container implements ArrayAccess, ContainerContract
     {
         $this[$key] = $value;
     }
+
+    /**
+     * Decorate a given type with chained dependencies.
+     *
+     * @param  string $abstract
+     * @param  string $outer
+     * @param  string[] ...$chain
+     * @return void
+     */
+    public function decorate($abstract, $outer, ...$chain)
+    {
+        $this->bind($abstract, $outer);
+
+        $this->buildDecoratorChain($abstract, $outer, $chain);
+    }
+
+    /**
+     * Builds a contextual dependency chain recursively, so that each element of the chain
+     * depends on the next one, up until the last one.
+     *
+     * This assumes that the last element is not a decorator anymore, so its dependencies will
+     * be resolved normally, as with any given type.
+     *
+     * @param  string $abstract
+     * @param  string $decorator
+     * @param  string[] $chain
+     * @return void
+     */
+    protected function buildDecoratorChain($abstract, $decorator, array $chain)
+    {
+        $concrete = array_shift($chain);
+        $this->when($decorator)->needs($abstract)->give($concrete);
+
+        if (! empty($chain)) {
+            $this->buildDecoratorChain($abstract, $concrete, $chain);
+        }
+    }
 }

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -828,6 +828,24 @@ class ContainerTest extends TestCase
         $this->assertEquals(['name' => 'taylor'], $container->makeWith('foo', ['name' => 'taylor']));
         $this->assertEquals(['name' => 'abigail'], $container->makeWith('foo', ['name' => 'abigail']));
     }
+
+    public function testDecorationChain()
+    {
+        $container = new Container;
+
+        $container->decorate(
+            ContainerDecoratorChainComponent::class,
+            ContainerDecoratorChainOuter::class,
+            ContainerDecoratorChainInner::class,
+            ContainerDecoratorChainConcreteComponent::class
+        );
+
+        $instance = $container->make(ContainerDecoratorChainComponent::class);
+
+        $this->assertInstanceOf(ContainerDecoratorChainOuter::class, $instance);
+        $this->assertInstanceOf(ContainerDecoratorChainInner::class, $instance->wrapped);
+        $this->assertInstanceOf(ContainerDecoratorChainConcreteComponent::class, $instance->wrapped->wrapped);
+    }
 }
 
 class ContainerConcreteStub
@@ -980,4 +998,41 @@ class ContainerTestContextInjectInstantiations implements IContainerContractStub
     {
         static::$instantiations++;
     }
+}
+
+interface ContainerDecoratorChainComponent
+{
+}
+
+class ContainerDecoratorChainConcreteComponent implements ContainerDecoratorChainComponent
+{
+}
+
+abstract class ContainerDecoratorChainAbstractDecorator implements ContainerDecoratorChainComponent
+{
+    /** @var ContainerDecoratorChainComponent */
+    public $wrapped;
+
+    /**
+     * @param ContainerDecoratorChainComponent $wrapped
+     */
+    public function __construct(ContainerDecoratorChainComponent $wrapped)
+    {
+        $this->wrapped = $wrapped;
+    }
+}
+
+class ContainerDecoratorChainInner extends ContainerDecoratorChainAbstractDecorator
+{
+    public $stub;
+
+    public function __construct(ContainerDecoratorChainComponent $wrapped, ContainerConcreteStub $stub)
+    {
+        parent::__construct($wrapped);
+        $this->stub = $stub;
+    }
+}
+
+class ContainerDecoratorChainOuter extends ContainerDecoratorChainAbstractDecorator
+{
 }


### PR DESCRIPTION
# Decorator chains
This PR allows decorator chains to be built out of the container easily and by using a combination of existing implementation code (regular bindings plus contextual bindings).

## The pattern

Given a decorator pattern such as:

```php
// The common interface
interface Component {}

// The two implementations: concrete one (the "original" component) and the abstract decorator
class ConcreteComponent implements Component {}
abstract class ComponentDecorator implements Component {
    public function __construct(Component $decorated) { /* init code */ }
}

// multiple decorators implemented throughout the code
class DecoratorOne extends ComponentDecorator {}
class DecoratorTwo extends ComponentDecorator {}
class DecoratorThree extends ComponentDecorator {}
```

## Current situation

Right now, an app has to do something like this every time the patttern is used or extended:

```php
app()->bind(Component::class, function () {
    // This can't be replaced by app()->make() calls because they all depend on Component interface.
    return new DecoratorThree(
        new DecoratorTwo(
            new DecoratorOne(
                // Only this one could be app()->make(ConcreteComponent::class)
                new ConcreteComponent
            )
        )
    );
});
```

Another option (the one implemented by this PR) is to use contextual binding, but this is also cumbersome to extend:

```php
app()->bind(Component::class, DecoratorThree::class);
app()->when(DecoratorThree::class)->needs(Component::class)->give(DecoratorTwo::class);
app()->when(DecoratorTwo::class)->needs(Component::class)->give(DecoratorOne::class);
app()->when(DecoratorOne::class)->needs(Component::class)->give(ConcreteComponent::class);
```

## Proposed solution

Single, easy to use method that receives an ordered list of types and makes all the contextual binding for you:

```php
app()->decorate(
    Component::class,
    DecoratorThree::class,
    DecoratorTwo::class,
    DecoratorOne::class,
    ConcreteComponent::class
);
```

Extensible, readable, easily modified. And it's syntax sugar, mostly, no code got edited. No BC breaks.
