### PR TITLE
Optional name prefix to auth routes

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -989,23 +989,24 @@ class Router implements RegistrarContract, BindingRegistrar
     /**
      * Register the typical authentication routes for an application.
      *
+     * @param  string  $namePrefix
      * @return void
      */
-    public function auth()
+    public function auth($namePrefix = '')
     {
         // Authentication Routes...
-        $this->get('login', 'Auth\LoginController@showLoginForm')->name('login');
+        $this->get('login', 'Auth\LoginController@showLoginForm')->name($namePrefix.'login');
         $this->post('login', 'Auth\LoginController@login');
-        $this->post('logout', 'Auth\LoginController@logout')->name('logout');
+        $this->post('logout', 'Auth\LoginController@logout')->name($namePrefix.'logout');
 
         // Registration Routes...
-        $this->get('register', 'Auth\RegisterController@showRegistrationForm')->name('register');
+        $this->get('register', 'Auth\RegisterController@showRegistrationForm')->name($namePrefix.'register');
         $this->post('register', 'Auth\RegisterController@register');
 
         // Password Reset Routes...
-        $this->get('password/reset', 'Auth\ForgotPasswordController@showLinkRequestForm')->name('password.request');
-        $this->post('password/email', 'Auth\ForgotPasswordController@sendResetLinkEmail')->name('password.email');
-        $this->get('password/reset/{token}', 'Auth\ResetPasswordController@showResetForm')->name('password.reset');
+        $this->get('password/reset', 'Auth\ForgotPasswordController@showLinkRequestForm')->name($namePrefix.'password.request');
+        $this->post('password/email', 'Auth\ForgotPasswordController@sendResetLinkEmail')->name($namePrefix.'password.email');
+        $this->get('password/reset/{token}', 'Auth\ResetPasswordController@showResetForm')->name($namePrefix.'password.reset');
         $this->post('password/reset', 'Auth\ResetPasswordController@reset');
     }
 


### PR DESCRIPTION
Since ```Route::group(['as' => 'foo.'], function () { ... });``` will prefix all routes' names with 'foo.', those that aren't named to begin with will end up having 'foo.' as their name.

This change will enable ```Route::auth('admin.');``` to prefix only the named auth routes, resulting in 'admin.login', 'admin.logout' etc.

Useful for systems with multiple auth paths.