### PR TITLE
[5.5] Use Authenticatable-functionality to update remember_token

### DIFF
--- a/CHANGELOG-5.4.md
+++ b/CHANGELOG-5.4.md
@@ -1,9 +1,18 @@
 # Release Notes for 5.4.x
 
-## [Unreleased]
+## v5.4.23 (2017-05-11)
+
+### Added
+- Added `Gate::abilities()` accessor ([#19143](https://github.com/laravel/framework/pull/19143), [e9e34b5](https://github.com/laravel/framework/commit/e9e34b5acd3feccec5ffe3ff6d84ff9009ff2a7a))
+- Added ability to eager load counts via `$withCount` property ([#19154](https://github.com/laravel/framework/pull/19154))
 
 ### Fixed
 - Fixed inversion of expected and actual on assertHeader ([#19110](https://github.com/laravel/framework/pull/19110))
+- Fixed filesystem bug in `Filesystem::files()` method on Windows ([#19157](https://github.com/laravel/framework/pull/19157))
+- Fixed bug in `Container::build()` ([#19161](https://github.com/laravel/framework/pull/19161), [bf669e1](https://github.com/laravel/framework/commit/bf669e16d61ef0225b86adc781ddcc752aafd62b))
+
+### Removed
+- Removed `window.Laravel` object ([#19135](https://github.com/laravel/framework/pull/19135))
 
 
 ## v5.4.22 (2017-05-08)

--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -118,6 +118,30 @@ class Gate implements GateContract
     }
 
     /**
+     * Define abilities for a resource.
+     *
+     * @param  string  $name
+     * @param  string  $class
+     * @param  array   $abilities
+     * @return $this
+     */
+    public function resource($name, $class, array $abilities = null)
+    {
+        $abilities = $abilities ?: [
+            'view'   => 'view',
+            'create' => 'create',
+            'update' => 'update',
+            'delete' => 'delete',
+        ];
+
+        foreach ($abilities as $ability => $method) {
+            $this->define($name.'.'.$ability, $class.'@'.$method);
+        }
+
+        return $this;
+    }
+
+    /**
      * Create the ability callback for a callback string.
      *
      * @param  string  $callback

--- a/src/Illuminate/Foundation/Auth/ResetsPasswords.php
+++ b/src/Illuminate/Foundation/Auth/ResetsPasswords.php
@@ -100,7 +100,7 @@ trait ResetsPasswords
      */
     protected function resetPassword($user, $password)
     {
-        $user->forceFill(['password' => bcrypt($password)]);
+        $user->password = bcrypt($password);
         $user->setRememberToken(Str::random(60));
         $user->save();
 

--- a/src/Illuminate/Foundation/Auth/ResetsPasswords.php
+++ b/src/Illuminate/Foundation/Auth/ResetsPasswords.php
@@ -100,10 +100,9 @@ trait ResetsPasswords
      */
     protected function resetPassword($user, $password)
     {
-        $user->forceFill([
-            'password' => bcrypt($password),
-            'remember_token' => Str::random(60),
-        ])->save();
+        $user->forceFill(['password' => bcrypt($password)]);
+        $user->setRememberToken(Str::random(60));
+        $user->save();
 
         $this->guard()->login($user);
     }

--- a/src/Illuminate/Routing/RouteSignatureParameters.php
+++ b/src/Illuminate/Routing/RouteSignatureParameters.php
@@ -36,6 +36,10 @@ class RouteSignatureParameters
     {
         list($class, $method) = Str::parseCallback($uses);
 
+        if (! method_exists($class, $method) && is_callable($class, $method)) {
+            return [];
+        }
+
         return (new ReflectionMethod($class, $method))->getParameters();
     }
 }

--- a/tests/Auth/AuthAccessGateTest.php
+++ b/tests/Auth/AuthAccessGateTest.php
@@ -35,6 +35,35 @@ class GateTest extends TestCase
         $this->assertFalse($gate->check('bar'));
     }
 
+    public function test_resource_gates_can_be_defined()
+    {
+        $gate = $this->getBasicGate();
+
+        $gate->resource('test', AccessGateTestResource::class);
+
+        $dummy = new AccessGateTestDummy;
+
+        $this->assertTrue($gate->check('test.view'));
+        $this->assertTrue($gate->check('test.create'));
+        $this->assertTrue($gate->check('test.update', $dummy));
+        $this->assertTrue($gate->check('test.delete', $dummy));
+    }
+
+    public function test_custom_resource_gates_can_be_defined()
+    {
+        $gate = $this->getBasicGate();
+
+        $abilities = [
+            'ability1' => 'foo',
+            'ability2' => 'bar',
+        ];
+
+        $gate->resource('test', AccessGateTestCustomResource::class, $abilities);
+
+        $this->assertTrue($gate->check('test.ability1'));
+        $this->assertTrue($gate->check('test.ability2'));
+    }
+
     public function test_before_callbacks_can_override_result_if_necessary()
     {
         $gate = $this->getBasicGate();
@@ -354,5 +383,41 @@ class AccessGateTestPolicyWithBefore
     public function update($user, AccessGateTestDummy $dummy)
     {
         return false;
+    }
+}
+
+class AccessGateTestResource
+{
+    public function view($user)
+    {
+        return true;
+    }
+
+    public function create($user)
+    {
+        return true;
+    }
+
+    public function update($user, AccessGateTestDummy $dummy)
+    {
+        return true;
+    }
+
+    public function delete($user, AccessGateTestDummy $dummy)
+    {
+        return true;
+    }
+}
+
+class AccessGateTestCustomResource
+{
+    public function foo($user)
+    {
+        return true;
+    }
+
+    public function bar($user)
+    {
+        return true;
     }
 }

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -1205,6 +1205,17 @@ class RoutingRouteTest extends TestCase
         $this->assertFalse(isset($_SERVER['route.test.controller.except.middleware']));
     }
 
+    public function testCallableControllerRouting()
+    {
+        $router = $this->getRouter();
+
+        $router->get('foo/bar', 'Illuminate\Tests\Routing\RouteTestControllerCallableStub@bar');
+        $router->get('foo/baz', 'Illuminate\Tests\Routing\RouteTestControllerCallableStub@baz');
+
+        $this->assertEquals('bar', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
+        $this->assertEquals('baz', $router->dispatch(Request::create('foo/baz', 'GET'))->getContent());
+    }
+
     public function testControllerMiddlewareGroups()
     {
         unset(
@@ -1369,6 +1380,14 @@ class RouteTestControllerStub extends Controller
     public function index()
     {
         return 'Hello World';
+    }
+}
+
+class RouteTestControllerCallableStub extends Controller
+{
+    public function __call($method, $arguments = [])
+    {
+        return $method;
     }
 }
 


### PR DESCRIPTION
`ResetsPasswords` currently assumes a user has a `remember_token` field. 
This changes this to using the `setRememberToken()`-function. 
True, it still assumes `Authenticatable`, but now you can intercept this and still use the built-in reset password functionality.