### PR TITLE
[5.5] Key MessageBag error messages by the rule they failed on

### DIFF
--- a/src/Illuminate/Contracts/Support/MessageBag.php
+++ b/src/Illuminate/Contracts/Support/MessageBag.php
@@ -16,9 +16,10 @@ interface MessageBag
      *
      * @param  string  $key
      * @param  string  $message
+     * @param  string  $rule
      * @return $this
      */
-    public function add($key, $message);
+    public function add($key, $message, $rule);
 
     /**
      * Merge a new array of messages into the bag.

--- a/src/Illuminate/Support/MessageBag.php
+++ b/src/Illuminate/Support/MessageBag.php
@@ -53,12 +53,13 @@ class MessageBag implements Arrayable, Countable, Jsonable, JsonSerializable, Me
      *
      * @param  string  $key
      * @param  string  $message
+     * @param  string  $rule
      * @return $this
      */
-    public function add($key, $message)
+    public function add($key, $message, $rule)
     {
         if ($this->isUnique($key, $message)) {
-            $this->messages[$key][] = $message;
+            $this->messages[$key][$rule] = $message;
         }
 
         return $this;

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -325,7 +325,7 @@ class Validator implements ValidatorContract
         if ($value instanceof UploadedFile && ! $value->isValid() &&
             $this->hasRule($attribute, array_merge($this->fileRules, $this->implicitRules))
         ) {
-            return $this->addFailure($attribute, 'uploaded', []);
+            return $this->addFailure($attribute, 'uploaded', [], $rule);
         }
 
         // If we have made it this far we will make sure the attribute is validatable and if it is
@@ -336,7 +336,7 @@ class Validator implements ValidatorContract
         $method = "validate{$rule}";
 
         if ($validatable && ! $this->$method($attribute, $value, $parameters, $this)) {
-            $this->addFailure($attribute, $rule, $parameters);
+            $this->addFailure($attribute, $rule, $parameters, $rule);
         }
     }
 
@@ -534,7 +534,7 @@ class Validator implements ValidatorContract
     {
         $this->messages->add($attribute, $this->makeReplacements(
             $this->getMessage($attribute, $rule), $attribute, $rule, $parameters
-        ));
+        ), $rule);
 
         $this->failedRules[$attribute][$rule] = $parameters;
     }

--- a/tests/Support/SupportMessageBagTest.php
+++ b/tests/Support/SupportMessageBagTest.php
@@ -16,22 +16,22 @@ class SupportMessageBagTest extends TestCase
     public function testUniqueness()
     {
         $container = new MessageBag;
-        $container->add('foo', 'bar');
-        $container->add('foo', 'bar');
+        $container->add('foo', 'bar', 'Required');
+        $container->add('foo', 'bar', 'Required');
         $messages = $container->getMessages();
-        $this->assertEquals(['bar'], $messages['foo']);
+        $this->assertEquals(['Required' => 'bar'], $messages['foo']);
     }
 
     public function testMessagesAreAdded()
     {
         $container = new MessageBag;
         $container->setFormat(':message');
-        $container->add('foo', 'bar');
-        $container->add('foo', 'baz');
-        $container->add('boom', 'bust');
+        $container->add('foo', 'bar', 'Required');
+        $container->add('foo', 'baz', 'Unique');
+        $container->add('boom', 'bust', 'Required');
         $messages = $container->getMessages();
-        $this->assertEquals(['bar', 'baz'], $messages['foo']);
-        $this->assertEquals(['bust'], $messages['boom']);
+        $this->assertEquals(['Required' => 'bar', 'Unique' => 'baz'], $messages['foo']);
+        $this->assertEquals(['Required' => 'bust'], $messages['boom']);
     }
 
     public function testMessagesMayBeMerged()
