### PR TITLE
[5.4] Gate resources

### DIFF
--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -111,14 +111,22 @@ class Gate implements GateContract
     /**
      * Define abilities for a resource.
      *
-     * @param  string $base
-     * @param  string $class
+     * @param  string  $name
+     * @param  string  $class
+     * @param  array   $abilities
      * @return $this
      */
-    public function resource($base, $class)
+    public function resource($name, $class, array $abilities = null)
     {
-        foreach(['view', 'create', 'update', 'delete'] as $ability){
-            $this->define($base . '.'. $ability, $class . '@' . $ability);
+        $abilities = $abilities ?: [
+            'view'   => 'view',
+            'create' => 'create',
+            'update' => 'update',
+            'delete' => 'delete',
+        ];
+
+        foreach ($abilities as $ability => $method) {
+            $this->define($name . '.' . $ability, $class . '@' . $method);
         }
 
         return $this;

--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -109,6 +109,22 @@ class Gate implements GateContract
     }
 
     /**
+     * Define abilities for a resource.
+     *
+     * @param  string $base
+     * @param  string $class
+     * @return $this
+     */
+    public function resource($base, $class)
+    {
+        foreach(['view', 'create', 'update', 'delete'] as $ability){
+            $this->define($base . '.'. $ability, $class . '@' . $ability);
+        }
+
+        return $this;
+    }
+
+    /**
      * Create the ability callback for a callback string.
      *
      * @param  string  $callback

--- a/tests/Auth/AuthAccessGateTest.php
+++ b/tests/Auth/AuthAccessGateTest.php
@@ -35,6 +35,35 @@ class GateTest extends TestCase
         $this->assertFalse($gate->check('bar'));
     }
 
+    public function test_resource_gates_can_be_defined()
+    {
+        $gate = $this->getBasicGate();
+
+        $gate->resource('test', AccessGateTestResource::class);
+
+        $dummy = new AccessGateTestDummy;
+
+        $this->assertTrue($gate->check('test.view'));
+        $this->assertTrue($gate->check('test.create'));
+        $this->assertTrue($gate->check('test.update', $dummy));
+        $this->assertTrue($gate->check('test.delete', $dummy));
+    }
+
+    public function test_custom_resource_gates_can_be_defined()
+    {
+        $gate = $this->getBasicGate();
+
+        $abilities = [
+            'ability1' => 'foo',
+            'ability2' => 'bar',
+        ];
+
+        $gate->resource('test', AccessGateTestCustomResource::class, $abilities);
+
+        $this->assertTrue($gate->check('test.ability1'));
+        $this->assertTrue($gate->check('test.ability2'));
+    }
+
     public function test_before_callbacks_can_override_result_if_necessary()
     {
         $gate = $this->getBasicGate();
@@ -341,5 +370,41 @@ class AccessGateTestPolicyWithBefore
     public function update($user, AccessGateTestDummy $dummy)
     {
         return false;
+    }
+}
+
+class AccessGateTestResource
+{
+    public function view($user)
+    {
+        return true;
+    }
+
+    public function create($user)
+    {
+        return true;
+    }
+
+    public function update($user, AccessGateTestDummy $dummy)
+    {
+        return true;
+    }
+
+    public function delete($user, AccessGateTestDummy $dummy)
+    {
+        return true;
+    }
+}
+
+class AccessGateTestCustomResource
+{
+    public function foo($user)
+    {
+        return true;
+    }
+
+    public function bar($user)
+    {
+        return true;
     }
 }


### PR DESCRIPTION
### Problem

I love policies for their ability to group authorization rules. However, I am personally not a huge fan of the auto-resolution of models to policies. While they work fine for simple models, they quickly break down when dealing with nested resources.

Moving everything to gates allows us to better handle these nested resources. However, gates can get **very** lengthy to define. Writing them as closures in your `AuthServiceProvider` could quickly turn into a very large file. Defining them using the `class@method` style gets us a little closer, but I think we can make it even better.

### Solution

This PR pulls from the concept of a route resource, and defines a simple method to quickly generate multiple gates for a particular resource.  Rather that defining gates like

```php
Gate::define('client.view', 'ClientPolicy@view');
Gate::define('client.create', 'ClientPolicy@create');
Gate::define('client.update', 'ClientPolicy@update');
Gate::define('client.delete', 'ClientPolicy@delete');
```

we can take advantage of a new `resource` method on the Gate.

```php
Gate::resource('client', 'ClientPolicy');
```

which will generate those 4 gates for us. We can use them normally with

```php
Gate::check('client.view', $client);
Gate::check('client.create');
Gate::check('client.update', $client);
Gate::check('client.delete', $client);
```

---

Now defining authentication rules for nested resources becomes incredibly easy.

```php
Gate::resource('client.document', 'ClientDocumentPolicy');
Gate::resource('user.document', 'UserDocumentPolicy');
```

and use them like

```php
Gate::check('client.document.view', [$client, $document]);
Gate::check('client.document.create', [$client]);
Gate::check('client.document.update', [$client, $document]);
Gate::check('client.document.delete', [$client, $document]);
```

---

The abilities are also easily customizable. If you don't like 'view', 'create', 'update', and 'delete', you can define your own. 

```php
$abilities = [
    'ability1' => 'foo',
    'ability2' => 'bar',
];
```

The key defines the ability name, and the value defines the method.  You can apply them as follows

```php
Gate::resource('client.document', 'ClientDocumentPolicy', $abilities);
Gate::resource('user.document', 'UserDocumentPolicy', $abilities);
```

and called by

```php
Gate::check('client.document.ability1');  //checks method 'foo' on the class 'ClientDocumentPolicy'
Gate::check('client.document.ability2');  //checks method 'bar' on the class 'ClientDocumentPolicy'
```

---

To be clear, this PR does not take away **any** of the existing functionality of Gates or Policies. The user can decide if they want to continue binding Policies to Models, or simply use gates instead.

While I'm sure there are lots of improvements we could make here, I think this is a very good first step, and gives us some very useful additional functionality.