### PR TITLE
[5.4] Use custom auth identifier column for "getAuthIdentifier" if set.

### DIFF
--- a/src/Illuminate/Auth/Authenticatable.php
+++ b/src/Illuminate/Auth/Authenticatable.php
@@ -28,7 +28,7 @@ trait Authenticatable
      */
     public function getAuthIdentifier()
     {
-        return $this->getAttribute($this->getAuthIdentifierName());
+        return $this->{$this->getAuthIdentifierName()};
     }
 
     /**

--- a/src/Illuminate/Auth/Authenticatable.php
+++ b/src/Illuminate/Auth/Authenticatable.php
@@ -28,7 +28,7 @@ trait Authenticatable
      */
     public function getAuthIdentifier()
     {
-        return $this->getKey();
+        return $this->getAttribute($this->getAuthIdentifierName());
     }
 
     /**


### PR DESCRIPTION
The `Authenticatable` trait includes methods to get the auth identifier name and value, but the `getAuthIdentifier` function will always return the primary key even if the column name is overridden.

This pull request updates that function to return the value for a custom auth identifier column, like [the `retrieveById` and `retrieveByToken` methods](https://github.com/laravel/framework/blob/e82c4425b362e5fb1df98d4c2de57c7db88dffc2/src/Illuminate/Auth/EloquentUserProvider.php#L45-L69) in the `EloquentUserProvider`.