### PR TITLE
Add withDefault to MorphOne relations.

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
@@ -5,17 +5,11 @@ namespace Illuminate\Database\Eloquent\Relations;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Relations\Concerns\HasDefault;
 
 class BelongsTo extends Relation
 {
-    /**
-     * Indicates if a default model instance should be used.
-     *
-     * Alternatively, may be a Closure or array.
-     *
-     * @var \Closure|array|bool
-     */
-    protected $withDefault;
+    use HasDefault;
 
     /**
      * The child model instance of the relation.
@@ -165,31 +159,6 @@ class BelongsTo extends Relation
     }
 
     /**
-     * Get the default value for this relation.
-     *
-     * @param  \Illuminate\Database\Eloquent\Model  $model
-     * @return \Illuminate\Database\Eloquent\Model|null
-     */
-    protected function getDefaultFor(Model $model)
-    {
-        if (! $this->withDefault) {
-            return;
-        }
-
-        $instance = $this->related->newInstance();
-
-        if (is_callable($this->withDefault)) {
-            return call_user_func($this->withDefault, $instance) ?: $instance;
-        }
-
-        if (is_array($this->withDefault)) {
-            $instance->forceFill($this->withDefault);
-        }
-
-        return $instance;
-    }
-
-    /**
      * Match the eagerly loaded results to their parents.
      *
      * @param  array   $models
@@ -328,19 +297,6 @@ class BelongsTo extends Relation
     }
 
     /**
-     * Return a new model instance in case the relationship does not exist.
-     *
-     * @param  \Closure|array|bool  $callback
-     * @return $this
-     */
-    public function withDefault($callback = true)
-    {
-        $this->withDefault = $callback;
-
-        return $this;
-    }
-
-    /**
      * Get the foreign key of the relationship.
      *
      * @return string
@@ -388,5 +344,16 @@ class BelongsTo extends Relation
     public function getRelation()
     {
         return $this->relation;
+    }
+
+    /**
+     * Make a new related instance for the given model.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $parent
+     * @return \Illuminate\Database\Eloquent\Model
+     */
+    protected function newRelatedInstanceFor(Model $parent)
+    {
+        return $this->related->newInstance();
     }
 }

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/HasDefault.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/HasDefault.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Relations\Concerns;
+
+use Illuminate\Database\Eloquent\Model;
+
+trait HasDefault
+{
+    /**
+     * Indicates if a default model instance should be used.
+     *
+     * Alternatively, may be a Closure or array.
+     *
+     * @var \Closure|array|bool
+     */
+    protected $withDefault;
+
+    /**
+     * Return a new model instance in case the relationship does not exist.
+     *
+     * @param  \Closure|array|bool  $callback
+     * @return $this
+     */
+    public function withDefault($callback = true)
+    {
+        $this->withDefault = $callback;
+
+        return $this;
+    }
+
+    /**
+     * Get the default value for this relation.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $parent
+     * @return \Illuminate\Database\Eloquent\Model|null
+     */
+    protected function getDefaultFor(Model $parent)
+    {
+        if (! $this->withDefault) {
+            return;
+        }
+
+        $instance = $this->newRelatedInstanceFor($parent);
+
+        if (is_callable($this->withDefault)) {
+            return call_user_func($this->withDefault, $instance) ?: $instance;
+        }
+
+        if (is_array($this->withDefault)) {
+            $instance->forceFill($this->withDefault);
+        }
+
+        return $instance;
+    }
+
+    /**
+     * Make a new related instance for the given model.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $parent
+     * @return \Illuminate\Database\Eloquent\Model
+     */
+    abstract protected function newRelatedInstanceFor(Model $parent);
+}

