### PR TITLE
Add macroable to FactoryBuilder class

### DIFF
--- a/src/Illuminate/Database/Eloquent/FactoryBuilder.php
+++ b/src/Illuminate/Database/Eloquent/FactoryBuilder.php
@@ -5,9 +5,12 @@ namespace Illuminate\Database\Eloquent;
 use Closure;
 use Faker\Generator as Faker;
 use InvalidArgumentException;
+use Illuminate\Support\Traits\Macroable;
 
 class FactoryBuilder
 {
+    use Macroable;
+
     /**
      * The model definitions in the container.
      *


### PR DESCRIPTION
This PR adds `Macroable` trait to the `Illuminate\Database\Eloquent\FactoryBuilder` class.

In my projects, I often use this bit of code inside of model factories:

```php
'user_id' => function() {
    return User::first()->id ?? factory(User::class)->create()->id;
},
```

If macros were available, the above code could look more like this:

```php
'user_id' => factory(User::class)->firstOrCreate(),
```

What do you think? 🌵