### PR TITLE
[5.4] unset the broadcastQueue property in broadcast payload

### DIFF
--- a/src/Illuminate/Broadcasting/BroadcastEvent.php
+++ b/src/Illuminate/Broadcasting/BroadcastEvent.php
@@ -69,6 +69,8 @@ class BroadcastEvent implements ShouldQueue
             $payload[$property->getName()] = $this->formatProperty($property->getValue($event));
         }
 
+        unset($payload['broadcastQueue']);
+
         return $payload;
     }
 


### PR DESCRIPTION
In reference to https://github.com/laravel/framework/pull/19703