### PR TITLE
[5.4] Add endOfMonth() to Console\Scheduling\ManagesFrequencies.

### DIFF
--- a/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
+++ b/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
@@ -294,7 +294,7 @@ trait ManagesFrequencies
         return function () {
             $now = Carbon::now();
 
-            return $now->day() == $now->daysInMonth();
+            return $now->day == $now->daysInMonth;
         };
     }
 

--- a/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
+++ b/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
@@ -274,6 +274,31 @@ trait ManagesFrequencies
     }
 
     /**
+     * Schedule the event to run on the last day of the month at a given time.
+     *
+     * @param  string  $time
+     * @return $this
+     */
+    public function endOfMonth($time = '0:0')
+    {
+        return $this->dailyAt($time)->when($this->isEndOfMonth());
+    }
+
+    /**
+     * Schedule the event to run on the last day of the month.
+     *
+     * @return \Closure
+     */
+    private function isEndOfMonth()
+    {
+        return function () {
+            $now = Carbon::now();
+
+            return $now->day() == $now->daysInMonth();
+        };
+    }
+
+    /**
      * Schedule the event to run quarterly.
      *
      * @return $this


### PR DESCRIPTION
The title says it all. The last day of the month is a common use case, this provides a convenience method for that use case akin to `weekends()` being a convenience method for its use case. Implementation is consistent with the similar combination of `between()` and `inTimeInterval()`. 