### PR TITLE
[5.5] Fix multiple switch statements

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
@@ -151,6 +151,10 @@ trait CompilesConditionals
      */
     protected function compileEndSwitch()
     {
+        if (! $this->firstCaseInSwitch) {
+            $this->firstCaseInSwitch = true;
+        }
+
         return '<?php endswitch; ?>';
     }
 }


### PR DESCRIPTION
When using multiple switch statements only the first statement is rendered correctly, this PR fixes that.