### PR TITLE
[5.4] Add ability to use Action Buttons with Slack Notifications Channel

### DIFF
--- a/src/Illuminate/Notifications/Channels/SlackWebhookChannel.php
+++ b/src/Illuminate/Notifications/Channels/SlackWebhookChannel.php
@@ -6,8 +6,8 @@ use GuzzleHttp\Client as HttpClient;
 use Illuminate\Notifications\Notification;
 use Illuminate\Notifications\Messages\SlackMessage;
 use Illuminate\Notifications\Messages\SlackAttachment;
-use Illuminate\Notifications\Messages\SlackAttachmentAction;
 use Illuminate\Notifications\Messages\SlackAttachmentField;
+use Illuminate\Notifications\Messages\SlackAttachmentAction;
 
 class SlackWebhookChannel
 {

--- a/src/Illuminate/Notifications/Channels/SlackWebhookChannel.php
+++ b/src/Illuminate/Notifications/Channels/SlackWebhookChannel.php
@@ -81,6 +81,7 @@ class SlackWebhookChannel
     {
         return collect($message->attachments)->map(function ($attachment) use ($message) {
             return array_filter([
+                'callback_id' => $attachment->callbackId,
                 'color' => $attachment->color ?: $message->color(),
                 'fallback' => $attachment->fallback,
                 'fields' => $this->fields($attachment),

--- a/src/Illuminate/Notifications/Channels/SlackWebhookChannel.php
+++ b/src/Illuminate/Notifications/Channels/SlackWebhookChannel.php
@@ -6,6 +6,7 @@ use GuzzleHttp\Client as HttpClient;
 use Illuminate\Notifications\Notification;
 use Illuminate\Notifications\Messages\SlackMessage;
 use Illuminate\Notifications\Messages\SlackAttachment;
+use Illuminate\Notifications\Messages\SlackAttachmentAction;
 use Illuminate\Notifications\Messages\SlackAttachmentField;
 
 class SlackWebhookChannel
@@ -83,6 +84,7 @@ class SlackWebhookChannel
                 'color' => $attachment->color ?: $message->color(),
                 'fallback' => $attachment->fallback,
                 'fields' => $this->fields($attachment),
+                'actions' => $this->actions($attachment),
                 'footer' => $attachment->footer,
                 'footer_icon' => $attachment->footerIcon,
                 'image_url' => $attachment->imageUrl,
@@ -109,6 +111,23 @@ class SlackWebhookChannel
             }
 
             return ['title' => $key, 'value' => $value, 'short' => true];
+        })->values()->all();
+    }
+
+    /**
+     * Format the attachment's actions.
+     *
+     * @param  \Illuminate\Notifications\Messages\SlackAttachment  $attachment
+     * @return array
+     */
+    protected function actions(SlackAttachment $attachment)
+    {
+        return collect($attachment->actions)->map(function ($value) {
+            if ($value instanceof SlackAttachmentAction) {
+                return $value->toArray();
+            }
+
+            return $value;
         })->values()->all();
     }
 }

--- a/src/Illuminate/Notifications/Messages/SlackActionConfirmationField.php
+++ b/src/Illuminate/Notifications/Messages/SlackActionConfirmationField.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Illuminate\Notifications\Messages;
+
+class SlackActionConfirmationField
+{
+    /**
+     * The title field of the confirmation field.
+     *
+     * @var string
+     */
+    protected $title;
+
+    /**
+     * The content of the confirmation field.
+     *
+     * @var string
+     */
+    protected $content;
+
+    /**
+     * The ok text of the confirmation field.
+     *
+     * @var string
+     */
+    protected $okText;
+
+    /**
+     * The dismiss text of the confirmation field.
+     *
+     * @var string
+     */
+    protected $dismissText;
+
+    /**
+     * Set the title of the field.
+     *
+     * @param  string  $title
+     * @return $this
+     */
+    public function title($title)
+    {
+        $this->title = $title;
+
+        return $this;
+    }
+
+    /**
+     * Set the text of the field.
+     *
+     * @param  string  $content
+     * @return $this
+     */
+    public function content($content)
+    {
+        $this->content = $content;
+
+        return $this;
+    }
+
+    /**
+     * Set the text of the field.
+     *
+     * @param  string  $okText
+     * @return $this
+     */
+    public function okText($okText)
+    {
+        $this->okText = $okText;
+
+        return $this;
+    }
+
+    /**
+     * Set the text of the field.
+     *
+     * @param  string  $dismissText
+     * @return $this
+     */
+    public function dismissText($dismissText)
+    {
+        $this->dismissText = $dismissText;
+
+        return $this;
+    }
+
+    /**
+     * Get the array representation of the attachment field.
+     *
+     * @return array
+     */
+    public function toArray()
+    {
+        return [
+            'title'        => $this->title,
+            'text'         => $this->content,
+            'ok_text'      => $this->okText,
+            'dismiss_text' => $this->dismissText,
+        ];
+    }
+}

--- a/src/Illuminate/Notifications/Messages/SlackActionConfirmationField.php
+++ b/src/Illuminate/Notifications/Messages/SlackActionConfirmationField.php
@@ -5,35 +5,35 @@ namespace Illuminate\Notifications\Messages;
 class SlackActionConfirmationField
 {
     /**
-     * The title field of the confirmation field.
+     * The title field of the pop up confirmation window.
      *
      * @var string
      */
     protected $title;
 
     /**
-     * The content of the confirmation field.
+     * The details of the consequences of performing an action.
      *
      * @var string
      */
     protected $content;
 
     /**
-     * The ok text of the confirmation field.
+     * The text label for the button to continue with an action.
      *
      * @var string
      */
-    protected $okText;
+    protected $okText = 'Okay';
 
     /**
-     * The dismiss text of the confirmation field.
+     * The text label for the button to cancel the action.
      *
      * @var string
      */
-    protected $dismissText;
+    protected $dismissText = 'Cancel';
 
     /**
-     * Set the title of the field.
+     * Set the title of the confirmation window.
      *
      * @param  string  $title
      * @return $this
@@ -46,7 +46,7 @@ class SlackActionConfirmationField
     }
 
     /**
-     * Set the text of the field.
+     * Set the content of the confirmation window.
      *
      * @param  string  $content
      * @return $this
@@ -59,7 +59,7 @@ class SlackActionConfirmationField
     }
 
     /**
-     * Set the text of the field.
+     * Set the text of the okay button.
      *
      * @param  string  $okText
      * @return $this
@@ -72,7 +72,7 @@ class SlackActionConfirmationField
     }
 
     /**
-     * Set the text of the field.
+     * Set the text of the dismiss button.
      *
      * @param  string  $dismissText
      * @return $this
@@ -85,7 +85,7 @@ class SlackActionConfirmationField
     }
 
     /**
-     * Get the array representation of the attachment field.
+     * Get the array representation of the confirmation window.
      *
      * @return array
      */

--- a/src/Illuminate/Notifications/Messages/SlackActionOption.php
+++ b/src/Illuminate/Notifications/Messages/SlackActionOption.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Illuminate\Notifications\Messages;
+
+class SlackActionOption
+{
+    /**
+     * The text displayed for the option.
+     *
+     * @var string
+     */
+    protected $text;
+
+    /**
+     * The value for the option.
+     *
+     * @var string
+     */
+    protected $value;
+
+    /**
+     * Set the title of the action option.
+     *
+     * @param  string  $text
+     * @return $this
+     */
+    public function text($text)
+    {
+        $this->text = $text;
+
+        return $this;
+    }
+
+    /**
+     * Set the value of the action option.
+     *
+     * @param  string  $value
+     * @return $this
+     */
+    public function value($value)
+    {
+        $this->value = $value;
+
+        return $this;
+    }
+
+    /**
+     * Get the array representation of the action option.
+     *
+     * @return array
+     */
+    public function toArray()
+    {
+        return [
+            'text' => $this->text,
+            'value' => $this->value,
+        ];
+    }
+}

--- a/src/Illuminate/Notifications/Messages/SlackAttachment.php
+++ b/src/Illuminate/Notifications/Messages/SlackAttachment.php
@@ -49,6 +49,13 @@ class SlackAttachment
     public $fields;
 
     /**
+     * The attachment's actions.
+     *
+     * @var array
+     */
+    public $actions;
+
+    /**
      * The fields containing markdown.
      *
      * @var array
@@ -170,6 +177,43 @@ class SlackAttachment
     public function fields(array $fields)
     {
         $this->fields = $fields;
+
+        return $this;
+    }
+
+    /**
+     * Add an action to the attachment.
+     *
+     * @param  \Closure|string  $title
+     * @param  array  $content
+     * @return $this
+     */
+    public function action($title, $content = [])
+    {
+        if (is_callable($title)) {
+            $callback = $title;
+
+            $callback($attachmentAction = new SlackAttachmentAction);
+
+            $this->actions[] = $attachmentAction;
+
+            return $this;
+        }
+
+        $this->actions[$title] = $content;
+
+        return $this;
+    }
+
+    /**
+     * Set the actions of the attachment.
+     *
+     * @param  array  $actions
+     * @return $this
+     */
+    public function actions(array $actions)
+    {
+        $this->actions = $actions;
 
         return $this;
     }

--- a/src/Illuminate/Notifications/Messages/SlackAttachment.php
+++ b/src/Illuminate/Notifications/Messages/SlackAttachment.php
@@ -91,6 +91,13 @@ class SlackAttachment
     public $timestamp;
 
     /**
+     * The attachment's callback ID
+     *
+     * @var string
+     */
+    public $callbackId;
+
+    /**
      * Set the title of the attachment.
      *
      * @param  string  $title
@@ -279,6 +286,19 @@ class SlackAttachment
     public function timestamp(Carbon $timestamp)
     {
         $this->timestamp = $timestamp->getTimestamp();
+
+        return $this;
+    }
+
+    /**
+     * Set the callback ID
+     *
+     * @param  $callbackId
+     * @return $this
+     */
+    public function callbackId($callbackId)
+    {
+        $this->callbackId = $callbackId;
 
         return $this;
     }

--- a/src/Illuminate/Notifications/Messages/SlackAttachment.php
+++ b/src/Illuminate/Notifications/Messages/SlackAttachment.php
@@ -91,7 +91,7 @@ class SlackAttachment
     public $timestamp;
 
     /**
-     * The attachment's callback ID
+     * The attachment's callback ID.
      *
      * @var string
      */
@@ -291,7 +291,7 @@ class SlackAttachment
     }
 
     /**
-     * Set the callback ID
+     * Set the callback ID.
      *
      * @param  $callbackId
      * @return $this

--- a/src/Illuminate/Notifications/Messages/SlackAttachmentAction.php
+++ b/src/Illuminate/Notifications/Messages/SlackAttachmentAction.php
@@ -1,0 +1,255 @@
+<?php
+
+namespace Illuminate\Notifications\Messages;
+
+use Closure;
+
+class SlackAttachmentAction
+{
+    /**
+     * The name field of the attachment action.
+     *
+     * @var string
+     */
+    protected $name;
+
+    /**
+     * The content of the attachment action.
+     *
+     * @var string
+     */
+    protected $content;
+
+    /**
+     * The type of the attachment action.
+     *
+     * @var string
+     */
+    protected $type = 'button';
+
+    /**
+     * The value of the attachment action.
+     *
+     * @var string
+     */
+    protected $value;
+
+    /**
+     * The action's confirmation fields.
+     *
+     * @var array
+     */
+    protected $confirmationFields;
+
+    /**
+     * The style of the attachment action.
+     *
+     * @var string
+     */
+    protected $style = 'default';
+
+    /**
+     * The options of the attachment action.
+     *
+     * @var array
+     */
+    protected $options;
+
+    /**
+     * The option groups of the attachment action.
+     *
+     * @var array
+     */
+    protected $optionGroups;
+
+    /**
+     * The minimum query length of the attachment action.
+     *
+     * @var int
+     */
+    protected $minQueryLength = 1;
+
+    /**
+     * The data source of the attachment action.
+     *
+     * @var string
+     */
+    protected $dataSource = 'static';
+
+    /**
+     * Set the name of the field.
+     *
+     * @param  string $name
+     *
+     * @return $this
+     */
+    public function name($name)
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    /**
+     * Set the content of the field.
+     *
+     * @param  string $content
+     *
+     * @return $this
+     */
+    public function text($content)
+    {
+        $this->content = $content;
+
+        return $this;
+    }
+
+    /**
+     * Set the type of the field.
+     *
+     * @param  string $type
+     *
+     * @return $this
+     */
+    public function type($type)
+    {
+        $this->type = $type;
+
+        return $this;
+    }
+
+    /**
+     * Set the value of the field.
+     *
+     * @param  string $value
+     *
+     * @return $this
+     */
+    public function value($value)
+    {
+        $this->value = $value;
+
+        return $this;
+    }
+
+    /**
+     * Add a confirmation field for the action.
+     *
+     * @param  \Closure $callback
+     *
+     * @return $this
+     */
+    public function confirmationField(Closure $callback)
+    {
+        $this->confirmationFields[] = $confirmationField = new SlackActionConfirmationField();
+
+        $callback($confirmationField);
+
+        return $this;
+    }
+
+    /**
+     * Set the confirmation fields of the action.
+     *
+     * @param  array $confirmationFields
+     *
+     * @return $this
+     */
+    public function confirmationFields(array $confirmationFields)
+    {
+        $this->confirmationFields = $confirmationFields;
+
+        return $this;
+    }
+
+    /**
+     * Set the style of the field.
+     *
+     * @param  string $style
+     *
+     * @return $this
+     */
+    public function style($style)
+    {
+        $this->style = $style;
+
+        return $this;
+    }
+
+    /**
+     * Set the options of the field.
+     *
+     * @param  array $options
+     *
+     * @return $this
+     */
+    public function options($options)
+    {
+        $this->options = $options;
+
+        return $this;
+    }
+
+    /**
+     * Set the options of the field.
+     *
+     * @param  array $optionGroups
+     *
+     * @return $this
+     */
+    public function optionGroups($optionGroups)
+    {
+        $this->optionGroups = $optionGroups;
+
+        return $this;
+    }
+
+    /**
+     * Set the minimum query length of the field.
+     *
+     * @param  int $minQueryLength
+     *
+     * @return $this
+     */
+    public function minQueryLength($minQueryLength)
+    {
+        $this->minQueryLength = $minQueryLength;
+
+        return $this;
+    }
+
+    /**
+     * Set the data source of the field.
+     *
+     * @param  string $dataSource
+     *
+     * @return $this
+     */
+    public function dataSource($dataSource)
+    {
+        $this->dataSource = $dataSource;
+
+        return $this;
+    }
+
+    /**
+     * Get the array representation of the attachment field.
+     *
+     * @return array
+     */
+    public function toArray()
+    {
+        return [
+            'name'             => $this->name,
+            'text'             => $this->content,
+            'type'             => $this->type,
+            'value'            => $this->value,
+            'confirm'          => $this->confirmationFields,
+            'style'            => $this->style,
+            'options'          => $this->options,
+            'option_groups'    => $this->optionGroups,
+            'min_query_length' => $this->minQueryLength,
+            'data_source'      => $this->dataSource,
+        ];
+    }
+}

