### PR TITLE
[5.4] Add pivot query scope to sync() and toggle() methods

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -451,6 +451,7 @@ trait InteractsWithPivotTable
         if ($applyScope !== null) {
             $applyScope($query);
         }
+        
         return $query;
     }
 

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -451,7 +451,7 @@ trait InteractsWithPivotTable
         if ($applyScope !== null) {
             $applyScope($query);
         }
-        
+
         return $query;
     }
 


### PR DESCRIPTION
It's currently not possible to call `sync()` etc. and have the ability to specify a `where()` condition.
The use case for this is when wanting to sync some associations that are segmented by a particular column.

To achieve this, a new method called `newScopedPivotQuery()` which can be passed a closure that will apply conditions to a `$query` object.    `sync()` `toggle()` and `syncWithoutDetaching()` will then call this new method, passing along any closure given.

An example would be:

Scoping tags association to a particular `type`:

```php
$type = 'colours';
$this->tags()->sync($tagIds, true, function ($query) use ($type) {
    $query->join('tags', 'taggables.tag_id', '=', 'tags.id')
         ->where('tags.type', $type);
});
```
