### PR TITLE
[5.4] Query Builder aggregate calls with lone 'order by' clauses break on SQL Server

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2025,7 +2025,7 @@ class Builder
      */
     public function aggregate($function, $columns = ['*'])
     {
-        $results = $this->cloneWithout(['columns'])
+        $results = $this->cloneWithout(['columns', 'orders'])
                         ->cloneWithoutBindings(['select'])
                         ->setAggregate($function, $columns)
                         ->get($columns);


### PR DESCRIPTION
This is an edge case found using Backpack/CRUD with ajax table enabled, resulting in the following exception:
```
SQLSTATE[42000]: [Microsoft][ODBC Driver 13 for SQL Server][SQL Server]Column "job_imports.id" is invalid in the ORDER BY clause because it is not contained in either an aggregate function or the GROUP BY clause. (SQL: select count(*) as aggregate from [job_imports] order by [id] desc)
```
Since 'order by' clauses serve no purpose for aggregate statements, they should be excluded from the query.