### PR TITLE
[5.4] Fix typo in InteractsWithAuthentication hasCredentials doc block

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithAuthentication.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithAuthentication.php
@@ -128,7 +128,7 @@ trait InteractsWithAuthentication
     }
 
     /**
-     * Return true is the credentials are valid, false otherwise.
+     * Return true if the credentials are valid, false otherwise.
      *
      * @param  array  $credentials
      * @param  string|null  $guard


### PR DESCRIPTION
the doc block for hasCredentials in InteractsWithAuthentication, currently states:
> Return true **is** the credentials are valid, false otherwise.

should state:
> Return true **if** the credentials are valid, false otherwise.