### PR TITLE
[5.4] Added helper function str_before(...)

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -34,9 +34,10 @@ class Str
      *
      * @param  string  $subject
      * @param  string  $search
+     * @param  bool  $before
      * @return string
      */
-    public static function after($subject, $search)
+    public static function after($subject, $search, $before = false)
     {
         if ($search == '') {
             return $subject;
@@ -48,7 +49,9 @@ class Str
             return $subject;
         }
 
-        return substr($subject, $pos + strlen($search));
+        return $before
+            ? substr($subject, 0, $pos)
+            : substr($subject, $pos + strlen($search));
     }
 
     /**
@@ -64,6 +67,18 @@ class Str
         }
 
         return preg_replace('/[^\x20-\x7E]/u', '', $value);
+    }
+
+    /**
+     * Return the string before the given value.
+     *
+     * @param  string  $subject
+     * @param  string  $search
+     * @return string
+     */
+    public static function before($subject, $search)
+    {
+        return static::after($subject, $search, $before = true);
     }
 
     /**

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -748,6 +748,20 @@ if (! function_exists('str_after')) {
     }
 }
 
+if (! function_exists('str_before')) {
+    /**
+     * Return the string before the given value.
+     *
+     * @param  string  $subject
+     * @param  string  $search
+     * @return string
+     */
+    function str_before($subject, $search)
+    {
+        return Str::before($subject, $search);
+    }
+}
+
 if (! function_exists('str_contains')) {
     /**
      * Determine if a given string contains a given substring.

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -259,6 +259,13 @@ class SupportHelpersTest extends TestCase
         $this->assertEquals('hannah', str_after('hannah', 'xxxx'));
     }
 
+    public function testStrBefore()
+    {
+        $this->assertEquals('foo', str_before('foobar', 'bar'));
+        $this->assertEquals('foo', str_before('foobbb', 'b'));
+        $this->assertEquals('foobar', str_before('foobar', 'xxxx'));
+    }
+
     public function testStrContains()
     {
         $this->assertTrue(Str::contains('taylor', 'ylo'));


### PR DESCRIPTION
Some times you need to extract the first part of an string, for example to get `john.doe` from `john.doe@example.com`.

Today I came across this need and with the recent addition of `str_after` I think `str_before` is missing in the helpers suite.

Example:

```php
$username = str_before('john.doe@example.com', '@');
echo $username; // john.doe
```