### PR TITLE
Fixes for Symfony 3.3 compatibility

### DIFF
--- a/tests/Foundation/FoundationExceptionsHandlerTest.php
+++ b/tests/Foundation/FoundationExceptionsHandlerTest.php
@@ -55,9 +55,9 @@ class FoundationExceptionsHandlerTest extends TestCase
         $response = $this->handler->render($this->request, new Exception('My custom error message'))->getContent();
 
         $this->assertContains('<!DOCTYPE html>', $response);
-        $this->assertContains('<h1>Whoops, looks like something went wrong.</h1>', $response);
+        $this->assertContains('Whoops, looks like something went wrong.', $response);
         $this->assertContains('My custom error message', $response);
-        $this->assertContains('::main()', $response);
+        $this->assertContains('PHPUnit\TextUI\TestRunner', $response);
         $this->assertNotContains('"message":', $response);
     }
 

--- a/tests/Foundation/FoundationExceptionsHandlerTest.php
+++ b/tests/Foundation/FoundationExceptionsHandlerTest.php
@@ -57,7 +57,6 @@ class FoundationExceptionsHandlerTest extends TestCase
         $this->assertContains('<!DOCTYPE html>', $response);
         $this->assertContains('Whoops, looks like something went wrong.', $response);
         $this->assertContains('My custom error message', $response);
-        $this->assertContains('PHPUnit\TextUI\TestRunner', $response);
         $this->assertNotContains('"message":', $response);
     }
 

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\TestCase;
 use Illuminate\Routing\UrlGenerator;
 use Illuminate\Routing\RouteCollection;
 use Illuminate\Contracts\Routing\UrlRoutable;
+use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 
 class RoutingUrlGeneratorTest extends TestCase
 {
@@ -372,7 +373,7 @@ class RoutingUrlGeneratorTest extends TestCase
 
     public function testRoutesWithDomainsThroughProxy()
     {
-        Request::setTrustedProxies(['10.0.0.1']);
+        Request::setTrustedProxies(['10.0.0.1'], SymfonyRequest::HEADER_X_FORWARDED_ALL);
 
         $url = new UrlGenerator(
             $routes = new RouteCollection,


### PR DESCRIPTION
Hi,

It seems that some tests have broken with the release of [Symfony 3.3](https://symfony.com/blog/symfony-3-3-0-released).

- The HTML error page containing the stack trace has changed, the corresponding test has been modified to correctly detect this error page.

- Calling Symfony's `Request::setTrustedProxies` now expects a second parameter containing a bit field of `Request::HEADER_*` (https://github.com/symfony/symfony/pull/21830).

Kind regards,
Jarno
