### PR TITLE
[5.4] fix date validator

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -339,7 +339,8 @@ trait ValidatesAttributes
 
         $date = date_parse($value);
 
-        return checkdate($date['month'], $date['day'], $date['year']);
+        return $date['error_count'] + $date['warning_count'] > 0 ? false : checkdate($date['month'], $date['day'],
+            $date['year']);
     }
 
     /**

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -2258,6 +2258,9 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['x' => '01/01/2000'], ['x' => 'date']);
         $this->assertTrue($v->passes());
 
+        $v = new Validator($trans, ['x' => '22/12/1990'], ['x' => 'date']);
+        $this->assertTrue($v->fails());
+
         $v = new Validator($trans, ['x' => '1325376000'], ['x' => 'date']);
         $this->assertTrue($v->fails());
 


### PR DESCRIPTION
I am not good at explaining the issues as it creates a lot of confusion explaining in sentences to me. I have attached tinker examples below which should explain the issue i guess. I am not sure if the current behavior is expected and is not a bug.  `check_date` returns true as the result returned from the `date_parse` function is different. 

```bash
>>> $date = date_parse('22/12/1990')
=> [
     "year" => 1990,
     "month" => 2,
     "day" => 12,
     "hour" => false,
     "minute" => false,
     "second" => false,
     "fraction" => false,
     "warning_count" => 0,
     "warnings" => [],
     "error_count" => 1,
     "errors" => [
       "Unexpected character",
     ],
     "is_localtime" => false,
   ]
>>> strtotime('22/12/1990')
=> false
>>> new DateTime('22/12/1990')
Exception with message 'DateTime::__construct(): Failed to parse time string (22/12/1990) at position 0 (2): Unexpected character'
>>> Carbon::parse('22/12/1990')
Exception with message 'DateTime::__construct(): Failed to parse time string (22/12/1990) at position 0 (2): Unexpected character'
>>> checkdate($date['month'], $date['day'], $date['year'])
=> true
// after changing the dateformat it works 
>>> Carbon::parse('12/22/1990')
=> Carbon\Carbon {#1642
     +"date": "1990-12-22 00:00:00.000000",
     +"timezone_type": 3,
     +"timezone": "UTC",
   }
>>> 

```