### PR TITLE
[5.5] Display Correct Presets

### DIFF
--- a/src/Illuminate/Foundation/Console/PresetCommand.php
+++ b/src/Illuminate/Foundation/Console/PresetCommand.php
@@ -15,7 +15,7 @@ class PresetCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'preset { type : The preset type (fresh, bootstrap, react) }';
+    protected $signature = 'preset { type : The preset type (none, bootstrap, vue, react) }';
 
     /**
      * The console command description.


### PR DESCRIPTION
In `$signature`, we display a preset that doesn't exist (`fresh`) and we omit a preset (`vue`). Seems a bit confusing.