### PR TITLE
[5.4] Allow string "true" and "false" to pass validation.

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -303,7 +303,7 @@ trait ValidatesAttributes
      */
     protected function validateBoolean($attribute, $value)
     {
-        $acceptable = [true, false, 0, 1, '0', '1'];
+        $acceptable = ['true', 'false', true, false, 0, 1, '0', '1'];
 
         return in_array($value, $acceptable, true);
     }

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1090,10 +1090,10 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
 
         $v = new Validator($trans, ['foo' => 'false'], ['foo' => 'Boolean']);
-        $this->assertFalse($v->passes());
+        $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['foo' => 'true'], ['foo' => 'Boolean']);
-        $this->assertFalse($v->passes());
+        $this->assertTrue($v->passes());
 
         $v = new Validator($trans, [], ['foo' => 'Boolean']);
         $this->assertTrue($v->passes());
@@ -1127,10 +1127,10 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
 
         $v = new Validator($trans, ['foo' => 'false'], ['foo' => 'Bool']);
-        $this->assertFalse($v->passes());
+        $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['foo' => 'true'], ['foo' => 'Bool']);
-        $this->assertFalse($v->passes());
+        $this->assertTrue($v->passes());
 
         $v = new Validator($trans, [], ['foo' => 'Bool']);
         $this->assertTrue($v->passes());


### PR DESCRIPTION
- Laravel Version: 5.4.21
- PHP Version: N/A
- Database Driver & Version: N/A

### Description:

When a `FormRequest` wishes to validate a query string parameter to be `Boolean` it fails because `"true"` and `"false"` are not explicitly booleans. However since string `'1'` and `'0'` pass boolean validation, surely it make sense to also allow the string versions of `"true"` and `"false"`?

This has basically thrown an error when any query string parameter of `?foo=true` was validated as string `"true"` therefore failed.

In my `FormRequest` class I had to do some nasty to then cast the type. At least for consistency I think this PR should be considered.