### PR TITLE
[5.5] Let any Exception be Responsable.

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -4,6 +4,7 @@ namespace Illuminate\Foundation\Exceptions;
 
 use Exception;
 use Whoops\Run as Whoops;
+use Illuminate\Support\Arr;
 use Psr\Log\LoggerInterface;
 use Illuminate\Http\Response;
 use Illuminate\Routing\Router;
@@ -309,7 +310,7 @@ class Handler implements ExceptionHandlerContract
 
             $handler->handleUnconditionally(true);
             $handler->setApplicationPaths(
-                array_flip(array_except(
+                array_flip(Arr::except(
                     array_flip($files->directories(base_path())), [base_path('vendor')]
                 ))
             );

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -14,6 +14,7 @@ use Illuminate\Http\RedirectResponse;
 use Whoops\Handler\PrettyPageHandler;
 use Illuminate\Auth\AuthenticationException;
 use Illuminate\Contracts\Container\Container;
+use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Session\TokenMismatchException;
 use Illuminate\Validation\ValidationException;
 use Illuminate\Auth\Access\AuthorizationException;
@@ -151,6 +152,8 @@ class Handler implements ExceptionHandlerContract
     {
         if (method_exists($e, 'render') && $response = $e->render($request)) {
             return Router::prepareResponse($request, $response);
+        } elseif ($e instanceof Responsable) {
+            return $e->toResponse();
         }
 
         $e = $this->prepareException($e);

--- a/tests/Foundation/FoundationExceptionsHandlerTest.php
+++ b/tests/Foundation/FoundationExceptionsHandlerTest.php
@@ -7,6 +7,7 @@ use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Container\Container;
 use Illuminate\Config\Repository as Config;
+use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Foundation\Exceptions\Handler;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 
@@ -61,6 +62,13 @@ class FoundationExceptionsHandlerTest extends TestCase
         $this->assertContains('"trace":', $response);
     }
 
+    public function testReturnsCustomResponseWhenExceptionImplementsResponsable()
+    {
+        $response = $this->handler->render($this->request, new CustomException)->getContent();
+
+        $this->assertSame('{"response":"My custom exception response"}', $response);
+    }
+
     public function testReturnsJsonWithoutStackTraceWhenAjaxRequestAndDebugFalseAndExceptionMessageIsMasked()
     {
         $this->config->shouldReceive('get')->with('app.debug', null)->once()->andReturn(false);
@@ -89,5 +97,13 @@ class FoundationExceptionsHandlerTest extends TestCase
         $this->assertNotContains('"file":', $response);
         $this->assertNotContains('"line":', $response);
         $this->assertNotContains('"trace":', $response);
+    }
+}
+
+class CustomException extends Exception implements Responsable
+{
+    public function toResponse()
+    {
+        return response()->json(['response' => 'My custom exception response']);
     }
 }


### PR DESCRIPTION
This PR lets any `Exception` returns its own `Response`.

When rendering the `Response`, a check will be done to ensure that the `Exception` implements `Responsable`.

---

This has to be returned before `$e = $this->prepareException($e);` as our `Responsable` exception could probably also extend one of the following exceptions:
- `\Illuminate\Database\Eloquent\ModelNotFoundException`
- `\Illuminate\Auth\Access\AuthorizationException`
- `\Illuminate\Session\TokenMismatchException`