### PR TITLE
Respect casts declaration on custom pivot models.

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -236,6 +236,10 @@ trait InteractsWithPivotTable
         // To create the attachment records, we will simply spin through the IDs given
         // and create a new record to insert for each ID. Each ID may actually be a
         // key in the array, with extra attributes to be placed in other columns.
+        $attributes = $this->using 
+                ? $this->newPivot()->forceFill($attributes)->getAttributes()
+                : $attributes;
+
         foreach ($ids as $key => $value) {
             $records[] = $this->formatAttachRecord(
                 $key, $value, $attributes, $hasTimestamps

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -236,7 +236,7 @@ trait InteractsWithPivotTable
         // To create the attachment records, we will simply spin through the IDs given
         // and create a new record to insert for each ID. Each ID may actually be a
         // key in the array, with extra attributes to be placed in other columns.
-        $attributes = $this->using 
+        $attributes = $this->using
                 ? $this->newPivot()->forceFill($attributes)->getAttributes()
                 : $attributes;
 

--- a/tests/Integration/Database/EloquentCustomPivotCastTest.php
+++ b/tests/Integration/Database/EloquentCustomPivotCastTest.php
@@ -1,10 +1,8 @@
 <?php
 
-use Faker\Generator;
 use Orchestra\Testbench\TestCase;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Factory;
 
 /**
  * @group integration
@@ -45,7 +43,6 @@ class EloquentCustomPivotCastTest extends TestCase
         });
     }
 
-
     public function test_casts_are_respected_on_attach()
     {
         $user = CustomPivotCastTestUser::forceCreate([
@@ -61,7 +58,6 @@ class EloquentCustomPivotCastTest extends TestCase
 
         $this->assertEquals(['foo' => 'bar'], $project->collaborators[0]->pivot->permissions);
     }
-
 
     public function test_casts_are_respected_on_sync()
     {
@@ -86,7 +82,6 @@ class CustomPivotCastTestUser extends Model
     public $timestamps = false;
 }
 
-
 class CustomPivotCastTestProject extends Model
 {
     public $table = 'projects';
@@ -99,7 +94,6 @@ class CustomPivotCastTestProject extends Model
         )->using(CustomPivotCastTestCollaborator::class)->withPivot('permissions');
     }
 }
-
 
 class CustomPivotCastTestCollaborator extends Illuminate\Database\Eloquent\Relations\Pivot
 {

--- a/tests/Integration/Database/EloquentCustomPivotCastTest.php
+++ b/tests/Integration/Database/EloquentCustomPivotCastTest.php
@@ -1,0 +1,109 @@
+<?php
+
+use Faker\Generator;
+use Orchestra\Testbench\TestCase;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Factory;
+
+/**
+ * @group integration
+ */
+class EloquentCustomPivotCastTest extends TestCase
+{
+    protected function getEnvironmentSetUp($app)
+    {
+        $app['config']->set('app.debug', 'true');
+
+        $app['config']->set('database.default', 'testbench');
+
+        $app['config']->set('database.connections.testbench', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+        ]);
+    }
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        Schema::create('users', function ($table) {
+            $table->increments('id');
+            $table->string('email');
+        });
+
+        Schema::create('projects', function ($table) {
+            $table->increments('id');
+            $table->string('name');
+        });
+
+        Schema::create('project_users', function ($table) {
+            $table->integer('user_id');
+            $table->integer('project_id');
+            $table->text('permissions');
+        });
+    }
+
+
+    public function test_casts_are_respected_on_attach()
+    {
+        $user = CustomPivotCastTestUser::forceCreate([
+            'email' => 'taylor@laravel.com',
+        ]);
+
+        $project = CustomPivotCastTestProject::forceCreate([
+            'name' => 'Test Project',
+        ]);
+
+        $project->collaborators()->attach($user, ['permissions' => ['foo' => 'bar']]);
+        $project = $project->fresh();
+
+        $this->assertEquals(['foo' => 'bar'], $project->collaborators[0]->pivot->permissions);
+    }
+
+
+    public function test_casts_are_respected_on_sync()
+    {
+        $user = CustomPivotCastTestUser::forceCreate([
+            'email' => 'taylor@laravel.com',
+        ]);
+
+        $project = CustomPivotCastTestProject::forceCreate([
+            'name' => 'Test Project',
+        ]);
+
+        $project->collaborators()->sync([$user->id => ['permissions' => ['foo' => 'bar']]]);
+        $project = $project->fresh();
+
+        $this->assertEquals(['foo' => 'bar'], $project->collaborators[0]->pivot->permissions);
+    }
+}
+
+class CustomPivotCastTestUser extends Model
+{
+    public $table = 'users';
+    public $timestamps = false;
+}
+
+
+class CustomPivotCastTestProject extends Model
+{
+    public $table = 'projects';
+    public $timestamps = false;
+
+    public function collaborators()
+    {
+        return $this->belongsToMany(
+            CustomPivotCastTestUser::class, 'project_users', 'project_id', 'user_id'
+        )->using(CustomPivotCastTestCollaborator::class)->withPivot('permissions');
+    }
+}
+
+
+class CustomPivotCastTestCollaborator extends Illuminate\Database\Eloquent\Relations\Pivot
+{
+    protected $casts = [
+        'permissions' => 'json',
+    ];
+}


### PR DESCRIPTION
This updates Laravel to respect casts definitions on custom pivot
models when using the ->using() method on a BelongsToMany relationship.