### PR TITLE
[5.5] Use CommonMark parser

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "ext-mbstring": "*",
         "ext-openssl": "*",
         "doctrine/inflector": "~1.0",
-        "erusev/parsedown": "~1.6",
+        "league/commonmark": "^0.11",
         "league/flysystem": "~1.0",
         "monolog/monolog": "~1.11",
         "mtdowling/cron-expression": "~1.0",

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "ext-mbstring": "*",
         "ext-openssl": "*",
         "doctrine/inflector": "~1.0",
-        "league/commonmark": "^0.11",
+        "league/commonmark": "^0.15",
         "league/flysystem": "~1.0",
         "monolog/monolog": "~1.11",
         "mtdowling/cron-expression": "~1.0",

--- a/src/Illuminate/Mail/Markdown.php
+++ b/src/Illuminate/Mail/Markdown.php
@@ -2,9 +2,9 @@
 
 namespace Illuminate\Mail;
 
-use Parsedown;
 use Illuminate\Support\Arr;
 use Illuminate\Support\HtmlString;
+use League\CommonMark\CommonMarkConverter;
 use Illuminate\Contracts\View\Factory as ViewFactory;
 use TijsVerkoyen\CssToInlineStyles\CssToInlineStyles;
 
@@ -90,9 +90,9 @@ class Markdown
      */
     public static function parse($text)
     {
-        $parsedown = new Parsedown;
-
-        return new HtmlString($parsedown->text($text));
+        return new HtmlString(
+            (new CommonMarkConverter)->convertToHtml($text)
+        );
     }
 
     /**

--- a/src/Illuminate/Mail/composer.json
+++ b/src/Illuminate/Mail/composer.json
@@ -18,7 +18,7 @@
         "illuminate/container": "5.5.*",
         "illuminate/contracts": "5.5.*",
         "illuminate/support": "5.5.*",
-        "league/commonmark": "^0.11",
+        "league/commonmark": "^0.15",
         "psr/log": "~1.0",
         "swiftmailer/swiftmailer": "~5.4",
         "tijsverkoyen/css-to-inline-styles": "~2.2"

--- a/src/Illuminate/Mail/composer.json
+++ b/src/Illuminate/Mail/composer.json
@@ -15,10 +15,10 @@
     ],
     "require": {
         "php": ">=7.0",
-        "erusev/parsedown": "~1.6",
         "illuminate/container": "5.5.*",
         "illuminate/contracts": "5.5.*",
         "illuminate/support": "5.5.*",
+        "league/commonmark": "^0.11",
         "psr/log": "~1.0",
         "swiftmailer/swiftmailer": "~5.4",
         "tijsverkoyen/css-to-inline-styles": "~2.2"

--- a/tests/Mail/MailMarkdownTest.php
+++ b/tests/Mail/MailMarkdownTest.php
@@ -63,6 +63,6 @@ class MailMarkdownTest extends TestCase
 
         $result = $markdown->parse('# Something');
 
-        $this->assertEquals('<h1>Something</h1>', $result);
+        $this->assertEquals("<h1>Something</h1>\n", $result);
     }
 }


### PR DESCRIPTION
Parsedown is faster than League's CommonMark parser, however Parsedown has no XSS protected whatsoever and CommonMark does (opt-in).

Since the Parsedown project doesn't seem to be interested in changing that ([see open issues.](https://github.com/erusev/parsedown/issues?utf8=%E2%9C%93&q=xss%20is%3Aopen)), I'd suggest switching.

I find myself installing `league/commonmark` for most projects to prevent XSS injections in comments, posts, or similar.

Internally Laravel uses Markdown only for emails, which are most likely queued, so speed is not a concern.