### PR TITLE
[5.5] fix updating nullable dates

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -728,9 +728,10 @@ trait HasAttributes
      */
     public function fromDateTime($value)
     {
-        return $this->asDateTime($value)->format(
-            $this->getDateFormat()
-        );
+        return $value == null
+            ? $value : $this->asDateTime($value)->format(
+                $this->getDateFormat()
+            );
     }
 
     /**

--- a/tests/Integration/Database/EloquentModelTest.php
+++ b/tests/Integration/Database/EloquentModelTest.php
@@ -1,0 +1,57 @@
+<?php
+
+use Orchestra\Testbench\TestCase;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * @group integration
+ */
+class EloquentModelTest extends TestCase
+{
+    protected function getEnvironmentSetUp($app)
+    {
+        $app['config']->set('app.debug', 'true');
+
+        $app['config']->set('database.default', 'testbench');
+
+        $app['config']->set('database.connections.testbench', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+        ]);
+    }
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        Schema::create('users', function ($table) {
+            $table->increments('id');
+            $table->timestamp('nullable_date')->nullable();
+        });
+    }
+
+    public function test_user_can_update_nullable_date()
+    {
+        $user = EloquentModelTestModel::create([
+            'nullable_date' => null,
+        ]);
+
+        $user->fill([
+            'nullable_date' => $now = \Carbon\Carbon::now(),
+        ]);
+        $this->assertTrue($user->isDirty('nullable_date'));
+
+        $user->save();
+        $this->assertEquals($now->toDateString(), $user->nullable_date->toDateString());
+    }
+}
+
+class EloquentModelTestModel extends Model
+{
+    public $table = 'users';
+    public $timestamps = false;
+    protected $guarded = ['id'];
+    protected $dates = ['nullable_date'];
+}


### PR DESCRIPTION
Currently if a `nullable` timestamp field had a value of `null`, when you update it ELoquent will attempt to cast the original value to Carbon instance, and since the value is `null` it's going to error.

Here's where we compare original and current value to build the `dirty` array:

https://github.com/laravel/framework/blob/master/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php#L1007-L1009

This change will check if the given value is null and just return it as is without attempting to cast it as a carbon instance.