### PR TITLE
[5.4] Model::getRouteKeyName() should return fully qualified key name

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1180,7 +1180,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public function getRouteKey()
     {
-        return $this->getAttribute($this->getRouteKeyName());
+        return $this->getAttribute($this->getKeyName());
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1190,7 +1190,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public function getRouteKeyName()
     {
-        return $this->getKeyName();
+        return $this->getQualifiedKeyName();
     }
 
     /**

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1139,13 +1139,13 @@ class DatabaseEloquentModelTest extends TestCase
     {
         $model = new EloquentModelNonIncrementingStub;
         $model->id = 'foo';
-        $this->assertEquals('foo', $model->getRouteKey());
+        $this->assertEquals('stub.foo', $model->getRouteKey());
     }
 
     public function testRouteNameIsPrimaryKeyName()
     {
         $model = new EloquentModelStub;
-        $this->assertEquals('id', $model->getRouteKeyName());
+        $this->assertEquals('stub.id', $model->getRouteKeyName());
     }
 
     public function testCloneModelMakesAFreshCopyOfTheModel()

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1139,7 +1139,7 @@ class DatabaseEloquentModelTest extends TestCase
     {
         $model = new EloquentModelNonIncrementingStub;
         $model->id = 'foo';
-        $this->assertEquals('stub.foo', $model->getRouteKey());
+        $this->assertEquals('foo', $model->getRouteKey());
     }
 
     public function testRouteNameIsPrimaryKeyName()


### PR DESCRIPTION
Implicit Route Binding fails if the model has a global scope that joins tables with an id column (column reference "id" is ambiguous).
This is because Model->getRouteKeyName() only returns the key column name (i.e. "id") instead of the fully qualified identifier (i.e. "users.id") to ImplicitRouteBinding::resolveForRoute