### PR TITLE
Set default value for $output

### DIFF
--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -115,7 +115,7 @@ class Command extends SymfonyCommand
         // when using $this->info in derived classes
         // Symfony\Component\Debug\Exception\FatalThrowableError]
         // Call to a member function writeln() on null
-        $this->output = new Symfony\Component\Console\Output\ConsoleOutput();
+        $this->output = new \Symfony\Component\Console\Output\ConsoleOutput();
     }
 
     /**

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -110,6 +110,12 @@ class Command extends SymfonyCommand
         if (! isset($this->signature)) {
             $this->specifyParameters();
         }
+        
+        // Set the default value to avoid the following error 
+        // when using $this->info in derived classes
+        // Symfony\Component\Debug\Exception\FatalThrowableError]  
+        // Call to a member function writeln() on null
+        $this->output = new Symfony\Component\Console\Output\ConsoleOutput();
     }
 
     /**

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -110,7 +110,7 @@ class Command extends SymfonyCommand
         if (! isset($this->signature)) {
             $this->specifyParameters();
         }
-        
+
         // Set the default value to avoid the following error
         // when using $this->info in derived classes
         // Symfony\Component\Debug\Exception\FatalThrowableError]

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -111,9 +111,9 @@ class Command extends SymfonyCommand
             $this->specifyParameters();
         }
         
-        // Set the default value to avoid the following error 
+        // Set the default value to avoid the following error
         // when using $this->info in derived classes
-        // Symfony\Component\Debug\Exception\FatalThrowableError]  
+        // Symfony\Component\Debug\Exception\FatalThrowableError]
         // Call to a member function writeln() on null
         $this->output = new Symfony\Component\Console\Output\ConsoleOutput();
     }


### PR DESCRIPTION
Set the default value for `$output` to avoid the following error 
when using `$this->info(..)` in derived classes

> Symfony\Component\Debug\Exception\FatalThrowableError]  
> Call to a member function writeln() on null

See also [this SO question](https://stackoverflow.com/questions/26698122/laravel-command-cannot-call-this-info-in-child-class). I just run in this problem some second ago.