### PR TITLE
[5.4] Corrected the optimistic setting of a value to a unknown type

### DIFF
--- a/src/Illuminate/Http/RedirectResponse.php
+++ b/src/Illuminate/Http/RedirectResponse.php
@@ -130,10 +130,10 @@ class RedirectResponse extends BaseRedirectResponse
      */
     public function withErrors($provider, $key = 'default')
     {
-        $value  = $this->parseErrors($provider);
+        $value = $this->parseErrors($provider);
         $errors = $this->session->get('errors');
 
-        if (!($errors instanceof ViewErrorBag)) {
+        if (! ($errors instanceof ViewErrorBag)) {
             $errors = new ViewErrorBag;
         }
 

--- a/src/Illuminate/Http/RedirectResponse.php
+++ b/src/Illuminate/Http/RedirectResponse.php
@@ -130,10 +130,15 @@ class RedirectResponse extends BaseRedirectResponse
      */
     public function withErrors($provider, $key = 'default')
     {
-        $value = $this->parseErrors($provider);
+        $value  = $this->parseErrors($provider);
+        $errors = $this->session->get('errors');
+
+        if (!($errors instanceof ViewErrorBag)) {
+            $errors = new ViewErrorBag;
+        }
 
         $this->session->flash(
-            'errors', $this->session->get('errors', new ViewErrorBag)->put($key, $value)
+            'errors', $errors->put($key, $value)
         );
 
         return $this;

--- a/src/Illuminate/Http/RedirectResponse.php
+++ b/src/Illuminate/Http/RedirectResponse.php
@@ -131,7 +131,7 @@ class RedirectResponse extends BaseRedirectResponse
     public function withErrors($provider, $key = 'default')
     {
         $value = $this->parseErrors($provider);
-        $errors = $this->session->get('errors');
+        $errors = $this->session->get('errors', new ViewErrorBag);
 
         if (! ($errors instanceof ViewErrorBag)) {
             $errors = new ViewErrorBag;


### PR DESCRIPTION
When calling ``` withErrors``` it assumes that any existing value in the session storage with key ```errors```  is of the correct data type. Due to ```errors``` is not a reserved key its very easy to get a ```BadMethodCallException``` exception.


For example
```php
$request->session()->put('errors', []);

$this->validate($request, [
    'name'  => 'required',
]);
```

This would trigger the following stack trace.

```shell
BadMethodCallException in RedirectResponse.php line 136:
Call to a member function put() on a non-object (array)
```