### PR TITLE
[5.4] Removes redundant else structure

### DIFF
--- a/src/Illuminate/Console/Scheduling/CommandBuilder.php
+++ b/src/Illuminate/Console/Scheduling/CommandBuilder.php
@@ -17,9 +17,9 @@ class CommandBuilder
     {
         if ($event->runInBackground) {
             return $this->buildBackgroundCommand($event);
-        } else {
-            return $this->buildForegroundCommand($event);
         }
+
+        return $this->buildForegroundCommand($event);
     }
 
     /**


### PR DESCRIPTION
Removes a redundant `else` after a return statement.