### PR TITLE
[5.4] Add new `diffAssoc()` method to collection

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -255,6 +255,17 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
+     * Get the items in the collection whose keys and values are not present in the given items.
+     *
+     * @param  mixed  $items
+     * @return static
+     */
+    public function diffAssoc($items)
+    {
+        return new static(array_diff_assoc($this->items, $this->getArrayableItems($items)));
+    }
+
+    /**
      * Get the items in the collection whose keys are not present in the given items.
      *
      * @param  mixed  $items

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -532,6 +532,13 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(['first_word' => 'Hello'], $c1->diffKeys($c2)->all());
     }
 
+    public function testDiffAssoc()
+    {
+        $c1 = new Collection(['id' => 1, 'first_word' => 'Hello', 'not_affected' => 'value']);
+        $c2 = new Collection(['id' => 123, 'foo_bar' => 'Hello', 'not_affected' => 'value']);
+        $this->assertEquals(['id' => 1, 'first_word' => 'Hello'], $c1->diffAssoc($c2)->all());
+    }
+
     public function testEach()
     {
         $c = new Collection($original = [1, 2, 'foo' => 'bar', 'bam' => 'baz']);


### PR DESCRIPTION
This PR introduces a `Collection` static function for using  `array_diff_assoc`on collections.

Using this suggested function `diffAssoc`, we can compare collections with respect to both keys and values.

From the [PHP documentation](https://secure.php.net/manual/en/function.array-diff-assoc.php):

    array_diff_assoc ( array $array1 , array $array2 )
	Compares array1 against array2 and returns the difference. Unlike array_diff() the array keys are also used in the comparison.

Usage: `diff` and `diffKeys`  and `diffAssoc`:

    $c1 = collect(
	['id' => 1,
	'username' => 'john',
	'is_active' => 1,
	'prefer_sms' => 1
	]);

	$c2 = collect(
		['id' => 2,
		'username' => 'doe',
		'is_active' => 1,
		]);
	
	$c1->diff($c2);
	//  ['username' => 'john']
	//  the 'id' difference is ignored because the value of the 'id' index in the first collection, which is '1', is present in the 'is_active' index in the second collection.

	$c1->diffKeys($c2);
	//  ['prefer_sms' => 1]

	$c1->diffAssoc($c2);
	//  ['id' => 1, 'username' => 'john' , 'prefer_sms' => 1]
