### PR TITLE
[5.4] Queue worker will pass connection + queue name to Looping event

### DIFF
--- a/src/Illuminate/Queue/Events/Looping.php
+++ b/src/Illuminate/Queue/Events/Looping.php
@@ -4,5 +4,30 @@ namespace Illuminate\Queue\Events;
 
 class Looping
 {
-    //
+    /**
+     * The connection name.
+     *
+     * @var string
+     */
+    public $connectionName;
+
+    /**
+     * The queue name.
+     *
+     * @var string
+     */
+    public $queue;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  string  $connectionName
+     * @param  string  $queue
+     * @return void
+     */
+    public function __construct($connectionName, $queue)
+    {
+        $this->connectionName = $connectionName;
+        $this->queue = $queue;
+    }
 }

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -88,7 +88,7 @@ class Worker
             // Before reserving any jobs, we will make sure this queue is not paused and
             // if it is we will just pause this worker for a given amount of time and
             // make sure we do not need to kill this worker process off completely.
-            if (! $this->daemonShouldRun($options)) {
+            if (! $this->daemonShouldRun($options, $connectionName, $queue)) {
                 $this->pauseWorker($options, $lastRestart);
 
                 continue;
@@ -156,13 +156,15 @@ class Worker
      * Determine if the daemon should process on this iteration.
      *
      * @param  WorkerOptions  $options
+     * @param  string  $connectionName
+     * @param  string  $queue
      * @return bool
      */
-    protected function daemonShouldRun(WorkerOptions $options)
+    protected function daemonShouldRun(WorkerOptions $options, $connectionName, $queue)
     {
         return ! (($this->manager->isDownForMaintenance() && ! $options->force) ||
             $this->paused ||
-            $this->events->until(new Events\Looping) === false);
+            $this->events->until(new Events\Looping($connectionName, $queue)) === false);
     }
 
     /**


### PR DESCRIPTION
This allows the `Queue\Events\Looping` to pass along the connection and queue names. I was working on some more detailed logging/status monitoring of different job processors for queues across multiple servers, and realized there was no easy way to hook onto this (I didn't want to hook onto the `JobProcessing` hook as this was too noisy)

I wrote a basic test as well, but it was somewhat hacky so I didn't include (there are also currently no other tests that look for the Looping event anywhere currently).  I can include in comments if you think it would be useful.

Basic example of what I was trying to accomplish below.  Please let me know if you think this is unnecessary/overkill and/or a better approach

        // Log an event at the beginning of each job processor loop.
        \Queue::looping(function(\Illuminate\Queue\Events\Looping $event) {
            \Log::info('Queue '.$event->queue.' running on connection '.$event->connectionName);
        });
