### PR TITLE
[5.4] add `force` option to some generators

### DIFF
--- a/src/Illuminate/Foundation/Console/MailMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/MailMakeCommand.php
@@ -35,7 +35,7 @@ class MailMakeCommand extends GeneratorCommand
      */
     public function fire()
     {
-        if (parent::fire() === false) {
+        if (parent::fire() === false && !$this->option('force')) {
             return;
         }
 
@@ -109,6 +109,8 @@ class MailMakeCommand extends GeneratorCommand
     {
         return [
             ['markdown', 'm', InputOption::VALUE_OPTIONAL, 'Create a new Markdown template for the mailable.'],
+
+            ['force', 'f', InputOption::VALUE_NONE, 'Force the generator to continue execution even if the mail already exists.'],
         ];
     }
 }

--- a/src/Illuminate/Foundation/Console/MailMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/MailMakeCommand.php
@@ -35,7 +35,7 @@ class MailMakeCommand extends GeneratorCommand
      */
     public function fire()
     {
-        if (parent::fire() === false && !$this->option('force')) {
+        if (parent::fire() === false && ! $this->option('force')) {
             return;
         }
 

--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -36,7 +36,7 @@ class ModelMakeCommand extends GeneratorCommand
      */
     public function fire()
     {
-        if (parent::fire() === false && !$this->option('force')) {
+        if (parent::fire() === false && ! $this->option('force')) {
             return;
         }
 

--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -36,7 +36,7 @@ class ModelMakeCommand extends GeneratorCommand
      */
     public function fire()
     {
-        if (parent::fire() === false) {
+        if (parent::fire() === false && !$this->option('force')) {
             return;
         }
 
@@ -114,7 +114,9 @@ class ModelMakeCommand extends GeneratorCommand
 
             ['controller', 'c', InputOption::VALUE_NONE, 'Create a new controller for the model.'],
 
-            ['resource', 'r', InputOption::VALUE_NONE, 'Indicates if the generated controller should be a resource controller'],
+            ['resource', 'r', InputOption::VALUE_NONE, 'Indicates if the generated controller should be a resource controller.'],
+
+            ['force', 'f', InputOption::VALUE_NONE, 'Force the generator to continue execution even if the model already exists.'],
         ];
     }
 }

--- a/src/Illuminate/Foundation/Console/NotificationMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/NotificationMakeCommand.php
@@ -35,7 +35,7 @@ class NotificationMakeCommand extends GeneratorCommand
      */
     public function fire()
     {
-        if (parent::fire() === false && !$this->option('force')) {
+        if (parent::fire() === false && ! $this->option('force')) {
             return;
         }
 

--- a/src/Illuminate/Foundation/Console/NotificationMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/NotificationMakeCommand.php
@@ -35,7 +35,7 @@ class NotificationMakeCommand extends GeneratorCommand
      */
     public function fire()
     {
-        if (parent::fire() === false) {
+        if (parent::fire() === false && !$this->option('force')) {
             return;
         }
 
@@ -109,6 +109,8 @@ class NotificationMakeCommand extends GeneratorCommand
     {
         return [
             ['markdown', 'm', InputOption::VALUE_OPTIONAL, 'Create a new Markdown template for the notification.'],
+
+            ['force', 'f', InputOption::VALUE_NONE, 'Force the generator to continue execution even if the notification already exists.'],
         ];
     }
 }


### PR DESCRIPTION
this will allow the user to continue execution of the command even if the class already exists.

Example:

User types `php artisan make:model Blog` but forgets to add the `-mcr` flags to make their migration and resource controller. Currently they would either have to write the migration and controller command themselves

```php
php artisan make:migration create_blogs_table --table=blogs
php artisan make:contoller BlogController --model=/App/Blog
```

or they could delete the `Blog` model and run the command again with the flags.

```php
php artisan make:model Blog -mcr
```

What this change allows us to do is run the flag commands immediately after the original command.

```php
php artisan make:model Blog -mcrf
```

This will still realize the model already exists and not try to create it again, but it will not `return false` and halt execution of the flagged commands. 