### PR TITLE
[5.4] Add $num optional parameter to Arr::random()

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -453,7 +453,13 @@ class Arr
 
         $keys = array_rand($array, $num);
 
-        return array_values(static::only($array, $keys));
+        $results = [];
+
+        foreach ($keys as $key) {
+            $results[] = $array[$key];
+        }
+
+        return $results;
     }
 
     /**

--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -441,12 +441,19 @@ class Arr
     /**
      * Get a random value from an array.
      *
-     * @param  array   $array
+     * @param  array  $array
+     * @param  int    $num
      * @return mixed
      */
-    public static function random($array)
+    public static function random($array, $num = 1)
     {
-        return $array[array_rand($array)];
+        if ($num == 1) {
+            return $array[array_rand($array)];
+        }
+
+        $keys = array_rand($array, $num);
+
+        return array_values(static::only($array, $keys));
     }
 
     /**

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -249,12 +249,13 @@ if (! function_exists('array_random')) {
     /**
      * Get a random value from an array.
      *
-     * @param  array   $array
+     * @param  array  $array
+     * @param  int    $num
      * @return mixed
      */
-    function array_random($array)
+    function array_random($array, $num = 1)
     {
-        return Arr::random($array);
+        return Arr::random($array, $num);
     }
 }
 

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -403,8 +403,14 @@ class SupportArrTest extends TestCase
     {
         $randomValue = Arr::random(['foo', 'bar', 'baz']);
 
-        $this->assertInternalType('string', $randomValue);
         $this->assertContains($randomValue, ['foo', 'bar', 'baz']);
+
+        $randomValues = Arr::random(['foo', 'bar', 'baz'], 2);
+
+        $this->assertInternalType('array', $randomValues);
+        $this->assertCount(2, $randomValues);
+        $this->assertContains($randomValues[0], ['foo', 'bar', 'baz']);
+        $this->assertContains($randomValues[1], ['foo', 'bar', 'baz']);
     }
 
     public function testSet()


### PR DESCRIPTION
Follow-up to #19741.

There is a bit of room for improvement. Mainly, the function would fail if requesting more items than available. This can be dealt with later, here I do this PR to quickly alter the method signature while it is fresh.

ping @calebporzio 
