### PR TITLE
[5.0] qualified primary key method added for primary key of joined table

### DIFF
--- a/src/Illuminate/Database/Eloquent/SoftDeletes.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletes.php
@@ -42,7 +42,7 @@ trait SoftDeletes {
 	{
 		if ($this->forceDeleting)
 		{
-			return $this->withTrashed()->where($this->getKeyName(), $this->getKey())->forceDelete();
+			return $this->withTrashed()->where($this->getPrimaryKeyName(), $this->getKey())->forceDelete();
 		}
 
 		return $this->runSoftDelete();
@@ -55,7 +55,7 @@ trait SoftDeletes {
 	 */
 	protected function runSoftDelete()
 	{
-		$query = $this->newQuery()->where($this->getKeyName(), $this->getKey());
+		$query = $this->newQuery()->where($this->getPrimaryKeyName(), $this->getKey());
 
 		$this->{$this->getDeletedAtColumn()} = $time = $this->freshTimestamp();
 
@@ -167,4 +167,20 @@ trait SoftDeletes {
 		return $this->getTable().'.'.$this->getDeletedAtColumn();
 	}
 
+    /**
+     * Get the primary key name
+     *
+     * @return string
+     */
+    public function getPrimaryKeyName()
+    {
+        if (count($this->getQuery()->joins) > 0)
+        {
+            return $this->getQualifiedKeyName();
+        }
+        else
+        {
+            return $this->getKeyName();
+        }
+    }
 }

--- a/tests/Database/DatabaseSoftDeletingTraitTest.php
+++ b/tests/Database/DatabaseSoftDeletingTraitTest.php
@@ -65,6 +65,10 @@ class DatabaseSoftDeletingTraitStub {
 	{
 		return 'id';
 	}
+	public function getPrimaryKeyName()
+	{
+		return 'id';
+	}
 	public function save()
 	{
 		//


### PR DESCRIPTION
### Description:
Database generates 'ambiguous column id' error when I use joins in global scope for the model with SoftDeletes

### Steps To Reproduce:

1. Use SoftDeletes in the model whose primary key is 'id'
2. Write a global scope for the model and join to table who has a column named 'id'
3. Try to delete the model.

### Solution
Use fully qualified primary key name when using joins.