### PR TITLE
[5.4] Fix Queue Prefix bug

### DIFF
--- a/src/Illuminate/Queue/Console/ListenCommand.php
+++ b/src/Illuminate/Queue/Console/ListenCommand.php
@@ -79,11 +79,9 @@ class ListenCommand extends Command
     {
         $connection = $connection ?: $this->laravel['config']['queue.default'];
 
-        $queue = $this->input->getOption('queue') ?: $this->laravel['config']->get(
+        return $this->input->getOption('queue') ?: $this->laravel['config']->get(
             "queue.connections.{$connection}.queue", 'default'
         );
-
-        return $this->laravel['config']->get('queue.prefix').$queue;
     }
 
     /**

--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -196,11 +196,9 @@ class WorkCommand extends Command
      */
     protected function getQueue($connection)
     {
-        $queue = $this->option('queue') ?: $this->laravel['config']->get(
+        return $this->option('queue') ?: $this->laravel['config']->get(
             "queue.connections.{$connection}.queue", 'default'
         );
-
-        return $this->laravel['config']->get('queue.prefix').$queue;
     }
 
     /**

--- a/src/Illuminate/Queue/DatabaseQueue.php
+++ b/src/Illuminate/Queue/DatabaseQueue.php
@@ -208,7 +208,7 @@ class DatabaseQueue extends Queue implements QueueContract
     {
         $job = $this->database->table($this->table)
                     ->lockForUpdate()
-                    ->where('queue', $this->getQueue($queue))
+                    ->where('queue', $queue)
                     ->where(function ($query) {
                         $this->isAvailable($query);
                         $this->isReservedButExpired($query);


### PR DESCRIPTION
The queue prefix introduced in `5.4.20` from here (https://github.com/laravel/framework/pull/18860) is broken and does not allow queue processing. This PR should fix issue https://github.com/laravel/framework/issues/18978

The reason is the queue driver is prefixing the `prefix` on all queues - which is correct. However, currently when you run `queue:work`, it is also prefixing the queue, before passing it to the driver, which adds *another* prefix:

`prefix-prefix-default`

It is even worse for `queue:listen` - which prefixes, passes it to `queue:work`, adds another prefix, and then passes it to the driver:

`prefix-prefix-prefix-default`

This PR removes the prefixing from the worker & listener. They dont need to worry about prefixing - but that is handling by the drivers upon receiving a queue name.


There is also a second bug specifically related to the database queue driver. It adds *another* prefix during the table lookup unneccessarily, resulting in an extreme instance of:

`prefix-prefix-prefix-prefix-default`

I've done some initial testing on this PR and it all seems to work on my integration tests. But feel free to test some more.