### PR TITLE
[5.4] Null Morph Map ErrorException

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -192,7 +192,9 @@ trait HasRelationships
      */
     public static function getActualClassNameForMorph($class)
     {
-        return Arr::get(Relation::morphMap(), $class, $class);
+        $map = Relation::morphMap() ?: [];
+
+        return Arr::get($map, $class, $class);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -192,9 +192,7 @@ trait HasRelationships
      */
     public static function getActualClassNameForMorph($class)
     {
-        $map = Relation::morphMap() ?: [];
-
-        return Arr::get($map, $class, $class);
+        return Arr::get(Relation::morphMap() ?: [], $class, $class);
     }
 
     /**


### PR DESCRIPTION
Currently, if you call `getActualClassNameForMorph` without the morph map set, it will throw an error because `Relation::morphMap()` returns `null` instead of (what I would expect) `[]`.

Is this expected behaviour? If so, why is this expected behaviour?