### PR TITLE
[5.5] Guess foreign key name considering $table

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1198,7 +1198,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public function getForeignKey()
     {
-        return Str::snake(class_basename($this)).'_'.$this->primaryKey;
+        return Str::singular($this->getTable()).'_'.$this->primaryKey;
     }
 
     /**


### PR DESCRIPTION
Foreign key column names are generally based on table names, not on model names.
So we should use `Str::singular($this->getTable())` instead of `Str::snake(class_basename($this))`.

For example... assume that we have three Eloquent models:

- `App\Post\Post`
- `App\Post\Revision`

Probably we name the tables like:

- `posts`
- `post_revisions`

```php
namespace App\Post;

class Revision
{
    protected $table = 'post_revisions';
}

// This should return "post_revision_id", not as "revision_id"
(new Revision)->getForeignKey();
```