### PR TITLE
[5.5] Save BelongsTo relations before Model in push

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -465,6 +465,19 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public function push()
     {
+        // Check for any BelongsTo relations and save those first.
+        foreach ($this->getRelations() as $method => $related) {
+            if (! ($this->$method() instanceof BelongsTo)) {
+                continue;
+            }
+
+            if (! $related->push()) {
+                return false;
+            }
+
+            $this->$method()->associate($related);
+        }
+
         if (! $this->save()) {
             return false;
         }

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -467,7 +467,10 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     {
         // Check for any BelongsTo relations and save those first.
         foreach ($this->getRelations() as $method => $related) {
-            if (! ($this->$method() instanceof BelongsTo)) {
+            if (! method_exists($this, $method)
+                || ! ($this->$method() instanceof BelongsTo)
+                || ! ($related instanceof self)
+            ) {
                 continue;
             }
 


### PR DESCRIPTION
Model::push has had issues in the past that were closed because it wasn't working properly in some cases. In one, Taylor was even in favor of it and asked for a pull request but it never happened.

I resolved this in my company's extended Model class and figured I would initiate a pull request to see if it could help the rest of the Laravel community as well.

The part I am most concerned about is whether or not the "$method" variable is *always* the name of the relationship method... so there may be some additional problem-solving needed around that. I'm hoping some sort of automated testing and/or community review can catch any mistakes I might not have been able to see at the time.