### PR TITLE
Replacing hardcoded protocol in mix helper

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -573,7 +573,7 @@ if (! function_exists('mix')) {
             $manifestDirectory = "/{$manifestDirectory}";
         }
 
-        if (file_exists(public_path($manifestDirectory.'/hot'))) {           
+        if (file_exists(public_path($manifestDirectory.'/hot'))) {
             return new HtmlString("//localhost:8080{$path}");
         }
 

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -575,6 +575,7 @@ if (! function_exists('mix')) {
 
         if (file_exists(public_path($manifestDirectory.'/hot'))) {
             $hotProtocol = request()->secure() ? 'https' : 'http';
+            
             return new HtmlString("{$hotProtocol}://localhost:8080{$path}");
         }
 

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -573,10 +573,8 @@ if (! function_exists('mix')) {
             $manifestDirectory = "/{$manifestDirectory}";
         }
 
-        if (file_exists(public_path($manifestDirectory.'/hot'))) {
-            $hotProtocol = request()->secure() ? 'https' : 'http';
-            
-            return new HtmlString("{$hotProtocol}://localhost:8080{$path}");
+        if (file_exists(public_path($manifestDirectory.'/hot'))) {           
+            return new HtmlString("//localhost:8080{$path}");
         }
 
         if (! $manifest) {

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -574,7 +574,8 @@ if (! function_exists('mix')) {
         }
 
         if (file_exists(public_path($manifestDirectory.'/hot'))) {
-            return new HtmlString("http://localhost:8080{$path}");
+            $hotProtocol = request()->secure() ? 'https' : 'http';
+            return new HtmlString("{$hotProtocol}://localhost:8080{$path}");
         }
 
         if (! $manifest) {


### PR DESCRIPTION
This does not solve "the whole problem" however currently the mix helper hardcodes the port and protocol.

When using SSL on your development environment browsers refuse to load the assets served by mix when using HMR over http

This change makes sure it uses the correct protocol.

Although it doesn't solve the issue of users not having SSL on "localhost"