### PR TITLE
[5.5] Use of argument (un)packing in throw_if/unless helpers

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -893,13 +893,13 @@ if (! function_exists('throw_if')) {
      *
      * @param  bool  $boolean
      * @param  \Throwable|string  $exception
-     * @param  array  ...$arguments
+     * @param  array  ...$parameters
      * @return void
      */
-    function throw_if($boolean, $exception, ...$arguments)
+    function throw_if($boolean, $exception, ...$parameters)
     {
         if ($boolean) {
-            throw (is_string($exception) ? new $exception(...$arguments) : $exception);
+            throw (is_string($exception) ? new $exception(...$parameters) : $exception);
         }
     }
 }
@@ -910,13 +910,13 @@ if (! function_exists('throw_unless')) {
      *
      * @param  bool  $boolean
      * @param  \Throwable|string  $exception
-     * @param  array  ...$arguments
+     * @param  array  ...$parameters
      * @return void
      */
-    function throw_unless($boolean, $exception, ...$arguments)
+    function throw_unless($boolean, $exception, ...$parameters)
     {
         if (! $boolean) {
-            throw (is_string($exception) ? new $exception(...$arguments) : $exception);
+            throw (is_string($exception) ? new $exception(...$parameters) : $exception);
         }
     }
 }

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -893,13 +893,13 @@ if (! function_exists('throw_if')) {
      *
      * @param  bool  $boolean
      * @param  \Throwable|string  $exception
-     * @param  string  $message
+     * @param  array  ...$arguments
      * @return void
      */
-    function throw_if($boolean, $exception, $message = '')
+    function throw_if($boolean, $exception, ...$arguments)
     {
         if ($boolean) {
-            throw (is_string($exception) ? new $exception($message) : $exception);
+            throw (is_string($exception) ? new $exception(...$arguments) : $exception);
         }
     }
 }
@@ -910,13 +910,13 @@ if (! function_exists('throw_unless')) {
      *
      * @param  bool  $boolean
      * @param  \Throwable|string  $exception
-     * @param  string  $message
+     * @param  array  ...$arguments
      * @return void
      */
-    function throw_unless($boolean, $exception, $message)
+    function throw_unless($boolean, $exception, ...$arguments)
     {
         if (! $boolean) {
-            throw (is_string($exception) ? new $exception($message) : $exception);
+            throw (is_string($exception) ? new $exception(...$arguments) : $exception);
         }
     }
 }


### PR DESCRIPTION
This change allows to pass more than one argument to the exception class.

For example [base exception](http://php.net/manual/en/exception.construct.php) class accepts message and code, so after this PR we can do this:
```php
throw_if($is_error, \Exception::class, $message, $code);
```