### PR TITLE
[5.5] clone query without order by for aggregates

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2073,6 +2073,11 @@ class Builder
     {
         $this->aggregate = compact('function', 'columns');
 
+        if (empty($this->groups)) {
+            $this->orders = null;
+            $this->bindings['order'] = [];
+        }
+
         return $this;
     }
 


### PR DESCRIPTION
Right now if there is a global scope that applies an order to the query, it will break counts and other aggregates when MySQL is in strict mode and there is no group-by in place (see issues like 15232, 18789, 14997, etc). This change is to fix that without having to set MySQL to non-strict mode or tell users to change their strict mode flags. It's also a low-impact change - if there are no groupings on the query, then any order is irrelevant anyway so this does not have any side-effects.