### PR TITLE
addslashes and stripslashes on $excludeId for unique validator

### DIFF
--- a/src/Illuminate/Validation/DatabasePresenceVerifier.php
+++ b/src/Illuminate/Validation/DatabasePresenceVerifier.php
@@ -49,7 +49,7 @@ class DatabasePresenceVerifier implements PresenceVerifierInterface
         $query = $this->table($collection)->where($column, '=', $value);
 
         if (! is_null($excludeId) && $excludeId != 'NULL') {
-            $query->where($idColumn ?: 'id', '<>', $excludeId);
+            $query->where($idColumn ?: 'id', '<>', stripslashes($excludeId));
         }
 
         return $this->addConditions($query, $extra)->count();

--- a/src/Illuminate/Validation/Rules/Unique.php
+++ b/src/Illuminate/Validation/Rules/Unique.php
@@ -173,7 +173,7 @@ class Unique
         return rtrim(sprintf('unique:%s,%s,%s,%s,%s',
             $this->table,
             $this->column,
-            $this->ignore ? '"'.str_replace('"', '\"', $this->ignore).'"' : 'NULL',
+            $this->ignore ? '"'.addslashes($this->ignore).'"' : 'NULL',
             $this->idColumn,
             $this->formatWheres()
         ), ',');

--- a/src/Illuminate/Validation/Rules/Unique.php
+++ b/src/Illuminate/Validation/Rules/Unique.php
@@ -173,7 +173,7 @@ class Unique
         return rtrim(sprintf('unique:%s,%s,%s,%s,%s',
             $this->table,
             $this->column,
-            $this->ignore ? '"'.$this->ignore.'"' : 'NULL',
+            $this->ignore ? '"'.str_replace('"', '\"', $this->ignore).'"' : 'NULL',
             $this->idColumn,
             $this->formatWheres()
         ), ',');


### PR DESCRIPTION
Fix string conversion when ignore containe double quote (binary string value)

ex for this string : unique:invitation,email,"ÔËŸ\x12êŒD\x08„gu|:Gl"",uuid
where $id  = ÔËŸ\x12êŒD\x08„gu|:Gl"
```php
Rule::unique('invitation', 'email')->ignore($id,  'uuid');
```

if $id is binary string that contains double quote, the string conversion is not working well.
i think for security issue, a base64 encoding can be better on parameters
 5.4