### PR TITLE
[5.4] Add `canAny` and `canEvery` Authorization Checks

### DIFF
--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -228,6 +228,34 @@ class Gate implements GateContract
     }
 
     /**
+     * Determine if any of the given abilities should be granted for the current user.
+     *
+     * @param  iterable  $abilities
+     * @param  array|mixed  $arguments
+     * @return bool
+     */
+    public function checkAny($abilities, $arguments = [])
+    {
+        return collect($abilities)->contains(function ($ability) use ($arguments) {
+            return $this->check($ability, $arguments);
+        });
+    }
+
+    /**
+     * Determine if every of the given abilities should be granted for the current user.
+     *
+     * @param  iterable  $abilities
+     * @param  array|mixed  $arguments
+     * @return bool
+     */
+    public function checkEvery($abilities, $arguments = [])
+    {
+        return collect($abilities)->every(function ($ability) use ($arguments) {
+            return $this->check($ability, $arguments);
+        });
+    }
+
+    /**
      * Determine if the given ability should be granted for the current user.
      *
      * @param  string  $ability

--- a/src/Illuminate/Contracts/Auth/Access/Gate.php
+++ b/src/Illuminate/Contracts/Auth/Access/Gate.php
@@ -74,6 +74,24 @@ interface Gate
     public function check($ability, $arguments = []);
 
     /**
+     * Determine if any of the given ability should be granted.
+     *
+     * @param  iterable  $abilities
+     * @param  array|mixed  $arguments
+     * @return bool
+     */
+    public function checkAny($abilities, $arguments = []);
+
+    /**
+     * Determine if every of the given ability should be granted.
+     *
+     * @param  iterable  $abilities
+     * @param  array|mixed  $arguments
+     * @return bool
+     */
+    public function checkEvery($abilities, $arguments = []);
+
+    /**
      * Determine if the given ability should be granted for the current user.
      *
      * @param  string  $ability

--- a/src/Illuminate/Foundation/Auth/Access/Authorizable.php
+++ b/src/Illuminate/Foundation/Auth/Access/Authorizable.php
@@ -41,4 +41,28 @@ trait Authorizable
     {
         return $this->cant($ability, $arguments);
     }
+
+    /**
+     * Determine if the entity has any of the given ability.
+     *
+     * @param  iterable  $abilities
+     * @param  array|mixed  $arguments
+     * @return bool
+     */
+    public function canAny($abilities, $arguments = [])
+    {
+        return app(Gate::class)->forUser($this)->checkAny($abilities, $arguments);
+    }
+
+    /**
+     * Determine if the entity has every given ability.
+     *
+     * @param  iterable     $abilities
+     * @param  array|mixed  $arguments
+     * @return bool
+     */
+    public function canEvery($abilities, $arguments = [])
+    {
+        return app(Gate::class)->forUser($this)->checkEvery($abilities, $arguments);
+    }
 }

--- a/src/Illuminate/View/Compilers/Concerns/CompilesAuthorizations.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesAuthorizations.php
@@ -16,6 +16,28 @@ trait CompilesAuthorizations
     }
 
     /**
+     * Compile the canAny statements into valid PHP.
+     *
+     * @param  string  $expression
+     * @return string
+     */
+    protected function compileCanAny($expression)
+    {
+        return "<?php if (app(\Illuminate\\Contracts\\Auth\\Access\\Gate::class)->checkAny{$expression}): ?>";
+    }
+
+    /**
+     * Compile the canEvery statements into valid PHP.
+     *
+     * @param  string  $expression
+     * @return string
+     */
+    protected function compileCanEvery($expression)
+    {
+        return "<?php if (app(\Illuminate\\Contracts\\Auth\\Access\\Gate::class)->checkEvery{$expression}): ?>";
+    }
+
+    /**
      * Compile the cannot statements into valid PHP.
      *
      * @param  string  $expression
@@ -38,6 +60,28 @@ trait CompilesAuthorizations
     }
 
     /**
+     * Compile the else-canAny statements into valid PHP.
+     *
+     * @param  string  $expression
+     * @return string
+     */
+    protected function compileElsecanAny($expression)
+    {
+        return "<?php elseif (app(\Illuminate\\Contracts\\Auth\\Access\\Gate::class)->checkAny{$expression}): ?>";
+    }
+
+    /**
+     * Compile the else-canEvery statements into valid PHP.
+     *
+     * @param  string  $expression
+     * @return string
+     */
+    protected function compileElsecanEvery($expression)
+    {
+        return "<?php elseif (app(\Illuminate\\Contracts\\Auth\\Access\\Gate::class)->checkEvery{$expression}): ?>";
+    }
+
+    /**
      * Compile the else-cannot statements into valid PHP.
      *
      * @param  string  $expression
@@ -54,6 +98,26 @@ trait CompilesAuthorizations
      * @return string
      */
     protected function compileEndcan()
