### PR TITLE
__isset must return true in Request.php

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -575,7 +575,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
      */
     public function __isset($key)
     {
-        return ! is_null($this->__get($key));
+        return true;
     }
 
     /**


### PR DESCRIPTION
The __get method does not return an exception so any property can be obtained