### PR TITLE
[5.5] Model serialization on custom connection

### DIFF
--- a/src/Illuminate/Contracts/Database/ModelIdentifier.php
+++ b/src/Illuminate/Contracts/Database/ModelIdentifier.php
@@ -12,6 +12,13 @@ class ModelIdentifier
     public $class;
 
     /**
+     * The connection name of the model.
+     *
+     * @var string|null
+     */
+    public $connection;
+
+    /**
      * The unique identifier of the model.
      *
      * This may be either a single ID or an array of IDs.
@@ -24,12 +31,14 @@ class ModelIdentifier
      * Create a new model identifier.
      *
      * @param  string  $class
+     * @param  mixed  $connection
      * @param  mixed  $id
      * @return void
      */
-    public function __construct($class, $id)
+    public function __construct($class, $connection, $id)
     {
         $this->id = $id;
+        $this->connection = $connection;
         $this->class = $class;
     }
 }

--- a/src/Illuminate/Contracts/Queue/QueueableCollection.php
+++ b/src/Illuminate/Contracts/Queue/QueueableCollection.php
@@ -12,6 +12,13 @@ interface QueueableCollection
     public function getQueueableClass();
 
     /**
+     * Get the connection of the entities being queued.
+     *
+     * @return string|null
+     */
+    public function getQueueableConnection();
+
+    /**
      * Get the identifiers for all of the entities.
      *
      * @return array

--- a/src/Illuminate/Contracts/Queue/QueueableEntity.php
+++ b/src/Illuminate/Contracts/Queue/QueueableEntity.php
@@ -10,4 +10,11 @@ interface QueueableEntity
      * @return mixed
      */
     public function getQueueableId();
