### PR TITLE
[5.5] Add patterns to routeIs method

### DIFF
--- a/CHANGELOG-5.5.md
+++ b/CHANGELOG-5.5.md
@@ -122,6 +122,8 @@
 - Support multiple values in `Router::has()` ([#18758](https://github.com/laravel/framework/pull/18758))
 - ⚠️ Bind empty optional route parameter to `null` instead of empty model instance ([#17521](https://github.com/laravel/framework/pull/17521))
 - ⚠️ Removed `Controller::missingMethod()` ([bf5d221](https://github.com/laravel/framework/commit/bf5d221037d9857a74020f2623839e282035a420))
+- Route `named()` accept patterns ([#19267](https://github.com/laravel/framework/pull/19267))
+- Router `is()` and `currentRouteNamed()` accepts patterns ([#19267](https://github.com/laravel/framework/pull/19267))
 
 ### Responses
 - ⚠️ Ensure `Arrayable` and `Jsonable` return a `JsonResponse` ([#17875](https://github.com/laravel/framework/pull/17875))

--- a/CHANGELOG-5.5.md
+++ b/CHANGELOG-5.5.md
@@ -115,6 +115,7 @@
 - Added a `validate()` macro onto `Request` ([#19063](https://github.com/laravel/framework/pull/19063))
 - Added `FormRequest::validated()` method ([#19112](https://github.com/laravel/framework/pull/19112))
 - ⚠️ Made `request()` helper and `Request::__get()` consistent ([a6ff272](https://github.com/laravel/framework/commit/a6ff272c54677a9f52718292fc0938ffb1871832))
+- Made `request()->routeIs()` work like `request()->fullUrlIs()` ([#19267](https://github.com/laravel/framework/pull/19267))
 
 ### Routing
 - Support fluent resource options ([#18767](https://github.com/laravel/framework/pull/18767), [bb02fb2](https://github.com/laravel/framework/commit/bb02fb27387a8aeb2a47da1fe5ff2e086920b744))

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -199,7 +199,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
      */
     public function routeIs()
     {
-        if (! $route = $this->route() || ! $routeName = $route->getName()) {
+        if (! ($route = $this->route()) || ! $routeName = $route->getName()) {
             return false;
         }
 

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -199,17 +199,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
      */
     public function routeIs()
     {
-        if (! ($route = $this->route()) || ! $routeName = $route->getName()) {
-            return false;
-        }
-
-        foreach (func_get_args() as $pattern) {
-            if (Str::is($pattern, $routeName)) {
-                return true;
-            }
-        }
-
-        return false;
+        return ($route = $this->route()) && call_user_func_array([$route, 'named'], func_get_args());
     }
 
     /**

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -193,14 +193,23 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
     }
 
     /**
-     * Check if the route name matches the given string.
+     * Determine if the route name matches a pattern.
      *
-     * @param  string  $name
      * @return bool
      */
-    public function routeIs($name)
+    public function routeIs()
     {
-        return $this->route() && $this->route()->named($name);
+        if ((! $route = $this->route()) || ! $routeName = $route->getName()) {
+            return false;
+        }
+
+        foreach (func_get_args() as $pattern) {
+            if (Str::is($pattern, $routeName)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -199,7 +199,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
      */
     public function routeIs()
     {
-        if ((! $route = $this->route()) || ! $routeName = $route->getName()) {
+        if (! $route = $this->route() || ! $routeName = $route->getName()) {
             return false;
         }
 

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -622,14 +622,23 @@ class Route
     }
 
     /**
-     * Determine whether the route's name matches the given name.
+     * Determine whether the route's name matches a pattern.
      *
-     * @param  string  $name
      * @return bool
      */
-    public function named($name)
+    public function named()
     {
-        return $this->getName() === $name;
+        if (is_null($routeName = $this->getName())) {
+            return false;
+        }
+
+        foreach (func_get_args() as $pattern) {
+            if (Str::is($pattern, $routeName)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -945,24 +945,17 @@ class Router implements RegistrarContract, BindingRegistrar
      */
     public function is()
     {
-        foreach (func_get_args() as $pattern) {
-            if (Str::is($pattern, $this->currentRouteName())) {
-                return true;
-            }
-        }
-
-        return false;
+        return call_user_func_array([$this, 'currentRouteNamed'], func_get_args());
     }
 
     /**
-     * Determine if the current route matches a given name.
+     * Determine if the current route matches a pattern.
      *
-     * @param  string  $name
      * @return bool
      */
-    public function currentRouteNamed($name)
+    public function currentRouteNamed()
     {
-        return $this->current() ? $this->current()->named($name) : false;
+        return ($route = $this->current()) && call_user_func_array([$route, 'named'], func_get_args());
     }
 
     /**

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -161,6 +161,8 @@ class HttpRequestTest extends TestCase
     {
         $request = Request::create('/foo/bar', 'GET');
 
+        $this->assertFalse($request->routeIs('foo.bar'));
+
         $request->setRouteResolver(function () use ($request) {
             $route = new Route('GET', '/foo/bar', ['as' => 'foo.bar']);
             $route->bind($request);

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -169,6 +169,7 @@ class HttpRequestTest extends TestCase
         });
 
         $this->assertTrue($request->routeIs('foo.bar'));
+        $this->assertTrue($request->routeIs('foo*', '*bar'));
         $this->assertFalse($request->routeIs('foo.foo'));
     }
 

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -102,7 +102,9 @@ class RoutingRouteTest extends TestCase
         $this->assertEquals('fred25', $router->dispatch(Request::create('fred', 'GET'))->getContent());
         $this->assertEquals('fred30', $router->dispatch(Request::create('fred/30', 'GET'))->getContent());
         $this->assertTrue($router->currentRouteNamed('foo'));
+        $this->assertTrue($router->currentRouteNamed('fo*'));
         $this->assertTrue($router->is('foo'));
+        $this->assertTrue($router->is('foo', 'bar'));
         $this->assertFalse($router->is('bar'));
 
         $router = $this->getRouter();


### PR DESCRIPTION
Same behaviour as `fullUrlIs`. We can check for a group named routes following conventions. For example on a sidebar, checking for `users.*` we can set active to the dropdown when we are on `users.edit`, `users.index`, etc.

Not sure if this should point to 5.4. I can do another pull request if needed

Thanks to @ConnorVG for helping with this :)