### PR TITLE
Support custom column name for softDeletes()

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -824,11 +824,12 @@ class Blueprint
     /**
      * Add a "deleted at" timestamp for the table.
      *
+     * @param  string  $column
      * @return \Illuminate\Support\Fluent
      */
-    public function softDeletes()
+    public function softDeletes($column = 'deleted_at')
     {
-        return $this->timestamp('deleted_at')->nullable();
+        return $this->timestamp($column)->nullable();
     }
 
     /**


### PR DESCRIPTION
Hi,

Changing the default `deleted_at` column name is possible by creating a new constant called `DELETED_AT`.

```php
$table->softDeletes(); // creates 'deleted_at' column

$table->softDeletes('left_at'); // creates 'left_at' column
```