### PR TITLE
[5.5] Let the exception handler render Validation exceptions from ValidatesRequests

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -218,7 +218,7 @@ class Handler implements ExceptionHandlerContract
 
         return redirect()->back()->withInput(
             $request->input()
-        )->withErrors($errors);
+        )->withErrors($errors, $e->errorBag);
     }
 
     /**

--- a/src/Illuminate/Foundation/Validation/ValidatesRequests.php
+++ b/src/Illuminate/Foundation/Validation/ValidatesRequests.php
@@ -33,9 +33,7 @@ trait ValidatesRequests
             $validator = $this->getValidationFactory()->make($request->all(), $validator);
         }
 
-        if ($validator->fails()) {
-            $this->throwValidationException($request, $validator);
-        }
+        $validator->validate();
 
         return $request->only(array_keys($validator->getRules()));
     }
@@ -51,11 +49,9 @@ trait ValidatesRequests
      */
     public function validate(Request $request, array $rules, array $messages = [], array $customAttributes = [])
     {
-        $validator = $this->getValidationFactory()->make($request->all(), $rules, $messages, $customAttributes);
-
-        if ($validator->fails()) {
-            $this->throwValidationException($request, $validator);
-        }
+        $this->getValidationFactory()
+             ->make($request->all(), $rules, $messages, $customAttributes)
+             ->validate();
 
         return $request->only(array_keys($rules));
     }
@@ -95,51 +91,6 @@ trait ValidatesRequests
         call_user_func($callback);
 
         $this->validatesRequestErrorBag = null;
