### PR TITLE
[5.4] Eloquent BelongsTo fails with incrementing key but using non-integer non-keys on the relation

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
@@ -127,11 +127,10 @@ class BelongsTo extends Relation
             }
         }
 
-        // If there are no keys that were not null we will just return an array with either
-        // null or 0 in (depending on if incrementing keys are in use) so the query wont
-        // fail plus returns zero results, which should be what the developer expects.
+        // If there are no keys that were not null we will just return an array with null
+        // so the query wont fail plus returns zero results, which should be what the developer expects.
         if (count($keys) === 0) {
-            return [$this->relationHasIncrementingId() ? 0 : null];
+            return [null];
         }
 
         sort($keys);

--- a/tests/Database/DatabaseEloquentBelongsToTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToTest.php
@@ -103,7 +103,7 @@ class DatabaseEloquentBelongsToTest extends TestCase
     public function testDefaultEagerConstraintsWhenIncrementing()
     {
         $relation = $this->getRelation();
-        $relation->getQuery()->shouldReceive('whereIn')->once()->with('relation.id', m::mustBe([0]));
+        $relation->getQuery()->shouldReceive('whereIn')->once()->with('relation.id', m::mustBe([null]));
         $models = [new MissingEloquentBelongsToModelStub, new MissingEloquentBelongsToModelStub];
         $relation->addEagerConstraints($models);
     }


### PR DESCRIPTION
When a model `belongsTo` another model with an incrementing primary key using a non-primary-key as the `other_key`, the generated query when eager loading causes SQL data type error and/or possibly yielding wrong result if the foreign key column is `null`.

Consider the following database structure:

* table `users`
    * `id` integer incrementing key
    * `role` string nullable

* table `user_roles`
    * `id` integer incrementing key
    * `ctf_role` string

The following code fragment demonstrate the example, where I am referencing column `users.role` on `user_roles.ctf_role` with string type.

```php
/**
 * @property string|null $role
 */
class User extends Model {
    public function userRole() : BelongsTo
    {
        return $this->belongsTo(UserRole::class, 'role', 'ctf_role');
    }
}

/**
 * @property integer $id
 * @property string $ctf_role
 */
class UserRole extends Model
{
    public function users() : HasMany {
        return $this->hasMany(User::class, 'role', 'ctf_role');
    }
}

User::whereRole(null)->first()->load(['userRole']);
```

If I put a `UserRole` with a non-numeric `ctf_role` (`test` in the following example), the following is the result:

```
Illuminate\Database\QueryException with message 'SQLSTATE[22018]: [Microsoft][ODBC Driver 13 for SQL Server][SQL Server]Conversion failed when converting the nvarchar value
'test' to data type int. (SQL: select * from [user_roles] where [user_roles].[ctf_role] in (0))'
```

If I put a `UserRole` with `ctf_role` set to `0`, the object will be erroneously loaded to the relation.

This pull request remove the bug by always return null in the key list no matter whether the key is incrementing or not.