### PR TITLE
Adds add_count functionality to Str::plural

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -227,7 +227,7 @@ class Str
      * @return string
      */
     public static function plural($value, $count = 2, $add_count = false)
-     {
+    {
         return ($add_count ? $count.' ' : '')
             .Pluralizer::plural($value, $count);
     }

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -228,8 +228,8 @@ class Str
      */
     public static function plural($value, $count = 2, $add_count = false)
      {
-        return ($add_count ? $count . ' ' : '')
-            . Pluralizer::plural($value, $count);
+        return ($add_count ? $count.' ' : '')
+            .Pluralizer::plural($value, $count);
     }
 
     /**

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -223,11 +223,13 @@ class Str
      *
      * @param  string  $value
      * @param  int     $count
+     * @param  bool    $add_count
      * @return string
      */
-    public static function plural($value, $count = 2)
-    {
-        return Pluralizer::plural($value, $count);
+    public static function plural($value, $count = 2, $add_count = false)
+     {
+        return ($add_count ? $count . ' ' : '')
+            . Pluralizer::plural($value, $count);
     }
 
     /**

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -227,9 +227,9 @@ class Str
      * @return string
      */
     public static function plural($value, $count = 2, $add_count = false)
-     {
-        return ($add_count ? $count . ' ' : '')
-            . Pluralizer::plural($value, $count);
+    {
+        return ($add_count ? $count.' ' : '')
+            .Pluralizer::plural($value, $count);
     }
 
     /**

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -1,701 +1,64 @@
 <?php
 
-use Illuminate\Support\Arr;
-use Illuminate\Support\Str;
-use Illuminate\Support\Collection;
-use Illuminate\Support\Debug\Dumper;
-use Illuminate\Contracts\Support\Htmlable;
-use Illuminate\Support\HigherOrderTapProxy;
+namespace Illuminate\Support;
 
-if (! function_exists('append_config')) {
+use Illuminate\Support\Traits\Macroable;
+
+class Str
+{
+    use Macroable;
+
     /**
-     * Assign high numeric IDs to a config item to force appending.
+     * The cache of snake-cased words.
      *
-     * @param  array  $array
-     * @return array
+     * @var array
      */
-    function append_config(array $array)
+    protected static $snakeCache = [];
+
+    /**
+     * The cache of camel-cased words.
+     *
+     * @var array
+     */
+    protected static $camelCache = [];
+
+    /**
+     * The cache of studly-cased words.
+     *
+     * @var array
+     */
+    protected static $studlyCache = [];
+
+    /**
+     * Transliterate a UTF-8 value to ASCII.
+     *
+     * @param  string  $value
+     * @return string
+     */
+    public static function ascii($value)
     {
-        $start = 9999;
-
-        foreach ($array as $key => $value) {
-            if (is_numeric($key)) {
-                $start++;
-
-                $array[$start] = Arr::pull($array, $key);
-            }
+        foreach (static::charsArray() as $key => $val) {
+            $value = str_replace($val, $key, $value);
         }
 
-        return $array;
+        return preg_replace('/[^\x20-\x7E]/u', '', $value);
     }
-}
 
-if (! function_exists('array_add')) {
-    /**
-     * Add an element to an array using "dot" notation if it doesn't exist.
-     *
-     * @param  array   $array
-     * @param  string  $key
-     * @param  mixed   $value
-     * @return array
-     */
-    function array_add($array, $key, $value)
-    {
-        return Arr::add($array, $key, $value);
-    }
-}
-
-if (! function_exists('array_collapse')) {
-    /**
-     * Collapse an array of arrays into a single array.
-     *
-     * @param  array  $array
-     * @return array
-     */
-    function array_collapse($array)
-    {
-        return Arr::collapse($array);
-    }
-}
-
-if (! function_exists('array_divide')) {
-    /**
-     * Divide an array into two arrays. One with keys and the other with values.
-     *
-     * @param  array  $array
-     * @return array
-     */
-    function array_divide($array)
-    {
-        return Arr::divide($array);
-    }
-}
-
-if (! function_exists('array_dot')) {
-    /**
-     * Flatten a multi-dimensional associative array with dots.
-     *
-     * @param  array   $array
-     * @param  string  $prepend
-     * @return array
-     */
-    function array_dot($array, $prepend = '')
-    {
-        return Arr::dot($array, $prepend);
-    }
-}
-
-if (! function_exists('array_except')) {
-    /**
-     * Get all of the given array except for a specified array of items.
-     *
-     * @param  array  $array
-     * @param  array|string  $keys
-     * @return array
-     */
-    function array_except($array, $keys)
-    {
-        return Arr::except($array, $keys);
-    }
-}
-
-if (! function_exists('array_first')) {
-    /**
-     * Return the first element in an array passing a given truth test.
-     *
-     * @param  array  $array
-     * @param  callable|null  $callback
-     * @param  mixed  $default
-     * @return mixed
-     */
-    function array_first($array, callable $callback = null, $default = null)
-    {
-        return Arr::first($array, $callback, $default);
-    }
-}
-
-if (! function_exists('array_flatten')) {
-    /**
-     * Flatten a multi-dimensional array into a single level.
-     *
-     * @param  array  $array
-     * @param  int  $depth
-     * @return array
-     */
-    function array_flatten($array, $depth = INF)
-    {
-        return Arr::flatten($array, $depth);
-    }
-}
-
-if (! function_exists('array_forget')) {
-    /**
-     * Remove one or many array items from a given array using "dot" notation.
-     *
-     * @param  array  $array
-     * @param  array|string  $keys
-     * @return void
-     */
-    function array_forget(&$array, $keys)
-    {
-        return Arr::forget($array, $keys);
-    }
-}
-
-if (! function_exists('array_get')) {
-    /**
-     * Get an item from an array using "dot" notation.
-     *
-     * @param  \ArrayAccess|array  $array
-     * @param  string  $key
-     * @param  mixed   $default
-     * @return mixed
-     */
-    function array_get($array, $key, $default = null)
-    {
-        return Arr::get($array, $key, $default);
-    }
-}
-
-if (! function_exists('array_has')) {
-    /**
-     * Check if an item or items exist in an array using "dot" notation.
-     *
-     * @param  \ArrayAccess|array  $array
-     * @param  string|array  $keys
-     * @return bool
-     */
-    function array_has($array, $keys)
-    {
-        return Arr::has($array, $keys);
-    }
-}
-
-if (! function_exists('array_last')) {
-    /**
-     * Return the last element in an array passing a given truth test.
-     *
-     * @param  array  $array
-     * @param  callable|null  $callback
-     * @param  mixed  $default
-     * @return mixed
-     */
-    function array_last($array, callable $callback = null, $default = null)
-    {
-        return Arr::last($array, $callback, $default);
-    }
-}
-
-if (! function_exists('array_only')) {
-    /**
-     * Get a subset of the items from the given array.
-     *
-     * @param  array  $array
-     * @param  array|string  $keys
-     * @return array
-     */
-    function array_only($array, $keys)
-    {
-        return Arr::only($array, $keys);
-    }
-}
-
-if (! function_exists('array_pluck')) {
-    /**
-     * Pluck an array of values from an array.
-     *
-     * @param  array   $array
-     * @param  string|array  $value
-     * @param  string|array|null  $key
-     * @return array
-     */
-    function array_pluck($array, $value, $key = null)
-    {
-        return Arr::pluck($array, $value, $key);
-    }
-}
-
-if (! function_exists('array_prepend')) {
-    /**
-     * Push an item onto the beginning of an array.
-     *
-     * @param  array  $array
-     * @param  mixed  $value
-     * @param  mixed  $key
-     * @return array
-     */
-    function array_prepend($array, $value, $key = null)
-    {
-        return Arr::prepend($array, $value, $key);
-    }
-}
-
-if (! function_exists('array_pull')) {
-    /**
-     * Get a value from the array, and remove it.
-     *
-     * @param  array   $array
-     * @param  string  $key
-     * @param  mixed   $default
-     * @return mixed
-     */
-    function array_pull(&$array, $key, $default = null)
-    {
-        return Arr::pull($array, $key, $default);
-    }
-}
-
-if (! function_exists('array_set')) {
-    /**
-     * Set an array item to a given value using "dot" notation.
-     *
-     * If no key is given to the method, the entire array will be replaced.
-     *
-     * @param  array   $array
-     * @param  string  $key
-     * @param  mixed   $value
-     * @return array
-     */
-    function array_set(&$array, $key, $value)
-    {
-        return Arr::set($array, $key, $value);
-    }
-}
-
-if (! function_exists('array_sort')) {
-    /**
-     * Sort the array using the given callback.
-     *
-     * @param  array  $array
-     * @param  callable  $callback
-     * @return array
-     */
-    function array_sort($array, callable $callback)
-    {
-        return Arr::sort($array, $callback);
-    }
-}
-
-if (! function_exists('array_sort_recursive')) {
-    /**
-     * Recursively sort an array by keys and values.
-     *
-     * @param  array  $array
-     * @return array
-     */
-    function array_sort_recursive($array)
-    {
-        return Arr::sortRecursive($array);
-    }
-}
-
-if (! function_exists('array_where')) {
-    /**
-     * Filter the array using the given callback.
-     *
-     * @param  array  $array
-     * @param  callable  $callback
-     * @return array
-     */
-    function array_where($array, callable $callback)
-    {
-        return Arr::where($array, $callback);
-    }
-}
-
-if (! function_exists('array_wrap')) {
-    /**
-     * If the given value is not an array, wrap it in one.
-     *
-     * @param  mixed  $value
-     * @return array
-     */
-    function array_wrap($value)
-    {
-        return Arr::wrap($value);
-    }
-}
-
-if (! function_exists('camel_case')) {
     /**
      * Convert a value to camel case.
      *
      * @param  string  $value
      * @return string
      */
-    function camel_case($value)
+    public static function camel($value)
     {
-        return Str::camel($value);
-    }
-}
-
-if (! function_exists('class_basename')) {
-    /**
-     * Get the class "basename" of the given object / class.
-     *
-     * @param  string|object  $class
-     * @return string
-     */
-    function class_basename($class)
-    {
-        $class = is_object($class) ? get_class($class) : $class;
-
-        return basename(str_replace('\\', '/', $class));
-    }
-}
-
-if (! function_exists('class_uses_recursive')) {
-    /**
-     * Returns all traits used by a class, its subclasses and trait of their traits.
-     *
-     * @param  object|string  $class
-     * @return array
-     */
-    function class_uses_recursive($class)
-    {
-        if (is_object($class)) {
-            $class = get_class($class);
+        if (isset(static::$camelCache[$value])) {
+            return static::$camelCache[$value];
         }
 
-        $results = [];
-
-        foreach (array_merge([$class => $class], class_parents($class)) as $class) {
-            $results += trait_uses_recursive($class);
-        }
-
-        return array_unique($results);
+        return static::$camelCache[$value] = lcfirst(static::studly($value));
     }
-}
 
-if (! function_exists('collect')) {
-    /**
-     * Create a collection from the given value.
-     *
-     * @param  mixed  $value
-     * @return \Illuminate\Support\Collection
-     */
-    function collect($value = null)
-    {
-        return new Collection($value);
-    }
-}
-
-if (! function_exists('data_fill')) {
-    /**
-     * Fill in data where it's missing.
-     *
-     * @param  mixed   $target
-     * @param  string|array  $key
-     * @param  mixed  $value
-     * @return mixed
-     */
-    function data_fill(&$target, $key, $value)
-    {
-        return data_set($target, $key, $value, false);
-    }
-}
-
-if (! function_exists('data_get')) {
-    /**
-     * Get an item from an array or object using "dot" notation.
-     *
-     * @param  mixed   $target
-     * @param  string|array  $key
-     * @param  mixed   $default
-     * @return mixed
-     */
-    function data_get($target, $key, $default = null)
-    {
-        if (is_null($key)) {
-            return $target;
-        }
-
-        $key = is_array($key) ? $key : explode('.', $key);
-
-        while (! is_null($segment = array_shift($key))) {
-            if ($segment === '*') {
-                if ($target instanceof Collection) {
-                    $target = $target->all();
-                } elseif (! is_array($target)) {
-                    return value($default);
-                }
-
-                $result = Arr::pluck($target, $key);
-
-                return in_array('*', $key) ? Arr::collapse($result) : $result;
-            }
-
-            if (Arr::accessible($target) && Arr::exists($target, $segment)) {
-                $target = $target[$segment];
-            } elseif (is_object($target) && isset($target->{$segment})) {
-                $target = $target->{$segment};
-            } else {
-                return value($default);
-            }
-        }
-
-        return $target;
-    }
-}
-
-if (! function_exists('data_set')) {
-    /**
-     * Set an item on an array or object using dot notation.
-     *
-     * @param  mixed  $target
-     * @param  string|array  $key
-     * @param  mixed  $value
-     * @param  bool  $overwrite
-     * @return mixed
-     */
-    function data_set(&$target, $key, $value, $overwrite = true)
-    {
-        $segments = is_array($key) ? $key : explode('.', $key);
-
-        if (($segment = array_shift($segments)) === '*') {
-            if (! Arr::accessible($target)) {
-                $target = [];
-            }
-
-            if ($segments) {
-                foreach ($target as &$inner) {
-                    data_set($inner, $segments, $value, $overwrite);
-                }
-            } elseif ($overwrite) {
-                foreach ($target as &$inner) {
-                    $inner = $value;
-                }
-            }
-        } elseif (Arr::accessible($target)) {
-            if ($segments) {
-                if (! Arr::exists($target, $segment)) {
-                    $target[$segment] = [];
-                }
-
-                data_set($target[$segment], $segments, $value, $overwrite);
-            } elseif ($overwrite || ! Arr::exists($target, $segment)) {
-                $target[$segment] = $value;
-            }
-        } elseif (is_object($target)) {
-            if ($segments) {
-                if (! isset($target->{$segment})) {
-                    $target->{$segment} = [];
-                }
-
-                data_set($target->{$segment}, $segments, $value, $overwrite);
-            } elseif ($overwrite || ! isset($target->{$segment})) {
-                $target->{$segment} = $value;
-            }
-        } else {
-            $target = [];
-
-            if ($segments) {
-                data_set($target[$segment], $segments, $value, $overwrite);
-            } elseif ($overwrite) {
-                $target[$segment] = $value;
-            }
-        }
-
-        return $target;
-    }
-}
-
-if (! function_exists('dd')) {
-    /**
-     * Dump the passed variables and end the script.
-     *
-     * @param  mixed
-     * @return void
-     */
-    function dd(...$args)
-    {
-        foreach ($args as $x) {
-            (new Dumper)->dump($x);
-        }
-
-        die(1);
-    }
-}
-
-if (! function_exists('e')) {
-    /**
-     * Escape HTML special characters in a string.
-     *
-     * @param  \Illuminate\Contracts\Support\Htmlable|string  $value
-     * @return string
-     */
-    function e($value)
-    {
-        if ($value instanceof Htmlable) {
-            return $value->toHtml();
-        }
-
-        return htmlspecialchars($value, ENT_QUOTES, 'UTF-8', false);
-    }
-}
-
-if (! function_exists('ends_with')) {
-    /**
-     * Determine if a given string ends with a given substring.
-     *
-     * @param  string  $haystack
-     * @param  string|array  $needles
-     * @return bool
-     */
-    function ends_with($haystack, $needles)
-    {
-        return Str::endsWith($haystack, $needles);
-    }
-}
-
-if (! function_exists('head')) {
-    /**
-     * Get the first element of an array. Useful for method chaining.
-     *
-     * @param  array  $array
-     * @return mixed
-     */
-    function head($array)
-    {
-        return reset($array);
-    }
-}
-
-if (! function_exists('kebab_case')) {
-    /**
-     * Convert a string to kebab case.
-     *
-     * @param  string  $value
-     * @return string
-     */
-    function kebab_case($value)
-    {
-        return Str::kebab($value);
-    }
-}
-
-if (! function_exists('last')) {
-    /**
-     * Get the last element from an array.
-     *
-     * @param  array  $array
-     * @return mixed
-     */
-    function last($array)
-    {
-        return end($array);
-    }
-}
-
-if (! function_exists('object_get')) {
-    /**
-     * Get an item from an object using "dot" notation.
-     *
-     * @param  object  $object
-     * @param  string  $key
-     * @param  mixed   $default
-     * @return mixed
-     */
-    function object_get($object, $key, $default = null)
-    {
-        if (is_null($key) || trim($key) == '') {
-            return $object;
-        }
-
-        foreach (explode('.', $key) as $segment) {
-            if (! is_object($object) || ! isset($object->{$segment})) {
-                return value($default);
-            }
-
-            $object = $object->{$segment};
-        }
-
-        return $object;
-    }
-}
-
-if (! function_exists('preg_replace_array')) {
-    /**
-     * Replace a given pattern with each value in the array in sequentially.
-     *
-     * @param  string  $pattern
-     * @param  array   $replacements
-     * @param  string  $subject
-     * @return string
-     */
-    function preg_replace_array($pattern, array $replacements, $subject)
-    {
-        return preg_replace_callback($pattern, function () use (&$replacements) {
-            foreach ($replacements as $key => $value) {
-                return array_shift($replacements);
-            }
-        }, $subject);
-    }
-}
-
-if (! function_exists('retry')) {
-    /**
-     * Retry an operation a given number of times.
-     *
-     * @param  int  $times
-     * @param  callable  $callback
-     * @param  int  $sleep
-     * @return mixed
-     *
-     * @throws \Exception
-     */
-    function retry($times, callable $callback, $sleep = 0)
-    {
-        $times--;
-
-        beginning:
-        try {
-            return $callback();
-        } catch (Exception $e) {
-            if (! $times) {
-                throw $e;
-            }
-
-            $times--;
-
-            if ($sleep) {
-                usleep($sleep * 1000);
-            }
-
-            goto beginning;
-        }
-    }
-}
-
-if (! function_exists('snake_case')) {
-    /**
-     * Convert a string to snake case.
-     *
-     * @param  string  $value
-     * @param  string  $delimiter
-     * @return string
-     */
-    function snake_case($value, $delimiter = '_')
-    {
-        return Str::snake($value, $delimiter);
-    }
-}
-
-if (! function_exists('starts_with')) {
-    /**
-     * Determine if a given string starts with a given substring.
-     *
-     * @param  string  $haystack
-     * @param  string|array  $needles
-     * @return bool
-     */
-    function starts_with($haystack, $needles)
-    {
-        return Str::startsWith($haystack, $needles);
-    }
-}
-
-if (! function_exists('str_contains')) {
     /**
      * Determine if a given string contains a given substring.
      *
@@ -703,13 +66,35 @@ if (! function_exists('str_contains')) {
      * @param  string|array  $needles
      * @return bool
      */
-    function str_contains($haystack, $needles)
+    public static function contains($haystack, $needles)
     {
-        return Str::contains($haystack, $needles);
-    }
-}
+        foreach ((array) $needles as $needle) {
+            if ($needle != '' && mb_strpos($haystack, $needle) !== false) {
+                return true;
+            }
+        }
 
-if (! function_exists('str_finish')) {
+        return false;
+    }
+
+    /**
+     * Determine if a given string ends with a given substring.
+     *
+     * @param  string  $haystack
+     * @param  string|array  $needles
+     * @return bool
+     */
+    public static function endsWith($haystack, $needles)
+    {
+        foreach ((array) $needles as $needle) {
+            if (substr($haystack, -strlen($needle)) === (string) $needle) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     /**
      * Cap a string with a single instance of a given value.
      *
@@ -717,13 +102,13 @@ if (! function_exists('str_finish')) {
      * @param  string  $cap
      * @return string
      */
-    function str_finish($value, $cap)
+    public static function finish($value, $cap)
     {
-        return Str::finish($value, $cap);
-    }
-}
+        $quoted = preg_quote($cap, '/');
 
-if (! function_exists('str_is')) {
+        return preg_replace('/(?:'.$quoted.')+$/u', '', $value).$cap;
+    }
+
     /**
      * Determine if a given string matches a given pattern.
      *
@@ -731,13 +116,49 @@ if (! function_exists('str_is')) {
      * @param  string  $value
      * @return bool
      */
-    function str_is($pattern, $value)
+    public static function is($pattern, $value)
     {
-        return Str::is($pattern, $value);
-    }
-}
+        if ($pattern == $value) {
+            return true;
+        }
 
-if (! function_exists('str_limit')) {
+        $pattern = preg_quote($pattern, '#');
+
+        // Asterisks are translated into zero-or-more regular expression wildcards
+        // to make it convenient to check if the strings starts with the given
+        // pattern such as "library/*", making any string check convenient.
+        $pattern = str_replace('\*', '.*', $pattern);
+
+        return (bool) preg_match('#^'.$pattern.'\z#u', $value);
+    }
+
+    /**
+     * Convert a string to kebab case.
+     *
+     * @param  string  $value
+     * @return string
+     */
+    public static function kebab($value)
+    {
+        return static::snake($value, '-');
+    }
+
+    /**
+     * Return the length of the given string.
+     *
+     * @param  string  $value
+     * @param  string  $encoding
+     * @return int
+     */
+    public static function length($value, $encoding = null)
+    {
+        if ($encoding) {
+            return mb_strlen($value, $encoding);
+        }
+
+        return mb_strlen($value);
+    }
+
     /**
      * Limit the number of characters in a string.
      *
@@ -746,42 +167,113 @@ if (! function_exists('str_limit')) {
      * @param  string  $end
      * @return string
      */
-    function str_limit($value, $limit = 100, $end = '...')
+    public static function limit($value, $limit = 100, $end = '...')
     {
-        return Str::limit($value, $limit, $end);
-    }
-}
+        if (mb_strwidth($value, 'UTF-8') <= $limit) {
+            return $value;
+        }
 
-if (! function_exists('str_plural')) {
+        return rtrim(mb_strimwidth($value, 0, $limit, '', 'UTF-8')).$end;
+    }
+
+    /**
+     * Convert the given string to lower-case.
+     *
+     * @param  string  $value
+     * @return string
+     */
+    public static function lower($value)
+    {
+        return mb_strtolower($value, 'UTF-8');
+    }
+
+    /**
+     * Limit the number of words in a string.
+     *
+     * @param  string  $value
+     * @param  int     $words
+     * @param  string  $end
+     * @return string
+     */
+    public static function words($value, $words = 100, $end = '...')
+    {
+        preg_match('/^\s*+(?:\S++\s*+){1,'.$words.'}/u', $value, $matches);
+
+        if (! isset($matches[0]) || static::length($value) === static::length($matches[0])) {
+            return $value;
+        }
+
+        return rtrim($matches[0]).$end;
+    }
+
+    /**
+     * Parse a Class@method style callback into class and method.
+     *
+     * @param  string  $callback
+     * @param  string|null  $default
+     * @return array
+     */
+    public static function parseCallback($callback, $default = null)
+    {
+        return static::contains($callback, '@') ? explode('@', $callback, 2) : [$callback, $default];
+    }
+
     /**
      * Get the plural form of an English word.
      *
      * @param  string  $value
      * @param  int     $count
+     * @param  bool    $add_count
      * @return string
      */
-    function str_plural($value, $count = 2)
-    {
-        return Str::plural($value, $count);
+    public static function plural($value, $count = 2, $add_count = false)
+     {
+        return ($add_count ? $count . ' ' : '')
+            . Pluralizer::plural($value, $count);
     }
-}
 
-if (! function_exists('str_random')) {
     /**
      * Generate a more truly "random" alpha-numeric string.
      *
      * @param  int  $length
      * @return string
-     *
-     * @throws \RuntimeException
      */
-    function str_random($length = 16)
+    public static function random($length = 16)
     {
-        return Str::random($length);
-    }
-}
+        $string = '';
 
-if (! function_exists('str_replace_array')) {
+        while (($len = strlen($string)) < $length) {
+            $size = $length - $len;
+
+            $bytes = random_bytes($size);
+
+            $string .= substr(str_replace(['/', '+', '='], '', base64_encode($bytes)), 0, $size);
+        }
+
+        return $string;
+    }
+
+    /**
+     * Generate a "random" alpha-numeric string.
+     *
+     * Should not be considered sufficient for cryptography, etc.
+     *
+     * @deprecated since version 5.3. Use the "random" method directly.
+     *
+     * @param  int  $length
+     * @return string
+     */
+    public static function quickRandom($length = 16)
+    {
+        if (PHP_MAJOR_VERSION > 5) {
+            return static::random($length);
+        }
+
+        $pool = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
+
+        return substr(str_shuffle(str_repeat($pool, $length)), 0, $length);
+    }
+
     /**
      * Replace a given value in the string sequentially with an array.
      *
@@ -790,13 +282,15 @@ if (! function_exists('str_replace_array')) {
      * @param  string  $subject
      * @return string
      */
-    function str_replace_array($search, array $replace, $subject)
+    public static function replaceArray($search, array $replace, $subject)
     {
-        return Str::replaceArray($search, $replace, $subject);
-    }
-}
+        foreach ($replace as $value) {
+            $subject = static::replaceFirst($search, $value, $subject);
+        }
 
-if (! function_exists('str_replace_first')) {
+        return $subject;
+    }
+
     /**
      * Replace the first occurrence of a given value in the string.
      *
@@ -805,13 +299,17 @@ if (! function_exists('str_replace_first')) {
      * @param  string  $subject
      * @return string
      */
-    function str_replace_first($search, $replace, $subject)
+    public static function replaceFirst($search, $replace, $subject)
     {
-        return Str::replaceFirst($search, $replace, $subject);
-    }
-}
+        $position = strpos($subject, $search);
 
-if (! function_exists('str_replace_last')) {
+        if ($position !== false) {
+            return substr_replace($subject, $replace, $position, strlen($search));
+        }
+
+        return $subject;
+    }
+
     /**
      * Replace the last occurrence of a given value in the string.
      *
@@ -820,26 +318,50 @@ if (! function_exists('str_replace_last')) {
      * @param  string  $subject
      * @return string
      */
-    function str_replace_last($search, $replace, $subject)
+    public static function replaceLast($search, $replace, $subject)
     {
-        return Str::replaceLast($search, $replace, $subject);
-    }
-}
+        $position = strrpos($subject, $search);
 
