### PR TITLE
[5.4] Allow non-method Callables

### DIFF
--- a/src/Illuminate/Routing/RouteSignatureParameters.php
+++ b/src/Illuminate/Routing/RouteSignatureParameters.php
@@ -36,6 +36,10 @@ class RouteSignatureParameters
     {
         list($class, $method) = Str::parseCallback($uses);
 
+        if (! method_exists($class, $method) && is_callable($class, $method)) {
+            return [];
+        }
+
         return (new ReflectionMethod($class, $method))->getParameters();
     }
 }

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -1205,6 +1205,17 @@ class RoutingRouteTest extends TestCase
         $this->assertFalse(isset($_SERVER['route.test.controller.except.middleware']));
     }
 
+    public function testCallableControllerRouting()
+    {
+        $router = $this->getRouter();
+
+        $router->get('foo/bar', 'Illuminate\Tests\Routing\RouteTestControllerCallableStub@bar');
+        $router->get('foo/baz', 'Illuminate\Tests\Routing\RouteTestControllerCallableStub@baz');
+
+        $this->assertEquals('bar', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
+        $this->assertEquals('baz', $router->dispatch(Request::create('foo/baz', 'GET'))->getContent());
+    }
+
     public function testControllerMiddlewareGroups()
     {
         unset(
@@ -1323,6 +1334,14 @@ class RouteTestControllerStub extends Controller
     public function index()
     {
         return 'Hello World';
+    }
+}
+
+class RouteTestControllerCallableStub extends Controller
+{
+    public function __call($method, $arguments = [])
+    {
+        return $method;
     }
 }
 


### PR DESCRIPTION
Currently if you have a dynamic controller method (via `__call`) it will fail because of `ReflectionMethod` not finding the explicit method.

Here is an example, say we have `ViewController` that is simply:
```php
namespace App\Http\Controllers;

class ViewController extends Controller
{
    /**
     * Get a static page view.
     *
     * @param string $method
     * @param array  $arguments
     *
     * @return \Illuminate\Http\Response
     */
    public function __call($method, $arguments = [])
    {
        return view($method)
            ->with($arguments);
    }
}
```

A route definition of:
```php
$router->get('/', [
    'as' => 'get::home',
    'uses' => 'ViewController@home',
]);
```

and a view `home.blade.php` of:
```html
<h1>We're home!</h1>
```

With the current setup it will fail with `Method App\Http\Controllers\ViewController::home() does not exist` but with the alteration it will succeed as it is _still callable_ just not an explicit method.