### PR TITLE
[5.5] Add a PasswordReset event.

### DIFF
--- a/src/Illuminate/Auth/Events/PasswordReset.php
+++ b/src/Illuminate/Auth/Events/PasswordReset.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Illuminate\Auth\Events;
+
+use Illuminate\Queue\SerializesModels;
+
+class PasswordReset
+{
+    use SerializesModels;
+
+    /**
+     * The user.
+     *
+     * @var \Illuminate\Contracts\Auth\Authenticatable
+     */
+    public $user;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
+     * @return void
+     */
+    public function __construct($user)
+    {
+        $this->user = $user;
+    }
+}

--- a/src/Illuminate/Foundation/Auth/ResetsPasswords.php
+++ b/src/Illuminate/Foundation/Auth/ResetsPasswords.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Str;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Password;
+use Illuminate\Auth\Events\PasswordReset;
 
 trait ResetsPasswords
 {
@@ -105,6 +106,8 @@ trait ResetsPasswords
         $user->setRememberToken(Str::random(60));
 
         $user->save();
+
+        event(new PasswordReset($user));
 
         $this->guard()->login($user);
     }


### PR DESCRIPTION
It is useful to track when a user password has been reset.
For instance to send a confirmation emal to the user, or to track when the password was last reset (as we might want to enforce the user to change his password every n-months)

---

This PR adds a `PasswordReset` event.