### PR TITLE
[5.4] Force database migration to use the writePdo

### DIFF
--- a/src/Illuminate/Database/Migrations/DatabaseMigrationRepository.php
+++ b/src/Illuminate/Database/Migrations/DatabaseMigrationRepository.php
@@ -161,7 +161,7 @@ class DatabaseMigrationRepository implements MigrationRepositoryInterface
      */
     protected function table()
     {
-        return $this->getConnection()->table($this->table);
+        return $this->getConnection()->table($this->table)->useWritePdo();
     }
 
     /**

--- a/tests/Database/DatabaseMigrationRepositoryTest.php
+++ b/tests/Database/DatabaseMigrationRepositoryTest.php
@@ -24,6 +24,7 @@ class DatabaseMigrationRepositoryTest extends TestCase
         $query->shouldReceive('orderBy')->once()->with('batch', 'asc')->andReturn($query);
         $query->shouldReceive('orderBy')->once()->with('migration', 'asc')->andReturn($query);
         $query->shouldReceive('pluck')->once()->with('migration')->andReturn(new Collection(['bar']));
+        $query->shouldReceive('useWritePdo')->once()->andReturn($query);
 
         $this->assertEquals(['bar'], $repo->getRan());
     }
@@ -41,6 +42,7 @@ class DatabaseMigrationRepositoryTest extends TestCase
         $query->shouldReceive('where')->once()->with('batch', 1)->andReturn($query);
         $query->shouldReceive('orderBy')->once()->with('migration', 'desc')->andReturn($query);
         $query->shouldReceive('get')->once()->andReturn(new Collection(['foo']));
+        $query->shouldReceive('useWritePdo')->once()->andReturn($query);
 
         $this->assertEquals(['foo'], $repo->getLast());
     }
@@ -53,6 +55,7 @@ class DatabaseMigrationRepositoryTest extends TestCase
         $repo->getConnectionResolver()->shouldReceive('connection')->with(null)->andReturn($connectionMock);
         $repo->getConnection()->shouldReceive('table')->once()->with('migrations')->andReturn($query);
         $query->shouldReceive('insert')->once()->with(['migration' => 'bar', 'batch' => 1]);
+        $query->shouldReceive('useWritePdo')->once()->andReturn($query);
 
         $repo->log('bar', 1);
     }
@@ -66,6 +69,7 @@ class DatabaseMigrationRepositoryTest extends TestCase
         $repo->getConnection()->shouldReceive('table')->once()->with('migrations')->andReturn($query);
         $query->shouldReceive('where')->once()->with('migration', 'foo')->andReturn($query);
         $query->shouldReceive('delete')->once();
+        $query->shouldReceive('useWritePdo')->once()->andReturn($query);
         $migration = (object) ['migration' => 'foo'];
 
         $repo->delete($migration);
@@ -89,6 +93,7 @@ class DatabaseMigrationRepositoryTest extends TestCase
         $repo->getConnectionResolver()->shouldReceive('connection')->with(null)->andReturn($connectionMock);
         $repo->getConnection()->shouldReceive('table')->once()->with('migrations')->andReturn($query);
         $query->shouldReceive('max')->once()->andReturn(1);
+        $query->shouldReceive('useWritePdo')->once()->andReturn($query);
 
         $this->assertEquals(1, $repo->getLastBatchNumber());
     }


### PR DESCRIPTION
Same fix as the https://github.com/laravel/framework/pull/18882 one, but against the 5.4 branch.