### PR TITLE
[5.5] Support more readable higher order collection methods

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -38,6 +38,17 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     ];
 
     /**
+     * The fillers to sandwich between a proxy and a method call.
+     *
+     * @var array
+     */
+    protected static $proxy_fillers = [
+        'On',
+        'By',
+        'Then',
+    ];
+
+    /**
      * Create a new collection.
      *
      * @param  mixed  $items
@@ -1693,9 +1704,35 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
         static::$proxies[] = $method;
     }
 
+    /**
+     * Add a filler word to the list of proxy fillers.
+     *
+     * @param  string  $filler
+     * @return void
+     */
+    public static function filler($filler)
+    {
+        static::$proxy_fillers[] = $filler;
+    }
+
+    /**
+     * Get the list of proxy methods supported.
+     *
+     * @return array
+     */
     public function getProxies()
     {
         return static::$proxies;
+    }
+
+    /**
+     * Get the list of proxy filler words supported.
+     *
+     * @return array
+     */
+    public function getFillers()
+    {
+        return static::$proxy_fillers;
     }
 
     /**
@@ -1709,7 +1746,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     public function __get($key)
     {
         if (! in_array($key, static::$proxies)) {
-            if (!starts_with($key, Str::cartesian(static::$proxies, ['On', 'By', 'Then']))) {
+            if (!starts_with($key, Str::cartesian(static::$proxies, static::$proxy_fillers))) {
                 throw new Exception("Property [{$key}] does not exist on this collection instance.");
             }
 

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1693,6 +1693,11 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
         static::$proxies[] = $method;
     }
 
+    public function getProxies()
+    {
+        return static::$proxies;
+    }
+
     /**
      * Dynamically access collection proxies.
      *
@@ -1704,7 +1709,11 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     public function __get($key)
     {
         if (! in_array($key, static::$proxies)) {
-            throw new Exception("Property [{$key}] does not exist on this collection instance.");
+            if (!starts_with($key, Str::cartesian(static::$proxies, ['On', 'By', 'Then']))) {
+                throw new Exception("Property [{$key}] does not exist on this collection instance.");
+            }
+
+            return ReadableHigherOrderCollectionProxy::perform($this, $key);
         }
 
         return new HigherOrderCollectionProxy($this, $key);

--- a/src/Illuminate/Support/ReadableHigherOrderCollectionProxy.php
+++ b/src/Illuminate/Support/ReadableHigherOrderCollectionProxy.php
@@ -70,16 +70,12 @@ class ReadableHigherOrderCollectionProxy
      */
     public function __call($method, $parameters)
     {
-        try {
-            return $this->collection->{$this->method}(function ($value) use ($method, $parameters) {
-                return $value->{$method}(...$parameters);
-            });
-        } catch(\Throwable $t) {
-            $method = Str::snake($method);
+        return $this->collection->{$this->method}(function ($value) use ($method, $parameters) {
+            if (!method_exists($value, $method)) {
+                $method = Str::snake($method);
+            }
 
-            return $this->collection->{$this->method}(function ($value) use ($method, $parameters) {
-                return $value->{$method}(...$parameters);
-            });
-        }
+            return $value->{$method}(...$parameters);
+        });
     }
 }

--- a/src/Illuminate/Support/ReadableHigherOrderCollectionProxy.php
+++ b/src/Illuminate/Support/ReadableHigherOrderCollectionProxy.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Illuminate\Support;
+
+class ReadableHigherOrderCollectionProxy
+{
+    /**
+     * The collection being operated on.
+     *
+     * @var \Illuminate\Support\Collection
+     */
+    protected $collection;
+
+    /**
+     * The method being proxied.
+     *
+     * @var string
+     */
+    protected $method;
+
+    /**
+     * Create a new proxy instance.
+     *
+     * @param  \Illuminate\Support\Collection  $collection
+     * @param  string  $method
+     * @return void
+     */
+    public function __construct(Collection $collection, $method)
+    {
+        $this->method = $method;
+        $this->collection = $collection;
+    }
+
+    public static function perform(Collection $collection, $method)
+    {
+        $action = 'filter';
+
+        foreach ($collection->getProxies() as $proxy) {
+            if (starts_with($method, $proxy)) {
+                $action = $proxy;
+            }
+        }
+
+        $method = str_replace(Str::cartesian($collection->getProxies(), ['On', 'By', 'Then']), '', $method);
+
+        $partial = new ReadableHigherOrderCollectionProxy($collection, $action);
+
+        return $partial->{$method}();
+    }
+
+    /**
+     * Proxy accessing an attribute onto the collection items.
+     *
+     * @param  string  $key
+     * @return mixed
+     */
+    public function __get($key)
+    {
+        return $this->collection->{$this->method}(function ($value) use ($key) {
+            return is_array($value) ? $value[$key] : $value->{$key};
+        });
+    }
+
+    /**
+     * Proxy a method call onto the collection items.
+     *
+     * @param  string  $method
+     * @param  array  $parameters
+     * @return mixed
+     */
+    public function __call($method, $parameters)
+    {
+        try {
+            return $this->collection->{$this->method}(function ($value) use ($method, $parameters) {
+                return $value->{$method}(...$parameters);
+            });
+        } catch(\Throwable $t) {
+            $method = Str::snake($method);
+
+            return $this->collection->{$this->method}(function ($value) use ($method, $parameters) {
+                return $value->{$method}(...$parameters);
+            });
+        }
+    }
+}

