### PR TITLE
[5.5] Support for multiword models to authorize resource controllers

### DIFF
--- a/src/Illuminate/Foundation/Auth/Access/AuthorizesRequests.php
+++ b/src/Illuminate/Foundation/Auth/Access/AuthorizesRequests.php
@@ -81,7 +81,7 @@ trait AuthorizesRequests
      */
     public function authorizeResource($model, $parameter = null, array $options = [], $request = null)
     {
-        $parameter = $parameter ?: lcfirst(class_basename($model));
+        $parameter = $parameter ?: snake_case(lcfirst(class_basename($model)));
 
         $middleware = [];
 


### PR DESCRIPTION
Not sure if this should be pushed to 5.4 branch or master branch.

Method `authorizeResource` in `framework/src/Illuminate/Foundation/Auth/Access/AuthorizesRequests.php` can be used to authorize resource controllers. So if we have model `Order` and resource controller `OrdersController` we can use 
`authorizeResorce(Order::class)` method in controller to authorize each REST method with `OrderPolicy`.

It works fine but if we want to authorize controller for multiword model for example: `OrderDetail` it will not work. The problem is this code

```php
public function authorizeResource($model, $parameter = null, array $options = [], $request = null)
{
    $parameter = $parameter ?: lcfirst(class_basename($model));
    ...
}
```

So when the second param is null, it will take model name and change the first letter to lowercase.
For example `$parameter` for model `Order` will be `order` but for model `OrderDetail` it will be `orderDetail`.
Unfortunatly this is wrong value because as default laravel params in route model binding are in `snake_case` not `camelCase`.
This issue returns always 401 Unauthorized. Of course we can specify the second param maually like so:
`authorizeResorce(OrderDetail::class, 'order_detail')` but nobody knows about that during implementing ACL feature in his laravel app.

To save time for future users, support for multiword models should be done automatically like so:
```php
public function authorizeResource($model, $parameter = null, array $options = [], $request = null)
{
    $parameter = $parameter ?: snake_case(lcfirst(class_basename($model))); 
    ...
}
```
Result for models:
- Order -> `order` (still the same)
- OrderDetail -> `order_detail` (snake case instead of camel case)