### PR TITLE
[5.5] Use intdiv.

### DIFF
--- a/src/Illuminate/Pagination/LengthAwarePaginator.php
+++ b/src/Illuminate/Pagination/LengthAwarePaginator.php
@@ -46,7 +46,7 @@ class LengthAwarePaginator extends AbstractPaginator implements Arrayable, Array
 
         $this->total = $total;
         $this->perPage = $perPage;
-        $this->lastPage = (int) ceil($total / $perPage);
+        $this->lastPage = intdiv($total, $perPage) + 1;
         $this->path = $this->path != '/' ? rtrim($this->path, '/') : $this->path;
         $this->currentPage = $this->setCurrentPage($currentPage, $this->pageName);
         $this->items = $items instanceof Collection ? $items : Collection::make($items);

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -130,7 +130,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
         $values = (isset($key) ? $this->pluck($key) : $this)
                     ->sort()->values();
 
-        $middle = (int) ($count / 2);
+        $middle = intdiv($count, 2);
 
         if ($count % 2) {
             return $values->get($middle);


### PR DESCRIPTION
We can directly use `intdiv` instead of casting to `int`