### PR TITLE
[5.4] Redis Queue: Fix Job having timeout set different from the one of the queue

### DIFF
--- a/src/Illuminate/Queue/LuaScripts.php
+++ b/src/Illuminate/Queue/LuaScripts.php
@@ -35,7 +35,8 @@ LUA;
 -- Pop the first job off of the queue...
 local job = redis.call('lpop', KEYS[1])
 local reserved = false
-local timeout = ARGV[2]
+local timeout  = tonumber(ARGV[2])
+local score    = tonumber(ARGV[1])
 
 if(job ~= false) then
     -- Increment the attempt count and place job on the reserved queue...
@@ -44,11 +45,12 @@ if(job ~= false) then
     
      -- Retrieve the timeout of the job if set, per documentation it has precedence
      -- on the one of the queue
-    if(reserved['timeout'] ~= nil) then
-        timeout = reserved['timeout']
+    local timeoutJob = tonumber(reserved['timeout'])
+    if(timeoutJob ~= nil) then
+        timeout = timeoutJob;
     end
     
-    local score = tonumber(ARGV[1]) + tonumber(timeout)
+    score = score + timeout
     
     reserved = cjson.encode(reserved)
     redis.call('zadd', KEYS[2], score, reserved)

--- a/src/Illuminate/Queue/LuaScripts.php
+++ b/src/Illuminate/Queue/LuaScripts.php
@@ -47,9 +47,12 @@ if(job ~= false) then
     
      -- Retrieve the timeout of the job if set, per documentation it has precedence
      -- on the one of the queue
-    local timeoutJob = tonumber(reserved['timeout'])
-    if(timeoutJob ~= nil) then
-        timeout = timeoutJob;
+    if(reserved['timeout'] ~= nil) then
+        timeout = tonumber(reserved['timeout'])
+    end
+    
+    if(timeout == nil) then
+       timeout = 0
     end
     
     score = score + timeout

--- a/src/Illuminate/Queue/LuaScripts.php
+++ b/src/Illuminate/Queue/LuaScripts.php
@@ -48,8 +48,10 @@ if(job ~= false) then
         timeout = reserved['timeout']
     end
     
+    local score = tonumber(ARGV[1]) + tonumber(timeout)
+    
     reserved = cjson.encode(reserved)
-    redis.call('zadd', KEYS[2], ARGV[1] + timeout , reserved)
+    redis.call('zadd', KEYS[2], score, reserved)
 end
 
 return {job, reserved}

--- a/src/Illuminate/Queue/LuaScripts.php
+++ b/src/Illuminate/Queue/LuaScripts.php
@@ -44,18 +44,18 @@ if(job ~= false) then
     -- Increment the attempt count and place job on the reserved queue...
     reserved = cjson.decode(job)    
     reserved['attempts'] = reserved['attempts'] + 1
+
     
      -- Retrieve the timeout of the job if set, per documentation it has precedence
      -- on the one of the queue
-    if(reserved['timeout'] ~= nil) then
-        timeout = tonumber(reserved['timeout'])
+    local timeoutJob = tonumber(reserved['timeout']);
+    if(timeoutJob ~= nil) then
+        timeout =  timeoutJob
     end
     
-    if(timeout == nil) then
-       timeout = 0
+    if(timeout ~= nil) then
+       score = score + timeout    
     end
-    
-    score = score + timeout
     
     reserved = cjson.encode(reserved)
     redis.call('zadd', KEYS[2], score, reserved)

--- a/src/Illuminate/Queue/LuaScripts.php
+++ b/src/Illuminate/Queue/LuaScripts.php
@@ -42,21 +42,20 @@ local score    = tonumber(ARGV[1])
 
 if(job ~= false) then
     -- Increment the attempt count and place job on the reserved queue...
-    reserved = cjson.decode(job)    
+    reserved = cjson.decode(job)
     reserved['attempts'] = reserved['attempts'] + 1
 
-    
-     -- Retrieve the timeout of the job if set, per documentation it has precedence
-     -- on the one of the queue
+    -- Retrieve the timeout of the job if set, per documentation it has precedence
+    -- on the one of the queue
     local timeoutJob = tonumber(reserved['timeout']);
     if(timeoutJob ~= nil) then
         timeout =  timeoutJob
     end
-    
+
     if(timeout ~= nil) then
        score = score + timeout    
     end
-    
+
     reserved = cjson.encode(reserved)
     redis.call('zadd', KEYS[2], score, reserved)
 end

--- a/src/Illuminate/Queue/LuaScripts.php
+++ b/src/Illuminate/Queue/LuaScripts.php
@@ -25,7 +25,9 @@ LUA;
      *
      * KEYS[1] - The queue to pop jobs from, for example: queues:foo
      * KEYS[2] - The queue to place reserved jobs on, for example: queues:foo:reserved
-     * ARGV[1] - The time at which the reserved job will expire
+     * ARGV[1] - Current time
+     * ARGV[2] - Default timeout. USed with ARGV[1] to calculate when the job should have finished.
+     *
      *
      * @return string
      */

--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -204,7 +204,7 @@ class RedisQueue extends Queue implements QueueContract
     {
         return $this->getConnection()->eval(
             LuaScripts::pop(), 2, $queue, $queue.':reserved',
-            $this->availableAt($this->retryAfter)
+            $this->currentTime(), $this->retryAfter
         );
     }
 


### PR DESCRIPTION
In the previous version, laravel added the possibility to have each job set their own timeout independently of the queue timeout.

This feature hasn't been implemented in the redis queue and leads to a duplication of job if used.

# Scenario
Queue timeout: 60 seconds
Job Timeout: 300 Seconds
Worker on queue: 2

## Current way the queue works
Before taking a job from the Redis queue, it migrates the queue:reserved. This check is done by verifying if any score in the reserved queue is lower than the current timestamp. Any job reaching this condition is put back in the working queue.

After the migration, the worker takes the job, assign in the reserved queue and set it's score as NOW()+ timeout of the queue.

### Problem
The job with a timeout of 300 is taken by a worker with a timeout of 60. The score in reserved will be NOW() + 60 sec. The second worker come along, the job hasn't finished yet (by its 300 timeout) but reached the queue timeout. The second worker then takes the job. The job is then duplicated in the queue.

### Solution
This PR verify if a job has a timeout set when poping it from the queue and putting it in the reserved queue. If it's the case, as per documentation, that timeout as precedence on the one of the queue.