### PR TITLE
Properties in traits for Eloquent

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php
@@ -32,20 +32,20 @@ trait GuardsAttributes
      *
      * @return array
      */
-	public function getFillable()
-	{
-		return array_merge($this->fillable,$this->getFillableTraits());
-	}
-	/**
-	 * Get the fillable attributes for the traits.
-	 *
-	 * @return array
-	 */
-	protected function getFillableTraits()
-	{
-		return $this->getTraitAttributes('fillable');
-	}
+    public function getFillable()
+    {
+        return array_merge($this->fillable, $this->getFillableTraits());
+    }
 
+    /**
+     * Get the fillable attributes for the traits.
+     *
+     * @return array
+     */
+    protected function getFillableTraits()
+    {
+        return $this->getTraitAttributes('fillable');
+    }
 
     /**
      * Set the fillable attributes for the model.
@@ -65,18 +65,20 @@ trait GuardsAttributes
      *
      * @return array
      */
-	public function getGuarded()
-	{
-		return array_merge($this->guarded, $this->getGuardedTraits());
-	}
-	/**
-	 * Get the guarded attributes for the traits.
-	 *
-	 * @return array
-	 */
-	protected function getGuardedTraits() {
-		return $this->getTraitAttributes('guarded');
-	}
+    public function getGuarded()
+    {
+        return array_merge($this->guarded, $this->getGuardedTraits());
+    }
+
+    /**
+     * Get the guarded attributes for the traits.
+     *
+     * @return array
+     */
+    protected function getGuardedTraits()
+    {
+        return $this->getTraitAttributes('guarded');
+    }
 
     /**
      * Set the guarded attributes for the model.

--- a/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php
@@ -32,10 +32,20 @@ trait GuardsAttributes
      *
      * @return array
      */
-    public function getFillable()
-    {
-        return $this->fillable;
-    }
+	public function getFillable()
+	{
+		return array_merge($this->fillable,$this->getFillableTraits());
+	}
+	/**
+	 * Get the fillable attributes for the traits.
+	 *
+	 * @return array
+	 */
+	protected function getFillableTraits()
+	{
+		return $this->getTraitAttributes('fillable');
+	}
+
 
     /**
      * Set the fillable attributes for the model.
@@ -55,10 +65,18 @@ trait GuardsAttributes
      *
      * @return array
      */
-    public function getGuarded()
-    {
-        return $this->guarded;
-    }
+	public function getGuarded()
+	{
+		return array_merge($this->guarded, $this->getGuardedTraits());
+	}
+	/**
+	 * Get the guarded attributes for the traits.
+	 *
+	 * @return array
+	 */
+	protected function getGuardedTraits() {
+		return $this->getTraitAttributes('guarded');
+	}
 
     /**
      * Set the guarded attributes for the model.

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -202,16 +202,25 @@ trait HasAttributes
      *
      * @return array
      */
-    protected function getArrayableAppends()
-    {
-        if (! count($this->appends)) {
-            return [];
-        }
-
-        return $this->getArrayableItems(
-            array_combine($this->appends, $this->appends)
-        );
-    }
+	protected function getArrayableAppends()
+	{
+		$appends = array_merge($this->appends, $this->getArrayableAppendsTraits());
+		if (! count($appends)) {
+			return [];
+		}
+		return $this->getArrayableItems(
+			array_combine($appends, $appends)
+		);
+	}
+	/**
+	 * Get all of the appendable values that are arrayable from traits.
+	 *
+	 * @return array
+	 */
+	protected function getArrayableAppendsTraits()
+	{
+		return $this->getTraitAttributes('appends');
+	}
 
     /**
      * Get the model's relationships in array form.
@@ -760,12 +769,21 @@ trait HasAttributes
      *
      * @return array
      */
