### PR TITLE
[5.4] Add twiceMonthly() to Console\Scheduling\ManagesFrequencies.

### DIFF
--- a/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
+++ b/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
@@ -274,6 +274,22 @@ trait ManagesFrequencies
     }
 
     /**
+     * Schedule the event to run twice monthly.
+     *
+     * @param  int  $first
+     * @param  int  $second
+     * @return $this
+     */
+    public function twiceMonthly($first = 1, $second = 16)
+    {
+        $days = $first.','.$second;
+
+        return $this->spliceIntoPosition(1, 0)
+            ->spliceIntoPosition(2, 0)
+            ->spliceIntoPosition(3, $days);
+    }
+
+    /**
      * Schedule the event to run quarterly.
      *
      * @return $this

--- a/tests/Console/Scheduling/FrequencyTest.php
+++ b/tests/Console/Scheduling/FrequencyTest.php
@@ -53,6 +53,11 @@ class FrequencyTest extends TestCase
         $this->assertEquals('0 15 4 * * *', $this->event->monthlyOn(4, '15:00')->getExpression());
     }
 
+    public function testTwiceMonthly()
+    {
+        $this->assertEquals('0 0 1,16 * * *', $this->event->twiceMonthly(1, 16)->getExpression());
+    }
+
     public function testMonthlyOnWithMinutes()
     {
         $this->assertEquals('15 15 4 * * *', $this->event->monthlyOn(4, '15:15')->getExpression());


### PR DESCRIPTION
The title says it all. The twice a month is a common use case, this provides a convenience method for that use case akin to `weekends()` being a convenience method for its use case. Defaults to the 1st and 16th, common for bi-monthly reporting & invoicing. Implementation is consistent with the similar `twiceDaily()`. Accompanied by appropriate test.