### PR TITLE
[5.4] Remove the `callable` type hint  for `array_sort`.

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -264,7 +264,7 @@ if (! function_exists('array_set')) {
 
 if (! function_exists('array_sort')) {
     /**
-     * Sort the array using the given callback or "dot" notation.
+     * Sort the array by the given callback or attribute name.
      *
      * @param  array  $array
      * @param  callable|string  $callback

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -264,13 +264,13 @@ if (! function_exists('array_set')) {
 
 if (! function_exists('array_sort')) {
     /**
-     * Sort the array using the given callback.
+     * Sort the array using the given callback or "dot" notation.
      *
      * @param  array  $array
-     * @param  callable  $callback
+     * @param  callable|string  $callback
      * @return array
      */
-    function array_sort($array, callable $callback)
+    function array_sort($array, $callback)
     {
         return Arr::sort($array, $callback);
     }


### PR DESCRIPTION
As `Arr::sort()` can accept a string, we should not force to use a `callable` here, and have to accept a string (with dot notation) too!