### PR TITLE
[5.5] Fixed a typo of using Faker in make:facory command's stub

### DIFF
--- a/src/Illuminate/Database/Console/Factories/stubs/factory.stub
+++ b/src/Illuminate/Database/Console/Factories/stubs/factory.stub
@@ -1,6 +1,6 @@
 <?php
 
-use Fake\Generator as Faker;
+use Faker\Generator as Faker;
 
 /*
 |--------------------------------------------------------------------------


### PR DESCRIPTION
There is a typo in the new `make:factory` command. it uses `Fake\Generator` instead of `Faker\Generator`.

I think I have to open pull request against `master` and not `5.4`.