### PR TITLE
[5.4] Refactors if structure

### DIFF
--- a/src/Illuminate/Console/ConfirmableTrait.php
+++ b/src/Illuminate/Console/ConfirmableTrait.php
@@ -21,20 +21,22 @@ trait ConfirmableTrait
 
         $shouldConfirm = $callback instanceof Closure ? call_user_func($callback) : $callback;
 
-        if ($shouldConfirm) {
-            if ($this->option('force')) {
-                return true;
-            }
+        if (! $shouldConfirm) {
+            return true;
+        }
 
-            $this->alert($warning);
+        if ($this->option('force')) {
+            return true;
+        }
 
-            $confirmed = $this->confirm('Do you really wish to run this command?');
+        $this->alert($warning);
 
-            if (! $confirmed) {
-                $this->comment('Command Cancelled!');
+        $confirmed = $this->confirm('Do you really wish to run this command?');
 
-                return false;
-            }
+        if (! $confirmed) {
+            $this->comment('Command Cancelled!');
+
+            return false;
         }
 
         return true;


### PR DESCRIPTION
Refactors the `if` structure in `ConfirmableTrait::confirmToProceed` by using an early return.
This reduces the indentation and improves readability.