### PR TITLE
[5.4] Fixes and optimizations for Str::after

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -38,13 +38,17 @@ class Str
      */
     public static function after($subject, $search)
     {
-        if (! static::contains($subject, $search)) {
+        if ($search == '') {
             return $subject;
         }
 
-        $end = strpos($subject, $search) + static::length($search);
+        $pos = strpos($subject, $search);
 
-        return static::substr($subject, $end, static::length($subject));
+        if ($pos === false) {
+            return $subject;
+        }
+
+        return substr($subject, $pos + strlen($search));
     }
 
     /**

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -80,7 +80,9 @@ class SupportStrTest extends TestCase
     {
         $this->assertEquals('nah', Str::after('hannah', 'han'));
         $this->assertEquals('nah', Str::after('hannah', 'n'));
+        $this->assertEquals('nah', Str::after('ééé hannah', 'han'));
         $this->assertEquals('hannah', Str::after('hannah', 'xxxx'));
+        $this->assertEquals('hannah', Str::after('hannah', ''));
     }
 
     public function testStrContains()


### PR DESCRIPTION
Follow-up to #19357.

* Correct results if there are multibyte characters before the search
* Do not trigger warning if search is an empty string

Also, should be significantly faster.

<br>
Unless I'm mistaken, here it should be fine to use single-byte functions.