### PR TITLE
[5.4] Added similar() collection method

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1372,6 +1372,23 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
+     * Filter items by the similarity of the given value.
+     *
+     * @param  mixed   $value
+     * @param  integer $threshold
+     * @return static
+     */
+    public function similar($value, $threshold = 85)
+    {
+        return $this->filter(function ($item) use ($value, $threshold) {
+
+            similar_text((string) $item, (string) $value, $similarity);
+
+            return $similarity >= $threshold;
+        });
+    }
+
+    /**
      * Get the collection of items as a plain array.
      *
      * @return array

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1374,8 +1374,8 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Filter items by the similarity of the given value.
      *
-     * @param  mixed   $value
-     * @param  integer $threshold
+     * @param  mixed $value
+     * @param  int $threshold
      * @return static
      */
     public function similar($value, $threshold = 85)

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1381,7 +1381,6 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     public function similar($value, $threshold = 85)
     {
         return $this->filter(function ($item) use ($value, $threshold) {
-
             similar_text((string) $item, (string) $value, $similarity);
 
             return $similarity >= $threshold;

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1546,7 +1546,7 @@ class SupportCollectionTest extends TestCase
     public function testSimilar()
     {
         $c = new Collection(['coat', 'cost', 'code']);
-        
+
         $f = $c->similar('foo');
         $this->assertInstanceOf(Collection::class, $f);
         $this->assertCount(0, $f);
@@ -1556,7 +1556,7 @@ class SupportCollectionTest extends TestCase
 
         $f = $c->similar('coast');
         $this->assertEquals(['coat', 'cost'], $f->values()->toArray());
-        
+
         $f = $c->similar('coast', 40);
         $this->assertEquals(['coat', 'cost', 'code'], $f->values()->toArray());
     }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1543,6 +1543,24 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals([3, 6, null], $c[2]->all());
     }
 
+    public function testSimilar()
+    {
+        $c = new Collection(['coat', 'cost', 'code']);
+        
+        $f = $c->similar('foo');
+        $this->assertInstanceOf(Collection::class, $f);
+        $this->assertCount(0, $f);
+
+        $f = $c->similar('costs');
+        $this->assertEquals(['cost'], $f->values()->toArray());
+
+        $f = $c->similar('coast');
+        $this->assertEquals(['coat', 'cost'], $f->values()->toArray());
+        
+        $f = $c->similar('coast', 40);
+        $this->assertEquals(['coat', 'cost', 'code'], $f->values()->toArray());
+    }
+
     public function testGettingMaxItemsFromCollection()
     {
         $c = new Collection([(object) ['foo' => 10], (object) ['foo' => 20]]);


### PR DESCRIPTION
Added possibility to filter collection items by the similarity of the given value.

#### Standard example
```php
$collection = collect(['coat', 'cost', 'code']);

$filtered = $collection->similar('coast');
$filtered->all(); // ['coat', 'cost']
```

#### It's also possible to filter using an optional threshold (default 85% similarity)
```php
$collection = collect(['coat', 'cost', 'code']);

$filtered = $collection->similar('coast', 40);
$filtered->all(); // ['coat', 'cost', 'code']
```

#### Values can be anything that can be casted to a string (Eloquent object for example)
```php
$collection = App\User::all();
$user = App\User::find(1);

$filtered = $collection->similar($user);
```