### PR TITLE
[5.4] Add a preg_fetch() helper

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -614,6 +614,23 @@ if (! function_exists('object_get')) {
     }
 }
 
+if (! function_exists('preg_fetch')) {
+    /**
+     * Perform a regular expression match and returns the matches.
+     *
+     * @param  string  $pattern
+     * @param  string  $subject
+     * @param  int     $flags
+     * @return array
+     */
+    function preg_fetch($pattern, $subject, $flags = 0)
+    {
+        $result = preg_match($pattern, $subject, $matches, $flags);
+        
+        return array_slice($matches, 1);
+    }
+}
+
 if (! function_exists('preg_replace_array')) {
     /**
      * Replace a given pattern with each value in the array in sequentially.


### PR DESCRIPTION
Add a `preg_fetch()` helper to get on the fly the `$matches` from a normal `preg_match()`.

```PHP
$matches = preg_fetch("/^(.+)@/", "foo@bar.com");

// returns: `["foo"]`
```