### PR TITLE
[5.4] update timestamp on soft delete only when its used

### DIFF
--- a/src/Illuminate/Database/Eloquent/SoftDeletes.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletes.php
@@ -62,13 +62,17 @@ trait SoftDeletes
 
         $time = $this->freshTimestamp();
 
-        $this->{$this->getDeletedAtColumn()} = $time;
-        $this->{$this->getUpdatedAtColumn()} = $time;
+        $columns = [$this->getDeletedAtColumn() => $this->fromDateTime($time)];
 
-        $query->update([
-            $this->getDeletedAtColumn() => $this->fromDateTime($time),
-            $this->getUpdatedAtColumn() => $this->fromDateTime($time),
-        ]);
+        $this->{$this->getDeletedAtColumn()} = $time;
+
+        if ($this->timestamps) {
+            $this->{$this->getUpdatedAtColumn()} = $time;
+
+            $columns[$this->getUpdatedAtColumn()] = $this->fromDateTime($time);
+        }
+
+        $query->update($columns);
     }
 
     /**

--- a/tests/Database/DatabaseSoftDeletingTraitTest.php
+++ b/tests/Database/DatabaseSoftDeletingTraitTest.php
@@ -57,6 +57,7 @@ class DatabaseSoftDeletingTraitStub
     use \Illuminate\Database\Eloquent\SoftDeletes;
     public $deleted_at;
     public $updated_at;
+    public $timestamps = true;
 
     public function newQuery()
     {


### PR DESCRIPTION
This PR fixes the issue reported in https://github.com/laravel/framework/issues/19620, the breaking change was introduced in https://github.com/laravel/framework/pull/19538

This PR doesn't revert, but only updates the `updated_at` column if the Model's timestamps = true.