### PR TITLE
[5.4] Fix queue prefixed failed jobs

### DIFF
--- a/src/Illuminate/Queue/Failed/DatabaseFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/DatabaseFailedJobProvider.php
@@ -58,6 +58,8 @@ class DatabaseFailedJobProvider implements FailedJobProviderInterface
 
         $exception = (string) $exception;
 
+        $queue = $this->stripQueuePrefix($queue);
+
         return $this->getTable()->insertGetId(compact(
             'connection', 'queue', 'payload', 'exception', 'failed_at'
         ));
@@ -113,5 +115,16 @@ class DatabaseFailedJobProvider implements FailedJobProviderInterface
     protected function getTable()
     {
         return $this->resolver->connection($this->database)->table($this->table);
+    }
+
+    /**
+     * Remove the driver based queue prefix from the queue name before storing in table.
+     *
+     * @param  string  $queue
+     * @return string
+     */
+    protected function stripQueuePrefix($queue)
+    {
+        return ltrim($queue, app('config')->get('queue.prefix'));
     }
 }


### PR DESCRIPTION
Currently when a prefixed queue job fails - it will be written to the queue table with the prefixed name:

`prefix-queue`

The problem is if you `php artisan queue:retry all` on this job - it will be pushed back to the queue driver and re-prefixed again:

`prefix-prefix-queue`

The best solution I can see is to strip the driver based queue prefix prior to inserting into the failed queue table. That way, when you retry the job, it is handled as normal by your queue driver prefixing.