### PR TITLE
[5.4]event helper "Illegal offset type"

### DIFF
--- a/src/Illuminate/Foundation/Http/Kernel.php
+++ b/src/Illuminate/Foundation/Http/Kernel.php
@@ -124,7 +124,7 @@ class Kernel implements KernelContract
             $response = $this->renderException($request, $e);
         }
 
-        event(new Events\RequestHandled($request, $response));
+        $this->app['events']->dispatch(new Events\RequestHandled($request, $response));
 
         return $response;
     }


### PR DESCRIPTION
when using hoa/core, hoa/ruler(^1.15), etc..
laravel event helper isn't valid because the hoa component is registered first.

```php
function event(...$args)
{
    return app('events')->dispatch(...$args);
}

// same
$this->app['events']->dispatch(...$args)
```