-    public function getDates()
-    {
-        $defaults = [static::CREATED_AT, static::UPDATED_AT];
-
-        return $this->usesTimestamps() ? array_merge($this->dates, $defaults) : $this->dates;
-    }
+	public function getDates()
+	{
+		$dates = array_merge($this->dates, $this->getDatesTraits());
+		$defaults = [static::CREATED_AT, static::UPDATED_AT];
+		return $this->usesTimestamps() ? array_merge($dates, $defaults) : $dates;
+	}
+	/**
+	 * Get the attributes that should be converted to dates from traits.
+	 *
+	 * @return array
+	 */
+	public function getDatesTraits()
+	{
+		return $this->getTraitAttributes('dates');
+	}
 
     /**
      * Get the format for database stored dates.
@@ -811,14 +829,23 @@ trait HasAttributes
      *
      * @return array
      */
-    public function getCasts()
-    {
-        if ($this->getIncrementing()) {
-            return array_merge([$this->getKeyName() => $this->getKeyType()], $this->casts);
-        }
-
-        return $this->casts;
-    }
+	public function getCasts()
+	{
+		$casts = array_merge($this->casts, $this->getCastsTraits());
+		if ($this->getIncrementing()) {
+			return array_merge([$this->getKeyName() => $this->getKeyType()], $casts);
+		}
+		return $casts;
+	}
+	/**
+	 * Get the casts array from traits.
+	 *
+	 * @return array
+	 */
+	public function getCastsTraits()
+	{
+		return $this->getTraitAttributes('casts');
+	}
 
     /**
      * Determine whether a value is Date / DateTime castable for inbound manipulation.

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -202,25 +202,27 @@ trait HasAttributes
      *
      * @return array
      */
-	protected function getArrayableAppends()
-	{
-		$appends = array_merge($this->appends, $this->getArrayableAppendsTraits());
-		if (! count($appends)) {
-			return [];
-		}
-		return $this->getArrayableItems(
-			array_combine($appends, $appends)
-		);
-	}
-	/**
-	 * Get all of the appendable values that are arrayable from traits.
-	 *
-	 * @return array
-	 */
-	protected function getArrayableAppendsTraits()
-	{
-		return $this->getTraitAttributes('appends');
-	}
+    protected function getArrayableAppends()
+    {
+        $appends = array_merge($this->appends, $this->getArrayableAppendsTraits());
+        if (! count($appends)) {
+            return [];
+        }
+
+        return $this->getArrayableItems(
+            array_combine($appends, $appends)
+        );
+    }
+
+    /**
+     * Get all of the appendable values that are arrayable from traits.
+     *
+     * @return array
+     */
+    protected function getArrayableAppendsTraits()
+    {
+        return $this->getTraitAttributes('appends');
+    }
 
     /**
      * Get the model's relationships in array form.
@@ -769,21 +771,23 @@ trait HasAttributes
      *
      * @return array
      */
-	public function getDates()
-	{
-		$dates = array_merge($this->dates, $this->getDatesTraits());
-		$defaults = [static::CREATED_AT, static::UPDATED_AT];
-		return $this->usesTimestamps() ? array_merge($dates, $defaults) : $dates;
-	}
-	/**
-	 * Get the attributes that should be converted to dates from traits.
-	 *
-	 * @return array
-	 */
-	public function getDatesTraits()
-	{
-		return $this->getTraitAttributes('dates');
-	}
+    public function getDates()
+    {
+        $dates = array_merge($this->dates, $this->getDatesTraits());
+        $defaults = [static::CREATED_AT, static::UPDATED_AT];
+
+        return $this->usesTimestamps() ? array_merge($dates, $defaults) : $dates;
+    }
+
+    /**
+     * Get the attributes that should be converted to dates from traits.
+     *
+     * @return array
+     */
+    public function getDatesTraits()
+    {
+        return $this->getTraitAttributes('dates');
+    }
 
     /**
      * Get the format for database stored dates.
@@ -829,23 +833,25 @@ trait HasAttributes
      *
      * @return array
      */
