### PR TITLE
[5.4] Unset remember token on logout

### DIFF
--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -491,7 +491,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
         $this->clearUserDataFromStorage();
 
         if (! is_null($this->user)) {
-            $this->cycleRememberToken($user);
+            $this->clearRememberToken($user);
         }
 
         if (isset($this->events)) {
@@ -532,6 +532,18 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
         $user->setRememberToken($token = Str::random(60));
 
         $this->provider->updateRememberToken($user, $token);
+    }
+
+    /**
+     * Clear the "remember me" token for the user.
+     *
+     * @param \Illuminate\Contracts\Auth\Authenticatable $user
+     */
+    protected function clearRememberToken(AuthenticatableContract $user)
+    {
+        $user->setRememberToken(null);
+
+        $this->provider->updateRememberToken($user, null);
     }
 
     /**


### PR DESCRIPTION
If I'm not mistaken, based on the authentication contract documentation (https://laravel.com/docs/5.4/authentication#the-user-provider-contract) this is actually the intended function on logout.