### PR TITLE
[5.5] In PHP7.1, the scope of the closure cannot be bound in "Macroable".

### DIFF
--- a/src/Illuminate/Support/Traits/Macroable.php
+++ b/src/Illuminate/Support/Traits/Macroable.php
@@ -3,8 +3,8 @@
 namespace Illuminate\Support\Traits;
 
 use Closure;
-use BadMethodCallException;
 use ReflectionFunction;
+use BadMethodCallException;
 
 trait Macroable
 {
@@ -56,7 +56,7 @@ trait Macroable
         if (static::$macros[$method] instanceof Closure) {
             $reflection = new ReflectionFunction(static::$macros[$method]);
 
-            /**
+            /*
              * If the closure from Closure::fromCallable() or ReflectionFunctionAbstract::getClosure(),
              * its name is not "{closure}".
              */
@@ -86,7 +86,7 @@ trait Macroable
         if (static::$macros[$method] instanceof Closure) {
             $reflection = new ReflectionFunction(static::$macros[$method]);
 
-            /**
+            /*
              * If it is a static closure, it looks like:
              * Closure [ <user, prototype Closure> static function {closure} ] {
              *     ... ...
@@ -97,7 +97,7 @@ trait Macroable
              *     ... ...
              * }
              */
-            if ($reflection->name === '{closure}' && strpos(explode(PHP_EOL, (string)$reflection)[0], 'static') !== false) {
+            if ($reflection->name === '{closure}' && strpos(explode(PHP_EOL, (string) $reflection)[0], 'static') !== false) {
                 return call_user_func_array(static::$macros[$method]->bindTo($this, static::class), $parameters);
             }
         }


### PR DESCRIPTION
When some closures are created using “Closure::fromCallable()”, the scope of the closure cannot be bound in "Macroable".
eg: 
```php
class A
{
    public function say1()
    {
        return 1;
    }
    public static function say2()
    {
        return 2;
    }
}

$closure1 = Closure::fromCallable([new A, 'say1']);
$closure2 = Closure::fromCallable([new A, 'say2']);
$closure3 = static function(){};
```