### PR TITLE
[5.5] Maintain package.json formatting in `artisan preset`

### DIFF
--- a/src/Illuminate/Foundation/Console/Presets/Preset.php
+++ b/src/Illuminate/Foundation/Console/Presets/Preset.php
@@ -41,7 +41,11 @@ class Preset
 
         file_put_contents(
             base_path('package.json'),
-            json_encode($packages, JSON_PRETTY_PRINT)
+            preg_replace(
+                '/^(  +?)\\1(?=[^ ])/m',
+                '$1',
+                json_encode($packages, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT) . PHP_EOL
+            )
         );
     }
 


### PR DESCRIPTION
Running `php artisan preset {type}` changes more than just dependencies in the `package.json` file.

`preg_replace` restores the 2-spaced JSON formatting of Node.js.

`JSON_UNESCAPED_SLASHES` prevents the npm scripts from containing unnecessary extra slashes:

```diff
-"development": "cross-env NODE_ENV=development node_modules/webpack/bin/webpack.js --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
+"development": "cross-env NODE_ENV=development node_modules\/webpack\/bin\/webpack.js --progress --hide-modules --config=node_modules\/laravel-mix\/setup\/webpack.config.js",
```