### PR TITLE
[5.4] Allow a database notification to modify the model used before it is saved

### DIFF
--- a/src/Illuminate/Notifications/Channels/DatabaseChannel.php
+++ b/src/Illuminate/Notifications/Channels/DatabaseChannel.php
@@ -16,12 +16,18 @@ class DatabaseChannel
      */
     public function send($notifiable, Notification $notification)
     {
-        return $notifiable->routeNotificationFor('database')->create([
+        $model = $notifiable->routeNotificationFor('database')->make([
             'id' => $notification->id,
             'type' => get_class($notification),
             'data' => $this->getData($notifiable, $notification),
             'read_at' => null,
         ]);
+
+        if (method_exists($notification, 'modifyDatabaseModel')) {
+            $notification->modifyDatabaseModel($model, $notifiable);
+        }
+
+        return $model->save();
     }
 
     /**

--- a/tests/Notifications/NotificationDatabaseChannelTest.php
+++ b/tests/Notifications/NotificationDatabaseChannelTest.php
@@ -21,12 +21,12 @@ class NotificationDatabaseChannelTest extends TestCase
         $notification->id = 1;
         $notifiable = Mockery::mock();
 
-        $notifiable->shouldReceive('routeNotificationFor->create')->with([
+        $notifiable->shouldReceive('routeNotificationFor->make')->with([
             'id' => 1,
             'type' => get_class($notification),
             'data' => ['invoice_id' => 1],
             'read_at' => null,
-        ]);
+        ])->andReturnSelf()->shouldReceive('save');
 
         $channel = new DatabaseChannel;
         $channel->send($notifiable, $notification);


### PR DESCRIPTION
Currently a database notification can only really store some serialized data. 

Here is an example of usage of this change:
The `type` gets set to the class name of the notification. This isn't to my liking, as I see it as being it's the same thing that `Relation::morphMap` exists to avoid. Therefore, with this change, on my notification class I can use
```php
public function modifyDatabaseModel($model, $notifiable)
{
    $model->type = 'custom_type_string';
}
```

This change also allows a developer to e.g. add additional relationships to the notification model, rather than relying on storing ids in the serialized data, which are then awkward to use when displaying the notifications. 