### PR TITLE
[5.4] Use Authenticatable-functionality to update remember_token

### DIFF
--- a/src/Illuminate/Foundation/Auth/ResetsPasswords.php
+++ b/src/Illuminate/Foundation/Auth/ResetsPasswords.php
@@ -100,10 +100,9 @@ trait ResetsPasswords
      */
     protected function resetPassword($user, $password)
     {
-        $user->forceFill([
-            'password' => bcrypt($password),
-            'remember_token' => Str::random(60),
-        ])->save();
+        $user->forceFill(['password' => bcrypt($password)]);
+        $user->setRememberToken(Str::random(60));
+        $user->save();
 
         $this->guard()->login($user);
     }


### PR DESCRIPTION
`ResetsPasswords` currently assumes a user has a `remember_token` field. 
This changes this to using the `setRememberToken()`-function. 
True, it still assumes `Authenticatable`, but now you can intercept this and still use the built-in reset password functionality.