### PR TITLE
[5.5] Blade If: initialize conditions property and fix docblock

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -38,6 +38,14 @@ class BladeCompiler extends Compiler implements CompilerInterface
     protected $customDirectives = [];
 
     /**
+     * All custom directives conditions, used
+     * by the "if" and "check" methods
+     * 
+     * @var array
+     */
+    protected $conditions = [];
+
+    /**
      * The file currently being compiled.
      *
      * @var string
@@ -350,7 +358,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
      * Register an "if" statement directive.
      *
      * @param  string  $name
-     * @param  \Closrue  $callback
+     * @param  \Closure  $callback
      * @return void
      */
     public function if($name, Closure $callback)


### PR DESCRIPTION
Nice implementation of the `if` method! Really glad it got into the framework.  

This PR just fixes a typo in the docblock and initializes the `$conditions` property