--- a/src/Illuminate/Support/ReadableHigherOrderCollectionProxy.php
+++ b/src/Illuminate/Support/ReadableHigherOrderCollectionProxy.php
@@ -41,7 +41,7 @@ class ReadableHigherOrderCollectionProxy
             }
         }
 
-        $method = str_replace(Str::cartesian($collection->getProxies(), ['On', 'By', 'Then']), '', $method);
+        $method = str_replace(Str::cartesian($collection->getProxies(), $collection->getFillers()), '', $method);
 
         $partial = new ReadableHigherOrderCollectionProxy($collection, $action);
 

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -649,4 +649,17 @@ class Str
 
         return $languageSpecific[$language] ?? null;
     }
+
+    public static function cartesian($left, $right)
+    {
+        $results = [];
+
+        foreach ($left as $lhs) {
+            foreach ($right as $rhs) {
+                $results[] = $lhs . $rhs;
+            }
+        }
+
+        return $results;
+    }
 }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1988,6 +1988,85 @@ class SupportCollectionTest extends TestCase
         );
     }
 
+    public function testReadableHigherOrderFilter()
+    {
+        $c = new Collection([
+            new class {
+                public $name = 'Alex';
+
+                public function active() {
+                    return true;
+                }
+            },
+            new class {
+                public $name = 'John';
+
+                public function active() {
+                    return false;
+                }
+            }
+        ]);
+
+        $this->assertCount(1, $c->filterByActive);
+
+        $d = new Collection([
+            new class {
+                public $name = 'Alex';
+
+                public function adminUser() {
+                    return true;
+                }
+            },
+            new class {
+                public $name = 'John';
+
+                public function adminUser() {
+                    return false;
+                }
+            }
+        ]);
+
+        $this->assertCount(1, $d->filterByAdminUser);
+
+        $e = new Collection([
+            new class {
+                public $name = 'Alex';
+
+                public function admin_user() {
+                    return true;
+                }
+            },
+            new class {
+                public $name = 'John';
+
+                public function admin_user() {
+                    return false;
+                }
+            }
+        ]);
+
+        $this->assertCount(1, $e->filterByAdminUser);
+
+        $e = new Collection([
+            new class {
+                public $name = 'Alex';
+
+                public function admin_user() {
+                    return true;
+                }
+            },
+            new class {
+                public $name = 'John';
+
+                public function admin_user() {
+                    return false;
+                }
+            }
+        ]);
+
+        $this->assertCount(1, $e->filterByAdminUser);
+    }
+
     public function testHigherOrderCollectionMap()
     {
         $person1 = (object) ['name' => 'Taylor'];

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2048,6 +2048,30 @@ class SupportCollectionTest extends TestCase
         $this->assertCount(1, $e->filterByAdminUser);
     }
 
+    public function testCustomFillerReadableHigherOrderFilter()
+    {
+        Collection::filler('BecauseOf');
+
+        $c = new Collection([
+            new class {
+                public $name = 'Alex';
+
+                public function active() {
+                    return true;
+                }
+            },
+            new class {
+                public $name = 'John';
+
+                public function active() {
+                    return false;
+                }
+            }
+        ]);
+
+        $this->assertCount(1, $c->filterBecauseOfActive);
+    }
+
     public function testHigherOrderCollectionMap()
     {
         $person1 = (object) ['name' => 'Taylor'];

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2046,25 +2046,6 @@ class SupportCollectionTest extends TestCase
         ]);
 
         $this->assertCount(1, $e->filterByAdminUser);
-
-        $e = new Collection([
-            new class {
-                public $name = 'Alex';
-
-                public function admin_user() {
-                    return true;
-                }
-            },
-            new class {
-                public $name = 'John';
-
-                public function admin_user() {
-                    return false;
-                }
-            }
-        ]);
-
-        $this->assertCount(1, $e->filterByAdminUser);
     }
 
     public function testHigherOrderCollectionMap()

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -259,6 +259,29 @@ class SupportStrTest extends TestCase
         $this->assertEquals('Мама', Str::ucfirst('мама'));
         $this->assertEquals('Мама мыла раму', Str::ucfirst('мама мыла раму'));
     }
+
+    public function testCartesian()
+    {
+        $one = [
+            'Hello',
+            'Hola',
+            'Hi',
+        ];
+
+        $two = [
+            'World',
+            'Universe',
+        ];
+
+        $this->assertEquals([
+            'HelloWorld',
+            'HelloUniverse',
+            'HolaWorld',
+            'HolaUniverse',
+            'HiWorld',
+            'HiUniverse',
+        ], Str::cartesian($one, $two));
+    }
 }
 
 class StringableObjectStub


### PR DESCRIPTION
This allows for more readable higher order methods

Instead of having 

`$collection->filter->action()` you can now have

`$collection->filterByAction` and similar.

There are a few different "filler" words, 

`On`, `Then`, `By`.

This should lead to a readable way of setting up any higher order method.

The higher order method also tries both CamelCase and snake_case method names, starting with the CamelCase.

Unfortunately, due to the way Macroable works, I couldn't figure out a way to get it to allow method calls, so it has to be a normal parameter call, but this is no different than any other higher order method call, it just allows it to read a little more easily.

This PR relies on: https://github.com/laravel/framework/pull/19846 