### PR TITLE
[5.4] Fix PHP Notice (Undefined index) when collation not set

### DIFF
--- a/src/Illuminate/Database/Connectors/MySqlConnector.php
+++ b/src/Illuminate/Database/Connectors/MySqlConnector.php
@@ -65,7 +65,7 @@ class MySqlConnector extends Connector implements ConnectorInterface
      */
     protected function getCollation(array $config)
     {
-        return ! is_null($config['collation']) ? " collate '{$config['collation']}'" : '';
+        return isset($config['collation']) ? " collate '{$config['collation']}'" : '';
     }
 
     /**


### PR DESCRIPTION
Fix PHP Notice when `collation` not set in config/database.php