### PR TITLE
[5.5] Change 419 error title

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/views/419.blade.php
+++ b/src/Illuminate/Foundation/Exceptions/views/419.blade.php
@@ -1,6 +1,6 @@
 @extends('errors::layout')
 
-@section('title', 'Logged out')
+@section('title', 'Page Expired')
 
 @section('message')
     The page has expired due to inactivity.


### PR DESCRIPTION
The original message for this view was "You've been logged out", but then, @taylorotwell decided to change it to "The page has expired". I suppose this was left unchanged accidentally

See:

- [Original Pull Request](https://github.com/laravel/framework/pull/18728)

- [Taylor's comment on changing the message](https://github.com/laravel/framework/pull/18728#issuecomment-292982832)