### PR TITLE
Add "base64:" prefix support to env() helper

### DIFF
--- a/src/Illuminate/Auth/Passwords/PasswordBrokerManager.php
+++ b/src/Illuminate/Auth/Passwords/PasswordBrokerManager.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Auth\Passwords;
 
 use Illuminate\Support\Arr;
-use Illuminate\Support\Str;
 use InvalidArgumentException;
 use Illuminate\Contracts\Auth\PasswordBrokerFactory as FactoryContract;
 
@@ -83,10 +82,6 @@ class PasswordBrokerManager implements FactoryContract
     protected function createTokenRepository(array $config)
     {
         $key = $this->app['config']['app.key'];
-
-        if (Str::startsWith($key, 'base64:')) {
-            $key = base64_decode(substr($key, 7));
-        }
 
         $connection = isset($config['connection']) ? $config['connection'] : null;
 

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -482,7 +482,7 @@ if (! function_exists('env')) {
         if (strlen($value) > 1 && Str::startsWith($value, '"') && Str::endsWith($value, '"')) {
             return substr($value, 1, -1);
         }
-        
+
         if (Str::startsWith($value, 'base64:')) {
             return base64_decode(substr($value, 7));
         }

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -482,6 +482,10 @@ if (! function_exists('env')) {
         if (strlen($value) > 1 && Str::startsWith($value, '"') && Str::endsWith($value, '"')) {
             return substr($value, 1, -1);
         }
+        
+        if (Str::startsWith($value, 'base64:')) {
+            return base64_decode(substr($value, 7));
+        }
 
         return $value;
     }


### PR DESCRIPTION
See https://github.com/laravel/internals/issues/266.
Not sure if I also have to remove the PasswordBrokerManager code...