### PR TITLE
[5.4] Avoid unneeded function call in Str::length()

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -152,7 +152,11 @@ class Str
      */
     public static function length($value, $encoding = null)
     {
-        return mb_strlen($value, $encoding ?: mb_internal_encoding());
+        if ($encoding) {
+            return mb_strlen($value, $encoding);
+        }
+
+        return mb_strlen($value);
     }
 
     /**


### PR DESCRIPTION
Follow-up to #19047.

```php
$nb = 10000;

$t1 = microtime(true);
for ($i = $nb; $i--; ) {
    mb_strlen('éééààà', mb_internal_encoding());
}
$t2 = microtime(true);
for ($i = $nb; $i--; ) {
    mb_strlen('éééààà');
}
$t3 = microtime(true);

echo $t2 - $t1, "\n", $t3 - $t2;
```

before 116ms, after 46ms