### PR TITLE
[5.4] Use blade comments

### DIFF
--- a/src/Illuminate/Notifications/resources/views/email.blade.php
+++ b/src/Illuminate/Notifications/resources/views/email.blade.php
@@ -41,14 +41,14 @@
 
 @endforeach
 
-<!-- Salutation -->
+{{-- Salutation --}}
 @if (! empty($salutation))
 {{ $salutation }}
 @else
 Regards,<br>{{ config('app.name') }}
 @endif
 
-<!-- Subcopy -->
+{{-- Subcopy --}}
 @isset($actionText)
 @component('mail::subcopy')
 If you’re having trouble clicking the "{{ $actionText }}" button, copy and paste the URL below


### PR DESCRIPTION
The HTML comments are not being removed in the plain text email:

```
&lt;!-- Salutation --&gt;
```