### PR TITLE
[5.4] Allow a plain text alternative view when using markdown within mailables

### DIFF
--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -192,7 +192,7 @@ class Mailable implements MailableContract
 
         return [
             'html' => $markdown->render($this->markdown, $data),
-            'text' => $markdown->renderText($this->markdown, $data),
+            'text' => isset($this->textView) ? $this->textView : $markdown->renderText($this->markdown, $data),
         ];
     }
 


### PR DESCRIPTION
Currently a mailable class which builds a message with the `markdown()` method, cannot specify an alternate text version:

```php
return $this->subject($this->subject)
            ->markdown('emails.enquiry')
            ->text('emails.enquiry_plain');  // Currently Ignored
```

In some cases, even when using the features of markdown to generate the html, you still need an alternate text version.  

This PR allows you to optionally specify a `text()` view in conjunction with a `markdown()` view, meaning the code above will work.