### PR TITLE
[5.5] Display packages that were auto discovered

### DIFF
--- a/src/Illuminate/Foundation/Console/PackageDiscoverCommand.php
+++ b/src/Illuminate/Foundation/Console/PackageDiscoverCommand.php
@@ -30,6 +30,10 @@ class PackageDiscoverCommand extends Command
     public function handle(PackageManifest $manifest)
     {
         $manifest->build();
+        
+        foreach (array_keys($manifest->manifest) as $package) {
+            $this->info('Auto discovered: '.$package);
+        }
 
         $this->info('Package manifest generated successfully.');
     }


### PR DESCRIPTION
Might be nice to display packages that were auto-discovered `¯\_(ツ)_/¯`

```
Generating optimized autoload files
> Illuminate\Foundation\ComposerScripts::postAutoloadDump
> @php artisan package:discover
Auto discovered: jaybizzle/package
Auto discovered: laravel/tinker
Package manifest generated successfully.
```