### PR TITLE
[5.5] prevent policies from being too greedy

### DIFF
--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -332,7 +332,9 @@ class Gate implements GateContract
     {
         if (isset($arguments[0])) {
             if (! is_null($policy = $this->getPolicyFor($arguments[0]))) {
-                return $this->resolvePolicyCallback($user, $ability, $arguments, $policy);
+                if ($policyCallback = $this->resolvePolicyCallback($user, $ability, $arguments, $policy)) {
+                    return $policyCallback;
+                }
             }
         }
 
@@ -390,10 +392,15 @@ class Gate implements GateContract
      * @param  string  $ability
      * @param  array  $arguments
      * @param  mixed  $policy
-     * @return callable
+     * @return bool|callable
      */
     protected function resolvePolicyCallback($user, $ability, array $arguments, $policy)
     {
+        // Check the method exists on the policy before we try to resolve it.
+        if (! is_callable([$policy, $this->formatAbilityToMethod($ability)])) {
+            return false;
+        }
+
         return function () use ($user, $ability, $arguments, $policy) {
             // This callback will be responsible for calling the policy's before method and
             // running this policy method if necessary. This is used to when objects are

--- a/tests/Auth/AuthAccessGateTest.php
+++ b/tests/Auth/AuthAccessGateTest.php
@@ -178,7 +178,7 @@ class GateTest extends TestCase
         $this->assertTrue($gate->check('update-dash', new AccessGateTestDummy));
     }
 
-    public function test_policy_default_to_false_if_method_does_not_exist()
+    public function test_policy_default_to_false_if_method_does_not_exist_and_gate_does_not_exist()
     {
         $gate = $this->getBasicGate();
 
@@ -216,6 +216,19 @@ class GateTest extends TestCase
         $gate->policy(AccessGateTestDummy::class, AccessGateTestPolicy::class);
 
         $this->assertTrue($gate->check('update', new AccessGateTestDummy));
+    }
+
+    public function test_policies_defer_to_gates_if_method_does_not_exist()
+    {
+        $gate = $this->getBasicGate();
+
+        $gate->define('nonexistent_method', function ($user) {
+            return true;
+        });
+
+        $gate->policy(AccessGateTestDummy::class, AccessGateTestPolicy::class);
+
+        $this->assertTrue($gate->check('nonexistent_method', new AccessGateTestDummy));
     }
 
     public function test_for_user_method_attaches_a_new_user_to_a_new_gate_instance()


### PR DESCRIPTION
this was originally sent to 5.4 (https://github.com/laravel/framework/pull/19106) and Taylor asked me to switch to 5.5

### Description:

Policies are too greedy, and will not defer to the gates if they do not have a method that matches the requested ability.

### Steps To Reproduce:

Let's assume a `App\Blog`, and `App\Policies\Blog`.

```php
namespace App\Policies;

class BlogPolicy
{
    /**
     * @return bool
     */
    public function update
    {
        return false;
    }
}
```

and the following `AuthServiceProvider`:

```php
namespace App\Providers;

use Illuminate\Contracts\Auth\Access\Gate;
use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;

class AuthServiceProvider extends ServiceProvider
{
    /**
     * The policy mappings for the application.
     *
     * @var array
     */
    protected $policies = [
        \App\Blog::class => \App\Policies\BlogPolicy::class,
    ];

    /**
     * Register any authentication / authorization services.
     *
     * @param \Illuminate\Contracts\Auth\Access\Gate $gate
     */
    public function boot(Gate $gate)
    {
        //register policies
        $this->registerPolicies();

        //define additional ability
        $gate->define('update-blog', function ($user, $blog) {
            return true;
        });
    }
}
```

Currently if you tried to use this ability, you would get an `AuthorizationException`, because the method didn't exist and the Gate would return `false`.

```php
namespace App\Http\Controllers;

use App\Blog;

class BlogController extends Controller
{
    /**
     * @return
     */
    public function update(Blog $blog)
    {
        $this->authorize('update-blog', $blog);
    }
```

This is because the Gate would see an `App\Blog` passed as the first argument, and try to resolve the callback from `App\Policies\BlogPolicy`.

### Solution

This PR makes sure the ability/method is callable on the policy, otherwise falls through to let the gate check for a matching ability, and then finally defaults to return `false`.

All tests are passing, including an additional one for this situation.