### PR TITLE
[5.4] Implemented getRoutesByName method

### DIFF
--- a/src/Illuminate/Routing/RouteCollection.php
+++ b/src/Illuminate/Routing/RouteCollection.php
@@ -316,6 +316,16 @@ class RouteCollection implements Countable, IteratorAggregate
     }
 
     /**
+     * Get all of the routes keyed by their name.
+     *
+     * @return array
+     */
+    public function getRoutesByName()
+    {
+        return $this->nameList;
+    }
+
+    /**
      * Get an iterator for the items.
      *
      * @return \ArrayIterator


### PR DESCRIPTION
Trying to dynamically generate some permissions in my app based on route names, I found out that `Route::getRoutes()` has `protected $namedList = []` and no method to get it. Then I saw `public function getRoutesByMethod()` and decided to create `getRoutesByName` too :smile: 