### PR TITLE
Allow faking only specific events

### DIFF
--- a/src/Illuminate/Support/Facades/Event.php
+++ b/src/Illuminate/Support/Facades/Event.php
@@ -15,9 +15,9 @@ class Event extends Facade
      *
      * @return void
      */
-    public static function fake()
+    public static function fake($eventsToFake = [])
     {
-        static::swap($fake = new EventFake);
+        static::swap($fake = new EventFake(static::getFacadeRoot(), $eventsToFake));
 
         Model::setEventDispatcher($fake);
     }

--- a/src/Illuminate/Support/Facades/Event.php
+++ b/src/Illuminate/Support/Facades/Event.php
@@ -13,6 +13,7 @@ class Event extends Facade
     /**
      * Replace the bound instance with a fake.
      *
+     * @param  array|string  $eventsToFake
      * @return void
      */
     public static function fake($eventsToFake = [])

--- a/src/Illuminate/Support/Testing/Fakes/EventFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/EventFake.php
@@ -17,6 +17,7 @@ class EventFake implements Dispatcher
 
     /**
      * The event types that should be intercepted instead of dispatched.
+     *
      * @var array
      */
     protected $eventsToFake;

--- a/src/Illuminate/Support/Testing/Fakes/EventFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/EventFake.php
@@ -29,6 +29,13 @@ class EventFake implements Dispatcher
      */
     protected $events = [];
 
+    /**
+     * Create a new event fake instance.
+     *
+     * @param  \Illuminate\Contracts\Events\Dispatcher  $dispatcher
+     * @param  array|string  $eventsToFake
+     * @return void
+     */
     public function __construct(Dispatcher $dispatcher, $eventsToFake = [])
     {
         $this->dispatcher = $dispatcher;

--- a/src/Illuminate/Support/Testing/Fakes/EventFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/EventFake.php
@@ -2,17 +2,36 @@
 
 namespace Illuminate\Support\Testing\Fakes;
 
+use Illuminate\Support\Arr;
 use PHPUnit\Framework\Assert as PHPUnit;
 use Illuminate\Contracts\Events\Dispatcher;
 
 class EventFake implements Dispatcher
 {
     /**
-     * All of the events that have been dispatched keyed by type.
+     * The original event dispatcher.
+     * @var Illuminate\Contracts\Events\Dispatcher
+     */
+    protected $dispatcher;
+
+    /**
+     * The event types that should be intercepted instead of dispatched.
+     * @var array
+     */
+    protected $eventsToFake;
+
+    /**
+     * All of the events that have been intercepted keyed by type.
      *
      * @var array
      */
     protected $events = [];
+
+    public function __construct(Dispatcher $dispatcher, $eventsToFake = [])
+    {
+        $this->dispatcher = $dispatcher;
+        $this->eventsToFake = Arr::wrap($eventsToFake);
+    }
 
     /**
      * Assert if an event was dispatched based on a truth-test callback.
@@ -159,7 +178,21 @@ class EventFake implements Dispatcher
     {
         $name = is_object($event) ? get_class($event) : (string) $event;
 
-        $this->events[$name][] = func_get_args();
+        if ($this->shouldFakeEvent($name)) {
+            $this->events[$name][] = func_get_args();
+        } else {
+            $this->dispatcher->dispatch($event, $payload, $halt);
+        }
+    }
+
+    /**
+     * Determine if an event should be faked or actually dispatched.
+     * @param  string  $eventName
+     * @return bool
+     */
+    protected function shouldFakeEvent($eventName)
+    {
+        return empty($this->eventsToFake) || in_array($eventName, $this->eventsToFake);
     }
 
     /**

--- a/src/Illuminate/Support/Testing/Fakes/EventFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/EventFake.php
@@ -197,6 +197,7 @@ class EventFake implements Dispatcher
 
     /**
      * Determine if an event should be faked or actually dispatched.
+     *
      * @param  string  $eventName
      * @return bool
      */

--- a/src/Illuminate/Support/Testing/Fakes/EventFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/EventFake.php
@@ -10,7 +10,8 @@ class EventFake implements Dispatcher
 {
     /**
      * The original event dispatcher.
-     * @var Illuminate\Contracts\Events\Dispatcher
+     *
+     * @var \Illuminate\Contracts\Events\Dispatcher
      */
     protected $dispatcher;
 
@@ -30,6 +31,7 @@ class EventFake implements Dispatcher
     public function __construct(Dispatcher $dispatcher, $eventsToFake = [])
     {
         $this->dispatcher = $dispatcher;
+
         $this->eventsToFake = Arr::wrap($eventsToFake);
     }
 


### PR DESCRIPTION
Sometimes you want most framework events to run, but just want to fake a handful that you want to make assertions about in a particular test.

This lets you do this sort of thing:

```php
public function testSomething()
{
    Event::fake([ShouldBeFaked::class]);

    $response = $this->get('/');

    Event::assertDispatched(ShouldBeFaked::class);
}
```

Seems fine ¯\\_(ツ)_/¯