### PR TITLE
[5.4] Make Arr::random($array, 1) return an array of one item

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -442,16 +442,16 @@ class Arr
      * Get a random value from an array.
      *
      * @param  array  $array
-     * @param  int    $num
+     * @param  int    $amount
      * @return mixed
      */
-    public static function random($array, $num = 1)
+    public static function random($array, $amount = 1)
     {
-        if ($num == 1) {
+        if ($amount == 1) {
             return $array[array_rand($array)];
         }
 
-        $keys = array_rand($array, $num);
+        $keys = array_rand($array, $amount);
 
         $results = [];
 

--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -443,7 +443,7 @@ class Arr
      * Get a random value from an array.
      *
      * @param  array  $array
-     * @param  int    $amount
+     * @param  int|null  $amount
      * @return mixed
      *
      * @throws \InvalidArgumentException
@@ -454,11 +454,15 @@ class Arr
             throw new InvalidArgumentException("You requested {$amount} items, but there are only {$count} items in the array.");
         }
 
-        if ($amount == 1) {
+        if (count(func_get_args()) == 1) {
             return $array[array_rand($array)];
         }
 
         $keys = array_rand($array, $amount);
+
+        if ($amount == 1) {
+            $keys = [$keys];
+        }
 
         $results = [];
 

--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Support;
 
 use ArrayAccess;
+use InvalidArgumentException;
 use Illuminate\Support\Traits\Macroable;
 
 class Arr
@@ -444,9 +445,15 @@ class Arr
      * @param  array  $array
      * @param  int    $amount
      * @return mixed
+     *
+     * @throws \InvalidArgumentException
      */
     public static function random($array, $amount = 1)
     {
+        if ($amount > ($count = count($array))) {
+            throw new InvalidArgumentException("You requested {$amount} items, but there are only {$count} items in the array.");
+        }
+
         if ($amount == 1) {
             return $array[array_rand($array)];
         }

--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -448,13 +448,13 @@ class Arr
      *
      * @throws \InvalidArgumentException
      */
-    public static function random($array, $amount = 1)
+    public static function random($array, $amount = null)
     {
-        if ($amount > ($count = count($array))) {
-            throw new InvalidArgumentException("You requested {$amount} items, but there are only {$count} items in the array.");
+        if (($requested = $amount ?: 1) > ($count = count($array))) {
+            throw new InvalidArgumentException("You requested {$requested} items, but there are only {$count} items in the array.");
         }
 
-        if (count(func_get_args()) == 1) {
+        if (is_null($amount)) {
             return $array[array_rand($array)];
         }
 

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1083,15 +1083,11 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
             throw new InvalidArgumentException("You requested {$amount} items, but there are only {$count} items in the collection.");
         }
 
-        $keys = array_rand($this->items, $amount);
-
         if (count(func_get_args()) == 0) {
-            return $this->items[$keys];
+            return Arr::random($this->items);
         }
 
-        $keys = array_wrap($keys);
-
-        return new static(array_intersect_key($this->items, array_flip($keys)));
+        return new static(Arr::random($this->items, $amount));
     }
 
     /**

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1077,13 +1077,13 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      *
      * @throws \InvalidArgumentException
      */
-    public function random($amount = 1)
+    public function random($amount = null)
     {
-        if ($amount > ($count = $this->count())) {
-            throw new InvalidArgumentException("You requested {$amount} items, but there are only {$count} items in the collection.");
+        if (($requested = $amount ?: 1) > ($count = $this->count())) {
+            throw new InvalidArgumentException("You requested {$requested} items, but there are only {$count} items in the collection.");
         }
 
-        if (count(func_get_args()) == 0) {
+        if (is_null($amount)) {
             return Arr::random($this->items);
         }
 

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -253,12 +253,8 @@ if (! function_exists('array_random')) {
      * @param  int|null  $num
      * @return mixed
      */
-    function array_random($array, $num = 1)
+    function array_random($array, $num = null)
     {
-        if (count(func_get_args()) == 1) {
-            return Arr::random($array);
-        }
-
         return Arr::random($array, $num);
     }
 }

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -250,11 +250,15 @@ if (! function_exists('array_random')) {
      * Get a random value from an array.
      *
      * @param  array  $array
-     * @param  int    $num
+     * @param  int|null  $num
      * @return mixed
      */
     function array_random($array, $num = 1)
     {
+        if (count(func_get_args()) == 1) {
+            return Arr::random($array);
+        }
+
         return Arr::random($array, $num);
     }
 }

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -405,6 +405,12 @@ class SupportArrTest extends TestCase
 
         $this->assertContains($randomValue, ['foo', 'bar', 'baz']);
 
+        $randomValues = Arr::random(['foo', 'bar', 'baz'], 1);
+
+        $this->assertInternalType('array', $randomValues);
+        $this->assertCount(1, $randomValues);
+        $this->assertContains($randomValues[0], ['foo', 'bar', 'baz']);
+
         $randomValues = Arr::random(['foo', 'bar', 'baz'], 2);
 
         $this->assertInternalType('array', $randomValues);


### PR DESCRIPTION
Follow-up to #19818.

A bit of proofreading would be welcome. For example I nearly forgot adding a `count(func_get_args())` in the array_random() helper, which was necessary before I make the optional parameter no more "magical".