### PR TITLE
[5.5] Properly test exceptions

### DIFF
--- a/tests/Auth/AuthAccessGateTest.php
+++ b/tests/Auth/AuthAccessGateTest.php
@@ -13,7 +13,8 @@ use Illuminate\Auth\Access\HandlesAuthorization;
 class GateTest extends TestCase
 {
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Callback must be a callable or a 'Class@method'
      */
     public function test_gate_throws_exception_on_invalid_callback_type()
     {
@@ -276,6 +277,7 @@ class GateTest extends TestCase
 
     /**
      * @expectedException \Illuminate\Auth\Access\AuthorizationException
+     * @expectedExceptionMessage You are not an admin.
      */
     public function test_authorize_throws_unauthorized_exception()
     {

--- a/tests/Auth/AuthGuardTest.php
+++ b/tests/Auth/AuthGuardTest.php
@@ -168,6 +168,7 @@ class AuthGuardTest extends TestCase
 
     /**
      * @expectedException \Illuminate\Auth\AuthenticationException
+     * @expectedExceptionMessage Unauthenticated.
      */
     public function testAuthenticateThrowsWhenUserIsNull()
     {

--- a/tests/Auth/AuthPasswordBrokerTest.php
+++ b/tests/Auth/AuthPasswordBrokerTest.php
@@ -24,7 +24,8 @@ class AuthPasswordBrokerTest extends TestCase
     }
 
     /**
-     * @expectedException UnexpectedValueException
+     * @expectedException \UnexpectedValueException
+     * @expectedExceptionMessage User must implement CanResetPassword interface.
      */
     public function testGetUserThrowsExceptionIfUserDoesntImplementCanResetPassword()
     {

--- a/tests/Auth/AuthenticateMiddlewareTest.php
+++ b/tests/Auth/AuthenticateMiddlewareTest.php
@@ -36,6 +36,7 @@ class AuthenticateMiddlewareTest extends TestCase
 
     /**
      * @expectedException \Illuminate\Auth\AuthenticationException
+     * @expectedExceptionMessage Unauthenticated.
      */
     public function testDefaultUnauthenticatedThrows()
     {
@@ -81,6 +82,7 @@ class AuthenticateMiddlewareTest extends TestCase
 
     /**
      * @expectedException \Illuminate\Auth\AuthenticationException
+     * @expectedExceptionMessage Unauthenticated.
      */
     public function testMultipleDriversUnauthenticatedThrows()
     {

--- a/tests/Auth/AuthorizeMiddlewareTest.php
+++ b/tests/Auth/AuthorizeMiddlewareTest.php
@@ -56,6 +56,7 @@ class AuthorizeMiddlewareTest extends TestCase
 
     /**
      * @expectedException \Illuminate\Auth\Access\AuthorizationException
+     * @expectedExceptionMessage This action is unauthorized.
      */
     public function testSimpleAbilityUnauthorized()
     {
@@ -95,6 +96,7 @@ class AuthorizeMiddlewareTest extends TestCase
 
     /**
      * @expectedException \Illuminate\Auth\Access\AuthorizationException
+     * @expectedExceptionMessage This action is unauthorized.
      */
     public function testModelTypeUnauthorized()
     {
@@ -136,6 +138,7 @@ class AuthorizeMiddlewareTest extends TestCase
 
     /**
      * @expectedException \Illuminate\Auth\Access\AuthorizationException
+     * @expectedExceptionMessage This action is unauthorized.
      */
     public function testModelUnauthorized()
     {

--- a/tests/Broadcasting/BroadcasterTest.php
+++ b/tests/Broadcasting/BroadcasterTest.php
@@ -58,7 +58,8 @@ class BroadcasterTest extends TestCase
     }
 
     /**
-     * @expectedException Symfony\Component\HttpKernel\Exception\HttpException
+     * @expectedException \Symfony\Component\HttpKernel\Exception\HttpException
+     * @expectedExceptionMessage
      */
     public function testNotFoundThrowsHttpException()
     {

--- a/tests/Cache/ClearCommandTest.php
+++ b/tests/Cache/ClearCommandTest.php
@@ -49,7 +49,8 @@ class ClearCommandTest extends TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage
      */
     public function testClearWithInvalidStoreArgument()
     {

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -493,7 +493,8 @@ class ContainerTest extends TestCase
     }
 
     /**
-     * @expectedException ReflectionException
+     * @expectedException \ReflectionException
+     * @expectedExceptionMessage Function ContainerTestCallStub() does not exist
      */
     public function testCallWithAtSignBasedClassReferencesWithoutMethodThrowsException()
     {
@@ -986,6 +987,7 @@ class ContainerTest extends TestCase
 
     /**
      * @expectedException \Illuminate\Container\EntryNotFoundException
+     * @expectedExceptionMessage
      */
     public function testUnknownEntryThrowsException()
     {

--- a/tests/Database/DatabaseConnectionFactoryTest.php
+++ b/tests/Database/DatabaseConnectionFactoryTest.php
@@ -73,7 +73,8 @@ class DatabaseConnectionFactoryTest extends TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage A driver must be specified.
      */
     public function testIfDriverIsntSetExceptionIsThrown()
     {
@@ -82,7 +83,8 @@ class DatabaseConnectionFactoryTest extends TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Unsupported driver [foo]
      */
     public function testExceptionIsThrownOnUnsupportedDriver()
     {

--- a/tests/Database/DatabaseConnectionTest.php
+++ b/tests/Database/DatabaseConnectionTest.php
@@ -225,6 +225,7 @@ class DatabaseConnectionTest extends TestCase
 
     /**
      * @expectedException \Illuminate\Database\QueryException
+     * @expectedExceptionMessage Deadlock found when trying to get lock (SQL: )
      */
     public function testTransactionMethodRetriesOnDeadlock()
     {
@@ -256,6 +257,7 @@ class DatabaseConnectionTest extends TestCase
 
     /**
      * @expectedException \Illuminate\Database\QueryException
+     * @expectedExceptionMessage server has gone away (SQL: foo)
      */
     public function testOnLostConnectionPDOIsNotSwappedWithinATransaction()
     {
@@ -309,6 +311,7 @@ class DatabaseConnectionTest extends TestCase
 
     /**
      * @expectedException \Illuminate\Database\QueryException
+     * @expectedExceptionMessage  (SQL: ) (SQL: )
      */
     public function testRunMethodNeverRetriesIfWithinTransaction()
     {

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -474,7 +474,8 @@ class DatabaseEloquentBuilderTest extends TestCase
     }
 
     /**
-     * @expectedException Illuminate\Database\Eloquent\RelationNotFoundException
+     * @expectedException \Illuminate\Database\Eloquent\RelationNotFoundException
+     * @expectedExceptionMessage Call to undefined relationship [invalid] on model [Mockery_18_Illuminate_Database_Eloquent_Model].
      */
     public function testGetRelationThrowsException()
     {

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -351,6 +351,7 @@ class DatabaseEloquentCollectionTest extends TestCase
 
     /**
      * @expectedException \LogicException
+     * @expectedExceptionMessage Queueing collections with multiple model types is not supported.
      */
     public function testQueueableCollectionImplementationThrowsExceptionOnMultipleModelTypes()
     {

--- a/tests/Database/DatabaseEloquentHasManyThroughIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentHasManyThroughIntegrationTest.php
@@ -102,6 +102,7 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
 
     /**
      * @expectedException \Illuminate\Database\Eloquent\ModelNotFoundException
+     * @expectedExceptionMessage No query results for model [Illuminate\Tests\Database\HasManyThroughTestPost].
      */
     public function testFirstOrFailThrowsAnException()
     {
@@ -113,6 +114,7 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
 
     /**
      * @expectedException \Illuminate\Database\Eloquent\ModelNotFoundException
+     * @expectedExceptionMessage No query results for model [Illuminate\Tests\Database\HasManyThroughTestPost].
      */
     public function testFindOrFailThrowsAnException()
     {

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -405,6 +405,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
 
     /**
      * @expectedException \Illuminate\Database\Eloquent\ModelNotFoundException
+     * @expectedExceptionMessage No query results for model [Illuminate\Tests\Database\EloquentTestUser] 1
      */
     public function testFindOrFailWithSingleIdThrowsModelNotFoundException()
     {
@@ -413,6 +414,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
 
     /**
      * @expectedException \Illuminate\Database\Eloquent\ModelNotFoundException
+     * @expectedExceptionMessage No query results for model [Illuminate\Tests\Database\EloquentTestUser] 1, 2
      */
     public function testFindOrFailWithMultipleIdsThrowsModelNotFoundException()
     {
@@ -866,7 +868,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
     }
 
     /**
-     * @expectedException Exception
+     * @expectedException \Exception
      */
     public function testSaveOrFailWithDuplicatedEntry()
     {

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -918,6 +918,7 @@ class DatabaseEloquentModelTest extends TestCase
 
     /**
      * @expectedException \Illuminate\Database\Eloquent\MassAssignmentException
+     * @expectedExceptionMessage name
      */
     public function testGlobalGuarded()
     {
@@ -1294,7 +1295,8 @@ class DatabaseEloquentModelTest extends TestCase
     }
 
     /**
-     * @expectedException LogicException
+     * @expectedException \LogicException
+     * @expectedExceptionMessage Illuminate\Tests\Database\EloquentModelStub::incorrectRelationStub must return a relationship instance.
      */
     public function testGetModelAttributeMethodThrowsExceptionIfNotRelation()
     {
@@ -1541,6 +1543,7 @@ class DatabaseEloquentModelTest extends TestCase
 
     /**
      * @expectedException \Illuminate\Database\Eloquent\JsonEncodingException
+     * @expectedExceptionMessage Unable to encode attribute [objectAttribute] for model [Illuminate\Tests\Database\EloquentModelCastingStub] to JSON: Malformed UTF-8 characters, possibly incorrectly encoded.
      */
     public function testModelAttributeCastingFailsOnUnencodableData()
     {

--- a/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
@@ -563,7 +563,8 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
     }
 
     /**
-     * @expectedException BadMethodCallException
+     * @expectedException \BadMethodCallException
+     * @expectedExceptionMessage Call to undefined method Illuminate\Database\Query\Builder::thisMethodDoesNotExist()
      */
     public function testMorphToWithBadMethodCall()
     {

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1789,7 +1789,8 @@ class DatabaseQueryBuilderTest extends TestCase
     }
 
     /**
-     * @expectedException BadMethodCallException
+     * @expectedException \BadMethodCallException
+     * @expectedExceptionMessage Call to undefined method Illuminate\Database\Query\Builder::noValidMethodHere()
      */
     public function testBuilderThrowsExpectedExceptionWithUndefinedMethod()
     {

--- a/tests/Encryption/EncrypterTest.php
+++ b/tests/Encryption/EncrypterTest.php
@@ -45,7 +45,7 @@ class EncrypterTest extends TestCase
     }
 
     /**
-     * @expectedException RuntimeException
+     * @expectedException \RuntimeException
      * @expectedExceptionMessage The only supported ciphers are AES-128-CBC and AES-256-CBC with the correct key lengths.
      */
     public function testDoNoAllowLongerKey()
@@ -54,7 +54,7 @@ class EncrypterTest extends TestCase
     }
 
     /**
-     * @expectedException RuntimeException
+     * @expectedException \RuntimeException
      * @expectedExceptionMessage The only supported ciphers are AES-128-CBC and AES-256-CBC with the correct key lengths.
      */
     public function testWithBadKeyLength()
@@ -63,7 +63,7 @@ class EncrypterTest extends TestCase
     }
 
     /**
-     * @expectedException RuntimeException
+     * @expectedException \RuntimeException
      * @expectedExceptionMessage The only supported ciphers are AES-128-CBC and AES-256-CBC with the correct key lengths.
      */
     public function testWithBadKeyLengthAlternativeCipher()
@@ -72,7 +72,7 @@ class EncrypterTest extends TestCase
     }
 
     /**
-     * @expectedException RuntimeException
+     * @expectedException \RuntimeException
      * @expectedExceptionMessage The only supported ciphers are AES-128-CBC and AES-256-CBC with the correct key lengths.
      */
     public function testWithUnsupportedCipher()
@@ -81,7 +81,7 @@ class EncrypterTest extends TestCase
     }
 
     /**
-     * @expectedException Illuminate\Contracts\Encryption\DecryptException
+     * @expectedException \Illuminate\Contracts\Encryption\DecryptException
      * @expectedExceptionMessage The payload is invalid.
      */
     public function testExceptionThrownWhenPayloadIsInvalid()
@@ -93,7 +93,7 @@ class EncrypterTest extends TestCase
     }
 
     /**
-     * @expectedException Illuminate\Contracts\Encryption\DecryptException
+     * @expectedException \Illuminate\Contracts\Encryption\DecryptException
      * @expectedExceptionMessage The MAC is invalid.
      */
     public function testExceptionThrownWithDifferentKey()

--- a/tests/Foundation/FoundationAuthorizesRequestsTraitTest.php
+++ b/tests/Foundation/FoundationAuthorizesRequestsTraitTest.php
@@ -31,6 +31,7 @@ class FoundationAuthorizesRequestsTraitTest extends TestCase
 
     /**
      * @expectedException \Illuminate\Auth\Access\AuthorizationException
+     * @expectedExceptionMessage This action is unauthorized.
      */
     public function test_exception_is_thrown_if_gate_check_fails()
     {

--- a/tests/Foundation/FoundationFormRequestTest.php
+++ b/tests/Foundation/FoundationFormRequestTest.php
@@ -37,6 +37,7 @@ class FoundationFormRequestTest extends TestCase
 
     /**
      * @expectedException \Illuminate\Validation\ValidationException
+     * @expectedExceptionMessage The given data failed to pass validation.
      */
     public function test_validate_throws_when_validation_fails()
     {
@@ -49,6 +50,7 @@ class FoundationFormRequestTest extends TestCase
 
     /**
      * @expectedException \Illuminate\Auth\Access\AuthorizationException
+     * @expectedExceptionMessage This action is unauthorized.
      */
     public function test_validate_method_throws_when_authorization_fails()
     {

--- a/tests/Foundation/FoundationHelpersTest.php
+++ b/tests/Foundation/FoundationHelpersTest.php
@@ -35,7 +35,8 @@ class FoundationHelpersTest extends TestCase
     }
 
     /**
-     * @expectedException Exception
+     * @expectedException \Exception
+     * @expectedExceptionMessage You must specify an expiration time when setting a value in the cache.
      */
     public function testCacheThrowsAnExceptionIfAnExpirationIsNotProvided()
     {

--- a/tests/Http/HttpJsonResponseTest.php
+++ b/tests/Http/HttpJsonResponseTest.php
@@ -75,7 +75,7 @@ class HttpJsonResponseTest extends TestCase
     }
 
     /**
-     * @expectedException        \InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      * @expectedExceptionMessage Type is not supported
      */
     public function testJsonErrorResource()

--- a/tests/Http/HttpRedirectResponseTest.php
+++ b/tests/Http/HttpRedirectResponseTest.php
@@ -121,7 +121,8 @@ class HttpRedirectResponseTest extends TestCase
     }
 
     /**
-     * @expectedException BadMethodCallException
+     * @expectedException \BadMethodCallException
+     * @expectedExceptionMessage Method [doesNotExist] does not exist on Redirect.
      */
     public function testMagicCallException()
     {

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -656,7 +656,8 @@ class HttpRequestTest extends TestCase
     }
 
     /**
-     * @expectedException RuntimeException
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage Session store not set on request.
      */
     public function testSessionMethod()
     {
@@ -687,7 +688,8 @@ class HttpRequestTest extends TestCase
     }
 
     /**
-     * @expectedException RuntimeException
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage Unable to generate fingerprint. Route unavailable.
      */
     public function testFingerprintWithoutRoute()
     {

--- a/tests/Http/HttpResponseTest.php
+++ b/tests/Http/HttpResponseTest.php
@@ -184,6 +184,7 @@ class HttpResponseTest extends TestCase
 
     /**
      * @expectedException \BadMethodCallException
+     * @expectedExceptionMessage Method [doesNotExist] does not exist on Redirect.
      */
     public function testMagicCallException()
     {

--- a/tests/Integration/Cache/CacheLockTest.php
+++ b/tests/Integration/Cache/CacheLockTest.php
@@ -74,6 +74,7 @@ class CacheLockTest extends TestCase
 
     /**
      * @expectedException \Illuminate\Contracts\Cache\LockTimeoutException
+     * @expectedExceptionMessage
      */
     public function test_locks_throw_timeout_if_block_expires()
     {

--- a/tests/Integration/Queue/ModelSerializationTest.php
+++ b/tests/Integration/Queue/ModelSerializationTest.php
@@ -104,7 +104,7 @@ class ModelSerializationTest extends TestCase
 
     /**
      * @test
-     * @expectedException LogicException
+     * @expectedException \LogicException
      * @expectedExceptionMessage  Queueing collections with multiple model connections is not supported.
      */
     public function it_fails_if_models_on_multi_connections()

--- a/tests/Log/LogWriterTest.php
+++ b/tests/Log/LogWriterTest.php
@@ -66,7 +66,8 @@ class LogWriterTest extends TestCase
     }
 
     /**
-     * @expectedException RuntimeException
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage Events dispatcher has not been set.
      */
     public function testListenShortcutFailsWithNoDispatcher()
     {

--- a/tests/Pipeline/PipelineTest.php
+++ b/tests/Pipeline/PipelineTest.php
@@ -133,6 +133,7 @@ class PipelineTest extends TestCase
 
     /**
      * @expectedException \RuntimeException
+     * @expectedExceptionMessage A container instance has not been passed to the Pipeline.
      */
     public function testPipelineThrowsExceptionOnResolveWithoutContainer()
     {

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -170,6 +170,7 @@ class RouteRegistrarTest extends TestCase
 
     /**
      * @expectedException \BadMethodCallException
+     * @expectedExceptionMessage Method [missing] does not exist.
      */
     public function testRegisteringNonApprovedAttributesThrows()
     {

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -481,6 +481,7 @@ class RoutingRouteTest extends TestCase
 
     /**
      * @expectedException \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
+     * @expectedExceptionMessage
      */
     public function testRoutesDontMatchNonMatchingPathsWithLeadingOptionals()
     {
@@ -493,6 +494,7 @@ class RoutingRouteTest extends TestCase
 
     /**
      * @expectedException \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
+     * @expectedExceptionMessage
      */
     public function testRoutesDontMatchNonMatchingDomain()
     {
@@ -733,6 +735,7 @@ class RoutingRouteTest extends TestCase
 
     /**
      * @expectedException \Illuminate\Database\Eloquent\ModelNotFoundException
+     * @expectedExceptionMessage No query results for model [Illuminate\Tests\Routing\RouteModelBindingNullStub].
      */
     public function testModelBindingWithNullReturn()
     {
@@ -987,7 +990,8 @@ class RoutingRouteTest extends TestCase
     }
 
     /**
-     * @expectedException UnexpectedValueException
+     * @expectedException \UnexpectedValueException
+     * @expectedExceptionMessage Invalid route action: [Illuminate\Tests\Routing\RouteTestControllerStub].
      */
     public function testInvalidActionException()
     {
@@ -1296,6 +1300,7 @@ class RoutingRouteTest extends TestCase
 
     /**
      * @expectedException \Illuminate\Database\Eloquent\ModelNotFoundException
+     * @expectedExceptionMessage
      */
     public function testImplicitBindingsWithOptionalParameterWithNonExistingKeyInUri()
     {

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -941,7 +941,7 @@ class SupportCollectionTest extends TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      */
     public function testRandomThrowsAnErrorWhenRequestingMoreItemsThanAreAvailable()
     {
@@ -1827,7 +1827,7 @@ class SupportCollectionTest extends TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      */
     public function testRandomThrowsAnExceptionUsingAmountBiggerThanCollectionSize()
     {

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -721,7 +721,7 @@ class SupportHelpersTest extends TestCase
     }
 
     /**
-     * @expectedException RuntimeException
+     * @expectedException \RuntimeException
      */
     public function testThrow()
     {
@@ -729,7 +729,7 @@ class SupportHelpersTest extends TestCase
     }
 
     /**
-     * @expectedException RuntimeException
+     * @expectedException \RuntimeException
      * @expectedExceptionMessage Test Message
      */
     public function testThrowWithString()

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -66,6 +66,7 @@ class ValidationValidatorTest extends TestCase
 
     /**
      * @expectedException \Illuminate\Validation\ValidationException
+     * @expectedExceptionMessage The given data failed to pass validation.
      */
     public function testValidateThrowsOnFail()
     {
@@ -2599,7 +2600,8 @@ class ValidationValidatorTest extends TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Validation rule required_if requires at least 2 parameters.
      */
     public function testExceptionThrownOnIncorrectParameterCount()
     {

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -22,6 +22,7 @@ class ViewBladeCompilerTest extends TestCase
 
     /**
      * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Please provide a valid cache path.
      */
     public function testCannotConstructWithBadCachePath()
     {

--- a/tests/View/ViewEngineResolverTest.php
+++ b/tests/View/ViewEngineResolverTest.php
@@ -20,7 +20,7 @@ class ViewEngineResolverTest extends TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      */
     public function testResolverThrowsExceptionOnUnknownEngine()
     {

--- a/tests/View/ViewFactoryTest.php
+++ b/tests/View/ViewFactoryTest.php
@@ -382,7 +382,7 @@ class ViewFactoryTest extends TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      */
     public function testExceptionIsThrownForUnknownExtension()
     {
@@ -392,7 +392,7 @@ class ViewFactoryTest extends TestCase
     }
 
     /**
-     * @expectedException Exception
+     * @expectedException \Exception
      * @expectedExceptionMessage section exception message
      */
     public function testExceptionsInSectionsAreThrown()
@@ -412,7 +412,7 @@ class ViewFactoryTest extends TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      * @expectedExceptionMessage Cannot end a section without first starting one.
      */
     public function testExtraStopSectionCallThrowsException()
@@ -425,7 +425,7 @@ class ViewFactoryTest extends TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      * @expectedExceptionMessage Cannot end a section without first starting one.
      */
     public function testExtraAppendSectionCallThrowsException()

--- a/tests/View/ViewFileViewFinderTest.php
+++ b/tests/View/ViewFileViewFinderTest.php
@@ -73,7 +73,7 @@ class ViewFinderTest extends TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      */
     public function testExceptionThrownWhenViewNotFound()
     {
@@ -86,7 +86,8 @@ class ViewFinderTest extends TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage No hint path defined for [name].
      */
     public function testExceptionThrownOnInvalidViewName()
     {
@@ -95,7 +96,8 @@ class ViewFinderTest extends TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage No hint path defined for [name].
      */
     public function testExceptionThrownWhenNoHintPathIsRegistered()
     {

--- a/tests/View/ViewTest.php
+++ b/tests/View/ViewTest.php
@@ -164,7 +164,8 @@ class ViewTest extends TestCase
     }
 
     /**
-     * @expectedException BadMethodCallException
+     * @expectedException \BadMethodCallException
+     * @expectedExceptionMessage Method [badMethodCall] does not exist on view.
      */
     public function testViewBadMethod()
     {


### PR DESCRIPTION
- Stay consistant with the `@expectedException` 
- Always test `@expectedExceptionMessage`