### PR TITLE
[5.5] Exception Handler Improvement in report()

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "erusev/parsedown": "~1.6",
         "filp/whoops": "~2.0",
         "league/flysystem": "~1.0",
-        "monolog/monolog": "~1.11",
+        "monolog/monolog": "~1.12",
         "mtdowling/cron-expression": "~1.0",
         "nesbot/carbon": "~1.20",
         "ramsey/uuid": "~3.0",

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -97,7 +97,7 @@ class Handler implements ExceptionHandlerContract
             throw $e; // throw the original exception
         }
 
-        $logger->error($e, $this->context());
+        $logger->error($e->getMessage(), (['exception' => $e] + $this->context()));
     }
 
     /**

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -97,7 +97,7 @@ class Handler implements ExceptionHandlerContract
             throw $e; // throw the original exception
         }
 
-        $logger->error($e->getMessage(), (['exception' => $e] + $this->context()));
+        $logger->error($e->getMessage(), array_merge($this->context(), ['exception' => $e]));
     }
 
     /**

--- a/src/Illuminate/Log/Writer.php
+++ b/src/Illuminate/Log/Writer.php
@@ -349,7 +349,9 @@ class Writer implements LogContract, PsrLoggerInterface
      */
     protected function getDefaultFormatter()
     {
-        return new LineFormatter(null, null, true, true);
+        $lineFormatter = new LineFormatter(null, null, true, true);
+        $lineFormatter->includeStacktraces();
+        return $lineFormatter;
     }
 
     /**

--- a/src/Illuminate/Log/Writer.php
+++ b/src/Illuminate/Log/Writer.php
@@ -351,6 +351,7 @@ class Writer implements LogContract, PsrLoggerInterface
     {
         $lineFormatter = new LineFormatter(null, null, true, true);
         $lineFormatter->includeStacktraces();
+
         return $lineFormatter;
     }
 

--- a/tests/Foundation/FoundationExceptionsHandlerTest.php
+++ b/tests/Foundation/FoundationExceptionsHandlerTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Foundation;
 
 use Exception;
 use Mockery as m;
+use Psr\Log\LoggerInterface;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Container\Container;
 use Illuminate\Config\Repository as Config;
@@ -47,6 +48,15 @@ class FoundationExceptionsHandlerTest extends TestCase
     public function tearDown()
     {
         m::close();
+    }
+
+    public function testHandlerReportsExceptionAsContext()
+    {
+        $logger = m::mock(LoggerInterface::class);
+        $this->container->instance(LoggerInterface::class, $logger);
+        $logger->shouldReceive('error')->withArgs(['Exception message', m::hasKey('exception')]);
+
+        $this->handler->report(new \RuntimeException('Exception message'));
     }
 
     public function testReturnsJsonWithStackTraceWhenAjaxRequestAndDebugTrue()


### PR DESCRIPTION
Several monolog handlers (and logging services) have first class support for logging exceptions. (New relic for example: https://github.com/Seldaek/monolog/blob/master/src/Monolog/Handler/NewRelicHandler.php#L88)  They are all consistent in that they expect the exception in the context at the key `'exception'`.  Additionally, it would be more user friendly to not have an exception (along with the whole large stacktrace) stringified in the message.

Tests are included, I am not sure what other expectations there are for logging exception in the laravel skeleton and other products.  Thanks.