### PR TITLE
[5.4] Included ability to pass extra variables to Blade @each 

### DIFF
--- a/src/Illuminate/View/Factory.php
+++ b/src/Illuminate/View/Factory.php
@@ -159,13 +159,14 @@ class Factory implements FactoryContract
     /**
      * Get the rendered contents of a partial from a loop.
      *
-     * @param  string  $view
-     * @param  array   $data
-     * @param  string  $iterator
-     * @param  string  $empty
+     * @param  string       $view
+     * @param  array        $data
+     * @param  string       $iterator
+     * @param  string|bool  $empty
+     * @param  array        $mergeData
      * @return string
      */
-    public function renderEach($view, $data, $iterator, $empty = 'raw|')
+    public function renderEach($view, $data, $iterator, $empty = 'raw|', $mergeData = [])
     {
         $result = '';
 
@@ -175,7 +176,7 @@ class Factory implements FactoryContract
         if (count($data) > 0) {
             foreach ($data as $key => $value) {
                 $result .= $this->make(
-                    $view, ['key' => $key, $iterator => $value]
+                    $view, array_merge(['key' => $key, $iterator => $value], $mergeData)
                 )->render();
             }
         }
@@ -184,6 +185,7 @@ class Factory implements FactoryContract
         // view. Alternatively, the "empty view" could be a raw string that begins
         // with "raw|" for convenience and to let this know that it is a string.
         else {
+            $empty = ($empty) ?: 'raw|';
             $result = Str::startsWith($empty, 'raw|')
                         ? substr($empty, 4)
                         : $this->make($empty)->render();

--- a/src/Illuminate/View/Factory.php
+++ b/src/Illuminate/View/Factory.php
@@ -188,7 +188,7 @@ class Factory implements FactoryContract
             $empty = ($empty) ?: 'raw|';
             $result = Str::startsWith($empty, 'raw|')
                         ? substr($empty, 4)
-                        : $this->make($empty)->render();
+                        : $this->make($empty, $mergeData)->render();
         }
 
         return $result;

--- a/src/Illuminate/View/Factory.php
+++ b/src/Illuminate/View/Factory.php
@@ -185,7 +185,7 @@ class Factory implements FactoryContract
         // view. Alternatively, the "empty view" could be a raw string that begins
         // with "raw|" for convenience and to let this know that it is a string.
         else {
-            $empty = ($empty) ?: 'raw|';
+            $empty = ($empty === false) ? 'raw|' : $empty;
             $result = Str::startsWith($empty, 'raw|')
                         ? substr($empty, 4)
                         : $this->make($empty, $mergeData)->render();

--- a/tests/View/ViewFactoryTest.php
+++ b/tests/View/ViewFactoryTest.php
@@ -61,7 +61,7 @@ class ViewFactoryTest extends TestCase
     public function testEmptyViewsCanBeReturnedFromRenderEach()
     {
         $factory = m::mock('Illuminate\View\Factory[make]', $this->getFactoryArgs());
-        $factory->shouldReceive('make')->once()->with('foo')->andReturn($mockView = m::mock('StdClass'));
+        $factory->shouldReceive('make')->once()->with('foo', [])->andReturn($mockView = m::mock('StdClass'));
         $mockView->shouldReceive('render')->once()->andReturn('empty');
 
         $this->assertEquals('empty', $factory->renderEach('view', [], 'iterator', 'foo', []));

--- a/tests/View/ViewFactoryTest.php
+++ b/tests/View/ViewFactoryTest.php
@@ -64,7 +64,7 @@ class ViewFactoryTest extends TestCase
         $factory->shouldReceive('make')->once()->with('foo')->andReturn($mockView = m::mock('StdClass'));
         $mockView->shouldReceive('render')->once()->andReturn('empty');
 
-        $this->assertEquals('empty', $factory->renderEach('view', [], 'iterator', 'foo'));
+        $this->assertEquals('empty', $factory->renderEach('view', [], 'iterator', 'foo', []));
     }
 
     public function testRawStringsMayBeReturnedFromRenderEach()


### PR DESCRIPTION
As it is not possible to pass extra variables to the @each, it's hard to avoid the @foreach sometimes.

with the inclusion of the $mergeData, it is simple to add new variables:

@each ('blog.post', $posts, 'post', 'blog.empty', ['data' => 'This is a sample data'])

This way, we can use the $data on our 'blog.post' view.


Note1: I've included the argument at the end to avoid break older versions.
Note2: Now the empty will accept 'false' as argument. If it is false, the code will add the 'raw|' to it. This is to make it easier to developers to 'jump' an argument that couldn't be used.