### PR TITLE
[5.4] Add helper function 'me()' as an alias for 'auth()->user()'

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -502,6 +502,18 @@ if (! function_exists('logger')) {
     }
 }
 
+if (! function_exists('me')) {
+    /**
+     * Retrieve the currently logged in user;
+     *
+     * @return \Illuminate\Contracts\Auth\Authenticatable|null
+     */
+    function me()
+    {
+        return auth()->user();
+    }
+}
+
 if (! function_exists('method_field')) {
     /**
      * Generate a form field to spoof the HTTP verb used by forms.


### PR DESCRIPTION
I'm taking a queue from the common API endpoint: `/user/me`

I think `me()` is an appropriate metaphor for the concept of `auth()->user()`

I think people would love to start using this.

Thanks for taking a peek!
- Caleb