### PR TITLE
[5.4] Fix in Cache (Redis Store) when calling many()

### DIFF
--- a/src/Illuminate/Cache/RedisStore.php
+++ b/src/Illuminate/Cache/RedisStore.php
@@ -73,7 +73,7 @@ class RedisStore extends TaggableStore implements Store
         }, $keys));
 
         foreach ($values as $index => $value) {
-            $results[$keys[$index]] = $this->unserialize($value);
+            $results[$keys[$index]] = ! is_null($value) ? $this->unserialize($value) : null;
         }
 
         return $results;

--- a/tests/Cache/CacheRedisStoreTest.php
+++ b/tests/Cache/CacheRedisStoreTest.php
@@ -32,19 +32,20 @@ class CacheRedisStoreTest extends TestCase
     {
         $redis = $this->getRedis();
         $redis->getRedis()->shouldReceive('connection')->once()->with('default')->andReturn($redis->getRedis());
-        $redis->getRedis()->shouldReceive('mget')->once()->with(['prefix:foo', 'prefix:fizz', 'prefix:norf'])
+        $redis->getRedis()->shouldReceive('mget')->once()->with(['prefix:foo', 'prefix:fizz', 'prefix:norf', 'prefix:null'])
             ->andReturn([
                 serialize('bar'),
                 serialize('buzz'),
                 serialize('quz'),
+                null,
             ]);
-        $this->assertEquals([
-            'foo'   => 'bar',
-            'fizz'  => 'buzz',
-            'norf'  => 'quz',
-        ], $redis->many([
-            'foo', 'fizz', 'norf',
-        ]));
+
+        $results = $redis->many(['foo', 'fizz', 'norf', 'null']);
+
+        $this->assertEquals('bar', $results['foo']);
+        $this->assertEquals('buzz', $results['fizz']);
+        $this->assertEquals('quz', $results['norf']);
+        $this->assertNull($results['null']);
     }
 
     public function testRedisValueIsReturnedForNumerics()


### PR DESCRIPTION
If the result of `mget()` for a value is null, calling `serialize(null)` will convert the value to false which will result the behaviour described in: https://github.com/laravel/framework/issues/18981

This PR fixes the issue by returning null as is same as we do with the `get()` method of the RedisStore.