### PR TITLE
[5.4] Add str_after helper function

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -30,6 +30,24 @@ class Str
     protected static $studlyCache = [];
 
     /**
+     * Return the remainder of a string after a given value.
+     *
+     * @param  string  $subject
+     * @param  string  $search
+     * @return string
+     */
+    public static function after($subject, $search)
+    {
+        if (! static::contains($subject, $search)) {
+            return '';
+        }
+
+        $searchEndPos =  strpos($subject, $search) + static::length($search);
+
+        return static::substr($subject, $searchEndPos, static::length($subject));
+    }
+
+    /**
      * Transliterate a UTF-8 value to ASCII.
      *
      * @param  string  $value

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -39,7 +39,7 @@ class Str
     public static function after($subject, $search)
     {
         if (! static::contains($subject, $search)) {
-            return '';
+            return $subject;
         }
 
         $searchEndPos = strpos($subject, $search) + static::length($search);

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -42,7 +42,7 @@ class Str
             return '';
         }
 
-        $searchEndPos =  strpos($subject, $search) + static::length($search);
+        $searchEndPos = strpos($subject, $search) + static::length($search);
 
         return static::substr($subject, $searchEndPos, static::length($subject));
     }

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -695,6 +695,20 @@ if (! function_exists('starts_with')) {
     }
 }
 
+if (! function_exists('str_after')) {
+    /**
+     * Return the remainder of a string after a given value.
+     *
+     * @param  string  $subject
+     * @param  string  $search
+     * @return string
+     */
+    function str_after($subject, $search)
+    {
+        return Str::after($subject, $search);
+    }
+}
+
 if (! function_exists('str_contains')) {
     /**
      * Determine if a given string contains a given substring.

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -256,7 +256,7 @@ class SupportHelpersTest extends TestCase
     {
         $this->assertEquals('nah', str_after('hannah', 'han'));
         $this->assertEquals('nah', str_after('hannah', 'n'));
-        $this->assertEmpty(str_after('hannah', 'caleb'));
+        $this->assertEmpty(str_after('hannah', 'xxxx'));
     }
 
     public function testStrContains()

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -252,6 +252,13 @@ class SupportHelpersTest extends TestCase
         $this->assertFalse(Str::endsWith('jason', ['no']));
     }
 
+    public function testStrAfter()
+    {
+        $this->assertEquals('nah', str_after('hannah', 'han'));
+        $this->assertEquals('nah', str_after('hannah', 'n'));
+        $this->assertEmpty(str_after('hannah', 'caleb'));
+    }
+
     public function testStrContains()
     {
         $this->assertTrue(Str::contains('taylor', 'ylo'));

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -256,7 +256,7 @@ class SupportHelpersTest extends TestCase
     {
         $this->assertEquals('nah', str_after('hannah', 'han'));
         $this->assertEquals('nah', str_after('hannah', 'n'));
-        $this->assertEmpty(str_after('hannah', 'xxxx'));
+        $this->assertEquals('hannah', str_after('hannah', 'xxxx'));
     }
 
     public function testStrContains()

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -80,7 +80,7 @@ class SupportStrTest extends TestCase
     {
         $this->assertEquals('nah', Str::after('hannah', 'han'));
         $this->assertEquals('nah', Str::after('hannah', 'n'));
-        $this->assertEmpty(Str::after('hannah', 'xxxx'));
+        $this->assertEquals('hannah', Str::after('hannah', 'xxxx'));
     }
 
     public function testStrContains()

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -76,6 +76,13 @@ class SupportStrTest extends TestCase
         $this->assertFalse(Str::endsWith(0.27, '8'));
     }
 
+    public function testStrAfter()
+    {
+        $this->assertEquals('nah', Str::after('hannah', 'han'));
+        $this->assertEquals('nah', Str::after('hannah', 'n'));
+        $this->assertEmpty(Str::after('hannah', 'xxxx'));
+    }
+
     public function testStrContains()
     {
         $this->assertTrue(Str::contains('taylor', 'ylo'));


### PR DESCRIPTION
I often come across cases where I need to retrieve everything after a piece of a string. Manually `preg_match` or `strpos` / `substr` is verbose IMO.

Here is the usage:
```
$title = str_after('Title: hello world', 'Title: ');
```

I've been using my own personal helper for this for some time now and have found it extremely handy, hoping you find the same!

Thanks for the endless amounts of hard work!
- Caleb