### PR TITLE
Flip expected and actual value on assertCookie

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -161,7 +161,7 @@ class TestResponse
             ? app('encrypter')->decrypt($cookieValue) : $cookieValue;
 
         PHPUnit::assertEquals(
-            $actual, $value,
+            $value, $actual,
             "Cookie [{$cookieName}] was found, but value [{$actual}] does not match [{$value}]."
         );
 


### PR DESCRIPTION
Problem: 

Test:
```
    $response->assertCookie("somecookie", 'expected');
```
Controller:

```
Cookie::queue('somecookie', 'actual', $days);
```
phpunit
```
There was 1 failure:

1) Tests\Feature\CookiesTest::cookie_must_be_stored
Cookie [somecookie] was found, but value [actual] does not match [expected].
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'actual'
+'expected'

```

Solution:
Flip expected and actual values