### PR TITLE
[5.4] allow `BelongsTo` relations to return defaults

### DIFF
--- a/tests/Database/DatabaseEloquentBelongsToTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToTest.php
@@ -9,9 +9,58 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class DatabaseEloquentBelongsToTest extends TestCase
 {
+    protected $builder;
+
+    protected $related;
+
     public function tearDown()
     {
         m::close();
+    }
+
+    public function testBelongsToWithDefault()
+    {
+        $relation = $this->getRelation()->withDefault(); //belongsTo relationships
+
+        $this->builder->shouldReceive('first')->once()->andReturnNull();
+
+        $newModel = new EloquentBelongsToModelStub();  //ie Blog
+
+        $this->related->shouldReceive('newInstance')->once()->andReturn($newModel);
+
+        $this->assertSame($newModel, $relation->getResults());
+    }
+
+    public function testBelongsToWithDynamicDefault()
+    {
+        $relation = $this->getRelation()->withDefault(function ($newModel) {
+            $newModel->username = 'taylor';
+        });
+
+        $this->builder->shouldReceive('first')->once()->andReturnNull();
+
+        $newModel = new EloquentBelongsToModelStub();
+
+        $this->related->shouldReceive('newInstance')->once()->andReturn($newModel);
+
+        $this->assertSame($newModel, $relation->getResults());
+
+        $this->assertSame('taylor', $newModel->username);
+    }
+
+    public function testBelongsToWithArrayDefault()
+    {
+        $relation = $this->getRelation()->withDefault(['username' => 'taylor']);
+
+        $this->builder->shouldReceive('first')->once()->andReturnNull();
+
+        $newModel = new EloquentBelongsToModelStub();
+
+        $this->related->shouldReceive('newInstance')->once()->andReturn($newModel);
+
+        $this->assertSame($newModel, $relation->getResults());
+
+        $this->assertSame('taylor', $newModel->username);
     }
 
     public function testUpdateMethodRetrievesModelAndUpdates()
@@ -126,18 +175,18 @@ class DatabaseEloquentBelongsToTest extends TestCase
 
     protected function getRelation($parent = null, $incrementing = true, $keyType = 'int')
     {
-        $builder = m::mock('Illuminate\Database\Eloquent\Builder');
-        $builder->shouldReceive('where')->with('relation.id', '=', 'foreign.value');
-        $related = m::mock('Illuminate\Database\Eloquent\Model');
-        $related->incrementing = $incrementing;
-        $related->shouldReceive('getKeyType')->andReturn($keyType);
-        $related->shouldReceive('getIncrementing')->andReturn($incrementing);
-        $related->shouldReceive('getKeyName')->andReturn('id');
-        $related->shouldReceive('getTable')->andReturn('relation');
-        $builder->shouldReceive('getModel')->andReturn($related);
+        $this->builder = m::mock('Illuminate\Database\Eloquent\Builder');
+        $this->builder->shouldReceive('where')->with('relation.id', '=', 'foreign.value');
+        $this->related = m::mock('Illuminate\Database\Eloquent\Model');
+        $this->related->incrementing = $incrementing;
+        $this->related->shouldReceive('getKeyType')->andReturn($keyType);
+        $this->related->shouldReceive('getIncrementing')->andReturn($incrementing);
+        $this->related->shouldReceive('getKeyName')->andReturn('id');
+        $this->related->shouldReceive('getTable')->andReturn('relation');
+        $this->builder->shouldReceive('getModel')->andReturn($this->related);
         $parent = $parent ?: new EloquentBelongsToModelStub;
 
-        return new BelongsTo($builder, $parent, 'foreign_key', 'id', 'relation');
+        return new BelongsTo($this->builder, $parent, 'foreign_key', 'id', 'relation');
     }
 }
 


### PR DESCRIPTION
continuation of https://github.com/laravel/framework/pull/19696

I was going to try and do all of the relationships right away but it is a little more confusing than I thought, so I'm going to keep it broken out with a PR for each relationship.

code only required minor tweaks from the `HasOne` implementation.

I've tested the code on an actual application of mine, and it *mostly* works. The place I run into an issue is if I have an eager loaded relationship on the model via the `$with` property. If I try to eager load the parent model, all the properties are set to null. If I don't eager load, everything works just fine.

Anyone have any ideas on why this is?

BTW, it is incredible how much cleaner and more readable my code becomes with this. really excited to get this in!