### PR TITLE
[5.5] Adding test that binds any identifier in the container

### DIFF
--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -977,6 +977,13 @@ class ContainerTest extends TestCase
         $this->assertEquals(true, $container->has('Illuminate\Tests\Container\IContainerContractStub'));
     }
 
+    public function testContainerCanBindAnyWord()
+    {
+        $container = new Container;
+        $container->bind('Taylor', stdClass::class);
+        $this->assertInstanceOf(stdClass::class, $container->get('Taylor'));
+    }
+
     /**
      * @expectedException \Illuminate\Container\EntryNotFoundException
      */


### PR DESCRIPTION
Following up on #19822, the Container should never lose the ability to bind any word (identifier) to a concrete. 

The reason I bring up this test is so we don't forget that by binding an interface to an implementation is not the only ability that the container should be compliant.