### PR TITLE
Added Failure Formatters

### DIFF
--- a/src/Illuminate/Validation/Concerns/FormatsMessages.php
+++ b/src/Illuminate/Validation/Concerns/FormatsMessages.php
@@ -18,7 +18,7 @@ trait FormatsMessages
      * @param  string  $rule
      * @return string
      */
-    protected function getMessage($attribute, $rule)
+    public function getMessage($attribute, $rule)
     {
         $inlineMessage = $this->getFromLocalArray(
             $attribute, $lowerRule = Str::snake($rule)

--- a/src/Illuminate/Validation/Factory.php
+++ b/src/Illuminate/Validation/Factory.php
@@ -6,6 +6,7 @@ use Closure;
 use Illuminate\Support\Str;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Translation\Translator;
+use Illuminate\Validation\FailureFormatters\FailureFormatter;
 use Illuminate\Contracts\Validation\Factory as FactoryContract;
 
 class Factory implements FactoryContract
@@ -23,6 +24,13 @@ class Factory implements FactoryContract
      * @var \Illuminate\Validation\PresenceVerifierInterface
      */
     protected $verifier;
+
+    /**
+     * The Failure Formatter implementation.
+     *
+     * @var \Illuminate\Validation\FailureFormatters\FailureFormatter
+     */
+    protected $failureFormatter;
 
     /**
      * The IoC container instance.
@@ -76,7 +84,7 @@ class Factory implements FactoryContract
     /**
      * Create a new Validator factory instance.
      *
-     * @param  \Illuminate\Contracts\Translation\Translator $translator
+     * @param  \Illuminate\Contracts\Translation\Translator  $translator
      * @param  \Illuminate\Contracts\Container\Container  $container
      * @return void
      */
@@ -103,6 +111,10 @@ class Factory implements FactoryContract
         $validator = $this->resolve(
             $data, $rules, $messages, $customAttributes
         );
+
+        if (! is_null($this->failureFormatter)) {
+            $validator->setFailureFormatter($this->failureFormatter);
+        }
 
         if (! is_null($this->verifier)) {
             $validator->setPresenceVerifier($this->verifier);
@@ -279,5 +291,15 @@ class Factory implements FactoryContract
     public function setPresenceVerifier(PresenceVerifierInterface $presenceVerifier)
     {
         $this->verifier = $presenceVerifier;
+    }
+
+    /**
+     * Set the Failure Formatter implementation.
+     *
+     * @param  \Illuminate\Validation\FailureFormatters\FailureFormatter  $failureFormatter
+     */
+    public function setFailureFormatter(FailureFormatter $failureFormatter)
+    {
+        $this->failureFormatter = $failureFormatter;
     }
 }

--- a/src/Illuminate/Validation/FailureFormatters/FailureFormatter.php
+++ b/src/Illuminate/Validation/FailureFormatters/FailureFormatter.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Illuminate\Validation\FailureFormatters;
+
+use Illuminate\Contracts\Validation\Validator;
+
+abstract class FailureFormatter
+{
+    /**
+     * Get formatted message.
+     *
+     * @param  \Illuminate\Contracts\Validation\Validator  $validator
+     * @param  string  $attribute
+     * @param  string  $rule
+     * @param  array   $parameters
+     * @return string
+     */
+    abstract public function message(Validator $validator, $attribute, $rule, $parameters);
+}

--- a/src/Illuminate/Validation/FailureFormatters/FailureFormatter.php
+++ b/src/Illuminate/Validation/FailureFormatters/FailureFormatter.php
@@ -16,4 +16,5 @@ abstract class FailureFormatter
      * @return string
      */
     abstract public function message(Validator $validator, $attribute, $rule, $parameters);
+
 }

--- a/src/Illuminate/Validation/FailureFormatters/Message.php
+++ b/src/Illuminate/Validation/FailureFormatters/Message.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Illuminate\Validation\FailureFormatters;
+
+use Illuminate\Contracts\Validation\Validator;
+
+class Message extends FailureFormatter
+{
+    /**
+     * Get formatted message.
+     *
+     * @param  \Illuminate\Contracts\Validation\Validator  $validator
+     * @param  string  $attribute
+     * @param  string  $rule
+     * @param  array   $parameters
+     * @return string
+     */
+    public function message(Validator $validator, $attribute, $rule, $parameters)
+    {
+        return $validator->makeReplacements(
+            $validator->getMessage($attribute, $rule), $attribute, $rule, $parameters
+        );
+    }
+}

--- a/src/Illuminate/Validation/FailureFormatters/Message.php
+++ b/src/Illuminate/Validation/FailureFormatters/Message.php
@@ -21,4 +21,5 @@ class Message extends FailureFormatter
             $validator->getMessage($attribute, $rule), $attribute, $rule, $parameters
         );
     }
