### PR TITLE
Migrate to container-based infraestructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: php
 
+sudo: false
+
 php:
   - 5.6
   - 7.0


### PR DESCRIPTION
Laravel is currently running in the TravisCI legacy infraestructure. Migrating to container-based infraestructure has [some interesting advantages](https://docs.travis-ci.com/user/migrating-from-legacy#Why-migrate-to-container-based-infrastructure%3F). Also, It doesn't affect the tests in any negative way (tests are passing).
([More information](https://docs.travis-ci.com/user/migrating-from-legacy))