### PR TITLE
[5.4] Added relative dates validation support

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -338,7 +338,7 @@ trait ValidatesAttributes
         }
 
         $date = date_parse($value);
-        
+
         if (isset($date['relative'])) {
             $date = date_parse(date('Y-m-d H:i:s', strtotime($value)));
         }

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -338,6 +338,10 @@ trait ValidatesAttributes
         }
 
         $date = date_parse($value);
+        
+        if (isset($date['relative'])) {
+            $date = date_parse(date('Y-m-d H:i:s', strtotime($value)));
+        }
 
         return checkdate($date['month'], $date['day'], $date['year']);
     }

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -2250,6 +2250,12 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['x' => new DateTime()], ['x' => 'date']);
         $this->assertTrue($v->passes());
 
+        $v = new Validator($trans, ['x' => '2006-12-12 10:00:00.5 +1 week +1 hour'], ['x' => 'date']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => 'tomorrow'], ['x' => 'date']);
+        $this->assertTrue($v->passes());
+
         $v = new Validator($trans, ['x' => '2000-01-01'], ['x' => 'date_format:Y-m-d']);
         $this->assertTrue($v->passes());
 


### PR DESCRIPTION
The related issue: https://github.com/laravel/framework/issues/18894

Currently, a `date` validation rule is successfully passed by relative dates with the "main part":
```
2006-12-12 10:00:00.5 +1 week +1 hour
```
Under the "main part" in this example I mean `2006-12-12 10:00:00.5`.

But the "fully" relative dates without the "main part" are not supported. Validation always fails.
```
+1 week +1 hour
yesterday
```
This PR was made to address this problem.