### PR TITLE
[5.4] Adding support to collection on Eloquent::find

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -266,7 +266,7 @@ class Builder
      */
     public function find($id, $columns = ['*'])
     {
-        if (is_array($id)) {
+        if (is_array($id) || $id instanceof Arrayable) {
             return $this->findMany($id, $columns);
         }
 

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -104,6 +104,18 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertEquals('baz', $result);
     }
 
+    public function testFindWithManyUsingCollection()
+    {
+        $ids = collect([1, 2]);
+        $builder = m::mock('Illuminate\Database\Eloquent\Builder[get]', [$this->getMockQueryBuilder()]);
+        $builder->getQuery()->shouldReceive('whereIn')->once()->with('foo_table.foo', $ids);
+        $builder->setModel($this->getMockModel());
+        $builder->shouldReceive('get')->with(['column'])->andReturn('baz');
+
+        $result = $builder->find($ids, ['column']);
+        $this->assertEquals('baz', $result);
+    }
+
     public function testFirstMethod()
     {
         $builder = m::mock('Illuminate\Database\Eloquent\Builder[get,take]', [$this->getMockQueryBuilder()]);


### PR DESCRIPTION
Most of eloquent query methods accepts array or `Arrayable`, and recently this changed on version 5.4... I'm upgrading a app from `5.2` and it used to work.

This fixed my problem, now:

````
Model::find(collect([1, 2]));
````

Works as expected.