### PR TITLE
Fix string conversion when ignore contains double quote (binary strin…

### DIFF
--- a/src/Illuminate/Validation/Rules/Unique.php
+++ b/src/Illuminate/Validation/Rules/Unique.php
@@ -173,7 +173,7 @@ class Unique
         return rtrim(sprintf('unique:%s,%s,%s,%s,%s',
             $this->table,
             $this->column,
-            $this->ignore ? '"'.$this->ignore.'"' : 'NULL',
+            $this->ignore ? '"'.str_replace('"', '\"', $this->ignore).'"' : 'NULL',
             $this->idColumn,
             $this->formatWheres()
         ), ',');


### PR DESCRIPTION
…g value)

ex for this string : unique:invitation,email,"ÔËŸ\x12êŒD\x08„gu|:Gl"",uuid
where $id  = ÔËŸ\x12êŒD\x08„gu|:Gl"
```php
Rule::unique('invitation', 'email')->ignore($id,  'uuid');
```

if $id is binary string that contains double quote, the string conversion is not wroking well.
i think for security issue, a base64 encoding can be better on parameters