### PR TITLE
[5.5] Added Validation Failure Formatter

### DIFF
--- a/src/Illuminate/Validation/Concerns/FormatsMessages.php
+++ b/src/Illuminate/Validation/Concerns/FormatsMessages.php
@@ -18,7 +18,7 @@ trait FormatsMessages
      * @param  string  $rule
      * @return string
      */
-    protected function getMessage($attribute, $rule)
+    public function getMessage($attribute, $rule)
     {
         $inlineMessage = $this->getFromLocalArray(
             $attribute, $lowerRule = Str::snake($rule)

--- a/src/Illuminate/Validation/Factory.php
+++ b/src/Illuminate/Validation/Factory.php
@@ -297,6 +297,7 @@ class Factory implements FactoryContract
      * Set the Failure Formatter implementation.
      *
      * @param  \Illuminate\Validation\FailureFormatters\FailureFormatterInterface  $failureFormatter
+     * @return void
      */
     public function setFailureFormatter(FailureFormatterInterface $failureFormatter)
     {

--- a/src/Illuminate/Validation/Factory.php
+++ b/src/Illuminate/Validation/Factory.php
@@ -6,8 +6,8 @@ use Closure;
 use Illuminate\Support\Str;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Translation\Translator;
-use Illuminate\Validation\FailureFormatters\FailureFormatter;
 use Illuminate\Contracts\Validation\Factory as FactoryContract;
+use Illuminate\Validation\FailureFormatters\FailureFormatterInterface;
 
 class Factory implements FactoryContract
 {
@@ -28,7 +28,7 @@ class Factory implements FactoryContract
     /**
      * The Failure Formatter implementation.
      *
-     * @var \Illuminate\Validation\FailureFormatters\FailureFormatter
+     * @var \Illuminate\Validation\FailureFormatters\FailureFormatterInterface
      */
     protected $failureFormatter;
 
@@ -296,9 +296,9 @@ class Factory implements FactoryContract
     /**
      * Set the Failure Formatter implementation.
      *
-     * @param  \Illuminate\Validation\FailureFormatters\FailureFormatter  $failureFormatter
+     * @param  \Illuminate\Validation\FailureFormatters\FailureFormatterInterface  $failureFormatter
      */
-    public function setFailureFormatter(FailureFormatter $failureFormatter)
+    public function setFailureFormatter(FailureFormatterInterface $failureFormatter)
     {
         $this->failureFormatter = $failureFormatter;
     }

--- a/src/Illuminate/Validation/Factory.php
+++ b/src/Illuminate/Validation/Factory.php
@@ -6,6 +6,7 @@ use Closure;
 use Illuminate\Support\Str;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Translation\Translator;
+use Illuminate\Validation\FailureFormatters\FailureFormatter;
 use Illuminate\Contracts\Validation\Factory as FactoryContract;
 
 class Factory implements FactoryContract
@@ -23,6 +24,13 @@ class Factory implements FactoryContract
      * @var \Illuminate\Validation\PresenceVerifierInterface
      */
     protected $verifier;
+
+    /**
+     * The Failure Formatter implementation.
+     *
+     * @var \Illuminate\Validation\FailureFormatters\FailureFormatter
+     */
+    protected $failureFormatter;
 
     /**
      * The IoC container instance.
@@ -103,6 +111,10 @@ class Factory implements FactoryContract
         $validator = $this->resolve(
             $data, $rules, $messages, $customAttributes
         );
+
+        if (! is_null($this->failureFormatter)) {
+            $validator->setFailureFormatter($this->failureFormatter);
+        }
 
         if (! is_null($this->verifier)) {
             $validator->setPresenceVerifier($this->verifier);
@@ -279,5 +291,15 @@ class Factory implements FactoryContract
     public function setPresenceVerifier(PresenceVerifierInterface $presenceVerifier)
     {
         $this->verifier = $presenceVerifier;
+    }
+
+    /**
+     * Set the Failure Formatter implementation.
+     *
+     * @param  \Illuminate\Validation\FailureFormatters\FailureFormatter  $failureFormatter
+     */
+    public function setFailureFormatter(FailureFormatter $failureFormatter)
+    {
+        $this->failureFormatter = $failureFormatter;
     }
 }

--- a/src/Illuminate/Validation/FailureFormatters/FailureFormatter.php
+++ b/src/Illuminate/Validation/FailureFormatters/FailureFormatter.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Illuminate\Validation\FailureFormatters;
+
+use Illuminate\Contracts\Validation\Validator;
+
+abstract class FailureFormatter
+{
+    /**
+     * Get formatted message.
+     *
+     * @param  \Illuminate\Contracts\Validation\Validator  $validator
+     * @param  string  $attribute
+     * @param  string  $rule
+     * @param  array   $parameters
+     * @return string
+     */
+    abstract public function message(Validator $validator, $attribute, $rule, $parameters);
+
+}

--- a/src/Illuminate/Validation/FailureFormatters/FailureFormatterInterface.php
+++ b/src/Illuminate/Validation/FailureFormatters/FailureFormatterInterface.php
@@ -4,7 +4,7 @@ namespace Illuminate\Validation\FailureFormatters;
 
 use Illuminate\Contracts\Validation\Validator;
 
-abstract class FailureFormatter
+interface FailureFormatterInterface
 {
     /**
      * Get formatted message.
@@ -15,6 +15,5 @@ abstract class FailureFormatter
      * @param  array   $parameters
      * @return string
      */
-    abstract public function message(Validator $validator, $attribute, $rule, $parameters);
-
+    public function message(Validator $validator, $attribute, $rule, $parameters);
 }

--- a/src/Illuminate/Validation/FailureFormatters/Message.php
+++ b/src/Illuminate/Validation/FailureFormatters/Message.php
@@ -4,7 +4,7 @@ namespace Illuminate\Validation\FailureFormatters;
 
 use Illuminate\Contracts\Validation\Validator;
 
-class Message extends FailureFormatter
+class Message implements FailureFormatterInterface
 {
     /**
      * Get formatted message.
@@ -21,5 +21,4 @@ class Message extends FailureFormatter
             $validator->getMessage($attribute, $rule), $attribute, $rule, $parameters
         );
     }
-
 }

--- a/src/Illuminate/Validation/FailureFormatters/Message.php
+++ b/src/Illuminate/Validation/FailureFormatters/Message.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Illuminate\Validation\FailureFormatters;
+
+use Illuminate\Contracts\Validation\Validator;
+
+class Message extends FailureFormatter
+{
+    /**
+     * Get formatted message.
+     *
+     * @param  \Illuminate\Contracts\Validation\Validator  $validator
+     * @param  string  $attribute
+     * @param  string  $rule
+     * @param  array   $parameters
+     * @return string
+     */
+    public function message(Validator $validator, $attribute, $rule, $parameters)
+    {
+        return $validator->makeReplacements(
+            $validator->getMessage($attribute, $rule), $attribute, $rule, $parameters
+        );
+    }
+
+}

--- a/src/Illuminate/Validation/FailureFormatters/Rule.php
+++ b/src/Illuminate/Validation/FailureFormatters/Rule.php
@@ -5,7 +5,7 @@ namespace Illuminate\Validation\FailureFormatters;
 use Illuminate\Support\Str;
 use Illuminate\Contracts\Validation\Validator;
 
-class Rule extends FailureFormatter
+class Rule implements FailureFormatterInterface
 {
     /**
      * Get formatted message.
@@ -20,5 +20,4 @@ class Rule extends FailureFormatter
     {
         return Str::snake($rule);
     }
-
 }

--- a/src/Illuminate/Validation/FailureFormatters/Rule.php
+++ b/src/Illuminate/Validation/FailureFormatters/Rule.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Illuminate\Validation\FailureFormatters;
+
+use Illuminate\Support\Str;
+use Illuminate\Contracts\Validation\Validator;
+
+class Rule extends FailureFormatter
+{
+    /**
+     * Get formatted message.
+     *
+     * @param  \Illuminate\Contracts\Validation\Validator  $validator
+     * @param  string $attribute
+     * @param  string $rule
+     * @param  array $parameters
+     * @return string
+     */
+    public function message(Validator $validator, $attribute, $rule, $parameters)
+    {
+        return Str::snake($rule);
+    }
+
+}

--- a/src/Illuminate/Validation/ValidationServiceProvider.php
+++ b/src/Illuminate/Validation/ValidationServiceProvider.php
@@ -22,6 +22,8 @@ class ValidationServiceProvider extends ServiceProvider
     {
         $this->registerPresenceVerifier();
 
+        $this->registerFailureFormatter();
+
         $this->registerValidationFactory();
     }
 
@@ -42,6 +44,8 @@ class ValidationServiceProvider extends ServiceProvider
                 $validator->setPresenceVerifier($app['validation.presence']);
             }
 
+            $validator->setFailureFormatter($app['validation.failure_formatter']);
+
             return $validator;
         });
     }
