### PR TITLE
Free memory when using chunk in queries

### DIFF
--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -35,7 +35,7 @@ trait BuildsQueries
             if ($callback($results, $page) === false) {
                 return false;
             }
-            
+
             unset($results);
 
             $page++;

--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -35,6 +35,8 @@ trait BuildsQueries
             if ($callback($results, $page) === false) {
                 return false;
             }
+            
+            unset($results);
 
             $page++;
         } while ($countResults == $count);


### PR DESCRIPTION
Unsetting the variable frees the memory through the loop. Really useful for large datasets.

I've run the following code as a test for the issue (PHP 5.6).

```php
User::truncate();

foreach (range(1, 100000) as $i) {
    User::create([
        'email'    => uniqid(),
        'name'     => 'foo',
        'password' => 'foo',
    ]);
}

User::chunk(5000, function ($user) {

    echo round(memory_get_peak_usage() / 1024 / 1024) . "\n";

});
```

Peak without commit: 39
Peak with commit: 29

If I'm right I think there could be more candidates to optimize. Maybe it's just a micro-optimization as this memory is just wasted during a small period of time in the loop.

Thanks.