### PR TITLE
[5.4] Fix container Build()

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -715,7 +715,7 @@ class Container implements ArrayAccess, ContainerContract
         // hand back the results of the functions, which allows functions to be
         // used as resolvers for more fine-tuned resolution of these objects.
         if ($concrete instanceof Closure) {
-            return $concrete($this, end($this->with));
+            return $concrete($this, $this->getLastParameterOverride());
         }
 
         $reflector = new ReflectionClass($concrete);
@@ -793,7 +793,7 @@ class Container implements ArrayAccess, ContainerContract
      */
     protected function hasParameterOverride($dependency)
     {
-        return array_key_exists($dependency->name, end($this->with));
+        return array_key_exists($dependency->name, $this->getLastParameterOverride());
     }
 
     /**
@@ -804,7 +804,17 @@ class Container implements ArrayAccess, ContainerContract
      */
     protected function getParameterOverride($dependency)
     {
-        return end($this->with)[$dependency->name];
+        return $this->getLastParameterOverride()[$dependency->name];
+    }
+
+    /**
+     * Get the last parameter override.
+     *
+     * @return array
+     */
+    protected function getLastParameterOverride()
+    {
+        return count($this->with) ? end($this->with) : [];
     }
 
     /**

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -838,6 +838,19 @@ class ContainerTest extends TestCase
         $this->assertEquals(['name' => 'taylor'], $container->makeWith('foo', ['name' => 'taylor']));
         $this->assertEquals(['name' => 'abigail'], $container->makeWith('foo', ['name' => 'abigail']));
     }
+
+    public function testCanBuildWithoutParameterStackWithNoConstructors()
+    {
+        $container = new Container;
+        $this->assertInstanceOf(ContainerConcreteStub::class, $container->build(ContainerConcreteStub::class));
+    }
+
+    public function testCanBuildWithoutParameterStackWithConstructors()
+    {
+        $container = new Container;
+        $container->bind('Illuminate\Tests\Container\IContainerContractStub', 'Illuminate\Tests\Container\ContainerImplementationStub');
+        $this->assertInstanceOf(ContainerDependentStub::class, $container->build(ContainerDependentStub::class));
+    }
 }
 
 class ContainerConcreteStub


### PR DESCRIPTION
So this PR attempts to fix a bug that I *think* was introduced in 5.4.16 (https://github.com/laravel/framework/commit/5d9b363448b9aac83b610166141b8bba9f1807f8), but only became visible in 5.4.19 (https://github.com/laravel/framework/commit/ebe568c440cee4998765de7f23813f8dac560d56)

It was identified in this issue: https://github.com/laravel/framework/issues/19122

Basically if you run `make()` or `makeWith()` - they will both call `resolve()` which will correctly set the parameter stack (using `$this->with`).

Depending on the path - `resolve()` may call `build()` - so the `build()` function uses the parameter stack as part of the process - which is all correct.

But the problem is you can also call `build()` directly (it is a `public` method). In this situation the parameter stack is never set (because it is not used) - but the function assumes it was. When the check on the parameter stack occurs, it can return `false` if the array was empty.

In 5.4.16 -> 5.4.18 this was not noticed, because the parameter stack would *always* have arrays (incorrectly) left over from previous use (that was the memory leak fixed in 5.4.19) - and thus would never return `false`. It would actually even possibly return an incorrect value from the previous build.

But in 5.4.19 we stopped the eronous/incorrect population of the parameter stack when it was not used, and now you can sometimes have a situation where `build()` checks an empty parameter stack.

Further - the reason all the test pass for 5.4.16 onwards is that there does not seem to be any `build()` tests in any of the framework unit tests? There are tests for `make()` etc that can call `build()` - but none for `build()` itself which is a public method - which is how this slipped through.

I've added a couple of tests that would fail without this change, to help prevent regression.