### PR TITLE
Fix for error that occurs when accessing nested collectible objects

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1571,7 +1571,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     {
         if (
             is_object($this->items[$key]) &&
-            !$this->items[$key] instanceof self &&
+            ! $this->items[$key] instanceof self &&
             (
                 $this->items[$key] instanceof Arrayable ||
                 $this->items[$key] instanceof Jsonable ||

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1579,7 +1579,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
                 $this->items[$key] instanceof Traversable
             )
         ) {
-            return new self($this->getArrayableItems($this->items[$key]));
+            return new self($this->items[$key]);
         }
         return $this->items[$key];
     }

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1569,6 +1569,18 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      */
     public function offsetGet($key)
     {
+        if (
+            is_object($this->items[$key]) &&
+            !$this->items[$key] instanceof self &&
+            (
+                $this->items[$key] instanceof Arrayable ||
+                $this->items[$key] instanceof Jsonable ||
+                $this->items[$key] instanceof JsonSerializable ||
+                $this->items[$key] instanceof Traversable
+            )
+        ) {
+            return new self($this->getArrayableItems($this->items[$key]));
+        }
         return $this->items[$key];
     }
 

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1581,6 +1581,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
         ) {
             return new self($this->items[$key]);
         }
+
         return $this->items[$key];
     }
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2154,9 +2154,15 @@ class SupportCollectionTest extends TestCase
         $this->assertSame(['michael', 'tom', 'taylor'], $collection->toArray());
     }
 
-    public function testAccessingNestedArrayableObject() {
-        $this->assertEquals('bar',collect(new TestArrayableObject())['foo']);
-        $this->assertEquals('bar',collect([new TestArrayableObject()])[0]['foo']);
+    public function testAccessingNestedCollectableObject() {
+        $Collection = collect([
+            new TestArrayableObject(),
+            new TestJsonableObject(),
+            new TestJsonSerializeObject()
+        ]);
+        $this->assertEquals('bar', $Collection[0]['foo']);
+        $this->assertEquals('bar', $Collection[1]['foo']);
+        $this->assertEquals('bar', $Collection[2]['foo']);
     }
 }
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2153,6 +2153,11 @@ class SupportCollectionTest extends TestCase
 
         $this->assertSame(['michael', 'tom', 'taylor'], $collection->toArray());
     }
+
+    public function testAccessingNestedArrayableObject() {
+        $this->assertEquals('bar',collect(new TestArrayableObject())['foo']);
+        $this->assertEquals('bar',collect([new TestArrayableObject()])[0]['foo']);
+    }
 }
 
 class TestSupportCollectionHigherOrderItem

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2154,11 +2154,12 @@ class SupportCollectionTest extends TestCase
         $this->assertSame(['michael', 'tom', 'taylor'], $collection->toArray());
     }
 
-    public function testAccessingNestedCollectableObject() {
+    public function testAccessingNestedCollectableObject()
+    {
         $Collection = collect([
             new TestArrayableObject(),
             new TestJsonableObject(),
-            new TestJsonSerializeObject()
+            new TestJsonSerializeObject(),
         ]);
         $this->assertEquals('bar', $Collection[0]['foo']);
         $this->assertEquals('bar', $Collection[1]['foo']);


### PR DESCRIPTION
I ran into what might be a bug with collections.

If you collect an object that is Arrayable, Jsonable, etc, you can access its attributes as if it were an array. However if you attempt to collect one or more of said objects nested inside an array it will throw an error when attempting to access the properties of those elements.

For example, lets try this code:
```php
// pulled from /tests/Support/SupportCollectionTest.php
class TestArrayableObject implements Arrayable
{
    public function toArray()
    {
        return ['foo' => 'bar'];
    }
}

echo collect(new TestArrayableObject)['foo']; // Outputs 'bar'

echo collect(array(new TestArrayableObject))[0]['foo']; // Throws an error
```
The error will look similar to this:
`Error: Cannot use object of type Illuminate\Tests\Support\TestArrayableObject as array`

The solution I implemented checks if the item being accessed can be returned as a collection, and if it can then it returns a new collection using the contents of the accessed element. This means that not only will objects nested in an array be accessible as an array, but 'collectable' objects nested in other 'collectable' objects will as well.

I included a test in this pull request that will fail with the current version of the Collection class, but will pass with the changes I made to the `offsetGet` function.