### PR TITLE
[5.4] Refactors if structure

### DIFF
--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -510,9 +510,11 @@ class Command extends SymfonyCommand
     protected function parseVerbosity($level = null)
     {
         if (isset($this->verbosityMap[$level])) {
-            $level = $this->verbosityMap[$level];
-        } elseif (! is_int($level)) {
-            $level = $this->verbosity;
+           return $this->verbosityMap[$level];
+        }
+
+        if (! is_int($level)) {
+           return $this->verbosity;
         }
 
         return $level;

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -510,11 +510,11 @@ class Command extends SymfonyCommand
     protected function parseVerbosity($level = null)
     {
         if (isset($this->verbosityMap[$level])) {
-           return $this->verbosityMap[$level];
+            return $this->verbosityMap[$level];
         }
 
         if (! is_int($level)) {
-           return $this->verbosity;
+            return $this->verbosity;
         }
 
         return $level;


### PR DESCRIPTION
Refactors the `if/ifelse` statement in the `Command::parseVerbosity` method to use early returns.
This makes it more readable and removes the use of the `else` keyword.