### PR TITLE
[5.4] Route isName

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -200,7 +200,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
      */
     public function routeIs($name)
     {
-        return $this->route() && $this->route()->getName() === $name;
+        return $this->route() && $this->route()->isName($name);
     }
 
     /**

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -593,7 +593,7 @@ class Route
 
     /**
      * Checks whether the route's name is equal to a given one.
-     * @param $name
+     * @param  string  $name
      * @return bool
      */
     public function isName($name)

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -592,6 +592,16 @@ class Route
     }
 
     /**
+     * Checks whether the route's name is equal to a given one
+     * @param $name
+     * @return bool
+     */
+    public function isName($name)
+    {
+        return $this->getName() === $name;
+    }
+
+    /**
      * Add or change the route name.
      *
      * @param  string  $name

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -592,7 +592,7 @@ class Route
     }
 
     /**
-     * Checks whether the route's name is equal to a given one
+     * Checks whether the route's name is equal to a given one.
      * @param $name
      * @return bool
      */

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -940,7 +940,7 @@ class Router implements RegistrarContract, BindingRegistrar
      */
     public function currentRouteNamed($name)
     {
-        return $this->current() ? $this->current()->getName() == $name : false;
+        return $this->current() ? $this->current()->isName($name) : false;
     }
 
     /**

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -157,7 +157,7 @@ class HttpRequestTest extends TestCase
         $this->assertTrue($request->is('/'));
     }
 
-    public function testIsRouteNameMethod()
+    public function testRouteIsMethod()
     {
         $request = Request::create('/foo/bar', 'GET');
 


### PR DESCRIPTION
Added `isName` method for `Route` instance to avoid some repetitive code.
Renamed test name because `Request` method `isRouteName` (https://github.com/laravel/framework/pull/19202) became `routeIs` after 26681eb1c8ba35a0129ad47d4f0f03af9c2baa45