### PR TITLE
Failing test for issue #19445

### DIFF
--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -2279,6 +2279,9 @@ class ValidationValidatorTest extends TestCase
 
         $v = new Validator($trans, ['x' => '2000-01-01T00:00:00+00:30'], ['x' => 'date_format:Y-m-d\TH:i:sP']);
         $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => '2000-01-01 00:00:00.000'], ['x' => 'date_format:Y-m-d H:i:s.v']);
+        $this->assertTrue($v->passes(), 'Milliseconds date validation failed');
     }
 
     public function testBeforeAndAfter()


### PR DESCRIPTION
Failing test for issue https://github.com/laravel/framework/issues/19445 Validate 'date' with 'milliseconds' (not 'microseconds').

Run `phpunit --filter=testValidateDateAndFormat` to see failing test.