### PR TITLE
[5.4] Add the method methodsWithoutModels in AuthorizesRequests Trait.

### DIFF
--- a/src/Illuminate/Foundation/Auth/Access/AuthorizesRequests.php
+++ b/src/Illuminate/Foundation/Auth/Access/AuthorizesRequests.php
@@ -86,7 +86,7 @@ trait AuthorizesRequests
         $middleware = [];
 
         foreach ($this->resourceAbilityMap() as $method => $ability) {
-            $modelName = in_array($method, ['index', 'create', 'store']) ? $model : $parameter;
+            $modelName = in_array($method, $this->methodsWithoutModels()) ? $model : $parameter;
 
             $middleware["can:{$ability},{$modelName}"][] = $method;
         }
@@ -111,5 +111,15 @@ trait AuthorizesRequests
             'update' => 'update',
             'destroy' => 'delete',
         ];
+    }
+
+    /**
+     * Get the list of resource methods which not wait for a parameter.
+     *
+     * @return array
+     */
+    protected function methodsWithoutModels()
+    {
+        return ['index', 'create', 'store'];
     }
 }


### PR DESCRIPTION
Hey guys!

In this trait we have the `resourceAbilityMap()` which allows us to add directly in controller some methods to check in the `authorize*` methods.

Actually we can't add methods which doesn't need any parameter, because the setting of `$modelName` is done with a hard coded array. 

I added this method to fix that.

Example of use : 
```php
// Untouched, already usable and overridable in controller. 
protected function resourceAbilityMap()
{
    return [
        'index'      => 'list',
        'datatables' => 'list', // Here, a new resource method.
        'show'       => 'view',
        'create'     => 'create',
        'store'      => 'create',
        'edit'       => 'update',
        'update'     => 'update',
        'destroy'    => 'delete',
    ];
}
// New, have to add it to allow devs to override this array.
protected function methodsWithoutModels()
{
   // This new resource method doesn't need any parameter, so I can add it here.
    return ['index', 'datatables', 'create', 'store'];
}
```

What do you think about that ?

Thx.