### PR TITLE
[5.5] Allow for building cartesian strings

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -649,4 +649,17 @@ class Str
 
         return $languageSpecific[$language] ?? null;
     }
+
+    public static function cartesian($left, $right)
+    {
+        $results = [];
+
+        foreach ($left as $lhs) {
+            foreach ($right as $rhs) {
+                $results[] = $lhs . $rhs;
+            }
+        }
+
+        return $results;
+    }
 }

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -259,6 +259,29 @@ class SupportStrTest extends TestCase
         $this->assertEquals('Мама', Str::ucfirst('мама'));
         $this->assertEquals('Мама мыла раму', Str::ucfirst('мама мыла раму'));
     }
+
+    public function testCartesian()
+    {
+        $one = [
+            'Hello',
+            'Hola',
+            'Hi',
+        ];
+
+        $two = [
+            'World',
+            'Universe',
+        ];
+
+        $this->assertEquals([
+            'HelloWorld',
+            'HelloUniverse',
+            'HolaWorld',
+            'HolaUniverse',
+            'HiWorld',
+            'HiUniverse',
+        ], Str::cartesian($one, $two));
+    }
 }
 
 class StringableObjectStub


### PR DESCRIPTION
I have found myself doing this a few times in my projects as a nice way to build up a predictable string of values.

I also have a use case for it in another PR for laravel core.