### PR TITLE
[5.4] Create a new "crossJoin" method

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -61,6 +61,23 @@ class Arr
     }
 
     /**
+     * Cross join the given arrays, returning all possible permutations.
+     *
+     * @param  array  ...$arrays
+     * @return array
+     */
+    public static function crossJoin(...$arrays)
+    {
+        return array_reduce($arrays, function ($results, $array) {
+            return static::collapse(array_map(function ($parent) use ($array) {
+                return array_map(function ($item) use ($parent) {
+                    return array_merge($parent, [$item]);
+                }, $array);
+            }, $results));
+        }, [[]]);
+    }
+
+    /**
      * Divide an array into two arrays. One with keys and the other with values.
      *
      * @param  array  $array

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -227,6 +227,19 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
+     * Cross join with the given lists, returning all possible permutations.
+     *
+     * @param  mixed  ...$lists
+     * @return static
+     */
+    public function crossJoin(...$lists)
+    {
+        return new static(Arr::crossJoin(
+            $this->items, ...array_map([$this, 'getArrayableItems'], $lists)
+        ));
+    }
+
+    /**
      * Get the items in the collection that are not present in the given items.
      *
      * @param  mixed  $items

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -35,6 +35,41 @@ class SupportArrTest extends TestCase
         $this->assertEquals(['foo', 'bar', 'baz'], Arr::collapse($data));
     }
 
+    public function testCrossJoin()
+    {
+        // Single dimension
+        $this->assertEquals(
+            [[1, 'a'], [1, 'b'], [1, 'c']],
+            Arr::crossJoin([1], ['a', 'b', 'c'])
+        );
+
+        // Square matrix
+        $this->assertEquals(
+            [[1, 'a'], [1, 'b'], [2, 'a'], [2, 'b']],
+            Arr::crossJoin([1, 2], ['a', 'b'])
+        );
+
+        // Rectangular matrix
+        $this->assertEquals(
+            [[1, 'a'], [1, 'b'], [1, 'c'], [2, 'a'], [2, 'b'], [2, 'c']],
+            Arr::crossJoin([1, 2], ['a', 'b', 'c'])
+        );
+
+        // 3D matrix
+        $this->assertEquals(
+            [
+                [1, 'a', 'I'], [1, 'a', 'II'], [1, 'a', 'III'],
+                [1, 'b', 'I'], [1, 'b', 'II'], [1, 'b', 'III'],
+                [2, 'a', 'I'], [2, 'a', 'II'], [2, 'a', 'III'],
+                [2, 'b', 'I'], [2, 'b', 'II'], [2, 'b', 'III'],
+            ],
+            Arr::crossJoin([1, 2], ['a', 'b'], ['I', 'II', 'III'])
+        );
+
+        // With 1 empty dimension
+        $this->assertEquals([], Arr::crossJoin([1, 2], [], ['I', 'II', 'III']));
+    }
+
     public function testDivide()
     {
         list($keys, $values) = Arr::divide(['name' => 'Desk']);

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -646,6 +646,35 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals([1, 2, 3, 4, 5, 6], $data->collapse()->all());
     }
 
+    public function testCrossJoin()
+    {
+        // Cross join with an array
+        $this->assertEquals(
+            [[1, 'a'], [1, 'b'], [2, 'a'], [2, 'b']],
+            (new Collection([1, 2]))->crossJoin(['a', 'b'])->all()
+        );
+
+        // Cross join with a collection
+        $this->assertEquals(
+            [[1, 'a'], [1, 'b'], [2, 'a'], [2, 'b']],
+            (new Collection([1, 2]))->crossJoin(new Collection(['a', 'b']))->all()
+        );
+
+        // Cross join with 2 collections
+        $this->assertEquals(
+            [
+                [1, 'a', 'I'], [1, 'a', 'II'],
+                [1, 'b', 'I'], [1, 'b', 'II'],
+                [2, 'a', 'I'], [2, 'a', 'II'],
+                [2, 'b', 'I'], [2, 'b', 'II'],
+            ],
+            (new Collection([1, 2]))->crossJoin(
+                new Collection(['a', 'b']),
+                new Collection(['I', 'II'])
+            )->all()
+        );
+    }
+
     public function testSort()
     {
         $data = (new Collection([5, 3, 1, 2, 4]))->sort();


### PR DESCRIPTION
This method returns a new matrix with all possible combinations between the lists:

```php
collect([1, 2])->crossJoin(['a', 'b']);

/*
    [
        [1, 'a'],
        [1, 'b'],
        [2, 'a'],
        [2, 'b'],
    ]
*/
```

---

Coupled with `eachSpread` (#19235), it can turn this ugly nested callback hell:

```php
$players->each(function ($player) use ($teams, $dates) {
    $teams->each(function ($team) use ($player, $dates) {
        $dates->each(function ($date) use ($player, $team) {
            $this->doSomethingWith($player, $team, $date);
        });
    });
});
```

...into this beautiful piece of declarative code:

```php
$players->crossJoin($teams, $dates)->eachSpread(function ($player, $team, $date) {
    $this->doSomethingWith($player, $team, $date);
});
```