### PR TITLE
[5.4] Fix Timeoutless Job

### DIFF
--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -131,7 +131,9 @@ class Worker
      */
     protected function registerTimeoutHandler($job, WorkerOptions $options)
     {
-        if ($options->timeout > 0 && $this->supportsAsyncSignals()) {
+        $timeout = $this->timeoutForJob($job, $options);
+
+        if ($timeout > 0 && $this->supportsAsyncSignals()) {
             // We will register a signal handler for the alarm signal so that we can kill this
             // process if it is running too long because it has frozen. This uses the async
             // signals supported in recent versions of PHP to accomplish it conveniently.
@@ -139,7 +141,7 @@ class Worker
                 $this->kill(1);
             });
 
-            pcntl_alarm($this->timeoutForJob($job, $options) + $options->sleep);
+            pcntl_alarm($timeout + $options->sleep);
         }
     }
 


### PR DESCRIPTION
If you set a job timeout to `0`, it's being simply ignored, my PR fixes it.

````php
class MyJob extends Job {
    public $timeout = 0;

    [...]
}
````


I haven't added any tests because there is no test at all for the timeout functionality.