### PR TITLE
Add Collection::timesWithKeys method

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -75,6 +75,22 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
+     * Create a new collection with keys, by invoking the callback a given amount of times.
+     *
+     * @param  int  $amount
+     * @param  callable  $callback
+     * @return static
+     */
+    public static function timesWithKeys($amount, callable $callback)
+    {
+        if ($amount < 1) {
+            return new static;
+        }
+
+        return (new static(range(1, $amount)))->mapWithKeys($callback);
+    }
+
+    /**
      * Get all of the items in the collection.
      *
      * @return array

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1006,15 +1006,15 @@ class SupportCollectionTest extends TestCase
     public function testTimesWithKeysMethod()
     {
         $two = Collection::times(2, function ($number) {
-            return ['slug-'.$number => 'Title ' . $number];
+            return ['slug-'.$number => 'Title '.$number];
         });
 
         $zero = Collection::times(0, function ($number) {
-            return ['slug-'.$number => 'Title ' . $number];
+            return ['slug-'.$number => 'Title '.$number];
         });
 
         $negative = Collection::times(-4, function ($number) {
-            return ['slug-'.$number => 'Title ' . $number];
+            return ['slug-'.$number => 'Title '.$number];
         });
 
         $this->assertEquals([['slug-1' => 'Title 1'], ['slug-2' => 'Title 2']], $two->all());

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1003,6 +1003,25 @@ class SupportCollectionTest extends TestCase
         $this->assertTrue($negative->isEmpty());
     }
 
+    public function testTimesWithKeysMethod()
+    {
+        $two = Collection::times(2, function ($number) {
+            return ['slug-'.$number => 'Title ' . $number];
+        });
+
+        $zero = Collection::times(0, function ($number) {
+            return ['slug-'.$number => 'Title ' . $number];
+        });
+
+        $negative = Collection::times(-4, function ($number) {
+            return ['slug-'.$number => 'Title ' . $number];
+        });
+
+        $this->assertEquals([['slug-1' => 'Title 1'], ['slug-2' => 'Title 2']], $two->all());
+        $this->assertTrue($zero->isEmpty());
+        $this->assertTrue($negative->isEmpty());
+    }
+
     public function testConstructMakeFromObject()
     {
         $object = new stdClass();


### PR DESCRIPTION
Create a new collection with keys, by invoking a callback a given amount of times.

Example usage:

```php
Collection::times(2, function ($number) {
    return ['slug-'.$number => 'Title '.$number];
})->toArray();

/**
 *   [
 *       ['slug-1' => 'Title 1'],
 *       ['slug-2' => 'Title 2']
 *   ]
 */
```