### PR TITLE
[5.5] Add Model::only method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -883,6 +883,23 @@ trait HasAttributes
     }
 
     /**
+     * Get a subset containing the provided attributes with values from the model.
+     * 
+     * @param  array|mixed  $attributes
+     * @return array
+     */
+    public function only($attributes)
+    {
+        $results = [];
+
+        foreach (is_array($attributes) ? $attributes : func_get_args() as $attribute) {
+            $results[$attribute] = $this->getAttribute($attribute);
+        }
+
+        return $results;
+    }
+
+    /**
      * Sync the original attributes with the current.
      *
      * @return $this

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -883,7 +883,7 @@ trait HasAttributes
     }
 
     /**
-     * Get a subset containing the provided attributes with values from the model.
+     * Get a subset of the model's attributes.
      * 
      * @param  array|mixed  $attributes
      * @return array

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -137,6 +137,18 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertFalse(isset($model['with']));
     }
 
+    public function testOnly()
+    {
+        $model = new EloquentModelStub;
+        $model->first_name = 'taylor';
+        $model->last_name = 'otwell';
+        $model->project = 'laravel';
+
+        $this->assertEquals(['project' => 'laravel'], $model->only('project'));
+        $this->assertEquals(['first_name' => 'taylor', 'last_name' => 'otwell'], $model->only('first_name', 'last_name'));
+        $this->assertEquals(['first_name' => 'taylor', 'last_name' => 'otwell'], $model->only(['first_name', 'last_name']));
+    }
+
     public function testNewInstanceReturnsNewInstanceWithAttributesSet()
     {
         $model = new EloquentModelStub;


### PR DESCRIPTION
Adds an `only` method to the `Model` class that behaves like `Request::only`, to quickly extract attributes from a model to an array.

```php
$user->only('first_name', 'last_name');
// ["first_name" => "Taylor", "last_name" => "Otwell"]
```