### PR TITLE
Refresh updated_at timestamp on soft delete

### DIFF
--- a/src/Illuminate/Database/Eloquent/SoftDeletes.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletes.php
@@ -60,9 +60,15 @@ trait SoftDeletes
     {
         $query = $this->newQueryWithoutScopes()->where($this->getKeyName(), $this->getKey());
 
-        $this->{$this->getDeletedAtColumn()} = $time = $this->freshTimestamp();
+        $time = $this->freshTimestamp();
 
-        $query->update([$this->getDeletedAtColumn() => $this->fromDateTime($time)]);
+        $this->{$this->getDeletedAtColumn()} = $time;
+        $this->{$this->getUpdatedAtColumn()} = $time;
+
+        $query->update([
+            $this->getDeletedAtColumn() => $this->fromDateTime($time),
+            $this->getUpdatedAtColumn() => $this->fromDateTime($time)
+        ]);
     }
 
     /**

--- a/tests/Database/DatabaseSoftDeletingTraitTest.php
+++ b/tests/Database/DatabaseSoftDeletingTraitTest.php
@@ -19,7 +19,10 @@ class DatabaseSoftDeletingTraitTest extends TestCase
         // $model->shouldReceive('newQuery')->andReturn($query = m::mock('StdClass'));
         $model->shouldReceive('newQueryWithoutScopes')->andReturn($query = m::mock('StdClass'));
         $query->shouldReceive('where')->once()->with('id', 1)->andReturn($query);
-        $query->shouldReceive('update')->once()->with(['deleted_at' => 'date-time']);
+        $query->shouldReceive('update')->once()->with([
+            'deleted_at' => 'date-time',
+            'updated_at' => 'date-time'
+        ]);
         $model->delete();
 
         $this->assertInstanceOf('Carbon\Carbon', $model->deleted_at);
@@ -53,6 +56,7 @@ class DatabaseSoftDeletingTraitStub
 {
     use \Illuminate\Database\Eloquent\SoftDeletes;
     public $deleted_at;
+    public $updated_at;
 
     public function newQuery()
     {
@@ -92,5 +96,10 @@ class DatabaseSoftDeletingTraitStub
     public function fromDateTime()
     {
         return 'date-time';
+    }
+
+    public function getUpdatedAtColumn()
+    {
+        return defined('static::UPDATED_AT') ? static::UPDATED_AT : 'updated_at';
     }
 }


### PR DESCRIPTION
For issue https://github.com/laravel/framework/issues/19529

Performing a soft delete updates the `updated_at` timestamp in the database but not on the model. Assumed the fix would be in line with the desired behaviour?

The changes to `SoftDeletes` makes the `testDeleteSetsSoftDeletedColumn` method on `DatabaseSoftDeletingTraitTest` fail, have written the code to get it passing again, but unsure if my thinking is in the right direction for the test.

Would appreciate any feedback as still pretty new to contributing. Thanks!