+
+    /**
+     * Get the connection of the entity.
+     *
+     * @return string|null
+     */
+    public function getQueueableConnection();
 }

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -358,6 +358,28 @@ class Collection extends BaseCollection implements QueueableCollection
     }
 
     /**
+     * Get the connection of the entities being queued.
+     *
+     * @return string|null
+     */
+    public function getQueueableConnection()
+    {
+        if ($this->count() === 0) {
+            return;
+        }
+
+        $connection = $this->first()->getConnectionName();
+
+        $this->each(function ($model) use ($connection) {
+            if ($model->getConnectionName() !== $connection) {
+                throw new LogicException('Queueing collections with multiple model connections is not supported.');
+            }
+        });
+
+        return $connection;
+    }
+
+    /**
      * Get the identifiers for all of the entities.
      *
      * @return array

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1200,6 +1200,16 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     }
 
     /**
+     * Get the queueable identity for the entity.
+     *
+     * @return mixed
+     */
+    public function getQueueableConnection()
+    {
+        return $this->getConnectionName();
+    }
+
+    /**
      * Get the value of the model's route key.
      *
      * @return mixed

--- a/src/Illuminate/Queue/SerializesAndRestoresModelIdentifiers.php
+++ b/src/Illuminate/Queue/SerializesAndRestoresModelIdentifiers.php
@@ -18,11 +18,11 @@ trait SerializesAndRestoresModelIdentifiers
     protected function getSerializedPropertyValue($value)
     {
         if ($value instanceof QueueableCollection) {
-            return new ModelIdentifier($value->getQueueableClass(), $value->getQueueableIds());
+            return new ModelIdentifier($value->getQueueableClass(), $value->getQueueableConnection(), $value->getQueueableIds());
         }
 
         if ($value instanceof QueueableEntity) {
-            return new ModelIdentifier(get_class($value), $value->getQueueableId());
+            return new ModelIdentifier(get_class($value), $value->getQueueableConnection(), $value->getQueueableId());
         }
 
         return $value;
@@ -42,8 +42,8 @@ trait SerializesAndRestoresModelIdentifiers
 
         return is_array($value->id)
                 ? $this->restoreCollection($value)
-                : $this->getQueryForModelRestoration(new $value->class)
-                            ->useWritePdo()->findOrFail($value->id);
+                : $this->getQueryForModelRestoration((new $value->class)->setConnection($value->connection))
+                    ->useWritePdo()->findOrFail($value->id);
     }
 
     /**
@@ -58,7 +58,7 @@ trait SerializesAndRestoresModelIdentifiers
             return new EloquentCollection;
         }
 
-        $model = new $value->class;
+        $model = (new $value->class)->setConnection($value->connection);
 
         return $this->getQueryForModelRestoration($model)->useWritePdo()
                     ->whereIn($model->getQualifiedKeyName(), $value->id)->get();

--- a/tests/Integration/Queue/ModelSerializationTest.php
+++ b/tests/Integration/Queue/ModelSerializationTest.php
@@ -140,7 +140,6 @@ class ModelSerializationTestClass
 
     public function __construct($user)
     {
-
         $this->user = $user;
     }
 }

--- a/tests/Integration/Queue/ModelSerializationTest.php
+++ b/tests/Integration/Queue/ModelSerializationTest.php
@@ -1,12 +1,7 @@
 <?php
 
-use Illuminate\Bus\Queueable;
-use Illuminate\Database\Eloquent\Model;
 use Orchestra\Testbench\TestCase;
-use Illuminate\Support\Facades\Queue;
-use Illuminate\Queue\InteractsWithQueue;
-use Illuminate\Contracts\Queue\ShouldQueue;
-use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Database\Eloquent\Model;
 
 /**
  * @group integration
@@ -53,11 +48,11 @@ class ModelSerializationTest extends TestCase
     public function it_serialize_user_on_default_connection()
     {
         $user = ModelSerializationTestUser::create([
-            'email' => 'mohamed@laravel.com'
+            'email' => 'mohamed@laravel.com',
         ]);
 
-        $user2 =ModelSerializationTestUser::create([
-            'email' => 'taylor@laravel.com'
+        $user2 = ModelSerializationTestUser::create([
+            'email' => 'taylor@laravel.com',
         ]);
 
         $serialized = serialize(new ModelSerializationTestClass($user));
@@ -83,11 +78,11 @@ class ModelSerializationTest extends TestCase
     public function it_serialize_user_on_different_connection()
     {
         $user = ModelSerializationTestUser::on('custom')->create([
-            'email' => 'mohamed@laravel.com'
+            'email' => 'mohamed@laravel.com',
         ]);
 
-        $user2 =ModelSerializationTestUser::on('custom')->create([
-            'email' => 'taylor@laravel.com'
+        $user2 = ModelSerializationTestUser::on('custom')->create([
+            'email' => 'taylor@laravel.com',
         ]);
 
         $serialized = serialize(new ModelSerializationTestClass($user));
@@ -115,11 +110,11 @@ class ModelSerializationTest extends TestCase
     public function it_fails_if_models_on_multi_connections()
     {
         $user = ModelSerializationTestUser::on('custom')->create([
-            'email' => 'mohamed@laravel.com'
+            'email' => 'mohamed@laravel.com',
         ]);
 
-        $user2 =ModelSerializationTestUser::create([
-            'email' => 'taylor@laravel.com'
+        $user2 = ModelSerializationTestUser::create([
+            'email' => 'taylor@laravel.com',
         ]);
 
         $serialized = serialize(new ModelSerializationTestClass(
@@ -137,12 +132,14 @@ class ModelSerializationTestUser extends Model
     public $timestamps = false;
 }
 
-class ModelSerializationTestClass{
+class ModelSerializationTestClass
+{
     use \Illuminate\Queue\SerializesModels;
 
     public $user;
 
-    public function __construct($user){
+    public function __construct($user)
+    {
 
         $this->user = $user;
     }

--- a/tests/Integration/Queue/ModelSerializationTest.php
+++ b/tests/Integration/Queue/ModelSerializationTest.php
@@ -1,0 +1,149 @@
+<?php
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Database\Eloquent\Model;
+use Orchestra\Testbench\TestCase;
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+
+/**
+ * @group integration
+ */
+class ModelSerializationTest extends TestCase
+{
+    protected function getEnvironmentSetUp($app)
+    {
+        $app['config']->set('app.debug', 'true');
+
+        $app['config']->set('database.default', 'testbench');
+
+        $app['config']->set('database.connections.testbench', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+        ]);
+
+        $app['config']->set('database.connections.custom', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+        ]);
+    }
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        Schema::create('users', function ($table) {
+            $table->increments('id');
+            $table->string('email');
+        });
+
+        Schema::connection('custom')->create('users', function ($table) {
+            $table->increments('id');
+            $table->string('email');
+        });
+    }
+
+    /**
+     * @test
+     */
+    public function it_serialize_user_on_default_connection()
+    {
+        $user = ModelSerializationTestUser::create([
+            'email' => 'mohamed@laravel.com'
+        ]);
+
+        $user2 =ModelSerializationTestUser::create([
+            'email' => 'taylor@laravel.com'
+        ]);
+
+        $serialized = serialize(new ModelSerializationTestClass($user));
+
+        $unSerialized = unserialize($serialized);
+
+        $this->assertEquals('testbench', $unSerialized->user->getConnectionName());
+        $this->assertEquals('mohamed@laravel.com', $unSerialized->user->email);
+
+        $serialized = serialize(new ModelSerializationTestClass(ModelSerializationTestUser::on('testbench')->get()));
+
+        $unSerialized = unserialize($serialized);
+
+        $this->assertEquals('testbench', $unSerialized->user[0]->getConnectionName());
+        $this->assertEquals('mohamed@laravel.com', $unSerialized->user[0]->email);
+        $this->assertEquals('testbench', $unSerialized->user[1]->getConnectionName());
+        $this->assertEquals('taylor@laravel.com', $unSerialized->user[1]->email);
+    }
+
+    /**
+     * @test
+     */
+    public function it_serialize_user_on_different_connection()
+    {
+        $user = ModelSerializationTestUser::on('custom')->create([
+            'email' => 'mohamed@laravel.com'
+        ]);
+
+        $user2 =ModelSerializationTestUser::on('custom')->create([
+            'email' => 'taylor@laravel.com'
+        ]);
+
+        $serialized = serialize(new ModelSerializationTestClass($user));
+
+        $unSerialized = unserialize($serialized);
+
+        $this->assertEquals('custom', $unSerialized->user->getConnectionName());
+        $this->assertEquals('mohamed@laravel.com', $unSerialized->user->email);
+
+        $serialized = serialize(new ModelSerializationTestClass(ModelSerializationTestUser::on('custom')->get()));
+
+        $unSerialized = unserialize($serialized);
+
+        $this->assertEquals('custom', $unSerialized->user[0]->getConnectionName());
+        $this->assertEquals('mohamed@laravel.com', $unSerialized->user[0]->email);
+        $this->assertEquals('custom', $unSerialized->user[1]->getConnectionName());
+        $this->assertEquals('taylor@laravel.com', $unSerialized->user[1]->email);
+    }
+
+    /**
+     * @test
+     * @expectedException LogicException
+     * @expectedExceptionMessage  Queueing collections with multiple model connections is not supported.
+     */
+    public function it_fails_if_models_on_multi_connections()
+    {
+        $user = ModelSerializationTestUser::on('custom')->create([
+            'email' => 'mohamed@laravel.com'
+        ]);
+
+        $user2 =ModelSerializationTestUser::create([
+            'email' => 'taylor@laravel.com'
+        ]);
+
+        $serialized = serialize(new ModelSerializationTestClass(
+            new \Illuminate\Database\Eloquent\Collection([$user, $user2])
+        ));
+
+        unserialize($serialized);
+    }
+}
+
+class ModelSerializationTestUser extends Model
+{
+    public $table = 'users';
+    public $guarded = ['id'];
+    public $timestamps = false;
+}
+
+class ModelSerializationTestClass{
+    use \Illuminate\Queue\SerializesModels;
+
+    public $user;
+
+    public function __construct($user){
+
+        $this->user = $user;
+    }
+}

--- a/tests/Queue/QueueSyncQueueTest.php
+++ b/tests/Queue/QueueSyncQueueTest.php
@@ -56,6 +56,11 @@ class SyncQueueTestEntity implements \Illuminate\Contracts\Queue\QueueableEntity
     {
         return 1;
     }
+
+    public function getQueueableConnection()
+    {
+        return null;
+    }
 }
 
 class SyncQueueTestHandler


### PR DESCRIPTION
Currently while we retrieve model instances from ModelIdentifier after unserialization we use the default connection, so currently if you have a queued job that has reference to models on a non-default connection the ModelIdentifier will try to bring models from the **default** connection causing wrong behaviour.

This PR adds a reference to the connection used inside ModelIdentifier to help retrieving models from the right connection in the future.