### PR TITLE
[5.5] fixes the error raised by using multiple switch cases

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
@@ -115,7 +115,7 @@ trait CompilesConditionals
     protected function compileSwitch($variable)
     {
         $this->firstCaseInSwitch = true;
-        
+
         return "<?php switch ({$variable}): ";
     }
 

--- a/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
@@ -9,7 +9,7 @@ trait CompilesConditionals
      *
      * @var bool
      */
-    protected $firstCaseInSwitch = true;
+    protected $firstCaseInSwitch;
 
     /**
      * Compile the has-section statements into valid PHP.
@@ -114,6 +114,8 @@ trait CompilesConditionals
      */
     protected function compileSwitch($variable)
     {
+        $this->firstCaseInSwitch = true;
+        
         return "<?php switch ({$variable}): ";
     }
 


### PR DESCRIPTION
- As mentioned by @danharper [here](https://github.com/laravel/framework/pull/19758) , using multiple switch cases results in an error. 
- This PR aims to fix that.