### PR TITLE
[5.4] Suppress error if calling Str::replaceFirst with an empty search

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -317,6 +317,10 @@ class Str
      */
     public static function replaceFirst($search, $replace, $subject)
     {
+        if ($search == '') {
+            return $subject;
+        }
+
         $position = strpos($subject, $search);
 
         if ($position !== false) {

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -188,6 +188,7 @@ class SupportStrTest extends TestCase
         $this->assertEquals('foo/qux? foo/bar?', Str::replaceFirst('bar?', 'qux?', 'foo/bar? foo/bar?'));
         $this->assertEquals('foo foobar', Str::replaceFirst('bar', '', 'foobar foobar'));
         $this->assertEquals('foobar foobar', Str::replaceFirst('xxx', 'yyy', 'foobar foobar'));
+        $this->assertEquals('foobar foobar', Str::replaceFirst('', 'yyy', 'foobar foobar'));
     }
 
     public function testReplaceLast()
@@ -196,6 +197,7 @@ class SupportStrTest extends TestCase
         $this->assertEquals('foo/bar? foo/qux?', Str::replaceLast('bar?', 'qux?', 'foo/bar? foo/bar?'));
         $this->assertEquals('foobar foo', Str::replaceLast('bar', '', 'foobar foobar'));
         $this->assertEquals('foobar foobar', Str::replaceLast('xxx', 'yyy', 'foobar foobar'));
+        $this->assertEquals('foobar foobar', Str::replaceLast('', 'yyy', 'foobar foobar'));
     }
 
     public function testSnake()


### PR DESCRIPTION
Interestingly enough, `strpos('foobar', '')` triggers a warning whereas `strrpos('foobar', '')` (used in replaceLast) doesn't.