### PR TITLE
[5.5] Run after-callbacks even if a callback event failed

### DIFF
--- a/src/Illuminate/Console/Scheduling/CallbackEvent.php
+++ b/src/Illuminate/Console/Scheduling/CallbackEvent.php
@@ -69,9 +69,9 @@ class CallbackEvent extends Event
         try {
             $response = $container->call($this->callback, $this->parameters);
         } finally {
-            parent::callAfterCallbacks($container);
-
             $this->removeMutex();
+
+            parent::callAfterCallbacks($container);
         }
 
         return $response;

--- a/src/Illuminate/Console/Scheduling/CallbackEvent.php
+++ b/src/Illuminate/Console/Scheduling/CallbackEvent.php
@@ -69,10 +69,10 @@ class CallbackEvent extends Event
         try {
             $response = $container->call($this->callback, $this->parameters);
         } finally {
+            parent::callAfterCallbacks($container);
+
             $this->removeMutex();
         }
-
-        parent::callAfterCallbacks($container);
 
         return $response;
     }


### PR DESCRIPTION
Currently if you use `exec()`, or `command()` an after-callback will run even if the command itself threw an exception since the command runs in a sub-process.

However when you use a callback event, any exception in the callback will prevent the script from continuing and thus cause the after-callbacks to never fire.

This PR fixes this issue by ensuring the after-callbacks are called even if the callback event failed.