### PR TITLE
[5.4 + LTS] Fix tests code coverage config.

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -21,8 +21,7 @@
         <whitelist processUncoveredFilesFromWhitelist="true">
             <directory suffix=".php">./src</directory>
             <exclude>
-                <directory>./src/Illuminate/Pagination/resources/views</directory>
-                <file>./src/Illuminate/Foundation/Console/Optimize/config.php</file>
+                <directory suffix=".blade.php">./src/</directory>
             </exclude>
         </whitelist>
     </filter>


### PR DESCRIPTION
Hi folks,
I've just seen that since.. a long time ago (don't know when exactly), the code coverage config is completely outdated, so all the views was dumped instead of lunching code coverage.

This post from @egorpe show exactly the issue: 
https://laracasts.com/discuss/channels/laravel/phpunit-coverage-for-laravel-framework-spits-out-html-instead-of-running-tests

You can see the failure on his travis build: 
https://travis-ci.org/egorpe/framework/jobs/241038092

This PR update the config, so the code coverage is passing now (but is actually a bit scary ^^")