### PR TITLE
[5.4] JsonResponse unsupported type error handling if flag set

### DIFF
--- a/src/Illuminate/Http/JsonResponse.php
+++ b/src/Illuminate/Http/JsonResponse.php
@@ -67,7 +67,7 @@ class JsonResponse extends BaseJsonResponse
             $this->data = json_encode($data, $this->encodingOptions);
         }
 
-        if (JSON_ERROR_NONE !== json_last_error()) {
+        if ($this->hasJsonError(json_last_error())) {
             throw new InvalidArgumentException(json_last_error_msg());
         }
 
@@ -82,5 +82,29 @@ class JsonResponse extends BaseJsonResponse
         $this->encodingOptions = (int) $options;
 
         return $this->setData($this->getData());
+    }
+
+    /**
+     * Checks the JSON encoding option is set.
+     *
+     * @param  int  $option
+     * @return bool
+     */
+    public function isEncodingOptionSet($option)
+    {
+        return (bool) ($this->encodingOptions & $option);
+    }
+
+    /**
+     * Checks if error happened during json_encode.
+     *
+     * @param  int  $jsonError
+     * @return bool
+     */
+    protected function hasJsonError($jsonError)
+    {
+        return $jsonError !== JSON_ERROR_NONE &&
+                ($jsonError !== JSON_ERROR_UNSUPPORTED_TYPE ||
+                ! $this->isEncodingOptionSet(JSON_PARTIAL_OUTPUT_ON_ERROR));
     }
 }

--- a/tests/Http/HttpJsonResponseTest.php
+++ b/tests/Http/HttpJsonResponseTest.php
@@ -73,6 +73,25 @@ class HttpJsonResponseTest extends TestCase
         $response->setStatusCode(404);
         $this->assertSame(404, $response->getStatusCode());
     }
+
+    /**
+     * @expectedException        \InvalidArgumentException
+     * @expectedExceptionMessage Type is not supported
+     */
+    public function testJsonErrorResource()
+    {
+        $resource = tmpfile();
+        $response = new \Illuminate\Http\JsonResponse(['resource' => $resource]);
+    }
+
+    public function testJsonErrorResourceWithPartialOutputOnError()
+    {
+        $resource = tmpfile();
+        $response = new \Illuminate\Http\JsonResponse(['resource' => $resource], 200, [], JSON_PARTIAL_OUTPUT_ON_ERROR);
+        $data = $response->getData();
+        $this->assertInstanceOf('StdClass', $data);
+        $this->assertNull($data->resource);
+    }
 }
 
 class JsonResponseTestJsonableObject implements Jsonable


### PR DESCRIPTION
Currently, `Illuminate\Http\JsonResponse` does not support **JSON_PARTIAL_OUTPUT_ON_ERROR** flag check on `json_encode()` error.

If the `JsonResponse` constructor `$data` argument contains a **resource** (maybe deep inside in an error stack - `$exception->getTrace()`) there is an `InvalidArgumentException` thrown (because of only the `json_last_error()` is checked).

According to [PHP Docs](http://php.net/manual/en/json.constants.php) there is a flag (**JSON_PARTIAL_OUTPUT_ON_ERROR**) for generating **NULL** values on `json_encode()` error - such as **resource** encoding.
> **JSON_ERROR_UNSUPPORTED_TYPE** (integer)
A value of an unsupported type was given to json_encode(), such as a resource. If the **JSON_PARTIAL_OUTPUT_ON_ERROR** option was given, **NULL** will be encoded in the place of the unsupported value. Available since PHP 5.5.0.

So the expected behavior is no `InvalidArgumentException` is thrown if the value of `json_last_error()` is **JSON_ERROR_UNSUPPORTED_TYPE** and the **JSON_PARTIAL_OUTPUT_ON_ERROR** flag is set (because the generated JSON is valid).