### PR TITLE
Fix the position of bound() in Container::instance() 

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -357,6 +357,8 @@ class Container implements ArrayAccess, ContainerContract
     {
         $this->removeAbstractAlias($abstract);
 
+        $is_bound = $this->bound($abstract);
+
         unset($this->aliases[$abstract]);
 
         // We'll check to determine if this type has been bound before, and if it has
@@ -364,7 +366,7 @@ class Container implements ArrayAccess, ContainerContract
         // can be updated with consuming classes that have gotten resolved here.
         $this->instances[$abstract] = $instance;
 
-        if ($this->bound($abstract)) {
+        if ($is_bound) {
             $this->rebound($abstract);
         }
     }

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -357,7 +357,7 @@ class Container implements ArrayAccess, ContainerContract
     {
         $this->removeAbstractAlias($abstract);
 
-        $is_bound = $this->bound($abstract);
+        $isBound = $this->bound($abstract);
 
         unset($this->aliases[$abstract]);
 
@@ -366,7 +366,7 @@ class Container implements ArrayAccess, ContainerContract
         // can be updated with consuming classes that have gotten resolved here.
         $this->instances[$abstract] = $instance;
 
-        if ($is_bound) {
+        if ($isBound) {
             $this->rebound($abstract);
         }
     }

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -337,6 +337,20 @@ class ContainerTest extends TestCase
         $this->assertTrue($_SERVER['__test.rebind']);
     }
 
+    public function testReboundListenersOnInstancesOnlyFiresIfWasAlreadyBound()
+    {
+        $_SERVER['__test.rebind'] = false;
+
+        $container = new Container;
+        $container->rebinding('foo', function () {
+            $_SERVER['__test.rebind'] = true;
+        });
+        $container->instance('foo', function () {
+        });
+
+        $this->assertFalse($_SERVER['__test.rebind']);
+    }
+
     /**
      * @expectedException \Illuminate\Contracts\Container\BindingResolutionException
      * @expectedExceptionMessage Unresolvable dependency resolving [Parameter #0 [ <required> $first ]] in class Illuminate\Tests\Container\ContainerMixedPrimitiveStub


### PR DESCRIPTION
Hi,
 
In instance() function, the code set the array of instances[$abstract]. And next, the code check to determine if type has been bound before,.However in bound(),  isset(this->instances[$abstract]) always be true because it is set just in last line, and $this->isAlias($abstract) always be false because it just unset($this->aliases[$abstract]):
file: /illuminate/Container/Container.php-line356
```php
public function instance($abstract, $instance)
{
    $this->removeAbstractAlias($abstract);

    unset($this->aliases[$abstract]);        
    $this->instances[$abstract] = $instance;//this is problem

    if ($this->bound($abstract)) {
        $this->rebound($abstract);
    }
}
```
file: /illuminate/Container/Container.php-line151
```php
public function bound($abstract)
{
    return isset($this->bindings[$abstract]) ||
           isset($this->instances[$abstract]) || ////this is problem
           $this->isAlias($abstract);
}
```
so rebound() function always fires incorrectly.
I change the position of  bound() function, so it will not be affected by the code in the instance().
More detail can see issues #19194
thanks!