### PR TITLE
Add implodeNice method for Collecitons

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -701,6 +701,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
         }
 
         $lastItem = array_pop($values);
+        
         return implode("$glue ", $values)."{$glue} {$conjunction} ".$lastItem;
     }
 

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -680,7 +680,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
         $first = $this->first();
 
         if (is_array($first) || is_object($first)) {
-            // Collection values are arrays, so get the values for the given key 
+            // Collection values are arrays, so get the values for the given key
             $values = $this->pluck($value)->all();
         } else {
             // Collection values are not arrays, so implode all collection values
@@ -688,7 +688,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
                 // Shift inputs, since $values is implicit
                 $conjunction = $glue;
             }
-            $glue   = $value;
+            $glue = $value;
             $values = $this->items;
         }
 
@@ -701,7 +701,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
         }
 
         $lastItem = array_pop($values);
-        return implode("$glue ", $values) . "{$glue} {$conjunction} " . $lastItem;
+        return implode("$glue ", $values)."{$glue} {$conjunction} ".$lastItem;
     }
 
     /**

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -701,7 +701,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
         }
 
         $lastItem = array_pop($values);
-        
+
         return implode("$glue ", $values)."{$glue} {$conjunction} ".$lastItem;
     }
 

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -668,6 +668,43 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
+     * Concatenate values of a given key as formatted English string, with a conjunction before the final item.
+     *
+     * @param  string  $value
+     * @param  string  $glue
+     * @param  string  $conjunction
+     * @return string
+     */
+    public function implodeNice($value, $glue = ',', $conjunction = 'and')
+    {
+        $first = $this->first();
+
+        if (is_array($first) || is_object($first)) {
+            // Collection values are arrays, so get the values for the given key 
+            $values = $this->pluck($value)->all();
+        } else {
+            // Collection values are not arrays, so implode all collection values
+            if ($glue != ',') {
+                // Shift inputs, since $values is implicit
+                $conjunction = $glue;
+            }
+            $glue   = $value;
+            $values = $this->items;
+        }
+
+        if (count($values) == 1) {
+            return array_shift($values);
+        }
+
+        if (count($values) == 2) {
+            return implode(" {$conjunction} ", $values);
+        }
+
+        $lastItem = array_pop($values);
+        return implode("$glue ", $values) . "{$glue} {$conjunction} " . $lastItem;
+    }
+
+    /**
      * Intersect the collection with the given items.
      *
      * @param  mixed  $items

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -692,7 +692,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
             $values = $this->items;
         }
 
-        if (count($values) == 1) {
+        if (count($values) <= 1) {
             return array_shift($values);
         }
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -900,6 +900,29 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals('taylor,dayle', $data->implode(','));
     }
 
+    public function testImplodeNice()
+    {
+        $data = new Collection([['name' => 'taylor', 'email' => 'foo'], ['name' => 'dayle', 'email' => 'bar'], ['name' => 'shawn', 'email' => 'baz']]);
+        $this->assertEquals('foo, bar, and baz', $data->implodeNice('email'));
+        $this->assertEquals('foo; bar; and baz', $data->implodeNice('email', ';'));
+        $this->assertEquals('foo; bar; and, finally, baz', $data->implodeNice('email', ';','and, finally,'));
+
+        $data = new Collection(['taylor']);
+        $this->assertEquals('taylor', $data->implodeNice(''));
+        $this->assertEquals('taylor', $data->implodeNice(','));
+        $this->assertEquals('taylor', $data->implodeNice(',', 'and, finally,'));
+
+        $data = new Collection(['taylor', 'dayle']);
+        $this->assertEquals('taylor and dayle', $data->implodeNice(''));
+        $this->assertEquals('taylor and dayle', $data->implodeNice(','));
+        $this->assertEquals('taylor and, finally, dayle', $data->implodeNice(',', 'and, finally,'));
+
+        $data = new Collection(['taylor', 'dayle', 'shawn']);
+        $this->assertEquals('taylor dayle and shawn', $data->implodeNice(''));
+        $this->assertEquals('taylor, dayle, and shawn', $data->implodeNice(','));
+        $this->assertEquals('taylor, dayle, and, finally, shawn', $data->implodeNice(',', 'and, finally,'));
+    }
+
     public function testTake()
     {
         $data = new Collection(['taylor', 'dayle', 'shawn']);

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -902,21 +902,29 @@ class SupportCollectionTest extends TestCase
 
     public function testImplodeNice()
     {
+        // With key provided, returns imploded values at that key
         $data = new Collection([['name' => 'taylor', 'email' => 'foo'], ['name' => 'dayle', 'email' => 'bar'], ['name' => 'shawn', 'email' => 'baz']]);
         $this->assertEquals('foo, bar, and baz', $data->implodeNice('email'));
         $this->assertEquals('foo; bar; and baz', $data->implodeNice('email', ';'));
         $this->assertEquals('foo; bar; and, finally, baz', $data->implodeNice('email', ';','and, finally,'));
 
+        // Empty collection returns null
+        $data = new Collection([]);
+        $this->assertEquals(null, $data->implodeNice(''));
+
+        // Single item returns the only item as string
         $data = new Collection(['taylor']);
         $this->assertEquals('taylor', $data->implodeNice(''));
         $this->assertEquals('taylor', $data->implodeNice(','));
         $this->assertEquals('taylor', $data->implodeNice(',', 'and, finally,'));
 
+        // Two items are returned with no glue (only conjunction)
         $data = new Collection(['taylor', 'dayle']);
         $this->assertEquals('taylor and dayle', $data->implodeNice(''));
         $this->assertEquals('taylor and dayle', $data->implodeNice(','));
         $this->assertEquals('taylor and, finally, dayle', $data->implodeNice(',', 'and, finally,'));
 
+        // Three or more items are imploded with glue and conjunction 
         $data = new Collection(['taylor', 'dayle', 'shawn']);
         $this->assertEquals('taylor dayle and shawn', $data->implodeNice(''));
         $this->assertEquals('taylor, dayle, and shawn', $data->implodeNice(','));

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -906,7 +906,7 @@ class SupportCollectionTest extends TestCase
         $data = new Collection([['name' => 'taylor', 'email' => 'foo'], ['name' => 'dayle', 'email' => 'bar'], ['name' => 'shawn', 'email' => 'baz']]);
         $this->assertEquals('foo, bar, and baz', $data->implodeNice('email'));
         $this->assertEquals('foo; bar; and baz', $data->implodeNice('email', ';'));
-        $this->assertEquals('foo; bar; and, finally, baz', $data->implodeNice('email', ';','and, finally,'));
+        $this->assertEquals('foo; bar; and, finally, baz', $data->implodeNice('email', ';', 'and, finally,'));
 
         // Empty collection returns null
         $data = new Collection([]);
@@ -924,7 +924,7 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals('taylor and dayle', $data->implodeNice(','));
         $this->assertEquals('taylor and, finally, dayle', $data->implodeNice(',', 'and, finally,'));
 
-        // Three or more items are imploded with glue and conjunction 
+        // Three or more items are imploded with glue and conjunction
         $data = new Collection(['taylor', 'dayle', 'shawn']);
         $this->assertEquals('taylor dayle and shawn', $data->implodeNice(''));
         $this->assertEquals('taylor, dayle, and shawn', $data->implodeNice(','));


### PR DESCRIPTION
Sometimes, you want a Collection to implode into a nicely-constructed string, such as a list of items on a  webpage.

This new method builds upon the existing `implode` method, and will return a string of the items like so: 

```
$data = new Collection(['dogs','cats','sheep']);
$data->implodeNice(','); // dogs, cats, and sheep
```

You can also implode only certain values in the Collection, specified by a key (identical to the current `implode` method functionality):

```
$data = new Collection([
    ['name' => 'taylor', 'email' => 'foo'],
    ['name' => 'dayle', 'email' => 'bar'],
    ['name' => 'shawn', 'email' => 'baz'],
]);
$data->implodeNice('name'); // taylor, dayle, and shawn
```

Hopefully this will be useful. Let me know if anyone has questions or feedback. I've also adapted this as an array helper, but will wait to see if this one works out before submitting a PR for that helper.

Thanks for all of the amazing work done for the Laravel community!

Jake