### PR TITLE
[5.4] Unable to delete XSRF token via response

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
+++ b/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
@@ -154,7 +154,7 @@ class VerifyCsrfToken
         $config = config('session');
 
         $isXSRFDeleted = $this->isXSRFDeleted($response->headers->getCookies());
-        if (!$isXSRFDeleted) {
+        if (! $isXSRFDeleted) {
             $response->headers->setCookie(
                 new Cookie(
                     'XSRF-TOKEN', $request->session()->token(),
@@ -168,7 +168,6 @@ class VerifyCsrfToken
     }
 
     /**
-     *
      * Checks if XSRF is to be deleted as part of the response
      *
      * @param $cookies

--- a/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
+++ b/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
@@ -168,7 +168,7 @@ class VerifyCsrfToken
     }
 
     /**
-     * Checks if XSRF is to be deleted as part of the response
+     * Checks if XSRF is to be deleted as part of the response.
      *
      * @param $cookies
      * @return bool

--- a/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
+++ b/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
@@ -153,8 +153,7 @@ class VerifyCsrfToken
     {
         $config = config('session');
 
-        $isXSRFDeleted = $this->isXSRFDeleted($response->headers->getCookies());
-        if (! $isXSRFDeleted) {
+        if (! $this->isXSRFDeleted($response->headers->getCookies())) {
             $response->headers->setCookie(
                 new Cookie(
                     'XSRF-TOKEN', $request->session()->token(),
@@ -168,15 +167,15 @@ class VerifyCsrfToken
     }
 
     /**
-     * Checks if XSRF is to be deleted as part of the response.
+     * Checks if cookies array contains an XSRF is to be deleted.
      *
-     * @param $cookies
+     * @param array $cookies
      * @return bool
      */
-    private function isXSRFDeleted($cookies)
+    private function isXSRFDeleted(array $cookies)
     {
         foreach ($cookies as $cookie) {
-            if ($cookie->getName() == 'XSRF-TOKEN' && $cookie->getValue() == null) {
+            if ($cookie->getName() == 'XSRF-TOKEN' && ! $cookie->getValue()) {
                 return true;
             }
         }

--- a/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
+++ b/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
@@ -180,7 +180,7 @@ class VerifyCsrfToken
                 return true;
             }
         }
-        
+
         return false;
     }
 }

--- a/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
+++ b/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
@@ -180,6 +180,7 @@ class VerifyCsrfToken
                 return true;
             }
         }
+        
         return false;
     }
 }

--- a/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
+++ b/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
@@ -154,8 +154,7 @@ class VerifyCsrfToken
         $config = config('session');
 
         $isXSRFDeleted = $this->isXSRFDeleted($response->headers->getCookies());
-        if (!$isXSRFDeleted)
-        {
+        if (!$isXSRFDeleted) {
             $response->headers->setCookie(
                 new Cookie(
                     'XSRF-TOKEN', $request->session()->token(),
@@ -169,6 +168,7 @@ class VerifyCsrfToken
     }
 
     /**
+     *
      * Checks if XSRF is to be deleted as part of the response
      *
      * @param $cookies


### PR DESCRIPTION
XSRF cookies are added in the responses but sometimes the users wants to delete them using $response->withCookie(\Cookie::forget('XSRF-TOKEN'))...

After it gets deleted, it generates another XSRF-TOKEN.

However, if deleting the XSRF-TOKEN is queued then it is successful. This fix ensures that XSRF isn't great if user wants it deleted.