@@ -53,26 +53,26 @@ class SupportMessageBagTest extends TestCase
     {
         $container = new MessageBag;
         $container->setFormat(':message');
-        $container->add('foo', 'bar');
-        $container->add('foo', 'baz');
-        $this->assertEquals(['bar', 'baz'], $container->get('foo'));
+        $container->add('foo', 'bar', 'Required');
+        $container->add('foo', 'baz', 'Unique');
+        $this->assertEquals(['Required' => 'bar', 'Unique' => 'baz'], $container->get('foo'));
     }
 
     public function testGetReturnsArrayOfMessagesByImplicitKey()
     {
         $container = new MessageBag;
         $container->setFormat(':message');
-        $container->add('foo.1', 'bar');
-        $container->add('foo.2', 'baz');
-        $this->assertEquals(['foo.1' => ['bar'], 'foo.2' => ['baz']], $container->get('foo.*'));
+        $container->add('foo.1', 'bar', 'Required');
+        $container->add('foo.2', 'baz', 'Unique');
+        $this->assertEquals(['foo.1' => ['Required' => 'bar'], 'foo.2' => ['Unique' => 'baz']], $container->get('foo.*'));
     }
 
     public function testFirstReturnsSingleMessage()
     {
         $container = new MessageBag;
         $container->setFormat(':message');
-        $container->add('foo', 'bar');
-        $container->add('foo', 'baz');
+        $container->add('foo', 'bar', 'Required');
+        $container->add('foo', 'baz', 'Unique');
         $messages = $container->getMessages();
         $this->assertEquals('bar', $container->first('foo'));
     }
@@ -89,8 +89,8 @@ class SupportMessageBagTest extends TestCase
     {
         $container = new MessageBag;
         $container->setFormat(':message');
-        $container->add('name.first', 'jon');
-        $container->add('name.last', 'snow');
+        $container->add('name.first', 'jon', 'Required');
+        $container->add('name.last', 'snow', 'Unique');
         $messages = $container->getMessages();
         $this->assertEquals('jon', $container->first('name.*'));
     }
@@ -99,7 +99,7 @@ class SupportMessageBagTest extends TestCase
     {
         $container = new MessageBag;
         $container->setFormat(':message');
-        $container->add('foo', 'bar');
+        $container->add('foo', 'bar', 'Required');
         $this->assertTrue($container->has('foo'));
         $this->assertFalse($container->has('bar'));
     }
