### PR TITLE
[5.4] Allow getDisplayableAttribute() to be used in custom replacers

### DIFF
--- a/src/Illuminate/Validation/Concerns/FormatsMessages.php
+++ b/src/Illuminate/Validation/Concerns/FormatsMessages.php
@@ -205,7 +205,7 @@ trait FormatsMessages
         );
 
         if (isset($this->replacers[Str::snake($rule)])) {
-            return $this->callReplacer($message, $attribute, Str::snake($rule), $parameters);
+            return $this->callReplacer($message, $attribute, Str::snake($rule), $parameters, $this);
         } elseif (method_exists($this, $replacer = "replace{$rule}")) {
             return $this->$replacer($message, $attribute, $rule, $parameters);
         }
@@ -219,7 +219,7 @@ trait FormatsMessages
      * @param  string  $attribute
      * @return string
      */
-    protected function getDisplayableAttribute($attribute)
+    public function getDisplayableAttribute($attribute)
     {
         $primaryAttribute = $this->getPrimaryAttribute($attribute);
 
@@ -328,16 +328,17 @@ trait FormatsMessages
      * @param  string  $attribute
      * @param  string  $rule
      * @param  array   $parameters
+     * @param  Illuminate\Validation\Validator  $validator
      * @return string|null
      */
-    protected function callReplacer($message, $attribute, $rule, $parameters)
+    protected function callReplacer($message, $attribute, $rule, $parameters, $validator)
     {
         $callback = $this->replacers[$rule];
 
         if ($callback instanceof Closure) {
             return call_user_func_array($callback, func_get_args());
         } elseif (is_string($callback)) {
-            return $this->callClassBasedReplacer($callback, $message, $attribute, $rule, $parameters);
+            return $this->callClassBasedReplacer($callback, $message, $attribute, $rule, $parameters, $validator);
         }
     }
 
@@ -349,9 +350,10 @@ trait FormatsMessages
      * @param  string  $attribute
      * @param  string  $rule
      * @param  array   $parameters
+     * @param  Illuminate\Validation\Validator  $validator
      * @return string
      */
-    protected function callClassBasedReplacer($callback, $message, $attribute, $rule, $parameters)
+    protected function callClassBasedReplacer($callback, $message, $attribute, $rule, $parameters, $validator)
     {
         list($class, $method) = Str::parseCallback($callback, 'replace');
 


### PR DESCRIPTION
Currently, custom replacers cannot access the getDisplayableAttribute method and so other field names in parameters cannot be replaced with custom attributes. The current solution for this appears to be to extend the Validator, as in #9982

By passing the Validator instance to custom replacers as an additional argument and making the getDisplayableAttribute() method public we can add this functionality.