### PR TITLE
[5.4] Added validator for console command ask function

### DIFF
--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -303,11 +303,12 @@ class Command extends SymfonyCommand
      *
      * @param  string  $question
      * @param  string  $default
+     * @param callable|null $validator
      * @return string
      */
-    public function ask($question, $default = null)
+    public function ask($question, $default = null, $validator = null)
     {
-        return $this->output->ask($question, $default);
+        return $this->output->ask($question, $default, $validator);
     }
 
     /**

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -303,7 +303,7 @@ class Command extends SymfonyCommand
      *
      * @param  string  $question
      * @param  string  $default
-     * @param callable|null $validator
+     * @param  callable|null $validator
      * @return string
      */
     public function ask($question, $default = null, $validator = null)


### PR DESCRIPTION
Since class `\Symfony\Component\Console\Style\SymfonyStyle` supports passing validation callback as third parameter, I updated the Laravel framework to support it.

Personally I come across the need. Have a work around to do validation after retrieving the user input, but that will break the user journey. Therefore I updated the `ask` function. I hope it doesn't harm.