### PR TITLE
[5.4] clone query without order by for aggregates

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2075,6 +2075,11 @@ class Builder
     {
         $this->aggregate = compact('function', 'columns');
 
+        if (empty($this->groups)) {
+            $this->orders = null;
+            $this->bindings['order'] = [];
+        }
+
         return $this;
     }
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2077,6 +2077,7 @@ class Builder
 
         if (empty($this->groups)) {
             $this->orders = null;
+
             $this->bindings['order'] = [];
         }
 


### PR DESCRIPTION
Same as #19022 but backported for the 5.4 branch.