### PR TITLE
[5.4] Add tests to recently updated middleware

### DIFF
--- a/tests/Foundation/Http/Middleware/TransformsRequestTest.php
+++ b/tests/Foundation/Http/Middleware/TransformsRequestTest.php
@@ -10,7 +10,10 @@ class TransformsRequestTest extends \PHPUnit_Framework_TestCase
     public function testLowerAgeAndAddBeer()
     {
         $middleware = new ManipulateInput();
-        $request = new Request(['name' => 'Damian', 'beers' => 4,], ['age' => 28]);
+        $request = new Request(
+            ['name' => 'Damian', 'beers' => 4,],
+            ['age' => 28]
+        );
 
         $middleware->handle($request, function (Request $request) {
             $this->assertEquals('Damian', $request->get('name'));
@@ -22,8 +25,15 @@ class TransformsRequestTest extends \PHPUnit_Framework_TestCase
     public function testAjaxLowerAgeAndAddBeer()
     {
         $middleware = new ManipulateInput();
-        $request = new Request(['name' => 'Damian', 'beers' => 4,], [], [], [], [],
-            ['CONTENT_TYPE' => '/json'], json_encode(['age' => 28]));
+        $request = new Request(
+            ['name' => 'Damian', 'beers' => 4,],
+            [],
+            [],
+            [],
+            [],
+            ['CONTENT_TYPE' => '/json'],
+            json_encode(['age' => 28])
+        );
 
         $middleware->handle($request, function (Request $request) {
             $this->assertEquals('Damian', $request->input('name'));

--- a/tests/Foundation/Http/Middleware/TransformsRequestTest.php
+++ b/tests/Foundation/Http/Middleware/TransformsRequestTest.php
@@ -11,7 +11,10 @@ class TransformsRequestTest extends \PHPUnit_Framework_TestCase
     {
         $middleware = new ManipulateInput();
         $request = new Request(
-            ['name' => 'Damian', 'beers' => 4,],
+            [
+                'name' => 'Damian',
+                'beers' => 4,
+            ],
             ['age' => 28]
         );
 
@@ -26,7 +29,10 @@ class TransformsRequestTest extends \PHPUnit_Framework_TestCase
     {
         $middleware = new ManipulateInput();
         $request = new Request(
-            ['name' => 'Damian', 'beers' => 4,],
+            [
+                'name' => 'Damian',
+                'beers' => 4,
+            ],
             [],
             [],
             [],

--- a/tests/Foundation/Http/Middleware/TransformsRequestTest.php
+++ b/tests/Foundation/Http/Middleware/TransformsRequestTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Illuminate\Tests\Foundation\Http\Middleware;
+
+use Illuminate\Http\Request;
+use Illuminate\Foundation\Http\Middleware\TransformsRequest;
+
+class TransformsRequestTest extends \PHPUnit_Framework_TestCase
+{
+    public function testLowerAgeAndAddBeer()
+    {
+        $middleware = new ManipulateInput();
+        $request = new Request(['name' => 'Damian', 'beers' => 4,], ['age' => 28]);
+
+        $middleware->handle($request, function (Request $request) {
+            $this->assertEquals('Damian', $request->get('name'));
+            $this->assertEquals(27, $request->get('age'));
+            $this->assertEquals(5, $request->get('beers'));
+        });
+    }
+
+    public function testAjaxTransform()
+    {
+        $middleware = new ManipulateInput();
+        $request = new Request(['name' => 'Damian', 'beers' => 4,], [], [], [], [],
+            ['CONTENT_TYPE' => '/json'], json_encode(['age' => 28]));
+
+        $middleware->handle($request, function (Request $request) {
+            $this->assertEquals('Damian', $request->input('name'));
+            $this->assertEquals(27, $request->input('age'));
+            $this->assertEquals(5, $request->input('beers'));
+        });
+    }
+}
+
+class ManipulateInput extends TransformsRequest
+{
+    protected function transform($key, $value)
+    {
+        if ($key === 'beers') {
+            $value++;
+        }
+        if ($key === 'age') {
+            $value--;
+        }
+
+        return $value;
+    }
+}

--- a/tests/Foundation/Http/Middleware/TransformsRequestTest.php
+++ b/tests/Foundation/Http/Middleware/TransformsRequestTest.php
@@ -19,7 +19,7 @@ class TransformsRequestTest extends \PHPUnit_Framework_TestCase
         });
     }
 
-    public function testAjaxTransform()
+    public function testAjaxLowerAgeAndAddBeer()
     {
         $middleware = new ManipulateInput();
         $request = new Request(['name' => 'Damian', 'beers' => 4,], [], [], [], [],


### PR DESCRIPTION
I recently updated TransformsRequest() middleware (https://github.com/laravel/framework/pull/18840) but skipped tests for it. With this PR I wish to pay that debt.