### PR TITLE
[5.4] Return the used traits from setUpTraits

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -92,7 +92,7 @@ abstract class TestCase extends BaseTestCase
     /**
      * Boot the testing helper traits.
      *
-     * @return void
+     * @return array
      */
     protected function setUpTraits()
     {
@@ -113,6 +113,8 @@ abstract class TestCase extends BaseTestCase
         if (isset($uses[WithoutEvents::class])) {
             $this->disableEventsForAllTests();
         }
+        
+        return $uses;
     }
 
     /**


### PR DESCRIPTION
Allows for the developer to add their own traits and actions during the setup phase without having to call: `$uses = array_flip(class_uses_recursive(static::class));` in the subclass.

Example usage before:
```
    protected function setUpTraits()
    {
        parent::setUpTraits();
        $uses = array_flip(class_uses_recursive(static::class));

        if(isset($uses[MyGreatTrait::class])) {
            $this->runMyUsefulThing();
        }
    }
```

Example usage with change from this pr:
```
    protected function setUpTraits()
    {
        $uses = parent::setUpTraits();

        if(isset($uses[MyGreatTrait::class])) {
            $this->runMyUsefulThing();
        }

        return $uses;
    }
```