### PR TITLE
[5.5] Let config get many keys at once.

### DIFF
--- a/src/Illuminate/Config/Repository.php
+++ b/src/Illuminate/Config/Repository.php
@@ -68,7 +68,7 @@ class Repository implements ArrayAccess, ConfigContract
                 list($key, $default) = [$default, null];
             }
 
-            Arr::set($config, $key, Arr::get($this->items, $key, $default));
+            $config[$key] = Arr::get($this->items, $key, $default);
         }
 
         return $config;

--- a/src/Illuminate/Config/Repository.php
+++ b/src/Illuminate/Config/Repository.php
@@ -40,13 +40,38 @@ class Repository implements ArrayAccess, ConfigContract
     /**
      * Get the specified configuration value.
      *
-     * @param  string  $key
+     * @param  array|string  $key
      * @param  mixed   $default
      * @return mixed
      */
     public function get($key, $default = null)
     {
+        if (is_array($key)) {
+            return $this->getMany($key);
+        }
+
         return Arr::get($this->items, $key, $default);
+    }
+
+    /**
+     * Get many configuration values.
+     *
+     * @param  array  $keys
+     * @return array
+     */
+    public function getMany($keys)
+    {
+        $config = [];
+
+        foreach ($keys as $key => $default) {
+            if (is_numeric($key)) {
+                list($key, $default) = [$default, null];
+            }
+
+            Arr::set($config, $key, Arr::get($this->items, $key, $default));
+        }
+
+        return $config;
     }
 
     /**

--- a/src/Illuminate/Contracts/Config/Repository.php
+++ b/src/Illuminate/Contracts/Config/Repository.php
@@ -15,7 +15,7 @@ interface Repository
     /**
      * Get the specified configuration value.
      *
-     * @param  string  $key
+     * @param  array|string  $key
      * @param  mixed   $default
      * @return mixed
      */

--- a/tests/Config/RepositoryTest.php
+++ b/tests/Config/RepositoryTest.php
@@ -32,6 +32,9 @@ class RepositoryTest extends TestCase
                 'aaa',
                 'zzz',
             ],
+            'x' => [
+                'z' => 'zoo',
+            ],
         ]);
 
         parent::setUp();
@@ -70,13 +73,13 @@ class RepositoryTest extends TestCase
         ]));
 
         $this->assertSame([
-            'x' => [
-                'y' => 'default',
-            ],
+            'x.y' => 'default',
+            'x.z' => 'zoo',
             'bar' => 'baz',
             'baz' => 'bat',
         ], $this->repository->get([
             'x.y' => 'default',
+            'x.z' => 'default',
             'bar' => 'default',
             'baz',
         ]));
@@ -95,13 +98,13 @@ class RepositoryTest extends TestCase
         ]));
 
         $this->assertSame([
-            'x' => [
-                'y' => 'default',
-            ],
+            'x.y' => 'default',
+            'x.z' => 'zoo',
             'bar' => 'baz',
             'baz' => 'bat',
         ], $this->repository->getMany([
             'x.y' => 'default',
+            'x.z' => 'default',
             'bar' => 'default',
             'baz',
         ]));

--- a/tests/Config/RepositoryTest.php
+++ b/tests/Config/RepositoryTest.php
@@ -22,6 +22,7 @@ class RepositoryTest extends TestCase
         $this->repository = new Repository($this->config = [
             'foo' => 'bar',
             'bar' => 'baz',
+            'baz' => 'bat',
             'null' => null,
             'associate' => [
                 'x' => 'xxx',
@@ -54,6 +55,56 @@ class RepositoryTest extends TestCase
     public function testGet()
     {
         $this->assertSame('bar', $this->repository->get('foo'));
+    }
+
+    public function testGetWithArrayOfKeys()
+    {
+        $this->assertSame([
+            'foo' => 'bar',
+            'bar' => 'baz',
+            'none' => null,
+        ], $this->repository->get([
+            'foo',
+            'bar',
+            'none',
+        ]));
+
+        $this->assertSame([
+            'x' => [
+                'y' => 'default',
+            ],
+            'bar' => 'baz',
+            'baz' => 'bat',
+        ], $this->repository->get([
+            'x.y' => 'default',
+            'bar' => 'default',
+            'baz',
+        ]));
+    }
+
+    public function testGetMany()
+    {
+        $this->assertSame([
+            'foo' => 'bar',
+            'bar' => 'baz',
+            'none' => null,
+        ], $this->repository->getMany([
+            'foo',
+            'bar',
+            'none',
+        ]));
+
+        $this->assertSame([
+            'x' => [
+                'y' => 'default',
+            ],
+            'bar' => 'baz',
+            'baz' => 'bat',
+        ], $this->repository->getMany([
+            'x.y' => 'default',
+            'bar' => 'default',
+            'baz',
+        ]));
     }
 
     public function testGetWithDefault()


### PR DESCRIPTION
Let config get many keys at once so that `$values = Config::getMany(['foo', 'bar.baz']);` is now possible.

A default value can also be set for each items to retrieve:
`$values = Config::getMany(['foo' => 'default_value', 'bar.baz' => 123]);` 

---

If `Config::get` is called with `$key` as an `array`, `Config::getMany` will be used.