### PR TITLE
[5.4] Implements Model Instance "Unique" Validation

### DIFF
--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -56,7 +56,7 @@ class Rule
     /**
      * Get a unique constraint builder instance.
      *
-     * @param  string  $table
+     * @param  string|\Illuminate\Database\Eloquent\Model  $table
      * @param  string  $column
      * @return \Illuminate\Validation\Rules\Unique
      */

--- a/src/Illuminate/Validation/Rules/Unique.php
+++ b/src/Illuminate/Validation/Rules/Unique.php
@@ -58,15 +58,34 @@ class Unique
      */
     public function __construct($table, $column = 'NULL')
     {
-        if ($table instanceof Model) {
-            $this->ignore = $table->getKey();
-            $this->idColumn = $table->getKeyName();
+        $this->table = is_string($table) ? $table : null;
+        $this->column = $column;
 
-            $table = $table->getTable();
+        $this->fill($table);
+    }
+
+    /**
+     * Fill the instance data from a possible model.
+     *
+     * @param  string|\Illuminate\Database\Eloquent\Model  $model
+     * @return void
+     */
+    protected function fill($model)
+    {
+        if (is_string($model) && is_subclass_of($model, Model::class)) {
+            $model = new $model;
         }
 
-        $this->table = $table;
-        $this->column = $column;
+        if (! ($model instanceof Model)) {
+            return;
+        }
+
+        $this->table = $model->getTable();
+        $this->idColumn = $model->getKeyName();
+
+        if (($key = $model->getKey()) !== null) {
+            $this->ignore = $key;
+        }
     }
 
     /**

--- a/src/Illuminate/Validation/Rules/Unique.php
+++ b/src/Illuminate/Validation/Rules/Unique.php
@@ -81,11 +81,8 @@ class Unique
         }
 
         $this->table = $model->getTable();
-        $this->idColumn = $model->getKeyName();
 
-        if (($key = $model->getKey()) !== null) {
-            $this->ignore = $key;
-        }
+        $this->ignore($model);
     }
 
     /**
@@ -149,6 +146,11 @@ class Unique
      */
     public function ignore($id, $idColumn = 'id')
     {
+        if ($id instanceof Model) {
+            $idColumn = $id->getKeyName();
+            $id = $id->getKey();
+        }
+
         $this->ignore = $id;
         $this->idColumn = $idColumn;
 

--- a/src/Illuminate/Validation/Rules/Unique.php
+++ b/src/Illuminate/Validation/Rules/Unique.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Validation\Rules;
 
 use Closure;
+use Illuminate\Database\Eloquent\Model;
 
 class Unique
 {
@@ -51,12 +52,19 @@ class Unique
     /**
      * Create a new unique rule instance.
      *
-     * @param  string  $table
+     * @param  string|\Illuminate\Database\Eloquent\Model  $table
      * @param  string  $column
      * @return void
      */
     public function __construct($table, $column = 'NULL')
     {
+        if ($table instanceof Model) {
+            $this->ignore = $table->getKey();
+            $this->idColumn = $table->getKeyName();
+
+            $table = $table->getTable();
+        }
+
         $this->table = $table;
         $this->column = $column;
     }

--- a/tests/Validation/ValidationUniqueRuleTest.php
+++ b/tests/Validation/ValidationUniqueRuleTest.php
@@ -38,6 +38,12 @@ class ValidationUniqueRuleTest extends TestCase
 
         $rule = new \Illuminate\Validation\Rules\Unique($model, 'column');
         $this->assertEquals('unique:table,column,"Connor Parks",id_column', (string) $rule);
+
+        $rule = new \Illuminate\Validation\Rules\Unique(ValidationUniqueRuleTestModel::class);
+        $this->assertEquals('unique:table,NULL,NULL,id_column', (string) $rule);
+
+        $rule = new \Illuminate\Validation\Rules\Unique(ValidationUniqueRuleTestModel::class, 'column');
+        $this->assertEquals('unique:table,column,NULL,id_column', (string) $rule);
     }
 }
 

--- a/tests/Validation/ValidationUniqueRuleTest.php
+++ b/tests/Validation/ValidationUniqueRuleTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Validation;
 
 use PHPUnit\Framework\TestCase;
+use Illuminate\Database\Eloquent\Model;
 
 class ValidationUniqueRuleTest extends TestCase
 {
@@ -21,5 +22,29 @@ class ValidationUniqueRuleTest extends TestCase
         $rule->ignore(null, 'id_column');
         $rule->where('foo', 'bar');
         $this->assertEquals('unique:table,column,NULL,id_column,foo,bar', (string) $rule);
+
+        $model = new ValidationUniqueRuleTestModel;
+
+        $rule = new \Illuminate\Validation\Rules\Unique($model);
+        $this->assertEquals('unique:table,NULL,NULL,id_column', (string) $rule);
+
+        $rule = new \Illuminate\Validation\Rules\Unique($model, 'column');
+        $this->assertEquals('unique:table,column,NULL,id_column', (string) $rule);
+
+        $model->setAttribute($model->getKeyName(), 'Connor Parks');
+
+        $rule = new \Illuminate\Validation\Rules\Unique($model);
+        $this->assertEquals('unique:table,NULL,"Connor Parks",id_column', (string) $rule);
+
+        $rule = new \Illuminate\Validation\Rules\Unique($model, 'column');
+        $this->assertEquals('unique:table,column,"Connor Parks",id_column', (string) $rule);
     }
+}
+
+class ValidationUniqueRuleTestModel extends Model
+{
+    protected $table = 'table';
+    protected $primaryKey = 'id_column';
+    protected $keyType = 'string';
+    public $incrementing = false;
 }

--- a/tests/Validation/ValidationUniqueRuleTest.php
+++ b/tests/Validation/ValidationUniqueRuleTest.php
@@ -44,6 +44,12 @@ class ValidationUniqueRuleTest extends TestCase
 
         $rule = new \Illuminate\Validation\Rules\Unique(ValidationUniqueRuleTestModel::class, 'column');
         $this->assertEquals('unique:table,column,NULL,id_column', (string) $rule);
+
+        $rule = (new \Illuminate\Validation\Rules\Unique(ValidationUniqueRuleTestModel::class))->ignore($model);
+        $this->assertEquals('unique:table,NULL,"Connor Parks",id_column', (string) $rule);
+
+        $rule = (new \Illuminate\Validation\Rules\Unique(ValidationUniqueRuleTestModel::class, 'column'))->ignore($model);
+        $this->assertEquals('unique:table,column,"Connor Parks",id_column', (string) $rule);
     }
 }
 


### PR DESCRIPTION
As discussed here: https://github.com/laravel/internals/issues/591#issuecomment-303684085 and followed up here: https://github.com/laravel/internals/issues/604

I'm unsure about class implementation at the moment as it could end up being a bit messy (checking for class existence and that it is indeed an extension of model), I'm also unsure if I should delegate this logic in the `__construct` method or not. I've done so in this PR.