### PR TITLE
[5.1] Backport missing postgresql-specific operators

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -193,7 +193,7 @@ class Builder
         '&', '|', '^', '<<', '>>',
         'rlike', 'regexp', 'not regexp',
         '~', '~*', '!~', '!~*', 'similar to',
-        'not similar to',
+        'not similar to', 'not ilike', '~~*', '!~~*',
     ];
 
     /**


### PR DESCRIPTION
Backports fix in #14224 to 5.1. Cherry-picks c68cee93be0c2cab547b2b4d0069f9c4a3f30bdf.