### PR TITLE
[5.5] Improved support for custom/changing directory structures

### DIFF
--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -25,7 +25,7 @@ abstract class ServiceProvider
      *
      * @var bool
      */
-    protected $viewNamespacesRegistered = false;
+    protected $applicationViewNamespacesRegistered = false;
 
     /**
      * The paths that should be published.
@@ -98,7 +98,7 @@ abstract class ServiceProvider
             $this->publishesViews($path, $namespace);
         }
 
-        $this->registerAlternateViewNamespaces($namespace);
+        $this->registerApplicationViewNamespaces($namespace);
         $this->app['view']->addNamespace($namespace, $path);
     }
 
@@ -106,9 +106,9 @@ abstract class ServiceProvider
      * @param  string  $namespace
      * @return void
      */
-    protected function registerAlternateViewNamespaces($namespace)
+    protected function registerApplicationViewNamespaces($namespace)
     {
-        if ($this->viewNamespacesRegistered) {
+        if ($this->applicationViewNamespacesRegistered) {
             return;
         }
 
@@ -118,7 +118,7 @@ abstract class ServiceProvider
             $this->app['view']->addNamespace($namespace, $viewPath);
         }
 
-        $this->viewNamespacesRegistered = true;
+        $this->applicationViewNamespacesRegistered = true;
     }
 
     /**

--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -94,21 +94,31 @@ abstract class ServiceProvider
      */
     protected function loadViewsFrom($path, $namespace, $publish = false)
     {
-        if (! $this->viewNamespacesRegistered) {
-            $viewPaths = $this->app['config']->get('view.paths', []);
-            foreach ($viewPaths as $viewPath) {
-                $viewPath = rtrim($viewPath, '/').'/vendor/'.$namespace;
-                $this->app['view']->addNamespace($namespace, $viewPath);
-            }
-
-            if ($publish) {
-                $this->publishesViews($path, $namespace);
-            }
-
-            $this->viewNamespacesRegistered = true;
+        if ($publish) {
+            $this->publishesViews($path, $namespace);
         }
 
+        $this->registerAlternateViewNamespaces($namespace);
         $this->app['view']->addNamespace($namespace, $path);
+    }
+
+    /**
+     * @param  string  $namespace
+     * @return void
+     */
+    protected function registerAlternateViewNamespaces($namespace)
+    {
+        if ($this->viewNamespacesRegistered) {
+            return;
+        }
+
+        $viewPaths = $this->app['config']->get('view.paths', []);
+        foreach ($viewPaths as $viewPath) {
+            $viewPath = rtrim($viewPath, '/').'/vendor/'.$namespace;
+            $this->app['view']->addNamespace($namespace, $viewPath);
+        }
+
+        $this->viewNamespacesRegistered = true;
     }
 
     /**

--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -19,12 +19,12 @@ abstract class ServiceProvider
      * @var bool
      */
     protected $defer = false;
-	
-	/**
-	 * Indicates whether the default view locations have been registered
-	 *
-	 * @var bool
-	 */
+
+    /**
+     * Indicates whether the default view locations have been registered.
+     *
+     * @var bool
+     */
     protected $viewNamespacesRegistered = false;
 
     /**
@@ -65,9 +65,9 @@ abstract class ServiceProvider
         $config = $this->app['config']->get($key, []);
 
         $this->app['config']->set($key, array_merge(require $path, $config));
-        
+
         if ($publish) {
-        	$this->publishesConfig($path, $key);
+            $this->publishesConfig($path, $key);
         }
     }
 
@@ -94,19 +94,19 @@ abstract class ServiceProvider
      */
     protected function loadViewsFrom($path, $namespace, $publish = false)
     {
-    	if (!$this->viewNamespacesRegistered) {
-    		$viewPaths = $this->app['config']->get('view.paths', []);
-    		foreach ($viewPaths as $viewPath) {
-			    $viewPath = rtrim($viewPath, '/').'/vendor/'.$namespace;
-			    $this->app['view']->addNamespace($namespace, $viewPath);
-		    }
-		    
-		    if ($publish) {
-    			$this->publishesViews($path, $namespace);
-		    }
-		    
-		    $this->viewNamespacesRegistered = true;
-	    }
+        if (! $this->viewNamespacesRegistered) {
+            $viewPaths = $this->app['config']->get('view.paths', []);
+            foreach ($viewPaths as $viewPath) {
+                $viewPath = rtrim($viewPath, '/').'/vendor/'.$namespace;
+                $this->app['view']->addNamespace($namespace, $viewPath);
+            }
+
+            if ($publish) {
+                $this->publishesViews($path, $namespace);
+            }
+
+            $this->viewNamespacesRegistered = true;
+        }
 
         $this->app['view']->addNamespace($namespace, $path);
     }
@@ -155,78 +155,78 @@ abstract class ServiceProvider
             $this->addPublishGroup($group, $paths);
         }
     }
