### PR TITLE
make models accept default values

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -138,6 +138,13 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     const UPDATED_AT = 'updated_at';
 
     /**
+     * The attributes that accept default values.
+     *
+     * @var array
+     */
+    protected $defaultable = [];
+
+    /**
      * Create a new Eloquent model instance.
      *
      * @param  array  $attributes
@@ -219,6 +226,12 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     public function fill(array $attributes)
     {
         $totallyGuarded = $this->totallyGuarded();
+
+        foreach ($this->fillable as $field) {
+            if( ! array_key_exists($field, $attributes) && array_key_exists($field, $this->defaultable)) {
+                $attributes[$field] = $this->defaultable[$field];
+            }
+        }
 
         foreach ($this->fillableFromArray($attributes) as $key => $value) {
             $key = $this->removeTableFromKey($key);

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -228,7 +228,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         $totallyGuarded = $this->totallyGuarded();
 
         foreach ($this->fillable as $field) {
-            if( ! array_key_exists($field, $attributes) && array_key_exists($field, $this->defaultable)) {
+            if(! array_key_exists($field, $attributes) && array_key_exists($field, $this->defaultable)) {
                 $attributes[$field] = $this->defaultable[$field];
             }
         }

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -228,7 +228,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         $totallyGuarded = $this->totallyGuarded();
 
         foreach ($this->fillable as $field) {
-            if(! array_key_exists($field, $attributes) && array_key_exists($field, $this->defaultable)) {
+            if (! array_key_exists($field, $attributes) && array_key_exists($field, $this->defaultable)) {
                 $attributes[$field] = $this->defaultable[$field];
             }
         }


### PR DESCRIPTION
This functionality is useful when we have models that could accepts some default values.

I needed it in one case where I had a model that have many Boolean values, so when creating/updating the model, and since the form that create/update it was using check-boxes to represent the attributes, I had to do multiple checks: if the value is not present (since it is not sent if the checkbox is not checked), than set it to false, or to some specific value.

