### PR TITLE
[5.4] User Access to Abilities

### DIFF
--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -469,4 +469,14 @@ class Gate implements GateContract
     {
         return call_user_func($this->userResolver);
     }
+
+    /**
+     * Get the abilities.
+     *
+     * @return array
+     */
+    public function getAbilities()
+    {
+        return $this->abilities;
+    }
 }


### PR DESCRIPTION
### Description

Currently the `abilities` are stored in the `Gate` class as a protected property. this PR adds a simple getter to return the defined abilities.

the router has an [identical method](https://github.com/laravel/framework/blob/5.4/src/Illuminate/Routing/Router.php#L1050) to access all the routes

### Use Case

Currently if you set up some kind of Role/Permission ACL, you possibly store the Permissions and the Roles in the database. Chances are, the developer is still the only person who can CRUD the Permissions, because they still need to be used in authorization in the code.  Then the layman are able to create the Roles and apply Permissions to them, and assign Roles to Users.

This would allow the programmer to skip storing the Permissions in the database, and instead simply define them on the Gate class.  Then when Permissions are being applied to the Roles, we could use this method to access all the Permissions/abilities available.

---

**If** you don't need to have a web UI to define Permissions, the database becomes an unnecessary extra repository, because (often) the ServiceProvider is simply pulling the Permissions out of the database, and registering them into the Gate (the new repository).  This PR will help eliminate that redundancy for projects that don't need the Permissions in a web UI.

---

I am currently testing out [Spatie's awesome permissions package](https://github.com/spatie/laravel-permission) and that's where this idea came from.