### PR TITLE
[5.5] Add whereAll and whereAny query builder methods

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -497,6 +497,10 @@ class Builder
      */
     public function where($column, $operator = null, $value = null, $boolean = 'and')
     {
+        if (is_array($column) && $operator !== null) {
+            return $this->whereAll($column, $operator, $value, $boolean);
+        }
+
         // If the column is an array, we will assume it is an array of key-value pairs
         // and can add them each as a where clause. We will maintain the boolean we
         // received when the method was called and pass it into the nested where.
@@ -642,6 +646,39 @@ class Builder
     public function orWhere($column, $operator = null, $value = null)
     {
         return $this->where($column, $operator, $value, 'or');
+    }
+
+    /**
+     * Add an nested "or where" clause of any columns to the query.
+     *
+     * @param  array   $columns
+     * @param  string  $operator
+     * @param  mixed   $value
+     * @return $this
+     */
+    public function whereAny(array $columns, $operator = null, $value = null)
+    {
+        return $this->whereNested(function ($query) use ($columns, $operator, $value) {
+            $query->whereAll($columns, $operator, $value, 'or');
+        });
+    }
+
+    /**
+     * Add a basic where clause of all columns to the query.
+     *
+     * @param  array   $columns
+     * @param  string  $operator
+     * @param  mixed   $value
+     * @param  string  $boolean
+     * @return $this
+     */
+    public function whereAll(array $columns, $operator = null, $value = null, $boolean = 'and')
+    {
+        foreach ($columns as $column) {
+            $this->where($column, $operator, $value, $boolean);
+        }
+
+        return $this;
     }
 
     /**

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -208,6 +208,30 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => 1], $builder->getBindings());
     }
 
+    public function testWhereAll()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereAll(['first_name', 'last_name'], 'like', 't%');
+        $this->assertEquals('select * from "users" where "first_name" like ? and "last_name" like ?', $builder->toSql());
+        $this->assertEquals([0 => 't%', 1 => 't%'], $builder->getBindings());
+    }
+
+    public function testWhereAllThroughWhere()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where(['type_1', 'type_2'], 1);
+        $this->assertEquals('select * from "users" where "type_1" = ? and "type_2" = ?', $builder->toSql());
+        $this->assertEquals([0 => 1, 1 => 1], $builder->getBindings());
+    }
+
+    public function testWhereAny()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereAny(['email', 'secondary_email'], 'like', '%.com');
+        $this->assertEquals('select * from "users" where ("email" like ? or "secondary_email" like ?)', $builder->toSql());
+        $this->assertEquals([0 => '%.com', 1 => '%.com'], $builder->getBindings());
+    }
+
     public function testMySqlWrappingProtectsQuotationMarks()
     {
         $builder = $this->getMySqlBuilder();


### PR DESCRIPTION
- whereAny adds a nested where clause matching value against any of given columns
- whereAll adds a basic where clause to all given columns
- where calls whereAll method when at least two params is given and the first being an array

Examples

## whereAny

```php
User::whereAny(['email', 'secondary_email'], 'like', '%.com');

```
```php

User::where(function ($query) {
    $query->where('email', 'like', '%.com')
          ->orWhere('secondary_email', 'like', '%.com');
});
```

## whereAll

```php
User::where(['type_1', 'type_2'], 1);

User::whereAll(['type_1', 'type_2'], 1);
```
```php
User::where('type_1', 1)
    ->where('type_2', 1);
```