### PR TITLE
[5.4] Makes cache() throw exception on incorrect first argument

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -231,15 +231,19 @@ if (! function_exists('cache')) {
             return app('cache')->get($arguments[0], isset($arguments[1]) ? $arguments[1] : null);
         }
 
-        if (is_array($arguments[0])) {
-            if (! isset($arguments[1])) {
-                throw new Exception(
-                    'You must set an expiration time when putting to the cache.'
-                );
-            }
-
-            return app('cache')->put(key($arguments[0]), reset($arguments[0]), $arguments[1]);
+        if (! is_array($arguments[0])) {
+            throw new Exception(
+                'The argument passed to the cache must be a string or an array.'
+            );
         }
+
+        if (! isset($arguments[1])) {
+            throw new Exception(
+                'You must set an expiration time when putting to the cache.'
+            );
+        }
+
+        return app('cache')->put(key($arguments[0]), reset($arguments[0]), $arguments[1]);
     }
 }
 


### PR DESCRIPTION
The cache() function will return nothing when the first argument is something else than a string or array.

This PR fixes that by throwing an exception when that is the case.
It also improves code styling by removing the nested ifs (so less indentation) and follows the 'golden path' guideline.