+
 }

--- a/src/Illuminate/Validation/FailureFormatters/Rule.php
+++ b/src/Illuminate/Validation/FailureFormatters/Rule.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Illuminate\Validation\FailureFormatters;
+
+use Illuminate\Support\Str;
+use Illuminate\Contracts\Validation\Validator;
+
+class Rule extends FailureFormatter
+{
+    /**
+     * Get formatted message.
+     *
+     * @param  \Illuminate\Contracts\Validation\Validator  $validator
+     * @param  string $attribute
+     * @param  string $rule
+     * @param  array $parameters
+     * @return string
+     */
+    public function message(Validator $validator, $attribute, $rule, $parameters)
+    {
+        return Str::snake($rule);
+    }
+}

--- a/src/Illuminate/Validation/FailureFormatters/Rule.php
+++ b/src/Illuminate/Validation/FailureFormatters/Rule.php
@@ -20,4 +20,5 @@ class Rule extends FailureFormatter
     {
         return Str::snake($rule);
     }
+
 }

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Validation;
 
-use Closure;
 use RuntimeException;
 use BadMethodCallException;
 use Illuminate\Support\Arr;
@@ -14,7 +13,9 @@ use Illuminate\Contracts\Translation\Translator;
 use Illuminate\Contracts\Validation\ImplicitRule;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Illuminate\Contracts\Validation\Rule as RuleContract;
+use Illuminate\Validation\FailureFormatters\FailureFormatter;
 use Illuminate\Contracts\Validation\Validator as ValidatorContract;
