### PR TITLE
[5.5] Adds inline eloquent factory states

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factory.php
@@ -87,10 +87,10 @@ class Factory implements ArrayAccess
      *
      * @param  string  $class
      * @param  string  $state
-     * @param  callable  $attributes
+     * @param  callable|array  $attributes
      * @return $this
      */
-    public function state($class, $state, callable $attributes)
+    public function state($class, $state, $attributes)
     {
         $this->states[$class][$state] = $attributes;
 

--- a/src/Illuminate/Database/Eloquent/FactoryBuilder.php
+++ b/src/Illuminate/Database/Eloquent/FactoryBuilder.php
@@ -254,7 +254,7 @@ class FactoryBuilder
     }
 
     /**
-     * Get the state attributes
+     * Get the state attributes.
      *
      * @param string $state
      * @param array $attributes
@@ -264,7 +264,7 @@ class FactoryBuilder
     {
         $stateAttributes = $this->states[$this->class][$state];
 
-        if (!is_callable($stateAttributes)) {
+        if (! is_callable($stateAttributes)) {
             return $stateAttributes;
         }
 

--- a/src/Illuminate/Database/Eloquent/FactoryBuilder.php
+++ b/src/Illuminate/Database/Eloquent/FactoryBuilder.php
@@ -244,13 +244,34 @@ class FactoryBuilder
                 throw new InvalidArgumentException("Unable to locate [{$state}] state for [{$this->class}].");
             }
 
-            $definition = array_merge($definition, call_user_func(
-                $this->states[$this->class][$state],
-                $this->faker, $attributes
-            ));
+            $definition = array_merge(
+                $definition,
+                $this->stateAttributes($state, $attributes)
+            );
         }
 
         return $definition;
+    }
+
+    /**
+     * Get the state attributes
+     *
+     * @param string $state
+     * @param array $attributes
+     * @return array
+     */
+    protected function stateAttributes($state, array $attributes)
+    {
+        $stateAttributes = $this->states[$this->class][$state];
+
+        if (!is_callable($stateAttributes)) {
+            return $stateAttributes;
+        }
+
+        return call_user_func(
+            $stateAttributes,
+            $this->faker, $attributes
+        );
     }
 
     /**

--- a/tests/Integration/Database/EloquentFactoryBuilderTest.php
+++ b/tests/Integration/Database/EloquentFactoryBuilderTest.php
@@ -41,11 +41,13 @@ class EloquentFactoryBuilderTest extends TestCase
             ];
         });
 
-        $factory->state(FactoryBuildableServer::class, 'inactive', function (Generator $faker) {
+        $factory->state(FactoryBuildableServer::class, 'callable', function (Generator $faker) {
             return [
-                'status' => 'inactive',
+                'status' => 'callable',
             ];
         });
+
+        $factory->state(FactoryBuildableServer::class, 'inline', ['status' => 'inline']);
 
         $app->singleton(Factory::class, function ($app) use ($factory) {
             return $factory;
@@ -112,14 +114,27 @@ class EloquentFactoryBuilderTest extends TestCase
     /**
      * @test
      */
-    public function creating_models_with_states()
+    public function creating_models_with_callable_states()
     {
         $server = factory(FactoryBuildableServer::class)->create();
 
-        $inactiveServer = factory(FactoryBuildableServer::class)->states('inactive')->create();
+        $callableServer = factory(FactoryBuildableServer::class)->states('callable')->create();
 
         $this->assertEquals('active', $server->status);
-        $this->assertEquals('inactive', $inactiveServer->status);
+        $this->assertEquals('callable', $callableServer->status);
+    }
+
+    /**
+     * @test
+     */
+    public function creating_models_with_inline_states()
+    {
+        $server = factory(FactoryBuildableServer::class)->create();
+
+        $inlineServer = factory(FactoryBuildableServer::class)->states('inline')->create();
+
+        $this->assertEquals('active', $server->status);
+        $this->assertEquals('inline', $inlineServer->status);
     }
 
     /**


### PR DESCRIPTION
Frequently with eloquent factory states, you only need to change one attribute to a scalar value. You often don't actually need to use Faker at all. This change allows you to simply pass an array as the 3rd argument instead of a closure.

![image](https://cloud.githubusercontent.com/assets/627060/25712892/84fec80a-30b8-11e7-8f74-2db95982f017.png)

Note: this is simply an addition of functionality. Closures still work as expected.