### PR TITLE
[5.4] require illuminate/database in illuminate/queue

### DIFF
--- a/src/Illuminate/Queue/composer.json
+++ b/src/Illuminate/Queue/composer.json
@@ -18,9 +18,9 @@
         "illuminate/console": "5.4.*",
         "illuminate/container": "5.4.*",
         "illuminate/contracts": "5.4.*",
+        "illuminate/database": "5.4.*",
         "illuminate/filesystem": "5.4.*",
         "illuminate/support": "5.4.*",
-        "illuminate/database": "5.4.*",
         "nesbot/carbon": "~1.20",
         "symfony/debug": "~3.2",
         "symfony/process": "~3.2"

--- a/src/Illuminate/Queue/composer.json
+++ b/src/Illuminate/Queue/composer.json
@@ -20,6 +20,7 @@
         "illuminate/contracts": "5.4.*",
         "illuminate/filesystem": "5.4.*",
         "illuminate/support": "5.4.*",
+        "illuminate/database": "5.4.*",
         "nesbot/carbon": "~1.20",
         "symfony/debug": "~3.2",
         "symfony/process": "~3.2"


### PR DESCRIPTION
Since we use the `Illuminate\Database\DetectsLostConnections` in our `Queue\Worker` class.