### PR TITLE
resolve aliases from container when using parameters

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -577,7 +577,7 @@ class Container implements ArrayAccess, ContainerContract
     protected function resolve($abstract, $parameters = [])
     {
         $abstract = $this->getAlias($abstract);
-        
+
         $needsContextualBuild = ! empty($parameters) || ! is_null(
             $this->getContextualConcrete($abstract)
         );

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -576,8 +576,10 @@ class Container implements ArrayAccess, ContainerContract
      */
     protected function resolve($abstract, $parameters = [])
     {
+        $abstract = $this->getAlias($abstract);
+        
         $needsContextualBuild = ! empty($parameters) || ! is_null(
-            $this->getContextualConcrete($abstract = $this->getAlias($abstract))
+            $this->getContextualConcrete($abstract)
         );
 
         // If an instance of the type is currently being managed as a singleton we'll

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -124,7 +124,7 @@ class ContainerTest extends TestCase
     public function testAliasesWithArrayOfParameters()
     {
         $container = new Container;
-        $container->bind('foo', function($app, $config) {
+        $container->bind('foo', function ($app, $config) {
             return $config;
         });
         $container->alias('foo', 'baz');

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -121,6 +121,16 @@ class ContainerTest extends TestCase
         $this->assertEquals('bar', $container->make('bat'));
     }
 
+    public function testAliasesWithArrayOfParameters()
+    {
+        $container = new Container;
+        $container->bind('foo', function($app, $config) {
+            return $config;
+        });
+        $container->alias('foo', 'baz');
+        $this->assertEquals([1, 2, 3], $container->makeWith('baz', [1, 2, 3]));
+    }
+
     public function testBindingsCanBeOverridden()
     {
         $container = new Container;


### PR DESCRIPTION
$app->bind(CustomClass::class, function($app, $params) { ... });
$app->alias(CustomClass::class, 'CustomAlias');
$app->makeWith('CustomAlias', [..]); // exception "Class CustomAlias does not exist"

When passing parameters to Illuminate/Container/Container resolve() method, the alias will not be resolved correctly. This pull request fixes that.