### PR TITLE
[5.5] Always use handle function for commands.

### DIFF
--- a/src/Illuminate/Auth/Console/ClearResetsCommand.php
+++ b/src/Illuminate/Auth/Console/ClearResetsCommand.php
@@ -25,7 +25,7 @@ class ClearResetsCommand extends Command
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         $this->laravel['auth.password']->broker($this->argument('name'))->getRepository()->deleteExpired();
 

--- a/src/Illuminate/Auth/Console/MakeAuthCommand.php
+++ b/src/Illuminate/Auth/Console/MakeAuthCommand.php
@@ -44,7 +44,7 @@ class MakeAuthCommand extends Command
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         $this->createDirectories();
 

--- a/src/Illuminate/Cache/Console/CacheTableCommand.php
+++ b/src/Illuminate/Cache/Console/CacheTableCommand.php
@@ -54,7 +54,7 @@ class CacheTableCommand extends Command
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         $fullPath = $this->createBaseMigration();
 

--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -47,7 +47,7 @@ abstract class GeneratorCommand extends Command
      *
      * @return bool|null
      */
-    public function fire()
+    public function handle()
     {
         $name = $this->qualifyClass($this->getNameInput());
 

--- a/src/Illuminate/Console/Scheduling/ScheduleFinishCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleFinishCommand.php
@@ -52,7 +52,7 @@ class ScheduleFinishCommand extends Command
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         collect($this->schedule->events())->filter(function ($value) {
             return $value->mutexName() == $this->argument('id');

--- a/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
@@ -45,7 +45,7 @@ class ScheduleRunCommand extends Command
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         $eventsRan = false;
 

--- a/src/Illuminate/Database/Console/Migrations/FreshCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/FreshCommand.php
@@ -29,7 +29,7 @@ class FreshCommand extends Command
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         if (! $this->confirmToProceed()) {
             return;

--- a/src/Illuminate/Database/Console/Migrations/InstallCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/InstallCommand.php
@@ -47,7 +47,7 @@ class InstallCommand extends Command
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         $this->repository->setSource($this->input->getOption('database'));
 

--- a/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
@@ -53,7 +53,7 @@ class MigrateCommand extends BaseCommand
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         if (! $this->confirmToProceed()) {
             return;

--- a/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
@@ -58,7 +58,7 @@ class MigrateMakeCommand extends BaseCommand
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         // It's possible for the developer to specify the tables to modify in this
         // schema operation. The developer may also specify if this table needs

--- a/src/Illuminate/Database/Console/Migrations/RefreshCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/RefreshCommand.php
@@ -29,7 +29,7 @@ class RefreshCommand extends Command
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         if (! $this->confirmToProceed()) {
             return;

--- a/src/Illuminate/Database/Console/Migrations/ResetCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/ResetCommand.php
@@ -49,7 +49,7 @@ class ResetCommand extends BaseCommand
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         if (! $this->confirmToProceed()) {
             return;

--- a/src/Illuminate/Database/Console/Migrations/RollbackCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/RollbackCommand.php
@@ -49,7 +49,7 @@ class RollbackCommand extends BaseCommand
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         if (! $this->confirmToProceed()) {
             return;

--- a/src/Illuminate/Database/Console/Migrations/StatusCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/StatusCommand.php
@@ -47,7 +47,7 @@ class StatusCommand extends BaseCommand
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         $this->migrator->setConnection($this->option('database'));
 

--- a/src/Illuminate/Database/Console/Seeds/SeedCommand.php
+++ b/src/Illuminate/Database/Console/Seeds/SeedCommand.php
@@ -51,7 +51,7 @@ class SeedCommand extends Command
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         if (! $this->confirmToProceed()) {
             return;

--- a/src/Illuminate/Database/Console/Seeds/SeederMakeCommand.php
+++ b/src/Illuminate/Database/Console/Seeds/SeederMakeCommand.php
@@ -55,7 +55,7 @@ class SeederMakeCommand extends GeneratorCommand
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         parent::fire();
 

--- a/src/Illuminate/Foundation/Console/AppNameCommand.php
+++ b/src/Illuminate/Foundation/Console/AppNameCommand.php
@@ -65,7 +65,7 @@ class AppNameCommand extends Command
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         $this->currentRoot = trim($this->laravel->getNamespace(), '\\');
 

--- a/src/Illuminate/Foundation/Console/ClearCompiledCommand.php
+++ b/src/Illuminate/Foundation/Console/ClearCompiledCommand.php
@@ -25,7 +25,7 @@ class ClearCompiledCommand extends Command
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         if (file_exists($servicesPath = $this->laravel->getCachedServicesPath())) {
             @unlink($servicesPath);

--- a/src/Illuminate/Foundation/Console/ConfigCacheCommand.php
+++ b/src/Illuminate/Foundation/Console/ConfigCacheCommand.php
@@ -47,7 +47,7 @@ class ConfigCacheCommand extends Command
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         $this->call('config:clear');
 

--- a/src/Illuminate/Foundation/Console/ConfigClearCommand.php
+++ b/src/Illuminate/Foundation/Console/ConfigClearCommand.php
@@ -46,7 +46,7 @@ class ConfigClearCommand extends Command
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         $this->files->delete($this->laravel->getCachedConfigPath());
 

--- a/src/Illuminate/Foundation/Console/DownCommand.php
+++ b/src/Illuminate/Foundation/Console/DownCommand.php
@@ -27,7 +27,7 @@ class DownCommand extends Command
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         file_put_contents(
             $this->laravel->storagePath().'/framework/down',

--- a/src/Illuminate/Foundation/Console/EnvironmentCommand.php
+++ b/src/Illuminate/Foundation/Console/EnvironmentCommand.php
@@ -25,7 +25,7 @@ class EnvironmentCommand extends Command
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         $this->line('<info>Current application environment:</info> <comment>'.$this->laravel['env'].'</comment>');
     }

--- a/src/Illuminate/Foundation/Console/EventGenerateCommand.php
+++ b/src/Illuminate/Foundation/Console/EventGenerateCommand.php
@@ -27,7 +27,7 @@ class EventGenerateCommand extends Command
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         $provider = $this->laravel->getProvider(EventServiceProvider::class);
 

--- a/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
+++ b/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
@@ -30,7 +30,7 @@ class KeyGenerateCommand extends Command
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         $key = $this->generateRandomKey();
 

--- a/src/Illuminate/Foundation/Console/ListenerMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ListenerMakeCommand.php
@@ -34,7 +34,7 @@ class ListenerMakeCommand extends GeneratorCommand
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         if (! $this->option('event')) {
             return $this->error('Missing required option: --event');

--- a/src/Illuminate/Foundation/Console/MailMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/MailMakeCommand.php
@@ -33,7 +33,7 @@ class MailMakeCommand extends GeneratorCommand
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         if (parent::fire() === false) {
             return;

--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -34,7 +34,7 @@ class ModelMakeCommand extends GeneratorCommand
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         if (parent::fire() === false) {
             return;

--- a/src/Illuminate/Foundation/Console/NotificationMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/NotificationMakeCommand.php
@@ -33,7 +33,7 @@ class NotificationMakeCommand extends GeneratorCommand
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         if (parent::fire() === false) {
             return;

--- a/src/Illuminate/Foundation/Console/OptimizeCommand.php
+++ b/src/Illuminate/Foundation/Console/OptimizeCommand.php
@@ -27,7 +27,7 @@ class OptimizeCommand extends Command
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         //
     }

--- a/src/Illuminate/Foundation/Console/RouteCacheCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteCacheCommand.php
@@ -48,7 +48,7 @@ class RouteCacheCommand extends Command
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         $this->call('route:clear');
 

--- a/src/Illuminate/Foundation/Console/RouteClearCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteClearCommand.php
@@ -46,7 +46,7 @@ class RouteClearCommand extends Command
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         $this->files->delete($this->laravel->getCachedRoutesPath());
 

--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -66,7 +66,7 @@ class RouteListCommand extends Command
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         if (count($this->routes) == 0) {
             return $this->error("Your application doesn't have any routes.");

--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -30,7 +30,7 @@ class ServeCommand extends Command
      *
      * @throws \Exception
      */
-    public function fire()
+    public function handle()
     {
         chdir($this->laravel->publicPath());
 

--- a/src/Illuminate/Foundation/Console/StorageLinkCommand.php
+++ b/src/Illuminate/Foundation/Console/StorageLinkCommand.php
@@ -25,7 +25,7 @@ class StorageLinkCommand extends Command
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         if (file_exists(public_path('storage'))) {
             return $this->error('The "public/storage" directory already exists.');

--- a/src/Illuminate/Foundation/Console/UpCommand.php
+++ b/src/Illuminate/Foundation/Console/UpCommand.php
@@ -25,7 +25,7 @@ class UpCommand extends Command
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         @unlink($this->laravel->storagePath().'/framework/down');
 

--- a/src/Illuminate/Foundation/Console/VendorPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/VendorPublishCommand.php
@@ -67,7 +67,7 @@ class VendorPublishCommand extends Command
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         $this->determineWhatShouldBePublished();
 

--- a/src/Illuminate/Foundation/Console/ViewClearCommand.php
+++ b/src/Illuminate/Foundation/Console/ViewClearCommand.php
@@ -47,7 +47,7 @@ class ViewClearCommand extends Command
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         $path = $this->laravel['config']['view.compiled'];
 

--- a/src/Illuminate/Notifications/Console/NotificationTableCommand.php
+++ b/src/Illuminate/Notifications/Console/NotificationTableCommand.php
@@ -54,7 +54,7 @@ class NotificationTableCommand extends Command
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         $fullPath = $this->createBaseMigration();
 

--- a/src/Illuminate/Queue/Console/FailedTableCommand.php
+++ b/src/Illuminate/Queue/Console/FailedTableCommand.php
@@ -55,7 +55,7 @@ class FailedTableCommand extends Command
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         $table = $this->laravel['config']['queue.failed.table'];
 

--- a/src/Illuminate/Queue/Console/FlushFailedCommand.php
+++ b/src/Illuminate/Queue/Console/FlushFailedCommand.php
@@ -25,7 +25,7 @@ class FlushFailedCommand extends Command
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         $this->laravel['queue.failer']->flush();
 

--- a/src/Illuminate/Queue/Console/ForgetFailedCommand.php
+++ b/src/Illuminate/Queue/Console/ForgetFailedCommand.php
@@ -26,7 +26,7 @@ class ForgetFailedCommand extends Command
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         if ($this->laravel['queue.failer']->forget($this->argument('id'))) {
             $this->info('Failed job deleted successfully!');

--- a/src/Illuminate/Queue/Console/ListFailedCommand.php
+++ b/src/Illuminate/Queue/Console/ListFailedCommand.php
@@ -33,7 +33,7 @@ class ListFailedCommand extends Command
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         if (count($jobs = $this->getFailedJobs()) == 0) {
             return $this->info('No failed jobs!');

--- a/src/Illuminate/Queue/Console/ListenCommand.php
+++ b/src/Illuminate/Queue/Console/ListenCommand.php
@@ -55,7 +55,7 @@ class ListenCommand extends Command
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         // We need to get the right queue for the connection which is set in the queue
         // configuration file for the application. We will pull it based on the set

--- a/src/Illuminate/Queue/Console/RestartCommand.php
+++ b/src/Illuminate/Queue/Console/RestartCommand.php
@@ -26,7 +26,7 @@ class RestartCommand extends Command
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         $this->laravel['cache']->forever('illuminate:queue:restart', Carbon::now()->getTimestamp());
 

--- a/src/Illuminate/Queue/Console/RetryCommand.php
+++ b/src/Illuminate/Queue/Console/RetryCommand.php
@@ -27,7 +27,7 @@ class RetryCommand extends Command
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         foreach ($this->getJobIds() as $id) {
             $job = $this->laravel['queue.failer']->find($id);

--- a/src/Illuminate/Queue/Console/TableCommand.php
+++ b/src/Illuminate/Queue/Console/TableCommand.php
@@ -55,7 +55,7 @@ class TableCommand extends Command
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         $table = $this->laravel['config']['queue.connections.database.table'];
 

--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -62,7 +62,7 @@ class WorkCommand extends Command
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         if ($this->downForMaintenance() && $this->option('once')) {
             return $this->worker->sleep($this->option('sleep'));

--- a/src/Illuminate/Session/Console/SessionTableCommand.php
+++ b/src/Illuminate/Session/Console/SessionTableCommand.php
@@ -54,7 +54,7 @@ class SessionTableCommand extends Command
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         $fullPath = $this->createBaseMigration();
 

--- a/tests/Database/SeedCommandTest.php
+++ b/tests/Database/SeedCommandTest.php
@@ -11,7 +11,7 @@ use Illuminate\Database\ConnectionResolverInterface;
 
 class SeedCommandTest extends TestCase
 {
-    public function testFire()
+    public function testHandle()
     {
         $seeder = Mockery::mock(Seeder::class);
         $seeder->shouldReceive('setContainer')->once()->andReturnSelf();
@@ -31,9 +31,9 @@ class SeedCommandTest extends TestCase
 
         // call run to set up IO, then fire manually.
         $command->run(new \Symfony\Component\Console\Input\ArrayInput(['--force' => true, '--database' => 'sqlite']), new \Symfony\Component\Console\Output\NullOutput);
-        $command->fire();
+        $command->handle();
 
-        $container->shouldHaveReceived('call')->with([$command, 'fire']);
+        $container->shouldHaveReceived('call')->with([$command, 'handle']);
     }
 
     protected function tearDown()


### PR DESCRIPTION
In commands and command stubs, `fire` has been replaced by `handle` since 970836c5368642d975c56aa71f8aecafddcd3fd8 (version `5.0.30`)