### PR TITLE
[5.4] Add min_ratio/max_ratio to dimension validator

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -470,15 +470,33 @@ trait ValidatesAttributes
      */
     protected function failsRatioCheck($parameters, $width, $height)
     {
-        if (! isset($parameters['ratio'])) {
+        if (! isset($parameters['ratio']) && ! isset($parameters['min_ratio']) && ! isset($parameters['max_ratio'])) {
             return false;
         }
 
-        list($numerator, $denominator) = array_replace(
-            [1, 1], array_filter(sscanf($parameters['ratio'], '%f/%d'))
-        );
+        $realRatio = $width / $height;
 
-        return abs($numerator / $denominator - $width / $height) > 0.000001;
+        $getDiff = function ($parameter) use ($realRatio) {
+            list($numerator, $denominator) = array_replace(
+                [1, 1], array_filter(sscanf($parameter, '%f/%d'))
+            );
+
+            return $realRatio - $numerator / $denominator;
+        };
+
+        if (isset($parameters['ratio']) && abs($getDiff($parameters['ratio'])) > 0.000001) {
+            return true;
+        }
+
+        if (isset($parameters['max_ratio']) && $getDiff($parameters['max_ratio']) > 0) {
+            return true;
+        }
+
+        if (isset($parameters['min_ratio']) && $getDiff($parameters['min_ratio']) < 0) {
+            return true;
+        }
+
+        return false;
     }
 
     /**

--- a/src/Illuminate/Validation/Rules/Dimensions.php
+++ b/src/Illuminate/Validation/Rules/Dimensions.php
@@ -114,6 +114,32 @@ class Dimensions
     }
 
     /**
+     * Set the "min_ratio" constraint.
+     *
+     * @param float $value
+     * @return $this
+     */
+    public function minRatio($value)
+    {
+        $this->constraints['min_ratio'] = $value;
+
+        return $this;
+    }
+
+    /**
+     * Set the "max_ratio" constraint.
+     *
+     * @param float $value
+     * @return $this
+     */
+    public function maxRatio($value)
+    {
+        $this->constraints['max_ratio'] = $value;
+
+        return $this;
+    }
+
+    /**
      * Convert the rule to a validation string.
      *
      * @return string

--- a/tests/Validation/ValidationDimensionsRuleTest.php
+++ b/tests/Validation/ValidationDimensionsRuleTest.php
@@ -21,5 +21,9 @@ class ValidationDimensionsRuleTest extends TestCase
         $rule = Rule::dimensions()->maxWidth(1000)->maxHeight(500)->ratio(3 / 2);
 
         $this->assertEquals('dimensions:max_width=1000,max_height=500,ratio=1.5', (string) $rule);
+
+        $rule = Rule::dimensions()->maxWidth(1000)->maxHeight(500)->maxRatio(3)->minRatio(2);
+
+        $this->assertEquals('dimensions:max_width=1000,max_height=500,max_ratio=3,min_ratio=2', (string) $rule);
     }
 }

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -2023,6 +2023,21 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['x' => $uploadedFile], ['x' => 'dimensions:ratio=1']);
         $this->assertTrue($v->fails());
 
+        $v = new Validator($trans, ['x' => $uploadedFile], ['x' => 'dimensions:min_ratio=1']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => $uploadedFile], ['x' => 'dimensions:min_ratio=2']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['x' => $uploadedFile], ['x' => 'dimensions:max_ratio=2']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => $uploadedFile], ['x' => 'dimensions:max_ratio=1']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['x' => $uploadedFile], ['x' => 'dimensions:max_ratio=3/2,min_ratio=3/2']);
+        $this->assertTrue($v->passes());
+
         // Knowing that demo image2.png has width = 4 and height = 2
         $uploadedFile = new \Symfony\Component\HttpFoundation\File\UploadedFile(__DIR__.'/fixtures/image2.png', '', null, null, null, true);
         $trans = $this->getIlluminateArrayTranslator();


### PR DESCRIPTION
We can now set the dimension ratio range to the image validator:

```
Rule::dimensions()->maxRatio(3)->minRatio(2);
```

or

```
dimensions:max_ratio=3,min_ratio=2
```