### PR TITLE
[5.4] Decode html entities in plain text email

### DIFF
--- a/src/Illuminate/Mail/Markdown.php
+++ b/src/Illuminate/Mail/Markdown.php
@@ -77,9 +77,13 @@ class Markdown
     {
         $this->view->flushFinderCache();
 
-        return new HtmlString(preg_replace("/[\r\n]{2,}/", "\n\n", $this->view->replaceNamespace(
+        $contents = $this->view->replaceNamespace(
             'mail', $this->markdownComponentPaths()
-        )->make($view, $data)->render()));
+        )->make($view, $data)->render();
+
+        return new HtmlString(
+            html_entity_decode(preg_replace("/[\r\n]{2,}/", "\n\n", $contents), ENT_QUOTES, 'UTF-8')
+        );
     }
 
     /**


### PR DESCRIPTION
Fixes https://github.com/laravel/framework/issues/19290. All it does is apply `html_entity_decode()` to decode the HTML entities that `e()` added.

XSS is unnecessary in plain text emails and the HTML entities impact the readability of the email.