### PR TITLE
[5.4] Fix inversion of expected and actual on assertHeader

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -114,7 +114,7 @@ class TestResponse
 
         if (! is_null($value)) {
             PHPUnit::assertEquals(
-                $this->headers->get($headerName), $value,
+                $value, $this->headers->get($headerName),
                 "Header [{$headerName}] was found, but value [{$actual}] does not match [{$value}]."
             );
         }

--- a/tests/Foundation/FoundationTestResponseTest.php
+++ b/tests/Foundation/FoundationTestResponseTest.php
@@ -39,6 +39,22 @@ class FoundationTestResponseTest extends TestCase
         $response->assertSeeText('foobar');
     }
 
+    public function testAssertHeader()
+    {
+        $baseResponse = tap(new Response, function ($response) {
+            $response->header('Location', '/foo');
+        });
+
+        $response = TestResponse::fromBaseResponse($baseResponse);
+
+        try {
+            $response->assertHeader('Location', '/bar');
+        } catch (\PHPUnit_Framework_ExpectationFailedException $e) {
+            $this->assertEquals('/bar', $e->getComparisonFailure()->getExpected());
+            $this->assertEquals('/foo', $e->getComparisonFailure()->getActual());
+        }
+    }
+
     public function testAssertJsonWithArray()
     {
         $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableSingleResourceStub));


### PR DESCRIPTION
Example: 
If we have a location header `/foo` in response and we test with the method `assertHeader('/bar')`,
we should have:
 - `expected` value equals to `/bar`
 - `actual` value equals to `/foo`

but we actually have:
 - `expected` value equals to `/foo`
 - `actual` value equals to `/bar`