+    {
+        return '<?php endif; ?>';
+    }
+
+    /**
+     * Compile the end-canAny statements into valid PHP.
+     *
+     * @return string
+     */
+    protected function compileEndcanAny()
+    {
+        return '<?php endif; ?>';
+    }
+
+    /**
+     * Compile the end-canEvery statements into valid PHP.
+     *
+     * @return string
+     */
+    protected function compileEndcanEvery()
     {
         return '<?php endif; ?>';
     }

--- a/tests/Auth/AuthAccessGateTest.php
+++ b/tests/Auth/AuthAccessGateTest.php
@@ -305,6 +305,60 @@ class GateTest extends TestCase
             return (object) ['id' => 1, 'isAdmin' => $isAdmin];
         });
     }
+
+    public function test_any_ability_check_passes_if_all_pass()
+    {
+        $gate = $this->getBasicGate();
+
+        $gate->policy(AccessGateTestDummy::class, AccessGateTestPolicyWithAllPermissions::class);
+
+        $this->assertTrue($gate->checkAny(['edit', 'update'], new AccessGateTestDummy));
+    }
+
+    public function test_any_ability_check_passes_if_at_least_one_passes()
+    {
+        $gate = $this->getBasicGate();
+
+        $gate->policy(AccessGateTestDummy::class, AccessGateTestPolicyWithMixedPermissions::class);
+
+        $this->assertTrue($gate->checkAny(['edit', 'update'], new AccessGateTestDummy));
+    }
+
+    public function test_any_ability_check_fails_if_none_pass()
+    {
+        $gate = $this->getBasicGate();
+
+        $gate->policy(AccessGateTestDummy::class, AccessGateTestPolicyWithNoPermissions::class);
+
+        $this->assertFalse($gate->checkAny(['edit', 'update'], new AccessGateTestDummy));
+    }
+
+    public function test_every_ability_check_passes_if_all_pass()
+    {
+        $gate = $this->getBasicGate();
+
+        $gate->policy(AccessGateTestDummy::class, AccessGateTestPolicyWithAllPermissions::class);
+
+        $this->assertTrue($gate->checkEvery(['edit', 'update'], new AccessGateTestDummy));
+    }
+
+    public function test_every_ability_check_fails_if_at_least_one_fails()
+    {
+        $gate = $this->getBasicGate();
+
+        $gate->policy(AccessGateTestDummy::class, AccessGateTestPolicyWithMixedPermissions::class);
+
+        $this->assertFalse($gate->checkEvery(['edit', 'update'], new AccessGateTestDummy));
+    }
+
+    public function test_every_ability_check_fails_if_none_pass()
+    {
+        $gate = $this->getBasicGate();
+
+        $gate->policy(AccessGateTestDummy::class, AccessGateTestPolicyWithNoPermissions::class);
+
+        $this->assertFalse($gate->checkEvery(['edit', 'update'], new AccessGateTestDummy));
+    }
 }
 
 class AccessGateTestClass
@@ -404,6 +458,45 @@ class AccessGateTestCustomResource
     }
 
     public function bar($user)
