### PR TITLE
[5.5] Also disable Xdebug for PHP 7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ services:
   - redis-server
 
 before_install:
-  - if [[ $TRAVIS_PHP_VERSION != 7.1 ]] ; then phpenv config-rm xdebug.ini; fi
+  - phpenv config-rm xdebug.ini
   - echo "extension = memcached.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
   - pecl install -f redis
   - travis_retry composer self-update


### PR DESCRIPTION
Also disable Xdebug for PHP 7.1

There is no reason to let it enabled, as this makes builds slower.