### PR TITLE
[5.5] Handle sqlite :memory: while deleting all tables

### DIFF
--- a/src/Illuminate/Database/Schema/SQLiteBuilder.php
+++ b/src/Illuminate/Database/Schema/SQLiteBuilder.php
@@ -23,7 +23,7 @@ class SQLiteBuilder extends Builder
     }
 
     /**
-     * Delete the database file.
+     * Delete the database file & re-create it.
      *
      * @return void
      */

--- a/src/Illuminate/Database/Schema/SQLiteBuilder.php
+++ b/src/Illuminate/Database/Schema/SQLiteBuilder.php
@@ -11,6 +11,24 @@ class SQLiteBuilder extends Builder
      */
     public function dropAllTables()
     {
+        if ($this->connection->getDatabaseName() != ':memory:') {
+            return $this->deleteDatabaseFile();
+        }
+
+        $this->connection->select($this->grammar->compileEnableWriteableSchema());
+
+        $this->connection->select($this->grammar->compileDropAllTables());
+
+        $this->connection->select($this->grammar->compileDisableWriteableSchema());
+    }
+
+    /**
+     * Delete the database file.
+     *
+     * @return void
+     */
+    public function deleteDatabaseFile()
+    {
         unlink($this->connection->getDatabaseName());
 
         touch($this->connection->getDatabaseName());

--- a/src/Illuminate/Database/Schema/SQLiteBuilder.php
+++ b/src/Illuminate/Database/Schema/SQLiteBuilder.php
@@ -12,7 +12,7 @@ class SQLiteBuilder extends Builder
     public function dropAllTables()
     {
         if ($this->connection->getDatabaseName() != ':memory:') {
-            return $this->deleteDatabaseFile();
+            return $this->refreshDatabaseFile();
         }
 
         $this->connection->select($this->grammar->compileEnableWriteableSchema());
@@ -27,7 +27,7 @@ class SQLiteBuilder extends Builder
      *
      * @return void
      */
-    public function deleteDatabaseFile()
+    public function refreshDatabaseFile()
     {
         unlink($this->connection->getDatabaseName());
 

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -552,7 +552,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
         $providers = $this->make(PackageManifest::class)->providers();
 
         (new ProviderRepository($this, new Filesystem, $this->getCachedServicesPath()))
-                    ->load(array_merge($providers, $this->config['app.providers']));
+                    ->load(array_merge($this->config['app.providers'], $providers));
     }
 
     /**

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -552,7 +552,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
         $providers = $this->make(PackageManifest::class)->providers();
 
         (new ProviderRepository($this, new Filesystem, $this->getCachedServicesPath()))
-                    ->load(array_merge($this->config['app.providers'], $providers));
+                    ->load(array_merge($providers, $this->config['app.providers']));
     }
 
     /**


### PR DESCRIPTION
If we use in-memory sqlite database the old delete commands work, they only fail in case we use a fail.

So this PR deletes and recreates the file if a file is used, but runs old command in case of in-memory.