-	
-	/**
-	 * Register a view path to be published to the app's configured view directory
-	 *
-	 * @param $path
-	 * @param $namespace
-	 * @param null $group
-	 */
+
+    /**
+     * Register a view path to be published to the app's configured view directory.
+     *
+     * @param $path
+     * @param $namespace
+     * @param null $group
+     */
     protected function publishesViews($path, $namespace, $group = null)
     {
-	    $viewPaths = $this->app['config']->get('view.paths', [resource_path('views/vendor/')]);
-	    $this->publishes([
-		    $path => rtrim($viewPaths[0], '/')."/vendor/$namespace"
-	    ], $group);
+        $viewPaths = $this->app['config']->get('view.paths', [resource_path('views/vendor/')]);
+        $this->publishes([
+            $path => rtrim($viewPaths[0], '/')."/vendor/$namespace",
+        ], $group);
     }
-	
-	/**
-	 * Register a config file to be published to the app's config directory
-	 *
-	 * @param $path
-	 * @param null $namespace
-	 */
+
+    /**
+     * Register a config file to be published to the app's config directory.
+     *
+     * @param $path
+     * @param null $namespace
+     */
     protected function publishesConfig($path, $namespace = null, $group = null)
     {
-    	if (null === $namespace) {
-		    $namespace = basename($path, '.php');
-	    }
-	    
-    	$this->publishes([$path => config_path("$namespace.php")], $group);
+        if (null === $namespace) {
+            $namespace = basename($path, '.php');
+        }
+
+        $this->publishes([$path => config_path("$namespace.php")], $group);
     }
-	
-	/**
-	 * Register a path to be published to the app's lang directory
-	 *
-	 * @param  string  $path
-	 * @param  string  $namespace
-	 * @param  string  $group
-	 * @return void
-	 */
+
+    /**
+     * Register a path to be published to the app's lang directory.
+     *
+     * @param  string  $path
+     * @param  string  $namespace
+     * @param  string  $group
+     * @return void
+     */
     protected function publishesTranslations($path, $namespace, $group = null)
     {
-    	$langPath = method_exists($this->app, 'langPath')
-		    ? $this->app->langPath()
-		    : resource_path('lang');
-    	
-	    $this->publishes([$path => rtrim($langPath, '/')."/vendor/$namespace"], $group);
+        $langPath = method_exists($this->app, 'langPath')
+            ? $this->app->langPath()
+            : resource_path('lang');
+
+        $this->publishes([$path => rtrim($langPath, '/')."/vendor/$namespace"], $group);
     }
-	
-	/**
-	 * Register a path to be published to the app's public directory
-	 *
-	 * @param  string  $path
-	 * @param  string  $namespace
-	 * @param  string  $group
-	 * @return void
-	 */
-	protected function publishesPublicAssets($path, $namespace, $group = null)
-	{
-		$this->publishes([$path => public_path("/vendor/$namespace")], $group);
-	}
-	
-	/**
-	 * Register a path to be published to the app's public directory
-	 *
-	 * @param  string  $path
-	 * @param  string  $group
-	 * @return void
-	 */
-	protected function publishesMigrations($path, $group = null)
-	{
-		$this->publishes([$path => database_path('migrations')], $group);
-	}
+
+    /**
+     * Register a path to be published to the app's public directory.
+     *
+     * @param  string  $path
+     * @param  string  $namespace
+     * @param  string  $group
+     * @return void
+     */
+    protected function publishesPublicAssets($path, $namespace, $group = null)
+    {
+        $this->publishes([$path => public_path("/vendor/$namespace")], $group);
+    }
+
+    /**
+     * Register a path to be published to the app's public directory.
+     *
+     * @param  string  $path
+     * @param  string  $group
+     * @return void
+     */
+    protected function publishesMigrations($path, $group = null)
+    {
+        $this->publishes([$path => database_path('migrations')], $group);
+    }
 
     /**
      * Ensure the publish array for the service provider is initialized.

--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -57,18 +57,13 @@ abstract class ServiceProvider
      *
      * @param  string  $path
      * @param  string  $key
-     * @param  bool  $publish
      * @return void
      */
