### PR TITLE
[5.5] Add better error message for missing app key

### DIFF
--- a/src/Illuminate/Encryption/EncryptionServiceProvider.php
+++ b/src/Illuminate/Encryption/EncryptionServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Encryption;
 
+use RuntimeException;
 use Illuminate\Support\Str;
 use Illuminate\Support\ServiceProvider;
 
@@ -22,6 +23,12 @@ class EncryptionServiceProvider extends ServiceProvider
             // want to make sure to convert them back to the raw bytes before encrypting.
             if (Str::startsWith($key = $config['key'], 'base64:')) {
                 $key = base64_decode(substr($key, 7));
+            }
+
+            if (is_null($key) || $key === '') {
+                throw new RuntimeException(
+                    'The application encryption key is missing. Run php artisan key:generate to generate it.'
+                );
             }
 
             return new Encrypter($key, $config['cipher']);

--- a/src/Illuminate/Encryption/EncryptionServiceProvider.php
+++ b/src/Illuminate/Encryption/EncryptionServiceProvider.php
@@ -18,17 +18,19 @@ class EncryptionServiceProvider extends ServiceProvider
         $this->app->singleton('encrypter', function ($app) {
             $config = $app->make('config')->get('app');
 
-            // If the key starts with "base64:", we will need to decode the key before handing
-            // it off to the encrypter. Keys may be base-64 encoded for presentation and we
-            // want to make sure to convert them back to the raw bytes before encrypting.
-            if (Str::startsWith($key = $config['key'], 'base64:')) {
-                $key = base64_decode(substr($key, 7));
-            }
+            $key = $config['key'];
 
             if (is_null($key) || $key === '') {
                 throw new RuntimeException(
                     'The application encryption key is missing. Run php artisan key:generate to generate it.'
                 );
+            }
+
+            // If the key starts with "base64:", we will need to decode the key before handing
+            // it off to the encrypter. Keys may be base-64 encoded for presentation and we
+            // want to make sure to convert them back to the raw bytes before encrypting.
+            if (Str::startsWith($key, 'base64:')) {
+                $key = base64_decode(substr($key, 7));
             }
 
             return new Encrypter($key, $config['cipher']);


### PR DESCRIPTION
Running `php artisan key:generate` is done automatically by `laravel new project_name` but the experience is still subpar when cloning an existing repo.

This is especially an issue on teams when cloning existing repos. Even more so with new team members who may not know Laravel (or PHP) that well.

The current error message "The only supported ciphers are AES-128-CBC and AES-256-CBC with the correct key lengths." is not helpful in determining what to do. It tells you that _something_ is wrong but doesn't pinpoint what that thing is.

Because the most common occurrence of this exception is an empty or missing `APP_KEY` I thought it would be beneficial to check for this and present a more helpful exception.