### PR TITLE
Use the Default Format set by the ErrorLogHandler

### DIFF
--- a/src/Illuminate/Log/Writer.php
+++ b/src/Illuminate/Log/Writer.php
@@ -254,11 +254,7 @@ class Writer implements LogContract, PsrLoggerInterface
      */
     public function useErrorLog($level = 'debug', $messageType = ErrorLogHandler::OPERATING_SYSTEM)
     {
-        $this->monolog->pushHandler(
-            $handler = new ErrorLogHandler($messageType, $this->parseLevel($level))
-        );
-
-        $handler->setFormatter($this->getDefaultFormatter());
+        $this->monolog->pushHandler(new ErrorLogHandler($messageType, $this->parseLevel($level)));
     }
 
     /**


### PR DESCRIPTION
## Issue
Currently, the defaultFormatter, set in Writer.php adds a `\n` at the end of each log, while the ErrorLogHandler removes that `\n` in its own `getDefaultFormatter()`.

ErrorLogHandler.php:60
```php
    /**
     * {@inheritDoc}
     */
    public function getDefaultFormatter()
    {
        return new LineFormatter('[%datetime%] %channel%.%level_name%: %message% %context% %extra%');
    }
```

## Proposal
My proposal is to remove the hard setting of a formatter, however, we could also set a new format that simply does not include the `\n`, either way will work for me.

Current output looks like this:

```
[2017-05-11 14:17:09] local.INFO: Here is a log message [] []
```

## Context
I am sending to error_log which end up in Loggly (12 Factor Application) and the incorrect format causes every log to have an empty log after it.