-    protected function mergeConfigFrom($path, $key, $publish = false)
+    protected function mergeConfigFrom($path, $key)
     {
         $config = $this->app['config']->get($key, []);
 
         $this->app['config']->set($key, array_merge(require $path, $config));
-
-        if ($publish) {
-            $this->publishesConfig($path, $key);
-        }
     }
 
     /**
@@ -89,15 +84,10 @@ abstract class ServiceProvider
      *
      * @param  string  $path
      * @param  string  $namespace
-     * @param  bool  $publish
      * @return void
      */
-    protected function loadViewsFrom($path, $namespace, $publish = false)
+    protected function loadViewsFrom($path, $namespace)
     {
-        if ($publish) {
-            $this->publishesViews($path, $namespace);
-        }
-
         $this->registerApplicationViewNamespaces($namespace);
         $this->app['view']->addNamespace($namespace, $path);
     }

--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -19,6 +19,13 @@ abstract class ServiceProvider
      * @var bool
      */
     protected $defer = false;
+	
+	/**
+	 * Indicates whether the default view locations have been registered
+	 *
+	 * @var bool
+	 */
+    protected $viewNamespacesRegistered = false;
 
     /**
      * The paths that should be published.
@@ -50,13 +57,18 @@ abstract class ServiceProvider
      *
      * @param  string  $path
      * @param  string  $key
+     * @param  bool  $publish
      * @return void
      */
-    protected function mergeConfigFrom($path, $key)
+    protected function mergeConfigFrom($path, $key, $publish = false)
     {
         $config = $this->app['config']->get($key, []);
 
         $this->app['config']->set($key, array_merge(require $path, $config));
+        
+        if ($publish) {
+        	$this->publishesConfig($path, $key);
+        }
     }
 
     /**
@@ -77,13 +89,24 @@ abstract class ServiceProvider
      *
      * @param  string  $path
      * @param  string  $namespace
+     * @param  bool  $publish
      * @return void
      */
-    protected function loadViewsFrom($path, $namespace)
+    protected function loadViewsFrom($path, $namespace, $publish = false)
     {
-        if (is_dir($appPath = $this->app->resourcePath().'/views/vendor/'.$namespace)) {
-            $this->app['view']->addNamespace($namespace, $appPath);
-        }
+    	if (!$this->viewNamespacesRegistered) {
+    		$viewPaths = $this->app['config']->get('view.paths', []);
+    		foreach ($viewPaths as $viewPath) {
+			    $viewPath = rtrim($viewPath, '/').'/vendor/'.$namespace;
+			    $this->app['view']->addNamespace($namespace, $viewPath);
+		    }
+		    
+		    if ($publish) {
+    			$this->publishesViews($path, $namespace);
+		    }
+		    
+		    $this->viewNamespacesRegistered = true;
+	    }
 
         $this->app['view']->addNamespace($namespace, $path);
     }
@@ -132,6 +155,78 @@ abstract class ServiceProvider
             $this->addPublishGroup($group, $paths);
         }
     }
