### PR TITLE
evaluate() delivers the concept better

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -295,7 +295,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
 
         return $this->evaluate($this->operatorForWhere($key, $operator, $value));
     }
-    
+
     /**
      * Determine if all items in the collection pass the given test.
      *

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -32,7 +32,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      * @var array
      */
     protected static $proxies = [
-        'contains', 'each', 'every', 'filter', 'first', 'flatMap',
+        'contains', 'each', 'every', 'evaluate', 'filter', 'first', 'flatMap',
         'map', 'partition', 'reject', 'sortBy', 'sortByDesc', 'sum',
     ];
 
@@ -273,7 +273,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      * @param  mixed  $value
      * @return bool
      */
-    public function every($key, $operator = null, $value = null)
+    public function evaluate($key, $operator = null, $value = null)
     {
         if (func_num_args() == 1) {
             $callback = $this->valueRetriever($key);
@@ -293,7 +293,22 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
             $operator = '=';
         }
 
-        return $this->every($this->operatorForWhere($key, $operator, $value));
+        return $this->evaluate($this->operatorForWhere($key, $operator, $value));
+    }
+    
+    /**
+     * Determine if all items in the collection pass the given test.
+     *
+     * @deprecated Use evaluate() method instead.
+     *
+     * @param  string|callable  $key
+     * @param  mixed  $operator
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function every($key, $operator = null, $value = null)
+    {
+        $this->evaluate($key, $operator, $value);
     }
 
     /**


### PR DESCRIPTION
Hi,

`every()` method determines if all items in the collection pass the given test but that name doesn't deliver the concept very well, so, I changed the name to `evaluate()`. The previous method is not broken, it just got a `@deprecated` annotation.

```php
// before
$collection->every(function ($value, $key) {
    // test
});

// after
$collection->evaluate(function ($value, $key) {
    // test
});
```