### PR TITLE
Make page number available in chunk closure

### DIFF
--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -32,7 +32,7 @@ trait BuildsQueries
             // On each chunk result set, we will pass them to the callback and then let the
             // developer take care of everything within the callback, which allows us to
             // keep the memory low for spinning through large result sets for working.
-            if ($callback($results,$page) === false) {
+            if ($callback($results, $page) === false) {
                 return false;
             }
 

--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -32,7 +32,7 @@ trait BuildsQueries
             // On each chunk result set, we will pass them to the callback and then let the
             // developer take care of everything within the callback, which allows us to
             // keep the memory low for spinning through large result sets for working.
-            if ($callback($results) === false) {
+            if ($callback($results,$page) === false) {
                 return false;
             }
 


### PR DESCRIPTION
I've run into a scenario where it would be really nice to have the page number available in a chunk closure; perhaps it could be accomplished another way and I'd love to hear feedback.

I'm using chunk to round up users by their estimated points and assign a rank back to them like this;
```php
User::orderBy('estimated_points', 'desc')->chunk(100,function($users,$page){

    foreach ($users as $key => $user) {
        $user->rank = (101*($page-1)) + ($key + 1);
        $user->save();
    }

});
```

I've roughly tested to make sure that the closure works fine without the second parameter on php 7.1 but I'm not sure other versions or scenarios and I'd be open to writing a test to ensure this functionality.

Thanks for your consideration.