### PR TITLE
[5.5] Return request data from controller validate() call

### DIFF
--- a/src/Illuminate/Foundation/Validation/ValidatesRequests.php
+++ b/src/Illuminate/Foundation/Validation/ValidatesRequests.php
@@ -23,11 +23,11 @@ trait ValidatesRequests
      *
      * @param  \Illuminate\Contracts\Validation\Validator|array  $validator
      * @param  \Illuminate\Http\Request|null  $request
-     * @return void
+     * @return array
      */
     public function validateWith($validator, Request $request = null)
     {
-        $request = $request ?: app('request');
+        $request = $request ?: request();
 
         if (is_array($validator)) {
             $validator = $this->getValidationFactory()->make($request->all(), $validator);
@@ -36,6 +36,8 @@ trait ValidatesRequests
         if ($validator->fails()) {
             $this->throwValidationException($request, $validator);
         }
+
+        return $request->only(array_keys($validator->getRules()));
     }
 
     /**
@@ -45,7 +47,7 @@ trait ValidatesRequests
      * @param  array  $rules
      * @param  array  $messages
      * @param  array  $customAttributes
-     * @return void
+     * @return array
      */
     public function validate(Request $request, array $rules, array $messages = [], array $customAttributes = [])
     {
@@ -54,6 +56,8 @@ trait ValidatesRequests
         if ($validator->fails()) {
             $this->throwValidationException($request, $validator);
         }
+
+        return $request->only(array_keys($rules));
     }
 
     /**
@@ -64,7 +68,7 @@ trait ValidatesRequests
      * @param  array  $rules
      * @param  array  $messages
      * @param  array  $customAttributes
-     * @return void
+     * @return array
      *
      * @throws \Illuminate\Validation\ValidationException
      */
@@ -73,6 +77,8 @@ trait ValidatesRequests
         $this->withErrorBag($errorBag, function () use ($request, $rules, $messages, $customAttributes) {
             $this->validate($request, $rules, $messages, $customAttributes);
         });
+
+        return $request->only(array_keys($rules));
     }
 
     /**


### PR DESCRIPTION
So that instead of this:

```php
public function store()
{
    $this->validate(request(), [
        'title' => 'required',
        'body' => 'required',
    ]);

    $data = request()->only('title', 'body');

    Post::create($data);
}
```

You can now do this:

```php
public function store()
{
    $data = $this->validate(request(), [
        'title' => 'required',
        'body' => 'required',
    ]);

    Post::create($data);
}
```