### PR TITLE
Event return type

### DIFF
--- a/src/Illuminate/Console/Scheduling/Schedule.php
+++ b/src/Illuminate/Console/Scheduling/Schedule.php
@@ -11,7 +11,7 @@ class Schedule
     /**
      * All of the events on the schedule.
      *
-     * @var array
+     * @var \Illuminate\Console\Scheduling\Event[]
      */
     protected $events = [];
 
@@ -136,7 +136,7 @@ class Schedule
     /**
      * Get all of the events on the schedule.
      *
-     * @return array
+     * @return \Illuminate\Console\Scheduling\Event[]
      */
     public function events()
     {


### PR DESCRIPTION
Added type to events array. It allows IDE complete methods when we use it in `foreach`

```php
foreach($this->events() as $event) {
   $event->dailyAt("10:40");
}
```
As far as I can find events array contains only Event or CallbackEvent which is inheritor of Event.