@@ -59,6 +63,22 @@ class ValidationServiceProvider extends ServiceProvider
     }
 
     /**
+     * Register failure formatter.
+     *
+     * @return void
+     */
+    protected function registerFailureFormatter()
+    {
+        $this->app->singleton('validation.failure_formatter', function ($app) {
+            $defaultFormatter = $app['config']['validation']['default_failure_formatter'];
+
+            $formatter = $app['config']['validation']['failure_formatters'][$defaultFormatter];
+
+            return new $formatter;
+        });
+    }
+
+    /**
      * Get the services provided by the provider.
      *
      * @return array
@@ -66,7 +86,7 @@ class ValidationServiceProvider extends ServiceProvider
     public function provides()
     {
         return [
-            'validator', 'validation.presence',
+            'validator', 'validation.presence', 'validation.failure_formatter'
         ];
     }
 }

--- a/src/Illuminate/Validation/ValidationServiceProvider.php
+++ b/src/Illuminate/Validation/ValidationServiceProvider.php
@@ -86,7 +86,7 @@ class ValidationServiceProvider extends ServiceProvider
     public function provides()
     {
         return [
-            'validator', 'validation.presence', 'validation.failure_formatter'
+            'validator', 'validation.presence', 'validation.failure_formatter',
         ];
     }
 }

--- a/src/Illuminate/Validation/ValidationServiceProvider.php
+++ b/src/Illuminate/Validation/ValidationServiceProvider.php
@@ -70,9 +70,11 @@ class ValidationServiceProvider extends ServiceProvider
     protected function registerFailureFormatter()
     {
         $this->app->singleton('validation.failure_formatter', function ($app) {
-            $defaultFormatter = $app['config']['validation']['default_failure_formatter'];
+            $config = $app['config'];
 
-            $formatter = $app['config']['validation']['failure_formatters'][$defaultFormatter];
+            $defaultFormatter = $config->get('validation.default_failure_formatter');
+
+            $formatter = $config->get('validation.failure_formatters'.$defaultFormatter);
 
             return new $formatter;
         });

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -13,8 +13,8 @@ use Illuminate\Contracts\Translation\Translator;
 use Illuminate\Contracts\Validation\ImplicitRule;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Illuminate\Contracts\Validation\Rule as RuleContract;
-use Illuminate\Validation\FailureFormatters\FailureFormatter;
 use Illuminate\Contracts\Validation\Validator as ValidatorContract;
+use Illuminate\Validation\FailureFormatters\FailureFormatterInterface;
 use Illuminate\Validation\FailureFormatters\Message as MessageFailureFormatter;
 
 class Validator implements ValidatorContract
@@ -46,7 +46,7 @@ class Validator implements ValidatorContract
     /**
      * The Failure Formatter implementation.
      *
-     * @var \Illuminate\Validation\FailureFormatters\FailureFormatter
+     * @var \Illuminate\Validation\FailureFormatters\FailureFormatterInterface
      */
     protected $failureFormatter;
 
