### PR TITLE
[5.5] Add options parameter to paginate and simplePaginate

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -683,7 +683,7 @@ class Builder
      *
      * @throws \InvalidArgumentException
      */
-    public function paginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null, array $options = [])
+    public function paginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null, $options = [])
     {
         $page = $page ?: Paginator::resolveCurrentPage($pageName);
 
@@ -711,7 +711,7 @@ class Builder
      * @param  array  $options (query, fragment)
      * @return \Illuminate\Contracts\Pagination\Paginator
      */
-    public function simplePaginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null, array $options = [])
+    public function simplePaginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null, $options = [])
     {
         $page = $page ?: Paginator::resolveCurrentPage($pageName);
 

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -678,11 +678,12 @@ class Builder
      * @param  array  $columns
      * @param  string  $pageName
      * @param  int|null  $page
+     * @param  array  $options (query, fragment)
      * @return \Illuminate\Contracts\Pagination\LengthAwarePaginator
      *
      * @throws \InvalidArgumentException
      */
-    public function paginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null)
+    public function paginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null, array $options = [])
     {
         $page = $page ?: Paginator::resolveCurrentPage($pageName);
 
@@ -692,10 +693,12 @@ class Builder
                                     ? $this->forPage($page, $perPage)->get($columns)
                                     : $this->model->newCollection();
 
-        return $this->paginator($results, $total, $perPage, $page, [
+        $options += [
             'path' => Paginator::resolveCurrentPath(),
             'pageName' => $pageName,
-        ]);
+        ];
+
+        return $this->paginator($results, $total, $perPage, $page, $options);
     }
 
     /**
@@ -705,9 +708,10 @@ class Builder
      * @param  array  $columns
      * @param  string  $pageName
      * @param  int|null  $page
+     * @param  array  $options (query, fragment)
      * @return \Illuminate\Contracts\Pagination\Paginator
      */
-    public function simplePaginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null)
+    public function simplePaginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null, array $options = [])
     {
         $page = $page ?: Paginator::resolveCurrentPage($pageName);
 
@@ -718,10 +722,12 @@ class Builder
         // paginator instances for these results with the given page and per page.
         $this->skip(($page - 1) * $perPage)->take($perPage + 1);
 
-        return $this->simplePaginator($this->get($columns), $perPage, $page, [
+        $options += [
             'path' => Paginator::resolveCurrentPath(),
             'pageName' => $pageName,
-        ]);
+        ];
+
+        return $this->simplePaginator($this->get($columns), $perPage, $page, $options);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -556,7 +556,7 @@ class BelongsToMany extends Relation
      * @param  array  $options (query, fragment)
      * @return \Illuminate\Contracts\Pagination\LengthAwarePaginator
      */
-    public function paginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null, array $options = [])
+    public function paginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null, $options = [])
     {
         $this->query->addSelect($this->shouldSelect($columns));
 
@@ -575,7 +575,7 @@ class BelongsToMany extends Relation
      * @param  array  $options (query, fragment)
      * @return \Illuminate\Contracts\Pagination\Paginator
      */
-    public function simplePaginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null, array $options = [])
+    public function simplePaginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null, $options = [])
     {
         $this->query->addSelect($this->shouldSelect($columns));
 

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -553,13 +553,14 @@ class BelongsToMany extends Relation
      * @param  array  $columns
      * @param  string  $pageName
      * @param  int|null  $page
+     * @param  array  $options (query, fragment)
      * @return \Illuminate\Contracts\Pagination\LengthAwarePaginator
      */
-    public function paginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null)
+    public function paginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null, array $options = [])
     {
         $this->query->addSelect($this->shouldSelect($columns));
 
-        return tap($this->query->paginate($perPage, $columns, $pageName, $page), function ($paginator) {
+        return tap($this->query->paginate($perPage, $columns, $pageName, $page, $options), function ($paginator) {
             $this->hydratePivotRelation($paginator->items());
         });
     }
@@ -571,13 +572,14 @@ class BelongsToMany extends Relation
      * @param  array  $columns
      * @param  string  $pageName
      * @param  int|null  $page
+     * @param  array  $options (query, fragment)
      * @return \Illuminate\Contracts\Pagination\Paginator
      */
-    public function simplePaginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null)
+    public function simplePaginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null, array $options = [])
     {
         $this->query->addSelect($this->shouldSelect($columns));
 
-        return tap($this->query->simplePaginate($perPage, $columns, $pageName, $page), function ($paginator) {
+        return tap($this->query->simplePaginate($perPage, $columns, $pageName, $page, $options), function ($paginator) {
             $this->hydratePivotRelation($paginator->items());
         });
     }

--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -375,13 +375,14 @@ class HasManyThrough extends Relation
      * @param  array  $columns
      * @param  string  $pageName
      * @param  int  $page
+     * @param  array  $options (query, fragment)
      * @return \Illuminate\Contracts\Pagination\LengthAwarePaginator
      */
-    public function paginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null)
+    public function paginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null, array $options = [])
     {
         $this->query->addSelect($this->shouldSelect($columns));
 
-        return $this->query->paginate($perPage, $columns, $pageName, $page);
+        return $this->query->paginate($perPage, $columns, $pageName, $page, $options);
     }
 
     /**
@@ -391,13 +392,14 @@ class HasManyThrough extends Relation
      * @param  array  $columns
      * @param  string  $pageName
      * @param  int|null  $page
+     * @param  array  $options (query, fragment)
      * @return \Illuminate\Contracts\Pagination\Paginator
      */
