### PR TITLE
Add str_ordinal helper

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -214,6 +214,27 @@ class Str
     }
 
     /**
+     * Append an ordinal indicator to a numeric value.
+     *
+     * @param  string|int  $value
+     * @param  bool  $superscript
+     * @return string
+     */
+    public static function ordinal($value, $superscript = false)
+    {
+    	$number = abs((int)$value);
+
+        $indicators = ['th','st','nd','rd','th','th','th','th','th','th'];
+
+        $suffix = $superscript ? '<sup>' . $indicators[$number % 10] . '</sup>' : $indicators[$number % 10];
+        if ($number % 100 >= 11 && $number % 100 <= 13) {
+            $suffix = $superscript ? '<sup>th</sup>' : 'th';
+        }
+
+        return number_format($number) . $suffix;
+    }
+
+    /**
      * Get the plural form of an English word.
      *
      * @param  string  $value

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -752,6 +752,20 @@ if (! function_exists('str_limit')) {
     }
 }
 
+if (! function_exists( 'str_ordinal')) {
+    /**
+     * Append an ordinal indicator to a numeric value.
+     *
+     * @param  string|int  $value
+     * @param  bool  $superscript
+     * @return string
+     */
+    function str_ordinal($value, $superscript)
+    {
+        return Str::ordinal($value, $superscript);
+    }
+}
+
 if (! function_exists('str_plural')) {
     /**
      * Get the plural form of an English word.

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -286,6 +286,21 @@ class SupportHelpersTest extends TestCase
         $this->assertEquals('这是一', Str::limit($nonAsciiString, 6, ''));
     }
 
+    public function testStrOrdinal()
+    {
+        $this->assertEquals('0th', Str::ordinal('foo'));
+        $this->assertEquals('0th', Str::ordinal(0));
+        $this->assertEquals('0th', Str::ordinal('0'));
+        $this->assertEquals('1st', Str::ordinal('1'));
+        $this->assertEquals('2nd', Str::ordinal('2'));
+        $this->assertEquals('3rd', Str::ordinal('3'));
+        $this->assertEquals('4th', Str::ordinal('4'));
+        $this->assertEquals('11th', Str::ordinal('11'));
+        $this->assertEquals('112th', Str::ordinal('112'));
+        $this->assertEquals('1,113th', Str::ordinal('1113'));
+        $this->assertEquals('1,000<sup>th</sup>', Str::ordinal('1000', true));
+    }
+
     public function testCamelCase()
     {
         $this->assertEquals('fooBar', camel_case('FooBar'));


### PR DESCRIPTION
Adds a helper function to append an ordinal indicator to a given number and optionally wrap the indicator in superscript tags.

    $value = str_ordinal('1');

    // 1st

    $value = str_ordinal('2', true);

    // 2<sup>nd</sup>

