### PR TITLE
[5.4] Faster implementation for Arr::crossJoin()

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -73,12 +73,15 @@ class Arr
 
         foreach ($arrays as $index => $array) {
             $append = [];
+
             foreach ($results as $product) {
                 foreach ($array as $item) {
                     $product[$index] = $item;
+
                     $append[] = $product;
                 }
             }
+
             $results = $append;
         }
 

--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -69,13 +69,20 @@ class Arr
      */
     public static function crossJoin(...$arrays)
     {
-        return array_reduce($arrays, function ($results, $array) {
-            return static::collapse(array_map(function ($parent) use ($array) {
-                return array_map(function ($item) use ($parent) {
-                    return array_merge($parent, [$item]);
-                }, $array);
-            }, $results));
-        }, [[]]);
+        $results = [[]];
+
+        foreach ($arrays as $index => $array) {
+            $append = [];
+            foreach ($results as $product) {
+                foreach ($array as $item) {
+                    $product[$index] = $item;
+                    $append[] = $product;
+                }
+            }
+            $results = $append;
+        }
+
+        return $results;
     }
 
     /**

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -38,25 +38,25 @@ class SupportArrTest extends TestCase
     public function testCrossJoin()
     {
         // Single dimension
-        $this->assertEquals(
+        $this->assertSame(
             [[1, 'a'], [1, 'b'], [1, 'c']],
             Arr::crossJoin([1], ['a', 'b', 'c'])
         );
 
         // Square matrix
-        $this->assertEquals(
+        $this->assertSame(
             [[1, 'a'], [1, 'b'], [2, 'a'], [2, 'b']],
             Arr::crossJoin([1, 2], ['a', 'b'])
         );
 
         // Rectangular matrix
-        $this->assertEquals(
+        $this->assertSame(
             [[1, 'a'], [1, 'b'], [1, 'c'], [2, 'a'], [2, 'b'], [2, 'c']],
             Arr::crossJoin([1, 2], ['a', 'b', 'c'])
         );
 
         // 3D matrix
-        $this->assertEquals(
+        $this->assertSame(
             [
                 [1, 'a', 'I'], [1, 'a', 'II'], [1, 'a', 'III'],
                 [1, 'b', 'I'], [1, 'b', 'II'], [1, 'b', 'III'],
@@ -67,17 +67,17 @@ class SupportArrTest extends TestCase
         );
 
         // With 1 empty dimension
-        $this->assertEquals([], Arr::crossJoin([], ['a', 'b'], ['I', 'II', 'III']));
-        $this->assertEquals([], Arr::crossJoin([1, 2], [], ['I', 'II', 'III']));
-        $this->assertEquals([], Arr::crossJoin([1, 2], ['a', 'b'], []));
+        $this->assertSame([], Arr::crossJoin([], ['a', 'b'], ['I', 'II', 'III']));
+        $this->assertSame([], Arr::crossJoin([1, 2], [], ['I', 'II', 'III']));
+        $this->assertSame([], Arr::crossJoin([1, 2], ['a', 'b'], []));
 
         // With empty arrays
-        $this->assertEquals([], Arr::crossJoin([], [], []));
-        $this->assertEquals([], Arr::crossJoin([], []));
-        $this->assertEquals([], Arr::crossJoin([]));
+        $this->assertSame([], Arr::crossJoin([], [], []));
+        $this->assertSame([], Arr::crossJoin([], []));
+        $this->assertSame([], Arr::crossJoin([]));
 
         // Not really a proper usage, still, test for preserving BC
-        $this->assertEquals([[]], Arr::crossJoin());
+        $this->assertSame([[]], Arr::crossJoin());
     }
 
     public function testDivide()

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -67,7 +67,17 @@ class SupportArrTest extends TestCase
         );
 
         // With 1 empty dimension
+        $this->assertEquals([], Arr::crossJoin([], ['a', 'b'], ['I', 'II', 'III']));
         $this->assertEquals([], Arr::crossJoin([1, 2], [], ['I', 'II', 'III']));
+        $this->assertEquals([], Arr::crossJoin([1, 2], ['a', 'b'], []));
+
+        // With empty arrays
+        $this->assertEquals([], Arr::crossJoin([], [], []));
+        $this->assertEquals([], Arr::crossJoin([], []));
+        $this->assertEquals([], Arr::crossJoin([]));
+
+        // Not really a proper usage, still, test for preserving BC
+        $this->assertEquals([[]], Arr::crossJoin());
     }
 
     public function testDivide()


### PR DESCRIPTION
Follow-up to #19236. ping @JosephSilber

Benchmarks, for 1000 iterations:

    Arr::crossJoin([1, 2], ['a', 'b'], ['I', 'II', 'III']);

    current: 429 ms
    new: 30 ms

    Arr::crossJoin([1, 2], ['a', 'b', 'c']);

    current: 205 ms
    new: 18 ms

props Serg for this [implementation](https://stackoverflow.com/questions/6311779/finding-cartesian-product-with-php-associative-arrays/15973172#15973172). (note I removed the `array_filter` line)

Also added a few tests to reinforce BC.