### PR TITLE
[5.4] Add assertDatabaseHasOne and assertDatabaseHasMany

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
@@ -18,8 +18,35 @@ trait InteractsWithDatabase
      */
     protected function assertDatabaseHas($table, array $data, $connection = null)
     {
+        return $this->assertDatabaseHasMany($table, null, $data, $connection);
+    }
+
+    /**
+     * Assert that a given where condition exists only one time in the database.
+     *
+     * @param  string  $table
+     * @param  array  $data
+     * @param  string  $connection
+     * @return $this
+     */
+    protected function assertDatabaseHasOne($table, array $data, $connection = null)
+    {
+        return $this->assertDatabaseHasMany($table, 1, $data, $connection);
+    }
+
+    /**
+     * Assert that a given where condition exists only a certain amount of times in the database.
+     *
+     * @param  string  $table
+     * @param  integer  $number
+     * @param  array  $data
+     * @param  string  $connection
+     * @return $this
+     */
+    protected function assertDatabaseHasMany($table, $number, array $data, $connection = null)
+    {
         $this->assertThat(
-            $table, new HasInDatabase($this->getConnection($connection), $data)
+            $table, new HasInDatabase($this->getConnection($connection), $data, $number)
         );
 
         return $this;

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
@@ -38,7 +38,7 @@ trait InteractsWithDatabase
      * Assert that a given where condition exists only a certain amount of times in the database.
      *
      * @param  string  $table
-     * @param  integer  $number
+     * @param  int|null  $number
      * @param  array  $data
      * @param  string  $connection
      * @return $this

--- a/src/Illuminate/Foundation/Testing/Constraints/HasInDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Constraints/HasInDatabase.php
@@ -31,7 +31,7 @@ class HasInDatabase extends PHPUnit_Framework_Constraint
     /**
      * The exact number of rows expected in the database table.
      *
-     * @var integer|null
+     * @var int|null
      */
     protected $number;
 
@@ -40,7 +40,7 @@ class HasInDatabase extends PHPUnit_Framework_Constraint
      *
      * @param  \Illuminate\Database\Connection  $database
      * @param  array  $data
-     * @param  integer  $number
+     * @param  int|null  $number
      * @return void
      */
     public function __construct(Connection $database, array $data, $number = null)


### PR DESCRIPTION
When asserting certain results were found in the database, I think it is convenient to have the possibility to test that exactly 1 results or N in particular were found:

`$this->assertDatabaseHasOne('posts', [ /***/ ]);

`$this->assertDatabaseHasMany('images', 3, [ /***/ ]);