-	public function getCasts()
-	{
-		$casts = array_merge($this->casts, $this->getCastsTraits());
-		if ($this->getIncrementing()) {
-			return array_merge([$this->getKeyName() => $this->getKeyType()], $casts);
-		}
-		return $casts;
-	}
-	/**
-	 * Get the casts array from traits.
-	 *
-	 * @return array
-	 */
-	public function getCastsTraits()
-	{
-		return $this->getTraitAttributes('casts');
-	}
+    public function getCasts()
+    {
+        $casts = array_merge($this->casts, $this->getCastsTraits());
+        if ($this->getIncrementing()) {
+            return array_merge([$this->getKeyName() => $this->getKeyType()], $casts);
+        }
+
+        return $casts;
+    }
+
+    /**
+     * Get the casts array from traits.
+     *
+     * @return array
+     */
+    public function getCastsTraits()
+    {
+        return $this->getTraitAttributes('casts');
+    }
 
     /**
      * Determine whether a value is Date / DateTime castable for inbound manipulation.

--- a/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
@@ -51,26 +51,27 @@ trait HasEvents
      *
      * @return array
      */
-	public function getObservableEvents()
-	{
-		return array_merge(
-			[
-				'creating', 'created', 'updating', 'updated',
-				'deleting', 'deleted', 'saving', 'saved',
-				'restoring', 'restored',
-			],
-			array_merge($this->observables, $this->getObservableEventTraits())
-		);
-	}
-	/**
-	 * Get the observable event names for traits.
-	 *
-	 * @return array
-	 */
-	protected function getObservableEventTraits()
-	{
-		return $this->getTraitAttributes('observables');
-	}
+    public function getObservableEvents()
+    {
+        return array_merge(
+            [
+                'creating', 'created', 'updating', 'updated',
+                'deleting', 'deleted', 'saving', 'saved',
+                'restoring', 'restored',
+            ],
+            array_merge($this->observables, $this->getObservableEventTraits())
+        );
+    }
+
+    /**
+     * Get the observable event names for traits.
+     *
+     * @return array
+     */
+    protected function getObservableEventTraits()
+    {
+        return $this->getTraitAttributes('observables');
+    }
 
     /**
      * Set the observable event names.

--- a/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
@@ -51,17 +51,26 @@ trait HasEvents
      *
      * @return array
      */
-    public function getObservableEvents()
-    {
-        return array_merge(
-            [
-                'creating', 'created', 'updating', 'updated',
-                'deleting', 'deleted', 'saving', 'saved',
-                'restoring', 'restored',
-            ],
-            $this->observables
-        );
-    }
+	public function getObservableEvents()
+	{
+		return array_merge(
+			[
+				'creating', 'created', 'updating', 'updated',
+				'deleting', 'deleted', 'saving', 'saved',
+				'restoring', 'restored',
+			],
+			array_merge($this->observables, $this->getObservableEventTraits())
+		);
+	}
+	/**
+	 * Get the observable event names for traits.
+	 *
+	 * @return array
+	 */
+	protected function getObservableEventTraits()
+	{
+		return $this->getTraitAttributes('observables');
+	}
 
     /**
      * Set the observable event names.

--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -441,7 +441,7 @@ trait HasRelationships
      */
     public function touches($relation)
     {
-		return in_array($relation, $this->getTouchedRelations());
+        return in_array($relation, $this->getTouchedRelations());
     }
 
     /**
@@ -574,19 +574,20 @@ trait HasRelationships
      *
      * @return array
      */
