### PR TITLE
[5.4] Notification Channels Array Cast

### DIFF
--- a/src/Illuminate/Notifications/NotificationSender.php
+++ b/src/Illuminate/Notifications/NotificationSender.php
@@ -85,7 +85,7 @@ class NotificationSender
                 continue;
             }
 
-            foreach ($viaChannels as $channel) {
+            foreach ((array) $viaChannels as $channel) {
                 $this->sendToNotifiable($notifiable, $notificationId, clone $original, $channel);
             }
         }


### PR DESCRIPTION
We document that notifications can return a `string` from their `via` method but doing so causes an error. This is an issue that I see cropping up quite often with people getting stuck on 'my notification is erroring' but they're just returning the class like so:
```php
/**
 * Get the notification's channels.
 *
 * @param  mixed  $notifiable
 * @return array|string
 */
public function via($notifiable)
{
    return MyChannel::class;
}
```

Which they don't expect to error because of the docblock. The same docblock also appears in the documentation.

[ResetPassword notification](https://github.com/laravel/framework/blob/5.4/src/Illuminate/Auth/Notifications/ResetPassword.php#L32)

[Custom Channel Documentation](https://laravel.com/docs/5.4/notifications#custom-channels)