### PR TITLE
[5.5] If applied this commit adds the isset_env() helper.

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -600,6 +600,26 @@ if (! function_exists('env')) {
     }
 }
 
+if (! function_exists('isset_env')) {
+    /**
+     * Checks if the value of an environment variable is set.
+     *
+     * @param  string  $key
+     * @return mixed
+     * @throws \Exception
+     */
+    function isset_env($key)
+    {
+        $value = getenv($key);
+
+        if (empty($value)) {
+            throw new Exception("Please set the {$key} in the env file");
+        }
+
+        return $value;
+    }
+}
+
 if (! function_exists('head')) {
     /**
      * Get the first element of an array. Useful for method chaining.


### PR DESCRIPTION
- Many times often working in a team I tend to check if a third party API key or other required credentials are set in the env file or not before executing any code in the controller method.
- This proposed `isset_env()` helper will throw an exception reminding the other dev in the team or any user to add their keys/credentials in the env file. 
- Comparison:

```php
    // At present it needs to be done like this, 
    // Also we need to repeat this long conditional every time for every env key check throughout our code.

    if (! env('PUSHER_API_KEY')) throw new Exception("Please add the Pusher API key in the env file");


    // With the proposed isset_env() helper

    isset_env('PUSHER_API_KEY');
```