### PR TITLE
[5.4] Add callback option to forget collection method

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -495,13 +495,17 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
-     * Remove an item from the collection by key.
+     * Remove items from the collection.
      *
-     * @param  string|array  $keys
+     * @param  string|array|callable  $keys
      * @return $this
      */
     public function forget($keys)
     {
+        if (! is_array($keys) && $this->useAsCallable($keys)) {
+            $keys = $this->filter($keys)->keys()->all();
+        }
+
         foreach ((array) $keys as $key) {
             $this->offsetUnset($key);
         }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -285,6 +285,21 @@ class SupportCollectionTest extends TestCase
         $this->assertTrue(isset($c['name']));
     }
 
+    public function testForgetWithCallback()
+    {
+        $c = new Collection([
+            1 => 'foo',
+            2 => 'bar',
+            3 => 'baz',
+        ]);
+
+        $this->assertEquals([
+            1 => 'foo',
+        ], $c->forget(function ($item) {
+            return substr($item, 0, 1) === 'b';
+        })->all());
+    }
+
     public function testCountable()
     {
         $c = new Collection(['foo', 'bar']);


### PR DESCRIPTION
The forget method on the Collection class now accepts a callable.

Here's an example of how it works.

```php
$c = new Collection([1, 2, 3, 4, 5]);
$c->forget(function ($item) {
    return $item > 3;
});

// $c is now [1, 2, 3]
```

I'll have to add the `function ($item, $key)` callback to the test as well. But what do you think so far of the idea?