### PR TITLE
add thumb_url to Slack Attachment

### DIFF
--- a/src/Illuminate/Notifications/Channels/SlackWebhookChannel.php
+++ b/src/Illuminate/Notifications/Channels/SlackWebhookChannel.php
@@ -88,6 +88,7 @@ class SlackWebhookChannel
                 'footer' => $attachment->footer,
                 'footer_icon' => $attachment->footerIcon,
                 'image_url' => $attachment->imageUrl,
+                'thumb_url' => $attachment->thumbUrl,
                 'mrkdwn_in' => $attachment->markdown,
                 'text' => $attachment->content,
                 'title' => $attachment->title,

--- a/src/Illuminate/Notifications/Messages/SlackAttachment.php
+++ b/src/Illuminate/Notifications/Messages/SlackAttachment.php
@@ -56,6 +56,13 @@ class SlackAttachment
     public $markdown;
 
     /**
+     * The attachment's thumb url.
+     *
+     * @var string
+     */
+    public $thumbUrl;
+
+    /**
      * The attachment's image url.
      *
      * @var string
@@ -196,6 +203,19 @@ class SlackAttachment
     public function image($url)
     {
         $this->imageUrl = $url;
+
+        return $this;
+    }
+
+    /**
+     * Set the thumb URL.
+     *
+     * @param string $url
+     * @return $this
+     */
+    public function thumb($url)
+    {
+        $this->thumbUrl = $url;
 
         return $this;
     }


### PR DESCRIPTION
add thumb_url to Slack Attachment https://api.slack.com/docs/message-attachments#thumb_url

so we can append image in the message content.