### PR TITLE
[5.4] Makes cache() return cache object when first argument is not a string/array

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -231,15 +231,17 @@ if (! function_exists('cache')) {
             return app('cache')->get($arguments[0], isset($arguments[1]) ? $arguments[1] : null);
         }
 
-        if (is_array($arguments[0])) {
-            if (! isset($arguments[1])) {
-                throw new Exception(
-                    'You must set an expiration time when putting to the cache.'
-                );
-            }
-
-            return app('cache')->put(key($arguments[0]), reset($arguments[0]), $arguments[1]);
+        if (! is_array($arguments[0])) {
+            return app('cache');
         }
+
+        if (! isset($arguments[1])) {
+            throw new Exception(
+                'You must set an expiration time when putting to the cache.'
+            );
+        }
+
+        return app('cache')->put(key($arguments[0]), reset($arguments[0]), $arguments[1]);
     }
 }
 


### PR DESCRIPTION
The cache() function will return nothing when the first argument is something else than a string or array.

This PR fixes that by returning the 'default' `app('cache')` when that is the case.
It also improves code styling by removing the nested ifs (so less indentation) and follows the 'golden path' guideline.