### PR TITLE
[5.5] Add methods to change unfurl options

### DIFF
--- a/src/Illuminate/Notifications/Channels/SlackWebhookChannel.php
+++ b/src/Illuminate/Notifications/Channels/SlackWebhookChannel.php
@@ -59,6 +59,8 @@ class SlackWebhookChannel
             'icon_emoji' => data_get($message, 'icon'),
             'icon_url' => data_get($message, 'image'),
             'link_names' => data_get($message, 'linkNames'),
+            'unfurl_links' => data_get($message, 'unfurlLinks'),
+            'unfurl_media' => data_get($message, 'unfurlMedia'),
             'username' => data_get($message, 'username'),
         ]);
 

--- a/src/Illuminate/Notifications/Messages/SlackMessage.php
+++ b/src/Illuminate/Notifications/Messages/SlackMessage.php
@@ -60,14 +60,14 @@ class SlackMessage
      *
      * @var bool
      */
-    public $unfurlLinks = true;
+    public $unfurlLinks;
 
     /**
      * Indicates if you want a preview of links to media inlined in the message.
      *
      * @var bool
      */
-    public $unfurlMedia = true;
+    public $unfurlMedia;
 
     /**
      * The message's attachments.
@@ -225,7 +225,7 @@ class SlackMessage
      *
      * @return $this
      */
-    public function unfurlLinks($unfurl = true)
+    public function unfurlLinks($unfurl)
     {
         $this->unfurlLinks = $unfurl;
 
@@ -237,7 +237,7 @@ class SlackMessage
      *
      * @return $this
      */
-    public function unfurlMedia($unfurl = true)
+    public function unfurlMedia($unfurl)
     {
         $this->unfurlMedia = $unfurl;
 

--- a/src/Illuminate/Notifications/Messages/SlackMessage.php
+++ b/src/Illuminate/Notifications/Messages/SlackMessage.php
@@ -56,6 +56,20 @@ class SlackMessage
     public $linkNames = 0;
 
     /**
+     * Indicates if you want a preview of links inlined in the message.
+     *
+     * @var bool
+     */
+    public $unfurlLinks = true;
+
+    /**
+     * Indicates if you want a preview of links to media inlined in the message.
+     *
+     * @var bool
+     */
+    public $unfurlMedia = true;
+
+    /**
      * The message's attachments.
      *
      * @var array
@@ -202,6 +216,30 @@ class SlackMessage
     public function linkNames()
     {
         $this->linkNames = 1;
+
+        return $this;
+    }
+
+    /**
+     * Find and link channel names and usernames.
+     *
+     * @return $this
+     */
+    public function unfurlLinks($unfurl = true)
+    {
+        $this->unfurlLinks = $unfurl;
+
+        return $this;
+    }
+
+    /**
+     * Find and link channel names and usernames.
+     *
+     * @return $this
+     */
+    public function unfurlMedia($unfurl = true)
+    {
+        $this->unfurlMedia = $unfurl;
 
         return $this;
     }


### PR DESCRIPTION
This pull request is about setting the unfurl options for a Slack notification. So that Slack does not perform a request to your server to show a preview of the page or media links in your message.

https://api.slack.com/docs/message-link-unfurling