### PR TITLE
Add dump method to Collection class

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -11,6 +11,7 @@ use CachingIterator;
 use JsonSerializable;
 use IteratorAggregate;
 use InvalidArgumentException;
+use Illuminate\Support\Debug\Dumper;
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Contracts\Support\Arrayable;
@@ -260,7 +261,13 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      */
     public function dump()
     {
-        dump($this->all());
+        (new static(func_get_args()))
+            ->push($this)
+            ->each(function ($item) {
+                (new Dumper)->dump($item);
+            });
+
+        return $this;
     }
 
     /**

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -252,6 +252,16 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     {
         dd($this->all());
     }
+    
+    /**
+     * Dump the collection.
+     *
+     * @return void
+     */
+    public function dump()
+    {
+        dump($this->all());
+    }
 
     /**
      * Get the items in the collection that are not present in the given items.

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -252,7 +252,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     {
         dd($this->all());
     }
-    
+
     /**
      * Dump the collection.
      *


### PR DESCRIPTION
This PR adds a `dump` method to `Illuminate\Support\Collection` so you can easily debug multiple spots in a collection chain.

The function accepts and dumps a variable number of arguments. This can be used to add labels in the output when dumping at multiple spots in a collection chain. Example of that behaviour can be found here: https://murze.be/2016/08/debugging-collection-chains/