### PR TITLE
[5.4] Fix for withOverlapping, the scheduled task would not resume 

### DIFF
--- a/src/Illuminate/Console/Scheduling/CallbackEvent.php
+++ b/src/Illuminate/Console/Scheduling/CallbackEvent.php
@@ -60,9 +60,9 @@ class CallbackEvent extends Event
         }
 
         register_shutdown_function(function()  {
-			$this->removeMutex();
-		});
-        
+            $this->removeMutex();
+        });
+
         try {
             $response = $container->call($this->callback, $this->parameters);
         } finally {

--- a/src/Illuminate/Console/Scheduling/CallbackEvent.php
+++ b/src/Illuminate/Console/Scheduling/CallbackEvent.php
@@ -59,6 +59,10 @@ class CallbackEvent extends Event
             $this->mutex->create($this);
         }
 
+        register_shutdown_function(function()  {
+			$this->removeMutex();
+		});
+        
         try {
             $response = $container->call($this->callback, $this->parameters);
         } finally {


### PR DESCRIPTION
Fix for withOverlapping, the scheduled task would not resume if an error occurred. 
This adds a last resort handler to clean up the mutex file if the application ended unexpectedly due to an fatal error.

Without this last ditch cleanup on application exit, the file will keep existing, and will not be cleaned up until the call ->withoutOverlapping() is removed from the scheduled task.

```
      $schedule->call(function() {
                   
            $worker = new Worker();
            $worker->workAlready();
        })
        ->name('automatic_email_sending')
        ->withoutOverlapping()
        ->when(function() {
            
            // weekdays 7:45 - 8:30
            // weekends 8:45 - 18:30
            $now = Carbon::now();
        
            if($now->dayOfWeek == Carbon::SUNDAY) {
                return false;
            }
        
            $start = $now->copy()->setTime(7,45, 0);
            $end = $now->copy()->setTime(19,30, 0);
        
            $random = new Random($now->diffInDays(Carbon::createFromDate(2017,1,1)));
        
            $int = $random->nextInt(0,45);
            $start->addMinutes($int);
        
            if ($now->isWeekend()) {
                $start->addHour();
                $end->subHour();
            }
            
            return $now->between($start, $end);
        });

-- Worker.php
    namespace Tschallacka\Workers;
    /**
      * cause a fatal error, Class Tschallacka\Workers\Carbon not found
      **/
    class Worker {
         public function workAlready() {
              $now = Carbon::now()
         } 
    }
```

