### PR TITLE
[5.5] Added nullable helper to request

### DIFF
--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -222,6 +222,25 @@ trait InteractsWithInput
     }
 
     /**
+     * Get a subset containing the provided keys and nullify empty inputs.
+     *
+     * @param  array|mixed  $keys
+     * @return array
+     */
+    public function nullable($keys)
+    {
+        $keys = is_array($keys) ? $keys : func_get_args();
+
+        $results = $this->all();
+
+        return array_map(function ($value) {
+            $value = is_array($value) ? $value : trim($value);
+
+            return ! empty($value) ? $value : null;
+        }, Arr::only($results, $keys));
+    }
+
+    /**
      * Retrieve a query string item from the request.
      *
      * @param  string  $key

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -317,6 +317,12 @@ class HttpRequestTest extends TestCase
         $this->assertEquals([], $request->except('age', 'name'));
     }
 
+    public function testNullableMethod()
+    {
+        $request = Request::create('/', 'GET', ['string' => 'Taylor', 'empty_string' => '', 'empty_array' => []]);
+        $this->assertEquals(['string' => 'Taylor', 'empty_string' => null, 'empty_array' => null], $request->nullable('string', 'empty_string', 'empty_array'));
+    }
+
     public function testQueryMethod()
     {
         $request = Request::create('/', 'GET', ['name' => 'Taylor']);


### PR DESCRIPTION
This adds a 'nullable' helper to the Request (input concern).

When working with APIs and you're updating a resource sometimes the input is presented as an empty string. In those cases you most likely want to 'remove' or 'reset' something.
However, using `intersect` would ignore this input and with `only` your database would become a mess after a while... Therefore a `nullable` helper to aid you in those if then situations.

## Example
```PHP
$requestedInput = [
    'name' => 'John Doe',
    'optional_description_i_want_to_reset' => '',
];
```

```PHP
$attributes = Request::nullable('name', 'optional_description_i_want_to_reset');

// Results in
$result = [
    'name' => 'John Doe',
    'optional_description_i_want_to_reset' => null,
];
```