### PR TITLE
[5.4] Added second $encoding parameter to length

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -147,11 +147,12 @@ class Str
      * Return the length of the given string.
      *
      * @param  string  $value
+     * @param  string  $encoding
      * @return int
      */
-    public static function length($value)
+    public static function length($value, $encoding = null)
     {
-        return mb_strlen($value);
+        return mb_strlen($value, $encoding ?: mb_internal_encoding());
     }
 
     /**


### PR DESCRIPTION
- Laravel Version: 5.4.21
- PHP Version: N/A
- Database Driver & Version: N/A

### Description:

I needed to use `Str::length($string, '8bit')` and whilst I could simply use `mb_strlen()` I thought it would be acceptable to also add this to the `Str::length` method.