### PR TITLE
[5.5] getPluralIndex : no need to go for 0

### DIFF
--- a/src/Illuminate/Translation/MessageSelector.php
+++ b/src/Illuminate/Translation/MessageSelector.php
@@ -109,6 +109,10 @@ class MessageSelector
      */
     public function getPluralIndex($locale, $number)
     {
+        if ($number == 0) {
+            return 1;
+        }
+
         switch ($locale) {
             case 'az':
             case 'az_AZ':


### PR DESCRIPTION
No need to go further when `$number` is 0