### PR TITLE
[5.4] Add support to keep old files when testing uploads

### DIFF
--- a/src/Illuminate/Support/Facades/Storage.php
+++ b/src/Illuminate/Support/Facades/Storage.php
@@ -13,15 +13,18 @@ class Storage extends Facade
      * Replace the given disk with a local, testing disk.
      *
      * @param  string  $disk
+     * @param  bool $doesntWantsOldFiles
      * @return void
      */
-    public static function fake($disk)
+    public static function fake($disk, $doesntWantsOldFiles = true)
     {
-        (new Filesystem)->cleanDirectory(
-            $root = storage_path('framework/testing/disks/'.$disk)
-        );
+        $rootPath = storage_path('framework/testing/disks/' . $disk);
 
-        static::set($disk, self::createLocalDriver(['root' => $root]));
+        if ($doesntWantsOldFiles) {
+            (new Filesystem)->cleanDirectory($rootPath);
+        }
+
+        static::set($disk, self::createLocalDriver(['root' => $rootPath]));
     }
 
     /**


### PR DESCRIPTION
This is useful when testing files upload. 

Use case: 

if you upload a batch of files and then you need to delete just one of them, you will be able to assert that the deleted one does not exist while the others do.

Suggestions are welcome and I will understand if this PR is not accepted.