### PR TITLE
[5.4] array_random helper

### DIFF
--- a/src/Illuminate/Database/Connectors/ConnectionFactory.php
+++ b/src/Illuminate/Database/Connectors/ConnectionFactory.php
@@ -138,7 +138,7 @@ class ConnectionFactory
     protected function getReadWriteConfig(array $config, $type)
     {
         return isset($config[$type][0])
-                        ? $config[$type][array_rand($config[$type])]
+                        ? Arr::random($config[$type])
                         : $config[$type];
     }
 

--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -439,6 +439,17 @@ class Arr
     }
 
     /**
+     * Get a random value from an array.
+     *
+     * @param  array   $array
+     * @return mixed
+     */
+    public static function random($array)
+    {
+        return $array[array_rand($array)];
+    }
+
+    /**
      * Set an array item to a given value using "dot" notation.
      *
      * If no key is given to the method, the entire array will be replaced.

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -245,6 +245,19 @@ if (! function_exists('array_pull')) {
     }
 }
 
+if (! function_exists('array_random')) {
+    /**
+     * Get a random value from an array.
+     *
+     * @param  array   $array
+     * @return mixed
+     */
+    function array_random($array)
+    {
+        return Arr::random($array);
+    }
+}
+
 if (! function_exists('array_set')) {
     /**
      * Set an array item to a given value using "dot" notation.

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -399,6 +399,17 @@ class SupportArrTest extends TestCase
         $this->assertEquals(['emails' => ['joe@example.com' => 'Joe', 'jane@localhost' => 'Jane']], $array);
     }
 
+    public function testRandom()
+    {
+        $number1 = Arr::random(range(1, 1000));
+        $number2 = Arr::random(range(1, 1000));
+        $number3 = Arr::random(range(1, 1000));
+
+        $this->assertNotSame($number1, $number2);
+
+        $this->assertEquals('bar', Arr::random(['foo' => 'bar']));
+    }
+
     public function testSet()
     {
         $array = ['products' => ['desk' => ['price' => 100]]];

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -401,13 +401,10 @@ class SupportArrTest extends TestCase
 
     public function testRandom()
     {
-        $number1 = Arr::random(range(1, 1000));
-        $number2 = Arr::random(range(1, 1000));
-        $number3 = Arr::random(range(1, 1000));
+        $randomValue = Arr::random(['foo', 'bar', 'baz']);
 
-        $this->assertNotSame($number1, $number2);
-
-        $this->assertEquals('bar', Arr::random(['foo' => 'bar']));
+        $this->assertInternalType('string', $randomValue);
+        $this->assertContains($randomValue, ['foo', 'bar', 'baz']);
     }
 
     public function testSet()


### PR DESCRIPTION
I know helper functions are unlikely to be pulled in, but figured I'd at least mention this. (I did include a usage of this helper in the framework FWIW)

I use this personally (especially in testing contexts).

The all to common pattern that makes me feel a little bit bad every time:
```
return $array[array_rand($array)];
```

same thing with new helper:
```
return array_random($array);
```

much cleaner IMO - let's see what you think though

Thanks as always!