--- a/src/Illuminate/Notifications/Messages/SlackAttachmentAction.php
+++ b/src/Illuminate/Notifications/Messages/SlackAttachmentAction.php
@@ -253,7 +253,7 @@ class SlackAttachmentAction
 
         // If set to null, Slack will show a generic confirmation window even if we have no data set.
         // Due to this, we only want to set the confirm attribute if we actually want a confirmation.
-        if($confirmation = $this->confirmArray()) {
+        if ($confirmation = $this->confirmArray()) {
             $action['confirm'] = $confirmation;
         }
 
@@ -261,18 +261,18 @@ class SlackAttachmentAction
     }
 
     /**
-    * Format the attachment's action confirmation windows.
-    *
-    * @return array
-    */
-   protected function confirmArray()
-   {
-       if ($this->confirmation instanceof SlackActionConfirmationField) {
-           return $this->confirmation->toArray();
-       }
+     * Get the array representation of the attachment action.
+     *
+     * @return array
+     */
+    protected function confirmArray()
+    {
+        if ($this->confirmation instanceof SlackActionConfirmationField) {
+            return $this->confirmation->toArray();
+        }
 
-       return $this->confirmation;
-   }
+        return $this->confirmation;
+    }
 
     /**
      * Format the actions's options.

--- a/src/Illuminate/Notifications/Messages/SlackAttachmentAction.php
+++ b/src/Illuminate/Notifications/Messages/SlackAttachmentAction.php
@@ -7,77 +7,83 @@ use Closure;
 class SlackAttachmentAction
 {
     /**
-     * The name field of the attachment action.
+     * The specific name of the action to be performed.
      *
      * @var string
      */
     protected $name;
 
     /**
-     * The content of the attachment action.
+     * The user-facing content for the message button or menu representing this action.
      *
      * @var string
      */
     protected $content;
 
     /**
-     * The type of the attachment action.
+     * The type of action. Can be either "button" or "select".
      *
      * @var string
      */
     protected $type = 'button';
 
     /**
-     * The value of the attachment action.
+     * The specific identifier for the action.
      *
      * @var string
      */
     protected $value;
 
     /**
-     * The action's confirmation fields.
+     * The optional confirmation fields to be shown
+     * be shown when an action button is clicked.
      *
      * @var array
      */
     protected $confirmationFields;
 
     /**
-     * The style of the attachment action.
+     * The style of the attachment action. Useful for
+     * emphasizing a primary or dangerous action.
      *
      * @var string
      */
     protected $style = 'default';
 
     /**
-     * The options of the attachment action.
+     * The individual options to appear in a message menu.
      *
      * @var array
      */
     protected $options;
 
     /**
-     * The option groups of the attachment action.
+     * An alternate, semi-hierarchal way to list available options in a
+     * message menu. This replaces and supersedes the options array.
      *
      * @var array
      */
     protected $optionGroups;
 
     /**
-     * The minimum query length of the attachment action.
-     *
-     * @var int
-     */
-    protected $minQueryLength = 1;
-
-    /**
-     * The data source of the attachment action.
+     * The data source of the attachment's actions.
+     * Can be "static", "users", "channels", "conversations", or "external".
      *
      * @var string
      */
     protected $dataSource = 'static';
 
     /**
-     * Set the name of the field.
+     * If present, Slack will wait until the specified number of characters are
+     * entered before sending a request to your app's external suggestions
+     * API endpoint. Only applies when data_source is set to external.
+     *
+     * @var int
+     */
+    protected $minQueryLength = 1;
+
+    /**
+     * Set the name of the action.
      *
      * @param  string $name
      *
@@ -91,7 +97,7 @@ class SlackAttachmentAction
     }
 
     /**
-     * Set the content of the field.
+     * Set the content of the action.
      *
      * @param  string $content
      *
@@ -105,7 +111,7 @@ class SlackAttachmentAction
     }
 
     /**
-     * Set the type of the field.
+     * Set the type of the action.
      *
      * @param  string $type
      *
@@ -119,7 +125,7 @@ class SlackAttachmentAction
     }
 
     /**
-     * Set the value of the field.
+     * Set the value of the action.
      *
      * @param  string $value
      *
@@ -163,7 +169,7 @@ class SlackAttachmentAction
     }
 
     /**
-     * Set the style of the field.
+     * Set the style of the action.
      *
      * @param  string $style
      *
@@ -177,7 +183,7 @@ class SlackAttachmentAction
     }
 
     /**
-     * Set the options of the field.
+     * Set the options of the action.
      *
      * @param  array $options
      *
@@ -191,7 +197,7 @@ class SlackAttachmentAction
     }
 
     /**
-     * Set the options of the field.
+     * Set the options of the action.
      *
      * @param  array $optionGroups
      *
@@ -205,21 +211,7 @@ class SlackAttachmentAction
     }
 
     /**
-     * Set the minimum query length of the field.
-     *
-     * @param  int $minQueryLength
-     *
-     * @return $this
-     */
-    public function minQueryLength($minQueryLength)
-    {
-        $this->minQueryLength = $minQueryLength;
-
-        return $this;
-    }
-
-    /**
-     * Set the data source of the field.
+     * Set the data source of the action.
      *
      * @param  string $dataSource
      *
@@ -233,7 +225,21 @@ class SlackAttachmentAction
     }
 
     /**
-     * Get the array representation of the attachment field.
+     * Set the minimum query length of the action.
+     *
+     * @param  int $minQueryLength
+     *
+     * @return $this
+     */
+    public function minQueryLength($minQueryLength)
+    {
+        $this->minQueryLength = $minQueryLength;
+
+        return $this;
+    }
+
+    /**
+     * Get the array representation of the attachment action.
      *
      * @return array
      */

