### PR TITLE
[5.4] Escape default value of yield blade directive

### DIFF
--- a/src/Illuminate/View/Concerns/ManagesLayouts.php
+++ b/src/Illuminate/View/Concerns/ManagesLayouts.php
@@ -143,7 +143,7 @@ trait ManagesLayouts
      */
     public function yieldContent($section, $default = '')
     {
-        $sectionContent = $default;
+        $sectionContent = e($default);
 
         if (isset($this->sections[$section])) {
             $sectionContent = $this->sections[$section];


### PR DESCRIPTION
This is in the same vein as #17453.

`@yield` accepts a default value as the second parameter. However, Laravel does not escape the data passed in via this parameter, opening up the possibility of an XSS attack if the developer is not aware of this.