### PR TITLE
[5.5] Add Route::view() helper

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -230,6 +230,19 @@ class Router implements RegistrarContract, BindingRegistrar
     }
 
     /**
+     * Register a new route that returns a view.
+     *
+     * @param string $uri
+     * @param string $view
+     * @return \Illuminate\Routing\Route
+     */
+    public function view($uri, $view)
+    {
+        return $this->get($uri, '\Illuminate\Routing\ViewController')
+            ->defaults('view', $view);
+    }
+
+    /**
      * Register a new route with the given verbs.
      *
      * @param  array|string  $methods

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -234,12 +234,14 @@ class Router implements RegistrarContract, BindingRegistrar
      *
      * @param string $uri
      * @param string $view
+     * @param array $data
      * @return \Illuminate\Routing\Route
      */
-    public function view($uri, $view)
+    public function view($uri, $view, $data = [])
     {
         return $this->get($uri, '\Illuminate\Routing\ViewController')
-            ->defaults('view', $view);
+            ->defaults('view', $view)
+            ->defaults('data', $data);
     }
 
     /**

--- a/src/Illuminate/Routing/ViewController.php
+++ b/src/Illuminate/Routing/ViewController.php
@@ -27,10 +27,11 @@ class ViewController extends Controller
      * Invoke the controller method.
      *
      * @param string $view
+     * @param array $data
      * @return \Illuminate\Contracts\View\View
      */
-    public function __invoke($view)
+    public function __invoke($view, $data)
     {
-        return $this->view->make($view);
+        return $this->view->make($view, $data);
     }
 }

--- a/src/Illuminate/Routing/ViewController.php
+++ b/src/Illuminate/Routing/ViewController.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Illuminate\Routing;
+
+use Illuminate\Contracts\View\Factory as ViewFactory;
+
+class ViewController extends Controller
+{
+    /**
+     * The view factory instance.
+     *
+     * @var \Illuminate\Contracts\View\Factory
+     */
+    protected $view;
+
+    /**
+     * Create a new view controller instance.
+     *
+     * @param \Illuminate\Contracts\View\Factory $view
+     */
+    public function __construct(ViewFactory $view)
+    {
+        $this->view = $view;
+    }
+
+    /**
+     * Invoke the controller method.
+     *
+     * @param string $view
+     * @return \Illuminate\Contracts\View\View
+     */
+    public function __invoke($view)
+    {
+        return $this->view->make($view);
+    }
+}

--- a/src/Illuminate/Routing/ViewController.php
+++ b/src/Illuminate/Routing/ViewController.php
@@ -17,6 +17,7 @@ class ViewController extends Controller
      * Create a new view controller instance.
      *
      * @param \Illuminate\Contracts\View\Factory $view
+     * @return void
      */
     public function __construct(ViewFactory $view)
     {

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -1384,7 +1384,7 @@ class RoutingRouteTest extends TestCase
     {
         $container = new Container;
         $factory = m::mock('Illuminate\View\Factory');
-        $factory->shouldReceive('make')->once()->with('pages.contact')->andReturn('Contact us');
+        $factory->shouldReceive('make')->once()->with('pages.contact', ['foo' => 'bar'])->andReturn('Contact us');
         $router = new Router(new Dispatcher, $container);
         $container->bind(ViewFactory::class, function () use ($factory) {
             return $factory;
@@ -1393,7 +1393,7 @@ class RoutingRouteTest extends TestCase
             return $router;
         });
 
-        $router->view('contact', 'pages.contact');
+        $router->view('contact', 'pages.contact', ['foo' => 'bar']);
 
         $this->assertEquals('Contact us', $router->dispatch(Request::create('contact', 'GET'))->getContent());
     }

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Routing;
 
 use stdClass;
+use Mockery as m;
 use Illuminate\Support\Str;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Route;
@@ -19,6 +20,7 @@ use Illuminate\Routing\ResourceRegistrar;
 use Illuminate\Contracts\Routing\Registrar;
 use Illuminate\Auth\Middleware\Authenticate;
 use Symfony\Component\HttpFoundation\Response;
+use Illuminate\Contracts\View\Factory as ViewFactory;
 use Illuminate\Routing\Middleware\SubstituteBindings;
 
 class RoutingRouteTest extends TestCase
@@ -1376,6 +1378,24 @@ class RoutingRouteTest extends TestCase
         $response = $router->dispatch(Request::create('contact_us', 'GET'));
         $this->assertTrue($response->isRedirect('contact'));
         $this->assertEquals(302, $response->getStatusCode());
+    }
+
+    public function testRouteView()
+    {
+        $container = new Container;
+        $factory = m::mock('Illuminate\View\Factory');
+        $factory->shouldReceive('make')->once()->with('pages.contact')->andReturn('Contact us');
+        $router = new Router(new Dispatcher, $container);
+        $container->bind(ViewFactory::class, function () use ($factory) {
+            return $factory;
+        });
+        $container->singleton(Registrar::class, function () use ($router) {
+            return $router;
+        });
+
+        $router->view('contact', 'pages.contact');
+
+        $this->assertEquals('Contact us', $router->dispatch(Request::create('contact', 'GET'))->getContent());
     }
 
     protected function getRouter()


### PR DESCRIPTION
This adds a new `Route::view()` method. The implementation works with route caching as it uses an internal `ViewController` class.

```php
Route::view('contact', 'pages.contact');
```

The first argument is the route and the second is the view name. 