### PR TITLE
Check file is loaded before trying to rollback it

### DIFF
--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -243,11 +243,15 @@ class Migrator
         // repository already returns these migration's names in reverse order.
         foreach ($migrations as $migration) {
             $migration = (object) $migration;
+            
+            if (! $file = Arr::get($files, $migration->migration)) {
+                continue;
+            }
 
-            $rolledBack[] = $files[$migration->migration];
+            $rolledBack[] = $file;
 
             $this->runDown(
-                $files[$migration->migration],
+                $file,
                 $migration, Arr::get($options, 'pretend', false)
             );
         }

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -243,7 +243,7 @@ class Migrator
         // repository already returns these migration's names in reverse order.
         foreach ($migrations as $migration) {
             $migration = (object) $migration;
-            
+
             if (! $file = Arr::get($files, $migration->migration)) {
                 continue;
             }


### PR DESCRIPTION
I have some migrations on separated folders, and i want to migrate / reset them separately...

Right now it's working great with migrate, but not for reset, when i do:

````
php artisan migrate --path=special/path
````

It works great, but when i do:

````
php artisan migrate:reset --path=special/path
````

It tries to reset all ran migrations, instead of resetting only the loaded files on `special/path`.

My PR fixes it, and probably won't make any difference for most use cases.

---------

Even with my PR, there is still another known issue, if you run reset and nothing was migrated, no output is printed... This is basically because here: https://github.com/laravel/framework/blob/5.4/src/Illuminate/Database/Migrations/Migrator.php#L272-L280 `$migrations` has all ran migrations, and we do the check with loaded file later.

I think totally come with another PR properly fixing it but it will require a more code changes.

Let me know your thoughts so i can work on the other PR.