### PR TITLE
[5.4] Add option for scaffolding auth tests

### DIFF
--- a/src/Illuminate/Auth/Console/MakeAuthCommand.php
+++ b/src/Illuminate/Auth/Console/MakeAuthCommand.php
@@ -48,7 +48,7 @@ class MakeAuthCommand extends Command
     protected $tests = [
         'LoginTest.stub' => 'Feature/LoginTest.php',
         'RegisterTest.stub' => 'Feature/RegisterTest.php',
-        'ResetsPasswordTest.stub' => 'Feature/ResetsPasswordTest.php'
+        'ResetsPasswordTest.stub' => 'Feature/ResetsPasswordTest.php',
     ];
 
     /**

--- a/src/Illuminate/Auth/Console/stubs/make/tests/LoginTest.stub
+++ b/src/Illuminate/Auth/Console/stubs/make/tests/LoginTest.stub
@@ -1,0 +1,80 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\User;
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\WithoutMiddleware;
+use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+
+class LoginTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    /**
+     * The login form can be displayed.
+     *
+     * @return void
+     */
+    public function testLoginFormDisplayed()
+    {
+        $response = $this->get('/login');
+
+        $response->assertStatus(200);
+    }
+
+    /**
+     * A valid user can be logged in.
+     *
+     * @return void
+     */
+    public function testLoginAValidUser()
+    {
+        $user = factory(User::class)->create();
+
+        $response = $this->post('/login', [
+            'email' => $user->email,
+            'password' => 'secret'
+        ]);
+
+        $response->assertStatus(302);
+
+        $this->seeIsAuthenticatedAs($user);
+    }
+
+    /**
+     * An invalid user cannot be logged in.
+     *
+     * @return void
+     */
+    public function testDoesNotLoginAnInvalidUser()
+    {
+        $user = factory(User::class)->create();
+
+        $response = $this->post('/login', [
+            'email' => $user->email,
+            'password' => 'invalid'
+        ]);
+
+        $response->assertSessionHasErrors();
+
+        $this->dontSeeIsAuthenticated();
+    }
+
+    /**
+     * A logged in user can be logged out.
+     *
+     * @return void
+     */
+    public function testLogoutAnAuthenticatedUser()
+    {
+        $user = factory(User::class)->create();
+
+        $response = $this->actingAs($user)->post('/logout');
+
+        $response->assertStatus(302);
+
+        $this->dontSeeIsAuthenticated();
+    }
+}

--- a/src/Illuminate/Auth/Console/stubs/make/tests/RegisterTest.stub
+++ b/src/Illuminate/Auth/Console/stubs/make/tests/RegisterTest.stub
@@ -1,0 +1,68 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\User;
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\WithoutMiddleware;
+use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+
+class RegisterTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    /**
+     * The registration form can be displayed.
+     *
+     * @return void
+     */
+    public function testRegisterFormDisplayed()
+    {
+        $response = $this->get('/register');
+
+        $response->assertStatus(200);
+    }
+
+    /**
+     * A valid user can be registered.
+     *
+     * @return void
+     */
+    public function testRegistersAValidUser()
+    {
+        $user = factory(User::class)->make();
+
+        $response = $this->post('register', [
+            'name' => $user->name,
+            'email' => $user->email,
+            'password' => 'secret',
+            'password_confirmation' => 'secret'
+        ]);
+
+        $response->assertStatus(302);
+
+        $this->seeIsAuthenticated();
+    }
+
+    /**
+     * An invalid user is not registered.
+     *
+     * @return void
+     */
+    public function testDoesNotRegisterAnInvalidUser()
+    {
+        $user = factory(User::class)->make();
+
+        $response = $this->post('register', [
+            'name' => $user->name,
+            'email' => $user->email,
+            'password' => 'secret',
+            'password_confirmation' => 'invalid'
+        ]);
+
+        $response->assertSessionHasErrors();
+
+        $this->dontSeeIsAuthenticated();
+    }
+}

--- a/src/Illuminate/Auth/Console/stubs/make/tests/ResetsPasswordTest.stub
+++ b/src/Illuminate/Auth/Console/stubs/make/tests/ResetsPasswordTest.stub
@@ -1,0 +1,90 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\User;
+use Tests\TestCase;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Password;
+use Illuminate\Auth\Notifications\ResetPassword;
+use Illuminate\Foundation\Testing\WithoutMiddleware;
+use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+
+class ResetsPasswordTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    /**
+     * Displays the reset password request form.
+     *
+     * @return void
+     */
+    public function testDisplaysPasswordResetRequestForm()
+    {
+        $response = $this->get('password/reset');
+
+        $response->assertStatus(200);
+    }
+
+    /**
+     * Sends the password reset email when the user exists.
+     *
+     * @return void
+     */
+    public function testSendsPasswordResetEmail()
+    {
+        $user = factory(User::class)->create();
+
+        $this->expectsNotification($user, ResetPassword::class);
+
+        $response = $this->post('password/email', ['email' => $user->email]);
+
+        $response->assertStatus(302);
+    }
+
+    /**
+     * Does not send a password reset email when the user does not exist.
+     *
+     * @return void
+     */
+    public function testDoesNotSendPasswordResetEmail()
+    {
+        $this->doesntExpectJobs(ResetPassword::class);
+
+        $this->post('password/email', ['email' => 'invalid@email.com']);
+    }
+
+    /**
+     * Displays the form to reset a password.
+     *
+     * @return void
+     */
+    public function testDisplaysPasswordResetForm()
+    {
+        $response = $this->get('/password/reset/token');
+
+        $response->assertStatus(200);
+    }
+
+    /**
+     * Allows a user to reset their password.
+     *
+     * @return void
+     */
+    public function testChangesAUsersPassword()
+    {
+        $user = factory(User::class)->create();
+
+        $token = Password::createToken($user);
+
+        $response = $this->post('/password/reset', [
+            'token' => $token,
+            'email' => $user->email,
+            'password' => 'password',
+            'password_confirmation' => 'password'
+        ]);
+
+        $this->assertTrue(Hash::check('password', $user->fresh()->password));
+    }
+}


### PR DESCRIPTION
I thought it might be beneficial to be able to quickly scaffold out some auth tests so as you're building out from the default setup you'll find out quickly if you're broken any of important registration/login/password reset flows. I thought it might also be helpful to other users who want to get more into testing to have some more fleshed out tests available to look at.

I've tried to be inspired by some of the tests I've seen within the framework and the ones published with Spark so that they feel at home. If it's something you actually think is worth having then they can be massaged to perfection but I thought I would offer this as a starting point to get the conversation rolling.