### PR TITLE
[5.4] Fix for ErrorException in FilesystemAdapter.php line 146: fopen(): …

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -143,7 +143,12 @@ class FilesystemAdapter implements FilesystemContract, CloudFilesystemContract
      */
     public function putFileAs($path, $file, $name, $options = [])
     {
-        $stream = fopen($file->getRealPath(), 'r+');
+        // If you server is under Windows and getRealPath() is false we use getPathName() instead.
+        if($file->getRealPath()) {
+            $stream = fopen($file->getRealPath(), 'r+');
+        } else {
+            $stream = fopen($file->getPathName(), 'r+');
+        }
 
         // Next, we will format the path of the file and store the file using a stream since
         // they provide better performance than alternatives. Once we write the file this


### PR DESCRIPTION
…Filename cannot be empty

If we upload a file under Windows web server, $file->getRealPath() return false. Then we need to use getPathName() to work normaly.