### PR TITLE
Added ability to get queue name from method

### DIFF
--- a/src/Illuminate/Broadcasting/BroadcastManager.php
+++ b/src/Illuminate/Broadcasting/BroadcastManager.php
@@ -113,7 +113,9 @@ class BroadcastManager implements FactoryContract
 
         $queue = null;
 
-        if (isset($event->broadcastQueue)) {
+        if (method_exists($event, 'broadcastQueue')) {
+            $queue = $event->broadcastQueue();
+        } elseif (isset($event->broadcastQueue)) {
             $queue = $event->broadcastQueue;
         } elseif (isset($event->queue)) {
             $queue = $event->queue;


### PR DESCRIPTION
When using Pusher, in order to specify which queue to use, `public $broadcastQueue = 'name_of_queue'` must be set.
Unfortunately, all public variables set in the event are sent onto Pusher - resulting in the end user receiving this, in addition to the intended payload.
### Steps To Reproduce:
Create an event, specifying `public $broadcastQueue`, and run the worker.
Watch for the event in a web app, or simply use the "Debug Console" in Pusher to see the payload.

### Usage

```php
//  SendPushEvent.php
...
public function broadcastQueue()
{
    return 'name_of_queue';
}
```
I figure this would be consistent with `broadcastOn` and `broadcastAs`.

Does anyone have any thoughts on the matter?