### PR TITLE
[5.5] Added new frontend preset for UIkit 3

### DIFF
--- a/src/Illuminate/Auth/Console/MakeAuthCommand.php
+++ b/src/Illuminate/Auth/Console/MakeAuthCommand.php
@@ -91,9 +91,9 @@ class MakeAuthCommand extends Command
     {
         foreach ($this->views as $key => $value) {
             if (file_exists(resource_path('views/'.$value)) && ! $this->option('force')) {
-                // if (! $this->confirm("The [{$value}] view already exists. Do you want to replace it?")) {
-                //     continue;
-                // }
+                if (! $this->confirm("The [{$value}] view already exists. Do you want to replace it?")) {
+                    continue;
+                }
             }
 
             copy(

--- a/src/Illuminate/Auth/Console/MakeAuthCommand.php
+++ b/src/Illuminate/Auth/Console/MakeAuthCommand.php
@@ -91,13 +91,13 @@ class MakeAuthCommand extends Command
     {
         foreach ($this->views as $key => $value) {
             if (file_exists(resource_path('views/'.$value)) && ! $this->option('force')) {
-                if (! $this->confirm("The [{$value}] view already exists. Do you want to replace it?")) {
-                    continue;
-                }
+                // if (! $this->confirm("The [{$value}] view already exists. Do you want to replace it?")) {
+                //     continue;
+                // }
             }
 
             copy(
-                __DIR__.'/stubs/make/views/'.$key,
+                $this->getStubPathForViews().$key,
                 resource_path('views/'.$value)
             );
         }
@@ -115,5 +115,16 @@ class MakeAuthCommand extends Command
             $this->getAppNamespace(),
             file_get_contents(__DIR__.'/stubs/make/controllers/HomeController.stub')
         );
+    }
+
+    protected function getStubPathForViews()
+    {
+        $packages = json_decode(file_get_contents(base_path('package.json')), true);
+
+        if (! empty($packages['devDependencies']['uikit'])) {
+            return  __DIR__.'/../../Foundation/Console/Presets/uikit3-stubs/views/';
+        }
+
+        return __DIR__.'/stubs/make/views/';
     }
 }

--- a/src/Illuminate/Foundation/Console/PresetCommand.php
+++ b/src/Illuminate/Foundation/Console/PresetCommand.php
@@ -15,7 +15,7 @@ class PresetCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'preset { type : The preset type (none, bootstrap, vue, react) }';
+    protected $signature = 'preset { type : The preset type (none, bootstrap, vue, react, uikit3) }';
 
     /**
      * The console command description.
@@ -35,7 +35,7 @@ class PresetCommand extends Command
             return call_user_func(static::$macros[$this->argument('type')], $this);
         }
 
-        if (! in_array($this->argument('type'), ['none', 'bootstrap', 'vue', 'react'])) {
+        if (! in_array($this->argument('type'), ['none', 'bootstrap', 'vue', 'react', 'uikit3'])) {
             throw new InvalidArgumentException('Invalid preset.');
         }
 
@@ -90,6 +90,19 @@ class PresetCommand extends Command
         Presets\React::install();
 
         $this->info('React scaffolding installed successfully.');
+        $this->comment('Please run "npm install && npm run dev" to compile your fresh scaffolding.');
+    }
+
+    /**
+     * Install the "uikit3" preset.
+     *
+     * @return void
+     */
+    public function uikit3()
+    {
+        Presets\UIKit3::install();
+
+        $this->info('UIKit3 scaffolding installed successfully.');
         $this->comment('Please run "npm install && npm run dev" to compile your fresh scaffolding.');
     }
 }

--- a/src/Illuminate/Foundation/Console/Presets/UIKit3.php
+++ b/src/Illuminate/Foundation/Console/Presets/UIKit3.php
@@ -17,7 +17,7 @@ class UIKit3 extends Preset
         static::updatePackages();
         static::updateWebpackConfiguration();
         static::updateBootstrapping();
-        //static::removeNodeModules();
+        static::removeNodeModules();
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/Presets/UIKit3.php
+++ b/src/Illuminate/Foundation/Console/Presets/UIKit3.php
@@ -5,7 +5,7 @@ namespace Illuminate\Foundation\Console\Presets;
 use Illuminate\Support\Arr;
 use Illuminate\Filesystem\Filesystem;
 
