### PR TITLE
[5.4]event helper "Illegal offset type"

### DIFF
--- a/src/Illuminate/Foundation/Auth/RegistersUsers.php
+++ b/src/Illuminate/Foundation/Auth/RegistersUsers.php
@@ -30,7 +30,7 @@ trait RegistersUsers
     {
         $this->validator($request->all())->validate();
 
-        event(new Registered($user = $this->create($request->all())));
+        dispatch(new Registered($user = $this->create($request->all())));
 
         $this->guard()->login($user);
 

--- a/src/Illuminate/Foundation/Auth/ThrottlesLogins.php
+++ b/src/Illuminate/Foundation/Auth/ThrottlesLogins.php
@@ -78,7 +78,7 @@ trait ThrottlesLogins
      */
     protected function fireLockoutEvent(Request $request)
     {
-        event(new Lockout($request));
+        dispatch(new Lockout($request));
     }
 
     /**

--- a/src/Illuminate/Foundation/Http/Kernel.php
+++ b/src/Illuminate/Foundation/Http/Kernel.php
@@ -124,7 +124,7 @@ class Kernel implements KernelContract
             $response = $this->renderException($request, $e);
         }
 
-        event(new Events\RequestHandled($request, $response));
+        $this->app['events']->dispatch(new Events\RequestHandled($request, $response));
 
         return $response;
     }


### PR DESCRIPTION
when using hoa/core, hoa/ruler(^1.15), etc..

laravel event helper isn't valid because the hoa component is registered first.

```
ErrorException in Event.php line 202:
Illegal offset type

in Event.php line 202
at HandleExceptions->handleError(2, 'Illegal offset type', '/path/to/laravel-project/vendor/hoa/core/Event.php', 202, array('eventId' => object(RequestHandled))) in Event.php line 202
at Event::getEvent(object(RequestHandled)) in Core.php line 507
at event(object(RequestHandled)) in Kernel.php line 127
at Kernel->handle(object(Request)) in index.php line 53
```

see https://laracasts.com/discuss/channels/testing/laravel-53-user-registration-event-throws-illegal-offset-error-in-newest-version-of-phpunit
see https://github.com/hoaproject/Core/blob/master/Core.php#L504