### PR TITLE
[5.4] Add new `conjoin()` method to collection

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -187,7 +187,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      * @param  \Traversable  $source
      * @return self
      */
-    public function conJoin($source)
+    public function conjoin($source)
     {
         $joinedCollection = new static($this);
 

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -182,6 +182,21 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
+     * Conjoin all values of a collection with those of another, regardless of keys.
+     *
+     * @param  \Traversable  $source
+     * @return self
+     */
+    public function conJoin($source)
+    {
+        foreach ($source as $item) {
+            $this->push($item);
+        }
+
+        return $this;
+    }
+
+    /**
      * Determine if an item exists in the collection.
      *
      * @param  mixed  $key

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -189,11 +189,13 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      */
     public function conJoin($source)
     {
+        $joinedCollection = new static($this);
+
         foreach ($source as $item) {
-            $this->push($item);
+            $joinedCollection->push($item);
         }
 
-        return $this;
+        return $joinedCollection;
     }
 
     /**

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1731,10 +1731,18 @@ class SupportCollectionTest extends TestCase
             3 => 'a',
             4 => 'b',
             5 => 'c',
+            6 => 'Jonny',
+            7 => 'from',
+            8 => 'Laroe',
+            9 => 'Jonny',
+            10 => 'from',
+            11 => 'Laroe',
         ];
 
         $collection = new Collection([4, 5, 6]);
-        $actual = $collection->conJoin(['a', 'b', 'c'])->toArray();
+        $collection = $collection->conJoin(['a', 'b', 'c']);
+        $collection = $collection->conJoin(['who' => 'Jonny', 'preposition' => 'from', 'where' => 'Laroe']);
+        $actual = $collection->conJoin(['who' => 'Jonny', 'preposition' => 'from', 'where' => 'Laroe'])->toArray();
 
         $this->assertSame($expected, $actual);
     }
@@ -1748,11 +1756,20 @@ class SupportCollectionTest extends TestCase
             3 => 'a',
             4 => 'b',
             5 => 'c',
+            6 => 'Jonny',
+            7 => 'from',
+            8 => 'Laroe',
+            9 => 'Jonny',
+            10 => 'from',
+            11 => 'Laroe',
         ];
 
         $firstCollection = new Collection([4, 5, 6]);
         $secondCollection = new Collection(['a', 'b', 'c']);
-        $actual = $firstCollection->conJoin($secondCollection)->toArray();
+        $thirdCollection = new Collection(['who' => 'Jonny', 'preposition' => 'from', 'where' => 'Laroe']);
+        $firstCollection = $firstCollection->conJoin($secondCollection);
+        $firstCollection = $firstCollection->conJoin($thirdCollection);
+        $actual = $firstCollection->conJoin($thirdCollection)->toArray();
 
         $this->assertSame($expected, $actual);
     }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1740,9 +1740,9 @@ class SupportCollectionTest extends TestCase
         ];
 
         $collection = new Collection([4, 5, 6]);
-        $collection = $collection->conJoin(['a', 'b', 'c']);
-        $collection = $collection->conJoin(['who' => 'Jonny', 'preposition' => 'from', 'where' => 'Laroe']);
-        $actual = $collection->conJoin(['who' => 'Jonny', 'preposition' => 'from', 'where' => 'Laroe'])->toArray();
+        $collection = $collection->conjoin(['a', 'b', 'c']);
+        $collection = $collection->conjoin(['who' => 'Jonny', 'preposition' => 'from', 'where' => 'Laroe']);
+        $actual = $collection->conjoin(['who' => 'Jonny', 'preposition' => 'from', 'where' => 'Laroe'])->toArray();
 
         $this->assertSame($expected, $actual);
     }
@@ -1767,9 +1767,9 @@ class SupportCollectionTest extends TestCase
         $firstCollection = new Collection([4, 5, 6]);
         $secondCollection = new Collection(['a', 'b', 'c']);
         $thirdCollection = new Collection(['who' => 'Jonny', 'preposition' => 'from', 'where' => 'Laroe']);
-        $firstCollection = $firstCollection->conJoin($secondCollection);
-        $firstCollection = $firstCollection->conJoin($thirdCollection);
-        $actual = $firstCollection->conJoin($thirdCollection)->toArray();
+        $firstCollection = $firstCollection->conjoin($secondCollection);
+        $firstCollection = $firstCollection->conjoin($thirdCollection);
+        $actual = $firstCollection->conjoin($thirdCollection)->toArray();
 
         $this->assertSame($expected, $actual);
     }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1722,6 +1722,41 @@ class SupportCollectionTest extends TestCase
         $this->assertSame($expected, $actual);
     }
 
+    public function testConJoinWithArray()
+    {
+        $expected = [
+            0 => 4,
+            1 => 5,
+            2 => 6,
+            3 => 'a',
+            4 => 'b',
+            5 => 'c',
+        ];
+
+        $collection = new Collection([4, 5, 6]);
+        $actual = $collection->conJoin(['a', 'b', 'c'])->toArray();
+
+        $this->assertSame($expected, $actual);
+    }
+
+    public function testConJoinWithCollection()
+    {
+        $expected = [
+            0 => 4,
+            1 => 5,
+            2 => 6,
+            3 => 'a',
+            4 => 'b',
+            5 => 'c',
+        ];
+
+        $firstCollection = new Collection([4, 5, 6]);
+        $secondCollection = new Collection(['a', 'b', 'c']);
+        $actual = $firstCollection->conJoin($secondCollection)->toArray();
+
+        $this->assertSame($expected, $actual);
+    }
+
     public function testReduce()
     {
         $data = new Collection([1, 2, 3]);


### PR DESCRIPTION
This function allows joining of a traversable object with the current collection, ignoring the keys. This is useful when stacking collections based on different models or sources to be used for a singular purpose, for example generating of combined lists based off of multiple collections without overwriting values of existing keys.

Internals discussion: https://github.com/laravel/internals/issues/568