### PR TITLE
[5.4] Container: Extend() can not fire the rebinding callback

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -344,8 +344,9 @@ class Container implements ArrayAccess, ContainerContract
         } else {
             $this->extenders[$abstract][] = $closure;
 
-            if($this->resolved($abstract))
+            if($this->resolved($abstract)) {
                 $this->rebound($abstract);
+            }
         }
     }
 

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -344,7 +344,7 @@ class Container implements ArrayAccess, ContainerContract
         } else {
             $this->extenders[$abstract][] = $closure;
 
-            if($this->resolved($abstract)) {
+            if($this->resolved($abstract))  {
                 $this->rebound($abstract);
             }
         }

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -344,7 +344,7 @@ class Container implements ArrayAccess, ContainerContract
         } else {
             $this->extenders[$abstract][] = $closure;
 
-            if($this->resolved($abstract))  {
+            if ($this->resolved($abstract)) {
                 $this->rebound($abstract);
             }
         }

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -343,6 +343,9 @@ class Container implements ArrayAccess, ContainerContract
             $this->rebound($abstract);
         } else {
             $this->extenders[$abstract][] = $closure;
+
+            if($this->resolved($abstract))
+                $this->rebound($abstract);
         }
     }
 

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -241,7 +241,7 @@ class ContainerTest extends TestCase
         $_SERVER['_test_rebind'] = false;
 
         $container = new Container;
-        $container->rebinding('foo', function (){
+        $container->rebinding('foo', function () {
             $_SERVER['_test_rebind'] = true;
         });
 
@@ -260,10 +260,10 @@ class ContainerTest extends TestCase
         $_SERVER['_test_rebind'] = false;
 
         $container = new Container;
-        $container->rebinding('foo', function (){
+        $container->rebinding('foo', function () {
             $_SERVER['_test_rebind'] = true;
         });
-        $container->bind('foo', function (){
+        $container->bind('foo', function () {
             $obj = new StdClass;
 
             return $obj;

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -236,6 +236,29 @@ class ContainerTest extends TestCase
         $this->assertEquals('foobar', $container->make('foo'));
     }
 
+    public function testExtendReBindingCallback()
+    {
+        $_SERVER['_test_rebind'] = false;
+
+        $container = new Container;
+        $container->rebinding('foo',function (){
+            $_SERVER['_test_rebind'] = true;
+        });
+        $container->bind('foo',function (){
+            $obj = new StdClass;
+
+            return $obj;
+        });
+
+        $container->make('foo');
+
+        $container->extend('foo', function ($obj, $container) {
+            return $obj;
+        });
+
+        $this->assertTrue($_SERVER['_test_rebind']);
+    }
+
     public function testResolutionOfDefaultParameters()
     {
         $container = new Container;


### PR DESCRIPTION
this is a test for instance():
```php
    public function testExtendReBindingInstance()
    {
        $_SERVER['_test_rebind'] = false;

        $container = new Container;
        $container->rebinding('foo',function (){
            $_SERVER['_test_rebind'] = true;
        });

        $obj = new StdClass;
        $container->instance('foo',$obj);

        $container->make('foo');

        $container->extend('foo', function ($obj, $container) {
            return $obj;
        });

        this->assertTrue($_SERVER['_test_rebind']);
    }
```
if we use instance() function to bind abstract, the rebinding() will be fired by extend().
However,
This is a test for bind():
```php
    public function testExtendReBinding()
    {
        $_SERVER['_test_rebind'] = false;

        $container = new Container;
        $container->rebinding('foo',function (){
            $_SERVER['_test_rebind'] = true;
        });
        $container->bind('foo',function (){
            $obj = new StdClass;

            return $obj;
        });

        $container->make('foo');

        $container->extend('foo', function ($obj, $container) {
            return $obj;
        });

        this->assertFalse($_SERVER['_test_rebind']);
    }
```
If we use bind() function to bind abstract, the rebinding() will not be fired by extend() after make() function.
Container behaves differently from instance() and bind() about rebinding callback after using extend(). 
More detail in #19241 