### PR TITLE
[5.4] Allow factory attributes to be factory instances themselves

### DIFF
--- a/src/Illuminate/Database/Eloquent/FactoryBuilder.php
+++ b/src/Illuminate/Database/Eloquent/FactoryBuilder.php
@@ -204,7 +204,7 @@ class FactoryBuilder
             $this->faker, $attributes
         );
 
-        return $this->callClosureAttributes(
+        return $this->expandAttributes(
             array_merge($this->applyStates($definition, $attributes), $attributes)
         );
     }
@@ -254,19 +254,25 @@ class FactoryBuilder
     }
 
     /**
-     * Evaluate any Closure attributes on the attribute array.
+     * Expand all attributes to their underlying values.
      *
      * @param  array  $attributes
      * @return array
      */
-    protected function callClosureAttributes(array $attributes)
+    protected function expandAttributes(array $attributes)
     {
         foreach ($attributes as &$attribute) {
-            $attribute = $attribute instanceof Closure
-                            ? $attribute($attributes) : $attribute;
+            if ($attribute instanceof Closure) {
+                $attribute = $attribute($attributes);
+            }
 
-            $attribute = $attribute instanceof Model
-                            ? $attribute->getKey() : $attribute;
+            if ($attribute instanceof static) {
+                $attribute = $attribute->create()->getKey();
+            }
+
+            if ($attribute instanceof Model) {
+                $attribute = $attribute->getKey();
+            }
         }
 
         return $attributes;


### PR DESCRIPTION
This is a backport of https://github.com/laravel/framework/pull/18879.

The original PR was accidentally made against master.