### PR TITLE
fix phpDoc return type on RouteRegistrar

### DIFF
--- a/src/Illuminate/Routing/RouteRegistrar.php
+++ b/src/Illuminate/Routing/RouteRegistrar.php
@@ -53,6 +53,7 @@ class RouteRegistrar
      * Create a new route registrar instance.
      *
      * @param  \Illuminate\Routing\Router  $router
+     * @return void
      */
     public function __construct(Router $router)
     {

--- a/src/Illuminate/Routing/RouteRegistrar.php
+++ b/src/Illuminate/Routing/RouteRegistrar.php
@@ -53,7 +53,6 @@ class RouteRegistrar
      * Create a new route registrar instance.
      *
      * @param  \Illuminate\Routing\Router  $router
-     * @return void
      */
     public function __construct(Router $router)
     {
@@ -96,7 +95,7 @@ class RouteRegistrar
     /**
      * Create a route group with shared attributes.
      *
-     * @param  \Closure  $callback
+     * @param  \Closure|string  $callback
      * @return void
      */
     public function group($callback)


### PR DESCRIPTION
The phpDoc on RouteRegistrar is wrong, causing my IDE to report errors. This pull request fixes the phpDoc to the correct types.