### PR TITLE
[5.4] Adds ability to eager load counts via property

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -158,7 +158,7 @@ trait QueriesRelationships
         if (empty($relations)) {
             return $this;
         }
- 
+
         if (is_null($this->query->columns)) {
             $this->query->select([$this->query->from.'.*']);
         }

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -155,6 +155,10 @@ trait QueriesRelationships
      */
     public function withCount($relations)
     {
+        if (empty($relations)) {
+            return $this;
+        }
+ 
         if (is_null($this->query->columns)) {
             $this->query->select([$this->query->from.'.*']);
         }

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -68,6 +68,13 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     protected $with = [];
 
     /**
+     * The relations to eager load the count on every query.
+     *
+     * @var array
+     */
+    protected $withCount = [];
+
+    /**
      * The number of models to return for pagination.
      *
      * @var int
@@ -809,7 +816,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         // Once we have the query builders, we will set the model instances so the
         // builder can easily access any information it may need from the model
         // while it is constructing and executing various queries against it.
-        return $builder->setModel($this)->with($this->with);
+        return $builder->setModel($this)->with($this->with)->withCount($this->withCount);
     }
 
     /**


### PR DESCRIPTION
This PR adds the ability to eager load counts via the protected property `$withCount` in the same way you can eager load relations with `$with`.
Like:
```
class FooBar extends \Illuminate\Database\Eloquent\Model
{
    protected $with      = ['foo', 'bar'];
    protected $withCount = ['baz', 'qux'];

    ...
}
```