### PR TITLE
Typehint the static middleware accessor in Route Facade

### DIFF
--- a/src/Illuminate/Support/Facades/Route.php
+++ b/src/Illuminate/Support/Facades/Route.php
@@ -13,6 +13,7 @@ namespace Illuminate\Support\Facades;
  * @method static \Illuminate\Routing\Route match(array|string $methods, string $uri, \Closure|array|string $action)
  * @method static void resource(string $name, string $controller, array $options = [])
  * @method static void group(array $attributes, \Closure $callback)
+ * @method static \Illuminate\Routing\Route middleware(array|string|null $middleware)
  * @method static \Illuminate\Routing\Route substituteBindings(\Illuminate\Routing\Route $route)
  * @method static void substituteImplicitBindings(\Illuminate\Routing\Route $route)
  *


### PR DESCRIPTION
Just noticed that my IDE couldn't find the static middleware function as used in the example api route from laravel/laravel, so I added the missing type hint for that.
Not sure if there are any more type hints missing now that you can change the order of functions in the route definition.

As this is a mere cosmetic/comments change, I guess it's fine to submit it to 5.4 instead of master.