### PR TITLE
Return the bound instance when using Container::instance

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -355,7 +355,7 @@ class Container implements ArrayAccess, ContainerContract
      *
      * @param  string  $abstract
      * @param  mixed   $instance
-     * @return void
+     * @return mixed
      */
     public function instance($abstract, $instance)
     {
@@ -373,6 +373,8 @@ class Container implements ArrayAccess, ContainerContract
         if ($isBound) {
             $this->rebound($abstract);
         }
+
+        return $instance;
     }
 
     /**

--- a/src/Illuminate/Contracts/Container/Container.php
+++ b/src/Illuminate/Contracts/Container/Container.php
@@ -85,7 +85,7 @@ interface Container
      *
      * @param  string  $abstract
      * @param  mixed   $instance
-     * @return void
+     * @return mixed
      */
     public function instance($abstract, $instance);
 

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -181,6 +181,16 @@ class ContainerTest extends TestCase
         $this->assertEquals('foobarbaz', $container->make('foo'));
     }
 
+    public function testBindingAnInstanceReturnsTheInstance()
+    {
+        $container = new Container;
+
+        $bound = new StdClass;
+        $resolved = $container->instance('foo', $bound);
+
+        $this->assertSame($bound, $resolved);
+    }
+
     public function testExtendInstancesArePreserved()
     {
         $container = new Container;


### PR DESCRIPTION
In many of my feature tests I need to replace something in the container with a test double, but keep a reference to the test double to use in my assertions.

Currently I'm declaring the variable at the same time I pass it into the container:

```php
$this->app->instance(CreditCardGateway::class, $creditCardGateway = new FakeCreditCardGateway);
$this->app->instance(WebhookDispatcher::class, $webhookDispatcher = new FakeWebhookDispatcher);
```

I think this is sort of grim, so this PR lets me rewrite that like this:

```php
$creditCardGateway = $this->app->instance(CreditCardGateway::class, new FakeCreditCardGateway);
$webhookDispatcher = $this->app->instance(WebhookDispatcher::class, new FakeWebhookDispatcher);
```

I think it makes it a lot easier to see where the variable is coming from at a glance 👍 