### PR TITLE
[5.4] Included ability to pass extra variables to Blade @each

### DIFF
--- a/src/Illuminate/View/Factory.php
+++ b/src/Illuminate/View/Factory.php
@@ -183,8 +183,8 @@ class Factory implements FactoryContract
         // If is actually data in the array, we will loop through the data and append
         // an instance of the partial view to the final result HTML passing in the
         // iterated value of this data array, allowing the views to access them.
-        if (count($data) > 0) {cd ~
-        
+        if (count($data) > 0) {
+
             foreach ($data as $key => $value) {
                 $result .= $this->make(
                     $view, array_merge(['key' => $key, $iterator => $value], $mergeData)

--- a/src/Illuminate/View/Factory.php
+++ b/src/Illuminate/View/Factory.php
@@ -159,23 +159,35 @@ class Factory implements FactoryContract
     /**
      * Get the rendered contents of a partial from a loop.
      *
-     * @param  string  $view
-     * @param  array   $data
-     * @param  string  $iterator
-     * @param  string  $empty
+     * @param  string        $view
+     * @param  array         $data
+     * @param  string        $iterator
+     * @param  string|array  $empty
+     * @param  array         $mergeData
      * @return string
      */
-    public function renderEach($view, $data, $iterator, $empty = 'raw|')
+    public function renderEach($view, $data, $iterator, $empty = 'raw|', $mergeData = [])
     {
         $result = '';
+
+        // Although no necessary, user can assign the $empty as null or false
+        // this way the $empty will receive the same value as the standard
+        // one - "raw|", which will print nothing if the data is empty
+        $empty = ($empty) ?: 'raw|';
+
+        // If $empty if an array, instead of an string, it will assign the
+        // array to the $mergeData, making it unnecessary to define an
+        // empty view to assign data to be passed to the view
+        $mergeData = (is_array($empty)) ? $empty : $mergeData;
 
         // If is actually data in the array, we will loop through the data and append
         // an instance of the partial view to the final result HTML passing in the
         // iterated value of this data array, allowing the views to access them.
-        if (count($data) > 0) {
+        if (count($data) > 0) {cd ~
+        
             foreach ($data as $key => $value) {
                 $result .= $this->make(
-                    $view, ['key' => $key, $iterator => $value]
+                    $view, array_merge(['key' => $key, $iterator => $value], $mergeData)
                 )->render();
             }
         }
@@ -186,7 +198,7 @@ class Factory implements FactoryContract
         else {
             $result = Str::startsWith($empty, 'raw|')
                         ? substr($empty, 4)
-                        : $this->make($empty)->render();
+                        : $this->make($empty, $mergeData)->render();
         }
 
         return $result;

--- a/tests/View/ViewFactoryTest.php
+++ b/tests/View/ViewFactoryTest.php
@@ -72,6 +72,45 @@ class ViewFactoryTest extends TestCase
         $this->assertEquals('foo', $this->getFactory()->renderEach('foo', [], 'item', 'raw|foo'));
     }
 
+    public function testRenderEachPassesExtraDataForViewOnPlaceOfEmptyView()
+    {
+        $extraVariable = ['extra' => 'variable'];
+
+        $factory = m::mock('Illuminate\View\Factory[make]', $this->getFactoryArgs());
+        $factory->shouldReceive('make')->once()->with('foo', array_merge(['key' => 'bar', 'value' => 'baz'], $extraVariable))->andReturn($mockView1 = m::mock('StdClass'));
+        $factory->shouldReceive('make')->once()->with('foo', array_merge(['key' => 'breeze', 'value' => 'boom'], $extraVariable))->andReturn($mockView2 = m::mock('StdClass'));
+        $mockView1->shouldReceive('render')->once()->andReturn('mock1');
+        $mockView2->shouldReceive('render')->once()->andReturn('mock2');
+
+        $result = $factory->renderEach('foo', ['bar' => 'baz', 'breeze' => 'boom'], 'value', $extraVariable);
+
+        $this->assertEquals('mock1mock2', $result);
+    }
+
+    public function testRenderEachPassesExtraDataForView()
+    {
+        $extraVariable = ['extra' => 'variable'];
+
+        $factory = m::mock('Illuminate\View\Factory[make]', $this->getFactoryArgs());
+        $factory->shouldReceive('make')->once()->with('foo', array_merge(['key' => 'bar', 'value' => 'baz'], $extraVariable))->andReturn($mockView1 = m::mock('StdClass'));
+        $factory->shouldReceive('make')->once()->with('foo', array_merge(['key' => 'breeze', 'value' => 'boom'], $extraVariable))->andReturn($mockView2 = m::mock('StdClass'));
+        $mockView1->shouldReceive('render')->once()->andReturn('mock1');
+        $mockView2->shouldReceive('render')->once()->andReturn('mock2');
+
+        $result = $factory->renderEach('foo', ['bar' => 'baz', 'breeze' => 'boom'], 'value', false, $extraVariable);
+
+        $this->assertEquals('mock1mock2', $result);
+    }
+
+    public function testRenderEachPassesExtraDataForEmptyView()
+    {
+        $factory = m::mock('Illuminate\View\Factory[make]', $this->getFactoryArgs());
+        $factory->shouldReceive('make')->once()->with('foo', array_merge([], ['extra' => 'variable']))->andReturn($mockView = m::mock('StdClass'));
+        $mockView->shouldReceive('render')->once()->andReturn('variable');
+
+        $this->assertEquals('variable', $factory->renderEach('view', [], 'iterator', 'foo', ['extra' => 'variable']));
+    }
+
     public function testEnvironmentAddsExtensionWithCustomResolver()
     {
         $factory = $this->getFactory();

--- a/tests/View/ViewFactoryTest.php
+++ b/tests/View/ViewFactoryTest.php
@@ -61,7 +61,7 @@ class ViewFactoryTest extends TestCase
     public function testEmptyViewsCanBeReturnedFromRenderEach()
     {
         $factory = m::mock('Illuminate\View\Factory[make]', $this->getFactoryArgs());
-        $factory->shouldReceive('make')->once()->with('foo')->andReturn($mockView = m::mock('StdClass'));
+        $factory->shouldReceive('make')->once()->with('foo', [])->andReturn($mockView = m::mock('StdClass'));
         $mockView->shouldReceive('render')->once()->andReturn('empty');
 
         $this->assertEquals('empty', $factory->renderEach('view', [], 'iterator', 'foo'));


### PR DESCRIPTION
Fixed of #18955.

As it is not possible to pass extra variables to the @each, it's hard to avoid the @foreach sometimes.

with the inclusion of the $mergeData, it is simple to add new variables:

Passing the empty view:
`@each ('blog.post', $posts, 'post', 'blog.empty', ['data' => 'This is a sample data'])`

Or withouth the empty view:
`@each ('blog.post', $posts, 'post', ['data' => 'This is a sample data'])`

Note: It is still possible to pass a empty value as the empty view:
`@each ('blog.post', $posts, 'post', false, ['data' => 'This is a sample data'])`

This way it is not mandatory to pass a false empty view, but if the developer wants to, it will not break the code.