### PR TITLE
[5.4] Dispatch the "Mail Sent" event only if mails should be sent

### DIFF
--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -208,9 +208,11 @@ class Mailer implements MailerContract, MailQueueContract
             $this->setGlobalTo($message);
         }
 
-        $this->sendSwiftMessage($message->getSwiftMessage());
+        if ($this->shouldSendMessage($swiftMessage = $message->getSwiftMessage())) {
+            $this->sendSwiftMessage($swiftMessage);
 
-        $this->dispatchSentEvent($message);
+            $this->dispatchSentEvent($message);
+        }
     }
 
     /**
@@ -432,10 +434,6 @@ class Mailer implements MailerContract, MailQueueContract
      */
     protected function sendSwiftMessage($message)
     {
-        if (! $this->shouldSendMessage($message)) {
-            return;
-        }
-
         try {
             return $this->swift->send($message, $this->failedRecipients);
         } finally {


### PR DESCRIPTION
Currently the event is dispatched even if you stop mail from sending in your `MessageSending` event.