### PR TITLE
[5.4] Added $this to return.

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -726,7 +726,7 @@ class Builder
      * Save a new model and return the instance.
      *
      * @param  array  $attributes
-     * @return \Illuminate\Database\Eloquent\Model
+     * @return \Illuminate\Database\Eloquent\Model|$this
      */
     public function create(array $attributes = [])
     {
@@ -739,7 +739,7 @@ class Builder
      * Save a new model and return the instance. Allow mass-assignment.
      *
      * @param  array  $attributes
-     * @return \Illuminate\Database\Eloquent\Model
+     * @return \Illuminate\Database\Eloquent\Model|$this
      */
     public function forceCreate(array $attributes)
     {


### PR DESCRIPTION
Say you have the below method:

```
/**
 * Create a new user.
 *
 * @param array $data
 * @return \App\User
 */
public function create(array $data)
{
     return User::forceCreate($data);
}
```

Then you use Barry's IDE Helper, and PhpStorm. PhpStorm starts complaining about the return type of your method via inspection.

![image](https://user-images.githubusercontent.com/127468/27663110-05797292-5c1e-11e7-9028-01c1efc3d802.png)

Add `$this` to the PHPDoc will resolve this error, and allow you to leverage auto complete on something like this:

```
User::forceCreate($data)->some_user_property;
```