### PR TITLE
[5.4] Add onlyWith eloquent query builder method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1016,6 +1016,25 @@ class Builder
     }
 
     /**
+     * Set the relationships that should be eager loaded and
+     * add a exists condition to the query with where clauses.
+     *
+     * @param  string|array  $relation
+     * @param  \Closure      $constraint
+     * @return $this
+     */
+    public function onlyWith($relation, Closure $constraint = null)
+    {
+        if (is_array($relation) && ! $constraint) {
+            $constraint = reset($relation);
+            $relation = key($relation);
+        }
+
+        return $this->whereHas($relation, $constraint)
+                    ->with([$relation => $constraint]);
+    }
+
+    /**
      * Prevent the specified relations from being eager loaded.
      *
      * @param  mixed  $relations

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -871,6 +871,24 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder->whereKey($collection);
     }
 
+    public function testOnlyWith()
+    {
+        $model = new EloquentBuilderTestModelParentStub;
+
+        $constraint = function ($q) {
+            $q->where('baz', 'bam');
+        };
+
+        $result = $model->onlyWith('foo', $constraint)
+                        ->onlyWith(['address' => $constraint])->toSql();
+
+        $builder = $model->whereHas('foo', $constraint)->with(['foo' => $constraint])
+                         ->whereHas('address', $constraint)->with(['address' => $constraint])
+                         ->toSql();
+
+        $this->assertEquals($builder, $result);
+    }
+
     protected function mockConnectionForModel($model, $database)
     {
         $grammarClass = 'Illuminate\Database\Query\Grammars\\'.$database.'Grammar';


### PR DESCRIPTION
https://github.com/laravel/internals/issues/606

Combines `whereHas` and `with` calls into one


### Example

```php
User::active()
    ->whereHas('post', function ($q) {
        $q->whereTitle('foo');
    })
    ->with(['post' => function ($q) {
        $q->whereTitle('foo');
    }]);
```

```php
User::active()
    ->onlyWith('post', function ($q) {
        $q->whereTitle('foo');
    });
```
