### PR TITLE
[5.4] Allow callback for dispatch failure [discussion needed]

### DIFF
--- a/src/Illuminate/Contracts/Bus/Dispatcher.php
+++ b/src/Illuminate/Contracts/Bus/Dispatcher.php
@@ -2,24 +2,28 @@
 
 namespace Illuminate\Contracts\Bus;
 
+use Closure;
+
 interface Dispatcher
 {
     /**
      * Dispatch a command to its appropriate handler.
      *
-     * @param  mixed  $command
+     * @param  mixed $command
+     * @param Closure|null $errorCallback
      * @return mixed
      */
-    public function dispatch($command);
+    public function dispatch($command, Closure $errorCallback = null);
 
     /**
      * Dispatch a command to its appropriate handler in the current process.
      *
-     * @param  mixed  $command
-     * @param  mixed  $handler
+     * @param  mixed $command
+     * @param  mixed $handler
+     * @param Closure|null $errorCallback
      * @return mixed
      */
-    public function dispatchNow($command, $handler = null);
+    public function dispatchNow($command, $handler = null, Closure $errorCallback = null);
 
     /**
      * Set the pipes commands should be piped through before dispatching.


### PR DESCRIPTION
Use Case : 

We have an external worker using beanstalkd. Laravel sends a `dispatch` and fails and will report an error that we cant connect, which is good but there is a problem.

Lets say we create a new `Setting` and this setting effects something on an API outside your app, so we created a job.

```
public function createSetting() {

    $setting = Setting::create([
        'name' => 'should_report_errors',
        'value' => true
    ]);

    dispatch(new SendSettingToApp($setting))

    return response()->json($setting);
}

```

With the current code we would have to write our own try catch , to make sure we are dispatching , with my changes you can do it like this 

```
public function createSetting() {

    $setting = Setting::create([
        'name' => 'should_report_errors',
        'value' => true
    ]);

    dispatch(new SendSettingToApp($setting, function() use($setting) {
         $setting->delete();
        // or we can do  DB::rollBack(); , as long as we start the transcations 
    }))

    return response()->json($setting);
}

```

I do not think this is the best method , so I would like to have a good discussion on how we should handle this within the framework.