### PR TITLE
[5.5] Improve testing for Higher Order Collections

### DIFF
--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -307,6 +307,28 @@ class SupportCollectionTest extends TestCase
         })->all());
     }
 
+    public function testHigherOrderFilter()
+    {
+        $c = new Collection([
+            new class {
+                public $name = 'Alex';
+
+                public function active() {
+                    return true;
+                }
+            },
+            new class {
+                public $name = 'John';
+
+                public function active() {
+                    return false;
+                }
+            }
+        ]);
+
+        $this->assertCount(1, $c->filter->active());
+    }
+
     public function testWhere()
     {
         $c = new Collection([['v' => 1], ['v' => 2], ['v' => 3], ['v' => '3'], ['v' => 4]]);


### PR DESCRIPTION
Just a small additional test for `filter` based higher order collections.