### PR TITLE
[5.4] Prevent applying global scopes on the factory while setting connection

### DIFF
--- a/src/Illuminate/Database/Eloquent/FactoryBuilder.php
+++ b/src/Illuminate/Database/Eloquent/FactoryBuilder.php
@@ -143,7 +143,7 @@ class FactoryBuilder
     protected function store($results)
     {
         $results->each(function ($model) {
-            $model->setConnection($model->query()->getConnection()->getName());
+            $model->setConnection($model->newQueryWithoutScopes()->getConnection()->getName());
 
             $model->save();
         });


### PR DESCRIPTION
With the changes in https://github.com/laravel/framework/pull/18846, we use:

```
$model->setConnection($model->query()->getConnection()->getName());
```

Using `$model->query()` applies the global scopes to the query which caused the problem reported in https://github.com/laravel/framework/issues/19254