### PR TITLE
Self-registering event listeners

### DIFF
--- a/src/Illuminate/Foundation/Support/Providers/EventServiceProvider.php
+++ b/src/Illuminate/Foundation/Support/Providers/EventServiceProvider.php
@@ -54,6 +54,12 @@ class EventServiceProvider extends ServiceProvider
      */
     public function listens()
     {
-        return $this->listen;
+        return array_merge_recursive(collect($this->listeners)->flatMap(function ($listener) {
+            return collect($listener::$hears)->map(function ($event) use ($listener) {
+                return ['event' => $event, 'listeners' => [$listener]];
+            })->all();
+        })->groupBy('event')->map(function ($listeners) {
+            return $listeners->pluck('listeners')->flatten(1)->all();
+        })->all(), $this->listen);
     }
 }


### PR DESCRIPTION
This is still just an early idea, but was talking through it with Taylor and thought it'd be a good idea to open a PR for discussion.

The general idea is to allow you to specify which events your listeners listen to *in the listener itself* instead of creating a mapping in your `EventServiceProvider`. Then all you'd need to do is throw your listeners in an array in the service provider to register them.

Here's what your `EventServiceProvider` might look like:

```php
class EventServiceProvider extends ServiceProvider
{
    protected $listeners = [
        \App\Listeners\SendFulfillmentFailedEmail::class,
        \App\Listeners\AttemptFulfillment::class,
    ];

    public function boot()
    {
        parent::boot();
    }
}
```

And here's what a listener would look like:

```php
class SendFulfillmentFailedEmail
{
    public static $hears = [
        \App\Events\FulfillmentFailed::class,
    ];

    public function handle($event)
    {
        Mail::to($event->makerEmail())->send(new FulfillmentFailedEmail($event->purchase));
    }
}
```

We'd want to support backwards compatibility with the old approach, which this implementation does as far as I have tested.

Things to explore/figure out:

- How does this affect the generators?
- Friendlier error handling