### PR TITLE
[5.4] Fixed duplicate // for public_path

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -598,7 +598,7 @@ if (! function_exists('public_path')) {
      */
     function public_path($path = '')
     {
-        return app()->make('path.public').($path ? starts_with($path, DIRECTORY_SEPARATOR) ? $path : DIRECTORY_SEPARATOR.$path : $path);
+        return app()->make('path.public').($path ? DIRECTORY_SEPARATOR.ltrim($path, DIRECTORY_SEPARATOR) : $path);
     }
 }
 

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -598,7 +598,7 @@ if (! function_exists('public_path')) {
      */
     function public_path($path = '')
     {
-        return app()->make('path.public').($path ? DIRECTORY_SEPARATOR.$path : $path);
+        return app()->make('path.public').($path ? starts_with($path, DIRECTORY_SEPARATOR) ? $path : DIRECTORY_SEPARATOR.$path : $path);
     }
 }
 


### PR DESCRIPTION
I noticed a duplicate forward slash when using {{ mix('example.css', 'vendor/package/') }}

Turns out laravel mix adds a forward slash to 'vendor/package' and the public_path doen't check if the path starts with an slash.