### PR TITLE
[5.4] Set data key when testing file uploads in nested array

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -308,7 +308,7 @@ trait MakesHttpRequests
             if (is_array($value)) {
                 $files[$key] = $this->extractFilesFromDataArray($value);
 
-                unset($data[$key]);
+                $data[$key] = $value;
             }
         }
 

--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -307,6 +307,8 @@ trait MakesHttpRequests
 
             if (is_array($value)) {
                 $files[$key] = $this->extractFilesFromDataArray($value);
+                
+                unset($data[$key]);
             }
         }
 

--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -307,7 +307,7 @@ trait MakesHttpRequests
 
             if (is_array($value)) {
                 $files[$key] = $this->extractFilesFromDataArray($value);
-                
+
                 unset($data[$key]);
             }
         }


### PR DESCRIPTION
Fix a bug that causes data keys to be overridden when testing a nested file upload array.


Example of bug in action:

*routes/web.php*
```php
Route::post('test', function () {
    Validator::make(request()->all(), [
        'foo' => 'required'
    ])->validate();
});
```

*tests/Feature/ExampleTest.php*
```php
<?php

namespace Tests\Feature;

use Tests\TestCase;
use Illuminate\Http\UploadedFile;

class ExampleTest extends TestCase
{
    public function testExample()
    {
        $this->postJson('test', [
            'foo' => 'bar',
            'images' => [UploadedFile::fake()->image('image.jpg')]
        ])->assertStatus(200);
    }
}
```

Test result:
```
Expected status code 200 but received 422.
Failed asserting that false is true.
```

This pr sets the value in the data which fixes the bug.

fixes #18671 