-if (! function_exists('str_singular')) {
+        if ($position !== false) {
+            return substr_replace($subject, $replace, $position, strlen($search));
+        }
+
+        return $subject;
+    }
+
+    /**
+     * Convert the given string to upper-case.
+     *
+     * @param  string  $value
+     * @return string
+     */
+    public static function upper($value)
+    {
+        return mb_strtoupper($value, 'UTF-8');
+    }
+
+    /**
+     * Convert the given string to title case.
+     *
+     * @param  string  $value
+     * @return string
+     */
+    public static function title($value)
+    {
+        return mb_convert_case($value, MB_CASE_TITLE, 'UTF-8');
+    }
+
     /**
      * Get the singular form of an English word.
      *
      * @param  string  $value
      * @return string
      */
-    function str_singular($value)
+    public static function singular($value)
     {
-        return Str::singular($value);
+        return Pluralizer::singular($value);
     }
-}
 
-if (! function_exists('str_slug')) {
     /**
      * Generate a URL friendly "slug" from a given string.
      *
@@ -847,111 +369,240 @@ if (! function_exists('str_slug')) {
      * @param  string  $separator
      * @return string
      */
-    function str_slug($title, $separator = '-')
+    public static function slug($title, $separator = '-')
     {
-        return Str::slug($title, $separator);
-    }
-}
+        $title = static::ascii($title);
 
