### PR TITLE
[5.5] Add Route::redirect() method

### DIFF
--- a/src/Illuminate/Routing/RedirectController.php
+++ b/src/Illuminate/Routing/RedirectController.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Illuminate\Routing;
+
+use Illuminate\Http\RedirectResponse;
+
+class RedirectController extends Controller
+{
+    public function __invoke($destination, $status = 301)
+    {
+        return new RedirectResponse($destination, $status);
+    }
+}

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -296,6 +296,21 @@ class Router implements RegistrarContract, BindingRegistrar
     }
 
     /**
+     * Create a redirect from one route to another.
+     *
+     * @param string $url
+     * @param string $destination
+     * @param int $status
+     * @return Route
+     */
+    public function redirect($url, $destination, $status = 301)
+    {
+        return $this->any($url, '\Illuminate\Routing\RedirectController')
+            ->defaults('destination', $destination)
+            ->defaults('status', $status);
+    }
+
+    /**
      * Update the group stack with the given attributes.
      *
      * @param  array  $attributes

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -1365,6 +1365,19 @@ class RoutingRouteTest extends TestCase
         $this->assertInstanceOf(\Illuminate\Http\JsonResponse::class, $response);
     }
 
+    public function testRouteRedirect()
+    {
+        $router = $this->getRouter();
+        $router->get('contact_us', function () {
+            throw new \Exception('Route should not be reachable.');
+        });
+        $router->redirect('contact_us', 'contact', 302);
+
+        $response = $router->dispatch(Request::create('contact_us', 'GET'));
+        $this->assertTrue($response->isRedirect('contact'));
+        $this->assertEquals(302, $response->getStatusCode());
+    }
+
     protected function getRouter()
     {
         $container = new Container;


### PR DESCRIPTION
This adds a new `Route::redirect()` method that handles simple redirects from one route to another. This implementation works with route caching because it uses an internal `RedirectController`.

The method accepts three arguments `$url`, `$destination`, and `$status`. The status is optional and defaults to 301.

```php
Route::redirect('contact_us', 'contact', 302);
```

The implementation is based off my package [Laravel route macros](https://github.com/brayniverse/laravel-route-macros) with one minor difference, the controller makes use of `__invoke` instead of a `handle` method. This is because when writing the test I couldn't find a way to attach the Route to the Request instance, and the `__invoke` method is handed each "parameter" - for some reason this works with Laravel's test suite but `$request->route('parameter')` does not 🤷‍♂️ . I can't think of any reason this `__invoke` approach will cause any problems.

✌️ 