### PR TITLE
[5.4] Use UrlGenerator interface instead of concrete implementation

### DIFF
--- a/src/Illuminate/Routing/Redirector.php
+++ b/src/Illuminate/Routing/Redirector.php
@@ -4,6 +4,7 @@ namespace Illuminate\Routing;
 
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Session\Store as SessionStore;
+use Illuminate\Contracts\Routing\UrlGenerator;
 
 class Redirector
 {
@@ -24,7 +25,7 @@ class Redirector
     /**
      * Create a new Redirector instance.
      *
-     * @param  \Illuminate\Routing\UrlGenerator  $generator
+     * @param  \Illuminate\Contracts\Routing\UrlGenerator  $generator
      * @return void
      */
     public function __construct(UrlGenerator $generator)


### PR DESCRIPTION
This PR fixes an issue where the Redirector class is using the concrete UrlGenerator implementation instead of the interface/contract.