### PR TITLE
do not reuse variable name in foreach loop

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -1128,8 +1128,8 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
             'view'                 => [\Illuminate\View\Factory::class, \Illuminate\Contracts\View\Factory::class],
         ];
 
-        foreach ($aliases as $key => $aliases) {
-            foreach ($aliases as $alias) {
+        foreach ($aliases as $key => $classes) {
+            foreach ($classes as $alias) {
                 $this->alias($key, $alias);
             }
         }


### PR DESCRIPTION
due the scoping of PHP foreach loops, this works fine. however it can be a little confusing from a readability standpoint.

I just rename the value of the first loop so there is no question which variable we are referring to.

also, if we were to ever use the `$aliases` variable after this loop, it would not contain what we expected.