### PR TITLE
[5.4] Translation getPluralIndex using language part of locale

### DIFF
--- a/src/Illuminate/Translation/MessageSelector.php
+++ b/src/Illuminate/Translation/MessageSelector.php
@@ -109,7 +109,7 @@ class MessageSelector
      */
     public function getPluralIndex($locale, $number)
     {
-        switch ($locale) {
+        switch (preg_replace('/^([^-_]+).*/', '$1', $locale)) {
             case 'az':
             case 'bo':
             case 'dz':


### PR DESCRIPTION
Translations in the format below were returning the wrong plural with locales like `pt_BR`, because it does not find the locale in the getPluralIndex and always returns the default `0`.

```
'apples' => 'There is one apple|There are many apples',

echo trans_choice('messages.apples', 1);
// There is one apple

echo trans_choice('messages.apples', 0);
// There is one apple
```