### PR TITLE
[5.4] Allow to create relations without attributes

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -276,7 +276,7 @@ abstract class HasOneOrMany extends Relation
      * @param  array  $attributes
      * @return \Illuminate\Database\Eloquent\Model
      */
-    public function create(array $attributes)
+    public function create(array $attributes = [])
     {
         return tap($this->related->newInstance($attributes), function ($instance) {
             $instance->setAttribute($this->getForeignKeyName(), $this->getParentKey());

--- a/src/Illuminate/Database/Eloquent/Relations/MorphOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphOneOrMany.php
@@ -174,7 +174,7 @@ abstract class MorphOneOrMany extends HasOneOrMany
      * @param  array  $attributes
      * @return \Illuminate\Database\Eloquent\Model
      */
-    public function create(array $attributes)
+    public function create(array $attributes = [])
     {
         $instance = $this->related->newInstance($attributes);
 


### PR DESCRIPTION
I found it useful in [one of my packages](https://github.com/cybercog/laravel-ban#apply-ban-for-the-entity) where I need to create related record but all attributes are optional. Right now we need to bypass an empty array to the relation `create` method:

```php
$user->bans()->create([]);
```

With this change we will be able to omit attributes variable:

```php
$user->bans()->create();
```

By the way `create` method calls `Illuminate\Database\Eloquent::newInstance` which has default value for `$attributes` already:

```php
public function newInstance($attributes = [], $exists = false)
```