### PR TITLE
Add first() str function

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -82,6 +82,25 @@ class Str
     }
 
     /**
+     * It only takes first letter of the words in a sentence.
+     *
+     * @param  string  $value
+     * @param  bool $upperCase
+     * @return string
+     */
+    public static function first($value, $upperCase = false)
+    {
+        $letters = '';
+        $value = (string) preg_replace(['/[!@#$%^&*\/]/', '/\s+/'], ['', ' '], trim($value));
+
+        foreach (explode(' ', $value) as $word) {
+            $letters .= static::substr($word, 0, 1);
+        }
+
+        return $upperCase ? static::upper($letters) : $letters;
+    }
+
+    /**
      * Determine if a given string contains a given substring.
      *
      * @param  string  $haystack

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -88,7 +88,7 @@ class Str
      * @param  bool $upperCase
      * @return string
      */
-    public static function first($value, $upperCase = false)
+    public static function acronym($value, $upperCase = false)
     {
         $letters = '';
         $value = (string) preg_replace(['/[!@#$%^&*\/]/', '/\s+/'], ['', ' '], trim($value));

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -230,6 +230,16 @@ class SupportStrTest extends TestCase
         $this->assertEquals('laravelPhpFramework', Str::camel('Laravel  -_-  php   -_-   framework   '));
     }
 
+    public function testFirst()
+    {
+        $this->assertEquals('lpf', Str::first('laravel php framework'));
+        $this->assertEquals('LPF', Str::first('laravel php framework', true));
+        $this->assertEquals('LPF', Str::first('Laravel PHP Framework'));
+        $this->assertEquals('LPf', Str::first('Laravel,       PHP  framework '));
+        $this->assertEquals('LPf', Str::first("Laravel,   \n    PHP  framework "));
+        $this->assertEquals('LPf', Str::first("Laravel,   \t    PHP  framework "));
+    }
+
     public function testSubstr()
     {
         $this->assertEquals('Ё', Str::substr('БГДЖИЛЁ', -1));

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -230,14 +230,14 @@ class SupportStrTest extends TestCase
         $this->assertEquals('laravelPhpFramework', Str::camel('Laravel  -_-  php   -_-   framework   '));
     }
 
-    public function testFirst()
+    public function testAcronym()
     {
-        $this->assertEquals('lpf', Str::first('laravel php framework'));
-        $this->assertEquals('LPF', Str::first('laravel php framework', true));
-        $this->assertEquals('LPF', Str::first('Laravel PHP Framework'));
-        $this->assertEquals('LPf', Str::first('Laravel,       PHP  framework '));
-        $this->assertEquals('LPf', Str::first("Laravel,   \n    PHP  framework "));
-        $this->assertEquals('LPf', Str::first("Laravel,   \t    PHP  framework "));
+        $this->assertEquals('lpf', Str::acronym('laravel php framework'));
+        $this->assertEquals('LPF', Str::acronym('laravel php framework', true));
+        $this->assertEquals('LPF', Str::acronym('Laravel PHP Framework'));
+        $this->assertEquals('LPf', Str::acronym('Laravel,       PHP  framework '));
+        $this->assertEquals('LPf', Str::acronym("Laravel,   \n    PHP  framework "));
+        $this->assertEquals('LPf', Str::acronym("Laravel,   \t    PHP  framework "));
     }
 
     public function testSubstr()


### PR DESCRIPTION
Resubmit of #19551 without the helper function, as I find the Str function useful, but I know Taylor doesn't normally accept new helpers that aren't used by the framework itself. Also, renaming function to `acronym()` for the sake of vervosity.

Example:

``` php
Str::acronym('Progressive Web Apps'); // PWA

Str::acronym('Toys & Games') // TG

Str::acronym('Uniforms, Work & Safety') // UWS

Str::acronym('Handbags & Wallets') // HW
```

The credit goes to the author of the original PR (@atayahmet)