### PR TITLE
[5.4] detect lock wait timeout as deadlock

### DIFF
--- a/src/Illuminate/Database/DetectsDeadlocks.php
+++ b/src/Illuminate/Database/DetectsDeadlocks.php
@@ -25,6 +25,7 @@ trait DetectsDeadlocks
             'database table is locked',
             'A table in the database is locked',
             'has been chosen as the deadlock victim',
+            'Lock wait timeout exceeded; try restarting transaction',
         ]);
     }
 }


### PR DESCRIPTION
Deadlock detection can be disabled to improve performance and lock wait timeout relied on instead

[https://dev.mysql.com/doc/refman/5.7/en/innodb-deadlock-detection.html](url)
> On high concurrency systems, deadlock detection can cause a slowdown when numerous threads wait for the same lock. At times, it may be more efficient to disable deadlock detection and rely on the innodb_lock_wait_timeout setting for transaction rollback when a deadlock occurs. Deadlock detection can be disabled using the innodb_deadlock_detect configuration option.
