### PR TITLE
[5.4] Escape Quotes when asserting to see texts

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -204,7 +204,7 @@ class TestResponse
      */
     public function assertSeeText($value)
     {
-        PHPUnit::assertContains($value, strip_tags($this->getContent()));
+        PHPUnit::assertContains(e($value), strip_tags($this->getContent()));
 
         return $this;
     }

--- a/tests/Foundation/FoundationTestResponseTest.php
+++ b/tests/Foundation/FoundationTestResponseTest.php
@@ -54,6 +54,19 @@ class FoundationTestResponseTest extends TestCase
         $response->assertSeeText('foobar');
     }
 
+    public function testAssertSeeTextWithQuotes()
+    {
+        $baseResponse = tap(new Response, function ($response) {
+            $response->setContent(\Mockery::mock(View::class, [
+                'render' => "<strong>Foo&#039;s</strong>",
+            ]));
+        });
+
+        $response = TestResponse::fromBaseResponse($baseResponse);
+
+        $response->assertSeeText("Foo's");
+    }
+
     public function testAssertHeader()
     {
         $baseResponse = tap(new Response, function ($response) {

--- a/tests/Foundation/FoundationTestResponseTest.php
+++ b/tests/Foundation/FoundationTestResponseTest.php
@@ -58,7 +58,7 @@ class FoundationTestResponseTest extends TestCase
     {
         $baseResponse = tap(new Response, function ($response) {
             $response->setContent(\Mockery::mock(View::class, [
-                'render' => "<strong>Foo&#039;s</strong>",
+                'render' => '<strong>Foo&#039;s</strong>',
             ]));
         });
 


### PR DESCRIPTION
When using `$response->assertSeeText()` I often pass in a content that may come from `$faker->name`, which have the potential of generating names with apostrophe and result in a failure because PHPUnit cannot assert that `Emelia Rempel&#039;` matches `Emelia Rempel'`.