### PR TITLE
Dynamic changing locale

### DIFF
--- a/src/Illuminate/Auth/Console/stubs/make/views/layouts/app.stub
+++ b/src/Illuminate/Auth/Console/stubs/make/views/layouts/app.stub
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ config('app.locale') }}">
+<html lang="{{ app()->getLocale() }}">
 <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">


### PR DESCRIPTION
This will fix a bug that shows the default locale specified in config in the HTML attribute, even if you manually change it in your application.

## Steps to reproduce bug:

1. Create a new laravel app & scaffoldd the authentication
2. Change the locale in the home controller by using `App::setLocale('custom');`
3. The locale in the html tag is still the old one, as it's grabbed from the config.