--- a/tests/Notifications/NotificationSlackChannelTest.php
+++ b/tests/Notifications/NotificationSlackChannelTest.php
@@ -155,6 +155,41 @@ class NotificationSlackChannelTest extends TestCase
             ]
         );
     }
+
+    public function testCorrectPayloadWithActionButtonsIsSentToSlack()
+    {
+        $this->validatePayload(
+            new NotificationSlackChannelWithActionButtonsTestNotification,
+            [
+                'json' => [
+                    'text' => 'Content',
+                    'attachments' => [
+                        [
+                            'title' => 'Laravel',
+                            'text' => 'Attachment Content',
+                            'title_link' => 'https://laravel.com',
+                            'callback_id' => 'laravel_123',
+                            'actions' => [
+                                [
+                                    'name' => 'laravel',
+                                    'style' => 'danger',
+                                    'text' => 'Cancel',
+                                    'type' => 'button',
+                                    'value' => 'laravel-cancel'
+                                ],
+                                [
+                                    'name' => 'laravel',
+                                    'text' => 'Okay',
+                                    'type' => 'button',
+                                    'value' => 'laravel-okay'
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ]
+        );
+    }
 }
 
 class NotificationSlackChannelTestNotifiable
@@ -253,3 +288,33 @@ class NotificationSlackChannelWithAttachmentFieldBuilderTestNotification extends
             });
     }
 }
