### PR TITLE
[5.4] Fix Queue Worker database connection issue

### DIFF
--- a/src/Illuminate/Database/DetectsLostConnections.php
+++ b/src/Illuminate/Database/DetectsLostConnections.php
@@ -28,6 +28,7 @@ trait DetectsLostConnections
             'SSL connection has been closed unexpectedly',
             'Error writing data to the connection',
             'Resource deadlock avoided',
+            'beginTransaction() on null',
         ]);
     }
 }

--- a/src/Illuminate/Database/DetectsLostConnections.php
+++ b/src/Illuminate/Database/DetectsLostConnections.php
@@ -28,7 +28,7 @@ trait DetectsLostConnections
             'SSL connection has been closed unexpectedly',
             'Error writing data to the connection',
             'Resource deadlock avoided',
-            'beginTransaction() on null',
+            'Transaction() on null',
         ]);
     }
 }

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -246,6 +246,8 @@ class Worker
             $this->stopWorkerIfLostConnection($e);
         } catch (Throwable $e) {
             $this->exceptions->report(new FatalThrowableError($e));
+
+            $this->stopWorkerIfLostConnection($e);
         }
     }
 
@@ -267,6 +269,8 @@ class Worker
             $this->stopWorkerIfLostConnection($e);
         } catch (Throwable $e) {
             $this->exceptions->report(new FatalThrowableError($e));
+
+            $this->stopWorkerIfLostConnection($e);
         }
     }
 


### PR DESCRIPTION
This PR solves https://github.com/laravel/framework/issues/19242 as confirmed in that issue.

It relates to two separate issues:

1. The `DetectsLostConnections` trait should include some string around transaction issues on `null` (which would imply a lost connection).

2. A transaction error on `null` results in a `Throwable` - not an `Exception` - so we need to have worker check for lost connections on `Throwable` as well.