### PR TITLE
Add Model::resolveRouteKey

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1192,7 +1192,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     public function resolveRouteKey($keytoresolve)
     {
         return $keytoresolve;
-    } 
+    }
 
     /**
      * Get the route key for the model.

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1184,6 +1184,17 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     }
 
     /**
+     * Resolve route key value for retrieving a record.
+     *
+     * @param $keytoresolve Record identifier to resolve
+     * @return mixed ID Resolved record identifier
+     */
+    public function resolveRouteKey($keytoresolve)
+    {
+        return $keytoresolve;
+    } 
+
+    /**
      * Get the route key for the model.
      *
      * @return string

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1186,7 +1186,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     /**
      * Resolve route key value for retrieving a record.
      *
-     * @param $keytoresolve Record identifier to resolve
+     * @param mixed $keytoresolve Record identifier to resolve
      * @return mixed ID Resolved record identifier
      */
     public function resolveRouteKey($keytoresolve)

--- a/src/Illuminate/Routing/ImplicitRouteBinding.php
+++ b/src/Illuminate/Routing/ImplicitRouteBinding.php
@@ -31,7 +31,7 @@ class ImplicitRouteBinding
             $model = $container->make($parameter->getClass()->name);
 
             $route->setParameter($parameterName, $model->where(
-                $model->getRouteKeyName(), $parameterValue
+                $model->getRouteKeyName(), $model->resolveRouteKey($parameterValue)
             )->firstOrFail());
         }
     }


### PR DESCRIPTION
Change `ImplicitRouteBinding` to use `resolveRouteKey` instead of raw parameter value.

Override the `resolveRouteKey` method on any `Model` to use a custom key resolution, a Hashid for example.

In my case, I'd like to override `resolveRouteKey` to optionally accept a Hashid instead of the raw ID of the record.  Because a Hashid is 1:1 with the numeric ID, I have no need to maintain 2 separate ID fields in the database.

My override looks like this:

```
    public function resolveRouteKey($key)
    {
        if(is_numeric($key))
            return $key;
        else
            return self::getIDFromHashID($key);
    }

```