### PR TITLE
[5.4] Allow returning full URL in mix() helper

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -557,11 +557,12 @@ if (! function_exists('mix')) {
      *
      * @param  string  $path
      * @param  string  $manifestDirectory
+     * @param  bool    $full
      * @return \Illuminate\Support\HtmlString
      *
      * @throws \Exception
      */
-    function mix($path, $manifestDirectory = '')
+    function mix($path, $manifestDirectory = '', $full = false)
     {
         static $manifest;
 
@@ -591,7 +592,9 @@ if (! function_exists('mix')) {
                 'webpack.mix.js output paths and try again.'
             );
         }
-
+        if ($full) {
+            return new HtmlString(url($manifestDirectory.$manifest[$path]));
+        }
         return new HtmlString($manifestDirectory.$manifest[$path]);
     }
 }

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -595,6 +595,7 @@ if (! function_exists('mix')) {
         if ($full) {
             return new HtmlString(url($manifestDirectory.$manifest[$path]));
         }
+
         return new HtmlString($manifestDirectory.$manifest[$path]);
     }
 }


### PR DESCRIPTION
This would stop the need to use `url(mix())`