### PR TITLE
[5.4] Return also $changes['to_detach'] from sync($ids, false)

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -82,7 +82,7 @@ trait InteractsWithPivotTable
     public function sync($ids, $detaching = true)
     {
         $changes = [
-            'attached' => [], 'detached' => [], 'updated' => [],
+            'attached' => [], 'detached' => [], 'to_detach' => [], 'updated' => [],
         ];
 
         // First we need to attach any of the associated models that are not currently
@@ -99,10 +99,13 @@ trait InteractsWithPivotTable
         // Next, we will take the differences of the currents and given IDs and detach
         // all of the entities that exist in the "current" array but are not in the
         // array of the new IDs given to the method which will complete the sync.
-        if ($detaching && count($detach) > 0) {
-            $this->detach($detach);
-
-            $changes['detached'] = $this->castKeys($detach);
+        if (count($detach) > 0) {
+            if ($detaching) {
+                $this->detach($detach);
+                $changes['detached'] = $this->castKeys($detach);
+            } else {
+                $changes['to_detach'] = $this->castKeys($detach);
+            }
         }
 
         // Now we are finally ready to attach the new records. Note that we'll disable


### PR DESCRIPTION
from https://github.com/laravel/internals/issues/605

There might be use case, to know what ids would be detached if `$detaching == true`

My use case involves custom detaching (queued detaching) so I need to know what ids would be detached.  
At the moment I have to compute `to_detach` myself and need one extra query.