### PR TITLE
[5.4] Don't re-escape a View instance passed as the default value to yield or section blade directives

### DIFF
--- a/src/Illuminate/View/Concerns/ManagesLayouts.php
+++ b/src/Illuminate/View/Concerns/ManagesLayouts.php
@@ -2,8 +2,8 @@
 
 namespace Illuminate\View\Concerns;
 
-use Illuminate\Contracts\View\View;
 use InvalidArgumentException;
+use Illuminate\Contracts\View\View;
 
 trait ManagesLayouts
 {

--- a/src/Illuminate/View/Concerns/ManagesLayouts.php
+++ b/src/Illuminate/View/Concerns/ManagesLayouts.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\View\Concerns;
 
+use Illuminate\Contracts\View\View;
 use InvalidArgumentException;
 
 trait ManagesLayouts
@@ -143,7 +144,7 @@ trait ManagesLayouts
      */
     public function yieldContent($section, $default = '')
     {
-        $sectionContent = e($default);
+        $sectionContent = $default instanceof View ? $default : e($default);
 
         if (isset($this->sections[$section])) {
             $sectionContent = $this->sections[$section];

--- a/src/Illuminate/View/Concerns/ManagesLayouts.php
+++ b/src/Illuminate/View/Concerns/ManagesLayouts.php
@@ -42,7 +42,7 @@ trait ManagesLayouts
                 $this->sectionStack[] = $section;
             }
         } else {
-            $this->extendSection($section, e($content));
+            $this->extendSection($section, $content instanceof View ? $content : e($content));
         }
     }
 

--- a/tests/View/ViewFactoryTest.php
+++ b/tests/View/ViewFactoryTest.php
@@ -202,6 +202,26 @@ class ViewFactoryTest extends TestCase
         $this->assertTrue($factory->doneRendering());
     }
 
+    public function testYieldDefault()
+    {
+        $factory = $this->getFactory();
+        $this->assertEquals('hi', $factory->yieldContent('foo', 'hi'));
+    }
+
+    public function testYieldDefaultIsEscaped()
+    {
+        $factory = $this->getFactory();
+        $this->assertEquals('&lt;p&gt;hi&lt;/p&gt;', $factory->yieldContent('foo', '<p>hi</p>'));
+    }
+
+    public function testYieldDefaultViewIsNotEscapedTwice()
+    {
+        $factory = $this->getFactory();
+        $view = m::mock('Illuminate\View\View');
+        $view->shouldReceive('__toString')->once()->andReturn('<p>hi</p>&lt;p&gt;already escaped&lt;/p&gt;');
+        $this->assertEquals('<p>hi</p>&lt;p&gt;already escaped&lt;/p&gt;', $factory->yieldContent('foo', $view));
+    }
+
     public function testBasicSectionHandling()
     {
         $factory = $this->getFactory();

--- a/tests/View/ViewFactoryTest.php
+++ b/tests/View/ViewFactoryTest.php
@@ -231,6 +231,29 @@ class ViewFactoryTest extends TestCase
         $this->assertEquals('hi', $factory->yieldContent('foo'));
     }
 
+    public function testBasicSectionDefault()
+    {
+        $factory = $this->getFactory();
+        $factory->startSection('foo', 'hi');
+        $this->assertEquals('hi', $factory->yieldContent('foo'));
+    }
+
+    public function testBasicSectionDefaultIsEscaped()
+    {
+        $factory = $this->getFactory();
+        $factory->startSection('foo', '<p>hi</p>');
+        $this->assertEquals('&lt;p&gt;hi&lt;/p&gt;', $factory->yieldContent('foo'));
+    }
+
+    public function testBasicSectionDefaultViewIsNotEscapedTwice()
+    {
+        $factory = $this->getFactory();
+        $view = m::mock('Illuminate\View\View');
+        $view->shouldReceive('__toString')->once()->andReturn('<p>hi</p>&lt;p&gt;already escaped&lt;/p&gt;');
+        $factory->startSection('foo', $view);
+        $this->assertEquals('<p>hi</p>&lt;p&gt;already escaped&lt;/p&gt;', $factory->yieldContent('foo'));
+    }
+
     public function testSectionExtending()
     {
         $placeholder = \Illuminate\View\Factory::parentPlaceholder('foo');


### PR DESCRIPTION
Based on feedback in #19643, this changes the handling of the default parameter of `@yield` to detect that a `View` instance has been passed and will no longer try to re-escape it. For consistency, this pull also changes the handling of the default parameter of `@section` to behave the same way.