### PR TITLE
[5.5] Simplify queueing notifications

### DIFF
--- a/src/Illuminate/Notifications/Notification.php
+++ b/src/Illuminate/Notifications/Notification.php
@@ -24,4 +24,15 @@ class Notification
     {
         return [];
     }
+
+    /**
+     * Sets the notification id.
+     *
+     * @param  string  $id
+     * @return void
+     */
+    public function setId($id)
+    {
+        $this->id = $id;
+    }
 }


### PR DESCRIPTION
- No need for the first clone since no change happens between that and the clone per channel
- No need to clone per channel since the ID is given per notifiable

The PR will make us clone the notification only once per notifiable, instead of once per notifiable per channel.