+use Illuminate\Validation\FailureFormatters\Message as MessageFailureFormatter;
 
 class Validator implements ValidatorContract
 {
@@ -41,6 +42,13 @@ class Validator implements ValidatorContract
      * @var \Illuminate\Validation\PresenceVerifierInterface
      */
     protected $presenceVerifier;
+
+    /**
+     * The Failure Formatter implementation.
+     *
+     * @var \Illuminate\Validation\FailureFormatters\FailureFormatter
+     */
+    protected $failureFormatter;
 
     /**
      * The failed validation rules.
@@ -203,6 +211,8 @@ class Validator implements ValidatorContract
         $this->customMessages = $messages;
         $this->data = $this->parseData($data);
         $this->customAttributes = $customAttributes;
+
+        $this->failureFormatter = new MessageFailureFormatter;
 
         $this->setRules($rules);
     }
@@ -575,9 +585,10 @@ class Validator implements ValidatorContract
      */
     protected function addFailure($attribute, $rule, $parameters)
     {
-        $this->messages->add($attribute, $this->makeReplacements(
-            $this->getMessage($attribute, $rule), $attribute, $rule, $parameters
-        ));
+        $this->messages->add(
+            $attribute,
+            $this->failureFormatter->message($this, $attribute, $rule, $parameters)
+        );
 
         $this->failedRules[$attribute][$rule] = $parameters;
     }
@@ -1053,6 +1064,17 @@ class Validator implements ValidatorContract
     public function setPresenceVerifier(PresenceVerifierInterface $presenceVerifier)
     {
         $this->presenceVerifier = $presenceVerifier;
+    }
+
+    /**
+     * Set Failure Formatter implementation.
+     *
+     * @param  \Illuminate\Validation\FailureFormatters\FailureFormatter  $failureFormatter
+     * @return void
+     */
+    public function setFailureFormatter(FailureFormatter $failureFormatter)
+    {
+        $this->failureFormatter = $failureFormatter;
     }
 
     /**

--- a/tests/Validation/ValidationFailureFormatterTest.php
+++ b/tests/Validation/ValidationFailureFormatterTest.php
@@ -6,10 +6,8 @@ use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Validation\Factory;
 use Illuminate\Contracts\Translation\Translator as TranslatorInterface;
-use Illuminate\Validation\FailureFormatters\{
-    Rule as RuleFailureFormatter,
-    Message as MessageFailureFormatter
-};
+use Illuminate\Validation\FailureFormatters\Rule as RuleFailureFormatter;
+use Illuminate\Validation\FailureFormatters\Message as MessageFailureFormatter;
 
 class ValidationFailureFormatterTest extends TestCase
 {
@@ -81,4 +79,5 @@ class ValidationFailureFormatterTest extends TestCase
             $validator->messages()->toArray()
         );
     }
+
 }

--- a/tests/Validation/ValidationFailureFormatterTest.php
+++ b/tests/Validation/ValidationFailureFormatterTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Illuminate\Tests\Validation;
+
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+use Illuminate\Validation\Factory;
+use Illuminate\Contracts\Translation\Translator as TranslatorInterface;
+use Illuminate\Validation\FailureFormatters\{
+    Rule as RuleFailureFormatter,
+    Message as MessageFailureFormatter
+};
+
+class ValidationFailureFormatterTest extends TestCase
+{
+    public function tearDown()
+    {
+        m::close();
+    }
+
+    public function testFailureFormattedAsMessage()
+    {
+        $translator = m::mock(TranslatorInterface::class);
+        $factory = new Factory($translator);
+        $validator = $factory->make(
+            ['foo' => 'bar'],
+            ['foo' => 'integer'],
+            ['integer' => 'Value should be of an integer type.']
+        );
+
+        $translator->shouldReceive('trans')
+                   ->andReturn('Value should be of an integer type.');
+
+        $this->assertFalse($validator->passes());
+        $this->assertEquals(
+            ['foo' => ['Value should be of an integer type.']],
+            $validator->messages()->toArray()
+        );
+    }
+
+    public function testFailureFormattedAsRule()
+    {
+        $translator = m::mock(TranslatorInterface::class);
+        $factory = new Factory($translator);
+        $factory->setFailureFormatter(new RuleFailureFormatter);
+        $validator = $factory->make(
+            ['foo' => 'bar'],
+            ['foo' => 'integer'],
+            ['integer' => 'Value should be of an integer type.']
+        );
+
+        $translator->shouldNotHaveReceived('trans');
+
+        $this->assertFalse($validator->passes());
+        $this->assertEquals(
+            ['foo' => ['integer']],
+            $validator->messages()->toArray()
+        );
+    }
+
+    public function testFailureFormattedAsMessageByValidatorOverwrite()
+    {
+        $translator = m::mock(TranslatorInterface::class);
+        $factory = new Factory($translator);
+        $factory->setFailureFormatter(new RuleFailureFormatter);
+        $validator = $factory->make(
+            ['foo' => 'bar'],
+            ['foo' => 'integer'],
+            ['integer' => 'Value should be of an integer type.']
+        );
+
+        // overwriting Factory set Failure Formatter
+        $validator->setFailureFormatter(new MessageFailureFormatter);
+
+        $translator->shouldReceive('trans')
+                   ->andReturn('Value should be of an integer type.');
+
+        $this->assertFalse($validator->passes());
+        $this->assertEquals(
+            ['foo' => ['Value should be of an integer type.']],
+            $validator->messages()->toArray()
+        );
+    }
+}


### PR DESCRIPTION
Adds formatting of the validation errors allowing to either return attribute with array of messages (as per existing set up), using `message => ['rule']` or any other format by adding new formatters.

The purpose of it is to provide greater flexibility with returned errors - personally I've been using it for quite some time with ajax requests where validation message is already present in the view and revealed based on the rule that didn't pass validation.

Example rules with `Illuminate\Validation\FailureFormatters\Rule` formatter:

```php
[
	'name' => 'string|min:5',
	'age' => 'integer'
]
```

Request:

```php
[
	'name' => 2,
	'age' => 'forty'
]
```

Errors:

```php
[
	'name' => ['string', 'min'],
	'age' => ['integer']
]
```

I've coded it the way so that it is backward compatible - using existing message set up as default.