### PR TITLE
[5.4] Tweak method name

### DIFF
--- a/src/Illuminate/Foundation/Auth/Access/AuthorizesRequests.php
+++ b/src/Illuminate/Foundation/Auth/Access/AuthorizesRequests.php
@@ -86,7 +86,7 @@ trait AuthorizesRequests
         $middleware = [];
 
         foreach ($this->resourceAbilityMap() as $method => $ability) {
-            $modelName = in_array($method, $this->methodsWithoutModels()) ? $model : $parameter;
+            $modelName = in_array($method, $this->resourceMethodsWithoutModels()) ? $model : $parameter;
 
             $middleware["can:{$ability},{$modelName}"][] = $method;
         }
@@ -118,7 +118,7 @@ trait AuthorizesRequests
      *
      * @return array
      */
-    protected function methodsWithoutModels()
+    protected function resourceMethodsWithoutModels()
     {
         return ['index', 'create', 'store'];
     }


### PR DESCRIPTION
Since this method is on the controller, we really don't want it to clash with any methods the user may define in their controller. Much better to be explicit.

Additionally, this fits better with the `resourceAbilityMap` method's name.