### PR TITLE
[5.5] Fix compatibility between FilesystemAdapter and the Filesystem interface

### DIFF
--- a/src/Illuminate/Contracts/Filesystem/Filesystem.php
+++ b/src/Illuminate/Contracts/Filesystem/Filesystem.php
@@ -41,10 +41,10 @@ interface Filesystem
      *
      * @param  string  $path
      * @param  string|resource  $contents
-     * @param  string  $visibility
+     * @param  mixed  $options
      * @return bool
      */
-    public function put($path, $contents, $visibility = null);
+    public function put($path, $contents, $visibility = []);
 
     /**
      * Get the visibility for the given path.

--- a/src/Illuminate/Contracts/Filesystem/Filesystem.php
+++ b/src/Illuminate/Contracts/Filesystem/Filesystem.php
@@ -44,7 +44,7 @@ interface Filesystem
      * @param  mixed  $options
      * @return bool
      */
-    public function put($path, $contents, $visibility = []);
+    public function put($path, $contents, $options = []);
 
     /**
      * Get the visibility for the given path.

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -102,8 +102,9 @@ class FilesystemAdapter implements FilesystemContract, CloudFilesystemContract
      */
     public function put($path, $contents, $options = [])
     {
-        $options = is_string($options) ? ['visibility' => $options]
-                : (array) $options;
+        $options = is_string($options) 
+                     ? ['visibility' => $options]
+                     : (array) $options;
 
         // If the given contents is actually a file or uploaded file instance than we will
         // automatically store the file using a stream. This provides a convenient path

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -97,14 +97,13 @@ class FilesystemAdapter implements FilesystemContract, CloudFilesystemContract
      *
      * @param  string  $path
      * @param  string|resource  $contents
-     * @param  array  $options
+     * @param  mixed  $options
      * @return bool
      */
     public function put($path, $contents, $options = [])
     {
-        if (is_string($options)) {
-            $options = ['visibility' => $options];
-        }
+        $options = is_string($options) ? ['visibility' => $options]
+            : (array) $options;
 
         // If the given contents is actually a file or uploaded file instance than we will
         // automatically store the file using a stream. This provides a convenient path
@@ -115,8 +114,8 @@ class FilesystemAdapter implements FilesystemContract, CloudFilesystemContract
         }
 
         return is_resource($contents)
-                ? $this->driver->putStream($path, $contents, $options)
-                : $this->driver->put($path, $contents, $options);
+            ? $this->driver->putStream($path, $contents, $options)
+            : $this->driver->put($path, $contents, $options);
     }
 
     /**

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -103,7 +103,7 @@ class FilesystemAdapter implements FilesystemContract, CloudFilesystemContract
     public function put($path, $contents, $options = [])
     {
         $options = is_string($options) ? ['visibility' => $options]
-            : (array) $options;
+                : (array) $options;
 
         // If the given contents is actually a file or uploaded file instance than we will
         // automatically store the file using a stream. This provides a convenient path
@@ -114,8 +114,8 @@ class FilesystemAdapter implements FilesystemContract, CloudFilesystemContract
         }
 
         return is_resource($contents)
-            ? $this->driver->putStream($path, $contents, $options)
-            : $this->driver->put($path, $contents, $options);
+                ? $this->driver->putStream($path, $contents, $options)
+                : $this->driver->put($path, $contents, $options);
     }
 
     /**


### PR DESCRIPTION
As mentioned in this issue: https://github.com/laravel/framework/issues/19270

The PR adjusts the interface and the implementation to match the exact signature.