### PR TITLE
[5.5] Allow macros to be registered using classes (in addition to closures)

### DIFF
--- a/src/Illuminate/Contracts/Support/Macro.php
+++ b/src/Illuminate/Contracts/Support/Macro.php
@@ -7,7 +7,7 @@ interface Macro
     /**
      * Return the callable macro.
      *
-     * @return callable
+     * @return  callable
      */
     public function handle();
 }

--- a/src/Illuminate/Contracts/Support/Macro.php
+++ b/src/Illuminate/Contracts/Support/Macro.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Illuminate\Contracts\Support;
+
+interface Macro
+{
+    /**
+     * Return the callable macro.
+     *
+     * @return callable
+     */
+    public function handle();
+}

--- a/src/Illuminate/Support/Traits/Macroable.php
+++ b/src/Illuminate/Support/Traits/Macroable.php
@@ -19,7 +19,7 @@ trait Macroable
      * Register a custom macro.
      *
      * @param  string $name
-     * @param  \Illuminate\Contracts\Support\Macro|callable $macro
+     * @param  \Illuminate\Contracts\Support\Macro|callable  $macro
      *
      * @return void
      */


### PR DESCRIPTION
In line with the new validation rule classes and the thought that everything should be in its own class, this **draft PR** adds the ability to **register macros using classes** in addition to closures (be it for collection, request, etc).

## How it can benefit

A messy service provider like so:

![screen shot 2017-06-26 at 20 07 51](https://user-images.githubusercontent.com/711940/27560564-f5505890-5ac4-11e7-933f-bdbbcf077d4a.png)

Can be reduced to just a few statements giving a better overview:

![screen shot 2017-06-26 at 20 09 47](https://user-images.githubusercontent.com/711940/27560570-f84a029e-5ac4-11e7-8b67-a1c857c6268c.png)

It's also neater to have everything separated so you don't have to go search where you registered a certain macro, it's all there in your project directory overview like any other class.

## How to use

Create a macro (for a collection for instance) and have it implement the macro class:

```php
<?php

namespace App\Macros\Collections;

use Illuminate\Contracts\Support\Macro;

class MyMacro implements Macro
{
    public function handle() : callable
    {
        return function ($array) {
            return array_merge($this->items, $array);
        };
    }
}
```

Bind the macro to a method name like usual:

```php
Collection::macro('myMacro', MyMacro::class);
```

That's it!

## Concerns

### Losing the closure completely

Right now it's just weird you have to return a closure inside the handle method. I tried an implementation similar to the one already in place to have the class using the Macroable trait adopt the handle method from the child macro class as-is, but PHP won't let me.

Something like:

```php
$reflection = new ReflectionClass($macro);
$closure = $reflection->getMethod('handle')->getClosure(new $macro);

return call_user_func_array($closure->bindTo($this, static::class), $parameters);
```

Unfortunately this only works for anonymous functions as it throws an exception when I want to bind MyMacro's method (now a closure) to another class' context. Any idea how to go about this?

### Other

- This is core functionality and can't be extracted to a package, therefore this PR.
- Does removing the `callable` typehint from the `macro` method pose any issues? Perhaps a new method to register a macro class would be better.
- Need to add/update tests, but would love a 👍 or 👎 before I put in the work.

Feedback welcome!