### PR TITLE
[5.5] Basic foreign key helper method in Blueprint

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -386,19 +386,24 @@ class Blueprint
     /**
      * Create a new basic foreign key column on the table.
      *
-     * @param  string  $string
+     * @param  string  $columnName
+     * @param  bool  $nullable
      * @param  string  $name
      * @return \Illuminate\Support\Fluent
      */
-    public function basicForeignKey($column, $name = null)
+    public function basicForeignKey($columnName, $nullable = false, $name = null)
     {
-        $this->integer($column)->unsigned();
+        $localColumn = $this->integer($columnName)->unsigned();
 
-        $on = Str::plural(
-            Str::replaceLast('_id', '', $column)
+        if ($nullable) {
+            $localColumn->nullable();
+        }
+
+        $table = Str::plural(
+            Str::replaceLast('_id', '', $columnName)
         );
 
-        return $this->foreign($column, $name)->references('id')->on($on);
+        return $this->foreign($columnName, $name)->references('id')->on($table);
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -393,7 +393,7 @@ class Blueprint
      */
     public function basicForeignKey($columnName, $nullable = false, $name = null)
     {
-        $localColumn = $this->integer($columnName)->unsigned();
+        $localColumn = $this->unsignedInteger($column);
 
         if ($nullable) {
             $localColumn->nullable();
@@ -403,7 +403,9 @@ class Blueprint
             Str::replaceLast('_id', '', $columnName)
         );
 
-        return $this->foreign($columnName, $name)->references('id')->on($table);
+        return $this->indexCommand('foreign', $columnName, $name)
+                    ->references('id')
+                    ->on($table);
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Database\Schema;
 
 use Closure;
+use Illuminate\Support\Str;
 use Illuminate\Support\Fluent;
 use Illuminate\Database\Connection;
 use Illuminate\Database\Schema\Grammars\Grammar;
@@ -380,6 +381,24 @@ class Blueprint
     public function index($columns, $name = null, $algorithm = null)
     {
         return $this->indexCommand('index', $columns, $name, $algorithm);
+    }
+
+    /**
+     * Create a new basic foreign key column on the table.
+     *
+     * @param  string  $string
+     * @param  string  $name
+     * @return \Illuminate\Support\Fluent
+     */
+    public function basicForeignKey($column, $name = null)
+    {
+        $this->integer($column)->unsigned();
+
+        $on = Str::plural(
+            Str::replaceLast('_id', '', $column)
+        );
+
+        return $this->foreign($column, $name)->references('id')->on($on);
     }
 
     /**


### PR DESCRIPTION
Just trying to reduce the amount of writing I need to do for a foreign key in my migrations. If I'm using Laravel conventions, instead of:

```php
Schema::create('posts', function ($table) {

    //

    $table->integer('user_id')
          ->unsigned();
    $table->foreign('user_id')
          ->references('id')
          ->on('users');
});
```

I can just write:

```php
Schema::create('posts', function ($table) {

    //

    $table->basicForeignKey('user_id');
});
```

Also, as you can continue chaining the foreign key as needed....

```php
Schema::create('posts', function ($table) {

    //

    $table->basicForeignKey('user_id')->onDelete('cascade');
});
```