### PR TITLE
[5.4] Refactors if structure

### DIFF
--- a/src/Illuminate/Console/Parser.php
+++ b/src/Illuminate/Console/Parser.php
@@ -64,7 +64,7 @@ class Parser
         foreach ($tokens as $token) {
             if (preg_match('/-{2,}(.*)/', $token, $matches)) {
                 $options[] = static::parseOption($matches[1]);
-                
+
                 continue;
             }
 

--- a/src/Illuminate/Console/Parser.php
+++ b/src/Illuminate/Console/Parser.php
@@ -64,9 +64,11 @@ class Parser
         foreach ($tokens as $token) {
             if (preg_match('/-{2,}(.*)/', $token, $matches)) {
                 $options[] = static::parseOption($matches[1]);
-            } else {
-                $arguments[] = static::parseArgument($token);
+                
+                continue;
             }
+
+            $arguments[] = static::parseArgument($token);
         }
 
         return [$arguments, $options];


### PR DESCRIPTION
Refactors the `if` structure in `Parser::parameters` by using an early return (`continue` in `foreach`).
This eliminates the use of the `else` keyword.