### PR TITLE
[5.5] Add missing methods to Mailer contract

### DIFF
--- a/src/Illuminate/Contracts/Mail/Mailer.php
+++ b/src/Illuminate/Contracts/Mail/Mailer.php
@@ -5,13 +5,75 @@ namespace Illuminate\Contracts\Mail;
 interface Mailer
 {
     /**
+     * Set the global from address and name.
+     *
+     * @param  string  $address
+     * @param  string|null  $name
+     * @return void
+     */
+    public function alwaysFrom($address, $name = null);
+
+    /**
+     * Set the global reply-to address and name.
+     *
+     * @param  string  $address
+     * @param  string|null  $name
+     * @return void
+     */
+    public function alwaysReplyTo($address, $name = null);
+
+    /**
+     * Set the global to address and name.
+     *
+     * @param  string  $address
+     * @param  string|null  $name
+     * @return void
+     */
+    public function alwaysTo($address, $name = null);
+
+    /**
+     * Begin the process of mailing a mailable class instance.
+     *
+     * @param  mixed  $users
+     * @return \Illuminate\Mail\PendingMail
+     */
+    public function to($users);
+
+    /**
+     * Begin the process of mailing a mailable class instance.
+     *
+     * @param  mixed  $users
+     * @return \Illuminate\Mail\PendingMail
+     */
+    public function bcc($users);
+
+    /**
      * Send a new message when only a raw text part.
      *
      * @param  string  $text
-     * @param  \Closure|string  $callback
-     * @return int
+     * @param  mixed  $callback
+     * @return void
      */
     public function raw($text, $callback);
+
+    /**
+     * Send a new message when only a plain part.
+     *
+     * @param  string  $view
+     * @param  array  $data
+     * @param  mixed  $callback
+     * @return void
+     */
+    public function plain($view, array $data, $callback);
+
+    /**
+     * Render the given message as a view.
+     *
+     * @param  string|array  $view
+     * @param  array  $data
+     * @return \Illuminate\View\View
+     */
+    public function render($view, array $data = []);
 
     /**
      * Send a new message using a view.


### PR DESCRIPTION
Fixes #18361

This PR adds some missing methods to the Mailer contract...

Also updated PHPDoc of the ``` raw ``` method to match it's implementation...