### PR TITLE
[5.4] fix mergeConfigFrom logic

### DIFF
--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -56,7 +56,7 @@ abstract class ServiceProvider
     {
         $config = $this->app['config']->get($key, []);
 
-        $this->app['config']->set($key,  $config + (require $path));
+        $this->app['config']->set($key, $config + (require $path));
     }
 
     /**

--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -56,7 +56,7 @@ abstract class ServiceProvider
     {
         $config = $this->app['config']->get($key, []);
 
-        $this->app['config']->set($key, array_merge(require $path, $config));
+        $this->app['config']->set($key, (require $path) + $config);
     }
 
     /**

--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -56,7 +56,7 @@ abstract class ServiceProvider
     {
         $config = $this->app['config']->get($key, []);
 
-        $this->app['config']->set($key, (require $path) + $config);
+        $this->app['config']->set($key,  $config + (require $path));
     }
 
     /**


### PR DESCRIPTION
array_merge crushes the config key as numeric
The behavior is going to be changed like this.

```
return [
   '1000' => 'hoge',
   '2000' => 'fuga',
];
```
=>
```
return [
   'hoge',
   'fuga',
];
```