### PR TITLE
Add the the str_before extra helper, it's the inverse of str_after

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -30,6 +30,28 @@ class Str
     protected static $studlyCache = [];
 
     /**
+     * Return the remainder of a string before a given value.
+     *
+     * @param  string  $subject
+     * @param  string  $search
+     * @return string
+     */
+    public static function before($subject, $search)
+    {
+        if ($search == '') {
+            return $subject;
+        }
+
+        $pos = strpos($subject, $search);
+
+        if ($pos === false) {
+            return $subject;
+        }
+
+        return substr($subject, 0, $pos);
+    }
+
+    /**
      * Return the remainder of a string after a given value.
      *
      * @param  string  $subject

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -748,6 +748,20 @@ if (! function_exists('starts_with')) {
     }
 }
 
+if (! function_exists('str_before')) {
+    /**
+     * Return the remainder of a string before a given value.
+     *
+     * @param  string  $subject
+     * @param  string  $search
+     * @return string
+     */
+    function str_before($subject, $search)
+    {
+        return Str::before($subject, $search);
+    }
+}
+
 if (! function_exists('str_after')) {
     /**
      * Return the remainder of a string after a given value.

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -88,6 +88,15 @@ class SupportStrTest extends TestCase
         $this->assertFalse(Str::endsWith(0.27, '8'));
     }
 
+    public function testStrBefore()
+    {
+        $this->assertEquals('han', Str::before('hannah', 'nah'));
+        $this->assertEquals('ha', Str::before('hannah', 'n'));
+        $this->assertEquals('ééé ', Str::before('ééé hannah', 'han'));
+        $this->assertEquals('hannah', Str::before('hannah', 'xxxx'));
+        $this->assertEquals('hannah', Str::before('hannah', ''));
+    }
+
     public function testStrAfter()
     {
         $this->assertEquals('nah', Str::after('hannah', 'han'));


### PR DESCRIPTION
Hello :)

This PR adds an extra string helper, `str_before` which is exactly the inverse of `str_after`.

----

My use case was:

I have an invitation system where I want to create a user with just the email while creating it with a name.
So I would receive the email in the controller, "a.fsardo@gmail.com" and I wanted my user to be:

`["name" => "a.fsardo", "email" => "a.fsardo@gmail.com"]`

Which would be from `str_before(request('email'), '@')`.

----

Since Laravel already has a str_after, for me it made sense that this one would be a no-brainer addition.

Hope this is helpful if not at least it was fun, the process of contributing.