### PR TITLE
[5.5] support milliseconds for date_format validation rule

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -358,7 +358,12 @@ trait ValidatesAttributes
             return false;
         }
 
-        $date = DateTime::createFromFormat($parameters[0], $value);
+        if (!preg_match('/v/', $parameters[0])) {
+            $date = DateTime::createFromFormat($parameters[0], $value);
+        } else {
+            $dateString = date($parameters[0], strtotime($value));
+            $date = new DateTime($dateString);
+        }
 
         return $date && $date->format($parameters[0]) == $value;
     }

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -358,12 +358,9 @@ trait ValidatesAttributes
             return false;
         }
 
-        if (!preg_match('/v/', $parameters[0])) {
-            $date = DateTime::createFromFormat($parameters[0], $value);
-        } else {
-            $dateString = date($parameters[0], strtotime($value));
-            $date = new DateTime($dateString);
-        }
+        $date = strpos($parameters[0], 'v') === false
+            ? DateTime::createFromFormat($parameters[0], $value)
+            : new DateTime(date($parameters[0], strtotime($value)));
 
         return $date && $date->format($parameters[0]) == $value;
     }

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -2282,6 +2282,9 @@ class ValidationValidatorTest extends TestCase
 
         $v = new Validator($trans, ['x' => '2000-01-01T00:00:00+00:30'], ['x' => 'date_format:Y-m-d\TH:i:sP']);
         $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => '2000-01-01 00:00:00.000'], ['x' => 'date_format:Y-m-d H:i:s.v']);
+        $this->assertTrue($v->passes(), 'Milliseconds date validation failed');
     }
 
     public function testBeforeAndAfter()


### PR DESCRIPTION
For issue https://github.com/laravel/framework/issues/19445.

The `v` character representing milliseconds was introduced in PHP 7 for the `date()` method and is currently not supported when calling `DateTime::createFromFormat()`. This provides a (hacky) work-around, so I'd appreciate any feedback on putting together a better solution.

I was unable to get this solely working using `date()` which failed to work where timezones were used in the date format specifically for characters `e`, `T`, `P` and in turn would fail on the respective unit tests. See further details on my last comment on the issue https://github.com/laravel/framework/issues/19445#issuecomment-306491065

I'm a newb to contributing so would appreciate it if you kept that in mind when providing feedback. Thank you!