### PR TITLE
[5.4] Implement `until` method on the `EventFake`

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/EventFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/EventFake.php
@@ -192,6 +192,6 @@ class EventFake implements Dispatcher
      */
     public function until($event, $payload = [])
     {
-        //
+        return $this->dispatch($event, $payload, true);
     }
 }


### PR DESCRIPTION
When dispatching events using the `until` method instead of the `dispatch` or `fire` methods, the given events were not being collected in the `events` array of the `EventFake` class.

This was resulting false negatives, e.g. `assertDispatched` is failing because the `until` method is not implemented like the `fire` and `dispatch` methods.

This is useful for testing model *halting* events like `saving`, `creating`, `updating`, `deleting`.

* Fixes #18923