### PR TITLE
[5.5] PostTooLargeException should return a 413.

### DIFF
--- a/src/Illuminate/Http/Exceptions/PostTooLargeException.php
+++ b/src/Illuminate/Http/Exceptions/PostTooLargeException.php
@@ -3,8 +3,21 @@
 namespace Illuminate\Http\Exceptions;
 
 use Exception;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 
-class PostTooLargeException extends Exception
+class PostTooLargeException extends HttpException
 {
-    //
+    /**
+     * PostTooLargeException constructor.
+     *
+     * @param  string|null  $message
+     * @param  \Exception|null  $previous
+     * @param  array  $headers
+     * @param  int  $code
+     * @return void
+     */
+    public function __construct($message = null, Exception $previous = null, array $headers = [], $code = 0)
+    {
+        parent::__construct(413, $message, $previous, $headers, $code);
+    }
 }


### PR DESCRIPTION
PostTooLargeException should return a 413.

---

See https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html