### PR TITLE
[5.5] No need to reinstall Redis as we only test PHP>=7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,6 @@ services:
 before_install:
   - if [[ $TRAVIS_PHP_VERSION != 7.1 ]] ; then phpenv config-rm xdebug.ini; fi
   - echo "extension = memcached.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
-  - pecl install -f redis
   - travis_retry composer self-update
 
 install:


### PR DESCRIPTION
No need to reinstall Redis as we only test PHP>=7.0

---

See https://github.com/laravel/framework/pull/18421/files#r106821125