### PR TITLE
[5.4] Fix bad method name in FilesystemServiceProvider

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemServiceProvider.php
+++ b/src/Illuminate/Filesystem/FilesystemServiceProvider.php
@@ -15,7 +15,7 @@ class FilesystemServiceProvider extends ServiceProvider
     {
         $this->registerNativeFilesystem();
 
-        $this->registerFlysystem();
+        $this->registerFilesystem();
     }
 
     /**
@@ -35,7 +35,7 @@ class FilesystemServiceProvider extends ServiceProvider
      *
      * @return void
      */
-    protected function registerFlysystem()
+    protected function registerFilesystem()
     {
         $this->registerManager();
 


### PR DESCRIPTION
This PR fixes a bad method name (typo) in FilesystemServiceProvider class.