### PR TITLE
[5.5] make:observer command

### DIFF
--- a/src/Illuminate/Foundation/Console/ObserverMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ObserverMakeCommand.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Illuminate\Foundation\Console;
+
+use Illuminate\Support\Str;
+use Illuminate\Console\GeneratorCommand;
+use Symfony\Component\Console\Input\InputOption;
+
+class ObserverMakeCommand extends GeneratorCommand
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'make:observer';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create a new observer class';
+
+    /**
+     * The type of class being generated.
+     *
+     * @var string
+     */
+    protected $type = 'Observer';
+
+    /**
+     * Build the class with the given name.
+     *
+     * @param  string  $name
+     * @return string
+     */
+    protected function buildClass($name)
+    {
+        $stub = parent::buildClass($name);
+
+        $model = $this->option('model');
+
+        return $model ? $this->replaceModel($stub, $model) : $stub;
+    }
+
+    /**
+     * Replace the model for the given stub.
+     *
+     * @param  string  $stub
+     * @param  string  $model
+     * @return string
+     */
+    protected function replaceModel($stub, $model)
+    {
+        $model = str_replace('/', '\\', $model);
+
+        if (Str::startsWith($model, '\\')) {
+            $stub = str_replace('NamespacedDummyModel', trim($model, '\\'), $stub);
+        } else {
+            $stub = str_replace('NamespacedDummyModel', $this->laravel->getNamespace().$model, $stub);
+        }
+
+        $model = class_basename(trim($model, '\\'));
+
+        $stub = str_replace('DummyModel', $model, $stub);
+
+        $stub = str_replace('dummyModel', Str::camel($model), $stub);
+
+        return str_replace('dummyPluralModel', Str::plural(Str::camel($model)), $stub);
+    }
+
+    /**
+     * Get the stub file for the generator.
+     *
+     * @return string
+     */
+    protected function getStub()
+    {
+        return $this->option('model')
+                    ? __DIR__.'/stubs/observer.stub'
+                    : __DIR__.'/stubs/observer.plain.stub';
+    }
+
+    /**
+     * Get the default namespace for the class.
+     *
+     * @param  string  $rootNamespace
+     * @return string
+     */
+    protected function getDefaultNamespace($rootNamespace)
+    {
+        return $rootNamespace.'\Observers';
+    }
+
+    /**
+     * Get the console command arguments.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [
+            ['model', 'm', InputOption::VALUE_OPTIONAL, 'The model that the observer applies to.'],
+        ];
+    }
+}

--- a/src/Illuminate/Foundation/Console/stubs/observer.plain.stub
+++ b/src/Illuminate/Foundation/Console/stubs/observer.plain.stub
@@ -1,0 +1,107 @@
+<?php
+
+namespace DummyNamespace;
+
+class DummyClass
+{
+
+    /**
+     * Listen to the Model creating event.
+     *
+     * @return void
+     */
+    public function creating()
+    {
+        //
+    }
+
+    /**
+     * Listen to the Model created event.
+     *
+     * @return void
+     */
+    public function created()
+    {
+        //
+    }
+
+    /**
+     * Listen to the Model updating event.
+     *
+     * @return void
+     */
+    public function updating()
+    {
+        //
+    }
+
+    /**
+     * Listen to the Model updated event.
+     *
+     * @return void
+     */
+    public function updated()
+    {
+        //
+    }
+
+    /**
+     * Listen to the Model saving event.
+     *
+     * @return void
+     */
+    public function saving()
+    {
+        //
+    }
+
+    /**
+     * Listen to the Model saved event.
+     *
+     * @return void
+     */
+    public function saved()
+    {
+        //
+    }
+
+    /**
+     * Listen to the Model deleting event.
+     *
+     * @return void
+     */
+    public function deleting()
+    {
+        //
+    }
+
+    /**
+     * Listen to the Model deleted event.
+     *
+     * @return void
+     */
+    public function deleted()
+    {
+        //
+    }
+
+    /**
+     * Listen to the Model restoring event.
+     *
+     * @return void
+     */
+    public function restoring()
+    {
+        //
+    }
+
+    /**
+     * Listen to the Model restored event.
+     *
+     * @return void
+     */
+    public function restored()
+    {
+        //
+    }
+}