--- a/src/Illuminate/Database/Eloquent/Relations/HasOne.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOne.php
@@ -4,17 +4,11 @@ namespace Illuminate\Database\Eloquent\Relations;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Relations\Concerns\HasDefault;
 
 class HasOne extends HasOneOrMany
 {
-    /**
-     * Indicates if a default model instance should be used.
-     *
-     * Alternatively, may be a Closure or array.
-     *
-     * @var \Closure|array|bool
-     */
-    protected $withDefault;
+    use HasDefault;
 
     /**
      * Get the results of the relationship.
@@ -43,33 +37,6 @@ class HasOne extends HasOneOrMany
     }
 
     /**
-     * Get the default value for this relation.
-     *
-     * @param  \Illuminate\Database\Eloquent\Model  $model
-     * @return \Illuminate\Database\Eloquent\Model|null
-     */
-    protected function getDefaultFor(Model $model)
-    {
-        if (! $this->withDefault) {
-            return;
-        }
-
-        $instance = $this->related->newInstance()->setAttribute(
-            $this->getForeignKeyName(), $model->getAttribute($this->localKey)
-        );
-
-        if (is_callable($this->withDefault)) {
-            return call_user_func($this->withDefault, $instance) ?: $instance;
-        }
-
-        if (is_array($this->withDefault)) {
-            $instance->forceFill($this->withDefault);
-        }
-
-        return $instance;
-    }
-
-    /**
      * Match the eagerly loaded results to their parents.
      *
      * @param  array  $models
@@ -83,15 +50,14 @@ class HasOne extends HasOneOrMany
     }
 
     /**
-     * Return a new model instance in case the relationship does not exist.
+     * Make a new related instance for the given model.
      *
-     * @param  \Closure|array|bool  $callback
-     * @return $this
+     * @param  \Illuminate\Database\Eloquent\Model  $parent
+     * @return \Illuminate\Database\Eloquent\Model
      */
-    public function withDefault($callback = true)
+    public function newRelatedInstanceFor(Model $parent)
     {
-        $this->withDefault = $callback;
-
-        return $this;
+        return $this->related->newInstance()
+            ->setAttribute($this->getForeignKeyName(), $parent->{$this->localKey});
     }
 }

--- a/src/Illuminate/Database/Eloquent/Relations/MorphOne.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphOne.php
@@ -2,10 +2,14 @@
 
 namespace Illuminate\Database\Eloquent\Relations;
 
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Relations\Concerns\HasDefault;
 
 class MorphOne extends MorphOneOrMany
 {
+    use HasDefault;
+
     /**
      * Get the results of the relationship.
      *
@@ -13,7 +17,7 @@ class MorphOne extends MorphOneOrMany
      */
     public function getResults()
     {
-        return $this->query->first();
+        return $this->query->first() ?: $this->getDefaultFor($this->parent);
     }
 
     /**
@@ -26,7 +30,7 @@ class MorphOne extends MorphOneOrMany
     public function initRelation(array $models, $relation)
     {
         foreach ($models as $model) {
-            $model->setRelation($relation, null);
+            $model->setRelation($relation, $this->getDefaultFor($model));
         }
 
         return $models;
@@ -43,5 +47,18 @@ class MorphOne extends MorphOneOrMany
     public function match(array $models, Collection $results, $relation)
     {
         return $this->matchOne($models, $results, $relation);
+    }
+
+    /**
+     * Make a new related instance for the given model.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $parent
+     * @return \Illuminate\Database\Eloquent\Model
+     */
+    public function newRelatedInstanceFor(Model $parent)
+    {
+        return $this->related->newInstance()
+            ->setAttribute($this->getForeignKeyName(), $parent->{$this->localKey})
+            ->setAttribute($this->getMorphType(), $this->morphClass);
     }
 }


### PR DESCRIPTION
This PR adds the default option for morph one relations.

I also moved the logic to a trait to avoid code duplication. The only difference between `morphOne`, `hasOne` and `belongsTo` was the code to create the related instance, so I extracted that to an abstract method. So in order to implement the withDefault feature in a relation, you need to include the trait HasDefault and then implement the `newRelatedInstanceFor` method. I hope this makes sense.