-    }
-
-    /**
-     * Throw the failed validation exception.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @param  \Illuminate\Contracts\Validation\Validator  $validator
-     * @return void
-     *
-     * @throws \Illuminate\Validation\ValidationException
-     */
-    protected function throwValidationException(Request $request, $validator)
-    {
-        throw new ValidationException($validator, $this->buildFailedValidationResponse(
-            $request, $this->formatValidationErrors($validator)
-        ));
-    }
-
-    /**
-     * Create the response for when a request fails validation.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @param  array  $errors
-     * @return \Symfony\Component\HttpFoundation\Response
-     */
-    protected function buildFailedValidationResponse(Request $request, array $errors)
-    {
-        if ($request->expectsJson()) {
-            return new JsonResponse($errors, 422);
-        }
-
-        return redirect()->to($this->getRedirectUrl())
-                        ->withInput($request->input())
-                        ->withErrors($errors, $this->errorBag());
-    }
-
-    /**
-     * Format the validation errors to be returned.
-     *
-     * @param  \Illuminate\Contracts\Validation\Validator  $validator
-     * @return array
-     */
-    protected function formatValidationErrors(Validator $validator)
-    {
-        return $validator->errors()->getMessages();
     }
 
     /**

--- a/src/Illuminate/Foundation/Validation/ValidatesRequests.php
+++ b/src/Illuminate/Foundation/Validation/ValidatesRequests.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Foundation\Validation;
 
 use Illuminate\Http\Request;
-use Illuminate\Routing\UrlGenerator;
 use Illuminate\Contracts\Validation\Factory;
 
 trait ValidatesRequests
@@ -88,16 +87,6 @@ trait ValidatesRequests
         call_user_func($callback);
 
         $this->validatesRequestErrorBag = null;
-    }
-
-    /**
-     * Get the key to be used for the view error bag.
-     *
-     * @return string
-     */
-    protected function errorBag()
-    {
-        return $this->validatesRequestErrorBag ?: 'default';
     }
 
     /**

--- a/src/Illuminate/Foundation/Validation/ValidatesRequests.php
+++ b/src/Illuminate/Foundation/Validation/ValidatesRequests.php
@@ -3,11 +3,8 @@
 namespace Illuminate\Foundation\Validation;
 
 use Illuminate\Http\Request;
-use Illuminate\Http\JsonResponse;
 use Illuminate\Routing\UrlGenerator;
 use Illuminate\Contracts\Validation\Factory;
-use Illuminate\Contracts\Validation\Validator;
-use Illuminate\Validation\ValidationException;
 
 trait ValidatesRequests
 {

--- a/src/Illuminate/Foundation/Validation/ValidatesRequests.php
+++ b/src/Illuminate/Foundation/Validation/ValidatesRequests.php
@@ -4,16 +4,10 @@ namespace Illuminate\Foundation\Validation;
 
 use Illuminate\Http\Request;
 use Illuminate\Contracts\Validation\Factory;
+use Illuminate\Validation\ValidationException;
 
 trait ValidatesRequests
 {
-    /**
-     * The default error bag.
-     *
-     * @var string
-     */
-    protected $validatesRequestErrorBag;
-
     /**
      * Run the validation routine against the given validator.
      *
@@ -66,27 +60,13 @@ trait ValidatesRequests
      */
     public function validateWithBag($errorBag, Request $request, array $rules, array $messages = [], array $customAttributes = [])
     {
-        $this->withErrorBag($errorBag, function () use ($request, $rules, $messages, $customAttributes) {
-            $this->validate($request, $rules, $messages, $customAttributes);
-        });
+        try {
+            return $this->validate($request, $rules, $messages, $customAttributes);
+        } catch (ValidationException $e) {
+            $e->errorBag = $errorBag;
 
-        return $request->only(array_keys($rules));
-    }
-
-    /**
-     * Execute a Closure within with a given error bag set as the default bag.
-     *
-     * @param  string  $errorBag
-     * @param  callable  $callback
-     * @return void
-     */
-    protected function withErrorBag($errorBag, callable $callback)
-    {
-        $this->validatesRequestErrorBag = $errorBag;
-
-        call_user_func($callback);
-
-        $this->validatesRequestErrorBag = null;
+            throw $e;
+        }
     }
 
     /**

--- a/src/Illuminate/Foundation/Validation/ValidatesRequests.php
+++ b/src/Illuminate/Foundation/Validation/ValidatesRequests.php
@@ -101,16 +101,6 @@ trait ValidatesRequests
     }
 
     /**
-     * Get the URL we should redirect to.
-     *
-     * @return string
-     */
-    protected function getRedirectUrl()
-    {
-        return app(UrlGenerator::class)->previous();
-    }
-
-    /**
      * Get a validation factory instance.
      *
      * @return \Illuminate\Contracts\Validation\Factory

--- a/src/Illuminate/Validation/ValidationException.php
+++ b/src/Illuminate/Validation/ValidationException.php
@@ -21,18 +21,27 @@ class ValidationException extends Exception
     public $response;
 
     /**
+     * The error bag used.
+     *
+     * @var string
+     */
+    public $errorBag;
+
+    /**
      * Create a new exception instance.
      *
      * @param  \Illuminate\Contracts\Validation\Validator  $validator
      * @param  \Symfony\Component\HttpFoundation\Response  $response
+     * @param  string  $errorBag
      * @return void
      */
-    public function __construct($validator, $response = null)
+    public function __construct($validator, $response = null, $errorBag = 'default')
     {
         parent::__construct('The given data failed to pass validation.');
 
         $this->response = $response;
         $this->validator = $validator;
+        $this->errorBag = $errorBag;
     }
 
     /**

--- a/src/Illuminate/Validation/ValidationException.php
+++ b/src/Illuminate/Validation/ValidationException.php
@@ -21,7 +21,7 @@ class ValidationException extends Exception
     public $response;
 
     /**
-     * The error bag used.
+     * The default error bag.
      *
      * @var string
      */


### PR DESCRIPTION
Instead of formatting the exception message from within the `ValidatesRequests` trait, we'll just call `Validator::validate()` which throws a `ValidationException` on failure, the handler later takes care of formatting the validation exceptions.