### PR TITLE
[5.5] Add Blade if method

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -358,6 +358,25 @@ class BladeCompiler extends Compiler implements CompilerInterface
     }
 
     /**
+     * Register a custom directive representing an if statement
+     * 
+     * @param  string   $name
+     * @param  callable $condition
+     * @return void
+     */
+    public function if($name, callable $condition)
+    {
+        $this->directive($name, function (...$args) use ($condition) {
+            $condition = (int) (true === $condition(...$args));
+            return "<?php if ($condition): ?>";
+        });
+
+        $this->directive('end'.$name, function () {
+            return "<?php endif; ?>";
+        });
+    }
+
+    /**
      * Get the list of custom directives.
      *
      * @return array

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -91,6 +91,38 @@ class ViewBladeCompilerTest extends TestCase
         }}'));
     }
 
+    public function testItGeneratesAnIfBlock()
+    {
+        $compiler = new BladeCompiler($this->getFiles(), __DIR__);
+
+        $compiler->if('foo', function () {
+            return 'John' == 'Mateus';
+        });
+
+        $this->assertArrayHasKey('foo', $compiler->getCustomDirectives());
+        $this->assertArrayHasKey('endfoo', $compiler->getCustomDirectives());
+        $this->assertEquals("<?php if (0): ?>", $compiler->getCustomDirectives()['foo']());
+        $this->assertEquals("<?php endif; ?>", $compiler->getCustomDirectives()['endfoo']());
+
+        $compiler->if('foo', function () {
+            return 'John' == 'John';
+        });
+
+        $this->assertEquals("<?php if (1): ?>", $compiler->getCustomDirectives()['foo']());
+    }
+
+    public function testItGeneratesAnIfBlockWithAnArgument()
+    {
+        $compiler = new BladeCompiler($this->getFiles(), __DIR__);
+
+        $compiler->if('foo', function ($name) {
+            return 'Mateus' == $name;
+        });
+
+        $this->assertEquals("<?php if (0): ?>", $compiler->getCustomDirectives()['foo']('John'));
+        $this->assertEquals("<?php if (1): ?>", $compiler->getCustomDirectives()['foo']('Mateus'));
+    }
+
     protected function getFiles()
     {
         return m::mock('Illuminate\Filesystem\Filesystem');


### PR DESCRIPTION
I was actually a bit ashamed of PRing this because it's not a really great thing, but after noticing I had some Blade directives that were just `if` statements and that I also had some `enddirective` directives and [this tweet](https://twitter.com/davidhemphill/status/877977885088161792), this may be okay    

basically,  

```php   
Blade::if('env', function ($env) {
    return app()->environment($env);
}); 

```  

equals

```php   
Blade::directive('env', function ($env) {
    return "<?php if (app()->environment($env)): ?>";
});  

Blade::directive('endenv', function () {
    return "<?php endif; ?>";
});
```