-	public function getTouchedRelations()
-	{
-		return array_merge($this->touches, $this->getTouchedTraits());
-	}
-	/**
-	 * Get the relationships that are touched on save from traits.
-	 *
-	 * @return array
-	 */
-	public function getTouchedTraits()
-	{
-		return $this->getTraitAttributes('touches');
-	}
+    public function getTouchedRelations()
+    {
+        return array_merge($this->touches, $this->getTouchedTraits());
+    }
+
+    /**
+     * Get the relationships that are touched on save from traits.
+     *
+     * @return array
+     */
+    public function getTouchedTraits()
+    {
+        return $this->getTraitAttributes('touches');
+    }
 
     /**
      * Set the relationships that are touched on save.

--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -441,7 +441,7 @@ trait HasRelationships
      */
     public function touches($relation)
     {
-        return in_array($relation, $this->touches);
+		return in_array($relation, $this->getTouchedRelations());
     }
 
     /**
@@ -451,7 +451,7 @@ trait HasRelationships
      */
     public function touchOwners()
     {
-        foreach ($this->touches as $relation) {
+        foreach ($this->getTouchedRelations() as $relation) {
             $this->$relation()->touch();
 
             if ($this->$relation instanceof self) {
@@ -574,10 +574,19 @@ trait HasRelationships
      *
      * @return array
      */
-    public function getTouchedRelations()
-    {
-        return $this->touches;
-    }
+	public function getTouchedRelations()
+	{
+		return array_merge($this->touches, $this->getTouchedTraits());
+	}
+	/**
+	 * Get the relationships that are touched on save from traits.
+	 *
+	 * @return array
+	 */
+	public function getTouchedTraits()
+	{
+		return $this->getTraitAttributes('touches');
+	}
 
     /**
      * Set the relationships that are touched on save.

--- a/src/Illuminate/Database/Eloquent/Concerns/HidesAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HidesAttributes.php
@@ -23,19 +23,21 @@ trait HidesAttributes
      *
      * @return array
      */
-	public function getHidden()
-	{
-		return array_merge($this->hidden, $this->getHiddenTraits());
-	}
-	/**
-	 * Get the hidden attributes for the model traits.
-	 *
-	 * @return array
-	 */
-	public function getHiddenTraits()
-	{
-		return $this->getTraitAttributes('hidden');
-	}
+    public function getHidden()
+    {
+        return array_merge($this->hidden, $this->getHiddenTraits());
+    }
+
+    /**
+     * Get the hidden attributes for the model traits.
+     *
+     * @return array
+     */
+    public function getHiddenTraits()
+    {
+        return $this->getTraitAttributes('hidden');
+    }
+
     /**
      * Set the hidden attributes for the model.
      *
@@ -67,19 +69,20 @@ trait HidesAttributes
      *
      * @return array
      */
-	public function getVisible()
-	{
-		return array_merge($this->visible, $this->getVisibleTraits());
-	}
-	/**
-	 * Get the visible attributes for the traits.
-	 *
-	 * @return array
-	 */
-	public function getVisibleTraits()
-	{
-		return $this->getTraitAttributes('visible');
-	}
+    public function getVisible()
+    {
+        return array_merge($this->visible, $this->getVisibleTraits());
+    }
+
+    /**
+     * Get the visible attributes for the traits.
+     *
+     * @return array
+     */
+    public function getVisibleTraits()
+    {
+        return $this->getTraitAttributes('visible');
+    }
 
     /**
      * Set the visible attributes for the model.

--- a/src/Illuminate/Database/Eloquent/Concerns/HidesAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HidesAttributes.php
@@ -23,11 +23,19 @@ trait HidesAttributes
      *
      * @return array
      */
-    public function getHidden()
-    {
-        return $this->hidden;
-    }
-
+	public function getHidden()
+	{
+		return array_merge($this->hidden, $this->getHiddenTraits());
+	}
+	/**
+	 * Get the hidden attributes for the model traits.
+	 *
+	 * @return array
+	 */
+	public function getHiddenTraits()
+	{
+		return $this->getTraitAttributes('hidden');
+	}
     /**
      * Set the hidden attributes for the model.
      *
@@ -59,10 +67,19 @@ trait HidesAttributes
      *
      * @return array
      */
-    public function getVisible()
-    {
-        return $this->visible;
-    }
+	public function getVisible()
+	{
+		return array_merge($this->visible, $this->getVisibleTraits());
+	}
+	/**
+	 * Get the visible attributes for the traits.
+	 *
+	 * @return array
+	 */
+	public function getVisibleTraits()
+	{
+		return $this->getTraitAttributes('visible');
+	}
 
     /**
      * Set the visible attributes for the model.

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -959,6 +959,24 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         $this->setRawAttributes(static::findOrFail($this->getKey())->attributes);
     }
 
+	/**
+	 * Get all attributes from traits with suffix trait name $attribute[TraitName].
+	 *
+	 * @param string $attribute
+	 * @return array
+	 */
+	protected function getTraitAttributes(string $attribute)
+	{
+		$class = static::class;
+		$attributes = [];
+		foreach (class_uses_recursive($class) as $trait) {
+			if(property_exists($this, $attribute.class_basename($trait))) {
+				$attributes = array_merge($this->{$attribute.class_basename($trait)}, $attributes);
+			}
+		}
+		return $attributes;
+	}
+
     /**
      * Clone the model into a new, non-existing instance.
      *

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -959,23 +959,24 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         $this->setRawAttributes(static::findOrFail($this->getKey())->attributes);
     }
 
-	/**
-	 * Get all attributes from traits with suffix trait name $attribute[TraitName].
-	 *
-	 * @param string $attribute
-	 * @return array
-	 */
-	protected function getTraitAttributes(string $attribute)
-	{
-		$class = static::class;
-		$attributes = [];
-		foreach (class_uses_recursive($class) as $trait) {
-			if(property_exists($this, $attribute.class_basename($trait))) {
-				$attributes = array_merge($this->{$attribute.class_basename($trait)}, $attributes);
-			}
-		}
-		return $attributes;
-	}
+    /**
+     * Get all attributes from traits with suffix trait name $attribute[TraitName].
+     *
+     * @param string $attribute
+     * @return array
+     */
+    protected function getTraitAttributes(string $attribute)
+    {
+        $class = static::class;
+        $attributes = [];
+        foreach (class_uses_recursive($class) as $trait) {
+            if (property_exists($this, $attribute.class_basename($trait))) {
+                $attributes = array_merge($this->{$attribute.class_basename($trait)}, $attributes);
+            }
+        }
+
+        return $attributes;
+    }
 
     /**
      * Clone the model into a new, non-existing instance.

--- a/tests/Database/DatabaseEloquentPropertyTrait.php
+++ b/tests/Database/DatabaseEloquentPropertyTrait.php
@@ -1,0 +1,206 @@
+<?php
+
+
+namespace Database;
+
+use Carbon\Carbon;
+use Illuminate\Database\Eloquent\MassAssignmentException;
+use Illuminate\Database\QueryException;
+use PHPUnit\Framework\TestCase;
+use Illuminate\Database\Connection;
+use Illuminate\Pagination\Paginator;
+use Illuminate\Database\Query\Builder;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Database\Capsule\Manager as DB;
+use Illuminate\Database\Eloquent\Model as Eloquent;
+use Illuminate\Database\Eloquent\SoftDeletingScope;
+
+class DatabaseEloquentTraitProperties extends TestCase
+{
+	public function setUp ()
+	{
+		$db = new DB;
+
+		$db->addConnection([
+			'driver' => 'sqlite',
+			'database' => ':memory:',
+		]);
+
+		$db->bootEloquent();
+		$db->setAsGlobal();
+
+		$this->createSchema();
+	}
+
+	/**
+	 * Setup the database schema.
+	 *
+	 * @return void
+	 */
+	public function createSchema ()
+	{
+		$this->schema()->create('flights', function ($table) {
+			$table->increments('id');
+			$table->string('name');
+			$table->boolean('is_admin')->nullable();
+			$table->timestamps();
+			$table->softDeletes();
+		});
+	}
+
+	/**
+	 * Tear down the database schema.
+	 *
+	 * @return void
+	 */
+	public function tearDown()
+	{
+		$this->schema()->drop('flights');
+	}
+
+	/**
+	 * Tests...
+	 */
+	public function testNameCanBeFilled()
+	{
+		$flight = TestFlightsWithTraitFillable::create(['name' => 'Airline supreme 2000']);
+
+		$this->assertTrue($flight->wasRecentlyCreated);
+	}
+
+	public function testNameCannotBeFilled()
+	{
+		$this->expectException(MassAssignmentException::class);
+		TestFlightsWithoutTrait::create(['name' => 'Airline supreme 2000']);
+	}
+
+	public function testCanAppend()
+	{
+		$flight = TestFlightsWithTraitAppends::create(['name' => 'Airline supreme 2000']);
+
+		$this->assertArrayHasKey('active', $flight->toArray());
+	}
+
+	public function testCanHides()
+	{
+		$flight = TestFlightWithTraitHides::create(['name' => 'Airline supreme 2000']);
+
+		$this->assertArrayNotHasKey('name', $flight->toArray());
+	}
+
+	public function testCanGuard()
+	{
+		// As name is not nullable, we will get a query exception, because we are not totally guarded a
+		// mass assignment exception is not thrown.
+		$this->expectException(QueryException::class);
+		TestFlightWithTraitGuard::create(['name' => 'Airline supreme 2000']);
+	}
+
+	public function testCanCast()
+	{
+		$flight = TestFlightWithTraitCast::create(['name' => 'Airline supreme 2000', 'is_admin' => true]);
+
+		$this->assertTrue(TestFlightWithTraitCast::find($flight->id)->is_admin === true);
+	}
+
+	/**
+	 * Get a database connection instance.
+	 *
+	 * @return Connection
+	 */
+	protected function connection ()
+	{
+		return Eloquent::getConnectionResolver()->connection();
+	}
+
+	/**
+	 * Get a schema builder instance.
+	 *
+	 * @return \Illuminate\Database\Schema\Builder
+	 */
+	protected function schema ()
+	{
+		return $this->connection()->getSchemaBuilder();
+	}
+}
+
+/**
+ * Eloquent Models...
+ */
+class TestFlightsWithoutTrait extends Eloquent
+{
+	protected $table = 'flights';
+}
+
+class TestFlightsWithTraitFillable extends Eloquent
+{
+	use NameFillable;
+
+	protected $table = 'flights';
+}
+
+trait NameFillable
+{
+	public $fillableNameFillable = ['name'];
+}
+
+class TestFlightsWithTraitAppends extends Eloquent
+{
+	use AttributeAppends;
+
+	protected $guarded = [];
+
+	protected $table = 'flights';
+}
+
+trait AttributeAppends
+{
+	public $appendsAttributeAppends = ['active'];
+
+	public function getActiveAttribute()
+	{
+		return true;
+	}
+}
+
+class TestFlightWithTraitHides extends Eloquent
+{
+	use AttributeHides;
+
+	protected $guarded = [];
+
+	protected $table = 'flights';
+}
+
+trait AttributeHides
+{
+	public $hiddenAttributeHides = ['name'];
+}
+
+class TestFlightWithTraitGuard extends Eloquent
+{
+	use AttributeGuardName;
+
+	protected $guarded = [];
+
+	protected $table = 'flights';
+}
+
+trait AttributeGuardName
+{
+	protected $guardedAttributeGuardName = ['name'];
+}
+
+class TestFlightWithTraitCast extends Eloquent
+{
+	use AttributeCast;
+
+	protected $guarded = [];
+
+	protected $table = 'flights';
+}
+
+trait AttributeCast
+{
+	public $castsAttributeCast = ['is_admin' => 'boolean'];
+}

--- a/tests/Database/DatabaseEloquentPropertyTrait.php
+++ b/tests/Database/DatabaseEloquentPropertyTrait.php
@@ -1,127 +1,122 @@
 <?php
 
-
 namespace Database;
 
-use Carbon\Carbon;
-use Illuminate\Database\Eloquent\MassAssignmentException;
-use Illuminate\Database\QueryException;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Database\Connection;
-use Illuminate\Pagination\Paginator;
 use Illuminate\Database\Query\Builder;
-use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Database\QueryException;
 use Illuminate\Database\Capsule\Manager as DB;
 use Illuminate\Database\Eloquent\Model as Eloquent;
-use Illuminate\Database\Eloquent\SoftDeletingScope;
+use Illuminate\Database\Eloquent\MassAssignmentException;
 
 class DatabaseEloquentTraitProperties extends TestCase
 {
-	public function setUp ()
-	{
-		$db = new DB;
+    public function setUp()
+    {
+        $db = new DB;
 
-		$db->addConnection([
-			'driver' => 'sqlite',
-			'database' => ':memory:',
-		]);
+        $db->addConnection([
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+        ]);
 
-		$db->bootEloquent();
-		$db->setAsGlobal();
+        $db->bootEloquent();
+        $db->setAsGlobal();
 
-		$this->createSchema();
-	}
+        $this->createSchema();
+    }
 
-	/**
-	 * Setup the database schema.
-	 *
-	 * @return void
-	 */
-	public function createSchema ()
-	{
-		$this->schema()->create('flights', function ($table) {
-			$table->increments('id');
-			$table->string('name');
-			$table->boolean('is_admin')->nullable();
-			$table->timestamps();
-			$table->softDeletes();
-		});
-	}
+    /**
+     * Setup the database schema.
+     *
+     * @return void
+     */
+    public function createSchema()
+    {
+        $this->schema()->create('flights', function ($table) {
+            $table->increments('id');
+            $table->string('name');
+            $table->boolean('is_admin')->nullable();
+            $table->timestamps();
+            $table->softDeletes();
+        });
+    }
 
-	/**
-	 * Tear down the database schema.
-	 *
-	 * @return void
-	 */
-	public function tearDown()
-	{
-		$this->schema()->drop('flights');
-	}
+    /**
+     * Tear down the database schema.
+     *
+     * @return void
+     */
+    public function tearDown()
+    {
+        $this->schema()->drop('flights');
+    }
 
-	/**
-	 * Tests...
-	 */
-	public function testNameCanBeFilled()
-	{
-		$flight = TestFlightsWithTraitFillable::create(['name' => 'Airline supreme 2000']);
+    /**
+     * Tests...
+     */
+    public function testNameCanBeFilled()
+    {
+        $flight = TestFlightsWithTraitFillable::create(['name' => 'Airline supreme 2000']);
 
-		$this->assertTrue($flight->wasRecentlyCreated);
-	}
+        $this->assertTrue($flight->wasRecentlyCreated);
+    }
 
-	public function testNameCannotBeFilled()
-	{
-		$this->expectException(MassAssignmentException::class);
-		TestFlightsWithoutTrait::create(['name' => 'Airline supreme 2000']);
-	}
+    public function testNameCannotBeFilled()
+    {
+        $this->expectException(MassAssignmentException::class);
+        TestFlightsWithoutTrait::create(['name' => 'Airline supreme 2000']);
+    }
 
-	public function testCanAppend()
-	{
-		$flight = TestFlightsWithTraitAppends::create(['name' => 'Airline supreme 2000']);
+    public function testCanAppend()
+    {
+        $flight = TestFlightsWithTraitAppends::create(['name' => 'Airline supreme 2000']);
 
-		$this->assertArrayHasKey('active', $flight->toArray());
-	}
+        $this->assertArrayHasKey('active', $flight->toArray());
+    }
 
-	public function testCanHides()
-	{
-		$flight = TestFlightWithTraitHides::create(['name' => 'Airline supreme 2000']);
+    public function testCanHides()
+    {
+        $flight = TestFlightWithTraitHides::create(['name' => 'Airline supreme 2000']);
 
-		$this->assertArrayNotHasKey('name', $flight->toArray());
-	}
+        $this->assertArrayNotHasKey('name', $flight->toArray());
+    }
 
-	public function testCanGuard()
-	{
-		// As name is not nullable, we will get a query exception, because we are not totally guarded a
-		// mass assignment exception is not thrown.
-		$this->expectException(QueryException::class);
-		TestFlightWithTraitGuard::create(['name' => 'Airline supreme 2000']);
-	}
+    public function testCanGuard()
+    {
+        // As name is not nullable, we will get a query exception, because we are not totally guarded a
+        // mass assignment exception is not thrown.
+        $this->expectException(QueryException::class);
+        TestFlightWithTraitGuard::create(['name' => 'Airline supreme 2000']);
+    }
 
-	public function testCanCast()
-	{
-		$flight = TestFlightWithTraitCast::create(['name' => 'Airline supreme 2000', 'is_admin' => true]);
+    public function testCanCast()
+    {
+        $flight = TestFlightWithTraitCast::create(['name' => 'Airline supreme 2000', 'is_admin' => true]);
 
-		$this->assertTrue(TestFlightWithTraitCast::find($flight->id)->is_admin === true);
-	}
+        $this->assertTrue(TestFlightWithTraitCast::find($flight->id)->is_admin === true);
+    }
 
-	/**
-	 * Get a database connection instance.
-	 *
-	 * @return Connection
-	 */
-	protected function connection ()
-	{
-		return Eloquent::getConnectionResolver()->connection();
-	}
+    /**
+     * Get a database connection instance.
+     *
+     * @return Connection
+     */
+    protected function connection()
+    {
+        return Eloquent::getConnectionResolver()->connection();
+    }
 
-	/**
-	 * Get a schema builder instance.
-	 *
-	 * @return \Illuminate\Database\Schema\Builder
-	 */
-	protected function schema ()
-	{
-		return $this->connection()->getSchemaBuilder();
-	}
+    /**
+     * Get a schema builder instance.
+     *
+     * @return \Illuminate\Database\Schema\Builder
+     */
+    protected function schema()
+    {
+        return $this->connection()->getSchemaBuilder();
+    }
 }
 
 /**
@@ -129,78 +124,78 @@ class DatabaseEloquentTraitProperties extends TestCase
  */
 class TestFlightsWithoutTrait extends Eloquent
 {
-	protected $table = 'flights';
+    protected $table = 'flights';
 }
 
 class TestFlightsWithTraitFillable extends Eloquent
 {
-	use NameFillable;
+    use NameFillable;
 
-	protected $table = 'flights';
+    protected $table = 'flights';
 }
 
 trait NameFillable
 {
-	public $fillableNameFillable = ['name'];
+    public $fillableNameFillable = ['name'];
 }
 
 class TestFlightsWithTraitAppends extends Eloquent
 {
-	use AttributeAppends;
+    use AttributeAppends;
 
-	protected $guarded = [];
+    protected $guarded = [];
 
-	protected $table = 'flights';
+    protected $table = 'flights';
 }
 
 trait AttributeAppends
 {
-	public $appendsAttributeAppends = ['active'];
+    public $appendsAttributeAppends = ['active'];
 
-	public function getActiveAttribute()
-	{
-		return true;
-	}
+    public function getActiveAttribute()
+    {
+        return true;
+    }
 }
 
 class TestFlightWithTraitHides extends Eloquent
 {
-	use AttributeHides;
+    use AttributeHides;
 
-	protected $guarded = [];
+    protected $guarded = [];
 
-	protected $table = 'flights';
+    protected $table = 'flights';
 }
 
 trait AttributeHides
 {
-	public $hiddenAttributeHides = ['name'];
+    public $hiddenAttributeHides = ['name'];
 }
 
 class TestFlightWithTraitGuard extends Eloquent
 {
-	use AttributeGuardName;
+    use AttributeGuardName;
 
-	protected $guarded = [];
+    protected $guarded = [];
 
-	protected $table = 'flights';
+    protected $table = 'flights';
 }
 
 trait AttributeGuardName
 {
-	protected $guardedAttributeGuardName = ['name'];
+    protected $guardedAttributeGuardName = ['name'];
 }
 
 class TestFlightWithTraitCast extends Eloquent
 {
-	use AttributeCast;
+    use AttributeCast;
 
-	protected $guarded = [];
+    protected $guarded = [];
 
-	protected $table = 'flights';
+    protected $table = 'flights';
 }
 
 trait AttributeCast
 {
-	public $castsAttributeCast = ['is_admin' => 'boolean'];
+    public $castsAttributeCast = ['is_admin' => 'boolean'];
 }


### PR DESCRIPTION
**Feature (For Eloquent):**
Defining properties on traits.
This feature gives the possibility for defining (
- Fillable
- Guarded
- Appends
- Dates
- Casts
- Observables
- Touches
- Hidden
- Visible
On your traits with the same syntax as boot on traits. 
So you can write `$casts[traitName]` or with any of the other properties.

**Example:**
Lets say you have a lot of models which all have `agreement_id` which should be fillable.
Now you can create a trait and defining `$fillable[traitName]`. 
This will now give the power of not having to define `agreement_id` on all the models, but just defining it on the trait.

**Advantages:**
- Short simple syntax which is already used in Laravel Eloquent traits for boot.
- Saves a lot of duplications from models.