### PR TITLE
[5.1] Fire saved event when model is dirty

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1482,7 +1482,9 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     protected function finishSave(array $options)
     {
-        $this->fireModelEvent('saved', false);
+        if ($this->isDirty()) {
+            $this->fireModelEvent('saved', false);
+        }
 
         $this->syncOriginal();
 


### PR DESCRIPTION
### Problem

Model event, updated is triggered when attributes are dirty (see [performUpdate](https://github.com/laravel/framework/blob/5.1/src/Illuminate/Database/Eloquent/Model.php#L1501)) but not saved. It is a little confused when using these two events.

### Modification

Fire saved when model is dirty to make the behavior of saved and updated inconsistent.