### PR TITLE
[5.4.21]bug fix. when use other connection in model, set the correct connecti…

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1039,7 +1039,7 @@ class Builder
     public function newModelInstance($attributes = [])
     {
         return $this->model->newInstance($attributes)->setConnection(
-            $this->query->getConnection()->getName()
+            $this->model->getConnectionName()
         );
     }
 


### PR DESCRIPTION
when use different connection in model, like `protected $connection='oracle'`, get data is ok, but if update or save, will got exception.  because of the connection info lost.
this pull request will fix the bug.

this bug appear on 5.4.21. 