### PR TITLE
spelling fixes for the `tests` directory

### DIFF
--- a/tests/Auth/AuthenticateMiddlewareTest.php
+++ b/tests/Auth/AuthenticateMiddlewareTest.php
@@ -109,7 +109,7 @@ class AuthenticateMiddlewareTest extends TestCase
         return $this->fail();
     }
 
-    public function testMultipleDriversAuthenticatedUdatesDefault()
+    public function testMultipleDriversAuthenticatedUpdatesDefault()
     {
         $this->registerAuthDriver('default', false);
 

--- a/tests/Database/DatabaseConnectionTest.php
+++ b/tests/Database/DatabaseConnectionTest.php
@@ -180,7 +180,7 @@ class DatabaseConnectionTest extends TestCase
         $connection->beginTransaction();
     }
 
-    public function testCommitedFiresEventsIfSet()
+    public function testCommittedFiresEventsIfSet()
     {
         $pdo = $this->createMock('Illuminate\Tests\Database\DatabaseConnectionTestMockPDO');
         $connection = $this->getMockConnection(['getName'], $pdo);

--- a/tests/Database/DatabaseConnectorTest.php
+++ b/tests/Database/DatabaseConnectorTest.php
@@ -96,13 +96,13 @@ class DatabaseConnectorTest extends TestCase
     public function testPostgresApplicationNameIsSet()
     {
         $dsn = 'pgsql:host=foo;dbname=bar';
-        $config = ['host' => 'foo', 'database' => 'bar', 'charset' => 'utf8', 'application_name' => 'Larvel App'];
+        $config = ['host' => 'foo', 'database' => 'bar', 'charset' => 'utf8', 'application_name' => 'Laravel App'];
         $connector = $this->getMockBuilder('Illuminate\Database\Connectors\PostgresConnector')->setMethods(['createConnection', 'getOptions'])->getMock();
         $connection = m::mock('stdClass');
         $connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->will($this->returnValue(['options']));
         $connector->expects($this->once())->method('createConnection')->with($this->equalTo($dsn), $this->equalTo($config), $this->equalTo(['options']))->will($this->returnValue($connection));
         $connection->shouldReceive('prepare')->once()->with('set names \'utf8\'')->andReturn($connection);
-        $connection->shouldReceive('prepare')->once()->with('set application_name to \'Larvel App\'')->andReturn($connection);
+        $connection->shouldReceive('prepare')->once()->with('set application_name to \'Laravel App\'')->andReturn($connection);
         $connection->shouldReceive('execute')->twice();
         $result = $connector->connect($config);
 

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -665,7 +665,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertEquals('select "id", (select count(*) from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id") as "foo_count" from "eloquent_builder_test_model_parent_stubs"', $builder->toSql());
     }
 
-    public function testWithCountAndContraintsAndHaving()
+    public function testWithCountAndConstraintsAndHaving()
     {
         $model = new EloquentBuilderTestModelParentStub;
 
@@ -696,7 +696,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertEquals('select "eloquent_builder_test_model_parent_stubs".*, (select count(*) from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id") as "foo_bar_count", (select count(*) from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id") as "foo_count" from "eloquent_builder_test_model_parent_stubs"', $builder->toSql());
     }
 
-    public function testHasWithContraintsAndHavingInSubquery()
+    public function testHasWithConstraintsAndHavingInSubquery()
     {
         $model = new EloquentBuilderTestModelParentStub;
 
@@ -709,7 +709,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertEquals(['baz', 'qux', 'quuux'], $builder->getBindings());
     }
 
-    public function testHasWithContraintsWithOrWhereAndHavingInSubquery()
+    public function testHasWithConstraintsWithOrWhereAndHavingInSubquery()
     {
         $model = new EloquentBuilderTestModelParentStub;
 
@@ -739,7 +739,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertEquals(['baz', 'quuuuuux', 'qux', 'quuux'], $builder->getBindings());
     }
 
-    public function testHasWithContraintsAndHavingInSubqueryWithCount()
+    public function testHasWithConstraintsAndHavingInSubqueryWithCount()
     {
         $model = new EloquentBuilderTestModelParentStub;
 

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -60,7 +60,7 @@ class DatabaseEloquentCollectionTest extends TestCase
         $this->assertFalse($c->contains($mockModel3));
     }
 
-    public function testContainsIndicatesIfDiffentModelInArray()
+    public function testContainsIndicatesIfDifferentModelInArray()
     {
         $mockModelFoo = m::namedMock('Foo', 'Illuminate\Database\Eloquent\Model');
         $mockModelFoo->shouldReceive('is')->with($mockModelFoo)->andReturn(true);

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -40,8 +40,8 @@ class FilesystemTest extends TestCase
         file_put_contents($this->tempDir.'/file.txt', 'Hello World');
         $files = new Filesystem();
         $files->chmod($this->tempDir.'/file.txt', 0755);
-        $filePermisson = substr(sprintf('%o', fileperms($this->tempDir.'/file.txt')), -4);
-        $this->assertEquals('0755', $filePermisson);
+        $filePermission = substr(sprintf('%o', fileperms($this->tempDir.'/file.txt')), -4);
+        $this->assertEquals('0755', $filePermission);
     }
 
     public function testGetChmod()
@@ -49,8 +49,8 @@ class FilesystemTest extends TestCase
         file_put_contents($this->tempDir.'/file.txt', 'Hello World');
         chmod($this->tempDir.'/file.txt', 0755);
         $files = new Filesystem();
-        $filePermisson = $files->chmod($this->tempDir.'/file.txt');
-        $this->assertEquals('0755', $filePermisson);
+        $filePermission = $files->chmod($this->tempDir.'/file.txt');
+        $this->assertEquals('0755', $filePermission);
     }
 
     public function testDeleteRemovesFiles()
@@ -254,14 +254,14 @@ class FilesystemTest extends TestCase
         $this->assertEquals($this->tempDir, $files->dirname($this->tempDir.'/foo.txt'));
     }
 
-    public function testTypeIndentifiesFile()
+    public function testTypeIdentifiesFile()
     {
         file_put_contents($this->tempDir.'/foo.txt', 'foo');
         $files = new Filesystem();
         $this->assertEquals('file', $files->type($this->tempDir.'/foo.txt'));
     }
 
-    public function testTypeIndentifiesDirectory()
+    public function testTypeIdentifiesDirectory()
     {
         mkdir($this->tempDir.'/foo');
         $files = new Filesystem();

--- a/tests/View/Blade/BladeLangTest.php
+++ b/tests/View/Blade/BladeLangTest.php
@@ -13,7 +13,7 @@ class BladeLangTest extends TestCase
         m::close();
     }
 
-    public function testStatementThatContainsNonConsecutiveParanthesisAreCompiled()
+    public function testStatementThatContainsNonConsecutiveParenthesisAreCompiled()
     {
         $compiler = new BladeCompiler($this->getFiles(), __DIR__);
         $string = "Foo @lang(function_call('foo(blah)')) bar";


### PR DESCRIPTION
- udates --> updates
- commited --> committed
- Larvel --> Laravel
- contraints --> constraints
- diffent --> different
- permisson --> permission
- indentifies --> identifies
- paranthesis --> parenthesis