### PR TITLE
Update "none" preset bootstrap stub

### DIFF
--- a/src/Illuminate/Foundation/Console/Presets/None.php
+++ b/src/Illuminate/Foundation/Console/Presets/None.php
@@ -54,5 +54,6 @@ class None extends Preset
     {
         file_put_contents(resource_path('assets/sass/app.scss'), ''.PHP_EOL);
         copy(__DIR__.'/none-stubs/app.js', resource_path('assets/js/app.js'));
+        copy(__DIR__.'/none-stubs/bootstrap.js', resource_path('assets/js/bootstrap.js'));
     }
 }

--- a/src/Illuminate/Foundation/Console/Presets/none-stubs/bootstrap.js
+++ b/src/Illuminate/Foundation/Console/Presets/none-stubs/bootstrap.js
@@ -1,0 +1,41 @@
+
+window._ = require('lodash');
+
+/**
+ * We'll load the axios HTTP library which allows us to easily issue requests
+ * to our Laravel back-end. This library automatically handles sending the
+ * CSRF token as a header based on the value of the "XSRF" token cookie.
+ */
+
+window.axios = require('axios');
+
+window.axios.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';
+
+/**
+ * Next we will register the CSRF Token as a common header with Axios so that
+ * all outgoing HTTP requests automatically have it attached. This is just
+ * a simple convenience so we don't have to attach every token manually.
+ */
+
+let token = document.head.querySelector('meta[name="csrf-token"]');
+
+if (token) {
+    window.axios.defaults.headers.common['X-CSRF-TOKEN'] = token.content;
+} else {
+    console.error('CSRF token not found: https://laravel.com/docs/csrf#csrf-x-csrf-token');
+}
+
+/**
+ * Echo exposes an expressive API for subscribing to channels and listening
+ * for events that are broadcast by Laravel. Echo and event broadcasting
+ * allows your team to easily build robust real-time web applications.
+ */
+
+// import Echo from 'laravel-echo'
+
+// window.Pusher = require('pusher-js');
+
+// window.Echo = new Echo({
+//     broadcaster: 'pusher',
+//     key: 'your-pusher-key'
+// });


### PR DESCRIPTION
Before this PR, running `php artisan preset none` would correctly remove all the scaffolding and package.json references, but it won't update the `resources/assets/js/bootstrap.js` file to reflect these changes. 

Specifically, because the jQuery and Bootstrap-Sass dependencies are removed as part of this preset, `bootstrap.js` shouldn't reference them. This PR copies over an updated stub to fix that.

🕵️
