### PR TITLE
[5.4] Add `make` method to `HasOneOrMany` and `MorphOneOrMany` relations

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -98,7 +98,7 @@ class Builder
     }
 
     /**
-     * Create and return and un-saved model instance.
+     * Create and return an un-saved model instance.
      *
      * @param  array  $attributes
      * @return \Illuminate\Database\Eloquent\Model

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -47,6 +47,19 @@ abstract class HasOneOrMany extends Relation
     }
 
     /**
+     * Create and return an un-saved instance of the related model.
+     *
+     * @param  array  $attributes
+     * @return \Illuminate\Database\Eloquent\Model
+     */
+    public function make(array $attributes = [])
+    {
+        return tap($this->related->newInstance($attributes), function ($instance) {
+            $instance->setAttribute($this->getForeignKeyName(), $this->getParentKey());
+        });
+    }
+
+    /**
      * Set the base constraints on the relation query.
      *
      * @return void

--- a/src/Illuminate/Database/Eloquent/Relations/MorphOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphOneOrMany.php
@@ -41,6 +41,22 @@ abstract class MorphOneOrMany extends HasOneOrMany
     }
 
     /**
+     * Create and return an un-saved instance of the related model.
+     *
+     * @param  array  $attributes
+     * @return \Illuminate\Database\Eloquent\Model
+     */
+    public function make(array $attributes = [])
+    {
+        return tap($this->related->newInstance($attributes), function ($instance) {
+            // When saving a polymorphic relationship, we need to set not only the foreign
+            // key, but also the foreign key type, which is typically the class name of
+            // the parent model. This makes the polymorphic item unique in the table.
+            $this->setForeignAttributesForCreate($instance);
+        });
+    }
+
+    /**
      * Set the base constraints on the relation query.
      *
      * @return void

--- a/tests/Database/DatabaseEloquentHasManyTest.php
+++ b/tests/Database/DatabaseEloquentHasManyTest.php
@@ -15,6 +15,15 @@ class DatabaseEloquentHasManyTest extends TestCase
         m::close();
     }
 
+    public function testMakeMethodDoesNotSaveNewModel()
+    {
+        $relation = $this->getRelation();
+        $instance = $this->expectNewModel($relation, ['name' => 'taylor']);
+        $instance->expects($this->never())->method('save');
+
+        $this->assertEquals($instance, $relation->make(['name' => 'taylor']));
+    }
+
     public function testCreateMethodProperlyCreatesNewModel()
     {
         $relation = $this->getRelation();

--- a/tests/Database/DatabaseEloquentHasOneTest.php
+++ b/tests/Database/DatabaseEloquentHasOneTest.php
@@ -73,6 +73,17 @@ class DatabaseEloquentHasOneTest extends TestCase
         $this->assertSame(1, $newModel->getAttribute('foreign_key'));
     }
 
+      public function testMakeMethodDoesNotSaveNewModel()
+      {
+          $relation = $this->getRelation();
+          $instance = $this->getMockBuilder('Illuminate\Database\Eloquent\Model')->setMethods(['newInstance', 'setAttribute'])->getMock();
+          $relation->getRelated()->shouldReceive('newInstance')->with(['name' => 'taylor'])->andReturn($instance);
+          $instance->expects($this->once())->method('setAttribute')->with('foreign_key', 1);
+          $instance->expects($this->never())->method('save');
+
+          $this->assertEquals($instance, $relation->make(['name' => 'taylor']));
+      }
+
     public function testSaveMethodSetsForeignKeyOnModel()
     {
         $relation = $this->getRelation();

--- a/tests/Database/DatabaseEloquentHasOneTest.php
+++ b/tests/Database/DatabaseEloquentHasOneTest.php
@@ -73,16 +73,16 @@ class DatabaseEloquentHasOneTest extends TestCase
         $this->assertSame(1, $newModel->getAttribute('foreign_key'));
     }
 
-      public function testMakeMethodDoesNotSaveNewModel()
-      {
-          $relation = $this->getRelation();
-          $instance = $this->getMockBuilder('Illuminate\Database\Eloquent\Model')->setMethods(['newInstance', 'setAttribute'])->getMock();
-          $relation->getRelated()->shouldReceive('newInstance')->with(['name' => 'taylor'])->andReturn($instance);
-          $instance->expects($this->once())->method('setAttribute')->with('foreign_key', 1);
-          $instance->expects($this->never())->method('save');
+    public function testMakeMethodDoesNotSaveNewModel()
+    {
+        $relation = $this->getRelation();
+        $instance = $this->getMockBuilder('Illuminate\Database\Eloquent\Model')->setMethods(['newInstance', 'setAttribute'])->getMock();
+        $relation->getRelated()->shouldReceive('newInstance')->with(['name' => 'taylor'])->andReturn($instance);
+        $instance->expects($this->once())->method('setAttribute')->with('foreign_key', 1);
+        $instance->expects($this->never())->method('save');
 
-          $this->assertEquals($instance, $relation->make(['name' => 'taylor']));
-      }
+        $this->assertEquals($instance, $relation->make(['name' => 'taylor']));
+    }
 
     public function testSaveMethodSetsForeignKeyOnModel()
     {

--- a/tests/Database/DatabaseEloquentMorphTest.php
+++ b/tests/Database/DatabaseEloquentMorphTest.php
@@ -58,6 +58,20 @@ class DatabaseEloquentMorphTest extends TestCase
         $relation->addEagerConstraints([$model1, $model2]);
     }
 
+    public function testMakeFunctionOnMorph()
+    {
+        $_SERVER['__eloquent.saved'] = false;
+        // Doesn't matter which relation type we use since they share the code...
+        $relation = $this->getOneRelation();
+        $instance = m::mock('Illuminate\Database\Eloquent\Model');
+        $instance->shouldReceive('setAttribute')->once()->with('morph_id', 1);
+        $instance->shouldReceive('setAttribute')->once()->with('morph_type', get_class($relation->getParent()));
+        $instance->shouldReceive('save')->never();
+        $relation->getRelated()->shouldReceive('newInstance')->once()->with(['name' => 'taylor'])->andReturn($instance);
+
+        $this->assertEquals($instance, $relation->make(['name' => 'taylor']));
+    }
+
     public function testCreateFunctionOnMorph()
     {
         // Doesn't matter which relation type we use since they share the code...


### PR DESCRIPTION
Implement a `make` method for instantiating eloquent models on `hasOne`, `hasMany`, `morphOne`, and `morphMany` relationships without performing inserts.

A similar example:

```php
$post->comments()
    ->make(['body' => 'Hi there!'])
    ->addZondas()
    ->save();
```

This is heavily inspired from this sweet PR (#19015) from @calebporzio, who implemented a `make` method on the query builder.