### PR TITLE
[5.4] Migration: add --once and --only options

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
@@ -16,11 +16,12 @@ class MigrateCommand extends BaseCommand
      */
     protected $signature = 'migrate {--database= : The database connection to use.}
                 {--force : Force the operation to run when in production.}
-                {--path= : The path of migrations files to be executed.}
+                {--once : Only run the first migration, so you can run them one by one.}
+                {--only= : Only run the specified migrations file.}
+                {--path= : The path to directory containing migrations files to be executed.}
                 {--pretend : Dump the SQL queries that would be run.}
                 {--seed : Indicates if the seed task should be re-run.}
-                {--step : Force the migrations to be run so they can be rolled back individually.}
-                {--once : Only run the first migration, so you can run them one by one.}';
+                {--step : Force the migrations to be run so they can be rolled back individually.}';
 
     /**
      * The console command description.
@@ -67,6 +68,7 @@ class MigrateCommand extends BaseCommand
         // so that migrations may be run for any path within the applications.
         $this->migrator->run($this->getMigrationPaths(), [
             'once' => $this->option('once'),
+            'only' => $this->option('only'),
             'pretend' => $this->option('pretend'),
             'step' => $this->option('step'),
         ]);

--- a/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
@@ -19,7 +19,8 @@ class MigrateCommand extends BaseCommand
                 {--path= : The path of migrations files to be executed.}
                 {--pretend : Dump the SQL queries that would be run.}
                 {--seed : Indicates if the seed task should be re-run.}
-                {--step : Force the migrations to be run so they can be rolled back individually.}';
+                {--step : Force the migrations to be run so they can be rolled back individually.}
+                {--once : Only run the first migration, so you can run them one by one.}';
 
     /**
      * The console command description.
@@ -65,6 +66,7 @@ class MigrateCommand extends BaseCommand
         // we will use the path relative to the root of this installation folder
         // so that migrations may be run for any path within the applications.
         $this->migrator->run($this->getMigrationPaths(), [
+            'once' => $this->option('once'),
             'pretend' => $this->option('pretend'),
             'step' => $this->option('step'),
         ]);

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -135,8 +135,8 @@ class Migrator
         // each migration's execution. We will also extract a few of the options.
         $batch = $this->repository->getNextBatchNumber();
 
+        $once = Arr::get($options, 'once', false);
         $pretend = Arr::get($options, 'pretend', false);
-
         $step = Arr::get($options, 'step', false);
 
         // Once we have the array of migrations, we will spin through them and run the
@@ -147,6 +147,10 @@ class Migrator
 
             if ($step) {
                 $batch++;
+            }
+
+            if ($once) {
+                return;
             }
         }
     }


### PR DESCRIPTION
Add following commands to `artisan migrate`:

- `--once` - only runs a single migration at a time.  Has been useful for me when I needed to step through a single migration at a time (and potentially roll back/re-run) without running much larger/longer migrations further down the chain.
- `--only=[file]` - runs only the specified migration.  It handles someone entering only the file basename, full filename, or full path to the migration file (explained in the comments above code)

I've been using these locally for a while, but others may find use.  Feel free to switch PR branch if you'd rather this go into 5.5 instead of 5.4, but it's a minor non-breaking addition.


Additionally, updated wording on the `--path` help text, since when I first read "path" I interpreted it as the path to a migration file to run, not a directory (hence adding the --only= option)