### PR TITLE
do not serialize string value using cache redis store

### DIFF
--- a/src/Illuminate/Cache/RedisStore.php
+++ b/src/Illuminate/Cache/RedisStore.php
@@ -261,7 +261,7 @@ class RedisStore extends TaggableStore implements Store
      */
     protected function serialize($value)
     {
-        return is_numeric($value) ? $value : serialize($value);
+        return (is_numeric($value) || is_string($value)) ? $value : serialize($value);
     }
 
     /**
@@ -272,6 +272,7 @@ class RedisStore extends TaggableStore implements Store
      */
     protected function unserialize($value)
     {
-        return is_numeric($value) ? $value : unserialize($value);
+        $unserialized = @unserialize($value);
+        return (is_numeric($value) || is_string($value)) ? $value : $unserialized;
     }
 }

--- a/src/Illuminate/Cache/RedisStore.php
+++ b/src/Illuminate/Cache/RedisStore.php
@@ -273,6 +273,7 @@ class RedisStore extends TaggableStore implements Store
     protected function unserialize($value)
     {
         $unserialized = @unserialize($value);
+        
         return (is_numeric($value) || is_string($value)) ? $value : $unserialized;
     }
 }

--- a/src/Illuminate/Cache/RedisStore.php
+++ b/src/Illuminate/Cache/RedisStore.php
@@ -273,7 +273,7 @@ class RedisStore extends TaggableStore implements Store
     protected function unserialize($value)
     {
         $unserialized = @unserialize($value);
-        
+
         return (is_numeric($value) || is_string($value)) ? $value : $unserialized;
     }
 }


### PR DESCRIPTION
Sometimes we need to share data through Redis or other database cross-platform.
However Laravel Cache facade will serialize anything except number using Redis-store.
It might be better to skip serialize string like Json/Html for cross-platform considerations.

[https://github.com/laravel/internals/issues/608](url)

Also added test for object/array serialization.