### PR TITLE
[5.5] Validate `on` to true for default checkbox value

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -303,7 +303,7 @@ trait ValidatesAttributes
      */
     protected function validateBoolean($attribute, $value)
     {
-        $acceptable = [true, false, 0, 1, '0', '1'];
+        $acceptable = [true, false, 0, 1, '0', '1', 'on'];
 
         return in_array($value, $acceptable, true);
     }
@@ -1072,9 +1072,11 @@ trait ValidatesAttributes
     protected function convertValuesToBoolean($values)
     {
         return array_map(function ($value) {
-            if ($value === 'true') {
+            if ($value === 'true' || $value === 'on') {
                 return true;
-            } elseif ($value === 'false') {
+            }
+
+            if ($value === 'false') {
                 return false;
             }
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1115,6 +1115,9 @@ class ValidationValidatorTest extends TestCase
 
         $v = new Validator($trans, ['foo' => 0], ['foo' => 'Boolean']);
         $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'on'], ['foo' => 'Boolean']);
+        $this->assertTrue($v->passes());
     }
 
     public function testValidateBool()
@@ -1151,6 +1154,9 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['foo' => 0], ['foo' => 'Bool']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'on'], ['foo' => 'Bool']);
         $this->assertTrue($v->passes());
     }
 


### PR DESCRIPTION
This allows `'on'` to be used as a valid `boolean` type equal to `true` on validation. This allows for the browser default checkbox value to be used for boolean validation. This stems from part of the discussion in [internals #514](https://github.com/laravel/internals/issues/514).

If a checkbox input has a `name` but no value the default is `'on'`. Reference: [WhatWG standard](https://html.spec.whatwg.org/multipage/forms.html#checkbox-state-(type=checkbox))

> The value IDL attribute is in mode default/on.

To test this, the following script can be ran in a browser console with support for `FormData.entries`.

<details>
<summary>Test Script</summary>

```javascript
var form = document.createElement('form');
var checkbox = document.createElement('input');
checkbox.type = 'checkbox';
checkbox.name = 'checked';
checkbox.checked = true;
var unchecked = document.createElement('input');
unchecked.type = 'checkbox';
unchecked.name = 'unchecked';
form.appendChild(checkbox);
form.appendChild(unchecked);

var data = new FormData(form);

for (var key of data.entries()) {
    console.log(key[0] + ' ' + key[1]);
}
```

</details>