### PR TITLE
[5.5] Set min PHP to 7.1 because of PHP support timeline.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,9 @@ env:
 matrix:
   fast_finish: true
   include:
-    - php: 7.0
+    - php: 7.1
       env: setup=lowest
-    - php: 7.0
+    - php: 7.1
       env: setup=stable
 
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 7.0
   - 7.1
 
 env:
@@ -27,7 +26,6 @@ services:
   - redis-server
 
 before_install:
-  - if [[ $TRAVIS_PHP_VERSION != 7.1 ]] ; then phpenv config-rm xdebug.ini; fi
   - echo "extension = memcached.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
   - pecl install -f redis
   - travis_retry composer self-update

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": ">=7.0",
+        "php": ">=7.1",
         "ext-mbstring": "*",
         "ext-openssl": "*",
         "doctrine/inflector": "~1.0",


### PR DESCRIPTION
Hello everybody,

some time ago Taylor announced that Laravel 5.5 require PHP 7+ (actually in the composer.json >=7.0) and will be an LTS Release. For some of our projects it is an requirement to use an LTS Version of Laravel, so after viewing the Support Timeline from PHP itself (https://secure.php.net/supported-versions.php) PHP 7.0 will get active support until 3 Dec 2017 and security fixes until 3 Dec 2018. I know that the plan for Laravel 5.5 would be: 2 years Bug fixes and 3 years security fixes. So (when it will released on 1 july 2017) the "bug fix support" will end on 2 july 2019 and the "security fixes support" will end on 2 july (2020 or 2022?). So Laravel would support versions that doesn't receive any PHP Security updates anymore.

For PHP 7.1 the timeline says: Bugfixes until 1 Dec 2018 and Securityfixes until 1 Dec 2019, so difference between PHP 7.1 EOL and Laravel 5.5 EOL would be only 7 months (enough time to update to the next LTS Version).

The changes required for migration PHP 7.0 to PHP 7.1 aren't so much, actually Laravel 5.4 runs on both without an error, and the improvements (speed, server requirements and so on) prevail.