### PR TITLE
[5.5] Make illuminate/container require psr-11

### DIFF
--- a/src/Illuminate/Container/composer.json
+++ b/src/Illuminate/Container/composer.json
@@ -15,7 +15,8 @@
     ],
     "require": {
         "php": ">=7.0",
-        "illuminate/contracts": "5.5.*"
+        "illuminate/contracts": "5.5.*",
+        "psr/container": "~1.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
With PR #19822, illuminate/container now requires psr11 interfaces.

See https://github.com/laravel/framework/blob/master/src/Illuminate/Container/EntryNotFoundException.php#L6