### PR TITLE
[5.5] Utilise null coalescing operator since we're bumping minimum to PHP 7

### DIFF
--- a/src/Illuminate/Auth/AuthManager.php
+++ b/src/Illuminate/Auth/AuthManager.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Auth;
 
 use Closure;
-use Illuminate\Support\Arr;
 use InvalidArgumentException;
 use Illuminate\Contracts\Auth\Factory as FactoryContract;
 

--- a/src/Illuminate/Auth/AuthManager.php
+++ b/src/Illuminate/Auth/AuthManager.php
@@ -121,7 +121,7 @@ class AuthManager implements FactoryContract
      */
     public function createSessionDriver($name, $config)
     {
-        $provider = $this->createUserProvider(Arr::get($config, 'provider'));
+        $provider = $this->createUserProvider($config['provider'] ?? null);
 
         $guard = new SessionGuard($name, $provider, $this->app['session.store']);
 
@@ -156,7 +156,7 @@ class AuthManager implements FactoryContract
         // that takes an API token field from the request and matches it to the
         // user in the database or another persistence layer where users are.
         $guard = new TokenGuard(
-            $this->createUserProvider(Arr::get($config, 'provider')),
+            $this->createUserProvider($config['provider'] ?? null),
             $this->app['request']
         );
 

--- a/src/Illuminate/Auth/CreatesUserProviders.php
+++ b/src/Illuminate/Auth/CreatesUserProviders.php
@@ -27,8 +27,9 @@ trait CreatesUserProviders
         $provider = $provider ?: $this->getDefaultUserProvider();
 
         $config = $this->app['config']['auth.providers.'.$provider];
+        $driver = $config['driver'] ?? null;
 
-        if (isset($this->customProviderCreators[$driver = Arr::get($config, 'driver')])) {
+        if (isset($this->customProviderCreators[$driver])) {
             return call_user_func(
                 $this->customProviderCreators[$driver], $this->app, $config
             );

--- a/src/Illuminate/Auth/CreatesUserProviders.php
+++ b/src/Illuminate/Auth/CreatesUserProviders.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Auth;
 
-use Illuminate\Support\Arr;
 use InvalidArgumentException;
 
 trait CreatesUserProviders

--- a/src/Illuminate/Auth/Passwords/PasswordBrokerManager.php
+++ b/src/Illuminate/Auth/Passwords/PasswordBrokerManager.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Auth\Passwords;
 
-use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
 use Illuminate\Contracts\Auth\PasswordBrokerFactory as FactoryContract;

--- a/src/Illuminate/Auth/Passwords/PasswordBrokerManager.php
+++ b/src/Illuminate/Auth/Passwords/PasswordBrokerManager.php
@@ -70,7 +70,7 @@ class PasswordBrokerManager implements FactoryContract
         // aggregate service of sorts providing a convenient interface for resets.
         return new PasswordBroker(
             $this->createTokenRepository($config),
-            $this->app['auth']->createUserProvider(Arr::get($config, 'provider'))
+            $this->app['auth']->createUserProvider($config['provider'] ?? null)
         );
     }
 

--- a/src/Illuminate/Auth/Passwords/PasswordBrokerManager.php
+++ b/src/Illuminate/Auth/Passwords/PasswordBrokerManager.php
@@ -88,7 +88,7 @@ class PasswordBrokerManager implements FactoryContract
             $key = base64_decode(substr($key, 7));
         }
 
-        $connection = isset($config['connection']) ? $config['connection'] : null;
+        $connection = $config['connection'] ?? null;
 
         return new DatabaseTokenRepository(
             $this->app['db']->connection($connection),

--- a/src/Illuminate/Broadcasting/BroadcastManager.php
+++ b/src/Illuminate/Broadcasting/BroadcastManager.php
@@ -211,7 +211,7 @@ class BroadcastManager implements FactoryContract
     {
         return new PusherBroadcaster(
             new Pusher($config['key'], $config['secret'],
-            $config['app_id'], Arr::get($config, 'options', []))
+            $config['app_id'], $config['options'] ?? [])
         );
     }
 
@@ -224,7 +224,7 @@ class BroadcastManager implements FactoryContract
     protected function createRedisDriver(array $config)
     {
         return new RedisBroadcaster(
-            $this->app->make('redis'), Arr::get($config, 'connection')
+            $this->app->make('redis'), $config['connection'] ?? null
         );
     }
 

--- a/src/Illuminate/Broadcasting/BroadcastManager.php
+++ b/src/Illuminate/Broadcasting/BroadcastManager.php
@@ -4,7 +4,6 @@ namespace Illuminate\Broadcasting;
 
 use Pusher;
 use Closure;
-use Illuminate\Support\Arr;
 use Psr\Log\LoggerInterface;
 use InvalidArgumentException;
 use Illuminate\Broadcasting\Broadcasters\LogBroadcaster;

--- a/src/Illuminate/Broadcasting/BroadcastManager.php
+++ b/src/Illuminate/Broadcasting/BroadcastManager.php
@@ -158,7 +158,7 @@ class BroadcastManager implements FactoryContract
      */
     protected function get($name)
     {
-        return isset($this->drivers[$name]) ? $this->drivers[$name] : $this->resolve($name);
+        return $this->drivers[$name] ?? $this->resolve($name);
     }
 
     /**

--- a/src/Illuminate/Bus/Dispatcher.php
+++ b/src/Illuminate/Bus/Dispatcher.php
@@ -145,7 +145,7 @@ class Dispatcher implements QueueingDispatcher
      */
     public function dispatchToQueue($command)
     {
-        $connection = isset($command->connection) ? $command->connection : null;
+        $connection = $command->connection ?? null;
 
         $queue = call_user_func($this->queueResolver, $connection);
 

--- a/src/Illuminate/Cache/CacheManager.php
+++ b/src/Illuminate/Cache/CacheManager.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Cache;
 
 use Closure;
-use Illuminate\Support\Arr;
 use InvalidArgumentException;
 use Illuminate\Contracts\Cache\Store;
 use Illuminate\Contracts\Cache\Factory as FactoryContract;

--- a/src/Illuminate/Cache/CacheManager.php
+++ b/src/Illuminate/Cache/CacheManager.php
@@ -164,9 +164,9 @@ class CacheManager implements FactoryContract
 
         $memcached = $this->app['memcached.connector']->connect(
             $config['servers'],
-            Arr::get($config, 'persistent_id'),
-            Arr::get($config, 'options', []),
-            array_filter(Arr::get($config, 'sasl', []))
+            $config['persistent_id'] ?? null,
+            $config['options'] ?? [],
+            array_filter($config['sasl'] ?? [])
         );
 
         return $this->repository(new MemcachedStore($memcached, $prefix));
@@ -192,7 +192,7 @@ class CacheManager implements FactoryContract
     {
         $redis = $this->app['redis'];
 
-        $connection = Arr::get($config, 'connection', 'default');
+        $connection = $config['connection'] ?? 'default';
 
         return $this->repository(new RedisStore($redis, $this->getPrefix($config), $connection));
     }
@@ -205,7 +205,7 @@ class CacheManager implements FactoryContract
      */
     protected function createDatabaseDriver(array $config)
     {
-        $connection = $this->app['db']->connection(Arr::get($config, 'connection'));
+        $connection = $this->app['db']->connection($config['connection'] ?? null);
 
         return $this->repository(
             new DatabaseStore(
@@ -241,7 +241,7 @@ class CacheManager implements FactoryContract
      */
     protected function getPrefix(array $config)
     {
-        return Arr::get($config, 'prefix') ?: $this->app['config']['cache.prefix'];
+        return $config['prefix'] ?? $this->app['config']['cache.prefix'];
     }
 
     /**

--- a/src/Illuminate/Cache/CacheManager.php
+++ b/src/Illuminate/Cache/CacheManager.php
@@ -75,7 +75,7 @@ class CacheManager implements FactoryContract
      */
     protected function get($name)
     {
-        return isset($this->stores[$name]) ? $this->stores[$name] : $this->resolve($name);
+        return $this->stores[$name] ?? $this->resolve($name);
     }
 
     /**

--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Cache;
 
 use Exception;
-use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
 use Illuminate\Contracts\Cache\Store;
 use Illuminate\Filesystem\Filesystem;

--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -47,7 +47,7 @@ class FileStore implements Store
      */
     public function get($key)
     {
-        return Arr::get($this->getPayload($key), 'data');
+        return $this->getPayload($key)['data'] ?? null;
     }
 
     /**

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -1197,7 +1197,6 @@ class Connection implements ConnectionInterface
      */
     public static function getResolver($driver)
     {
-        return isset(static::$resolvers[$driver]) ?
-                     static::$resolvers[$driver] : null;
+        return static::$resolvers[$driver] ?? null;
     }
 }

--- a/src/Illuminate/Database/Connectors/Connector.php
+++ b/src/Illuminate/Database/Connectors/Connector.php
@@ -4,7 +4,6 @@ namespace Illuminate\Database\Connectors;
 
 use PDO;
 use Exception;
-use Illuminate\Support\Arr;
 use Doctrine\DBAL\Driver\PDOConnection;
 use Illuminate\Database\DetectsLostConnections;
 

--- a/src/Illuminate/Database/Connectors/Connector.php
+++ b/src/Illuminate/Database/Connectors/Connector.php
@@ -36,7 +36,7 @@ class Connector
     public function createConnection($dsn, array $config, array $options)
     {
         list($username, $password) = [
-            Arr::get($config, 'username'), Arr::get($config, 'password'),
+            $config['username'] ?? null, $config['password'] ?? null,
         ];
 
         try {
@@ -109,7 +109,7 @@ class Connector
      */
     public function getOptions(array $config)
     {
-        $options = Arr::get($config, 'options', []);
+        $options = $config['options'] ?? [];
 
         return array_diff_key($this->options, $options) + $options;
     }

--- a/src/Illuminate/Database/Connectors/SqlServerConnector.php
+++ b/src/Illuminate/Database/Connectors/SqlServerConnector.php
@@ -61,7 +61,7 @@ class SqlServerConnector extends Connector implements ConnectorInterface
     protected function prefersOdbc(array $config)
     {
         return in_array('odbc', $this->getAvailableDrivers()) &&
-               Arr::get($config, 'odbc') === true;
+               ($config['odbc'] ?? null) === true;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Database\Eloquent\Concerns;
 
 use Closure;
-use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Query\Expression;

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -228,9 +228,7 @@ trait QueriesRelationships
      */
     public function mergeConstraintsFrom(Builder $from)
     {
-        $whereBindings = Arr::get(
-            $from->getQuery()->getRawBindings(), 'where', []
-        );
+        $whereBindings = $from->getQuery()->getRawBindings()['where'] ?? [];
 
         // Here we have some other query that we want to merge the where constraints from. We will
         // copy over any where constraints on the query as well as remove any global scopes the

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -193,7 +193,7 @@ trait QueriesRelationships
             // Finally we will add the proper result column alias to the query and run the subselect
             // statement against the query builder. Then we will return the builder instance back
             // to the developer for further constraint chaining that needs to take place on it.
-            $column = isset($alias) ? $alias : Str::snake($name.'_count');
+            $column = $alias ?? Str::snake($name.'_count');
 
             $this->selectSub($query->toBase(), $column);
         }

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -616,9 +616,8 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     protected function getKeyForSaveQuery()
     {
-        return isset($this->original[$this->getKeyName()])
-                        ? $this->original[$this->getKeyName()]
-                        : $this->getAttribute($this->getKeyName());
+        return $this->original[$this->getKeyName()]
+                        ?? $this->getAttribute($this->getKeyName());
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -555,7 +555,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 
         $this->syncOriginal();
 
-        if (Arr::get($options, 'touch', true)) {
+        if ($options['touch'] ?? true) {
             $this->touchOwners();
         }
     }

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Database\Eloquent\Relations;
 
-use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -743,7 +743,7 @@ class BelongsToMany extends Relation
     public function saveMany($models, array $pivotAttributes = [])
     {
         foreach ($models as $key => $model) {
-            $this->save($model, (array) Arr::get($pivotAttributes, $key), false);
+            $this->save($model, (array) ($pivotAttributes[$key] ?? []), false);
         }
 
         $this->touchIfTouching();
@@ -785,7 +785,7 @@ class BelongsToMany extends Relation
         $instances = [];
 
         foreach ($records as $key => $record) {
-            $instances[] = $this->create($record, (array) Arr::get($joinings, $key), false);
+            $instances[] = $this->create($record, (array) ($joinings[$key] ?? []), false);
         }
 
         $this->touchIfTouching();

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -135,9 +135,9 @@ class Migrator
         // each migration's execution. We will also extract a few of the options.
         $batch = $this->repository->getNextBatchNumber();
 
-        $pretend = Arr::get($options, 'pretend', false);
+        $pretend = $options['pretend'] ?? false;
 
-        $step = Arr::get($options, 'step', false);
+        $step = $options['step'] ?? false;
 
         // Once we have the array of migrations, we will spin through them and run the
         // migrations "up" so the changes are made to the databases. We'll then log
@@ -217,7 +217,7 @@ class Migrator
      */
     protected function getMigrationsForRollback(array $options)
     {
-        if (($steps = Arr::get($options, 'step', 0)) > 0) {
+        if (($steps = $options['step'] ?? 0) > 0) {
             return $this->repository->getMigrations($steps);
         } else {
             return $this->repository->getLast();
@@ -248,7 +248,7 @@ class Migrator
 
             $this->runDown(
                 $files[$migration->migration],
-                $migration, Arr::get($options, 'pretend', false)
+                $migration, $options['pretend'] ?? false
             );
         }
 

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Database\Migrations;
 
-use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Support\Collection;
 use Illuminate\Filesystem\Filesystem;

--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -279,7 +279,7 @@ class Dispatcher implements DispatcherContract
      */
     public function getListeners($eventName)
     {
-        $listeners = isset($this->listeners[$eventName]) ? $this->listeners[$eventName] : [];
+        $listeners = $this->listeners[$eventName] ?? [];
 
         $listeners = array_merge(
             $listeners, $this->getWildcardListeners($eventName)
@@ -445,10 +445,10 @@ class Dispatcher implements DispatcherContract
         list($listener, $job) = $this->createListenerAndJob($class, $method, $arguments);
 
         $connection = $this->resolveQueue()->connection(
-            isset($listener->connection) ? $listener->connection : null
+            $listener->connection ?? null
         );
 
-        $queue = isset($listener->queue) ? $listener->queue : null;
+        $queue = $listener->queue ?? null;
 
         isset($listener->delay)
                     ? $connection->laterOn($queue, $listener->delay, $job)
@@ -482,8 +482,8 @@ class Dispatcher implements DispatcherContract
     protected function propagateListenerOptions($listener, $job)
     {
         return tap($job, function ($job) use ($listener) {
-            $job->tries = isset($listener->tries) ? $listener->tries : null;
-            $job->timeout = isset($listener->timeout) ? $listener->timeout : null;
+            $job->tries = $listener->tries ?? null;
+            $job->timeout = $listener->timeout ?? null;
         });
     }
 

--- a/src/Illuminate/Filesystem/FilesystemManager.php
+++ b/src/Illuminate/Filesystem/FilesystemManager.php
@@ -147,9 +147,9 @@ class FilesystemManager implements FactoryContract
      */
     public function createLocalDriver(array $config)
     {
-        $permissions = isset($config['permissions']) ? $config['permissions'] : [];
+        $permissions = $config['permissions'] ?? [];
 
-        $links = Arr::get($config, 'links') === 'skip'
+        $links = ($config['links'] ?? null) === 'skip'
             ? LocalAdapter::SKIP_LINKS
             : LocalAdapter::DISALLOW_LINKS;
 
@@ -239,7 +239,7 @@ class FilesystemManager implements FactoryContract
      */
     protected function getRackspaceContainer(Rackspace $client, array $config)
     {
-        $urlType = Arr::get($config, 'url_type');
+        $urlType = $config['url_type'] ?? null;
 
         $store = $client->objectStoreService('cloudFiles', $config['region'], $urlType);
 

--- a/src/Illuminate/Filesystem/FilesystemManager.php
+++ b/src/Illuminate/Filesystem/FilesystemManager.php
@@ -94,7 +94,7 @@ class FilesystemManager implements FactoryContract
      */
     protected function get($name)
     {
-        return isset($this->disks[$name]) ? $this->disks[$name] : $this->resolve($name);
+        return $this->disks[$name] ?? $this->resolve($name);
     }
 
     /**
@@ -185,9 +185,9 @@ class FilesystemManager implements FactoryContract
     {
         $s3Config = $this->formatS3Config($config);
 
-        $root = isset($s3Config['root']) ? $s3Config['root'] : null;
+        $root = $s3Config['root'] ?? null;
 
-        $options = isset($config['options']) ? $config['options'] : [];
+        $options = $config['options'] ?? [];
 
         return $this->adapt($this->createFlysystem(
             new S3Adapter(new S3Client($s3Config), $s3Config['bucket'], $root, $options), $config
@@ -223,7 +223,7 @@ class FilesystemManager implements FactoryContract
             'username' => $config['username'], 'apiKey' => $config['key'],
         ]);
 
-        $root = isset($config['root']) ? $config['root'] : null;
+        $root = $config['root'] ?? null;
 
         return $this->adapt($this->createFlysystem(
             new RackspaceAdapter($this->getRackspaceContainer($client, $config), $root), $config

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -518,7 +518,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
      */
     public function detectEnvironment(Closure $callback)
     {
-        $args = isset($_SERVER['argv']) ? $_SERVER['argv'] : null;
+        $args = $_SERVER['argv'] ?? null;
 
         return $this['env'] = (new EnvironmentDetector)->detect($callback, $args);
     }

--- a/src/Illuminate/Foundation/Auth/Access/AuthorizesRequests.php
+++ b/src/Illuminate/Foundation/Auth/Access/AuthorizesRequests.php
@@ -67,7 +67,7 @@ trait AuthorizesRequests
     {
         $map = $this->resourceAbilityMap();
 
-        return isset($map[$ability]) ? $map[$ability] : $ability;
+        return $map[$ability] ?? $ability;
     }
 
     /**

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -228,7 +228,7 @@ if (! function_exists('cache')) {
         }
 
         if (is_string($arguments[0])) {
-            return app('cache')->get($arguments[0], isset($arguments[1]) ? $arguments[1] : null);
+            return app('cache')->get($arguments[0], $arguments[1] ?? null);
         }
 
         if (! is_array($arguments[0])) {
@@ -476,7 +476,7 @@ if (! function_exists('factory')) {
         $arguments = func_get_args();
 
         if (isset($arguments[1]) && is_string($arguments[1])) {
-            return $factory->of($arguments[0], $arguments[1])->times(isset($arguments[2]) ? $arguments[2] : null);
+            return $factory->of($arguments[0], $arguments[1])->times($arguments[2] ?? null);
         } elseif (isset($arguments[1])) {
             return $factory->of($arguments[0])->times($arguments[1]);
         } else {

--- a/src/Illuminate/Hashing/BcryptHasher.php
+++ b/src/Illuminate/Hashing/BcryptHasher.php
@@ -88,6 +88,6 @@ class BcryptHasher implements HasherContract
      */
     protected function cost(array $options = [])
     {
-        return isset($options['rounds']) ? $options['rounds'] : $this->rounds;
+        return $options['rounds'] ?? $this->rounds;
     }
 }

--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -242,9 +242,8 @@ class Mailable implements MailableContract, Renderable
      */
     protected function buildMarkdownText($markdown, $data)
     {
-        return isset($this->textView)
-                ? $this->textView
-                : $markdown->renderText($this->markdown, $data);
+        return $this->textView
+                ?? $markdown->renderText($this->markdown, $data);
     }
 
     /**
@@ -473,7 +472,7 @@ class Mailable implements MailableContract, Renderable
             $recipient = $this->normalizeRecipient($recipient);
 
             $this->{$property}[] = [
-                'name' => isset($recipient->name) ? $recipient->name : null,
+                'name' => $recipient->name ?? null,
                 'address' => $recipient->email,
             ];
         }
@@ -529,7 +528,7 @@ class Mailable implements MailableContract, Renderable
         );
 
         $expected = [
-            'name' => isset($expected->name) ? $expected->name : null,
+            'name' => $expected->name ?? null,
             'address' => $expected->email,
         ];
 

--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Mail;
 
 use Swift_Mailer;
-use Illuminate\Support\Arr;
 use InvalidArgumentException;
 use Illuminate\Contracts\View\Factory;
 use Illuminate\Support\Traits\Macroable;

--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -277,9 +277,9 @@ class Mailer implements MailerContract, MailQueueContract
         // named keys instead, allowing the developers to use one or the other.
         if (is_array($view)) {
             return [
-                Arr::get($view, 'html'),
-                Arr::get($view, 'text'),
-                Arr::get($view, 'raw'),
+                $view['html'] ?? null,
+                $view['text'] ?? null,
+                $view['raw'] ?? null,
             ];
         }
 

--- a/src/Illuminate/Mail/Markdown.php
+++ b/src/Illuminate/Mail/Markdown.php
@@ -41,8 +41,8 @@ class Markdown
     public function __construct(ViewFactory $view, array $options = [])
     {
         $this->view = $view;
-        $this->theme = Arr::get($options, 'theme', 'default');
-        $this->loadComponentsFrom(Arr::get($options, 'paths', []));
+        $this->theme = $options['theme'] ?? 'default';
+        $this->loadComponentsFrom($options['paths'] ?? []);
     }
 
     /**

--- a/src/Illuminate/Mail/Markdown.php
+++ b/src/Illuminate/Mail/Markdown.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Mail;
 
 use Parsedown;
-use Illuminate\Support\Arr;
 use Illuminate\Support\HtmlString;
 use Illuminate\Contracts\View\Factory as ViewFactory;
 use TijsVerkoyen\CssToInlineStyles\CssToInlineStyles;

--- a/src/Illuminate/Mail/TransportManager.php
+++ b/src/Illuminate/Mail/TransportManager.php
@@ -146,7 +146,7 @@ class TransportManager extends Manager
         $config = $this->app['config']->get('services.sparkpost', []);
 
         return new SparkPostTransport(
-            $this->guzzle($config), $config['secret'], Arr::get($config, 'options', [])
+            $this->guzzle($config), $config['secret'], $config['options'] ?? []
         );
     }
 
@@ -179,7 +179,7 @@ class TransportManager extends Manager
     protected function guzzle($config)
     {
         return new HttpClient(Arr::add(
-            Arr::get($config, 'guzzle', []), 'connect_timeout', 60
+            $config['guzzle'] ?? [], 'connect_timeout', 60
         ));
     }
 

--- a/src/Illuminate/Queue/Connectors/BeanstalkdConnector.php
+++ b/src/Illuminate/Queue/Connectors/BeanstalkdConnector.php
@@ -18,7 +18,7 @@ class BeanstalkdConnector implements ConnectorInterface
      */
     public function connect(array $config)
     {
-        $retryAfter = Arr::get($config, 'retry_after', Pheanstalk::DEFAULT_TTR);
+        $retryAfter = $config['retry_after'] ?? Pheanstalk::DEFAULT_TTR;
 
         return new BeanstalkdQueue($this->pheanstalk($config), $config['queue'], $retryAfter);
     }
@@ -33,9 +33,9 @@ class BeanstalkdConnector implements ConnectorInterface
     {
         return new Pheanstalk(
             $config['host'],
-            Arr::get($config, 'port', PheanstalkInterface::DEFAULT_PORT),
-            Arr::get($config, 'timeout', Connection::DEFAULT_CONNECT_TIMEOUT),
-            Arr::get($config, 'persistent', false)
+            $config['port'] ?? PheanstalkInterface::DEFAULT_PORT,
+            $config['timeout'] ?? Connection::DEFAULT_CONNECT_TIMEOUT,
+            $config['persistent'] ?? false
         );
     }
 }

--- a/src/Illuminate/Queue/Connectors/BeanstalkdConnector.php
+++ b/src/Illuminate/Queue/Connectors/BeanstalkdConnector.php
@@ -4,7 +4,6 @@ namespace Illuminate\Queue\Connectors;
 
 use Pheanstalk\Connection;
 use Pheanstalk\Pheanstalk;
-use Illuminate\Support\Arr;
 use Pheanstalk\PheanstalkInterface;
 use Illuminate\Queue\BeanstalkdQueue;
 

--- a/src/Illuminate/Queue/Connectors/DatabaseConnector.php
+++ b/src/Illuminate/Queue/Connectors/DatabaseConnector.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Queue\Connectors;
 
-use Illuminate\Support\Arr;
 use Illuminate\Queue\DatabaseQueue;
 use Illuminate\Database\ConnectionResolverInterface;
 

--- a/src/Illuminate/Queue/Connectors/DatabaseConnector.php
+++ b/src/Illuminate/Queue/Connectors/DatabaseConnector.php
@@ -35,10 +35,10 @@ class DatabaseConnector implements ConnectorInterface
     public function connect(array $config)
     {
         return new DatabaseQueue(
-            $this->connections->connection(Arr::get($config, 'connection')),
+            $this->connections->connection($config['connection'] ?? null),
             $config['table'],
             $config['queue'],
-            Arr::get($config, 'retry_after', 60)
+            $config['retry_after'] ?? 60
         );
     }
 }

--- a/src/Illuminate/Queue/Connectors/RedisConnector.php
+++ b/src/Illuminate/Queue/Connectors/RedisConnector.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Queue\Connectors;
 
-use Illuminate\Support\Arr;
 use Illuminate\Queue\RedisQueue;
 use Illuminate\Contracts\Redis\Factory as Redis;
 

--- a/src/Illuminate/Queue/Connectors/RedisConnector.php
+++ b/src/Illuminate/Queue/Connectors/RedisConnector.php
@@ -45,8 +45,8 @@ class RedisConnector implements ConnectorInterface
     {
         return new RedisQueue(
             $this->redis, $config['queue'],
-            Arr::get($config, 'connection', $this->connection),
-            Arr::get($config, 'retry_after', 60)
+            $config['connection'] ?? $this->connection,
+            $config['retry_after'] ?? 60
         );
     }
 }

--- a/src/Illuminate/Queue/Connectors/SqsConnector.php
+++ b/src/Illuminate/Queue/Connectors/SqsConnector.php
@@ -23,7 +23,7 @@ class SqsConnector implements ConnectorInterface
         }
 
         return new SqsQueue(
-            new SqsClient($config), $config['queue'], Arr::get($config, 'prefix', '')
+            new SqsClient($config), $config['queue'], $config['prefix'] ?? ''
         );
     }
 

--- a/src/Illuminate/Queue/Console/ListFailedCommand.php
+++ b/src/Illuminate/Queue/Console/ListFailedCommand.php
@@ -82,7 +82,7 @@ class ListFailedCommand extends Command
         $payload = json_decode($payload, true);
 
         if ($payload && (! isset($payload['data']['command']))) {
-            return Arr::get($payload, 'job');
+            return $payload['job'] ?? null;
         } elseif ($payload && isset($payload['data']['command'])) {
             return $this->matchJobName($payload);
         }
@@ -101,7 +101,7 @@ class ListFailedCommand extends Command
         if (isset($matches[1])) {
             return $matches[1];
         } else {
-            return Arr::get($payload, 'job');
+            return $payload['job'] ?? null;
         }
     }
 

--- a/src/Illuminate/Queue/Jobs/Job.php
+++ b/src/Illuminate/Queue/Jobs/Job.php
@@ -195,7 +195,7 @@ abstract class Job
      */
     public function maxTries()
     {
-        return Arr::get($this->payload(), 'maxTries');
+        return $this->payload()['maxTries'] ?? null;
     }
 
     /**
@@ -205,7 +205,7 @@ abstract class Job
      */
     public function timeout()
     {
-        return Arr::get($this->payload(), 'timeout');
+        return $this->payload()['timeout'] ?? null;
     }
 
     /**

--- a/src/Illuminate/Queue/Jobs/Job.php
+++ b/src/Illuminate/Queue/Jobs/Job.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Queue\Jobs;
 
-use Illuminate\Support\Arr;
 use Illuminate\Queue\InteractsWithTime;
 
 abstract class Job

--- a/src/Illuminate/Queue/Jobs/RedisJob.php
+++ b/src/Illuminate/Queue/Jobs/RedisJob.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Queue\Jobs;
 
-use Illuminate\Support\Arr;
 use Illuminate\Queue\RedisQueue;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Queue\Job as JobContract;

--- a/src/Illuminate/Queue/Jobs/RedisJob.php
+++ b/src/Illuminate/Queue/Jobs/RedisJob.php
@@ -105,7 +105,7 @@ class RedisJob extends Job implements JobContract
      */
     public function attempts()
     {
-        return Arr::get($this->decoded, 'attempts') + 1;
+        return ($this->decoded['attempts'] ?? null) + 1;
     }
 
     /**
@@ -115,7 +115,7 @@ class RedisJob extends Job implements JobContract
      */
     public function getJobId()
     {
-        return Arr::get($this->decoded, 'id');
+        return $this->decoded['id'] ?? null;
     }
 
     /**

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -116,8 +116,8 @@ abstract class Queue
         return [
             'displayName' => $this->getDisplayName($job),
             'job' => 'Illuminate\Queue\CallQueuedHandler@call',
-            'maxTries' => isset($job->tries) ? $job->tries : null,
-            'timeout' => isset($job->timeout) ? $job->timeout : null,
+            'maxTries' => $job->tries ?? null,
+            'timeout' => $job->timeout ?? null,
             'data' => [
                 'commandName' => get_class($job),
                 'command' => serialize(clone $job),

--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -95,7 +95,7 @@ class RedisQueue extends Queue implements QueueContract
     {
         $this->getConnection()->rpush($this->getQueue($queue), $payload);
 
-        return Arr::get(json_decode($payload, true), 'id');
+        return json_decode($payload, true)['id'] ?? null;
     }
 
     /**
@@ -126,7 +126,7 @@ class RedisQueue extends Queue implements QueueContract
             $this->getQueue($queue).':delayed', $this->availableAt($delay), $payload
         );
 
-        return Arr::get(json_decode($payload, true), 'id');
+        return json_decode($payload, true)['id'] ?? null;
     }
 
     /**

--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Queue;
 
-use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Queue\Jobs\RedisJob;
 use Illuminate\Contracts\Redis\Factory as Redis;

--- a/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
+++ b/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
@@ -92,7 +92,7 @@ class PhpRedisConnector
      */
     protected function establishConnection($client, array $config)
     {
-        $client->{Arr::get($config, 'persistent', false) === true ? 'pconnect' : 'connect'}(
+        $client->{($config['persistent'] ?? false) === true ? 'pconnect' : 'connect'}(
             $config['host'], $config['port'], Arr::get($config, 'timeout', 0)
         );
     }
@@ -109,8 +109,8 @@ class PhpRedisConnector
         return new RedisCluster(
             null,
             array_values($servers),
-            Arr::get($options, 'timeout', 0),
-            Arr::get($options, 'read_timeout', 0),
+            $options['timeout'] ?? 0,
+            $options['read_timeout'] ?? 0,
             isset($options['persistent']) && $options['persistent']
         );
     }

--- a/src/Illuminate/Redis/RedisManager.php
+++ b/src/Illuminate/Redis/RedisManager.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Redis;
 
-use Illuminate\Support\Arr;
 use InvalidArgumentException;
 use Illuminate\Contracts\Redis\Factory;
 

--- a/src/Illuminate/Redis/RedisManager.php
+++ b/src/Illuminate/Redis/RedisManager.php
@@ -70,7 +70,7 @@ class RedisManager implements Factory
     {
         $name = $name ?: 'default';
 
-        $options = Arr::get($this->config, 'options', []);
+        $options = $this->config['options'] ?? [];
 
         if (isset($this->config[$name])) {
             return $this->connector()->connect($this->config[$name], $options);
@@ -93,10 +93,10 @@ class RedisManager implements Factory
      */
     protected function resolveCluster($name)
     {
-        $clusterOptions = Arr::get($this->config, 'clusters.options', []);
+        $clusterOptions = $this->config['clusters']['options'] ?? [];
 
         return $this->connector()->connectToCluster(
-            $this->config['clusters'][$name], $clusterOptions, Arr::get($this->config, 'options', [])
+            $this->config['clusters'][$name], $clusterOptions, $this->config['options'] ?? []
         );
     }
 

--- a/src/Illuminate/Routing/MiddlewareNameResolver.php
+++ b/src/Illuminate/Routing/MiddlewareNameResolver.php
@@ -38,7 +38,7 @@ class MiddlewareNameResolver
         } else {
             list($name, $parameters) = array_pad(explode(':', $name, 2), 2, null);
 
-            return (isset($map[$name]) ? $map[$name] : $name).
+            return ($map[$name] ?? $name).
                    (! is_null($parameters) ? ':'.$parameters : '');
         }
     }

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -557,7 +557,7 @@ class Route
      */
     public function getPrefix()
     {
-        return isset($this->action['prefix']) ? $this->action['prefix'] : null;
+        return $this->action['prefix'] ?? null;
     }
 
     /**
@@ -605,7 +605,7 @@ class Route
      */
     public function getName()
     {
-        return isset($this->action['as']) ? $this->action['as'] : null;
+        return $this->action['as'] ?? null;
     }
 
     /**
@@ -682,7 +682,7 @@ class Route
      */
     public function getActionName()
     {
-        return isset($this->action['controller']) ? $this->action['controller'] : 'Closure';
+        return $this->action['controller'] ?? 'Closure';
     }
 
     /**

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -745,7 +745,7 @@ class Route
     public function middleware($middleware = null)
     {
         if (is_null($middleware)) {
-            return (array) Arr::get($this->action, 'middleware', []);
+            return (array) ($this->action['middleware'] ?? []);
         }
 
         if (is_string($middleware)) {
@@ -753,7 +753,7 @@ class Route
         }
 
         $this->action['middleware'] = array_merge(
-            (array) Arr::get($this->action, 'middleware', []), $middleware
+            (array) ($this->action['middleware'] ?? []), $middleware
         );
 
         return $this;

--- a/src/Illuminate/Routing/RouteCollection.php
+++ b/src/Illuminate/Routing/RouteCollection.php
@@ -281,7 +281,7 @@ class RouteCollection implements Countable, IteratorAggregate
      */
     public function getByName($name)
     {
-        return isset($this->nameList[$name]) ? $this->nameList[$name] : null;
+        return $this->nameList[$name] ?? null;
     }
 
     /**
@@ -292,7 +292,7 @@ class RouteCollection implements Countable, IteratorAggregate
      */
     public function getByAction($action)
     {
-        return isset($this->actionList[$action]) ? $this->actionList[$action] : null;
+        return $this->actionList[$action] ?? null;
     }
 
     /**

--- a/src/Illuminate/Routing/RouteGroup.php
+++ b/src/Illuminate/Routing/RouteGroup.php
@@ -57,7 +57,7 @@ class RouteGroup
      */
     protected static function formatPrefix($new, $old)
     {
-        $old = Arr::get($old, 'prefix');
+        $old = $old['prefix'] ?? null;
 
         return isset($new['prefix']) ? trim($old, '/').'/'.trim($new['prefix'], '/') : $old;
     }
@@ -87,7 +87,7 @@ class RouteGroup
     protected static function formatAs($new, $old)
     {
         if (isset($old['as'])) {
-            $new['as'] = $old['as'].Arr::get($new, 'as', '');
+            $new['as'] = $old['as'].($new['as'] ?? '');
         }
 
         return $new;

--- a/src/Illuminate/Routing/RouteGroup.php
+++ b/src/Illuminate/Routing/RouteGroup.php
@@ -45,7 +45,7 @@ class RouteGroup
                     : trim($new['namespace'], '\\');
         }
 
-        return isset($old['namespace']) ? $old['namespace'] : null;
+        return $old['namespace'] ?? null;
     }
 
     /**
@@ -72,8 +72,8 @@ class RouteGroup
     protected static function formatWhere($new, $old)
     {
         return array_merge(
-            isset($old['where']) ? $old['where'] : [],
-            isset($new['where']) ? $new['where'] : []
+            $old['where'] ?? [],
+            $new['where'] ?? []
         );
     }
 

--- a/src/Illuminate/Routing/RouteParameterBinder.php
+++ b/src/Illuminate/Routing/RouteParameterBinder.php
@@ -106,7 +106,7 @@ class RouteParameterBinder
     protected function replaceDefaults(array $parameters)
     {
         foreach ($parameters as $key => $value) {
-            $parameters[$key] = isset($value) ? $value : Arr::get($this->route->defaults, $key);
+            $parameters[$key] = $value ?? Arr::get($this->route->defaults, $key);
         }
 
         foreach ($this->route->defaults as $key => $value) {

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -378,7 +378,7 @@ class Router implements RegistrarContract, BindingRegistrar
         if (! empty($this->groupStack)) {
             $last = end($this->groupStack);
 
-            return isset($last['prefix']) ? $last['prefix'] : '';
+            return $last['prefix'] ?? '';
         }
 
         return '';
@@ -521,7 +521,7 @@ class Router implements RegistrarContract, BindingRegistrar
     protected function addWhereClausesToRoute($route)
     {
         $route->where(array_merge(
-            $this->patterns, isset($route->getAction()['where']) ? $route->getAction()['where'] : []
+            $this->patterns, $route->getAction()['where'] ?? []
         ));
 
         return $route;
@@ -1027,7 +1027,7 @@ class Router implements RegistrarContract, BindingRegistrar
 
         $action = $this->current()->getAction();
 
-        return isset($action['controller']) ? $action['controller'] : null;
+        return $action['controller'] ?? null;
     }
 
     /**

--- a/src/Illuminate/Session/Middleware/StartSession.php
+++ b/src/Illuminate/Session/Middleware/StartSession.php
@@ -176,8 +176,8 @@ class StartSession
         if ($this->sessionIsPersistent($config = $this->manager->getSessionConfig())) {
             $response->headers->setCookie(new Cookie(
                 $session->getName(), $session->getId(), $this->getCookieExpirationDate(),
-                $config['path'], $config['domain'], Arr::get($config, 'secure', false),
-                Arr::get($config, 'http_only', true), false, $config['same_site'] ?? null
+                $config['path'], $config['domain'], $config['secure'] ?? false,
+                $config['http_only'] ?? true, false, $config['same_site'] ?? null
             ));
         }
     }
@@ -189,7 +189,7 @@ class StartSession
      */
     protected function getSessionLifetimeInSeconds()
     {
-        return Arr::get($this->manager->getSessionConfig(), 'lifetime') * 60;
+        return ($this->manager->getSessionConfig()['lifetime'] ?? null) * 60;
     }
 
     /**
@@ -211,7 +211,7 @@ class StartSession
      */
     protected function sessionConfigured()
     {
-        return ! is_null(Arr::get($this->manager->getSessionConfig(), 'driver'));
+        return ! is_null($this->manager->getSessionConfig()['driver'] ?? null);
     }
 
     /**

--- a/src/Illuminate/Session/Middleware/StartSession.php
+++ b/src/Illuminate/Session/Middleware/StartSession.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Session\Middleware;
 
 use Closure;
-use Illuminate\Support\Arr;
 use Illuminate\Http\Request;
 use Illuminate\Support\Carbon;
 use Illuminate\Session\SessionManager;

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -154,8 +154,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
         // only one level deep so we do not need to do any fancy searching through it.
         $this->load('*', '*', $locale);
 
-        $line = isset($this->loaded['*']['*'][$locale][$key])
-                    ? $this->loaded['*']['*'][$locale][$key] : null;
+        $line = $this->loaded['*']['*'][$locale][$key] ?? null;
 
         // If we can't find a translation for the JSON key, we will attempt to translate it
         // using the typical translation file. This way developers can always just use a

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -630,7 +630,7 @@ trait ValidatesAttributes
      */
     protected function getUniqueIds($parameters)
     {
-        $idColumn = isset($parameters[3]) ? $parameters[3] : 'id';
+        $idColumn = $parameters[3] ?? 'id';
 
         return [$idColumn, $this->prepareUniqueId($parameters[2])];
     }

--- a/src/Illuminate/View/Concerns/ManagesLayouts.php
+++ b/src/Illuminate/View/Concerns/ManagesLayouts.php
@@ -191,7 +191,7 @@ trait ManagesLayouts
      */
     public function getSection($name, $default = null)
     {
-        return isset($this->getSections()[$name]) ? $this->getSections()[$name] : $default;
+        return $this->getSections()[$name] ?? $default;
     }
 
     /**

--- a/src/Illuminate/View/Concerns/ManagesLoops.php
+++ b/src/Illuminate/View/Concerns/ManagesLoops.php
@@ -29,7 +29,7 @@ trait ManagesLoops
         $this->loopsStack[] = [
             'iteration' => 0,
             'index' => 0,
-            'remaining' => isset($length) ? $length : null,
+            'remaining' => $length ?? null,
             'count' => $length,
             'first' => true,
             'last' => isset($length) ? $length == 1 : null,


### PR DESCRIPTION
* Only convert `Arr::get()` with known key, any key that may include unknown `.` should be kept to use `Arr::get()`.
* Convert `isset($x) ? $x : $y` to `$x ?? $y`.