### PR TITLE
add hasAny() method

### DIFF
--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -92,6 +92,25 @@ trait InteractsWithInput
     }
 
     /**
+     * Determine if the request contains any of the given inputs.
+     *
+     * @param  dynamic  $key
+     * @return bool
+     */
+    public function hasAny(...$keys)
+    {
+        $input = $this->all();
+
+        foreach ($keys as $key) {
+            if (Arr::has($input, $key)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * Determine if the request contains a non-empty value for an input item.
      *
      * @param  string|array  $key

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -233,6 +233,25 @@ class HttpRequestTest extends TestCase
         $this->assertTrue($request->has('foo.baz'));
     }
 
+    public function testHasAnyMethod()
+    {
+        $request = Request::create('/', 'GET', ['name' => 'Taylor', 'age' => '', 'city' => null]);
+        $this->assertTrue($request->hasAny('name'));
+        $this->assertTrue($request->hasAny('age'));
+        $this->assertTrue($request->hasAny('city'));
+        $this->assertFalse($request->hasAny('foo'));
+        $this->assertTrue($request->hasAny('name', 'email'));
+
+        $request = Request::create('/', 'GET', ['name' => 'Taylor', 'email' => 'foo']);
+        $this->assertTrue($request->hasAny('name', 'email'));
+        $this->assertFalse($request->hasAny('surname', 'password'));
+
+        $request = Request::create('/', 'GET', ['foo' => ['bar' => null, 'baz' => '']]);
+        $this->assertTrue($request->hasAny('foo.bar'));
+        $this->assertTrue($request->hasAny('foo.baz'));
+        $this->assertFalse($request->hasAny('foo.bax'));
+    }
+
     public function testFilledMethod()
     {
         $request = Request::create('/', 'GET', ['name' => 'Taylor', 'age' => '', 'city' => null]);


### PR DESCRIPTION
I found myself many times checking with interminable ORs if the request contains any of the inputs I specified for different purposes. I always create a helper method to check the request like `if (array_any_key_exists($request->all(), 'name', 'surname', 'email'))` but it will not be necessary, just `if ($request->hasAny('name', 'surname', 'email'))`