### PR TITLE
[5.4] Offer prepare() prior to handle() for Commands

### DIFF
--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -177,6 +177,7 @@ class Command extends SymfonyCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        method_exists($this, 'prepare') && $this->prepare();
         $method = method_exists($this, 'handle') ? 'handle' : 'fire';
 
         return $this->laravel->call([$this, $method]);


### PR DESCRIPTION
Sometimes we want to perform actions before running the command. This seems like a clean way to offer that for the developer to perform actions before the command handler.