### PR TITLE
[5.5] Collection support sort by key

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1303,6 +1303,34 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
+     * Sort the collection by key.
+     *
+     * @param  int  $options
+     * @param  bool  $descending
+     * @return static
+     */
+    public function sortByKey($options = SORT_REGULAR, $descending = false)
+    {
+        $items = $this->items;
+
+        $descending ? krsort($items, $options)
+                    : ksort($items, $options);
+
+        return new static($items);
+    }
+
+    /**
+     * Sort the collection in descending order by key.
+     *
+     * @param  int  $options
+     * @return static
+     */
+    public function sortByKeyDesc($options = SORT_REGULAR)
+    {
+        return $this->sortByKey($options, true);
+    }
+
+    /**
      * Splice a portion of the underlying collection array.
      *
      * @param  int  $offset

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -760,6 +760,15 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals([1 => 'dayle', 0 => 'taylor'], $data->all());
     }
 
+    public function testSortByKey()
+    {
+        $data = (new Collection([1 => 'taylor', 0 => 'dayle']))->sortByKey();
+        $this->assertEquals(['dayle', 'taylor'], array_values($data->all()));
+
+        $data = (new Collection(['taylor', 'dayle']))->sortByKeyDesc();
+        $this->assertEquals(['dayle', 'taylor'], array_values($data->all()));
+    }
+
     public function testReverse()
     {
         $data = new Collection(['zaeed', 'alan']);


### PR DESCRIPTION
This PR let Collection support sort by key in quick way.

```php
(new Collection([1 => 'foo', 0 => 'bar']))->sortByKey();
// ['bar', 'foo']

(new Collection(['foo', 'bar']))->sortByKeyDesc();
// ['bar', 'foo']
```