### PR TITLE
Make the Collection::times callback optional

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -65,10 +65,14 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      * @param  callable  $callback
      * @return static
      */
-    public static function times($amount, callable $callback)
+    public static function times($amount, callable $callback = null)
     {
         if ($amount < 1) {
             return new static;
+        }
+
+        if ($callback == null) {
+            return new static(range(1, $amount));
         }
 
         return (new static(range(1, $amount)))->map($callback);

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -71,7 +71,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
             return new static;
         }
 
-        if ($callback == null) {
+        if (is_null($callback)) {
             return new static(range(1, $amount));
         }
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -998,9 +998,12 @@ class SupportCollectionTest extends TestCase
             return 'slug-'.$number;
         });
 
+        $range = Collection::times(5);
+
         $this->assertEquals(['slug-1', 'slug-2'], $two->all());
         $this->assertTrue($zero->isEmpty());
         $this->assertTrue($negative->isEmpty());
+        $this->assertEquals(range(1, 5), $range->all());
     }
 
     public function testConstructMakeFromObject()


### PR DESCRIPTION
Follow up on #19276

Allows calls to `Collection::times` without the callback parameter, so you can create simple range collections and maybe modify them manually later with `map` or `mapWithKeys` methods.

Use case example:

```php
Collection::times(2)->mapWithKeys(function ($number) {
    return ['slug-'.$number => 'Title '.$number];
})->toArray();


/**
 *   [
 *       ['slug-1' => 'Title 1'],
 *       ['slug-2' => 'Title 2']
 *   ]
 */
```