### PR TITLE
[5.5] Change datetime to datetime2

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -468,7 +468,7 @@ class SqlServerGrammar extends Grammar
      */
     protected function typeDateTime(Fluent $column)
     {
-        return "datetime($column->precision)";
+        return "datetime2($column->precision)";
     }
 
     /**
@@ -513,10 +513,10 @@ class SqlServerGrammar extends Grammar
     protected function typeTimestamp(Fluent $column)
     {
         if ($column->useCurrent) {
-            return "datetime($column->precision) default CURRENT_TIMESTAMP";
+            return "datetime2($column->precision) default CURRENT_TIMESTAMP";
         }
 
-        return "datetime($column->precision)";
+        return "datetime2($column->precision)";
     }
 
     /**

--- a/tests/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintTest.php
@@ -73,6 +73,6 @@ class DatabaseSchemaBlueprintTest extends TestCase
         $this->assertEquals(['alter table "users" add column "created" datetime default CURRENT_TIMESTAMP not null'], $blueprint->toSql($connection, new SQLiteGrammar));
 
         $blueprint = clone $base;
-        $this->assertEquals(['alter table "users" add "created" datetime(0) default CURRENT_TIMESTAMP not null'], $blueprint->toSql($connection, new SqlServerGrammar));
+        $this->assertEquals(['alter table "users" add "created" datetime2(0) default CURRENT_TIMESTAMP not null'], $blueprint->toSql($connection, new SqlServerGrammar));
     }
 }

--- a/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
@@ -446,7 +446,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('alter table "users" add "foo" datetime(0) not null', $statements[0]);
+        $this->assertEquals('alter table "users" add "foo" datetime2(0) not null', $statements[0]);
     }
 
     public function testAddingDateTimeTz()
@@ -486,7 +486,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('alter table "users" add "foo" datetime(0) not null', $statements[0]);
+        $this->assertEquals('alter table "users" add "foo" datetime2(0) not null', $statements[0]);
     }
 
     public function testAddingTimeStampTz()
@@ -506,7 +506,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('alter table "users" add "created_at" datetime(0) null, "updated_at" datetime(0) null', $statements[0]);
+        $this->assertEquals('alter table "users" add "created_at" datetime2(0) null, "updated_at" datetime2(0) null', $statements[0]);
     }
 
     public function testAddingTimeStampsTz()


### PR DESCRIPTION
Previous PR #18847 added a precision parameter to the ``` datetime ``` column, however this parameter isn't supported by SQLServer.

Instead of reverting the change we can change the column used by the Schema builder to ``` datetime2 ``` this column is available since SQLServer 2008 and supports the precision parameter.

[Link to datetime docs](https://docs.microsoft.com/en-us/sql/t-sql/data-types/datetime-transact-sql)
[Link to datetime2 docs](https://docs.microsoft.com/en-us/sql/t-sql/data-types/datetime2-transact-sql)

> datetime2 can be considered as an extension of the existing datetime type that has a larger date range, a larger default fractional precision, and optional user-specified precision.