### PR TITLE
Required if with array field as the reference field

### DIFF
--- a/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
@@ -260,6 +260,7 @@ trait ReplacesAttributes
     protected function replaceRequiredIf($message, $attribute, $rule, $parameters)
     {
         $value = Arr::get($this->data, $parameters[0]);
+        
         if (is_array($value)) {
             $validValues = array_unique(array_splice($parameters, 1, count($parameters) - 1));
             $value = implode(' or ', $validValues);

--- a/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
@@ -259,6 +259,12 @@ trait ReplacesAttributes
      */
     protected function replaceRequiredIf($message, $attribute, $rule, $parameters)
     {
+        $value = Arr::get($this->data, $parameters[0]);
+        if (is_array($value)) {
+            $validValues = array_unique(array_splice($parameters, 1, count($parameters) - 1));
+            $value = implode(' or ', $validValues);
+        }
+        
         $parameters[1] = $this->getDisplayableValue($parameters[0], Arr::get($this->data, $parameters[0]));
 
         $parameters[0] = $this->getDisplayableAttribute($parameters[0]);

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1055,7 +1055,11 @@ trait ValidatesAttributes
         if (is_bool($other)) {
             $values = $this->convertValuesToBoolean($values);
         }
-
+        
+        if (is_array($other)) {
+            return empty(array_intersect($other, $values));
+        }
+        
         if (in_array($other, $values)) {
             return $this->validateRequired($attribute, $value);
         }


### PR DESCRIPTION
Add functionality to check arrays when an array field passed as the field to check.
Example:
--HTML--
`<input type="checkbox" name="todo[]" value="buy milk">`
`<input type="checkbox" name="todo[]" value="buy bread">`
`<input type="checkbox" name="todo[]" value="go to the bank">`


--Rule--
`['grocery_shop' => required_if:todo,buy milk,buy bread]`

I have done simple modification to validateRequiredIf method of Illuminate\Validation\Concerns\ValidatesAttributes class and replaceRequiredIf method of Illuminate\Validation\Concerns\ReplacesAttributes class