+
+class NotificationSlackChannelWithActionButtonsTestNotification extends Notification
+{
+    public function toSlack($notifiable)
+    {
+        return (new SlackMessage)
+            ->content('Content')
+            ->attachment(function ($attachment) {
+                $attachment->title('Laravel', 'https://laravel.com')
+                    ->content('Attachment Content')
+                    ->callbackId('laravel_123')
+                    ->actions([
+                        [
+                            'name' => 'laravel',
+                            'style' => 'danger',
+                            'text' => 'Cancel',
+                            'type' => 'button',
+                            'value' => 'laravel-cancel'
+                        ],
+                        [
+                            'name' => 'laravel',
+                            'text' => 'Okay',
+                            'type' => 'button',
+                            'value' => 'laravel-okay'
+                        ],
+                    ]);
+            });
+    }
+}
+

--- a/tests/Notifications/NotificationSlackChannelTest.php
+++ b/tests/Notifications/NotificationSlackChannelTest.php
@@ -317,4 +317,3 @@ class NotificationSlackChannelWithActionButtonsTestNotification extends Notifica
             });
     }
 }
-

--- a/tests/Notifications/NotificationSlackChannelTest.php
+++ b/tests/Notifications/NotificationSlackChannelTest.php
@@ -194,7 +194,7 @@ class NotificationSlackChannelTest extends TestCase
                                     'style' => 'default',
                                     'options' => null,
                                     'min_query_length' => 1,
