### PR TITLE
[5.4] nextDue for Schedule Event

### DIFF
--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -3,9 +3,9 @@
 namespace Illuminate\Console\Scheduling;
 
 use Closure;
+use DateTime;
 use Carbon\Carbon;
 use Cron\CronExpression;
-use DateTime;
 use GuzzleHttp\Client as HttpClient;
 use Illuminate\Contracts\Mail\Mailer;
 use Symfony\Component\Process\Process;
@@ -662,6 +662,4 @@ class Event
 
         return Carbon::instance($nextDue);
     }
-
-
 }

--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -5,6 +5,7 @@ namespace Illuminate\Console\Scheduling;
 use Closure;
 use Carbon\Carbon;
 use Cron\CronExpression;
+use DateTime;
 use GuzzleHttp\Client as HttpClient;
 use Illuminate\Contracts\Mail\Mailer;
 use Symfony\Component\Process\Process;
@@ -645,4 +646,22 @@ class Event
 
         return $this;
     }
+
+    /**
+     * Determine next due date for Event.
+     * @param DateTime|string $currentTime Relative calculation date
+     * @param int $nth Number of matches to skip before returning a matching next run date
+     * @param bool $allowCurrentDate Return the current date if it matches the cron expression.
+     * @return Carbon
+     */
+    public function nextDue($currentTime = 'now', $nth = 0, $allowCurrentDate = false)
+    {
+        $nextDue = CronExpression::factory(
+            $this->getExpression()
+        )->getNextRunDate($currentTime, $nth, $allowCurrentDate);
+
+        return Carbon::instance($nextDue);
+    }
+
+
 }

--- a/tests/Console/Scheduling/EventTest.php
+++ b/tests/Console/Scheduling/EventTest.php
@@ -55,4 +55,12 @@ class EventTest extends TestCase
         $event->appendOutputTo('/dev/null');
         $this->assertSame("php -i >> {$quote}/dev/null{$quote} 2>&1", $event->buildCommand());
     }
+
+    public function testNextDue()
+    {
+        $event = new Event(m::mock('Illuminate\Console\Scheduling\Mutex'), 'php -i');
+        $event->dailyAt("10:15");
+
+        $this->assertSame("10:15:00", $event->nextDue()->toTimeString());
+    }
 }

--- a/tests/Console/Scheduling/EventTest.php
+++ b/tests/Console/Scheduling/EventTest.php
@@ -59,8 +59,8 @@ class EventTest extends TestCase
     public function testNextDue()
     {
         $event = new Event(m::mock('Illuminate\Console\Scheduling\Mutex'), 'php -i');
-        $event->dailyAt("10:15");
+        $event->dailyAt('10:15');
 
-        $this->assertSame("10:15:00", $event->nextDue()->toTimeString());
+        $this->assertSame('10:15:00', $event->nextDue()->toTimeString());
     }
 }


### PR DESCRIPTION
Added a wrapper that allows find out when the next Carbon time Event will run.
For example this allows you to list events and their next run time in schedule method for debug:

```php
protected function schedule(Schedule $schedule)
{
    $schedule->command('inspire')->yearly()->name("Inspire");

    foreach ($schedule->events() as $event) {
        echo $event->description . " will run next time at " . $event->nextDue()->toDateTimeString() . "\n";
    }
}
```