### PR TITLE
[5.5] Unify the exception response format when converting to JSON

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -197,7 +197,7 @@ class Handler implements ExceptionHandlerContract
 
         if ($request->expectsJson()) {
             return response()->json([
-                'message' => $e->getMessage(), 'errors' => $errors
+                'message' => $e->getMessage(), 'errors' => $errors,
             ], 422);
         }
 

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -196,7 +196,9 @@ class Handler implements ExceptionHandlerContract
         $errors = $e->validator->errors()->getMessages();
 
         if ($request->expectsJson()) {
-            return response()->json($errors, 422);
+            return response()->json([
+                'message' => $e->getMessage(), 'errors' => $errors
+            ], 422);
         }
 
         return redirect()->back()->withInput(


### PR DESCRIPTION
Currently any normal Exception is converted to this JSON structure:

```json
{"message": "..."}
```

In case debug mode is on, several other attributes appear (file, line, & trace).

However there are two exceptions to this structure, first a validation exceptions returns the following:

```json
{
    "test": [
      "The test field is required."
    ]
  }
```

And an `AuthenticationException` returns:

```json
{"error" : "Unauthenticated."}
```

In this PR I'm attempting to unify the error response by returning the following from a validation exceptions:

```json
{
  "message": "The given data failed to pass validation.",
  "errors": {
    "test": [
      "The test field is required."
    ]
  }
}
```

If that PR is approved I'm going to change the response format in https://github.com/laravel/laravel/blob/develop/app/Exceptions/Handler.php#L55 as well, this will make it standard across the framework to have a `message` attribute in a JSON error response that consumers can use to render a message to the end user or log it somewhere for later.