### PR TITLE
[5.4] Casted attributes should not be dirty

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1007,7 +1007,9 @@ trait HasAttributes
      */
     protected function originalIsNumericallyEquivalent($key)
     {
-        if (in_array($this->getCastType($key), ['bool', 'boolean'])) return true;
+        if (in_array($this->getCastType($key), ['bool', 'boolean'], true)) {
+            return true;
+        }
 
         $current = $this->attributes[$key];
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -981,7 +981,7 @@ trait HasAttributes
     protected function originalIsEquivalent($key)
     {
         return $this->originalIsNumericallyEquivalent($key)
-            && $this->originalIsBooleanEquivalent($key);
+            && ($this->originalIsBooleanEquivalent($key));
     }
 
     /**
@@ -1007,6 +1007,8 @@ trait HasAttributes
      */
     protected function originalIsNumericallyEquivalent($key)
     {
+        if (in_array($this->getCastType($key), ['bool', 'boolean'])) return true;
+
         $current = $this->attributes[$key];
 
         $original = $this->original[$key];

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -471,6 +471,7 @@ trait HasAttributes
                 return (string) $value;
             case 'bool':
             case 'boolean':
+                $this->original[$key] = (bool) $value;
                 return (bool) $value;
             case 'object':
                 return $this->fromJson($value, true);

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -471,8 +471,6 @@ trait HasAttributes
                 return (string) $value;
             case 'bool':
             case 'boolean':
-                $this->original[$key] = (bool) $value;
-
                 return (bool) $value;
             case 'object':
                 return $this->fromJson($value, true);
@@ -966,12 +964,39 @@ trait HasAttributes
             if (! array_key_exists($key, $this->original)) {
                 $dirty[$key] = $value;
             } elseif ($value !== $this->original[$key] &&
-                    ! $this->originalIsNumericallyEquivalent($key)) {
+                    ! $this->originalIsEquivalent($key)) {
                 $dirty[$key] = $value;
             }
         }
 
         return $dirty;
+    }
+
+    /**
+     * Determine if the new and old values for a given key are equivalent.
+     *
+     * @param  string  $key
+     * @return bool
+     */
+    protected function originalIsEquivalent($key)
+    {
+        return $this->originalIsNumericallyEquivalent($key)
+            && $this->originalIsBooleanEquivalent($key);
+    }
+
+    /**
+     * Determine if the new and old values for a given key are boolean equivalent.
+     *
+     * @param  string  $key
+     * @return bool
+     */
+    protected function originalIsBooleanEquivalent($key)
+    {
+        $current = $this->attributes[$key];
+
+        $original = $this->original[$key];
+
+        return (bool) $current === (bool) $original;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -472,6 +472,7 @@ trait HasAttributes
             case 'bool':
             case 'boolean':
                 $this->original[$key] = (bool) $value;
+
                 return (bool) $value;
             case 'object':
                 return $this->fromJson($value, true);

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -69,12 +69,11 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testCastedAttributesDirty()
     {
-        $model = new EloquentModelCastingStub(['booleanAttribute' => 0, 'nonCastedAttribute' => 'John']);
+        $model = new EloquentModelCastingStub(['booleanAttribute' => 0]);
         $model->syncOriginal();
 
         $this->assertSame(false, $model->booleanAttribute);
 
-        $model->nonCastedAttribute = 'John';
         $model->booleanAttribute = false;
 
         $this->assertEquals([], $model->getDirty());

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -67,6 +67,19 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertTrue($model->isDirty(['foo', 'bar']));
     }
 
+    public function testCastedAttributesDirty()
+    {
+        $model = new EloquentModelCastingStub(['booleanAttribute' => 0, 'nonCastedAttribute' => 'John']);
+        $model->syncOriginal();
+
+        $this->assertSame(false, $model->booleanAttribute);
+
+        $model->nonCastedAttribute = 'John';
+        $model->booleanAttribute = false;
+
+        $this->assertEquals([], $model->getDirty());
+    }
+
     public function testCleanAttributes()
     {
         $model = new EloquentModelStub(['foo' => '1', 'bar' => 2, 'baz' => 3]);
@@ -1893,6 +1906,8 @@ class EloquentModelGetMutatorsStub extends Model
 
 class EloquentModelCastingStub extends Model
 {
+    protected $guarded = [];
+
     protected $casts = [
         'intAttribute' => 'int',
         'floatAttribute' => 'float',


### PR DESCRIPTION
When a boolean field comes from the DB, MySQL in my case, it comes as 0 for false and 1 for true. I have a cast on my model to cast it to PHP boolean. After the casting, Laravel sets the field as dirty.

I couldn't finish my fix yet. :(