### PR TITLE
[5.4] Add Model::refresh()

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -956,7 +956,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 
         $this->load(array_keys($this->relations));
 
-        $this->setRawAttributes(static::find($this->getKey())->attributes);
+        $this->setRawAttributes(static::findOrFail($this->getKey())->attributes);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -944,6 +944,23 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     }
 
     /**
+     * Reload the current model instance with fresh attributes from the database.
+     *
+     * @param  array|string  $with
+     * @return static|null
+     */
+    public function refresh()
+    {
+        if (! $this->exists) {
+            return;
+        }
+
+        $this->load(array_keys($this->relations));
+
+        $this->setRawAttributes(static::find($this->getKey())->attributes);
+    }
+
+    /**
      * Clone the model into a new, non-existing instance.
      *
      * @param  array|null  $except

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -946,8 +946,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     /**
      * Reload the current model instance with fresh attributes from the database.
      *
-     * @param  array|string  $with
-     * @return static|null
+     * @return void
      */
     public function refresh()
     {


### PR DESCRIPTION
This method eliminates the need for:

```php
$user = $user->fresh()
```

You can do this instead:

```php
$user->refresh()
```