-                                    'data_source' => 'static'
+                                    'data_source' => 'static',
                                 ],
                             ],
                         ],

--- a/tests/Notifications/NotificationSlackChannelTest.php
+++ b/tests/Notifications/NotificationSlackChannelTest.php
@@ -175,13 +175,13 @@ class NotificationSlackChannelTest extends TestCase
                                     'style' => 'danger',
                                     'text' => 'Cancel',
                                     'type' => 'button',
-                                    'value' => 'laravel-cancel'
+                                    'value' => 'laravel-cancel',
                                 ],
                                 [
                                     'name' => 'laravel',
                                     'text' => 'Okay',
                                     'type' => 'button',
-                                    'value' => 'laravel-okay'
+                                    'value' => 'laravel-okay',
                                 ],
                             ],
                         ],
@@ -305,13 +305,13 @@ class NotificationSlackChannelWithActionButtonsTestNotification extends Notifica
                             'style' => 'danger',
                             'text' => 'Cancel',
                             'type' => 'button',
-                            'value' => 'laravel-cancel'
+                            'value' => 'laravel-cancel',
                         ],
                         [
                             'name' => 'laravel',
                             'text' => 'Okay',
                             'type' => 'button',
-                            'value' => 'laravel-okay'
+                            'value' => 'laravel-okay',
                         ],
                     ]);
             });

