### PR TITLE
Added domain helper to route

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -456,7 +456,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
         }
 
         return sha1(implode('|', array_merge(
-            $route->methods(), [$route->domain(), $route->uri(), $this->ip()]
+            $route->methods(), [$route->getDomain(), $route->uri(), $this->ip()]
         )));
     }
 

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -407,7 +407,7 @@ class Route
      */
     protected function compileParameterNames()
     {
-        preg_match_all('/\{(.*?)\}/', $this->domain().$this->uri, $matches);
+        preg_match_all('/\{(.*?)\}/', $this->getDomain().$this->uri, $matches);
 
         return array_map(function ($m) {
             return trim($m, '?');
@@ -527,10 +527,23 @@ class Route
      *
      * @return string|null
      */
-    public function domain()
+    public function getDomain()
     {
         return isset($this->action['domain'])
                 ? str_replace(['http://', 'https://'], '', $this->action['domain']) : null;
+    }
+
+    /**
+     * Add a domain to the route URI.
+     *
+     * @param  string  $domain
+     * @return $this
+     */
+    public function domain($domain)
+    {
+        $this->action['domain'] = $domain;
+
+        return $this;
     }
 
     /**

--- a/src/Illuminate/Routing/RouteCollection.php
+++ b/src/Illuminate/Routing/RouteCollection.php
@@ -64,7 +64,7 @@ class RouteCollection implements Countable, IteratorAggregate
      */
     protected function addToCollections($route)
     {
-        $domainAndUri = $route->domain().$route->uri();
+        $domainAndUri = $route->getDomain().$route->uri();
 
         foreach ($route->methods() as $method) {
             $this->routes[$method][$domainAndUri] = $route;

--- a/src/Illuminate/Routing/RouteCompiler.php
+++ b/src/Illuminate/Routing/RouteCompiler.php
@@ -36,7 +36,7 @@ class RouteCompiler
         $uri = preg_replace('/\{(\w+?)\?\}/', '{$1}', $this->route->uri());
 
         return (
-            new SymfonyRoute($uri, $optionals, $this->route->wheres, [], $this->route->domain() ?: '')
+            new SymfonyRoute($uri, $optionals, $this->route->wheres, [], $this->route->getDomain() ?: '')
         )->compile();
     }
 

--- a/src/Illuminate/Routing/RouteUrlGenerator.php
+++ b/src/Illuminate/Routing/RouteUrlGenerator.php
@@ -111,7 +111,7 @@ class RouteUrlGenerator
      */
     protected function getRouteDomain($route, &$parameters)
     {
-        return $route->domain() ? $this->formatDomain($route, $parameters) : null;
+        return $route->getDomain() ? $this->formatDomain($route, $parameters) : null;
     }
 
     /**
@@ -124,7 +124,7 @@ class RouteUrlGenerator
     protected function formatDomain($route, &$parameters)
     {
         return $this->addPortToDomain(
-            $this->getRouteScheme($route).$route->domain()
+            $this->getRouteScheme($route).$route->getDomain()
         );
     }
 

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -155,7 +155,7 @@ class RouteRegistrarTest extends TestCase
             $router->get('users', 'UsersController@index');
         });
 
-        $this->assertEquals('{account}.myapp.com', $this->getRoute()->domain());
+        $this->assertEquals('{account}.myapp.com', $this->getRoute()->getDomain());
     }
 
     public function testCanRegisterGroupWithDomainAndNamePrefix()
@@ -164,7 +164,7 @@ class RouteRegistrarTest extends TestCase
             $router->get('users', 'UsersController@index')->name('users');
         });
 
-        $this->assertEquals('{account}.myapp.com', $this->getRoute()->domain());
+        $this->assertEquals('{account}.myapp.com', $this->getRoute()->getDomain());
         $this->assertEquals('api.users', $this->getRoute()->getName());
     }
 


### PR DESCRIPTION
Hi there,

I am currently working on a app with a lot of different subdomains. While configuring all routes, I found out there wasn't a helper method like _middleware_ or _prefix_, so I created one;

```php
protected function mapWebRoutes()
{
    Route::middleware('web')
         ->domain('app.example.com')
         ->namespace($this->namespace)
         ->group(base_path('routes/web.php'));
}
```

Test cases still needs to be done, but first checking if you guys like the idea 😄 