### PR TITLE
[5.4] Refactors if statement

### DIFF
--- a/src/Illuminate/Console/Parser.php
+++ b/src/Illuminate/Console/Parser.php
@@ -106,13 +106,13 @@ class Parser
     {
         list($token, $description) = static::extractDescription($token);
 
+        $shortcut = null;
+
         $matches = preg_split('/\s*\|\s*/', $token, 2);
 
         if (isset($matches[1])) {
             $shortcut = $matches[0];
             $token = $matches[1];
-        } else {
-            $shortcut = null;
         }
 
         switch (true) {


### PR DESCRIPTION
Refactors the `if` structure in `Parser::parseOption` by placing the default `$shortcut` assignment before the `if` statement.
This eliminates the use of the `else` keyword.