### PR TITLE
[5.5] fix migrate:fresh for sqlite

### DIFF
--- a/src/Illuminate/Database/Schema/SQLiteBuilder.php
+++ b/src/Illuminate/Database/Schema/SQLiteBuilder.php
@@ -11,10 +11,8 @@ class SQLiteBuilder extends Builder
      */
     public function dropAllTables()
     {
-        $this->connection->select($this->grammar->compileEnableWriteableSchema());
+        unlink($this->connection->getDatabaseName());
 
-        $this->connection->select($this->grammar->compileDropAllTables());
-
-        $this->connection->select($this->grammar->compileDisableWriteableSchema());
+        touch($this->connection->getDatabaseName());
     }
 }


### PR DESCRIPTION
As reported in https://github.com/laravel/framework/issues/19634

`migrate:fresh` doesn't seem to work in sqlite, the first step of deleting all tables appear to work but running the `migrate` command later shows:

```
table "migrations" already exists
```

However if you run `migrate:fresh` again it'll work, so for some reason it doesn't work in one go!

In this PR I replace the code for deleting all tables with a code that deletes the database file and recreates it. Not sure if it's the best solution though.