### PR TITLE
[5.5] Letting `where` in query builder take an array

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -543,7 +543,7 @@ class Builder
         // If the value is an array, we will assume the developer wants to add a
         // where in clause to the query. We will allow a short-cut here
         // for convenience so the developer doesn't have to check.
-        if (is_array($value)) {
+        if (is_array($value) || $value instanceof Arrayable) {
             return $this->whereIn($column, $value, $boolean, $operator != '=');
         }
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -540,6 +540,13 @@ class Builder
             return $this->whereNull($column, $boolean, $operator != '=');
         }
 
+        // If the value is an array, we will assume the developer wants to add a
+        // where in clause to the query. We will allow a short-cut here
+        // for convenience so the developer doesn't have to check.
+        if (is_array($value)) {
+            return $this->whereIn($column, $value, $boolean, $operator != '=');
+        }
+
         // If the column is making a JSON reference we'll check to see if the value
         // is a boolean. If it is, we'll add the raw boolean string as an actual
         // value to the query to ensure this is properly handled by the query.

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -240,6 +240,14 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => 1, 1 => 2, 2 => 3], $builder->getBindings());
     }
 
+    public function testArrayablePassedToWhereMapToWhereIn()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('id', collect([1, 2, 3]));
+        $this->assertEquals('select * from "users" where "id" in (?, ?, ?)', $builder->toSql());
+        $this->assertEquals([0 => 1, 1 => 2, 2 => 3], $builder->getBindings());
+    }
+
     public function testMySqlWrappingProtectsQuotationMarks()
     {
         $builder = $this->getMySqlBuilder();

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -208,6 +208,38 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => 1], $builder->getBindings());
     }
 
+    public function testArraysPassedToWhereWithNoOperatorMapToWhereIn()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('id', [1, 2, 3]);
+        $this->assertEquals('select * from "users" where "id" in (?, ?, ?)', $builder->toSql());
+        $this->assertEquals([0 => 1, 1 => 2, 2 => 3], $builder->getBindings());
+    }
+
+    public function testArraysPassedToWhereWithEqualOperatorMapToWhereIn()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('id', '=', [1, 2, 3]);
+        $this->assertEquals('select * from "users" where "id" in (?, ?, ?)', $builder->toSql());
+        $this->assertEquals([0 => 1, 1 => 2, 2 => 3], $builder->getBindings());
+    }
+
+    public function testArraysPassedToWhereWithNonEqualOperatorMapToWhereNotIn()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('id', '!=', [1, 2, 3]);
+        $this->assertEquals('select * from "users" where "id" not in (?, ?, ?)', $builder->toSql());
+        $this->assertEquals([0 => 1, 1 => 2, 2 => 3], $builder->getBindings());
+    }
+
+    public function testArraysPassedToOrWhereMapToOrWhereIn()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('id', 1)->orWhere('id', '=', [2, 3]);
+        $this->assertEquals('select * from "users" where "id" = ? or "id" in (?, ?)', $builder->toSql());
+        $this->assertEquals([0 => 1, 1 => 2, 2 => 3], $builder->getBindings());
+    }
+
     public function testMySqlWrappingProtectsQuotationMarks()
     {
         $builder = $this->getMySqlBuilder();


### PR DESCRIPTION
## Description
There was a discussion on internals, https://github.com/laravel/internals/issues/572, 
about adding `in` as an operator for `where`.  I riffed on it and ignored adding `in` as
a focus and simply mapped values of arrays to be passed along to `whereIn`.

This functionality is similar to `where` doing something like

`where('id', '=', null)` translates to `whereNull('id')`

Now `where('id', [1,2])` or `where('id', '=', [1,2])`
will translate to `whereIn('id', [1,2])`.

And, like `where` with `null` will map any operator other than `=`
to `whereNotNull`, we map it to `whereNotIn`.

This functionality exists in other ecosystems, which doesn't necessarily warrant that 
it should be part of ours, but I had some extra time and decided to make a PR for it
because I haven't made a Laravel PR in forever, and it was something some folk seemed
interested in.  Low hanging fruit and what not.  As such, I submit it for feedback.

## Known Concerns
- Expanding the implicit API of `where`
- More code to maintain
- Would possibly prevent errors from being raised when people accidentally send arrays to `where` clauses
- Because arrays and associative arrays are the same data structures, there could be some weird behaviors (the same that `whereIn` could see).
- API is shoddy with 3 args, `where('id', '=', [1,2])` looks silly and incorrect.  We allow the same for `null`, but it's not ideal.

