### PR TITLE
[5.4] Add "make" method to Eloquent Query Builder

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -713,6 +713,17 @@ class Builder
     }
 
     /**
+     * Create and return and un-saved model instance.
+     *
+     * @param  array  $attributes
+     * @return \Illuminate\Database\Eloquent\Model
+     */
+    public function make(array $attributes = [])
+    {
+        return $this->newModelInstance($attributes);
+    }
+
+    /**
      * Save a new model and return the instance.
      *
      * @param  array  $attributes

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -114,6 +114,14 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEquals('taylor', $model->name);
     }
 
+    public function testMakeMethodDoesNotSaveNewModel()
+    {
+        $_SERVER['__eloquent.saved'] = false;
+        $model = EloquentModelSaveStub::make(['name' => 'taylor']);
+        $this->assertFalse($_SERVER['__eloquent.saved']);
+        $this->assertEquals('taylor', $model->name);
+    }
+
     public function testForceCreateMethodSavesNewModelWithGuardedAttributes()
     {
         $_SERVER['__eloquent.saved'] = false;


### PR DESCRIPTION
While recording a recent [podcast](http://twentypercent.fm/macros), @DanielCoulbourne and I discussed the benefit of having a `make` method for models as an alternative to the `create` method that does the persistence right away. @tillkruss expressed interest in the `make` method as well.

Simple Example:
```
Post::make(['title' => 'Hello World!'])->save();
```

Down the road we both would love to see something like the following:
```
Post::make(['title' => 'Hello World!'])
    ->withAuthor($author)
    ->withCompany($company)
    ->save();
```
We are in the process of implementing this functionality as an alternative to:
```
$author->posts()->save(new Post(['title' => 'Hello World', 'company_id' => $company->id]));
```
For now, getting the make the `make` method into Laravel would be a big help in situations where you find yourself doing this: `new Post(....`

Thanks!