### PR TITLE
[5.5] Ensure Redis is available in Cache locks test

### DIFF
--- a/tests/Integration/Cache/CacheLockTest.php
+++ b/tests/Integration/Cache/CacheLockTest.php
@@ -3,15 +3,17 @@
 use Carbon\Carbon;
 use Orchestra\Testbench\TestCase;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Tests\Redis\InteractsWithRedis;
 
 /**
  * @group integration
  */
 class CacheLockTest extends TestCase
 {
-    public function test_locks_can_be_acquired_and_released()
+    use InteractsWithRedis;
+
+    public function test_memcached_locks_can_be_acquired_and_released()
     {
-        // Memcached...
         Cache::store('memcached')->lock('foo')->release();
         $this->assertTrue(Cache::store('memcached')->lock('foo', 10)->get());
         $this->assertFalse(Cache::store('memcached')->lock('foo', 10)->get());
@@ -19,26 +21,22 @@ class CacheLockTest extends TestCase
         $this->assertTrue(Cache::store('memcached')->lock('foo', 10)->get());
         $this->assertFalse(Cache::store('memcached')->lock('foo', 10)->get());
         Cache::store('memcached')->lock('foo')->release();
-
-        // Redis...
-        Cache::store('redis')->lock('foo')->release();
-        $this->assertTrue(Cache::store('redis')->lock('foo', 10)->get());
-        $this->assertFalse(Cache::store('redis')->lock('foo', 10)->get());
-        Cache::store('redis')->lock('foo')->release();
-        $this->assertTrue(Cache::store('redis')->lock('foo', 10)->get());
-        $this->assertFalse(Cache::store('redis')->lock('foo', 10)->get());
-        Cache::store('redis')->lock('foo')->release();
     }
 
-    public function test_locks_can_run_callbacks()
+    public function test_redis_locks_can_be_acquired_and_released()
     {
-        Cache::store('memcached')->lock('foo')->release();
-        $this->assertEquals('taylor', Cache::store('memcached')->lock('foo', 10)->get(function () {
-            return 'taylor';
-        }));
+        $this->ifRedisAvailable(function () {
+            Cache::store('redis')->lock('foo')->release();
+            $this->assertTrue(Cache::store('redis')->lock('foo', 10)->get());
+            $this->assertFalse(Cache::store('redis')->lock('foo', 10)->get());
+            Cache::store('redis')->lock('foo')->release();
+            $this->assertTrue(Cache::store('redis')->lock('foo', 10)->get());
+            $this->assertFalse(Cache::store('redis')->lock('foo', 10)->get());
+            Cache::store('redis')->lock('foo')->release();
+        });
     }
 
-    public function test_locks_can_block_for_seconds()
+    public function test_memcached_locks_can_block_for_seconds()
     {
         Carbon::setTestNow();
 
@@ -49,14 +47,29 @@ class CacheLockTest extends TestCase
 
         Cache::store('memcached')->lock('foo')->release();
         $this->assertTrue(Cache::store('memcached')->lock('foo', 10)->block(1));
+    }
 
-        Cache::store('redis')->lock('foo')->release();
-        $this->assertEquals('taylor', Cache::store('redis')->lock('foo', 10)->block(1, function () {
+    public function test_redis_locks_can_block_for_seconds()
+    {
+        $this->ifRedisAvailable(function () {
+            Carbon::setTestNow();
+
+            Cache::store('redis')->lock('foo')->release();
+            $this->assertEquals('taylor', Cache::store('redis')->lock('foo', 10)->block(1, function () {
+                return 'taylor';
+            }));
+
+            Cache::store('redis')->lock('foo')->release();
+            $this->assertTrue(Cache::store('redis')->lock('foo', 10)->block(1));
+        });
+    }
+
+    public function test_locks_can_run_callbacks()
+    {
+        Cache::store('memcached')->lock('foo')->release();
+        $this->assertEquals('taylor', Cache::store('memcached')->lock('foo', 10)->get(function () {
             return 'taylor';
         }));
-
-        Cache::store('redis')->lock('foo')->release();
-        $this->assertTrue(Cache::store('redis')->lock('foo', 10)->block(1));
     }
 
     /**

--- a/tests/Redis/InteractsWithRedis.php
+++ b/tests/Redis/InteractsWithRedis.php
@@ -72,4 +72,13 @@ trait InteractsWithRedis
 
         return $providers;
     }
+
+    public function ifRedisAvailable($callback)
+    {
+        $this->setUpRedis();
+
+        $callback();
+
+        $this->tearDownRedis();
+    }
 }


### PR DESCRIPTION
Checking Redis availability before testing cache locks (same as other Redis tests).

(Added a helper method while I was at it..)
