### PR TITLE
[5.5] Fix Whoops exception rendering

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -245,17 +245,20 @@ class Handler implements ExceptionHandlerContract
      */
     protected function convertExceptionToResponse(Exception $e)
     {
+        $headers = $this->isHttpException($e) ? $e->getHeaders() : [];
+        $statusCode = $this->isHttpException($e) ? $e->getStatusCode() : 500;
+
         if (config('app.debug')) {
             return SymfonyResponse::create(
-                $this->renderExceptionWithWhoops($e), $e->getStatusCode(), $e->getHeaders()
+                $this->renderExceptionWithWhoops($e), $statusCode, $headers
             );
         } else {
             $e = FlattenException::create($e);
 
             return SymfonyResponse::create(
                 (new SymfonyExceptionHandler(false))->getHtml($e),
-                $e->getStatusCode(),
-                $e->getHeaders()
+                $statusCode,
+                $headers
             );
         }
     }

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -268,9 +268,11 @@ class Handler implements ExceptionHandlerContract
      */
     protected function renderExceptionWithWhoops(Exception $e)
     {
-        return tap(
-            (new Whoops)->pushHandler($this->whoopsHandler())
-        )->handleException($e);
+        $whoops = tap(new Whoops, function ($whoops) {
+            $whoops->pushHandler($this->whoopsHandler());
+        });
+
+        return $whoops->handleException($e);
     }
 
     /**
@@ -280,13 +282,15 @@ class Handler implements ExceptionHandlerContract
      */
     protected function whoopsHandler()
     {
-        $files = new Filesystem;
+        return tap(new PrettyPageHandler, function ($handler) {
+            $files = new Filesystem;
 
-        return tap(new PrettyPageHandler)->setApplicationPaths(
-            array_flip(array_except(
-                array_flip($files->directories(base_path())), [base_path('vendor')]
-            ))
-        );
+            $handler->setApplicationPaths(
+                array_flip(array_except(
+                    array_flip($files->directories(base_path())), [base_path('vendor')]
+                ))
+            );
+        });
     }
 
     /**

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -253,12 +253,8 @@ class Handler implements ExceptionHandlerContract
                 $this->renderExceptionWithWhoops($e), $statusCode, $headers
             );
         } else {
-            $e = FlattenException::create($e);
-
             return SymfonyResponse::create(
-                (new SymfonyExceptionHandler(false))->getHtml($e),
-                $statusCode,
-                $headers
+                $this->renderExceptionWithSymfony($e), $statusCode, $headers
             );
         }
     }
@@ -278,6 +274,19 @@ class Handler implements ExceptionHandlerContract
         });
 
         return $whoops->handleException($e);
+    }
+
+    /**
+     * Render an exception to a string using Symfony.
+     *
+     * @param  \Exception  $e
+     * @return string
+     */
+    protected function renderExceptionWithSymfony(Exception $e)
+    {
+        $e = FlattenException::create($e);
+
+        return (new SymfonyExceptionHandler(false))->getHtml($e);
     }
 
     /**

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -270,6 +270,8 @@ class Handler implements ExceptionHandlerContract
     {
         $whoops = tap(new Whoops, function ($whoops) {
             $whoops->pushHandler($this->whoopsHandler());
+            $whoops->writeToOutput(false);
+            $whoops->allowQuit(false);
         });
 
         return $whoops->handleException($e);
@@ -285,6 +287,7 @@ class Handler implements ExceptionHandlerContract
         return tap(new PrettyPageHandler, function ($handler) {
             $files = new Filesystem;
 
+            $handler->handleUnconditionally(true);
             $handler->setApplicationPaths(
                 array_flip(array_except(
                     array_flip($files->directories(base_path())), [base_path('vendor')]


### PR DESCRIPTION
The new Whoops setup is slightly broken. The defaults cause Whoops to output directly to the browser, call exit, and prevent testing when using the command line (because it returns an empty string when configured to not exit)

I've done a few things here:
1. A slight refactoring around Whoops and Symfony error handlers to simplify things.
2. Reconfigure whoops to always return a response to the exception handler
3. Use Symfony's error handler as a backup if configuring or running Whoops fails.
4. Fix a problem with rendering non-http exceptions that was hidden behind the fact that Whoops was calling exit.