### PR TITLE
[5.4] Automatically retrieve model class name for translation replacements

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2,12 +2,12 @@
 
 namespace Illuminate\Database\Eloquent;
 
-use Lang;
 use Exception;
 use ArrayAccess;
 use JsonSerializable;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
+use Illuminate\Support\Facades\Lang;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Routing\UrlRoutable;

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Database\Eloquent;
 
+use Lang;
 use Exception;
 use ArrayAccess;
 use JsonSerializable;
@@ -1200,7 +1201,23 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public function getTranslationName()
     {
+        $key = $this->getTranslationNameKey();
+
+        if (Lang::has($key)) {
+            return Lang::get($key);
+        }
+
         return Str::snake(class_basename($this), ' ');
+    }
+
+    /**
+     * Get the translation name key for the model.
+     *
+     * @return string
+     */
+    public function getTranslationNameKey()
+    {
+        return 'models.'.Str::snake(class_basename($this));
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1194,6 +1194,16 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     }
 
     /**
+     * Get the translation name for the model.
+     *
+     * @return string
+     */
+    public function getTranslationName()
+    {
+        return Str::snake(class_basename($this), ' ');
+    }
+
+    /**
      * Get the default foreign key name for the model.
      *
      * @return string

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -264,7 +264,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
         $replace = $this->sortReplacements($replace);
 
         foreach ($replace as $key => $value) {
-            if ($value instanceOf \Illuminate\Database\Eloquent\Model) {
+            if ($value instanceof \Illuminate\Database\Eloquent\Model) {
                 $value = $value->getTranslationName();
             }
 

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -264,6 +264,10 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
         $replace = $this->sortReplacements($replace);
 
         foreach ($replace as $key => $value) {
+            if ($value instanceOf \Illuminate\Database\Eloquent\Model) {
+                $value = $value->getTranslationName();
+            }
+
             $line = str_replace(
                 [':'.$key, ':'.Str::upper($key), ':'.Str::ucfirst($key)],
                 [$value, Str::upper($value), Str::ucfirst($value)],


### PR DESCRIPTION
This is a similar vein to the `route('users.show', $user)` idea.

Have been working with translations with errors and status messages and have wanted something like this so you can simply do...

```php
$user = User::create($attributes);

$message = trans('crud.created', ['model' => $user]);
```

In you translations, you could have...

```php
<?php

// ./resources/lang/en/crud.php

return [
    'created' => ':Model was successfully created',
    'updated' => ':Model was successfully updated',
    // etc
];
```

A user can also define the model name translations in an optional `models.php` lang file for different languages, but defaults to the class name if not present.

Obviously this is not the only place it could be useful, but you get the idea.

I know that `model.php` doesn't currently utilise any traits, not sure if thats a standards thing or what, but thought I'd put it out there. I could always swap the functionality over to the translator to do the checking and just have the `getTranslationNameKey` in the model.

Will wait for feedback on if this is even suitable / wanted for the framework though.