### PR TITLE
Remove import of Schema in migration stubs.

### DIFF
--- a/src/Illuminate/Database/Migrations/stubs/blank.stub
+++ b/src/Illuminate/Database/Migrations/stubs/blank.stub
@@ -1,6 +1,5 @@
 <?php
 
-use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
 

--- a/src/Illuminate/Database/Migrations/stubs/create.stub
+++ b/src/Illuminate/Database/Migrations/stubs/create.stub
@@ -1,6 +1,5 @@
 <?php
 
-use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
 

--- a/src/Illuminate/Database/Migrations/stubs/update.stub
+++ b/src/Illuminate/Database/Migrations/stubs/update.stub
@@ -1,6 +1,5 @@
 <?php
 
-use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
 


### PR DESCRIPTION
Default app/config.php contains a Schema alias to the facade.

So an import is unnecessary.