### PR TITLE
[5.5] Add a "validated" method to the form request

### DIFF
--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -103,6 +103,16 @@ class FormRequest extends Request implements ValidatesWhenResolved
     }
 
     /**
+     * Get the validated data from the request.
+     *
+     * @return array
+     */
+    public function validated()
+    {
+        return $this->only(array_keys($this->container->call([$this, 'rules'])));
+    }
+
+    /**
      * Get data to be validated from the request.
      *
      * @return array

--- a/tests/Foundation/FoundationFormRequestTest.php
+++ b/tests/Foundation/FoundationFormRequestTest.php
@@ -26,6 +26,15 @@ class FoundationFormRequestTest extends TestCase
         $this->mocks = [];
     }
 
+    public function test_validated_method_returns_the_validated_data()
+    {
+        $request = $this->createRequest(['name' => 'specified', 'with' => 'extras']);
+
+        $request->validate();
+
+        $this->assertEquals(['name' => 'specified'], $request->validated());
+    }
+
     /**
      * @expectedException \Illuminate\Validation\ValidationException
      */


### PR DESCRIPTION
Would allow you to only get the validated input from the request:

```php
public function store(MySpecialSnowflakeRequest $request)
{
    return Zonda::create($request->validated());
}
```