### PR TITLE
[5.4] Container: Contextual binding does not works on instance alias

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -355,8 +355,6 @@ class Container implements ArrayAccess, ContainerContract
      */
     public function instance($abstract, $instance)
     {
-        $this->removeAbstractAlias($abstract);
-
         $isBound = $this->bound($abstract);
 
         unset($this->aliases[$abstract]);

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -586,11 +586,11 @@ class ContainerTest extends TestCase
         );
     }
 
-    public function testContextualBindingNotWorksOnExistingAliasedInstancesBack()
+    public function testContextualBindingWorksOnExistingAliasedInstanceBack()
     {
         $container = new Container;
 
-        $container->alias('Illuminate\Tests\Container\IContainerContractStub','stub');
+        $container->alias('Illuminate\Tests\Container\IContainerContractStub', 'stub');
         $container->instance('stub', new ContainerImplementationStub);
 
         $container->when('Illuminate\Tests\Container\ContainerTestContextInjectOne')->needs('stub')->give('Illuminate\Tests\Container\ContainerImplementationStubTwo');
@@ -601,11 +601,11 @@ class ContainerTest extends TestCase
         );
     }
 
-    public function testContextualBindingWorksOnExistingAliasedSingtontonBack()
+    public function testContextualBindingWorksOnExistingAliasedbindBack()
     {
         $container = new Container;
 
-        $container->alias('Illuminate\Tests\Container\IContainerContractStub','stub');
+        $container->alias('Illuminate\Tests\Container\IContainerContractStub', 'stub');
         $container->bind('stub', ContainerImplementationStub::class);
 
         $container->when('Illuminate\Tests\Container\ContainerTestContextInjectOne')->needs('stub')->give('Illuminate\Tests\Container\ContainerImplementationStubTwo');

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -586,6 +586,36 @@ class ContainerTest extends TestCase
         );
     }
 
+    public function testContextualBindingNotWorksOnExistingAliasedInstancesBack()
+    {
+        $container = new Container;
+
+        $container->alias('Illuminate\Tests\Container\IContainerContractStub','stub');
+        $container->instance('stub', new ContainerImplementationStub);
+
+        $container->when('Illuminate\Tests\Container\ContainerTestContextInjectOne')->needs('stub')->give('Illuminate\Tests\Container\ContainerImplementationStubTwo');
+
+        $this->assertInstanceOf(
+            'Illuminate\Tests\Container\ContainerImplementationStubTwo',
+            $container->make('Illuminate\Tests\Container\ContainerTestContextInjectOne')->impl
+        );
+    }
+
+    public function testContextualBindingWorksOnExistingAliasedSingtontonBack()
+    {
+        $container = new Container;
+
+        $container->alias('Illuminate\Tests\Container\IContainerContractStub','stub');
+        $container->bind('stub', ContainerImplementationStub::class);
+
+        $container->when('Illuminate\Tests\Container\ContainerTestContextInjectOne')->needs('stub')->give('Illuminate\Tests\Container\ContainerImplementationStubTwo');
+
+        $this->assertInstanceOf(
+            'Illuminate\Tests\Container\ContainerImplementationStubTwo',
+            $container->make('Illuminate\Tests\Container\ContainerTestContextInjectOne')->impl
+        );
+    }
+
     public function testContextualBindingWorksOnNewAliasedInstances()
     {
         $container = new Container;


### PR DESCRIPTION
Hi,
    Contextual binding does not work on a existing aliased instance, it will throw a exception "Target [Illuminate\Tests\Container\IContainerContractStub] is not instantiable while building [Illuminate\Tests\Container\ContainerTestContextInjectOne]."

### Steps To Reproduce
```php
public function testContextualBindingWorksOnExistingAliasedInstances()
{
    $container = new Container;

    $container->alias('Illuminate\Tests\Container\IContainerContractStub', 'stub');
    $container->instance('stub', new ContainerImplementationStub);

    $container->when('Illuminate\Tests\Container\ContainerTestContextInjectOne')->needs('stub')->give('Illuminate\Tests\Container\ContainerImplementationStubTwo');

    $this->assertInstanceOf(
        'Illuminate\Tests\Container\ContainerImplementationStubTwo',
        $container->make('Illuminate\Tests\Container\ContainerTestContextInjectOne')->impl
    ); 
}
```
In issue #19259, @taylorotwell says it is ok:
```php
public function testContextualBindingWorksOnBoundAlias()
{
    $container = new Container;

    $container->alias('Illuminate\Tests\Container\IContainerContractStub', 'stub');
    $container->singleton('stub', ContainerImplementationStub::class);

    $container->when('Illuminate\Tests\Container\ContainerTestContextInjectOne')->needs('stub')->give('Illuminate\Tests\Container\ContainerImplementationStubTwo');

    $this->assertInstanceOf(
        'Illuminate\Tests\Container\ContainerImplementationStubTwo',
        $container->make('Illuminate\Tests\Container\ContainerTestContextInjectOne')->impl
    ); 
}
```
So I think something is wrong with instance, not singleton(0 or bind().
```php
class ContainerTestContextInjectOne
{
    public $impl;

    public function __construct(IContainerContractStub $impl)
    {
        $this->impl = $impl;
    }
}

interface IContainerContractStub
{
}

class ContainerImplementationStub implements IContainerContractStub
{
}

class ContainerImplementationStubTwo implements IContainerContractStub
{
}
```
More detail in #19268