### PR TITLE
[5.1] Make testing traits work with PHPUnit correctly.

### DIFF
--- a/src/Illuminate/Foundation/Testing/DatabaseMigrations.php
+++ b/src/Illuminate/Foundation/Testing/DatabaseMigrations.php
@@ -4,9 +4,6 @@ namespace Illuminate\Foundation\Testing;
 
 trait DatabaseMigrations
 {
-    /**
-     * @before
-     */
     public function runDatabaseMigrations()
     {
         $this->artisan('migrate');

--- a/src/Illuminate/Foundation/Testing/DatabaseTransactions.php
+++ b/src/Illuminate/Foundation/Testing/DatabaseTransactions.php
@@ -4,9 +4,6 @@ namespace Illuminate\Foundation\Testing;
 
 trait DatabaseTransactions
 {
-    /**
-     * @before
-     */
     public function beginDatabaseTransaction()
     {
         $this->app->make('db')->beginTransaction();

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -35,6 +35,8 @@ abstract class TestCase extends PHPUnit_Framework_TestCase
         if (! $this->app) {
             $this->refreshApplication();
         }
+
+        $this->setUpTraits();
     }
 
     /**
@@ -60,6 +62,28 @@ abstract class TestCase extends PHPUnit_Framework_TestCase
 
         if (class_exists('Mockery')) {
             Mockery::close();
+        }
+    }
+
+    /**
+     * Boot the testing helper traits.
+     *
+     * @return void
+     */
+    protected function setUpTraits()
+    {
+        $uses = array_flip(class_uses_recursive(get_class($this)));
+        if (isset($uses[DatabaseTransactions::class])) {
+            $this->beginDatabaseTransaction();
+        }
+        if (isset($uses[DatabaseMigrations::class])) {
+            $this->runDatabaseMigrations();
+        }
+        if (isset($uses[WithoutMiddleware::class])) {
+            $this->disableMiddlewareForAllTests();
+        }
+        if (isset($uses[WithoutEvents::class])) {
+            $this->disableEventsForAllTests();
         }
     }
 

--- a/src/Illuminate/Foundation/Testing/WithoutEvents.php
+++ b/src/Illuminate/Foundation/Testing/WithoutEvents.php
@@ -6,9 +6,6 @@ use Exception;
 
 trait WithoutEvents
 {
-    /**
-     * @before
-     */
     public function disableEventsForAllTests()
     {
         if (method_exists($this, 'withoutEvents')) {

--- a/src/Illuminate/Foundation/Testing/WithoutMiddleware.php
+++ b/src/Illuminate/Foundation/Testing/WithoutMiddleware.php
@@ -6,9 +6,6 @@ use Exception;
 
 trait WithoutMiddleware
 {
-    /**
-     * @before
-     */
     public function disableMiddlewareForAllTests()
     {
         if (method_exists($this, 'withoutMiddleware')) {


### PR DESCRIPTION
When testing with PHPUnit in Laravel 5.1 the testing traits `DatabaseTransactions` and `DatabaseMigrations` aren't triggered until _after_ the setup method. Thus, using them for testing database interaction does not work correctly.

This issue has been fixed in later versions of Laravel, but not 5.1. 
https://github.com/laravel/framework/commit/231213d5f8ef9779e25af61dcedea0a0984b3cf9

This fix makes sure, the traits are triggered before any test and setups run.

