### PR TITLE
Add listen helper

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -483,6 +483,20 @@ if (! function_exists('event')) {
     }
 }
 
+if (! function_exists('listen')) {
+    /**
+     * Register an event listener.
+     *
+     * @param  string|array  $events
+     * @param  mixed  $listener
+     * @return void
+     */
+    function listen(...$args)
+    {
+        app('events')->listen(...$args);
+    }
+}
+
 if (! function_exists('factory')) {
     /**
      * Create a model factory builder for a given class, name, and amount.


### PR DESCRIPTION
Adds the ability to create "quick, one-off" ephemeral listeners for situations where a proper ServiceProvider registered listener is too much.