### PR TITLE
Fix use statement on non existing class

### DIFF
--- a/src/Illuminate/Foundation/Console/stubs/test.stub
+++ b/src/Illuminate/Foundation/Console/stubs/test.stub
@@ -3,7 +3,7 @@
 namespace DummyNamespace;
 
 use Tests\TestCase;
-use Illuminate\Foundation\Testing\FreshDatabase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 
 class DummyClass extends TestCase
 {


### PR DESCRIPTION
Fixes #19754 by replace the import statement of `Illuminate\Foundation\Testing\FreshDatabase` which is a non existing class and replacing it with `Illuminate\Foundation\Testing\RefreshDatabase`