### PR TITLE
[5.4] Database load balancing

### DIFF
--- a/src/Illuminate/Database/Connectors/ConnectionFactory.php
+++ b/src/Illuminate/Database/Connectors/ConnectionFactory.php
@@ -138,6 +138,7 @@ class ConnectionFactory
     protected function getReadWriteConfig(array $config, $type)
     {
         $randomConfig = mt_rand(0, count($config[$type]) - 1);
+
         return isset($config[$type][0])
                         ? $config[$type][$randomConfig]
                         : $config[$type];

--- a/src/Illuminate/Database/Connectors/ConnectionFactory.php
+++ b/src/Illuminate/Database/Connectors/ConnectionFactory.php
@@ -137,7 +137,7 @@ class ConnectionFactory
      */
     protected function getReadWriteConfig(array $config, $type)
     {
-        $randomConfig = mt_rand(0, count($config[$type])-1);
+        $randomConfig = mt_rand(0, count($config[$type]) - 1);
         return isset($config[$type][0])
                         ? $config[$type][$randomConfig]
                         : $config[$type];

--- a/src/Illuminate/Database/Connectors/ConnectionFactory.php
+++ b/src/Illuminate/Database/Connectors/ConnectionFactory.php
@@ -137,8 +137,9 @@ class ConnectionFactory
      */
     protected function getReadWriteConfig(array $config, $type)
     {
+        $randomConfig = mt_rand(0, count($config[$type])-1);
         return isset($config[$type][0])
-                        ? $config[$type][array_rand($config[$type])]
+                        ? $config[$type][$randomConfig]
                         : $config[$type];
     }
 


### PR DESCRIPTION
It has to do with performance & better randomness as [PHP](http://php.net/manual/en/function.mt-rand.php) says. Yes! On the database "load-balancing" with two or more hosts it brings benefits (or I hope so).

> Many random number generators of older libcs have dubious or unknown characteristics and are slow. The mt_rand() function is a drop-in replacement for the older rand(). It uses a random number generator with known characteristics using the Mersenne Twister, which will produce random numbers four times faster than what the average libc rand() provides.

Thanks.