+    {
+        return true;
+    }
+}
+
+class AccessGateTestPolicyWithMixedPermissions
+{
+    public function edit($user, AccessGateTestDummy $dummy)
+    {
+        return false;
+    }
+
+    public function update($user, AccessGateTestDummy $dummy)
+    {
+        return true;
+    }
+}
+
+class AccessGateTestPolicyWithNoPermissions
+{
+    public function edit($user, AccessGateTestDummy $dummy)
+    {
+        return false;
+    }
+
+    public function update($user, AccessGateTestDummy $dummy)
+    {
+        return false;
+    }
+}
+
+class AccessGateTestPolicyWithAllPermissions
+{
+    public function edit($user, AccessGateTestDummy $dummy)
+    {
+        return true;
+    }
+
+    public function update($user, AccessGateTestDummy $dummy)
     {
         return true;
     }

--- a/tests/View/Blade/BladeCanAnyStatementsTest.php
+++ b/tests/View/Blade/BladeCanAnyStatementsTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Illuminate\Tests\Blade;
+
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+use Illuminate\View\Compilers\BladeCompiler;
+
+class BladeCanAnyStatementsTest extends TestCase
+{
+    public function tearDown()
+    {
+        m::close();
+    }
+
+    public function testCanStatementsAreCompiled()
+    {
+        $compiler = new BladeCompiler($this->getFiles(), __DIR__);
+        $string = '@canAny (\'update\', [$post])
+breeze
+@elsecanAny (\'delete\', [$post])
+sneeze
+@endcanAny';
+        $expected = '<?php if (app(\\Illuminate\\Contracts\\Auth\\Access\\Gate::class)->checkAny(\'update\', [$post])): ?>
+breeze
+<?php elseif (app(\\Illuminate\\Contracts\\Auth\\Access\\Gate::class)->checkAny(\'delete\', [$post])): ?>
+sneeze
+<?php endif; ?>';
+        $this->assertEquals($expected, $compiler->compileString($string));
+    }
+
+    protected function getFiles()
+    {
+        return m::mock('Illuminate\Filesystem\Filesystem');
+    }
+}

--- a/tests/View/Blade/BladeCanEveryStatementsTest.php
+++ b/tests/View/Blade/BladeCanEveryStatementsTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Illuminate\Tests\Blade;
+
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+use Illuminate\View\Compilers\BladeCompiler;
+
+class BladeCanEveryStatementsTest extends TestCase
+{
+    public function tearDown()
+    {
+        m::close();
+    }
+
+    public function testCanStatementsAreCompiled()
+    {
+        $compiler = new BladeCompiler($this->getFiles(), __DIR__);
+        $string = '@canEvery (\'update\', [$post])
+breeze
+@elsecanEvery (\'delete\', [$post])
+sneeze
+@endcanEvery';
+        $expected = '<?php if (app(\\Illuminate\\Contracts\\Auth\\Access\\Gate::class)->checkEvery(\'update\', [$post])): ?>
+breeze
+<?php elseif (app(\\Illuminate\\Contracts\\Auth\\Access\\Gate::class)->checkEvery(\'delete\', [$post])): ?>
+sneeze
+<?php endif; ?>';
+        $this->assertEquals($expected, $compiler->compileString($string));
+    }
+
+    protected function getFiles()
+    {
+        return m::mock('Illuminate\Filesystem\Filesystem');
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/laravel/internals/issues/657

This PR adds two methods that allows checking of multiple permissions at once, making the code more readable, especially simplifying things in blade.

```html
@canAny([‘edit’, ‘update’], $post) <!— or @canEvery —>
@elsecanAny([‘edit’, ‘update’], $comment) <!— or @elsecanEvery —>
@endcan <!— or @endcanAny, @endcanEvery —>
```

```php
if ($user->canAny([‘edit’, ‘update’], $post)) {
    //
}

if ($user->canEvery([‘edit’, ‘update’], $post)) {
    //
}
```

There was some discussion in the internals thread about the naming of the methods, and I'm currently conflicted. One thing I don't like about ...checkEvery($abilities... is that every refers to a singular noun, while all refers to a plural noun. It's less fluent to read and requires an extra "brain-cycle" to register, because you trip over it linguistically. As opposed to ...checkAll($abilities.... I do think checkEvery is more explicit in its meaning though. (This is in the gate class, not the blade directive.)
=> I'll let @taylorotwell decide how he would like them named.

Also, I'm not sure if this should be considered a breaking change and moved to Laravel 5.5 because the Gate contract now has two new methods in it, and could potentially break existing custom Gate implementations that rely on the old contract without those two new methods?