### PR TITLE
Separate email validation

### DIFF
--- a/src/Illuminate/Foundation/Auth/SendsPasswordResetEmails.php
+++ b/src/Illuminate/Foundation/Auth/SendsPasswordResetEmails.php
@@ -25,7 +25,7 @@ trait SendsPasswordResetEmails
      */
     public function sendResetLinkEmail(Request $request)
     {
-        $this->validate($request, ['email' => 'required|email']);
+        $this->validateEmail($request);
 
         // We will send the password reset link to this user. Once we have attempted
         // to send the link, we will examine the response then see the message we
@@ -37,6 +37,17 @@ trait SendsPasswordResetEmails
         return $response == Password::RESET_LINK_SENT
                     ? $this->sendResetLinkResponse($response)
                     : $this->sendResetLinkFailedResponse($request, $response);
+    }
+    
+    /**
+     * Validates the email.
+     *
+     * @param \Illuminate\Http\Request  $request
+     * @return void
+     */
+    protected function validateEmail(Request $request)
+    {
+        $this->validate($request, ['email' => 'required|email']);
     }
 
     /**

--- a/src/Illuminate/Foundation/Auth/SendsPasswordResetEmails.php
+++ b/src/Illuminate/Foundation/Auth/SendsPasswordResetEmails.php
@@ -38,7 +38,7 @@ trait SendsPasswordResetEmails
                     ? $this->sendResetLinkResponse($response)
                     : $this->sendResetLinkFailedResponse($request, $response);
     }
-    
+
     /**
      * Validates the email.
      *


### PR DESCRIPTION
Changed the line that validates the email to its own method.
This way its easier to override only the validation rules, instead of the whole 'sendResetLinkEmail' method.