### PR TITLE
[5.4] Adds isRouteName method

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -193,6 +193,22 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
     }
 
     /**
+     * Check if route name matches string.
+     *
+     * @param  string  $name
+     *
+     * @return boolean
+     */
+    public function isRouteName($name)
+    {
+        if ($this->route()->getName() == $name) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
      * Determine if the current request URL and query string matches a pattern.
      *
      * @return bool

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -197,7 +197,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
      *
      * @param  string  $name
      *
-     * @return boolean
+     * @return bool
      */
     public function isRouteName($name)
     {

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -201,11 +201,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
      */
     public function isRouteName($name)
     {
-        if ($this->route()->getName() == $name) {
-            return true;
-        }
-
-        return false;
+        return $this->route()->getName() === $name;
     }
 
     /**

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -2,9 +2,9 @@
 
 namespace Illuminate\Tests\Http;
 
+use Mockery as m;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Route;
-use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -2,9 +2,9 @@
 
 namespace Illuminate\Tests\Http;
 
-use Mockery as m;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Route;
+use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 
@@ -155,6 +155,21 @@ class HttpRequestTest extends TestCase
         $request = Request::create('/', 'GET');
 
         $this->assertTrue($request->is('/'));
+    }
+
+    public function testIsRouteNameMethod()
+    {
+        $request = Request::create('/foo/bar', 'GET');
+
+        $request->setRouteResolver(function () use ($request) {
+            $route = new Route('GET', '/foo/bar', ['as' => 'foo.bar']);
+            $route->bind($request);
+
+            return $route;
+        });
+
+        $this->assertTrue($request->isRouteName('foo.bar'));
+        $this->assertFalse($request->isRouteName('foo.foo'));
     }
 
     public function testAjaxMethod()


### PR DESCRIPTION
Adds a `isRouteName` method to the Request.

For use cases such as `Request::isRouteName(‘foo.bar’)` this allows easier route changes in the future.