### PR TITLE
[5.4] Identify migration files organised into sub-directories

### DIFF
--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -4,8 +4,6 @@ namespace Illuminate\Database\Migrations;
 
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
-use RecursiveIteratorIterator;
-use RecursiveDirectoryIterator;
 use Illuminate\Support\Collection;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Database\ConnectionResolverInterface as Resolver;
@@ -438,16 +436,13 @@ class Migrator
      */
     public function getAllMigrationFiles($path)
     {
-        $directoryIterator = new RecursiveDirectoryIterator($path);
-        $iteratorIterator = new RecursiveIteratorIterator($directoryIterator);
-        $files = [];
-        foreach ($iteratorIterator as $iteratee) {
-            if ($iteratee->isFile() && preg_match('/^.*_.*\.php$/', $iteratee->getFilename())) {
-                $files[] = $iteratee->getRealPath();
-            }
-        }
+        $files = $this->files->allFiles($path);
 
-        return $files;
+        return Collection::make($files)->filter(function ($file) {
+            return preg_match('/^.*_.*\.php$/', $file->getFilename());
+        })->map(function ($file) {
+            return $file->getRealPath();
+        })->all();
     }
 
     /**

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -436,16 +436,17 @@ class Migrator
      * @param  string  $path
      * @return array
      */
-    public function getAllMigrationFiles(string $path)
+    public function getAllMigrationFiles($path)
     {
         $directoryIterator = new RecursiveDirectoryIterator($path);
         $iteratorIterator = new RecursiveIteratorIterator($directoryIterator);
         $files = [];
         foreach ($iteratorIterator as $iteratee) {
             if ($iteratee->isFile() && preg_match('/^.*_.*\.php$/', $iteratee->getFilename())) {
-                array_push($files, $iteratee->getRealPath());
+                $files[] = $iteratee->getRealPath();
             }
         }
+
         return $files;
     }
 


### PR DESCRIPTION
``php artisan migrate`` command is identifying migration files only in ``database/migrations`` directory. If there are more migration files and they are organised into sub-directories by developer, they are not identified. This pull request will make laravel migration to identify all migration files in the sub directories of the given path.