### PR TITLE
[5.4] Allow checking fake string jobs

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/QueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/QueueFake.php
@@ -129,7 +129,7 @@ class QueueFake extends QueueManager implements Queue
      */
     public function push($job, $data = '', $queue = null)
     {
-        $this->jobs[get_class($job)][] = [
+        $this->jobs[is_object($job) ? get_class($job) : $job][] = [
             'job' => $job,
             'queue' => $queue,
         ];


### PR DESCRIPTION
`QueueFake` assumes all pushed jobs are objects but doesn't count for when you do `Queue::push('Class@method')`, this PR fixes that.