### PR TITLE
[5.4] Blade parenthesis parse fix

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -268,7 +268,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
     protected function compileStatements($value)
     {
         return preg_replace_callback(
-            '/\B@(@?\w+(?:::\w+)?)([ \t]*)(\( ( (?>[^()]+) | (?3) )* \))?/x', function ($match) {
+            '/\B@(@?\w+(?:::\w+)?)([ \t]*)(\( ( (?>( (([\\\'"])(?>(?>(?!\7)[^\\\\]|\\\\.)+ | (?6))*?\7) |[^()"\\\']+)) | (?3) )* \))?/x', function ($match) {
                 return $this->compileStatement($match);
             }, $value
         );

--- a/tests/View/Blade/BladeExpressionTest.php
+++ b/tests/View/Blade/BladeExpressionTest.php
@@ -27,6 +27,18 @@ class BladeExpressionTest extends TestCase
         $this->assertEquals('<html <?php echo e($foo); ?> <?php echo app(\'translator\')->getFromJson(\'foo\'); ?>>', $compiler->compileString('<html {{ $foo }} @lang(\'foo\')>'));
     }
 
+    public function testExpressionParse()
+    {
+        $compiler = new BladeCompiler($this->getFiles(), __DIR__);
+        $this->assertEquals('<?php echo $__env->yieldContent(\'test\'); ?>', $compiler->compileString('@yield(\'test\')'));
+        $this->assertEquals('<?php echo $__env->yieldContent; ?>(\'te\'st\')', $compiler->compileString('@yield(\'te\'st\')'));
+        $this->assertEquals('<?php echo $__env->yieldContent; ?>(\'test")', $compiler->compileString('@yield(\'test")'));
+        $this->assertEquals('<?php echo $__env->yieldContent(\'te\\\'st\'); ?>', $compiler->compileString('@yield(\'te\\\'st\')'));
+        $this->assertEquals('<?php echo $__env->yieldContent(\'te"st\'); ?>', $compiler->compileString('@yield(\'te"st\')'));
+        $this->assertEquals('<?php echo $__env->yieldContent(\'(: test :)\'); ?>', $compiler->compileString('@yield(\'(: test :)\')'));
+        $this->assertEquals('<?php echo $__env->yieldContent(\'test :)\'); ?> <?php echo $__env->yieldContent(("\'that :)\'")); ?>', $compiler->compileString('@yield(\'test :)\') @yield(("\'that :)\'"))'));
+    }
+
     protected function getFiles()
     {
         return m::mock('Illuminate\Filesystem\Filesystem');


### PR DESCRIPTION
fix blade expression parsing like: 

```
@section('content', '\'test\' ":)"')
```
#18317 