### PR TITLE
[5.4] Fixes phpdocs on abstract ServiceProvider class (Re-fix)

### DIFF
--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -9,7 +9,7 @@ abstract class ServiceProvider
     /**
      * The application instance.
      *
-     * @var \Illuminate\Foundation\Application
+     * @var \Illuminate\Contracts\Foundation\Application
      */
     protected $app;
 
@@ -37,7 +37,7 @@ abstract class ServiceProvider
     /**
      * Create a new service provider instance.
      *
-     * @param  \Illuminate\Foundation\Application  $app
+     * @param  \Illuminate\Contracts\Foundation\Application $app
      * @return void
      */
     public function __construct($app)


### PR DESCRIPTION
Restore phpDocs original parameter class. 

This is a rollback of another Pull-Request ([#18248](https://github.com/laravel/framework/pull/18248)) that breaks other Projects not using the Illuminate\Foundation.

Lumen framework is one example. It uses only the Illuminate\Support package, but Illuminate\Foundation is not loaded and IDE's complain, because this 

There is a supporting [comment](https://github.com/laravel/framework/pull/18248#issuecomment-286721997) from @atehnix : 

> Illuminate/support is sometimes used with its own implementation of \Illuminate\Contracts\Foundation\Application, without using laravel/framework. 
Therefore, I believe that this change is wrong.
