### PR TITLE
[5.5] Add a validate method onto the request

### DIFF
--- a/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Foundation\Providers;
 
+use Illuminate\Http\Request;
 use Illuminate\Support\AggregateServiceProvider;
 
 class FoundationServiceProvider extends AggregateServiceProvider
@@ -14,4 +15,30 @@ class FoundationServiceProvider extends AggregateServiceProvider
     protected $providers = [
         FormRequestServiceProvider::class,
     ];
+
+    /**
+     * Register the service provider.
+     *
+     * @return void
+     */
+    public function register()
+    {
+        parent::register();
+
+        $this->registerRequestValidate();
+    }
+
+    /**
+     * Register the "validate" macro on the request.
+     *
+     * @return void
+     */
+    public function registerRequestValidate()
+    {
+        Request::macro('validate', function (array $rules, ...$params) {
+            validator()->validate($this->all(), $rules, ...$params);
+
+            return $this->only(array_keys($rules));
+        });
+    }
 }


### PR DESCRIPTION
This will allow calling `validate` directly on the request object:

```php
$data = request()->validate([
    'title' => 'required',
    'body' => 'required',
]);
```