### PR TITLE
[5.4] Add callSilent method for seeders

### DIFF
--- a/src/Illuminate/Database/Seeder.php
+++ b/src/Illuminate/Database/Seeder.php
@@ -38,6 +38,17 @@ abstract class Seeder
     }
 
     /**
+     * Seed the given connection from the given path silently.
+     *
+     * @param  string  $class
+     * @return void
+     */
+    public function callSilent($class)
+    {
+        $this->resolve($class)->__invoke();
+    }
+
+    /**
      * Resolve an instance of the given seeder class.
      *
      * @param  string  $class

--- a/src/Illuminate/Database/Seeder.php
+++ b/src/Illuminate/Database/Seeder.php
@@ -38,7 +38,7 @@ abstract class Seeder
     }
 
     /**
-     * Seed the given connection from the given path silently.
+     * Silently seed the given connection from the given path.
      *
      * @param  string  $class
      * @return void


### PR DESCRIPTION
This method allows you to **call a seeder silently** (suppressing its output).

Useful when you want to provide a custom output (ex. A progress bar), instead of getting the typical _"Seeding ..."_ output message.