### PR TITLE
[5.5] Provide a Notification Channel contract

### DIFF
--- a/src/Illuminate/Contracts/Notifications/Channel.php
+++ b/src/Illuminate/Contracts/Notifications/Channel.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Illuminate\Contracts\Notifications;
+
+use Illuminate\Notifications\Notification;
+
+interface Channel
+{
+    /**
+     * Send the given notification.
+     *
+     * @param  mixed $notifiable
+     * @param  \Illuminate\Notifications\Notification $notification
+     * @return \Psr\Http\Message\ResponseInterface
+     */
+    public function send($notifiable, Notification $notification);
+}

--- a/src/Illuminate/Notifications/Channels/BroadcastChannel.php
+++ b/src/Illuminate/Notifications/Channels/BroadcastChannel.php
@@ -7,8 +7,9 @@ use Illuminate\Notifications\Notification;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Notifications\Messages\BroadcastMessage;
 use Illuminate\Notifications\Events\BroadcastNotificationCreated;
+use Illuminate\Contracts\Notifications\Channel as ChannelContract;
 
-class BroadcastChannel
+class BroadcastChannel implements ChannelContract
 {
     /**
      * The event dispatcher.

--- a/src/Illuminate/Notifications/Channels/DatabaseChannel.php
+++ b/src/Illuminate/Notifications/Channels/DatabaseChannel.php
@@ -4,8 +4,9 @@ namespace Illuminate\Notifications\Channels;
 
 use RuntimeException;
 use Illuminate\Notifications\Notification;
+use Illuminate\Contracts\Notifications\Channel as ChannelContract;
 
-class DatabaseChannel
+class DatabaseChannel implements ChannelContract
 {
     /**
      * Send the given notification.

--- a/src/Illuminate/Notifications/Channels/MailChannel.php
+++ b/src/Illuminate/Notifications/Channels/MailChannel.php
@@ -8,8 +8,9 @@ use Illuminate\Mail\Markdown;
 use Illuminate\Contracts\Mail\Mailer;
 use Illuminate\Contracts\Mail\Mailable;
 use Illuminate\Notifications\Notification;
+use Illuminate\Contracts\Notifications\Channel as ChannelContract;
 
-class MailChannel
+class MailChannel implements ChannelContract
 {
     /**
      * The mailer implementation.

--- a/src/Illuminate/Notifications/Channels/NexmoSmsChannel.php
+++ b/src/Illuminate/Notifications/Channels/NexmoSmsChannel.php
@@ -5,8 +5,9 @@ namespace Illuminate\Notifications\Channels;
 use Nexmo\Client as NexmoClient;
 use Illuminate\Notifications\Notification;
 use Illuminate\Notifications\Messages\NexmoMessage;
+use Illuminate\Contracts\Notifications\Channel as ChannelContract;
 
-class NexmoSmsChannel
+class NexmoSmsChannel implements ChannelContract
 {
     /**
      * The Nexmo client instance.

--- a/src/Illuminate/Notifications/Channels/SlackWebhookChannel.php
+++ b/src/Illuminate/Notifications/Channels/SlackWebhookChannel.php
@@ -7,8 +7,9 @@ use Illuminate\Notifications\Notification;
 use Illuminate\Notifications\Messages\SlackMessage;
 use Illuminate\Notifications\Messages\SlackAttachment;
 use Illuminate\Notifications\Messages\SlackAttachmentField;
+use Illuminate\Contracts\Notifications\Channel as ChannelContract;
 
-class SlackWebhookChannel
+class SlackWebhookChannel implements ChannelContract
 {
     /**
      * The HTTP client instance.

--- a/tests/Notifications/NotificationBroadcastChannelTest.php
+++ b/tests/Notifications/NotificationBroadcastChannelTest.php
@@ -53,6 +53,7 @@ class NotificationBroadcastChannelTest extends TestCase
             return $event->connection == 'sync';
         }));
         $channel = new BroadcastChannel($events);
+        $this->assertInstanceOf(\Illuminate\Contracts\Notifications\Channel::class, $channel);
         $channel->send($notifiable, $notification);
     }
 }

--- a/tests/Notifications/NotificationDatabaseChannelTest.php
+++ b/tests/Notifications/NotificationDatabaseChannelTest.php
@@ -29,6 +29,7 @@ class NotificationDatabaseChannelTest extends TestCase
         ]);
 
         $channel = new DatabaseChannel;
+        $this->assertInstanceOf(\Illuminate\Contracts\Notifications\Channel::class, $channel);
         $channel->send($notifiable, $notification);
     }
 }

--- a/tests/Notifications/NotificationNexmoChannelTest.php
+++ b/tests/Notifications/NotificationNexmoChannelTest.php
@@ -22,6 +22,7 @@ class NotificationNexmoChannelTest extends TestCase
         $channel = new \Illuminate\Notifications\Channels\NexmoSmsChannel(
             $nexmo = Mockery::mock(\Nexmo\Client::class), '4444444444'
         );
+        $this->assertInstanceOf(\Illuminate\Contracts\Notifications\Channel::class, $channel);
 
         $nexmo->shouldReceive('message->send')->with([
             'type' => 'text',

--- a/tests/Notifications/NotificationSlackChannelTest.php
+++ b/tests/Notifications/NotificationSlackChannelTest.php
@@ -25,6 +25,7 @@ class NotificationSlackChannelTest extends TestCase
         $channel = new \Illuminate\Notifications\Channels\SlackWebhookChannel(
             $http = Mockery::mock('GuzzleHttp\Client')
         );
+        $this->assertInstanceOf(\Illuminate\Contracts\Notifications\Channel::class, $channel);
 
         $http->shouldReceive('post')->with('url', $payload);
 


### PR DESCRIPTION
Provide a Notification Channel contract.

---

When using a large numbers of channels, built-in or custom, it makes it easier to rely on an interface; to make sure that the `send` will always be defined in a Channel.