### PR TITLE
Fixed sending Mailable object from Notification

### DIFF
--- a/src/Illuminate/Notifications/Channels/MailChannel.php
+++ b/src/Illuminate/Notifications/Channels/MailChannel.php
@@ -47,11 +47,11 @@ class MailChannel
      */
     public function send($notifiable, Notification $notification)
     {
-        if (! $notifiable->routeNotificationFor('mail')) {
+        $message = $notification->toMail($notifiable);
+
+        if (! $notifiable->routeNotificationFor('mail') && ! $message instanceof Mailable) {
             return;
         }
-
-        $message = $notification->toMail($notifiable);
 
         if ($message instanceof Mailable) {
             return $message->send($this->mailer);


### PR DESCRIPTION
If we try to send mail notification via `Mailable` object
**Example from documentation**:
```php
use App\Mail\InvoicePaid as Mailable;

/**
 * Get the mail representation of the notification.
 *
 * @param  mixed  $notifiable
 * @return Mailable
 */
public function toMail($notifiable)
{
    return (new Mailable($this->invoice))->to($this->user->email);
}
```
and our model hasn't _email_ field, we should add `routeNotificationForMail` method
```php
class User extends Authenticatable
{
    use Notifiable;

    /**
     * Route notifications for the mail channel.
     *
     * @return string
     */
    public function routeNotificationForMail()
    {
        return $this->email_address;
    }
}
```
if we wouldn't do it, laravel tries to get `$this->email` 
```php
public function routeNotificationFor($driver)
    {
        if (method_exists($this, $method = 'routeNotificationFor'.Str::studly($driver))) {
            return $this->{$method}();
        }

        switch ($driver) {
            case 'database':
                return $this->notifications();
            case 'mail':
                //Here
                return $this->email;
            case 'nexmo':
                return $this->phone_number;
        }
    }
```
recieves `null` and email wouldn't be sended
```php
public function send($notifiable, Notification $notification)
    {
        if (! $notifiable->routeNotificationFor('mail')) {
            //Because void returns here
            return;
        }

        $message = $notification->toMail($notifiable);

        if ($message instanceof Mailable) {
            return $message->send($this->mailer);
        }

        $this->mailer->send($this->buildView($message), $message->data(), function ($mailMessage) use ($notifiable, $notification, $message) {
            $this->buildMessage($mailMessage, $notifiable, $notification, $message);
        });
    }
```

If we will set `routeNotificationForMail` method, email will be successfuly sended but on address seted through `->to($this->user->email)` method.
I think we shouldn't return void on sending email for `Mailable` objects if _email_ field not exists in the Model.
Or it would be better to check for non-empty `to` property of the `Mailable` object, and if it's empty try to **_set/replace/append_** value from returned `routeNotificationForMail` method?
