### PR TITLE
[5.5][WIP] custom relations

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -15,6 +15,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\CustomRelation;
 use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 
 trait HasRelationships
@@ -42,6 +43,19 @@ trait HasRelationships
         'belongsToMany', 'morphToMany', 'morphedByMany',
         'guessBelongsToManyRelation', 'findFirstMethodThatIsntRelation',
     ];
+
+    /**
+     * Define a custom relationship.
+     *
+     * @param \Illuminate\Database\Eloquent\Model $custom
+     * @return \Illuminate\Database\Eloquent\Relations\CustomRelation
+     */
+    public function customRelation(Model $custom)
+    {
+        $query = $custom->newQuery();
+
+        return new CustomRelation($query, $this, $custom);
+    }
 
     /**
      * Define a one-to-one relationship.

--- a/src/Illuminate/Database/Eloquent/Relations/CustomRelation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/CustomRelation.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Relations;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Model;
+
+class CustomRelation extends Relation
+{
+    /**
+     * @var \Illuminate\Database\Eloquent\Model
+     */
+    protected $custom;
+
+    /**
+     * Create a new belongs to relationship instance.
+     *
+     * @param \Illuminate\Database\Eloquent\Builder $query
+     * @param \Illuminate\Database\Eloquent\Model   $parent
+     * @param \Illuminate\Database\Eloquent\Model   $custom
+     */
+    public function __construct(Builder $query, Model $parent, Model $custom)
+    {
+        $this->custom = $custom;
+
+        parent::__construct($query, $parent);
+    }
+
+    /**
+     * Set the base constraints on the relation query.
+     *
+     * @return void
+     */
+    public function addConstraints()
+    {
+        //custom relationships have no constraints
+    }
+
+    /**
+     * Set the constraints for an eager load of the relation.
+     *
+     * @param  array $models
+     * @return void
+     */
+    public function addEagerConstraints(array $models)
+    {
+        //custom relationships have no eager constraints
+    }
+
+    /**
+     * Initialize the relation on a set of models.
+     *
+     * @param  array  $models
+     * @param  string $relation
+     * @return array
+     */
+    public function initRelation(array $models, $relation)
+    {
+        foreach ($models as $model) {
+            $model->setRelation($relation, $this->related->newCollection());
+        }
+
+        return $models;
+    }
+
+    /**
+     * Match the eagerly loaded results to their parents.
+     *
+     * @param  array                                    $models
+     * @param  \Illuminate\Database\Eloquent\Collection $results
+     * @param  string                                   $relation
+     * @return array
+     */
+    public function match(array $models, Collection $results, $relation)
+    {
+        //custom relationships have no matches
+    }
+
+    /**
+     * Get the results of the relationship.
+     *
+     * @return \Illuminate\Database\Eloquent\Model
+     */
+    public function getResults()
+    {
+        return $this->custom;
+    }
+}

--- a/src/Illuminate/Database/Eloquent/Relations/CustomRelation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/CustomRelation.php
@@ -2,9 +2,9 @@
 
 namespace Illuminate\Database\Eloquent\Relations;
 
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
-use Illuminate\Database\Eloquent\Model;
 
 class CustomRelation extends Relation
 {


### PR DESCRIPTION
this PR is the *very delayed* result of the following issues.

https://github.com/laravel/framework/issues/8830
https://github.com/laravel/framework/issues/13056
https://github.com/laravel/internals/issues/47

The motivation behind this PR is to allow the Null Object pattern to work with Eloquent relationships.  I have the need in some applications for both a null object and a pseudo object, and this PR should hopefully allow for both of those options.

### Examples

I've tried to simplify the examples down as best I can to make them easier to understand. Please be aware that I'm sure there are other ways to accomplish certain things other than the way I've presented it in the code. If you'd like to share other ways you are accomplishing this goal, please leave a comment. It is much appreciated to see other ways of looking at it.

**Null Object**

The application has `Order`s that have discounts applied to them through `Coupon`s (example stolen from @adamwathan 's Laracon EU talk).

Our 'orders' table has the structure:

- id
- coupon_id

Our order would look something like this:

```php
class Order
{
    public function coupon
    {
        return $this->belongsTo(Coupon::class);
    }
}
```

The view might look like:

```blade
@if ($order->coupon)
    Your coupon has given you a discount of {{ $order->coupon->discount }}.
@else
    Your coupon has given you a discount of 0.
@endif
```

With our updated code:

```php
class Order
{
    public function coupon
    {
        if ($this->coupon_id) {
            return $this->belongsTo(Coupon::class);
        }

        $nullCoupon = new Coupon([
            'discount' => 0,
        ]);

        return $this->customRelation($nullCoupon);
    }
}
```

our view could be:

```blade
Your coupon has given you a discount of {{ $order->coupon->discount }}.
```

**Pseudo Object**

The application displays blogs, that can be written by a registered user in the system, or a guest user.  The table structure looks like the following:

- id
- title
- content
- author_id (nullable)  --> foreign key to the user table
- first_name (nullable)
- last_name (nullable)
- email (nullable)

In the current version of Laravel, you would have a simple `belongsTo` relationship.

```php
class Blog
{
    public function author()
    {
        return $this->belongsTo(User::class);
    }

    public function getGuestAuthorAttribute()
    {
        return new User([
            'first_name' => $this->first_name,
            'last_name'  => $this->last_name,
            'email'      => $this->email,
        ]);
    }
}
```

Then in the views you could do something similar to the following:

```blade
This blog was written by {{ ($blog->author) ? $blog->author->name : $blog->guestAuthor->name}}.
```

With the change we could combine some things and move the conditional into the Model.

```php
class Blog
{
    public function author()
    {
        if ($this->author_id) {
            return $this->belongsTo(User::class);
        }

        $guestAuthor = new User([
            'first_name' => $this->first_name,
            'last_name'  => $this->last_name,
            'email'      => $this->email,
        ]

        return $this->customRelation($guestAuthor);
    }
}
```

and our view might be simplified to

```blade
This blog was written by {{ $blog->author->name}}.
```

### Limitations

Originally I was thinking with this method we would essentially be able to return *anything* from the custom relationship. However, due to the fact we call `setRelation` on the results of the relationship, we **need** to pass in an Eloquent Model.

Also, because we are returning this dummy model, chaining will not work properly. Not sure if there is any way around this.

### Questions

1. Could we refactor to allow things other than Eloquent models in the custom relation?
2. Would it be better to refactor the `getRelationshipFromMethod` function to allow things other than `Relation`s? This would require checking that the `$relation` was an instance of `Relation` before we called the `getResults` method.

### Summation

In these examples I've used the default objects to create the Null and Pseudo objects. You could just as easily create custom objects like `GuestUser` and `NullTeam`.

Is this perfect? Probably not, but I want to get the conversation started, and hopefully this is a good jumping off point to start supporting this type of ability.

### Side Note

the branch name of this PR is a little off topic, because originally I was trying to allow null objects to be returned from relationships, but I realized half way through essentially you could create any type of custom relationship with this edit.

😅  *phew*