### PR TITLE
[5.4] Fix queue size when using beanstalk driver

### DIFF
--- a/src/Illuminate/Queue/BeanstalkdQueue.php
+++ b/src/Illuminate/Queue/BeanstalkdQueue.php
@@ -55,7 +55,7 @@ class BeanstalkdQueue extends Queue implements QueueContract
     {
         $queue = $this->getQueue($queue);
 
-        return (int) $this->pheanstalk->statsTube($queue)->total_jobs;
+        return (int) $this->pheanstalk->statsTube($queue)->current_jobs_ready;
     }
 
     /**


### PR DESCRIPTION
The "total_jobs" property is not the actual number of jobs left to process,
but the cumulative count of jobs created in this tube in the current beanstalkd process,
so it's not decreasing when a job is done.
I think it's better to return the "current_jobs_ready" because it is representing the actual number of jobs waiting to be processed.