### PR TITLE
[5.5] Fix conflicts on ModelMakeCommand

### DIFF
--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -133,19 +133,15 @@ class ModelMakeCommand extends GeneratorCommand
     protected function getOptions()
     {
         return [
-<<<<<<< HEAD
             ['all', 'a', InputOption::VALUE_NONE, 'Generate a migration, factory, and resource controller for the model'],
 
             ['controller', 'c', InputOption::VALUE_NONE, 'Create a new controller for the model'],
 
-            ['factory', 'f', InputOption::VALUE_NONE, 'Create a new factory for the model'],
-=======
+            ['factory', 'fa', InputOption::VALUE_NONE, 'Create a new factory for the model'],
+
             ['force', 'f', InputOption::VALUE_NONE, 'Create the class even if the model already exists.'],
 
             ['migration', 'm', InputOption::VALUE_NONE, 'Create a new migration file for the model.'],
->>>>>>> 5.4
-
-            ['migration', 'm', InputOption::VALUE_NONE, 'Create a new migration file for the model'],
 
             ['resource', 'r', InputOption::VALUE_NONE, 'Indicates if the generated controller should be a resource controller.'],
         ];


### PR DESCRIPTION
I've renamed the shortcut for the factory, otherwise it would throw an error saying that 2 shortcuts with the same name exist.