### PR TITLE
[5.4] Add @hasAnySections blade directive with test

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
@@ -16,6 +16,17 @@ trait CompilesConditionals
     }
 
     /**
+     * Compile the has-any-sections statements into valid PHP.
+     *
+     * @param  string  $expression
+     * @return string
+     */
+    protected function compileHasAnySections($expression)
+    {
+        return "<?php if (! empty(trim(implode('', array_map(function(\$section) use (\$__env) { return \$__env->yieldContent(\$section); }, {$expression}))))): ?>";
+    }
+
+    /**
      * Compile the if statements into valid PHP.
      *
      * @param  string  $expression

--- a/tests/View/Blade/BladeHasAnySectionsTest.php
+++ b/tests/View/Blade/BladeHasAnySectionsTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Illuminate\Tests\Blade;
+
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+use Illuminate\View\Compilers\BladeCompiler;
+
+class BladeHasAnySectionsTest extends TestCase
+{
+    public function tearDown()
+    {
+        m::close();
+    }
+
+    public function testHasAnySectionsStatementsAreCompiled()
+    {
+        $compiler = new BladeCompiler($this->getFiles(), __DIR__);
+        $string = '@hasAnySections(["section1", "section2"])
+breeze
+@endif';
+        $expected = '<?php if (! empty(trim(implode(\'\', array_map(function($section) use ($__env) { return $__env->yieldContent($section); }, (["section1", "section2"])))))): ?>
+breeze
+<?php endif; ?>';
+        $this->assertEquals($expected, $compiler->compileString($string));
+    }
+
+    protected function getFiles()
+    {
+        return m::mock('Illuminate\Filesystem\Filesystem');
+    }
+}


### PR DESCRIPTION
The @hasAnySections directive accepts an array of section names and
displays the enclosed html if any or all of the given sections are
present. This is useful for situations where boilerplate html is
required if any of a given number of sections are present in the view.

Example:

    @hasAnySections(['breadcrumbs', 'title'])
        <section class="title-bar">
            @yield('breadcrumbs')
            @yield('title')
        </section>
    @endif