### PR TITLE
[5.5] Add Blade @class directive

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -506,6 +506,25 @@ class Arr
     }
 
     /**
+     * Retrieve values that don't have a key & keys that have a truthy value.
+     *
+     * @param  array  $array
+     * @return array
+     */
+    public static function toggledValues($array)
+    {
+        $values = array_map(function ($value, $key) {
+            if (is_numeric($key)) {
+                return $value;
+            }
+
+            return $value ? $key : null;
+        }, $array, array_keys($array));
+
+        return array_unique(array_filter($values));
+    }
+
+    /**
      * Filter the array using the given callback.
      *
      * @param  array  $array

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -289,6 +289,19 @@ if (! function_exists('array_sort_recursive')) {
     }
 }
 
+if (! function_exists('array_toggled_values')) {
+    /**
+     * Retrieve values that don't have a key & keys that have a truthy value.
+     *
+     * @param  array  $array
+     * @return array
+     */
+    function array_toggled_values($array)
+    {
+        return Arr::toggledValues($array);
+    }
+}
+
 if (! function_exists('array_where')) {
     /**
      * Filter the array using the given callback.

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Str;
 class BladeCompiler extends Compiler implements CompilerInterface
 {
     use Concerns\CompilesAuthorizations,
+        Concerns\CompilesClassNames,
         Concerns\CompilesComments,
         Concerns\CompilesComponents,
         Concerns\CompilesConditionals,

--- a/src/Illuminate/View/Compilers/Concerns/CompilesClassNames.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesClassNames.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Illuminate\View\Compilers\Concerns;
+
+trait CompilesClassNames
+{
+    protected function compileClass($expression)
+    {
+        $expression = $this->stripParentheses($expression);
+
+        return "<?php echo 'class=\"'.implode(' ', array_toggled_values({$expression})).'\"'; ?>";
+    }
+}

--- a/tests/View/Blade/BladeClassTest.php
+++ b/tests/View/Blade/BladeClassTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Illuminate\Tests\Blade;
+
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+use Illuminate\View\Compilers\BladeCompiler;
+
+class BladeClassTest extends TestCase
+{
+    public function tearDown()
+    {
+        m::close();
+    }
+
+    public function testToggledClassesAreCompiled()
+    {
+        $compiler = new BladeCompiler($this->getFiles(), __DIR__);
+        $this->assertEquals('<?php echo \'class="\'.implode(\' \', array_toggled_values([])).\'"\'; ?>', $compiler->compileString('@class([])'));
+        $this->assertEquals('<?php echo \'class="\'.implode(\' \', array_toggled_values(["foo"])).\'"\'; ?>', $compiler->compileString('@class(["foo"])'));
+        $this->assertEquals('<?php echo \'class="\'.implode(\' \', array_toggled_values(["foo", "bar" => true, "baz" => false])).\'"\'; ?>', $compiler->compileString('@class(["foo", "bar" => true, "baz" => false])'));
+        $this->assertEquals('<div <?php echo \'class="\'.implode(\' \', array_toggled_values(["foo"])).\'"\'; ?>>Hi</div>', $compiler->compileString('<div @class(["foo"])>Hi</div>'));
+    }
+
+    protected function getFiles()
+    {
+        return m::mock('Illuminate\Filesystem\Filesystem');
+    }
+}


### PR DESCRIPTION
This PR adds an `@class` directive that behaves like Vue's `:class` property, providing an easy way to render conditional html classes.

```html
<div @class(['project', '-large' => $project->is_large])>
  <!-- ... -->
</div>

<div @class([
  'alert',
  'alert-success' => $errors->isEmpty(),
  'alert-error' => $errors->isNotEmpty(),
])>
  {{ $errors->isEmpty() ? 'Ok!' : 'Oh no!' }}
</div>
```

Don't know where the preferred place would be to keep the logic, so for now I created an `array_toggled_values` helper. This function expects an array and returns a set of unique values consisting of a) values that have a numeric key (`alert` in the example) and b) keys that have a truthy value (`alert-success` in the example).

- Is there interest in implementing this in the framework?
- Should I get rid of the `array_toggled_values` function in favor of something else?
- Do I need to write some sort of integration test anywhere? Currently only the compiler concern is tested.