### PR TITLE
[5.4] fix comment

### DIFF
--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -134,7 +134,6 @@ trait BuildsQueries
      * Create a new simple paginator instance.
      *
      * @param  \Illuminate\Support\Collection  $items
-     * @param  int $total
      * @param  int $perPage
      * @param  int $currentPage
      * @param  array  $options


### PR DESCRIPTION
Fix parameter type in phpDoc