### PR TITLE
[5.4] Fixed Filesystem::files bug

### DIFF
--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -374,7 +374,7 @@ class Filesystem
      */
     public function files($directory)
     {
-        $glob = glob($directory.'/*');
+        $glob = glob($directory.DIRECTORY_SEPARATOR.'*');
 
         if ($glob === false) {
             return [];


### PR DESCRIPTION
Filesystem::files uses glob($directory.'/*');

On Windows this returns a / rather than a \ on the last directory separator and seems to be an oddity in the php core glob() function.

Example using glob($directory.'/*');

```
>>> $path = 'C:\filestest';
>>> File::files($path)
=> [
     "C:\filestest/testfile1.txt",
     "C:\filestest/testfile2.txt",
     "C:\filestest/testfile3.txt",
   ]

```
Example using glob($directory.DIRECTORY_SEPARATOR.'*');

```
>>> $path = 'C:\filestest';
>>> File::files($path)
=> [
     "C:\filestest\testfile1.txt",
     "C:\filestest\testfile2.txt",
     "C:\filestest\testfile3.txt",
   ]
```