### PR TITLE
[5.4] Add ability to keep old files when testing uploads [second attempt] 

### DIFF
--- a/src/Illuminate/Support/Facades/Storage.php
+++ b/src/Illuminate/Support/Facades/Storage.php
@@ -10,18 +10,40 @@ use Illuminate\Filesystem\Filesystem;
 class Storage extends Facade
 {
     /**
+     * Tells the fake method whether to clean the working directory.
+     *
+     * @var boolean
+     */
+    protected static $doesntWantOldFiles = true;
+
+    /**
+     * Keeps the testing files.
+     *
+     * @return self
+     */
+    public static function withOldFiles()
+    {
+        static::$doesntWantOldFiles = false;
+
+        return new static;
+    }
+
+    /**
      * Replace the given disk with a local, testing disk.
      *
      * @param  string  $disk
+     *
      * @return void
      */
     public static function fake($disk)
     {
-        (new Filesystem)->cleanDirectory(
-            $root = storage_path('framework/testing/disks/'.$disk)
-        );
+        $rootPath = storage_path('framework/testing/disks/' . $disk);
 
-        static::set($disk, self::createLocalDriver(['root' => $root]));
+        if (static::$doesntWantOldFiles) {
+            (new Filesystem)->cleanDirectory($rootPath);
+        }
+
+        static::set($disk, self::createLocalDriver(['root' => $rootPath]));
     }
 
     /**

--- a/src/Illuminate/Support/Facades/Storage.php
+++ b/src/Illuminate/Support/Facades/Storage.php
@@ -10,26 +10,7 @@ use Illuminate\Filesystem\Filesystem;
 class Storage extends Facade
 {
     /**
-     * Tells the fake method whether to clean the working directory.
-     *
-     * @var boolean
-     */
-    protected static $doesntWantOldFiles = true;
-
-    /**
-     * Keeps the testing files.
-     *
-     * @return self
-     */
-    public static function withOldFiles()
-    {
-        static::$doesntWantOldFiles = false;
-
-        return new static;
-    }
-
-    /**
-     * Replace the given disk with a local, testing disk.
+     * Replace the given disk with a local testing disk.
      *
      * @param  string  $disk
      *
@@ -37,13 +18,25 @@ class Storage extends Facade
      */
     public static function fake($disk)
     {
-        $rootPath = storage_path('framework/testing/disks/' . $disk);
+        (new Filesystem)->cleanDirectory(
+            $root = storage_path('framework/testing/disks/'.$disk)
+        );
 
-        if (static::$doesntWantOldFiles) {
-            (new Filesystem)->cleanDirectory($rootPath);
-        }
+        static::set($disk, self::createLocalDriver(['root' => $root]));
+    }
 
-        static::set($disk, self::createLocalDriver(['root' => $rootPath]));
+    /**
+     * Replace the given disk with a local testing persistent disk.
+     *
+     * @param  string  $disk
+     *
+     * @return void
+     */
+    public static function persistentFake($disk)
+    {
+        static::set($disk, self::createLocalDriver([
+            'root' => storage_path('framework/testing/disks/' . $disk)
+        ]));
     }
 
     /**

--- a/src/Illuminate/Support/Facades/Storage.php
+++ b/src/Illuminate/Support/Facades/Storage.php
@@ -26,10 +26,9 @@ class Storage extends Facade
     }
 
     /**
-     * Replace the given disk with a local testing persistent disk.
+     * Replace the given disk with a persistent local testing disk.
      *
      * @param  string  $disk
-     *
      * @return void
      */
     public static function persistentFake($disk)


### PR DESCRIPTION
Hi guys, 

This is my second attempt to get this behavior into the framework.

This PR had been closed in the past due to the uses of Boolean variables. It does not introduce breaking changes because it keeps the actual behavior by default.

They way how it can be used is like so: 

```php
Storage::withOldFiles()->fake($disk)
```

Whether users want to keep the uploaded files when testing and make assertions to them.

```php
Storage::fake($disk)
```

Whether you want to keep the actual behavior.

---
Even though I will understand if this PR is not accepted, I would like to see something similar to this in the framework.

@taylorotwell I will appreciate your thoughts on this. 

Thanks, 




