### PR TITLE
[5.5] Add dedicated method for registration routes.

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -1035,15 +1035,22 @@ class Router implements RegistrarContract, BindingRegistrar
         $this->post('login', 'Auth\LoginController@login');
         $this->post('logout', 'Auth\LoginController@logout')->name('logout');
 
-        // Registration Routes...
-        $this->get('register', 'Auth\RegisterController@showRegistrationForm')->name('register');
-        $this->post('register', 'Auth\RegisterController@register');
-
         // Password Reset Routes...
         $this->get('password/reset', 'Auth\ForgotPasswordController@showLinkRequestForm')->name('password.request');
         $this->post('password/email', 'Auth\ForgotPasswordController@sendResetLinkEmail')->name('password.email');
         $this->get('password/reset/{token}', 'Auth\ResetPasswordController@showResetForm')->name('password.reset');
         $this->post('password/reset', 'Auth\ResetPasswordController@reset');
+    }
+
+    /**
+     * Register the typical registration routes for an application.
+     *
+     * @return void
+     */
+    public function registration()
+    {
+        $this->get('register', 'Auth\RegisterController@showRegistrationForm')->name('register');
+        $this->post('register', 'Auth\RegisterController@register');
     }
 
     /**

--- a/src/Illuminate/Support/Facades/Auth.php
+++ b/src/Illuminate/Support/Facades/Auth.php
@@ -44,5 +44,6 @@ class Auth extends Facade
     public static function routes()
     {
         static::$app->make('router')->auth();
+        static::$app->make('router')->registration();
     }
 }


### PR DESCRIPTION
This PR will add a separate method for registration routes.

## Use Case
Most of our applications does not allow registration and thus we need to copy/paste only the authentication routes for every project. Separating the registration route will allow us to use the core auth route without registration.

This will also prevent users having issues like when password routes name are added incase we just copied the routes.

```php
Route::auth();
Route::registration();
```

Thanks!