### PR TITLE
[5.4] fix eloquent collection contains issue

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -85,8 +85,7 @@ class Collection extends BaseCollection implements QueueableCollection
 
         if ($key instanceof Model) {
             return parent::contains(function ($model) use ($key) {
-                return $model->getKey() == $key->getKey() &&
-                       get_class($model) == get_class($key);
+                return $model->is($key);
             });
         }
 

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -83,7 +83,12 @@ class Collection extends BaseCollection implements QueueableCollection
             return parent::contains(...func_get_args());
         }
 
-        $key = $key instanceof Model ? $key->getKey() : $key;
+        if ($key instanceof Model) {
+            return parent::contains(function ($model) use ($key) {
+                return $model->getKey() == $key->getKey() &&
+                       get_class($model) == get_class($key);
+            });
+        }
 
         return parent::contains(function ($model) use ($key) {
             return $model->getKey() == $key;

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -57,6 +57,18 @@ class DatabaseEloquentCollectionTest extends TestCase
         $this->assertFalse($c->contains($mockModel3));
     }
 
+    public function testContainsIndicatesIfDiffentModelInArray()
+    {
+        $mockModelFoo = m::namedMock('Foo', 'Illuminate\Database\Eloquent\Model');
+        $mockModelFoo->shouldReceive('getKey')->andReturn(1);
+        $mockModelBar = m::namedMock('Bar', 'Illuminate\Database\Eloquent\Model');
+        $mockModelBar->shouldReceive('getKey')->andReturn(1);
+        $c = new Collection([$mockModelFoo]);
+
+        $this->assertTrue($c->contains($mockModelFoo));
+        $this->assertFalse($c->contains($mockModelBar));
+    }
+
     public function testContainsIndicatesIfKeyedModelInArray()
     {
         $mockModel = m::mock('Illuminate\Database\Eloquent\Model');

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -46,10 +46,16 @@ class DatabaseEloquentCollectionTest extends TestCase
     {
         $mockModel = m::mock('Illuminate\Database\Eloquent\Model');
         $mockModel->shouldReceive('getKey')->andReturn(1);
+        $mockModel->shouldReceive('is')->with($mockModel)->andReturn(true);
+        $mockModel->shouldReceive('is')->andReturn(false);
         $mockModel2 = m::mock('Illuminate\Database\Eloquent\Model');
         $mockModel2->shouldReceive('getKey')->andReturn(2);
+        $mockModel2->shouldReceive('is')->with($mockModel2)->andReturn(true);
+        $mockModel2->shouldReceive('is')->andReturn(false);
         $mockModel3 = m::mock('Illuminate\Database\Eloquent\Model');
         $mockModel3->shouldReceive('getKey')->andReturn(3);
+        $mockModel3->shouldReceive('is')->with($mockModel3)->andReturn(true);
+        $mockModel3->shouldReceive('is')->andReturn(false);
         $c = new Collection([$mockModel, $mockModel2]);
 
         $this->assertTrue($c->contains($mockModel));
@@ -61,8 +67,12 @@ class DatabaseEloquentCollectionTest extends TestCase
     {
         $mockModelFoo = m::namedMock('Foo', 'Illuminate\Database\Eloquent\Model');
         $mockModelFoo->shouldReceive('getKey')->andReturn(1);
+        $mockModelFoo->shouldReceive('is')->with($mockModelFoo)->andReturn(true);
+        $mockModelFoo->shouldReceive('is')->andReturn(false);
         $mockModelBar = m::namedMock('Bar', 'Illuminate\Database\Eloquent\Model');
         $mockModelBar->shouldReceive('getKey')->andReturn(1);
+        $mockModelBar->shouldReceive('is')->with($mockModelBar)->andReturn(true);
+        $mockModelBar->shouldReceive('is')->andReturn(false);
         $c = new Collection([$mockModelFoo]);
 
         $this->assertTrue($c->contains($mockModelFoo));

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -45,15 +45,12 @@ class DatabaseEloquentCollectionTest extends TestCase
     public function testContainsIndicatesIfModelInArray()
     {
         $mockModel = m::mock('Illuminate\Database\Eloquent\Model');
-        $mockModel->shouldReceive('getKey')->andReturn(1);
         $mockModel->shouldReceive('is')->with($mockModel)->andReturn(true);
         $mockModel->shouldReceive('is')->andReturn(false);
         $mockModel2 = m::mock('Illuminate\Database\Eloquent\Model');
-        $mockModel2->shouldReceive('getKey')->andReturn(2);
         $mockModel2->shouldReceive('is')->with($mockModel2)->andReturn(true);
         $mockModel2->shouldReceive('is')->andReturn(false);
         $mockModel3 = m::mock('Illuminate\Database\Eloquent\Model');
-        $mockModel3->shouldReceive('getKey')->andReturn(3);
         $mockModel3->shouldReceive('is')->with($mockModel3)->andReturn(true);
         $mockModel3->shouldReceive('is')->andReturn(false);
         $c = new Collection([$mockModel, $mockModel2]);
@@ -66,11 +63,9 @@ class DatabaseEloquentCollectionTest extends TestCase
     public function testContainsIndicatesIfDiffentModelInArray()
     {
         $mockModelFoo = m::namedMock('Foo', 'Illuminate\Database\Eloquent\Model');
-        $mockModelFoo->shouldReceive('getKey')->andReturn(1);
         $mockModelFoo->shouldReceive('is')->with($mockModelFoo)->andReturn(true);
         $mockModelFoo->shouldReceive('is')->andReturn(false);
         $mockModelBar = m::namedMock('Bar', 'Illuminate\Database\Eloquent\Model');
-        $mockModelBar->shouldReceive('getKey')->andReturn(1);
         $mockModelBar->shouldReceive('is')->with($mockModelBar)->andReturn(true);
         $mockModelBar->shouldReceive('is')->andReturn(false);
         $c = new Collection([$mockModelFoo]);


### PR DESCRIPTION
I think this pull request can fix below issue:

```php
$post = Post::create(['id' => 1]);
$comment = Comment::create(['id' => 1]);

$collection = new EloquentCollection([$post]);

$collection->contains($comment); // expect is false, but true given
```