### PR TITLE
[5.5] Load app.providers before auto discovered providers

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -552,7 +552,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
         $providers = $this->make(PackageManifest::class)->providers();
 
         (new ProviderRepository($this, new Filesystem, $this->getCachedServicesPath()))
-                    ->load(array_merge($providers, $this->config['app.providers']));
+                    ->load(array_merge($this->config['app.providers'], $providers));
     }
 
     /**


### PR DESCRIPTION
Is there a particular reason that auto discovered providers are loaded before `app.providers`?

The way it currently work doesn't allow our package (which overrides some of the migration commands) to be auto-discovered. Well, it is discovered, but the order in which things get registered means our package is overwritten by the default `MigrationServiceProvider`.

This is out package service provider https://github.com/JayBizzle/Laravel-Migrations-Organiser/blob/master/src/MigrationsOrganiserServiceProvider.php

I know we can still define the service providers in `app.providers`, and that fixes the issue,  but wondered if there was any impact in switching the order?