-if (! function_exists('studly_case')) {
+        // Convert all dashes/underscores into separator
+        $flip = $separator == '-' ? '_' : '-';
+
+        $title = preg_replace('!['.preg_quote($flip).']+!u', $separator, $title);
+
+        // Remove all characters that are not the separator, letters, numbers, or whitespace.
+        $title = preg_replace('![^'.preg_quote($separator).'\pL\pN\s]+!u', '', mb_strtolower($title));
+
+        // Replace all separator characters and whitespace by a single separator
+        $title = preg_replace('!['.preg_quote($separator).'\s]+!u', $separator, $title);
+
+        return trim($title, $separator);
+    }
+
+    /**
+     * Convert a string to snake case.
+     *
+     * @param  string  $value
+     * @param  string  $delimiter
+     * @return string
+     */
+    public static function snake($value, $delimiter = '_')
+    {
+        $key = $value;
+
+        if (isset(static::$snakeCache[$key][$delimiter])) {
+            return static::$snakeCache[$key][$delimiter];
+        }
+
+        if (! ctype_lower($value)) {
+            $value = preg_replace('/\s+/u', '', $value);
+
+            $value = static::lower(preg_replace('/(.)(?=[A-Z])/u', '$1'.$delimiter, $value));
+        }
+
+        return static::$snakeCache[$key][$delimiter] = $value;
+    }
+
+    /**
+     * Determine if a given string starts with a given substring.
+     *
+     * @param  string  $haystack
+     * @param  string|array  $needles
+     * @return bool
+     */
+    public static function startsWith($haystack, $needles)
+    {
+        foreach ((array) $needles as $needle) {
+            if ($needle != '' && substr($haystack, 0, strlen($needle)) === (string) $needle) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     /**
      * Convert a value to studly caps case.
      *
      * @param  string  $value
      * @return string
      */
-    function studly_case($value)
+    public static function studly($value)
     {
-        return Str::studly($value);
-    }
-}
+        $key = $value;
 
-if (! function_exists('tap')) {
-    /**
-     * Call the given Closure with the given value then return the value.
-     *
-     * @param  mixed  $value
-     * @param  callable|null  $callback
-     * @return mixed
-     */
-    function tap($value, $callback = null)
-    {
-        if (is_null($callback)) {
-            return new HigherOrderTapProxy($value);
+        if (isset(static::$studlyCache[$key])) {
+            return static::$studlyCache[$key];
         }
 
-        $callback($value);
+        $value = ucwords(str_replace(['-', '_'], ' ', $value));
 
-        return $value;
+        return static::$studlyCache[$key] = str_replace(' ', '', $value);
     }
-}
 
-if (! function_exists('title_case')) {
     /**
-     * Convert a value to title case.
+     * Returns the portion of string specified by the start and length parameters.
      *
-     * @param  string  $value
+     * @param  string  $string
+     * @param  int  $start
+     * @param  int|null  $length
      * @return string
      */
-    function title_case($value)
+    public static function substr($string, $start, $length = null)
     {
-        return Str::title($value);
+        return mb_substr($string, $start, $length, 'UTF-8');
     }
-}
 
-if (! function_exists('trait_uses_recursive')) {
     /**
-     * Returns all traits used by a trait and its traits.
+     * Make a string's first character uppercase.
      *
-     * @param  string  $trait
+     * @param  string  $string
+     * @return string
+     */
+    public static function ucfirst($string)
+    {
+        return static::upper(static::substr($string, 0, 1)).static::substr($string, 1);
+    }
+
+    /**
+     * Returns the replacements for the ascii method.
+     *
+     * Note: Adapted from Stringy\Stringy.
+     *
+     * @see https://github.com/danielstjules/Stringy/blob/2.3.1/LICENSE.txt
+     *
      * @return array
      */
-    function trait_uses_recursive($trait)
+    protected static function charsArray()
     {
-        $traits = class_uses($trait);
+        static $charsArray;
 
-        foreach ($traits as $trait) {
-            $traits += trait_uses_recursive($trait);
+        if (isset($charsArray)) {
+            return $charsArray;
         }
 
-        return $traits;
-    }
-}
-
-if (! function_exists('value')) {
-    /**
-     * Return the default value of the given value.
-     *
-     * @param  mixed  $value
-     * @return mixed
-     */
-    function value($value)
-    {
-        return $value instanceof Closure ? $value() : $value;
-    }
-}
-
-if (! function_exists('windows_os')) {
-    /**
-     * Determine whether the current environment is Windows based.
-     *
-     * @return bool
-     */
-    function windows_os()
-    {
-        return strtolower(substr(PHP_OS, 0, 3)) === 'win';
-    }
-}
-
-if (! function_exists('with')) {
-    /**
-     * Return the given object. Useful for chaining.
-     *
-     * @param  mixed  $object
-     * @return mixed
-     */
-    function with($object)
-    {
-        return $object;
+        return $charsArray = [
+            '0'    => ['°', '₀', '۰'],
+            '1'    => ['¹', '₁', '۱'],
+            '2'    => ['²', '₂', '۲'],
+            '3'    => ['³', '₃', '۳'],
+            '4'    => ['⁴', '₄', '۴', '٤'],
+            '5'    => ['⁵', '₅', '۵', '٥'],
+            '6'    => ['⁶', '₆', '۶', '٦'],
+            '7'    => ['⁷', '₇', '۷'],
+            '8'    => ['⁸', '₈', '۸'],
+            '9'    => ['⁹', '₉', '۹'],
+            'a'    => ['à', 'á', 'ả', 'ã', 'ạ', 'ă', 'ắ', 'ằ', 'ẳ', 'ẵ', 'ặ', 'â', 'ấ', 'ầ', 'ẩ', 'ẫ', 'ậ', 'ā', 'ą', 'å', 'α', 'ά', 'ἀ', 'ἁ', 'ἂ', 'ἃ', 'ἄ', 'ἅ', 'ἆ', 'ἇ', 'ᾀ', 'ᾁ', 'ᾂ', 'ᾃ', 'ᾄ', 'ᾅ', 'ᾆ', 'ᾇ', 'ὰ', 'ά', 'ᾰ', 'ᾱ', 'ᾲ', 'ᾳ', 'ᾴ', 'ᾶ', 'ᾷ', 'а', 'أ', 'အ', 'ာ', 'ါ', 'ǻ', 'ǎ', 'ª', 'ა', 'अ', 'ا'],
+            'b'    => ['б', 'β', 'Ъ', 'Ь', 'ب', 'ဗ', 'ბ'],
+            'c'    => ['ç', 'ć', 'č', 'ĉ', 'ċ'],
+            'd'    => ['ď', 'ð', 'đ', 'ƌ', 'ȡ', 'ɖ', 'ɗ', 'ᵭ', 'ᶁ', 'ᶑ', 'д', 'δ', 'د', 'ض', 'ဍ', 'ဒ', 'დ'],
+            'e'    => ['é', 'è', 'ẻ', 'ẽ', 'ẹ', 'ê', 'ế', 'ề', 'ể', 'ễ', 'ệ', 'ë', 'ē', 'ę', 'ě', 'ĕ', 'ė', 'ε', 'έ', 'ἐ', 'ἑ', 'ἒ', 'ἓ', 'ἔ', 'ἕ', 'ὲ', 'έ', 'е', 'ё', 'э', 'є', 'ə', 'ဧ', 'ေ', 'ဲ', 'ე', 'ए', 'إ', 'ئ'],
+            'f'    => ['ф', 'φ', 'ف', 'ƒ', 'ფ'],
+            'g'    => ['ĝ', 'ğ', 'ġ', 'ģ', 'г', 'ґ', 'γ', 'ဂ', 'გ', 'گ'],
+            'h'    => ['ĥ', 'ħ', 'η', 'ή', 'ح', 'ه', 'ဟ', 'ှ', 'ჰ'],
+            'i'    => ['í', 'ì', 'ỉ', 'ĩ', 'ị', 'î', 'ï', 'ī', 'ĭ', 'į', 'ı', 'ι', 'ί', 'ϊ', 'ΐ', 'ἰ', 'ἱ', 'ἲ', 'ἳ', 'ἴ', 'ἵ', 'ἶ', 'ἷ', 'ὶ', 'ί', 'ῐ', 'ῑ', 'ῒ', 'ΐ', 'ῖ', 'ῗ', 'і', 'ї', 'и', 'ဣ', 'ိ', 'ီ', 'ည်', 'ǐ', 'ი', 'इ'],
+            'j'    => ['ĵ', 'ј', 'Ј', 'ჯ', 'ج'],
+            'k'    => ['ķ', 'ĸ', 'к', 'κ', 'Ķ', 'ق', 'ك', 'က', 'კ', 'ქ', 'ک'],
+            'l'    => ['ł', 'ľ', 'ĺ', 'ļ', 'ŀ', 'л', 'λ', 'ل', 'လ', 'ლ'],
+            'm'    => ['м', 'μ', 'م', 'မ', 'მ'],
+            'n'    => ['ñ', 'ń', 'ň', 'ņ', 'ŉ', 'ŋ', 'ν', 'н', 'ن', 'န', 'ნ'],
+            'o'    => ['ó', 'ò', 'ỏ', 'õ', 'ọ', 'ô', 'ố', 'ồ', 'ổ', 'ỗ', 'ộ', 'ơ', 'ớ', 'ờ', 'ở', 'ỡ', 'ợ', 'ø', 'ō', 'ő', 'ŏ', 'ο', 'ὀ', 'ὁ', 'ὂ', 'ὃ', 'ὄ', 'ὅ', 'ὸ', 'ό', 'о', 'و', 'θ', 'ို', 'ǒ', 'ǿ', 'º', 'ო', 'ओ'],
+            'p'    => ['п', 'π', 'ပ', 'პ', 'پ'],
+            'q'    => ['ყ'],
+            'r'    => ['ŕ', 'ř', 'ŗ', 'р', 'ρ', 'ر', 'რ'],
+            's'    => ['ś', 'š', 'ş', 'с', 'σ', 'ș', 'ς', 'س', 'ص', 'စ', 'ſ', 'ს'],
+            't'    => ['ť', 'ţ', 'т', 'τ', 'ț', 'ت', 'ط', 'ဋ', 'တ', 'ŧ', 'თ', 'ტ'],
+            'u'    => ['ú', 'ù', 'ủ', 'ũ', 'ụ', 'ư', 'ứ', 'ừ', 'ử', 'ữ', 'ự', 'û', 'ū', 'ů', 'ű', 'ŭ', 'ų', 'µ', 'у', 'ဉ', 'ု', 'ူ', 'ǔ', 'ǖ', 'ǘ', 'ǚ', 'ǜ', 'უ', 'उ'],
+            'v'    => ['в', 'ვ', 'ϐ'],
+            'w'    => ['ŵ', 'ω', 'ώ', 'ဝ', 'ွ'],
+            'x'    => ['χ', 'ξ'],
+            'y'    => ['ý', 'ỳ', 'ỷ', 'ỹ', 'ỵ', 'ÿ', 'ŷ', 'й', 'ы', 'υ', 'ϋ', 'ύ', 'ΰ', 'ي', 'ယ'],
+            'z'    => ['ź', 'ž', 'ż', 'з', 'ζ', 'ز', 'ဇ', 'ზ'],
+            'aa'   => ['ع', 'आ', 'آ'],
+            'ae'   => ['ä', 'æ', 'ǽ'],
+            'ai'   => ['ऐ'],
+            'at'   => ['@'],
+            'ch'   => ['ч', 'ჩ', 'ჭ', 'چ'],
+            'dj'   => ['ђ', 'đ'],
+            'dz'   => ['џ', 'ძ'],
+            'ei'   => ['ऍ'],
+            'gh'   => ['غ', 'ღ'],
+            'ii'   => ['ई'],
+            'ij'   => ['ĳ'],
+            'kh'   => ['х', 'خ', 'ხ'],
+            'lj'   => ['љ'],
+            'nj'   => ['њ'],
+            'oe'   => ['ö', 'œ', 'ؤ'],
+            'oi'   => ['ऑ'],
+            'oii'  => ['ऒ'],
+            'ps'   => ['ψ'],
+            'sh'   => ['ш', 'შ', 'ش'],
+            'shch' => ['щ'],
+            'ss'   => ['ß'],
+            'sx'   => ['ŝ'],
+            'th'   => ['þ', 'ϑ', 'ث', 'ذ', 'ظ'],
+            'ts'   => ['ц', 'ც', 'წ'],
+            'ue'   => ['ü'],
+            'uu'   => ['ऊ'],
+            'ya'   => ['я'],
+            'yu'   => ['ю'],
+            'zh'   => ['ж', 'ჟ', 'ژ'],
+            '(c)'  => ['©'],
+            'A'    => ['Á', 'À', 'Ả', 'Ã', 'Ạ', 'Ă', 'Ắ', 'Ằ', 'Ẳ', 'Ẵ', 'Ặ', 'Â', 'Ấ', 'Ầ', 'Ẩ', 'Ẫ', 'Ậ', 'Å', 'Ā', 'Ą', 'Α', 'Ά', 'Ἀ', 'Ἁ', 'Ἂ', 'Ἃ', 'Ἄ', 'Ἅ', 'Ἆ', 'Ἇ', 'ᾈ', 'ᾉ', 'ᾊ', 'ᾋ', 'ᾌ', 'ᾍ', 'ᾎ', 'ᾏ', 'Ᾰ', 'Ᾱ', 'Ὰ', 'Ά', 'ᾼ', 'А', 'Ǻ', 'Ǎ'],
+            'B'    => ['Б', 'Β', 'ब'],
+            'C'    => ['Ç', 'Ć', 'Č', 'Ĉ', 'Ċ'],
+            'D'    => ['Ď', 'Ð', 'Đ', 'Ɖ', 'Ɗ', 'Ƌ', 'ᴅ', 'ᴆ', 'Д', 'Δ'],
+            'E'    => ['É', 'È', 'Ẻ', 'Ẽ', 'Ẹ', 'Ê', 'Ế', 'Ề', 'Ể', 'Ễ', 'Ệ', 'Ë', 'Ē', 'Ę', 'Ě', 'Ĕ', 'Ė', 'Ε', 'Έ', 'Ἐ', 'Ἑ', 'Ἒ', 'Ἓ', 'Ἔ', 'Ἕ', 'Έ', 'Ὲ', 'Е', 'Ё', 'Э', 'Є', 'Ə'],
+            'F'    => ['Ф', 'Φ'],
+            'G'    => ['Ğ', 'Ġ', 'Ģ', 'Г', 'Ґ', 'Γ'],
+            'H'    => ['Η', 'Ή', 'Ħ'],
+            'I'    => ['Í', 'Ì', 'Ỉ', 'Ĩ', 'Ị', 'Î', 'Ï', 'Ī', 'Ĭ', 'Į', 'İ', 'Ι', 'Ί', 'Ϊ', 'Ἰ', 'Ἱ', 'Ἳ', 'Ἴ', 'Ἵ', 'Ἶ', 'Ἷ', 'Ῐ', 'Ῑ', 'Ὶ', 'Ί', 'И', 'І', 'Ї', 'Ǐ', 'ϒ'],
+            'K'    => ['К', 'Κ'],
+            'L'    => ['Ĺ', 'Ł', 'Л', 'Λ', 'Ļ', 'Ľ', 'Ŀ', 'ल'],
+            'M'    => ['М', 'Μ'],
+            'N'    => ['Ń', 'Ñ', 'Ň', 'Ņ', 'Ŋ', 'Н', 'Ν'],
+            'O'    => ['Ó', 'Ò', 'Ỏ', 'Õ', 'Ọ', 'Ô', 'Ố', 'Ồ', 'Ổ', 'Ỗ', 'Ộ', 'Ơ', 'Ớ', 'Ờ', 'Ở', 'Ỡ', 'Ợ', 'Ø', 'Ō', 'Ő', 'Ŏ', 'Ο', 'Ό', 'Ὀ', 'Ὁ', 'Ὂ', 'Ὃ', 'Ὄ', 'Ὅ', 'Ὸ', 'Ό', 'О', 'Θ', 'Ө', 'Ǒ', 'Ǿ'],
+            'P'    => ['П', 'Π'],
+            'R'    => ['Ř', 'Ŕ', 'Р', 'Ρ', 'Ŗ'],
+            'S'    => ['Ş', 'Ŝ', 'Ș', 'Š', 'Ś', 'С', 'Σ'],
+            'T'    => ['Ť', 'Ţ', 'Ŧ', 'Ț', 'Т', 'Τ'],
+            'U'    => ['Ú', 'Ù', 'Ủ', 'Ũ', 'Ụ', 'Ư', 'Ứ', 'Ừ', 'Ử', 'Ữ', 'Ự', 'Û', 'Ū', 'Ů', 'Ű', 'Ŭ', 'Ų', 'У', 'Ǔ', 'Ǖ', 'Ǘ', 'Ǚ', 'Ǜ'],
+            'V'    => ['В'],
+            'W'    => ['Ω', 'Ώ', 'Ŵ'],
+            'X'    => ['Χ', 'Ξ'],
+            'Y'    => ['Ý', 'Ỳ', 'Ỷ', 'Ỹ', 'Ỵ', 'Ÿ', 'Ῠ', 'Ῡ', 'Ὺ', 'Ύ', 'Ы', 'Й', 'Υ', 'Ϋ', 'Ŷ'],
+            'Z'    => ['Ź', 'Ž', 'Ż', 'З', 'Ζ'],
+            'AE'   => ['Ä', 'Æ', 'Ǽ'],
+            'CH'   => ['Ч'],
+            'DJ'   => ['Ђ'],
+            'DZ'   => ['Џ'],
+            'GX'   => ['Ĝ'],
+            'HX'   => ['Ĥ'],
+            'IJ'   => ['Ĳ'],
+            'JX'   => ['Ĵ'],
+            'KH'   => ['Х'],
+            'LJ'   => ['Љ'],
+            'NJ'   => ['Њ'],
+            'OE'   => ['Ö', 'Œ'],
+            'PS'   => ['Ψ'],
+            'SH'   => ['Ш'],
+            'SHCH' => ['Щ'],
+            'SS'   => ['ẞ'],
+            'TH'   => ['Þ'],
+            'TS'   => ['Ц'],
+            'UE'   => ['Ü'],
+            'YA'   => ['Я'],
+            'YU'   => ['Ю'],
+            'ZH'   => ['Ж'],
+            ' '    => ["\xC2\xA0", "\xE2\x80\x80", "\xE2\x80\x81", "\xE2\x80\x82", "\xE2\x80\x83", "\xE2\x80\x84", "\xE2\x80\x85", "\xE2\x80\x86", "\xE2\x80\x87", "\xE2\x80\x88", "\xE2\x80\x89", "\xE2\x80\x8A", "\xE2\x80\xAF", "\xE2\x81\x9F", "\xE3\x80\x80"],
+        ];
     }
 }

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -1,82 +1,540 @@
 <?php
 
-namespace Illuminate\Support;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Debug\Dumper;
+use Illuminate\Contracts\Support\Htmlable;
+use Illuminate\Support\HigherOrderTapProxy;
 
-use Illuminate\Support\Traits\Macroable;
-
-class Str
-{
-    use Macroable;
-
+if (! function_exists('append_config')) {
     /**
-     * The cache of snake-cased words.
+     * Assign high numeric IDs to a config item to force appending.
      *
-     * @var array
+     * @param  array  $array
+     * @return array
      */
-    protected static $snakeCache = [];
-
-    /**
-     * The cache of camel-cased words.
-     *
-     * @var array
-     */
-    protected static $camelCache = [];
-
-    /**
-     * The cache of studly-cased words.
-     *
-     * @var array
-     */
-    protected static $studlyCache = [];
-
-    /**
-     * Transliterate a UTF-8 value to ASCII.
-     *
-     * @param  string  $value
-     * @return string
-     */
-    public static function ascii($value)
+    function append_config(array $array)
     {
-        foreach (static::charsArray() as $key => $val) {
-            $value = str_replace($val, $key, $value);
+        $start = 9999;
+
+        foreach ($array as $key => $value) {
+            if (is_numeric($key)) {
+                $start++;
+
+                $array[$start] = Arr::pull($array, $key);
+            }
         }
 
-        return preg_replace('/[^\x20-\x7E]/u', '', $value);
+        return $array;
     }
+}
 
+if (! function_exists('array_add')) {
+    /**
+     * Add an element to an array using "dot" notation if it doesn't exist.
+     *
+     * @param  array   $array
+     * @param  string  $key
+     * @param  mixed   $value
+     * @return array
+     */
+    function array_add($array, $key, $value)
+    {
+        return Arr::add($array, $key, $value);
+    }
+}
+
+if (! function_exists('array_collapse')) {
+    /**
+     * Collapse an array of arrays into a single array.
+     *
+     * @param  array  $array
+     * @return array
+     */
+    function array_collapse($array)
+    {
+        return Arr::collapse($array);
+    }
+}
+
+if (! function_exists('array_divide')) {
+    /**
+     * Divide an array into two arrays. One with keys and the other with values.
+     *
+     * @param  array  $array
+     * @return array
+     */
+    function array_divide($array)
+    {
+        return Arr::divide($array);
+    }
+}
+
+if (! function_exists('array_dot')) {
+    /**
+     * Flatten a multi-dimensional associative array with dots.
+     *
+     * @param  array   $array
+     * @param  string  $prepend
+     * @return array
+     */
+    function array_dot($array, $prepend = '')
+    {
+        return Arr::dot($array, $prepend);
+    }
+}
+
+if (! function_exists('array_except')) {
+    /**
+     * Get all of the given array except for a specified array of items.
+     *
+     * @param  array  $array
+     * @param  array|string  $keys
+     * @return array
+     */
+    function array_except($array, $keys)
+    {
+        return Arr::except($array, $keys);
+    }
+}
+
+if (! function_exists('array_first')) {
+    /**
+     * Return the first element in an array passing a given truth test.
+     *
+     * @param  array  $array
+     * @param  callable|null  $callback
+     * @param  mixed  $default
+     * @return mixed
+     */
+    function array_first($array, callable $callback = null, $default = null)
+    {
+        return Arr::first($array, $callback, $default);
+    }
+}
+
+if (! function_exists('array_flatten')) {
+    /**
+     * Flatten a multi-dimensional array into a single level.
+     *
+     * @param  array  $array
+     * @param  int  $depth
+     * @return array
+     */
+    function array_flatten($array, $depth = INF)
+    {
+        return Arr::flatten($array, $depth);
+    }
+}
+
+if (! function_exists('array_forget')) {
+    /**
+     * Remove one or many array items from a given array using "dot" notation.
+     *
+     * @param  array  $array
+     * @param  array|string  $keys
+     * @return void
+     */
+    function array_forget(&$array, $keys)
+    {
+        return Arr::forget($array, $keys);
+    }
+}
+
+if (! function_exists('array_get')) {
+    /**
+     * Get an item from an array using "dot" notation.
+     *
+     * @param  \ArrayAccess|array  $array
+     * @param  string  $key
+     * @param  mixed   $default
+     * @return mixed
+     */
+    function array_get($array, $key, $default = null)
+    {
+        return Arr::get($array, $key, $default);
+    }
+}
+
+if (! function_exists('array_has')) {
+    /**
+     * Check if an item or items exist in an array using "dot" notation.
+     *
+     * @param  \ArrayAccess|array  $array
+     * @param  string|array  $keys
+     * @return bool
+     */
+    function array_has($array, $keys)
+    {
+        return Arr::has($array, $keys);
+    }
+}
+
+if (! function_exists('array_last')) {
+    /**
+     * Return the last element in an array passing a given truth test.
+     *
+     * @param  array  $array
+     * @param  callable|null  $callback
+     * @param  mixed  $default
+     * @return mixed
+     */
+    function array_last($array, callable $callback = null, $default = null)
+    {
+        return Arr::last($array, $callback, $default);
+    }
+}
+
+if (! function_exists('array_only')) {
+    /**
+     * Get a subset of the items from the given array.
+     *
+     * @param  array  $array
+     * @param  array|string  $keys
+     * @return array
+     */
+    function array_only($array, $keys)
+    {
+        return Arr::only($array, $keys);
+    }
+}
+
+if (! function_exists('array_pluck')) {
+    /**
+     * Pluck an array of values from an array.
+     *
+     * @param  array   $array
+     * @param  string|array  $value
+     * @param  string|array|null  $key
+     * @return array
+     */
+    function array_pluck($array, $value, $key = null)
+    {
+        return Arr::pluck($array, $value, $key);
+    }
+}
+
+if (! function_exists('array_prepend')) {
+    /**
+     * Push an item onto the beginning of an array.
+     *
+     * @param  array  $array
+     * @param  mixed  $value
+     * @param  mixed  $key
+     * @return array
+     */
+    function array_prepend($array, $value, $key = null)
+    {
+        return Arr::prepend($array, $value, $key);
+    }
+}
+
+if (! function_exists('array_pull')) {
+    /**
+     * Get a value from the array, and remove it.
+     *
+     * @param  array   $array
+     * @param  string  $key
+     * @param  mixed   $default
+     * @return mixed
+     */
+    function array_pull(&$array, $key, $default = null)
+    {
+        return Arr::pull($array, $key, $default);
+    }
+}
+
+if (! function_exists('array_set')) {
+    /**
+     * Set an array item to a given value using "dot" notation.
+     *
+     * If no key is given to the method, the entire array will be replaced.
+     *
+     * @param  array   $array
+     * @param  string  $key
+     * @param  mixed   $value
+     * @return array
+     */
+    function array_set(&$array, $key, $value)
+    {
+        return Arr::set($array, $key, $value);
+    }
+}
+
+if (! function_exists('array_sort')) {
+    /**
+     * Sort the array using the given callback.
+     *
+     * @param  array  $array
+     * @param  callable  $callback
+     * @return array
+     */
+    function array_sort($array, callable $callback)
+    {
+        return Arr::sort($array, $callback);
+    }
+}
+
+if (! function_exists('array_sort_recursive')) {
+    /**
+     * Recursively sort an array by keys and values.
+     *
+     * @param  array  $array
+     * @return array
+     */
+    function array_sort_recursive($array)
+    {
+        return Arr::sortRecursive($array);
+    }
+}
+
+if (! function_exists('array_where')) {
+    /**
+     * Filter the array using the given callback.
+     *
+     * @param  array  $array
+     * @param  callable  $callback
+     * @return array
+     */
+    function array_where($array, callable $callback)
+    {
+        return Arr::where($array, $callback);
+    }
+}
+
+if (! function_exists('array_wrap')) {
+    /**
+     * If the given value is not an array, wrap it in one.
+     *
+     * @param  mixed  $value
+     * @return array
+     */
+    function array_wrap($value)
+    {
+        return Arr::wrap($value);
+    }
+}
+
+if (! function_exists('camel_case')) {
     /**
      * Convert a value to camel case.
      *
      * @param  string  $value
      * @return string
      */
-    public static function camel($value)
+    function camel_case($value)
     {
-        if (isset(static::$camelCache[$value])) {
-            return static::$camelCache[$value];
+        return Str::camel($value);
+    }
+}
+
+if (! function_exists('class_basename')) {
+    /**
+     * Get the class "basename" of the given object / class.
+     *
+     * @param  string|object  $class
+     * @return string
+     */
+    function class_basename($class)
+    {
+        $class = is_object($class) ? get_class($class) : $class;
+
+        return basename(str_replace('\\', '/', $class));
+    }
+}
+
+if (! function_exists('class_uses_recursive')) {
+    /**
+     * Returns all traits used by a class, its subclasses and trait of their traits.
+     *
+     * @param  object|string  $class
+     * @return array
+     */
+    function class_uses_recursive($class)
+    {
+        if (is_object($class)) {
+            $class = get_class($class);
         }
 
-        return static::$camelCache[$value] = lcfirst(static::studly($value));
-    }
+        $results = [];
 
+        foreach (array_merge([$class => $class], class_parents($class)) as $class) {
+            $results += trait_uses_recursive($class);
+        }
+
+        return array_unique($results);
+    }
+}
+
+if (! function_exists('collect')) {
     /**
-     * Determine if a given string contains a given substring.
+     * Create a collection from the given value.
      *
-     * @param  string  $haystack
-     * @param  string|array  $needles
-     * @return bool
+     * @param  mixed  $value
+     * @return \Illuminate\Support\Collection
      */
-    public static function contains($haystack, $needles)
+    function collect($value = null)
     {
-        foreach ((array) $needles as $needle) {
-            if ($needle != '' && mb_strpos($haystack, $needle) !== false) {
-                return true;
+        return new Collection($value);
+    }
+}
+
+if (! function_exists('data_fill')) {
+    /**
+     * Fill in data where it's missing.
+     *
+     * @param  mixed   $target
+     * @param  string|array  $key
+     * @param  mixed  $value
+     * @return mixed
+     */
+    function data_fill(&$target, $key, $value)
+    {
+        return data_set($target, $key, $value, false);
+    }
+}
+
+if (! function_exists('data_get')) {
+    /**
+     * Get an item from an array or object using "dot" notation.
+     *
+     * @param  mixed   $target
+     * @param  string|array  $key
+     * @param  mixed   $default
+     * @return mixed
+     */
+    function data_get($target, $key, $default = null)
+    {
+        if (is_null($key)) {
+            return $target;
+        }
+
+        $key = is_array($key) ? $key : explode('.', $key);
+
+        while (! is_null($segment = array_shift($key))) {
+            if ($segment === '*') {
+                if ($target instanceof Collection) {
+                    $target = $target->all();
+                } elseif (! is_array($target)) {
+                    return value($default);
+                }
+
+                $result = Arr::pluck($target, $key);
+
+                return in_array('*', $key) ? Arr::collapse($result) : $result;
+            }
+
+            if (Arr::accessible($target) && Arr::exists($target, $segment)) {
+                $target = $target[$segment];
+            } elseif (is_object($target) && isset($target->{$segment})) {
+                $target = $target->{$segment};
+            } else {
+                return value($default);
             }
         }
 
-        return false;
+        return $target;
     }
+}
 
+if (! function_exists('data_set')) {
+    /**
+     * Set an item on an array or object using dot notation.
+     *
+     * @param  mixed  $target
+     * @param  string|array  $key
+     * @param  mixed  $value
+     * @param  bool  $overwrite
+     * @return mixed
+     */
+    function data_set(&$target, $key, $value, $overwrite = true)
+    {
+        $segments = is_array($key) ? $key : explode('.', $key);
+
+        if (($segment = array_shift($segments)) === '*') {
+            if (! Arr::accessible($target)) {
+                $target = [];
+            }
+
+            if ($segments) {
+                foreach ($target as &$inner) {
+                    data_set($inner, $segments, $value, $overwrite);
+                }
+            } elseif ($overwrite) {
+                foreach ($target as &$inner) {
+                    $inner = $value;
+                }
+            }
+        } elseif (Arr::accessible($target)) {
+            if ($segments) {
+                if (! Arr::exists($target, $segment)) {
+                    $target[$segment] = [];
+                }
+
+                data_set($target[$segment], $segments, $value, $overwrite);
+            } elseif ($overwrite || ! Arr::exists($target, $segment)) {
+                $target[$segment] = $value;
+            }
+        } elseif (is_object($target)) {
+            if ($segments) {
+                if (! isset($target->{$segment})) {
+                    $target->{$segment} = [];
+                }
+
+                data_set($target->{$segment}, $segments, $value, $overwrite);
+            } elseif ($overwrite || ! isset($target->{$segment})) {
+                $target->{$segment} = $value;
+            }
+        } else {
+            $target = [];
+
+            if ($segments) {
+                data_set($target[$segment], $segments, $value, $overwrite);
+            } elseif ($overwrite) {
+                $target[$segment] = $value;
+            }
+        }
+
+        return $target;
+    }
+}
+
+if (! function_exists('dd')) {
+    /**
+     * Dump the passed variables and end the script.
+     *
+     * @param  mixed
+     * @return void
+     */
+    function dd(...$args)
+    {
+        foreach ($args as $x) {
+            (new Dumper)->dump($x);
+        }
+
+        die(1);
+    }
+}
+
+if (! function_exists('e')) {
+    /**
+     * Escape HTML special characters in a string.
+     *
+     * @param  \Illuminate\Contracts\Support\Htmlable|string  $value
+     * @return string
+     */
+    function e($value)
+    {
+        if ($value instanceof Htmlable) {
+            return $value->toHtml();
+        }
+
+        return htmlspecialchars($value, ENT_QUOTES, 'UTF-8', false);
+    }
+}
+
+if (! function_exists('ends_with')) {
     /**
      * Determine if a given string ends with a given substring.
      *
@@ -84,17 +542,174 @@ class Str
      * @param  string|array  $needles
      * @return bool
      */
-    public static function endsWith($haystack, $needles)
+    function ends_with($haystack, $needles)
     {
-        foreach ((array) $needles as $needle) {
-            if (substr($haystack, -strlen($needle)) === (string) $needle) {
-                return true;
-            }
+        return Str::endsWith($haystack, $needles);
+    }
+}
+
+if (! function_exists('head')) {
+    /**
+     * Get the first element of an array. Useful for method chaining.
+     *
+     * @param  array  $array
+     * @return mixed
+     */
+    function head($array)
+    {
+        return reset($array);
+    }
+}
+
+if (! function_exists('kebab_case')) {
+    /**
+     * Convert a string to kebab case.
+     *
+     * @param  string  $value
+     * @return string
+     */
+    function kebab_case($value)
+    {
+        return Str::kebab($value);
+    }
+}
+
+if (! function_exists('last')) {
+    /**
+     * Get the last element from an array.
+     *
+     * @param  array  $array
+     * @return mixed
+     */
+    function last($array)
+    {
+        return end($array);
+    }
+}
+
+if (! function_exists('object_get')) {
+    /**
+     * Get an item from an object using "dot" notation.
+     *
+     * @param  object  $object
+     * @param  string  $key
+     * @param  mixed   $default
+     * @return mixed
+     */
+    function object_get($object, $key, $default = null)
+    {
+        if (is_null($key) || trim($key) == '') {
+            return $object;
         }
 
-        return false;
-    }
+        foreach (explode('.', $key) as $segment) {
+            if (! is_object($object) || ! isset($object->{$segment})) {
+                return value($default);
+            }
 
+            $object = $object->{$segment};
+        }
+
+        return $object;
+    }
+}
+
+if (! function_exists('preg_replace_array')) {
+    /**
+     * Replace a given pattern with each value in the array in sequentially.
+     *
+     * @param  string  $pattern
+     * @param  array   $replacements
+     * @param  string  $subject
+     * @return string
+     */
+    function preg_replace_array($pattern, array $replacements, $subject)
+    {
+        return preg_replace_callback($pattern, function () use (&$replacements) {
+            foreach ($replacements as $key => $value) {
+                return array_shift($replacements);
+            }
+        }, $subject);
+    }
+}
+
+if (! function_exists('retry')) {
+    /**
+     * Retry an operation a given number of times.
+     *
+     * @param  int  $times
+     * @param  callable  $callback
+     * @param  int  $sleep
+     * @return mixed
+     *
+     * @throws \Exception
+     */
+    function retry($times, callable $callback, $sleep = 0)
+    {
+        $times--;
+
+        beginning:
+        try {
+            return $callback();
+        } catch (Exception $e) {
+            if (! $times) {
+                throw $e;
+            }
+
+            $times--;
+
+            if ($sleep) {
+                usleep($sleep * 1000);
+            }
+
+            goto beginning;
+        }
+    }
+}
+
+if (! function_exists('snake_case')) {
+    /**
+     * Convert a string to snake case.
+     *
+     * @param  string  $value
+     * @param  string  $delimiter
+     * @return string
+     */
+    function snake_case($value, $delimiter = '_')
+    {
+        return Str::snake($value, $delimiter);
+    }
+}
+
+if (! function_exists('starts_with')) {
+    /**
+     * Determine if a given string starts with a given substring.
+     *
+     * @param  string  $haystack
+     * @param  string|array  $needles
+     * @return bool
+     */
+    function starts_with($haystack, $needles)
+    {
+        return Str::startsWith($haystack, $needles);
+    }
+}
+
+if (! function_exists('str_contains')) {
+    /**
+     * Determine if a given string contains a given substring.
+     *
+     * @param  string  $haystack
+     * @param  string|array  $needles
+     * @return bool
+     */
+    function str_contains($haystack, $needles)
+    {
+        return Str::contains($haystack, $needles);
+    }
+}
+
+if (! function_exists('str_finish')) {
     /**
      * Cap a string with a single instance of a given value.
      *
@@ -102,13 +717,13 @@ class Str
      * @param  string  $cap
      * @return string
      */
-    public static function finish($value, $cap)
+    function str_finish($value, $cap)
     {
-        $quoted = preg_quote($cap, '/');
-
-        return preg_replace('/(?:'.$quoted.')+$/u', '', $value).$cap;
+        return Str::finish($value, $cap);
     }
+}
 
+if (! function_exists('str_is')) {
     /**
      * Determine if a given string matches a given pattern.
      *
@@ -116,49 +731,13 @@ class Str
      * @param  string  $value
      * @return bool
      */
-    public static function is($pattern, $value)
+    function str_is($pattern, $value)
     {
-        if ($pattern == $value) {
-            return true;
-        }
-
-        $pattern = preg_quote($pattern, '#');
-
-        // Asterisks are translated into zero-or-more regular expression wildcards
-        // to make it convenient to check if the strings starts with the given
-        // pattern such as "library/*", making any string check convenient.
-        $pattern = str_replace('\*', '.*', $pattern);
-
-        return (bool) preg_match('#^'.$pattern.'\z#u', $value);
+        return Str::is($pattern, $value);
     }
+}
 
-    /**
-     * Convert a string to kebab case.
-     *
-     * @param  string  $value
-     * @return string
-     */
-    public static function kebab($value)
-    {
-        return static::snake($value, '-');
-    }
-
-    /**
-     * Return the length of the given string.
-     *
-     * @param  string  $value
-     * @param  string  $encoding
-     * @return int
-     */
-    public static function length($value, $encoding = null)
-    {
-        if ($encoding) {
-            return mb_strlen($value, $encoding);
-        }
-
-        return mb_strlen($value);
-    }
-
+if (! function_exists('str_limit')) {
     /**
      * Limit the number of characters in a string.
      *
@@ -167,113 +746,42 @@ class Str
      * @param  string  $end
      * @return string
      */
-    public static function limit($value, $limit = 100, $end = '...')
+    function str_limit($value, $limit = 100, $end = '...')
     {
-        if (mb_strwidth($value, 'UTF-8') <= $limit) {
-            return $value;
-        }
-
-        return rtrim(mb_strimwidth($value, 0, $limit, '', 'UTF-8')).$end;
+        return Str::limit($value, $limit, $end);
     }
+}
 
-    /**
-     * Convert the given string to lower-case.
-     *
-     * @param  string  $value
-     * @return string
-     */
-    public static function lower($value)
-    {
-        return mb_strtolower($value, 'UTF-8');
-    }
-
-    /**
-     * Limit the number of words in a string.
-     *
-     * @param  string  $value
-     * @param  int     $words
-     * @param  string  $end
-     * @return string
-     */
-    public static function words($value, $words = 100, $end = '...')
-    {
-        preg_match('/^\s*+(?:\S++\s*+){1,'.$words.'}/u', $value, $matches);
-
-        if (! isset($matches[0]) || static::length($value) === static::length($matches[0])) {
-            return $value;
-        }
-
-        return rtrim($matches[0]).$end;
-    }
-
-    /**
-     * Parse a Class@method style callback into class and method.
-     *
-     * @param  string  $callback
-     * @param  string|null  $default
-     * @return array
-     */
-    public static function parseCallback($callback, $default = null)
-    {
-        return static::contains($callback, '@') ? explode('@', $callback, 2) : [$callback, $default];
-    }
-
+if (! function_exists('str_plural')) {
     /**
      * Get the plural form of an English word.
      *
      * @param  string  $value
      * @param  int     $count
-     * @param  bool    $add_count
      * @return string
      */
-    public static function plural($value, $count = 2, $add_count = false)
+    function str_plural($value, $count = 2, $add_count = false)
     {
-        return ($add_count ? $count.' ' : '')
-            .Pluralizer::plural($value, $count);
+        return Str::plural($value, $count, $add_count);
     }
+}
 
+if (! function_exists('str_random')) {
     /**
      * Generate a more truly "random" alpha-numeric string.
      *
      * @param  int  $length
      * @return string
+     *
+     * @throws \RuntimeException
      */
-    public static function random($length = 16)
+    function str_random($length = 16)
     {
-        $string = '';
-
-        while (($len = strlen($string)) < $length) {
-            $size = $length - $len;
-
-            $bytes = random_bytes($size);
-
-            $string .= substr(str_replace(['/', '+', '='], '', base64_encode($bytes)), 0, $size);
-        }
-
-        return $string;
+        return Str::random($length);
     }
+}
 
-    /**
-     * Generate a "random" alpha-numeric string.
-     *
-     * Should not be considered sufficient for cryptography, etc.
-     *
-     * @deprecated since version 5.3. Use the "random" method directly.
-     *
-     * @param  int  $length
-     * @return string
-     */
-    public static function quickRandom($length = 16)
-    {
-        if (PHP_MAJOR_VERSION > 5) {
-            return static::random($length);
-        }
-
-        $pool = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
-
-        return substr(str_shuffle(str_repeat($pool, $length)), 0, $length);
-    }
-
+if (! function_exists('str_replace_array')) {
     /**
      * Replace a given value in the string sequentially with an array.
      *
@@ -282,15 +790,13 @@ class Str
      * @param  string  $subject
      * @return string
      */
-    public static function replaceArray($search, array $replace, $subject)
+    function str_replace_array($search, array $replace, $subject)
     {
-        foreach ($replace as $value) {
-            $subject = static::replaceFirst($search, $value, $subject);
-        }
-
-        return $subject;
+        return Str::replaceArray($search, $replace, $subject);
     }
+}
 
+if (! function_exists('str_replace_first')) {
     /**
      * Replace the first occurrence of a given value in the string.
      *
@@ -299,17 +805,13 @@ class Str
      * @param  string  $subject
      * @return string
      */
-    public static function replaceFirst($search, $replace, $subject)
+    function str_replace_first($search, $replace, $subject)
     {
-        $position = strpos($subject, $search);
-
-        if ($position !== false) {
-            return substr_replace($subject, $replace, $position, strlen($search));
-        }
-
-        return $subject;
+        return Str::replaceFirst($search, $replace, $subject);
     }
+}
 
+if (! function_exists('str_replace_last')) {
     /**
      * Replace the last occurrence of a given value in the string.
      *
@@ -318,50 +820,26 @@ class Str
      * @param  string  $subject
      * @return string
      */
-    public static function replaceLast($search, $replace, $subject)
+    function str_replace_last($search, $replace, $subject)
     {
-        $position = strrpos($subject, $search);
-
-        if ($position !== false) {
-            return substr_replace($subject, $replace, $position, strlen($search));
-        }
-
-        return $subject;
+        return Str::replaceLast($search, $replace, $subject);
     }
+}
 
-    /**
-     * Convert the given string to upper-case.
-     *
-     * @param  string  $value
-     * @return string
-     */
-    public static function upper($value)
-    {
-        return mb_strtoupper($value, 'UTF-8');
-    }
-
-    /**
-     * Convert the given string to title case.
-     *
-     * @param  string  $value
-     * @return string
-     */
-    public static function title($value)
-    {
-        return mb_convert_case($value, MB_CASE_TITLE, 'UTF-8');
-    }
-
+if (! function_exists('str_singular')) {
     /**
      * Get the singular form of an English word.
      *
      * @param  string  $value
      * @return string
      */
-    public static function singular($value)
+    function str_singular($value)
     {
-        return Pluralizer::singular($value);
+        return Str::singular($value);
     }
+}
 
+if (! function_exists('str_slug')) {
     /**
      * Generate a URL friendly "slug" from a given string.
      *
@@ -369,240 +847,111 @@ class Str
      * @param  string  $separator
      * @return string
      */
-    public static function slug($title, $separator = '-')
+    function str_slug($title, $separator = '-')
     {
-        $title = static::ascii($title);
-
-        // Convert all dashes/underscores into separator
-        $flip = $separator == '-' ? '_' : '-';
-
-        $title = preg_replace('!['.preg_quote($flip).']+!u', $separator, $title);
-
-        // Remove all characters that are not the separator, letters, numbers, or whitespace.
-        $title = preg_replace('![^'.preg_quote($separator).'\pL\pN\s]+!u', '', mb_strtolower($title));
-
-        // Replace all separator characters and whitespace by a single separator
-        $title = preg_replace('!['.preg_quote($separator).'\s]+!u', $separator, $title);
-
-        return trim($title, $separator);
+        return Str::slug($title, $separator);
     }
+}
 
-    /**
-     * Convert a string to snake case.
-     *
-     * @param  string  $value
-     * @param  string  $delimiter
-     * @return string
-     */
-    public static function snake($value, $delimiter = '_')
-    {
-        $key = $value;
-
-        if (isset(static::$snakeCache[$key][$delimiter])) {
-            return static::$snakeCache[$key][$delimiter];
-        }
-
-        if (! ctype_lower($value)) {
-            $value = preg_replace('/\s+/u', '', $value);
-
-            $value = static::lower(preg_replace('/(.)(?=[A-Z])/u', '$1'.$delimiter, $value));
-        }
-
-        return static::$snakeCache[$key][$delimiter] = $value;
-    }
-
-    /**
-     * Determine if a given string starts with a given substring.
-     *
-     * @param  string  $haystack
-     * @param  string|array  $needles
-     * @return bool
-     */
-    public static function startsWith($haystack, $needles)
-    {
-        foreach ((array) $needles as $needle) {
-            if ($needle != '' && substr($haystack, 0, strlen($needle)) === (string) $needle) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
+if (! function_exists('studly_case')) {
     /**
      * Convert a value to studly caps case.
      *
      * @param  string  $value
      * @return string
      */
-    public static function studly($value)
+    function studly_case($value)
     {
-        $key = $value;
+        return Str::studly($value);
+    }
+}
 
-        if (isset(static::$studlyCache[$key])) {
-            return static::$studlyCache[$key];
+if (! function_exists('tap')) {
+    /**
+     * Call the given Closure with the given value then return the value.
+     *
+     * @param  mixed  $value
+     * @param  callable|null  $callback
+     * @return mixed
+     */
+    function tap($value, $callback = null)
+    {
+        if (is_null($callback)) {
+            return new HigherOrderTapProxy($value);
         }
 
-        $value = ucwords(str_replace(['-', '_'], ' ', $value));
+        $callback($value);
 
-        return static::$studlyCache[$key] = str_replace(' ', '', $value);
+        return $value;
     }
+}
 
+if (! function_exists('title_case')) {
     /**
-     * Returns the portion of string specified by the start and length parameters.
+     * Convert a value to title case.
      *
-     * @param  string  $string
-     * @param  int  $start
-     * @param  int|null  $length
+     * @param  string  $value
      * @return string
      */
-    public static function substr($string, $start, $length = null)
+    function title_case($value)
     {
-        return mb_substr($string, $start, $length, 'UTF-8');
+        return Str::title($value);
     }
+}
 
+if (! function_exists('trait_uses_recursive')) {
     /**
-     * Make a string's first character uppercase.
+     * Returns all traits used by a trait and its traits.
      *
-     * @param  string  $string
-     * @return string
-     */
-    public static function ucfirst($string)
-    {
-        return static::upper(static::substr($string, 0, 1)).static::substr($string, 1);
-    }
-
-    /**
-     * Returns the replacements for the ascii method.
-     *
-     * Note: Adapted from Stringy\Stringy.
-     *
-     * @see https://github.com/danielstjules/Stringy/blob/2.3.1/LICENSE.txt
-     *
+     * @param  string  $trait
      * @return array
      */
-    protected static function charsArray()
+    function trait_uses_recursive($trait)
     {
-        static $charsArray;
+        $traits = class_uses($trait);
 
-        if (isset($charsArray)) {
-            return $charsArray;
+        foreach ($traits as $trait) {
+            $traits += trait_uses_recursive($trait);
         }
 
-        return $charsArray = [
-            '0'    => ['°', '₀', '۰'],
-            '1'    => ['¹', '₁', '۱'],
-            '2'    => ['²', '₂', '۲'],
-            '3'    => ['³', '₃', '۳'],
-            '4'    => ['⁴', '₄', '۴', '٤'],
-            '5'    => ['⁵', '₅', '۵', '٥'],
-            '6'    => ['⁶', '₆', '۶', '٦'],
-            '7'    => ['⁷', '₇', '۷'],
-            '8'    => ['⁸', '₈', '۸'],
-            '9'    => ['⁹', '₉', '۹'],
-            'a'    => ['à', 'á', 'ả', 'ã', 'ạ', 'ă', 'ắ', 'ằ', 'ẳ', 'ẵ', 'ặ', 'â', 'ấ', 'ầ', 'ẩ', 'ẫ', 'ậ', 'ā', 'ą', 'å', 'α', 'ά', 'ἀ', 'ἁ', 'ἂ', 'ἃ', 'ἄ', 'ἅ', 'ἆ', 'ἇ', 'ᾀ', 'ᾁ', 'ᾂ', 'ᾃ', 'ᾄ', 'ᾅ', 'ᾆ', 'ᾇ', 'ὰ', 'ά', 'ᾰ', 'ᾱ', 'ᾲ', 'ᾳ', 'ᾴ', 'ᾶ', 'ᾷ', 'а', 'أ', 'အ', 'ာ', 'ါ', 'ǻ', 'ǎ', 'ª', 'ა', 'अ', 'ا'],
-            'b'    => ['б', 'β', 'Ъ', 'Ь', 'ب', 'ဗ', 'ბ'],
-            'c'    => ['ç', 'ć', 'č', 'ĉ', 'ċ'],
-            'd'    => ['ď', 'ð', 'đ', 'ƌ', 'ȡ', 'ɖ', 'ɗ', 'ᵭ', 'ᶁ', 'ᶑ', 'д', 'δ', 'د', 'ض', 'ဍ', 'ဒ', 'დ'],
-            'e'    => ['é', 'è', 'ẻ', 'ẽ', 'ẹ', 'ê', 'ế', 'ề', 'ể', 'ễ', 'ệ', 'ë', 'ē', 'ę', 'ě', 'ĕ', 'ė', 'ε', 'έ', 'ἐ', 'ἑ', 'ἒ', 'ἓ', 'ἔ', 'ἕ', 'ὲ', 'έ', 'е', 'ё', 'э', 'є', 'ə', 'ဧ', 'ေ', 'ဲ', 'ე', 'ए', 'إ', 'ئ'],
-            'f'    => ['ф', 'φ', 'ف', 'ƒ', 'ფ'],
-            'g'    => ['ĝ', 'ğ', 'ġ', 'ģ', 'г', 'ґ', 'γ', 'ဂ', 'გ', 'گ'],
-            'h'    => ['ĥ', 'ħ', 'η', 'ή', 'ح', 'ه', 'ဟ', 'ှ', 'ჰ'],
-            'i'    => ['í', 'ì', 'ỉ', 'ĩ', 'ị', 'î', 'ï', 'ī', 'ĭ', 'į', 'ı', 'ι', 'ί', 'ϊ', 'ΐ', 'ἰ', 'ἱ', 'ἲ', 'ἳ', 'ἴ', 'ἵ', 'ἶ', 'ἷ', 'ὶ', 'ί', 'ῐ', 'ῑ', 'ῒ', 'ΐ', 'ῖ', 'ῗ', 'і', 'ї', 'и', 'ဣ', 'ိ', 'ီ', 'ည်', 'ǐ', 'ი', 'इ'],
-            'j'    => ['ĵ', 'ј', 'Ј', 'ჯ', 'ج'],
-            'k'    => ['ķ', 'ĸ', 'к', 'κ', 'Ķ', 'ق', 'ك', 'က', 'კ', 'ქ', 'ک'],
-            'l'    => ['ł', 'ľ', 'ĺ', 'ļ', 'ŀ', 'л', 'λ', 'ل', 'လ', 'ლ'],
-            'm'    => ['м', 'μ', 'م', 'မ', 'მ'],
-            'n'    => ['ñ', 'ń', 'ň', 'ņ', 'ŉ', 'ŋ', 'ν', 'н', 'ن', 'န', 'ნ'],
-            'o'    => ['ó', 'ò', 'ỏ', 'õ', 'ọ', 'ô', 'ố', 'ồ', 'ổ', 'ỗ', 'ộ', 'ơ', 'ớ', 'ờ', 'ở', 'ỡ', 'ợ', 'ø', 'ō', 'ő', 'ŏ', 'ο', 'ὀ', 'ὁ', 'ὂ', 'ὃ', 'ὄ', 'ὅ', 'ὸ', 'ό', 'о', 'و', 'θ', 'ို', 'ǒ', 'ǿ', 'º', 'ო', 'ओ'],
-            'p'    => ['п', 'π', 'ပ', 'პ', 'پ'],
-            'q'    => ['ყ'],
-            'r'    => ['ŕ', 'ř', 'ŗ', 'р', 'ρ', 'ر', 'რ'],
-            's'    => ['ś', 'š', 'ş', 'с', 'σ', 'ș', 'ς', 'س', 'ص', 'စ', 'ſ', 'ს'],
-            't'    => ['ť', 'ţ', 'т', 'τ', 'ț', 'ت', 'ط', 'ဋ', 'တ', 'ŧ', 'თ', 'ტ'],
-            'u'    => ['ú', 'ù', 'ủ', 'ũ', 'ụ', 'ư', 'ứ', 'ừ', 'ử', 'ữ', 'ự', 'û', 'ū', 'ů', 'ű', 'ŭ', 'ų', 'µ', 'у', 'ဉ', 'ု', 'ူ', 'ǔ', 'ǖ', 'ǘ', 'ǚ', 'ǜ', 'უ', 'उ'],
-            'v'    => ['в', 'ვ', 'ϐ'],
-            'w'    => ['ŵ', 'ω', 'ώ', 'ဝ', 'ွ'],
-            'x'    => ['χ', 'ξ'],
-            'y'    => ['ý', 'ỳ', 'ỷ', 'ỹ', 'ỵ', 'ÿ', 'ŷ', 'й', 'ы', 'υ', 'ϋ', 'ύ', 'ΰ', 'ي', 'ယ'],
-            'z'    => ['ź', 'ž', 'ż', 'з', 'ζ', 'ز', 'ဇ', 'ზ'],
-            'aa'   => ['ع', 'आ', 'آ'],
-            'ae'   => ['ä', 'æ', 'ǽ'],
-            'ai'   => ['ऐ'],
-            'at'   => ['@'],
-            'ch'   => ['ч', 'ჩ', 'ჭ', 'چ'],
-            'dj'   => ['ђ', 'đ'],
-            'dz'   => ['џ', 'ძ'],
-            'ei'   => ['ऍ'],
-            'gh'   => ['غ', 'ღ'],
-            'ii'   => ['ई'],
-            'ij'   => ['ĳ'],
-            'kh'   => ['х', 'خ', 'ხ'],
-            'lj'   => ['љ'],
-            'nj'   => ['њ'],
-            'oe'   => ['ö', 'œ', 'ؤ'],
-            'oi'   => ['ऑ'],
-            'oii'  => ['ऒ'],
-            'ps'   => ['ψ'],
-            'sh'   => ['ш', 'შ', 'ش'],
-            'shch' => ['щ'],
-            'ss'   => ['ß'],
-            'sx'   => ['ŝ'],
-            'th'   => ['þ', 'ϑ', 'ث', 'ذ', 'ظ'],
-            'ts'   => ['ц', 'ც', 'წ'],
-            'ue'   => ['ü'],
-            'uu'   => ['ऊ'],
-            'ya'   => ['я'],
-            'yu'   => ['ю'],
-            'zh'   => ['ж', 'ჟ', 'ژ'],
-            '(c)'  => ['©'],
-            'A'    => ['Á', 'À', 'Ả', 'Ã', 'Ạ', 'Ă', 'Ắ', 'Ằ', 'Ẳ', 'Ẵ', 'Ặ', 'Â', 'Ấ', 'Ầ', 'Ẩ', 'Ẫ', 'Ậ', 'Å', 'Ā', 'Ą', 'Α', 'Ά', 'Ἀ', 'Ἁ', 'Ἂ', 'Ἃ', 'Ἄ', 'Ἅ', 'Ἆ', 'Ἇ', 'ᾈ', 'ᾉ', 'ᾊ', 'ᾋ', 'ᾌ', 'ᾍ', 'ᾎ', 'ᾏ', 'Ᾰ', 'Ᾱ', 'Ὰ', 'Ά', 'ᾼ', 'А', 'Ǻ', 'Ǎ'],
-            'B'    => ['Б', 'Β', 'ब'],
-            'C'    => ['Ç', 'Ć', 'Č', 'Ĉ', 'Ċ'],
-            'D'    => ['Ď', 'Ð', 'Đ', 'Ɖ', 'Ɗ', 'Ƌ', 'ᴅ', 'ᴆ', 'Д', 'Δ'],
-            'E'    => ['É', 'È', 'Ẻ', 'Ẽ', 'Ẹ', 'Ê', 'Ế', 'Ề', 'Ể', 'Ễ', 'Ệ', 'Ë', 'Ē', 'Ę', 'Ě', 'Ĕ', 'Ė', 'Ε', 'Έ', 'Ἐ', 'Ἑ', 'Ἒ', 'Ἓ', 'Ἔ', 'Ἕ', 'Έ', 'Ὲ', 'Е', 'Ё', 'Э', 'Є', 'Ə'],
-            'F'    => ['Ф', 'Φ'],
-            'G'    => ['Ğ', 'Ġ', 'Ģ', 'Г', 'Ґ', 'Γ'],
-            'H'    => ['Η', 'Ή', 'Ħ'],
-            'I'    => ['Í', 'Ì', 'Ỉ', 'Ĩ', 'Ị', 'Î', 'Ï', 'Ī', 'Ĭ', 'Į', 'İ', 'Ι', 'Ί', 'Ϊ', 'Ἰ', 'Ἱ', 'Ἳ', 'Ἴ', 'Ἵ', 'Ἶ', 'Ἷ', 'Ῐ', 'Ῑ', 'Ὶ', 'Ί', 'И', 'І', 'Ї', 'Ǐ', 'ϒ'],
-            'K'    => ['К', 'Κ'],
-            'L'    => ['Ĺ', 'Ł', 'Л', 'Λ', 'Ļ', 'Ľ', 'Ŀ', 'ल'],
-            'M'    => ['М', 'Μ'],
-            'N'    => ['Ń', 'Ñ', 'Ň', 'Ņ', 'Ŋ', 'Н', 'Ν'],
-            'O'    => ['Ó', 'Ò', 'Ỏ', 'Õ', 'Ọ', 'Ô', 'Ố', 'Ồ', 'Ổ', 'Ỗ', 'Ộ', 'Ơ', 'Ớ', 'Ờ', 'Ở', 'Ỡ', 'Ợ', 'Ø', 'Ō', 'Ő', 'Ŏ', 'Ο', 'Ό', 'Ὀ', 'Ὁ', 'Ὂ', 'Ὃ', 'Ὄ', 'Ὅ', 'Ὸ', 'Ό', 'О', 'Θ', 'Ө', 'Ǒ', 'Ǿ'],
-            'P'    => ['П', 'Π'],
-            'R'    => ['Ř', 'Ŕ', 'Р', 'Ρ', 'Ŗ'],
-            'S'    => ['Ş', 'Ŝ', 'Ș', 'Š', 'Ś', 'С', 'Σ'],
-            'T'    => ['Ť', 'Ţ', 'Ŧ', 'Ț', 'Т', 'Τ'],
-            'U'    => ['Ú', 'Ù', 'Ủ', 'Ũ', 'Ụ', 'Ư', 'Ứ', 'Ừ', 'Ử', 'Ữ', 'Ự', 'Û', 'Ū', 'Ů', 'Ű', 'Ŭ', 'Ų', 'У', 'Ǔ', 'Ǖ', 'Ǘ', 'Ǚ', 'Ǜ'],
-            'V'    => ['В'],
-            'W'    => ['Ω', 'Ώ', 'Ŵ'],
-            'X'    => ['Χ', 'Ξ'],
-            'Y'    => ['Ý', 'Ỳ', 'Ỷ', 'Ỹ', 'Ỵ', 'Ÿ', 'Ῠ', 'Ῡ', 'Ὺ', 'Ύ', 'Ы', 'Й', 'Υ', 'Ϋ', 'Ŷ'],
-            'Z'    => ['Ź', 'Ž', 'Ż', 'З', 'Ζ'],
-            'AE'   => ['Ä', 'Æ', 'Ǽ'],
-            'CH'   => ['Ч'],
-            'DJ'   => ['Ђ'],
-            'DZ'   => ['Џ'],
-            'GX'   => ['Ĝ'],
-            'HX'   => ['Ĥ'],
-            'IJ'   => ['Ĳ'],
-            'JX'   => ['Ĵ'],
-            'KH'   => ['Х'],
-            'LJ'   => ['Љ'],
-            'NJ'   => ['Њ'],
-            'OE'   => ['Ö', 'Œ'],
-            'PS'   => ['Ψ'],
-            'SH'   => ['Ш'],
-            'SHCH' => ['Щ'],
-            'SS'   => ['ẞ'],
-            'TH'   => ['Þ'],
-            'TS'   => ['Ц'],
-            'UE'   => ['Ü'],
-            'YA'   => ['Я'],
-            'YU'   => ['Ю'],
-            'ZH'   => ['Ж'],
-            ' '    => ["\xC2\xA0", "\xE2\x80\x80", "\xE2\x80\x81", "\xE2\x80\x82", "\xE2\x80\x83", "\xE2\x80\x84", "\xE2\x80\x85", "\xE2\x80\x86", "\xE2\x80\x87", "\xE2\x80\x88", "\xE2\x80\x89", "\xE2\x80\x8A", "\xE2\x80\xAF", "\xE2\x81\x9F", "\xE3\x80\x80"],
-        ];
+        return $traits;
+    }
+}
+
+if (! function_exists('value')) {
+    /**
+     * Return the default value of the given value.
+     *
+     * @param  mixed  $value
+     * @return mixed
+     */
+    function value($value)
+    {
+        return $value instanceof Closure ? $value() : $value;
+    }
+}
+
+if (! function_exists('windows_os')) {
+    /**
+     * Determine whether the current environment is Windows based.
+     *
+     * @return bool
+     */
+    function windows_os()
+    {
+        return strtolower(substr(PHP_OS, 0, 3)) === 'win';
+    }
+}
+
+if (! function_exists('with')) {
+    /**
+     * Return the given object. Useful for chaining.
+     *
+     * @param  mixed  $object
+     * @return mixed
+     */
+    function with($object)
+    {
+        return $object;
     }
 }


### PR DESCRIPTION
This adds the ability to have the `Str::plural` method prepend the string with the given count.
`Str::plural('reply', 2,)` will output: `replies`
`Str::plural('reply', 2, true)` will output: `2 replies`

In this way you can do this in a template, for example:
```
This post has {{ str_plural('reply', $post->replies_count, true) }}
```
instead of:
```
This post has {{ $post->replies_count }} {{ str_plural('reply', $post->replies_count) }}
```