### PR TITLE
[5.5] Automatically add route prefix to resource routes

### DIFF
--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -388,6 +388,10 @@ class ResourceRegistrar
         // the resource action. Otherwise we'll just use an empty string for here.
         $prefix = isset($options['as']) ? $options['as'].'.' : '';
 
+        if (empty($prefix) && ! empty($options['prefix'])) {
+            $prefix = isset($options['prefix']) ? $options['prefix'].'.' : '';
+        }
+
         return trim(sprintf('%s%s.%s', $prefix, $name, $method), '.');
     }
 

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -271,6 +271,10 @@ class Router implements RegistrarContract, BindingRegistrar
             $registrar = new ResourceRegistrar($this);
         }
 
+        if (empty($options['prefix']) && ! empty($this->getLastGroupPrefix())) {
+            $options['prefix'] = $this->getLastGroupPrefix();
+        }
+
         return new PendingResourceRegistration(
             $registrar, $name, $controller, $options
         );

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -1123,13 +1123,13 @@ class RoutingRouteTest extends TestCase
         $router = $this->getRouter();
         $router->resource('prefix/foo.bar', 'FooController');
 
-        $this->assertTrue($router->getRoutes()->hasNamedRoute('foo.bar.index'));
-        $this->assertTrue($router->getRoutes()->hasNamedRoute('foo.bar.show'));
-        $this->assertTrue($router->getRoutes()->hasNamedRoute('foo.bar.create'));
-        $this->assertTrue($router->getRoutes()->hasNamedRoute('foo.bar.store'));
-        $this->assertTrue($router->getRoutes()->hasNamedRoute('foo.bar.edit'));
-        $this->assertTrue($router->getRoutes()->hasNamedRoute('foo.bar.update'));
-        $this->assertTrue($router->getRoutes()->hasNamedRoute('foo.bar.destroy'));
+        $this->assertTrue($router->getRoutes()->hasNamedRoute('prefix.foo.bar.index'));
+        $this->assertTrue($router->getRoutes()->hasNamedRoute('prefix.foo.bar.show'));
+        $this->assertTrue($router->getRoutes()->hasNamedRoute('prefix.foo.bar.create'));
+        $this->assertTrue($router->getRoutes()->hasNamedRoute('prefix.foo.bar.store'));
+        $this->assertTrue($router->getRoutes()->hasNamedRoute('prefix.foo.bar.edit'));
+        $this->assertTrue($router->getRoutes()->hasNamedRoute('prefix.foo.bar.update'));
+        $this->assertTrue($router->getRoutes()->hasNamedRoute('prefix.foo.bar.destroy'));
 
         $router = $this->getRouter();
         $router->resource('foo', 'FooController', ['names' => [


### PR DESCRIPTION
# Issue:

Currently whenever we define a resource route through `Route::resource('foo','FooController');` method, it automatically names in pattern such as `foo.index`, `foo.create` etc. This behavior continues after we add route prefix to our routes. Following are the service providers in which i am adding prefix to routes.

# Steps to Reproduce
![screenshot from 2017-07-01 21-51-39](https://user-images.githubusercontent.com/839335/27763967-b3482608-5ea7-11e7-9a3e-c529372d8254.png)
![screenshot from 2017-07-01 21-51-45](https://user-images.githubusercontent.com/839335/27763970-c79b684a-5ea7-11e7-9364-37c1c2d79429.png)

Following are the routes file listed in above service providers:

![screenshot from 2017-07-01 21-44-37](https://user-images.githubusercontent.com/839335/27763975-f859ca9e-5ea7-11e7-8449-efcce61a68af.png)
![screenshot from 2017-07-01 21-44-43](https://user-images.githubusercontent.com/839335/27763976-fd343f0e-5ea7-11e7-8730-0f768f56a382.png)

Finally following is the output of the command `php artisan routes:list`:

![screenshot from 2017-07-01 21-45-32](https://user-images.githubusercontent.com/839335/27763981-18ba484a-5ea8-11e7-825b-04a07ca14cf8.png)

As you can see from the last screenshot, i have two resource `ProductsController` with different routes, but they both share the same name. Whenever i will use the `route` helper to get the url of a route, it will always give me the last route of the same name.

# Implementation
This PR fixes the stated issue in *Steps To Reproduce* section, and automatically adds the route prefix to the name of the resource route action methods. 


