### PR TITLE
[5.5] Job : declare missing abstract getRawBody function.

### DIFF
--- a/src/Illuminate/Queue/Jobs/Job.php
+++ b/src/Illuminate/Queue/Jobs/Job.php
@@ -182,6 +182,13 @@ abstract class Job
     }
 
     /**
+     * Get the raw body of the job.
+     *
+     * @return string
+     */
+    abstract public function getRawBody();
+
+    /**
      * The number of times to attempt a job.
      *
      * @return int|null


### PR DESCRIPTION
declare missing abstract `getRawBody` function.