### PR TITLE
[5.4] Add ability to remove a global scope with another global scope

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -888,7 +888,7 @@ class Builder
         $builder = clone $this;
 
         foreach ($this->scopes as $identifier => $scope) {
-            if (!isset($builder->scopes[$identifier])) {
+            if (! isset($builder->scopes[$identifier])) {
                 continue;
             }
 

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -887,7 +887,11 @@ class Builder
 
         $builder = clone $this;
 
-        foreach ($this->scopes as $scope) {
+        foreach ($this->scopes as $identifier => $scope) {
+            if (!isset($builder->scopes[$identifier])) {
+                continue;
+            }
+
             $builder->callScope(function (Builder $builder) use ($scope) {
                 // If the scope is a Closure we will just go ahead and call the scope with the
                 // builder instance. The "callScope" method will properly group the clauses

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -3,11 +3,11 @@
 namespace Illuminate\Tests\Database;
 
 use Exception;
-use Illuminate\Database\Eloquent\SoftDeletes;
-use Illuminate\Database\Eloquent\SoftDeletingScope;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Capsule\Manager as DB;
 use Illuminate\Database\Eloquent\Relations\Pivot;
+use Illuminate\Database\Eloquent\SoftDeletingScope;
 use Illuminate\Database\Eloquent\Model as Eloquent;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Pagination\AbstractPaginator as Paginator;

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -3,6 +3,8 @@
 namespace Illuminate\Tests\Database;
 
 use Exception;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Database\Eloquent\SoftDeletingScope;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Database\Capsule\Manager as DB;
 use Illuminate\Database\Eloquent\Relations\Pivot;
@@ -89,6 +91,14 @@ class DatabaseEloquentIntegrationTest extends TestCase
                 $table->morphs('imageable');
                 $table->string('name');
                 $table->timestamps();
+            });
+
+            $this->schema($connection)->create('soft_deleted_users', function ($table) {
+                $table->increments('id');
+                $table->string('name')->nullable();
+                $table->string('email');
+                $table->timestamps();
+                $table->softDeletes();
             });
         }
 
@@ -1012,6 +1022,14 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertNotNull($user->fresh());
     }
 
+    public function testGlobalScopeCanBeRemovedByOtherGlobalScope()
+    {
+        $user = EloquentTestUserWithGlobalScopeRemovingOtherScope::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']);
+        $user->delete();
+
+        $this->assertNotNull(EloquentTestUserWithGlobalScopeRemovingOtherScope::find($user->id));
+    }
+
     public function testForPageAfterIdCorrectlyPaginates()
     {
         EloquentTestUser::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']);
@@ -1221,6 +1239,24 @@ class EloquentTestUserWithOmittingGlobalScope extends EloquentTestUser
         static::addGlobalScope(function ($builder) {
             $builder->where('email', '!=', 'taylorotwell@gmail.com');
         });
+    }
+}
+
+class EloquentTestUserWithGlobalScopeRemovingOtherScope extends Eloquent
+{
+    use SoftDeletes;
+
+    protected $table = 'soft_deleted_users';
+
+    protected $guarded = [];
+
+    public static function boot()
+    {
+        static::addGlobalScope(function ($builder) {
+            $builder->withoutGlobalScope(SoftDeletingScope::class);
+        });
+
+        parent::boot();
     }
 }
 


### PR DESCRIPTION
As described in #19282, there is currently no way to remove a global scope with another global scope.
Example use case would be to automatically allow users with elevated privileges to view soft-deleted models.

```php
class Product extends Model 
{

    use SoftDeletes;

    protected static function boot()
    {
        static::addGlobalScope(function(Builder $query) {
            if (auth()->user()->hasElevatedPrivileges()) {
                $query->withoutGlobalScope(SoftDeletingScope::class);
            }
        });

        parent::boot();
    }
}
```

This allows for replacing:
```php
class ProductController extends Controller
{
    public function show($productId, Request $request)
    {
        if ($request->user()->hasElevatedPrivileges()) {
            return Product::withTrashed()->findOrFail($productId);
        }

        return Product::findOrFail($productId);
    }
}
```
with
```php
class ProductController extends Controller
{
    public function show(Product $product)
    {
        return $product;
    }
}
```