### PR TITLE
[5.4] JsonResponse handle unsupported type with flag

### DIFF
--- a/src/Illuminate/Http/JsonResponse.php
+++ b/src/Illuminate/Http/JsonResponse.php
@@ -84,16 +84,14 @@ class JsonResponse extends BaseJsonResponse
         return $this->setData($this->getData());
     }
 
-
-
     /**
      * Checks if error happened during json_encode.
      *
      * @param  int  $jsonLastError
-     * @return boolean
+     * @return bool
      */
     protected function hasJsonError($jsonLastError)
     {
-        return ($jsonLastError !== JSON_ERROR_NONE && ($jsonLastError !== JSON_ERROR_UNSUPPORTED_TYPE || !($this->encodingOptions & JSON_PARTIAL_OUTPUT_ON_ERROR)));
+        return $jsonLastError !== JSON_ERROR_NONE && ($jsonLastError !== JSON_ERROR_UNSUPPORTED_TYPE || ! ($this->encodingOptions & JSON_PARTIAL_OUTPUT_ON_ERROR));
     }
 }

--- a/src/Illuminate/Http/JsonResponse.php
+++ b/src/Illuminate/Http/JsonResponse.php
@@ -67,7 +67,7 @@ class JsonResponse extends BaseJsonResponse
             $this->data = json_encode($data, $this->encodingOptions);
         }
 
-        if (JSON_ERROR_NONE !== json_last_error()) {
+        if ($this->hasJsonError(json_last_error())) {
             throw new InvalidArgumentException(json_last_error_msg());
         }
 
@@ -82,5 +82,18 @@ class JsonResponse extends BaseJsonResponse
         $this->encodingOptions = (int) $options;
 
         return $this->setData($this->getData());
+    }
+
+
+
+    /**
+     * Checks if error happened during json_encode.
+     *
+     * @param  int  $jsonLastError
+     * @return boolean
+     */
+    protected function hasJsonError($jsonLastError)
+    {
+        return ($jsonLastError !== JSON_ERROR_NONE && ($jsonLastError !== JSON_ERROR_UNSUPPORTED_TYPE || !($this->encodingOptions & JSON_PARTIAL_OUTPUT_ON_ERROR)));
     }
 }

--- a/tests/Http/HttpJsonResponseTest.php
+++ b/tests/Http/HttpJsonResponseTest.php
@@ -73,6 +73,25 @@ class HttpJsonResponseTest extends TestCase
         $response->setStatusCode(404);
         $this->assertSame(404, $response->getStatusCode());
     }
+
+    /**
+     * @expectedException        \InvalidArgumentException
+     * @expectedExceptionMessage Type is not supported
+     */
+    public function testJsonErrorResource()
+    {
+        $resource = tmpfile();
+        $response = new \Illuminate\Http\JsonResponse(['resource' => $resource]);
+    }
+
+    public function testJsonErrorResourceWithPartialOutputOnError()
+    {
+        $resource = tmpfile();
+        $response = new \Illuminate\Http\JsonResponse(['resource' => $resource], 200, [], JSON_PARTIAL_OUTPUT_ON_ERROR);
+        $data = $response->getData();
+        $this->assertInstanceOf('StdClass', $data);
+        $this->assertNull($data->resource);
+    }
 }
 
 class JsonResponseTestJsonableObject implements Jsonable


### PR DESCRIPTION
handling JSON_PARTIAL_OUTPUT_ON_ERROR flag (e.g. w/ resource)

[PHP docs](http://php.net/manual/en/json.constants.php)
**JSON_ERROR_UNSUPPORTED_TYPE** (integer)
A value of an unsupported type was given to json_encode(), such as a resource. If the **JSON_PARTIAL_OUTPUT_ON_ERROR** option was given, NULL will be encoded in the place of the unsupported value. Available since PHP 5.5.0.