### PR TITLE
[5.4] Optimize string verification in testSharedGet() by just checking the length

### DIFF
--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -371,7 +371,7 @@ class FilesystemTest extends TestCase
                 $files->put($this->tempDir.'/file.txt', $content, true);
                 $read = $files->get($this->tempDir.'/file.txt', true);
 
-                exit(($read === $content) ? 1 : 0);
+                exit(strlen($read) === strlen($content) ? 1 : 0);
             }
         }
 


### PR DESCRIPTION
Follow-up to #12796 and #16066.

Comparing strings of several MBs has some cost, while PHP stores strings' length, and checking the length is sufficient in the case here.

```php
$nb = 1000;

$read = str_repeat('123456', 1000000);
$content = str_repeat('123456', 1000000);

$t1 = microtime(true);
for ($i = $nb; $i--; ) {
    $read === $content;
}
$t2 = microtime(true);
for ($i = $nb; $i--; ) {
    strlen($read) === strlen($content);
}
$t3 = microtime(true);

echo $t2 - $t1;
echo "\n";
echo $t3 - $t2;
echo "\n\n";
echo $t2 - $t1 == 0 ? 'N/A' : ($t3 - $t2) * 100 / ($t2 - $t1);
```

So, for 1000 iterations:
before - 3.8630001544952 seconds
after - 0.0099999904632568 seconds

0.25886590896509 % (which means 400x faster)