--- a/src/Illuminate/Foundation/Console/stubs/observer.stub
+++ b/src/Illuminate/Foundation/Console/stubs/observer.stub
@@ -1,0 +1,119 @@
+<?php
+
+namespace DummyNamespace;
+
+use NamespacedDummyModel;
+
+class DummyClass
+{
+
+    /**
+     * Listen to the DummyModel creating event.
+     *
+     * \NamespacedDummyModel  $dummyModel
+     * @return void
+     */
+    public function creating(DummyModel $dummyModel)
+    {
+        //
+    }
+
+    /**
+     * Listen to the DummyModel created event.
+     *
+     * \NamespacedDummyModel  $dummyModel
+     * @return void
+     */
+    public function created(DummyModel $dummyModel)
+    {
+        //
+    }
+
+    /**
+     * Listen to the DummyModel updating event.
+     *
+     * \NamespacedDummyModel  $dummyModel
+     * @return void
+     */
+    public function updating(DummyModel $dummyModel)
+    {
+        //
+    }
+
+    /**
+     * Listen to the DummyModel updated event.
+     *
+     * \NamespacedDummyModel  $dummyModel
+     * @return void
+     */
+    public function updated(DummyModel $dummyModel)
+    {
+        //
+    }
+
+    /**
+     * Listen to the DummyModel saving event.
+     *
+     * \NamespacedDummyModel  $dummyModel
+     * @return void
+     */
+    public function saving(DummyModel $dummyModel)
+    {
+        //
+    }
+
+    /**
+     * Listen to the DummyModel saved event.
+     *
+     * \NamespacedDummyModel  $dummyModel
+     * @return void
+     */
+    public function saved(DummyModel $dummyModel)
+    {
+        //
+    }
+
+    /**
+     * Listen to the DummyModel deleting event.
+     *
+     * \NamespacedDummyModel  $dummyModel
+     * @return void
+     */
+    public function deleting(DummyModel $dummyModel)
+    {
+        //
+    }
+
+    /**
+     * Listen to the DummyModel deleted event.
+     *
+     * \NamespacedDummyModel  $dummyModel
+     * @return void
+     */
+    public function deleted(DummyModel $dummyModel)
+    {
+        //
+    }
+
+    /**
+     * Listen to the DummyModel restoring event.
+     *
+     * \NamespacedDummyModel  $dummyModel
+     * @return void
+     */
+    public function restoring(DummyModel $dummyModel)
+    {
+        //
+    }
+
+    /**
+     * Listen to the DummyModel restored event.
+     *
+     * \NamespacedDummyModel  $dummyModel
+     * @return void
+     */
+    public function restored(DummyModel $dummyModel)
+    {
+        //
+    }
+}

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -24,6 +24,7 @@ use Illuminate\Foundation\Console\ModelMakeCommand;
 use Illuminate\Foundation\Console\RouteListCommand;
 use Illuminate\Foundation\Console\ViewClearCommand;
 use Illuminate\Session\Console\SessionTableCommand;
+use Illuminate\Foundation\Console\ObserverMakeCommand;
 use Illuminate\Foundation\Console\PolicyMakeCommand;
 use Illuminate\Foundation\Console\RouteCacheCommand;
 use Illuminate\Foundation\Console\RouteClearCommand;
@@ -140,6 +141,7 @@ class ArtisanServiceProvider extends ServiceProvider
         'ModelMake' => 'command.model.make',
         'NotificationMake' => 'command.notification.make',
         'NotificationTable' => 'command.notification.table',
+        'ObserverMake' => 'command.observer.make',
         'PolicyMake' => 'command.policy.make',
         'ProviderMake' => 'command.provider.make',
         'QueueFailedTable' => 'command.queue.failed-table',
@@ -912,6 +914,18 @@ class ArtisanServiceProvider extends ServiceProvider
     {
         $this->app->singleton('command.policy.make', function ($app) {
             return new PolicyMakeCommand($app['files']);
+        });
+    }
+
+    /**
+     * Register the command.
+     *
+     * @return void
+     */
+    protected function registerObserverMakeCommand()
+    {
+        $this->app->singleton('command.observer.make', function ($app) {
+            return new ObserverMakeCommand($app['files']);
         });
     }
 


### PR DESCRIPTION
Allows to generate observers from the command line, if the `model` option is specified it generates one with all the typehints/docblocks  

