### PR TITLE
[5.4] [WIP] Fix container

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -241,9 +241,12 @@ class Container implements ArrayAccess, ContainerContract
     protected function getClosure($abstract, $concrete)
     {
         return function ($container, $parameters = []) use ($abstract, $concrete) {
-            $method = ($abstract == $concrete) ? 'build' : 'make';
 
-            return $container->$method($concrete, $parameters);
+            if ($abstract == $concrete) {
+                return $container->build($concrete);
+            }
+
+            return $container->makeWith($concrete, $parameters);
         };
     }
 

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -241,7 +241,6 @@ class Container implements ArrayAccess, ContainerContract
     protected function getClosure($abstract, $concrete)
     {
         return function ($container, $parameters = []) use ($abstract, $concrete) {
-
             if ($abstract == $concrete) {
                 return $container->build($concrete);
             }

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -692,6 +692,26 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     /**
      * Resolve the given type from the container.
      *
+     * (Overriding Container::makeWith)
+     *
+     * @param  string  $abstract
+     * @param  array  $parameters
+     * @return mixed
+     */
+    public function makeWith($abstract, array $parameters)
+    {
+        $abstract = $this->getAlias($abstract);
+
+        if (isset($this->deferredServices[$abstract])) {
+            $this->loadDeferredProvider($abstract);
+        }
+
+        return parent::makeWith($abstract, $parameters);
+    }
+
+    /**
+     * Resolve the given type from the container.
+     *
      * (Overriding Container::make)
      *
      * @param  string  $abstract

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -799,6 +799,14 @@ class ContainerTest extends TestCase
         $this->assertEquals([1, 2, 3], $container->makeWith('foo', [1, 2, 3]));
     }
 
+    public function testResolvingWithUsingAnInterface()
+    {
+        $container = new Container;
+        $container->bind(IContainerContractStub::class, ContainerInjectVariableStubWithInterfaceImplementation::class);
+        $instance = $container->makeWith(IContainerContractStub::class, ['something' => 'laurence']);
+        $this->assertEquals('laurence', $instance->something);
+    }
+
     public function testNestedParameterOverride()
     {
         $container = new Container;
@@ -864,6 +872,7 @@ interface IContainerContractStub
 class ContainerImplementationStub implements IContainerContractStub
 {
 }
+
 class ContainerImplementationStubTwo implements IContainerContractStub
 {
 }
@@ -981,6 +990,16 @@ class ContainerStaticMethodStub
 }
 
 class ContainerInjectVariableStub
+{
+    public $something;
+
+    public function __construct(ContainerConcreteStub $concrete, $something)
+    {
+        $this->something = $something;
+    }
+}
+
+class ContainerInjectVariableStubWithInterfaceImplementation implements IContainerContractStub
 {
     public $something;
 


### PR DESCRIPTION
This is an attempt to fix https://github.com/laravel/framework/issues/19175

The current `getClosure()` does the following call:

`return $container->$method($concrete, $parameters);`

But `$method` can only ever be `make($abstract)` or `build($concrete)`. Both of these only take a single parameter as of https://github.com/laravel/framework/commit/ff993b806dcb21ba8a5367594e87d113338c1670 - yet we are trying to pass in 2 parameters.

The problem is if you originally called `makeWith()` - and you end up down this path due to an interface being used, you end up with `$parameters` dropping off and not being passed along when `make()` is called here.

The limitation we have to work with is there cant be an interface change for 5.4. So we cant change `make()` to accept the second `$parameters` (which is probably the best solution here).

This PR switches the `getClosure()` to use the `makeWith()`, allowing the parameters to happily continue along until they are needed.

But - switching to `makeWith()` we create another issue: `Application.php` extends the `make()` function, to load any deferred providers. We need to also allow that to occur for `makeWith()`?

I've labelled this WIP - because although all the tests are green - I'm worried about unintended side effects here. Specifically would anyone have a custom implementation of Application that does not extend the Framework version? What would occur to their deferred providers in that instance?

I think we should get some people to test in real applications and see before we commit this.

The alternative is we leave the behavior as is for 5.4, and just fix it in 5.5 with a contract change, which will allow for a better and safer refactor, rather than doing this on a point release?