### PR TITLE
[5.5] Add source metadata to log statement controlled by config option

### DIFF
--- a/src/Illuminate/Log/LogServiceProvider.php
+++ b/src/Illuminate/Log/LogServiceProvider.php
@@ -58,7 +58,7 @@ class LogServiceProvider extends ServiceProvider
     protected function configureHandler(Writer $log)
     {
         $logLineLevel = $this->logLineLevel();
-        if($logLineLevel) {
+        if ($logLineLevel) {
             $log->useLineNumbers($logLineLevel);
         }
         $this->{'configure'.ucfirst($this->handler()).'Handler'}($log);
@@ -141,7 +141,6 @@ class LogServiceProvider extends ServiceProvider
 
         return 'debug';
     }
-
 
     /**
      * Get the log line number reporting level for the application.

--- a/src/Illuminate/Log/LogServiceProvider.php
+++ b/src/Illuminate/Log/LogServiceProvider.php
@@ -57,6 +57,10 @@ class LogServiceProvider extends ServiceProvider
      */
     protected function configureHandler(Writer $log)
     {
+        $logLineLevel = $this->logLineLevel();
+        if($logLineLevel) {
+            $log->useLineNumbers($logLineLevel);
+        }
         $this->{'configure'.ucfirst($this->handler()).'Handler'}($log);
     }
 
@@ -136,6 +140,21 @@ class LogServiceProvider extends ServiceProvider
         }
 
         return 'debug';
+    }
+
+
+    /**
+     * Get the log line number reporting level for the application.
+     *
+     * @return string|null
+     */
+    protected function logLineLevel()
+    {
+        if ($this->app->bound('config')) {
+            return $this->app->make('config')->get('app.log_line_level', null);
+        }
+
+        return null;
     }
 
     /**

--- a/src/Illuminate/Log/LogServiceProvider.php
+++ b/src/Illuminate/Log/LogServiceProvider.php
@@ -57,8 +57,7 @@ class LogServiceProvider extends ServiceProvider
      */
     protected function configureHandler(Writer $log)
     {
-        $logLineLevel = $this->logLineLevel();
-        if ($logLineLevel) {
+        if ($logLineLevel = $this->logLineLevel()) {
             $log->useLineNumbers($logLineLevel);
         }
         $this->{'configure'.ucfirst($this->handler()).'Handler'}($log);
@@ -150,10 +149,8 @@ class LogServiceProvider extends ServiceProvider
     protected function logLineLevel()
     {
         if ($this->app->bound('config')) {
-            return $this->app->make('config')->get('app.log_line_level', null);
+            return $this->app->make('config')->get('app.log_line_level');
         }
-
-        return null;
     }
 
     /**

--- a/src/Illuminate/Log/Writer.php
+++ b/src/Illuminate/Log/Writer.php
@@ -214,10 +214,8 @@ class Writer implements LogContract, PsrLoggerInterface
     {
         // Note that the '3' is so that the information about Laravel call
         // stack is skipped. Works as expected with all log level messages.
-    
         $this->monolog->pushProcessor(new IntrospectionProcessor($this->parseLevel($level), [], 3));
     }
-
 
     /**
      * Register a file log handler.

--- a/src/Illuminate/Log/Writer.php
+++ b/src/Illuminate/Log/Writer.php
@@ -213,10 +213,7 @@ class Writer implements LogContract, PsrLoggerInterface
     public function useLineNumbers($level = 'debug')
     {
         // Note that the '3' is so that the information about Laravel call
-        // stack is skipped. Specifically the following calls are skipped:
-        // Illuminate\Log\Writer@writeLog
-        // Illuminate\Log\Writer@info
-        // Illuminate\Foundation\helpers@info
+        // stack is skipped. Works as expected with all log level messages.
     
         $this->monolog->pushProcessor(new IntrospectionProcessor($this->parseLevel($level), [], 3));
     }

--- a/src/Illuminate/Log/Writer.php
+++ b/src/Illuminate/Log/Writer.php
@@ -15,6 +15,7 @@ use Monolog\Handler\RotatingFileHandler;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Support\Arrayable;
+use Monolog\Processor\IntrospectionProcessor;
 use Psr\Log\LoggerInterface as PsrLoggerInterface;
 use Illuminate\Contracts\Logging\Log as LogContract;
 
@@ -202,6 +203,24 @@ class Writer implements LogContract, PsrLoggerInterface
 
         $this->monolog->{$level}($message, $context);
     }
+
+    /**
+     * Register a handler to output line numbers and call information with log statements.
+     *
+     * @param  string  $level
+     * @return void
+     */
+    public function useLineNumbers($level = 'debug')
+    {
+        // Note that the '3' is so that the information about Laravel call
+        // stack is skipped. Specifically the following calls are skipped:
+        // Illuminate\Log\Writer@writeLog
+        // Illuminate\Log\Writer@info
+        // Illuminate\Foundation\helpers@info
+    
+        $this->monolog->pushProcessor(new IntrospectionProcessor($this->parseLevel($level), [], 3));
+    }
+
 
     /**
      * Register a file log handler.


### PR DESCRIPTION
This is an implementation of [Proposal 627](https://github.com/laravel/internals/issues/627), which adds a config option to have log statements include file, line-number, class, and function from where the log statement was called.

As pointed out by one of the individuals on the linked thread Monolog's IntrospectionProcessor involves getting a full debug_backtrace which is expensive, hence as suggested this change allows a user to specify in the config/app.php file the level for which this operation should be done. That is:
- 'debug': do for all debug statements and above
- 'info': do for all info statements and above
- ...

Where the debug < info < notice < warning < error < critical < alert < emergency [[source]](https://github.com/Seldaek/monolog/blob/master/doc/01-usage.md#log-levels)

### Testing
Tested with all log levels as defined in [Laravel docs](https://laravel.com/docs/5.4/errors#logging) and works as expected.

### Note
Since the Monolog instance is wrapped by Laravel's Writer class, the Monolog instance will report that a `Log::info()` was called from `writeLog` function within Writer class, but Monolog has a parameter to skip a specified number of stack calls. So I utilized this option to skip the Laravel wrapper code and hence return the line where the user called `Log::info()`. While this approach may not be the best, the other option is to tell users to write their log statements as follows: `Log::getMonolog()->info()` which is not ideal.

#### Other Attempts
I also tried just skipping the 'Illuminate' class name by passing it to Monolog as follows:
```
$this->monolog->pushProcessor(
    new IntrospectionProcessor($this->parseLevel($level), 
                               ['Illuminate\\'])
);
```
But this produces the following log statement:
```
[2017-06-24 00:42:40] local.INFO: hello world  {"file":"/home/pawel/blog/vendor/laravel/framework/src/Illuminate/Foundation/helpers.php","line":498,"class":null,"function":"info"}
```
The reason this is not skipped is because `framework/src/Illuminate/Foundation/helpers.php` has no namespace so Monolog does not skip it.

### Additional Changes
If this change ends up getting accepted, the `config/app.php` file of `laravel/laravel` should be updated to include the following line in 'Logging Configuration' section:
```
'log_line_level' => env('APP_LOG_LINE_LEVEL', null),
```
So by default IntrospectionProcessor would not be added, and for people who do want to include it, the config can be easily modified.