### PR TITLE
[5.5] Load core providers before package providers

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -552,7 +552,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
         $providers = $this->make(PackageManifest::class)->providers();
 
         (new ProviderRepository($this, new Filesystem, $this->getCachedServicesPath()))
-                    ->load(array_merge($providers, $this->config['app.providers']));
+                    ->load(array_merge($this->config['app.providers'], $providers));
     }
 
     /**


### PR DESCRIPTION
This change will ensure that package providers in the config file will be loaded before auto-discovered package providers.

Example of a problem caused by this:
In PassportServiceProvider we use the Auth facade which isn't available until the Auth service provider is registered.