### PR TITLE
[5.4] Ensure that date with format DD/MM/YYY fails

### DIFF
--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -2258,6 +2258,9 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['x' => '01/01/2000'], ['x' => 'date']);
         $this->assertTrue($v->passes());
 
+        $v = new Validator($trans, ['x' => '22/12/1990'], ['x' => 'date']);
+        $this->assertTrue($v->fails());
+
         $v = new Validator($trans, ['x' => '1325376000'], ['x' => 'date']);
         $this->assertTrue($v->fails());
 


### PR DESCRIPTION
Ensure that a date with format `DD/MM/YYY` fails

---

**CHECK https://github.com/laravel/framework/pull/19679 FIRST**