### PR TITLE
[5.4] adding base url to paginated array for ease of knowing where the request is going

### DIFF
--- a/src/Illuminate/Pagination/LengthAwarePaginator.php
+++ b/src/Illuminate/Pagination/LengthAwarePaginator.php
@@ -170,6 +170,7 @@ class LengthAwarePaginator extends AbstractPaginator implements Arrayable, Array
             'from' => $this->firstItem(),
             'to' => $this->lastItem(),
             'data' => $this->items->toArray(),
+            'base_url' => $this->path
         ];
     }
 

--- a/src/Illuminate/Pagination/LengthAwarePaginator.php
+++ b/src/Illuminate/Pagination/LengthAwarePaginator.php
@@ -170,7 +170,7 @@ class LengthAwarePaginator extends AbstractPaginator implements Arrayable, Array
             'from' => $this->firstItem(),
             'to' => $this->lastItem(),
             'data' => $this->items->toArray(),
-            'path' => $this->path
+            'path' => $this->path,
         ];
     }
 

--- a/src/Illuminate/Pagination/LengthAwarePaginator.php
+++ b/src/Illuminate/Pagination/LengthAwarePaginator.php
@@ -170,7 +170,7 @@ class LengthAwarePaginator extends AbstractPaginator implements Arrayable, Array
             'from' => $this->firstItem(),
             'to' => $this->lastItem(),
             'data' => $this->items->toArray(),
-            'base_url' => $this->path
+            'path' => $this->path
         ];
     }
 

--- a/src/Illuminate/Pagination/Paginator.php
+++ b/src/Illuminate/Pagination/Paginator.php
@@ -149,7 +149,7 @@ class Paginator extends AbstractPaginator implements Arrayable, ArrayAccess, Cou
             'from' => $this->firstItem(),
             'to' => $this->lastItem(),
             'data' => $this->items->toArray(),
-            'base_url' => $this->path
+            'path' => $this->path
         ];
     }
 

--- a/src/Illuminate/Pagination/Paginator.php
+++ b/src/Illuminate/Pagination/Paginator.php
@@ -149,6 +149,7 @@ class Paginator extends AbstractPaginator implements Arrayable, ArrayAccess, Cou
             'from' => $this->firstItem(),
             'to' => $this->lastItem(),
             'data' => $this->items->toArray(),
+            'base_url' => $this->path
         ];
     }
 

--- a/src/Illuminate/Pagination/Paginator.php
+++ b/src/Illuminate/Pagination/Paginator.php
@@ -149,7 +149,7 @@ class Paginator extends AbstractPaginator implements Arrayable, ArrayAccess, Cou
             'from' => $this->firstItem(),
             'to' => $this->lastItem(),
             'data' => $this->items->toArray(),
-            'path' => $this->path
+            'path' => $this->path,
         ];
     }
 

--- a/tests/Pagination/LengthAwarePaginatorTest.php
+++ b/tests/Pagination/LengthAwarePaginatorTest.php
@@ -9,7 +9,7 @@ class LengthAwarePaginatorTest extends TestCase
 {
     public function setUp()
     {
-        $this->p = new LengthAwarePaginator($array = ['item3', 'item4', 'item5'], 4, 2, 2);
+        $this->p = new LengthAwarePaginator($array = ['item1', 'item2', 'item3', 'item4'], 4, 2, 2);
     }
 
     public function tearDown()

--- a/tests/Pagination/LengthAwarePaginatorTest.php
+++ b/tests/Pagination/LengthAwarePaginatorTest.php
@@ -9,7 +9,7 @@ class LengthAwarePaginatorTest extends TestCase
 {
     public function setUp()
     {
-        $this->p = new LengthAwarePaginator($array = ['item1', 'item2', 'item3', 'item4'], 4, 2, 2);
+        $this->p = new LengthAwarePaginator($array = ['item3', 'item4', 'item5'], 4, 2, 2);
     }
 
     public function tearDown()

--- a/tests/Pagination/PaginatorTest.php
+++ b/tests/Pagination/PaginatorTest.php
@@ -9,7 +9,8 @@ class PaginatorTest extends TestCase
 {
     public function testSimplePaginatorReturnsRelevantContextInformation()
     {
-        $p = new Paginator($array = ['item3', 'item4', 'item5'], 2, 2);
+        $p = new Paginator($array = ['item1', 'item2', 'item3'], 2, 2,
+            ['path' => 'http://website.com/test']);
 
         $this->assertEquals(2, $p->currentPage());
         $this->assertTrue($p->hasPages());
@@ -24,6 +25,7 @@ class PaginatorTest extends TestCase
                     'from' => 3,
                     'to' => 4,
                     'data' => ['item3', 'item4'],
+                    'path' => 'http://website.com/test'
                     ];
 
         $this->assertEquals($pageInfo, $p->toArray());

--- a/tests/Pagination/PaginatorTest.php
+++ b/tests/Pagination/PaginatorTest.php
@@ -9,8 +9,7 @@ class PaginatorTest extends TestCase
 {
     public function testSimplePaginatorReturnsRelevantContextInformation()
     {
-        $p = new Paginator($array = ['item3', 'item4', 'item5'], 2, 2,
-            ['path' => 'http://website.com/test']);
+        $p = new Paginator($array = ['item3', 'item4', 'item5'], 2, 2);
 
         $this->assertEquals(2, $p->currentPage());
         $this->assertTrue($p->hasPages());
@@ -25,7 +24,7 @@ class PaginatorTest extends TestCase
                     'from' => 3,
                     'to' => 4,
                     'data' => ['item3', 'item4'],
-                    'path' => 'http://website.com/test'
+                    'path' => '/',
                     ];
 
         $this->assertEquals($pageInfo, $p->toArray());

--- a/tests/Pagination/PaginatorTest.php
+++ b/tests/Pagination/PaginatorTest.php
@@ -9,7 +9,7 @@ class PaginatorTest extends TestCase
 {
     public function testSimplePaginatorReturnsRelevantContextInformation()
     {
-        $p = new Paginator($array = ['item1', 'item2', 'item3'], 2, 2,
+        $p = new Paginator($array = ['item3', 'item4', 'item5'], 2, 2,
             ['path' => 'http://website.com/test']);
 
         $this->assertEquals(2, $p->currentPage());


### PR DESCRIPTION
Use case : 

I am creating a pagination component in vuejs , this allows me to easily grab the base url to go to a different page far out. This stops us from having to pass in the base url our selves or parsing the next page url etc. Also if there are no prev/next pages we have no idea where the data came from. 

