### PR TITLE
[5.4] Add fresh method on Eloquent\Collection.

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -146,7 +146,17 @@ class Collection extends BaseCollection implements QueueableCollection
      */
     public function fresh($with = [])
     {
-        return $this->map->fresh($with);
+        $model = $this->first();
+
+        $freshModels = $model->newQueryWithoutScopes()
+            ->with(is_string($with) ? func_get_args() : $with)
+            ->whereIn($model->getKeyName(), $this->modelKeys())
+            ->get()
+            ->getDictionary();
+
+        return $this->map(function ($model) use ($freshModels) {
+            return $model->exists ? $freshModels[$model->getKey()] : null;
+        });
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -127,7 +127,7 @@ class Collection extends BaseCollection implements QueueableCollection
      * Run a map over each of the items.
      *
      * @param  callable  $callback
-     * @return \Illuminate\Support\Collection
+     * @return \Illuminate\Support\Collection|static
      */
     public function map(callable $callback)
     {
@@ -136,6 +136,17 @@ class Collection extends BaseCollection implements QueueableCollection
         return $result->contains(function ($item) {
             return ! $item instanceof Model;
         }) ? $result->toBase() : $result;
+    }
+
+    /**
+     * Reload a fresh model instance from the database for all the entities.
+     *
+     * @param  array|string  $with
+     * @return static
+     */
+    public function fresh($with = [])
+    {
+        return $this->map->fresh($with);
     }
 
     /**

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -212,24 +212,6 @@ class DatabaseEloquentCollectionTest extends TestCase
         $this->assertInstanceOf(Collection::class, $cAfterMap);
     }
 
-    public function testFresh()
-    {
-        $one = m::mock('Illuminate\Database\Eloquent\Model');
-        $oneFresh = m::mock('Illuminate\Database\Eloquent\Model');
-        $one->shouldReceive('fresh')->andReturn($oneFresh);
-
-        $two = m::mock('Illuminate\Database\Eloquent\Model');
-        $twoFresh = m::mock('Illuminate\Database\Eloquent\Model');
-        $two->shouldReceive('fresh')->andReturn($twoFresh);
-
-        $c = new Collection([$one, $two]);
-
-        $cAfterFresh = $c->fresh();
-
-        $this->assertEquals(new Collection([$oneFresh, $twoFresh]), $cAfterFresh);
-        $this->assertInstanceOf(Collection::class, $cAfterFresh);
-    }
-
     public function testMappingToNonModelsReturnsABaseCollection()
     {
         $one = m::mock('Illuminate\Database\Eloquent\Model');

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -212,6 +212,24 @@ class DatabaseEloquentCollectionTest extends TestCase
         $this->assertInstanceOf(Collection::class, $cAfterMap);
     }
 
+    public function testFresh()
+    {
+        $one = m::mock('Illuminate\Database\Eloquent\Model');
+        $oneFresh = m::mock('Illuminate\Database\Eloquent\Model');
+        $one->shouldReceive('fresh')->andReturn($oneFresh);
+
+        $two = m::mock('Illuminate\Database\Eloquent\Model');
+        $twoFresh = m::mock('Illuminate\Database\Eloquent\Model');
+        $two->shouldReceive('fresh')->andReturn($twoFresh);
+
+        $c = new Collection([$one, $two]);
+
+        $cAfterFresh = $c->fresh();
+
+        $this->assertEquals(new Collection([$oneFresh, $twoFresh]), $cAfterFresh);
+        $this->assertInstanceOf(Collection::class, $cAfterFresh);
+    }
+
     public function testMappingToNonModelsReturnsABaseCollection()
     {
         $one = m::mock('Illuminate\Database\Eloquent\Model');

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -1069,6 +1069,48 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertTrue($saved->is($retrieved));
     }
 
+    public function testFreshMethodOnModel()
+    {
+        \Carbon\Carbon::setTestNow('now');
+        $now = \Carbon\Carbon::getTestNow();
+
+        $storedUser1 = EloquentTestUser::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']);
+        $storedUser1->newQuery()->update(['email' => 'dev@mathieutu.ovh', 'name' => 'Mathieu TUDISCO']);
+        $freshStoredUser1 = $storedUser1->fresh();
+
+        $storedUser2 = EloquentTestUser::create(['id' => 2, 'email' => 'taylorotwell@gmail.com']);
+        $storedUser2->newQuery()->update(['email' => 'dev@mathieutu.ovh']);
+        $freshStoredUser2 = $storedUser2->fresh();
+
+        $notStoredUser = new EloquentTestUser(['id' => 3, 'email' => 'taylorotwell@gmail.com']);
+        $freshNotStoredUser = $notStoredUser->fresh();
+
+        $this->assertEquals(['id' => 1, 'email' => 'taylorotwell@gmail.com', 'created_at' => $now, 'updated_at' => $now], $storedUser1->toArray());
+        $this->assertEquals(['id' => 1, 'name' => 'Mathieu TUDISCO', 'email' => 'dev@mathieutu.ovh', 'created_at' => $now, 'updated_at' => $now], $freshStoredUser1->toArray());
+        $this->assertInstanceOf(EloquentTestUser::class, $storedUser1);
+
+        $this->assertEquals(['id' => 2, 'email' => 'taylorotwell@gmail.com', 'created_at' => $now, 'updated_at' => $now], $storedUser2->toArray());
+        $this->assertEquals(['id' => 2, 'name' => null, 'email' => 'dev@mathieutu.ovh', 'created_at' => $now, 'updated_at' => $now], $freshStoredUser2->toArray());
+        $this->assertInstanceOf(EloquentTestUser::class, $storedUser2);
+
+        $this->assertEquals(['id' => 3, 'email' => 'taylorotwell@gmail.com'], $notStoredUser->toArray());
+        $this->assertEquals(null, $freshNotStoredUser);
+    }
+
+    public function testFreshMethodOnCollection()
+    {
+        EloquentTestUser::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']);
+        EloquentTestUser::create(['id' => 2, 'email' => 'taylorotwell@gmail.com']);
+
+        $users = EloquentTestUser::all()
+            ->add(new EloquentTestUser(['id' => 3, 'email' => 'taylorotwell@gmail.com']));
+
+        EloquentTestUser::find(1)->update(['name' => 'Mathieu TUDISCO']);
+        EloquentTestUser::find(2)->update(['email' => 'dev@mathieutu.ovh']);
+
+        $this->assertEquals($users->map->fresh(), $users->fresh());
+    }
+
     /**
      * Helpers...
      */

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -1071,8 +1071,8 @@ class DatabaseEloquentIntegrationTest extends TestCase
 
     public function testFreshMethodOnModel()
     {
-        \Carbon\Carbon::setTestNow('now');
-        $now = \Carbon\Carbon::getTestNow();
+        $now = \Carbon\Carbon::now();
+        \Carbon\Carbon::setTestNow($now);
 
         $storedUser1 = EloquentTestUser::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']);
         $storedUser1->newQuery()->update(['email' => 'dev@mathieutu.ovh', 'name' => 'Mathieu TUDISCO']);


### PR DESCRIPTION
Hi,
This PR adds this simple handy method which permit to `fresh` all the models in an Eloquent collection.
It also adds two tests: one for the actual `Model::fresh()` method, and one for the brand new `Collection::fresh()` one.

Wait for your comments (or your merge :P)!
Matt'