### PR TITLE
[5.4] first_case() support helper

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -97,7 +97,7 @@ class Str
             $letters .= static::substr($word, 0, 1);
         }
 
-        return $upperCase ? static:upper($letters) : $letters;
+        return $upperCase ? static::upper($letters) : $letters;
     }
 
     /**

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -88,7 +88,7 @@ class Str
      * @param  bool $upperCase
      * @return string
      */
-    function first($value, $upperCase = false)
+    public static function first($value, $upperCase = false)
     {
         $letters  = '';
         $value    = (string) preg_replace(['/[!@#$%^&*\/]/', '/\s+/'], ['', ' '], trim($value));

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -82,6 +82,25 @@ class Str
     }
 
     /**
+     * It only takes first letter of the words in a sentence
+     *
+     * @param  string  $sentence
+     * @param  bool
+     * @return string
+     */
+    function first($value, $upperCase = false): string
+    {
+        $letters  = '';
+        $value    = (string) preg_replace('/\s+/', ' ', trim($value));
+
+        foreach(explode(' ', $value) as $word) {
+            $letters .= static::substr($word, 0, 1);
+        }
+
+        return $upperCase ? static:upper($letters) : $letters;
+    }
+
+    /**
      * Determine if a given string contains a given substring.
      *
      * @param  string  $haystack

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -84,8 +84,8 @@ class Str
     /**
      * It only takes first letter of the words in a sentence
      *
-     * @param  string  $sentence
-     * @param  bool
+     * @param  string  $value
+     * @param  bool $upperCase
      * @return string
      */
     function first($value, $upperCase = false)

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -82,7 +82,7 @@ class Str
     }
 
     /**
-     * It only takes first letter of the words in a sentence
+     * It only takes first letter of the words in a sentence.
      *
      * @param  string  $value
      * @param  bool $upperCase
@@ -90,8 +90,8 @@ class Str
      */
     public static function first($value, $upperCase = false)
     {
-        $letters  = '';
-        $value    = (string) preg_replace(['/[!@#$%^&*\/]/', '/\s+/'], ['', ' '], trim($value));
+        $letters = '';
+        $value = (string) preg_replace(['/[!@#$%^&*\/]/', '/\s+/'], ['', ' '], trim($value));
 
         foreach(explode(' ', $value) as $word) {
             $letters .= static::substr($word, 0, 1);

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -93,7 +93,7 @@ class Str
         $letters = '';
         $value = (string) preg_replace(['/[!@#$%^&*\/]/', '/\s+/'], ['', ' '], trim($value));
 
-        foreach(explode(' ', $value) as $word) {
+        foreach (explode(' ', $value) as $word) {
             $letters .= static::substr($word, 0, 1);
         }
 

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -91,7 +91,7 @@ class Str
     function first($value, $upperCase = false)
     {
         $letters  = '';
-        $value    = (string) preg_replace('/\s+/', ' ', trim($value));
+        $value    = (string) preg_replace(['/[!@#$%^&*\/]/', '/\s+/'], ['', ' '], trim($value));
 
         foreach(explode(' ', $value) as $word) {
             $letters .= static::substr($word, 0, 1);

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -88,7 +88,7 @@ class Str
      * @param  bool
      * @return string
      */
-    function first($value, $upperCase = false): string
+    function first($value, $upperCase = false)
     {
         $letters  = '';
         $value    = (string) preg_replace('/\s+/', ' ', trim($value));

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -329,6 +329,20 @@ if (! function_exists('camel_case')) {
     }
 }
 
+if (! function_exists('first_case')) {
+    /**
+     * It only takes first letter of the words in a sentence
+     *
+     * @param  string  $sentence
+     * @param  bool
+     * @return string
+     */
+    function first_case($value)
+    {
+        return Str::first($value);
+    }
+}
+
 if (! function_exists('class_basename')) {
     /**
      * Get the class "basename" of the given object / class.

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -333,13 +333,13 @@ if (! function_exists('first_case')) {
     /**
      * It only takes first letter of the words in a sentence
      *
-     * @param  string  $sentence
-     * @param  bool
+     * @param  string  $value
+     * @param  bool $upperCase
      * @return string
      */
-    function first_case($value)
+    function first_case($value, $upperCase = false)
     {
-        return Str::first($value);
+        return Str::first($value, $upperCase);
     }
 }
 

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -331,7 +331,7 @@ if (! function_exists('camel_case')) {
 
 if (! function_exists('first_case')) {
     /**
-     * It only takes first letter of the words in a sentence
+     * It only takes first letter of the words in a sentence.
      *
      * @param  string  $value
      * @param  bool $upperCase

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -230,6 +230,16 @@ class SupportStrTest extends TestCase
         $this->assertEquals('laravelPhpFramework', Str::camel('Laravel  -_-  php   -_-   framework   '));
     }
 
+    public function testFirst()
+    {
+        $this->assertEquals('lpf', Str::first('laravel php framework'));
+        $this->assertEquals('LPF', Str::first('laravel php framework', true));
+        $this->assertEquals('LPF', Str::first('Laravel PHP Framework'));
+        $this->assertEquals('LPf', Str::first('Laravel,       PHP  framework '));
+        $this->assertEquals('LPf', Str::first("Laravel,   \n    PHP  framework "));
+        $this->assertEquals('LPf', Str::first("Laravel,   \t    PHP  framework "));
+    }
+
     public function testSubstr()
     {
         $this->assertEquals('Ё', Str::substr('БГДЖИЛЁ', -1));


### PR DESCRIPTION
It only takes first letter of the words in a sentence. This will be usefull helper when you generate coupon code or product code from a category name. 

Example:

```php
first_case('Progressive Web Apps'); // PWA

first_case('Toys & Games') // TG

first_case('Uniforms, Work & Safety') // UWS

first_case('Handbags & Wallets') // HW
```