### PR TITLE
Fix bound alias context

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -674,7 +674,7 @@ class Container implements ArrayAccess, ContainerContract
         }
 
         foreach ($this->abstractAliases[$abstract] as $alias) {
-            if (! is_null($binding = $this->findInContextualBindings($alias))) {
+            if (! isset($this->bindings[$alias]) && ! is_null($binding = $this->findInContextualBindings($alias))) {
                 return $binding;
             }
         }

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -590,6 +590,25 @@ class ContainerTest extends TestCase
         );
     }
 
+    public function testContextualBindingNotWorksOnBoundAliase()
+    {
+        $container = new Container;
+
+        $container->alias('Illuminate\Tests\Container\IContainerContractStub','stub');
+        $container->bind('stub', ContainerImplementationStub::class);
+
+        $container->when('Illuminate\Tests\Container\ContainerTestContextInjectOne')->needs('stub')->give('Illuminate\Tests\Container\ContainerImplementationStubTwo');
+
+        try {
+            $container->make('Illuminate\Tests\Container\ContainerTestContextInjectOne');
+
+            throw new \Exception('Contextual binding works on the bound aliase');
+        }catch (\Exception $e){
+            $this->assertSame('Target [Illuminate\Tests\Container\IContainerContractStub] is not instantiable while building [Illuminate\Tests\Container\ContainerTestContextInjectOne].',
+                $e->getMessage());
+        }
+    }
+
     public function testContextualBindingDoesntOverrideNonContextualResolution()
     {
         $container = new Container;

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -590,7 +590,11 @@ class ContainerTest extends TestCase
         );
     }
 
-    public function testContextualBindingNotWorksOnBoundAliase()
+    /**
+     * @expectedException \Illuminate\Contracts\Container\BindingResolutionException
+     * @expectedExceptionMessage Target [Illuminate\Tests\Container\IContainerContractStub] is not instantiable while building [Illuminate\Tests\Container\ContainerTestContextInjectOne].
+     */
+    public function testContextualBindingNotWorksOnBoundAlias()
     {
         $container = new Container;
 
@@ -599,14 +603,7 @@ class ContainerTest extends TestCase
 
         $container->when('Illuminate\Tests\Container\ContainerTestContextInjectOne')->needs('stub')->give('Illuminate\Tests\Container\ContainerImplementationStubTwo');
 
-        try {
-            $container->make('Illuminate\Tests\Container\ContainerTestContextInjectOne');
-
-            throw new \Exception('Contextual binding works on the bound aliase');
-        }catch (\Exception $e){
-            $this->assertSame('Target [Illuminate\Tests\Container\IContainerContractStub] is not instantiable while building [Illuminate\Tests\Container\ContainerTestContextInjectOne].',
-                $e->getMessage());
-        }
+        $container->make('Illuminate\Tests\Container\ContainerTestContextInjectOne');
     }
 
     public function testContextualBindingDoesntOverrideNonContextualResolution()


### PR DESCRIPTION
here is my test code:
```php
public function testContextualBindingWorksOnBoundAlias()
{
    $container = new Container;

    $container->alias('Illuminate\Tests\Container\IContainerContractStub','stub');
    $container->bind('stub', ContainerImplementationStub::class);

    $container->when('Illuminate\Tests\Container\ContainerTestContextInjectOne')->needs('stub')->give('Illuminate\Tests\Container\ContainerImplementationStubTwo');

    $this->assertInstanceOf(
        'Illuminate\Tests\Container\ContainerImplementationStubTwo',
        $container->make('Illuminate\Tests\Container\ContainerTestContextInjectOne')->impl
    ); 
}
```

According to my understanding, if ‘ stub’ is bound to another class, it can not alias to or represent the class 'Illuminate\Tests\Container\IContainerContractStub' anymore. However, in the case, 'stub' can still work in contextual binding in needs().

```php
class ContainerTestContextInjectOne
{
    public $impl;

    public function __construct(IContainerContractStub $impl)
    {
        $this->impl = $impl;
    }
}

interface IContainerContractStub
{
}

class ContainerImplementationStub implements IContainerContractStub
{
}

class ContainerImplementationStubTwo implements IContainerContractStub
{
}
```
More detail information is in issue #19225.
thanks!