### PR TITLE
Allow insert with only default values in postgresql

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -81,6 +81,20 @@ class PostgresGrammar extends Grammar
 
         return $this->compileInsert($query, $values).' returning '.$this->wrap($sequence);
     }
+    
+    /**
+     * @inheritdoc
+     */
+    public function compileInsert(Builder $query, array $values)
+    {
+        $table = $this->wrapTable($query->from);
+
+        if (empty($values)) {
+            return "insert into $table DEFAULT VALUES";
+        }
+
+        return parent::compileInsert($query, $values);
+    }
 
     /**
      * Compile an update statement into SQL.


### PR DESCRIPTION
```sql
CREATE TABLE t1 (
 id SERIAL
);
```
```php
$entity = new T1();
$entity->save();
```
Generates
```sql
insert into t1 DEFAULT VALUES
```
instead of
```sql
insert into t1 () values ()
```