### PR TITLE
[5.4] Conditional broadcasting

### DIFF
--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -548,9 +548,9 @@ class Dispatcher implements DispatcherContract
 
         return $this;
     }
-    
+
     /**
-     * Check if event should be broadcasted by condition
+     * Check if event should be broadcasted by condition.
      *
      * @param $event
      *
@@ -558,10 +558,10 @@ class Dispatcher implements DispatcherContract
      */
     protected function checkBroadcastCondition($event)
     {
-        if (method_exists($event, 'broadcastCondition')) {
-            return $event->broadcastCondition();
+        if (method_exists($event, 'broadcastWhen')) {
+            return $event->broadcastWhen();
         }
-        
+
         return true;
     }
 }

--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -242,7 +242,9 @@ class Dispatcher implements DispatcherContract
      */
     protected function shouldBroadcast(array $payload)
     {
-        return isset($payload[0]) && $payload[0] instanceof ShouldBroadcast;
+        return isset($payload[0]) &&
+               $payload[0] instanceof ShouldBroadcast &&
+               $this->checkBroadcastCondition($payload[0]);
     }
 
     /**
@@ -545,5 +547,21 @@ class Dispatcher implements DispatcherContract
         $this->queueResolver = $resolver;
 
         return $this;
+    }
+    
+    /**
+     * Check if event should be broadcasted by condition
+     *
+     * @param $event
+     *
+     * @return bool
+     */
+    protected function checkBroadcastCondition($event)
+    {
+        if (method_exists($event, 'broadcastCondition')) {
+            return $event->broadcastCondition();
+        }
+        
+        return true;
     }
 }

--- a/tests/Events/EventsDispatcherTest.php
+++ b/tests/Events/EventsDispatcherTest.php
@@ -2,10 +2,10 @@
 
 namespace Illuminate\Tests\Events;
 
-use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Events\Dispatcher;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
 
 class EventsDispatcherTest extends TestCase
 {
@@ -240,26 +240,26 @@ class EventsDispatcherTest extends TestCase
         $this->assertSame('fooo', $_SERVER['__event.test1']);
         $this->assertSame('baar', $_SERVER['__event.test2']);
     }
-    
+
     public function testShouldBroadcastSuccess()
     {
         $d = m::mock(Dispatcher::class);
-        
+
         $d->makePartial()->shouldAllowMockingProtectedMethods();
-        
+
         $event = new BroadcastEvent();
-        
+
         $this->assertTrue($d->shouldBroadcast([$event]));
     }
-    
+
     public function testShouldBroadcastFail()
     {
         $d = m::mock(Dispatcher::class);
-        
+
         $d->makePartial()->shouldAllowMockingProtectedMethods();
-        
+
         $event = new BroadcastFalseCondition();
-        
+
         $this->assertFalse($d->shouldBroadcast([$event]));
     }
 }
@@ -304,7 +304,7 @@ class BroadcastEvent implements ShouldBroadcast
     {
         return ['test-channel'];
     }
-    
+
     public function broadcastWhen()
     {
         return true;

--- a/tests/Events/EventsDispatcherTest.php
+++ b/tests/Events/EventsDispatcherTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Events;
 
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Events\Dispatcher;
@@ -239,6 +240,28 @@ class EventsDispatcherTest extends TestCase
         $this->assertSame('fooo', $_SERVER['__event.test1']);
         $this->assertSame('baar', $_SERVER['__event.test2']);
     }
+    
+    public function testShouldBroadcastSuccess()
+    {
+        $d = m::mock(Dispatcher::class);
+        
+        $d->makePartial()->shouldAllowMockingProtectedMethods();
+        
+        $event = new BroadcastEvent();
+        
+        $this->assertTrue($d->shouldBroadcast([$event]));
+    }
+    
+    public function testShouldBroadcastFail()
+    {
+        $d = m::mock(Dispatcher::class);
+        
+        $d->makePartial()->shouldAllowMockingProtectedMethods();
+        
+        $event = new BroadcastFalseCondition();
+        
+        $this->assertFalse($d->shouldBroadcast([$event]));
+    }
 }
 
 class TestDispatcherQueuedHandler implements \Illuminate\Contracts\Queue\ShouldQueue
@@ -273,4 +296,25 @@ interface SomeEventInterface
 class AnotherEvent implements SomeEventInterface
 {
     //
+}
+
+class BroadcastEvent implements ShouldBroadcast
+{
+    public function broadcastOn()
+    {
+        return ['test-channel'];
+    }
+    
+    public function broadcastWhen()
+    {
+        return true;
+    }
+}
+
+class BroadcastFalseCondition extends BroadcastEvent
+{
+    public function broadcastWhen()
+    {
+        return false;
+    }
 }


### PR DESCRIPTION
Sometimes we should broadcast event only if some condition is true.

Example:

```php
class Win implements ShouldBroadcast
{
    protected $score;
    protected $reportScore;
    
    public function __construct($score)
    {
        $this->score = $score;
    }
    
    public function broadcastCondition() {
        return $this->score > $this->reportScore;
    }

    public function broadcastOn()
    {
        return ['general-channel'];
    }
}
```