### PR TITLE
Avoid storeCurrentUrl() via content-type in StartSession.php

### DIFF
--- a/src/Illuminate/Session/Middleware/StartSession.php
+++ b/src/Illuminate/Session/Middleware/StartSession.php
@@ -62,12 +62,15 @@ class StartSession
         }
 
         $response = $next($request);
+        $content_type = $response->headers->get('content-type');
 
         // Again, if the session has been configured we will need to close out the session
         // so that the attributes may be persisted to some storage medium. We will also
         // add the session identifier cookie to the application response headers now.
         if ($this->sessionConfigured()) {
-            $this->storeCurrentUrl($request, $session);
+            if(starts_with($content_type, 'text/html')) {
+                $this->storeCurrentUrl($request, $session);
+            }
 
             $this->addCookieToResponse($response, $session);
         }


### PR DESCRIPTION
I'd like to avoid storeCurrentUrl() via content-type in Illuminate\Session\Middleware\StartSession

Because when we need to provide image from storage with auth, validation redirection URL is possibly wrong.

The story is like this.

1. Access to a specific page which has <img> tag. (<= storeCurrentUrl() called first here.)
2. The <img> tag source is from storage folder and is only for logged in user. (The Previous URL is overwritten by calling storeCurrentUrl() again here.)
3. The validation redirects us to wrong URL. In this case image URL.


However, I also think we should be able to set content-type(s) to avoid storeCurrentUrl() in config/session.php like the next.

    return [
    
        ...,
    
        'previous_content_types' => ['text/html', 'text/xml']
    
    ];

Thank you.