--- a/tests/Notifications/NotificationSlackChannelTest.php
+++ b/tests/Notifications/NotificationSlackChannelTest.php
@@ -180,11 +180,11 @@ class NotificationSlackChannelTest extends TestCase
                                         'title' => 'Are You Sure?',
                                         'text' => 'Are you sure you want to cancel?',
                                         'ok_text' => 'Yes, Cancel',
-                                        'dismiss_text' => 'Dismiss'
+                                        'dismiss_text' => 'Dismiss',
                                     ],
                                     'options' => null,
                                     'min_query_length' => 1,
-                                    'data_source' => 'static'
+                                    'data_source' => 'static',
                                 ],
                                 [
                                     'name' => 'laravel',
@@ -235,7 +235,7 @@ class NotificationSlackChannelTest extends TestCase
                                         ],
                                     ],
                                     'min_query_length' => 5,
-                                    'data_source' => 'external'
+                                    'data_source' => 'external',
                                 ],
                                 [
                                     'name' => 'laravel',
@@ -245,7 +245,7 @@ class NotificationSlackChannelTest extends TestCase
                                     'style' => 'default',
                                     'options' => null,
                                     'min_query_length' => 1,
-                                    'data_source' => 'static'
+                                    'data_source' => 'static',
                                 ],
                             ],
                         ],
