### PR TITLE
[5.4] Add ability to pass accepted values as argument list

### DIFF
--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -34,22 +34,26 @@ class Rule
     /**
      * Get an in constraint builder instance.
      *
-     * @param  array  $values
+     * @param  array|string  $values
      * @return \Illuminate\Validation\Rules\In
      */
-    public static function in(array $values)
+    public static function in($values)
     {
+        $values = is_array($values) ? $values : func_get_args();
+
         return new Rules\In($values);
     }
 
     /**
      * Get a not_in constraint builder instance.
      *
-     * @param  array  $values
+     * @param  array|string  $values
      * @return \Illuminate\Validation\Rules\NotIn
      */
-    public static function notIn(array $values)
+    public static function notIn($values)
     {
+        $values = is_array($values) ? $values : func_get_args();
+
         return new Rules\NotIn($values);
     }
 


### PR DESCRIPTION
This adds ability to pass the allowed(or not allowed) values for `in` and `notIn` rules as argument list instead of an array(like `Model::with()`).

For example:
```php
Rule::in('foo', 'bar', 'baz');
```
will be equivalent to:
```php
Rule::in(['foo', 'bar', 'baz']);
```

The values, even if they are not necessarily strings, are being cast to strings in the `implode` call in `Illuminate\Validation\Rules\In::__toString()`, so I think the `array|string` parameter hint is OK. Another option would be to just call it `mixed`.