-class Bootstrap extends Preset
+class UIKit3 extends Preset
 {
     /**
      * Install the preset.
@@ -15,9 +15,9 @@ class Bootstrap extends Preset
     public static function install()
     {
         static::updatePackages();
-        static::updateSass();
+        static::updateWebpackConfiguration();
         static::updateBootstrapping();
-        static::removeNodeModules();
+        //static::removeNodeModules();
     }
 
     /**
@@ -28,20 +28,19 @@ class Bootstrap extends Preset
      */
     protected static function updatePackageArray(array $packages)
     {
-        return ['bootstrap-sass' => '^3.3.7', 'jquery' => '^3.1.1'] + Arr::except($packages, [
-            'uikit'
+        return ['uikit' => '*', 'jquery' => '^3.1.1' ] + Arr::except($packages, [
+            'bootstrap-sass'
         ]);
     }
 
     /**
-     * Update the Sass files for the application.
+     * Update the Webpack configuration.
      *
      * @return void
      */
-    protected static function updateSass()
+    protected static function updateWebpackConfiguration()
     {
-        copy(__DIR__.'/bootstrap-stubs/_variables.scss', resource_path('assets/sass/_variables.scss'));
-        copy(__DIR__.'/bootstrap-stubs/app.scss', resource_path('assets/sass/app.scss'));
+        copy(__DIR__.'/vue-stubs/webpack.mix.js', base_path('webpack.mix.js'));
     }
 
     /**
@@ -51,10 +50,14 @@ class Bootstrap extends Preset
      */
     protected static function updateBootstrapping()
     {
+        copy(__DIR__.'/uikit3-stubs/app.scss', resource_path('assets/sass/app.scss'));
+
         tap(new Filesystem, function ($filesystem) {
+            $filesystem->delete(resource_path('assets/sass/_variables.scss'));
+
             $bootstrapJs = str_replace(
-                "window.UIkit = require('uikit');",
                 "require('bootstrap-sass');",
+                "window.UIkit = require('uikit');",
                 $filesystem->get(resource_path('assets/js/bootstrap.js'))
             );
 

--- a/src/Illuminate/Foundation/Console/Presets/uikit3-stubs/app.scss
+++ b/src/Illuminate/Foundation/Console/Presets/uikit3-stubs/app.scss
@@ -1,0 +1,74 @@
+// Breakpoints
+$xsmall-min: 0;
+$xsmall-max: 479px;
+
+$small-min: 480px;
+$small-max: 767px;
+
+$medium-min: 768px;
+$medium-max:  959px;
+
+$large-min: 960px;
+$large-max: 1219px;
+
+$xlarge-min: 1220px;
+
+// UIkit 3
+
+// Base
+@import 'node_modules/uikit/src/scss/variables.scss';
+@import 'node_modules/uikit/src/scss/mixins.scss';
+@import 'node_modules/uikit/src/scss/components/base.scss';
+@import 'node_modules/uikit/src/scss/components/inverse.scss';
+
+// Elements
+@import 'node_modules/uikit/src/scss/components/link.scss';
+@import 'node_modules/uikit/src/scss/components/heading.scss';
+@import 'node_modules/uikit/src/scss/components/divider.scss';
+@import 'node_modules/uikit/src/scss/components/list.scss';
+@import 'node_modules/uikit/src/scss/components/description-list.scss';
+@import 'node_modules/uikit/src/scss/components/table.scss';
+@import 'node_modules/uikit/src/scss/components/icon.scss';
+@import 'node_modules/uikit/src/scss/components/form.scss'; // After: Icon
+@import 'node_modules/uikit/src/scss/components/button.scss';
+
+// Layout
+@import 'node_modules/uikit/src/scss/components/section.scss';
+@import 'node_modules/uikit/src/scss/components/container.scss';
+@import 'node_modules/uikit/src/scss/components/grid.scss';
+@import 'node_modules/uikit/src/scss/components/tile.scss';
+@import 'node_modules/uikit/src/scss/components/card.scss';
+
+// Common
+@import 'node_modules/uikit/src/scss/components/close.scss'; // After: Icon
+@import 'node_modules/uikit/src/scss/components/spinner.scss'; // After: Icon
+@import 'node_modules/uikit/src/scss/components/totop.scss'; // After: Icon
+@import 'node_modules/uikit/src/scss/components/alert.scss'; // After: Close
+@import 'node_modules/uikit/src/scss/components/badge.scss';
+@import 'node_modules/uikit/src/scss/components/label.scss';
+@import 'node_modules/uikit/src/scss/components/overlay.scss'; // After: Icon
+@import 'node_modules/uikit/src/scss/components/article.scss'; // After: Subnav
+@import 'node_modules/uikit/src/scss/components/comment.scss'; // After: Subnav
+@import 'node_modules/uikit/src/scss/components/search.scss'; // After: Icon
+
+// Navs
+@import 'node_modules/uikit/src/scss/components/nav.scss';
+@import 'node_modules/uikit/src/scss/components/navbar.scss'; // After: Card, Grid, Nav, Icon, Search
+@import 'node_modules/uikit/src/scss/components/subnav.scss';
+@import 'node_modules/uikit/src/scss/components/breadcrumb.scss';
+@import 'node_modules/uikit/src/scss/components/pagination.scss';
+@import 'node_modules/uikit/src/scss/components/tab.scss';
+@import 'node_modules/uikit/src/scss/components/slidenav.scss'; // After: Icon
+@import 'node_modules/uikit/src/scss/components/dotnav.scss';
+
+// JavaScript
+@import 'node_modules/uikit/src/scss/components/accordion.scss';
+@import 'node_modules/uikit/src/scss/components/drop.scss'; // After: Card
+@import 'node_modules/uikit/src/scss/components/dropdown.scss'; // After: Card
+@import 'node_modules/uikit/src/scss/components/modal.scss'; // After: Close
+@import 'node_modules/uikit/src/scss/components/sticky.scss';
+@import 'node_modules/uikit/src/scss/components/offcanvas.scss';
+@import 'node_modules/uikit/src/scss/components/switcher.scss';
+@import 'node_modules/uikit/src/scss/components/notification.scss';
+
+@import 'node_modules/uikit/src/scss/components/_import.utilities.scss';

--- a/src/Illuminate/Foundation/Console/Presets/uikit3-stubs/views/auth/login.stub
+++ b/src/Illuminate/Foundation/Console/Presets/uikit3-stubs/views/auth/login.stub
@@ -1,0 +1,68 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container">
+    <div class="row">
+        <div class="col-md-8 col-md-offset-2">
+            <div class="panel panel-default">
+                <div class="panel-heading">Login</div>
+                <div class="panel-body">
+                    <form class="form-horizontal" role="form" method="POST" action="{{ route('login') }}">
+                        {{ csrf_field() }}
+
+                        <div class="form-group{{ $errors->has('email') ? ' has-error' : '' }}">
+                            <label for="email" class="col-md-4 control-label">E-Mail Address</label>
+
+                            <div class="col-md-6">
+                                <input id="email" type="email" class="form-control" name="email" value="{{ old('email') }}" required autofocus>
+
+                                @if ($errors->has('email'))
+                                    <span class="help-block">
+                                        <strong>{{ $errors->first('email') }}</strong>
+                                    </span>
+                                @endif
+                            </div>
+                        </div>
+
+                        <div class="form-group{{ $errors->has('password') ? ' has-error' : '' }}">
+                            <label for="password" class="col-md-4 control-label">Password</label>
+
+                            <div class="col-md-6">
+                                <input id="password" type="password" class="form-control" name="password" required>
+
+                                @if ($errors->has('password'))
+                                    <span class="help-block">
+                                        <strong>{{ $errors->first('password') }}</strong>
+                                    </span>
+                                @endif
+                            </div>
+                        </div>
+
+                        <div class="form-group">
+                            <div class="col-md-6 col-md-offset-4">
+                                <div class="checkbox">
+                                    <label>
+                                        <input type="checkbox" name="remember" {{ old('remember') ? 'checked' : '' }}> Remember Me
+                                    </label>
+                                </div>
+                            </div>
+                        </div>
+
+                        <div class="form-group">
+                            <div class="col-md-8 col-md-offset-4">
+                                <button type="submit" class="btn btn-primary">
+                                    Login
+                                </button>
+
+                                <a class="btn btn-link" href="{{ route('password.request') }}">
+                                    Forgot Your Password?
+                                </a>
+                            </div>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection

--- a/src/Illuminate/Foundation/Console/Presets/uikit3-stubs/views/auth/login.stub
+++ b/src/Illuminate/Foundation/Console/Presets/uikit3-stubs/views/auth/login.stub
@@ -1,68 +1,57 @@
 @extends('layouts.app')
 
 @section('content')
-<div class="container">
-    <div class="row">
-        <div class="col-md-8 col-md-offset-2">
-            <div class="panel panel-default">
-                <div class="panel-heading">Login</div>
-                <div class="panel-body">
-                    <form class="form-horizontal" role="form" method="POST" action="{{ route('login') }}">
+    <div class="uk-section">
+        <div class="uk-container uk-container-center">
+
+            <div class="uk-width-1-2@m uk-align-center">
+
+                <div class="uk-padding uk-box-shadow-large">
+
+                    <h2>Login</h2>
+
+                    <form class="uk-form-stacked" role="form" method="POST" = action="{{ route('login') }}">
+
                         {{ csrf_field() }}
 
-                        <div class="form-group{{ $errors->has('email') ? ' has-error' : '' }}">
-                            <label for="email" class="col-md-4 control-label">E-Mail Address</label>
+                        <div>
+                            <label class="uk-form-label">Email Address</label>
+                            <input id="email" type="email" class="uk-input{{ $errors->has('email') ? ' uk-form-danger' : '' }}" name="email" value="{{ old('email') }}" required autofocus>
 
-                            <div class="col-md-6">
-                                <input id="email" type="email" class="form-control" name="email" value="{{ old('email') }}" required autofocus>
-
-                                @if ($errors->has('email'))
-                                    <span class="help-block">
-                                        <strong>{{ $errors->first('email') }}</strong>
-                                    </span>
-                                @endif
-                            </div>
-                        </div>
-
-                        <div class="form-group{{ $errors->has('password') ? ' has-error' : '' }}">
-                            <label for="password" class="col-md-4 control-label">Password</label>
-
-                            <div class="col-md-6">
-                                <input id="password" type="password" class="form-control" name="password" required>
-
-                                @if ($errors->has('password'))
-                                    <span class="help-block">
-                                        <strong>{{ $errors->first('password') }}</strong>
-                                    </span>
-                                @endif
-                            </div>
-                        </div>
-
-                        <div class="form-group">
-                            <div class="col-md-6 col-md-offset-4">
-                                <div class="checkbox">
-                                    <label>
-                                        <input type="checkbox" name="remember" {{ old('remember') ? 'checked' : '' }}> Remember Me
-                                    </label>
+                            @if ($errors->has('email'))
+                                <div class="uk-alert-danger" uk-alert>
+                                    {{ $errors->first('email') }}
                                 </div>
-                            </div>
+                            @endif
                         </div>
 
-                        <div class="form-group">
-                            <div class="col-md-8 col-md-offset-4">
-                                <button type="submit" class="btn btn-primary">
-                                    Login
-                                </button>
+                        <div class="uk-margin">
+                            <label class="uk-form-label">Password</label>
+                            <input id="password" type="password" class="uk-input{{ $errors->has('password') ? ' uk-form-danger' : '' }}" name="password" value="{{ old('password') }}" required>
 
-                                <a class="btn btn-link" href="{{ route('password.request') }}">
-                                    Forgot Your Password?
-                                </a>
-                            </div>
+                            @if ($errors->has('password'))
+                                <div class="uk-alert-danger" uk-alert>
+                                    {{ $errors->first('password') }}
+                                </div>
+                            @endif
                         </div>
+
+                        <div class="uk-margin">
+                           <label><input class="uk-checkbox" type="checkbox" name="remember"{{ old('remember') ? ' checked' : '' }}> Remember me</label>
+                        </div>
+
+                        <div class="uk-margin">
+                            <button class="uk-button uk-button-primary" type="submit" name="button">Login</button>
+                            <a class="uk-float-right" href="{{ route('password.request') }}">
+                                Forgot Your Password?
+                            </a>
+                        </div>
+
                     </form>
+
                 </div>
             </div>
+
         </div>
     </div>
-</div>
 @endsection

--- a/src/Illuminate/Foundation/Console/Presets/uikit3-stubs/views/auth/passwords/email.stub
+++ b/src/Illuminate/Foundation/Console/Presets/uikit3-stubs/views/auth/passwords/email.stub
@@ -1,0 +1,46 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container">
+    <div class="row">
+        <div class="col-md-8 col-md-offset-2">
+            <div class="panel panel-default">
+                <div class="panel-heading">Reset Password</div>
+                <div class="panel-body">
+                    @if (session('status'))
+                        <div class="alert alert-success">
+                            {{ session('status') }}
+                        </div>
+                    @endif
+
+                    <form class="form-horizontal" role="form" method="POST" action="{{ route('password.email') }}">
+                        {{ csrf_field() }}
+
+                        <div class="form-group{{ $errors->has('email') ? ' has-error' : '' }}">
+                            <label for="email" class="col-md-4 control-label">E-Mail Address</label>
+
+                            <div class="col-md-6">
+                                <input id="email" type="email" class="form-control" name="email" value="{{ old('email') }}" required>
+
+                                @if ($errors->has('email'))
+                                    <span class="help-block">
+                                        <strong>{{ $errors->first('email') }}</strong>
+                                    </span>
+                                @endif
+                            </div>
+                        </div>
+
+                        <div class="form-group">
+                            <div class="col-md-6 col-md-offset-4">
+                                <button type="submit" class="btn btn-primary">
+                                    Send Password Reset Link
+                                </button>
+                            </div>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection

--- a/src/Illuminate/Foundation/Console/Presets/uikit3-stubs/views/auth/passwords/email.stub
+++ b/src/Illuminate/Foundation/Console/Presets/uikit3-stubs/views/auth/passwords/email.stub
@@ -1,46 +1,45 @@
 @extends('layouts.app')
 
 @section('content')
-<div class="container">
-    <div class="row">
-        <div class="col-md-8 col-md-offset-2">
-            <div class="panel panel-default">
-                <div class="panel-heading">Reset Password</div>
-                <div class="panel-body">
+    <div class="uk-section">
+        <div class="uk-container uk-container-center">
+
+            <div class="uk-width-1-2@m uk-align-center">
+
+                <div class="uk-padding uk-box-shadow-large">
+
+                    <h2>Reset Password</h2>
+
                     @if (session('status'))
-                        <div class="alert alert-success">
+                        <div class="uk-alert-primary" uk-alert>
                             {{ session('status') }}
                         </div>
                     @endif
 
-                    <form class="form-horizontal" role="form" method="POST" action="{{ route('password.email') }}">
+                    <form class="uk-form-stacked" role="form" method="POST" = action="{{ route('password.email') }}">
+
                         {{ csrf_field() }}
 
-                        <div class="form-group{{ $errors->has('email') ? ' has-error' : '' }}">
-                            <label for="email" class="col-md-4 control-label">E-Mail Address</label>
+                        <div>
+                            <label class="uk-form-label">Email Address</label>
+                            <input id="email" type="email" class="uk-input{{ $errors->has('email') ? ' uk-form-danger' : '' }}" name="email" value="{{ old('email') }}" required autofocus>
 
-                            <div class="col-md-6">
-                                <input id="email" type="email" class="form-control" name="email" value="{{ old('email') }}" required>
-
-                                @if ($errors->has('email'))
-                                    <span class="help-block">
-                                        <strong>{{ $errors->first('email') }}</strong>
-                                    </span>
-                                @endif
-                            </div>
+                            @if ($errors->has('email'))
+                                <div class="uk-alert-danger" uk-alert>
+                                    {{ $errors->first('email') }}
+                                </div>
+                            @endif
                         </div>
 
-                        <div class="form-group">
-                            <div class="col-md-6 col-md-offset-4">
-                                <button type="submit" class="btn btn-primary">
-                                    Send Password Reset Link
-                                </button>
-                            </div>
+                        <div class="uk-margin">
+                            <button class="uk-button uk-button-primary" type="submit" name="button">Send Password Reset Link</button>
                         </div>
+
                     </form>
+
                 </div>
             </div>
+
         </div>
     </div>
-</div>
 @endsection

--- a/src/Illuminate/Foundation/Console/Presets/uikit3-stubs/views/auth/passwords/reset.stub
+++ b/src/Illuminate/Foundation/Console/Presets/uikit3-stubs/views/auth/passwords/reset.stub
@@ -1,0 +1,76 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container">
+    <div class="row">
+        <div class="col-md-8 col-md-offset-2">
+            <div class="panel panel-default">
+                <div class="panel-heading">Reset Password</div>
+
+                <div class="panel-body">
+                    @if (session('status'))
+                        <div class="alert alert-success">
+                            {{ session('status') }}
+                        </div>
+                    @endif
+
+                    <form class="form-horizontal" role="form" method="POST" action="{{ route('password.request') }}">
+                        {{ csrf_field() }}
+
+                        <input type="hidden" name="token" value="{{ $token }}">
+
+                        <div class="form-group{{ $errors->has('email') ? ' has-error' : '' }}">
+                            <label for="email" class="col-md-4 control-label">E-Mail Address</label>
+
+                            <div class="col-md-6">
+                                <input id="email" type="email" class="form-control" name="email" value="{{ $email or old('email') }}" required autofocus>
+
+                                @if ($errors->has('email'))
+                                    <span class="help-block">
+                                        <strong>{{ $errors->first('email') }}</strong>
+                                    </span>
+                                @endif
+                            </div>
+                        </div>
+
+                        <div class="form-group{{ $errors->has('password') ? ' has-error' : '' }}">
+                            <label for="password" class="col-md-4 control-label">Password</label>
+
+                            <div class="col-md-6">
+                                <input id="password" type="password" class="form-control" name="password" required>
+
+                                @if ($errors->has('password'))
+                                    <span class="help-block">
+                                        <strong>{{ $errors->first('password') }}</strong>
+                                    </span>
+                                @endif
+                            </div>
+                        </div>
+
+                        <div class="form-group{{ $errors->has('password_confirmation') ? ' has-error' : '' }}">
+                            <label for="password-confirm" class="col-md-4 control-label">Confirm Password</label>
+                            <div class="col-md-6">
+                                <input id="password-confirm" type="password" class="form-control" name="password_confirmation" required>
+
+                                @if ($errors->has('password_confirmation'))
+                                    <span class="help-block">
+                                        <strong>{{ $errors->first('password_confirmation') }}</strong>
+                                    </span>
+                                @endif
+                            </div>
+                        </div>
+
+                        <div class="form-group">
+                            <div class="col-md-6 col-md-offset-4">
+                                <button type="submit" class="btn btn-primary">
+                                    Reset Password
+                                </button>
+                            </div>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection

--- a/src/Illuminate/Foundation/Console/Presets/uikit3-stubs/views/auth/passwords/reset.stub
+++ b/src/Illuminate/Foundation/Console/Presets/uikit3-stubs/views/auth/passwords/reset.stub
@@ -1,76 +1,69 @@
 @extends('layouts.app')
 
 @section('content')
-<div class="container">
-    <div class="row">
-        <div class="col-md-8 col-md-offset-2">
-            <div class="panel panel-default">
-                <div class="panel-heading">Reset Password</div>
+    <div class="uk-section">
+        <div class="uk-container uk-container-center">
 
-                <div class="panel-body">
+            <div class="uk-width-1-2@m uk-align-center">
+
+                <div class="uk-padding uk-box-shadow-large">
+
+                    <h2>Set New Password</h2>
+
                     @if (session('status'))
-                        <div class="alert alert-success">
+                        <div class="uk-alert-primary" uk-alert>
                             {{ session('status') }}
                         </div>
                     @endif
 
-                    <form class="form-horizontal" role="form" method="POST" action="{{ route('password.request') }}">
+                    <form class="uk-form-stacked" role="form" method="POST" = action="{{ route('password.request') }}">
+
                         {{ csrf_field() }}
 
                         <input type="hidden" name="token" value="{{ $token }}">
 
-                        <div class="form-group{{ $errors->has('email') ? ' has-error' : '' }}">
-                            <label for="email" class="col-md-4 control-label">E-Mail Address</label>
+                        <div>
+                            <label class="uk-form-label">Email Address</label>
+                            <input id="email" type="email" class="uk-input{{ $errors->has('email') ? ' uk-form-danger' : '' }}" name="email" value="{{ old('email') }}" required>
 
-                            <div class="col-md-6">
-                                <input id="email" type="email" class="form-control" name="email" value="{{ $email or old('email') }}" required autofocus>
-
-                                @if ($errors->has('email'))
-                                    <span class="help-block">
-                                        <strong>{{ $errors->first('email') }}</strong>
-                                    </span>
-                                @endif
-                            </div>
+                            @if ($errors->has('email'))
+                                <div class="uk-alert-danger" uk-alert>
+                                    {{ $errors->first('email') }}
+                                </div>
+                            @endif
                         </div>
 
-                        <div class="form-group{{ $errors->has('password') ? ' has-error' : '' }}">
-                            <label for="password" class="col-md-4 control-label">Password</label>
+                        <div class="uk-margin">
+                            <label class="uk-form-label">Password</label>
+                            <input id="password" type="password" class="uk-input{{ $errors->has('password') ? ' uk-form-danger' : '' }}" name="password" value="{{ old('password') }}" required>
 
-                            <div class="col-md-6">
-                                <input id="password" type="password" class="form-control" name="password" required>
-
-                                @if ($errors->has('password'))
-                                    <span class="help-block">
-                                        <strong>{{ $errors->first('password') }}</strong>
-                                    </span>
-                                @endif
-                            </div>
+                            @if ($errors->has('password'))
+                                <div class="uk-alert-danger" uk-alert>
+                                    {{ $errors->first('password') }}
+                                </div>
+                            @endif
                         </div>
 
-                        <div class="form-group{{ $errors->has('password_confirmation') ? ' has-error' : '' }}">
-                            <label for="password-confirm" class="col-md-4 control-label">Confirm Password</label>
-                            <div class="col-md-6">
-                                <input id="password-confirm" type="password" class="form-control" name="password_confirmation" required>
+                        <div class="uk-margin">
+                            <label class="uk-form-label">Confirm Password</label>
+                            <input id="password_confirmation" type="password" class="uk-input{{ $errors->has('password_confirmation') ? ' uk-form-danger' : '' }}" name="password_confirmation" value="{{ old('password_confirmation') }}" required>
 
-                                @if ($errors->has('password_confirmation'))
-                                    <span class="help-block">
-                                        <strong>{{ $errors->first('password_confirmation') }}</strong>
-                                    </span>
-                                @endif
-                            </div>
+                            @if ($errors->has('password_confirmation'))
+                                <div class="uk-alert-danger" uk-alert>
+                                    {{ $errors->first('password_confirmation') }}
+                                </div>
+                            @endif
                         </div>
 
-                        <div class="form-group">
-                            <div class="col-md-6 col-md-offset-4">
-                                <button type="submit" class="btn btn-primary">
-                                    Reset Password
-                                </button>
-                            </div>
+                        <div class="uk-margin">
+                            <button class="uk-button uk-button-primary" type="submit" name="button">Reset Password</button>
                         </div>
+
                     </form>
+
                 </div>
             </div>
+
         </div>
     </div>
-</div>
 @endsection

--- a/src/Illuminate/Foundation/Console/Presets/uikit3-stubs/views/auth/register.stub
+++ b/src/Illuminate/Foundation/Console/Presets/uikit3-stubs/views/auth/register.stub
@@ -1,0 +1,76 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container">
+    <div class="row">
+        <div class="col-md-8 col-md-offset-2">
+            <div class="panel panel-default">
+                <div class="panel-heading">Register</div>
+                <div class="panel-body">
+                    <form class="form-horizontal" role="form" method="POST" action="{{ route('register') }}">
+                        {{ csrf_field() }}
+
+                        <div class="form-group{{ $errors->has('name') ? ' has-error' : '' }}">
+                            <label for="name" class="col-md-4 control-label">Name</label>
+
+                            <div class="col-md-6">
+                                <input id="name" type="text" class="form-control" name="name" value="{{ old('name') }}" required autofocus>
+
+                                @if ($errors->has('name'))
+                                    <span class="help-block">
+                                        <strong>{{ $errors->first('name') }}</strong>
+                                    </span>
+                                @endif
+                            </div>
+                        </div>
+
+                        <div class="form-group{{ $errors->has('email') ? ' has-error' : '' }}">
+                            <label for="email" class="col-md-4 control-label">E-Mail Address</label>
+
+                            <div class="col-md-6">
+                                <input id="email" type="email" class="form-control" name="email" value="{{ old('email') }}" required>
+
+                                @if ($errors->has('email'))
+                                    <span class="help-block">
+                                        <strong>{{ $errors->first('email') }}</strong>
+                                    </span>
+                                @endif
+                            </div>
+                        </div>
+
+                        <div class="form-group{{ $errors->has('password') ? ' has-error' : '' }}">
+                            <label for="password" class="col-md-4 control-label">Password</label>
+
+                            <div class="col-md-6">
+                                <input id="password" type="password" class="form-control" name="password" required>
+
+                                @if ($errors->has('password'))
+                                    <span class="help-block">
+                                        <strong>{{ $errors->first('password') }}</strong>
+                                    </span>
+                                @endif
+                            </div>
+                        </div>
+
+                        <div class="form-group">
+                            <label for="password-confirm" class="col-md-4 control-label">Confirm Password</label>
+
+                            <div class="col-md-6">
+                                <input id="password-confirm" type="password" class="form-control" name="password_confirmation" required>
+                            </div>
+                        </div>
+
+                        <div class="form-group">
+                            <div class="col-md-6 col-md-offset-4">
+                                <button type="submit" class="btn btn-primary">
+                                    Register
+                                </button>
+                            </div>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection

--- a/src/Illuminate/Foundation/Console/Presets/uikit3-stubs/views/auth/register.stub
+++ b/src/Illuminate/Foundation/Console/Presets/uikit3-stubs/views/auth/register.stub
@@ -1,76 +1,75 @@
 @extends('layouts.app')
 
 @section('content')
-<div class="container">
-    <div class="row">
-        <div class="col-md-8 col-md-offset-2">
-            <div class="panel panel-default">
-                <div class="panel-heading">Register</div>
-                <div class="panel-body">
-                    <form class="form-horizontal" role="form" method="POST" action="{{ route('register') }}">
+    <div class="uk-section">
+        <div class="uk-container uk-container-center">
+
+            <div class="uk-width-1-2@m uk-align-center">
+
+                <div class="uk-padding uk-box-shadow-large">
+
+                    <h2>Register</h2>
+
+                    <form class="uk-form-stacked" role="form" method="POST" = action="{{ route('register') }}">
+
                         {{ csrf_field() }}
 
-                        <div class="form-group{{ $errors->has('name') ? ' has-error' : '' }}">
-                            <label for="name" class="col-md-4 control-label">Name</label>
+                        <div>
+                            <label class="uk-form-label">Name</label>
+                            <input id="name" type="text" class="uk-input{{ $errors->has('name') ? ' uk-form-danger' : '' }}" name="name" value="{{ old('name') }}" required autofocus>
 
-                            <div class="col-md-6">
-                                <input id="name" type="text" class="form-control" name="name" value="{{ old('name') }}" required autofocus>
-
-                                @if ($errors->has('name'))
-                                    <span class="help-block">
-                                        <strong>{{ $errors->first('name') }}</strong>
-                                    </span>
-                                @endif
-                            </div>
+                            @if ($errors->has('name'))
+                                <div class="uk-alert-danger" uk-alert>
+                                    {{ $errors->first('name') }}
+                                </div>
+                            @endif
                         </div>
 
-                        <div class="form-group{{ $errors->has('email') ? ' has-error' : '' }}">
-                            <label for="email" class="col-md-4 control-label">E-Mail Address</label>
+                        <div class="uk-margin">
+                            <label class="uk-form-label">Email Address</label>
+                            <input id="email" type="email" class="uk-input{{ $errors->has('email') ? ' uk-form-danger' : '' }}" name="email" value="{{ old('email') }}" required>
 
-                            <div class="col-md-6">
-                                <input id="email" type="email" class="form-control" name="email" value="{{ old('email') }}" required>
-
-                                @if ($errors->has('email'))
-                                    <span class="help-block">
-                                        <strong>{{ $errors->first('email') }}</strong>
-                                    </span>
-                                @endif
-                            </div>
+                            @if ($errors->has('email'))
+                                <div class="uk-alert-danger" uk-alert>
+                                    {{ $errors->first('email') }}
+                                </div>
+                            @endif
                         </div>
 
-                        <div class="form-group{{ $errors->has('password') ? ' has-error' : '' }}">
-                            <label for="password" class="col-md-4 control-label">Password</label>
+                        <div class="uk-margin">
+                            <label class="uk-form-label">Password</label>
+                            <input id="password" type="password" class="uk-input{{ $errors->has('password') ? ' uk-form-danger' : '' }}" name="password" value="{{ old('password') }}" required>
 
-                            <div class="col-md-6">
-                                <input id="password" type="password" class="form-control" name="password" required>
-
-                                @if ($errors->has('password'))
-                                    <span class="help-block">
-                                        <strong>{{ $errors->first('password') }}</strong>
-                                    </span>
-                                @endif
-                            </div>
+                            @if ($errors->has('password'))
+                                <div class="uk-alert-danger" uk-alert>
+                                    {{ $errors->first('password') }}
+                                </div>
+                            @endif
                         </div>
 
-                        <div class="form-group">
-                            <label for="password-confirm" class="col-md-4 control-label">Confirm Password</label>
+                        <div class="uk-margin">
+                            <label class="uk-form-label">Confirm Password</label>
+                            <input id="password_confirmation" type="password" class="uk-input{{ $errors->has('password_confirmation') ? ' uk-form-danger' : '' }}" name="password_confirmation" value="{{ old('password_confirmation') }}" required>
 
-                            <div class="col-md-6">
-                                <input id="password-confirm" type="password" class="form-control" name="password_confirmation" required>
-                            </div>
+                            @if ($errors->has('password_confirmation'))
+                                <div class="uk-alert-danger" uk-alert>
+                                    {{ $errors->first('password_confirmation') }}
+                                </div>
+                            @endif
                         </div>
 
-                        <div class="form-group">
-                            <div class="col-md-6 col-md-offset-4">
-                                <button type="submit" class="btn btn-primary">
-                                    Register
-                                </button>
-                            </div>
+                        <div class="uk-margin">
+                            <button class="uk-button uk-button-primary" type="submit" name="button">Register</button>
+                            <a class="uk-float-right" href="{{ route('login') }}">
+                                Already have an account?
+                            </a>
                         </div>
+
                     </form>
+
                 </div>
             </div>
+
         </div>
     </div>
-</div>
 @endsection

--- a/src/Illuminate/Foundation/Console/Presets/uikit3-stubs/views/home.stub
+++ b/src/Illuminate/Foundation/Console/Presets/uikit3-stubs/views/home.stub
@@ -1,0 +1,17 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container">
+    <div class="row">
+        <div class="col-md-8 col-md-offset-2">
+            <div class="panel panel-default">
+                <div class="panel-heading">Dashboard</div>
+
+                <div class="panel-body">
+                    You are logged in!
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection

--- a/src/Illuminate/Foundation/Console/Presets/uikit3-stubs/views/home.stub
+++ b/src/Illuminate/Foundation/Console/Presets/uikit3-stubs/views/home.stub
@@ -1,17 +1,16 @@
 @extends('layouts.app')
 
 @section('content')
-<div class="container">
-    <div class="row">
-        <div class="col-md-8 col-md-offset-2">
-            <div class="panel panel-default">
-                <div class="panel-heading">Dashboard</div>
 
-                <div class="panel-body">
-                    You are logged in!
-                </div>
-            </div>
+<div class="uk-section">
+    <div class="uk-container uk-container-expand">
+
+        <div class="uk-card uk-card-primary uk-card-body uk-width-1-2@m uk-align-center">
+            <h3 class="uk-card-title">Dashboard</h3>
+            <p>You are logged in!</p>
         </div>
+
     </div>
 </div>
+
 @endsection

--- a/src/Illuminate/Foundation/Console/Presets/uikit3-stubs/views/layouts/app.stub
+++ b/src/Illuminate/Foundation/Console/Presets/uikit3-stubs/views/layouts/app.stub
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="{{ app()->getLocale() }}">
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    <!-- CSRF Token -->
+    <meta name="csrf-token" content="{{ csrf_token() }}">
+
+    <title>{{ config('app.name', 'Laravel') }}</title>
+
+    <!-- Styles -->
+    <link href="{{ asset('css/app.css') }}" rel="stylesheet">
+</head>
+<body>
+    <div id="app">
+        <nav class="navbar navbar-default navbar-static-top">
+            <div class="container">
+                <div class="navbar-header">
+
+                    <!-- Collapsed Hamburger -->
+                    <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#app-navbar-collapse">
+                        <span class="sr-only">Toggle Navigation</span>
+                        <span class="icon-bar"></span>
+                        <span class="icon-bar"></span>
+                        <span class="icon-bar"></span>
+                    </button>
+
+                    <!-- Branding Image -->
+                    <a class="navbar-brand" href="{{ url('/') }}">
+                        {{ config('app.name', 'Laravel') }}
+                    </a>
+                </div>
+
+                <div class="collapse navbar-collapse" id="app-navbar-collapse">
+                    <!-- Left Side Of Navbar -->
+                    <ul class="nav navbar-nav">
+                        &nbsp;
+                    </ul>
+
+                    <!-- Right Side Of Navbar -->
+                    <ul class="nav navbar-nav navbar-right">
+                        <!-- Authentication Links -->
+                        @if (Auth::guest())
+                            <li><a href="{{ route('login') }}">Login</a></li>
+                            <li><a href="{{ route('register') }}">Register</a></li>
+                        @else
+                            <li class="dropdown">
+                                <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">
+                                    {{ Auth::user()->name }} <span class="caret"></span>
+                                </a>
+
+                                <ul class="dropdown-menu" role="menu">
+                                    <li>
+                                        <a href="{{ route('logout') }}"
+                                            onclick="event.preventDefault();
+                                                     document.getElementById('logout-form').submit();">
+                                            Logout
+                                        </a>
+
+                                        <form id="logout-form" action="{{ route('logout') }}" method="POST" style="display: none;">
+                                            {{ csrf_field() }}
+                                        </form>
+                                    </li>
+                                </ul>
+                            </li>
+                        @endif
+                    </ul>
+                </div>
+            </div>
+        </nav>
+
+        @yield('content')
+    </div>
+
+    <!-- Scripts -->
+    <script src="{{ asset('js/app.js') }}"></script>
+</body>
+</html>

--- a/src/Illuminate/Foundation/Console/Presets/uikit3-stubs/views/layouts/app.stub
+++ b/src/Illuminate/Foundation/Console/Presets/uikit3-stubs/views/layouts/app.stub
@@ -15,61 +15,50 @@
 </head>
 <body>
     <div id="app">
-        <nav class="navbar navbar-default navbar-static-top">
-            <div class="container">
-                <div class="navbar-header">
+        <div class="uk-box-shadow-medium uk-navbar-container uk-navbar-primary" uk-navbar="mode: click">
+            <div class="uk-container uk-container-expand uk-width-1-1">
 
-                    <!-- Collapsed Hamburger -->
-                    <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#app-navbar-collapse">
-                        <span class="sr-only">Toggle Navigation</span>
-                        <span class="icon-bar"></span>
-                        <span class="icon-bar"></span>
-                        <span class="icon-bar"></span>
-                    </button>
+                <nav class="uk-navbar">
 
-                    <!-- Branding Image -->
-                    <a class="navbar-brand" href="{{ url('/') }}">
-                        {{ config('app.name', 'Laravel') }}
-                    </a>
-                </div>
+                    <div class="uk-navbar-left">
+                        <!-- Branding Image -->
+                        <a class="uk-navbar-item uk-logo" href="{{ url('/') }}">
+                            {{ config('app.name', 'Laravel') }}
+                        </a>
+                    </div>
 
-                <div class="collapse navbar-collapse" id="app-navbar-collapse">
-                    <!-- Left Side Of Navbar -->
-                    <ul class="nav navbar-nav">
-                        &nbsp;
-                    </ul>
+                    <div class="uk-navbar-right">
+                        <ul class="uk-navbar-nav">
+                            @if (Auth::guest())
+                                <li><a href="{{ route('login') }}">Login</a></li>
+                                <li><a href="{{ route('register') }}">Register</a></li>
+                            @else
+                                <li>
+                                    <a href="#">{{ Auth::user()->name }}</a>
+                                    <div class="uk-navbar-dropdown">
+                                        <ul class="uk-nav uk-navbar-dropdown-nav">
+                                            <li>
+                                                <a href="{{ route('logout') }}"
+                                                    onclick="event.preventDefault();
+                                                             document.getElementById('logout-form').submit();">
+                                                    Logout
+                                                </a>
 
-                    <!-- Right Side Of Navbar -->
-                    <ul class="nav navbar-nav navbar-right">
-                        <!-- Authentication Links -->
-                        @if (Auth::guest())
-                            <li><a href="{{ route('login') }}">Login</a></li>
-                            <li><a href="{{ route('register') }}">Register</a></li>
-                        @else
-                            <li class="dropdown">
-                                <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">
-                                    {{ Auth::user()->name }} <span class="caret"></span>
-                                </a>
+                                                <form id="logout-form" action="{{ route('logout') }}" method="POST" style="display: none;">
+                                                    {{ csrf_field() }}
+                                                </form>
+                                            </li>
+                                        </ul>
+                                    </div>
+                                </li>
+                            @endif
+                        </ul>
+                    </div>
 
-                                <ul class="dropdown-menu" role="menu">
-                                    <li>
-                                        <a href="{{ route('logout') }}"
-                                            onclick="event.preventDefault();
-                                                     document.getElementById('logout-form').submit();">
-                                            Logout
-                                        </a>
+                </nav>
 
-                                        <form id="logout-form" action="{{ route('logout') }}" method="POST" style="display: none;">
-                                            {{ csrf_field() }}
-                                        </form>
-                                    </li>
-                                </ul>
-                            </li>
-                        @endif
-                    </ul>
-                </div>
             </div>
-        </nav>
+        </div>
 
         @yield('content')
     </div>


### PR DESCRIPTION
I'm aware many people use plenty of different frontend framework, and you cannot support them all and this will most likely get closed straight away, however you have to try! And if not maybe we could brain storm a way to enable this functionality without going into the laravel core?

This PR basically adds a new preset for UIkit 3, as Bootstrap is largely old, unmaintained and missing many features that newer frameworks provide, I believe @themsaid has also dabbled with UIkit so hopefully see's the value in this PR.

Usage is simply `artisan preset uikit3`

This will do the basic scaffolding of importing their modular css, to allow users to optimise their css file sizes with only what they need.

It replaces the bootstrap npm package which gets included in the `bootstrap.js`

Additionally if you run `artisan make:auth` once you've run the preset, you'll also get the auth templates.

They will generate markup that will create layouts like the below

![screencapture-uikit-dev-login-1496494954318](https://cloud.githubusercontent.com/assets/1094740/26753760/aa64ec04-4865-11e7-87b5-aca73844cbe3.png)
![screencapture-uikit-dev-password-reset-1496495004051](https://cloud.githubusercontent.com/assets/1094740/26753759/aa63cb1c-4865-11e7-935f-15f3b17d151c.png)

 -----------

As mentioned before, if you do not feel comfortable merging this into the core, I'd hope some could suggest ways we could make adding 3rd Party Presets easy for those who don't want to be slapped with bootstrap from 2013 🐙 