### PR TITLE
[5.4] Add apiResource function to Router

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -252,7 +252,7 @@ class Router implements RegistrarContract, BindingRegistrar
 
         $registrar->register($name, $controller, $options);
     }
-    
+
     /**
      * Route an api resource to a controller.
      *

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -264,7 +264,7 @@ class Router implements RegistrarContract, BindingRegistrar
     public function apiResource($name, $controller, array $options = [])
     {
         $this->resource($name, $controller, array_merge([
-            'only' => ['index', 'show', 'store', 'update', 'destroy']
+            'only' => ['index', 'show', 'store', 'update', 'destroy'],
         ], $options));
     }
 

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -252,6 +252,21 @@ class Router implements RegistrarContract, BindingRegistrar
 
         $registrar->register($name, $controller, $options);
     }
+    
+    /**
+     * Route an api resource to a controller.
+     *
+     * @param  string  $name
+     * @param  string  $controller
+     * @param  array  $options
+     * @return void
+     */
+    public function apiResource($name, $controller, array $options = [])
+    {
+        $this->resource($name, $controller, array_merge([
+            'only' => ['index', 'show', 'store', 'update', 'destroy']
+        ], $options));
+    }
 
     /**
      * Create a route group with shared attributes.


### PR DESCRIPTION
The route resource function is very useful but an API doesn't need the create and edit routes. This pull request would allow that functionality with a new apiResource function that would work the same way as the original resource function just without the two unnecessary routes.

`Route::apiResource('photos', 'PhotoController');`