-    public function simplePaginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null)
+    public function simplePaginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null, array $options = [])
     {
         $this->query->addSelect($this->shouldSelect($columns));
 
-        return $this->query->simplePaginate($perPage, $columns, $pageName, $page);
+        return $this->query->simplePaginate($perPage, $columns, $pageName, $page, $options);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -378,7 +378,7 @@ class HasManyThrough extends Relation
      * @param  array  $options (query, fragment)
      * @return \Illuminate\Contracts\Pagination\LengthAwarePaginator
      */
-    public function paginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null, array $options = [])
+    public function paginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null, $options = [])
     {
         $this->query->addSelect($this->shouldSelect($columns));
 
@@ -395,7 +395,7 @@ class HasManyThrough extends Relation
      * @param  array  $options (query, fragment)
      * @return \Illuminate\Contracts\Pagination\Paginator
      */
-    public function simplePaginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null, array $options = [])
+    public function simplePaginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null, $options = [])
     {
         $this->query->addSelect($this->shouldSelect($columns));
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1721,7 +1721,7 @@ class Builder
      * @param  array  $options (query, fragment)
      * @return \Illuminate\Contracts\Pagination\LengthAwarePaginator
      */
-    public function paginate($perPage = 15, $columns = ['*'], $pageName = 'page', $page = null, array $options = [])
+    public function paginate($perPage = 15, $columns = ['*'], $pageName = 'page', $page = null, $options = [])
     {
         $page = $page ?: Paginator::resolveCurrentPage($pageName);
 
@@ -1749,7 +1749,7 @@ class Builder
      * @param  array  $options (query, fragment)
      * @return \Illuminate\Contracts\Pagination\Paginator
      */
-    public function simplePaginate($perPage = 15, $columns = ['*'], $pageName = 'page', $page = null, array $options = [])
+    public function simplePaginate($perPage = 15, $columns = ['*'], $pageName = 'page', $page = null, $options = [])
     {
         $page = $page ?: Paginator::resolveCurrentPage($pageName);
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1718,9 +1718,10 @@ class Builder
      * @param  array  $columns
      * @param  string  $pageName
      * @param  int|null  $page
+     * @param  array  $options (query, fragment)
      * @return \Illuminate\Contracts\Pagination\LengthAwarePaginator
      */
-    public function paginate($perPage = 15, $columns = ['*'], $pageName = 'page', $page = null)
+    public function paginate($perPage = 15, $columns = ['*'], $pageName = 'page', $page = null, array $options = [])
     {
         $page = $page ?: Paginator::resolveCurrentPage($pageName);
 
@@ -1728,10 +1729,12 @@ class Builder
 
         $results = $total ? $this->forPage($page, $perPage)->get($columns) : collect();
 
-        return $this->paginator($results, $total, $perPage, $page, [
+        $options += [
             'path' => Paginator::resolveCurrentPath(),
             'pageName' => $pageName,
-        ]);
+        ];
+
+        return $this->paginator($results, $total, $perPage, $page, $options);
     }
 
     /**
@@ -1743,18 +1746,21 @@ class Builder
      * @param  array  $columns
      * @param  string  $pageName
      * @param  int|null  $page
+     * @param  array  $options (query, fragment)
      * @return \Illuminate\Contracts\Pagination\Paginator
      */
-    public function simplePaginate($perPage = 15, $columns = ['*'], $pageName = 'page', $page = null)
+    public function simplePaginate($perPage = 15, $columns = ['*'], $pageName = 'page', $page = null, array $options = [])
     {
         $page = $page ?: Paginator::resolveCurrentPage($pageName);
 
         $this->skip(($page - 1) * $perPage)->take($perPage + 1);
 
-        return $this->simplePaginator($this->get($columns), $perPage, $page, [
+        $options += [
             'path' => Paginator::resolveCurrentPath(),
             'pageName' => $pageName,
-        ]);
+        ];
+
+        return $this->simplePaginator($this->get($columns), $perPage, $page, $options);
     }
 
     /**

--- a/src/Illuminate/Pagination/LengthAwarePaginator.php
+++ b/src/Illuminate/Pagination/LengthAwarePaginator.php
@@ -38,7 +38,7 @@ class LengthAwarePaginator extends AbstractPaginator implements Arrayable, Array
      * @param  array  $options (path, query, fragment, pageName)
      * @return void
      */
-    public function __construct($items, $total, $perPage, $currentPage = null, array $options = [])
+    public function __construct($items, $total, $perPage, $currentPage = null, $options = [])
     {
         foreach ($options as $key => $value) {
             $this->{$key} = $value;

--- a/src/Illuminate/Pagination/Paginator.php
+++ b/src/Illuminate/Pagination/Paginator.php
@@ -30,7 +30,7 @@ class Paginator extends AbstractPaginator implements Arrayable, ArrayAccess, Cou
      * @param  array  $options (path, query, fragment, pageName)
      * @return void
      */
-    public function __construct($items, $perPage, $currentPage = null, array $options = [])
+    public function __construct($items, $perPage, $currentPage = null, $options = [])
     {
         foreach ($options as $key => $value) {
             $this->{$key} = $value;


### PR DESCRIPTION
Currently on ``` paginate ``` and ``` simplePaginate ``` we're passing an array with with ``` path ``` and ``` pathName ```, however ``` Paginator ``` and ``` LengthAwarePaginator ``` supports  ``` path, query, fragment, pageName ``` for the options arrray.

This PR adds the ability to pass these options to the ``` Paginator ```...