### PR TITLE
Fixing issue with nullable dates

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1002,7 +1002,7 @@ trait HasAttributes
 
         if ($current === $original) {
             return true;
-        } elseif (is_null($current)) {
+        } elseif (is_null($current) || (is_null($original) && !is_null($current))) {
             return false;
         } elseif ($this->isDateAttribute($key)) {
             return $this->fromDateTime($current) ===

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1002,7 +1002,7 @@ trait HasAttributes
 
         if ($current === $original) {
             return true;
-        } elseif (is_null($current) || (is_null($original) && !is_null($current))) {
+        } elseif (is_null($current) || (is_null($original) && ! is_null($current))) {
             return false;
         } elseif ($this->isDateAttribute($key)) {
             return $this->fromDateTime($current) ===


### PR DESCRIPTION
When a date column is nullable in the database, and the date is updated from `null` to a new value, a call to `$this-fromDateTime($original)` is made, with `null` as the argument. This results in an error when `Carbon::createFromFormat()` is called with the value `null`.