### PR TITLE
[5.4] add $idType param to Blueprint::morphs

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -900,13 +900,14 @@ class Blueprint
     /**
      * Add the proper columns for a polymorphic table.
      *
-     * @param  string  $name
+     * @param  string       $name
      * @param  string|null  $indexName
+     * @param  string       $idType
      * @return void
      */
-    public function morphs($name, $indexName = null)
+    public function morphs($name, $indexName = null, $idType = 'unsignedInteger')
     {
-        $this->unsignedInteger("{$name}_id");
+        $this->$idType("{$name}_id");
 
         $this->string("{$name}_type");
 
@@ -916,13 +917,14 @@ class Blueprint
     /**
      * Add nullable columns for a polymorphic table.
      *
-     * @param  string  $name
+     * @param  string       $name
      * @param  string|null  $indexName
+     * @param  string       $idType
      * @return void
      */
-    public function nullableMorphs($name, $indexName = null)
+    public function nullableMorphs($name, $indexName = null, $idType = 'unsignedInteger')
     {
-        $this->unsignedInteger("{$name}_id")->nullable();
+        $this->$idType("{$name}_id")->nullable();
 
         $this->string("{$name}_type")->nullable();
 


### PR DESCRIPTION
In one of the projects I work on we use unsigned big ints for all primary keys, so standard practice for our morphs is to also use unsigned big ints. This change allows users the option to configure that as needed, and could also work the other way, if they're only using small ints or something.