### PR TITLE
$Validator->fails() doesn't return true if error is added by errors()->add method

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -255,7 +255,9 @@ class Validator implements ValidatorContract
      */
     public function passes()
     {
-        $this->messages = new MessageBag;
+        if (!$this->messages) {
+            $this->messages = new MessageBag;
+        }
 
         // We'll spin through each rule, validating the attributes attached to that
         // rule. Any error messages will be added to the containers with each of

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -255,7 +255,7 @@ class Validator implements ValidatorContract
      */
     public function passes()
     {
-        if (!$this->messages) {
+        if (! $this->messages) {
             $this->messages = new MessageBag;
         }
 

--- a/tests/Validation/ValidationErrorsAdd.php
+++ b/tests/Validation/ValidationErrorsAdd.php
@@ -11,7 +11,7 @@ class ValidationErrorsAdd extends TestCase
 {
     public function testFailsCalledAfterErrorsAddDoesNotReturnTrue()
     {
-    	$translator = m::mock(Translator::class);
+        $translator = m::mock(Translator::class);
         $factory = new Factory($translator);
         $validator = $factory->make(['foo' => 'bar'], ['baz' => 'boom']);
 

--- a/tests/Validation/ValidationErrorsAdd.php
+++ b/tests/Validation/ValidationErrorsAdd.php
@@ -5,7 +5,6 @@ namespace Illuminate\Tests\Validation;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Validation\Factory;
-use Illuminate\Validation\Validator;
 use Illuminate\Contracts\Translation\Translator;
 
 class ValidationErrorsAdd extends TestCase

--- a/tests/Validation/ValidationErrorsAdd.php
+++ b/tests/Validation/ValidationErrorsAdd.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Illuminate\Tests\Validation;
+
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+use Illuminate\Validation\Factory;
+use Illuminate\Validation\Validator;
+use Illuminate\Contracts\Translation\Translator;
+
+class ValidationErrorsAdd extends TestCase
+{
+    public function testFailsCalledAfterErrorsAddDoesNotReturnTrue()
+    {
+    	$translator = m::mock(Translator::class);
+        $factory = new Factory($translator);
+        $validator = $factory->make(['foo' => 'bar'], ['baz' => 'boom']);
+
+        $this->assertEquals(false, $validator->fails());
+
+        $validator->errors()->add('foo', 'bar');
+
+        $this->assertEquals(true, $validator->fails());
+    }
+}


### PR DESCRIPTION
I noticed a weird scenario, where I added an error in validator errors, using
`$validator->errors()->add('field', 'oh oh, something is wrong with this field');`

Then, I called fails method
`$validator->fails()`

But, I noticed that it returns *false*.

Here is my complete code for referrence
```
$validator = Validator::make($request->all(), $rules);
        
$folder = Folder::find(1);
        
if (!$folder instanceof Folder || ($folder instanceof Folder && $folder['user_id'] != Auth::id())) {
    $validator->messages()->add('folder', 'Field invalid');
}
        
var_dump($validator->fails());
```