### PR TITLE
[5.5] Refactor container

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -245,7 +245,7 @@ class Container implements ArrayAccess, ContainerContract
                 return $container->build($concrete);
             }
 
-            return $container->makeWith($concrete, $parameters);
+            return $container->make($concrete, $parameters);
         };
     }
 
@@ -547,26 +547,27 @@ class Container implements ArrayAccess, ContainerContract
     }
 
     /**
-     * Resolve the given type with the given parameter overrides.
+     * An alias function name for make().
      *
      * @param  string  $abstract
      * @param  array  $parameters
      * @return mixed
      */
-    public function makeWith($abstract, array $parameters)
+    public function makeWith($abstract, array $parameters = [])
     {
-        return $this->resolve($abstract, $parameters);
+        return $this->make($abstract, $parameters);
     }
 
     /**
      * Resolve the given type from the container.
      *
      * @param  string  $abstract
+     * @param  array  $parameters
      * @return mixed
      */
-    public function make($abstract)
+    public function make($abstract, array $parameters = [])
     {
-        return $this->resolve($abstract);
+        return $this->resolve($abstract, $parameters);
     }
 
     /**
@@ -788,7 +789,7 @@ class Container implements ArrayAccess, ContainerContract
     }
 
     /**
-     * Determine if the given dependency has a parameter override from makeWith.
+     * Determine if the given dependency has a parameter override.
      *
      * @param  \ReflectionParameter  $dependency
      * @return bool

--- a/src/Illuminate/Contracts/Container/Container.php
+++ b/src/Illuminate/Contracts/Container/Container.php
@@ -109,9 +109,10 @@ interface Container
      * Resolve the given type from the container.
      *
      * @param  string  $abstract
+     * @param  array  $parameters
      * @return mixed
      */
-    public function make($abstract);
+    public function make($abstract, array $parameters = []);
 
     /**
      * Call the given Closure / class@method and inject its dependencies.

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -692,13 +692,13 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     /**
      * Resolve the given type from the container.
      *
-     * (Overriding Container::makeWith)
+     * (Overriding Container::make)
      *
      * @param  string  $abstract
      * @param  array  $parameters
      * @return mixed
      */
-    public function makeWith($abstract, array $parameters)
+    public function make($abstract, array $parameters = [])
     {
         $abstract = $this->getAlias($abstract);
 
@@ -706,26 +706,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
             $this->loadDeferredProvider($abstract);
         }
 
-        return parent::makeWith($abstract, $parameters);
-    }
-
-    /**
-     * Resolve the given type from the container.
-     *
-     * (Overriding Container::make)
-     *
-     * @param  string  $abstract
-     * @return mixed
-     */
-    public function make($abstract)
-    {
-        $abstract = $this->getAlias($abstract);
-
-        if (isset($this->deferredServices[$abstract])) {
-            $this->loadDeferredProvider($abstract);
-        }
-
-        return parent::make($abstract);
+        return parent::make($abstract, $parameters);
     }
 
     /**

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -128,7 +128,7 @@ class ContainerTest extends TestCase
             return $config;
         });
         $container->alias('foo', 'baz');
-        $this->assertEquals([1, 2, 3], $container->makeWith('baz', [1, 2, 3]));
+        $this->assertEquals([1, 2, 3], $container->make('baz', [1, 2, 3]));
     }
 
     public function testBindingsCanBeOverridden()
@@ -783,10 +783,26 @@ class ContainerTest extends TestCase
         $this->assertEquals('taylor', $instance->name);
     }
 
+    public function testMakeWithMethodIsAnAliasForMakeMethod()
+    {
+        $mock = $this->getMockBuilder(Container::class)
+                     ->setMethods(['make'])
+                     ->getMock();
+
+        $mock->expects($this->once())
+             ->method('make')
+             ->with(ContainerDefaultValueStub::class, ['default' => 'laurence'])
+             ->will($this->returnValue(new StdClass));
+
+        $result = $mock->makeWith(ContainerDefaultValueStub::class, ['default' => 'laurence']);
+
+        $this->assertInstanceOf(StdClass::class, $result);
+    }
+
     public function testResolvingWithArrayOfParameters()
     {
         $container = new Container;
-        $instance = $container->makeWith(ContainerDefaultValueStub::class, ['default' => 'adam']);
+        $instance = $container->make(ContainerDefaultValueStub::class, ['default' => 'adam']);
         $this->assertEquals('adam', $instance->default);
 
         $instance = $container->make(ContainerDefaultValueStub::class);
@@ -796,14 +812,14 @@ class ContainerTest extends TestCase
             return $config;
         });
 
-        $this->assertEquals([1, 2, 3], $container->makeWith('foo', [1, 2, 3]));
+        $this->assertEquals([1, 2, 3], $container->make('foo', [1, 2, 3]));
     }
 
     public function testResolvingWithUsingAnInterface()
     {
         $container = new Container;
         $container->bind(IContainerContractStub::class, ContainerInjectVariableStubWithInterfaceImplementation::class);
-        $instance = $container->makeWith(IContainerContractStub::class, ['something' => 'laurence']);
+        $instance = $container->make(IContainerContractStub::class, ['something' => 'laurence']);
         $this->assertEquals('laurence', $instance->something);
     }
 
@@ -811,7 +827,7 @@ class ContainerTest extends TestCase
     {
         $container = new Container;
         $container->bind('foo', function ($app, $config) {
-            return $app->makeWith('bar', ['name' => 'Taylor']);
+            return $app->make('bar', ['name' => 'Taylor']);
         });
         $container->bind('bar', function ($app, $config) {
             return $config;
@@ -832,7 +848,7 @@ class ContainerTest extends TestCase
             return $config;
         });
 
-        $this->assertEquals([], $container->makeWith('foo', ['something']));
+        $this->assertEquals([], $container->make('foo', ['something']));
     }
 
     public function testSingletonBindingsNotRespectedWithMakeParameters()
@@ -843,8 +859,8 @@ class ContainerTest extends TestCase
             return $config;
         });
 
-        $this->assertEquals(['name' => 'taylor'], $container->makeWith('foo', ['name' => 'taylor']));
-        $this->assertEquals(['name' => 'abigail'], $container->makeWith('foo', ['name' => 'abigail']));
+        $this->assertEquals(['name' => 'taylor'], $container->make('foo', ['name' => 'taylor']));
+        $this->assertEquals(['name' => 'abigail'], $container->make('foo', ['name' => 'abigail']));
     }
 
     public function testCanBuildWithoutParameterStackWithNoConstructors()


### PR DESCRIPTION
With 5.5 we can refactor Container with a small contract change, which should greatly improve the maintainability of Container moving forward. We only need one `make()` path to handle, rather than the current situation of both `makeWith()` and `make()`.

This PR includes keeping `makeWith()` as an alias of `make()` - so people already using `makeWith()` in their code do not need to change anything.

The only "break" is the contract for custom implementations - but even that is a simply optional parameter addition and would not require changing any current code in applications (apart from the contract implementation).