### PR TITLE
Add formatted var_dump to blade

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -84,6 +84,13 @@ class BladeCompiler extends Compiler implements CompilerInterface
     protected $echoFormat = 'e(%s)';
 
     /**
+     * Array of opening and closing tags for var_dump echos.
+     *
+     * @var string
+     */
+    protected $vardumpTags = ['{##', '##}'];
+
+    /**
      * Array of footer lines to be added to template.
      *
      * @var array

--- a/src/Illuminate/View/Compilers/Concerns/CompilesEchos.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesEchos.php
@@ -30,6 +30,7 @@ trait CompilesEchos
             'compileRawEchos',
             'compileEscapedEchos',
             'compileRegularEchos',
+            'compileVardumpEcho'
         ];
     }
 
@@ -87,6 +88,24 @@ trait CompilesEchos
             $whitespace = empty($matches[3]) ? '' : $matches[3].$matches[3];
 
             return $matches[1] ? $matches[0] : "<?php echo e({$this->compileEchoDefaults($matches[2])}); ?>{$whitespace}";
+        };
+
+        return preg_replace_callback($pattern, $callback, $value);
+    }
+
+    /**
+     * Compile the "var_dump function with <pre/> tag for format output " echo statements.
+     *
+     * @param  string $value
+     * @return string
+     */
+    protected function compileVardumpEcho($value)
+    {
+        $pattern = sprintf('/(@)?%s\s*(.+?)\s*%s(\r?\n)?/s', $this->vardumpTags[0], $this->vardumpTags[1]);
+        $callback = function ($matches) {
+            $whitespace = empty($matches[3]) ? '' : $matches[3] . $matches[3];
+
+            return $matches[1] ? substr($matches[0], 1) : "<?php echo '<pre>', var_dump({$this->compileEchoDefaults($matches[2])}), '</pre>' ; ?>{$whitespace}";
         };
 
         return preg_replace_callback($pattern, $callback, $value);

--- a/tests/View/Blade/BladeEchoTest.php
+++ b/tests/View/Blade/BladeEchoTest.php
@@ -83,6 +83,15 @@ class BladeEchoTest extends TestCase
             $compiler->compileString('{{ myfunc("foo or bar") }}'));
         $this->assertEquals('<?php echo e(myfunc("$name or \'foo\'")); ?>',
             $compiler->compileString('{{ myfunc("$name or \'foo\'") }}'));
+
+        $this->assertEquals('<?php echo \'<pre>\', var_dump($name), \'</pre>\' ; ?>', $compiler->compileString('{##$name##}'));
+        $this->assertEquals('<?php echo \'<pre>\', var_dump($name), \'</pre>\' ; ?>', $compiler->compileString('{## $name ##}'));
+        $this->assertEquals('<?php echo \'<pre>\', var_dump($name), \'</pre>\' ; ?>', $compiler->compileString('{##
+            $name
+        ##}'));
+        $this->assertEquals('<?php echo \'<pre>\', var_dump(isset($name) ? $name : \'foo\'), \'</pre>\' ; ?>',
+            $compiler->compileString('{## $name or \'foo\' ##}'));
+
     }
 
     public function testEscapedWithAtEchosAreCompiled()


### PR DESCRIPTION
some developers using var_dump() so if we add this shortcut will be easy for them 
`{## $var ##}`
instead of 
`{!! '<pre>'.var_dump($var).'</pre>' !!}`