### PR TITLE
[5.5] Use ::class notation in tests

### DIFF
--- a/tests/Auth/AuthDatabaseTokenRepositoryTest.php
+++ b/tests/Auth/AuthDatabaseTokenRepositoryTest.php
@@ -28,11 +28,11 @@ class AuthDatabaseTokenRepositoryTest extends TestCase
     {
         $repo = $this->getRepo();
         $repo->getHasher()->shouldReceive('make')->andReturn('hashed-token');
-        $repo->getConnection()->shouldReceive('table')->with('table')->andReturn($query = m::mock('stdClass'));
+        $repo->getConnection()->shouldReceive('table')->with('table')->andReturn($query = m::mock(\stdClass::class));
         $query->shouldReceive('where')->with('email', 'email')->andReturn($query);
         $query->shouldReceive('delete')->once();
         $query->shouldReceive('insert')->once();
-        $user = m::mock('Illuminate\Contracts\Auth\CanResetPassword');
+        $user = m::mock(\Illuminate\Contracts\Auth\CanResetPassword::class);
         $user->shouldReceive('getEmailForPasswordReset')->andReturn('email');
 
         $results = $repo->create($user);
@@ -44,10 +44,10 @@ class AuthDatabaseTokenRepositoryTest extends TestCase
     public function testExistReturnsFalseIfNoRowFoundForUser()
     {
         $repo = $this->getRepo();
-        $repo->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($query = m::mock('stdClass'));
+        $repo->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($query = m::mock(\stdClass::class));
         $query->shouldReceive('where')->once()->with('email', 'email')->andReturn($query);
         $query->shouldReceive('first')->andReturn(null);
-        $user = m::mock('Illuminate\Contracts\Auth\CanResetPassword');
+        $user = m::mock(\Illuminate\Contracts\Auth\CanResetPassword::class);
         $user->shouldReceive('getEmailForPasswordReset')->andReturn('email');
 
         $this->assertFalse($repo->exists($user, 'token'));
@@ -57,11 +57,11 @@ class AuthDatabaseTokenRepositoryTest extends TestCase
     {
         $repo = $this->getRepo();
         $repo->getHasher()->shouldReceive('check')->with('token', 'hashed-token')->andReturn(true);
-        $repo->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($query = m::mock('stdClass'));
+        $repo->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($query = m::mock(\stdClass::class));
         $query->shouldReceive('where')->once()->with('email', 'email')->andReturn($query);
         $date = Carbon::now()->subSeconds(300000)->toDateTimeString();
         $query->shouldReceive('first')->andReturn((object) ['created_at' => $date, 'token' => 'hashed-token']);
-        $user = m::mock('Illuminate\Contracts\Auth\CanResetPassword');
+        $user = m::mock(\Illuminate\Contracts\Auth\CanResetPassword::class);
         $user->shouldReceive('getEmailForPasswordReset')->andReturn('email');
 
         $this->assertFalse($repo->exists($user, 'token'));
@@ -71,11 +71,11 @@ class AuthDatabaseTokenRepositoryTest extends TestCase
     {
         $repo = $this->getRepo();
         $repo->getHasher()->shouldReceive('check')->with('token', 'hashed-token')->andReturn(true);
-        $repo->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($query = m::mock('stdClass'));
+        $repo->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($query = m::mock(\stdClass::class));
         $query->shouldReceive('where')->once()->with('email', 'email')->andReturn($query);
         $date = Carbon::now()->subMinutes(10)->toDateTimeString();
         $query->shouldReceive('first')->andReturn((object) ['created_at' => $date, 'token' => 'hashed-token']);
-        $user = m::mock('Illuminate\Contracts\Auth\CanResetPassword');
+        $user = m::mock(\Illuminate\Contracts\Auth\CanResetPassword::class);
         $user->shouldReceive('getEmailForPasswordReset')->andReturn('email');
 
         $this->assertTrue($repo->exists($user, 'token'));
@@ -85,11 +85,11 @@ class AuthDatabaseTokenRepositoryTest extends TestCase
     {
         $repo = $this->getRepo();
         $repo->getHasher()->shouldReceive('check')->with('wrong-token', 'hashed-token')->andReturn(false);
-        $repo->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($query = m::mock('stdClass'));
+        $repo->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($query = m::mock(\stdClass::class));
         $query->shouldReceive('where')->once()->with('email', 'email')->andReturn($query);
         $date = Carbon::now()->subMinutes(10)->toDateTimeString();
         $query->shouldReceive('first')->andReturn((object) ['created_at' => $date, 'token' => 'hashed-token']);
-        $user = m::mock('Illuminate\Contracts\Auth\CanResetPassword');
+        $user = m::mock(\Illuminate\Contracts\Auth\CanResetPassword::class);
         $user->shouldReceive('getEmailForPasswordReset')->andReturn('email');
 
         $this->assertFalse($repo->exists($user, 'wrong-token'));
@@ -98,10 +98,10 @@ class AuthDatabaseTokenRepositoryTest extends TestCase
     public function testDeleteMethodDeletesByToken()
     {
         $repo = $this->getRepo();
-        $repo->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($query = m::mock('stdClass'));
+        $repo->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($query = m::mock(\stdClass::class));
         $query->shouldReceive('where')->once()->with('email', 'email')->andReturn($query);
         $query->shouldReceive('delete')->once();
-        $user = m::mock('Illuminate\Contracts\Auth\CanResetPassword');
+        $user = m::mock(\Illuminate\Contracts\Auth\CanResetPassword::class);
         $user->shouldReceive('getEmailForPasswordReset')->andReturn('email');
 
         $repo->delete($user);
@@ -110,7 +110,7 @@ class AuthDatabaseTokenRepositoryTest extends TestCase
     public function testDeleteExpiredMethodDeletesExpiredTokens()
     {
         $repo = $this->getRepo();
-        $repo->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($query = m::mock('stdClass'));
+        $repo->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($query = m::mock(\stdClass::class));
         $query->shouldReceive('where')->once()->with('created_at', '<', m::any())->andReturn($query);
         $query->shouldReceive('delete')->once();
 
@@ -120,8 +120,8 @@ class AuthDatabaseTokenRepositoryTest extends TestCase
     protected function getRepo()
     {
         return new DatabaseTokenRepository(
-            m::mock('Illuminate\Database\Connection'),
-            m::mock('Illuminate\Contracts\Hashing\Hasher'),
+            m::mock(\Illuminate\Database\Connection::class),
+            m::mock(\Illuminate\Contracts\Hashing\Hasher::class),
             'table', 'key');
     }
 }

--- a/tests/Auth/AuthDatabaseUserProviderTest.php
+++ b/tests/Auth/AuthDatabaseUserProviderTest.php
@@ -15,24 +15,24 @@ class AuthDatabaseUserProviderTest extends TestCase
 
     public function testRetrieveByIDReturnsUserWhenUserIsFound()
     {
-        $conn = m::mock('Illuminate\Database\Connection');
+        $conn = m::mock(\Illuminate\Database\Connection::class);
         $conn->shouldReceive('table')->once()->with('foo')->andReturn($conn);
         $conn->shouldReceive('find')->once()->with(1)->andReturn(['id' => 1, 'name' => 'Dayle']);
-        $hasher = m::mock('Illuminate\Contracts\Hashing\Hasher');
+        $hasher = m::mock(\Illuminate\Contracts\Hashing\Hasher::class);
         $provider = new DatabaseUserProvider($conn, $hasher, 'foo');
         $user = $provider->retrieveById(1);
 
-        $this->assertInstanceOf('Illuminate\Auth\GenericUser', $user);
+        $this->assertInstanceOf(\Illuminate\Auth\GenericUser::class, $user);
         $this->assertEquals(1, $user->getAuthIdentifier());
         $this->assertEquals('Dayle', $user->name);
     }
 
     public function testRetrieveByIDReturnsNullWhenUserIsNotFound()
     {
-        $conn = m::mock('Illuminate\Database\Connection');
+        $conn = m::mock(\Illuminate\Database\Connection::class);
         $conn->shouldReceive('table')->once()->with('foo')->andReturn($conn);
         $conn->shouldReceive('find')->once()->with(1)->andReturn(null);
-        $hasher = m::mock('Illuminate\Contracts\Hashing\Hasher');
+        $hasher = m::mock(\Illuminate\Contracts\Hashing\Hasher::class);
         $provider = new DatabaseUserProvider($conn, $hasher, 'foo');
         $user = $provider->retrieveById(1);
 
@@ -41,26 +41,26 @@ class AuthDatabaseUserProviderTest extends TestCase
 
     public function testRetrieveByCredentialsReturnsUserWhenUserIsFound()
     {
-        $conn = m::mock('Illuminate\Database\Connection');
+        $conn = m::mock(\Illuminate\Database\Connection::class);
         $conn->shouldReceive('table')->once()->with('foo')->andReturn($conn);
         $conn->shouldReceive('where')->once()->with('username', 'dayle');
         $conn->shouldReceive('first')->once()->andReturn(['id' => 1, 'name' => 'taylor']);
-        $hasher = m::mock('Illuminate\Contracts\Hashing\Hasher');
+        $hasher = m::mock(\Illuminate\Contracts\Hashing\Hasher::class);
         $provider = new DatabaseUserProvider($conn, $hasher, 'foo');
         $user = $provider->retrieveByCredentials(['username' => 'dayle', 'password' => 'foo']);
 
-        $this->assertInstanceOf('Illuminate\Auth\GenericUser', $user);
+        $this->assertInstanceOf(\Illuminate\Auth\GenericUser::class, $user);
         $this->assertEquals(1, $user->getAuthIdentifier());
         $this->assertEquals('taylor', $user->name);
     }
 
     public function testRetrieveByCredentialsReturnsNullWhenUserIsFound()
     {
-        $conn = m::mock('Illuminate\Database\Connection');
+        $conn = m::mock(\Illuminate\Database\Connection::class);
         $conn->shouldReceive('table')->once()->with('foo')->andReturn($conn);
         $conn->shouldReceive('where')->once()->with('username', 'dayle');
         $conn->shouldReceive('first')->once()->andReturn(null);
-        $hasher = m::mock('Illuminate\Contracts\Hashing\Hasher');
+        $hasher = m::mock(\Illuminate\Contracts\Hashing\Hasher::class);
         $provider = new DatabaseUserProvider($conn, $hasher, 'foo');
         $user = $provider->retrieveByCredentials(['username' => 'dayle']);
 
@@ -69,11 +69,11 @@ class AuthDatabaseUserProviderTest extends TestCase
 
     public function testCredentialValidation()
     {
-        $conn = m::mock('Illuminate\Database\Connection');
-        $hasher = m::mock('Illuminate\Contracts\Hashing\Hasher');
+        $conn = m::mock(\Illuminate\Database\Connection::class);
+        $hasher = m::mock(\Illuminate\Contracts\Hashing\Hasher::class);
         $hasher->shouldReceive('check')->once()->with('plain', 'hash')->andReturn(true);
         $provider = new DatabaseUserProvider($conn, $hasher, 'foo');
-        $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');
+        $user = m::mock(\Illuminate\Contracts\Auth\Authenticatable::class);
         $user->shouldReceive('getAuthPassword')->once()->andReturn('hash');
         $result = $provider->validateCredentials($user, ['password' => 'plain']);
 

--- a/tests/Auth/AuthEloquentUserProviderTest.php
+++ b/tests/Auth/AuthEloquentUserProviderTest.php
@@ -16,7 +16,7 @@ class AuthEloquentUserProviderTest extends TestCase
     public function testRetrieveByIDReturnsUser()
     {
         $provider = $this->getProviderMock();
-        $mock = m::mock('stdClass');
+        $mock = m::mock(\stdClass::class);
         $mock->shouldReceive('newQuery')->once()->andReturn($mock);
         $mock->shouldReceive('getAuthIdentifierName')->once()->andReturn('id');
         $mock->shouldReceive('where')->once()->with('id', 1)->andReturn($mock);
@@ -30,7 +30,7 @@ class AuthEloquentUserProviderTest extends TestCase
     public function testRetrieveByCredentialsReturnsUser()
     {
         $provider = $this->getProviderMock();
-        $mock = m::mock('stdClass');
+        $mock = m::mock(\stdClass::class);
         $mock->shouldReceive('newQuery')->once()->andReturn($mock);
         $mock->shouldReceive('where')->once()->with('username', 'dayle');
         $mock->shouldReceive('first')->once()->andReturn('bar');
@@ -42,11 +42,11 @@ class AuthEloquentUserProviderTest extends TestCase
 
     public function testCredentialValidation()
     {
-        $conn = m::mock('Illuminate\Database\Connection');
-        $hasher = m::mock('Illuminate\Contracts\Hashing\Hasher');
+        $conn = m::mock(\Illuminate\Database\Connection::class);
+        $hasher = m::mock(\Illuminate\Contracts\Hashing\Hasher::class);
         $hasher->shouldReceive('check')->once()->with('plain', 'hash')->andReturn(true);
         $provider = new EloquentUserProvider($hasher, 'foo');
-        $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');
+        $user = m::mock(\Illuminate\Contracts\Auth\Authenticatable::class);
         $user->shouldReceive('getAuthPassword')->once()->andReturn('hash');
         $result = $provider->validateCredentials($user, ['password' => 'plain']);
 
@@ -55,18 +55,18 @@ class AuthEloquentUserProviderTest extends TestCase
 
     public function testModelsCanBeCreated()
     {
-        $hasher = m::mock('Illuminate\Contracts\Hashing\Hasher');
-        $provider = new EloquentUserProvider($hasher, 'Illuminate\Tests\Auth\EloquentProviderUserStub');
+        $hasher = m::mock(\Illuminate\Contracts\Hashing\Hasher::class);
+        $provider = new EloquentUserProvider($hasher, \Illuminate\Tests\Auth\EloquentProviderUserStub::class);
         $model = $provider->createModel();
 
-        $this->assertInstanceOf('Illuminate\Tests\Auth\EloquentProviderUserStub', $model);
+        $this->assertInstanceOf(\Illuminate\Tests\Auth\EloquentProviderUserStub::class, $model);
     }
 
     protected function getProviderMock()
     {
-        $hasher = m::mock('Illuminate\Contracts\Hashing\Hasher');
+        $hasher = m::mock(\Illuminate\Contracts\Hashing\Hasher::class);
 
-        return $this->getMockBuilder('Illuminate\Auth\EloquentUserProvider')->setMethods(['createModel'])->setConstructorArgs([$hasher, 'foo'])->getMock();
+        return $this->getMockBuilder(\Illuminate\Auth\EloquentUserProvider::class)->setMethods(['createModel'])->setConstructorArgs([$hasher, 'foo'])->getMock();
     }
 }
 

--- a/tests/Auth/AuthGuardTest.php
+++ b/tests/Auth/AuthGuardTest.php
@@ -69,7 +69,7 @@ class AuthGuardTest extends TestCase
     public function testAttemptCallsRetrieveByCredentials()
     {
         $guard = $this->getGuard();
-        $guard->setDispatcher($events = m::mock('Illuminate\Contracts\Events\Dispatcher'));
+        $guard->setDispatcher($events = m::mock(\Illuminate\Contracts\Events\Dispatcher::class));
         $events->shouldReceive('dispatch')->once()->with(m::type(Attempting::class));
         $events->shouldReceive('dispatch')->once()->with(m::type(Failed::class));
         $guard->getProvider()->shouldReceive('retrieveByCredentials')->once()->with(['foo']);
@@ -79,10 +79,10 @@ class AuthGuardTest extends TestCase
     public function testAttemptReturnsUserInterface()
     {
         list($session, $provider, $request, $cookie) = $this->getMocks();
-        $guard = $this->getMockBuilder('Illuminate\Auth\SessionGuard')->setMethods(['login'])->setConstructorArgs(['default', $provider, $session, $request])->getMock();
-        $guard->setDispatcher($events = m::mock('Illuminate\Contracts\Events\Dispatcher'));
+        $guard = $this->getMockBuilder(\Illuminate\Auth\SessionGuard::class)->setMethods(['login'])->setConstructorArgs(['default', $provider, $session, $request])->getMock();
+        $guard->setDispatcher($events = m::mock(\Illuminate\Contracts\Events\Dispatcher::class));
         $events->shouldReceive('dispatch')->once()->with(m::type(Attempting::class));
-        $user = $this->createMock('Illuminate\Contracts\Auth\Authenticatable');
+        $user = $this->createMock(\Illuminate\Contracts\Auth\Authenticatable::class);
         $guard->getProvider()->shouldReceive('retrieveByCredentials')->once()->andReturn($user);
         $guard->getProvider()->shouldReceive('validateCredentials')->with($user, ['foo'])->andReturn(true);
         $guard->expects($this->once())->method('login')->with($this->equalTo($user));
@@ -92,7 +92,7 @@ class AuthGuardTest extends TestCase
     public function testAttemptReturnsFalseIfUserNotGiven()
     {
         $mock = $this->getGuard();
-        $mock->setDispatcher($events = m::mock('Illuminate\Contracts\Events\Dispatcher'));
+        $mock->setDispatcher($events = m::mock(\Illuminate\Contracts\Events\Dispatcher::class));
         $events->shouldReceive('dispatch')->once()->with(m::type(Attempting::class));
         $events->shouldReceive('dispatch')->once()->with(m::type(Failed::class));
         $mock->getProvider()->shouldReceive('retrieveByCredentials')->once()->andReturn(null);
@@ -102,8 +102,8 @@ class AuthGuardTest extends TestCase
     public function testLoginStoresIdentifierInSession()
     {
         list($session, $provider, $request, $cookie) = $this->getMocks();
-        $mock = $this->getMockBuilder('Illuminate\Auth\SessionGuard')->setMethods(['getName'])->setConstructorArgs(['default', $provider, $session, $request])->getMock();
-        $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');
+        $mock = $this->getMockBuilder(\Illuminate\Auth\SessionGuard::class)->setMethods(['getName'])->setConstructorArgs(['default', $provider, $session, $request])->getMock();
+        $user = m::mock(\Illuminate\Contracts\Auth\Authenticatable::class);
         $mock->expects($this->once())->method('getName')->will($this->returnValue('foo'));
         $user->shouldReceive('getAuthIdentifier')->once()->andReturn('bar');
         $mock->getSession()->shouldReceive('put')->with('foo', 'bar')->once();
@@ -127,11 +127,11 @@ class AuthGuardTest extends TestCase
     public function testLoginFiresLoginAndAuthenticatedEvents()
     {
         list($session, $provider, $request, $cookie) = $this->getMocks();
-        $mock = $this->getMockBuilder('Illuminate\Auth\SessionGuard')->setMethods(['getName'])->setConstructorArgs(['default', $provider, $session, $request])->getMock();
-        $mock->setDispatcher($events = m::mock('Illuminate\Contracts\Events\Dispatcher'));
-        $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');
-        $events->shouldReceive('dispatch')->once()->with(m::type('Illuminate\Auth\Events\Login'));
-        $events->shouldReceive('dispatch')->once()->with(m::type('Illuminate\Auth\Events\Authenticated'));
+        $mock = $this->getMockBuilder(\Illuminate\Auth\SessionGuard::class)->setMethods(['getName'])->setConstructorArgs(['default', $provider, $session, $request])->getMock();
+        $mock->setDispatcher($events = m::mock(\Illuminate\Contracts\Events\Dispatcher::class));
+        $user = m::mock(\Illuminate\Contracts\Auth\Authenticatable::class);
+        $events->shouldReceive('dispatch')->once()->with(m::type(\Illuminate\Auth\Events\Login::class));
+        $events->shouldReceive('dispatch')->once()->with(m::type(\Illuminate\Auth\Events\Authenticated::class));
         $mock->expects($this->once())->method('getName')->will($this->returnValue('foo'));
         $user->shouldReceive('getAuthIdentifier')->once()->andReturn('bar');
         $mock->getSession()->shouldReceive('put')->with('foo', 'bar')->once();
@@ -142,7 +142,7 @@ class AuthGuardTest extends TestCase
     public function testFailedAttemptFiresFailedEvent()
     {
         $guard = $this->getGuard();
-        $guard->setDispatcher($events = m::mock('Illuminate\Contracts\Events\Dispatcher'));
+        $guard->setDispatcher($events = m::mock(\Illuminate\Contracts\Events\Dispatcher::class));
         $events->shouldReceive('dispatch')->once()->with(m::type(Attempting::class));
         $events->shouldReceive('dispatch')->once()->with(m::type(Failed::class));
         $guard->getProvider()->shouldReceive('retrieveByCredentials')->once()->with(['foo'])->andReturn(null);
@@ -151,7 +151,7 @@ class AuthGuardTest extends TestCase
 
     public function testAuthenticateReturnsUserWhenUserIsNotNull()
     {
-        $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');
+        $user = m::mock(\Illuminate\Contracts\Auth\Authenticatable::class);
         $guard = $this->getGuard()->setUser($user);
 
         $this->assertEquals($user, $guard->authenticate());
@@ -159,9 +159,9 @@ class AuthGuardTest extends TestCase
 
     public function testSetUserFiresAuthenticatedEvent()
     {
-        $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');
+        $user = m::mock(\Illuminate\Contracts\Auth\Authenticatable::class);
         $guard = $this->getGuard();
-        $guard->setDispatcher($events = m::mock('Illuminate\Contracts\Events\Dispatcher'));
+        $guard->setDispatcher($events = m::mock(\Illuminate\Contracts\Events\Dispatcher::class));
         $events->shouldReceive('dispatch')->once()->with(m::type(Authenticated::class));
         $guard->setUser($user);
     }
@@ -179,7 +179,7 @@ class AuthGuardTest extends TestCase
 
     public function testIsAuthedReturnsTrueWhenUserIsNotNull()
     {
-        $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');
+        $user = m::mock(\Illuminate\Contracts\Auth\Authenticatable::class);
         $mock = $this->getGuard();
         $mock->setUser($user);
         $this->assertTrue($mock->check());
@@ -189,7 +189,7 @@ class AuthGuardTest extends TestCase
     public function testIsAuthedReturnsFalseWhenUserIsNull()
     {
         list($session, $provider, $request, $cookie) = $this->getMocks();
-        $mock = $this->getMockBuilder('Illuminate\Auth\SessionGuard')->setMethods(['user'])->setConstructorArgs(['default', $provider, $session, $request])->getMock();
+        $mock = $this->getMockBuilder(\Illuminate\Auth\SessionGuard::class)->setMethods(['user'])->setConstructorArgs(['default', $provider, $session, $request])->getMock();
         $mock->expects($this->exactly(2))->method('user')->will($this->returnValue(null));
         $this->assertFalse($mock->check());
         $this->assertTrue($mock->guest());
@@ -197,7 +197,7 @@ class AuthGuardTest extends TestCase
 
     public function testUserMethodReturnsCachedUser()
     {
-        $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');
+        $user = m::mock(\Illuminate\Contracts\Auth\Authenticatable::class);
         $mock = $this->getGuard();
         $mock->setUser($user);
         $this->assertSame($user, $mock->user());
@@ -214,7 +214,7 @@ class AuthGuardTest extends TestCase
     {
         $mock = $this->getGuard();
         $mock->getSession()->shouldReceive('get')->once()->andReturn(1);
-        $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');
+        $user = m::mock(\Illuminate\Contracts\Auth\Authenticatable::class);
         $mock->getProvider()->shouldReceive('retrieveById')->once()->with(1)->andReturn($user);
         $this->assertSame($user, $mock->user());
         $this->assertSame($user, $mock->getUser());
@@ -223,9 +223,9 @@ class AuthGuardTest extends TestCase
     public function testLogoutRemovesSessionTokenAndRememberMeCookie()
     {
         list($session, $provider, $request, $cookie) = $this->getMocks();
-        $mock = $this->getMockBuilder('Illuminate\Auth\SessionGuard')->setMethods(['getName', 'getRecallerName', 'recaller'])->setConstructorArgs(['default', $provider, $session, $request])->getMock();
-        $mock->setCookieJar($cookies = m::mock('Illuminate\Cookie\CookieJar'));
-        $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');
+        $mock = $this->getMockBuilder(\Illuminate\Auth\SessionGuard::class)->setMethods(['getName', 'getRecallerName', 'recaller'])->setConstructorArgs(['default', $provider, $session, $request])->getMock();
+        $mock->setCookieJar($cookies = m::mock(\Illuminate\Cookie\CookieJar::class));
+        $user = m::mock(\Illuminate\Contracts\Auth\Authenticatable::class);
         $user->shouldReceive('setRememberToken')->once();
         $mock->expects($this->once())->method('getName')->will($this->returnValue('foo'));
         $mock->expects($this->once())->method('getRecallerName')->will($this->returnValue('bar'));
@@ -244,9 +244,9 @@ class AuthGuardTest extends TestCase
     public function testLogoutDoesNotEnqueueRememberMeCookieForDeletionIfCookieDoesntExist()
     {
         list($session, $provider, $request, $cookie) = $this->getMocks();
-        $mock = $this->getMockBuilder('Illuminate\Auth\SessionGuard')->setMethods(['getName', 'recaller'])->setConstructorArgs(['default', $provider, $session, $request])->getMock();
-        $mock->setCookieJar($cookies = m::mock('Illuminate\Cookie\CookieJar'));
-        $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');
+        $mock = $this->getMockBuilder(\Illuminate\Auth\SessionGuard::class)->setMethods(['getName', 'recaller'])->setConstructorArgs(['default', $provider, $session, $request])->getMock();
+        $mock->setCookieJar($cookies = m::mock(\Illuminate\Cookie\CookieJar::class));
+        $user = m::mock(\Illuminate\Contracts\Auth\Authenticatable::class);
         $user->shouldReceive('setRememberToken')->once();
         $mock->expects($this->once())->method('getName')->will($this->returnValue('foo'));
         $mock->expects($this->once())->method('recaller')->will($this->returnValue(null));
@@ -261,15 +261,15 @@ class AuthGuardTest extends TestCase
     public function testLogoutFiresLogoutEvent()
     {
         list($session, $provider, $request, $cookie) = $this->getMocks();
-        $mock = $this->getMockBuilder('Illuminate\Auth\SessionGuard')->setMethods(['clearUserDataFromStorage'])->setConstructorArgs(['default', $provider, $session, $request])->getMock();
+        $mock = $this->getMockBuilder(\Illuminate\Auth\SessionGuard::class)->setMethods(['clearUserDataFromStorage'])->setConstructorArgs(['default', $provider, $session, $request])->getMock();
         $mock->expects($this->once())->method('clearUserDataFromStorage');
-        $mock->setDispatcher($events = m::mock('Illuminate\Contracts\Events\Dispatcher'));
-        $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');
+        $mock->setDispatcher($events = m::mock(\Illuminate\Contracts\Events\Dispatcher::class));
+        $user = m::mock(\Illuminate\Contracts\Auth\Authenticatable::class);
         $user->shouldReceive('setRememberToken')->once();
         $provider->shouldReceive('updateRememberToken')->once();
         $events->shouldReceive('dispatch')->once()->with(m::type(Authenticated::class));
         $mock->setUser($user);
-        $events->shouldReceive('dispatch')->once()->with(m::type('Illuminate\Auth\Events\Logout'));
+        $events->shouldReceive('dispatch')->once()->with(m::type(\Illuminate\Auth\Events\Logout::class));
         $mock->logout();
     }
 
@@ -283,7 +283,7 @@ class AuthGuardTest extends TestCase
         $cookie->shouldReceive('queue')->once()->with($foreverCookie);
         $guard->getSession()->shouldReceive('put')->once()->with($guard->getName(), 'foo');
         $session->shouldReceive('migrate')->once();
-        $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');
+        $user = m::mock(\Illuminate\Contracts\Auth\Authenticatable::class);
         $user->shouldReceive('getAuthIdentifier')->andReturn('foo');
         $user->shouldReceive('getRememberToken')->andReturn('recaller');
         $user->shouldReceive('setRememberToken')->never();
@@ -301,7 +301,7 @@ class AuthGuardTest extends TestCase
         $cookie->shouldReceive('queue')->once()->with($foreverCookie);
         $guard->getSession()->shouldReceive('put')->once()->with($guard->getName(), 'foo');
         $session->shouldReceive('migrate')->once();
-        $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');
+        $user = m::mock(\Illuminate\Contracts\Auth\Authenticatable::class);
         $user->shouldReceive('getAuthIdentifier')->andReturn('foo');
         $user->shouldReceive('getRememberToken')->andReturn(null);
         $user->shouldReceive('setRememberToken')->once();
@@ -313,9 +313,9 @@ class AuthGuardTest extends TestCase
     {
         list($session, $provider, $request, $cookie) = $this->getMocks();
 
-        $guard = m::mock('Illuminate\Auth\SessionGuard', ['default', $provider, $session])->makePartial();
+        $guard = m::mock(\Illuminate\Auth\SessionGuard::class, ['default', $provider, $session])->makePartial();
 
-        $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');
+        $user = m::mock(\Illuminate\Contracts\Auth\Authenticatable::class);
         $guard->getProvider()->shouldReceive('retrieveById')->once()->with(10)->andReturn($user);
         $guard->shouldReceive('login')->once()->with($user, false);
 
@@ -325,7 +325,7 @@ class AuthGuardTest extends TestCase
     public function testLoginUsingIdFailure()
     {
         list($session, $provider, $request, $cookie) = $this->getMocks();
-        $guard = m::mock('Illuminate\Auth\SessionGuard', ['default', $provider, $session])->makePartial();
+        $guard = m::mock(\Illuminate\Auth\SessionGuard::class, ['default', $provider, $session])->makePartial();
 
         $guard->getProvider()->shouldReceive('retrieveById')->once()->with(11)->andReturn(null);
         $guard->shouldNotReceive('login');
@@ -336,9 +336,9 @@ class AuthGuardTest extends TestCase
     public function testOnceUsingIdSetsUser()
     {
         list($session, $provider, $request, $cookie) = $this->getMocks();
-        $guard = m::mock('Illuminate\Auth\SessionGuard', ['default', $provider, $session])->makePartial();
+        $guard = m::mock(\Illuminate\Auth\SessionGuard::class, ['default', $provider, $session])->makePartial();
 
-        $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');
+        $user = m::mock(\Illuminate\Contracts\Auth\Authenticatable::class);
         $guard->getProvider()->shouldReceive('retrieveById')->once()->with(10)->andReturn($user);
         $guard->shouldReceive('setUser')->once()->with($user);
 
@@ -348,7 +348,7 @@ class AuthGuardTest extends TestCase
     public function testOnceUsingIdFailure()
     {
         list($session, $provider, $request, $cookie) = $this->getMocks();
-        $guard = m::mock('Illuminate\Auth\SessionGuard', ['default', $provider, $session])->makePartial();
+        $guard = m::mock(\Illuminate\Auth\SessionGuard::class, ['default', $provider, $session])->makePartial();
 
         $guard->getProvider()->shouldReceive('retrieveById')->once()->with(11)->andReturn(null);
         $guard->shouldNotReceive('setUser');
@@ -363,7 +363,7 @@ class AuthGuardTest extends TestCase
         $request = \Symfony\Component\HttpFoundation\Request::create('/', 'GET', [], [$guard->getRecallerName() => 'id|recaller']);
         $guard = new \Illuminate\Auth\SessionGuard('default', $provider, $session, $request);
         $guard->getSession()->shouldReceive('get')->once()->with($guard->getName())->andReturn(null);
-        $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');
+        $user = m::mock(\Illuminate\Contracts\Auth\Authenticatable::class);
         $guard->getProvider()->shouldReceive('retrieveByToken')->once()->with('id', 'recaller')->andReturn($user);
         $user->shouldReceive('getAuthIdentifier')->once()->andReturn('bar');
         $guard->getSession()->shouldReceive('put')->with($guard->getName(), 'bar')->once();
@@ -375,8 +375,8 @@ class AuthGuardTest extends TestCase
     public function testLoginOnceSetsUser()
     {
         list($session, $provider, $request, $cookie) = $this->getMocks();
-        $guard = m::mock('Illuminate\Auth\SessionGuard', ['default', $provider, $session])->makePartial();
-        $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');
+        $guard = m::mock(\Illuminate\Auth\SessionGuard::class, ['default', $provider, $session])->makePartial();
+        $user = m::mock(\Illuminate\Contracts\Auth\Authenticatable::class);
         $guard->getProvider()->shouldReceive('retrieveByCredentials')->once()->with(['foo'])->andReturn($user);
         $guard->getProvider()->shouldReceive('validateCredentials')->once()->with($user, ['foo'])->andReturn(true);
         $guard->shouldReceive('setUser')->once()->with($user);
@@ -386,8 +386,8 @@ class AuthGuardTest extends TestCase
     public function testLoginOnceFailure()
     {
         list($session, $provider, $request, $cookie) = $this->getMocks();
-        $guard = m::mock('Illuminate\Auth\SessionGuard', ['default', $provider, $session])->makePartial();
-        $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');
+        $guard = m::mock(\Illuminate\Auth\SessionGuard::class, ['default', $provider, $session])->makePartial();
+        $user = m::mock(\Illuminate\Contracts\Auth\Authenticatable::class);
         $guard->getProvider()->shouldReceive('retrieveByCredentials')->once()->with(['foo'])->andReturn($user);
         $guard->getProvider()->shouldReceive('validateCredentials')->once()->with($user, ['foo'])->andReturn(false);
         $this->assertFalse($guard->once(['foo']));
@@ -403,15 +403,15 @@ class AuthGuardTest extends TestCase
     protected function getMocks()
     {
         return [
-            m::mock('Illuminate\Contracts\Session\Session'),
-            m::mock('Illuminate\Contracts\Auth\UserProvider'),
+            m::mock(\Illuminate\Contracts\Session\Session::class),
+            m::mock(\Illuminate\Contracts\Auth\UserProvider::class),
             \Symfony\Component\HttpFoundation\Request::create('/', 'GET'),
-            m::mock('Illuminate\Cookie\CookieJar'),
+            m::mock(\Illuminate\Cookie\CookieJar::class),
         ];
     }
 
     protected function getCookieJar()
     {
-        return new \Illuminate\Cookie\CookieJar(Request::create('/foo', 'GET'), m::mock('Illuminate\Contracts\Encryption\Encrypter'), ['domain' => 'foo.com', 'path' => '/', 'secure' => false, 'httpOnly' => false]);
+        return new \Illuminate\Cookie\CookieJar(Request::create('/foo', 'GET'), m::mock(\Illuminate\Contracts\Encryption\Encrypter::class), ['domain' => 'foo.com', 'path' => '/', 'secure' => false, 'httpOnly' => false]);
     }
 }

--- a/tests/Auth/AuthPasswordBrokerTest.php
+++ b/tests/Auth/AuthPasswordBrokerTest.php
@@ -17,7 +17,7 @@ class AuthPasswordBrokerTest extends TestCase
     public function testIfUserIsNotFoundErrorRedirectIsReturned()
     {
         $mocks = $this->getMocks();
-        $broker = $this->getMockBuilder('Illuminate\Auth\Passwords\PasswordBroker')->setMethods(['getUser', 'makeErrorRedirect'])->setConstructorArgs(array_values($mocks))->getMock();
+        $broker = $this->getMockBuilder(\Illuminate\Auth\Passwords\PasswordBroker::class)->setMethods(['getUser', 'makeErrorRedirect'])->setConstructorArgs(array_values($mocks))->getMock();
         $broker->expects($this->once())->method('getUser')->will($this->returnValue(null));
 
         $this->assertEquals(PasswordBroker::INVALID_USER, $broker->sendResetLink(['credentials']));
@@ -37,7 +37,7 @@ class AuthPasswordBrokerTest extends TestCase
     public function testUserIsRetrievedByCredentials()
     {
         $broker = $this->getBroker($mocks = $this->getMocks());
-        $mocks['users']->shouldReceive('retrieveByCredentials')->once()->with(['foo'])->andReturn($user = m::mock('Illuminate\Contracts\Auth\CanResetPassword'));
+        $mocks['users']->shouldReceive('retrieveByCredentials')->once()->with(['foo'])->andReturn($user = m::mock(\Illuminate\Contracts\Auth\CanResetPassword::class));
 
         $this->assertEquals($user, $broker->getUser(['foo']));
     }
@@ -45,8 +45,8 @@ class AuthPasswordBrokerTest extends TestCase
     public function testBrokerCreatesTokenAndRedirectsWithoutError()
     {
         $mocks = $this->getMocks();
-        $broker = $this->getMockBuilder('Illuminate\Auth\Passwords\PasswordBroker')->setMethods(['emailResetLink', 'getUri'])->setConstructorArgs(array_values($mocks))->getMock();
-        $mocks['users']->shouldReceive('retrieveByCredentials')->once()->with(['foo'])->andReturn($user = m::mock('Illuminate\Contracts\Auth\CanResetPassword'));
+        $broker = $this->getMockBuilder(\Illuminate\Auth\Passwords\PasswordBroker::class)->setMethods(['emailResetLink', 'getUri'])->setConstructorArgs(array_values($mocks))->getMock();
+        $mocks['users']->shouldReceive('retrieveByCredentials')->once()->with(['foo'])->andReturn($user = m::mock(\Illuminate\Contracts\Auth\CanResetPassword::class));
         $mocks['tokens']->shouldReceive('create')->once()->with($user)->andReturn('token');
         $callback = function () {
         };
@@ -68,7 +68,7 @@ class AuthPasswordBrokerTest extends TestCase
     {
         $creds = ['password' => 'foo', 'password_confirmation' => 'bar'];
         $broker = $this->getBroker($mocks = $this->getMocks());
-        $mocks['users']->shouldReceive('retrieveByCredentials')->once()->with($creds)->andReturn($user = m::mock('Illuminate\Contracts\Auth\CanResetPassword'));
+        $mocks['users']->shouldReceive('retrieveByCredentials')->once()->with($creds)->andReturn($user = m::mock(\Illuminate\Contracts\Auth\CanResetPassword::class));
 
         $this->assertEquals(PasswordBroker::INVALID_PASSWORD, $broker->reset($creds, function () {
         }));
@@ -78,7 +78,7 @@ class AuthPasswordBrokerTest extends TestCase
     {
         $creds = ['password' => null, 'password_confirmation' => null];
         $broker = $this->getBroker($mocks = $this->getMocks());
-        $mocks['users']->shouldReceive('retrieveByCredentials')->once()->with($creds)->andReturn($user = m::mock('Illuminate\Contracts\Auth\CanResetPassword'));
+        $mocks['users']->shouldReceive('retrieveByCredentials')->once()->with($creds)->andReturn($user = m::mock(\Illuminate\Contracts\Auth\CanResetPassword::class));
 
         $this->assertEquals(PasswordBroker::INVALID_PASSWORD, $broker->reset($creds, function () {
         }));
@@ -88,7 +88,7 @@ class AuthPasswordBrokerTest extends TestCase
     {
         $creds = ['password' => 'abc', 'password_confirmation' => 'abc'];
         $broker = $this->getBroker($mocks = $this->getMocks());
-        $mocks['users']->shouldReceive('retrieveByCredentials')->once()->with($creds)->andReturn($user = m::mock('Illuminate\Contracts\Auth\CanResetPassword'));
+        $mocks['users']->shouldReceive('retrieveByCredentials')->once()->with($creds)->andReturn($user = m::mock(\Illuminate\Contracts\Auth\CanResetPassword::class));
 
         $this->assertEquals(PasswordBroker::INVALID_PASSWORD, $broker->reset($creds, function () {
         }));
@@ -101,7 +101,7 @@ class AuthPasswordBrokerTest extends TestCase
         $broker->validator(function ($credentials) {
             return strlen($credentials['password']) >= 7;
         });
-        $mocks['users']->shouldReceive('retrieveByCredentials')->once()->with($creds)->andReturn($user = m::mock('Illuminate\Contracts\Auth\CanResetPassword'));
+        $mocks['users']->shouldReceive('retrieveByCredentials')->once()->with($creds)->andReturn($user = m::mock(\Illuminate\Contracts\Auth\CanResetPassword::class));
 
         $this->assertEquals(PasswordBroker::INVALID_PASSWORD, $broker->reset($creds, function () {
         }));
@@ -110,8 +110,8 @@ class AuthPasswordBrokerTest extends TestCase
     public function testRedirectReturnedByRemindWhenRecordDoesntExistInTable()
     {
         $creds = ['token' => 'token'];
-        $broker = $this->getMockBuilder('Illuminate\Auth\Passwords\PasswordBroker')->setMethods(['validateNewPassword'])->setConstructorArgs(array_values($mocks = $this->getMocks()))->getMock();
-        $mocks['users']->shouldReceive('retrieveByCredentials')->once()->with(Arr::except($creds, ['token']))->andReturn($user = m::mock('Illuminate\Contracts\Auth\CanResetPassword'));
+        $broker = $this->getMockBuilder(\Illuminate\Auth\Passwords\PasswordBroker::class)->setMethods(['validateNewPassword'])->setConstructorArgs(array_values($mocks = $this->getMocks()))->getMock();
+        $mocks['users']->shouldReceive('retrieveByCredentials')->once()->with(Arr::except($creds, ['token']))->andReturn($user = m::mock(\Illuminate\Contracts\Auth\CanResetPassword::class));
         $broker->expects($this->once())->method('validateNewPassword')->will($this->returnValue(true));
         $mocks['tokens']->shouldReceive('exists')->with($user, 'token')->andReturn(false);
 
@@ -122,8 +122,8 @@ class AuthPasswordBrokerTest extends TestCase
     public function testResetRemovesRecordOnReminderTableAndCallsCallback()
     {
         unset($_SERVER['__password.reset.test']);
-        $broker = $this->getMockBuilder('Illuminate\Auth\Passwords\PasswordBroker')->setMethods(['validateReset', 'getPassword', 'getToken'])->setConstructorArgs(array_values($mocks = $this->getMocks()))->getMock();
-        $broker->expects($this->once())->method('validateReset')->will($this->returnValue($user = m::mock('Illuminate\Contracts\Auth\CanResetPassword')));
+        $broker = $this->getMockBuilder(\Illuminate\Auth\Passwords\PasswordBroker::class)->setMethods(['validateReset', 'getPassword', 'getToken'])->setConstructorArgs(array_values($mocks = $this->getMocks()))->getMock();
+        $broker->expects($this->once())->method('validateReset')->will($this->returnValue($user = m::mock(\Illuminate\Contracts\Auth\CanResetPassword::class)));
         $mocks['tokens']->shouldReceive('delete')->once()->with($user);
         $callback = function ($user, $password) {
             $_SERVER['__password.reset.test'] = compact('user', 'password');
@@ -143,9 +143,9 @@ class AuthPasswordBrokerTest extends TestCase
     protected function getMocks()
     {
         $mocks = [
-            'tokens' => m::mock('Illuminate\Auth\Passwords\TokenRepositoryInterface'),
-            'users'  => m::mock('Illuminate\Contracts\Auth\UserProvider'),
-            'mailer' => m::mock('Illuminate\Contracts\Mail\Mailer'),
+            'tokens' => m::mock(\Illuminate\Auth\Passwords\TokenRepositoryInterface::class),
+            'users'  => m::mock(\Illuminate\Contracts\Auth\UserProvider::class),
+            'mailer' => m::mock(\Illuminate\Contracts\Mail\Mailer::class),
             'view'   => 'resetLinkView',
         ];
 

--- a/tests/Bus/BusDispatcherTest.php
+++ b/tests/Bus/BusDispatcherTest.php
@@ -19,20 +19,20 @@ class BusDispatcherTest extends TestCase
     {
         $container = new Container;
         $dispatcher = new Dispatcher($container, function () {
-            $mock = m::mock('Illuminate\Contracts\Queue\Queue');
+            $mock = m::mock(\Illuminate\Contracts\Queue\Queue::class);
             $mock->shouldReceive('push')->once();
 
             return $mock;
         });
 
-        $dispatcher->dispatch(m::mock('Illuminate\Contracts\Queue\ShouldQueue'));
+        $dispatcher->dispatch(m::mock(\Illuminate\Contracts\Queue\ShouldQueue::class));
     }
 
     public function testCommandsThatShouldQueueIsQueuedUsingCustomHandler()
     {
         $container = new Container;
         $dispatcher = new Dispatcher($container, function () {
-            $mock = m::mock('Illuminate\Contracts\Queue\Queue');
+            $mock = m::mock(\Illuminate\Contracts\Queue\Queue::class);
             $mock->shouldReceive('push')->once();
 
             return $mock;
@@ -45,8 +45,8 @@ class BusDispatcherTest extends TestCase
     {
         $container = new Container;
         $dispatcher = new Dispatcher($container, function () {
-            $mock = m::mock('Illuminate\Contracts\Queue\Queue');
-            $mock->shouldReceive('laterOn')->once()->with('foo', 10, m::type('Illuminate\Tests\Bus\BusDispatcherTestSpecificQueueAndDelayCommand'));
+            $mock = m::mock(\Illuminate\Contracts\Queue\Queue::class);
+            $mock->shouldReceive('laterOn')->once()->with('foo', 10, m::type(\Illuminate\Tests\Bus\BusDispatcherTestSpecificQueueAndDelayCommand::class));
 
             return $mock;
         });
@@ -57,7 +57,7 @@ class BusDispatcherTest extends TestCase
     public function testDispatchNowShouldNeverQueue()
     {
         $container = new Container;
-        $mock = m::mock('Illuminate\Contracts\Queue\Queue');
+        $mock = m::mock(\Illuminate\Contracts\Queue\Queue::class);
         $mock->shouldReceive('push')->never();
         $dispatcher = new Dispatcher($container, function () use ($mock) {
             return $mock;
@@ -69,7 +69,7 @@ class BusDispatcherTest extends TestCase
     public function testDispatcherCanDispatchStandAloneHandler()
     {
         $container = new Container;
-        $mock = m::mock('Illuminate\Contracts\Queue\Queue');
+        $mock = m::mock(\Illuminate\Contracts\Queue\Queue::class);
         $dispatcher = new Dispatcher($container, function () use ($mock) {
             return $mock;
         });
@@ -96,7 +96,7 @@ class BusDispatcherTest extends TestCase
         });
 
         $dispatcher = new Dispatcher($container, function () {
-            $mock = m::mock('Illuminate\Contracts\Queue\Queue');
+            $mock = m::mock(\Illuminate\Contracts\Queue\Queue::class);
             $mock->shouldReceive('push')->once();
 
             return $mock;

--- a/tests/Cache/CacheApcStoreTest.php
+++ b/tests/Cache/CacheApcStoreTest.php
@@ -8,7 +8,7 @@ class CacheApcStoreTest extends TestCase
 {
     public function testGetReturnsNullWhenNotFound()
     {
-        $apc = $this->getMockBuilder('Illuminate\Cache\ApcWrapper')->setMethods(['get'])->getMock();
+        $apc = $this->getMockBuilder(\Illuminate\Cache\ApcWrapper::class)->setMethods(['get'])->getMock();
         $apc->expects($this->once())->method('get')->with($this->equalTo('foobar'))->will($this->returnValue(null));
         $store = new \Illuminate\Cache\ApcStore($apc, 'foo');
         $this->assertNull($store->get('bar'));
@@ -16,7 +16,7 @@ class CacheApcStoreTest extends TestCase
 
     public function testAPCValueIsReturned()
     {
-        $apc = $this->getMockBuilder('Illuminate\Cache\ApcWrapper')->setMethods(['get'])->getMock();
+        $apc = $this->getMockBuilder(\Illuminate\Cache\ApcWrapper::class)->setMethods(['get'])->getMock();
         $apc->expects($this->once())->method('get')->will($this->returnValue('bar'));
         $store = new \Illuminate\Cache\ApcStore($apc);
         $this->assertEquals('bar', $store->get('foo'));
@@ -24,7 +24,7 @@ class CacheApcStoreTest extends TestCase
 
     public function testGetMultipleReturnsNullWhenNotFoundAndValueWhenFound()
     {
-        $apc = $this->getMockBuilder('Illuminate\Cache\ApcWrapper')->setMethods(['get'])->getMock();
+        $apc = $this->getMockBuilder(\Illuminate\Cache\ApcWrapper::class)->setMethods(['get'])->getMock();
         $apc->expects($this->exactly(3))->method('get')->willReturnMap([
             ['foo', 'qux'],
             ['bar', null],
@@ -40,7 +40,7 @@ class CacheApcStoreTest extends TestCase
 
     public function testSetMethodProperlyCallsAPC()
     {
-        $apc = $this->getMockBuilder('Illuminate\Cache\ApcWrapper')->setMethods(['put'])->getMock();
+        $apc = $this->getMockBuilder(\Illuminate\Cache\ApcWrapper::class)->setMethods(['put'])->getMock();
         $apc->expects($this->once())->method('put')->with($this->equalTo('foo'), $this->equalTo('bar'), $this->equalTo(60));
         $store = new \Illuminate\Cache\ApcStore($apc);
         $store->put('foo', 'bar', 1);
@@ -48,7 +48,7 @@ class CacheApcStoreTest extends TestCase
 
     public function testSetMultipleMethodProperlyCallsAPC()
     {
-        $apc = $this->getMockBuilder('Illuminate\Cache\ApcWrapper')->setMethods(['put'])->getMock();
+        $apc = $this->getMockBuilder(\Illuminate\Cache\ApcWrapper::class)->setMethods(['put'])->getMock();
         $apc->expects($this->exactly(3))->method('put')->withConsecutive([
             $this->equalTo('foo'), $this->equalTo('bar'), $this->equalTo(60),
         ], [
@@ -66,7 +66,7 @@ class CacheApcStoreTest extends TestCase
 
     public function testIncrementMethodProperlyCallsAPC()
     {
-        $apc = $this->getMockBuilder('Illuminate\Cache\ApcWrapper')->setMethods(['increment'])->getMock();
+        $apc = $this->getMockBuilder(\Illuminate\Cache\ApcWrapper::class)->setMethods(['increment'])->getMock();
         $apc->expects($this->once())->method('increment')->with($this->equalTo('foo'), $this->equalTo(5));
         $store = new \Illuminate\Cache\ApcStore($apc);
         $store->increment('foo', 5);
@@ -74,7 +74,7 @@ class CacheApcStoreTest extends TestCase
 
     public function testDecrementMethodProperlyCallsAPC()
     {
-        $apc = $this->getMockBuilder('Illuminate\Cache\ApcWrapper')->setMethods(['decrement'])->getMock();
+        $apc = $this->getMockBuilder(\Illuminate\Cache\ApcWrapper::class)->setMethods(['decrement'])->getMock();
         $apc->expects($this->once())->method('decrement')->with($this->equalTo('foo'), $this->equalTo(5));
         $store = new \Illuminate\Cache\ApcStore($apc);
         $store->decrement('foo', 5);
@@ -82,7 +82,7 @@ class CacheApcStoreTest extends TestCase
 
     public function testStoreItemForeverProperlyCallsAPC()
     {
-        $apc = $this->getMockBuilder('Illuminate\Cache\ApcWrapper')->setMethods(['put'])->getMock();
+        $apc = $this->getMockBuilder(\Illuminate\Cache\ApcWrapper::class)->setMethods(['put'])->getMock();
         $apc->expects($this->once())->method('put')->with($this->equalTo('foo'), $this->equalTo('bar'), $this->equalTo(0));
         $store = new \Illuminate\Cache\ApcStore($apc);
         $store->forever('foo', 'bar');
@@ -90,7 +90,7 @@ class CacheApcStoreTest extends TestCase
 
     public function testForgetMethodProperlyCallsAPC()
     {
-        $apc = $this->getMockBuilder('Illuminate\Cache\ApcWrapper')->setMethods(['delete'])->getMock();
+        $apc = $this->getMockBuilder(\Illuminate\Cache\ApcWrapper::class)->setMethods(['delete'])->getMock();
         $apc->expects($this->once())->method('delete')->with($this->equalTo('foo'));
         $store = new \Illuminate\Cache\ApcStore($apc);
         $store->forget('foo');
@@ -98,7 +98,7 @@ class CacheApcStoreTest extends TestCase
 
     public function testFlushesCached()
     {
-        $apc = $this->getMockBuilder('Illuminate\Cache\ApcWrapper')->setMethods(['flush'])->getMock();
+        $apc = $this->getMockBuilder(\Illuminate\Cache\ApcWrapper::class)->setMethods(['flush'])->getMock();
         $apc->expects($this->once())->method('flush')->willReturn(true);
         $store = new \Illuminate\Cache\ApcStore($apc);
         $result = $store->flush();

--- a/tests/Cache/CacheArrayStoreTest.php
+++ b/tests/Cache/CacheArrayStoreTest.php
@@ -32,7 +32,7 @@ class CacheArrayStoreTest extends TestCase
 
     public function testStoreItemForeverProperlyStoresInArray()
     {
-        $mock = $this->getMockBuilder('Illuminate\Cache\ArrayStore')->setMethods(['put'])->getMock();
+        $mock = $this->getMockBuilder(\Illuminate\Cache\ArrayStore::class)->setMethods(['put'])->getMock();
         $mock->expects($this->once())->method('put')->with($this->equalTo('foo'), $this->equalTo('bar'), $this->equalTo(0));
         $mock->forever('foo', 'bar');
     }

--- a/tests/Cache/CacheDatabaseStoreTest.php
+++ b/tests/Cache/CacheDatabaseStoreTest.php
@@ -17,7 +17,7 @@ class CacheDatabaseStoreTest extends TestCase
     public function testNullIsReturnedWhenItemNotFound()
     {
         $store = $this->getStore();
-        $table = m::mock('stdClass');
+        $table = m::mock(\stdClass::class);
         $store->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($table);
         $table->shouldReceive('where')->once()->with('key', '=', 'prefixfoo')->andReturn($table);
         $table->shouldReceive('first')->once()->andReturn(null);
@@ -27,8 +27,8 @@ class CacheDatabaseStoreTest extends TestCase
 
     public function testNullIsReturnedAndItemDeletedWhenItemIsExpired()
     {
-        $store = $this->getMockBuilder('Illuminate\Cache\DatabaseStore')->setMethods(['forget'])->setConstructorArgs($this->getMocks())->getMock();
-        $table = m::mock('stdClass');
+        $store = $this->getMockBuilder(\Illuminate\Cache\DatabaseStore::class)->setMethods(['forget'])->setConstructorArgs($this->getMocks())->getMock();
+        $table = m::mock(\stdClass::class);
         $store->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($table);
         $table->shouldReceive('where')->once()->with('key', '=', 'prefixfoo')->andReturn($table);
         $table->shouldReceive('first')->once()->andReturn((object) ['expiration' => 1]);
@@ -40,7 +40,7 @@ class CacheDatabaseStoreTest extends TestCase
     public function testDecryptedValueIsReturnedWhenItemIsValid()
     {
         $store = $this->getStore();
-        $table = m::mock('stdClass');
+        $table = m::mock(\stdClass::class);
         $store->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($table);
         $table->shouldReceive('where')->once()->with('key', '=', 'prefixfoo')->andReturn($table);
         $table->shouldReceive('first')->once()->andReturn((object) ['value' => serialize('bar'), 'expiration' => 999999999999999]);
@@ -50,8 +50,8 @@ class CacheDatabaseStoreTest extends TestCase
 
     public function testValueIsInsertedWhenNoExceptionsAreThrown()
     {
-        $store = $this->getMockBuilder('Illuminate\Cache\DatabaseStore')->setMethods(['getTime'])->setConstructorArgs($this->getMocks())->getMock();
-        $table = m::mock('stdClass');
+        $store = $this->getMockBuilder(\Illuminate\Cache\DatabaseStore::class)->setMethods(['getTime'])->setConstructorArgs($this->getMocks())->getMock();
+        $table = m::mock(\stdClass::class);
         $store->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($table);
         $store->expects($this->once())->method('getTime')->will($this->returnValue(1));
         $table->shouldReceive('insert')->once()->with(['key' => 'prefixfoo', 'value' => serialize('bar'), 'expiration' => 61]);
@@ -61,8 +61,8 @@ class CacheDatabaseStoreTest extends TestCase
 
     public function testValueIsUpdatedWhenInsertThrowsException()
     {
-        $store = $this->getMockBuilder('Illuminate\Cache\DatabaseStore')->setMethods(['getTime'])->setConstructorArgs($this->getMocks())->getMock();
-        $table = m::mock('stdClass');
+        $store = $this->getMockBuilder(\Illuminate\Cache\DatabaseStore::class)->setMethods(['getTime'])->setConstructorArgs($this->getMocks())->getMock();
+        $table = m::mock(\stdClass::class);
         $store->getConnection()->shouldReceive('table')->with('table')->andReturn($table);
         $store->expects($this->once())->method('getTime')->will($this->returnValue(1));
         $table->shouldReceive('insert')->once()->with(['key' => 'prefixfoo', 'value' => serialize('bar'), 'expiration' => 61])->andReturnUsing(function () {
@@ -76,7 +76,7 @@ class CacheDatabaseStoreTest extends TestCase
 
     public function testForeverCallsStoreItemWithReallyLongTime()
     {
-        $store = $this->getMockBuilder('Illuminate\Cache\DatabaseStore')->setMethods(['put'])->setConstructorArgs($this->getMocks())->getMock();
+        $store = $this->getMockBuilder(\Illuminate\Cache\DatabaseStore::class)->setMethods(['put'])->setConstructorArgs($this->getMocks())->getMock();
         $store->expects($this->once())->method('put')->with($this->equalTo('foo'), $this->equalTo('bar'), $this->equalTo(5256000));
         $store->forever('foo', 'bar');
     }
@@ -84,7 +84,7 @@ class CacheDatabaseStoreTest extends TestCase
     public function testItemsMayBeRemovedFromCache()
     {
         $store = $this->getStore();
-        $table = m::mock('stdClass');
+        $table = m::mock(\stdClass::class);
         $store->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($table);
         $table->shouldReceive('where')->once()->with('key', '=', 'prefixfoo')->andReturn($table);
         $table->shouldReceive('delete')->once();
@@ -95,7 +95,7 @@ class CacheDatabaseStoreTest extends TestCase
     public function testItemsMayBeFlushedFromCache()
     {
         $store = $this->getStore();
-        $table = m::mock('stdClass');
+        $table = m::mock(\stdClass::class);
         $store->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($table);
         $table->shouldReceive('delete')->once()->andReturn(2);
 
@@ -106,8 +106,8 @@ class CacheDatabaseStoreTest extends TestCase
     public function testIncrementReturnsCorrectValues()
     {
         $store = $this->getStore();
-        $table = m::mock('stdClass');
-        $cache = m::mock('stdClass');
+        $table = m::mock(\stdClass::class);
+        $cache = m::mock(\stdClass::class);
 
         $store->getConnection()->shouldReceive('transaction')->once()->with(m::type('Closure'))->andReturnUsing(function ($closure) {
             return $closure();
@@ -145,8 +145,8 @@ class CacheDatabaseStoreTest extends TestCase
     public function testDecrementReturnsCorrectValues()
     {
         $store = $this->getStore();
-        $table = m::mock('stdClass');
-        $cache = m::mock('stdClass');
+        $table = m::mock(\stdClass::class);
+        $cache = m::mock(\stdClass::class);
 
         $store->getConnection()->shouldReceive('transaction')->once()->with(m::type('Closure'))->andReturnUsing(function ($closure) {
             return $closure();
@@ -183,11 +183,11 @@ class CacheDatabaseStoreTest extends TestCase
 
     protected function getStore()
     {
-        return new DatabaseStore(m::mock('Illuminate\Database\Connection'), 'table', 'prefix');
+        return new DatabaseStore(m::mock(\Illuminate\Database\Connection::class), 'table', 'prefix');
     }
 
     protected function getMocks()
     {
-        return [m::mock('Illuminate\Database\Connection'), 'table', 'prefix'];
+        return [m::mock(\Illuminate\Database\Connection::class), 'table', 'prefix'];
     }
 }

--- a/tests/Cache/CacheEventsTest.php
+++ b/tests/Cache/CacheEventsTest.php
@@ -177,7 +177,7 @@ class CacheEventsTest extends TestCase
 
     protected function getDispatcher()
     {
-        return m::mock('Illuminate\Events\Dispatcher');
+        return m::mock(\Illuminate\Events\Dispatcher::class);
     }
 
     protected function getRepository($dispatcher)

--- a/tests/Cache/CacheFileStoreTest.php
+++ b/tests/Cache/CacheFileStoreTest.php
@@ -48,7 +48,7 @@ class CacheFileStoreTest extends TestCase
         $files = $this->mockFilesystem();
         $contents = '0000000000';
         $files->expects($this->once())->method('get')->will($this->returnValue($contents));
-        $store = $this->getMockBuilder('Illuminate\Cache\FileStore')->setMethods(['forget'])->setConstructorArgs([$files, __DIR__])->getMock();
+        $store = $this->getMockBuilder(\Illuminate\Cache\FileStore::class)->setMethods(['forget'])->setConstructorArgs([$files, __DIR__])->getMock();
         $store->expects($this->once())->method('forget');
         $value = $store->get('foo');
         $this->assertNull($value);
@@ -66,7 +66,7 @@ class CacheFileStoreTest extends TestCase
     public function testStoreItemProperlyStoresValues()
     {
         $files = $this->mockFilesystem();
-        $store = $this->getMockBuilder('Illuminate\Cache\FileStore')->setMethods(['expiration'])->setConstructorArgs([$files, __DIR__])->getMock();
+        $store = $this->getMockBuilder(\Illuminate\Cache\FileStore::class)->setMethods(['expiration'])->setConstructorArgs([$files, __DIR__])->getMock();
         $store->expects($this->once())->method('expiration')->with($this->equalTo(10))->will($this->returnValue(1111111111));
         $contents = '1111111111'.serialize('Hello World');
         $hash = sha1('foo');
@@ -169,6 +169,6 @@ class CacheFileStoreTest extends TestCase
 
     protected function mockFilesystem()
     {
-        return $this->createMock('Illuminate\Filesystem\Filesystem');
+        return $this->createMock(\Illuminate\Filesystem\Filesystem::class);
     }
 }

--- a/tests/Cache/CacheMemcachedConnectorTest.php
+++ b/tests/Cache/CacheMemcachedConnectorTest.php
@@ -92,7 +92,7 @@ class CacheMemcachedConnectorTest extends TestCase
 
     protected function memcachedMockWithAddServer($returnedVersion = [])
     {
-        $memcached = m::mock('stdClass');
+        $memcached = m::mock(\stdClass::class);
         $memcached->shouldReceive('addServer')->once()->with($this->getHost(), $this->getPort(), $this->getWeight());
         $memcached->shouldReceive('getServerList')->once()->andReturn([]);
 
@@ -101,7 +101,7 @@ class CacheMemcachedConnectorTest extends TestCase
 
     protected function connectorMock()
     {
-        return $this->getMockBuilder('Illuminate\Cache\MemcachedConnector')->setMethods(['createMemcachedInstance'])->getMock();
+        return $this->getMockBuilder(\Illuminate\Cache\MemcachedConnector::class)->setMethods(['createMemcachedInstance'])->getMock();
     }
 
     protected function connect(

--- a/tests/Cache/CacheMemcachedStoreTest.php
+++ b/tests/Cache/CacheMemcachedStoreTest.php
@@ -14,7 +14,7 @@ class CacheMemcachedStoreTest extends TestCase
             $this->markTestSkipped('Memcached module not installed');
         }
 
-        $memcache = $this->getMockBuilder('stdClass')->setMethods(['get', 'getResultCode'])->getMock();
+        $memcache = $this->getMockBuilder(\stdClass::class)->setMethods(['get', 'getResultCode'])->getMock();
         $memcache->expects($this->once())->method('get')->with($this->equalTo('foo:bar'))->will($this->returnValue(null));
         $memcache->expects($this->once())->method('getResultCode')->will($this->returnValue(1));
         $store = new MemcachedStore($memcache, 'foo');
@@ -27,7 +27,7 @@ class CacheMemcachedStoreTest extends TestCase
             $this->markTestSkipped('Memcached module not installed');
         }
 
-        $memcache = $this->getMockBuilder('stdClass')->setMethods(['get', 'getResultCode'])->getMock();
+        $memcache = $this->getMockBuilder(\stdClass::class)->setMethods(['get', 'getResultCode'])->getMock();
         $memcache->expects($this->once())->method('get')->will($this->returnValue('bar'));
         $memcache->expects($this->once())->method('getResultCode')->will($this->returnValue(0));
         $store = new MemcachedStore($memcache);
@@ -40,7 +40,7 @@ class CacheMemcachedStoreTest extends TestCase
             $this->markTestSkipped('Memcached module not installed');
         }
 
-        $memcache = $this->getMockBuilder('stdClass')->setMethods(['getMulti', 'getResultCode'])->getMock();
+        $memcache = $this->getMockBuilder(\stdClass::class)->setMethods(['getMulti', 'getResultCode'])->getMock();
         $memcache->expects($this->once())->method('getMulti')->with(
             ['foo:foo', 'foo:bar', 'foo:baz']
         )->will($this->returnValue([

--- a/tests/Cache/CacheRedisStoreTest.php
+++ b/tests/Cache/CacheRedisStoreTest.php
@@ -144,6 +144,6 @@ class CacheRedisStoreTest extends TestCase
 
     protected function getRedis()
     {
-        return new \Illuminate\Cache\RedisStore(m::mock('Illuminate\Contracts\Redis\Factory'), 'prefix');
+        return new \Illuminate\Cache\RedisStore(m::mock(\Illuminate\Contracts\Redis\Factory::class), 'prefix');
     }
 }

--- a/tests/Cache/CacheRepositoryTest.php
+++ b/tests/Cache/CacheRepositoryTest.php
@@ -147,8 +147,8 @@ class CacheRepositoryTest extends TestCase
 
     protected function getRepository()
     {
-        $dispatcher = new \Illuminate\Events\Dispatcher(m::mock('Illuminate\Container\Container'));
-        $repository = new \Illuminate\Cache\Repository(m::mock('Illuminate\Contracts\Cache\Store'));
+        $dispatcher = new \Illuminate\Events\Dispatcher(m::mock(\Illuminate\Container\Container::class));
+        $repository = new \Illuminate\Cache\Repository(m::mock(\Illuminate\Contracts\Cache\Store::class));
 
         $repository->setEventDispatcher($dispatcher);
 

--- a/tests/Cache/CacheTableCommandTest.php
+++ b/tests/Cache/CacheTableCommandTest.php
@@ -17,10 +17,10 @@ class CacheTableCommandTest extends TestCase
     public function testCreateMakesMigration()
     {
         $command = new CacheTableCommandTestStub(
-            $files = m::mock('Illuminate\Filesystem\Filesystem'),
-            $composer = m::mock('Illuminate\Support\Composer')
+            $files = m::mock(\Illuminate\Filesystem\Filesystem::class),
+            $composer = m::mock(\Illuminate\Support\Composer::class)
         );
-        $creator = m::mock('Illuminate\Database\Migrations\MigrationCreator')->shouldIgnoreMissing();
+        $creator = m::mock(\Illuminate\Database\Migrations\MigrationCreator::class)->shouldIgnoreMissing();
 
         $app = new Application;
         $app->useDatabasePath(__DIR__);

--- a/tests/Cache/CacheTaggedCacheTest.php
+++ b/tests/Cache/CacheTaggedCacheTest.php
@@ -62,13 +62,13 @@ class CacheTaggedCacheTest extends TestCase
 
     public function testRedisCacheTagsPushForeverKeysCorrectly()
     {
-        $store = m::mock('Illuminate\Contracts\Cache\Store');
-        $tagSet = m::mock('Illuminate\Cache\TagSet', [$store, ['foo', 'bar']]);
+        $store = m::mock(\Illuminate\Contracts\Cache\Store::class);
+        $tagSet = m::mock(\Illuminate\Cache\TagSet::class, [$store, ['foo', 'bar']]);
         $tagSet->shouldReceive('getNamespace')->andReturn('foo|bar');
         $tagSet->shouldReceive('getNames')->andReturn(['foo', 'bar']);
         $redis = new \Illuminate\Cache\RedisTaggedCache($store, $tagSet);
         $store->shouldReceive('getPrefix')->andReturn('prefix:');
-        $store->shouldReceive('connection')->andReturn($conn = m::mock('stdClass'));
+        $store->shouldReceive('connection')->andReturn($conn = m::mock(\stdClass::class));
         $conn->shouldReceive('sadd')->once()->with('prefix:foo:forever_ref', 'prefix:'.sha1('foo|bar').':key1');
         $conn->shouldReceive('sadd')->once()->with('prefix:bar:forever_ref', 'prefix:'.sha1('foo|bar').':key1');
 
@@ -79,13 +79,13 @@ class CacheTaggedCacheTest extends TestCase
 
     public function testRedisCacheTagsPushStandardKeysCorrectly()
     {
-        $store = m::mock('Illuminate\Contracts\Cache\Store');
-        $tagSet = m::mock('Illuminate\Cache\TagSet', [$store, ['foo', 'bar']]);
+        $store = m::mock(\Illuminate\Contracts\Cache\Store::class);
+        $tagSet = m::mock(\Illuminate\Cache\TagSet::class, [$store, ['foo', 'bar']]);
         $tagSet->shouldReceive('getNamespace')->andReturn('foo|bar');
         $tagSet->shouldReceive('getNames')->andReturn(['foo', 'bar']);
         $redis = new \Illuminate\Cache\RedisTaggedCache($store, $tagSet);
         $store->shouldReceive('getPrefix')->andReturn('prefix:');
-        $store->shouldReceive('connection')->andReturn($conn = m::mock('stdClass'));
+        $store->shouldReceive('connection')->andReturn($conn = m::mock(\stdClass::class));
         $conn->shouldReceive('sadd')->once()->with('prefix:foo:standard_ref', 'prefix:'.sha1('foo|bar').':key1');
         $conn->shouldReceive('sadd')->once()->with('prefix:bar:standard_ref', 'prefix:'.sha1('foo|bar').':key1');
         $store->shouldReceive('push')->with(sha1('foo|bar').':key1', 'key1:value');
@@ -95,12 +95,12 @@ class CacheTaggedCacheTest extends TestCase
 
     public function testRedisCacheTagsCanBeFlushed()
     {
-        $store = m::mock('Illuminate\Contracts\Cache\Store');
-        $tagSet = m::mock('Illuminate\Cache\TagSet', [$store, ['foo', 'bar']]);
+        $store = m::mock(\Illuminate\Contracts\Cache\Store::class);
+        $tagSet = m::mock(\Illuminate\Cache\TagSet::class, [$store, ['foo', 'bar']]);
         $tagSet->shouldReceive('getNamespace')->andReturn('foo|bar');
         $redis = new \Illuminate\Cache\RedisTaggedCache($store, $tagSet);
         $store->shouldReceive('getPrefix')->andReturn('prefix:');
-        $store->shouldReceive('connection')->andReturn($conn = m::mock('stdClass'));
+        $store->shouldReceive('connection')->andReturn($conn = m::mock(\stdClass::class));
 
         // Forever tag keys
         $conn->shouldReceive('smembers')->once()->with('prefix:foo:forever_ref')->andReturn(['key1', 'key2']);

--- a/tests/Cache/ClearCommandTest.php
+++ b/tests/Cache/ClearCommandTest.php
@@ -17,10 +17,10 @@ class ClearCommandTest extends TestCase
     public function testClearWithNoStoreArgument()
     {
         $command = new ClearCommandTestStub(
-            $cacheManager = m::mock('Illuminate\Cache\CacheManager')
+            $cacheManager = m::mock(\Illuminate\Cache\CacheManager::class)
         );
 
-        $cacheRepository = m::mock('Illuminate\Contracts\Cache\Repository');
+        $cacheRepository = m::mock(\Illuminate\Contracts\Cache\Repository::class);
 
         $app = new Application;
         $command->setLaravel($app);
@@ -34,10 +34,10 @@ class ClearCommandTest extends TestCase
     public function testClearWithStoreArgument()
     {
         $command = new ClearCommandTestStub(
-            $cacheManager = m::mock('Illuminate\Cache\CacheManager')
+            $cacheManager = m::mock(\Illuminate\Cache\CacheManager::class)
         );
 
-        $cacheRepository = m::mock('Illuminate\Contracts\Cache\Repository');
+        $cacheRepository = m::mock(\Illuminate\Contracts\Cache\Repository::class);
 
         $app = new Application;
         $command->setLaravel($app);
@@ -54,10 +54,10 @@ class ClearCommandTest extends TestCase
     public function testClearWithInvalidStoreArgument()
     {
         $command = new ClearCommandTestStub(
-            $cacheManager = m::mock('Illuminate\Cache\CacheManager')
+            $cacheManager = m::mock(\Illuminate\Cache\CacheManager::class)
         );
 
-        $cacheRepository = m::mock('Illuminate\Contracts\Cache\Repository');
+        $cacheRepository = m::mock(\Illuminate\Contracts\Cache\Repository::class);
 
         $app = new Application;
         $command->setLaravel($app);
@@ -71,10 +71,10 @@ class ClearCommandTest extends TestCase
     public function testClearWithTagsOption()
     {
         $command = new ClearCommandTestStub(
-            $cacheManager = m::mock('Illuminate\Cache\CacheManager')
+            $cacheManager = m::mock(\Illuminate\Cache\CacheManager::class)
         );
 
-        $cacheRepository = m::mock('Illuminate\Contracts\Cache\Repository');
+        $cacheRepository = m::mock(\Illuminate\Contracts\Cache\Repository::class);
 
         $app = new Application;
         $command->setLaravel($app);
@@ -89,10 +89,10 @@ class ClearCommandTest extends TestCase
     public function testClearWithStoreArgumentAndTagsOption()
     {
         $command = new ClearCommandTestStub(
-            $cacheManager = m::mock('Illuminate\Cache\CacheManager')
+            $cacheManager = m::mock(\Illuminate\Cache\CacheManager::class)
         );
 
-        $cacheRepository = m::mock('Illuminate\Contracts\Cache\Repository');
+        $cacheRepository = m::mock(\Illuminate\Contracts\Cache\Repository::class);
 
         $app = new Application;
         $command->setLaravel($app);

--- a/tests/Console/ConsoleApplicationTest.php
+++ b/tests/Console/ConsoleApplicationTest.php
@@ -15,8 +15,8 @@ class ConsoleApplicationTest extends TestCase
     public function testAddSetsLaravelInstance()
     {
         $app = $this->getMockConsole(['addToParent']);
-        $command = m::mock('Illuminate\Console\Command');
-        $command->shouldReceive('setLaravel')->once()->with(m::type('Illuminate\Contracts\Foundation\Application'));
+        $command = m::mock(\Illuminate\Console\Command::class);
+        $command->shouldReceive('setLaravel')->once()->with(m::type(\Illuminate\Contracts\Foundation\Application::class));
         $app->expects($this->once())->method('addToParent')->with($this->equalTo($command))->will($this->returnValue($command));
         $result = $app->add($command);
 
@@ -47,10 +47,10 @@ class ConsoleApplicationTest extends TestCase
 
     protected function getMockConsole(array $methods)
     {
-        $app = m::mock('Illuminate\Contracts\Foundation\Application', ['version' => '5.5']);
-        $events = m::mock('Illuminate\Contracts\Events\Dispatcher', ['dispatch' => null]);
+        $app = m::mock(\Illuminate\Contracts\Foundation\Application::class, ['version' => '5.5']);
+        $events = m::mock(\Illuminate\Contracts\Events\Dispatcher::class, ['dispatch' => null]);
 
-        $console = $this->getMockBuilder('Illuminate\Console\Application')->setMethods($methods)->setConstructorArgs([
+        $console = $this->getMockBuilder(\Illuminate\Console\Application::class)->setMethods($methods)->setConstructorArgs([
             $app, $events, 'test-version',
         ])->getMock();
 

--- a/tests/Console/ConsoleEventSchedulerTest.php
+++ b/tests/Console/ConsoleEventSchedulerTest.php
@@ -14,10 +14,10 @@ class ConsoleEventSchedulerTest extends TestCase
 
         $container = \Illuminate\Container\Container::getInstance();
 
-        $container->instance('Illuminate\Console\Scheduling\Mutex', m::mock('Illuminate\Console\Scheduling\CacheMutex'));
+        $container->instance(\Illuminate\Console\Scheduling\Mutex::class, m::mock(\Illuminate\Console\Scheduling\CacheMutex::class));
 
         $container->instance(
-            'Illuminate\Console\Scheduling\Schedule', $this->schedule = new Schedule(m::mock('Illuminate\Console\Scheduling\Mutex'))
+            \Illuminate\Console\Scheduling\Schedule::class, $this->schedule = new Schedule(m::mock(\Illuminate\Console\Scheduling\Mutex::class))
         );
     }
 

--- a/tests/Console/ConsoleScheduledEventTest.php
+++ b/tests/Console/ConsoleScheduledEventTest.php
@@ -35,7 +35,7 @@ class ConsoleScheduledEventTest extends TestCase
         $app->shouldReceive('isDownForMaintenance')->andReturn(false);
         $app->shouldReceive('environment')->andReturn('production');
 
-        $event = new Event(m::mock('Illuminate\Console\Scheduling\Mutex'), 'php foo');
+        $event = new Event(m::mock(\Illuminate\Console\Scheduling\Mutex::class), 'php foo');
         $this->assertEquals('* * * * * *', $event->getExpression());
         $this->assertTrue($event->isDue($app));
         $this->assertTrue($event->skip(function () {
@@ -45,25 +45,25 @@ class ConsoleScheduledEventTest extends TestCase
             return true;
         })->filtersPass($app));
 
-        $event = new Event(m::mock('Illuminate\Console\Scheduling\Mutex'), 'php foo');
+        $event = new Event(m::mock(\Illuminate\Console\Scheduling\Mutex::class), 'php foo');
         $this->assertEquals('* * * * * *', $event->getExpression());
         $this->assertFalse($event->environments('local')->isDue($app));
 
-        $event = new Event(m::mock('Illuminate\Console\Scheduling\Mutex'), 'php foo');
+        $event = new Event(m::mock(\Illuminate\Console\Scheduling\Mutex::class), 'php foo');
         $this->assertEquals('* * * * * *', $event->getExpression());
         $this->assertFalse($event->when(function () {
             return false;
         })->filtersPass($app));
 
         // chained rules should be commutative
-        $eventA = new Event(m::mock('Illuminate\Console\Scheduling\Mutex'), 'php foo');
-        $eventB = new Event(m::mock('Illuminate\Console\Scheduling\Mutex'), 'php foo');
+        $eventA = new Event(m::mock(\Illuminate\Console\Scheduling\Mutex::class), 'php foo');
+        $eventB = new Event(m::mock(\Illuminate\Console\Scheduling\Mutex::class), 'php foo');
         $this->assertEquals(
             $eventA->daily()->hourly()->getExpression(),
             $eventB->hourly()->daily()->getExpression());
 
-        $eventA = new Event(m::mock('Illuminate\Console\Scheduling\Mutex'), 'php foo');
-        $eventB = new Event(m::mock('Illuminate\Console\Scheduling\Mutex'), 'php foo');
+        $eventA = new Event(m::mock(\Illuminate\Console\Scheduling\Mutex::class), 'php foo');
+        $eventB = new Event(m::mock(\Illuminate\Console\Scheduling\Mutex::class), 'php foo');
         $this->assertEquals(
             $eventA->weekdays()->hourly()->getExpression(),
             $eventB->hourly()->weekdays()->getExpression());
@@ -76,11 +76,11 @@ class ConsoleScheduledEventTest extends TestCase
         $app->shouldReceive('environment')->andReturn('production');
         Carbon::setTestNow(Carbon::create(2015, 1, 1, 0, 0, 0));
 
-        $event = new Event(m::mock('Illuminate\Console\Scheduling\Mutex'), 'php foo');
+        $event = new Event(m::mock(\Illuminate\Console\Scheduling\Mutex::class), 'php foo');
         $this->assertEquals('* * * * 4 *', $event->thursdays()->getExpression());
         $this->assertTrue($event->isDue($app));
 
-        $event = new Event(m::mock('Illuminate\Console\Scheduling\Mutex'), 'php foo');
+        $event = new Event(m::mock(\Illuminate\Console\Scheduling\Mutex::class), 'php foo');
         $this->assertEquals('0 19 * * 3 *', $event->wednesdays()->at('19:00')->timezone('EST')->getExpression());
         $this->assertTrue($event->isDue($app));
     }
@@ -92,7 +92,7 @@ class ConsoleScheduledEventTest extends TestCase
         $app->shouldReceive('environment')->andReturn('production');
         Carbon::setTestNow(Carbon::now()->startOfDay()->addHours(9));
 
-        $event = new Event(m::mock('Illuminate\Console\Scheduling\Mutex'), 'php foo');
+        $event = new Event(m::mock(\Illuminate\Console\Scheduling\Mutex::class), 'php foo');
         $this->assertTrue($event->between('8:00', '10:00')->filtersPass($app));
         $this->assertTrue($event->between('9:00', '9:00')->filtersPass($app));
         $this->assertFalse($event->between('10:00', '11:00')->filtersPass($app));

--- a/tests/Console/Scheduling/CacheOverlappingStrategyTest.php
+++ b/tests/Console/Scheduling/CacheOverlappingStrategyTest.php
@@ -23,7 +23,7 @@ class CacheMutexTest extends TestCase
     {
         parent::setUp();
 
-        $this->cacheRepository = m::mock('Illuminate\Contracts\Cache\Repository');
+        $this->cacheRepository = m::mock(\Illuminate\Contracts\Cache\Repository::class);
         $this->cacheMutex = new CacheMutex($this->cacheRepository);
     }
 

--- a/tests/Console/Scheduling/EventTest.php
+++ b/tests/Console/Scheduling/EventTest.php
@@ -17,14 +17,14 @@ class EventTest extends TestCase
     {
         $quote = (DIRECTORY_SEPARATOR == '\\') ? '"' : "'";
 
-        $event = new Event(m::mock('Illuminate\Console\Scheduling\Mutex'), 'php -i');
+        $event = new Event(m::mock(\Illuminate\Console\Scheduling\Mutex::class), 'php -i');
 
         $defaultOutput = (DIRECTORY_SEPARATOR == '\\') ? 'NUL' : '/dev/null';
         $this->assertSame("php -i > {$quote}{$defaultOutput}{$quote} 2>&1", $event->buildCommand());
 
         $quote = (DIRECTORY_SEPARATOR == '\\') ? '"' : "'";
 
-        $event = new Event(m::mock('Illuminate\Console\Scheduling\Mutex'), 'php -i');
+        $event = new Event(m::mock(\Illuminate\Console\Scheduling\Mutex::class), 'php -i');
         $event->runInBackground();
 
         $defaultOutput = (DIRECTORY_SEPARATOR == '\\') ? 'NUL' : '/dev/null';
@@ -35,12 +35,12 @@ class EventTest extends TestCase
     {
         $quote = (DIRECTORY_SEPARATOR == '\\') ? '"' : "'";
 
-        $event = new Event(m::mock('Illuminate\Console\Scheduling\Mutex'), 'php -i');
+        $event = new Event(m::mock(\Illuminate\Console\Scheduling\Mutex::class), 'php -i');
 
         $event->sendOutputTo('/dev/null');
         $this->assertSame("php -i > {$quote}/dev/null{$quote} 2>&1", $event->buildCommand());
 
-        $event = new Event(m::mock('Illuminate\Console\Scheduling\Mutex'), 'php -i');
+        $event = new Event(m::mock(\Illuminate\Console\Scheduling\Mutex::class), 'php -i');
 
         $event->sendOutputTo('/my folder/foo.log');
         $this->assertSame("php -i > {$quote}/my folder/foo.log{$quote} 2>&1", $event->buildCommand());
@@ -50,7 +50,7 @@ class EventTest extends TestCase
     {
         $quote = (DIRECTORY_SEPARATOR == '\\') ? '"' : "'";
 
-        $event = new Event(m::mock('Illuminate\Console\Scheduling\Mutex'), 'php -i');
+        $event = new Event(m::mock(\Illuminate\Console\Scheduling\Mutex::class), 'php -i');
 
         $event->appendOutputTo('/dev/null');
         $this->assertSame("php -i >> {$quote}/dev/null{$quote} 2>&1", $event->buildCommand());
@@ -58,7 +58,7 @@ class EventTest extends TestCase
 
     public function testNextRunDate()
     {
-        $event = new Event(m::mock('Illuminate\Console\Scheduling\Mutex'), 'php -i');
+        $event = new Event(m::mock(\Illuminate\Console\Scheduling\Mutex::class), 'php -i');
         $event->dailyAt('10:15');
 
         $this->assertSame('10:15:00', $event->nextRunDate()->toTimeString());

--- a/tests/Console/Scheduling/FrequencyTest.php
+++ b/tests/Console/Scheduling/FrequencyTest.php
@@ -16,7 +16,7 @@ class FrequencyTest extends TestCase
     public function setUp()
     {
         $this->event = new Event(
-            m::mock('Illuminate\Console\Scheduling\Mutex'),
+            m::mock(\Illuminate\Console\Scheduling\Mutex::class),
             'php foo'
         );
     }

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -58,34 +58,34 @@ class ContainerTest extends TestCase
     public function testAutoConcreteResolution()
     {
         $container = new Container;
-        $this->assertInstanceOf('Illuminate\Tests\Container\ContainerConcreteStub', $container->make('Illuminate\Tests\Container\ContainerConcreteStub'));
+        $this->assertInstanceOf(\Illuminate\Tests\Container\ContainerConcreteStub::class, $container->make(\Illuminate\Tests\Container\ContainerConcreteStub::class));
     }
 
     public function testSharedConcreteResolution()
     {
         $container = new Container;
-        $container->singleton('Illuminate\Tests\Container\ContainerConcreteStub');
+        $container->singleton(\Illuminate\Tests\Container\ContainerConcreteStub::class);
 
-        $var1 = $container->make('Illuminate\Tests\Container\ContainerConcreteStub');
-        $var2 = $container->make('Illuminate\Tests\Container\ContainerConcreteStub');
+        $var1 = $container->make(\Illuminate\Tests\Container\ContainerConcreteStub::class);
+        $var2 = $container->make(\Illuminate\Tests\Container\ContainerConcreteStub::class);
         $this->assertSame($var1, $var2);
     }
 
     public function testAbstractToConcreteResolution()
     {
         $container = new Container;
-        $container->bind('Illuminate\Tests\Container\IContainerContractStub', 'Illuminate\Tests\Container\ContainerImplementationStub');
-        $class = $container->make('Illuminate\Tests\Container\ContainerDependentStub');
-        $this->assertInstanceOf('Illuminate\Tests\Container\ContainerImplementationStub', $class->impl);
+        $container->bind(\Illuminate\Tests\Container\IContainerContractStub::class, \Illuminate\Tests\Container\ContainerImplementationStub::class);
+        $class = $container->make(\Illuminate\Tests\Container\ContainerDependentStub::class);
+        $this->assertInstanceOf(\Illuminate\Tests\Container\ContainerImplementationStub::class, $class->impl);
     }
 
     public function testNestedDependencyResolution()
     {
         $container = new Container;
-        $container->bind('Illuminate\Tests\Container\IContainerContractStub', 'Illuminate\Tests\Container\ContainerImplementationStub');
-        $class = $container->make('Illuminate\Tests\Container\ContainerNestedDependentStub');
-        $this->assertInstanceOf('Illuminate\Tests\Container\ContainerDependentStub', $class->inner);
-        $this->assertInstanceOf('Illuminate\Tests\Container\ContainerImplementationStub', $class->inner->impl);
+        $container->bind(\Illuminate\Tests\Container\IContainerContractStub::class, \Illuminate\Tests\Container\ContainerImplementationStub::class);
+        $class = $container->make(\Illuminate\Tests\Container\ContainerNestedDependentStub::class);
+        $this->assertInstanceOf(\Illuminate\Tests\Container\ContainerDependentStub::class, $class->inner);
+        $this->assertInstanceOf(\Illuminate\Tests\Container\ContainerImplementationStub::class, $class->inner->impl);
     }
 
     public function testContainerIsPassedToResolvers()
@@ -224,14 +224,14 @@ class ContainerTest extends TestCase
         ContainerLazyExtendStub::$initialized = false;
 
         $container = new Container;
-        $container->bind('Illuminate\Tests\Container\ContainerLazyExtendStub');
-        $container->extend('Illuminate\Tests\Container\ContainerLazyExtendStub', function ($obj, $container) {
+        $container->bind(\Illuminate\Tests\Container\ContainerLazyExtendStub::class);
+        $container->extend(\Illuminate\Tests\Container\ContainerLazyExtendStub::class, function ($obj, $container) {
             $obj->init();
 
             return $obj;
         });
         $this->assertFalse(ContainerLazyExtendStub::$initialized);
-        $container->make('Illuminate\Tests\Container\ContainerLazyExtendStub');
+        $container->make(\Illuminate\Tests\Container\ContainerLazyExtendStub::class);
         $this->assertTrue(ContainerLazyExtendStub::$initialized);
     }
 
@@ -319,8 +319,8 @@ class ContainerTest extends TestCase
     public function testResolutionOfDefaultParameters()
     {
         $container = new Container;
-        $instance = $container->make('Illuminate\Tests\Container\ContainerDefaultValueStub');
-        $this->assertInstanceOf('Illuminate\Tests\Container\ContainerConcreteStub', $instance->stub);
+        $instance = $container->make(\Illuminate\Tests\Container\ContainerDefaultValueStub::class);
+        $this->assertInstanceOf(\Illuminate\Tests\Container\ContainerConcreteStub::class, $instance->stub);
         $this->assertEquals('taylor', $instance->default);
     }
 
@@ -355,7 +355,7 @@ class ContainerTest extends TestCase
     public function testResolvingCallbacksAreCalledForType()
     {
         $container = new Container;
-        $container->resolving('stdClass', function ($object) {
+        $container->resolving(\stdClass::class, function ($object) {
             return $object->name = 'taylor';
         });
         $container->bind('foo', function () {
@@ -438,7 +438,7 @@ class ContainerTest extends TestCase
     public function testInternalClassWithDefaultParameters()
     {
         $container = new Container;
-        $container->make('Illuminate\Tests\Container\ContainerMixedPrimitiveStub', []);
+        $container->make(\Illuminate\Tests\Container\ContainerMixedPrimitiveStub::class, []);
     }
 
     /**
@@ -448,7 +448,7 @@ class ContainerTest extends TestCase
     public function testBindingResolutionExceptionMessage()
     {
         $container = new Container;
-        $container->make('Illuminate\Tests\Container\IContainerContractStub', []);
+        $container->make(\Illuminate\Tests\Container\IContainerContractStub::class, []);
     }
 
     /**
@@ -458,7 +458,7 @@ class ContainerTest extends TestCase
     public function testBindingResolutionExceptionMessageIncludesBuildStack()
     {
         $container = new Container;
-        $container->make('Illuminate\Tests\Container\ContainerTestContextInjectOne', []);
+        $container->make(\Illuminate\Tests\Container\ContainerTestContextInjectOne::class, []);
     }
 
     public function testCallWithDependencies()
@@ -468,14 +468,14 @@ class ContainerTest extends TestCase
             return func_get_args();
         });
 
-        $this->assertInstanceOf('stdClass', $result[0]);
+        $this->assertInstanceOf(\stdClass::class, $result[0]);
         $this->assertEquals([], $result[1]);
 
         $result = $container->call(function (stdClass $foo, $bar = []) {
             return func_get_args();
         }, ['bar' => 'taylor']);
 
-        $this->assertInstanceOf('stdClass', $result[0]);
+        $this->assertInstanceOf(\stdClass::class, $result[0]);
         $this->assertEquals('taylor', $result[1]);
 
         /*
@@ -488,7 +488,7 @@ class ContainerTest extends TestCase
         $this->assertInstanceOf('Closure', $result);
         $result = $result();
 
-        $this->assertInstanceOf('stdClass', $result[0]);
+        $this->assertInstanceOf(\stdClass::class, $result[0]);
         $this->assertEquals('taylor', $result[1]);
     }
 
@@ -509,16 +509,16 @@ class ContainerTest extends TestCase
 
         $container = new Container;
         $result = $container->call('Illuminate\Tests\Container\ContainerTestCallStub@inject');
-        $this->assertInstanceOf('Illuminate\Tests\Container\ContainerConcreteStub', $result[0]);
+        $this->assertInstanceOf(\Illuminate\Tests\Container\ContainerConcreteStub::class, $result[0]);
         $this->assertEquals('taylor', $result[1]);
 
         $container = new Container;
         $result = $container->call('Illuminate\Tests\Container\ContainerTestCallStub@inject', ['default' => 'foo']);
-        $this->assertInstanceOf('Illuminate\Tests\Container\ContainerConcreteStub', $result[0]);
+        $this->assertInstanceOf(\Illuminate\Tests\Container\ContainerConcreteStub::class, $result[0]);
         $this->assertEquals('foo', $result[1]);
 
         $container = new Container;
-        $result = $container->call('Illuminate\Tests\Container\ContainerTestCallStub', ['foo', 'bar'], 'work');
+        $result = $container->call(\Illuminate\Tests\Container\ContainerTestCallStub::class, ['foo', 'bar'], 'work');
         $this->assertEquals(['foo', 'bar'], $result);
     }
 
@@ -534,15 +534,15 @@ class ContainerTest extends TestCase
     {
         $container = new Container;
         $result = $container->call('Illuminate\Tests\Container\ContainerStaticMethodStub::inject');
-        $this->assertInstanceOf('Illuminate\Tests\Container\ContainerConcreteStub', $result[0]);
+        $this->assertInstanceOf(\Illuminate\Tests\Container\ContainerConcreteStub::class, $result[0]);
         $this->assertEquals('taylor', $result[1]);
     }
 
     public function testCallWithGlobalMethodName()
     {
         $container = new Container;
-        $result = $container->call('Illuminate\Tests\Container\containerTestInject');
-        $this->assertInstanceOf('Illuminate\Tests\Container\ContainerConcreteStub', $result[0]);
+        $result = $container->call(\Illuminate\Tests\Container\containerTestInject::class);
+        $this->assertInstanceOf(\Illuminate\Tests\Container\ContainerConcreteStub::class, $result[0]);
         $this->assertEquals('taylor', $result[1]);
     }
 
@@ -567,47 +567,47 @@ class ContainerTest extends TestCase
     {
         $container = new Container;
 
-        $container->bind('Illuminate\Tests\Container\IContainerContractStub', 'Illuminate\Tests\Container\ContainerImplementationStub');
+        $container->bind(\Illuminate\Tests\Container\IContainerContractStub::class, \Illuminate\Tests\Container\ContainerImplementationStub::class);
 
-        $container->when('Illuminate\Tests\Container\ContainerTestContextInjectOne')->needs('Illuminate\Tests\Container\IContainerContractStub')->give('Illuminate\Tests\Container\ContainerImplementationStub');
-        $container->when('Illuminate\Tests\Container\ContainerTestContextInjectTwo')->needs('Illuminate\Tests\Container\IContainerContractStub')->give('Illuminate\Tests\Container\ContainerImplementationStubTwo');
+        $container->when(\Illuminate\Tests\Container\ContainerTestContextInjectOne::class)->needs(\Illuminate\Tests\Container\IContainerContractStub::class)->give(\Illuminate\Tests\Container\ContainerImplementationStub::class);
+        $container->when(\Illuminate\Tests\Container\ContainerTestContextInjectTwo::class)->needs(\Illuminate\Tests\Container\IContainerContractStub::class)->give(\Illuminate\Tests\Container\ContainerImplementationStubTwo::class);
 
-        $one = $container->make('Illuminate\Tests\Container\ContainerTestContextInjectOne');
-        $two = $container->make('Illuminate\Tests\Container\ContainerTestContextInjectTwo');
+        $one = $container->make(\Illuminate\Tests\Container\ContainerTestContextInjectOne::class);
+        $two = $container->make(\Illuminate\Tests\Container\ContainerTestContextInjectTwo::class);
 
-        $this->assertInstanceOf('Illuminate\Tests\Container\ContainerImplementationStub', $one->impl);
-        $this->assertInstanceOf('Illuminate\Tests\Container\ContainerImplementationStubTwo', $two->impl);
+        $this->assertInstanceOf(\Illuminate\Tests\Container\ContainerImplementationStub::class, $one->impl);
+        $this->assertInstanceOf(\Illuminate\Tests\Container\ContainerImplementationStubTwo::class, $two->impl);
 
         /*
          * Test With Closures
          */
         $container = new Container;
 
-        $container->bind('Illuminate\Tests\Container\IContainerContractStub', 'Illuminate\Tests\Container\ContainerImplementationStub');
+        $container->bind(\Illuminate\Tests\Container\IContainerContractStub::class, \Illuminate\Tests\Container\ContainerImplementationStub::class);
 
-        $container->when('Illuminate\Tests\Container\ContainerTestContextInjectOne')->needs('Illuminate\Tests\Container\IContainerContractStub')->give('Illuminate\Tests\Container\ContainerImplementationStub');
-        $container->when('Illuminate\Tests\Container\ContainerTestContextInjectTwo')->needs('Illuminate\Tests\Container\IContainerContractStub')->give(function ($container) {
-            return $container->make('Illuminate\Tests\Container\ContainerImplementationStubTwo');
+        $container->when(\Illuminate\Tests\Container\ContainerTestContextInjectOne::class)->needs(\Illuminate\Tests\Container\IContainerContractStub::class)->give(\Illuminate\Tests\Container\ContainerImplementationStub::class);
+        $container->when(\Illuminate\Tests\Container\ContainerTestContextInjectTwo::class)->needs(\Illuminate\Tests\Container\IContainerContractStub::class)->give(function ($container) {
+            return $container->make(\Illuminate\Tests\Container\ContainerImplementationStubTwo::class);
         });
 
-        $one = $container->make('Illuminate\Tests\Container\ContainerTestContextInjectOne');
-        $two = $container->make('Illuminate\Tests\Container\ContainerTestContextInjectTwo');
+        $one = $container->make(\Illuminate\Tests\Container\ContainerTestContextInjectOne::class);
+        $two = $container->make(\Illuminate\Tests\Container\ContainerTestContextInjectTwo::class);
 
-        $this->assertInstanceOf('Illuminate\Tests\Container\ContainerImplementationStub', $one->impl);
-        $this->assertInstanceOf('Illuminate\Tests\Container\ContainerImplementationStubTwo', $two->impl);
+        $this->assertInstanceOf(\Illuminate\Tests\Container\ContainerImplementationStub::class, $one->impl);
+        $this->assertInstanceOf(\Illuminate\Tests\Container\ContainerImplementationStubTwo::class, $two->impl);
     }
 
     public function testContextualBindingWorksForExistingInstancedBindings()
     {
         $container = new Container;
 
-        $container->instance('Illuminate\Tests\Container\IContainerContractStub', new ContainerImplementationStub);
+        $container->instance(\Illuminate\Tests\Container\IContainerContractStub::class, new ContainerImplementationStub);
 
-        $container->when('Illuminate\Tests\Container\ContainerTestContextInjectOne')->needs('Illuminate\Tests\Container\IContainerContractStub')->give('Illuminate\Tests\Container\ContainerImplementationStubTwo');
+        $container->when(\Illuminate\Tests\Container\ContainerTestContextInjectOne::class)->needs(\Illuminate\Tests\Container\IContainerContractStub::class)->give(\Illuminate\Tests\Container\ContainerImplementationStubTwo::class);
 
         $this->assertInstanceOf(
-            'Illuminate\Tests\Container\ContainerImplementationStubTwo',
-            $container->make('Illuminate\Tests\Container\ContainerTestContextInjectOne')->impl
+            \Illuminate\Tests\Container\ContainerImplementationStubTwo::class,
+            $container->make(\Illuminate\Tests\Container\ContainerTestContextInjectOne::class)->impl
         );
     }
 
@@ -615,13 +615,13 @@ class ContainerTest extends TestCase
     {
         $container = new Container;
 
-        $container->when('Illuminate\Tests\Container\ContainerTestContextInjectOne')->needs('Illuminate\Tests\Container\IContainerContractStub')->give('Illuminate\Tests\Container\ContainerImplementationStubTwo');
+        $container->when(\Illuminate\Tests\Container\ContainerTestContextInjectOne::class)->needs(\Illuminate\Tests\Container\IContainerContractStub::class)->give(\Illuminate\Tests\Container\ContainerImplementationStubTwo::class);
 
-        $container->instance('Illuminate\Tests\Container\IContainerContractStub', new ContainerImplementationStub);
+        $container->instance(\Illuminate\Tests\Container\IContainerContractStub::class, new ContainerImplementationStub);
 
         $this->assertInstanceOf(
-            'Illuminate\Tests\Container\ContainerImplementationStubTwo',
-            $container->make('Illuminate\Tests\Container\ContainerTestContextInjectOne')->impl
+            \Illuminate\Tests\Container\ContainerImplementationStubTwo::class,
+            $container->make(\Illuminate\Tests\Container\ContainerTestContextInjectOne::class)->impl
         );
     }
 
@@ -630,13 +630,13 @@ class ContainerTest extends TestCase
         $container = new Container;
 
         $container->instance('stub', new ContainerImplementationStub);
-        $container->alias('stub', 'Illuminate\Tests\Container\IContainerContractStub');
+        $container->alias('stub', \Illuminate\Tests\Container\IContainerContractStub::class);
 
-        $container->when('Illuminate\Tests\Container\ContainerTestContextInjectOne')->needs('Illuminate\Tests\Container\IContainerContractStub')->give('Illuminate\Tests\Container\ContainerImplementationStubTwo');
+        $container->when(\Illuminate\Tests\Container\ContainerTestContextInjectOne::class)->needs(\Illuminate\Tests\Container\IContainerContractStub::class)->give(\Illuminate\Tests\Container\ContainerImplementationStubTwo::class);
 
         $this->assertInstanceOf(
-            'Illuminate\Tests\Container\ContainerImplementationStubTwo',
-            $container->make('Illuminate\Tests\Container\ContainerTestContextInjectOne')->impl
+            \Illuminate\Tests\Container\ContainerImplementationStubTwo::class,
+            $container->make(\Illuminate\Tests\Container\ContainerTestContextInjectOne::class)->impl
         );
     }
 
@@ -644,14 +644,14 @@ class ContainerTest extends TestCase
     {
         $container = new Container;
 
-        $container->when('Illuminate\Tests\Container\ContainerTestContextInjectOne')->needs('Illuminate\Tests\Container\IContainerContractStub')->give('Illuminate\Tests\Container\ContainerImplementationStubTwo');
+        $container->when(\Illuminate\Tests\Container\ContainerTestContextInjectOne::class)->needs(\Illuminate\Tests\Container\IContainerContractStub::class)->give(\Illuminate\Tests\Container\ContainerImplementationStubTwo::class);
 
         $container->instance('stub', new ContainerImplementationStub);
-        $container->alias('stub', 'Illuminate\Tests\Container\IContainerContractStub');
+        $container->alias('stub', \Illuminate\Tests\Container\IContainerContractStub::class);
 
         $this->assertInstanceOf(
-            'Illuminate\Tests\Container\ContainerImplementationStubTwo',
-            $container->make('Illuminate\Tests\Container\ContainerTestContextInjectOne')->impl
+            \Illuminate\Tests\Container\ContainerImplementationStubTwo::class,
+            $container->make(\Illuminate\Tests\Container\ContainerTestContextInjectOne::class)->impl
         );
     }
 
@@ -659,14 +659,14 @@ class ContainerTest extends TestCase
     {
         $container = new Container;
 
-        $container->when('Illuminate\Tests\Container\ContainerTestContextInjectOne')->needs('Illuminate\Tests\Container\IContainerContractStub')->give('Illuminate\Tests\Container\ContainerImplementationStubTwo');
+        $container->when(\Illuminate\Tests\Container\ContainerTestContextInjectOne::class)->needs(\Illuminate\Tests\Container\IContainerContractStub::class)->give(\Illuminate\Tests\Container\ContainerImplementationStubTwo::class);
 
         $container->bind('stub', ContainerImplementationStub::class);
-        $container->alias('stub', 'Illuminate\Tests\Container\IContainerContractStub');
+        $container->alias('stub', \Illuminate\Tests\Container\IContainerContractStub::class);
 
         $this->assertInstanceOf(
-            'Illuminate\Tests\Container\ContainerImplementationStubTwo',
-            $container->make('Illuminate\Tests\Container\ContainerTestContextInjectOne')->impl
+            \Illuminate\Tests\Container\ContainerImplementationStubTwo::class,
+            $container->make(\Illuminate\Tests\Container\ContainerTestContextInjectOne::class)->impl
         );
     }
 
@@ -675,18 +675,18 @@ class ContainerTest extends TestCase
         $container = new Container;
 
         $container->instance('stub', new ContainerImplementationStub);
-        $container->alias('stub', 'Illuminate\Tests\Container\IContainerContractStub');
+        $container->alias('stub', \Illuminate\Tests\Container\IContainerContractStub::class);
 
-        $container->when('Illuminate\Tests\Container\ContainerTestContextInjectTwo')->needs('Illuminate\Tests\Container\IContainerContractStub')->give('Illuminate\Tests\Container\ContainerImplementationStubTwo');
+        $container->when(\Illuminate\Tests\Container\ContainerTestContextInjectTwo::class)->needs(\Illuminate\Tests\Container\IContainerContractStub::class)->give(\Illuminate\Tests\Container\ContainerImplementationStubTwo::class);
 
         $this->assertInstanceOf(
-            'Illuminate\Tests\Container\ContainerImplementationStubTwo',
-            $container->make('Illuminate\Tests\Container\ContainerTestContextInjectTwo')->impl
+            \Illuminate\Tests\Container\ContainerImplementationStubTwo::class,
+            $container->make(\Illuminate\Tests\Container\ContainerTestContextInjectTwo::class)->impl
         );
 
         $this->assertInstanceOf(
-            'Illuminate\Tests\Container\ContainerImplementationStub',
-            $container->make('Illuminate\Tests\Container\ContainerTestContextInjectOne')->impl
+            \Illuminate\Tests\Container\ContainerImplementationStub::class,
+            $container->make(\Illuminate\Tests\Container\ContainerTestContextInjectOne::class)->impl
         );
     }
 
@@ -696,17 +696,17 @@ class ContainerTest extends TestCase
 
         $container = new Container;
 
-        $container->instance('Illuminate\Tests\Container\IContainerContractStub', new ContainerImplementationStub);
-        $container->instance('Illuminate\Tests\Container\ContainerTestContextInjectInstantiations', new ContainerTestContextInjectInstantiations);
+        $container->instance(\Illuminate\Tests\Container\IContainerContractStub::class, new ContainerImplementationStub);
+        $container->instance(\Illuminate\Tests\Container\ContainerTestContextInjectInstantiations::class, new ContainerTestContextInjectInstantiations);
 
         $this->assertEquals(1, ContainerTestContextInjectInstantiations::$instantiations);
 
-        $container->when('Illuminate\Tests\Container\ContainerTestContextInjectOne')->needs('Illuminate\Tests\Container\IContainerContractStub')->give('Illuminate\Tests\Container\ContainerTestContextInjectInstantiations');
+        $container->when(\Illuminate\Tests\Container\ContainerTestContextInjectOne::class)->needs(\Illuminate\Tests\Container\IContainerContractStub::class)->give(\Illuminate\Tests\Container\ContainerTestContextInjectInstantiations::class);
 
-        $container->make('Illuminate\Tests\Container\ContainerTestContextInjectOne');
-        $container->make('Illuminate\Tests\Container\ContainerTestContextInjectOne');
-        $container->make('Illuminate\Tests\Container\ContainerTestContextInjectOne');
-        $container->make('Illuminate\Tests\Container\ContainerTestContextInjectOne');
+        $container->make(\Illuminate\Tests\Container\ContainerTestContextInjectOne::class);
+        $container->make(\Illuminate\Tests\Container\ContainerTestContextInjectOne::class);
+        $container->make(\Illuminate\Tests\Container\ContainerTestContextInjectOne::class);
+        $container->make(\Illuminate\Tests\Container\ContainerTestContextInjectOne::class);
 
         $this->assertEquals(1, ContainerTestContextInjectInstantiations::$instantiations);
     }
@@ -714,20 +714,20 @@ class ContainerTest extends TestCase
     public function testContainerTags()
     {
         $container = new Container;
-        $container->tag('Illuminate\Tests\Container\ContainerImplementationStub', 'foo', 'bar');
-        $container->tag('Illuminate\Tests\Container\ContainerImplementationStubTwo', ['foo']);
+        $container->tag(\Illuminate\Tests\Container\ContainerImplementationStub::class, 'foo', 'bar');
+        $container->tag(\Illuminate\Tests\Container\ContainerImplementationStubTwo::class, ['foo']);
 
         $this->assertCount(1, $container->tagged('bar'));
         $this->assertCount(2, $container->tagged('foo'));
-        $this->assertInstanceOf('Illuminate\Tests\Container\ContainerImplementationStub', $container->tagged('foo')[0]);
-        $this->assertInstanceOf('Illuminate\Tests\Container\ContainerImplementationStub', $container->tagged('bar')[0]);
-        $this->assertInstanceOf('Illuminate\Tests\Container\ContainerImplementationStubTwo', $container->tagged('foo')[1]);
+        $this->assertInstanceOf(\Illuminate\Tests\Container\ContainerImplementationStub::class, $container->tagged('foo')[0]);
+        $this->assertInstanceOf(\Illuminate\Tests\Container\ContainerImplementationStub::class, $container->tagged('bar')[0]);
+        $this->assertInstanceOf(\Illuminate\Tests\Container\ContainerImplementationStubTwo::class, $container->tagged('foo')[1]);
 
         $container = new Container;
-        $container->tag(['Illuminate\Tests\Container\ContainerImplementationStub', 'Illuminate\Tests\Container\ContainerImplementationStubTwo'], ['foo']);
+        $container->tag([\Illuminate\Tests\Container\ContainerImplementationStub::class, \Illuminate\Tests\Container\ContainerImplementationStubTwo::class], ['foo']);
         $this->assertCount(2, $container->tagged('foo'));
-        $this->assertInstanceOf('Illuminate\Tests\Container\ContainerImplementationStub', $container->tagged('foo')[0]);
-        $this->assertInstanceOf('Illuminate\Tests\Container\ContainerImplementationStubTwo', $container->tagged('foo')[1]);
+        $this->assertInstanceOf(\Illuminate\Tests\Container\ContainerImplementationStub::class, $container->tagged('foo')[0]);
+        $this->assertInstanceOf(\Illuminate\Tests\Container\ContainerImplementationStubTwo::class, $container->tagged('foo')[1]);
 
         $this->assertEmpty($container->tagged('this_tag_does_not_exist'));
     }
@@ -736,10 +736,10 @@ class ContainerTest extends TestCase
     {
         $container = new Container;
         $containerConcreteStub = new ContainerConcreteStub;
-        $container->instance('Illuminate\Tests\Container\ContainerConcreteStub', $containerConcreteStub);
-        $this->assertTrue($container->isShared('Illuminate\Tests\Container\ContainerConcreteStub'));
-        $container->forgetInstance('Illuminate\Tests\Container\ContainerConcreteStub');
-        $this->assertFalse($container->isShared('Illuminate\Tests\Container\ContainerConcreteStub'));
+        $container->instance(\Illuminate\Tests\Container\ContainerConcreteStub::class, $containerConcreteStub);
+        $this->assertTrue($container->isShared(\Illuminate\Tests\Container\ContainerConcreteStub::class));
+        $container->forgetInstance(\Illuminate\Tests\Container\ContainerConcreteStub::class);
+        $this->assertFalse($container->isShared(\Illuminate\Tests\Container\ContainerConcreteStub::class));
     }
 
     public function testForgetInstancesForgetsAllInstances()
@@ -806,16 +806,16 @@ class ContainerTest extends TestCase
     public function testContainerCanInjectSimpleVariable()
     {
         $container = new Container;
-        $container->when('Illuminate\Tests\Container\ContainerInjectVariableStub')->needs('$something')->give(100);
-        $instance = $container->make('Illuminate\Tests\Container\ContainerInjectVariableStub');
+        $container->when(\Illuminate\Tests\Container\ContainerInjectVariableStub::class)->needs('$something')->give(100);
+        $instance = $container->make(\Illuminate\Tests\Container\ContainerInjectVariableStub::class);
         $this->assertEquals(100, $instance->something);
 
         $container = new Container;
-        $container->when('Illuminate\Tests\Container\ContainerInjectVariableStub')->needs('$something')->give(function ($container) {
-            return $container->make('Illuminate\Tests\Container\ContainerConcreteStub');
+        $container->when(\Illuminate\Tests\Container\ContainerInjectVariableStub::class)->needs('$something')->give(function ($container) {
+            return $container->make(\Illuminate\Tests\Container\ContainerConcreteStub::class);
         });
-        $instance = $container->make('Illuminate\Tests\Container\ContainerInjectVariableStub');
-        $this->assertInstanceOf('Illuminate\Tests\Container\ContainerConcreteStub', $instance->something);
+        $instance = $container->make(\Illuminate\Tests\Container\ContainerInjectVariableStub::class);
+        $this->assertInstanceOf(\Illuminate\Tests\Container\ContainerConcreteStub::class, $instance->something);
     }
 
     public function testContainerGetFactory()
@@ -847,25 +847,25 @@ class ContainerTest extends TestCase
     {
         $container = new Container;
 
-        $container->bind('Illuminate\Tests\Container\IContainerContractStub', 'Illuminate\Tests\Container\ContainerImplementationStub');
-        $container->alias('Illuminate\Tests\Container\IContainerContractStub', 'interface-stub');
+        $container->bind(\Illuminate\Tests\Container\IContainerContractStub::class, \Illuminate\Tests\Container\ContainerImplementationStub::class);
+        $container->alias(\Illuminate\Tests\Container\IContainerContractStub::class, 'interface-stub');
 
-        $container->alias('Illuminate\Tests\Container\ContainerImplementationStub', 'stub-1');
+        $container->alias(\Illuminate\Tests\Container\ContainerImplementationStub::class, 'stub-1');
 
-        $container->when('Illuminate\Tests\Container\ContainerTestContextInjectOne')->needs('interface-stub')->give('stub-1');
-        $container->when('Illuminate\Tests\Container\ContainerTestContextInjectTwo')->needs('interface-stub')->give('Illuminate\Tests\Container\ContainerImplementationStubTwo');
+        $container->when(\Illuminate\Tests\Container\ContainerTestContextInjectOne::class)->needs('interface-stub')->give('stub-1');
+        $container->when(\Illuminate\Tests\Container\ContainerTestContextInjectTwo::class)->needs('interface-stub')->give(\Illuminate\Tests\Container\ContainerImplementationStubTwo::class);
 
-        $one = $container->make('Illuminate\Tests\Container\ContainerTestContextInjectOne');
-        $two = $container->make('Illuminate\Tests\Container\ContainerTestContextInjectTwo');
+        $one = $container->make(\Illuminate\Tests\Container\ContainerTestContextInjectOne::class);
+        $two = $container->make(\Illuminate\Tests\Container\ContainerTestContextInjectTwo::class);
 
-        $this->assertInstanceOf('Illuminate\Tests\Container\ContainerImplementationStub', $one->impl);
-        $this->assertInstanceOf('Illuminate\Tests\Container\ContainerImplementationStubTwo', $two->impl);
+        $this->assertInstanceOf(\Illuminate\Tests\Container\ContainerImplementationStub::class, $one->impl);
+        $this->assertInstanceOf(\Illuminate\Tests\Container\ContainerImplementationStubTwo::class, $two->impl);
     }
 
     public function testResolvingCallbacksShouldBeFiredWhenCalledWithAliases()
     {
         $container = new Container;
-        $container->alias('stdClass', 'std');
+        $container->alias(\stdClass::class, 'std');
         $container->resolving('std', function ($object) {
             return $object->name = 'taylor';
         });
@@ -966,7 +966,7 @@ class ContainerTest extends TestCase
     public function testCanBuildWithoutParameterStackWithConstructors()
     {
         $container = new Container;
-        $container->bind('Illuminate\Tests\Container\IContainerContractStub', 'Illuminate\Tests\Container\ContainerImplementationStub');
+        $container->bind(\Illuminate\Tests\Container\IContainerContractStub::class, \Illuminate\Tests\Container\ContainerImplementationStub::class);
         $this->assertInstanceOf(ContainerDependentStub::class, $container->build(ContainerDependentStub::class));
     }
 }

--- a/tests/Cookie/Middleware/EncryptCookiesTest.php
+++ b/tests/Cookie/Middleware/EncryptCookiesTest.php
@@ -41,7 +41,7 @@ class EncryptCookiesTest extends TestCase
     public function testSetCookieEncryption()
     {
         $this->router->get($this->setCookiePath, [
-            'middleware' => 'Illuminate\Tests\Cookie\Middleware\EncryptCookiesTestMiddleware',
+            'middleware' => \Illuminate\Tests\Cookie\Middleware\EncryptCookiesTestMiddleware::class,
             'uses' => 'Illuminate\Tests\Cookie\Middleware\EncryptCookiesTestController@setCookies',
         ]);
 
@@ -58,7 +58,7 @@ class EncryptCookiesTest extends TestCase
     public function testQueuedCookieEncryption()
     {
         $this->router->get($this->queueCookiePath, [
-            'middleware' => ['Illuminate\Tests\Cookie\Middleware\EncryptCookiesTestMiddleware', 'Illuminate\Tests\Cookie\Middleware\AddQueuedCookiesToResponseTestMiddleware'],
+            'middleware' => [\Illuminate\Tests\Cookie\Middleware\EncryptCookiesTestMiddleware::class, \Illuminate\Tests\Cookie\Middleware\AddQueuedCookiesToResponseTestMiddleware::class],
             'uses' => 'Illuminate\Tests\Cookie\Middleware\EncryptCookiesTestController@queueCookies',
         ]);
 

--- a/tests/Database/DatabaseConnectionFactoryTest.php
+++ b/tests/Database/DatabaseConnectionFactoryTest.php
@@ -77,7 +77,7 @@ class DatabaseConnectionFactoryTest extends TestCase
      */
     public function testIfDriverIsntSetExceptionIsThrown()
     {
-        $factory = new ConnectionFactory($container = m::mock('Illuminate\Container\Container'));
+        $factory = new ConnectionFactory($container = m::mock(\Illuminate\Container\Container::class));
         $factory->createConnector(['foo']);
     }
 
@@ -86,14 +86,14 @@ class DatabaseConnectionFactoryTest extends TestCase
      */
     public function testExceptionIsThrownOnUnsupportedDriver()
     {
-        $factory = new ConnectionFactory($container = m::mock('Illuminate\Container\Container'));
+        $factory = new ConnectionFactory($container = m::mock(\Illuminate\Container\Container::class));
         $container->shouldReceive('bound')->once()->andReturn(false);
         $factory->createConnector(['driver' => 'foo']);
     }
 
     public function testCustomConnectorsCanBeResolvedViaContainer()
     {
-        $factory = new ConnectionFactory($container = m::mock('Illuminate\Container\Container'));
+        $factory = new ConnectionFactory($container = m::mock(\Illuminate\Container\Container::class));
         $container->shouldReceive('bound')->once()->with('db.connector.foo')->andReturn(true);
         $container->shouldReceive('make')->once()->with('db.connector.foo')->andReturn('connector');
 

--- a/tests/Database/DatabaseConnectionTest.php
+++ b/tests/Database/DatabaseConnectionTest.php
@@ -16,7 +16,7 @@ class DatabaseConnectionTest extends TestCase
     public function testSettingDefaultCallsGetDefaultGrammar()
     {
         $connection = $this->getMockConnection();
-        $mock = m::mock('stdClass');
+        $mock = m::mock(\stdClass::class);
         $connection->expects($this->once())->method('getDefaultQueryGrammar')->will($this->returnValue($mock));
         $connection->useDefaultQueryGrammar();
         $this->assertEquals($mock, $connection->getQueryGrammar());
@@ -25,7 +25,7 @@ class DatabaseConnectionTest extends TestCase
     public function testSettingDefaultCallsGetDefaultPostProcessor()
     {
         $connection = $this->getMockConnection();
-        $mock = m::mock('stdClass');
+        $mock = m::mock(\stdClass::class);
         $connection->expects($this->once())->method('getDefaultPostProcessor')->will($this->returnValue($mock));
         $connection->useDefaultPostProcessor();
         $this->assertEquals($mock, $connection->getPostProcessor());
@@ -40,8 +40,8 @@ class DatabaseConnectionTest extends TestCase
 
     public function testSelectProperlyCallsPDO()
     {
-        $pdo = $this->getMockBuilder('Illuminate\Tests\Database\DatabaseConnectionTestMockPDO')->setMethods(['prepare'])->getMock();
-        $writePdo = $this->getMockBuilder('Illuminate\Tests\Database\DatabaseConnectionTestMockPDO')->setMethods(['prepare'])->getMock();
+        $pdo = $this->getMockBuilder(\Illuminate\Tests\Database\DatabaseConnectionTestMockPDO::class)->setMethods(['prepare'])->getMock();
+        $writePdo = $this->getMockBuilder(\Illuminate\Tests\Database\DatabaseConnectionTestMockPDO::class)->setMethods(['prepare'])->getMock();
         $writePdo->expects($this->never())->method('prepare');
         $statement = $this->getMockBuilder('PDOStatement')->setMethods(['execute', 'fetchAll', 'bindValue'])->getMock();
         $statement->expects($this->once())->method('bindValue')->with('foo', 'bar', 2);
@@ -85,7 +85,7 @@ class DatabaseConnectionTest extends TestCase
 
     public function testStatementProperlyCallsPDO()
     {
-        $pdo = $this->getMockBuilder('Illuminate\Tests\Database\DatabaseConnectionTestMockPDO')->setMethods(['prepare'])->getMock();
+        $pdo = $this->getMockBuilder(\Illuminate\Tests\Database\DatabaseConnectionTestMockPDO::class)->setMethods(['prepare'])->getMock();
         $statement = $this->getMockBuilder('PDOStatement')->setMethods(['execute', 'bindValue'])->getMock();
         $statement->expects($this->once())->method('bindValue')->with(1, 'bar', 2);
         $statement->expects($this->once())->method('execute')->will($this->returnValue('foo'));
@@ -102,7 +102,7 @@ class DatabaseConnectionTest extends TestCase
 
     public function testAffectingStatementProperlyCallsPDO()
     {
-        $pdo = $this->getMockBuilder('Illuminate\Tests\Database\DatabaseConnectionTestMockPDO')->setMethods(['prepare'])->getMock();
+        $pdo = $this->getMockBuilder(\Illuminate\Tests\Database\DatabaseConnectionTestMockPDO::class)->setMethods(['prepare'])->getMock();
         $statement = $this->getMockBuilder('PDOStatement')->setMethods(['execute', 'rowCount', 'bindValue'])->getMock();
         $statement->expects($this->once())->method('bindValue')->with('foo', 'bar', 2);
         $statement->expects($this->once())->method('execute');
@@ -120,7 +120,7 @@ class DatabaseConnectionTest extends TestCase
 
     public function testTransactionLevelNotIncrementedOnTransactionException()
     {
-        $pdo = $this->createMock('Illuminate\Tests\Database\DatabaseConnectionTestMockPDO');
+        $pdo = $this->createMock(\Illuminate\Tests\Database\DatabaseConnectionTestMockPDO::class);
         $pdo->expects($this->once())->method('beginTransaction')->will($this->throwException(new \Exception));
         $connection = $this->getMockConnection([], $pdo);
         try {
@@ -132,7 +132,7 @@ class DatabaseConnectionTest extends TestCase
 
     public function testBeginTransactionMethodRetriesOnFailure()
     {
-        $pdo = $this->createMock('Illuminate\Tests\Database\DatabaseConnectionTestMockPDO');
+        $pdo = $this->createMock(\Illuminate\Tests\Database\DatabaseConnectionTestMockPDO::class);
         $pdo->expects($this->exactly(2))->method('beginTransaction');
         $pdo->expects($this->at(0))->method('beginTransaction')->will($this->throwException(new \ErrorException('server has gone away')));
         $connection = $this->getMockConnection(['reconnect'], $pdo);
@@ -143,11 +143,11 @@ class DatabaseConnectionTest extends TestCase
 
     public function testBeginTransactionMethodNeverRetriesIfWithinTransaction()
     {
-        $pdo = $this->createMock('Illuminate\Tests\Database\DatabaseConnectionTestMockPDO');
+        $pdo = $this->createMock(\Illuminate\Tests\Database\DatabaseConnectionTestMockPDO::class);
         $pdo->expects($this->once())->method('beginTransaction');
         $pdo->expects($this->once())->method('exec')->will($this->throwException(new \Exception));
         $connection = $this->getMockConnection(['reconnect'], $pdo);
-        $queryGrammar = $this->createMock('Illuminate\Database\Query\Grammars\Grammar');
+        $queryGrammar = $this->createMock(\Illuminate\Database\Query\Grammars\Grammar::class);
         $queryGrammar->expects($this->once())->method('supportsSavepoints')->will($this->returnValue(true));
         $connection->setQueryGrammar($queryGrammar);
         $connection->expects($this->never())->method('reconnect');
@@ -162,7 +162,7 @@ class DatabaseConnectionTest extends TestCase
 
     public function testSwapPDOWithOpenTransactionResetsTransactionLevel()
     {
-        $pdo = $this->createMock('Illuminate\Tests\Database\DatabaseConnectionTestMockPDO');
+        $pdo = $this->createMock(\Illuminate\Tests\Database\DatabaseConnectionTestMockPDO::class);
         $pdo->expects($this->once())->method('beginTransaction')->will($this->returnValue(true));
         $connection = $this->getMockConnection([], $pdo);
         $connection->beginTransaction();
@@ -172,48 +172,48 @@ class DatabaseConnectionTest extends TestCase
 
     public function testBeganTransactionFiresEventsIfSet()
     {
-        $pdo = $this->createMock('Illuminate\Tests\Database\DatabaseConnectionTestMockPDO');
+        $pdo = $this->createMock(\Illuminate\Tests\Database\DatabaseConnectionTestMockPDO::class);
         $connection = $this->getMockConnection(['getName'], $pdo);
         $connection->expects($this->any())->method('getName')->will($this->returnValue('name'));
-        $connection->setEventDispatcher($events = m::mock('Illuminate\Contracts\Events\Dispatcher'));
-        $events->shouldReceive('dispatch')->once()->with(m::type('Illuminate\Database\Events\TransactionBeginning'));
+        $connection->setEventDispatcher($events = m::mock(\Illuminate\Contracts\Events\Dispatcher::class));
+        $events->shouldReceive('dispatch')->once()->with(m::type(\Illuminate\Database\Events\TransactionBeginning::class));
         $connection->beginTransaction();
     }
 
     public function testCommitedFiresEventsIfSet()
     {
-        $pdo = $this->createMock('Illuminate\Tests\Database\DatabaseConnectionTestMockPDO');
+        $pdo = $this->createMock(\Illuminate\Tests\Database\DatabaseConnectionTestMockPDO::class);
         $connection = $this->getMockConnection(['getName'], $pdo);
         $connection->expects($this->any())->method('getName')->will($this->returnValue('name'));
-        $connection->setEventDispatcher($events = m::mock('Illuminate\Contracts\Events\Dispatcher'));
-        $events->shouldReceive('dispatch')->once()->with(m::type('Illuminate\Database\Events\TransactionCommitted'));
+        $connection->setEventDispatcher($events = m::mock(\Illuminate\Contracts\Events\Dispatcher::class));
+        $events->shouldReceive('dispatch')->once()->with(m::type(\Illuminate\Database\Events\TransactionCommitted::class));
         $connection->commit();
     }
 
     public function testRollBackedFiresEventsIfSet()
     {
-        $pdo = $this->createMock('Illuminate\Tests\Database\DatabaseConnectionTestMockPDO');
+        $pdo = $this->createMock(\Illuminate\Tests\Database\DatabaseConnectionTestMockPDO::class);
         $connection = $this->getMockConnection(['getName'], $pdo);
         $connection->expects($this->any())->method('getName')->will($this->returnValue('name'));
         $connection->beginTransaction();
-        $connection->setEventDispatcher($events = m::mock('Illuminate\Contracts\Events\Dispatcher'));
-        $events->shouldReceive('dispatch')->once()->with(m::type('Illuminate\Database\Events\TransactionRolledBack'));
+        $connection->setEventDispatcher($events = m::mock(\Illuminate\Contracts\Events\Dispatcher::class));
+        $events->shouldReceive('dispatch')->once()->with(m::type(\Illuminate\Database\Events\TransactionRolledBack::class));
         $connection->rollBack();
     }
 
     public function testRedundantRollBackFiresNoEvent()
     {
-        $pdo = $this->createMock('Illuminate\Tests\Database\DatabaseConnectionTestMockPDO');
+        $pdo = $this->createMock(\Illuminate\Tests\Database\DatabaseConnectionTestMockPDO::class);
         $connection = $this->getMockConnection(['getName'], $pdo);
         $connection->expects($this->any())->method('getName')->will($this->returnValue('name'));
-        $connection->setEventDispatcher($events = m::mock('Illuminate\Contracts\Events\Dispatcher'));
+        $connection->setEventDispatcher($events = m::mock(\Illuminate\Contracts\Events\Dispatcher::class));
         $events->shouldNotReceive('dispatch');
         $connection->rollBack();
     }
 
     public function testTransactionMethodRunsSuccessfully()
     {
-        $pdo = $this->getMockBuilder('Illuminate\Tests\Database\DatabaseConnectionTestMockPDO')->setMethods(['beginTransaction', 'commit'])->getMock();
+        $pdo = $this->getMockBuilder(\Illuminate\Tests\Database\DatabaseConnectionTestMockPDO::class)->setMethods(['beginTransaction', 'commit'])->getMock();
         $mock = $this->getMockConnection([], $pdo);
         $pdo->expects($this->once())->method('beginTransaction');
         $pdo->expects($this->once())->method('commit');
@@ -228,7 +228,7 @@ class DatabaseConnectionTest extends TestCase
      */
     public function testTransactionMethodRetriesOnDeadlock()
     {
-        $pdo = $this->getMockBuilder('Illuminate\Tests\Database\DatabaseConnectionTestMockPDO')->setMethods(['beginTransaction', 'commit', 'rollBack'])->getMock();
+        $pdo = $this->getMockBuilder(\Illuminate\Tests\Database\DatabaseConnectionTestMockPDO::class)->setMethods(['beginTransaction', 'commit', 'rollBack'])->getMock();
         $mock = $this->getMockConnection([], $pdo);
         $pdo->expects($this->exactly(3))->method('beginTransaction');
         $pdo->expects($this->exactly(3))->method('rollBack');
@@ -240,7 +240,7 @@ class DatabaseConnectionTest extends TestCase
 
     public function testTransactionMethodRollsbackAndThrows()
     {
-        $pdo = $this->getMockBuilder('Illuminate\Tests\Database\DatabaseConnectionTestMockPDO')->setMethods(['beginTransaction', 'commit', 'rollBack'])->getMock();
+        $pdo = $this->getMockBuilder(\Illuminate\Tests\Database\DatabaseConnectionTestMockPDO::class)->setMethods(['beginTransaction', 'commit', 'rollBack'])->getMock();
         $mock = $this->getMockConnection([], $pdo);
         $pdo->expects($this->once())->method('beginTransaction');
         $pdo->expects($this->once())->method('rollBack');
@@ -295,10 +295,10 @@ class DatabaseConnectionTest extends TestCase
 
     public function testRunMethodRetriesOnFailure()
     {
-        $method = (new \ReflectionClass('Illuminate\Database\Connection'))->getMethod('run');
+        $method = (new \ReflectionClass(\Illuminate\Database\Connection::class))->getMethod('run');
         $method->setAccessible(true);
 
-        $pdo = $this->createMock('Illuminate\Tests\Database\DatabaseConnectionTestMockPDO');
+        $pdo = $this->createMock(\Illuminate\Tests\Database\DatabaseConnectionTestMockPDO::class);
         $mock = $this->getMockConnection(['tryAgainIfCausedByLostConnection'], $pdo);
         $mock->expects($this->once())->method('tryAgainIfCausedByLostConnection');
 
@@ -312,10 +312,10 @@ class DatabaseConnectionTest extends TestCase
      */
     public function testRunMethodNeverRetriesIfWithinTransaction()
     {
-        $method = (new \ReflectionClass('Illuminate\Database\Connection'))->getMethod('run');
+        $method = (new \ReflectionClass(\Illuminate\Database\Connection::class))->getMethod('run');
         $method->setAccessible(true);
 
-        $pdo = $this->getMockBuilder('Illuminate\Tests\Database\DatabaseConnectionTestMockPDO')->setMethods(['beginTransaction'])->getMock();
+        $pdo = $this->getMockBuilder(\Illuminate\Tests\Database\DatabaseConnectionTestMockPDO::class)->setMethods(['beginTransaction'])->getMock();
         $mock = $this->getMockConnection(['tryAgainIfCausedByLostConnection'], $pdo);
         $pdo->expects($this->once())->method('beginTransaction');
         $mock->expects($this->never())->method('tryAgainIfCausedByLostConnection');
@@ -329,10 +329,10 @@ class DatabaseConnectionTest extends TestCase
     public function testFromCreatesNewQueryBuilder()
     {
         $conn = $this->getMockConnection();
-        $conn->setQueryGrammar(m::mock('Illuminate\Database\Query\Grammars\Grammar'));
-        $conn->setPostProcessor(m::mock('Illuminate\Database\Query\Processors\Processor'));
+        $conn->setQueryGrammar(m::mock(\Illuminate\Database\Query\Grammars\Grammar::class));
+        $conn->setPostProcessor(m::mock(\Illuminate\Database\Query\Processors\Processor::class));
         $builder = $conn->table('users');
-        $this->assertInstanceOf('Illuminate\Database\Query\Builder', $builder);
+        $this->assertInstanceOf(\Illuminate\Database\Query\Builder::class, $builder);
         $this->assertEquals('users', $builder->from);
     }
 
@@ -342,7 +342,7 @@ class DatabaseConnectionTest extends TestCase
         $date->shouldReceive('format')->once()->with('foo')->andReturn('bar');
         $bindings = ['test' => $date];
         $conn = $this->getMockConnection();
-        $grammar = m::mock('Illuminate\Database\Query\Grammars\Grammar');
+        $grammar = m::mock(\Illuminate\Database\Query\Grammars\Grammar::class);
         $grammar->shouldReceive('getDateFormat')->once()->andReturn('foo');
         $conn->setQueryGrammar($grammar);
         $result = $conn->prepareBindings($bindings);
@@ -353,8 +353,8 @@ class DatabaseConnectionTest extends TestCase
     {
         $connection = $this->getMockConnection();
         $connection->logQuery('foo', [], time());
-        $connection->setEventDispatcher($events = m::mock('Illuminate\Contracts\Events\Dispatcher'));
-        $events->shouldReceive('dispatch')->once()->with(m::type('Illuminate\Database\Events\QueryExecuted'));
+        $connection->setEventDispatcher($events = m::mock(\Illuminate\Contracts\Events\Dispatcher::class));
+        $events->shouldReceive('dispatch')->once()->with(m::type(\Illuminate\Database\Events\QueryExecuted::class));
         $connection->logQuery('foo', [], null);
     }
 
@@ -372,7 +372,7 @@ class DatabaseConnectionTest extends TestCase
     {
         $connection = $this->getMockConnection();
         $schema = $connection->getSchemaBuilder();
-        $this->assertInstanceOf('Illuminate\Database\Schema\Builder', $schema);
+        $this->assertInstanceOf(\Illuminate\Database\Schema\Builder::class, $schema);
         $this->assertSame($connection, $schema->getConnection());
     }
 
@@ -380,7 +380,7 @@ class DatabaseConnectionTest extends TestCase
     {
         $pdo = $pdo ?: new DatabaseConnectionTestMockPDO;
         $defaults = ['getDefaultQueryGrammar', 'getDefaultPostProcessor', 'getDefaultSchemaGrammar'];
-        $connection = $this->getMockBuilder('Illuminate\Database\Connection')->setMethods(array_merge($defaults, $methods))->setConstructorArgs([$pdo])->getMock();
+        $connection = $this->getMockBuilder(\Illuminate\Database\Connection::class)->setMethods(array_merge($defaults, $methods))->setConstructorArgs([$pdo])->getMock();
         $connection->enableQueryLog();
 
         return $connection;

--- a/tests/Database/DatabaseConnectorTest.php
+++ b/tests/Database/DatabaseConnectorTest.php
@@ -25,7 +25,7 @@ class DatabaseConnectorTest extends TestCase
      */
     public function testMySqlConnectCallsCreateConnectionWithProperArguments($dsn, $config)
     {
-        $connector = $this->getMockBuilder('Illuminate\Database\Connectors\MySqlConnector')->setMethods(['createConnection', 'getOptions'])->getMock();
+        $connector = $this->getMockBuilder(\Illuminate\Database\Connectors\MySqlConnector::class)->setMethods(['createConnection', 'getOptions'])->getMock();
         $connection = m::mock('PDO');
         $connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->will($this->returnValue(['options']));
         $connector->expects($this->once())->method('createConnection')->with($this->equalTo($dsn), $this->equalTo($config), $this->equalTo(['options']))->will($this->returnValue($connection));
@@ -50,8 +50,8 @@ class DatabaseConnectorTest extends TestCase
     {
         $dsn = 'pgsql:host=foo;dbname=bar;port=111';
         $config = ['host' => 'foo', 'database' => 'bar', 'port' => 111, 'charset' => 'utf8'];
-        $connector = $this->getMockBuilder('Illuminate\Database\Connectors\PostgresConnector')->setMethods(['createConnection', 'getOptions'])->getMock();
-        $connection = m::mock('stdClass');
+        $connector = $this->getMockBuilder(\Illuminate\Database\Connectors\PostgresConnector::class)->setMethods(['createConnection', 'getOptions'])->getMock();
+        $connection = m::mock(\stdClass::class);
         $connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->will($this->returnValue(['options']));
         $connector->expects($this->once())->method('createConnection')->with($this->equalTo($dsn), $this->equalTo($config), $this->equalTo(['options']))->will($this->returnValue($connection));
         $connection->shouldReceive('prepare')->once()->with('set names \'utf8\'')->andReturn($connection);
@@ -65,8 +65,8 @@ class DatabaseConnectorTest extends TestCase
     {
         $dsn = 'pgsql:host=foo;dbname=bar';
         $config = ['host' => 'foo', 'database' => 'bar', 'schema' => 'public', 'charset' => 'utf8'];
-        $connector = $this->getMockBuilder('Illuminate\Database\Connectors\PostgresConnector')->setMethods(['createConnection', 'getOptions'])->getMock();
-        $connection = m::mock('stdClass');
+        $connector = $this->getMockBuilder(\Illuminate\Database\Connectors\PostgresConnector::class)->setMethods(['createConnection', 'getOptions'])->getMock();
+        $connection = m::mock(\stdClass::class);
         $connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->will($this->returnValue(['options']));
         $connector->expects($this->once())->method('createConnection')->with($this->equalTo($dsn), $this->equalTo($config), $this->equalTo(['options']))->will($this->returnValue($connection));
         $connection->shouldReceive('prepare')->once()->with('set names \'utf8\'')->andReturn($connection);
@@ -81,8 +81,8 @@ class DatabaseConnectorTest extends TestCase
     {
         $dsn = 'pgsql:host=foo;dbname=bar';
         $config = ['host' => 'foo', 'database' => 'bar', 'schema' => ['public', 'user'], 'charset' => 'utf8'];
-        $connector = $this->getMockBuilder('Illuminate\Database\Connectors\PostgresConnector')->setMethods(['createConnection', 'getOptions'])->getMock();
-        $connection = m::mock('stdClass');
+        $connector = $this->getMockBuilder(\Illuminate\Database\Connectors\PostgresConnector::class)->setMethods(['createConnection', 'getOptions'])->getMock();
+        $connection = m::mock(\stdClass::class);
         $connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->will($this->returnValue(['options']));
         $connector->expects($this->once())->method('createConnection')->with($this->equalTo($dsn), $this->equalTo($config), $this->equalTo(['options']))->will($this->returnValue($connection));
         $connection->shouldReceive('prepare')->once()->with('set names \'utf8\'')->andReturn($connection);
@@ -97,8 +97,8 @@ class DatabaseConnectorTest extends TestCase
     {
         $dsn = 'pgsql:host=foo;dbname=bar';
         $config = ['host' => 'foo', 'database' => 'bar', 'charset' => 'utf8', 'application_name' => 'Larvel App'];
-        $connector = $this->getMockBuilder('Illuminate\Database\Connectors\PostgresConnector')->setMethods(['createConnection', 'getOptions'])->getMock();
-        $connection = m::mock('stdClass');
+        $connector = $this->getMockBuilder(\Illuminate\Database\Connectors\PostgresConnector::class)->setMethods(['createConnection', 'getOptions'])->getMock();
+        $connection = m::mock(\stdClass::class);
         $connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->will($this->returnValue(['options']));
         $connector->expects($this->once())->method('createConnection')->with($this->equalTo($dsn), $this->equalTo($config), $this->equalTo(['options']))->will($this->returnValue($connection));
         $connection->shouldReceive('prepare')->once()->with('set names \'utf8\'')->andReturn($connection);
@@ -113,8 +113,8 @@ class DatabaseConnectorTest extends TestCase
     {
         $dsn = 'sqlite::memory:';
         $config = ['database' => ':memory:'];
-        $connector = $this->getMockBuilder('Illuminate\Database\Connectors\SQLiteConnector')->setMethods(['createConnection', 'getOptions'])->getMock();
-        $connection = m::mock('stdClass');
+        $connector = $this->getMockBuilder(\Illuminate\Database\Connectors\SQLiteConnector::class)->setMethods(['createConnection', 'getOptions'])->getMock();
+        $connection = m::mock(\stdClass::class);
         $connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->will($this->returnValue(['options']));
         $connector->expects($this->once())->method('createConnection')->with($this->equalTo($dsn), $this->equalTo($config), $this->equalTo(['options']))->will($this->returnValue($connection));
         $result = $connector->connect($config);
@@ -126,8 +126,8 @@ class DatabaseConnectorTest extends TestCase
     {
         $dsn = 'sqlite:'.__DIR__;
         $config = ['database' => __DIR__];
-        $connector = $this->getMockBuilder('Illuminate\Database\Connectors\SQLiteConnector')->setMethods(['createConnection', 'getOptions'])->getMock();
-        $connection = m::mock('stdClass');
+        $connector = $this->getMockBuilder(\Illuminate\Database\Connectors\SQLiteConnector::class)->setMethods(['createConnection', 'getOptions'])->getMock();
+        $connection = m::mock(\stdClass::class);
         $connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->will($this->returnValue(['options']));
         $connector->expects($this->once())->method('createConnection')->with($this->equalTo($dsn), $this->equalTo($config), $this->equalTo(['options']))->will($this->returnValue($connection));
         $result = $connector->connect($config);
@@ -139,8 +139,8 @@ class DatabaseConnectorTest extends TestCase
     {
         $config = ['host' => 'foo', 'database' => 'bar', 'port' => 111];
         $dsn = $this->getDsn($config);
-        $connector = $this->getMockBuilder('Illuminate\Database\Connectors\SqlServerConnector')->setMethods(['createConnection', 'getOptions'])->getMock();
-        $connection = m::mock('stdClass');
+        $connector = $this->getMockBuilder(\Illuminate\Database\Connectors\SqlServerConnector::class)->setMethods(['createConnection', 'getOptions'])->getMock();
+        $connection = m::mock(\stdClass::class);
         $connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->will($this->returnValue(['options']));
         $connector->expects($this->once())->method('createConnection')->with($this->equalTo($dsn), $this->equalTo($config), $this->equalTo(['options']))->will($this->returnValue($connection));
         $result = $connector->connect($config);
@@ -152,8 +152,8 @@ class DatabaseConnectorTest extends TestCase
     {
         $config = ['host' => 'foo', 'database' => 'bar', 'port' => 111, 'readonly' => true, 'charset' => 'utf-8', 'pooling' => false, 'appname' => 'baz'];
         $dsn = $this->getDsn($config);
-        $connector = $this->getMockBuilder('Illuminate\Database\Connectors\SqlServerConnector')->setMethods(['createConnection', 'getOptions'])->getMock();
-        $connection = m::mock('stdClass');
+        $connector = $this->getMockBuilder(\Illuminate\Database\Connectors\SqlServerConnector::class)->setMethods(['createConnection', 'getOptions'])->getMock();
+        $connection = m::mock(\stdClass::class);
         $connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->will($this->returnValue(['options']));
         $connector->expects($this->once())->method('createConnection')->with($this->equalTo($dsn), $this->equalTo($config), $this->equalTo(['options']))->will($this->returnValue($connection));
         $result = $connector->connect($config);

--- a/tests/Database/DatabaseEloquentBelongsToManyTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyTest.php
@@ -27,7 +27,7 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
         $model2->fill(['name' => 'dayle', 'pivot_user_id' => 3, 'pivot_role_id' => 4]);
         $models = [$model1, $model2];
 
-        $baseBuilder = m::mock('Illuminate\Database\Query\Builder');
+        $baseBuilder = m::mock(\Illuminate\Database\Query\Builder::class);
 
         $relation = $this->getRelation();
         $relation->getParent()->shouldReceive('getConnectionName')->andReturn('foo.connection');
@@ -41,7 +41,7 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
         $relation->getQuery()->shouldReceive('getQuery')->once()->andReturn($baseBuilder);
         $results = $relation->get();
 
-        $this->assertInstanceOf('Illuminate\Database\Eloquent\Collection', $results);
+        $this->assertInstanceOf(\Illuminate\Database\Eloquent\Collection::class, $results);
 
         // Make sure the foreign keys were set on the pivot models...
         $this->assertEquals('user_id', $results[0]->pivot->getForeignKey());
@@ -67,7 +67,7 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
         $model2->fill(['name' => 'dayle', 'pivot_user_id' => 3, 'pivot_role_id' => 4]);
         $models = [$model1, $model2];
 
-        $baseBuilder = m::mock('Illuminate\Database\Query\Builder');
+        $baseBuilder = m::mock(\Illuminate\Database\Query\Builder::class);
 
         $relation = $this->getRelation()->withTimestamps();
         $relation->getParent()->shouldReceive('getConnectionName')->andReturn('foo.connection');
@@ -125,8 +125,8 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
         $relation->getRelated()->shouldReceive('newCollection')->andReturnUsing(function ($array = []) {
             return new Collection($array);
         });
-        $model = m::mock('Illuminate\Database\Eloquent\Model');
-        $model->shouldReceive('setRelation')->once()->with('foo', m::type('Illuminate\Database\Eloquent\Collection'));
+        $model = m::mock(\Illuminate\Database\Eloquent\Model::class);
+        $model->shouldReceive('setRelation')->once()->with('foo', m::type(\Illuminate\Database\Eloquent\Collection::class));
         $models = $relation->initRelation([$model], 'foo');
 
         $this->assertEquals([$model], $models);
@@ -145,11 +145,11 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
 
     public function testAttachInsertsPivotTableRecord()
     {
-        $relation = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\BelongsToMany')->setMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
-        $query = m::mock('stdClass');
+        $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\BelongsToMany::class)->setMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
+        $query = m::mock(\stdClass::class);
         $query->shouldReceive('from')->once()->with('user_role')->andReturn($query);
         $query->shouldReceive('insert')->once()->with([['user_id' => 1, 'role_id' => 2, 'foo' => 'bar']])->andReturn(true);
-        $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock('stdClass'));
+        $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock(\stdClass::class));
         $mockQueryBuilder->shouldReceive('newQuery')->once()->andReturn($query);
         $relation->expects($this->once())->method('touchIfTouching');
 
@@ -158,8 +158,8 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
 
     public function testAttachMultipleInsertsPivotTableRecord()
     {
-        $relation = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\BelongsToMany')->setMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
-        $query = m::mock('stdClass');
+        $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\BelongsToMany::class)->setMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
+        $query = m::mock(\stdClass::class);
         $query->shouldReceive('from')->once()->with('user_role')->andReturn($query);
         $query->shouldReceive('insert')->once()->with(
             [
@@ -167,7 +167,7 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
                 ['user_id' => 1, 'role_id' => 3, 'baz' => 'boom', 'foo' => 'bar'],
             ]
         )->andReturn(true);
-        $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock('stdClass'));
+        $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock(\stdClass::class));
         $mockQueryBuilder->shouldReceive('newQuery')->once()->andReturn($query);
         $relation->expects($this->once())->method('touchIfTouching');
 
@@ -176,8 +176,8 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
 
     public function testAttachMethodConvertsCollectionToArrayOfKeys()
     {
-        $relation = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\BelongsToMany')->setMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
-        $query = m::mock('stdClass');
+        $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\BelongsToMany::class)->setMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
+        $query = m::mock(\stdClass::class);
         $query->shouldReceive('from')->once()->with('user_role')->andReturn($query);
         $query->shouldReceive('insert')->once()->with(
             [
@@ -186,7 +186,7 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
                 ['user_id' => 1, 'role_id' => 3],
             ]
         )->andReturn(true);
-        $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock('stdClass'));
+        $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock(\stdClass::class));
         $mockQueryBuilder->shouldReceive('newQuery')->once()->andReturn($query);
         $relation->expects($this->once())->method('touchIfTouching');
 
@@ -201,12 +201,12 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
 
     public function testAttachInsertsPivotTableRecordWithTimestampsWhenNecessary()
     {
-        $relation = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\BelongsToMany')->setMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
+        $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\BelongsToMany::class)->setMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
         $relation->withTimestamps();
-        $query = m::mock('stdClass');
+        $query = m::mock(\stdClass::class);
         $query->shouldReceive('from')->once()->with('user_role')->andReturn($query);
         $query->shouldReceive('insert')->once()->with([['user_id' => 1, 'role_id' => 2, 'foo' => 'bar', 'created_at' => 'time', 'updated_at' => 'time']])->andReturn(true);
-        $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock('stdClass'));
+        $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock(\stdClass::class));
         $mockQueryBuilder->shouldReceive('newQuery')->once()->andReturn($query);
         $relation->getParent()->shouldReceive('freshTimestamp')->once()->andReturn('time');
         $relation->expects($this->once())->method('touchIfTouching');
@@ -216,12 +216,12 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
 
     public function testAttachInsertsPivotTableRecordWithCustomTimestampColumns()
     {
-        $relation = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\BelongsToMany')->setMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
+        $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\BelongsToMany::class)->setMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
         $relation->withTimestamps('custom_created_at', 'custom_updated_at');
-        $query = m::mock('stdClass');
+        $query = m::mock(\stdClass::class);
         $query->shouldReceive('from')->once()->with('user_role')->andReturn($query);
         $query->shouldReceive('insert')->once()->with([['user_id' => 1, 'role_id' => 2, 'foo' => 'bar', 'custom_created_at' => 'time', 'custom_updated_at' => 'time']])->andReturn(true);
-        $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock('stdClass'));
+        $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock(\stdClass::class));
         $mockQueryBuilder->shouldReceive('newQuery')->once()->andReturn($query);
         $relation->getParent()->shouldReceive('freshTimestamp')->once()->andReturn('time');
         $relation->expects($this->once())->method('touchIfTouching');
@@ -231,12 +231,12 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
 
     public function testAttachInsertsPivotTableRecordWithACreatedAtTimestamp()
     {
-        $relation = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\BelongsToMany')->setMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
+        $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\BelongsToMany::class)->setMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
         $relation->withPivot('created_at');
-        $query = m::mock('stdClass');
+        $query = m::mock(\stdClass::class);
         $query->shouldReceive('from')->once()->with('user_role')->andReturn($query);
         $query->shouldReceive('insert')->once()->with([['user_id' => 1, 'role_id' => 2, 'foo' => 'bar', 'created_at' => 'time']])->andReturn(true);
-        $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock('stdClass'));
+        $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock(\stdClass::class));
         $mockQueryBuilder->shouldReceive('newQuery')->once()->andReturn($query);
         $relation->getParent()->shouldReceive('freshTimestamp')->once()->andReturn('time');
         $relation->expects($this->once())->method('touchIfTouching');
@@ -246,12 +246,12 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
 
     public function testAttachInsertsPivotTableRecordWithAnUpdatedAtTimestamp()
     {
-        $relation = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\BelongsToMany')->setMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
+        $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\BelongsToMany::class)->setMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
         $relation->withPivot('updated_at');
-        $query = m::mock('stdClass');
+        $query = m::mock(\stdClass::class);
         $query->shouldReceive('from')->once()->with('user_role')->andReturn($query);
         $query->shouldReceive('insert')->once()->with([['user_id' => 1, 'role_id' => 2, 'foo' => 'bar', 'updated_at' => 'time']])->andReturn(true);
-        $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock('stdClass'));
+        $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock(\stdClass::class));
         $mockQueryBuilder->shouldReceive('newQuery')->once()->andReturn($query);
         $relation->getParent()->shouldReceive('freshTimestamp')->once()->andReturn('time');
         $relation->expects($this->once())->method('touchIfTouching');
@@ -261,13 +261,13 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
 
     public function testDetachRemovesPivotTableRecord()
     {
-        $relation = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\BelongsToMany')->setMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
-        $query = m::mock('stdClass');
+        $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\BelongsToMany::class)->setMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
+        $query = m::mock(\stdClass::class);
         $query->shouldReceive('from')->once()->with('user_role')->andReturn($query);
         $query->shouldReceive('where')->once()->with('user_id', 1)->andReturn($query);
         $query->shouldReceive('whereIn')->once()->with('role_id', [1, 2, 3]);
         $query->shouldReceive('delete')->once()->andReturn(true);
-        $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock('stdClass'));
+        $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock(\stdClass::class));
         $mockQueryBuilder->shouldReceive('newQuery')->once()->andReturn($query);
         $relation->expects($this->once())->method('touchIfTouching');
 
@@ -276,13 +276,13 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
 
     public function testDetachWithSingleIDRemovesPivotTableRecord()
     {
-        $relation = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\BelongsToMany')->setMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
-        $query = m::mock('stdClass');
+        $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\BelongsToMany::class)->setMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
+        $query = m::mock(\stdClass::class);
         $query->shouldReceive('from')->once()->with('user_role')->andReturn($query);
         $query->shouldReceive('where')->once()->with('user_id', 1)->andReturn($query);
         $query->shouldReceive('whereIn')->once()->with('role_id', [1]);
         $query->shouldReceive('delete')->once()->andReturn(true);
-        $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock('stdClass'));
+        $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock(\stdClass::class));
         $mockQueryBuilder->shouldReceive('newQuery')->once()->andReturn($query);
         $relation->expects($this->once())->method('touchIfTouching');
 
@@ -291,13 +291,13 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
 
     public function testDetachMethodConvertsCollectionToArrayOfKeys()
     {
-        $relation = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\BelongsToMany')->setMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
-        $query = m::mock('stdClass');
+        $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\BelongsToMany::class)->setMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
+        $query = m::mock(\stdClass::class);
         $query->shouldReceive('from')->once()->with('user_role')->andReturn($query);
         $query->shouldReceive('where')->once()->with('user_id', 1)->andReturn($query);
         $query->shouldReceive('whereIn')->once()->with('role_id', [1, 2, 3]);
         $query->shouldReceive('delete')->once()->andReturn(true);
-        $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock('stdClass'));
+        $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock(\stdClass::class));
         $mockQueryBuilder->shouldReceive('newQuery')->once()->andReturn($query);
         $relation->expects($this->once())->method('touchIfTouching');
 
@@ -312,13 +312,13 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
 
     public function testDetachMethodClearsAllPivotRecordsWhenNoIDsAreGiven()
     {
-        $relation = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\BelongsToMany')->setMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
-        $query = m::mock('stdClass');
+        $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\BelongsToMany::class)->setMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
+        $query = m::mock(\stdClass::class);
         $query->shouldReceive('from')->once()->with('user_role')->andReturn($query);
         $query->shouldReceive('where')->once()->with('user_id', 1)->andReturn($query);
         $query->shouldReceive('whereIn')->never();
         $query->shouldReceive('delete')->once()->andReturn(true);
-        $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock('stdClass'));
+        $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock(\stdClass::class));
         $mockQueryBuilder->shouldReceive('newQuery')->once()->andReturn($query);
         $relation->expects($this->once())->method('touchIfTouching');
 
@@ -363,8 +363,8 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
 
     public function testCreateMethodCreatesNewModelAndInsertsAttachmentRecord()
     {
-        $relation = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\BelongsToMany')->setMethods(['attach'])->setConstructorArgs($this->getRelationArguments())->getMock();
-        $relation->getRelated()->shouldReceive('newInstance')->once()->andReturn($model = m::mock('stdClass'))->with(['attributes']);
+        $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\BelongsToMany::class)->setMethods(['attach'])->setConstructorArgs($this->getRelationArguments())->getMock();
+        $relation->getRelated()->shouldReceive('newInstance')->once()->andReturn($model = m::mock(\stdClass::class))->with(['attributes']);
         $model->shouldReceive('save')->once();
         $model->shouldReceive('getKey')->andReturn('foo');
         $relation->expects($this->once())->method('attach')->with('foo', ['joining']);
@@ -377,7 +377,7 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
      */
     public function testFindOrFailThrowsException()
     {
-        $relation = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\BelongsToMany')->setMethods(['find'])->setConstructorArgs($this->getRelationArguments())->getMock();
+        $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\BelongsToMany::class)->setMethods(['find'])->setConstructorArgs($this->getRelationArguments())->getMock();
         $relation->expects($this->once())->method('find')->with('foo')->will($this->returnValue(null));
 
         try {
@@ -394,7 +394,7 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
      */
     public function testFirstOrFailThrowsException()
     {
-        $relation = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\BelongsToMany')->setMethods(['first'])->setConstructorArgs($this->getRelationArguments())->getMock();
+        $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\BelongsToMany::class)->setMethods(['first'])->setConstructorArgs($this->getRelationArguments())->getMock();
         $relation->expects($this->once())->method('first')->with(['id' => 'foo'])->will($this->returnValue(null));
 
         try {
@@ -408,8 +408,8 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
 
     public function testFindOrNewMethodFindsModel()
     {
-        $relation = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\BelongsToMany')->setMethods(['find'])->setConstructorArgs($this->getRelationArguments())->getMock();
-        $relation->expects($this->once())->method('find')->with('foo')->will($this->returnValue($model = m::mock('stdClass')));
+        $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\BelongsToMany::class)->setMethods(['find'])->setConstructorArgs($this->getRelationArguments())->getMock();
+        $relation->expects($this->once())->method('find')->with('foo')->will($this->returnValue($model = m::mock(\stdClass::class)));
         $relation->getRelated()->shouldReceive('newInstance')->never();
 
         $this->assertInstanceOf(stdClass::class, $relation->findOrNew('foo'));
@@ -417,18 +417,18 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
 
     public function testFindOrNewMethodReturnsNewModel()
     {
-        $relation = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\BelongsToMany')->setMethods(['find'])->setConstructorArgs($this->getRelationArguments())->getMock();
+        $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\BelongsToMany::class)->setMethods(['find'])->setConstructorArgs($this->getRelationArguments())->getMock();
         $relation->expects($this->once())->method('find')->with('foo')->will($this->returnValue(null));
-        $relation->getRelated()->shouldReceive('newInstance')->once()->andReturn($model = m::mock('stdClass'));
+        $relation->getRelated()->shouldReceive('newInstance')->once()->andReturn($model = m::mock(\stdClass::class));
 
         $this->assertInstanceOf(stdClass::class, $relation->findOrNew('foo'));
     }
 
     public function testFirstOrNewMethodFindsFirstModel()
     {
-        $relation = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\BelongsToMany')->setMethods(['where'])->setConstructorArgs($this->getRelationArguments())->getMock();
+        $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\BelongsToMany::class)->setMethods(['where'])->setConstructorArgs($this->getRelationArguments())->getMock();
         $relation->expects($this->once())->method('where')->with(['foo'])->will($this->returnValue($relation->getQuery()));
-        $relation->getQuery()->shouldReceive('first')->once()->andReturn($model = m::mock('stdClass'));
+        $relation->getQuery()->shouldReceive('first')->once()->andReturn($model = m::mock(\stdClass::class));
         $relation->getRelated()->shouldReceive('newInstance')->never();
 
         $this->assertInstanceOf(stdClass::class, $relation->firstOrNew(['foo']));
@@ -436,19 +436,19 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
 
     public function testFirstOrNewMethodReturnsNewModel()
     {
-        $relation = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\BelongsToMany')->setMethods(['where'])->setConstructorArgs($this->getRelationArguments())->getMock();
+        $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\BelongsToMany::class)->setMethods(['where'])->setConstructorArgs($this->getRelationArguments())->getMock();
         $relation->expects($this->once())->method('where')->with(['foo'])->will($this->returnValue($relation->getQuery()));
         $relation->getQuery()->shouldReceive('first')->once()->andReturn(null);
-        $relation->getRelated()->shouldReceive('newInstance')->once()->andReturn($model = m::mock('stdClass'));
+        $relation->getRelated()->shouldReceive('newInstance')->once()->andReturn($model = m::mock(\stdClass::class));
 
         $this->assertInstanceOf(stdClass::class, $relation->firstOrNew(['foo']));
     }
 
     public function testFirstOrCreateMethodFindsFirstModel()
     {
-        $relation = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\BelongsToMany')->setMethods(['where', 'create'])->setConstructorArgs($this->getRelationArguments())->getMock();
+        $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\BelongsToMany::class)->setMethods(['where', 'create'])->setConstructorArgs($this->getRelationArguments())->getMock();
         $relation->expects($this->once())->method('where')->with(['foo'])->will($this->returnValue($relation->getQuery()));
-        $relation->getQuery()->shouldReceive('first')->once()->andReturn($model = m::mock('stdClass'));
+        $relation->getQuery()->shouldReceive('first')->once()->andReturn($model = m::mock(\stdClass::class));
         $relation->expects($this->never())->method('create')->with(['foo'])->will($this->returnValue(null));
 
         $this->assertInstanceOf(stdClass::class, $relation->firstOrCreate(['foo']));
@@ -456,19 +456,19 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
 
     public function testFirstOrCreateMethodReturnsNewModel()
     {
-        $relation = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\BelongsToMany')->setMethods(['where', 'create'])->setConstructorArgs($this->getRelationArguments())->getMock();
+        $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\BelongsToMany::class)->setMethods(['where', 'create'])->setConstructorArgs($this->getRelationArguments())->getMock();
         $relation->expects($this->once())->method('where')->with(['foo'])->will($this->returnValue($relation->getQuery()));
         $relation->getQuery()->shouldReceive('first')->once()->andReturn(null);
-        $relation->expects($this->once())->method('create')->with(['foo'])->will($this->returnValue($model = m::mock('stdClass')));
+        $relation->expects($this->once())->method('create')->with(['foo'])->will($this->returnValue($model = m::mock(\stdClass::class)));
 
         $this->assertInstanceOf(stdClass::class, $relation->firstOrCreate(['foo']));
     }
 
     public function testUpdateOrCreateMethodFindsFirstModelAndUpdates()
     {
-        $relation = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\BelongsToMany')->setMethods(['where', 'create'])->setConstructorArgs($this->getRelationArguments())->getMock();
+        $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\BelongsToMany::class)->setMethods(['where', 'create'])->setConstructorArgs($this->getRelationArguments())->getMock();
         $relation->expects($this->once())->method('where')->with(['foo'])->will($this->returnValue($relation->getQuery()));
-        $relation->getQuery()->shouldReceive('first')->once()->andReturn($model = m::mock('stdClass'));
+        $relation->getQuery()->shouldReceive('first')->once()->andReturn($model = m::mock(\stdClass::class));
         $model->shouldReceive('fill')->once();
         $model->shouldReceive('save')->once();
         $relation->expects($this->never())->method('create')->with(['foo'])->will($this->returnValue(null));
@@ -478,10 +478,10 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
 
     public function testUpdateOrCreateMethodReturnsNewModel()
     {
-        $relation = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\BelongsToMany')->setMethods(['where', 'create'])->setConstructorArgs($this->getRelationArguments())->getMock();
+        $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\BelongsToMany::class)->setMethods(['where', 'create'])->setConstructorArgs($this->getRelationArguments())->getMock();
         $relation->expects($this->once())->method('where')->with(['bar'])->will($this->returnValue($relation->getQuery()));
         $relation->getQuery()->shouldReceive('first')->once()->andReturn(null);
-        $relation->expects($this->once())->method('create')->with(['foo'])->will($this->returnValue($model = m::mock('stdClass')));
+        $relation->expects($this->once())->method('create')->with(['foo'])->will($this->returnValue($model = m::mock(\stdClass::class)));
 
         $this->assertInstanceOf(stdClass::class, $relation->updateOrCreate(['bar'], ['foo']));
     }
@@ -491,11 +491,11 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
      */
     public function testSyncMethodSyncsIntermediateTableWithGivenArray($list)
     {
-        $relation = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\BelongsToMany')->setMethods(['attach', 'detach'])->setConstructorArgs($this->getRelationArguments())->getMock();
-        $query = m::mock('stdClass');
+        $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\BelongsToMany::class)->setMethods(['attach', 'detach'])->setConstructorArgs($this->getRelationArguments())->getMock();
+        $query = m::mock(\stdClass::class);
         $query->shouldReceive('from')->once()->with('user_role')->andReturn($query);
         $query->shouldReceive('where')->once()->with('user_id', 1)->andReturn($query);
-        $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock('stdClass'));
+        $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock(\stdClass::class));
         $mockQueryBuilder->shouldReceive('newQuery')->once()->andReturn($query);
         $query->shouldReceive('pluck')->once()->with('role_id')->andReturn(new BaseCollection([1, 2, 3]));
         $relation->expects($this->once())->method('attach')->with($this->equalTo('x'), $this->equalTo([]), $this->equalTo(false));
@@ -516,11 +516,11 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
 
     public function testSyncMethodSyncsIntermediateTableWithGivenArrayAndAttributes()
     {
-        $relation = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\BelongsToMany')->setMethods(['attach', 'detach', 'touchIfTouching', 'updateExistingPivot'])->setConstructorArgs($this->getRelationArguments())->getMock();
-        $query = m::mock('stdClass');
+        $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\BelongsToMany::class)->setMethods(['attach', 'detach', 'touchIfTouching', 'updateExistingPivot'])->setConstructorArgs($this->getRelationArguments())->getMock();
+        $query = m::mock(\stdClass::class);
         $query->shouldReceive('from')->once()->with('user_role')->andReturn($query);
         $query->shouldReceive('where')->once()->with('user_id', 1)->andReturn($query);
-        $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock('stdClass'));
+        $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock(\stdClass::class));
         $mockQueryBuilder->shouldReceive('newQuery')->once()->andReturn($query);
         $query->shouldReceive('pluck')->once()->with('role_id')->andReturn(new BaseCollection([1, 2, 3]));
         $relation->expects($this->once())->method('attach')->with($this->equalTo(4), $this->equalTo(['foo' => 'bar']), $this->equalTo(false));
@@ -533,11 +533,11 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
 
     public function testSyncMethodDoesntReturnValuesThatWereNotUpdated()
     {
-        $relation = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\BelongsToMany')->setMethods(['attach', 'detach', 'touchIfTouching', 'updateExistingPivot'])->setConstructorArgs($this->getRelationArguments())->getMock();
-        $query = m::mock('stdClass');
+        $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\BelongsToMany::class)->setMethods(['attach', 'detach', 'touchIfTouching', 'updateExistingPivot'])->setConstructorArgs($this->getRelationArguments())->getMock();
+        $query = m::mock(\stdClass::class);
         $query->shouldReceive('from')->once()->with('user_role')->andReturn($query);
         $query->shouldReceive('where')->once()->with('user_id', 1)->andReturn($query);
-        $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock('stdClass'));
+        $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock(\stdClass::class));
         $mockQueryBuilder->shouldReceive('newQuery')->once()->andReturn($query);
         $query->shouldReceive('pluck')->once()->with('role_id')->andReturn(new BaseCollection([1, 2, 3]));
         $relation->expects($this->once())->method('attach')->with($this->equalTo(4), $this->equalTo(['foo' => 'bar']), $this->equalTo(false));
@@ -556,7 +556,7 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
         $relation->getRelated()->shouldReceive('getQualifiedKeyName')->andReturn('table.id');
         $relation->getQuery()->shouldReceive('select')->once()->with('table.id')->andReturn($relation->getQuery());
         $relation->getQuery()->shouldReceive('pluck')->once()->with('id')->andReturn([1, 2, 3]);
-        $relation->getRelated()->shouldReceive('newQuery')->once()->andReturn($query = m::mock('stdClass'));
+        $relation->getRelated()->shouldReceive('newQuery')->once()->andReturn($query = m::mock(\stdClass::class));
         $query->shouldReceive('whereIn')->once()->with('id', [1, 2, 3])->andReturn($query);
         $query->shouldReceive('update')->once()->with(['updated_at' => '100']);
 
@@ -568,11 +568,11 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
      */
     public function testToggleMethodTogglesIntermediateTableWithGivenArray($list)
     {
-        $relation = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\BelongsToMany')->setMethods(['attach', 'detach'])->setConstructorArgs($this->getRelationArguments())->getMock();
-        $query = m::mock('stdClass');
+        $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\BelongsToMany::class)->setMethods(['attach', 'detach'])->setConstructorArgs($this->getRelationArguments())->getMock();
+        $query = m::mock(\stdClass::class);
         $query->shouldReceive('from')->once()->with('user_role')->andReturn($query);
         $query->shouldReceive('where')->once()->with('user_id', 1)->andReturn($query);
-        $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock('stdClass'));
+        $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock(\stdClass::class));
         $mockQueryBuilder->shouldReceive('newQuery')->once()->andReturn($query);
         $query->shouldReceive('pluck')->once()->with('role_id')->andReturn(new BaseCollection([1, 2, 3]));
         $relation->expects($this->once())->method('attach')->with($this->equalTo(['x' => []]), $this->equalTo([]), $this->equalTo(false));
@@ -593,11 +593,11 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
 
     public function testToggleMethodCanLeaveRelatedTimestampsIntact()
     {
-        $relation = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\BelongsToMany')->setMethods(['attach', 'detach'])->setConstructorArgs($this->getRelationArguments())->getMock();
-        $query = m::mock('stdClass');
+        $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\BelongsToMany::class)->setMethods(['attach', 'detach'])->setConstructorArgs($this->getRelationArguments())->getMock();
+        $query = m::mock(\stdClass::class);
         $query->shouldReceive('from')->once()->with('user_role')->andReturn($query);
         $query->shouldReceive('where')->once()->with('user_id', 1)->andReturn($query);
-        $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock('stdClass'));
+        $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock(\stdClass::class));
         $mockQueryBuilder->shouldReceive('newQuery')->once()->andReturn($query);
         $query->shouldReceive('pluck')->once()->with('role_id')->andReturn(new BaseCollection([1, 2, 3]));
         $relation->expects($this->once())->method('attach')->with($this->equalTo(['x' => []]), $this->equalTo([]), $this->equalTo(false));
@@ -610,11 +610,11 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
 
     public function testToggleMethodTogglesIntermediateTableWithGivenArrayAndAttributes()
     {
-        $relation = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\BelongsToMany')->setMethods(['attach', 'detach', 'touchIfTouching', 'updateExistingPivot'])->setConstructorArgs($this->getRelationArguments())->getMock();
-        $query = m::mock('stdClass');
+        $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\BelongsToMany::class)->setMethods(['attach', 'detach', 'touchIfTouching', 'updateExistingPivot'])->setConstructorArgs($this->getRelationArguments())->getMock();
+        $query = m::mock(\stdClass::class);
         $query->shouldReceive('from')->once()->with('user_role')->andReturn($query);
         $query->shouldReceive('where')->once()->with('user_id', 1)->andReturn($query);
-        $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock('stdClass'));
+        $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock(\stdClass::class));
         $mockQueryBuilder->shouldReceive('newQuery')->once()->andReturn($query);
         $query->shouldReceive('pluck')->once()->with('role_id')->andReturn(new BaseCollection([1, 2, 3]));
         $relation->expects($this->once())->method('attach')->with($this->equalTo([4 => ['foo' => 'bar']]), [], $this->equalTo(false));
@@ -626,7 +626,7 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
 
     public function testTouchIfTouching()
     {
-        $relation = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\BelongsToMany')->setMethods(['touch', 'touchingParent'])->setConstructorArgs($this->getRelationArguments())->getMock();
+        $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\BelongsToMany::class)->setMethods(['touch', 'touchingParent'])->setConstructorArgs($this->getRelationArguments())->getMock();
         $relation->expects($this->once())->method('touchingParent')->will($this->returnValue(true));
         $relation->getParent()->shouldReceive('touch')->once();
         $relation->getParent()->shouldReceive('touches')->once()->with('relation_name')->andReturn(true);
@@ -637,11 +637,11 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
 
     public function testSyncMethodConvertsEloquentCollectionToArrayOfKeys()
     {
-        $relation = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\BelongsToMany')->setMethods(['attach', 'detach', 'touchIfTouching', 'formatRecordsList'])->setConstructorArgs($this->getRelationArguments())->getMock();
-        $query = m::mock('stdClass');
+        $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\BelongsToMany::class)->setMethods(['attach', 'detach', 'touchIfTouching', 'formatRecordsList'])->setConstructorArgs($this->getRelationArguments())->getMock();
+        $query = m::mock(\stdClass::class);
         $query->shouldReceive('from')->once()->with('user_role')->andReturn($query);
         $query->shouldReceive('where')->once()->with('user_id', 1)->andReturn($query);
-        $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock('stdClass'));
+        $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock(\stdClass::class));
         $mockQueryBuilder->shouldReceive('newQuery')->once()->andReturn($query);
         $query->shouldReceive('pluck')->once()->with('role_id')->andReturn(new BaseCollection([1, 2, 3]));
 
@@ -656,11 +656,11 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
 
     public function testSyncMethodConvertsBaseCollectionToArrayOfKeys()
     {
-        $relation = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\BelongsToMany')->setMethods(['attach', 'detach', 'touchIfTouching', 'formatRecordsList'])->setConstructorArgs($this->getRelationArguments())->getMock();
-        $query = m::mock('stdClass');
+        $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\BelongsToMany::class)->setMethods(['attach', 'detach', 'touchIfTouching', 'formatRecordsList'])->setConstructorArgs($this->getRelationArguments())->getMock();
+        $query = m::mock(\stdClass::class);
         $query->shouldReceive('from')->once()->with('user_role')->andReturn($query);
         $query->shouldReceive('where')->once()->with('user_id', 1)->andReturn($query);
-        $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock('stdClass'));
+        $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock(\stdClass::class));
         $mockQueryBuilder->shouldReceive('newQuery')->once()->andReturn($query);
         $query->shouldReceive('pluck')->once()->with('role_id')->andReturn(new BaseCollection([1, 2, 3]));
 
@@ -671,14 +671,14 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
 
     public function testWherePivotParamsUsedForNewQueries()
     {
-        $relation = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\BelongsToMany')->setMethods(['attach', 'detach', 'touchIfTouching', 'formatRecordsList'])->setConstructorArgs($this->getRelationArguments())->getMock();
+        $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\BelongsToMany::class)->setMethods(['attach', 'detach', 'touchIfTouching', 'formatRecordsList'])->setConstructorArgs($this->getRelationArguments())->getMock();
 
         // we expect to call $relation->wherePivot()
         $relation->getQuery()->shouldReceive('where')->once()->andReturn($relation);
 
         // Our sync() call will produce a new query
-        $mockQueryBuilder = m::mock('stdClass');
-        $query = m::mock('stdClass');
+        $mockQueryBuilder = m::mock(\stdClass::class);
+        $query = m::mock(\stdClass::class);
         $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder);
         $mockQueryBuilder->shouldReceive('newQuery')->once()->andReturn($query);
 
@@ -708,20 +708,20 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
 
     public function getRelationArguments()
     {
-        $parent = m::mock('Illuminate\Database\Eloquent\Model');
+        $parent = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $parent->shouldReceive('getKey')->andReturn(1);
         $parent->shouldReceive('getCreatedAtColumn')->andReturn('created_at');
         $parent->shouldReceive('getUpdatedAtColumn')->andReturn('updated_at');
         $parent->shouldReceive('getAttribute')->with('id')->andReturn(1);
 
-        $builder = m::mock('Illuminate\Database\Eloquent\Builder');
-        $related = m::mock('Illuminate\Database\Eloquent\Model');
+        $builder = m::mock(\Illuminate\Database\Eloquent\Builder::class);
+        $related = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $builder->shouldReceive('getModel')->andReturn($related);
 
         $related->shouldReceive('getTable')->andReturn('roles');
         $related->shouldReceive('getKeyName')->andReturn('id');
         $related->shouldReceive('newPivot')->andReturnUsing(function () {
-            $reflector = new ReflectionClass('Illuminate\Database\Eloquent\Relations\Pivot');
+            $reflector = new ReflectionClass(\Illuminate\Database\Eloquent\Relations\Pivot::class);
 
             return $reflector->newInstanceArgs(func_get_args());
         });

--- a/tests/Database/DatabaseEloquentBelongsToTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToTest.php
@@ -17,7 +17,7 @@ class DatabaseEloquentBelongsToTest extends TestCase
     public function testUpdateMethodRetrievesModelAndUpdates()
     {
         $relation = $this->getRelation();
-        $mock = m::mock('Illuminate\Database\Eloquent\Model');
+        $mock = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $mock->shouldReceive('fill')->once()->with(['attributes'])->andReturn($mock);
         $mock->shouldReceive('save')->once()->andReturn(true);
         $relation->getQuery()->shouldReceive('first')->once()->andReturn($mock);
@@ -44,7 +44,7 @@ class DatabaseEloquentBelongsToTest extends TestCase
     public function testRelationIsProperlyInitialized()
     {
         $relation = $this->getRelation();
-        $model = m::mock('Illuminate\Database\Eloquent\Model');
+        $model = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $model->shouldReceive('setRelation')->once()->with('foo', null);
         $models = $relation->initRelation([$model], 'foo');
 
@@ -54,9 +54,9 @@ class DatabaseEloquentBelongsToTest extends TestCase
     public function testModelsAreProperlyMatchedToParents()
     {
         $relation = $this->getRelation();
-        $result1 = m::mock('stdClass');
+        $result1 = m::mock(\stdClass::class);
         $result1->shouldReceive('getAttribute')->with('id')->andReturn(1);
-        $result2 = m::mock('stdClass');
+        $result2 = m::mock(\stdClass::class);
         $result2->shouldReceive('getAttribute')->with('id')->andReturn(2);
         $model1 = new EloquentBelongsToModelStub;
         $model1->foreign_key = 1;
@@ -70,10 +70,10 @@ class DatabaseEloquentBelongsToTest extends TestCase
 
     public function testAssociateMethodSetsForeignKeyOnModel()
     {
-        $parent = m::mock('Illuminate\Database\Eloquent\Model');
+        $parent = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $parent->shouldReceive('getAttribute')->once()->with('foreign_key')->andReturn('foreign.value');
         $relation = $this->getRelation($parent);
-        $associate = m::mock('Illuminate\Database\Eloquent\Model');
+        $associate = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $associate->shouldReceive('getAttribute')->once()->with('id')->andReturn(1);
         $parent->shouldReceive('setAttribute')->once()->with('foreign_key', 1);
         $parent->shouldReceive('setRelation')->once()->with('relation', $associate);
@@ -83,7 +83,7 @@ class DatabaseEloquentBelongsToTest extends TestCase
 
     public function testDissociateMethodUnsetsForeignKeyOnModel()
     {
-        $parent = m::mock('Illuminate\Database\Eloquent\Model');
+        $parent = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $parent->shouldReceive('getAttribute')->once()->with('foreign_key')->andReturn('foreign.value');
         $relation = $this->getRelation($parent);
         $parent->shouldReceive('setAttribute')->once()->with('foreign_key', null);
@@ -93,7 +93,7 @@ class DatabaseEloquentBelongsToTest extends TestCase
 
     public function testAssociateMethodSetsForeignKeyOnModelById()
     {
-        $parent = m::mock('Illuminate\Database\Eloquent\Model');
+        $parent = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $parent->shouldReceive('getAttribute')->once()->with('foreign_key')->andReturn('foreign.value');
         $relation = $this->getRelation($parent);
         $parent->shouldReceive('setAttribute')->once()->with('foreign_key', 1);
@@ -126,9 +126,9 @@ class DatabaseEloquentBelongsToTest extends TestCase
 
     protected function getRelation($parent = null, $incrementing = true, $keyType = 'int')
     {
-        $builder = m::mock('Illuminate\Database\Eloquent\Builder');
+        $builder = m::mock(\Illuminate\Database\Eloquent\Builder::class);
         $builder->shouldReceive('where')->with('relation.id', '=', 'foreign.value');
-        $related = m::mock('Illuminate\Database\Eloquent\Model');
+        $related = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $related->incrementing = $incrementing;
         $related->shouldReceive('getKeyType')->andReturn($keyType);
         $related->shouldReceive('getIncrementing')->andReturn($incrementing);

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -45,7 +45,7 @@ class DatabaseEloquentBuilderTest extends TestCase
     public function testFindOrNewMethodModelNotFound()
     {
         $model = $this->getMockModel();
-        $model->shouldReceive('findOrNew')->once()->andReturn(m::mock('Illuminate\Database\Eloquent\Model'));
+        $model->shouldReceive('findOrNew')->once()->andReturn(m::mock(\Illuminate\Database\Eloquent\Model::class));
 
         $builder = m::mock('Illuminate\Database\Eloquent\Builder[first]', [$this->getMockQueryBuilder()]);
         $builder->setModel($model);
@@ -55,7 +55,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $result = $model->findOrNew('bar', ['column']);
         $findResult = $builder->find('bar', ['column']);
         $this->assertNull($findResult);
-        $this->assertInstanceOf('Illuminate\Database\Eloquent\Model', $result);
+        $this->assertInstanceOf(\Illuminate\Database\Eloquent\Model::class, $result);
     }
 
     /**
@@ -183,7 +183,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder->shouldReceive('forPage')->once()->with(3, 2)->andReturnSelf();
         $builder->shouldReceive('get')->times(3)->andReturn($chunk1, $chunk2, $chunk3);
 
-        $callbackAssertor = m::mock('stdClass');
+        $callbackAssertor = m::mock(\stdClass::class);
         $callbackAssertor->shouldReceive('doSomething')->once()->with($chunk1);
         $callbackAssertor->shouldReceive('doSomething')->once()->with($chunk2);
         $callbackAssertor->shouldReceive('doSomething')->never()->with($chunk3);
@@ -204,7 +204,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder->shouldReceive('forPage')->once()->with(2, 2)->andReturnSelf();
         $builder->shouldReceive('get')->times(2)->andReturn($chunk1, $chunk2);
 
-        $callbackAssertor = m::mock('stdClass');
+        $callbackAssertor = m::mock(\stdClass::class);
         $callbackAssertor->shouldReceive('doSomething')->once()->with($chunk1);
         $callbackAssertor->shouldReceive('doSomething')->once()->with($chunk2);
 
@@ -224,7 +224,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder->shouldReceive('forPage')->never()->with(2, 2);
         $builder->shouldReceive('get')->times(1)->andReturn($chunk1);
 
-        $callbackAssertor = m::mock('stdClass');
+        $callbackAssertor = m::mock(\stdClass::class);
         $callbackAssertor->shouldReceive('doSomething')->once()->with($chunk1);
         $callbackAssertor->shouldReceive('doSomething')->never()->with($chunk2);
 
@@ -244,7 +244,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder->shouldReceive('forPage')->once()->with(1, 0)->andReturnSelf();
         $builder->shouldReceive('get')->times(1)->andReturn($chunk);
 
-        $callbackAssertor = m::mock('stdClass');
+        $callbackAssertor = m::mock(\stdClass::class);
         $callbackAssertor->shouldReceive('doSomething')->never();
 
         $builder->chunk(0, function ($results) use ($callbackAssertor) {
@@ -265,7 +265,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder->shouldReceive('forPageAfterId')->once()->with(2, 11, 'someIdField')->andReturnSelf();
         $builder->shouldReceive('get')->times(3)->andReturn($chunk1, $chunk2, $chunk3);
 
-        $callbackAssertor = m::mock('stdClass');
+        $callbackAssertor = m::mock(\stdClass::class);
         $callbackAssertor->shouldReceive('doSomething')->once()->with($chunk1);
         $callbackAssertor->shouldReceive('doSomething')->once()->with($chunk2);
         $callbackAssertor->shouldReceive('doSomething')->never()->with($chunk3);
@@ -286,7 +286,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder->shouldReceive('forPageAfterId')->once()->with(2, 2, 'someIdField')->andReturnSelf();
         $builder->shouldReceive('get')->times(2)->andReturn($chunk1, $chunk2);
 
-        $callbackAssertor = m::mock('stdClass');
+        $callbackAssertor = m::mock(\stdClass::class);
         $callbackAssertor->shouldReceive('doSomething')->once()->with($chunk1);
         $callbackAssertor->shouldReceive('doSomething')->once()->with($chunk2);
 
@@ -304,7 +304,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder->shouldReceive('forPageAfterId')->once()->with(0, 0, 'someIdField')->andReturnSelf();
         $builder->shouldReceive('get')->times(1)->andReturn($chunk);
 
-        $callbackAssertor = m::mock('stdClass');
+        $callbackAssertor = m::mock(\stdClass::class);
         $callbackAssertor->shouldReceive('doSomething')->never();
 
         $builder->chunkById(0, function ($results) use ($callbackAssertor) {
@@ -367,9 +367,9 @@ class DatabaseEloquentBuilderTest extends TestCase
     {
         unset($_SERVER['__test.builder']);
         $builder = new \Illuminate\Database\Eloquent\Builder(new \Illuminate\Database\Query\Builder(
-            m::mock('Illuminate\Database\ConnectionInterface'),
-            m::mock('Illuminate\Database\Query\Grammars\Grammar'),
-            m::mock('Illuminate\Database\Query\Processors\Processor')
+            m::mock(\Illuminate\Database\ConnectionInterface::class),
+            m::mock(\Illuminate\Database\Query\Grammars\Grammar::class),
+            m::mock(\Illuminate\Database\Query\Processors\Processor::class)
         ));
         $builder->macro('fooBar', function ($builder) {
             $_SERVER['__test.builder'] = $builder;
@@ -427,7 +427,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder->setEagerLoads(['orders' => function ($query) {
             $_SERVER['__eloquent.constrain'] = $query;
         }]);
-        $relation = m::mock('stdClass');
+        $relation = m::mock(\stdClass::class);
         $relation->shouldReceive('addEagerConstraints')->once()->with(['models']);
         $relation->shouldReceive('initRelation')->once()->with(['models'], 'orders')->andReturn(['models']);
         $relation->shouldReceive('getEager')->once()->andReturn(['results']);
@@ -444,8 +444,8 @@ class DatabaseEloquentBuilderTest extends TestCase
     {
         $builder = $this->getBuilder();
         $builder->setModel($this->getMockModel());
-        $builder->getModel()->shouldReceive('orders')->once()->andReturn($relation = m::mock('stdClass'));
-        $relationQuery = m::mock('stdClass');
+        $builder->getModel()->shouldReceive('orders')->once()->andReturn($relation = m::mock(\stdClass::class));
+        $relationQuery = m::mock(\stdClass::class);
         $relation->shouldReceive('getQuery')->andReturn($relationQuery);
         $relationQuery->shouldReceive('with')->once()->with(['lines' => null, 'lines.details' => null]);
         $builder->setEagerLoads(['orders' => null, 'orders.lines' => null, 'orders.lines.details' => null]);
@@ -457,13 +457,13 @@ class DatabaseEloquentBuilderTest extends TestCase
     {
         $builder = $this->getBuilder();
         $builder->setModel($this->getMockModel());
-        $builder->getModel()->shouldReceive('orders')->once()->andReturn($relation = m::mock('stdClass'));
-        $builder->getModel()->shouldReceive('ordersGroups')->once()->andReturn($groupsRelation = m::mock('stdClass'));
+        $builder->getModel()->shouldReceive('orders')->once()->andReturn($relation = m::mock(\stdClass::class));
+        $builder->getModel()->shouldReceive('ordersGroups')->once()->andReturn($groupsRelation = m::mock(\stdClass::class));
 
-        $relationQuery = m::mock('stdClass');
+        $relationQuery = m::mock(\stdClass::class);
         $relation->shouldReceive('getQuery')->andReturn($relationQuery);
 
-        $groupRelationQuery = m::mock('stdClass');
+        $groupRelationQuery = m::mock(\stdClass::class);
         $groupsRelation->shouldReceive('getQuery')->andReturn($groupRelationQuery);
         $groupRelationQuery->shouldReceive('with')->once()->with(['lines' => null, 'lines.details' => null]);
 
@@ -534,7 +534,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder = $this->getBuilder();
         $builder->getQuery()->shouldReceive('foobar')->once()->andReturn('foo');
 
-        $this->assertInstanceOf('Illuminate\Database\Eloquent\Builder', $builder->foobar());
+        $this->assertInstanceOf(\Illuminate\Database\Eloquent\Builder::class, $builder->foobar());
 
         $builder = $this->getBuilder();
         $builder->getQuery()->shouldReceive('insert')->once()->with(['bar'])->andReturn('foo');
@@ -555,7 +555,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     public function testNestedWhere()
     {
-        $nestedQuery = m::mock('Illuminate\Database\Eloquent\Builder');
+        $nestedQuery = m::mock(\Illuminate\Database\Eloquent\Builder::class);
         $nestedRawQuery = $this->getMockQueryBuilder();
         $nestedQuery->shouldReceive('getQuery')->once()->andReturn($nestedRawQuery);
         $model = $this->getMockModel()->makePartial();
@@ -877,8 +877,8 @@ class DatabaseEloquentBuilderTest extends TestCase
         $processorClass = 'Illuminate\Database\Query\Processors\\'.$database.'Processor';
         $grammar = new $grammarClass;
         $processor = new $processorClass;
-        $connection = m::mock('Illuminate\Database\ConnectionInterface', ['getQueryGrammar' => $grammar, 'getPostProcessor' => $processor]);
-        $resolver = m::mock('Illuminate\Database\ConnectionResolverInterface', ['connection' => $connection]);
+        $connection = m::mock(\Illuminate\Database\ConnectionInterface::class, ['getQueryGrammar' => $grammar, 'getPostProcessor' => $processor]);
+        $resolver = m::mock(\Illuminate\Database\ConnectionResolverInterface::class, ['connection' => $connection]);
         $class = get_class($model);
         $class::setConnectionResolver($resolver);
     }
@@ -890,7 +890,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     protected function getMockModel()
     {
-        $model = m::mock('Illuminate\Database\Eloquent\Model');
+        $model = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $model->shouldReceive('getKeyName')->andReturn('foo');
         $model->shouldReceive('getTable')->andReturn('foo_table');
         $model->shouldReceive('getQualifiedKeyName')->andReturn('foo_table.foo');
@@ -900,7 +900,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     protected function getMockQueryBuilder()
     {
-        $query = m::mock('Illuminate\Database\Query\Builder');
+        $query = m::mock(\Illuminate\Database\Query\Builder::class);
         $query->shouldReceive('from')->with('foo_table');
 
         return $query;
@@ -960,17 +960,17 @@ class EloquentBuilderTestModelParentStub extends \Illuminate\Database\Eloquent\M
 {
     public function foo()
     {
-        return $this->belongsTo('Illuminate\Tests\Database\EloquentBuilderTestModelCloseRelatedStub');
+        return $this->belongsTo(\Illuminate\Tests\Database\EloquentBuilderTestModelCloseRelatedStub::class);
     }
 
     public function address()
     {
-        return $this->belongsTo('Illuminate\Tests\Database\EloquentBuilderTestModelCloseRelatedStub', 'foo_id');
+        return $this->belongsTo(\Illuminate\Tests\Database\EloquentBuilderTestModelCloseRelatedStub::class, 'foo_id');
     }
 
     public function activeFoo()
     {
-        return $this->belongsTo('Illuminate\Tests\Database\EloquentBuilderTestModelCloseRelatedStub', 'foo_id')->where('active', true);
+        return $this->belongsTo(\Illuminate\Tests\Database\EloquentBuilderTestModelCloseRelatedStub::class, 'foo_id')->where('active', true);
     }
 }
 
@@ -978,12 +978,12 @@ class EloquentBuilderTestModelCloseRelatedStub extends \Illuminate\Database\Eloq
 {
     public function bar()
     {
-        return $this->hasMany('Illuminate\Tests\Database\EloquentBuilderTestModelFarRelatedStub');
+        return $this->hasMany(\Illuminate\Tests\Database\EloquentBuilderTestModelFarRelatedStub::class);
     }
 
     public function baz()
     {
-        return $this->hasMany('Illuminate\Tests\Database\EloquentBuilderTestModelFarRelatedStub');
+        return $this->hasMany(\Illuminate\Tests\Database\EloquentBuilderTestModelFarRelatedStub::class);
     }
 }
 
@@ -997,31 +997,31 @@ class EloquentBuilderTestModelSelfRelatedStub extends \Illuminate\Database\Eloqu
 
     public function parentFoo()
     {
-        return $this->belongsTo('Illuminate\Tests\Database\EloquentBuilderTestModelSelfRelatedStub', 'parent_id', 'id', 'parent');
+        return $this->belongsTo(\Illuminate\Tests\Database\EloquentBuilderTestModelSelfRelatedStub::class, 'parent_id', 'id', 'parent');
     }
 
     public function childFoo()
     {
-        return $this->hasOne('Illuminate\Tests\Database\EloquentBuilderTestModelSelfRelatedStub', 'parent_id', 'id');
+        return $this->hasOne(\Illuminate\Tests\Database\EloquentBuilderTestModelSelfRelatedStub::class, 'parent_id', 'id');
     }
 
     public function childFoos()
     {
-        return $this->hasMany('Illuminate\Tests\Database\EloquentBuilderTestModelSelfRelatedStub', 'parent_id', 'id', 'children');
+        return $this->hasMany(\Illuminate\Tests\Database\EloquentBuilderTestModelSelfRelatedStub::class, 'parent_id', 'id', 'children');
     }
 
     public function parentBars()
     {
-        return $this->belongsToMany('Illuminate\Tests\Database\EloquentBuilderTestModelSelfRelatedStub', 'self_pivot', 'child_id', 'parent_id', 'parent_bars');
+        return $this->belongsToMany(\Illuminate\Tests\Database\EloquentBuilderTestModelSelfRelatedStub::class, 'self_pivot', 'child_id', 'parent_id', 'parent_bars');
     }
 
     public function childBars()
     {
-        return $this->belongsToMany('Illuminate\Tests\Database\EloquentBuilderTestModelSelfRelatedStub', 'self_pivot', 'parent_id', 'child_id', 'child_bars');
+        return $this->belongsToMany(\Illuminate\Tests\Database\EloquentBuilderTestModelSelfRelatedStub::class, 'self_pivot', 'parent_id', 'child_id', 'child_bars');
     }
 
     public function bazes()
     {
-        return $this->hasMany('Illuminate\Tests\Database\EloquentBuilderTestModelFarRelatedStub', 'foreign_key', 'id', 'bar');
+        return $this->hasMany(\Illuminate\Tests\Database\EloquentBuilderTestModelFarRelatedStub::class, 'foreign_key', 'id', 'bar');
     }
 }

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -44,13 +44,13 @@ class DatabaseEloquentCollectionTest extends TestCase
 
     public function testContainsIndicatesIfModelInArray()
     {
-        $mockModel = m::mock('Illuminate\Database\Eloquent\Model');
+        $mockModel = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $mockModel->shouldReceive('is')->with($mockModel)->andReturn(true);
         $mockModel->shouldReceive('is')->andReturn(false);
-        $mockModel2 = m::mock('Illuminate\Database\Eloquent\Model');
+        $mockModel2 = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $mockModel2->shouldReceive('is')->with($mockModel2)->andReturn(true);
         $mockModel2->shouldReceive('is')->andReturn(false);
-        $mockModel3 = m::mock('Illuminate\Database\Eloquent\Model');
+        $mockModel3 = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $mockModel3->shouldReceive('is')->with($mockModel3)->andReturn(true);
         $mockModel3->shouldReceive('is')->andReturn(false);
         $c = new Collection([$mockModel, $mockModel2]);
@@ -62,10 +62,10 @@ class DatabaseEloquentCollectionTest extends TestCase
 
     public function testContainsIndicatesIfDiffentModelInArray()
     {
-        $mockModelFoo = m::namedMock('Foo', 'Illuminate\Database\Eloquent\Model');
+        $mockModelFoo = m::namedMock('Foo', \Illuminate\Database\Eloquent\Model::class);
         $mockModelFoo->shouldReceive('is')->with($mockModelFoo)->andReturn(true);
         $mockModelFoo->shouldReceive('is')->andReturn(false);
-        $mockModelBar = m::namedMock('Bar', 'Illuminate\Database\Eloquent\Model');
+        $mockModelBar = m::namedMock('Bar', \Illuminate\Database\Eloquent\Model::class);
         $mockModelBar->shouldReceive('is')->with($mockModelBar)->andReturn(true);
         $mockModelBar->shouldReceive('is')->andReturn(false);
         $c = new Collection([$mockModelFoo]);
@@ -76,10 +76,10 @@ class DatabaseEloquentCollectionTest extends TestCase
 
     public function testContainsIndicatesIfKeyedModelInArray()
     {
-        $mockModel = m::mock('Illuminate\Database\Eloquent\Model');
+        $mockModel = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $mockModel->shouldReceive('getKey')->andReturn('1');
         $c = new Collection([$mockModel]);
-        $mockModel2 = m::mock('Illuminate\Database\Eloquent\Model');
+        $mockModel2 = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $mockModel2->shouldReceive('getKey')->andReturn('2');
         $c->add($mockModel2);
 
@@ -90,10 +90,10 @@ class DatabaseEloquentCollectionTest extends TestCase
 
     public function testContainsKeyAndValueIndicatesIfModelInArray()
     {
-        $mockModel1 = m::mock('Illuminate\Database\Eloquent\Model');
+        $mockModel1 = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $mockModel1->shouldReceive('offsetExists')->with('name')->andReturn(true);
         $mockModel1->shouldReceive('offsetGet')->with('name')->andReturn('Taylor');
-        $mockModel2 = m::mock('Illuminate\Database\Eloquent\Model');
+        $mockModel2 = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $mockModel2->shouldReceive('offsetExists')->andReturn(true);
         $mockModel2->shouldReceive('offsetGet')->with('name')->andReturn('Abigail');
         $c = new Collection([$mockModel1, $mockModel2]);
@@ -105,9 +105,9 @@ class DatabaseEloquentCollectionTest extends TestCase
 
     public function testContainsClosureIndicatesIfModelInArray()
     {
-        $mockModel1 = m::mock('Illuminate\Database\Eloquent\Model');
+        $mockModel1 = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $mockModel1->shouldReceive('getKey')->andReturn(1);
-        $mockModel2 = m::mock('Illuminate\Database\Eloquent\Model');
+        $mockModel2 = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $mockModel2->shouldReceive('getKey')->andReturn(2);
         $c = new Collection([$mockModel1, $mockModel2]);
 
@@ -121,7 +121,7 @@ class DatabaseEloquentCollectionTest extends TestCase
 
     public function testFindMethodFindsModelById()
     {
-        $mockModel = m::mock('Illuminate\Database\Eloquent\Model');
+        $mockModel = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $mockModel->shouldReceive('getKey')->andReturn(1);
         $c = new Collection([$mockModel]);
 
@@ -153,8 +153,8 @@ class DatabaseEloquentCollectionTest extends TestCase
 
     public function testLoadMethodEagerLoadsGivenRelationships()
     {
-        $c = $this->getMockBuilder('Illuminate\Database\Eloquent\Collection')->setMethods(['first'])->setConstructorArgs([['foo']])->getMock();
-        $mockItem = m::mock('stdClass');
+        $c = $this->getMockBuilder(\Illuminate\Database\Eloquent\Collection::class)->setMethods(['first'])->setConstructorArgs([['foo']])->getMock();
+        $mockItem = m::mock(\stdClass::class);
         $c->expects($this->once())->method('first')->will($this->returnValue($mockItem));
         $mockItem->shouldReceive('newQuery')->once()->andReturn($mockItem);
         $mockItem->shouldReceive('with')->with(['bar', 'baz'])->andReturn($mockItem);
@@ -166,13 +166,13 @@ class DatabaseEloquentCollectionTest extends TestCase
 
     public function testCollectionDictionaryReturnsModelKeys()
     {
-        $one = m::mock('Illuminate\Database\Eloquent\Model');
+        $one = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $one->shouldReceive('getKey')->andReturn(1);
 
-        $two = m::mock('Illuminate\Database\Eloquent\Model');
+        $two = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $two->shouldReceive('getKey')->andReturn(2);
 
-        $three = m::mock('Illuminate\Database\Eloquent\Model');
+        $three = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $three->shouldReceive('getKey')->andReturn(3);
 
         $c = new Collection([$one, $two, $three]);
@@ -182,13 +182,13 @@ class DatabaseEloquentCollectionTest extends TestCase
 
     public function testCollectionMergesWithGivenCollection()
     {
-        $one = m::mock('Illuminate\Database\Eloquent\Model');
+        $one = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $one->shouldReceive('getKey')->andReturn(1);
 
-        $two = m::mock('Illuminate\Database\Eloquent\Model');
+        $two = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $two->shouldReceive('getKey')->andReturn(2);
 
-        $three = m::mock('Illuminate\Database\Eloquent\Model');
+        $three = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $three->shouldReceive('getKey')->andReturn(3);
 
         $c1 = new Collection([$one, $two]);
@@ -199,8 +199,8 @@ class DatabaseEloquentCollectionTest extends TestCase
 
     public function testMap()
     {
-        $one = m::mock('Illuminate\Database\Eloquent\Model');
-        $two = m::mock('Illuminate\Database\Eloquent\Model');
+        $one = m::mock(\Illuminate\Database\Eloquent\Model::class);
+        $two = m::mock(\Illuminate\Database\Eloquent\Model::class);
 
         $c = new Collection([$one, $two]);
 
@@ -214,8 +214,8 @@ class DatabaseEloquentCollectionTest extends TestCase
 
     public function testMappingToNonModelsReturnsABaseCollection()
     {
-        $one = m::mock('Illuminate\Database\Eloquent\Model');
-        $two = m::mock('Illuminate\Database\Eloquent\Model');
+        $one = m::mock(\Illuminate\Database\Eloquent\Model::class);
+        $two = m::mock(\Illuminate\Database\Eloquent\Model::class);
 
         $c = (new Collection([$one, $two]))->map(function ($item) {
             return 'not-a-model';
@@ -226,13 +226,13 @@ class DatabaseEloquentCollectionTest extends TestCase
 
     public function testCollectionDiffsWithGivenCollection()
     {
-        $one = m::mock('Illuminate\Database\Eloquent\Model');
+        $one = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $one->shouldReceive('getKey')->andReturn(1);
 
-        $two = m::mock('Illuminate\Database\Eloquent\Model');
+        $two = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $two->shouldReceive('getKey')->andReturn(2);
 
-        $three = m::mock('Illuminate\Database\Eloquent\Model');
+        $three = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $three->shouldReceive('getKey')->andReturn(3);
 
         $c1 = new Collection([$one, $two]);
@@ -243,13 +243,13 @@ class DatabaseEloquentCollectionTest extends TestCase
 
     public function testCollectionIntersectsWithGivenCollection()
     {
-        $one = m::mock('Illuminate\Database\Eloquent\Model');
+        $one = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $one->shouldReceive('getKey')->andReturn(1);
 
-        $two = m::mock('Illuminate\Database\Eloquent\Model');
+        $two = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $two->shouldReceive('getKey')->andReturn(2);
 
-        $three = m::mock('Illuminate\Database\Eloquent\Model');
+        $three = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $three->shouldReceive('getKey')->andReturn(3);
 
         $c1 = new Collection([$one, $two]);
@@ -260,10 +260,10 @@ class DatabaseEloquentCollectionTest extends TestCase
 
     public function testCollectionReturnsUniqueItems()
     {
-        $one = m::mock('Illuminate\Database\Eloquent\Model');
+        $one = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $one->shouldReceive('getKey')->andReturn(1);
 
-        $two = m::mock('Illuminate\Database\Eloquent\Model');
+        $two = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $two->shouldReceive('getKey')->andReturn(2);
 
         $c = new Collection([$one, $two, $two]);
@@ -273,13 +273,13 @@ class DatabaseEloquentCollectionTest extends TestCase
 
     public function testOnlyReturnsCollectionWithGivenModelKeys()
     {
-        $one = m::mock('Illuminate\Database\Eloquent\Model');
+        $one = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $one->shouldReceive('getKey')->andReturn(1);
 
-        $two = m::mock('Illuminate\Database\Eloquent\Model');
+        $two = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $two->shouldReceive('getKey')->andReturn(2);
 
-        $three = m::mock('Illuminate\Database\Eloquent\Model');
+        $three = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $three->shouldReceive('getKey')->andReturn(3);
 
         $c = new Collection([$one, $two, $three]);
@@ -291,13 +291,13 @@ class DatabaseEloquentCollectionTest extends TestCase
 
     public function testExceptReturnsCollectionWithoutGivenModelKeys()
     {
-        $one = m::mock('Illuminate\Database\Eloquent\Model');
+        $one = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $one->shouldReceive('getKey')->andReturn(1);
 
-        $two = m::mock('Illuminate\Database\Eloquent\Model');
+        $two = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $two->shouldReceive('getKey')->andReturn('2');
 
-        $three = m::mock('Illuminate\Database\Eloquent\Model');
+        $three = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $three->shouldReceive('getKey')->andReturn(3);
 
         $c = new Collection([$one, $two, $three]);

--- a/tests/Database/DatabaseEloquentHasManyTest.php
+++ b/tests/Database/DatabaseEloquentHasManyTest.php
@@ -35,7 +35,7 @@ class DatabaseEloquentHasManyTest extends TestCase
     public function testFindOrNewMethodFindsModel()
     {
         $relation = $this->getRelation();
-        $relation->getQuery()->shouldReceive('find')->once()->with('foo', ['*'])->andReturn($model = m::mock('stdClass'));
+        $relation->getQuery()->shouldReceive('find')->once()->with('foo', ['*'])->andReturn($model = m::mock(\stdClass::class));
         $model->shouldReceive('setAttribute')->never();
 
         $this->assertInstanceOf(stdClass::class, $relation->findOrNew('foo'));
@@ -45,7 +45,7 @@ class DatabaseEloquentHasManyTest extends TestCase
     {
         $relation = $this->getRelation();
         $relation->getQuery()->shouldReceive('find')->once()->with('foo', ['*'])->andReturn(null);
-        $relation->getRelated()->shouldReceive('newInstance')->once()->with()->andReturn($model = m::mock('stdClass'));
+        $relation->getRelated()->shouldReceive('newInstance')->once()->with()->andReturn($model = m::mock(\stdClass::class));
         $model->shouldReceive('setAttribute')->once()->with('foreign_key', 1);
 
         $this->assertInstanceOf(stdClass::class, $relation->findOrNew('foo'));
@@ -55,7 +55,7 @@ class DatabaseEloquentHasManyTest extends TestCase
     {
         $relation = $this->getRelation();
         $relation->getQuery()->shouldReceive('where')->once()->with(['foo'])->andReturn($relation->getQuery());
-        $relation->getQuery()->shouldReceive('first')->once()->with()->andReturn($model = m::mock('stdClass'));
+        $relation->getQuery()->shouldReceive('first')->once()->with()->andReturn($model = m::mock(\stdClass::class));
         $model->shouldReceive('setAttribute')->never();
 
         $this->assertInstanceOf(stdClass::class, $relation->firstOrNew(['foo']));
@@ -65,7 +65,7 @@ class DatabaseEloquentHasManyTest extends TestCase
     {
         $relation = $this->getRelation();
         $relation->getQuery()->shouldReceive('where')->once()->with(['foo' => 'bar'])->andReturn($relation->getQuery());
-        $relation->getQuery()->shouldReceive('first')->once()->with()->andReturn($model = m::mock('stdClass'));
+        $relation->getQuery()->shouldReceive('first')->once()->with()->andReturn($model = m::mock(\stdClass::class));
         $relation->getRelated()->shouldReceive('newInstance')->never();
         $model->shouldReceive('setAttribute')->never();
 
@@ -96,7 +96,7 @@ class DatabaseEloquentHasManyTest extends TestCase
     {
         $relation = $this->getRelation();
         $relation->getQuery()->shouldReceive('where')->once()->with(['foo'])->andReturn($relation->getQuery());
-        $relation->getQuery()->shouldReceive('first')->once()->with()->andReturn($model = m::mock('stdClass'));
+        $relation->getQuery()->shouldReceive('first')->once()->with()->andReturn($model = m::mock(\stdClass::class));
         $relation->getRelated()->shouldReceive('newInstance')->never();
         $model->shouldReceive('setAttribute')->never();
         $model->shouldReceive('save')->never();
@@ -108,7 +108,7 @@ class DatabaseEloquentHasManyTest extends TestCase
     {
         $relation = $this->getRelation();
         $relation->getQuery()->shouldReceive('where')->once()->with(['foo' => 'bar'])->andReturn($relation->getQuery());
-        $relation->getQuery()->shouldReceive('first')->once()->with()->andReturn($model = m::mock('stdClass'));
+        $relation->getQuery()->shouldReceive('first')->once()->with()->andReturn($model = m::mock(\stdClass::class));
         $relation->getRelated()->shouldReceive('newInstance')->never();
         $model->shouldReceive('setAttribute')->never();
         $model->shouldReceive('save')->never();
@@ -140,7 +140,7 @@ class DatabaseEloquentHasManyTest extends TestCase
     {
         $relation = $this->getRelation();
         $relation->getQuery()->shouldReceive('where')->once()->with(['foo'])->andReturn($relation->getQuery());
-        $relation->getQuery()->shouldReceive('first')->once()->with()->andReturn($model = m::mock('stdClass'));
+        $relation->getQuery()->shouldReceive('first')->once()->with()->andReturn($model = m::mock(\stdClass::class));
         $relation->getRelated()->shouldReceive('newInstance')->never();
         $model->shouldReceive('fill')->once()->with(['bar']);
         $model->shouldReceive('save')->once();
@@ -153,7 +153,7 @@ class DatabaseEloquentHasManyTest extends TestCase
         $relation = $this->getRelation();
         $relation->getQuery()->shouldReceive('where')->once()->with(['foo'])->andReturn($relation->getQuery());
         $relation->getQuery()->shouldReceive('first')->once()->with()->andReturn(null);
-        $relation->getRelated()->shouldReceive('newInstance')->once()->with(['foo'])->andReturn($model = m::mock('stdClass'));
+        $relation->getRelated()->shouldReceive('newInstance')->once()->with(['foo'])->andReturn($model = m::mock(\stdClass::class));
         $model->shouldReceive('save')->once()->andReturn(true);
         $model->shouldReceive('fill')->once()->with(['bar']);
         $model->shouldReceive('setAttribute')->once()->with('foreign_key', 1);
@@ -175,11 +175,11 @@ class DatabaseEloquentHasManyTest extends TestCase
     public function testRelationIsProperlyInitialized()
     {
         $relation = $this->getRelation();
-        $model = m::mock('Illuminate\Database\Eloquent\Model');
+        $model = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $relation->getRelated()->shouldReceive('newCollection')->andReturnUsing(function ($array = []) {
             return new Collection($array);
         });
-        $model->shouldReceive('setRelation')->once()->with('foo', m::type('Illuminate\Database\Eloquent\Collection'));
+        $model->shouldReceive('setRelation')->once()->with('foo', m::type(\Illuminate\Database\Eloquent\Collection::class));
         $models = $relation->initRelation([$model], 'foo');
 
         $this->assertEquals([$model], $models);
@@ -248,12 +248,12 @@ class DatabaseEloquentHasManyTest extends TestCase
 
     protected function getRelation()
     {
-        $builder = m::mock('Illuminate\Database\Eloquent\Builder');
+        $builder = m::mock(\Illuminate\Database\Eloquent\Builder::class);
         $builder->shouldReceive('whereNotNull')->with('table.foreign_key');
         $builder->shouldReceive('where')->with('table.foreign_key', '=', 1);
-        $related = m::mock('Illuminate\Database\Eloquent\Model');
+        $related = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $builder->shouldReceive('getModel')->andReturn($related);
-        $parent = m::mock('Illuminate\Database\Eloquent\Model');
+        $parent = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $parent->shouldReceive('getAttribute')->with('id')->andReturn(1);
         $parent->shouldReceive('getCreatedAtColumn')->andReturn('created_at');
         $parent->shouldReceive('getUpdatedAtColumn')->andReturn('updated_at');
@@ -263,7 +263,7 @@ class DatabaseEloquentHasManyTest extends TestCase
 
     protected function expectNewModel($relation, $attributes = null)
     {
-        $model = $this->getMockBuilder('Illuminate\Database\Eloquent\Model')->setMethods(['setAttribute', 'save'])->getMock();
+        $model = $this->getMockBuilder(\Illuminate\Database\Eloquent\Model::class)->setMethods(['setAttribute', 'save'])->getMock();
         $relation->getRelated()->shouldReceive('newInstance')->with($attributes)->andReturn($model);
         $model->expects($this->once())->method('setAttribute')->with('foreign_key', 1);
 

--- a/tests/Database/DatabaseEloquentHasOneTest.php
+++ b/tests/Database/DatabaseEloquentHasOneTest.php
@@ -76,7 +76,7 @@ class DatabaseEloquentHasOneTest extends TestCase
     public function testMakeMethodDoesNotSaveNewModel()
     {
         $relation = $this->getRelation();
-        $instance = $this->getMockBuilder('Illuminate\Database\Eloquent\Model')->setMethods(['save', 'newInstance', 'setAttribute'])->getMock();
+        $instance = $this->getMockBuilder(\Illuminate\Database\Eloquent\Model::class)->setMethods(['save', 'newInstance', 'setAttribute'])->getMock();
         $relation->getRelated()->shouldReceive('newInstance')->with(['name' => 'taylor'])->andReturn($instance);
         $instance->expects($this->once())->method('setAttribute')->with('foreign_key', 1);
         $instance->expects($this->never())->method('save');
@@ -87,7 +87,7 @@ class DatabaseEloquentHasOneTest extends TestCase
     public function testSaveMethodSetsForeignKeyOnModel()
     {
         $relation = $this->getRelation();
-        $mockModel = $this->getMockBuilder('Illuminate\Database\Eloquent\Model')->setMethods(['save'])->getMock();
+        $mockModel = $this->getMockBuilder(\Illuminate\Database\Eloquent\Model::class)->setMethods(['save'])->getMock();
         $mockModel->expects($this->once())->method('save')->will($this->returnValue(true));
         $result = $relation->save($mockModel);
 
@@ -98,7 +98,7 @@ class DatabaseEloquentHasOneTest extends TestCase
     public function testCreateMethodProperlyCreatesNewModel()
     {
         $relation = $this->getRelation();
-        $created = $this->getMockBuilder('Illuminate\Database\Eloquent\Model')->setMethods(['save', 'getKey', 'setAttribute'])->getMock();
+        $created = $this->getMockBuilder(\Illuminate\Database\Eloquent\Model::class)->setMethods(['save', 'getKey', 'setAttribute'])->getMock();
         $created->expects($this->once())->method('save')->will($this->returnValue(true));
         $relation->getRelated()->shouldReceive('newInstance')->once()->with(['name' => 'taylor'])->andReturn($created);
         $created->expects($this->once())->method('setAttribute')->with('foreign_key', 1);
@@ -120,7 +120,7 @@ class DatabaseEloquentHasOneTest extends TestCase
     public function testRelationIsProperlyInitialized()
     {
         $relation = $this->getRelation();
-        $model = m::mock('Illuminate\Database\Eloquent\Model');
+        $model = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $model->shouldReceive('setRelation')->once()->with('foo', null);
         $models = $relation->initRelation([$model], 'foo');
 
@@ -164,17 +164,17 @@ class DatabaseEloquentHasOneTest extends TestCase
     public function testRelationCountQueryCanBeBuilt()
     {
         $relation = $this->getRelation();
-        $builder = m::mock('Illuminate\Database\Eloquent\Builder');
+        $builder = m::mock(\Illuminate\Database\Eloquent\Builder::class);
 
-        $baseQuery = m::mock('Illuminate\Database\Query\Builder');
+        $baseQuery = m::mock(\Illuminate\Database\Query\Builder::class);
         $baseQuery->from = 'one';
-        $parentQuery = m::mock('Illuminate\Database\Query\Builder');
+        $parentQuery = m::mock(\Illuminate\Database\Query\Builder::class);
         $parentQuery->from = 'two';
 
         $builder->shouldReceive('getQuery')->once()->andReturn($baseQuery);
         $builder->shouldReceive('getQuery')->once()->andReturn($parentQuery);
 
-        $builder->shouldReceive('select')->once()->with(m::type('Illuminate\Database\Query\Expression'))->andReturnSelf();
+        $builder->shouldReceive('select')->once()->with(m::type(\Illuminate\Database\Query\Expression::class))->andReturnSelf();
         $relation->getParent()->shouldReceive('getTable')->andReturn('table');
         $builder->shouldReceive('whereColumn')->once()->with('table.id', '=', 'table.foreign_key');
 
@@ -183,12 +183,12 @@ class DatabaseEloquentHasOneTest extends TestCase
 
     protected function getRelation()
     {
-        $this->builder = m::mock('Illuminate\Database\Eloquent\Builder');
+        $this->builder = m::mock(\Illuminate\Database\Eloquent\Builder::class);
         $this->builder->shouldReceive('whereNotNull')->with('table.foreign_key');
         $this->builder->shouldReceive('where')->with('table.foreign_key', '=', 1);
-        $this->related = m::mock('Illuminate\Database\Eloquent\Model');
+        $this->related = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $this->builder->shouldReceive('getModel')->andReturn($this->related);
-        $this->parent = m::mock('Illuminate\Database\Eloquent\Model');
+        $this->parent = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $this->parent->shouldReceive('getAttribute')->with('id')->andReturn(1);
         $this->parent->shouldReceive('getCreatedAtColumn')->andReturn('created_at');
         $this->parent->shouldReceive('getUpdatedAtColumn')->andReturn('updated_at');

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -132,22 +132,22 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertTrue(isset($model->friends));
 
         $model = EloquentTestUser::find(1);
-        $this->assertInstanceOf('Illuminate\Tests\Database\EloquentTestUser', $model);
+        $this->assertInstanceOf(\Illuminate\Tests\Database\EloquentTestUser::class, $model);
         $this->assertEquals(1, $model->id);
 
         $model = EloquentTestUser::find(2);
-        $this->assertInstanceOf('Illuminate\Tests\Database\EloquentTestUser', $model);
+        $this->assertInstanceOf(\Illuminate\Tests\Database\EloquentTestUser::class, $model);
         $this->assertEquals(2, $model->id);
 
         $missing = EloquentTestUser::find(3);
         $this->assertNull($missing);
 
         $collection = EloquentTestUser::find([]);
-        $this->assertInstanceOf('Illuminate\Database\Eloquent\Collection', $collection);
+        $this->assertInstanceOf(\Illuminate\Database\Eloquent\Collection::class, $collection);
         $this->assertEquals(0, $collection->count());
 
         $collection = EloquentTestUser::find([1, 2, 3]);
-        $this->assertInstanceOf('Illuminate\Database\Eloquent\Collection', $collection);
+        $this->assertInstanceOf(\Illuminate\Database\Eloquent\Collection::class, $collection);
         $this->assertEquals(2, $collection->count());
 
         $models = EloquentTestUser::where('id', 1)->cursor();
@@ -174,9 +174,9 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $models = EloquentTestUser::oldest('id')->get();
 
         $this->assertEquals(2, $models->count());
-        $this->assertInstanceOf('Illuminate\Database\Eloquent\Collection', $models);
-        $this->assertInstanceOf('Illuminate\Tests\Database\EloquentTestUser', $models[0]);
-        $this->assertInstanceOf('Illuminate\Tests\Database\EloquentTestUser', $models[1]);
+        $this->assertInstanceOf(\Illuminate\Database\Eloquent\Collection::class, $models);
+        $this->assertInstanceOf(\Illuminate\Tests\Database\EloquentTestUser::class, $models[0]);
+        $this->assertInstanceOf(\Illuminate\Tests\Database\EloquentTestUser::class, $models[1]);
         $this->assertEquals('taylorotwell@gmail.com', $models[0]->email);
         $this->assertEquals('abigailotwell@gmail.com', $models[1]->email);
     }
@@ -193,9 +193,9 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $models = EloquentTestUser::oldest('id')->paginate(2);
 
         $this->assertEquals(2, $models->count());
-        $this->assertInstanceOf('Illuminate\Pagination\LengthAwarePaginator', $models);
-        $this->assertInstanceOf('Illuminate\Tests\Database\EloquentTestUser', $models[0]);
-        $this->assertInstanceOf('Illuminate\Tests\Database\EloquentTestUser', $models[1]);
+        $this->assertInstanceOf(\Illuminate\Pagination\LengthAwarePaginator::class, $models);
+        $this->assertInstanceOf(\Illuminate\Tests\Database\EloquentTestUser::class, $models[0]);
+        $this->assertInstanceOf(\Illuminate\Tests\Database\EloquentTestUser::class, $models[1]);
         $this->assertEquals('taylorotwell@gmail.com', $models[0]->email);
         $this->assertEquals('abigailotwell@gmail.com', $models[1]->email);
 
@@ -205,8 +205,8 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $models = EloquentTestUser::oldest('id')->paginate(2);
 
         $this->assertEquals(1, $models->count());
-        $this->assertInstanceOf('Illuminate\Pagination\LengthAwarePaginator', $models);
-        $this->assertInstanceOf('Illuminate\Tests\Database\EloquentTestUser', $models[0]);
+        $this->assertInstanceOf(\Illuminate\Pagination\LengthAwarePaginator::class, $models);
+        $this->assertInstanceOf(\Illuminate\Tests\Database\EloquentTestUser::class, $models[0]);
         $this->assertEquals('foo@gmail.com', $models[0]->email);
     }
 
@@ -218,7 +218,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $models = EloquentTestUser::oldest('id')->paginate(2);
 
         $this->assertEquals(0, $models->count());
-        $this->assertInstanceOf('Illuminate\Pagination\LengthAwarePaginator', $models);
+        $this->assertInstanceOf(\Illuminate\Pagination\LengthAwarePaginator::class, $models);
 
         Paginator::currentPageResolver(function () {
             return 2;
@@ -233,7 +233,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $models = EloquentTestUser::oldest('id')->paginate();
 
         $this->assertEquals(0, $models->count());
-        $this->assertInstanceOf('Illuminate\Pagination\LengthAwarePaginator', $models);
+        $this->assertInstanceOf(\Illuminate\Pagination\LengthAwarePaginator::class, $models);
     }
 
     public function testCountForPaginationWithGrouping()
@@ -386,11 +386,11 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $single = EloquentTestUser::findOrFail(1);
         $multiple = EloquentTestUser::findOrFail([1, 2]);
 
-        $this->assertInstanceOf('Illuminate\Tests\Database\EloquentTestUser', $single);
+        $this->assertInstanceOf(\Illuminate\Tests\Database\EloquentTestUser::class, $single);
         $this->assertEquals('taylorotwell@gmail.com', $single->email);
-        $this->assertInstanceOf('Illuminate\Database\Eloquent\Collection', $multiple);
-        $this->assertInstanceOf('Illuminate\Tests\Database\EloquentTestUser', $multiple[0]);
-        $this->assertInstanceOf('Illuminate\Tests\Database\EloquentTestUser', $multiple[1]);
+        $this->assertInstanceOf(\Illuminate\Database\Eloquent\Collection::class, $multiple);
+        $this->assertInstanceOf(\Illuminate\Tests\Database\EloquentTestUser::class, $multiple[0]);
+        $this->assertInstanceOf(\Illuminate\Tests\Database\EloquentTestUser::class, $multiple[1]);
     }
 
     /**
@@ -419,8 +419,8 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $user = $post->user;
 
         $this->assertTrue(isset($user->post->name));
-        $this->assertInstanceOf('Illuminate\Tests\Database\EloquentTestUser', $user);
-        $this->assertInstanceOf('Illuminate\Tests\Database\EloquentTestPost', $post);
+        $this->assertInstanceOf(\Illuminate\Tests\Database\EloquentTestUser::class, $user);
+        $this->assertInstanceOf(\Illuminate\Tests\Database\EloquentTestPost::class, $post);
         $this->assertEquals('taylorotwell@gmail.com', $user->email);
         $this->assertEquals('First Post', $post->name);
     }
@@ -442,13 +442,13 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $posts = $user->posts;
         $post2 = $user->posts()->where('name', 'Second Post')->first();
 
-        $this->assertInstanceOf('Illuminate\Database\Eloquent\Collection', $posts);
+        $this->assertInstanceOf(\Illuminate\Database\Eloquent\Collection::class, $posts);
         $this->assertEquals(2, $posts->count());
-        $this->assertInstanceOf('Illuminate\Tests\Database\EloquentTestPost', $posts[0]);
-        $this->assertInstanceOf('Illuminate\Tests\Database\EloquentTestPost', $posts[1]);
-        $this->assertInstanceOf('Illuminate\Tests\Database\EloquentTestPost', $post2);
+        $this->assertInstanceOf(\Illuminate\Tests\Database\EloquentTestPost::class, $posts[0]);
+        $this->assertInstanceOf(\Illuminate\Tests\Database\EloquentTestPost::class, $posts[1]);
+        $this->assertInstanceOf(\Illuminate\Tests\Database\EloquentTestPost::class, $post2);
         $this->assertEquals('Second Post', $post2->name);
-        $this->assertInstanceOf('Illuminate\Tests\Database\EloquentTestUser', $post2->user);
+        $this->assertInstanceOf(\Illuminate\Tests\Database\EloquentTestUser::class, $post2->user);
         $this->assertEquals('taylorotwell@gmail.com', $post2->user->email);
     }
 
@@ -464,8 +464,8 @@ class DatabaseEloquentIntegrationTest extends TestCase
 
         $models = EloquentTestUser::on('second_connection')->fromQuery('SELECT * FROM users WHERE email = ?', ['abigailotwell@gmail.com']);
 
-        $this->assertInstanceOf('Illuminate\Database\Eloquent\Collection', $models);
-        $this->assertInstanceOf('Illuminate\Tests\Database\EloquentTestUser', $models[0]);
+        $this->assertInstanceOf(\Illuminate\Database\Eloquent\Collection::class, $models);
+        $this->assertInstanceOf(\Illuminate\Tests\Database\EloquentTestUser::class, $models[0]);
         $this->assertEquals('abigailotwell@gmail.com', $models[0]->email);
         $this->assertEquals('second_connection', $models[0]->getConnectionName());
         $this->assertEquals(1, $models->count());
@@ -724,10 +724,10 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $post->photos()->create(['name' => 'Hero 1']);
         $post->photos()->create(['name' => 'Hero 2']);
 
-        $this->assertInstanceOf('Illuminate\Database\Eloquent\Collection', $user->photos);
-        $this->assertInstanceOf('Illuminate\Tests\Database\EloquentTestPhoto', $user->photos[0]);
-        $this->assertInstanceOf('Illuminate\Database\Eloquent\Collection', $post->photos);
-        $this->assertInstanceOf('Illuminate\Tests\Database\EloquentTestPhoto', $post->photos[0]);
+        $this->assertInstanceOf(\Illuminate\Database\Eloquent\Collection::class, $user->photos);
+        $this->assertInstanceOf(\Illuminate\Tests\Database\EloquentTestPhoto::class, $user->photos[0]);
+        $this->assertInstanceOf(\Illuminate\Database\Eloquent\Collection::class, $post->photos);
+        $this->assertInstanceOf(\Illuminate\Tests\Database\EloquentTestPhoto::class, $post->photos[0]);
         $this->assertEquals(2, $user->photos->count());
         $this->assertEquals(2, $post->photos->count());
         $this->assertEquals('Avatar 1', $user->photos[0]->name);
@@ -737,10 +737,10 @@ class DatabaseEloquentIntegrationTest extends TestCase
 
         $photos = EloquentTestPhoto::orderBy('name')->get();
 
-        $this->assertInstanceOf('Illuminate\Database\Eloquent\Collection', $photos);
+        $this->assertInstanceOf(\Illuminate\Database\Eloquent\Collection::class, $photos);
         $this->assertEquals(4, $photos->count());
-        $this->assertInstanceOf('Illuminate\Tests\Database\EloquentTestUser', $photos[0]->imageable);
-        $this->assertInstanceOf('Illuminate\Tests\Database\EloquentTestPost', $photos[2]->imageable);
+        $this->assertInstanceOf(\Illuminate\Tests\Database\EloquentTestUser::class, $photos[0]->imageable);
+        $this->assertInstanceOf(\Illuminate\Tests\Database\EloquentTestPost::class, $photos[2]->imageable);
         $this->assertEquals('taylorotwell@gmail.com', $photos[1]->imageable->email);
         $this->assertEquals('First Post', $photos[3]->imageable->name);
     }
@@ -748,8 +748,8 @@ class DatabaseEloquentIntegrationTest extends TestCase
     public function testMorphMapIsUsedForCreatingAndFetchingThroughRelation()
     {
         Relation::morphMap([
-            'user' => 'Illuminate\Tests\Database\EloquentTestUser',
-            'post' => 'Illuminate\Tests\Database\EloquentTestPost',
+            'user' => \Illuminate\Tests\Database\EloquentTestUser::class,
+            'post' => \Illuminate\Tests\Database\EloquentTestPost::class,
         ]);
 
         $user = EloquentTestUser::create(['email' => 'taylorotwell@gmail.com']);
@@ -759,10 +759,10 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $post->photos()->create(['name' => 'Hero 1']);
         $post->photos()->create(['name' => 'Hero 2']);
 
-        $this->assertInstanceOf('Illuminate\Database\Eloquent\Collection', $user->photos);
-        $this->assertInstanceOf('Illuminate\Tests\Database\EloquentTestPhoto', $user->photos[0]);
-        $this->assertInstanceOf('Illuminate\Database\Eloquent\Collection', $post->photos);
-        $this->assertInstanceOf('Illuminate\Tests\Database\EloquentTestPhoto', $post->photos[0]);
+        $this->assertInstanceOf(\Illuminate\Database\Eloquent\Collection::class, $user->photos);
+        $this->assertInstanceOf(\Illuminate\Tests\Database\EloquentTestPhoto::class, $user->photos[0]);
+        $this->assertInstanceOf(\Illuminate\Database\Eloquent\Collection::class, $post->photos);
+        $this->assertInstanceOf(\Illuminate\Tests\Database\EloquentTestPhoto::class, $post->photos[0]);
         $this->assertEquals(2, $user->photos->count());
         $this->assertEquals(2, $post->photos->count());
         $this->assertEquals('Avatar 1', $user->photos[0]->name);
@@ -779,8 +779,8 @@ class DatabaseEloquentIntegrationTest extends TestCase
     public function testMorphMapIsUsedWhenFetchingParent()
     {
         Relation::morphMap([
-            'user' => 'Illuminate\Tests\Database\EloquentTestUser',
-            'post' => 'Illuminate\Tests\Database\EloquentTestPost',
+            'user' => \Illuminate\Tests\Database\EloquentTestUser::class,
+            'post' => \Illuminate\Tests\Database\EloquentTestPost::class,
         ]);
 
         $user = EloquentTestUser::create(['email' => 'taylorotwell@gmail.com']);
@@ -788,16 +788,16 @@ class DatabaseEloquentIntegrationTest extends TestCase
 
         $photo = EloquentTestPhoto::first();
         $this->assertEquals('user', $photo->imageable_type);
-        $this->assertInstanceOf('Illuminate\Tests\Database\EloquentTestUser', $photo->imageable);
+        $this->assertInstanceOf(\Illuminate\Tests\Database\EloquentTestUser::class, $photo->imageable);
     }
 
     public function testMorphMapIsMergedByDefault()
     {
         $map1 = [
-            'user' => 'Illuminate\Tests\Database\EloquentTestUser',
+            'user' => \Illuminate\Tests\Database\EloquentTestUser::class,
         ];
         $map2 = [
-            'post' => 'Illuminate\Tests\Database\EloquentTestPost',
+            'post' => \Illuminate\Tests\Database\EloquentTestPost::class,
         ];
 
         Relation::morphMap($map1);
@@ -809,10 +809,10 @@ class DatabaseEloquentIntegrationTest extends TestCase
     public function testMorphMapOverwritesCurrentMap()
     {
         $map1 = [
-            'user' => 'Illuminate\Tests\Database\EloquentTestUser',
+            'user' => \Illuminate\Tests\Database\EloquentTestUser::class,
         ];
         $map2 = [
-            'post' => 'Illuminate\Tests\Database\EloquentTestPost',
+            'post' => \Illuminate\Tests\Database\EloquentTestPost::class,
         ];
 
         Relation::morphMap($map1, false);
@@ -1037,7 +1037,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
             // ignore the exception
         }
 
-        $this->assertInstanceOf('Illuminate\Tests\Database\EloquentTestItem', $item);
+        $this->assertInstanceOf(\Illuminate\Tests\Database\EloquentTestItem::class, $item);
     }
 
     public function testBelongsToManyCustomPivot()
@@ -1150,32 +1150,32 @@ class EloquentTestUser extends Eloquent
 
     public function friends()
     {
-        return $this->belongsToMany('Illuminate\Tests\Database\EloquentTestUser', 'friends', 'user_id', 'friend_id');
+        return $this->belongsToMany(\Illuminate\Tests\Database\EloquentTestUser::class, 'friends', 'user_id', 'friend_id');
     }
 
     public function friendsOne()
     {
-        return $this->belongsToMany('Illuminate\Tests\Database\EloquentTestUser', 'friends', 'user_id', 'friend_id')->wherePivot('user_id', 1);
+        return $this->belongsToMany(\Illuminate\Tests\Database\EloquentTestUser::class, 'friends', 'user_id', 'friend_id')->wherePivot('user_id', 1);
     }
 
     public function friendsTwo()
     {
-        return $this->belongsToMany('Illuminate\Tests\Database\EloquentTestUser', 'friends', 'user_id', 'friend_id')->wherePivot('user_id', 2);
+        return $this->belongsToMany(\Illuminate\Tests\Database\EloquentTestUser::class, 'friends', 'user_id', 'friend_id')->wherePivot('user_id', 2);
     }
 
     public function posts()
     {
-        return $this->hasMany('Illuminate\Tests\Database\EloquentTestPost', 'user_id');
+        return $this->hasMany(\Illuminate\Tests\Database\EloquentTestPost::class, 'user_id');
     }
 
     public function post()
     {
-        return $this->hasOne('Illuminate\Tests\Database\EloquentTestPost', 'user_id');
+        return $this->hasOne(\Illuminate\Tests\Database\EloquentTestPost::class, 'user_id');
     }
 
     public function photos()
     {
-        return $this->morphMany('Illuminate\Tests\Database\EloquentTestPhoto', 'imageable');
+        return $this->morphMany(\Illuminate\Tests\Database\EloquentTestPhoto::class, 'imageable');
     }
 
     public function postWithPhotos()
@@ -1191,8 +1191,8 @@ class EloquentTestUserWithCustomFriendPivot extends EloquentTestUser
 {
     public function friends()
     {
-        return $this->belongsToMany('Illuminate\Tests\Database\EloquentTestUser', 'friends', 'user_id', 'friend_id')
-                        ->using('Illuminate\Tests\Database\EloquentTestFriendPivot')->withPivot('user_id', 'friend_id', 'friend_level_id');
+        return $this->belongsToMany(\Illuminate\Tests\Database\EloquentTestUser::class, 'friends', 'user_id', 'friend_id')
+                        ->using(\Illuminate\Tests\Database\EloquentTestFriendPivot::class)->withPivot('user_id', 'friend_id', 'friend_level_id');
     }
 }
 
@@ -1235,22 +1235,22 @@ class EloquentTestPost extends Eloquent
 
     public function user()
     {
-        return $this->belongsTo('Illuminate\Tests\Database\EloquentTestUser', 'user_id');
+        return $this->belongsTo(\Illuminate\Tests\Database\EloquentTestUser::class, 'user_id');
     }
 
     public function photos()
     {
-        return $this->morphMany('Illuminate\Tests\Database\EloquentTestPhoto', 'imageable');
+        return $this->morphMany(\Illuminate\Tests\Database\EloquentTestPhoto::class, 'imageable');
     }
 
     public function childPosts()
     {
-        return $this->hasMany('Illuminate\Tests\Database\EloquentTestPost', 'parent_id');
+        return $this->hasMany(\Illuminate\Tests\Database\EloquentTestPost::class, 'parent_id');
     }
 
     public function parentPost()
     {
-        return $this->belongsTo('Illuminate\Tests\Database\EloquentTestPost', 'parent_id');
+        return $this->belongsTo(\Illuminate\Tests\Database\EloquentTestPost::class, 'parent_id');
     }
 }
 

--- a/tests/Database/DatabaseEloquentIntegrationWithTablePrefixTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationWithTablePrefixTest.php
@@ -84,8 +84,8 @@ class DatabaseEloquentIntegrationWithTablePrefixTest extends TestCase
 
         $models = EloquentTestUser::fromQuery('SELECT * FROM prefix_users WHERE email = ?', ['abigailotwell@gmail.com']);
 
-        $this->assertInstanceOf('Illuminate\Database\Eloquent\Collection', $models);
-        $this->assertInstanceOf('Illuminate\Tests\Database\EloquentTestUser', $models[0]);
+        $this->assertInstanceOf(\Illuminate\Database\Eloquent\Collection::class, $models);
+        $this->assertInstanceOf(\Illuminate\Tests\Database\EloquentTestUser::class, $models[0]);
         $this->assertEquals('abigailotwell@gmail.com', $models[0]->email);
         $this->assertEquals(1, $models->count());
     }

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -153,7 +153,7 @@ class DatabaseEloquentModelTest extends TestCase
     {
         $model = new EloquentModelStub;
         $instance = $model->newInstance(['name' => 'taylor']);
-        $this->assertInstanceOf('Illuminate\Tests\Database\EloquentModelStub', $instance);
+        $this->assertInstanceOf(\Illuminate\Tests\Database\EloquentModelStub::class, $instance);
         $this->assertEquals('taylor', $instance->name);
     }
 
@@ -224,13 +224,13 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testUpdateProcess()
     {
-        $model = $this->getMockBuilder('Illuminate\Tests\Database\EloquentModelStub')->setMethods(['newQueryWithoutScopes', 'updateTimestamps'])->getMock();
-        $query = m::mock('Illuminate\Database\Eloquent\Builder');
+        $model = $this->getMockBuilder(\Illuminate\Tests\Database\EloquentModelStub::class)->setMethods(['newQueryWithoutScopes', 'updateTimestamps'])->getMock();
+        $query = m::mock(\Illuminate\Database\Eloquent\Builder::class);
         $query->shouldReceive('where')->once()->with('id', '=', 1);
         $query->shouldReceive('update')->once()->with(['name' => 'taylor'])->andReturn(1);
         $model->expects($this->once())->method('newQueryWithoutScopes')->will($this->returnValue($query));
         $model->expects($this->once())->method('updateTimestamps');
-        $model->setEventDispatcher($events = m::mock('Illuminate\Contracts\Events\Dispatcher'));
+        $model->setEventDispatcher($events = m::mock(\Illuminate\Contracts\Events\Dispatcher::class));
         $events->shouldReceive('until')->once()->with('eloquent.saving: '.get_class($model), $model)->andReturn(true);
         $events->shouldReceive('until')->once()->with('eloquent.updating: '.get_class($model), $model)->andReturn(true);
         $events->shouldReceive('fire')->once()->with('eloquent.updated: '.get_class($model), $model)->andReturn(true);
@@ -247,12 +247,12 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testUpdateProcessDoesntOverrideTimestamps()
     {
-        $model = $this->getMockBuilder('Illuminate\Tests\Database\EloquentModelStub')->setMethods(['newQueryWithoutScopes'])->getMock();
-        $query = m::mock('Illuminate\Database\Eloquent\Builder');
+        $model = $this->getMockBuilder(\Illuminate\Tests\Database\EloquentModelStub::class)->setMethods(['newQueryWithoutScopes'])->getMock();
+        $query = m::mock(\Illuminate\Database\Eloquent\Builder::class);
         $query->shouldReceive('where')->once()->with('id', '=', 1);
         $query->shouldReceive('update')->once()->with(['created_at' => 'foo', 'updated_at' => 'bar'])->andReturn(1);
         $model->expects($this->once())->method('newQueryWithoutScopes')->will($this->returnValue($query));
-        $model->setEventDispatcher($events = m::mock('Illuminate\Contracts\Events\Dispatcher'));
+        $model->setEventDispatcher($events = m::mock(\Illuminate\Contracts\Events\Dispatcher::class));
         $events->shouldReceive('until');
         $events->shouldReceive('fire');
 
@@ -266,10 +266,10 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testSaveIsCancelledIfSavingEventReturnsFalse()
     {
-        $model = $this->getMockBuilder('Illuminate\Tests\Database\EloquentModelStub')->setMethods(['newQueryWithoutScopes'])->getMock();
-        $query = m::mock('Illuminate\Database\Eloquent\Builder');
+        $model = $this->getMockBuilder(\Illuminate\Tests\Database\EloquentModelStub::class)->setMethods(['newQueryWithoutScopes'])->getMock();
+        $query = m::mock(\Illuminate\Database\Eloquent\Builder::class);
         $model->expects($this->once())->method('newQueryWithoutScopes')->will($this->returnValue($query));
-        $model->setEventDispatcher($events = m::mock('Illuminate\Contracts\Events\Dispatcher'));
+        $model->setEventDispatcher($events = m::mock(\Illuminate\Contracts\Events\Dispatcher::class));
         $events->shouldReceive('until')->once()->with('eloquent.saving: '.get_class($model), $model)->andReturn(false);
         $model->exists = true;
 
@@ -278,10 +278,10 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testUpdateIsCancelledIfUpdatingEventReturnsFalse()
     {
-        $model = $this->getMockBuilder('Illuminate\Tests\Database\EloquentModelStub')->setMethods(['newQueryWithoutScopes'])->getMock();
-        $query = m::mock('Illuminate\Database\Eloquent\Builder');
+        $model = $this->getMockBuilder(\Illuminate\Tests\Database\EloquentModelStub::class)->setMethods(['newQueryWithoutScopes'])->getMock();
+        $query = m::mock(\Illuminate\Database\Eloquent\Builder::class);
         $model->expects($this->once())->method('newQueryWithoutScopes')->will($this->returnValue($query));
-        $model->setEventDispatcher($events = m::mock('Illuminate\Contracts\Events\Dispatcher'));
+        $model->setEventDispatcher($events = m::mock(\Illuminate\Contracts\Events\Dispatcher::class));
         $events->shouldReceive('until')->once()->with('eloquent.saving: '.get_class($model), $model)->andReturn(true);
         $events->shouldReceive('until')->once()->with('eloquent.updating: '.get_class($model), $model)->andReturn(false);
         $model->exists = true;
@@ -292,10 +292,10 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testEventsCanBeFiredWithCustomEventObjects()
     {
-        $model = $this->getMockBuilder('Illuminate\Tests\Database\EloquentModelEventObjectStub')->setMethods(['newQueryWithoutScopes'])->getMock();
-        $query = m::mock('Illuminate\Database\Eloquent\Builder');
+        $model = $this->getMockBuilder(\Illuminate\Tests\Database\EloquentModelEventObjectStub::class)->setMethods(['newQueryWithoutScopes'])->getMock();
+        $query = m::mock(\Illuminate\Database\Eloquent\Builder::class);
         $model->expects($this->once())->method('newQueryWithoutScopes')->will($this->returnValue($query));
-        $model->setEventDispatcher($events = m::mock('Illuminate\Contracts\Events\Dispatcher'));
+        $model->setEventDispatcher($events = m::mock(\Illuminate\Contracts\Events\Dispatcher::class));
         $events->shouldReceive('until')->once()->with(m::type(EloquentModelSavingEventStub::class))->andReturn(false);
         $model->exists = true;
 
@@ -304,9 +304,9 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testUpdateProcessWithoutTimestamps()
     {
-        $model = $this->getMockBuilder('Illuminate\Tests\Database\EloquentModelEventObjectStub')->setMethods(['newQueryWithoutScopes', 'updateTimestamps', 'fireModelEvent'])->getMock();
+        $model = $this->getMockBuilder(\Illuminate\Tests\Database\EloquentModelEventObjectStub::class)->setMethods(['newQueryWithoutScopes', 'updateTimestamps', 'fireModelEvent'])->getMock();
         $model->timestamps = false;
-        $query = m::mock('Illuminate\Database\Eloquent\Builder');
+        $query = m::mock(\Illuminate\Database\Eloquent\Builder::class);
         $query->shouldReceive('where')->once()->with('id', '=', 1);
         $query->shouldReceive('update')->once()->with(['name' => 'taylor'])->andReturn(1);
         $model->expects($this->once())->method('newQueryWithoutScopes')->will($this->returnValue($query));
@@ -322,13 +322,13 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testUpdateUsesOldPrimaryKey()
     {
-        $model = $this->getMockBuilder('Illuminate\Tests\Database\EloquentModelStub')->setMethods(['newQueryWithoutScopes', 'updateTimestamps'])->getMock();
-        $query = m::mock('Illuminate\Database\Eloquent\Builder');
+        $model = $this->getMockBuilder(\Illuminate\Tests\Database\EloquentModelStub::class)->setMethods(['newQueryWithoutScopes', 'updateTimestamps'])->getMock();
+        $query = m::mock(\Illuminate\Database\Eloquent\Builder::class);
         $query->shouldReceive('where')->once()->with('id', '=', 1);
         $query->shouldReceive('update')->once()->with(['id' => 2, 'foo' => 'bar'])->andReturn(1);
         $model->expects($this->once())->method('newQueryWithoutScopes')->will($this->returnValue($query));
         $model->expects($this->once())->method('updateTimestamps');
-        $model->setEventDispatcher($events = m::mock('Illuminate\Contracts\Events\Dispatcher'));
+        $model->setEventDispatcher($events = m::mock(\Illuminate\Contracts\Events\Dispatcher::class));
         $events->shouldReceive('until')->once()->with('eloquent.saving: '.get_class($model), $model)->andReturn(true);
         $events->shouldReceive('until')->once()->with('eloquent.updating: '.get_class($model), $model)->andReturn(true);
         $events->shouldReceive('fire')->once()->with('eloquent.updated: '.get_class($model), $model)->andReturn(true);
@@ -345,7 +345,7 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testTimestampsAreReturnedAsObjects()
     {
-        $model = $this->getMockBuilder('Illuminate\Tests\Database\EloquentDateModelStub')->setMethods(['getDateFormat'])->getMock();
+        $model = $this->getMockBuilder(\Illuminate\Tests\Database\EloquentDateModelStub::class)->setMethods(['getDateFormat'])->getMock();
         $model->expects($this->any())->method('getDateFormat')->will($this->returnValue('Y-m-d'));
         $model->setRawAttributes([
             'created_at' => '2012-12-04',
@@ -358,7 +358,7 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testTimestampsAreReturnedAsObjectsFromPlainDatesAndTimestamps()
     {
-        $model = $this->getMockBuilder('Illuminate\Tests\Database\EloquentDateModelStub')->setMethods(['getDateFormat'])->getMock();
+        $model = $this->getMockBuilder(\Illuminate\Tests\Database\EloquentDateModelStub::class)->setMethods(['getDateFormat'])->getMock();
         $model->expects($this->any())->method('getDateFormat')->will($this->returnValue('Y-m-d H:i:s'));
         $model->setRawAttributes([
             'created_at' => '2012-12-04',
@@ -376,8 +376,8 @@ class DatabaseEloquentModelTest extends TestCase
             'updated_at' => \Carbon\Carbon::now(),
         ];
         $model = new EloquentDateModelStub;
-        \Illuminate\Database\Eloquent\Model::setConnectionResolver($resolver = m::mock('Illuminate\Database\ConnectionResolverInterface'));
-        $resolver->shouldReceive('connection')->andReturn($mockConnection = m::mock('stdClass'));
+        \Illuminate\Database\Eloquent\Model::setConnectionResolver($resolver = m::mock(\Illuminate\Database\ConnectionResolverInterface::class));
+        $resolver->shouldReceive('connection')->andReturn($mockConnection = m::mock(\stdClass::class));
         $mockConnection->shouldReceive('getQueryGrammar')->andReturn($mockConnection);
         $mockConnection->shouldReceive('getDateFormat')->andReturn('Y-m-d H:i:s');
         $instance = $model->newInstance($timestamps);
@@ -392,8 +392,8 @@ class DatabaseEloquentModelTest extends TestCase
             'updated_at' => \Carbon\Carbon::now(),
         ];
         $model = new EloquentDateModelStub;
-        \Illuminate\Database\Eloquent\Model::setConnectionResolver($resolver = m::mock('Illuminate\Database\ConnectionResolverInterface'));
-        $resolver->shouldReceive('connection')->andReturn($mockConnection = m::mock('stdClass'));
+        \Illuminate\Database\Eloquent\Model::setConnectionResolver($resolver = m::mock(\Illuminate\Database\ConnectionResolverInterface::class));
+        $resolver->shouldReceive('connection')->andReturn($mockConnection = m::mock(\stdClass::class));
         $mockConnection->shouldReceive('getQueryGrammar')->andReturn($mockConnection);
         $mockConnection->shouldReceive('getDateFormat')->andReturn('Y-m-d H:i:s');
         $instance = $model->newInstance($timestamps);
@@ -453,13 +453,13 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testInsertProcess()
     {
-        $model = $this->getMockBuilder('Illuminate\Tests\Database\EloquentModelStub')->setMethods(['newQueryWithoutScopes', 'updateTimestamps', 'refresh'])->getMock();
-        $query = m::mock('Illuminate\Database\Eloquent\Builder');
+        $model = $this->getMockBuilder(\Illuminate\Tests\Database\EloquentModelStub::class)->setMethods(['newQueryWithoutScopes', 'updateTimestamps', 'refresh'])->getMock();
+        $query = m::mock(\Illuminate\Database\Eloquent\Builder::class);
         $query->shouldReceive('insertGetId')->once()->with(['name' => 'taylor'], 'id')->andReturn(1);
         $model->expects($this->once())->method('newQueryWithoutScopes')->will($this->returnValue($query));
         $model->expects($this->once())->method('updateTimestamps');
 
-        $model->setEventDispatcher($events = m::mock('Illuminate\Contracts\Events\Dispatcher'));
+        $model->setEventDispatcher($events = m::mock(\Illuminate\Contracts\Events\Dispatcher::class));
         $events->shouldReceive('until')->once()->with('eloquent.saving: '.get_class($model), $model)->andReturn(true);
         $events->shouldReceive('until')->once()->with('eloquent.creating: '.get_class($model), $model)->andReturn(true);
         $events->shouldReceive('fire')->once()->with('eloquent.created: '.get_class($model), $model);
@@ -471,14 +471,14 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEquals(1, $model->id);
         $this->assertTrue($model->exists);
 
-        $model = $this->getMockBuilder('Illuminate\Tests\Database\EloquentModelStub')->setMethods(['newQueryWithoutScopes', 'updateTimestamps', 'refresh'])->getMock();
-        $query = m::mock('Illuminate\Database\Eloquent\Builder');
+        $model = $this->getMockBuilder(\Illuminate\Tests\Database\EloquentModelStub::class)->setMethods(['newQueryWithoutScopes', 'updateTimestamps', 'refresh'])->getMock();
+        $query = m::mock(\Illuminate\Database\Eloquent\Builder::class);
         $query->shouldReceive('insert')->once()->with(['name' => 'taylor']);
         $model->expects($this->once())->method('newQueryWithoutScopes')->will($this->returnValue($query));
         $model->expects($this->once())->method('updateTimestamps');
         $model->setIncrementing(false);
 
-        $model->setEventDispatcher($events = m::mock('Illuminate\Contracts\Events\Dispatcher'));
+        $model->setEventDispatcher($events = m::mock(\Illuminate\Contracts\Events\Dispatcher::class));
         $events->shouldReceive('until')->once()->with('eloquent.saving: '.get_class($model), $model)->andReturn(true);
         $events->shouldReceive('until')->once()->with('eloquent.creating: '.get_class($model), $model)->andReturn(true);
         $events->shouldReceive('fire')->once()->with('eloquent.created: '.get_class($model), $model);
@@ -493,10 +493,10 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testInsertIsCancelledIfCreatingEventReturnsFalse()
     {
-        $model = $this->getMockBuilder('Illuminate\Tests\Database\EloquentModelStub')->setMethods(['newQueryWithoutScopes'])->getMock();
-        $query = m::mock('Illuminate\Database\Eloquent\Builder');
+        $model = $this->getMockBuilder(\Illuminate\Tests\Database\EloquentModelStub::class)->setMethods(['newQueryWithoutScopes'])->getMock();
+        $query = m::mock(\Illuminate\Database\Eloquent\Builder::class);
         $model->expects($this->once())->method('newQueryWithoutScopes')->will($this->returnValue($query));
-        $model->setEventDispatcher($events = m::mock('Illuminate\Contracts\Events\Dispatcher'));
+        $model->setEventDispatcher($events = m::mock(\Illuminate\Contracts\Events\Dispatcher::class));
         $events->shouldReceive('until')->once()->with('eloquent.saving: '.get_class($model), $model)->andReturn(true);
         $events->shouldReceive('until')->once()->with('eloquent.creating: '.get_class($model), $model)->andReturn(false);
 
@@ -506,8 +506,8 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testDeleteProperlyDeletesModel()
     {
-        $model = $this->getMockBuilder('Illuminate\Database\Eloquent\Model')->setMethods(['newQueryWithoutScopes', 'updateTimestamps', 'touchOwners'])->getMock();
-        $query = m::mock('Illuminate\Database\Eloquent\Builder');
+        $model = $this->getMockBuilder(\Illuminate\Database\Eloquent\Model::class)->setMethods(['newQueryWithoutScopes', 'updateTimestamps', 'touchOwners'])->getMock();
+        $query = m::mock(\Illuminate\Database\Eloquent\Builder::class);
         $query->shouldReceive('where')->once()->with('id', '=', 1)->andReturn($query);
         $query->shouldReceive('delete')->once();
         $model->expects($this->once())->method('newQueryWithoutScopes')->will($this->returnValue($query));
@@ -519,8 +519,8 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testPushNoRelations()
     {
-        $model = $this->getMockBuilder('Illuminate\Tests\Database\EloquentModelStub')->setMethods(['newQueryWithoutScopes', 'updateTimestamps', 'refresh'])->getMock();
-        $query = m::mock('Illuminate\Database\Eloquent\Builder');
+        $model = $this->getMockBuilder(\Illuminate\Tests\Database\EloquentModelStub::class)->setMethods(['newQueryWithoutScopes', 'updateTimestamps', 'refresh'])->getMock();
+        $query = m::mock(\Illuminate\Database\Eloquent\Builder::class);
         $query->shouldReceive('insertGetId')->once()->with(['name' => 'taylor'], 'id')->andReturn(1);
         $model->expects($this->once())->method('newQueryWithoutScopes')->will($this->returnValue($query));
         $model->expects($this->once())->method('updateTimestamps');
@@ -535,8 +535,8 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testPushEmptyOneRelation()
     {
-        $model = $this->getMockBuilder('Illuminate\Tests\Database\EloquentModelStub')->setMethods(['newQueryWithoutScopes', 'updateTimestamps', 'refresh'])->getMock();
-        $query = m::mock('Illuminate\Database\Eloquent\Builder');
+        $model = $this->getMockBuilder(\Illuminate\Tests\Database\EloquentModelStub::class)->setMethods(['newQueryWithoutScopes', 'updateTimestamps', 'refresh'])->getMock();
+        $query = m::mock(\Illuminate\Database\Eloquent\Builder::class);
         $query->shouldReceive('insertGetId')->once()->with(['name' => 'taylor'], 'id')->andReturn(1);
         $model->expects($this->once())->method('newQueryWithoutScopes')->will($this->returnValue($query));
         $model->expects($this->once())->method('updateTimestamps');
@@ -553,16 +553,16 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testPushOneRelation()
     {
-        $related1 = $this->getMockBuilder('Illuminate\Tests\Database\EloquentModelStub')->setMethods(['newQueryWithoutScopes', 'updateTimestamps', 'refresh'])->getMock();
-        $query = m::mock('Illuminate\Database\Eloquent\Builder');
+        $related1 = $this->getMockBuilder(\Illuminate\Tests\Database\EloquentModelStub::class)->setMethods(['newQueryWithoutScopes', 'updateTimestamps', 'refresh'])->getMock();
+        $query = m::mock(\Illuminate\Database\Eloquent\Builder::class);
         $query->shouldReceive('insertGetId')->once()->with(['name' => 'related1'], 'id')->andReturn(2);
         $related1->expects($this->once())->method('newQueryWithoutScopes')->will($this->returnValue($query));
         $related1->expects($this->once())->method('updateTimestamps');
         $related1->name = 'related1';
         $related1->exists = false;
 
-        $model = $this->getMockBuilder('Illuminate\Tests\Database\EloquentModelStub')->setMethods(['newQueryWithoutScopes', 'updateTimestamps', 'refresh'])->getMock();
-        $query = m::mock('Illuminate\Database\Eloquent\Builder');
+        $model = $this->getMockBuilder(\Illuminate\Tests\Database\EloquentModelStub::class)->setMethods(['newQueryWithoutScopes', 'updateTimestamps', 'refresh'])->getMock();
+        $query = m::mock(\Illuminate\Database\Eloquent\Builder::class);
         $query->shouldReceive('insertGetId')->once()->with(['name' => 'taylor'], 'id')->andReturn(1);
         $model->expects($this->once())->method('newQueryWithoutScopes')->will($this->returnValue($query));
         $model->expects($this->once())->method('updateTimestamps');
@@ -582,8 +582,8 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testPushEmptyManyRelation()
     {
-        $model = $this->getMockBuilder('Illuminate\Tests\Database\EloquentModelStub')->setMethods(['newQueryWithoutScopes', 'updateTimestamps', 'refresh'])->getMock();
-        $query = m::mock('Illuminate\Database\Eloquent\Builder');
+        $model = $this->getMockBuilder(\Illuminate\Tests\Database\EloquentModelStub::class)->setMethods(['newQueryWithoutScopes', 'updateTimestamps', 'refresh'])->getMock();
+        $query = m::mock(\Illuminate\Database\Eloquent\Builder::class);
         $query->shouldReceive('insertGetId')->once()->with(['name' => 'taylor'], 'id')->andReturn(1);
         $model->expects($this->once())->method('newQueryWithoutScopes')->will($this->returnValue($query));
         $model->expects($this->once())->method('updateTimestamps');
@@ -600,24 +600,24 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testPushManyRelation()
     {
-        $related1 = $this->getMockBuilder('Illuminate\Tests\Database\EloquentModelStub')->setMethods(['newQueryWithoutScopes', 'updateTimestamps', 'refresh'])->getMock();
-        $query = m::mock('Illuminate\Database\Eloquent\Builder');
+        $related1 = $this->getMockBuilder(\Illuminate\Tests\Database\EloquentModelStub::class)->setMethods(['newQueryWithoutScopes', 'updateTimestamps', 'refresh'])->getMock();
+        $query = m::mock(\Illuminate\Database\Eloquent\Builder::class);
         $query->shouldReceive('insertGetId')->once()->with(['name' => 'related1'], 'id')->andReturn(2);
         $related1->expects($this->once())->method('newQueryWithoutScopes')->will($this->returnValue($query));
         $related1->expects($this->once())->method('updateTimestamps');
         $related1->name = 'related1';
         $related1->exists = false;
 
-        $related2 = $this->getMockBuilder('Illuminate\Tests\Database\EloquentModelStub')->setMethods(['newQueryWithoutScopes', 'updateTimestamps', 'refresh'])->getMock();
-        $query = m::mock('Illuminate\Database\Eloquent\Builder');
+        $related2 = $this->getMockBuilder(\Illuminate\Tests\Database\EloquentModelStub::class)->setMethods(['newQueryWithoutScopes', 'updateTimestamps', 'refresh'])->getMock();
+        $query = m::mock(\Illuminate\Database\Eloquent\Builder::class);
         $query->shouldReceive('insertGetId')->once()->with(['name' => 'related2'], 'id')->andReturn(3);
         $related2->expects($this->once())->method('newQueryWithoutScopes')->will($this->returnValue($query));
         $related2->expects($this->once())->method('updateTimestamps');
         $related2->name = 'related2';
         $related2->exists = false;
 
-        $model = $this->getMockBuilder('Illuminate\Tests\Database\EloquentModelStub')->setMethods(['newQueryWithoutScopes', 'updateTimestamps', 'refresh'])->getMock();
-        $query = m::mock('Illuminate\Database\Eloquent\Builder');
+        $model = $this->getMockBuilder(\Illuminate\Tests\Database\EloquentModelStub::class)->setMethods(['newQueryWithoutScopes', 'updateTimestamps', 'refresh'])->getMock();
+        $query = m::mock(\Illuminate\Database\Eloquent\Builder::class);
         $query->shouldReceive('insertGetId')->once()->with(['name' => 'taylor'], 'id')->andReturn(1);
         $model->expects($this->once())->method('newQueryWithoutScopes')->will($this->returnValue($query));
         $model->expects($this->once())->method('updateTimestamps');
@@ -635,16 +635,16 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testNewQueryReturnsEloquentQueryBuilder()
     {
-        $conn = m::mock('Illuminate\Database\Connection');
-        $grammar = m::mock('Illuminate\Database\Query\Grammars\Grammar');
-        $processor = m::mock('Illuminate\Database\Query\Processors\Processor');
+        $conn = m::mock(\Illuminate\Database\Connection::class);
+        $grammar = m::mock(\Illuminate\Database\Query\Grammars\Grammar::class);
+        $processor = m::mock(\Illuminate\Database\Query\Processors\Processor::class);
         $conn->shouldReceive('getQueryGrammar')->once()->andReturn($grammar);
         $conn->shouldReceive('getPostProcessor')->once()->andReturn($processor);
-        EloquentModelStub::setConnectionResolver($resolver = m::mock('Illuminate\Database\ConnectionResolverInterface'));
+        EloquentModelStub::setConnectionResolver($resolver = m::mock(\Illuminate\Database\ConnectionResolverInterface::class));
         $resolver->shouldReceive('connection')->andReturn($conn);
         $model = new EloquentModelStub;
         $builder = $model->newQuery();
-        $this->assertInstanceOf('Illuminate\Database\Eloquent\Builder', $builder);
+        $this->assertInstanceOf(\Illuminate\Database\Eloquent\Builder::class, $builder);
     }
 
     public function testGetAndSetTableOperations()
@@ -665,7 +665,7 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testConnectionManagement()
     {
-        EloquentModelStub::setConnectionResolver($resolver = m::mock('Illuminate\Database\ConnectionResolverInterface'));
+        EloquentModelStub::setConnectionResolver($resolver = m::mock(\Illuminate\Database\ConnectionResolverInterface::class));
         $model = m::mock('Illuminate\Tests\Database\EloquentModelStub[getConnectionName,connection]');
 
         $retval = $model->setConnection('foo');
@@ -962,25 +962,25 @@ class DatabaseEloquentModelTest extends TestCase
     {
         $model = new EloquentModelStub;
         $this->addMockConnection($model);
-        $relation = $model->hasOne('Illuminate\Tests\Database\EloquentModelSaveStub');
+        $relation = $model->hasOne(\Illuminate\Tests\Database\EloquentModelSaveStub::class);
         $this->assertEquals('save_stub.eloquent_model_stub_id', $relation->getQualifiedForeignKeyName());
 
         $model = new EloquentModelStub;
         $this->addMockConnection($model);
-        $relation = $model->hasOne('Illuminate\Tests\Database\EloquentModelSaveStub', 'foo');
+        $relation = $model->hasOne(\Illuminate\Tests\Database\EloquentModelSaveStub::class, 'foo');
         $this->assertEquals('save_stub.foo', $relation->getQualifiedForeignKeyName());
         $this->assertSame($model, $relation->getParent());
-        $this->assertInstanceOf('Illuminate\Tests\Database\EloquentModelSaveStub', $relation->getQuery()->getModel());
+        $this->assertInstanceOf(\Illuminate\Tests\Database\EloquentModelSaveStub::class, $relation->getQuery()->getModel());
     }
 
     public function testMorphOneCreatesProperRelation()
     {
         $model = new EloquentModelStub;
         $this->addMockConnection($model);
-        $relation = $model->morphOne('Illuminate\Tests\Database\EloquentModelSaveStub', 'morph');
+        $relation = $model->morphOne(\Illuminate\Tests\Database\EloquentModelSaveStub::class, 'morph');
         $this->assertEquals('save_stub.morph_id', $relation->getQualifiedForeignKeyName());
         $this->assertEquals('save_stub.morph_type', $relation->getQualifiedMorphType());
-        $this->assertEquals('Illuminate\Tests\Database\EloquentModelStub', $relation->getMorphClass());
+        $this->assertEquals(\Illuminate\Tests\Database\EloquentModelStub::class, $relation->getMorphClass());
     }
 
     public function testCorrectMorphClassIsReturned()
@@ -989,7 +989,7 @@ class DatabaseEloquentModelTest extends TestCase
         $model = new EloquentModelStub;
 
         try {
-            $this->assertEquals('Illuminate\Tests\Database\EloquentModelStub', $model->getMorphClass());
+            $this->assertEquals(\Illuminate\Tests\Database\EloquentModelStub::class, $model->getMorphClass());
         } finally {
             Relation::morphMap([], false);
         }
@@ -999,26 +999,26 @@ class DatabaseEloquentModelTest extends TestCase
     {
         $model = new EloquentModelStub;
         $this->addMockConnection($model);
-        $relation = $model->hasMany('Illuminate\Tests\Database\EloquentModelSaveStub');
+        $relation = $model->hasMany(\Illuminate\Tests\Database\EloquentModelSaveStub::class);
         $this->assertEquals('save_stub.eloquent_model_stub_id', $relation->getQualifiedForeignKeyName());
 
         $model = new EloquentModelStub;
         $this->addMockConnection($model);
-        $relation = $model->hasMany('Illuminate\Tests\Database\EloquentModelSaveStub', 'foo');
+        $relation = $model->hasMany(\Illuminate\Tests\Database\EloquentModelSaveStub::class, 'foo');
 
         $this->assertEquals('save_stub.foo', $relation->getQualifiedForeignKeyName());
         $this->assertSame($model, $relation->getParent());
-        $this->assertInstanceOf('Illuminate\Tests\Database\EloquentModelSaveStub', $relation->getQuery()->getModel());
+        $this->assertInstanceOf(\Illuminate\Tests\Database\EloquentModelSaveStub::class, $relation->getQuery()->getModel());
     }
 
     public function testMorphManyCreatesProperRelation()
     {
         $model = new EloquentModelStub;
         $this->addMockConnection($model);
-        $relation = $model->morphMany('Illuminate\Tests\Database\EloquentModelSaveStub', 'morph');
+        $relation = $model->morphMany(\Illuminate\Tests\Database\EloquentModelSaveStub::class, 'morph');
         $this->assertEquals('save_stub.morph_id', $relation->getQualifiedForeignKeyName());
         $this->assertEquals('save_stub.morph_type', $relation->getQualifiedMorphType());
-        $this->assertEquals('Illuminate\Tests\Database\EloquentModelStub', $relation->getMorphClass());
+        $this->assertEquals(\Illuminate\Tests\Database\EloquentModelStub::class, $relation->getMorphClass());
     }
 
     public function testBelongsToCreatesProperRelation()
@@ -1028,7 +1028,7 @@ class DatabaseEloquentModelTest extends TestCase
         $relation = $model->belongsToStub();
         $this->assertEquals('belongs_to_stub_id', $relation->getForeignKey());
         $this->assertSame($model, $relation->getParent());
-        $this->assertInstanceOf('Illuminate\Tests\Database\EloquentModelSaveStub', $relation->getQuery()->getModel());
+        $this->assertInstanceOf(\Illuminate\Tests\Database\EloquentModelSaveStub::class, $relation->getQuery()->getModel());
 
         $model = new EloquentModelStub;
         $this->addMockConnection($model);
@@ -1047,7 +1047,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEquals('morph_to_stub_type', $relation->getMorphType());
         $this->assertEquals('morphToStub', $relation->getRelation());
         $this->assertSame($model, $relation->getParent());
-        $this->assertInstanceOf('Illuminate\Tests\Database\EloquentModelSaveStub', $relation->getQuery()->getModel());
+        $this->assertInstanceOf(\Illuminate\Tests\Database\EloquentModelSaveStub::class, $relation->getQuery()->getModel());
 
         // $this->morphTo(null, 'type', 'id');
         $relation2 = $model->morphToStubWithKeys();
@@ -1073,20 +1073,20 @@ class DatabaseEloquentModelTest extends TestCase
         $model = new EloquentModelStub;
         $this->addMockConnection($model);
 
-        $relation = $model->belongsToMany('Illuminate\Tests\Database\EloquentModelSaveStub');
+        $relation = $model->belongsToMany(\Illuminate\Tests\Database\EloquentModelSaveStub::class);
         $this->assertEquals('eloquent_model_save_stub_eloquent_model_stub.eloquent_model_stub_id', $relation->getQualifiedForeignPivotKeyName());
         $this->assertEquals('eloquent_model_save_stub_eloquent_model_stub.eloquent_model_save_stub_id', $relation->getQualifiedRelatedPivotKeyName());
         $this->assertSame($model, $relation->getParent());
-        $this->assertInstanceOf('Illuminate\Tests\Database\EloquentModelSaveStub', $relation->getQuery()->getModel());
+        $this->assertInstanceOf(\Illuminate\Tests\Database\EloquentModelSaveStub::class, $relation->getQuery()->getModel());
         $this->assertEquals(__FUNCTION__, $relation->getRelationName());
 
         $model = new EloquentModelStub;
         $this->addMockConnection($model);
-        $relation = $model->belongsToMany('Illuminate\Tests\Database\EloquentModelSaveStub', 'table', 'foreign', 'other');
+        $relation = $model->belongsToMany(\Illuminate\Tests\Database\EloquentModelSaveStub::class, 'table', 'foreign', 'other');
         $this->assertEquals('table.foreign', $relation->getQualifiedForeignPivotKeyName());
         $this->assertEquals('table.other', $relation->getQualifiedRelatedPivotKeyName());
         $this->assertSame($model, $relation->getParent());
-        $this->assertInstanceOf('Illuminate\Tests\Database\EloquentModelSaveStub', $relation->getQuery()->getModel());
+        $this->assertInstanceOf(\Illuminate\Tests\Database\EloquentModelSaveStub::class, $relation->getQuery()->getModel());
     }
 
     public function testRelationsWithVariedConnections()
@@ -1095,78 +1095,78 @@ class DatabaseEloquentModelTest extends TestCase
         $model = new EloquentModelStub;
         $model->setConnection('non_default');
         $this->addMockConnection($model);
-        $relation = $model->hasOne('Illuminate\Tests\Database\EloquentNoConnectionModelStub');
+        $relation = $model->hasOne(\Illuminate\Tests\Database\EloquentNoConnectionModelStub::class);
         $this->assertEquals('non_default', $relation->getRelated()->getConnectionName());
 
         $model = new EloquentModelStub;
         $model->setConnection('non_default');
         $this->addMockConnection($model);
-        $relation = $model->hasOne('Illuminate\Tests\Database\EloquentDifferentConnectionModelStub');
+        $relation = $model->hasOne(\Illuminate\Tests\Database\EloquentDifferentConnectionModelStub::class);
         $this->assertEquals('different_connection', $relation->getRelated()->getConnectionName());
 
         // Morph One
         $model = new EloquentModelStub;
         $model->setConnection('non_default');
         $this->addMockConnection($model);
-        $relation = $model->morphOne('Illuminate\Tests\Database\EloquentNoConnectionModelStub', 'type');
+        $relation = $model->morphOne(\Illuminate\Tests\Database\EloquentNoConnectionModelStub::class, 'type');
         $this->assertEquals('non_default', $relation->getRelated()->getConnectionName());
 
         $model = new EloquentModelStub;
         $model->setConnection('non_default');
         $this->addMockConnection($model);
-        $relation = $model->morphOne('Illuminate\Tests\Database\EloquentDifferentConnectionModelStub', 'type');
+        $relation = $model->morphOne(\Illuminate\Tests\Database\EloquentDifferentConnectionModelStub::class, 'type');
         $this->assertEquals('different_connection', $relation->getRelated()->getConnectionName());
 
         // Belongs to
         $model = new EloquentModelStub;
         $model->setConnection('non_default');
         $this->addMockConnection($model);
-        $relation = $model->belongsTo('Illuminate\Tests\Database\EloquentNoConnectionModelStub');
+        $relation = $model->belongsTo(\Illuminate\Tests\Database\EloquentNoConnectionModelStub::class);
         $this->assertEquals('non_default', $relation->getRelated()->getConnectionName());
 
         $model = new EloquentModelStub;
         $model->setConnection('non_default');
         $this->addMockConnection($model);
-        $relation = $model->belongsTo('Illuminate\Tests\Database\EloquentDifferentConnectionModelStub');
+        $relation = $model->belongsTo(\Illuminate\Tests\Database\EloquentDifferentConnectionModelStub::class);
         $this->assertEquals('different_connection', $relation->getRelated()->getConnectionName());
 
         // has many
         $model = new EloquentModelStub;
         $model->setConnection('non_default');
         $this->addMockConnection($model);
-        $relation = $model->hasMany('Illuminate\Tests\Database\EloquentNoConnectionModelStub');
+        $relation = $model->hasMany(\Illuminate\Tests\Database\EloquentNoConnectionModelStub::class);
         $this->assertEquals('non_default', $relation->getRelated()->getConnectionName());
 
         $model = new EloquentModelStub;
         $model->setConnection('non_default');
         $this->addMockConnection($model);
-        $relation = $model->hasMany('Illuminate\Tests\Database\EloquentDifferentConnectionModelStub');
+        $relation = $model->hasMany(\Illuminate\Tests\Database\EloquentDifferentConnectionModelStub::class);
         $this->assertEquals('different_connection', $relation->getRelated()->getConnectionName());
 
         // has many through
         $model = new EloquentModelStub;
         $model->setConnection('non_default');
         $this->addMockConnection($model);
-        $relation = $model->hasManyThrough('Illuminate\Tests\Database\EloquentNoConnectionModelStub', 'Illuminate\Tests\Database\EloquentModelSaveStub');
+        $relation = $model->hasManyThrough(\Illuminate\Tests\Database\EloquentNoConnectionModelStub::class, \Illuminate\Tests\Database\EloquentModelSaveStub::class);
         $this->assertEquals('non_default', $relation->getRelated()->getConnectionName());
 
         $model = new EloquentModelStub;
         $model->setConnection('non_default');
         $this->addMockConnection($model);
-        $relation = $model->hasManyThrough('Illuminate\Tests\Database\EloquentDifferentConnectionModelStub', 'Illuminate\Tests\Database\EloquentModelSaveStub');
+        $relation = $model->hasManyThrough(\Illuminate\Tests\Database\EloquentDifferentConnectionModelStub::class, \Illuminate\Tests\Database\EloquentModelSaveStub::class);
         $this->assertEquals('different_connection', $relation->getRelated()->getConnectionName());
 
         // belongs to many
         $model = new EloquentModelStub;
         $model->setConnection('non_default');
         $this->addMockConnection($model);
-        $relation = $model->belongsToMany('Illuminate\Tests\Database\EloquentNoConnectionModelStub');
+        $relation = $model->belongsToMany(\Illuminate\Tests\Database\EloquentNoConnectionModelStub::class);
         $this->assertEquals('non_default', $relation->getRelated()->getConnectionName());
 
         $model = new EloquentModelStub;
         $model->setConnection('non_default');
         $this->addMockConnection($model);
-        $relation = $model->belongsToMany('Illuminate\Tests\Database\EloquentDifferentConnectionModelStub');
+        $relation = $model->belongsToMany(\Illuminate\Tests\Database\EloquentDifferentConnectionModelStub::class);
         $this->assertEquals('different_connection', $relation->getRelated()->getConnectionName());
     }
 
@@ -1231,7 +1231,7 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testModelObserversCanBeAttachedToModels()
     {
-        EloquentModelStub::setEventDispatcher($events = m::mock('Illuminate\Contracts\Events\Dispatcher'));
+        EloquentModelStub::setEventDispatcher($events = m::mock(\Illuminate\Contracts\Events\Dispatcher::class));
         $events->shouldReceive('listen')->once()->with('eloquent.creating: Illuminate\Tests\Database\EloquentModelStub', 'Illuminate\Tests\Database\EloquentTestObserverStub@creating');
         $events->shouldReceive('listen')->once()->with('eloquent.saved: Illuminate\Tests\Database\EloquentModelStub', 'Illuminate\Tests\Database\EloquentTestObserverStub@saved');
         $events->shouldReceive('forget');
@@ -1241,11 +1241,11 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testModelObserversCanBeAttachedToModelsWithString()
     {
-        EloquentModelStub::setEventDispatcher($events = m::mock('Illuminate\Contracts\Events\Dispatcher'));
+        EloquentModelStub::setEventDispatcher($events = m::mock(\Illuminate\Contracts\Events\Dispatcher::class));
         $events->shouldReceive('listen')->once()->with('eloquent.creating: Illuminate\Tests\Database\EloquentModelStub', 'Illuminate\Tests\Database\EloquentTestObserverStub@creating');
         $events->shouldReceive('listen')->once()->with('eloquent.saved: Illuminate\Tests\Database\EloquentModelStub', 'Illuminate\Tests\Database\EloquentTestObserverStub@saved');
         $events->shouldReceive('forget');
-        EloquentModelStub::observe('Illuminate\Tests\Database\EloquentTestObserverStub');
+        EloquentModelStub::observe(\Illuminate\Tests\Database\EloquentTestObserverStub::class);
         EloquentModelStub::flushEventListeners();
     }
 
@@ -1369,7 +1369,7 @@ class DatabaseEloquentModelTest extends TestCase
         $model->syncOriginalAttribute('id');
         $model->foo = 2;
 
-        $model->shouldReceive('newQuery')->andReturn($query = m::mock('stdClass'));
+        $model->shouldReceive('newQuery')->andReturn($query = m::mock(\stdClass::class));
         $query->shouldReceive('where')->andReturn($query);
         $query->shouldReceive('increment');
 
@@ -1384,7 +1384,7 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testRelationshipTouchOwnersIsPropagated()
     {
-        $relation = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\BelongsTo')->setMethods(['touch'])->disableOriginalConstructor()->getMock();
+        $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\BelongsTo::class)->setMethods(['touch'])->disableOriginalConstructor()->getMock();
         $relation->expects($this->once())->method('touch');
 
         $model = m::mock('Illuminate\Tests\Database\EloquentModelStub[partner]');
@@ -1401,7 +1401,7 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testRelationshipTouchOwnersIsNotPropagatedIfNoRelationshipResult()
     {
-        $relation = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\BelongsTo')->setMethods(['touch'])->disableOriginalConstructor()->getMock();
+        $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\BelongsTo::class)->setMethods(['touch'])->disableOriginalConstructor()->getMock();
         $relation->expects($this->once())->method('touch');
 
         $model = m::mock('Illuminate\Tests\Database\EloquentModelStub[partner]');
@@ -1595,8 +1595,8 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testIntKeyTypePreserved()
     {
-        $model = $this->getMockBuilder('Illuminate\Tests\Database\EloquentModelStub')->setMethods(['newQueryWithoutScopes', 'updateTimestamps', 'refresh'])->getMock();
-        $query = m::mock('Illuminate\Database\Eloquent\Builder');
+        $model = $this->getMockBuilder(\Illuminate\Tests\Database\EloquentModelStub::class)->setMethods(['newQueryWithoutScopes', 'updateTimestamps', 'refresh'])->getMock();
+        $query = m::mock(\Illuminate\Database\Eloquent\Builder::class);
         $query->shouldReceive('insertGetId')->once()->with([], 'id')->andReturn(1);
         $model->expects($this->once())->method('newQueryWithoutScopes')->will($this->returnValue($query));
 
@@ -1606,8 +1606,8 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testStringKeyTypePreserved()
     {
-        $model = $this->getMockBuilder('Illuminate\Tests\Database\EloquentKeyTypeModelStub')->setMethods(['newQueryWithoutScopes', 'updateTimestamps', 'refresh'])->getMock();
-        $query = m::mock('Illuminate\Database\Eloquent\Builder');
+        $model = $this->getMockBuilder(\Illuminate\Tests\Database\EloquentKeyTypeModelStub::class)->setMethods(['newQueryWithoutScopes', 'updateTimestamps', 'refresh'])->getMock();
+        $query = m::mock(\Illuminate\Database\Eloquent\Builder::class);
         $query->shouldReceive('insertGetId')->once()->with([], 'id')->andReturn('string id');
         $model->expects($this->once())->method('newQueryWithoutScopes')->will($this->returnValue($query));
 
@@ -1675,10 +1675,10 @@ class DatabaseEloquentModelTest extends TestCase
 
     protected function addMockConnection($model)
     {
-        $model->setConnectionResolver($resolver = m::mock('Illuminate\Database\ConnectionResolverInterface'));
-        $resolver->shouldReceive('connection')->andReturn(m::mock('Illuminate\Database\Connection'));
-        $model->getConnection()->shouldReceive('getQueryGrammar')->andReturn(m::mock('Illuminate\Database\Query\Grammars\Grammar'));
-        $model->getConnection()->shouldReceive('getPostProcessor')->andReturn(m::mock('Illuminate\Database\Query\Processors\Processor'));
+        $model->setConnectionResolver($resolver = m::mock(\Illuminate\Database\ConnectionResolverInterface::class));
+        $resolver->shouldReceive('connection')->andReturn(m::mock(\Illuminate\Database\Connection::class));
+        $model->getConnection()->shouldReceive('getQueryGrammar')->andReturn(m::mock(\Illuminate\Database\Query\Grammars\Grammar::class));
+        $model->getConnection()->shouldReceive('getPostProcessor')->andReturn(m::mock(\Illuminate\Database\Query\Processors\Processor::class));
     }
 }
 
@@ -1699,7 +1699,7 @@ class EloquentModelStub extends Model
     public $scopesCalled = [];
     protected $table = 'stub';
     protected $guarded = [];
-    protected $morph_to_stub_type = 'Illuminate\Tests\Database\EloquentModelSaveStub';
+    protected $morph_to_stub_type = \Illuminate\Tests\Database\EloquentModelSaveStub::class;
 
     public function getListItemsAttribute($value)
     {
@@ -1728,7 +1728,7 @@ class EloquentModelStub extends Model
 
     public function belongsToStub()
     {
-        return $this->belongsTo('Illuminate\Tests\Database\EloquentModelSaveStub');
+        return $this->belongsTo(\Illuminate\Tests\Database\EloquentModelSaveStub::class);
     }
 
     public function morphToStub()
@@ -1753,7 +1753,7 @@ class EloquentModelStub extends Model
 
     public function belongsToExplicitKeyStub()
     {
-        return $this->belongsTo('Illuminate\Tests\Database\EloquentModelSaveStub', 'foo');
+        return $this->belongsTo(\Illuminate\Tests\Database\EloquentModelSaveStub::class, 'foo');
     }
 
     public function incorrectRelationStub()
@@ -1825,7 +1825,7 @@ class EloquentModelFindWithWritePdoStub extends Model
 {
     public function newQuery()
     {
-        $mock = m::mock('Illuminate\Database\Eloquent\Builder');
+        $mock = m::mock(\Illuminate\Database\Eloquent\Builder::class);
         $mock->shouldReceive('useWritePdo')->once()->andReturnSelf();
         $mock->shouldReceive('find')->once()->with(1)->andReturn('foo');
 
@@ -1837,9 +1837,9 @@ class EloquentModelDestroyStub extends Model
 {
     public function newQuery()
     {
-        $mock = m::mock('Illuminate\Database\Eloquent\Builder');
+        $mock = m::mock(\Illuminate\Database\Eloquent\Builder::class);
         $mock->shouldReceive('whereIn')->once()->with('id', [1, 2, 3])->andReturn($mock);
-        $mock->shouldReceive('get')->once()->andReturn([$model = m::mock('stdClass')]);
+        $mock->shouldReceive('get')->once()->andReturn([$model = m::mock(\stdClass::class)]);
         $model->shouldReceive('delete')->once();
 
         return $mock;
@@ -1855,7 +1855,7 @@ class EloquentModelHydrateRawStub extends Model
 
     public function getConnection()
     {
-        $mock = m::mock('Illuminate\Database\Connection');
+        $mock = m::mock(\Illuminate\Database\Connection::class);
         $mock->shouldReceive('select')->once()->with('SELECT ?', ['foo'])->andReturn([]);
 
         return $mock;
@@ -1866,7 +1866,7 @@ class EloquentModelWithStub extends Model
 {
     public function newQuery()
     {
-        $mock = m::mock('Illuminate\Database\Eloquent\Builder');
+        $mock = m::mock(\Illuminate\Database\Eloquent\Builder::class);
         $mock->shouldReceive('with')->once()->with(['foo', 'bar'])->andReturn('foo');
 
         return $mock;

--- a/tests/Database/DatabaseEloquentMorphTest.php
+++ b/tests/Database/DatabaseEloquentMorphTest.php
@@ -63,7 +63,7 @@ class DatabaseEloquentMorphTest extends TestCase
         $_SERVER['__eloquent.saved'] = false;
         // Doesn't matter which relation type we use since they share the code...
         $relation = $this->getOneRelation();
-        $instance = m::mock('Illuminate\Database\Eloquent\Model');
+        $instance = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $instance->shouldReceive('setAttribute')->once()->with('morph_id', 1);
         $instance->shouldReceive('setAttribute')->once()->with('morph_type', get_class($relation->getParent()));
         $instance->shouldReceive('save')->never();
@@ -76,7 +76,7 @@ class DatabaseEloquentMorphTest extends TestCase
     {
         // Doesn't matter which relation type we use since they share the code...
         $relation = $this->getOneRelation();
-        $created = m::mock('Illuminate\Database\Eloquent\Model');
+        $created = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $created->shouldReceive('setAttribute')->once()->with('morph_id', 1);
         $created->shouldReceive('setAttribute')->once()->with('morph_type', get_class($relation->getParent()));
         $relation->getRelated()->shouldReceive('newInstance')->once()->with(['name' => 'taylor'])->andReturn($created);
@@ -88,7 +88,7 @@ class DatabaseEloquentMorphTest extends TestCase
     public function testFindOrNewMethodFindsModel()
     {
         $relation = $this->getOneRelation();
-        $relation->getQuery()->shouldReceive('find')->once()->with('foo', ['*'])->andReturn($model = m::mock('Illuminate\Database\Eloquent\Model'));
+        $relation->getQuery()->shouldReceive('find')->once()->with('foo', ['*'])->andReturn($model = m::mock(\Illuminate\Database\Eloquent\Model::class));
         $relation->getRelated()->shouldReceive('newInstance')->never();
         $model->shouldReceive('setAttribute')->never();
         $model->shouldReceive('save')->never();
@@ -100,7 +100,7 @@ class DatabaseEloquentMorphTest extends TestCase
     {
         $relation = $this->getOneRelation();
         $relation->getQuery()->shouldReceive('find')->once()->with('foo', ['*'])->andReturn(null);
-        $relation->getRelated()->shouldReceive('newInstance')->once()->with()->andReturn($model = m::mock('Illuminate\Database\Eloquent\Model'));
+        $relation->getRelated()->shouldReceive('newInstance')->once()->with()->andReturn($model = m::mock(\Illuminate\Database\Eloquent\Model::class));
         $model->shouldReceive('setAttribute')->once()->with('morph_id', 1);
         $model->shouldReceive('setAttribute')->once()->with('morph_type', get_class($relation->getParent()));
         $model->shouldReceive('save')->never();
@@ -112,7 +112,7 @@ class DatabaseEloquentMorphTest extends TestCase
     {
         $relation = $this->getOneRelation();
         $relation->getQuery()->shouldReceive('where')->once()->with(['foo'])->andReturn($relation->getQuery());
-        $relation->getQuery()->shouldReceive('first')->once()->with()->andReturn($model = m::mock('Illuminate\Database\Eloquent\Model'));
+        $relation->getQuery()->shouldReceive('first')->once()->with()->andReturn($model = m::mock(\Illuminate\Database\Eloquent\Model::class));
         $relation->getRelated()->shouldReceive('newInstance')->never();
         $model->shouldReceive('setAttribute')->never();
         $model->shouldReceive('save')->never();
@@ -124,7 +124,7 @@ class DatabaseEloquentMorphTest extends TestCase
     {
         $relation = $this->getOneRelation();
         $relation->getQuery()->shouldReceive('where')->once()->with(['foo' => 'bar'])->andReturn($relation->getQuery());
-        $relation->getQuery()->shouldReceive('first')->once()->with()->andReturn($model = m::mock('Illuminate\Database\Eloquent\Model'));
+        $relation->getQuery()->shouldReceive('first')->once()->with()->andReturn($model = m::mock(\Illuminate\Database\Eloquent\Model::class));
         $relation->getRelated()->shouldReceive('newInstance')->never();
         $model->shouldReceive('setAttribute')->never();
         $model->shouldReceive('save')->never();
@@ -137,7 +137,7 @@ class DatabaseEloquentMorphTest extends TestCase
         $relation = $this->getOneRelation();
         $relation->getQuery()->shouldReceive('where')->once()->with(['foo'])->andReturn($relation->getQuery());
         $relation->getQuery()->shouldReceive('first')->once()->with()->andReturn(null);
-        $relation->getRelated()->shouldReceive('newInstance')->once()->with(['foo'])->andReturn($model = m::mock('Illuminate\Database\Eloquent\Model'));
+        $relation->getRelated()->shouldReceive('newInstance')->once()->with(['foo'])->andReturn($model = m::mock(\Illuminate\Database\Eloquent\Model::class));
         $model->shouldReceive('setAttribute')->once()->with('morph_id', 1);
         $model->shouldReceive('setAttribute')->once()->with('morph_type', get_class($relation->getParent()));
         $model->shouldReceive('save')->never();
@@ -150,7 +150,7 @@ class DatabaseEloquentMorphTest extends TestCase
         $relation = $this->getOneRelation();
         $relation->getQuery()->shouldReceive('where')->once()->with(['foo' => 'bar'])->andReturn($relation->getQuery());
         $relation->getQuery()->shouldReceive('first')->once()->with()->andReturn(null);
-        $relation->getRelated()->shouldReceive('newInstance')->once()->with(['foo' => 'bar', 'baz' => 'qux'])->andReturn($model = m::mock('Illuminate\Database\Eloquent\Model'));
+        $relation->getRelated()->shouldReceive('newInstance')->once()->with(['foo' => 'bar', 'baz' => 'qux'])->andReturn($model = m::mock(\Illuminate\Database\Eloquent\Model::class));
         $model->shouldReceive('setAttribute')->once()->with('morph_id', 1);
         $model->shouldReceive('setAttribute')->once()->with('morph_type', get_class($relation->getParent()));
         $model->shouldReceive('save')->never();
@@ -162,7 +162,7 @@ class DatabaseEloquentMorphTest extends TestCase
     {
         $relation = $this->getOneRelation();
         $relation->getQuery()->shouldReceive('where')->once()->with(['foo'])->andReturn($relation->getQuery());
-        $relation->getQuery()->shouldReceive('first')->once()->with()->andReturn($model = m::mock('Illuminate\Database\Eloquent\Model'));
+        $relation->getQuery()->shouldReceive('first')->once()->with()->andReturn($model = m::mock(\Illuminate\Database\Eloquent\Model::class));
         $relation->getRelated()->shouldReceive('newInstance')->never();
         $model->shouldReceive('setAttribute')->never();
         $model->shouldReceive('save')->never();
@@ -174,7 +174,7 @@ class DatabaseEloquentMorphTest extends TestCase
     {
         $relation = $this->getOneRelation();
         $relation->getQuery()->shouldReceive('where')->once()->with(['foo' => 'bar'])->andReturn($relation->getQuery());
-        $relation->getQuery()->shouldReceive('first')->once()->with()->andReturn($model = m::mock('Illuminate\Database\Eloquent\Model'));
+        $relation->getQuery()->shouldReceive('first')->once()->with()->andReturn($model = m::mock(\Illuminate\Database\Eloquent\Model::class));
         $relation->getRelated()->shouldReceive('newInstance')->never();
         $model->shouldReceive('setAttribute')->never();
         $model->shouldReceive('save')->never();
@@ -187,7 +187,7 @@ class DatabaseEloquentMorphTest extends TestCase
         $relation = $this->getOneRelation();
         $relation->getQuery()->shouldReceive('where')->once()->with(['foo'])->andReturn($relation->getQuery());
         $relation->getQuery()->shouldReceive('first')->once()->with()->andReturn(null);
-        $relation->getRelated()->shouldReceive('newInstance')->once()->with(['foo'])->andReturn($model = m::mock('Illuminate\Database\Eloquent\Model'));
+        $relation->getRelated()->shouldReceive('newInstance')->once()->with(['foo'])->andReturn($model = m::mock(\Illuminate\Database\Eloquent\Model::class));
         $model->shouldReceive('setAttribute')->once()->with('morph_id', 1);
         $model->shouldReceive('setAttribute')->once()->with('morph_type', get_class($relation->getParent()));
         $model->shouldReceive('save')->once()->andReturn(true);
@@ -200,7 +200,7 @@ class DatabaseEloquentMorphTest extends TestCase
         $relation = $this->getOneRelation();
         $relation->getQuery()->shouldReceive('where')->once()->with(['foo' => 'bar'])->andReturn($relation->getQuery());
         $relation->getQuery()->shouldReceive('first')->once()->with()->andReturn(null);
-        $relation->getRelated()->shouldReceive('newInstance')->once()->with(['foo' => 'bar', 'baz' => 'qux'])->andReturn($model = m::mock('Illuminate\Database\Eloquent\Model'));
+        $relation->getRelated()->shouldReceive('newInstance')->once()->with(['foo' => 'bar', 'baz' => 'qux'])->andReturn($model = m::mock(\Illuminate\Database\Eloquent\Model::class));
         $model->shouldReceive('setAttribute')->once()->with('morph_id', 1);
         $model->shouldReceive('setAttribute')->once()->with('morph_type', get_class($relation->getParent()));
         $model->shouldReceive('save')->once()->andReturn(true);
@@ -212,7 +212,7 @@ class DatabaseEloquentMorphTest extends TestCase
     {
         $relation = $this->getOneRelation();
         $relation->getQuery()->shouldReceive('where')->once()->with(['foo'])->andReturn($relation->getQuery());
-        $relation->getQuery()->shouldReceive('first')->once()->with()->andReturn($model = m::mock('Illuminate\Database\Eloquent\Model'));
+        $relation->getQuery()->shouldReceive('first')->once()->with()->andReturn($model = m::mock(\Illuminate\Database\Eloquent\Model::class));
         $relation->getRelated()->shouldReceive('newInstance')->never();
         $model->shouldReceive('setAttribute')->never();
         $model->shouldReceive('fill')->once()->with(['bar']);
@@ -226,7 +226,7 @@ class DatabaseEloquentMorphTest extends TestCase
         $relation = $this->getOneRelation();
         $relation->getQuery()->shouldReceive('where')->once()->with(['foo'])->andReturn($relation->getQuery());
         $relation->getQuery()->shouldReceive('first')->once()->with()->andReturn(null);
-        $relation->getRelated()->shouldReceive('newInstance')->once()->with(['foo'])->andReturn($model = m::mock('Illuminate\Database\Eloquent\Model'));
+        $relation->getRelated()->shouldReceive('newInstance')->once()->with(['foo'])->andReturn($model = m::mock(\Illuminate\Database\Eloquent\Model::class));
         $model->shouldReceive('setAttribute')->once()->with('morph_id', 1);
         $model->shouldReceive('setAttribute')->once()->with('morph_type', get_class($relation->getParent()));
         $model->shouldReceive('save')->once()->andReturn(true);
@@ -238,7 +238,7 @@ class DatabaseEloquentMorphTest extends TestCase
     public function testCreateFunctionOnNamespacedMorph()
     {
         $relation = $this->getNamespacedRelation('namespace');
-        $created = m::mock('Illuminate\Database\Eloquent\Model');
+        $created = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $created->shouldReceive('setAttribute')->once()->with('morph_id', 1);
         $created->shouldReceive('setAttribute')->once()->with('morph_type', 'namespace');
         $relation->getRelated()->shouldReceive('newInstance')->once()->with(['name' => 'taylor'])->andReturn($created);
@@ -249,12 +249,12 @@ class DatabaseEloquentMorphTest extends TestCase
 
     protected function getOneRelation()
     {
-        $builder = m::mock('Illuminate\Database\Eloquent\Builder');
+        $builder = m::mock(\Illuminate\Database\Eloquent\Builder::class);
         $builder->shouldReceive('whereNotNull')->once()->with('table.morph_id');
         $builder->shouldReceive('where')->once()->with('table.morph_id', '=', 1);
-        $related = m::mock('Illuminate\Database\Eloquent\Model');
+        $related = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $builder->shouldReceive('getModel')->andReturn($related);
-        $parent = m::mock('Illuminate\Database\Eloquent\Model');
+        $parent = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $parent->shouldReceive('getAttribute')->with('id')->andReturn(1);
         $parent->shouldReceive('getMorphClass')->andReturn(get_class($parent));
         $builder->shouldReceive('where')->once()->with('table.morph_type', get_class($parent));
@@ -264,12 +264,12 @@ class DatabaseEloquentMorphTest extends TestCase
 
     protected function getManyRelation()
     {
-        $builder = m::mock('Illuminate\Database\Eloquent\Builder');
+        $builder = m::mock(\Illuminate\Database\Eloquent\Builder::class);
         $builder->shouldReceive('whereNotNull')->once()->with('table.morph_id');
         $builder->shouldReceive('where')->once()->with('table.morph_id', '=', 1);
-        $related = m::mock('Illuminate\Database\Eloquent\Model');
+        $related = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $builder->shouldReceive('getModel')->andReturn($related);
-        $parent = m::mock('Illuminate\Database\Eloquent\Model');
+        $parent = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $parent->shouldReceive('getAttribute')->with('id')->andReturn(1);
         $parent->shouldReceive('getMorphClass')->andReturn(get_class($parent));
         $builder->shouldReceive('where')->once()->with('table.morph_type', get_class($parent));
@@ -285,10 +285,10 @@ class DatabaseEloquentMorphTest extends TestCase
             $alias => 'Foo\Bar\EloquentModelNamespacedStub',
         ]);
 
-        $builder = m::mock('Illuminate\Database\Eloquent\Builder');
+        $builder = m::mock(\Illuminate\Database\Eloquent\Builder::class);
         $builder->shouldReceive('whereNotNull')->once()->with('table.morph_id');
         $builder->shouldReceive('where')->once()->with('table.morph_id', '=', 1);
-        $related = m::mock('Illuminate\Database\Eloquent\Model');
+        $related = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $builder->shouldReceive('getModel')->andReturn($related);
         $parent = m::mock('Foo\Bar\EloquentModelNamespacedStub');
         $parent->shouldReceive('getAttribute')->with('id')->andReturn(1);

--- a/tests/Database/DatabaseEloquentMorphToManyTest.php
+++ b/tests/Database/DatabaseEloquentMorphToManyTest.php
@@ -27,11 +27,11 @@ class DatabaseEloquentMorphToManyTest extends TestCase
 
     public function testAttachInsertsPivotTableRecord()
     {
-        $relation = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\MorphToMany')->setMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
-        $query = m::mock('stdClass');
+        $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\MorphToMany::class)->setMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
+        $query = m::mock(\stdClass::class);
         $query->shouldReceive('from')->once()->with('taggables')->andReturn($query);
         $query->shouldReceive('insert')->once()->with([['taggable_id' => 1, 'taggable_type' => get_class($relation->getParent()), 'tag_id' => 2, 'foo' => 'bar']])->andReturn(true);
-        $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock('stdClass'));
+        $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock(\stdClass::class));
         $mockQueryBuilder->shouldReceive('newQuery')->once()->andReturn($query);
         $relation->expects($this->once())->method('touchIfTouching');
 
@@ -40,14 +40,14 @@ class DatabaseEloquentMorphToManyTest extends TestCase
 
     public function testDetachRemovesPivotTableRecord()
     {
-        $relation = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\MorphToMany')->setMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
-        $query = m::mock('stdClass');
+        $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\MorphToMany::class)->setMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
+        $query = m::mock(\stdClass::class);
         $query->shouldReceive('from')->once()->with('taggables')->andReturn($query);
         $query->shouldReceive('where')->once()->with('taggable_id', 1)->andReturn($query);
         $query->shouldReceive('where')->once()->with('taggable_type', get_class($relation->getParent()))->andReturn($query);
         $query->shouldReceive('whereIn')->once()->with('tag_id', [1, 2, 3]);
         $query->shouldReceive('delete')->once()->andReturn(true);
-        $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock('stdClass'));
+        $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock(\stdClass::class));
         $mockQueryBuilder->shouldReceive('newQuery')->once()->andReturn($query);
         $relation->expects($this->once())->method('touchIfTouching');
 
@@ -56,14 +56,14 @@ class DatabaseEloquentMorphToManyTest extends TestCase
 
     public function testDetachMethodClearsAllPivotRecordsWhenNoIDsAreGiven()
     {
-        $relation = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\MorphToMany')->setMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
-        $query = m::mock('stdClass');
+        $relation = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\MorphToMany::class)->setMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
+        $query = m::mock(\stdClass::class);
         $query->shouldReceive('from')->once()->with('taggables')->andReturn($query);
         $query->shouldReceive('where')->once()->with('taggable_id', 1)->andReturn($query);
         $query->shouldReceive('where')->once()->with('taggable_type', get_class($relation->getParent()))->andReturn($query);
         $query->shouldReceive('whereIn')->never();
         $query->shouldReceive('delete')->once()->andReturn(true);
-        $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock('stdClass'));
+        $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock(\stdClass::class));
         $mockQueryBuilder->shouldReceive('newQuery')->once()->andReturn($query);
         $relation->expects($this->once())->method('touchIfTouching');
 
@@ -79,7 +79,7 @@ class DatabaseEloquentMorphToManyTest extends TestCase
 
     public function getRelationArguments()
     {
-        $parent = m::mock('Illuminate\Database\Eloquent\Model');
+        $parent = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $parent->shouldReceive('getMorphClass')->andReturn(get_class($parent));
         $parent->shouldReceive('getKey')->andReturn(1);
         $parent->shouldReceive('getCreatedAtColumn')->andReturn('created_at');
@@ -87,8 +87,8 @@ class DatabaseEloquentMorphToManyTest extends TestCase
         $parent->shouldReceive('getMorphClass')->andReturn(get_class($parent));
         $parent->shouldReceive('getAttribute')->with('id')->andReturn(1);
 
-        $builder = m::mock('Illuminate\Database\Eloquent\Builder');
-        $related = m::mock('Illuminate\Database\Eloquent\Model');
+        $builder = m::mock(\Illuminate\Database\Eloquent\Builder::class);
+        $related = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $builder->shouldReceive('getModel')->andReturn($related);
 
         $related->shouldReceive('getTable')->andReturn('tags');

--- a/tests/Database/DatabaseEloquentMorphToTest.php
+++ b/tests/Database/DatabaseEloquentMorphToTest.php
@@ -41,12 +41,12 @@ class DatabaseEloquentMorphToTest extends TestCase
 
     public function testAssociateMethodSetsForeignKeyAndTypeOnModel()
     {
-        $parent = m::mock('Illuminate\Database\Eloquent\Model');
+        $parent = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $parent->shouldReceive('getAttribute')->once()->with('foreign_key')->andReturn('foreign.value');
 
         $relation = $this->getRelationAssociate($parent);
 
-        $associate = m::mock('Illuminate\Database\Eloquent\Model');
+        $associate = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $associate->shouldReceive('getKey')->once()->andReturn(1);
         $associate->shouldReceive('getMorphClass')->once()->andReturn('Model');
 
@@ -59,7 +59,7 @@ class DatabaseEloquentMorphToTest extends TestCase
 
     public function testDissociateMethodDeletesUnsetsKeyAndTypeOnModel()
     {
-        $parent = m::mock('Illuminate\Database\Eloquent\Model');
+        $parent = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $parent->shouldReceive('getAttribute')->once()->with('foreign_key')->andReturn('foreign.value');
 
         $relation = $this->getRelation($parent);
@@ -73,9 +73,9 @@ class DatabaseEloquentMorphToTest extends TestCase
 
     protected function getRelationAssociate($parent)
     {
-        $builder = m::mock('Illuminate\Database\Eloquent\Builder');
+        $builder = m::mock(\Illuminate\Database\Eloquent\Builder::class);
         $builder->shouldReceive('where')->with('relation.id', '=', 'foreign.value');
-        $related = m::mock('Illuminate\Database\Eloquent\Model');
+        $related = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $related->shouldReceive('getKey')->andReturn(1);
         $related->shouldReceive('getTable')->andReturn('relation');
         $builder->shouldReceive('getModel')->andReturn($related);
@@ -85,9 +85,9 @@ class DatabaseEloquentMorphToTest extends TestCase
 
     public function getRelation($parent = null, $builder = null)
     {
-        $builder = $builder ?: m::mock('Illuminate\Database\Eloquent\Builder');
+        $builder = $builder ?: m::mock(\Illuminate\Database\Eloquent\Builder::class);
         $builder->shouldReceive('where')->with('relation.id', '=', 'foreign.value');
-        $related = m::mock('Illuminate\Database\Eloquent\Model');
+        $related = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $related->shouldReceive('getKeyName')->andReturn('id');
         $related->shouldReceive('getTable')->andReturn('relation');
         $builder->shouldReceive('getModel')->andReturn($related);

--- a/tests/Database/DatabaseEloquentPivotTest.php
+++ b/tests/Database/DatabaseEloquentPivotTest.php
@@ -94,11 +94,11 @@ class DatabaseEloquentPivotTest extends TestCase
         $parent = m::mock('Illuminate\Database\Eloquent\Model[getConnectionName]');
         $parent->guard([]);
         $parent->shouldReceive('getConnectionName')->once()->andReturn('connection');
-        $pivot = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\Pivot')->setMethods(['newQuery'])->setConstructorArgs([$parent, ['foo' => 'bar'], 'table'])->getMock();
+        $pivot = $this->getMockBuilder(\Illuminate\Database\Eloquent\Relations\Pivot::class)->setMethods(['newQuery'])->setConstructorArgs([$parent, ['foo' => 'bar'], 'table'])->getMock();
         $pivot->setPivotKeys('foreign', 'other');
         $pivot->foreign = 'foreign.value';
         $pivot->other = 'other.value';
-        $query = m::mock('stdClass');
+        $query = m::mock(\stdClass::class);
         $query->shouldReceive('where')->once()->with(['foreign' => 'foreign.value', 'other' => 'other.value'])->andReturn($query);
         $query->shouldReceive('delete')->once()->andReturn(true);
         $pivot->expects($this->once())->method('newQuery')->will($this->returnValue($query));

--- a/tests/Database/DatabaseEloquentPolymorphicRelationsIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentPolymorphicRelationsIntegrationTest.php
@@ -139,7 +139,7 @@ class EloquentManyToManyPolymorphicTestPost extends Eloquent
 
     public function tags()
     {
-        return $this->morphToMany('Illuminate\Tests\Database\EloquentManyToManyPolymorphicTestTag', 'taggable');
+        return $this->morphToMany(\Illuminate\Tests\Database\EloquentManyToManyPolymorphicTestTag::class, 'taggable');
     }
 }
 
@@ -150,7 +150,7 @@ class EloquentManyToManyPolymorphicTestImage extends Eloquent
 
     public function tags()
     {
-        return $this->morphToMany('Illuminate\Tests\Database\EloquentManyToManyPolymorphicTestTag', 'taggable');
+        return $this->morphToMany(\Illuminate\Tests\Database\EloquentManyToManyPolymorphicTestTag::class, 'taggable');
     }
 }
 
@@ -161,11 +161,11 @@ class EloquentManyToManyPolymorphicTestTag extends Eloquent
 
     public function posts()
     {
-        return $this->morphedByMany('Illuminate\Tests\Database\EloquentManyToManyPolymorphicTestPost', 'taggable');
+        return $this->morphedByMany(\Illuminate\Tests\Database\EloquentManyToManyPolymorphicTestPost::class, 'taggable');
     }
 
     public function images()
     {
-        return $this->morphedByMany('Illuminate\Tests\Database\EloquentManyToManyPolymorphicTestImage', 'taggable');
+        return $this->morphedByMany(\Illuminate\Tests\Database\EloquentManyToManyPolymorphicTestImage::class, 'taggable');
     }
 }

--- a/tests/Database/DatabaseEloquentRelationTest.php
+++ b/tests/Database/DatabaseEloquentRelationTest.php
@@ -48,7 +48,7 @@ class DatabaseEloquentRelationTest extends TestCase
         Relation::morphMap([EloquentRelationResetModelStub::class]);
 
         $this->assertEquals([
-            'reset' => 'Illuminate\Tests\Database\EloquentRelationResetModelStub',
+            'reset' => \Illuminate\Tests\Database\EloquentRelationResetModelStub::class,
         ], Relation::morphMap());
 
         Relation::morphMap([], false);

--- a/tests/Database/DatabaseMigrationCreatorTest.php
+++ b/tests/Database/DatabaseMigrationCreatorTest.php
@@ -67,8 +67,8 @@ class DatabaseMigrationCreatorTest extends TestCase
 
     protected function getCreator()
     {
-        $files = m::mock('Illuminate\Filesystem\Filesystem');
+        $files = m::mock(\Illuminate\Filesystem\Filesystem::class);
 
-        return $this->getMockBuilder('Illuminate\Database\Migrations\MigrationCreator')->setMethods(['getDatePrefix'])->setConstructorArgs([$files])->getMock();
+        return $this->getMockBuilder(\Illuminate\Database\Migrations\MigrationCreator::class)->setMethods(['getDatePrefix'])->setConstructorArgs([$files])->getMock();
     }
 }

--- a/tests/Database/DatabaseMigrationInstallCommandTest.php
+++ b/tests/Database/DatabaseMigrationInstallCommandTest.php
@@ -14,7 +14,7 @@ class DatabaseMigrationInstallCommandTest extends TestCase
 
     public function testFireCallsRepositoryToInstall()
     {
-        $command = new \Illuminate\Database\Console\Migrations\InstallCommand($repo = m::mock('Illuminate\Database\Migrations\MigrationRepositoryInterface'));
+        $command = new \Illuminate\Database\Console\Migrations\InstallCommand($repo = m::mock(\Illuminate\Database\Migrations\MigrationRepositoryInterface::class));
         $command->setLaravel(new \Illuminate\Foundation\Application);
         $repo->shouldReceive('setSource')->once()->with('foo');
         $repo->shouldReceive('createRepository')->once();

--- a/tests/Database/DatabaseMigrationMakeCommandTest.php
+++ b/tests/Database/DatabaseMigrationMakeCommandTest.php
@@ -16,8 +16,8 @@ class DatabaseMigrationMakeCommandTest extends TestCase
     public function testBasicCreateDumpsAutoload()
     {
         $command = new MigrateMakeCommand(
-            $creator = m::mock('Illuminate\Database\Migrations\MigrationCreator'),
-            $composer = m::mock('Illuminate\Support\Composer'),
+            $creator = m::mock(\Illuminate\Database\Migrations\MigrationCreator::class),
+            $composer = m::mock(\Illuminate\Support\Composer::class),
             __DIR__.'/vendor'
         );
         $app = new \Illuminate\Foundation\Application;
@@ -32,8 +32,8 @@ class DatabaseMigrationMakeCommandTest extends TestCase
     public function testBasicCreateGivesCreatorProperArguments()
     {
         $command = new MigrateMakeCommand(
-            $creator = m::mock('Illuminate\Database\Migrations\MigrationCreator'),
-            m::mock('Illuminate\Support\Composer')->shouldIgnoreMissing(),
+            $creator = m::mock(\Illuminate\Database\Migrations\MigrationCreator::class),
+            m::mock(\Illuminate\Support\Composer::class)->shouldIgnoreMissing(),
             __DIR__.'/vendor'
         );
         $app = new \Illuminate\Foundation\Application;
@@ -47,8 +47,8 @@ class DatabaseMigrationMakeCommandTest extends TestCase
     public function testBasicCreateGivesCreatorProperArgumentsWhenTableIsSet()
     {
         $command = new MigrateMakeCommand(
-            $creator = m::mock('Illuminate\Database\Migrations\MigrationCreator'),
-            m::mock('Illuminate\Support\Composer')->shouldIgnoreMissing(),
+            $creator = m::mock(\Illuminate\Database\Migrations\MigrationCreator::class),
+            m::mock(\Illuminate\Support\Composer::class)->shouldIgnoreMissing(),
             __DIR__.'/vendor'
         );
         $app = new \Illuminate\Foundation\Application;
@@ -62,8 +62,8 @@ class DatabaseMigrationMakeCommandTest extends TestCase
     public function testCanSpecifyPathToCreateMigrationsIn()
     {
         $command = new MigrateMakeCommand(
-            $creator = m::mock('Illuminate\Database\Migrations\MigrationCreator'),
-            m::mock('Illuminate\Support\Composer')->shouldIgnoreMissing(),
+            $creator = m::mock(\Illuminate\Database\Migrations\MigrationCreator::class),
+            m::mock(\Illuminate\Support\Composer::class)->shouldIgnoreMissing(),
             __DIR__.'/vendor'
         );
         $app = new \Illuminate\Foundation\Application;

--- a/tests/Database/DatabaseMigrationMigrateCommandTest.php
+++ b/tests/Database/DatabaseMigrationMigrateCommandTest.php
@@ -16,7 +16,7 @@ class DatabaseMigrationMigrateCommandTest extends TestCase
 
     public function testBasicMigrationsCallMigratorWithProperArguments()
     {
-        $command = new MigrateCommand($migrator = m::mock('Illuminate\Database\Migrations\Migrator'), __DIR__.'/vendor');
+        $command = new MigrateCommand($migrator = m::mock(\Illuminate\Database\Migrations\Migrator::class), __DIR__.'/vendor');
         $app = new ApplicationDatabaseMigrationStub(['path.database' => __DIR__]);
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);
@@ -31,8 +31,8 @@ class DatabaseMigrationMigrateCommandTest extends TestCase
 
     public function testMigrationRepositoryCreatedWhenNecessary()
     {
-        $params = [$migrator = m::mock('Illuminate\Database\Migrations\Migrator'), __DIR__.'/vendor'];
-        $command = $this->getMockBuilder('Illuminate\Database\Console\Migrations\MigrateCommand')->setMethods(['call'])->setConstructorArgs($params)->getMock();
+        $params = [$migrator = m::mock(\Illuminate\Database\Migrations\Migrator::class), __DIR__.'/vendor'];
+        $command = $this->getMockBuilder(\Illuminate\Database\Console\Migrations\MigrateCommand::class)->setMethods(['call'])->setConstructorArgs($params)->getMock();
         $app = new ApplicationDatabaseMigrationStub(['path.database' => __DIR__]);
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);
@@ -48,7 +48,7 @@ class DatabaseMigrationMigrateCommandTest extends TestCase
 
     public function testTheCommandMayBePretended()
     {
-        $command = new MigrateCommand($migrator = m::mock('Illuminate\Database\Migrations\Migrator'), __DIR__.'/vendor');
+        $command = new MigrateCommand($migrator = m::mock(\Illuminate\Database\Migrations\Migrator::class), __DIR__.'/vendor');
         $app = new ApplicationDatabaseMigrationStub(['path.database' => __DIR__]);
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);
@@ -63,7 +63,7 @@ class DatabaseMigrationMigrateCommandTest extends TestCase
 
     public function testTheDatabaseMayBeSet()
     {
-        $command = new MigrateCommand($migrator = m::mock('Illuminate\Database\Migrations\Migrator'), __DIR__.'/vendor');
+        $command = new MigrateCommand($migrator = m::mock(\Illuminate\Database\Migrations\Migrator::class), __DIR__.'/vendor');
         $app = new ApplicationDatabaseMigrationStub(['path.database' => __DIR__]);
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);
@@ -78,7 +78,7 @@ class DatabaseMigrationMigrateCommandTest extends TestCase
 
     public function testStepMayBeSet()
     {
-        $command = new MigrateCommand($migrator = m::mock('Illuminate\Database\Migrations\Migrator'), __DIR__.'/vendor');
+        $command = new MigrateCommand($migrator = m::mock(\Illuminate\Database\Migrations\Migrator::class), __DIR__.'/vendor');
         $app = new ApplicationDatabaseMigrationStub(['path.database' => __DIR__]);
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);

--- a/tests/Database/DatabaseMigrationRepositoryTest.php
+++ b/tests/Database/DatabaseMigrationRepositoryTest.php
@@ -17,8 +17,8 @@ class DatabaseMigrationRepositoryTest extends TestCase
     public function testGetRanMigrationsListMigrationsByPackage()
     {
         $repo = $this->getRepository();
-        $query = m::mock('stdClass');
-        $connectionMock = m::mock('Illuminate\Database\Connection');
+        $query = m::mock(\stdClass::class);
+        $connectionMock = m::mock(\Illuminate\Database\Connection::class);
         $repo->getConnectionResolver()->shouldReceive('connection')->with(null)->andReturn($connectionMock);
         $repo->getConnection()->shouldReceive('table')->once()->with('migrations')->andReturn($query);
         $query->shouldReceive('orderBy')->once()->with('batch', 'asc')->andReturn($query);
@@ -31,12 +31,12 @@ class DatabaseMigrationRepositoryTest extends TestCase
 
     public function testGetLastMigrationsGetsAllMigrationsWithTheLatestBatchNumber()
     {
-        $repo = $this->getMockBuilder('Illuminate\Database\Migrations\DatabaseMigrationRepository')->setMethods(['getLastBatchNumber'])->setConstructorArgs([
-            $resolver = m::mock('Illuminate\Database\ConnectionResolverInterface'), 'migrations',
+        $repo = $this->getMockBuilder(\Illuminate\Database\Migrations\DatabaseMigrationRepository::class)->setMethods(['getLastBatchNumber'])->setConstructorArgs([
+            $resolver = m::mock(\Illuminate\Database\ConnectionResolverInterface::class), 'migrations',
         ])->getMock();
         $repo->expects($this->once())->method('getLastBatchNumber')->will($this->returnValue(1));
-        $query = m::mock('stdClass');
-        $connectionMock = m::mock('Illuminate\Database\Connection');
+        $query = m::mock(\stdClass::class);
+        $connectionMock = m::mock(\Illuminate\Database\Connection::class);
         $repo->getConnectionResolver()->shouldReceive('connection')->with(null)->andReturn($connectionMock);
         $repo->getConnection()->shouldReceive('table')->once()->with('migrations')->andReturn($query);
         $query->shouldReceive('where')->once()->with('batch', 1)->andReturn($query);
@@ -50,8 +50,8 @@ class DatabaseMigrationRepositoryTest extends TestCase
     public function testLogMethodInsertsRecordIntoMigrationTable()
     {
         $repo = $this->getRepository();
-        $query = m::mock('stdClass');
-        $connectionMock = m::mock('Illuminate\Database\Connection');
+        $query = m::mock(\stdClass::class);
+        $connectionMock = m::mock(\Illuminate\Database\Connection::class);
         $repo->getConnectionResolver()->shouldReceive('connection')->with(null)->andReturn($connectionMock);
         $repo->getConnection()->shouldReceive('table')->once()->with('migrations')->andReturn($query);
         $query->shouldReceive('insert')->once()->with(['migration' => 'bar', 'batch' => 1]);
@@ -63,8 +63,8 @@ class DatabaseMigrationRepositoryTest extends TestCase
     public function testDeleteMethodRemovesAMigrationFromTheTable()
     {
         $repo = $this->getRepository();
-        $query = m::mock('stdClass');
-        $connectionMock = m::mock('Illuminate\Database\Connection');
+        $query = m::mock(\stdClass::class);
+        $connectionMock = m::mock(\Illuminate\Database\Connection::class);
         $repo->getConnectionResolver()->shouldReceive('connection')->with(null)->andReturn($connectionMock);
         $repo->getConnection()->shouldReceive('table')->once()->with('migrations')->andReturn($query);
         $query->shouldReceive('where')->once()->with('migration', 'foo')->andReturn($query);
@@ -77,8 +77,8 @@ class DatabaseMigrationRepositoryTest extends TestCase
 
     public function testGetNextBatchNumberReturnsLastBatchNumberPlusOne()
     {
-        $repo = $this->getMockBuilder('Illuminate\Database\Migrations\DatabaseMigrationRepository')->setMethods(['getLastBatchNumber'])->setConstructorArgs([
-            m::mock('Illuminate\Database\ConnectionResolverInterface'), 'migrations',
+        $repo = $this->getMockBuilder(\Illuminate\Database\Migrations\DatabaseMigrationRepository::class)->setMethods(['getLastBatchNumber'])->setConstructorArgs([
+            m::mock(\Illuminate\Database\ConnectionResolverInterface::class), 'migrations',
         ])->getMock();
         $repo->expects($this->once())->method('getLastBatchNumber')->will($this->returnValue(1));
 
@@ -88,8 +88,8 @@ class DatabaseMigrationRepositoryTest extends TestCase
     public function testGetLastBatchNumberReturnsMaxBatch()
     {
         $repo = $this->getRepository();
-        $query = m::mock('stdClass');
-        $connectionMock = m::mock('Illuminate\Database\Connection');
+        $query = m::mock(\stdClass::class);
+        $connectionMock = m::mock(\Illuminate\Database\Connection::class);
         $repo->getConnectionResolver()->shouldReceive('connection')->with(null)->andReturn($connectionMock);
         $repo->getConnection()->shouldReceive('table')->once()->with('migrations')->andReturn($query);
         $query->shouldReceive('max')->once()->andReturn(1);
@@ -101,8 +101,8 @@ class DatabaseMigrationRepositoryTest extends TestCase
     public function testCreateRepositoryCreatesProperDatabaseTable()
     {
         $repo = $this->getRepository();
-        $schema = m::mock('stdClass');
-        $connectionMock = m::mock('Illuminate\Database\Connection');
+        $schema = m::mock(\stdClass::class);
+        $connectionMock = m::mock(\Illuminate\Database\Connection::class);
         $repo->getConnectionResolver()->shouldReceive('connection')->with(null)->andReturn($connectionMock);
         $repo->getConnection()->shouldReceive('getSchemaBuilder')->once()->andReturn($schema);
         $schema->shouldReceive('create')->once()->with('migrations', m::type('Closure'));
@@ -112,6 +112,6 @@ class DatabaseMigrationRepositoryTest extends TestCase
 
     protected function getRepository()
     {
-        return new DatabaseMigrationRepository(m::mock('Illuminate\Database\ConnectionResolverInterface'), 'migrations');
+        return new DatabaseMigrationRepository(m::mock(\Illuminate\Database\ConnectionResolverInterface::class), 'migrations');
     }
 }

--- a/tests/Database/DatabaseMigrationResetCommandTest.php
+++ b/tests/Database/DatabaseMigrationResetCommandTest.php
@@ -16,7 +16,7 @@ class DatabaseMigrationResetCommandTest extends TestCase
 
     public function testResetCommandCallsMigratorWithProperArguments()
     {
-        $command = new ResetCommand($migrator = m::mock('Illuminate\Database\Migrations\Migrator'));
+        $command = new ResetCommand($migrator = m::mock(\Illuminate\Database\Migrations\Migrator::class));
         $app = new ApplicationDatabaseResetStub(['path.database' => __DIR__]);
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);
@@ -31,7 +31,7 @@ class DatabaseMigrationResetCommandTest extends TestCase
 
     public function testResetCommandCanBePretended()
     {
-        $command = new ResetCommand($migrator = m::mock('Illuminate\Database\Migrations\Migrator'));
+        $command = new ResetCommand($migrator = m::mock(\Illuminate\Database\Migrations\Migrator::class));
         $app = new ApplicationDatabaseResetStub(['path.database' => __DIR__]);
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);

--- a/tests/Database/DatabaseMigrationRollbackCommandTest.php
+++ b/tests/Database/DatabaseMigrationRollbackCommandTest.php
@@ -16,7 +16,7 @@ class DatabaseMigrationRollbackCommandTest extends TestCase
 
     public function testRollbackCommandCallsMigratorWithProperArguments()
     {
-        $command = new RollbackCommand($migrator = m::mock('Illuminate\Database\Migrations\Migrator'));
+        $command = new RollbackCommand($migrator = m::mock(\Illuminate\Database\Migrations\Migrator::class));
         $app = new ApplicationDatabaseRollbackStub(['path.database' => __DIR__]);
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);
@@ -30,7 +30,7 @@ class DatabaseMigrationRollbackCommandTest extends TestCase
 
     public function testRollbackCommandCallsMigratorWithStepOption()
     {
-        $command = new RollbackCommand($migrator = m::mock('Illuminate\Database\Migrations\Migrator'));
+        $command = new RollbackCommand($migrator = m::mock(\Illuminate\Database\Migrations\Migrator::class));
         $app = new ApplicationDatabaseRollbackStub(['path.database' => __DIR__]);
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);
@@ -44,7 +44,7 @@ class DatabaseMigrationRollbackCommandTest extends TestCase
 
     public function testRollbackCommandCanBePretended()
     {
-        $command = new RollbackCommand($migrator = m::mock('Illuminate\Database\Migrations\Migrator'));
+        $command = new RollbackCommand($migrator = m::mock(\Illuminate\Database\Migrations\Migrator::class));
         $app = new ApplicationDatabaseRollbackStub(['path.database' => __DIR__]);
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);
@@ -58,7 +58,7 @@ class DatabaseMigrationRollbackCommandTest extends TestCase
 
     public function testRollbackCommandCanBePretendedWithStepOption()
     {
-        $command = new RollbackCommand($migrator = m::mock('Illuminate\Database\Migrations\Migrator'));
+        $command = new RollbackCommand($migrator = m::mock(\Illuminate\Database\Migrations\Migrator::class));
         $app = new ApplicationDatabaseRollbackStub(['path.database' => __DIR__]);
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -731,7 +731,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
     protected function getConnection()
     {
-        return m::mock('Illuminate\Database\Connection');
+        return m::mock(\Illuminate\Database\Connection::class);
     }
 
     public function getGrammar()

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -555,7 +555,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
     protected function getConnection()
     {
-        return m::mock('Illuminate\Database\Connection');
+        return m::mock(\Illuminate\Database\Connection::class);
     }
 
     public function getGrammar()

--- a/tests/Database/DatabaseProcessorTest.php
+++ b/tests/Database/DatabaseProcessorTest.php
@@ -14,12 +14,12 @@ class DatabaseProcessorTest extends TestCase
 
     public function testInsertGetIdProcessing()
     {
-        $pdo = $this->createMock('Illuminate\Tests\Database\ProcessorTestPDOStub');
+        $pdo = $this->createMock(\Illuminate\Tests\Database\ProcessorTestPDOStub::class);
         $pdo->expects($this->once())->method('lastInsertId')->with($this->equalTo('id'))->will($this->returnValue('1'));
-        $connection = m::mock('Illuminate\Database\Connection');
+        $connection = m::mock(\Illuminate\Database\Connection::class);
         $connection->shouldReceive('insert')->once()->with('sql', ['foo']);
         $connection->shouldReceive('getPdo')->once()->andReturn($pdo);
-        $builder = m::mock('Illuminate\Database\Query\Builder');
+        $builder = m::mock(\Illuminate\Database\Query\Builder::class);
         $builder->shouldReceive('getConnection')->andReturn($connection);
         $processor = new \Illuminate\Database\Query\Processors\Processor;
         $result = $processor->processInsertGetId($builder, 'sql', ['foo'], 'id');

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1416,9 +1416,9 @@ class DatabaseQueryBuilderTest extends TestCase
     public function testUpdateOrInsertMethod()
     {
         $builder = m::mock('Illuminate\Database\Query\Builder[where,exists,insert]', [
-            m::mock('Illuminate\Database\ConnectionInterface'),
+            m::mock(\Illuminate\Database\ConnectionInterface::class),
             new \Illuminate\Database\Query\Grammars\Grammar,
-            m::mock('Illuminate\Database\Query\Processors\Processor'),
+            m::mock(\Illuminate\Database\Query\Processors\Processor::class),
         ]);
 
         $builder->shouldReceive('where')->once()->with(['email' => 'foo'])->andReturn(m::self());
@@ -1428,9 +1428,9 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertTrue($builder->updateOrInsert(['email' => 'foo'], ['name' => 'bar']));
 
         $builder = m::mock('Illuminate\Database\Query\Builder[where,exists,update]', [
-            m::mock('Illuminate\Database\ConnectionInterface'),
+            m::mock(\Illuminate\Database\ConnectionInterface::class),
             new \Illuminate\Database\Query\Grammars\Grammar,
-            m::mock('Illuminate\Database\Query\Processors\Processor'),
+            m::mock(\Illuminate\Database\Query\Processors\Processor::class),
         ]);
 
         $builder->shouldReceive('where')->once()->with(['email' => 'foo'])->andReturn(m::self());
@@ -1530,9 +1530,9 @@ class DatabaseQueryBuilderTest extends TestCase
     public function testMySqlUpdateWrappingJson()
     {
         $grammar = new \Illuminate\Database\Query\Grammars\MySqlGrammar;
-        $processor = m::mock('Illuminate\Database\Query\Processors\Processor');
+        $processor = m::mock(\Illuminate\Database\Query\Processors\Processor::class);
 
-        $connection = $this->createMock('Illuminate\Database\ConnectionInterface');
+        $connection = $this->createMock(\Illuminate\Database\ConnectionInterface::class);
         $connection->expects($this->once())
                     ->method('update')
                     ->with(
@@ -1548,9 +1548,9 @@ class DatabaseQueryBuilderTest extends TestCase
     public function testMySqlUpdateWithJsonRemovesBindingsCorrectly()
     {
         $grammar = new \Illuminate\Database\Query\Grammars\MySqlGrammar;
-        $processor = m::mock('Illuminate\Database\Query\Processors\Processor');
+        $processor = m::mock(\Illuminate\Database\Query\Processors\Processor::class);
 
-        $connection = m::mock('Illuminate\Database\ConnectionInterface');
+        $connection = m::mock(\Illuminate\Database\ConnectionInterface::class);
         $connection->shouldReceive('update')
                     ->once()
                     ->with(
@@ -1699,7 +1699,7 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $method = 'whereFooBarAndBazOrQux';
         $parameters = ['corge', 'waldo', 'fred'];
-        $builder = m::mock('Illuminate\Database\Query\Builder')->makePartial();
+        $builder = m::mock(\Illuminate\Database\Query\Builder::class)->makePartial();
 
         $builder->shouldReceive('where')->with('foo_bar', '=', $parameters[0], 'and')->once()->andReturnSelf();
         $builder->shouldReceive('where')->with('baz', '=', $parameters[1], 'and')->once()->andReturnSelf();
@@ -1712,7 +1712,7 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $method = 'whereIosVersionAndAndroidVersionOrOrientation';
         $parameters = ['6.1', '4.2', 'Vertical'];
-        $builder = m::mock('Illuminate\Database\Query\Builder')->makePartial();
+        $builder = m::mock(\Illuminate\Database\Query\Builder::class)->makePartial();
 
         $builder->shouldReceive('where')->with('ios_version', '=', '6.1', 'and')->once()->andReturnSelf();
         $builder->shouldReceive('where')->with('android_version', '=', '4.2', 'and')->once()->andReturnSelf();
@@ -1939,7 +1939,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->shouldReceive('forPage')->once()->with(3, 2)->andReturnSelf();
         $builder->shouldReceive('get')->times(3)->andReturn($chunk1, $chunk2, $chunk3);
 
-        $callbackAssertor = m::mock('stdClass');
+        $callbackAssertor = m::mock(\stdClass::class);
         $callbackAssertor->shouldReceive('doSomething')->once()->with($chunk1);
         $callbackAssertor->shouldReceive('doSomething')->once()->with($chunk2);
         $callbackAssertor->shouldReceive('doSomething')->never()->with($chunk3);
@@ -1960,7 +1960,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->shouldReceive('forPage')->once()->with(2, 2)->andReturnSelf();
         $builder->shouldReceive('get')->times(2)->andReturn($chunk1, $chunk2);
 
-        $callbackAssertor = m::mock('stdClass');
+        $callbackAssertor = m::mock(\stdClass::class);
         $callbackAssertor->shouldReceive('doSomething')->once()->with($chunk1);
         $callbackAssertor->shouldReceive('doSomething')->once()->with($chunk2);
 
@@ -1980,7 +1980,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->shouldReceive('forPage')->never()->with(2, 2);
         $builder->shouldReceive('get')->times(1)->andReturn($chunk1);
 
-        $callbackAssertor = m::mock('stdClass');
+        $callbackAssertor = m::mock(\stdClass::class);
         $callbackAssertor->shouldReceive('doSomething')->once()->with($chunk1);
         $callbackAssertor->shouldReceive('doSomething')->never()->with($chunk2);
 
@@ -2000,7 +2000,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->shouldReceive('forPage')->once()->with(1, 0)->andReturnSelf();
         $builder->shouldReceive('get')->times(1)->andReturn($chunk);
 
-        $callbackAssertor = m::mock('stdClass');
+        $callbackAssertor = m::mock(\stdClass::class);
         $callbackAssertor->shouldReceive('doSomething')->never();
 
         $builder->chunk(0, function ($results) use ($callbackAssertor) {
@@ -2021,7 +2021,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->shouldReceive('forPageAfterId')->once()->with(2, 11, 'someIdField')->andReturnSelf();
         $builder->shouldReceive('get')->times(3)->andReturn($chunk1, $chunk2, $chunk3);
 
-        $callbackAssertor = m::mock('stdClass');
+        $callbackAssertor = m::mock(\stdClass::class);
         $callbackAssertor->shouldReceive('doSomething')->once()->with($chunk1);
         $callbackAssertor->shouldReceive('doSomething')->once()->with($chunk2);
         $callbackAssertor->shouldReceive('doSomething')->never()->with($chunk3);
@@ -2042,7 +2042,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->shouldReceive('forPageAfterId')->once()->with(2, 2, 'someIdField')->andReturnSelf();
         $builder->shouldReceive('get')->times(2)->andReturn($chunk1, $chunk2);
 
-        $callbackAssertor = m::mock('stdClass');
+        $callbackAssertor = m::mock(\stdClass::class);
         $callbackAssertor->shouldReceive('doSomething')->once()->with($chunk1);
         $callbackAssertor->shouldReceive('doSomething')->once()->with($chunk2);
 
@@ -2060,7 +2060,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->shouldReceive('forPageAfterId')->once()->with(0, 0, 'someIdField')->andReturnSelf();
         $builder->shouldReceive('get')->times(1)->andReturn($chunk);
 
-        $callbackAssertor = m::mock('stdClass');
+        $callbackAssertor = m::mock(\stdClass::class);
         $callbackAssertor->shouldReceive('doSomething')->never();
 
         $builder->chunkById(0, function ($results) use ($callbackAssertor) {
@@ -2079,7 +2079,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->shouldReceive('forPageAfterId')->once()->with(2, 10, 'table.id')->andReturnSelf();
         $builder->shouldReceive('get')->times(2)->andReturn($chunk1, $chunk2);
 
-        $callbackAssertor = m::mock('stdClass');
+        $callbackAssertor = m::mock(\stdClass::class);
         $callbackAssertor->shouldReceive('doSomething')->once()->with($chunk1);
         $callbackAssertor->shouldReceive('doSomething')->never()->with($chunk2);
 
@@ -2180,41 +2180,41 @@ class DatabaseQueryBuilderTest extends TestCase
     protected function getBuilder()
     {
         $grammar = new \Illuminate\Database\Query\Grammars\Grammar;
-        $processor = m::mock('Illuminate\Database\Query\Processors\Processor');
+        $processor = m::mock(\Illuminate\Database\Query\Processors\Processor::class);
 
-        return new Builder(m::mock('Illuminate\Database\ConnectionInterface'), $grammar, $processor);
+        return new Builder(m::mock(\Illuminate\Database\ConnectionInterface::class), $grammar, $processor);
     }
 
     protected function getPostgresBuilder()
     {
         $grammar = new \Illuminate\Database\Query\Grammars\PostgresGrammar;
-        $processor = m::mock('Illuminate\Database\Query\Processors\Processor');
+        $processor = m::mock(\Illuminate\Database\Query\Processors\Processor::class);
 
-        return new Builder(m::mock('Illuminate\Database\ConnectionInterface'), $grammar, $processor);
+        return new Builder(m::mock(\Illuminate\Database\ConnectionInterface::class), $grammar, $processor);
     }
 
     protected function getMySqlBuilder()
     {
         $grammar = new \Illuminate\Database\Query\Grammars\MySqlGrammar;
-        $processor = m::mock('Illuminate\Database\Query\Processors\Processor');
+        $processor = m::mock(\Illuminate\Database\Query\Processors\Processor::class);
 
-        return new Builder(m::mock('Illuminate\Database\ConnectionInterface'), $grammar, $processor);
+        return new Builder(m::mock(\Illuminate\Database\ConnectionInterface::class), $grammar, $processor);
     }
 
     protected function getSQLiteBuilder()
     {
         $grammar = new \Illuminate\Database\Query\Grammars\SQLiteGrammar;
-        $processor = m::mock('Illuminate\Database\Query\Processors\Processor');
+        $processor = m::mock(\Illuminate\Database\Query\Processors\Processor::class);
 
-        return new Builder(m::mock('Illuminate\Database\ConnectionInterface'), $grammar, $processor);
+        return new Builder(m::mock(\Illuminate\Database\ConnectionInterface::class), $grammar, $processor);
     }
 
     protected function getSqlServerBuilder()
     {
         $grammar = new \Illuminate\Database\Query\Grammars\SqlServerGrammar;
-        $processor = m::mock('Illuminate\Database\Query\Processors\Processor');
+        $processor = m::mock(\Illuminate\Database\Query\Processors\Processor::class);
 
-        return new Builder(m::mock('Illuminate\Database\ConnectionInterface'), $grammar, $processor);
+        return new Builder(m::mock(\Illuminate\Database\ConnectionInterface::class), $grammar, $processor);
     }
 
     protected function getMySqlBuilderWithProcessor()
@@ -2222,7 +2222,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $grammar = new \Illuminate\Database\Query\Grammars\MySqlGrammar;
         $processor = new \Illuminate\Database\Query\Processors\MySqlProcessor;
 
-        return new Builder(m::mock('Illuminate\Database\ConnectionInterface'), $grammar, $processor);
+        return new Builder(m::mock(\Illuminate\Database\ConnectionInterface::class), $grammar, $processor);
     }
 
     /**
@@ -2230,10 +2230,10 @@ class DatabaseQueryBuilderTest extends TestCase
      */
     protected function getMockQueryBuilder()
     {
-        $builder = m::mock('Illuminate\Database\Query\Builder', [
-            m::mock('Illuminate\Database\ConnectionInterface'),
+        $builder = m::mock(\Illuminate\Database\Query\Builder::class, [
+            m::mock(\Illuminate\Database\ConnectionInterface::class),
             new \Illuminate\Database\Query\Grammars\Grammar,
-            m::mock('Illuminate\Database\Query\Processors\Processor'),
+            m::mock(\Illuminate\Database\Query\Processors\Processor::class),
         ])->makePartial();
 
         return $builder;

--- a/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
@@ -510,7 +510,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
 
     protected function getConnection()
     {
-        return m::mock('Illuminate\Database\Connection');
+        return m::mock(\Illuminate\Database\Connection::class);
     }
 
     public function getGrammar()

--- a/tests/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintTest.php
@@ -19,11 +19,11 @@ class DatabaseSchemaBlueprintTest extends TestCase
 
     public function testToSqlRunsCommandsFromBlueprint()
     {
-        $conn = m::mock('Illuminate\Database\Connection');
+        $conn = m::mock(\Illuminate\Database\Connection::class);
         $conn->shouldReceive('statement')->once()->with('foo');
         $conn->shouldReceive('statement')->once()->with('bar');
-        $grammar = m::mock('Illuminate\Database\Schema\Grammars\MySqlGrammar');
-        $blueprint = $this->getMockBuilder('Illuminate\Database\Schema\Blueprint')->setMethods(['toSql'])->setConstructorArgs(['users'])->getMock();
+        $grammar = m::mock(\Illuminate\Database\Schema\Grammars\MySqlGrammar::class);
+        $blueprint = $this->getMockBuilder(\Illuminate\Database\Schema\Blueprint::class)->setMethods(['toSql'])->setConstructorArgs(['users'])->getMock();
         $blueprint->expects($this->once())->method('toSql')->with($this->equalTo($conn), $this->equalTo($grammar))->will($this->returnValue(['foo', 'bar']));
 
         $blueprint->build($conn, $grammar);
@@ -61,7 +61,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
             $table->timestamp('created')->useCurrent();
         });
 
-        $connection = m::mock('Illuminate\Database\Connection');
+        $connection = m::mock(\Illuminate\Database\Connection::class);
 
         $blueprint = clone $base;
         $this->assertEquals(['alter table `users` add `created` timestamp(0) default CURRENT_TIMESTAMP not null'], $blueprint->toSql($connection, new MySqlGrammar));

--- a/tests/Database/DatabaseSchemaBuilderTest.php
+++ b/tests/Database/DatabaseSchemaBuilderTest.php
@@ -15,8 +15,8 @@ class DatabaseSchemaBuilderTest extends TestCase
 
     public function testHasTableCorrectlyCallsGrammar()
     {
-        $connection = m::mock('Illuminate\Database\Connection');
-        $grammar = m::mock('stdClass');
+        $connection = m::mock(\Illuminate\Database\Connection::class);
+        $grammar = m::mock(\stdClass::class);
         $connection->shouldReceive('getSchemaGrammar')->andReturn($grammar);
         $builder = new Builder($connection);
         $grammar->shouldReceive('compileTableExists')->once()->andReturn('sql');
@@ -28,8 +28,8 @@ class DatabaseSchemaBuilderTest extends TestCase
 
     public function testTableHasColumns()
     {
-        $connection = m::mock('Illuminate\Database\Connection');
-        $grammar = m::mock('stdClass');
+        $connection = m::mock(\Illuminate\Database\Connection::class);
+        $grammar = m::mock(\stdClass::class);
         $connection->shouldReceive('getSchemaGrammar')->andReturn($grammar);
         $builder = m::mock('Illuminate\Database\Schema\Builder[getColumnListing]', [$connection]);
         $builder->shouldReceive('getColumnListing')->with('users')->twice()->andReturn(['id', 'firstname']);
@@ -40,10 +40,10 @@ class DatabaseSchemaBuilderTest extends TestCase
 
     public function testGetColumnTypeAddsPrefix()
     {
-        $connection = m::mock('Illuminate\Database\Connection');
-        $column = m::mock('stdClass');
-        $type = m::mock('stdClass');
-        $grammar = m::mock('stdClass');
+        $connection = m::mock(\Illuminate\Database\Connection::class);
+        $column = m::mock(\stdClass::class);
+        $type = m::mock(\stdClass::class);
+        $grammar = m::mock(\stdClass::class);
         $connection->shouldReceive('getSchemaGrammar')->once()->andReturn($grammar);
         $builder = new Builder($connection);
         $connection->shouldReceive('getTablePrefix')->once()->andReturn('prefix_');

--- a/tests/Database/DatabaseSeederTest.php
+++ b/tests/Database/DatabaseSeederTest.php
@@ -32,10 +32,10 @@ class DatabaseSeederTest extends TestCase
     public function testCallResolveTheClassAndCallsRun()
     {
         $seeder = new TestSeeder;
-        $seeder->setContainer($container = m::mock('Illuminate\Container\Container'));
+        $seeder->setContainer($container = m::mock(\Illuminate\Container\Container::class));
         $output = m::mock('Symfony\Component\Console\Output\OutputInterface');
         $output->shouldReceive('writeln')->once()->andReturn('foo');
-        $command = m::mock('Illuminate\Console\Command');
+        $command = m::mock(\Illuminate\Console\Command::class);
         $command->shouldReceive('getOutput')->once()->andReturn($output);
         $seeder->setCommand($command);
         $container->shouldReceive('make')->once()->with('ClassName')->andReturn($child = m::mock(Seeder::class));
@@ -49,20 +49,20 @@ class DatabaseSeederTest extends TestCase
     public function testSetContainer()
     {
         $seeder = new TestSeeder;
-        $container = m::mock('Illuminate\Container\Container');
+        $container = m::mock(\Illuminate\Container\Container::class);
         $this->assertEquals($seeder->setContainer($container), $seeder);
     }
 
     public function testSetCommand()
     {
         $seeder = new TestSeeder;
-        $command = m::mock('Illuminate\Console\Command');
+        $command = m::mock(\Illuminate\Console\Command::class);
         $this->assertEquals($seeder->setCommand($command), $seeder);
     }
 
     public function testInjectDependenciesOnRunMethod()
     {
-        $container = m::mock('Illuminate\Container\Container');
+        $container = m::mock(\Illuminate\Container\Container::class);
         $container->shouldReceive('call');
 
         $seeder = new TestDepsSeeder;

--- a/tests/Database/DatabaseSoftDeletingScopeTest.php
+++ b/tests/Database/DatabaseSoftDeletingScopeTest.php
@@ -15,8 +15,8 @@ class DatabaseSoftDeletingScopeTest extends TestCase
     public function testApplyingScopeToABuilder()
     {
         $scope = m::mock('Illuminate\Database\Eloquent\SoftDeletingScope[extend]');
-        $builder = m::mock('Illuminate\Database\Eloquent\Builder');
-        $model = m::mock('Illuminate\Database\Eloquent\Model');
+        $builder = m::mock(\Illuminate\Database\Eloquent\Builder::class);
+        $model = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $model->shouldReceive('getQualifiedDeletedAtColumn')->once()->andReturn('table.deleted_at');
         $builder->shouldReceive('whereNull')->once()->with('table.deleted_at');
 
@@ -26,16 +26,16 @@ class DatabaseSoftDeletingScopeTest extends TestCase
     public function testRestoreExtension()
     {
         $builder = new \Illuminate\Database\Eloquent\Builder(new \Illuminate\Database\Query\Builder(
-            m::mock('Illuminate\Database\ConnectionInterface'),
-            m::mock('Illuminate\Database\Query\Grammars\Grammar'),
-            m::mock('Illuminate\Database\Query\Processors\Processor')
+            m::mock(\Illuminate\Database\ConnectionInterface::class),
+            m::mock(\Illuminate\Database\Query\Grammars\Grammar::class),
+            m::mock(\Illuminate\Database\Query\Processors\Processor::class)
         ));
         $scope = new \Illuminate\Database\Eloquent\SoftDeletingScope;
         $scope->extend($builder);
         $callback = $builder->getMacro('restore');
-        $givenBuilder = m::mock('Illuminate\Database\Eloquent\Builder');
+        $givenBuilder = m::mock(\Illuminate\Database\Eloquent\Builder::class);
         $givenBuilder->shouldReceive('withTrashed')->once();
-        $givenBuilder->shouldReceive('getModel')->once()->andReturn($model = m::mock('stdClass'));
+        $givenBuilder->shouldReceive('getModel')->once()->andReturn($model = m::mock(\stdClass::class));
         $model->shouldReceive('getDeletedAtColumn')->once()->andReturn('deleted_at');
         $givenBuilder->shouldReceive('update')->once()->with(['deleted_at' => null]);
 
@@ -45,15 +45,15 @@ class DatabaseSoftDeletingScopeTest extends TestCase
     public function testWithTrashedExtension()
     {
         $builder = new \Illuminate\Database\Eloquent\Builder(new \Illuminate\Database\Query\Builder(
-            m::mock('Illuminate\Database\ConnectionInterface'),
-            m::mock('Illuminate\Database\Query\Grammars\Grammar'),
-            m::mock('Illuminate\Database\Query\Processors\Processor')
+            m::mock(\Illuminate\Database\ConnectionInterface::class),
+            m::mock(\Illuminate\Database\Query\Grammars\Grammar::class),
+            m::mock(\Illuminate\Database\Query\Processors\Processor::class)
         ));
         $scope = m::mock('Illuminate\Database\Eloquent\SoftDeletingScope[remove]');
         $scope->extend($builder);
         $callback = $builder->getMacro('withTrashed');
-        $givenBuilder = m::mock('Illuminate\Database\Eloquent\Builder');
-        $givenBuilder->shouldReceive('getModel')->andReturn($model = m::mock('Illuminate\Database\Eloquent\Model'));
+        $givenBuilder = m::mock(\Illuminate\Database\Eloquent\Builder::class);
+        $givenBuilder->shouldReceive('getModel')->andReturn($model = m::mock(\Illuminate\Database\Eloquent\Model::class));
         $givenBuilder->shouldReceive('withoutGlobalScope')->with($scope)->andReturn($givenBuilder);
         $result = $callback($givenBuilder);
 
@@ -63,17 +63,17 @@ class DatabaseSoftDeletingScopeTest extends TestCase
     public function testOnlyTrashedExtension()
     {
         $builder = new \Illuminate\Database\Eloquent\Builder(new \Illuminate\Database\Query\Builder(
-            m::mock('Illuminate\Database\ConnectionInterface'),
-            m::mock('Illuminate\Database\Query\Grammars\Grammar'),
-            m::mock('Illuminate\Database\Query\Processors\Processor')
+            m::mock(\Illuminate\Database\ConnectionInterface::class),
+            m::mock(\Illuminate\Database\Query\Grammars\Grammar::class),
+            m::mock(\Illuminate\Database\Query\Processors\Processor::class)
         ));
-        $model = m::mock('Illuminate\Database\Eloquent\Model');
+        $model = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $model->shouldDeferMissing();
         $scope = m::mock('Illuminate\Database\Eloquent\SoftDeletingScope[remove]');
         $scope->extend($builder);
         $callback = $builder->getMacro('onlyTrashed');
-        $givenBuilder = m::mock('Illuminate\Database\Eloquent\Builder');
-        $givenBuilder->shouldReceive('getQuery')->andReturn($query = m::mock('stdClass'));
+        $givenBuilder = m::mock(\Illuminate\Database\Eloquent\Builder::class);
+        $givenBuilder->shouldReceive('getQuery')->andReturn($query = m::mock(\stdClass::class));
         $givenBuilder->shouldReceive('getModel')->andReturn($model);
         $givenBuilder->shouldReceive('withoutGlobalScope')->with($scope)->andReturn($givenBuilder);
         $model->shouldReceive('getQualifiedDeletedAtColumn')->andReturn('table.deleted_at');
@@ -86,17 +86,17 @@ class DatabaseSoftDeletingScopeTest extends TestCase
     public function testWithoutTrashedExtension()
     {
         $builder = new \Illuminate\Database\Eloquent\Builder(new \Illuminate\Database\Query\Builder(
-            m::mock('Illuminate\Database\ConnectionInterface'),
-            m::mock('Illuminate\Database\Query\Grammars\Grammar'),
-            m::mock('Illuminate\Database\Query\Processors\Processor')
+            m::mock(\Illuminate\Database\ConnectionInterface::class),
+            m::mock(\Illuminate\Database\Query\Grammars\Grammar::class),
+            m::mock(\Illuminate\Database\Query\Processors\Processor::class)
         ));
-        $model = m::mock('Illuminate\Database\Eloquent\Model');
+        $model = m::mock(\Illuminate\Database\Eloquent\Model::class);
         $model->shouldDeferMissing();
         $scope = m::mock('Illuminate\Database\Eloquent\SoftDeletingScope[remove]');
         $scope->extend($builder);
         $callback = $builder->getMacro('withoutTrashed');
-        $givenBuilder = m::mock('Illuminate\Database\Eloquent\Builder');
-        $givenBuilder->shouldReceive('getQuery')->andReturn($query = m::mock('stdClass'));
+        $givenBuilder = m::mock(\Illuminate\Database\Eloquent\Builder::class);
+        $givenBuilder->shouldReceive('getQuery')->andReturn($query = m::mock(\stdClass::class));
         $givenBuilder->shouldReceive('getModel')->andReturn($model);
         $givenBuilder->shouldReceive('withoutGlobalScope')->with($scope)->andReturn($givenBuilder);
         $model->shouldReceive('getQualifiedDeletedAtColumn')->andReturn('table.deleted_at');

--- a/tests/Database/DatabaseSoftDeletingTraitTest.php
+++ b/tests/Database/DatabaseSoftDeletingTraitTest.php
@@ -14,10 +14,10 @@ class DatabaseSoftDeletingTraitTest extends TestCase
 
     public function testDeleteSetsSoftDeletedColumn()
     {
-        $model = m::mock('Illuminate\Tests\Database\DatabaseSoftDeletingTraitStub');
+        $model = m::mock(\Illuminate\Tests\Database\DatabaseSoftDeletingTraitStub::class);
         $model->shouldDeferMissing();
-        // $model->shouldReceive('newQuery')->andReturn($query = m::mock('stdClass'));
-        $model->shouldReceive('newQueryWithoutScopes')->andReturn($query = m::mock('stdClass'));
+        // $model->shouldReceive('newQuery')->andReturn($query = m::mock(\stdClass::class));
+        $model->shouldReceive('newQueryWithoutScopes')->andReturn($query = m::mock(\stdClass::class));
         $query->shouldReceive('where')->once()->with('id', 1)->andReturn($query);
         $query->shouldReceive('update')->once()->with([
             'deleted_at' => 'date-time',
@@ -30,7 +30,7 @@ class DatabaseSoftDeletingTraitTest extends TestCase
 
     public function testRestore()
     {
-        $model = m::mock('Illuminate\Tests\Database\DatabaseSoftDeletingTraitStub');
+        $model = m::mock(\Illuminate\Tests\Database\DatabaseSoftDeletingTraitStub::class);
         $model->shouldDeferMissing();
         $model->shouldReceive('fireModelEvent')->with('restoring')->andReturn(true);
         $model->shouldReceive('save')->once();
@@ -43,7 +43,7 @@ class DatabaseSoftDeletingTraitTest extends TestCase
 
     public function testRestoreCancel()
     {
-        $model = m::mock('Illuminate\Tests\Database\DatabaseSoftDeletingTraitStub');
+        $model = m::mock(\Illuminate\Tests\Database\DatabaseSoftDeletingTraitStub::class);
         $model->shouldDeferMissing();
         $model->shouldReceive('fireModelEvent')->with('restoring')->andReturn(false);
         $model->shouldReceive('save')->never();

--- a/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
@@ -571,7 +571,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
 
     protected function getConnection()
     {
-        return m::mock('Illuminate\Database\Connection');
+        return m::mock(\Illuminate\Database\Connection::class);
     }
 
     public function getGrammar()

--- a/tests/Events/EventsDispatcherTest.php
+++ b/tests/Events/EventsDispatcherTest.php
@@ -42,8 +42,8 @@ class EventsDispatcherTest extends TestCase
 
     public function testContainerResolutionOfEventHandlers()
     {
-        $d = new Dispatcher($container = m::mock('Illuminate\Container\Container'));
-        $container->shouldReceive('make')->once()->with('FooHandler')->andReturn($handler = m::mock('stdClass'));
+        $d = new Dispatcher($container = m::mock(\Illuminate\Container\Container::class));
+        $container->shouldReceive('make')->once()->with('FooHandler')->andReturn($handler = m::mock(\stdClass::class));
         $handler->shouldReceive('onFooEvent')->once()->with('foo', 'bar');
         $d->listen('foo', 'FooHandler@onFooEvent');
         $d->fire('foo', ['foo', 'bar']);
@@ -51,8 +51,8 @@ class EventsDispatcherTest extends TestCase
 
     public function testContainerResolutionOfEventHandlersWithDefaultMethods()
     {
-        $d = new Dispatcher($container = m::mock('Illuminate\Container\Container'));
-        $container->shouldReceive('make')->once()->with('FooHandler')->andReturn($handler = m::mock('stdClass'));
+        $d = new Dispatcher($container = m::mock(\Illuminate\Container\Container::class));
+        $container->shouldReceive('make')->once()->with('FooHandler')->andReturn($handler = m::mock(\stdClass::class));
         $handler->shouldReceive('handle')->once()->with('foo', 'bar');
         $d->listen('foo', 'FooHandler');
         $d->fire('foo', ['foo', 'bar']);
@@ -170,11 +170,11 @@ class EventsDispatcherTest extends TestCase
     public function testQueuedEventHandlersAreQueued()
     {
         $d = new Dispatcher;
-        $queue = m::mock('Illuminate\Contracts\Queue\Queue');
+        $queue = m::mock(\Illuminate\Contracts\Queue\Queue::class);
 
         $queue->shouldReceive('connection')->once()->with(null)->andReturnSelf();
 
-        $queue->shouldReceive('pushOn')->once()->with(null, m::type('Illuminate\Events\CallQueuedListener'));
+        $queue->shouldReceive('pushOn')->once()->with(null, m::type(\Illuminate\Events\CallQueuedListener::class));
 
         $d->setQueueResolver(function () use ($queue) {
             return $queue;
@@ -188,7 +188,7 @@ class EventsDispatcherTest extends TestCase
     {
         unset($_SERVER['__event.test']);
         $d = new Dispatcher;
-        $d->listen('Illuminate\Tests\Events\ExampleEvent', function () {
+        $d->listen(\Illuminate\Tests\Events\ExampleEvent::class, function () {
             $_SERVER['__event.test'] = 'baz';
         });
         $d->fire(new ExampleEvent);
@@ -200,7 +200,7 @@ class EventsDispatcherTest extends TestCase
     {
         unset($_SERVER['__event.test']);
         $d = new Dispatcher;
-        $d->listen('Illuminate\Tests\Events\SomeEventInterface', function () {
+        $d->listen(\Illuminate\Tests\Events\SomeEventInterface::class, function () {
             $_SERVER['__event.test'] = 'bar';
         });
         $d->fire(new AnotherEvent);
@@ -212,10 +212,10 @@ class EventsDispatcherTest extends TestCase
     {
         unset($_SERVER['__event.test']);
         $d = new Dispatcher;
-        $d->listen('Illuminate\Tests\Events\AnotherEvent', function () {
+        $d->listen(\Illuminate\Tests\Events\AnotherEvent::class, function () {
             $_SERVER['__event.test1'] = 'fooo';
         });
-        $d->listen('Illuminate\Tests\Events\SomeEventInterface', function () {
+        $d->listen(\Illuminate\Tests\Events\SomeEventInterface::class, function () {
             $_SERVER['__event.test2'] = 'baar';
         });
         $d->fire(new AnotherEvent);

--- a/tests/Foundation/FoundationApplicationTest.php
+++ b/tests/Foundation/FoundationApplicationTest.php
@@ -16,19 +16,19 @@ class FoundationApplicationTest extends TestCase
     public function testSetLocaleSetsLocaleAndFiresLocaleChangedEvent()
     {
         $app = new Application;
-        $app['config'] = $config = m::mock('stdClass');
+        $app['config'] = $config = m::mock(\stdClass::class);
         $config->shouldReceive('set')->once()->with('app.locale', 'foo');
-        $app['translator'] = $trans = m::mock('stdClass');
+        $app['translator'] = $trans = m::mock(\stdClass::class);
         $trans->shouldReceive('setLocale')->once()->with('foo');
-        $app['events'] = $events = m::mock('stdClass');
-        $events->shouldReceive('dispatch')->once()->with(m::type('Illuminate\Foundation\Events\LocaleUpdated'));
+        $app['events'] = $events = m::mock(\stdClass::class);
+        $events->shouldReceive('dispatch')->once()->with(m::type(\Illuminate\Foundation\Events\LocaleUpdated::class));
 
         $app->setLocale('foo');
     }
 
     public function testServiceProvidersAreCorrectlyRegistered()
     {
-        $provider = m::mock('Illuminate\Tests\Foundation\ApplicationBasicServiceProviderStub');
+        $provider = m::mock(\Illuminate\Tests\Foundation\ApplicationBasicServiceProviderStub::class);
         $class = get_class($provider);
         $provider->shouldReceive('register')->once();
         $app = new Application;
@@ -39,7 +39,7 @@ class FoundationApplicationTest extends TestCase
 
     public function testServiceProvidersAreCorrectlyRegisteredWhenRegisterMethodIsNotPresent()
     {
-        $provider = m::mock('Illuminate\Support\ServiceProvider');
+        $provider = m::mock(\Illuminate\Support\ServiceProvider::class);
         $class = get_class($provider);
         $provider->shouldReceive('register')->never();
         $app = new Application;
@@ -51,7 +51,7 @@ class FoundationApplicationTest extends TestCase
     public function testDeferredServicesMarkedAsBound()
     {
         $app = new Application;
-        $app->setDeferredServices(['foo' => 'Illuminate\Tests\Foundation\ApplicationDeferredServiceProviderStub']);
+        $app->setDeferredServices(['foo' => \Illuminate\Tests\Foundation\ApplicationDeferredServiceProviderStub::class]);
         $this->assertTrue($app->bound('foo'));
         $this->assertEquals('foo', $app->make('foo'));
     }
@@ -59,19 +59,19 @@ class FoundationApplicationTest extends TestCase
     public function testDeferredServicesAreSharedProperly()
     {
         $app = new Application;
-        $app->setDeferredServices(['foo' => 'Illuminate\Tests\Foundation\ApplicationDeferredSharedServiceProviderStub']);
+        $app->setDeferredServices(['foo' => \Illuminate\Tests\Foundation\ApplicationDeferredSharedServiceProviderStub::class]);
         $this->assertTrue($app->bound('foo'));
         $one = $app->make('foo');
         $two = $app->make('foo');
-        $this->assertInstanceOf('stdClass', $one);
-        $this->assertInstanceOf('stdClass', $two);
+        $this->assertInstanceOf(\stdClass::class, $one);
+        $this->assertInstanceOf(\stdClass::class, $two);
         $this->assertSame($one, $two);
     }
 
     public function testDeferredServicesCanBeExtended()
     {
         $app = new Application;
-        $app->setDeferredServices(['foo' => 'Illuminate\Tests\Foundation\ApplicationDeferredServiceProviderStub']);
+        $app->setDeferredServices(['foo' => \Illuminate\Tests\Foundation\ApplicationDeferredServiceProviderStub::class]);
         $app->extend('foo', function ($instance, $container) {
             return $instance.'bar';
         });
@@ -81,9 +81,9 @@ class FoundationApplicationTest extends TestCase
     public function testDeferredServiceProviderIsRegisteredOnlyOnce()
     {
         $app = new Application;
-        $app->setDeferredServices(['foo' => 'Illuminate\Tests\Foundation\ApplicationDeferredServiceProviderCountStub']);
+        $app->setDeferredServices(['foo' => \Illuminate\Tests\Foundation\ApplicationDeferredServiceProviderCountStub::class]);
         $obj = $app->make('foo');
-        $this->assertInstanceOf('stdClass', $obj);
+        $this->assertInstanceOf(\stdClass::class, $obj);
         $this->assertSame($obj, $app->make('foo'));
         $this->assertEquals(1, ApplicationDeferredServiceProviderCountStub::$count);
     }
@@ -92,7 +92,7 @@ class FoundationApplicationTest extends TestCase
     {
         ApplicationDeferredServiceProviderStub::$initialized = false;
         $app = new Application;
-        $app->setDeferredServices(['foo' => 'Illuminate\Tests\Foundation\ApplicationDeferredServiceProviderStub']);
+        $app->setDeferredServices(['foo' => \Illuminate\Tests\Foundation\ApplicationDeferredServiceProviderStub::class]);
         $this->assertTrue($app->bound('foo'));
         $this->assertFalse(ApplicationDeferredServiceProviderStub::$initialized);
         $app->extend('foo', function ($instance, $container) {
@@ -106,7 +106,7 @@ class FoundationApplicationTest extends TestCase
     public function testDeferredServicesCanRegisterFactories()
     {
         $app = new Application;
-        $app->setDeferredServices(['foo' => 'Illuminate\Tests\Foundation\ApplicationFactoryProviderStub']);
+        $app->setDeferredServices(['foo' => \Illuminate\Tests\Foundation\ApplicationFactoryProviderStub::class]);
         $this->assertTrue($app->bound('foo'));
         $this->assertEquals(1, $app->make('foo'));
         $this->assertEquals(2, $app->make('foo'));
@@ -117,8 +117,8 @@ class FoundationApplicationTest extends TestCase
     {
         $app = new Application;
         $app->setDeferredServices([
-            'foo' => 'Illuminate\Tests\Foundation\ApplicationMultiProviderStub',
-            'bar' => 'Illuminate\Tests\Foundation\ApplicationMultiProviderStub',
+            'foo' => \Illuminate\Tests\Foundation\ApplicationMultiProviderStub::class,
+            'bar' => \Illuminate\Tests\Foundation\ApplicationMultiProviderStub::class,
         ]);
         $this->assertEquals('foo', $app->make('foo'));
         $this->assertEquals('foobar', $app->make('bar'));
@@ -157,7 +157,7 @@ class FoundationApplicationTest extends TestCase
         $app = new Application;
         $closure = function () {
         };
-        $app->beforeBootstrapping('Illuminate\Foundation\Bootstrap\RegisterFacades', $closure);
+        $app->beforeBootstrapping(\Illuminate\Foundation\Bootstrap\RegisterFacades::class, $closure);
         $this->assertArrayHasKey(0, $app['events']->getListeners('bootstrapping: Illuminate\Foundation\Bootstrap\RegisterFacades'));
         // $this->assertSame($closure, $app['events']->getListeners('bootstrapping: Illuminate\Foundation\Bootstrap\RegisterFacades')[0]);
     }
@@ -167,7 +167,7 @@ class FoundationApplicationTest extends TestCase
         $app = new Application;
         $closure = function () {
         };
-        $app->afterBootstrapping('Illuminate\Foundation\Bootstrap\RegisterFacades', $closure);
+        $app->afterBootstrapping(\Illuminate\Foundation\Bootstrap\RegisterFacades::class, $closure);
         $this->assertArrayHasKey(0, $app['events']->getListeners('bootstrapped: Illuminate\Foundation\Bootstrap\RegisterFacades'));
         // $this->assertSame($closure, $app['events']->getListeners('bootstrapped: Illuminate\Foundation\Bootstrap\RegisterFacades')[0]);
     }

--- a/tests/Foundation/FoundationComposerTest.php
+++ b/tests/Foundation/FoundationComposerTest.php
@@ -16,9 +16,9 @@ class FoundationComposerTest extends TestCase
     {
         $escape = '\\' === DIRECTORY_SEPARATOR ? '"' : '\'';
 
-        $composer = $this->getMockBuilder('Illuminate\Support\Composer')->setMethods(['getProcess'])->setConstructorArgs([$files = m::mock('Illuminate\Filesystem\Filesystem'), __DIR__])->getMock();
+        $composer = $this->getMockBuilder(\Illuminate\Support\Composer::class)->setMethods(['getProcess'])->setConstructorArgs([$files = m::mock(\Illuminate\Filesystem\Filesystem::class), __DIR__])->getMock();
         $files->shouldReceive('exists')->once()->with(__DIR__.'/composer.phar')->andReturn(true);
-        $process = m::mock('stdClass');
+        $process = m::mock(\stdClass::class);
         $composer->expects($this->once())->method('getProcess')->will($this->returnValue($process));
         $process->shouldReceive('setCommandLine')->once()->with($escape.PHP_BINARY.$escape.' composer.phar dump-autoload');
         $process->shouldReceive('run')->once();
@@ -28,9 +28,9 @@ class FoundationComposerTest extends TestCase
 
     public function testDumpAutoloadRunsTheCorrectCommandWhenComposerIsntPresent()
     {
-        $composer = $this->getMockBuilder('Illuminate\Support\Composer')->setMethods(['getProcess'])->setConstructorArgs([$files = m::mock('Illuminate\Filesystem\Filesystem'), __DIR__])->getMock();
+        $composer = $this->getMockBuilder(\Illuminate\Support\Composer::class)->setMethods(['getProcess'])->setConstructorArgs([$files = m::mock(\Illuminate\Filesystem\Filesystem::class), __DIR__])->getMock();
         $files->shouldReceive('exists')->once()->with(__DIR__.'/composer.phar')->andReturn(false);
-        $process = m::mock('stdClass');
+        $process = m::mock(\stdClass::class);
         $composer->expects($this->once())->method('getProcess')->will($this->returnValue($process));
         $process->shouldReceive('setCommandLine')->once()->with('composer dump-autoload');
         $process->shouldReceive('run')->once();

--- a/tests/Foundation/FoundationExceptionsHandlerTest.php
+++ b/tests/Foundation/FoundationExceptionsHandlerTest.php
@@ -27,7 +27,7 @@ class FoundationExceptionsHandlerTest extends TestCase
     {
         $this->config = m::mock(Config::class);
 
-        $this->request = m::mock('stdClass');
+        $this->request = m::mock(\stdClass::class);
 
         $this->container = Container::setInstance(new Container);
 
@@ -35,7 +35,7 @@ class FoundationExceptionsHandlerTest extends TestCase
             return $this->config;
         });
 
-        $this->container->singleton('Illuminate\Contracts\Routing\ResponseFactory', function () {
+        $this->container->singleton(\Illuminate\Contracts\Routing\ResponseFactory::class, function () {
             return new \Illuminate\Routing\ResponseFactory(
                 m::mock(\Illuminate\Contracts\View\Factory::class),
                 m::mock(\Illuminate\Routing\Redirector::class)

--- a/tests/Foundation/FoundationHelpersTest.php
+++ b/tests/Foundation/FoundationHelpersTest.php
@@ -16,10 +16,10 @@ class FoundationHelpersTest extends TestCase
     public function testCache()
     {
         $app = new Application;
-        $app['cache'] = $cache = m::mock('stdClass');
+        $app['cache'] = $cache = m::mock(\stdClass::class);
 
         // 1. cache()
-        $this->assertInstanceOf('stdClass', cache());
+        $this->assertInstanceOf(\stdClass::class, cache());
 
         // 2. cache(['foo' => 'bar'], 1);
         $cache->shouldReceive('put')->once()->with('foo', 'bar', 1);

--- a/tests/Foundation/FoundationProviderRepositoryTest.php
+++ b/tests/Foundation/FoundationProviderRepositoryTest.php
@@ -14,12 +14,12 @@ class FoundationProviderRepositoryTest extends TestCase
 
     public function testServicesAreRegisteredWhenManifestIsNotRecompiled()
     {
-        $app = m::mock('Illuminate\Foundation\Application');
+        $app = m::mock(\Illuminate\Foundation\Application::class);
 
-        $repo = m::mock('Illuminate\Foundation\ProviderRepository[createProvider,loadManifest,shouldRecompile]', [$app, m::mock('Illuminate\Filesystem\Filesystem'), [__DIR__.'/services.php']]);
+        $repo = m::mock('Illuminate\Foundation\ProviderRepository[createProvider,loadManifest,shouldRecompile]', [$app, m::mock(\Illuminate\Filesystem\Filesystem::class), [__DIR__.'/services.php']]);
         $repo->shouldReceive('loadManifest')->once()->andReturn(['eager' => ['foo'], 'deferred' => ['deferred'], 'providers' => ['providers'], 'when' => []]);
         $repo->shouldReceive('shouldRecompile')->once()->andReturn(false);
-        $provider = m::mock('Illuminate\Support\ServiceProvider');
+        $provider = m::mock(\Illuminate\Support\ServiceProvider::class);
 
         $app->shouldReceive('register')->once()->with('foo');
         $app->shouldReceive('runningInConsole')->andReturn(false);
@@ -30,21 +30,21 @@ class FoundationProviderRepositoryTest extends TestCase
 
     public function testManifestIsProperlyRecompiled()
     {
-        $app = m::mock('Illuminate\Foundation\Application');
+        $app = m::mock(\Illuminate\Foundation\Application::class);
 
-        $repo = m::mock('Illuminate\Foundation\ProviderRepository[createProvider,loadManifest,writeManifest,shouldRecompile]', [$app, m::mock('Illuminate\Filesystem\Filesystem'), [__DIR__.'/services.php']]);
+        $repo = m::mock('Illuminate\Foundation\ProviderRepository[createProvider,loadManifest,writeManifest,shouldRecompile]', [$app, m::mock(\Illuminate\Filesystem\Filesystem::class), [__DIR__.'/services.php']]);
 
         $repo->shouldReceive('loadManifest')->once()->andReturn(['eager' => [], 'deferred' => ['deferred']]);
         $repo->shouldReceive('shouldRecompile')->once()->andReturn(true);
 
         // foo mock is just a deferred provider
-        $repo->shouldReceive('createProvider')->once()->with('foo')->andReturn($fooMock = m::mock('stdClass'));
+        $repo->shouldReceive('createProvider')->once()->with('foo')->andReturn($fooMock = m::mock(\stdClass::class));
         $fooMock->shouldReceive('isDeferred')->once()->andReturn(true);
         $fooMock->shouldReceive('provides')->once()->andReturn(['foo.provides1', 'foo.provides2']);
         $fooMock->shouldReceive('when')->once()->andReturn([]);
 
         // bar mock is added to eagers since it's not reserved
-        $repo->shouldReceive('createProvider')->once()->with('bar')->andReturn($barMock = m::mock('Illuminate\Support\ServiceProvider'));
+        $repo->shouldReceive('createProvider')->once()->with('bar')->andReturn($barMock = m::mock(\Illuminate\Support\ServiceProvider::class));
         $barMock->shouldReceive('isDeferred')->once()->andReturn(false);
         $repo->shouldReceive('writeManifest')->once()->andReturnUsing(function ($manifest) {
             return $manifest;
@@ -59,7 +59,7 @@ class FoundationProviderRepositoryTest extends TestCase
 
     public function testShouldRecompileReturnsCorrectValue()
     {
-        $repo = new \Illuminate\Foundation\ProviderRepository(m::mock('Illuminate\Contracts\Foundation\Application'), new \Illuminate\Filesystem\Filesystem, __DIR__.'/services.php');
+        $repo = new \Illuminate\Foundation\ProviderRepository(m::mock(\Illuminate\Contracts\Foundation\Application::class), new \Illuminate\Filesystem\Filesystem, __DIR__.'/services.php');
         $this->assertTrue($repo->shouldRecompile(null, []));
         $this->assertTrue($repo->shouldRecompile(['providers' => ['foo']], ['foo', 'bar']));
         $this->assertFalse($repo->shouldRecompile(['providers' => ['foo']], ['foo']));
@@ -67,7 +67,7 @@ class FoundationProviderRepositoryTest extends TestCase
 
     public function testLoadManifestReturnsParsedJSON()
     {
-        $repo = new \Illuminate\Foundation\ProviderRepository(m::mock('Illuminate\Contracts\Foundation\Application'), $files = m::mock('Illuminate\Filesystem\Filesystem'), __DIR__.'/services.php');
+        $repo = new \Illuminate\Foundation\ProviderRepository(m::mock(\Illuminate\Contracts\Foundation\Application::class), $files = m::mock(\Illuminate\Filesystem\Filesystem::class), __DIR__.'/services.php');
         $files->shouldReceive('exists')->once()->with(__DIR__.'/services.php')->andReturn(true);
         $files->shouldReceive('getRequire')->once()->with(__DIR__.'/services.php')->andReturn($array = ['users' => ['dayle' => true], 'when' => []]);
 
@@ -76,7 +76,7 @@ class FoundationProviderRepositoryTest extends TestCase
 
     public function testWriteManifestStoresToProperLocation()
     {
-        $repo = new \Illuminate\Foundation\ProviderRepository(m::mock('Illuminate\Contracts\Foundation\Application'), $files = m::mock('Illuminate\Filesystem\Filesystem'), __DIR__.'/services.php');
+        $repo = new \Illuminate\Foundation\ProviderRepository(m::mock(\Illuminate\Contracts\Foundation\Application::class), $files = m::mock(\Illuminate\Filesystem\Filesystem::class), __DIR__.'/services.php');
         $files->shouldReceive('put')->once()->with(__DIR__.'/services.php', '<?php return '.var_export(['foo'], true).';');
 
         $result = $repo->writeManifest(['foo']);

--- a/tests/Http/HttpJsonResponseTest.php
+++ b/tests/Http/HttpJsonResponseTest.php
@@ -13,7 +13,7 @@ class HttpJsonResponseTest extends TestCase
     {
         $response = new \Illuminate\Http\JsonResponse(new JsonResponseTestJsonableObject);
         $data = $response->getData();
-        $this->assertInstanceOf('stdClass', $data);
+        $this->assertInstanceOf(\stdClass::class, $data);
         $this->assertEquals('bar', $data->foo);
     }
 
@@ -21,7 +21,7 @@ class HttpJsonResponseTest extends TestCase
     {
         $response = new \Illuminate\Http\JsonResponse(new JsonResponseTestJsonSerializeObject);
         $data = $response->getData();
-        $this->assertInstanceOf('stdClass', $data);
+        $this->assertInstanceOf(\stdClass::class, $data);
         $this->assertEquals('bar', $data->foo);
     }
 
@@ -29,7 +29,7 @@ class HttpJsonResponseTest extends TestCase
     {
         $response = new \Illuminate\Http\JsonResponse(new JsonResponseTestArrayableObject);
         $data = $response->getData();
-        $this->assertInstanceOf('stdClass', $data);
+        $this->assertInstanceOf(\stdClass::class, $data);
         $this->assertEquals('bar', $data->foo);
     }
 
@@ -37,7 +37,7 @@ class HttpJsonResponseTest extends TestCase
     {
         $response = new \Illuminate\Http\JsonResponse(['foo' => 'bar']);
         $data = $response->getData();
-        $this->assertInstanceOf('stdClass', $data);
+        $this->assertInstanceOf(\stdClass::class, $data);
         $this->assertEquals('bar', $data->foo);
     }
 
@@ -89,7 +89,7 @@ class HttpJsonResponseTest extends TestCase
         $resource = tmpfile();
         $response = new \Illuminate\Http\JsonResponse(['resource' => $resource], 200, [], JSON_PARTIAL_OUTPUT_ON_ERROR);
         $data = $response->getData();
-        $this->assertInstanceOf('stdClass', $data);
+        $this->assertInstanceOf(\stdClass::class, $data);
         $this->assertNull($data->resource);
     }
 }

--- a/tests/Http/HttpRedirectResponseTest.php
+++ b/tests/Http/HttpRedirectResponseTest.php
@@ -31,7 +31,7 @@ class HttpRedirectResponseTest extends TestCase
     {
         $response = new RedirectResponse('foo.bar');
         $response->setRequest(Request::create('/', 'GET', ['name' => 'Taylor', 'age' => 26]));
-        $response->setSession($session = m::mock('Illuminate\Session\Store'));
+        $response->setSession($session = m::mock(\Illuminate\Session\Store::class));
         $session->shouldReceive('flash')->twice();
         $response->with(['name', 'age']);
     }
@@ -51,7 +51,7 @@ class HttpRedirectResponseTest extends TestCase
     {
         $response = new RedirectResponse('foo.bar');
         $response->setRequest(Request::create('/', 'GET', ['name' => 'Taylor', 'age' => 26]));
-        $response->setSession($session = m::mock('Illuminate\Session\Store'));
+        $response->setSession($session = m::mock(\Illuminate\Session\Store::class));
         $session->shouldReceive('flashInput')->once()->with(['name' => 'Taylor', 'age' => 26]);
         $response->withInput();
     }
@@ -60,7 +60,7 @@ class HttpRedirectResponseTest extends TestCase
     {
         $response = new RedirectResponse('foo.bar');
         $response->setRequest(Request::create('/', 'GET', ['name' => 'Taylor', 'age' => 26]));
-        $response->setSession($session = m::mock('Illuminate\Session\Store'));
+        $response->setSession($session = m::mock(\Illuminate\Session\Store::class));
         $session->shouldReceive('flashInput')->once()->with(['name' => 'Taylor']);
         $response->onlyInput('name');
     }
@@ -69,7 +69,7 @@ class HttpRedirectResponseTest extends TestCase
     {
         $response = new RedirectResponse('foo.bar');
         $response->setRequest(Request::create('/', 'GET', ['name' => 'Taylor', 'age' => 26]));
-        $response->setSession($session = m::mock('Illuminate\Session\Store'));
+        $response->setSession($session = m::mock(\Illuminate\Session\Store::class));
         $session->shouldReceive('flashInput')->once()->with(['name' => 'Taylor']);
         $response->exceptInput('age');
     }
@@ -78,10 +78,10 @@ class HttpRedirectResponseTest extends TestCase
     {
         $response = new RedirectResponse('foo.bar');
         $response->setRequest(Request::create('/', 'GET', ['name' => 'Taylor', 'age' => 26]));
-        $response->setSession($session = m::mock('Illuminate\Session\Store'));
-        $session->shouldReceive('get')->with('errors', m::type('Illuminate\Support\ViewErrorBag'))->andReturn(new \Illuminate\Support\ViewErrorBag);
-        $session->shouldReceive('flash')->once()->with('errors', m::type('Illuminate\Support\ViewErrorBag'));
-        $provider = m::mock('Illuminate\Contracts\Support\MessageProvider');
+        $response->setSession($session = m::mock(\Illuminate\Session\Store::class));
+        $session->shouldReceive('get')->with('errors', m::type(\Illuminate\Support\ViewErrorBag::class))->andReturn(new \Illuminate\Support\ViewErrorBag);
+        $session->shouldReceive('flash')->once()->with('errors', m::type(\Illuminate\Support\ViewErrorBag::class));
+        $provider = m::mock(\Illuminate\Contracts\Support\MessageProvider::class);
         $provider->shouldReceive('getMessageBag')->once()->andReturn(new \Illuminate\Support\MessageBag);
         $response->withErrors($provider);
     }
@@ -93,7 +93,7 @@ class HttpRedirectResponseTest extends TestCase
         $this->assertNull($response->getSession());
 
         $request = Request::create('/', 'GET');
-        $session = m::mock('Illuminate\Session\Store');
+        $session = m::mock(\Illuminate\Session\Store::class);
         $response->setRequest($request);
         $response->setSession($session);
         $this->assertSame($request, $response->getRequest());
@@ -104,9 +104,9 @@ class HttpRedirectResponseTest extends TestCase
     {
         $response = new RedirectResponse('foo.bar');
         $response->setRequest(Request::create('/', 'GET', ['name' => 'Taylor', 'age' => 26]));
-        $response->setSession($session = m::mock('Illuminate\Session\Store'));
-        $session->shouldReceive('get')->with('errors', m::type('Illuminate\Support\ViewErrorBag'))->andReturn(new \Illuminate\Support\ViewErrorBag);
-        $session->shouldReceive('flash')->once()->with('errors', m::type('Illuminate\Support\ViewErrorBag'));
+        $response->setSession($session = m::mock(\Illuminate\Session\Store::class));
+        $session->shouldReceive('get')->with('errors', m::type(\Illuminate\Support\ViewErrorBag::class))->andReturn(new \Illuminate\Support\ViewErrorBag);
+        $session->shouldReceive('flash')->once()->with('errors', m::type(\Illuminate\Support\ViewErrorBag::class));
         $provider = ['foo' => 'bar'];
         $response->withErrors($provider);
     }
@@ -115,7 +115,7 @@ class HttpRedirectResponseTest extends TestCase
     {
         $response = new RedirectResponse('foo.bar');
         $response->setRequest(Request::create('/', 'GET', ['name' => 'Taylor', 'age' => 26]));
-        $response->setSession($session = m::mock('Illuminate\Session\Store'));
+        $response->setSession($session = m::mock(\Illuminate\Session\Store::class));
         $session->shouldReceive('flash')->once()->with('foo', 'bar');
         $response->withFoo('bar');
     }

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -460,14 +460,14 @@ class HttpRequestTest extends TestCase
 
     public function testAllInputReturnsInputAndFiles()
     {
-        $file = $this->getMockBuilder('Illuminate\Http\UploadedFile')->setConstructorArgs([__FILE__, 'photo.jpg'])->getMock();
+        $file = $this->getMockBuilder(\Illuminate\Http\UploadedFile::class)->setConstructorArgs([__FILE__, 'photo.jpg'])->getMock();
         $request = Request::create('/?boom=breeze', 'GET', ['foo' => 'bar'], [], ['baz' => $file]);
         $this->assertEquals(['foo' => 'bar', 'baz' => $file, 'boom' => 'breeze'], $request->all());
     }
 
     public function testAllInputReturnsNestedInputAndFiles()
     {
-        $file = $this->getMockBuilder('Illuminate\Http\UploadedFile')->setConstructorArgs([__FILE__, 'photo.jpg'])->getMock();
+        $file = $this->getMockBuilder(\Illuminate\Http\UploadedFile::class)->setConstructorArgs([__FILE__, 'photo.jpg'])->getMock();
         $request = Request::create('/?boom=breeze', 'GET', ['foo' => ['bar' => 'baz']], [], ['foo' => ['photo' => $file]]);
         $this->assertEquals(['foo' => ['bar' => 'baz', 'photo' => $file], 'boom' => 'breeze'], $request->all());
     }
@@ -529,7 +529,7 @@ class HttpRequestTest extends TestCase
     public function testOldMethodCallsSession()
     {
         $request = Request::create('/', 'GET');
-        $session = m::mock('Illuminate\Session\Store');
+        $session = m::mock(\Illuminate\Session\Store::class);
         $session->shouldReceive('getOldInput')->once()->with('foo', 'bar')->andReturn('boom');
         $request->setLaravelSession($session);
         $this->assertEquals('boom', $request->old('foo', 'bar'));
@@ -538,7 +538,7 @@ class HttpRequestTest extends TestCase
     public function testFlushMethodCallsSession()
     {
         $request = Request::create('/', 'GET');
-        $session = m::mock('Illuminate\Session\Store');
+        $session = m::mock(\Illuminate\Session\Store::class);
         $session->shouldReceive('flashInput')->once();
         $request->setLaravelSession($session);
         $request->flush();
@@ -790,7 +790,7 @@ class HttpRequestTest extends TestCase
 
     public function testHttpRequestFlashCallsSessionFlashInputWithInputData()
     {
-        $session = m::mock('Illuminate\Session\Store');
+        $session = m::mock(\Illuminate\Session\Store::class);
         $session->shouldReceive('flashInput')->once()->with(['name' => 'Taylor', 'email' => 'foo']);
         $request = Request::create('/', 'GET', ['name' => 'Taylor', 'email' => 'foo']);
         $request->setLaravelSession($session);
@@ -799,7 +799,7 @@ class HttpRequestTest extends TestCase
 
     public function testHttpRequestFlashOnlyCallsFlashWithProperParameters()
     {
-        $session = m::mock('Illuminate\Session\Store');
+        $session = m::mock(\Illuminate\Session\Store::class);
         $session->shouldReceive('flashInput')->once()->with(['name' => 'Taylor']);
         $request = Request::create('/', 'GET', ['name' => 'Taylor', 'email' => 'foo']);
         $request->setLaravelSession($session);
@@ -808,7 +808,7 @@ class HttpRequestTest extends TestCase
 
     public function testHttpRequestFlashExceptCallsFlashWithProperParameters()
     {
-        $session = m::mock('Illuminate\Session\Store');
+        $session = m::mock(\Illuminate\Session\Store::class);
         $session->shouldReceive('flashInput')->once()->with(['name' => 'Taylor']);
         $request = Request::create('/', 'GET', ['name' => 'Taylor', 'email' => 'foo']);
         $request->setLaravelSession($session);

--- a/tests/Http/HttpResponseTest.php
+++ b/tests/Http/HttpResponseTest.php
@@ -54,7 +54,7 @@ class HttpResponseTest extends TestCase
 
     public function testRenderablesAreRendered()
     {
-        $mock = m::mock('Illuminate\Contracts\Support\Renderable');
+        $mock = m::mock(\Illuminate\Contracts\Support\Renderable::class);
         $mock->shouldReceive('render')->once()->andReturn('foo');
         $response = new \Illuminate\Http\Response($mock);
         $this->assertEquals('foo', $response->getContent());
@@ -102,7 +102,7 @@ class HttpResponseTest extends TestCase
     {
         $response = new RedirectResponse('foo.bar');
         $response->setRequest(Request::create('/', 'GET', ['name' => 'Taylor', 'age' => 26]));
-        $response->setSession($session = m::mock('Illuminate\Session\Store'));
+        $response->setSession($session = m::mock(\Illuminate\Session\Store::class));
         $session->shouldReceive('flashInput')->once()->with(['name' => 'Taylor']);
         $response->onlyInput('name');
     }
@@ -111,7 +111,7 @@ class HttpResponseTest extends TestCase
     {
         $response = new RedirectResponse('foo.bar');
         $response->setRequest(Request::create('/', 'GET', ['name' => 'Taylor', 'age' => 26]));
-        $response->setSession($session = m::mock('Illuminate\Session\Store'));
+        $response->setSession($session = m::mock(\Illuminate\Session\Store::class));
         $session->shouldReceive('flashInput')->once()->with(['name' => 'Taylor']);
         $response->exceptInput('age');
     }
@@ -120,10 +120,10 @@ class HttpResponseTest extends TestCase
     {
         $response = new RedirectResponse('foo.bar');
         $response->setRequest(Request::create('/', 'GET', ['name' => 'Taylor', 'age' => 26]));
-        $response->setSession($session = m::mock('Illuminate\Session\Store'));
-        $session->shouldReceive('get')->with('errors', m::type('Illuminate\Support\ViewErrorBag'))->andReturn(new \Illuminate\Support\ViewErrorBag);
-        $session->shouldReceive('flash')->once()->with('errors', m::type('Illuminate\Support\ViewErrorBag'));
-        $provider = m::mock('Illuminate\Contracts\Support\MessageProvider');
+        $response->setSession($session = m::mock(\Illuminate\Session\Store::class));
+        $session->shouldReceive('get')->with('errors', m::type(\Illuminate\Support\ViewErrorBag::class))->andReturn(new \Illuminate\Support\ViewErrorBag);
+        $session->shouldReceive('flash')->once()->with('errors', m::type(\Illuminate\Support\ViewErrorBag::class));
+        $provider = m::mock(\Illuminate\Contracts\Support\MessageProvider::class);
         $provider->shouldReceive('getMessageBag')->once()->andReturn(new \Illuminate\Support\MessageBag);
         $response->withErrors($provider);
     }
@@ -135,7 +135,7 @@ class HttpResponseTest extends TestCase
         $this->assertNull($response->getSession());
 
         $request = Request::create('/', 'GET');
-        $session = m::mock('Illuminate\Session\Store');
+        $session = m::mock(\Illuminate\Session\Store::class);
         $response->setRequest($request);
         $response->setSession($session);
         $this->assertSame($request, $response->getRequest());
@@ -146,9 +146,9 @@ class HttpResponseTest extends TestCase
     {
         $response = new RedirectResponse('foo.bar');
         $response->setRequest(Request::create('/', 'GET', ['name' => 'Taylor', 'age' => 26]));
-        $response->setSession($session = m::mock('Illuminate\Session\Store'));
-        $session->shouldReceive('get')->with('errors', m::type('Illuminate\Support\ViewErrorBag'))->andReturn(new \Illuminate\Support\ViewErrorBag);
-        $session->shouldReceive('flash')->once()->with('errors', m::type('Illuminate\Support\ViewErrorBag'));
+        $response->setSession($session = m::mock(\Illuminate\Session\Store::class));
+        $session->shouldReceive('get')->with('errors', m::type(\Illuminate\Support\ViewErrorBag::class))->andReturn(new \Illuminate\Support\ViewErrorBag);
+        $session->shouldReceive('flash')->once()->with('errors', m::type(\Illuminate\Support\ViewErrorBag::class));
         $provider = ['foo' => 'bar'];
         $response->withErrors($provider);
     }
@@ -177,7 +177,7 @@ class HttpResponseTest extends TestCase
     {
         $response = new RedirectResponse('foo.bar');
         $response->setRequest(Request::create('/', 'GET', ['name' => 'Taylor', 'age' => 26]));
-        $response->setSession($session = m::mock('Illuminate\Session\Store'));
+        $response->setSession($session = m::mock(\Illuminate\Session\Store::class));
         $session->shouldReceive('flash')->once()->with('foo', 'bar');
         $response->withFoo('bar');
     }

--- a/tests/Log/LogWriterTest.php
+++ b/tests/Log/LogWriterTest.php
@@ -15,28 +15,28 @@ class LogWriterTest extends TestCase
 
     public function testFileHandlerCanBeAdded()
     {
-        $writer = new Writer($monolog = m::mock('Monolog\Logger'));
-        $monolog->shouldReceive('pushHandler')->once()->with(m::type('Monolog\Handler\StreamHandler'));
+        $writer = new Writer($monolog = m::mock(\Monolog\Logger::class));
+        $monolog->shouldReceive('pushHandler')->once()->with(m::type(\Monolog\Handler\StreamHandler::class));
         $writer->useFiles(__DIR__);
     }
 
     public function testRotatingFileHandlerCanBeAdded()
     {
-        $writer = new Writer($monolog = m::mock('Monolog\Logger'));
-        $monolog->shouldReceive('pushHandler')->once()->with(m::type('Monolog\Handler\RotatingFileHandler'));
+        $writer = new Writer($monolog = m::mock(\Monolog\Logger::class));
+        $monolog->shouldReceive('pushHandler')->once()->with(m::type(\Monolog\Handler\RotatingFileHandler::class));
         $writer->useDailyFiles(__DIR__, 5);
     }
 
     public function testErrorLogHandlerCanBeAdded()
     {
-        $writer = new Writer($monolog = m::mock('Monolog\Logger'));
-        $monolog->shouldReceive('pushHandler')->once()->with(m::type('Monolog\Handler\ErrorLogHandler'));
+        $writer = new Writer($monolog = m::mock(\Monolog\Logger::class));
+        $monolog->shouldReceive('pushHandler')->once()->with(m::type(\Monolog\Handler\ErrorLogHandler::class));
         $writer->useErrorLog();
     }
 
     public function testMethodsPassErrorAdditionsToMonolog()
     {
-        $writer = new Writer($monolog = m::mock('Monolog\Logger'));
+        $writer = new Writer($monolog = m::mock(\Monolog\Logger::class));
         $monolog->shouldReceive('error')->once()->with('foo', []);
 
         $writer->error('foo');
@@ -44,7 +44,7 @@ class LogWriterTest extends TestCase
 
     public function testWriterFiresEventsDispatcher()
     {
-        $writer = new Writer($monolog = m::mock('Monolog\Logger'), $events = new \Illuminate\Events\Dispatcher);
+        $writer = new Writer($monolog = m::mock(\Monolog\Logger::class), $events = new \Illuminate\Events\Dispatcher);
         $monolog->shouldReceive('error')->once()->with('foo', []);
 
         $events->listen(\Illuminate\Log\Events\MessageLogged::class, function ($event) {
@@ -70,14 +70,14 @@ class LogWriterTest extends TestCase
      */
     public function testListenShortcutFailsWithNoDispatcher()
     {
-        $writer = new Writer($monolog = m::mock('Monolog\Logger'));
+        $writer = new Writer($monolog = m::mock(\Monolog\Logger::class));
         $writer->listen(function () {
         });
     }
 
     public function testListenShortcut()
     {
-        $writer = new Writer($monolog = m::mock('Monolog\Logger'), $events = m::mock('Illuminate\Contracts\Events\Dispatcher'));
+        $writer = new Writer($monolog = m::mock(\Monolog\Logger::class), $events = m::mock(\Illuminate\Contracts\Events\Dispatcher::class));
 
         $callback = function () {
             return 'success';

--- a/tests/Mail/MailMailerTest.php
+++ b/tests/Mail/MailMailerTest.php
@@ -17,10 +17,10 @@ class MailMailerTest extends TestCase
     public function testMailerSendSendsMessageWithProperViewContent()
     {
         unset($_SERVER['__mailer.test']);
-        $mailer = $this->getMockBuilder('Illuminate\Mail\Mailer')->setMethods(['createMessage'])->setConstructorArgs($this->getMocks())->getMock();
+        $mailer = $this->getMockBuilder(\Illuminate\Mail\Mailer::class)->setMethods(['createMessage'])->setConstructorArgs($this->getMocks())->getMock();
         $message = m::mock('Swift_Mime_SimpleMessage');
         $mailer->expects($this->once())->method('createMessage')->will($this->returnValue($message));
-        $view = m::mock('stdClass');
+        $view = m::mock(\stdClass::class);
         $mailer->getViewFactory()->shouldReceive('make')->once()->with('foo', ['data', 'message' => $message])->andReturn($view);
         $view->shouldReceive('render')->once()->andReturn('rendered.view');
         $message->shouldReceive('setBody')->once()->with('rendered.view', 'text/html');
@@ -37,10 +37,10 @@ class MailMailerTest extends TestCase
     public function testMailerSendSendsMessageWithProperViewContentUsingHtmlStrings()
     {
         unset($_SERVER['__mailer.test']);
-        $mailer = $this->getMockBuilder('Illuminate\Mail\Mailer')->setMethods(['createMessage'])->setConstructorArgs($this->getMocks())->getMock();
+        $mailer = $this->getMockBuilder(\Illuminate\Mail\Mailer::class)->setMethods(['createMessage'])->setConstructorArgs($this->getMocks())->getMock();
         $message = m::mock('Swift_Mime_SimpleMessage');
         $mailer->expects($this->once())->method('createMessage')->will($this->returnValue($message));
-        $view = m::mock('stdClass');
+        $view = m::mock(\stdClass::class);
         $mailer->getViewFactory()->shouldReceive('make')->never();
         $view->shouldReceive('render')->never();
         $message->shouldReceive('setBody')->once()->with('rendered.view', 'text/html');
@@ -58,10 +58,10 @@ class MailMailerTest extends TestCase
     public function testMailerSendSendsMessageWithProperPlainViewContent()
     {
         unset($_SERVER['__mailer.test']);
-        $mailer = $this->getMockBuilder('Illuminate\Mail\Mailer')->setMethods(['createMessage'])->setConstructorArgs($this->getMocks())->getMock();
+        $mailer = $this->getMockBuilder(\Illuminate\Mail\Mailer::class)->setMethods(['createMessage'])->setConstructorArgs($this->getMocks())->getMock();
         $message = m::mock('Swift_Mime_SimpleMessage');
         $mailer->expects($this->once())->method('createMessage')->will($this->returnValue($message));
-        $view = m::mock('stdClass');
+        $view = m::mock(\stdClass::class);
         $mailer->getViewFactory()->shouldReceive('make')->once()->with('foo', ['data', 'message' => $message])->andReturn($view);
         $mailer->getViewFactory()->shouldReceive('make')->once()->with('bar', ['data', 'message' => $message])->andReturn($view);
         $view->shouldReceive('render')->twice()->andReturn('rendered.view');
@@ -80,10 +80,10 @@ class MailMailerTest extends TestCase
     public function testMailerSendSendsMessageWithProperPlainViewContentWhenExplicit()
     {
         unset($_SERVER['__mailer.test']);
-        $mailer = $this->getMockBuilder('Illuminate\Mail\Mailer')->setMethods(['createMessage'])->setConstructorArgs($this->getMocks())->getMock();
+        $mailer = $this->getMockBuilder(\Illuminate\Mail\Mailer::class)->setMethods(['createMessage'])->setConstructorArgs($this->getMocks())->getMock();
         $message = m::mock('Swift_Mime_SimpleMessage');
         $mailer->expects($this->once())->method('createMessage')->will($this->returnValue($message));
-        $view = m::mock('stdClass');
+        $view = m::mock(\stdClass::class);
         $mailer->getViewFactory()->shouldReceive('make')->once()->with('foo', ['data', 'message' => $message])->andReturn($view);
         $mailer->getViewFactory()->shouldReceive('make')->once()->with('bar', ['data', 'message' => $message])->andReturn($view);
         $view->shouldReceive('render')->twice()->andReturn('rendered.view');
@@ -103,7 +103,7 @@ class MailMailerTest extends TestCase
     {
         unset($_SERVER['__mailer.test']);
         $mailer = $this->getMailer();
-        $view = m::mock('stdClass');
+        $view = m::mock(\stdClass::class);
         $mailer->getViewFactory()->shouldReceive('make')->once()->andReturn($view);
         $view->shouldReceive('render')->once()->andReturn('rendered.view');
         $this->setSwiftMailer($mailer);
@@ -121,7 +121,7 @@ class MailMailerTest extends TestCase
         $mailer = $this->getMailer();
         $mailer->getSwiftMailer()->shouldReceive('getTransport')->andReturn($transport = m::mock('Swift_Transport'));
         $transport->shouldReceive('stop');
-        $view = m::mock('stdClass');
+        $view = m::mock(\stdClass::class);
         $mailer->getViewFactory()->shouldReceive('make')->once()->andReturn($view);
         $view->shouldReceive('render')->once()->andReturn('rendered.view');
         $swift = new FailingSwiftMailerStub;
@@ -136,11 +136,11 @@ class MailMailerTest extends TestCase
     public function testEventsAreDispatched()
     {
         unset($_SERVER['__mailer.test']);
-        $events = m::mock('Illuminate\Contracts\Events\Dispatcher');
-        $events->shouldReceive('until')->once()->with(m::type('Illuminate\Mail\Events\MessageSending'));
-        $events->shouldReceive('dispatch')->once()->with(m::type('Illuminate\Mail\Events\MessageSent'));
+        $events = m::mock(\Illuminate\Contracts\Events\Dispatcher::class);
+        $events->shouldReceive('until')->once()->with(m::type(\Illuminate\Mail\Events\MessageSending::class));
+        $events->shouldReceive('dispatch')->once()->with(m::type(\Illuminate\Mail\Events\MessageSent::class));
         $mailer = $this->getMailer($events);
-        $view = m::mock('stdClass');
+        $view = m::mock(\stdClass::class);
         $mailer->getViewFactory()->shouldReceive('make')->once()->andReturn($view);
         $view->shouldReceive('render')->once()->andReturn('rendered.view');
         $this->setSwiftMailer($mailer);
@@ -164,7 +164,7 @@ class MailMailerTest extends TestCase
 
     protected function getMailer($events = null)
     {
-        return new Mailer(m::mock('Illuminate\Contracts\View\Factory'), m::mock('Swift_Mailer'), $events);
+        return new Mailer(m::mock(\Illuminate\Contracts\View\Factory::class), m::mock('Swift_Mailer'), $events);
     }
 
     public function setSwiftMailer($mailer)
@@ -180,7 +180,7 @@ class MailMailerTest extends TestCase
 
     protected function getMocks()
     {
-        return [m::mock('Illuminate\Contracts\View\Factory'), m::mock('Swift_Mailer')];
+        return [m::mock(\Illuminate\Contracts\View\Factory::class), m::mock('Swift_Mailer')];
     }
 }
 

--- a/tests/Mail/MailMarkdownTest.php
+++ b/tests/Mail/MailMarkdownTest.php
@@ -13,7 +13,7 @@ class MailMarkdownTest extends TestCase
 
     public function testRenderFunctionReturnsHtml()
     {
-        $viewFactory = \Mockery::mock('Illuminate\View\Factory');
+        $viewFactory = \Mockery::mock(\Illuminate\View\Factory::class);
         $markdown = new \Illuminate\Mail\Markdown($viewFactory);
         $viewFactory->shouldReceive('flushFinderCache')->once();
         $viewFactory->shouldReceive('replaceNamespace')->once()->with('mail', $markdown->htmlComponentPaths())->andReturnSelf();
@@ -28,7 +28,7 @@ class MailMarkdownTest extends TestCase
 
     public function testRenderFunctionReturnsHtmlWithCustomTheme()
     {
-        $viewFactory = \Mockery::mock('Illuminate\View\Factory');
+        $viewFactory = \Mockery::mock(\Illuminate\View\Factory::class);
         $markdown = new \Illuminate\Mail\Markdown($viewFactory);
         $markdown->theme('yaz');
         $viewFactory->shouldReceive('flushFinderCache')->once();
@@ -44,7 +44,7 @@ class MailMarkdownTest extends TestCase
 
     public function testRenderTextReturnsText()
     {
-        $viewFactory = \Mockery::mock('Illuminate\View\Factory');
+        $viewFactory = \Mockery::mock(\Illuminate\View\Factory::class);
         $markdown = new \Illuminate\Mail\Markdown($viewFactory);
         $viewFactory->shouldReceive('flushFinderCache')->once();
         $viewFactory->shouldReceive('replaceNamespace')->once()->with('mail', $markdown->markdownComponentPaths())->andReturnSelf();
@@ -58,7 +58,7 @@ class MailMarkdownTest extends TestCase
 
     public function testParseReturnsParsedMarkdown()
     {
-        $viewFactory = \Mockery::mock('Illuminate\View\Factory');
+        $viewFactory = \Mockery::mock(\Illuminate\View\Factory::class);
         $markdown = new \Illuminate\Mail\Markdown($viewFactory);
 
         $result = $markdown->parse('# Something');

--- a/tests/Mail/MailMessageTest.php
+++ b/tests/Mail/MailMessageTest.php
@@ -98,9 +98,9 @@ class MailMessageTest extends TestCase
 
     public function testBasicAttachment()
     {
-        $swift = m::mock('stdClass');
-        $message = $this->getMockBuilder('Illuminate\Mail\Message')->setMethods(['createAttachmentFromPath'])->setConstructorArgs([$swift])->getMock();
-        $attachment = m::mock('stdClass');
+        $swift = m::mock(\stdClass::class);
+        $message = $this->getMockBuilder(\Illuminate\Mail\Message::class)->setMethods(['createAttachmentFromPath'])->setConstructorArgs([$swift])->getMock();
+        $attachment = m::mock(\stdClass::class);
         $message->expects($this->once())->method('createAttachmentFromPath')->with($this->equalTo('foo.jpg'))->will($this->returnValue($attachment));
         $swift->shouldReceive('attach')->once()->with($attachment);
         $attachment->shouldReceive('setContentType')->once()->with('image/jpeg');
@@ -110,9 +110,9 @@ class MailMessageTest extends TestCase
 
     public function testDataAttachment()
     {
-        $swift = m::mock('stdClass');
-        $message = $this->getMockBuilder('Illuminate\Mail\Message')->setMethods(['createAttachmentFromData'])->setConstructorArgs([$swift])->getMock();
-        $attachment = m::mock('stdClass');
+        $swift = m::mock(\stdClass::class);
+        $message = $this->getMockBuilder(\Illuminate\Mail\Message::class)->setMethods(['createAttachmentFromData'])->setConstructorArgs([$swift])->getMock();
+        $attachment = m::mock(\stdClass::class);
         $message->expects($this->once())->method('createAttachmentFromData')->with($this->equalTo('foo'), $this->equalTo('name'))->will($this->returnValue($attachment));
         $swift->shouldReceive('attach')->once()->with($attachment);
         $attachment->shouldReceive('setContentType')->once()->with('image/jpeg');

--- a/tests/Notifications/NotificationBroadcastChannelTest.php
+++ b/tests/Notifications/NotificationBroadcastChannelTest.php
@@ -21,8 +21,8 @@ class NotificationBroadcastChannelTest extends TestCase
         $notification->id = 1;
         $notifiable = Mockery::mock();
 
-        $events = Mockery::mock('Illuminate\Contracts\Events\Dispatcher');
-        $events->shouldReceive('dispatch')->once()->with(Mockery::type('Illuminate\Notifications\Events\BroadcastNotificationCreated'));
+        $events = Mockery::mock(\Illuminate\Contracts\Events\Dispatcher::class);
+        $events->shouldReceive('dispatch')->once()->with(Mockery::type(\Illuminate\Notifications\Events\BroadcastNotificationCreated::class));
         $channel = new BroadcastChannel($events);
         $channel->send($notifiable, $notification);
     }
@@ -48,7 +48,7 @@ class NotificationBroadcastChannelTest extends TestCase
         $notification->id = 1;
         $notifiable = Mockery::mock();
 
-        $events = Mockery::mock('Illuminate\Contracts\Events\Dispatcher');
+        $events = Mockery::mock(\Illuminate\Contracts\Events\Dispatcher::class);
         $events->shouldReceive('dispatch')->once()->with(Mockery::on(function ($event) {
             return $event->connection == 'sync';
         }));

--- a/tests/Notifications/NotificationSendQueuedNotificationTest.php
+++ b/tests/Notifications/NotificationSendQueuedNotificationTest.php
@@ -16,7 +16,7 @@ class NotificationSendQueuedNotificationTest extends TestCase
     public function testNotificationsCanBeSent()
     {
         $job = new SendQueuedNotifications('notifiables', 'notification');
-        $manager = Mockery::mock('Illuminate\Notifications\ChannelManager');
+        $manager = Mockery::mock(\Illuminate\Notifications\ChannelManager::class);
         $manager->shouldReceive('sendNow')->once()->with('notifiables', 'notification', null);
         $job->handle($manager);
     }

--- a/tests/Pipeline/PipelineTest.php
+++ b/tests/Pipeline/PipelineTest.php
@@ -17,7 +17,7 @@ class PipelineTest extends TestCase
 
         $result = (new Pipeline(new \Illuminate\Container\Container))
                     ->send('foo')
-                    ->through(['Illuminate\Tests\Pipeline\PipelineTestPipeOne', $pipeTwo])
+                    ->through([\Illuminate\Tests\Pipeline\PipelineTestPipeOne::class, $pipeTwo])
                     ->then(function ($piped) {
                         return $piped;
                     });
@@ -123,7 +123,7 @@ class PipelineTest extends TestCase
     {
         $pipelineInstance = new Pipeline(new \Illuminate\Container\Container);
         $result = $pipelineInstance->send('data')
-            ->through('Illuminate\Tests\Pipeline\PipelineTestPipeOne')
+            ->through(\Illuminate\Tests\Pipeline\PipelineTestPipeOne::class)
             ->via('differentMethod')
             ->then(function ($piped) {
                 return $piped;
@@ -137,7 +137,7 @@ class PipelineTest extends TestCase
     public function testPipelineThrowsExceptionOnResolveWithoutContainer()
     {
         (new Pipeline)->send('data')
-            ->through('Illuminate\Tests\Pipeline\PipelineTestPipeOne')
+            ->through(\Illuminate\Tests\Pipeline\PipelineTestPipeOne::class)
             ->then(function ($piped) {
                 return $piped;
             });

--- a/tests/Queue/QueueBeanstalkdJobTest.php
+++ b/tests/Queue/QueueBeanstalkdJobTest.php
@@ -16,7 +16,7 @@ class QueueBeanstalkdJobTest extends TestCase
     {
         $job = $this->getJob();
         $job->getPheanstalkJob()->shouldReceive('getData')->once()->andReturn(json_encode(['job' => 'foo', 'data' => ['data']]));
-        $job->getContainer()->shouldReceive('make')->once()->with('foo')->andReturn($handler = m::mock('stdClass'));
+        $job->getContainer()->shouldReceive('make')->once()->with('foo')->andReturn($handler = m::mock(\stdClass::class));
         $handler->shouldReceive('fire')->once()->with($job, ['data']);
 
         $job->fire();
@@ -26,7 +26,7 @@ class QueueBeanstalkdJobTest extends TestCase
     {
         $job = $this->getJob();
         $job->getPheanstalkJob()->shouldReceive('getData')->once()->andReturn(json_encode(['job' => 'foo', 'data' => ['data']]));
-        $job->getContainer()->shouldReceive('make')->once()->with('foo')->andReturn($handler = m::mock('Illuminate\Tests\Queue\BeanstalkdJobTestFailedTest'));
+        $job->getContainer()->shouldReceive('make')->once()->with('foo')->andReturn($handler = m::mock(\Illuminate\Tests\Queue\BeanstalkdJobTestFailedTest::class));
         $handler->shouldReceive('failed')->once()->with(['data'], m::type('Exception'));
 
         $job->failed(new \Exception);
@@ -59,7 +59,7 @@ class QueueBeanstalkdJobTest extends TestCase
     protected function getJob()
     {
         return new \Illuminate\Queue\Jobs\BeanstalkdJob(
-            m::mock('Illuminate\Container\Container'),
+            m::mock(\Illuminate\Container\Container::class),
             m::mock('Pheanstalk\Pheanstalk'),
             m::mock('Pheanstalk\Job'),
             'connection-name',

--- a/tests/Queue/QueueBeanstalkdQueueTest.php
+++ b/tests/Queue/QueueBeanstalkdQueueTest.php
@@ -39,7 +39,7 @@ class QueueBeanstalkdQueueTest extends TestCase
     public function testPopProperlyPopsJobOffOfBeanstalkd()
     {
         $queue = new \Illuminate\Queue\BeanstalkdQueue(m::mock('Pheanstalk\Pheanstalk'), 'default', 60);
-        $queue->setContainer(m::mock('Illuminate\Container\Container'));
+        $queue->setContainer(m::mock(\Illuminate\Container\Container::class));
         $pheanstalk = $queue->getPheanstalk();
         $pheanstalk->shouldReceive('watchOnly')->once()->with('default')->andReturn($pheanstalk);
         $job = m::mock('Pheanstalk\Job');
@@ -47,7 +47,7 @@ class QueueBeanstalkdQueueTest extends TestCase
 
         $result = $queue->pop();
 
-        $this->assertInstanceOf('Illuminate\Queue\Jobs\BeanstalkdJob', $result);
+        $this->assertInstanceOf(\Illuminate\Queue\Jobs\BeanstalkdJob::class, $result);
     }
 
     public function testDeleteProperlyRemoveJobsOffBeanstalkd()

--- a/tests/Queue/QueueDatabaseQueueUnitTest.php
+++ b/tests/Queue/QueueDatabaseQueueUnitTest.php
@@ -16,9 +16,9 @@ class QueueDatabaseQueueUnitTest extends TestCase
 
     public function testPushProperlyPushesJobOntoDatabase()
     {
-        $queue = $this->getMockBuilder('Illuminate\Queue\DatabaseQueue')->setMethods(['currentTime'])->setConstructorArgs([$database = m::mock('Illuminate\Database\Connection'), 'table', 'default'])->getMock();
+        $queue = $this->getMockBuilder(\Illuminate\Queue\DatabaseQueue::class)->setMethods(['currentTime'])->setConstructorArgs([$database = m::mock(\Illuminate\Database\Connection::class), 'table', 'default'])->getMock();
         $queue->expects($this->any())->method('currentTime')->will($this->returnValue('time'));
-        $database->shouldReceive('table')->with('table')->andReturn($query = m::mock('stdClass'));
+        $database->shouldReceive('table')->with('table')->andReturn($query = m::mock(\stdClass::class));
         $query->shouldReceive('insertGetId')->once()->andReturnUsing(function ($array) {
             $this->assertEquals('default', $array['queue']);
             $this->assertEquals(json_encode(['displayName' => 'foo', 'job' => 'foo', 'maxTries' => null, 'timeout' => null, 'data' => ['data']]), $array['payload']);
@@ -33,12 +33,12 @@ class QueueDatabaseQueueUnitTest extends TestCase
     public function testDelayedPushProperlyPushesJobOntoDatabase()
     {
         $queue = $this->getMockBuilder(
-            'Illuminate\Queue\DatabaseQueue')->setMethods(
+            \Illuminate\Queue\DatabaseQueue::class)->setMethods(
             ['currentTime'])->setConstructorArgs(
-            [$database = m::mock('Illuminate\Database\Connection'), 'table', 'default']
+            [$database = m::mock(\Illuminate\Database\Connection::class), 'table', 'default']
         )->getMock();
         $queue->expects($this->any())->method('currentTime')->will($this->returnValue('time'));
-        $database->shouldReceive('table')->with('table')->andReturn($query = m::mock('stdClass'));
+        $database->shouldReceive('table')->with('table')->andReturn($query = m::mock(\stdClass::class));
         $query->shouldReceive('insertGetId')->once()->andReturnUsing(function ($array) {
             $this->assertEquals('default', $array['queue']);
             $this->assertEquals(json_encode(['displayName' => 'foo', 'job' => 'foo', 'maxTries' => null, 'timeout' => null, 'data' => ['data']]), $array['payload']);
@@ -57,8 +57,8 @@ class QueueDatabaseQueueUnitTest extends TestCase
         $job = new stdClass;
         $job->invalid = "\xc3\x28";
 
-        $queue = $this->getMockForAbstractClass('Illuminate\Queue\Queue');
-        $class = new ReflectionClass('Illuminate\Queue\Queue');
+        $queue = $this->getMockForAbstractClass(\Illuminate\Queue\Queue::class);
+        $class = new ReflectionClass(\Illuminate\Queue\Queue::class);
 
         $createPayload = $class->getMethod('createPayload');
         $createPayload->setAccessible(true);
@@ -71,8 +71,8 @@ class QueueDatabaseQueueUnitTest extends TestCase
     {
         $this->expectException('InvalidArgumentException');
 
-        $queue = $this->getMockForAbstractClass('Illuminate\Queue\Queue');
-        $class = new ReflectionClass('Illuminate\Queue\Queue');
+        $queue = $this->getMockForAbstractClass(\Illuminate\Queue\Queue::class);
+        $class = new ReflectionClass(\Illuminate\Queue\Queue::class);
 
         $createPayload = $class->getMethod('createPayload');
         $createPayload->setAccessible(true);
@@ -83,11 +83,11 @@ class QueueDatabaseQueueUnitTest extends TestCase
 
     public function testBulkBatchPushesOntoDatabase()
     {
-        $database = m::mock('Illuminate\Database\Connection');
-        $queue = $this->getMockBuilder('Illuminate\Queue\DatabaseQueue')->setMethods(['currentTime', 'availableAt'])->setConstructorArgs([$database, 'table', 'default'])->getMock();
+        $database = m::mock(\Illuminate\Database\Connection::class);
+        $queue = $this->getMockBuilder(\Illuminate\Queue\DatabaseQueue::class)->setMethods(['currentTime', 'availableAt'])->setConstructorArgs([$database, 'table', 'default'])->getMock();
         $queue->expects($this->any())->method('currentTime')->will($this->returnValue('created'));
         $queue->expects($this->any())->method('availableAt')->will($this->returnValue('available'));
-        $database->shouldReceive('table')->with('table')->andReturn($query = m::mock('stdClass'));
+        $database->shouldReceive('table')->with('table')->andReturn($query = m::mock(\stdClass::class));
         $query->shouldReceive('insert')->once()->andReturnUsing(function ($records) {
             $this->assertEquals([[
                 'queue' => 'queue',

--- a/tests/Queue/QueueListenerTest.php
+++ b/tests/Queue/QueueListenerTest.php
@@ -16,7 +16,7 @@ class QueueListenerTest extends TestCase
     {
         $process = m::mock('Symfony\Component\Process\Process')->makePartial();
         $process->shouldReceive('run')->once();
-        $listener = m::mock('Illuminate\Queue\Listener')->makePartial();
+        $listener = m::mock(\Illuminate\Queue\Listener::class)->makePartial();
         $listener->shouldReceive('memoryExceeded')->once()->with(1)->andReturn(false);
 
         $listener->runProcess($process, 1);
@@ -26,7 +26,7 @@ class QueueListenerTest extends TestCase
     {
         $process = m::mock('Symfony\Component\Process\Process')->makePartial();
         $process->shouldReceive('run')->once();
-        $listener = m::mock('Illuminate\Queue\Listener')->makePartial();
+        $listener = m::mock(\Illuminate\Queue\Listener::class)->makePartial();
         $listener->shouldReceive('memoryExceeded')->once()->with(1)->andReturn(true);
         $listener->shouldReceive('stop')->once();
 

--- a/tests/Queue/QueueManagerTest.php
+++ b/tests/Queue/QueueManagerTest.php
@@ -20,12 +20,12 @@ class QueueManagerTest extends TestCase
                 'queue.default' => 'sync',
                 'queue.connections.sync' => ['driver' => 'sync'],
             ],
-            'encrypter' => $encrypter = m::mock('Illuminate\Contracts\Encryption\Encrypter'),
+            'encrypter' => $encrypter = m::mock(\Illuminate\Contracts\Encryption\Encrypter::class),
         ];
 
         $manager = new QueueManager($app);
-        $connector = m::mock('stdClass');
-        $queue = m::mock('stdClass');
+        $connector = m::mock(\stdClass::class);
+        $queue = m::mock(\stdClass::class);
         $queue->shouldReceive('setConnectionName')->once()->with('sync')->andReturnSelf();
         $connector->shouldReceive('connect')->once()->with(['driver' => 'sync'])->andReturn($queue);
         $manager->addConnector('sync', function () use ($connector) {
@@ -43,12 +43,12 @@ class QueueManagerTest extends TestCase
                 'queue.default' => 'sync',
                 'queue.connections.foo' => ['driver' => 'bar'],
             ],
-            'encrypter' => $encrypter = m::mock('Illuminate\Contracts\Encryption\Encrypter'),
+            'encrypter' => $encrypter = m::mock(\Illuminate\Contracts\Encryption\Encrypter::class),
         ];
 
         $manager = new QueueManager($app);
-        $connector = m::mock('stdClass');
-        $queue = m::mock('stdClass');
+        $connector = m::mock(\stdClass::class);
+        $queue = m::mock(\stdClass::class);
         $queue->shouldReceive('setConnectionName')->once()->with('foo')->andReturnSelf();
         $connector->shouldReceive('connect')->once()->with(['driver' => 'bar'])->andReturn($queue);
         $manager->addConnector('bar', function () use ($connector) {
@@ -65,12 +65,12 @@ class QueueManagerTest extends TestCase
             'config' => [
                 'queue.default' => 'null',
             ],
-            'encrypter' => $encrypter = m::mock('Illuminate\Contracts\Encryption\Encrypter'),
+            'encrypter' => $encrypter = m::mock(\Illuminate\Contracts\Encryption\Encrypter::class),
         ];
 
         $manager = new QueueManager($app);
-        $connector = m::mock('stdClass');
-        $queue = m::mock('stdClass');
+        $connector = m::mock(\stdClass::class);
+        $queue = m::mock(\stdClass::class);
         $queue->shouldReceive('setConnectionName')->once()->with('null')->andReturnSelf();
         $connector->shouldReceive('connect')->once()->with(['driver' => 'null'])->andReturn($queue);
         $manager->addConnector('null', function () use ($connector) {

--- a/tests/Queue/QueueRedisJobTest.php
+++ b/tests/Queue/QueueRedisJobTest.php
@@ -15,7 +15,7 @@ class QueueRedisJobTest extends TestCase
     public function testFireProperlyCallsTheJobHandler()
     {
         $job = $this->getJob();
-        $job->getContainer()->shouldReceive('make')->once()->with('foo')->andReturn($handler = m::mock('stdClass'));
+        $job->getContainer()->shouldReceive('make')->once()->with('foo')->andReturn($handler = m::mock(\stdClass::class));
         $handler->shouldReceive('fire')->once()->with($job, ['data']);
 
         $job->fire();

--- a/tests/Queue/QueueRedisQueueTest.php
+++ b/tests/Queue/QueueRedisQueueTest.php
@@ -14,7 +14,7 @@ class QueueRedisQueueTest extends TestCase
 
     public function testPushProperlyPushesJobOntoRedis()
     {
-        $queue = $this->getMockBuilder('Illuminate\Queue\RedisQueue')->setMethods(['getRandomId'])->setConstructorArgs([$redis = m::mock('Illuminate\Contracts\Redis\Factory'), 'default'])->getMock();
+        $queue = $this->getMockBuilder(\Illuminate\Queue\RedisQueue::class)->setMethods(['getRandomId'])->setConstructorArgs([$redis = m::mock(\Illuminate\Contracts\Redis\Factory::class), 'default'])->getMock();
         $queue->expects($this->once())->method('getRandomId')->will($this->returnValue('foo'));
         $redis->shouldReceive('connection')->once()->andReturn($redis);
         $redis->shouldReceive('rpush')->once()->with('queues:default', json_encode(['displayName' => 'foo', 'job' => 'foo', 'maxTries' => null, 'timeout' => null, 'data' => ['data'], 'id' => 'foo', 'attempts' => 0]));
@@ -25,7 +25,7 @@ class QueueRedisQueueTest extends TestCase
 
     public function testDelayedPushProperlyPushesJobOntoRedis()
     {
-        $queue = $this->getMockBuilder('Illuminate\Queue\RedisQueue')->setMethods(['availableAt', 'getRandomId'])->setConstructorArgs([$redis = m::mock('Illuminate\Contracts\Redis\Factory'), 'default'])->getMock();
+        $queue = $this->getMockBuilder(\Illuminate\Queue\RedisQueue::class)->setMethods(['availableAt', 'getRandomId'])->setConstructorArgs([$redis = m::mock(\Illuminate\Contracts\Redis\Factory::class), 'default'])->getMock();
         $queue->expects($this->once())->method('getRandomId')->will($this->returnValue('foo'));
         $queue->expects($this->once())->method('availableAt')->with(1)->will($this->returnValue(2));
 
@@ -43,7 +43,7 @@ class QueueRedisQueueTest extends TestCase
     public function testDelayedPushWithDateTimeProperlyPushesJobOntoRedis()
     {
         $date = \Carbon\Carbon::now();
-        $queue = $this->getMockBuilder('Illuminate\Queue\RedisQueue')->setMethods(['availableAt', 'getRandomId'])->setConstructorArgs([$redis = m::mock('Illuminate\Contracts\Redis\Factory'), 'default'])->getMock();
+        $queue = $this->getMockBuilder(\Illuminate\Queue\RedisQueue::class)->setMethods(['availableAt', 'getRandomId'])->setConstructorArgs([$redis = m::mock(\Illuminate\Contracts\Redis\Factory::class), 'default'])->getMock();
         $queue->expects($this->once())->method('getRandomId')->will($this->returnValue('foo'));
         $queue->expects($this->once())->method('availableAt')->with($date)->will($this->returnValue(2));
 

--- a/tests/Queue/QueueSqsJobTest.php
+++ b/tests/Queue/QueueSqsJobTest.php
@@ -28,7 +28,7 @@ class QueueSqsJobTest extends TestCase
             ->getMock();
 
         // Use Mockery to mock the IoC Container
-        $this->mockedContainer = m::mock('Illuminate\Container\Container');
+        $this->mockedContainer = m::mock(\Illuminate\Container\Container::class);
 
         $this->mockedJob = 'foo';
         $this->mockedData = ['data'];
@@ -53,7 +53,7 @@ class QueueSqsJobTest extends TestCase
     public function testFireProperlyCallsTheJobHandler()
     {
         $job = $this->getJob();
-        $job->getContainer()->shouldReceive('make')->once()->with('foo')->andReturn($handler = m::mock('stdClass'));
+        $job->getContainer()->shouldReceive('make')->once()->with('foo')->andReturn($handler = m::mock(\stdClass::class));
         $handler->shouldReceive('fire')->once()->with($job, ['data']);
         $job->fire();
     }
@@ -64,7 +64,7 @@ class QueueSqsJobTest extends TestCase
             ->setMethods(['deleteMessage'])
             ->disableOriginalConstructor()
             ->getMock();
-        $queue = $this->getMockBuilder('Illuminate\Queue\SqsQueue')->setMethods(['getQueue'])->setConstructorArgs([$this->mockedSqsClient, $this->queueName, $this->account])->getMock();
+        $queue = $this->getMockBuilder(\Illuminate\Queue\SqsQueue::class)->setMethods(['getQueue'])->setConstructorArgs([$this->mockedSqsClient, $this->queueName, $this->account])->getMock();
         $queue->setContainer($this->mockedContainer);
         $job = $this->getJob();
         $job->getSqs()->expects($this->once())->method('deleteMessage')->with(['QueueUrl' => $this->queueUrl, 'ReceiptHandle' => $this->mockedReceiptHandle]);
@@ -77,7 +77,7 @@ class QueueSqsJobTest extends TestCase
             ->setMethods(['changeMessageVisibility'])
             ->disableOriginalConstructor()
             ->getMock();
-        $queue = $this->getMockBuilder('Illuminate\Queue\SqsQueue')->setMethods(['getQueue'])->setConstructorArgs([$this->mockedSqsClient, $this->queueName, $this->account])->getMock();
+        $queue = $this->getMockBuilder(\Illuminate\Queue\SqsQueue::class)->setMethods(['getQueue'])->setConstructorArgs([$this->mockedSqsClient, $this->queueName, $this->account])->getMock();
         $queue->setContainer($this->mockedContainer);
         $job = $this->getJob();
         $job->getSqs()->expects($this->once())->method('changeMessageVisibility')->with(['QueueUrl' => $this->queueUrl, 'ReceiptHandle' => $this->mockedReceiptHandle, 'VisibilityTimeout' => $this->releaseDelay]);

--- a/tests/Queue/QueueSqsQueueTest.php
+++ b/tests/Queue/QueueSqsQueueTest.php
@@ -61,18 +61,18 @@ class QueueSqsQueueTest extends TestCase
 
     public function testPopProperlyPopsJobOffOfSqs()
     {
-        $queue = $this->getMockBuilder('Illuminate\Queue\SqsQueue')->setMethods(['getQueue'])->setConstructorArgs([$this->sqs, $this->queueName, $this->account])->getMock();
-        $queue->setContainer(m::mock('Illuminate\Container\Container'));
+        $queue = $this->getMockBuilder(\Illuminate\Queue\SqsQueue::class)->setMethods(['getQueue'])->setConstructorArgs([$this->sqs, $this->queueName, $this->account])->getMock();
+        $queue->setContainer(m::mock(\Illuminate\Container\Container::class));
         $queue->expects($this->once())->method('getQueue')->with($this->queueName)->will($this->returnValue($this->queueUrl));
         $this->sqs->shouldReceive('receiveMessage')->once()->with(['QueueUrl' => $this->queueUrl, 'AttributeNames' => ['ApproximateReceiveCount']])->andReturn($this->mockedReceiveMessageResponseModel);
         $result = $queue->pop($this->queueName);
-        $this->assertInstanceOf('Illuminate\Queue\Jobs\SqsJob', $result);
+        $this->assertInstanceOf(\Illuminate\Queue\Jobs\SqsJob::class, $result);
     }
 
     public function testDelayedPushWithDateTimeProperlyPushesJobOntoSqs()
     {
         $now = \Carbon\Carbon::now();
-        $queue = $this->getMockBuilder('Illuminate\Queue\SqsQueue')->setMethods(['createPayload', 'secondsUntil', 'getQueue'])->setConstructorArgs([$this->sqs, $this->queueName, $this->account])->getMock();
+        $queue = $this->getMockBuilder(\Illuminate\Queue\SqsQueue::class)->setMethods(['createPayload', 'secondsUntil', 'getQueue'])->setConstructorArgs([$this->sqs, $this->queueName, $this->account])->getMock();
         $queue->expects($this->once())->method('createPayload')->with($this->mockedJob, $this->mockedData)->will($this->returnValue($this->mockedPayload));
         $queue->expects($this->once())->method('secondsUntil')->with($now)->will($this->returnValue(5));
         $queue->expects($this->once())->method('getQueue')->with($this->queueName)->will($this->returnValue($this->queueUrl));
@@ -83,7 +83,7 @@ class QueueSqsQueueTest extends TestCase
 
     public function testDelayedPushProperlyPushesJobOntoSqs()
     {
-        $queue = $this->getMockBuilder('Illuminate\Queue\SqsQueue')->setMethods(['createPayload', 'secondsUntil', 'getQueue'])->setConstructorArgs([$this->sqs, $this->queueName, $this->account])->getMock();
+        $queue = $this->getMockBuilder(\Illuminate\Queue\SqsQueue::class)->setMethods(['createPayload', 'secondsUntil', 'getQueue'])->setConstructorArgs([$this->sqs, $this->queueName, $this->account])->getMock();
         $queue->expects($this->once())->method('createPayload')->with($this->mockedJob, $this->mockedData)->will($this->returnValue($this->mockedPayload));
         $queue->expects($this->once())->method('secondsUntil')->with($this->mockedDelay)->will($this->returnValue($this->mockedDelay));
         $queue->expects($this->once())->method('getQueue')->with($this->queueName)->will($this->returnValue($this->queueUrl));
@@ -94,7 +94,7 @@ class QueueSqsQueueTest extends TestCase
 
     public function testPushProperlyPushesJobOntoSqs()
     {
-        $queue = $this->getMockBuilder('Illuminate\Queue\SqsQueue')->setMethods(['createPayload', 'getQueue'])->setConstructorArgs([$this->sqs, $this->queueName, $this->account])->getMock();
+        $queue = $this->getMockBuilder(\Illuminate\Queue\SqsQueue::class)->setMethods(['createPayload', 'getQueue'])->setConstructorArgs([$this->sqs, $this->queueName, $this->account])->getMock();
         $queue->expects($this->once())->method('createPayload')->with($this->mockedJob, $this->mockedData)->will($this->returnValue($this->mockedPayload));
         $queue->expects($this->once())->method('getQueue')->with($this->queueName)->will($this->returnValue($this->queueUrl));
         $this->sqs->shouldReceive('sendMessage')->once()->with(['QueueUrl' => $this->queueUrl, 'MessageBody' => $this->mockedPayload])->andReturn($this->mockedSendMessageResponseModel);
@@ -104,7 +104,7 @@ class QueueSqsQueueTest extends TestCase
 
     public function testSizeProperlyReadsSqsQueueSize()
     {
-        $queue = $this->getMockBuilder('Illuminate\Queue\SqsQueue')->setMethods(['getQueue'])->setConstructorArgs([$this->sqs, $this->queueName, $this->account])->getMock();
+        $queue = $this->getMockBuilder(\Illuminate\Queue\SqsQueue::class)->setMethods(['getQueue'])->setConstructorArgs([$this->sqs, $this->queueName, $this->account])->getMock();
         $queue->expects($this->once())->method('getQueue')->with($this->queueName)->will($this->returnValue($this->queueUrl));
         $this->sqs->shouldReceive('getQueueAttributes')->once()->with(['QueueUrl' => $this->queueUrl, 'AttributeNames' => ['ApproximateNumberOfMessages']])->andReturn($this->mockedQueueAttributesResponseModel);
         $size = $queue->size($this->queueName);

--- a/tests/Queue/QueueSyncQueueTest.php
+++ b/tests/Queue/QueueSyncQueueTest.php
@@ -22,8 +22,8 @@ class QueueSyncQueueTest extends TestCase
         $container = new \Illuminate\Container\Container;
         $sync->setContainer($container);
 
-        $sync->push('Illuminate\Tests\Queue\SyncQueueTestHandler', ['foo' => 'bar']);
-        $this->assertInstanceOf('Illuminate\Queue\Jobs\SyncJob', $_SERVER['__sync.test'][0]);
+        $sync->push(\Illuminate\Tests\Queue\SyncQueueTestHandler::class, ['foo' => 'bar']);
+        $this->assertInstanceOf(\Illuminate\Queue\Jobs\SyncJob::class, $_SERVER['__sync.test'][0]);
         $this->assertEquals(['foo' => 'bar'], $_SERVER['__sync.test'][1]);
     }
 
@@ -34,14 +34,14 @@ class QueueSyncQueueTest extends TestCase
         $sync = new \Illuminate\Queue\SyncQueue;
         $container = new \Illuminate\Container\Container;
         Container::setInstance($container);
-        $events = m::mock('Illuminate\Contracts\Events\Dispatcher');
+        $events = m::mock(\Illuminate\Contracts\Events\Dispatcher::class);
         $events->shouldReceive('fire')->times(3);
         $container->instance('events', $events);
-        $container->instance('Illuminate\Contracts\Events\Dispatcher', $events);
+        $container->instance(\Illuminate\Contracts\Events\Dispatcher::class, $events);
         $sync->setContainer($container);
 
         try {
-            $sync->push('Illuminate\Tests\Queue\FailingSyncQueueTestHandler', ['foo' => 'bar']);
+            $sync->push(\Illuminate\Tests\Queue\FailingSyncQueueTestHandler::class, ['foo' => 'bar']);
         } catch (Exception $e) {
             $this->assertTrue($_SERVER['__sync.failed']);
         }

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -181,7 +181,7 @@ class RouteRegistrarTest extends TestCase
     public function testCanRegisterResource()
     {
         $this->router->middleware('resource-middleware')
-                     ->resource('users', 'Illuminate\Tests\Routing\RouteRegistrarControllerStub');
+                     ->resource('users', \Illuminate\Tests\Routing\RouteRegistrarControllerStub::class);
 
         $this->seeResponse('deleted', Request::create('users/1', 'DELETE'));
         $this->seeMiddleware('resource-middleware');
@@ -189,7 +189,7 @@ class RouteRegistrarTest extends TestCase
 
     public function testCanLimitMethodsOnRegisteredResource()
     {
-        $this->router->resource('users', 'Illuminate\Tests\Routing\RouteRegistrarControllerStub')
+        $this->router->resource('users', \Illuminate\Tests\Routing\RouteRegistrarControllerStub::class)
                      ->only('index', 'show', 'destroy');
 
         $this->assertCount(3, $this->router->getRoutes());
@@ -201,7 +201,7 @@ class RouteRegistrarTest extends TestCase
 
     public function testCanExcludeMethodsOnRegisteredResource()
     {
-        $this->router->resource('users', 'Illuminate\Tests\Routing\RouteRegistrarControllerStub')
+        $this->router->resource('users', \Illuminate\Tests\Routing\RouteRegistrarControllerStub::class)
                      ->except(['index', 'create', 'store', 'show', 'edit']);
 
         $this->assertCount(2, $this->router->getRoutes());
@@ -212,13 +212,13 @@ class RouteRegistrarTest extends TestCase
 
     public function testCanNameRoutesOnRegisteredResource()
     {
-        $this->router->resource('users', 'Illuminate\Tests\Routing\RouteRegistrarControllerStub')
+        $this->router->resource('users', \Illuminate\Tests\Routing\RouteRegistrarControllerStub::class)
                      ->only('create', 'store')->names([
                          'create' => 'user.build',
                          'store' => 'user.save',
                      ]);
 
-        $this->router->resource('posts', 'Illuminate\Tests\Routing\RouteRegistrarControllerStub')
+        $this->router->resource('posts', \Illuminate\Tests\Routing\RouteRegistrarControllerStub::class)
                     ->only('create', 'destroy')
                     ->name('create', 'posts.make')
                     ->name('destroy', 'posts.remove');
@@ -231,10 +231,10 @@ class RouteRegistrarTest extends TestCase
 
     public function testCanOverrideParametersOnRegisteredResource()
     {
-        $this->router->resource('users', 'Illuminate\Tests\Routing\RouteRegistrarControllerStub')
+        $this->router->resource('users', \Illuminate\Tests\Routing\RouteRegistrarControllerStub::class)
                      ->parameters(['users' => 'admin_user']);
 
-        $this->router->resource('posts', 'Illuminate\Tests\Routing\RouteRegistrarControllerStub')
+        $this->router->resource('posts', \Illuminate\Tests\Routing\RouteRegistrarControllerStub::class)
                      ->parameter('posts', 'topic');
 
         $this->assertContains('admin_user', $this->router->getRoutes()->getByName('users.show')->uri);
@@ -243,10 +243,10 @@ class RouteRegistrarTest extends TestCase
 
     public function testCanSetMiddlewareOnRegisteredResource()
     {
-        $this->router->resource('users', 'Illuminate\Tests\Routing\RouteRegistrarControllerStub')
-                     ->middleware('Illuminate\Tests\Routing\RouteRegistrarMiddlewareStub');
+        $this->router->resource('users', \Illuminate\Tests\Routing\RouteRegistrarControllerStub::class)
+                     ->middleware(\Illuminate\Tests\Routing\RouteRegistrarMiddlewareStub::class);
 
-        $this->seeMiddleware('Illuminate\Tests\Routing\RouteRegistrarMiddlewareStub');
+        $this->seeMiddleware(\Illuminate\Tests\Routing\RouteRegistrarMiddlewareStub::class);
     }
 
     public function testCanSetRouteName()

--- a/tests/Routing/RoutingRedirectorTest.php
+++ b/tests/Routing/RoutingRedirectorTest.php
@@ -18,10 +18,10 @@ class RoutingRedirectorTest extends TestCase
     {
         $this->headers = m::mock('Symfony\Component\HttpFoundation\HeaderBag');
 
-        $this->request = m::mock('Illuminate\Http\Request');
+        $this->request = m::mock(\Illuminate\Http\Request::class);
         $this->request->headers = $this->headers;
 
-        $this->url = m::mock('Illuminate\Routing\UrlGenerator');
+        $this->url = m::mock(\Illuminate\Routing\UrlGenerator::class);
         $this->url->shouldReceive('getRequest')->andReturn($this->request);
         $this->url->shouldReceive('to')->with('bar', [], null)->andReturn('http://foo.com/bar');
         $this->url->shouldReceive('to')->with('bar', [], true)->andReturn('https://foo.com/bar');
@@ -29,7 +29,7 @@ class RoutingRedirectorTest extends TestCase
         $this->url->shouldReceive('to')->with('http://foo.com/bar', [], null)->andReturn('http://foo.com/bar');
         $this->url->shouldReceive('to')->with('/', [], null)->andReturn('http://foo.com/');
 
-        $this->session = m::mock('Illuminate\Session\Store');
+        $this->session = m::mock(\Illuminate\Session\Store::class);
 
         $this->redirect = new Redirector($this->url);
         $this->redirect->setSession($this->session);
@@ -44,7 +44,7 @@ class RoutingRedirectorTest extends TestCase
     {
         $response = $this->redirect->to('bar');
 
-        $this->assertInstanceOf('Illuminate\Http\RedirectResponse', $response);
+        $this->assertInstanceOf(\Illuminate\Http\RedirectResponse::class, $response);
         $this->assertEquals('http://foo.com/bar', $response->getTargetUrl());
         $this->assertEquals(302, $response->getStatusCode());
         $this->assertEquals($this->session, $response->getSession());

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -214,9 +214,9 @@ class RoutingRouteTest extends TestCase
         $this->assertEquals('hello', $router->dispatch(Request::create('foo/bar', 'POST'))->getContent());
         $router->get('foo/bar')->uses(function () {
             return 'middleware';
-        })->middleware('Illuminate\Tests\Routing\RouteTestControllerMiddleware');
+        })->middleware(\Illuminate\Tests\Routing\RouteTestControllerMiddleware::class);
         $this->assertEquals('middleware', $router->dispatch(Request::create('foo/bar'))->getContent());
-        $this->assertContains('Illuminate\Tests\Routing\RouteTestControllerMiddleware', $router->getCurrentRoute()->middleware());
+        $this->assertContains(\Illuminate\Tests\Routing\RouteTestControllerMiddleware::class, $router->getCurrentRoute()->middleware());
         $router->get('foo/bar');
         $router->dispatch(Request::create('foo/bar', 'GET'));
     }
@@ -243,8 +243,8 @@ class RoutingRouteTest extends TestCase
             return 'hello';
         }]);
 
-        $router->aliasMiddleware('two', 'Illuminate\Tests\Routing\RoutingTestMiddlewareGroupTwo');
-        $router->middlewareGroup('web', ['Illuminate\Tests\Routing\RoutingTestMiddlewareGroupOne', 'two:taylor']);
+        $router->aliasMiddleware('two', \Illuminate\Tests\Routing\RoutingTestMiddlewareGroupTwo::class);
+        $router->middlewareGroup('web', [\Illuminate\Tests\Routing\RoutingTestMiddlewareGroupOne::class, 'two:taylor']);
 
         $this->assertEquals('caught taylor', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
         $this->assertTrue($_SERVER['__middleware.group']);
@@ -260,9 +260,9 @@ class RoutingRouteTest extends TestCase
             return 'hello';
         }]);
 
-        $router->aliasMiddleware('two', 'Illuminate\Tests\Routing\RoutingTestMiddlewareGroupTwo');
+        $router->aliasMiddleware('two', \Illuminate\Tests\Routing\RoutingTestMiddlewareGroupTwo::class);
         $router->middlewareGroup('first', ['two:abigail']);
-        $router->middlewareGroup('web', ['Illuminate\Tests\Routing\RoutingTestMiddlewareGroupOne', 'first']);
+        $router->middlewareGroup('web', [\Illuminate\Tests\Routing\RoutingTestMiddlewareGroupOne::class, 'first']);
 
         $this->assertEquals('caught abigail', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
         $this->assertTrue($_SERVER['__middleware.group']);
@@ -306,7 +306,7 @@ class RoutingRouteTest extends TestCase
         });
 
         $this->assertEquals('hello', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
-        $this->assertInstanceOf('stdClass', $_SERVER['__test.route_inject'][0]);
+        $this->assertInstanceOf(\stdClass::class, $_SERVER['__test.route_inject'][0]);
         $this->assertEquals('bar', $_SERVER['__test.route_inject'][1]);
 
         unset($_SERVER['__test.route_inject']);
@@ -449,7 +449,7 @@ class RoutingRouteTest extends TestCase
 
         $values = array_values($_SERVER['__test.controller_callAction_parameters']);
 
-        $this->assertInstanceOf('Illuminate\Http\Request', $values[0]);
+        $this->assertInstanceOf(\Illuminate\Http\Request::class, $values[0]);
         $this->assertEquals(1, $values[1]->value);
         $this->assertNull($values[2]);
         $this->assertNull($values[3]);
@@ -678,7 +678,7 @@ class RoutingRouteTest extends TestCase
         $router->get('foo/{bar}', ['middleware' => SubstituteBindings::class, 'uses' => function ($name) {
             return $name;
         }]);
-        $router->bind('bar', 'Illuminate\Tests\Routing\RouteBindingStub');
+        $router->bind('bar', \Illuminate\Tests\Routing\RouteBindingStub::class);
         $this->assertEquals('TAYLOR', $router->dispatch(Request::create('foo/taylor', 'GET'))->getContent());
     }
 
@@ -725,7 +725,7 @@ class RoutingRouteTest extends TestCase
         $router->get('foo/{bar}', ['middleware' => SubstituteBindings::class, 'uses' => function ($name) {
             return $name;
         }]);
-        $router->model('bar', 'Illuminate\Tests\Routing\RouteModelBindingStub');
+        $router->model('bar', \Illuminate\Tests\Routing\RouteModelBindingStub::class);
         $this->assertEquals('TAYLOR', $router->dispatch(Request::create('foo/taylor', 'GET'))->getContent());
     }
 
@@ -738,7 +738,7 @@ class RoutingRouteTest extends TestCase
         $router->get('foo/{bar}', ['middleware' => SubstituteBindings::class, 'uses' => function ($name) {
             return $name;
         }]);
-        $router->model('bar', 'Illuminate\Tests\Routing\RouteModelBindingNullStub');
+        $router->model('bar', \Illuminate\Tests\Routing\RouteModelBindingNullStub::class);
         $router->dispatch(Request::create('foo/taylor', 'GET'))->getContent();
     }
 
@@ -748,7 +748,7 @@ class RoutingRouteTest extends TestCase
         $router->get('foo/{bar}', ['middleware' => SubstituteBindings::class, 'uses' => function ($name) {
             return $name;
         }]);
-        $router->model('bar', 'Illuminate\Tests\Routing\RouteModelBindingNullStub', function () {
+        $router->model('bar', \Illuminate\Tests\Routing\RouteModelBindingNullStub::class, function () {
             return 'missing';
         });
         $this->assertEquals('missing', $router->dispatch(Request::create('foo/taylor', 'GET'))->getContent());
@@ -760,7 +760,7 @@ class RoutingRouteTest extends TestCase
         $router->get('foo/{bar}', ['middleware' => SubstituteBindings::class, 'uses' => function ($name) {
             return $name;
         }]);
-        $router->model('bar', 'Illuminate\Tests\Routing\RouteModelBindingNullStub', function ($value) {
+        $router->model('bar', \Illuminate\Tests\Routing\RouteModelBindingNullStub::class, function ($value) {
             return (new RouteModelBindingClosureStub)->findAlternate($value);
         });
         $this->assertEquals('tayloralt', $router->dispatch(Request::create('foo/TAYLOR', 'GET'))->getContent());
@@ -769,7 +769,7 @@ class RoutingRouteTest extends TestCase
     public function testModelBindingWithCompoundParameterName()
     {
         $router = $this->getRouter();
-        $router->resource('foo-bar', 'Illuminate\Tests\Routing\RouteTestResourceControllerWithModelParameter', ['middleware' => SubstituteBindings::class]);
+        $router->resource('foo-bar', \Illuminate\Tests\Routing\RouteTestResourceControllerWithModelParameter::class, ['middleware' => SubstituteBindings::class]);
         $this->assertEquals('12345', $router->dispatch(Request::create('foo-bar/12345', 'GET'))->getContent());
     }
 
@@ -779,8 +779,8 @@ class RoutingRouteTest extends TestCase
     public function testModelBindingWithCompoundParameterNameAndRouteBinding()
     {
         $router = $this->getRouter();
-        $router->model('foo_bar', 'Illuminate\Tests\Routing\RoutingTestUserModel');
-        $router->resource('foo-bar', 'Illuminate\Tests\Routing\RouteTestResourceControllerWithModelParameter', ['middleware' => SubstituteBindings::class]);
+        $router->model('foo_bar', \Illuminate\Tests\Routing\RoutingTestUserModel::class);
+        $router->resource('foo-bar', \Illuminate\Tests\Routing\RouteTestResourceControllerWithModelParameter::class, ['middleware' => SubstituteBindings::class]);
         $this->assertEquals('12345', $router->dispatch(Request::create('foo-bar/12345', 'GET'))->getContent());
     }
 
@@ -791,11 +791,11 @@ class RoutingRouteTest extends TestCase
         $container->singleton(Registrar::class, function () use ($router) {
             return $router;
         });
-        $container->bind('Illuminate\Tests\Routing\RouteModelInterface', 'Illuminate\Tests\Routing\RouteModelBindingStub');
+        $container->bind(\Illuminate\Tests\Routing\RouteModelInterface::class, \Illuminate\Tests\Routing\RouteModelBindingStub::class);
         $router->get('foo/{bar}', ['middleware' => SubstituteBindings::class, 'uses' => function ($name) {
             return $name;
         }]);
-        $router->model('bar', 'Illuminate\Tests\Routing\RouteModelInterface');
+        $router->model('bar', \Illuminate\Tests\Routing\RouteModelInterface::class);
         $this->assertEquals('TAYLOR', $router->dispatch(Request::create('foo/taylor', 'GET'))->getContent());
     }
 
@@ -990,7 +990,7 @@ class RoutingRouteTest extends TestCase
     public function testInvalidActionException()
     {
         $router = $this->getRouter();
-        $router->get('/', ['uses' => 'Illuminate\Tests\Routing\RouteTestControllerStub']);
+        $router->get('/', ['uses' => \Illuminate\Tests\Routing\RouteTestControllerStub::class]);
 
         $router->dispatch(Request::create('/'));
     }
@@ -1177,11 +1177,11 @@ class RoutingRouteTest extends TestCase
 
         $router->dispatchToRoute($request);
 
-        $this->assertInstanceOf('Illuminate\Http\Request', $_SERVER['__router.request']);
+        $this->assertInstanceOf(\Illuminate\Http\Request::class, $_SERVER['__router.request']);
         $this->assertEquals($_SERVER['__router.request'], $request);
         unset($_SERVER['__router.request']);
 
-        $this->assertInstanceOf('Illuminate\Routing\Route', $_SERVER['__router.route']);
+        $this->assertInstanceOf(\Illuminate\Routing\Route::class, $_SERVER['__router.route']);
         $this->assertEquals($_SERVER['__router.route']->uri(), $route->uri());
         unset($_SERVER['__router.route']);
     }
@@ -1211,7 +1211,7 @@ class RoutingRouteTest extends TestCase
 
         $this->assertEquals('Hello World', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
         $this->assertTrue($_SERVER['route.test.controller.middleware']);
-        $this->assertEquals('Illuminate\Http\Response', $_SERVER['route.test.controller.middleware.class']);
+        $this->assertEquals(\Illuminate\Http\Response::class, $_SERVER['route.test.controller.middleware.class']);
         $this->assertEquals(0, $_SERVER['route.test.controller.middleware.parameters.one']);
         $this->assertEquals(['foo', 'bar'], $_SERVER['route.test.controller.middleware.parameters.two']);
         $this->assertFalse(isset($_SERVER['route.test.controller.except.middleware']));
@@ -1238,15 +1238,15 @@ class RoutingRouteTest extends TestCase
         $router = $this->getRouter();
 
         $router->middlewareGroup('web', [
-            'Illuminate\Tests\Routing\RouteTestControllerMiddleware',
-            'Illuminate\Tests\Routing\RouteTestControllerMiddlewareTwo',
+            \Illuminate\Tests\Routing\RouteTestControllerMiddleware::class,
+            \Illuminate\Tests\Routing\RouteTestControllerMiddlewareTwo::class,
         ]);
 
         $router->get('foo/bar', 'Illuminate\Tests\Routing\RouteTestControllerMiddlewareGroupStub@index');
 
         $this->assertEquals('caught', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
         $this->assertTrue($_SERVER['route.test.controller.middleware']);
-        $this->assertEquals('Illuminate\Http\Response', $_SERVER['route.test.controller.middleware.class']);
+        $this->assertEquals(\Illuminate\Http\Response::class, $_SERVER['route.test.controller.middleware.class']);
     }
 
     public function testImplicitBindings()
@@ -1317,7 +1317,7 @@ class RoutingRouteTest extends TestCase
             return $router;
         });
 
-        $container->bind('Illuminate\Tests\Routing\RoutingTestUserModel', 'Illuminate\Tests\Routing\RoutingTestExtendedUserModel');
+        $container->bind(\Illuminate\Tests\Routing\RoutingTestUserModel::class, \Illuminate\Tests\Routing\RoutingTestExtendedUserModel::class);
         $router->get('foo/{bar}', [
             'middleware' => SubstituteBindings::class,
             'uses' => function (RoutingTestUserModel $bar) use ($phpunit) {
@@ -1330,12 +1330,12 @@ class RoutingRouteTest extends TestCase
     public function testDispatchingCallableActionClasses()
     {
         $router = $this->getRouter();
-        $router->get('foo/bar', 'Illuminate\Tests\Routing\ActionStub');
+        $router->get('foo/bar', \Illuminate\Tests\Routing\ActionStub::class);
 
         $this->assertEquals('hello', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
 
         $router->get('foo/bar2', [
-            'uses' => 'Illuminate\Tests\Routing\ActionStub',
+            'uses' => \Illuminate\Tests\Routing\ActionStub::class,
         ]);
 
         $this->assertEquals('hello', $router->dispatch(Request::create('foo/bar2', 'GET'))->getContent());
@@ -1383,10 +1383,10 @@ class RouteTestControllerStub extends Controller
 {
     public function __construct()
     {
-        $this->middleware('Illuminate\Tests\Routing\RouteTestControllerMiddleware');
+        $this->middleware(\Illuminate\Tests\Routing\RouteTestControllerMiddleware::class);
         $this->middleware('Illuminate\Tests\Routing\RouteTestControllerParameterizedMiddlewareOne:0');
         $this->middleware('Illuminate\Tests\Routing\RouteTestControllerParameterizedMiddlewareTwo:foo,bar');
-        $this->middleware('Illuminate\Tests\Routing\RouteTestControllerExceptMiddleware', ['except' => 'index']);
+        $this->middleware(\Illuminate\Tests\Routing\RouteTestControllerExceptMiddleware::class, ['except' => 'index']);
     }
 
     public function index()

--- a/tests/Session/EncryptedSessionStoreTest.php
+++ b/tests/Session/EncryptedSessionStoreTest.php
@@ -43,7 +43,7 @@ class EncryptedSessionStoreTest extends TestCase
 
     public function getSession()
     {
-        $reflection = new ReflectionClass('Illuminate\Session\EncryptedStore');
+        $reflection = new ReflectionClass(\Illuminate\Session\EncryptedStore::class);
 
         return $reflection->newInstanceArgs($this->getMocks());
     }
@@ -53,7 +53,7 @@ class EncryptedSessionStoreTest extends TestCase
         return [
             $this->getSessionName(),
             m::mock('SessionHandlerInterface'),
-            m::mock('Illuminate\Contracts\Encryption\Encrypter'),
+            m::mock(\Illuminate\Contracts\Encryption\Encrypter::class),
             $this->getSessionId(),
         ];
     }

--- a/tests/Session/SessionStoreTest.php
+++ b/tests/Session/SessionStoreTest.php
@@ -344,7 +344,7 @@ class SessionStoreTest extends TestCase
 
     public function getSession()
     {
-        $reflection = new ReflectionClass('Illuminate\Session\Store');
+        $reflection = new ReflectionClass(\Illuminate\Session\Store::class);
 
         return $reflection->newInstanceArgs($this->getMocks());
     }

--- a/tests/Session/SessionTableCommandTest.php
+++ b/tests/Session/SessionTableCommandTest.php
@@ -17,10 +17,10 @@ class SessionTableCommandTest extends TestCase
     public function testCreateMakesMigration()
     {
         $command = new SessionTableCommandTestStub(
-            $files = m::mock('Illuminate\Filesystem\Filesystem'),
-            $composer = m::mock('Illuminate\Support\Composer')
+            $files = m::mock(\Illuminate\Filesystem\Filesystem::class),
+            $composer = m::mock(\Illuminate\Support\Composer::class)
         );
-        $creator = m::mock('Illuminate\Database\Migrations\MigrationCreator')->shouldIgnoreMissing();
+        $creator = m::mock(\Illuminate\Database\Migrations\MigrationCreator::class)->shouldIgnoreMissing();
 
         $app = new Application;
         $app->useDatabasePath(__DIR__);

--- a/tests/Support/SupportCapsuleManagerTraitTest.php
+++ b/tests/Support/SupportCapsuleManagerTraitTest.php
@@ -23,17 +23,17 @@ class SupportCapsuleManagerTraitTest extends TestCase
 
         $this->assertNull($this->setupContainer($app));
         $this->assertEquals($app, $this->getContainer());
-        $this->assertInstanceOf('Illuminate\Support\Fluent', $app['config']);
+        $this->assertInstanceOf(\Illuminate\Support\Fluent::class, $app['config']);
     }
 
     public function testSetupContainerForCapsuleWhenConfigIsBound()
     {
         $this->container = null;
         $app = new Container;
-        $app['config'] = m::mock('Illuminate\Config\Repository');
+        $app['config'] = m::mock(\Illuminate\Config\Repository::class);
 
         $this->assertNull($this->setupContainer($app));
         $this->assertEquals($app, $this->getContainer());
-        $this->assertInstanceOf('Illuminate\Config\Repository', $app['config']);
+        $this->assertInstanceOf(\Illuminate\Config\Repository::class, $app['config']);
     }
 }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -160,9 +160,9 @@ class SupportCollectionTest extends TestCase
 
     public function testToArrayCallsToArrayOnEachItemInCollection()
     {
-        $item1 = m::mock('Illuminate\Contracts\Support\Arrayable');
+        $item1 = m::mock(\Illuminate\Contracts\Support\Arrayable::class);
         $item1->shouldReceive('toArray')->once()->andReturn('foo.array');
-        $item2 = m::mock('Illuminate\Contracts\Support\Arrayable');
+        $item2 = m::mock(\Illuminate\Contracts\Support\Arrayable::class);
         $item2->shouldReceive('toArray')->once()->andReturn('bar.array');
         $c = new Collection([$item1, $item2]);
         $results = $c->toArray();
@@ -174,7 +174,7 @@ class SupportCollectionTest extends TestCase
     {
         $item1 = m::mock('JsonSerializable');
         $item1->shouldReceive('jsonSerialize')->once()->andReturn('foo.json');
-        $item2 = m::mock('Illuminate\Contracts\Support\Arrayable');
+        $item2 = m::mock(\Illuminate\Contracts\Support\Arrayable::class);
         $item2->shouldReceive('toArray')->once()->andReturn('bar.array');
         $c = new Collection([$item1, $item2]);
         $results = $c->jsonSerialize();

--- a/tests/Support/SupportFacadeTest.php
+++ b/tests/Support/SupportFacadeTest.php
@@ -23,7 +23,7 @@ class SupportFacadeTest extends TestCase
     public function testFacadeCallsUnderlyingApplication()
     {
         $app = new ApplicationStub;
-        $app->setAttributes(['foo' => $mock = m::mock('stdClass')]);
+        $app->setAttributes(['foo' => $mock = m::mock(\stdClass::class)]);
         $mock->shouldReceive('bar')->once()->andReturn('baz');
         FacadeStub::setFacadeApplication($app);
         $this->assertEquals('baz', FacadeStub::bar());

--- a/tests/Support/SupportFluentTest.php
+++ b/tests/Support/SupportFluentTest.php
@@ -81,7 +81,7 @@ class SupportFluentTest extends TestCase
         $this->assertEquals('Taylor', $fluent->name);
         $this->assertTrue($fluent->developer);
         $this->assertEquals(25, $fluent->age);
-        $this->assertInstanceOf('Illuminate\Support\Fluent', $fluent->programmer());
+        $this->assertInstanceOf(\Illuminate\Support\Fluent::class, $fluent->programmer());
     }
 
     public function testIssetMagicMethod()
@@ -106,7 +106,7 @@ class SupportFluentTest extends TestCase
 
     public function testToJsonEncodesTheToArrayResult()
     {
-        $fluent = $this->getMockBuilder('Illuminate\Support\Fluent')->setMethods(['toArray'])->getMock();
+        $fluent = $this->getMockBuilder(\Illuminate\Support\Fluent::class)->setMethods(['toArray'])->getMock();
         $fluent->expects($this->once())->method('toArray')->will($this->returnValue('foo'));
         $results = $fluent->toJson();
 

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -241,7 +241,7 @@ class SupportHelpersTest extends TestCase
     {
         $str = 'A \'quote\' is <b>bold</b>';
         $this->assertEquals('A &#039;quote&#039; is &lt;b&gt;bold&lt;/b&gt;', e($str));
-        $html = m::mock('Illuminate\Contracts\Support\Htmlable');
+        $html = m::mock(\Illuminate\Contracts\Support\Htmlable::class);
         $html->shouldReceive('toHtml')->andReturn($str);
         $this->assertEquals($str, e($html));
     }
@@ -680,17 +680,17 @@ class SupportHelpersTest extends TestCase
     public function testClassUsesRecursiveShouldReturnTraitsOnParentClasses()
     {
         $this->assertEquals([
-            'Illuminate\Tests\Support\SupportTestTraitOne' => 'Illuminate\Tests\Support\SupportTestTraitOne',
-            'Illuminate\Tests\Support\SupportTestTraitTwo' => 'Illuminate\Tests\Support\SupportTestTraitTwo',
+            \Illuminate\Tests\Support\SupportTestTraitOne::class => \Illuminate\Tests\Support\SupportTestTraitOne::class,
+            \Illuminate\Tests\Support\SupportTestTraitTwo::class => \Illuminate\Tests\Support\SupportTestTraitTwo::class,
         ],
-        class_uses_recursive('Illuminate\Tests\Support\SupportTestClassTwo'));
+        class_uses_recursive(\Illuminate\Tests\Support\SupportTestClassTwo::class));
     }
 
     public function testClassUsesRecursiveAcceptsObject()
     {
         $this->assertEquals([
-            'Illuminate\Tests\Support\SupportTestTraitOne' => 'Illuminate\Tests\Support\SupportTestTraitOne',
-            'Illuminate\Tests\Support\SupportTestTraitTwo' => 'Illuminate\Tests\Support\SupportTestTraitTwo',
+            \Illuminate\Tests\Support\SupportTestTraitOne::class => \Illuminate\Tests\Support\SupportTestTraitOne::class,
+            \Illuminate\Tests\Support\SupportTestTraitTwo::class => \Illuminate\Tests\Support\SupportTestTraitTwo::class,
         ],
         class_uses_recursive(new SupportTestClassTwo));
     }

--- a/tests/Support/SupportNamespacedItemResolverTest.php
+++ b/tests/Support/SupportNamespacedItemResolverTest.php
@@ -19,7 +19,7 @@ class SupportNamespacedItemResolverTest extends TestCase
 
     public function testParsedItemsAreCached()
     {
-        $r = $this->getMockBuilder('Illuminate\Support\NamespacedItemResolver')->setMethods(['parseBasicSegments', 'parseNamespacedSegments'])->getMock();
+        $r = $this->getMockBuilder(\Illuminate\Support\NamespacedItemResolver::class)->setMethods(['parseBasicSegments', 'parseNamespacedSegments'])->getMock();
         $r->setParsedKey('foo.bar', ['foo']);
         $r->expects($this->never())->method('parseBasicSegments');
         $r->expects($this->never())->method('parseNamespacedSegments');

--- a/tests/Support/SupportServiceProviderTest.php
+++ b/tests/Support/SupportServiceProviderTest.php
@@ -13,7 +13,7 @@ class SupportServiceProviderTest extends TestCase
         ServiceProvider::$publishes = [];
         ServiceProvider::$publishGroups = [];
 
-        $app = m::mock('Illuminate\\Foundation\\Application')->makePartial();
+        $app = m::mock(\Illuminate\Foundation\Application::class)->makePartial();
         $one = new ServiceProviderForTestingOne($app);
         $one->boot();
         $two = new ServiceProviderForTestingTwo($app);
@@ -29,8 +29,8 @@ class SupportServiceProviderTest extends TestCase
     {
         $toPublish = ServiceProvider::publishableProviders();
         $expected = [
-            'Illuminate\Tests\Support\ServiceProviderForTestingOne',
-            'Illuminate\Tests\Support\ServiceProviderForTestingTwo',
+            \Illuminate\Tests\Support\ServiceProviderForTestingOne::class,
+            \Illuminate\Tests\Support\ServiceProviderForTestingTwo::class,
         ];
         $this->assertEquals($expected, $toPublish, 'Publishable service providers do not return expected set of providers.');
     }
@@ -43,7 +43,7 @@ class SupportServiceProviderTest extends TestCase
 
     public function testSimpleAssetsArePublishedCorrectly()
     {
-        $toPublish = ServiceProvider::pathsToPublish('Illuminate\Tests\Support\ServiceProviderForTestingOne');
+        $toPublish = ServiceProvider::pathsToPublish(\Illuminate\Tests\Support\ServiceProviderForTestingOne::class);
         $this->assertArrayHasKey('source/unmarked/one', $toPublish, 'Service provider does not return expected published path key.');
         $this->assertArrayHasKey('source/tagged/one', $toPublish, 'Service provider does not return expected published path key.');
         $this->assertEquals(['source/unmarked/one' => 'destination/unmarked/one', 'source/tagged/one' => 'destination/tagged/one'], $toPublish, 'Service provider does not return expected set of published paths.');
@@ -51,7 +51,7 @@ class SupportServiceProviderTest extends TestCase
 
     public function testMultipleAssetsArePublishedCorrectly()
     {
-        $toPublish = ServiceProvider::pathsToPublish('Illuminate\Tests\Support\ServiceProviderForTestingTwo');
+        $toPublish = ServiceProvider::pathsToPublish(\Illuminate\Tests\Support\ServiceProviderForTestingTwo::class);
         $this->assertArrayHasKey('source/unmarked/two/a', $toPublish, 'Service provider does not return expected published path key.');
         $this->assertArrayHasKey('source/unmarked/two/b', $toPublish, 'Service provider does not return expected published path key.');
         $this->assertArrayHasKey('source/unmarked/two/c', $toPublish, 'Service provider does not return expected published path key.');
@@ -69,7 +69,7 @@ class SupportServiceProviderTest extends TestCase
 
     public function testSimpleTaggedAssetsArePublishedCorrectly()
     {
-        $toPublish = ServiceProvider::pathsToPublish('Illuminate\Tests\Support\ServiceProviderForTestingOne', 'some_tag');
+        $toPublish = ServiceProvider::pathsToPublish(\Illuminate\Tests\Support\ServiceProviderForTestingOne::class, 'some_tag');
         $this->assertArrayNotHasKey('source/tagged/two/a', $toPublish, 'Service provider does return unexpected tagged path key.');
         $this->assertArrayNotHasKey('source/tagged/two/b', $toPublish, 'Service provider does return unexpected tagged path key.');
         $this->assertArrayHasKey('source/tagged/one', $toPublish, 'Service provider does not return expected tagged path key.');
@@ -78,7 +78,7 @@ class SupportServiceProviderTest extends TestCase
 
     public function testMultipleTaggedAssetsArePublishedCorrectly()
     {
-        $toPublish = ServiceProvider::pathsToPublish('Illuminate\Tests\Support\ServiceProviderForTestingTwo', 'some_tag');
+        $toPublish = ServiceProvider::pathsToPublish(\Illuminate\Tests\Support\ServiceProviderForTestingTwo::class, 'some_tag');
         $this->assertArrayHasKey('source/tagged/two/a', $toPublish, 'Service provider does not return expected tagged path key.');
         $this->assertArrayHasKey('source/tagged/two/b', $toPublish, 'Service provider does not return expected tagged path key.');
         $this->assertArrayNotHasKey('source/tagged/one', $toPublish, 'Service provider does return unexpected tagged path key.');

--- a/tests/Translation/TranslationFileLoaderTest.php
+++ b/tests/Translation/TranslationFileLoaderTest.php
@@ -15,7 +15,7 @@ class TranslationFileLoaderTest extends TestCase
 
     public function testLoadMethodWithoutNamespacesProperlyCallsLoader()
     {
-        $loader = new FileLoader($files = m::mock('Illuminate\Filesystem\Filesystem'), __DIR__);
+        $loader = new FileLoader($files = m::mock(\Illuminate\Filesystem\Filesystem::class), __DIR__);
         $files->shouldReceive('exists')->once()->with(__DIR__.'/en/foo.php')->andReturn(true);
         $files->shouldReceive('getRequire')->once()->with(__DIR__.'/en/foo.php')->andReturn(['messages']);
 
@@ -24,7 +24,7 @@ class TranslationFileLoaderTest extends TestCase
 
     public function testLoadMethodWithNamespacesProperlyCallsLoader()
     {
-        $loader = new FileLoader($files = m::mock('Illuminate\Filesystem\Filesystem'), __DIR__);
+        $loader = new FileLoader($files = m::mock(\Illuminate\Filesystem\Filesystem::class), __DIR__);
         $files->shouldReceive('exists')->once()->with('bar/en/foo.php')->andReturn(true);
         $files->shouldReceive('exists')->once()->with(__DIR__.'/vendor/namespace/en/foo.php')->andReturn(false);
         $files->shouldReceive('getRequire')->once()->with('bar/en/foo.php')->andReturn(['foo' => 'bar']);
@@ -35,7 +35,7 @@ class TranslationFileLoaderTest extends TestCase
 
     public function testLoadMethodWithNamespacesProperlyCallsLoaderAndLoadsLocalOverrides()
     {
-        $loader = new FileLoader($files = m::mock('Illuminate\Filesystem\Filesystem'), __DIR__);
+        $loader = new FileLoader($files = m::mock(\Illuminate\Filesystem\Filesystem::class), __DIR__);
         $files->shouldReceive('exists')->once()->with('bar/en/foo.php')->andReturn(true);
         $files->shouldReceive('exists')->once()->with(__DIR__.'/vendor/namespace/en/foo.php')->andReturn(true);
         $files->shouldReceive('getRequire')->once()->with('bar/en/foo.php')->andReturn(['foo' => 'bar']);
@@ -47,7 +47,7 @@ class TranslationFileLoaderTest extends TestCase
 
     public function testEmptyArraysReturnedWhenFilesDontExist()
     {
-        $loader = new FileLoader($files = m::mock('Illuminate\Filesystem\Filesystem'), __DIR__);
+        $loader = new FileLoader($files = m::mock(\Illuminate\Filesystem\Filesystem::class), __DIR__);
         $files->shouldReceive('exists')->once()->with(__DIR__.'/en/foo.php')->andReturn(false);
         $files->shouldReceive('getRequire')->never();
 
@@ -56,7 +56,7 @@ class TranslationFileLoaderTest extends TestCase
 
     public function testEmptyArraysReturnedWhenFilesDontExistForNamespacedItems()
     {
-        $loader = new FileLoader($files = m::mock('Illuminate\Filesystem\Filesystem'), __DIR__);
+        $loader = new FileLoader($files = m::mock(\Illuminate\Filesystem\Filesystem::class), __DIR__);
         $files->shouldReceive('getRequire')->never();
 
         $this->assertEquals([], $loader->load('en', 'foo', 'bar'));
@@ -64,7 +64,7 @@ class TranslationFileLoaderTest extends TestCase
 
     public function testLoadMethodForJSONProperlyCallsLoader()
     {
-        $loader = new FileLoader($files = m::mock('Illuminate\Filesystem\Filesystem'), __DIR__);
+        $loader = new FileLoader($files = m::mock(\Illuminate\Filesystem\Filesystem::class), __DIR__);
         $files->shouldReceive('exists')->once()->with(__DIR__.'/en.json')->andReturn(true);
         $files->shouldReceive('get')->once()->with(__DIR__.'/en.json')->andReturn('{"foo":"bar"}');
 

--- a/tests/Translation/TranslationTranslatorTest.php
+++ b/tests/Translation/TranslationTranslatorTest.php
@@ -14,28 +14,28 @@ class TranslationTranslatorTest extends TestCase
 
     public function testHasMethodReturnsFalseWhenReturnedTranslationIsNull()
     {
-        $t = $this->getMockBuilder('Illuminate\Translation\Translator')->setMethods(['get'])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
+        $t = $this->getMockBuilder(\Illuminate\Translation\Translator::class)->setMethods(['get'])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
         $t->expects($this->once())->method('get')->with($this->equalTo('foo'), $this->equalTo([]), $this->equalTo('bar'))->will($this->returnValue('foo'));
         $this->assertFalse($t->has('foo', 'bar'));
 
-        $t = $this->getMockBuilder('Illuminate\Translation\Translator')->setMethods(['get'])->setConstructorArgs([$this->getLoader(), 'en', 'sp'])->getMock();
+        $t = $this->getMockBuilder(\Illuminate\Translation\Translator::class)->setMethods(['get'])->setConstructorArgs([$this->getLoader(), 'en', 'sp'])->getMock();
         $t->expects($this->once())->method('get')->with($this->equalTo('foo'), $this->equalTo([]), $this->equalTo('bar'))->will($this->returnValue('bar'));
         $this->assertTrue($t->has('foo', 'bar'));
 
-        $t = $this->getMockBuilder('Illuminate\Translation\Translator')->setMethods(['get'])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
+        $t = $this->getMockBuilder(\Illuminate\Translation\Translator::class)->setMethods(['get'])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
         $t->expects($this->once())->method('get')->with($this->equalTo('foo'), $this->equalTo([]), $this->equalTo('bar'), false)->will($this->returnValue('bar'));
         $this->assertTrue($t->hasForLocale('foo', 'bar'));
 
-        $t = $this->getMockBuilder('Illuminate\Translation\Translator')->setMethods(['get'])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
+        $t = $this->getMockBuilder(\Illuminate\Translation\Translator::class)->setMethods(['get'])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
         $t->expects($this->once())->method('get')->with($this->equalTo('foo'), $this->equalTo([]), $this->equalTo('bar'), false)->will($this->returnValue('foo'));
         $this->assertFalse($t->hasForLocale('foo', 'bar'));
 
-        $t = $this->getMockBuilder('Illuminate\Translation\Translator')->setMethods(['load', 'getLine'])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
+        $t = $this->getMockBuilder(\Illuminate\Translation\Translator::class)->setMethods(['load', 'getLine'])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
         $t->expects($this->any())->method('load')->with($this->equalTo('*'), $this->equalTo('foo'), $this->equalTo('en'))->will($this->returnValue(null));
         $t->expects($this->once())->method('getLine')->with($this->equalTo('*'), $this->equalTo('foo'), $this->equalTo('en'), null, $this->equalTo([]))->will($this->returnValue('bar'));
         $this->assertTrue($t->hasForLocale('foo'));
 
-        $t = $this->getMockBuilder('Illuminate\Translation\Translator')->setMethods(['load', 'getLine'])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
+        $t = $this->getMockBuilder(\Illuminate\Translation\Translator::class)->setMethods(['load', 'getLine'])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
         $t->expects($this->any())->method('load')->with($this->equalTo('*'), $this->equalTo('foo'), $this->equalTo('en'))->will($this->returnValue(null));
         $t->expects($this->once())->method('getLine')->with($this->equalTo('*'), $this->equalTo('foo'), $this->equalTo('en'), null, $this->equalTo([]))->will($this->returnValue('foo'));
         $this->assertFalse($t->hasForLocale('foo'));
@@ -51,7 +51,7 @@ class TranslationTranslatorTest extends TestCase
 
     public function testGetMethodProperlyLoadsAndRetrievesItemWithCapitalization()
     {
-        $t = $this->getMockBuilder('Illuminate\Translation\Translator')->setMethods(null)->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
+        $t = $this->getMockBuilder(\Illuminate\Translation\Translator::class)->setMethods(null)->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
         $t->getLoader()->shouldReceive('load')->once()->with('en', 'bar', 'foo')->andReturn(['foo' => 'foo', 'baz' => 'breeze :Foo :BAR']);
         $this->assertEquals('breeze Bar FOO', $t->get('foo::bar.baz', ['foo' => 'bar', 'bar' => 'foo'], 'en'));
         $this->assertEquals('foo', $t->get('foo::bar.foo'));
@@ -75,9 +75,9 @@ class TranslationTranslatorTest extends TestCase
 
     public function testChoiceMethodProperlyLoadsAndRetrievesItem()
     {
-        $t = $this->getMockBuilder('Illuminate\Translation\Translator')->setMethods(['get'])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
+        $t = $this->getMockBuilder(\Illuminate\Translation\Translator::class)->setMethods(['get'])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
         $t->expects($this->once())->method('get')->with($this->equalTo('foo'), $this->equalTo(['replace']), $this->equalTo('en'))->will($this->returnValue('line'));
-        $t->setSelector($selector = m::mock('Illuminate\Translation\MessageSelector'));
+        $t->setSelector($selector = m::mock(\Illuminate\Translation\MessageSelector::class));
         $selector->shouldReceive('choose')->once()->with('line', 10, 'en')->andReturn('choiced');
 
         $t->choice('foo', 10, ['replace']);
@@ -85,9 +85,9 @@ class TranslationTranslatorTest extends TestCase
 
     public function testChoiceMethodProperlyCountsCollectionsAndLoadsAndRetrievesItem()
     {
-        $t = $this->getMockBuilder('Illuminate\Translation\Translator')->setMethods(['get'])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
+        $t = $this->getMockBuilder(\Illuminate\Translation\Translator::class)->setMethods(['get'])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
         $t->expects($this->exactly(2))->method('get')->with($this->equalTo('foo'), $this->equalTo(['replace']), $this->equalTo('en'))->will($this->returnValue('line'));
-        $t->setSelector($selector = m::mock('Illuminate\Translation\MessageSelector'));
+        $t->setSelector($selector = m::mock(\Illuminate\Translation\MessageSelector::class));
         $selector->shouldReceive('choose')->twice()->with('line', 3, 'en')->andReturn('choiced');
 
         $values = ['foo', 'bar', 'baz'];
@@ -159,6 +159,6 @@ class TranslationTranslatorTest extends TestCase
 
     protected function getLoader()
     {
-        return m::mock('Illuminate\Translation\LoaderInterface');
+        return m::mock(\Illuminate\Translation\LoaderInterface::class);
     }
 }

--- a/tests/Validation/ValidationDatabasePresenceVerifierTest.php
+++ b/tests/Validation/ValidationDatabasePresenceVerifierTest.php
@@ -14,10 +14,10 @@ class ValidationDatabasePresenceVerifierTest extends TestCase
 
     public function testBasicCount()
     {
-        $verifier = new \Illuminate\Validation\DatabasePresenceVerifier($db = m::mock('Illuminate\Database\ConnectionResolverInterface'));
+        $verifier = new \Illuminate\Validation\DatabasePresenceVerifier($db = m::mock(\Illuminate\Database\ConnectionResolverInterface::class));
         $verifier->setConnection('connection');
-        $db->shouldReceive('connection')->once()->with('connection')->andReturn($conn = m::mock('stdClass'));
-        $conn->shouldReceive('table')->once()->with('table')->andReturn($builder = m::mock('stdClass'));
+        $db->shouldReceive('connection')->once()->with('connection')->andReturn($conn = m::mock(\stdClass::class));
+        $conn->shouldReceive('table')->once()->with('table')->andReturn($builder = m::mock(\stdClass::class));
         $builder->shouldReceive('useWritePdo')->once()->andReturn($builder);
         $builder->shouldReceive('where')->with('column', '=', 'value')->andReturn($builder);
         $extra = ['foo' => 'NULL', 'bar' => 'NOT_NULL', 'baz' => 'taylor', 'faz' => true, 'not' => '!admin'];
@@ -33,10 +33,10 @@ class ValidationDatabasePresenceVerifierTest extends TestCase
 
     public function testBasicCountWithClosures()
     {
-        $verifier = new \Illuminate\Validation\DatabasePresenceVerifier($db = m::mock('Illuminate\Database\ConnectionResolverInterface'));
+        $verifier = new \Illuminate\Validation\DatabasePresenceVerifier($db = m::mock(\Illuminate\Database\ConnectionResolverInterface::class));
         $verifier->setConnection('connection');
-        $db->shouldReceive('connection')->once()->with('connection')->andReturn($conn = m::mock('stdClass'));
-        $conn->shouldReceive('table')->once()->with('table')->andReturn($builder = m::mock('stdClass'));
+        $db->shouldReceive('connection')->once()->with('connection')->andReturn($conn = m::mock(\stdClass::class));
+        $conn->shouldReceive('table')->once()->with('table')->andReturn($builder = m::mock(\stdClass::class));
         $builder->shouldReceive('useWritePdo')->once()->andReturn($builder);
         $builder->shouldReceive('where')->with('column', '=', 'value')->andReturn($builder);
         $closure = function ($query) {

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -240,9 +240,9 @@ class ValidationValidatorTest extends TestCase
         $trans = $this->getIlluminateArrayTranslator();
         $trans->addLines(['validation.foo' => 'foo!'], 'en');
         $v = new Validator($trans, [], ['name' => 'required']);
-        $v->setContainer($container = m::mock('Illuminate\Container\Container'));
+        $v->setContainer($container = m::mock(\Illuminate\Container\Container::class));
         $v->addReplacer('required', 'Foo@bar');
-        $container->shouldReceive('make')->once()->with('Foo')->andReturn($foo = m::mock('stdClass'));
+        $container->shouldReceive('make')->once()->with('Foo')->andReturn($foo = m::mock(\stdClass::class));
         $foo->shouldReceive('bar')->once()->andReturn('replaced!');
         $v->passes();
         $v->messages()->setFormat(':message');
@@ -1491,42 +1491,42 @@ class ValidationValidatorTest extends TestCase
     {
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['email' => 'foo'], ['email' => 'Unique:users']);
-        $mock = m::mock('Illuminate\Validation\PresenceVerifierInterface');
+        $mock = m::mock(\Illuminate\Validation\PresenceVerifierInterface::class);
         $mock->shouldReceive('setConnection')->once()->with(null);
         $mock->shouldReceive('getCount')->once()->with('users', 'email', 'foo', null, null, [])->andReturn(0);
         $v->setPresenceVerifier($mock);
         $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['email' => 'foo'], ['email' => 'Unique:connection.users']);
-        $mock = m::mock('Illuminate\Validation\PresenceVerifierInterface');
+        $mock = m::mock(\Illuminate\Validation\PresenceVerifierInterface::class);
         $mock->shouldReceive('setConnection')->once()->with('connection');
         $mock->shouldReceive('getCount')->once()->with('users', 'email', 'foo', null, null, [])->andReturn(0);
         $v->setPresenceVerifier($mock);
         $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['email' => 'foo'], ['email' => 'Unique:users,email_addr,1']);
-        $mock = m::mock('Illuminate\Validation\PresenceVerifierInterface');
+        $mock = m::mock(\Illuminate\Validation\PresenceVerifierInterface::class);
         $mock->shouldReceive('setConnection')->once()->with(null);
         $mock->shouldReceive('getCount')->once()->with('users', 'email_addr', 'foo', '1', 'id', [])->andReturn(1);
         $v->setPresenceVerifier($mock);
         $this->assertFalse($v->passes());
 
         $v = new Validator($trans, ['email' => 'foo'], ['email' => 'Unique:users,email_addr,1,id_col']);
-        $mock = m::mock('Illuminate\Validation\PresenceVerifierInterface');
+        $mock = m::mock(\Illuminate\Validation\PresenceVerifierInterface::class);
         $mock->shouldReceive('setConnection')->once()->with(null);
         $mock->shouldReceive('getCount')->once()->with('users', 'email_addr', 'foo', '1', 'id_col', [])->andReturn(2);
         $v->setPresenceVerifier($mock);
         $this->assertFalse($v->passes());
 
         $v = new Validator($trans, ['users' => [['id' => 1, 'email' => 'foo']]], ['users.*.email' => 'Unique:users,email,[users.*.id]']);
-        $mock = m::mock('Illuminate\Validation\PresenceVerifierInterface');
+        $mock = m::mock(\Illuminate\Validation\PresenceVerifierInterface::class);
         $mock->shouldReceive('setConnection')->once()->with(null);
         $mock->shouldReceive('getCount')->once()->with('users', 'email', 'foo', '1', 'id', [])->andReturn(1);
         $v->setPresenceVerifier($mock);
         $this->assertFalse($v->passes());
 
         $v = new Validator($trans, ['email' => 'foo'], ['email' => 'Unique:users,email_addr,NULL,id_col,foo,bar']);
-        $mock = m::mock('Illuminate\Validation\PresenceVerifierInterface');
+        $mock = m::mock(\Illuminate\Validation\PresenceVerifierInterface::class);
         $mock->shouldReceive('setConnection')->once()->with(null);
         $mock->shouldReceive('getCount')->once()->with('users', 'email_addr', 'foo', null, 'id_col', ['foo' => 'bar'])->andReturn(2);
         $v->setPresenceVerifier($mock);
@@ -1539,7 +1539,7 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, [['email' => 'foo', 'type' => 'bar']], [
             '*.email' => 'unique:users', '*.type' => 'exists:user_types',
         ]);
-        $mock = m::mock('Illuminate\Validation\PresenceVerifierInterface');
+        $mock = m::mock(\Illuminate\Validation\PresenceVerifierInterface::class);
         $mock->shouldReceive('setConnection')->twice()->with(null);
         $mock->shouldReceive('getCount')->with('users', 'email', 'foo', null, null, [])->andReturn(0);
         $mock->shouldReceive('getCount')->with('user_types', 'type', 'bar', null, null, [])->andReturn(1);
@@ -1553,7 +1553,7 @@ class ValidationValidatorTest extends TestCase
             '*.email' => (new Unique('users'))->where($closure),
             '*.type' => (new Exists('user_types'))->where($closure),
         ]);
-        $mock = m::mock('Illuminate\Validation\PresenceVerifierInterface');
+        $mock = m::mock(\Illuminate\Validation\PresenceVerifierInterface::class);
         $mock->shouldReceive('setConnection')->twice()->with(null);
         $mock->shouldReceive('getCount')->with('users', 'email', 'foo', null, 'id', [$closure])->andReturn(0);
         $mock->shouldReceive('getCount')->with('user_types', 'type', 'bar', null, null, [$closure])->andReturn(1);
@@ -1565,7 +1565,7 @@ class ValidationValidatorTest extends TestCase
     {
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['email' => 'foo'], ['email' => 'Exists:users']);
-        $mock = m::mock('Illuminate\Validation\PresenceVerifierInterface');
+        $mock = m::mock(\Illuminate\Validation\PresenceVerifierInterface::class);
         $mock->shouldReceive('setConnection')->once()->with(null);
         $mock->shouldReceive('getCount')->once()->with('users', 'email', 'foo', null, null, [])->andReturn(true);
         $v->setPresenceVerifier($mock);
@@ -1573,28 +1573,28 @@ class ValidationValidatorTest extends TestCase
 
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['email' => 'foo'], ['email' => 'Exists:users,email,account_id,1,name,taylor']);
-        $mock = m::mock('Illuminate\Validation\PresenceVerifierInterface');
+        $mock = m::mock(\Illuminate\Validation\PresenceVerifierInterface::class);
         $mock->shouldReceive('setConnection')->once()->with(null);
         $mock->shouldReceive('getCount')->once()->with('users', 'email', 'foo', null, null, ['account_id' => 1, 'name' => 'taylor'])->andReturn(true);
         $v->setPresenceVerifier($mock);
         $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['email' => 'foo'], ['email' => 'Exists:users,email_addr']);
-        $mock = m::mock('Illuminate\Validation\PresenceVerifierInterface');
+        $mock = m::mock(\Illuminate\Validation\PresenceVerifierInterface::class);
         $mock->shouldReceive('setConnection')->once()->with(null);
         $mock->shouldReceive('getCount')->once()->with('users', 'email_addr', 'foo', null, null, [])->andReturn(false);
         $v->setPresenceVerifier($mock);
         $this->assertFalse($v->passes());
 
         $v = new Validator($trans, ['email' => ['foo']], ['email' => 'Exists:users,email_addr']);
-        $mock = m::mock('Illuminate\Validation\PresenceVerifierInterface');
+        $mock = m::mock(\Illuminate\Validation\PresenceVerifierInterface::class);
         $mock->shouldReceive('setConnection')->once()->with(null);
         $mock->shouldReceive('getMultiCount')->once()->with('users', 'email_addr', ['foo'], [])->andReturn(false);
         $v->setPresenceVerifier($mock);
         $this->assertFalse($v->passes());
 
         $v = new Validator($trans, ['email' => 'foo'], ['email' => 'Exists:connection.users']);
-        $mock = m::mock('Illuminate\Validation\PresenceVerifierInterface');
+        $mock = m::mock(\Illuminate\Validation\PresenceVerifierInterface::class);
         $mock->shouldReceive('setConnection')->once()->with('connection');
         $mock->shouldReceive('getCount')->once()->with('users', 'email', 'foo', null, null, [])->andReturn(true);
         $v->setPresenceVerifier($mock);
@@ -1605,14 +1605,14 @@ class ValidationValidatorTest extends TestCase
     {
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['id' => 'foo'], ['id' => 'Integer|Exists:users,id']);
-        $mock = m::mock('Illuminate\Validation\PresenceVerifierInterface');
+        $mock = m::mock(\Illuminate\Validation\PresenceVerifierInterface::class);
         $mock->shouldReceive('getCount')->never();
         $v->setPresenceVerifier($mock);
         $this->assertFalse($v->passes());
 
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['id' => '1'], ['id' => 'Integer|Exists:users,id']);
-        $mock = m::mock('Illuminate\Validation\PresenceVerifierInterface');
+        $mock = m::mock(\Illuminate\Validation\PresenceVerifierInterface::class);
         $mock->shouldReceive('setConnection')->once()->with(null);
         $mock->shouldReceive('getCount')->once()->with('users', 'id', '1', null, null, [])->andReturn(true);
         $v->setPresenceVerifier($mock);
@@ -2550,9 +2550,9 @@ class ValidationValidatorTest extends TestCase
         $trans = $this->getIlluminateArrayTranslator();
         $trans->addLines(['validation.foo' => 'foo!'], 'en');
         $v = new Validator($trans, ['name' => 'taylor'], ['name' => 'foo']);
-        $v->setContainer($container = m::mock('Illuminate\Container\Container'));
+        $v->setContainer($container = m::mock(\Illuminate\Container\Container::class));
         $v->addExtension('foo', 'Foo@bar');
-        $container->shouldReceive('make')->once()->with('Foo')->andReturn($foo = m::mock('stdClass'));
+        $container->shouldReceive('make')->once()->with('Foo')->andReturn($foo = m::mock(\stdClass::class));
         $foo->shouldReceive('bar')->once()->andReturn(false);
         $this->assertFalse($v->passes());
         $v->messages()->setFormat(':message');
@@ -2564,9 +2564,9 @@ class ValidationValidatorTest extends TestCase
         $trans = $this->getIlluminateArrayTranslator();
         $trans->addLines(['validation.foo' => 'foo!'], 'en');
         $v = new Validator($trans, ['name' => 'taylor'], ['name' => 'foo']);
-        $v->setContainer($container = m::mock('Illuminate\Container\Container'));
+        $v->setContainer($container = m::mock(\Illuminate\Container\Container::class));
         $v->addExtension('foo', 'Foo');
-        $container->shouldReceive('make')->once()->with('Foo')->andReturn($foo = m::mock('stdClass'));
+        $container->shouldReceive('make')->once()->with('Foo')->andReturn($foo = m::mock(\stdClass::class));
         $foo->shouldReceive('validate')->once()->andReturn(false);
         $this->assertFalse($v->passes());
         $v->messages()->setFormat(':message');
@@ -3554,7 +3554,7 @@ class ValidationValidatorTest extends TestCase
 
     protected function getTranslator()
     {
-        return m::mock('Illuminate\Contracts\Translation\Translator');
+        return m::mock(\Illuminate\Contracts\Translation\Translator::class);
     }
 
     public function getIlluminateArrayTranslator()

--- a/tests/View/Blade/AbstractBladeTestCase.php
+++ b/tests/View/Blade/AbstractBladeTestCase.php
@@ -12,7 +12,7 @@ abstract class AbstractBladeTestCase extends TestCase
 
     public function setUp()
     {
-        $this->compiler = new BladeCompiler(m::mock('Illuminate\Filesystem\Filesystem'), __DIR__);
+        $this->compiler = new BladeCompiler(m::mock(\Illuminate\Filesystem\Filesystem::class), __DIR__);
         parent::setUp();
     }
 

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -93,7 +93,7 @@ class ViewBladeCompilerTest extends TestCase
 
     protected function getFiles()
     {
-        return m::mock('Illuminate\Filesystem\Filesystem');
+        return m::mock(\Illuminate\Filesystem\Filesystem::class);
     }
 
     public function testGetTagsProvider()

--- a/tests/View/ViewCompilerEngineTest.php
+++ b/tests/View/ViewCompilerEngineTest.php
@@ -39,6 +39,6 @@ class ViewCompilerEngineTest extends TestCase
 
     protected function getEngine()
     {
-        return new CompilerEngine(m::mock('Illuminate\View\Compilers\CompilerInterface'));
+        return new CompilerEngine(m::mock(\Illuminate\View\Compilers\CompilerInterface::class));
     }
 }

--- a/tests/View/ViewFactoryTest.php
+++ b/tests/View/ViewFactoryTest.php
@@ -20,7 +20,7 @@ class ViewFactoryTest extends TestCase
 
         $factory = $this->getFactory();
         $factory->getFinder()->shouldReceive('find')->once()->with('view')->andReturn('path.php');
-        $factory->getEngineResolver()->shouldReceive('resolve')->once()->with('php')->andReturn($engine = m::mock('Illuminate\View\Engines\EngineInterface'));
+        $factory->getEngineResolver()->shouldReceive('resolve')->once()->with('php')->andReturn($engine = m::mock(\Illuminate\View\Engines\EngineInterface::class));
         $factory->getFinder()->shouldReceive('addExtension')->once()->with('php');
         $factory->setDispatcher(new \Illuminate\Events\Dispatcher);
         $factory->creator('view', function ($view) {
@@ -48,8 +48,8 @@ class ViewFactoryTest extends TestCase
     public function testRenderEachCreatesViewForEachItemInArray()
     {
         $factory = m::mock('Illuminate\View\Factory[make]', $this->getFactoryArgs());
-        $factory->shouldReceive('make')->once()->with('foo', ['key' => 'bar', 'value' => 'baz'])->andReturn($mockView1 = m::mock('stdClass'));
-        $factory->shouldReceive('make')->once()->with('foo', ['key' => 'breeze', 'value' => 'boom'])->andReturn($mockView2 = m::mock('stdClass'));
+        $factory->shouldReceive('make')->once()->with('foo', ['key' => 'bar', 'value' => 'baz'])->andReturn($mockView1 = m::mock(\stdClass::class));
+        $factory->shouldReceive('make')->once()->with('foo', ['key' => 'breeze', 'value' => 'boom'])->andReturn($mockView2 = m::mock(\stdClass::class));
         $mockView1->shouldReceive('render')->once()->andReturn('dayle');
         $mockView2->shouldReceive('render')->once()->andReturn('rees');
 
@@ -61,7 +61,7 @@ class ViewFactoryTest extends TestCase
     public function testEmptyViewsCanBeReturnedFromRenderEach()
     {
         $factory = m::mock('Illuminate\View\Factory[make]', $this->getFactoryArgs());
-        $factory->shouldReceive('make')->once()->with('foo')->andReturn($mockView = m::mock('stdClass'));
+        $factory->shouldReceive('make')->once()->with('foo')->andReturn($mockView = m::mock(\stdClass::class));
         $mockView->shouldReceive('render')->once()->andReturn('empty');
 
         $this->assertEquals('empty', $factory->renderEach('view', [], 'iterator', 'foo'));
@@ -82,7 +82,7 @@ class ViewFactoryTest extends TestCase
         $factory->getFinder()->shouldReceive('addExtension')->once()->with('foo');
         $factory->getEngineResolver()->shouldReceive('register')->once()->with('bar', $resolver);
         $factory->getFinder()->shouldReceive('find')->once()->with('view')->andReturn('path.foo');
-        $factory->getEngineResolver()->shouldReceive('resolve')->once()->with('bar')->andReturn($engine = m::mock('Illuminate\View\Engines\EngineInterface'));
+        $factory->getEngineResolver()->shouldReceive('resolve')->once()->with('bar')->andReturn($engine = m::mock(\Illuminate\View\Engines\EngineInterface::class));
         $factory->getDispatcher()->shouldReceive('fire');
 
         $factory->addExtension('foo', 'bar', $resolver);
@@ -153,8 +153,8 @@ class ViewFactoryTest extends TestCase
     {
         $factory = $this->getFactory();
         $factory->getDispatcher()->shouldReceive('listen')->once()->with('composing: foo', m::type('Closure'));
-        $factory->setContainer($container = m::mock('Illuminate\Container\Container'));
-        $container->shouldReceive('make')->once()->with('FooComposer')->andReturn($composer = m::mock('stdClass'));
+        $factory->setContainer($container = m::mock(\Illuminate\Container\Container::class));
+        $container->shouldReceive('make')->once()->with('FooComposer')->andReturn($composer = m::mock(\stdClass::class));
         $composer->shouldReceive('compose')->once()->with('view')->andReturn('composed');
         $callback = $factory->composer('foo', 'FooComposer');
         $callback = $callback[0];
@@ -166,8 +166,8 @@ class ViewFactoryTest extends TestCase
     {
         $factory = $this->getFactory();
         $factory->getDispatcher()->shouldReceive('listen')->once()->with('composing: foo', m::type('Closure'));
-        $factory->setContainer($container = m::mock('Illuminate\Container\Container'));
-        $container->shouldReceive('make')->once()->with('FooComposer')->andReturn($composer = m::mock('stdClass'));
+        $factory->setContainer($container = m::mock(\Illuminate\Container\Container::class));
+        $container->shouldReceive('make')->once()->with('FooComposer')->andReturn($composer = m::mock(\stdClass::class));
         $composer->shouldReceive('doComposer')->once()->with('view')->andReturn('composed');
         $callback = $factory->composer('foo', 'FooComposer@doComposer');
         $callback = $callback[0];
@@ -178,7 +178,7 @@ class ViewFactoryTest extends TestCase
     public function testCallComposerCallsProperEvent()
     {
         $factory = $this->getFactory();
-        $view = m::mock('Illuminate\View\View');
+        $view = m::mock(\Illuminate\View\View::class);
         $view->shouldReceive('name')->once()->andReturn('name');
         $factory->getDispatcher()->shouldReceive('fire')->once()->with('composing: name', [$view]);
 
@@ -259,7 +259,7 @@ class ViewFactoryTest extends TestCase
     public function testTranslation()
     {
         $container = new \Illuminate\Container\Container;
-        $container->instance('translator', $translator = m::mock('stdClass'));
+        $container->instance('translator', $translator = m::mock(\stdClass::class));
         $translator->shouldReceive('getFromJson')->with('Foo', ['name' => 'taylor'])->andReturn('Bar');
         $factory = $this->getFactory();
         $factory->setContainer($container);
@@ -365,7 +365,7 @@ class ViewFactoryTest extends TestCase
     {
         $factory = $this->getFactory();
         $factory->getFinder()->shouldReceive('find')->twice()->with('foo.bar')->andReturn('path.php');
-        $factory->getEngineResolver()->shouldReceive('resolve')->twice()->with('php')->andReturn(m::mock('Illuminate\View\Engines\EngineInterface'));
+        $factory->getEngineResolver()->shouldReceive('resolve')->twice()->with('php')->andReturn(m::mock(\Illuminate\View\Engines\EngineInterface::class));
         $factory->getDispatcher()->shouldReceive('fire');
         $factory->make('foo/bar');
         $factory->make('foo.bar');
@@ -375,7 +375,7 @@ class ViewFactoryTest extends TestCase
     {
         $factory = $this->getFactory();
         $factory->getFinder()->shouldReceive('find')->twice()->with('vendor/package::foo.bar')->andReturn('path.php');
-        $factory->getEngineResolver()->shouldReceive('resolve')->twice()->with('php')->andReturn(m::mock('Illuminate\View\Engines\EngineInterface'));
+        $factory->getEngineResolver()->shouldReceive('resolve')->twice()->with('php')->andReturn(m::mock(\Illuminate\View\Engines\EngineInterface::class));
         $factory->getDispatcher()->shouldReceive('fire');
         $factory->make('vendor/package::foo/bar');
         $factory->make('vendor/package::foo.bar');
@@ -397,7 +397,7 @@ class ViewFactoryTest extends TestCase
      */
     public function testExceptionsInSectionsAreThrown()
     {
-        $engine = new \Illuminate\View\Engines\CompilerEngine(m::mock('Illuminate\View\Compilers\CompilerInterface'));
+        $engine = new \Illuminate\View\Engines\CompilerEngine(m::mock(\Illuminate\View\Compilers\CompilerInterface::class));
         $engine->getCompiler()->shouldReceive('getCompiledPath')->andReturnUsing(function ($path) {
             return $path;
         });
@@ -543,18 +543,18 @@ class ViewFactoryTest extends TestCase
     protected function getFactory()
     {
         return new Factory(
-            m::mock('Illuminate\View\Engines\EngineResolver'),
-            m::mock('Illuminate\View\ViewFinderInterface'),
-            m::mock('Illuminate\Contracts\Events\Dispatcher')
+            m::mock(\Illuminate\View\Engines\EngineResolver::class),
+            m::mock(\Illuminate\View\ViewFinderInterface::class),
+            m::mock(\Illuminate\Contracts\Events\Dispatcher::class)
         );
     }
 
     protected function getFactoryArgs()
     {
         return [
-            m::mock('Illuminate\View\Engines\EngineResolver'),
-            m::mock('Illuminate\View\ViewFinderInterface'),
-            m::mock('Illuminate\Contracts\Events\Dispatcher'),
+            m::mock(\Illuminate\View\Engines\EngineResolver::class),
+            m::mock(\Illuminate\View\ViewFinderInterface::class),
+            m::mock(\Illuminate\Contracts\Events\Dispatcher::class),
         ];
     }
 }

--- a/tests/View/ViewFileViewFinderTest.php
+++ b/tests/View/ViewFileViewFinderTest.php
@@ -143,6 +143,6 @@ class ViewFinderTest extends TestCase
 
     protected function getFinder()
     {
-        return new \Illuminate\View\FileViewFinder(m::mock('Illuminate\Filesystem\Filesystem'), [__DIR__]);
+        return new \Illuminate\View\FileViewFinder(m::mock(\Illuminate\Filesystem\Filesystem::class), [__DIR__]);
     }
 }

--- a/tests/View/ViewTest.php
+++ b/tests/View/ViewTest.php
@@ -69,8 +69,8 @@ class ViewTest extends TestCase
     public function testRenderSectionsReturnsEnvironmentSections()
     {
         $view = m::mock('Illuminate\View\View[render]', [
-            m::mock('Illuminate\View\Factory'),
-            m::mock('Illuminate\View\Engines\EngineInterface'),
+            m::mock(\Illuminate\View\Factory::class),
+            m::mock(\Illuminate\View\Engines\EngineInterface::class),
             'view',
             'path',
             [],
@@ -101,12 +101,12 @@ class ViewTest extends TestCase
         $view->getFactory()->shouldReceive('make')->once()->with('foo', ['data']);
         $result = $view->nest('key', 'foo', ['data']);
 
-        $this->assertInstanceOf('Illuminate\View\View', $result);
+        $this->assertInstanceOf(\Illuminate\View\View::class, $result);
     }
 
     public function testViewAcceptsArrayableImplementations()
     {
-        $arrayable = m::mock('Illuminate\Contracts\Support\Arrayable');
+        $arrayable = m::mock(\Illuminate\Contracts\Support\Arrayable::class);
         $arrayable->shouldReceive('toArray')->once()->andReturn(['foo' => 'bar', 'baz' => ['qux', 'corge']]);
 
         $view = $this->getView($arrayable);
@@ -182,7 +182,7 @@ class ViewTest extends TestCase
         $view->getFactory()->shouldReceive('decrementRender')->once()->ordered();
         $view->getFactory()->shouldReceive('flushStateIfDoneRendering')->once();
 
-        $view->renderable = m::mock('Illuminate\Contracts\Support\Renderable');
+        $view->renderable = m::mock(\Illuminate\Contracts\Support\Renderable::class);
         $view->renderable->shouldReceive('render')->once()->andReturn('text');
         $this->assertEquals('contents', $view->render());
     }
@@ -208,7 +208,7 @@ class ViewTest extends TestCase
         $view = $this->getView();
         $errors = ['foo' => 'bar', 'qu' => 'ux'];
         $this->assertSame($view, $view->withErrors($errors));
-        $this->assertInstanceOf('Illuminate\Support\MessageBag', $view->errors);
+        $this->assertInstanceOf(\Illuminate\Support\MessageBag::class, $view->errors);
         $foo = $view->errors->get('foo');
         $this->assertEquals($foo[0], 'bar');
         $qu = $view->errors->get('qu');
@@ -222,8 +222,8 @@ class ViewTest extends TestCase
     protected function getView($data = [])
     {
         return new View(
-            m::mock('Illuminate\View\Factory'),
-            m::mock('Illuminate\View\Engines\EngineInterface'),
+            m::mock(\Illuminate\View\Factory::class),
+            m::mock(\Illuminate\View\Engines\EngineInterface::class),
             'view',
             'path',
             $data


### PR DESCRIPTION
Use `::class` notation in tests

---

Re-open https://github.com/laravel/framework/pull/17518 - this could be merged just before `5.5` final release

---

**Note:**
This is achieved with regexp Search and Replace in PHPStorm - with 2 or 3 other manual replacements:

- `'Monolog\\([^:@'\[\]]*)'` -> `\\Monolog\\$1::class`
- `'Illuminate\\([^:@'\[\]]*)'` -> `\\Illuminate\\$1::class`
- `'stdClass'` -> `\\stdClass::class`