### PR TITLE
[5.4] Arr::pluck - handle situation when itemKey is an object

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -380,6 +380,10 @@ class Arr
             } else {
                 $itemKey = data_get($item, $key);
 
+                if (gettype($itemKey) === "object") {
+                    $itemKey = (string) $itemKey;
+                }
+                
                 $results[$itemKey] = $itemValue;
             }
         }

--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -380,10 +380,10 @@ class Arr
             } else {
                 $itemKey = data_get($item, $key);
 
-                if (gettype($itemKey) === "object") {
+                if (gettype($itemKey) === 'object') {
                     $itemKey = (string) $itemKey;
                 }
-                
+
                 $results[$itemKey] = $itemValue;
             }
         }

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Support;
 
 use stdClass;
 use ArrayObject;
+use Carbon\Carbon;
 use Illuminate\Support\Arr;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Support\Collection;
@@ -368,6 +369,15 @@ class SupportArrTest extends TestCase
             'Taylor' => ['name' => 'Taylor', 'role' => 'developer'],
             'Abigail' => ['name' => 'Abigail', 'role' => 'developer'],
         ], $test2);
+    }
+
+    public function testPluckWithCarbonKeys()
+    {
+        $array = [
+            ['start' => new Carbon('2017-07-25 00:00:00'), 'end' => new Carbon('2017-07-30 00:00:00')],
+        ];
+        $array = Arr::pluck($array, 'end', 'start');
+        $this->assertEquals(['2017-07-25 00:00:00' => '2017-07-30 00:00:00'], $array);
     }
 
     public function testPrepend()


### PR DESCRIPTION
When using `pluck` on a collection who's items are `Eloquent` models and some of the fields are casted as `date` an error is thrown: 

```
[2017-06-30 11:20:34] local.ERROR: ErrorException: Illegal offset type in /var/www/html/tpt/vendor/laravel/framework/src/Illuminate/Support/Arr.php:365
Stack trace:
#0 /var/www/html/tpt/vendor/laravel/framework/src/Illuminate/Support/Arr.php(365): Illuminate\Foundation\Bootstrap\HandleExceptions->handleError(2, 'Illegal offset ...', '/var/www/html/t...', 365, Array)
#1 /var/www/html/tpt/vendor/laravel/framework/src/Illuminate/Support/Collection.php(689): Illuminate\Support\Arr::pluck(Array, Array, Array)
#2 /var/www/html/tpt/app/Console/Commands/Test.php(48): Illuminate\Support\Collection->pluck('id', 'start_at')
#3 [internal function]: App\Console\Commands\Test->handle()
#4 /var/www/html/tpt/vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php(29): call_user_func_array(Array, Array)
#5 /var/www/html/tpt/vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php(87): Illuminate\Container\BoundMethod::Illuminate\Container\{closure}()
#6 /var/www/html/tpt/vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php(31): Illuminate\Container\BoundMethod::callBoundMethod(Object(Illuminate\Foundation\Application), Array, Object(Closure))
#7 /var/www/html/tpt/vendor/laravel/framework/src/Illuminate/Container/Container.php(531): Illuminate\Container\BoundMethod::call(Object(Illuminate\Foundation\Application), Array, Array, NULL)
#8 /var/www/html/tpt/vendor/laravel/framework/src/Illuminate/Console/Command.php(182): Illuminate\Container\Container->call(Array)
#9 /var/www/html/tpt/vendor/symfony/console/Command/Command.php(264): Illuminate\Console\Command->execute(Object(Symfony\Component\Console\Input\ArgvInput), Object(Illuminate\Console\OutputStyle))
#10 /var/www/html/tpt/vendor/laravel/framework/src/Illuminate/Console/Command.php(167): Symfony\Component\Console\Command\Command->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Illuminate\Console\OutputStyle))
#11 /var/www/html/tpt/vendor/symfony/console/Application.php(835): Illuminate\Console\Command->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#12 /var/www/html/tpt/vendor/symfony/console/Application.php(200): Symfony\Component\Console\Application->doRunCommand(Object(App\Console\Commands\Test), Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#13 /var/www/html/tpt/vendor/symfony/console/Application.php(124): Symfony\Component\Console\Application->doRun(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#14 /var/www/html/tpt/vendor/laravel/framework/src/Illuminate/Foundation/Console/Kernel.php(122): Symfony\Component\Console\Application->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#15 /var/www/html/tpt/artisan(35): Illuminate\Foundation\Console\Kernel->handle(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#16 {main}  
```

This commit is meant to fix this issue.