@@ -108,9 +108,9 @@ class SupportMessageBagTest extends TestCase
     {
         $container = new MessageBag;
         $container->setFormat(':message');
-        $container->add('foo', 'bar');
-        $container->add('bar', 'foo');
-        $container->add('boom', 'baz');
+        $container->add('foo', 'bar', 'Required');
+        $container->add('bar', 'foo', 'Unique');
+        $container->add('boom', 'baz', 'Min');
         $this->assertTrue($container->hasAny(['foo', 'bar']));
         $this->assertTrue($container->hasAny('foo', 'bar'));
         $this->assertTrue($container->hasAny(['boom', 'baz']));
@@ -124,9 +124,9 @@ class SupportMessageBagTest extends TestCase
     {
         $container = new MessageBag;
         $container->setFormat(':message');
-        $container->add('foo', 'bar');
-        $container->add('bar', 'foo');
-        $container->add('boom', 'baz');
+        $container->add('foo', 'bar', 'Required');
+        $container->add('bar', 'foo', 'Unique');
+        $container->add('boom', 'baz', 'Min');
         $this->assertTrue($container->has(['foo', 'bar', 'boom']));
         $this->assertFalse($container->has(['foo', 'bar', 'boom', 'baz']));
         $this->assertFalse($container->has(['foo', 'baz']));
@@ -144,23 +144,23 @@ class SupportMessageBagTest extends TestCase
     {
         $container = new MessageBag;
         $container->setFormat(':message');
-        $container->add('foo', 'bar');
-        $container->add('boom', 'baz');
-        $this->assertEquals(['bar', 'baz'], $container->all());
+        $container->add('foo', 'bar', 'Required');
+        $container->add('boom', 'baz', 'Unique');
+        $this->assertEquals(['Required' => 'bar', 'Unique' => 'baz'], $container->all());
     }
 
     public function testFormatIsRespected()
     {
         $container = new MessageBag;
         $container->setFormat('<p>:message</p>');
-        $container->add('foo', 'bar');
-        $container->add('boom', 'baz');
+        $container->add('foo', 'bar', 'Required');
+        $container->add('boom', 'baz', 'Unique');
         $this->assertEquals('<p>bar</p>', $container->first('foo'));
-        $this->assertEquals(['<p>bar</p>'], $container->get('foo'));
-        $this->assertEquals(['<p>bar</p>', '<p>baz</p>'], $container->all());
+        $this->assertEquals(['Required' => '<p>bar</p>'], $container->get('foo'));
+        $this->assertEquals(['Required' => '<p>bar</p>', 'Unique' => '<p>baz</p>'], $container->all());
         $this->assertEquals('bar', $container->first('foo', ':message'));
-        $this->assertEquals(['bar'], $container->get('foo', ':message'));
-        $this->assertEquals(['bar', 'baz'], $container->all(':message'));
+        $this->assertEquals(['Required' => 'bar'], $container->get('foo', ':message'));
+        $this->assertEquals(['Required' => 'bar', 'Unique' => 'baz'], $container->all(':message'));
 
         $container->setFormat(':key :message');
         $this->assertEquals('foo bar', $container->first('foo'));
@@ -170,20 +170,20 @@ class SupportMessageBagTest extends TestCase
     {
         $container = new MessageBag;
         $container->setFormat(':message');
-        $container->add('foo', 'bar');
-        $container->add('boom', 'baz');
+        $container->add('foo', 'bar', 'Required');
+        $container->add('boom', 'baz', 'Unique');
 
-        $this->assertEquals(['foo' => ['bar'], 'boom' => ['baz']], $container->toArray());
+        $this->assertEquals(['foo' => ['Required' => 'bar'], 'boom' => ['Unique' => 'baz']], $container->toArray());
     }
 
     public function testMessageBagReturnsExpectedJson()
     {
         $container = new MessageBag;
         $container->setFormat(':message');
-        $container->add('foo', 'bar');
-        $container->add('boom', 'baz');
+        $container->add('foo', 'bar', 'Required');
+        $container->add('boom', 'baz', 'Unique');
 
-        $this->assertEquals('{"foo":["bar"],"boom":["baz"]}', $container->toJson());
+        $this->assertEquals('{"foo":{"Required":"bar"},"boom":{"Unique":"baz"}}', $container->toJson());
     }
 
     public function testCountReturnsCorrectValue()
@@ -191,9 +191,9 @@ class SupportMessageBagTest extends TestCase
         $container = new MessageBag;
         $this->assertCount(0, $container);
 
-        $container->add('foo', 'bar');
-        $container->add('foo', 'baz');
-        $container->add('boom', 'baz');
+        $container->add('foo', 'bar', 'Required');
+        $container->add('foo', 'baz', 'Unique');
+        $container->add('boom', 'baz', 'Required');
 
         $this->assertCount(3, $container);
     }
@@ -202,8 +202,8 @@ class SupportMessageBagTest extends TestCase
     {
         $container = new MessageBag;
 
-        $container->add('foo', 'bar');
-        $container->add('boom', 'baz');
+        $container->add('foo', 'bar', 'Required');
+        $container->add('boom', 'baz', 'Required');
 
         $this->assertCount(2, $container);
     }
@@ -218,7 +218,7 @@ class SupportMessageBagTest extends TestCase
     {
         $container = new MessageBag;
         $container->setFormat(':message');
-        $container->add('foo.bar', 'baz');
+        $container->add('foo.bar', 'baz', 'Required');
         $messages = $container->getMessages();
         $this->assertEquals('baz', $container->first('foo.*'));
     }


### PR DESCRIPTION
Take the following simple (non-realistic) validation example...

```php
    $rules = [
        'username' => 'required|min:5|alpha',
    ];

    $messages = [
        'username.min' => 'username not long enough',
        'username.alpha' => 'username should only contain letters',
    ];

    $validator = Validator::make(request()->all(), $rules, $messages);

    return redirect()->back()->withErrors($validator)->withInput();
```

Given the input `1234` for the `username` the message bag would look something like this...

```
ViewErrorBag {#144 ▼
  #bags: array:1 [▼
    "default" => MessageBag {#145 ▼
      #messages: array:1 [▼
        "username" => array:2 [▼
          0 => "username not long enough",
          1 => "username should only contain letters",
        ]
      ]
      #format: ":message"
    }
  ]
}
```

We can see that the validation error messages are present, but there is no way to tell (programatically) what type of validation those error messages failed on.

This change would key the error messages by the validation rule they failed on, so the MessageBag would look like this....

```
ViewErrorBag {#144 ▼
  #bags: array:1 [▼
    "default" => MessageBag {#145 ▼
      #messages: array:1 [▼
        "username" => array:2 [▼
          'Min' => "username not long enough",
          'Alpha' => "username should only contain letters",
        ]
      ]
      #format: ":message"
    }
  ]
}
```

We sometimes need to load different sub-templates based on the type of validation failure, and this would make it much simpler.

Note: I used capitalised key names as this keeps it consistent with the `$failedRules` array on the Validator. Having said that, i think that has inconsistencies as the `uploaded` rule is always lowercase 😕

I think this would be mostly backward compatible unless people are relying on an indexed array in the message bag...but I have targeted v5.5 just to be safe.