### PR TITLE
[5.4] Add Route::view('/', 'home') feature

### DIFF
--- a/src/Illuminate/Routing/RouteAction.php
+++ b/src/Illuminate/Routing/RouteAction.php
@@ -39,7 +39,11 @@ class RouteAction
             $action['uses'] = static::findCallable($action);
         }
 
-        if (is_string($action['uses']) && ! Str::contains($action['uses'], '@')) {
+        if (! is_string($action['uses']) || static::actionReferencesView($action['uses'])) {
+            return $action;
+        }
+
+        if (! static::actionReferencesControllerMethod($action['uses'])) {
             $action['uses'] = static::makeInvokable($action['uses']);
         }
 
@@ -70,6 +74,32 @@ class RouteAction
         return Arr::first($action, function ($value, $key) {
             return is_callable($value) && is_numeric($key);
         });
+    }
+
+    /**
+     * Determine whether an action references a view.
+     *
+     * @param  mixed  $action
+     * @return bool
+     */
+    public static function actionReferencesView($action)
+    {
+        if (! is_string($action)) {
+            return false;
+        }
+
+        return Str::startsWith($action, 'view:');
+    }
+
+    /**
+     * Determine whether an action references a controller method.
+     *
+     * @param  string  $action
+     * @return bool
+     */
+    protected static function actionReferencesControllerMethod($action)
+    {
+        return Str::contains($action, '@');
     }
 
     /**

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -123,6 +123,18 @@ class Router implements RegistrarContract, BindingRegistrar
     }
 
     /**
+     * Register a new view route with the router.
+     *
+     * @param  string  $uri
+     * @param  string  $view
+     * @return \Illuminate\Routing\Route
+     */
+    public function view($uri, $view)
+    {
+        return $this->get($uri, "view:$view");
+    }
+
+    /**
      * Register a new GET route with the router.
      *
      * @param  string  $uri
@@ -369,10 +381,14 @@ class Router implements RegistrarContract, BindingRegistrar
      */
     protected function createRoute($methods, $uri, $action)
     {
+        if (RouteAction::actionReferencesView($action)) {
+            $action = ['uses' => $action];
+        }
+
         // If the route is routing to a controller we will parse the route action into
         // an acceptable array format before registering it and creating this route
         // instance itself. We need to build the Closure that will call this out.
-        if ($this->actionReferencesController($action)) {
+        elseif ($this->actionReferencesController($action)) {
             $action = $this->convertToControllerAction($action);
         }
 


### PR DESCRIPTION
This makes it possible to replace this code:

```php
Route::get('/', function() {
    return view('home');
});
```

With this:

```php
Route::view('/', 'home');
```

Which is both more pleasant on the eyes and the latter can be cached while the former can't which therefor blocks all your routes from being cached.

Beside that, it makes a few things available in the view. The current `Request` object is available in the view under the `$request` variable. And all route parameters are also available in the view, like so:

```php
Route::view('/{foo}', 'home'); // now $foo is available in the view
```