### PR TITLE
[5.5] New Preset option for Bulma css library

### DIFF
--- a/src/Illuminate/Foundation/Console/PresetCommand.php
+++ b/src/Illuminate/Foundation/Console/PresetCommand.php
@@ -15,7 +15,7 @@ class PresetCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'preset { type : The preset type (none, bootstrap, vue, react) }';
+    protected $signature = 'preset { type : The preset type (none, bootstrap, bulma, vue, react) }';
 
     /**
      * The console command description.
@@ -64,6 +64,19 @@ class PresetCommand extends Command
         Presets\Bootstrap::install();
 
         $this->info('Bootstrap scaffolding installed successfully.');
+        $this->comment('Please run "npm install && npm run dev" to compile your fresh scaffolding.');
+    }
+
+    /**
+     * Install the "bulma" preset.
+     *
+     * @return void
+     */
+    protected function bulma()
+    {
+        Presets\Bulma::install();
+
+        $this->info('Bulma scaffolding installed successfully.');
         $this->comment('Please run "npm install && npm run dev" to compile your fresh scaffolding.');
     }
 

--- a/src/Illuminate/Foundation/Console/PresetCommand.php
+++ b/src/Illuminate/Foundation/Console/PresetCommand.php
@@ -35,7 +35,7 @@ class PresetCommand extends Command
             return call_user_func(static::$macros[$this->argument('type')], $this);
         }
 
-        if (! in_array($this->argument('type'), ['none', 'bootstrap', 'vue', 'react'])) {
+        if (! in_array($this->argument('type'), ['none', 'bootstrap', 'bulma', 'vue', 'react'])) {
             throw new InvalidArgumentException('Invalid preset.');
         }
 

--- a/src/Illuminate/Foundation/Console/Presets/Bulma.php
+++ b/src/Illuminate/Foundation/Console/Presets/Bulma.php
@@ -5,7 +5,7 @@ namespace Illuminate\Foundation\Console\Presets;
 use Illuminate\Support\Arr;
 use Illuminate\Filesystem\Filesystem;
 
-class Bootstrap extends Preset
+class Bulma extends Preset
 {
     /**
      * Install the preset.

--- a/src/Illuminate/Foundation/Console/Presets/Bulma.php
+++ b/src/Illuminate/Foundation/Console/Presets/Bulma.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Illuminate\Foundation\Console\Presets;
+
+use Illuminate\Support\Arr;
+use Illuminate\Filesystem\Filesystem;
+
+class Bootstrap extends Preset
+{
+    /**
+     * Install the preset.
+     *
+     * @return void
+     */
+    public static function install()
+    {
+        static::updatePackages();
+        static::updateSass();
+        static::removeNodeModules();
+    }
+
+    /**
+     * Update the given package array.
+     *
+     * @param  array  $packages
+     * @return array
+     */
+    protected static function updatePackageArray(array $packages)
+    {
+        return [
+            'bulma' => '0.4.2',
+        ] + Arr::except($packages, ['bootstrap-sass']);
+    }
+
+    /**
+     * Update the Sass files for the application.
+     *
+     * @return void
+     */
+    protected static function updateSass()
+    {
+        copy(__DIR__.'/bulma-stubs/app.scss', resource_path('assets/sass/app.scss'));
+
+        (new Filesystem)->delete(
+            resource_path('assets/sass/_variables.scss')
+        );
+    }
+}

--- a/src/Illuminate/Foundation/Console/Presets/bulma-stubs/app.scss
+++ b/src/Illuminate/Foundation/Console/Presets/bulma-stubs/app.scss
@@ -1,0 +1,6 @@
+
+// Fonts
+@import url(https://fonts.googleapis.com/css?family=Raleway:300,400,600);
+
+// Bootstrap
+@import "node_modules/bulma/bulma";


### PR DESCRIPTION
I've notice over the last few months that many Laravel developers like the Bulma CSS library. I wanted to include a preset to quickly remove Bootstrap and get Bulma up and running. 

Thanks as always guys.