### PR TITLE
[5.4] Fix a case where causedByLostConnection is passed a throwable

### DIFF
--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -247,7 +247,7 @@ class Worker
 
             $this->stopWorkerIfLostConnection($e);
         } catch (Throwable $e) {
-            $this->exceptions->report(new FatalThrowableError($e));
+            $this->exceptions->report($e = new FatalThrowableError($e));
 
             $this->stopWorkerIfLostConnection($e);
         }
@@ -270,7 +270,7 @@ class Worker
 
             $this->stopWorkerIfLostConnection($e);
         } catch (Throwable $e) {
-            $this->exceptions->report(new FatalThrowableError($e));
+            $this->exceptions->report($e = new FatalThrowableError($e));
 
             $this->stopWorkerIfLostConnection($e);
         }


### PR DESCRIPTION
In https://github.com/laravel/framework/blob/5.4/src/Illuminate/Database/DetectsLostConnections.php#L16 `causedByLostConnection()` receives the exception as the first argument but it's type hinted `Exception`, in this case if a throwable was thrown instead we get something like:

```
Argument 1 passed to Illuminate\Queue\Worker::causedByLostConnection() must be an instance of Exception, instance of Error given
```

This PR fixes that.