### PR TITLE
[5.5] Clear Carbon mock in tear down.

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Foundation\Testing;
 
 use Mockery;
+use Carbon\Carbon;
 use Illuminate\Support\Facades\Facade;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Console\Application as Artisan;
@@ -147,6 +148,10 @@ abstract class TestCase extends BaseTestCase
 
         if (class_exists('Mockery')) {
             Mockery::close();
+        }
+
+        if (class_exists(Carbon::class)) {
+            Carbon::setTestNow();
         }
 
         $this->afterApplicationCreatedCallbacks = [];


### PR DESCRIPTION
When I was running through my whole testsuite I encountered a problem that the Carbon mock was not reset after each test. I don’t know if this should be done by the framework, like `Mockery::close()`, or that I should add it to my own TestCase.