### PR TITLE
Update chunk method to have preserve_keys option

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1128,9 +1128,11 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      * Chunk the underlying collection array.
      *
      * @param  int  $size
+     * @param  bool $preserve_keys
+     * 
      * @return static
      */
-    public function chunk($size)
+    public function chunk($size, $preserve_keys = true)
     {
         if ($size <= 0) {
             return new static;
@@ -1138,7 +1140,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
 
         $chunks = [];
 
-        foreach (array_chunk($this->items, $size, true) as $chunk) {
+        foreach (array_chunk($this->items, $size, $preserve_keys) as $chunk) {
             $chunks[] = new static($chunk);
         }
 

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1129,7 +1129,6 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      *
      * @param  int  $size
      * @param  bool $preserve_keys
-     * 
      * @return static
      */
     public function chunk($size, $preserve_keys = true)


### PR DESCRIPTION
It seems necessary for chunking key-less arrays to force reindexing the chunk numerically. This PR adds `preserve_keys` option to `chunk` method. Related to this: #19182