### PR TITLE
[5.4] Use eval instead of require so that we don't have to generate files for real-time facades

### DIFF
--- a/src/Illuminate/Foundation/AliasLoader.php
+++ b/src/Illuminate/Foundation/AliasLoader.php
@@ -88,26 +88,9 @@ class AliasLoader
      */
     protected function loadFacade($alias)
     {
-        require $this->ensureFacadeExists($alias);
-    }
-
-    /**
-     * Ensure that the given alias has an existing real-time facade class.
-     *
-     * @param  string  $alias
-     * @return string
-     */
-    protected function ensureFacadeExists($alias)
-    {
-        if (file_exists($path = storage_path('framework/cache/facade-'.sha1($alias).'.php'))) {
-            return $path;
-        }
-
-        file_put_contents($path, $this->formatFacadeStub(
+        eval('?>' . $this->formatFacadeStub(
             $alias, file_get_contents(__DIR__.'/stubs/facade.stub')
         ));
-
-        return $path;
     }
 
     /**


### PR DESCRIPTION
The generation (and caching) of files for real-time facade classes was useless imo. AFAIK there was no real performance boost to writing and caching those files, since we were only skipping one `str_replace()` call.

So if there's no performance boost, my personal preference is to avoid generating files whenever possible. This PR uses `eval()` instead of `require` so that we can skip writing an actual file. Yes `eval()` has a bad rep, but in this case it's really no big deal, since it does exactly the same thing as an include.