### PR TITLE
[5.4] fix `encrypt` helper param type

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -424,7 +424,7 @@ if (! function_exists('encrypt')) {
     /**
      * Encrypt the given value.
      *
-     * @param  string  $value
+     * @param  mixed  $value
      * @return string
      */
     function encrypt($value)


### PR DESCRIPTION
According to [the documentation](https://laravel.com/docs/5.4/encryption#using-the-encrypter), `encrypt` helper can take any value type. And in `\Illuminate\Encryption\Encrypter::encrypt` file, `$value` param is declared as mixed (correct).

So I think it's `mixed`, not `string`.