### PR TITLE
[5.4] Container: Add a new method to remove extenders of abstract

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -1065,6 +1065,20 @@ class Container implements ArrayAccess, ContainerContract
     }
 
     /**
+     * Remove all the extend closure of abstract
+     *
+     * @param string $abstract
+     */
+    public function forgetExtenders($abstract)
+    {
+        $abstract = $this->getAlias($abstract);
+
+        if (isset($this->extenders[$abstract])) {
+            unset($this->extenders[$abstract]);
+        }
+    }
+
+    /**
      * Drop all of the stale instances and aliases.
      *
      * @param  string  $abstract

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -1065,7 +1065,7 @@ class Container implements ArrayAccess, ContainerContract
     }
 
     /**
-     * Remove all the extend closure of abstract
+     * Remove all the extend closure of abstract.
      *
      * @param string $abstract
      */

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -236,6 +236,32 @@ class ContainerTest extends TestCase
         $this->assertEquals('foobar', $container->make('foo'));
     }
 
+    public function testUnsetExtend()
+    {
+        $container = new Container;
+        $container->bind('foo', function () {
+            $obj = new StdClass;
+            $obj->foo = 'bar';
+
+            return $obj;
+        });
+
+        $container->extend('foo', function ($obj, $container) {
+            $obj->bar = 'baz';
+
+            return $obj;
+        });
+
+        unset($container['foo']);
+        $container->forgetExtenders('foo');
+
+        $container->bind('foo', function () {
+            return 'foo';
+        });
+
+        $this->assertEquals('foo', $container->make('foo'));
+    }
+
     public function testResolutionOfDefaultParameters()
     {
         $container = new Container;


### PR DESCRIPTION
```php
public function testExtendAfterResolve()
{
    $container = new Container;
    $container->bind('foo', function () {
        $obj = new StdClass;
        $obj->foo = 'bar';

        return $obj;
    });

    $container->extend('foo', function ($obj, $container) {
        $obj->bar = 'baz';

        return $obj;
    });

    unset($container['foo']);

    $container->bind('foo', function () {
        return 'foo';
    });

    $obj = $container->make('foo');
}
```
It will throw a exception 'Attempt to assign property of non-object'.
If we want to rebind the abstract that has been changed by extend(), we can not clear the $extenders[]. So we can never rebind 'foo' to a closure that returns string likes 'foo'.