### PR TITLE
[5.4] Fix eloquent get dirty with casted attributes

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -997,9 +997,27 @@ trait HasAttributes
         } elseif ($this->hasCast($key)) {
             return $this->castAttribute($key, $current) === $this->castAttribute($key, $original);
         } else {
-            return is_numeric($current) && is_numeric($original)
-                && strcmp((string) $current, (string) $original) === 0;
+            return $this->originalIsNumericallyEquivalent($key);
         }
+    }
+
+    /**
+     * Determine if the new and old values for a given key are numerically equivalent.
+     *
+     * @param  string  $key
+     * @return bool
+     */
+    protected function originalIsNumericallyEquivalent($key)
+    {
+        $current = $this->attributes[$key];
+
+        $original = $this->original[$key];
+
+        // This method checks if the two values are numerically equivalent even if they
+        // are different types. This is in case the two values are not the same type
+        // we can do a fair comparison of the two values to know if this is dirty.
+        return is_numeric($current) && is_numeric($original)
+            && strcmp((string) $current, (string) $original) === 0;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -964,7 +964,7 @@ trait HasAttributes
             if (! array_key_exists($key, $this->original)) {
                 $dirty[$key] = $value;
             } elseif ($value !== $this->original[$key] &&
-                    ! $this->originalIsNumericallyEquivalent($key)) {
+                    ! $this->originalIsEquivalent($key)) {
                 $dirty[$key] = $value;
             }
         }
@@ -973,22 +973,33 @@ trait HasAttributes
     }
 
     /**
-     * Determine if the new and old values for a given key are numerically equivalent.
+     * Determine if the new and old values for a given key are equivalent.
      *
      * @param  string  $key
      * @return bool
      */
-    protected function originalIsNumericallyEquivalent($key)
+    protected function originalIsEquivalent($key)
     {
         $current = $this->attributes[$key];
 
         $original = $this->original[$key];
 
-        // This method checks if the two values are numerically equivalent even if they
-        // are different types. This is in case the two values are not the same type
-        // we can do a fair comparison of the two values to know if this is dirty.
-        return is_numeric($current) && is_numeric($original)
-            && strcmp((string) $current, (string) $original) === 0;
+        if ($current === $original) {
+            return true;
+        }
+
+        if (is_null($current) || is_null($original)) {
+            return false;
+        }
+
+        if (in_array($key, $this->getDates()) || $this->isDateCastable($key)) {
+            return $this->asDateTime($current)->eq($this->asDateTime($original));
+        } elseif ($this->hasCast($key)) {
+            return $this->castAttribute($key, $current) === $this->castAttribute($key, $original);
+        } else {
+            return is_numeric($current) && is_numeric($original)
+                && strcmp((string) $current, (string) $original) === 0;
+        }
     }
 
     /**

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1503,6 +1503,51 @@ class DatabaseEloquentModelTest extends TestCase
         $model->getAttributes();
     }
 
+    public function testModelAttributesCastedNotDirty()
+    {
+        $model = new EloquentModelCastingStub;
+        $model->setDateFormat('Y-m-d H:i:s');
+        $model->intAttribute = '3';
+        $model->floatAttribute = '4.0';
+        $model->stringAttribute = 2.5;
+        $model->boolAttribute = 1;
+        $model->booleanAttribute = 0;
+        $model->objectAttribute = ['foo' => 'bar'];
+        $obj = new StdClass;
+        $obj->foo = 'bar';
+        $model->arrayAttribute = $obj;
+        $model->jsonAttribute = ['foo' => 'bar'];
+        $model->dateAttribute = '1969-07-20';
+        $model->datetimeAttribute = '1969-07-20 22:56:00';
+        $model->timestampAttribute = '1969-07-20 22:56:00';
+
+        $model->syncOriginal();
+
+        $model->intAttribute = $model->intAttribute;
+        $model->floatAttribute = $model->floatAttribute;
+        $model->stringAttribute = $model->stringAttribute;
+        $model->boolAttribute = $model->boolAttribute;
+        $model->booleanAttribute = $model->booleanAttribute;
+        $model->objectAttribute = $model->objectAttribute;
+        $model->arrayAttribute = $model->arrayAttribute;
+        $model->jsonAttribute = $model->jsonAttribute;
+        $model->dateAttribute = $model->dateAttribute;
+        $model->datetimeAttribute = $model->datetimeAttribute;
+        $model->timestampAttribute = $model->timestampAttribute;
+
+        $this->assertFalse($model->isDirty('intAttribute'));
+        $this->assertFalse($model->isDirty('floatAttribute'));
+        $this->assertFalse($model->isDirty('stringAttribute'));
+        $this->assertFalse($model->isDirty('boolAttribute'));
+        $this->assertFalse($model->isDirty('booleanAttribute'));
+        $this->assertFalse($model->isDirty('objectAttribute'));
+        $this->assertFalse($model->isDirty('arrayAttribute'));
+        $this->assertFalse($model->isDirty('jsonAttribute'));
+        $this->assertFalse($model->isDirty('dateAttribute'));
+        $this->assertFalse($model->isDirty('datetimeAttribute'));
+        $this->assertFalse($model->isDirty('timestampAttribute'));
+    }
+
     public function testUpdatingNonExistentModelFails()
     {
         $model = new EloquentModelStub;


### PR DESCRIPTION
Equivalent values were being considered as different in `getDirty` method.

This happens when the attributes are casted.

```
$model = new Model;
$model->boolAttribute = 1;
$model->syncOriginal();
$model->boolAttribute = $model->boolAttribute;

// Fail because true !== 1
$this->assertFalse($model->isDirty('boolAttribute'));
```