### PR TITLE
[5.5] Ensure a 304 response is properly returned.

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -666,6 +666,10 @@ class Router implements RegistrarContract, BindingRegistrar
             $response = new Response($response);
         }
 
+        if ($response->getStatusCode() === Response::HTTP_NOT_MODIFIED) {
+            $response->setNotModified();
+        }
+
         return $response->prepare($request);
     }
 

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Routing;
 
+use DateTime;
 use stdClass;
 use Mockery as m;
 use Illuminate\Support\Str;
@@ -154,6 +155,20 @@ class RoutingRouteTest extends TestCase
             return 'closure';
         }]);
         $this->assertEquals('closure', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
+    }
+
+    public function testNotModifiedResponseIsProperlyReturned()
+    {
+        $router = $this->getRouter();
+        $router->get('test', function () {
+            return (new Response('test', 304, ['foo' => 'bar']))->setLastModified(new DateTime);
+        });
+
+        $response = $router->dispatch(Request::create('test', 'GET'));
+        $this->assertSame(304, $response->getStatusCode());
+        $this->assertEmpty($response->getContent());
+        $this->assertSame('bar', $response->headers->get('foo'));
+        $this->assertNull($response->getLastModified());
     }
 
     public function testClosureMiddleware()


### PR DESCRIPTION
We can decide at any time to return a `304` response.
This PR ensures that the content is `null` and that the following headers are always removed:

- `Allow`
- `Content-Encoding`
- `Content-Language`
- `Content-Length`
- `Content-MD5`
- `Content-Type`
- `Last-Modified`