### PR TITLE
Ability to add a view as the action in router definition

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -643,21 +643,6 @@ class Route
     }
 
     /**
-     * Sets the view that will be used as the action for the route.
-     *
-     * @param string $view
-     * @return $this
-     */
-    public function view($view)
-    {
-        $this->action['uses'] = function () use ($view) {
-            return view($view);
-        };
-
-        return $this;
-    }
-
-    /**
      * Set the handler for the route.
      *
      * @param  \Closure|string  $action

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -643,6 +643,21 @@ class Route
     }
 
     /**
+     * Sets the view that will be used as the action for the route
+     *
+     * @param string $view
+     * @return $this
+     */
+    public function view($view)
+    {
+        $this->action['uses'] = function () use ($view) {
+            return view($view);
+        };
+
+        return $this;
+    }
+
+    /**
      * Set the handler for the route.
      *
      * @param  \Closure|string  $action

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -643,7 +643,7 @@ class Route
     }
 
     /**
-     * Sets the view that will be used as the action for the route
+     * Sets the view that will be used as the action for the route.
      *
      * @param string $view
      * @return $this

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -377,6 +377,13 @@ class Router implements RegistrarContract, BindingRegistrar
      */
     protected function createRoute($methods, $uri, $action)
     {
+        // If the route action is a view then turn in into a callable function returning it.
+        if ($action instanceof \Illuminate\Contracts\View\View) {
+            $action = function () use ($action) {
+                return $action;
+            };
+        }
+
         // If the route is routing to a controller we will parse the route action into
         // an acceptable array format before registering it and creating this route
         // instance itself. We need to build the Closure that will call this out.

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -11,6 +11,7 @@ use Illuminate\Http\Response;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Collection;
 use Illuminate\Container\Container;
+use Illuminate\Contracts\View\View;
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Contracts\Events\Dispatcher;
@@ -378,7 +379,7 @@ class Router implements RegistrarContract, BindingRegistrar
     protected function createRoute($methods, $uri, $action)
     {
         // If the route action is a view then turn in into a callable function returning it.
-        if ($action instanceof \Illuminate\Contracts\View\View) {
+        if ($action instanceof View) {
             $action = function () use ($action) {
                 return $action;
             };


### PR DESCRIPTION
Sometimes I just want to return a view from closure in the routes file which results in the following code:

```
Route::get('home', function () {
    return view('home');
});
```

This PR allows you to pass the view as the second parameter in the route definition.

```
Route::get('home', view('home'));
```
