### PR TITLE
[5.4] Add assertViewIs() to TestResponse

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -406,6 +406,21 @@ class TestResponse
     }
 
     /**
+     * Assert that the response view equals the given value.
+     *
+     * @param  string $value
+     * @return $this
+     */
+    public function assertViewIs($value)
+    {
+        $this->ensureResponseHasView();
+
+        PHPUnit::assertEquals($value, $this->original->getName());
+
+        return $this;
+    }
+
+    /**
      * Assert that the response view has a given piece of bound data.
      *
      * @param  string|array  $key

--- a/tests/Foundation/FoundationTestResponseTest.php
+++ b/tests/Foundation/FoundationTestResponseTest.php
@@ -12,6 +12,21 @@ use Symfony\Component\HttpFoundation\BinaryFileResponse;
 
 class FoundationTestResponseTest extends TestCase
 {
+    public function testAssertViewIs()
+    {
+        $baseResponse = tap(new Response, function ($response) {
+            $response->setContent(\Mockery::mock(View::class, [
+                'render' => 'hello world',
+                'getData' => ['foo' => 'bar'],
+                'getName' => 'dir.my-view',
+            ]));
+        });
+
+        $response = TestResponse::fromBaseResponse($baseResponse);
+
+        $response->assertViewIs('dir.my-view');
+    }
+
     public function testAssertViewHas()
     {
         $baseResponse = tap(new Response, function ($response) {


### PR DESCRIPTION
Adds `assertViewIs()` to allow for something like:
```php
$this->actingAs($admin)
  ->get('dashboard')
  ->assertViewIs('admin-dashboard');
```

I think/hope I tested it correctly.