### PR TITLE
[5.5] Attempt to fix AuthenticateSession/remember_me issue

### DIFF
--- a/src/Illuminate/Auth/Recaller.php
+++ b/src/Illuminate/Auth/Recaller.php
@@ -31,7 +31,7 @@ class Recaller
      */
     public function id()
     {
-        return explode('|', $this->recaller, 2)[0];
+        return explode('|', $this->recaller, 3)[0];
     }
 
     /**
@@ -41,7 +41,17 @@ class Recaller
      */
     public function token()
     {
-        return explode('|', $this->recaller, 2)[1];
+        return explode('|', $this->recaller, 3)[1];
+    }
+
+    /**
+     * Get the password from the recaller.
+     *
+     * @return string
+     */
+    public function hash()
+    {
+        return explode('|', $this->recaller, 3)[2];
     }
 
     /**
@@ -51,7 +61,7 @@ class Recaller
      */
     public function valid()
     {
-        return $this->properString() && $this->hasBothSegments();
+        return $this->properString() && $this->hasAllSegments();
     }
 
     /**
@@ -65,14 +75,14 @@ class Recaller
     }
 
     /**
-     * Determine if the recaller has both segments.
+     * Determine if the recaller has all segments.
      *
      * @return bool
      */
-    protected function hasBothSegments()
+    protected function hasAllSegments()
     {
         $segments = explode('|', $this->recaller);
 
-        return count($segments) == 2 && trim($segments[0]) !== '' && trim($segments[1]) !== '';
+        return count($segments) == 3 && trim($segments[0]) !== '' && trim($segments[1]) !== '';
     }
 }

--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -461,7 +461,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
     protected function queueRecallerCookie(AuthenticatableContract $user)
     {
         $this->getCookieJar()->queue($this->createRecaller(
-            $user->getAuthIdentifier().'|'.$user->getRememberToken()
+            $user->getAuthIdentifier().'|'.$user->getRememberToken().'|'.$user->getAuthPassword()
         ));
     }
 

--- a/src/Illuminate/Session/Middleware/AuthenticateSession.php
+++ b/src/Illuminate/Session/Middleware/AuthenticateSession.php
@@ -39,8 +39,12 @@ class AuthenticateSession
             return $next($request);
         }
 
-        if (! $request->session()->has('password_hash') && $this->auth->viaRemember()) {
-            $this->logout($request);
+        if ($this->auth->viaRemember()) {
+            $passwordHash = explode('|', $request->cookies->get($this->auth->getRecallerName()))[2];
+
+            if ($passwordHash != $request->user()->getAuthPassword()) {
+                $this->logout($request);
+            }
         }
 
         if (! $request->session()->has('password_hash')) {

--- a/tests/Auth/AuthGuardTest.php
+++ b/tests/Auth/AuthGuardTest.php
@@ -279,12 +279,13 @@ class AuthGuardTest extends TestCase
         $guard = new \Illuminate\Auth\SessionGuard('default', $provider, $session, $request);
         $guard->setCookieJar($cookie);
         $foreverCookie = new \Symfony\Component\HttpFoundation\Cookie($guard->getRecallerName(), 'foo');
-        $cookie->shouldReceive('forever')->once()->with($guard->getRecallerName(), 'foo|recaller')->andReturn($foreverCookie);
+        $cookie->shouldReceive('forever')->once()->with($guard->getRecallerName(), 'foo|recaller|bar')->andReturn($foreverCookie);
         $cookie->shouldReceive('queue')->once()->with($foreverCookie);
         $guard->getSession()->shouldReceive('put')->once()->with($guard->getName(), 'foo');
         $session->shouldReceive('migrate')->once();
         $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');
         $user->shouldReceive('getAuthIdentifier')->andReturn('foo');
+        $user->shouldReceive('getAuthPassword')->andReturn('bar');
         $user->shouldReceive('getRememberToken')->andReturn('recaller');
         $user->shouldReceive('setRememberToken')->never();
         $provider->shouldReceive('updateRememberToken')->never();
@@ -303,6 +304,7 @@ class AuthGuardTest extends TestCase
         $session->shouldReceive('migrate')->once();
         $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');
         $user->shouldReceive('getAuthIdentifier')->andReturn('foo');
+        $user->shouldReceive('getAuthPassword')->andReturn('foo');
         $user->shouldReceive('getRememberToken')->andReturn(null);
         $user->shouldReceive('setRememberToken')->once();
         $provider->shouldReceive('updateRememberToken')->once();
@@ -360,7 +362,7 @@ class AuthGuardTest extends TestCase
     {
         $guard = $this->getGuard();
         list($session, $provider, $request, $cookie) = $this->getMocks();
-        $request = \Symfony\Component\HttpFoundation\Request::create('/', 'GET', [], [$guard->getRecallerName() => 'id|recaller']);
+        $request = \Symfony\Component\HttpFoundation\Request::create('/', 'GET', [], [$guard->getRecallerName() => 'id|recaller|baz']);
         $guard = new \Illuminate\Auth\SessionGuard('default', $provider, $session, $request);
         $guard->getSession()->shouldReceive('get')->once()->with($guard->getName())->andReturn(null);
         $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');


### PR DESCRIPTION
This PR explains the issue with the current AuthenticateSession when login is done via the remember_me token.

When the session expires, `$request->session()->has('password_hash')` will return false so it'll log the user out even if he's logged in vie `remember_me`.

To fix this we store the user password hash while logged in, we save that to the remember_me token, and in case the user is being logged in via remember_me later we'll use that hash to compare with the current hash and see if the user should be logged out.

Note: while upgrading from 5.4 to 5.5 all remember_me cookies will be considered invalid and users will be logged out.