### PR TITLE
[5.4] Add __wakeup in AliasLoader.php for Singleton

### DIFF
--- a/src/Illuminate/Foundation/AliasLoader.php
+++ b/src/Illuminate/Foundation/AliasLoader.php
@@ -239,4 +239,15 @@ class AliasLoader
     {
         //
     }
+
+    /**
+     * Private unserialize method to prevent unserializing of the *Singleton*
+     * instance.
+     *
+     * @return void
+     */
+    private function __wakeup()
+    {
+        //
+    }
 }


### PR DESCRIPTION
The magic method __wakeup is declared as private to prevent unserializing of an instance of the class via the global function unserialize().

reference:
https://laravel-taiwan.github.io/php-the-right-way/pages/Design-Patterns.html