@@ -1069,10 +1069,10 @@ class Validator implements ValidatorContract
     /**
      * Set Failure Formatter implementation.
      *
-     * @param  \Illuminate\Validation\FailureFormatters\FailureFormatter  $failureFormatter
+     * @param  \Illuminate\Validation\FailureFormatters\FailureFormatterInterface  $failureFormatter
      * @return void
      */
-    public function setFailureFormatter(FailureFormatter $failureFormatter)
+    public function setFailureFormatter(FailureFormatterInterface $failureFormatter)
     {
         $this->failureFormatter = $failureFormatter;
     }

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Validation;
 
-use Closure;
 use RuntimeException;
 use BadMethodCallException;
 use Illuminate\Support\Arr;
@@ -14,7 +13,9 @@ use Illuminate\Contracts\Translation\Translator;
 use Illuminate\Contracts\Validation\ImplicitRule;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Illuminate\Contracts\Validation\Rule as RuleContract;
+use Illuminate\Validation\FailureFormatters\FailureFormatter;
 use Illuminate\Contracts\Validation\Validator as ValidatorContract;
+use Illuminate\Validation\FailureFormatters\Message as MessageFailureFormatter;
 
 class Validator implements ValidatorContract
 {
@@ -41,6 +42,13 @@ class Validator implements ValidatorContract
      * @var \Illuminate\Validation\PresenceVerifierInterface
      */
     protected $presenceVerifier;
+
+    /**
+     * The Failure Formatter implementation.
+     *
+     * @var \Illuminate\Validation\FailureFormatters\FailureFormatter
+     */
+    protected $failureFormatter;
 
     /**
      * The failed validation rules.
@@ -203,6 +211,8 @@ class Validator implements ValidatorContract
         $this->customMessages = $messages;
         $this->data = $this->parseData($data);
         $this->customAttributes = $customAttributes;
+
+        $this->failureFormatter = new MessageFailureFormatter;
 
         $this->setRules($rules);
     }
@@ -575,9 +585,10 @@ class Validator implements ValidatorContract
      */
     protected function addFailure($attribute, $rule, $parameters)
     {
-        $this->messages->add($attribute, $this->makeReplacements(
-            $this->getMessage($attribute, $rule), $attribute, $rule, $parameters
-        ));
+        $this->messages->add(
+            $attribute,
+            $this->failureFormatter->message($this, $attribute, $rule, $parameters)
+        );
 
         $this->failedRules[$attribute][$rule] = $parameters;
     }
@@ -1053,6 +1064,17 @@ class Validator implements ValidatorContract
     public function setPresenceVerifier(PresenceVerifierInterface $presenceVerifier)
     {
         $this->presenceVerifier = $presenceVerifier;
+    }
+
+    /**
+     * Set Failure Formatter implementation.
+     *
+     * @param  \Illuminate\Validation\FailureFormatters\FailureFormatter  $failureFormatter
+     * @return void
+     */
+    public function setFailureFormatter(FailureFormatter $failureFormatter)
+    {
+        $this->failureFormatter = $failureFormatter;
     }
 
     /**

--- a/tests/Validation/ValidationFailureFormatterTest.php
+++ b/tests/Validation/ValidationFailureFormatterTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Illuminate\Tests\Validation;
+
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+use Illuminate\Validation\Factory;
+use Illuminate\Contracts\Translation\Translator as TranslatorInterface;
+use Illuminate\Validation\FailureFormatters\Rule as RuleFailureFormatter;
+use Illuminate\Validation\FailureFormatters\Message as MessageFailureFormatter;
+
+class ValidationFailureFormatterTest extends TestCase
+{
+    public function tearDown()
+    {
+        m::close();
+    }
+
+    public function testFailureFormattedAsMessage()
+    {
+        $translator = m::mock(TranslatorInterface::class);
+        $factory = new Factory($translator);
+        $validator = $factory->make(
+            ['foo' => 'bar'],
+            ['foo' => 'integer'],
+            ['integer' => 'Value should be of an integer type.']
+        );
+
+        $translator->shouldReceive('trans')
+                   ->andReturn('Value should be of an integer type.');
+
+        $this->assertFalse($validator->passes());
+        $this->assertEquals(
+            ['foo' => ['Value should be of an integer type.']],
+            $validator->messages()->toArray()
+        );
+    }
+
+    public function testFailureFormattedAsRule()
+    {
+        $translator = m::mock(TranslatorInterface::class);
+        $factory = new Factory($translator);
+        $factory->setFailureFormatter(new RuleFailureFormatter);
+        $validator = $factory->make(
+            ['foo' => 'bar'],
+            ['foo' => 'integer'],
+            ['integer' => 'Value should be of an integer type.']
+        );
+
+        $translator->shouldNotHaveReceived('trans');
+
+        $this->assertFalse($validator->passes());
+        $this->assertEquals(
+            ['foo' => ['integer']],
+            $validator->messages()->toArray()
+        );
+    }
+
+    public function testFailureFormattedAsMessageByValidatorOverwrite()
+    {
+        $translator = m::mock(TranslatorInterface::class);
+        $factory = new Factory($translator);
+        $factory->setFailureFormatter(new RuleFailureFormatter);
+        $validator = $factory->make(
+            ['foo' => 'bar'],
+            ['foo' => 'integer'],
+            ['integer' => 'Value should be of an integer type.']
+        );
+
+        // overwriting Factory set Failure Formatter
+        $validator->setFailureFormatter(new MessageFailureFormatter);
+
+        $translator->shouldReceive('trans')
+                   ->andReturn('Value should be of an integer type.');
+
+        $this->assertFalse($validator->passes());
+        $this->assertEquals(
+            ['foo' => ['Value should be of an integer type.']],
+            $validator->messages()->toArray()
+        );
+    }
+
+}

--- a/tests/Validation/ValidationFailureFormatterTest.php
+++ b/tests/Validation/ValidationFailureFormatterTest.php
@@ -79,5 +79,4 @@ class ValidationFailureFormatterTest extends TestCase
             $validator->messages()->toArray()
         );
     }
-
 }


### PR DESCRIPTION
Adds formatting of the validation errors allowing to either return attribute with array of messages (as per existing set up), using `message => ['rule']` or any other format by adding new formatters.

The purpose of it is to provide greater flexibility with returned errors - personally I've been using it for quite some time with ajax requests where validation message is already present in the view and revealed based on the rule that didn't pass validation.

Example rules:

```php
[
	'name' => 'string|min:5',
	'age' => 'integer'
]
```

Request:

```php
[
	'name' => 2,
	'age' => 'forty'
]
```

Errors using `Illuminate\Validation\FailureFormatters\Rule` formatter:

```php
[
	'name' => ['string', 'min'],
	'age' => ['integer']
]
```

I've coded it the way so that it is backward compatible - using existing message set up as default.