### PR TITLE
[5.4] Implicit Route Binding fails if the target model has a global scope t…

### DIFF
--- a/src/Illuminate/Routing/ImplicitRouteBinding.php
+++ b/src/Illuminate/Routing/ImplicitRouteBinding.php
@@ -31,7 +31,7 @@ class ImplicitRouteBinding
             $model = $container->make($parameter->getClass()->name);
 
             $route->setParameter($parameterName, $model->where(
-                $model->getTable() . '.' . $model->getRouteKeyName(), $parameterValue
+                $model->getTable().'.'.$model->getRouteKeyName(), $parameterValue
             )->firstOrFail());
         }
     }

--- a/src/Illuminate/Routing/ImplicitRouteBinding.php
+++ b/src/Illuminate/Routing/ImplicitRouteBinding.php
@@ -31,7 +31,7 @@ class ImplicitRouteBinding
             $model = $container->make($parameter->getClass()->name);
 
             $route->setParameter($parameterName, $model->where(
-                $model->getRouteKeyName(), $parameterValue
+                $model->getTable() . '.' . $model->getRouteKeyName(), $parameterValue
             )->firstOrFail());
         }
     }


### PR DESCRIPTION
…hat joins tables

If the joined table has a field named as the searched model primary key (usually id) the join fails (column reference "<keyname>" is ambiguous).

ref. https://github.com/laravel/framework/pull/18998