+	
+	/**
+	 * Register a view path to be published to the app's configured view directory
+	 *
+	 * @param $path
+	 * @param $namespace
+	 * @param null $group
+	 */
+    protected function publishesViews($path, $namespace, $group = null)
+    {
+	    $viewPaths = $this->app['config']->get('view.paths', [resource_path('views/vendor/')]);
+	    $this->publishes([
+		    $path => rtrim($viewPaths[0], '/')."/vendor/$namespace"
+	    ], $group);
+    }
+	
+	/**
+	 * Register a config file to be published to the app's config directory
+	 *
+	 * @param $path
+	 * @param null $namespace
+	 */
+    protected function publishesConfig($path, $namespace = null, $group = null)
+    {
+    	if (null === $namespace) {
+		    $namespace = basename($path, '.php');
+	    }
+	    
+    	$this->publishes([$path => config_path("$namespace.php")], $group);
+    }
+	
+	/**
+	 * Register a path to be published to the app's lang directory
+	 *
+	 * @param  string  $path
+	 * @param  string  $namespace
+	 * @param  string  $group
+	 * @return void
+	 */
+    protected function publishesTranslations($path, $namespace, $group = null)
+    {
+    	$langPath = method_exists($this->app, 'langPath')
+		    ? $this->app->langPath()
+		    : resource_path('lang');
+    	
+	    $this->publishes([$path => rtrim($langPath, '/')."/vendor/$namespace"], $group);
+    }
+	
+	/**
+	 * Register a path to be published to the app's public directory
+	 *
+	 * @param  string  $path
+	 * @param  string  $namespace
+	 * @param  string  $group
+	 * @return void
+	 */
+	protected function publishesPublicAssets($path, $namespace, $group = null)
+	{
+		$this->publishes([$path => public_path("/vendor/$namespace")], $group);
+	}
+	
+	/**
+	 * Register a path to be published to the app's public directory
+	 *
+	 * @param  string  $path
+	 * @param  string  $group
+	 * @return void
+	 */
+	protected function publishesMigrations($path, $group = null)
+	{
+		$this->publishes([$path => database_path('migrations')], $group);
+	}
 
     /**
      * Ensure the publish array for the service provider is initialized.

--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -165,7 +165,7 @@ abstract class ServiceProvider
      */
     protected function publishesViews($path, $namespace, $group = null)
     {
-        $viewPaths = $this->app['config']->get('view.paths', [resource_path('views/vendor/')]);
+        $viewPaths = $this->app['config']->get('view.paths', [resource_path('views')]);
         $this->publishes([
             $path => rtrim($viewPaths[0], '/')."/vendor/$namespace",
         ], $group);

--- a/tests/Support/SupportServiceProviderTest.php
+++ b/tests/Support/SupportServiceProviderTest.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Tests\Support;
 
+use Illuminate\Config\Repository;
+use Illuminate\Foundation\Application;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Support\ServiceProvider;
@@ -34,6 +36,23 @@ class SupportServiceProviderTest extends TestCase
         ];
         $this->assertEquals($expected, $toPublish, 'Publishable service providers do not return expected set of providers.');
     }
+	
+	public function testPublishesViews()
+	{
+		$app = new Application();
+		$app->instance('config', new Repository([
+			'view' => [
+				'paths' => [
+					'path/to/views'
+				]
+			]
+		]));
+		$provider = new ServiceProviderForTestingThree($app);
+		$provider->boot();
+		
+		$haystack = ServiceProvider::pathsToPublish(ServiceProviderForTestingThree::class);
+		$this->assertContains('path/to/views/vendor/my-namespace', $haystack, 'publishesViews does not publish to the configured view directory'.print_r($haystack, true));
+	}
 
     public function testPublishableGroups()
     {
@@ -133,4 +152,16 @@ class ServiceProviderForTestingTwo extends ServiceProvider
         $this->publishes(['source/tagged/two/a' => 'destination/tagged/two/a'], 'some_tag');
         $this->publishes(['source/tagged/two/b' => 'destination/tagged/two/b'], 'some_tag');
     }
+}
+
+class ServiceProviderForTestingThree extends ServiceProvider
+{
+	public function register()
+	{
+	}
+	
+	public function boot()
+	{
+		$this->publishesViews('source/unmarked/three/a', 'my-namespace');
+	}
 }

--- a/tests/Support/SupportServiceProviderTest.php
+++ b/tests/Support/SupportServiceProviderTest.php
@@ -51,7 +51,18 @@ class SupportServiceProviderTest extends TestCase
         $provider->boot();
 
         $haystack = ServiceProvider::pathsToPublish(ServiceProviderForTestingThree::class);
-        $this->assertContains('path/to/views/vendor/my-namespace', $haystack, 'publishesViews does not publish to the configured view directory'.print_r($haystack, true));
+        $this->assertContains('path/to/views/vendor/my-namespace', $haystack, 'publishesViews does not publish to the configured view directory');
+    }
+
+    public function testPublishesDefaultViews()
+    {
+        $app = new Application();
+        $app->instance('config', new Repository([]));
+        $provider = new ServiceProviderForTestingThree($app);
+        $provider->boot();
+
+        $haystack = ServiceProvider::pathsToPublish(ServiceProviderForTestingThree::class);
+        $this->assertContains($app->resourcePath('views/vendor/my-namespace'), $haystack, 'publishesViews does not publish to the default view directory when no view.paths are set');
     }
 
     public function testPublishableGroups()