@@ -364,17 +364,17 @@ class NotificationSlackChannelWithActionButtonsTestNotification extends Notifica
                     ->content('Attachment Content')
                     ->callbackId('laravel_123')
                     ->action(function ($action) {
-                       $action->name('laravel')
-                              ->text('Cancel')
-                              ->style('danger')
-                              ->type('button')
-                              ->value('laravel-cancel')
-                              ->confirmation(function($confirm) {
-                                  $confirm->title('Are You Sure?')
-                                          ->content('Are you sure you want to cancel?')
-                                          ->okText('Yes, Cancel')
-                                          ->dismissText('Dismiss');
-                              });
+                        $action->name('laravel')
+                               ->text('Cancel')
+                               ->style('danger')
+                               ->type('button')
+                               ->value('laravel-cancel')
+                               ->confirmation(function ($confirm) {
+                                   $confirm->title('Are You Sure?')
+                                           ->content('Are you sure you want to cancel?')
+                                           ->okText('Yes, Cancel')
+                                           ->dismissText('Dismiss');
+                               });
                     })
                     ->action(function ($action) {
                         $action->name('laravel')
@@ -397,21 +397,21 @@ class NotificationSlackChannelWithActionMenusTestNotification extends Notificati
                     ->content('Attachment Content')
                     ->callbackId('laravel_123')
                     ->action(function ($action) {
-                       $action->name('laravel')
-                              ->text('Cancel')
-                              ->style('danger')
-                              ->type('select')
-                              ->value('laravel-cancel')
-                              ->minQueryLength(5)
-                              ->dataSource('external')
-                              ->option(function($option) {
-                                $option->text('First Option')
-                                        ->value('first_option');
-                              })
-                              ->option(function($option) {
-                                  $option->text('Second Option')
-                                         ->value('second_option');
-                              });
+                        $action->name('laravel')
+                               ->text('Cancel')
+                               ->style('danger')
+                               ->type('select')
+                               ->value('laravel-cancel')
+                               ->minQueryLength(5)
+                               ->dataSource('external')
+                               ->option(function ($option) {
+                                   $option->text('First Option')
+                                          ->value('first_option');
+                               })
+                               ->option(function ($option) {
+                                   $option->text('Second Option')
+                                          ->value('second_option');
+                               });
                     })
                     ->action(function ($action) {
                         $action->name('laravel')


### PR DESCRIPTION
Slack has recently added the ability to use Action Buttons when sending messages via Slack Apps. These allow users to perform programmed actions by simply clicking an Action Button contained in a message.

This PR adds support for using these buttons to the Slack Notification Channel. It's a simple extension of the already existing attachment method for Slack Notifications.

The PR is fully backward compatible, as it introduces no breaking changes - just new methods for adding these Action Buttons. 

@taylorotwell If this PR is merged, I'd be happy to put together a second PR for adding documentation to the Laravel website!

Slack documentation for Action Buttons: https://api.slack.com/docs/message-buttons
Slack Action Buttons "Field Guide": https://api.slack.com/docs/interactive-message-field-guide

A demo of the new method with action buttons and a confirmation window for a destructive action:
```php
public function toSlack($notifiable)
{
    return (new SlackMessage)
        ->content('Content')
        ->attachment(function ($attachment) {
            $attachment->title('Laravel', 'https://laravel.com')
                ->content('Attachment Content')
                ->callbackId('laravel_123')
                ->action(function ($action) {
                   $action->name('laravel')
                          ->text('Cancel')
                          ->style('danger')
                          ->type('button')
                          ->value('laravel-cancel')
                          ->confirmation(function($confirm) {
                              $confirm->title('Are You Sure?')
                                      ->content('Are you sure you want to cancel?')
                                      ->okText('Yes, Cancel')
                                      ->dismissText('Dismiss');
                          });
                })
                ->action(function ($action) {
                    $action->name('laravel')
                           ->text('Okay')
                           ->type('button')
                           ->value('laravel-okay');
                });
        });
}
```

And a demo of the method using a select dropdown for providing action options:
```php
public function toSlack($notifiable)
{
    return (new SlackMessage)
        ->content('Content')
        ->attachment(function ($attachment) {
            $attachment->title('Laravel', 'https://laravel.com')
                ->content('Attachment Content')
                ->callbackId('laravel_123')
                ->action(function ($action) {
                   $action->name('laravel')
                          ->text('Cancel')
                          ->style('danger')
                          ->type('select')
                          ->value('laravel-cancel')
                          ->option(function($option) {
                            $option->text('First Option')
                                    ->value('first_option');
                          })
                          ->option(function($option) {
                              $option->text('Second Option')
                                     ->value('second_option');
                          });
                })
                ->action(function ($action) {
                    $action->name('laravel')
                           ->text('Okay')
                           ->type('button')
                           ->value('laravel-okay');
                });
        });
}
```