### PR TITLE
[5.5] Clone Job specific properties

### DIFF
--- a/src/Illuminate/Broadcasting/BroadcastEvent.php
+++ b/src/Illuminate/Broadcasting/BroadcastEvent.php
@@ -97,4 +97,14 @@ class BroadcastEvent implements ShouldQueue
     {
         return get_class($this->event);
     }
+
+    /**
+     * Prepare the instance for cloning.
+     *
+     * @return void
+     */
+    public function __clone()
+    {
+        $this->event = clone $this->event;
+    }
 }

--- a/src/Illuminate/Mail/SendQueuedMailable.php
+++ b/src/Illuminate/Mail/SendQueuedMailable.php
@@ -61,4 +61,14 @@ class SendQueuedMailable
     {
         return get_class($this->mailable);
     }
+
+    /**
+     * Prepare the instance for cloning.
+     *
+     * @return void
+     */
+    public function __clone()
+    {
+        $this->mailable = clone $this->mailable;
+    }
 }

--- a/src/Illuminate/Notifications/SendQueuedNotifications.php
+++ b/src/Illuminate/Notifications/SendQueuedNotifications.php
@@ -66,4 +66,15 @@ class SendQueuedNotifications implements ShouldQueue
     {
         return get_class($this->notification);
     }
+
+    /**
+     * Prepare the instance for cloning.
+     *
+     * @return void
+     */
+    public function __clone()
+    {
+        $this->notifiables = clone $this->notifiables;
+        $this->notification = clone $this->notification;
+    }
 }


### PR DESCRIPTION
Taking a `Mailable` for example, while queuing it a `SendQueuedMailable` is dispatched which holds the mailable as a `$mailable` property.

While the job is being serialized, if the mailable uses the `SerializesModels` trait all properties referencing an Eloquent Model will have its value replaced with a `ModelIdentifier`, taking into account that we serialize a cone of the job `in Queue::createObjectPayload()` one might think that the mailer object will still hold references to Model objects in the original job instance, but this is not the case since the original job and the clone both points to the same reference of the mailable, and thus the __sleep method that ran while serializing will affect the mailable in the original as well.