### PR TITLE
Foreign helper: Relationship + dropRelationship

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -283,6 +283,18 @@ class Blueprint
     }
 
     /**
+     * Drops a relationship
+     *
+     * @param  string  $table
+     * @param  string  $column
+     * @return \Illuminate\Support\Fluent
+     */
+    public function dropRelationship($table, $column)
+    {
+        return $this->dropForeign("{$table}_{$column}_foreign");
+    }
+
+    /**
      * Indicate that the timestamp columns should be dropped.
      *
      * @return void
@@ -392,6 +404,20 @@ class Blueprint
     public function foreign($columns, $name = null)
     {
         return $this->indexCommand('foreign', $columns, $name);
+    }
+
+    /**
+     * Creates a relationship
+     *
+     * @param  string  $column
+     * @param  string  $name
+     * @return \Illuminate\Support\Fluent
+     */
+    public function relationship($columns, $references, $on = 'id')
+    {
+        return $this->foreign($column)
+                    ->references($references)
+                    ->on($on);
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -410,14 +410,15 @@ class Blueprint
      * Creates a relationship.
      *
      * @param  string  $column
-     * @param  string  $name
+     * @param  string  $table
+     * @param  string  $references
      * @return \Illuminate\Support\Fluent
      */
-    public function relationship($columns, $references, $on = 'id')
+    public function relationship($columns, $table, $references = 'id')
     {
         return $this->foreign($column)
                     ->references($references)
-                    ->on($on);
+                    ->on($table);
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -414,7 +414,7 @@ class Blueprint
      * @param  string  $references
      * @return \Illuminate\Support\Fluent
      */
-    public function relationship($columns, $table, $references = 'id')
+    public function relationship($column, $table, $references = 'id')
     {
         return $this->foreign($column)
                     ->references($references)

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -283,7 +283,7 @@ class Blueprint
     }
 
     /**
-     * Drops a relationship
+     * Drops a relationship.
      *
      * @param  string  $table
      * @param  string  $column
@@ -407,7 +407,7 @@ class Blueprint
     }
 
     /**
-     * Creates a relationship
+     * Creates a relationship.
      *
      * @param  string  $column
      * @param  string  $name


### PR DESCRIPTION
Typically, creating a relationship requires 3 methods: `foreign()`, `references()`, `on()`. With this helper, the user will only have to use a single method with 3 parameters (two required, one optional).

Similarly, to drop the relationships, you have to remember the default syntax (`TABLE`_`COLUMN`_foreign). With this helper, users won't have to remember.

`relationship()` still allows for chain with `onDelete` or similar.

Maybe this is a terrible idea? If so, please let me know :) It just feels easier and I imagine it would lover the barrier for people new to the whole migrations concept (as I remember having some trouble with the whole `foreign()->references()->on()`)