### PR TITLE
Deprecated Auth::routes() in favour of Route::auth()

### DIFF
--- a/src/Illuminate/Auth/Console/stubs/make/routes.stub
+++ b/src/Illuminate/Auth/Console/stubs/make/routes.stub
@@ -1,4 +1,4 @@
 
-Auth::routes();
+Route::auth();
 
 Route::get('/home', 'HomeController@index')->name('home');

--- a/src/Illuminate/Support/Facades/Auth.php
+++ b/src/Illuminate/Support/Facades/Auth.php
@@ -39,6 +39,9 @@ class Auth extends Facade
     /**
      * Register the typical authentication routes for an application.
      *
+     * @deprecated For code consistency Route::auth() should be used instead of this method.
+     * @see \Illuminate\Routing\Router::auth() For method parameters and usage.
+     *
      * @return void
      */
     public static function routes()


### PR DESCRIPTION
It really makes no sense to have this parasite method on the Auth facade.