### PR TITLE
[5.5] If applied this commit adds the blade directive for the Switch statement

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
@@ -5,6 +5,13 @@ namespace Illuminate\View\Compilers\Concerns;
 trait CompilesConditionals
 {
     /**
+     * Identifier for the first case in switch statement
+     *
+     * @var bool
+     */
+    protected $firstCaseInSwitch = true;
+
+    /**
      * Compile the has-section statements into valid PHP.
      *
      * @param  string  $expression
@@ -97,5 +104,51 @@ trait CompilesConditionals
     protected function compileEndIsset()
     {
         return '<?php endif; ?>';
+    }
+
+    /**
+     * Compile the switch statements into valid PHP.
+     *
+     * @param  string  $variable
+     * @return string
+     */
+    protected function compileSwitch($variable)
+    {
+        return "<?php switch ({$variable}): ";
+    }
+
+    /**
+     * Compile the case statements into valid PHP.
+     *
+     * @param  string  $value
+     * @return string
+     */
+    protected function compileCase($value)
+    {
+        if ($this->firstCaseInSwitch) {
+            $this->firstCaseInSwitch = false;
+            return "case{$value}: ?>";
+        }
+        return "<?php case{$value}: ?>";
+    }
+
+    /**
+     * Compile the default statements in switch case into valid PHP.
+     *
+     * @return string
+     */
+    protected function compileDefault()
+    {
+        return "<?php default: ?>";
+    }
+
+    /**
+     * Compile the end switch statements into valid PHP.
+     *
+     * @return string
+     */
+    protected function compileEndSwitch()
+    {
+        return "<?php endswitch; ?>";
     }
 }

--- a/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
@@ -127,8 +127,10 @@ trait CompilesConditionals
     {
         if ($this->firstCaseInSwitch) {
             $this->firstCaseInSwitch = false;
+
             return "case{$value}: ?>";
         }
+        
         return "<?php case{$value}: ?>";
     }
 

--- a/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
@@ -130,7 +130,7 @@ trait CompilesConditionals
 
             return "case{$value}: ?>";
         }
-        
+
         return "<?php case{$value}: ?>";
     }
 

--- a/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
@@ -5,7 +5,7 @@ namespace Illuminate\View\Compilers\Concerns;
 trait CompilesConditionals
 {
     /**
-     * Identifier for the first case in switch statement
+     * Identifier for the first case in switch statement.
      *
      * @var bool
      */
@@ -139,7 +139,7 @@ trait CompilesConditionals
      */
     protected function compileDefault()
     {
-        return "<?php default: ?>";
+        return '<?php default: ?>';
     }
 
     /**
@@ -149,6 +149,6 @@ trait CompilesConditionals
      */
     protected function compileEndSwitch()
     {
-        return "<?php endswitch; ?>";
+        return '<?php endswitch; ?>';
     }
 }


### PR DESCRIPTION
- Contributors, since this has not been added till now I think there might be a valid reason for that which I am not aware of, so feel free to close this PR :)
- Reason for doing it: To practice making a core contribution(as this is my first time) and giving back to the amazing Laravel community what I can. 

How to use:

```php
@switch($i)

    @case(1)
    <p>Case 1</p>
    @break

    @case(2)
    <p>Case 2</p>
    @break

    @default
    <p>Default</p>

@endswitch
```