### PR TITLE
Ability to discard or fail job on missing model.

### DIFF
--- a/src/Illuminate/Queue/CallQueuedHandler.php
+++ b/src/Illuminate/Queue/CallQueuedHandler.php
@@ -38,9 +38,11 @@ class CallQueuedHandler
             $job, unserialize($data['command'])
         );
 
-        $this->dispatcher->dispatchNow(
-            $command, $handler = $this->resolveHandler($job, $command)
-        );
+        if (! $job->isDeleted() && ! $job->hasFailed()) {
+            $this->dispatcher->dispatchNow(
+                $command, $handler = $this->resolveHandler($job, $command)
+            );
+        }
 
         if (! $job->hasFailed() && ! $job->isReleased()) {
             $this->ensureNextJobInChainIsDispatched($command);

--- a/src/Illuminate/Queue/SerializesModels.php
+++ b/src/Illuminate/Queue/SerializesModels.php
@@ -32,6 +32,7 @@ trait SerializesModels
     public function deleteForMissingModels()
     {
         $this->deleteForMissingModels = true;
+        $this->failForMissingModels = false;
 
         return $this;
     }
@@ -43,6 +44,7 @@ trait SerializesModels
      */
     public function failForMissingModels()
     {
+        $this->deleteForMissingModels = false;
         $this->failForMissingModels = true;
 
         return $this;

--- a/src/Illuminate/Queue/SerializesModels.php
+++ b/src/Illuminate/Queue/SerializesModels.php
@@ -15,7 +15,7 @@ trait SerializesModels
      *
      * @var bool
      */
-    protected $discardForMissingModels = false;
+    protected $deleteForMissingModels = false;
 
     /**
      * Indicates that the job should fail for missing models.
@@ -29,9 +29,9 @@ trait SerializesModels
      *
      * @var bool
      */
-    public function discardForMissingModels()
+    public function deleteForMissingModels()
     {
-        $this->discardForMissingModels = true;
+        $this->deleteForMissingModels = true;
 
         return $this;
     }
@@ -55,7 +55,7 @@ trait SerializesModels
      */
     public function continueForMissingModels()
     {
-        $this->discardForMissingModels = false;
+        $this->deleteForMissingModels = false;
         $this->failForMissingModels = false;
 
         return $this;
@@ -94,7 +94,7 @@ trait SerializesModels
                     $this->getPropertyValue($property)
                 ));
             } catch (ModelNotFoundException $e) {
-                if (isset($this->discardForMissingModels) && $this->discardForMissingModels) {
+                if (isset($this->deleteForMissingModels) && $this->deleteForMissingModels) {
                     return $this->delete();
                 }
 

--- a/src/Illuminate/Queue/SerializesModels.php
+++ b/src/Illuminate/Queue/SerializesModels.php
@@ -15,24 +15,24 @@ trait SerializesModels
      *
      * @var bool
      */
-    protected $deleteForMissingModels = false;
+    protected $deleteWhenMissingModels = false;
 
     /**
      * Indicates that the job should fail for missing models.
      *
      * @var bool
      */
-    protected $failForMissingModels = true;
+    protected $failWhenMissingModels = true;
 
     /**
      * Indicate that the job should be deleted for missing models.
      *
      * @var bool
      */
-    public function deleteForMissingModels()
+    public function deleteWhenMissingModels()
     {
-        $this->deleteForMissingModels = true;
-        $this->failForMissingModels = false;
+        $this->deleteWhenMissingModels = true;
+        $this->failWhenMissingModels = false;
 
         return $this;
     }
@@ -42,10 +42,10 @@ trait SerializesModels
      *
      * @var bool
      */
-    public function failForMissingModels()
+    public function failWhenMissingModels()
     {
-        $this->deleteForMissingModels = false;
-        $this->failForMissingModels = true;
+        $this->deleteWhenMissingModels = false;
+        $this->failWhenMissingModels = true;
 
         return $this;
     }
@@ -55,10 +55,10 @@ trait SerializesModels
      *
      * @var bool
      */
-    public function continueForMissingModels()
+    public function continueWhenMissingModels()
     {
-        $this->deleteForMissingModels = false;
-        $this->failForMissingModels = false;
+        $this->deleteWhenMissingModels = false;
+        $this->failWhenMissingModels = false;
 
         return $this;
     }
@@ -96,11 +96,11 @@ trait SerializesModels
                     $this->getPropertyValue($property)
                 ));
             } catch (ModelNotFoundException $e) {
-                if (isset($this->deleteForMissingModels) && $this->deleteForMissingModels) {
+                if (isset($this->deleteWhenMissingModels) && $this->deleteWhenMissingModels) {
                     return $this->delete();
                 }
 
-                if (isset($this->failForMissingModels) && $this->failForMissingModels) {
+                if (isset($this->failWhenMissingModels) && $this->failWhenMissingModels) {
                     return $this->fail($e);
                 }
 

--- a/tests/Integration/Queue/CallQueuedHandlerTest.php
+++ b/tests/Integration/Queue/CallQueuedHandlerTest.php
@@ -1,0 +1,66 @@
+<?php
+
+use Orchestra\Testbench\TestCase;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * @group integration
+ */
+class CallQueuedHandlerTest extends TestCase
+{
+    public function test_job_can_be_dispatched()
+    {
+        CallQueuedHandlerTestJob::$handled = false;
+
+        $instance = new Illuminate\Queue\CallQueuedHandler(new Illuminate\Bus\Dispatcher(app()));
+
+        $job = Mockery::mock('Illuminate\Contracts\Queue\Job');
+        $job->shouldReceive('hasFailed')->andReturn(false);
+        $job->shouldReceive('isDeleted')->andReturn(false);
+        $job->shouldReceive('isReleased')->andReturn(false);
+        $job->shouldReceive('isDeletedOrReleased')->andReturn(false);
+        $job->shouldReceive('delete')->once();
+
+        $instance->call($job, [
+            'command' => serialize(new CallQueuedHandlerTestJob),
+        ]);
+
+
+        $this->assertTrue(CallQueuedHandlerTestJob::$handled);
+    }
+
+    public function test_job_is_not_dispatched_if_it_has_already_been_deleted()
+    {
+        // It may be possible for the job to be deleted during unserialization, so we dont
+        // want to fire the job in that scenario...
+
+        CallQueuedHandlerTestJob::$handled = false;
+
+        $instance = new Illuminate\Queue\CallQueuedHandler(new Illuminate\Bus\Dispatcher(app()));
+
+        $job = Mockery::mock('Illuminate\Contracts\Queue\Job');
+        $job->shouldReceive('hasFailed')->andReturn(false);
+        $job->shouldReceive('isReleased')->andReturn(false);
+        $job->shouldReceive('isDeleted')->andReturn(true);
+        $job->shouldReceive('isDeletedOrReleased')->andReturn(true);
+
+        $instance->call($job, [
+            'command' => serialize(new CallQueuedHandlerTestJob),
+        ]);
+
+
+        $this->assertFalse(CallQueuedHandlerTestJob::$handled);
+    }
+}
+
+class CallQueuedHandlerTestJob
+{
+    use Illuminate\Queue\InteractsWithQueue;
+
+    public static $handled = false;
+
+    public function handle()
+    {
+        static::$handled = true;
+    }
+}

--- a/tests/Integration/Queue/CallQueuedHandlerTest.php
+++ b/tests/Integration/Queue/CallQueuedHandlerTest.php
@@ -1,7 +1,6 @@
 <?php
 
 use Orchestra\Testbench\TestCase;
-use Illuminate\Database\Eloquent\Model;
 
 /**
  * @group integration
@@ -25,7 +24,6 @@ class CallQueuedHandlerTest extends TestCase
             'command' => serialize(new CallQueuedHandlerTestJob),
         ]);
 
-
         $this->assertTrue(CallQueuedHandlerTestJob::$handled);
     }
 
@@ -47,7 +45,6 @@ class CallQueuedHandlerTest extends TestCase
         $instance->call($job, [
             'command' => serialize(new CallQueuedHandlerTestJob),
         ]);
-
 
         $this->assertFalse(CallQueuedHandlerTestJob::$handled);
     }

--- a/tests/Integration/Queue/ModelSerializationTest.php
+++ b/tests/Integration/Queue/ModelSerializationTest.php
@@ -146,14 +146,14 @@ class ModelSerializationTest extends TestCase
     /**
      * @test
      */
-    public function test_delete_method_is_called_if_instructed_to_discard()
+    public function test_delete_method_is_called_if_instructed_to_delete()
     {
         $user = ModelSerializationTestUser::create([
             'email' => 'mohamed@laravel.com',
         ]);
 
         $job = new ModelSerializationTestDiscardClass($user);
-        $job->discardForMissingModels();
+        $job->deleteForMissingModels();
         $serialized = serialize($job);
 
         $user->delete();

--- a/tests/Integration/Queue/ModelSerializationTest.php
+++ b/tests/Integration/Queue/ModelSerializationTest.php
@@ -135,7 +135,7 @@ class ModelSerializationTest extends TestCase
         ]);
 
         $job = new ModelSerializationTestDiscardClass($user);
-        $job->continueForMissingModels();
+        $job->continueWhenMissingModels();
         $serialized = serialize($job);
 
         $user->delete();
@@ -153,7 +153,7 @@ class ModelSerializationTest extends TestCase
         ]);
 
         $job = new ModelSerializationTestDiscardClass($user);
-        $job->deleteForMissingModels();
+        $job->deleteWhenMissingModels();
         $serialized = serialize($job);
 
         $user->delete();
@@ -173,7 +173,7 @@ class ModelSerializationTest extends TestCase
         ]);
 
         $job = new ModelSerializationTestDiscardClass($user);
-        $job->failForMissingModels();
+        $job->failWhenMissingModels();
         $serialized = serialize($job);
 
         $user->delete();


### PR DESCRIPTION
This allows you to discard or fail a job immediately if there is a
missing model during deserialization. Otherwise the job will keep
attempting up to its attempt threshold, which could be high.

This also changes the default behavior to fail on the first missing
model exception. This can be reverted to its existing behavior using
the `->continueForMissingModels()` method.