--- a/tests/Support/SupportServiceProviderTest.php
+++ b/tests/Support/SupportServiceProviderTest.php
@@ -2,10 +2,10 @@
 
 namespace Illuminate\Tests\Support;
 
-use Illuminate\Config\Repository;
-use Illuminate\Foundation\Application;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Config\Repository;
+use Illuminate\Foundation\Application;
 use Illuminate\Support\ServiceProvider;
 
 class SupportServiceProviderTest extends TestCase
@@ -36,23 +36,23 @@ class SupportServiceProviderTest extends TestCase
         ];
         $this->assertEquals($expected, $toPublish, 'Publishable service providers do not return expected set of providers.');
     }
-	
-	public function testPublishesViews()
-	{
-		$app = new Application();
-		$app->instance('config', new Repository([
-			'view' => [
-				'paths' => [
-					'path/to/views'
-				]
-			]
-		]));
-		$provider = new ServiceProviderForTestingThree($app);
-		$provider->boot();
-		
-		$haystack = ServiceProvider::pathsToPublish(ServiceProviderForTestingThree::class);
-		$this->assertContains('path/to/views/vendor/my-namespace', $haystack, 'publishesViews does not publish to the configured view directory'.print_r($haystack, true));
-	}
+
+    public function testPublishesViews()
+    {
+        $app = new Application();
+        $app->instance('config', new Repository([
+            'view' => [
+                'paths' => [
+                    'path/to/views',
+                ],
+            ],
+        ]));
+        $provider = new ServiceProviderForTestingThree($app);
+        $provider->boot();
+
+        $haystack = ServiceProvider::pathsToPublish(ServiceProviderForTestingThree::class);
+        $this->assertContains('path/to/views/vendor/my-namespace', $haystack, 'publishesViews does not publish to the configured view directory'.print_r($haystack, true));
+    }
 
     public function testPublishableGroups()
     {
@@ -156,12 +156,12 @@ class ServiceProviderForTestingTwo extends ServiceProvider
 
 class ServiceProviderForTestingThree extends ServiceProvider
 {
-	public function register()
-	{
-	}
-	
-	public function boot()
-	{
-		$this->publishesViews('source/unmarked/three/a', 'my-namespace');
-	}
+    public function register()
+    {
+    }
+
+    public function boot()
+    {
+        $this->publishesViews('source/unmarked/three/a', 'my-namespace');
+    }
 }


### PR DESCRIPTION
The current `ServiceProvider` implementation assumes that Laravel is configured in its default state, and the way the `publishes()` method works makes it fairly dependent on the default application structure as described in Laravel's documentation.

For example, because the documentation says to use:

```php
$this->publishes([
    __DIR__.'/path/to/views' => resource_path('views/vendor/courier'),
]);
```

If Laravel ever decides to move the default `views/` directory to somewhere else—say `base_path('views')`—all existing packages will have to update and drop backwards compatibility.

This PR adds the following new `ServiceProvider` methods:

  - `publishesViews($path, $namespace, $group = null)`
  - `publishesConfig($path, $namespace = null, $group = null)`
  - `publishesTranslations($path, $namespace, $group = null)`
  - `publishesPublicAssets($path, $namespace, $group = null)`
  - `publishesMigrations($path, $group = null)`

Because each of these methods determines where to publish the files, they can easily be updated as the framework grows/changes over time.

The other upside is that we can use the currently configured paths instead of the framework defaults where appropriate. So, in the example of views, if your `config('view.paths')` is set to `base_path('views')`, calling `publishesViews(__DIR__.'/views', 'courier')` will automatically publish to `views/vendor/courier` instead of `resources/views/vendor/courier`.

The PR also adds a `$publish` flag to:

  - `mergeConfigFrom($path, $key, $publish = false)`
  - `loadViewsFrom($path, $namespace, $publish = false)`

Which will automatically call `publishesConfig` and `publishesViews` for you respectively.

Finally, this PR updates the `loadViewsFrom` method to use the `config('view.paths')` value rather than hard coding `$this->app->resourcePath().'/views/vendor/'.$namespace`.

This is important because currently there is no way to override vendor view files if you've put your views directory anywhere other than `resources/views/` (unless you manually add a call to `addNamespace()` for each package you've installed).

_This PR still needs to have tests added and will probably need some code style changes._