### PR TITLE
Add query buider 'unless' method (inverse of 'when')

### DIFF
--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -95,6 +95,25 @@ trait BuildsQueries
     }
 
     /**
+     * Apply the callback's query changes if the given "value" is false.
+     *
+     * @param  mixed  $value
+     * @param  callable  $callback
+     * @param  callable  $default
+     * @return mixed
+     */
+    public function unless($value, $callback, $default = null)
+    {
+        if (! $value) {
+            return $callback($this, $value) ?: $this;
+        } elseif ($default) {
+            return $default($this, $value) ?: $this;
+        }
+
+        return $this;
+    }
+
+    /**
      * Create a new length-aware paginator instance.
      *
      * @param  \Illuminate\Support\Collection  $items


### PR DESCRIPTION
Here is a recent snippet of code where "unless" would have been useful:

without "unless"
```
$query->when($sortColumn !== 'title', function ($query) {
    return $query->orderBy($sortColumn, 'desc');
})
```

with "unless"
```
$query->unless($sortColumn === 'title', function ($query) {
    return $query->orderBy($sortColumn, 'desc');
})
```

I also would like this method in `Collection.php` - if people like the concept, I'll submit another PR, but let's see how this goes.

Thanks for all the hard work!
- Caleb