### PR TITLE
[5.5] Added isNotEmpty to complement isEmpty

### DIFF
--- a/src/Illuminate/Contracts/Pagination/Paginator.php
+++ b/src/Illuminate/Contracts/Pagination/Paginator.php
@@ -100,6 +100,13 @@ interface Paginator
     public function isEmpty();
 
     /**
+     * Determine if the list of items is not empty.
+     *
+     * @return bool
+     */
+    public function isNotEmpty();
+
+    /**
      * Render the paginator using a given view.
      *
      * @param  string|null  $view

--- a/src/Illuminate/Contracts/Support/MessageBag.php
+++ b/src/Illuminate/Contracts/Support/MessageBag.php
@@ -85,6 +85,13 @@ interface MessageBag extends Arrayable
     public function isEmpty();
 
     /**
+     * Determine if the message bag has any messages.
+     *
+     * @return bool
+     */
+    public function isNotEmpty();
+
+    /**
      * Get the number of messages in the container.
      *
      * @return int

--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -466,6 +466,16 @@ abstract class AbstractPaginator implements Htmlable
     }
 
     /**
+     * Determine if the list of items is not empty.
+     *
+     * @return bool
+     */
+    public function isNotEmpty()
+    {
+        return $this->items->isNotEmpty();
+    }
+
+    /**
      * Get the number of items for the current page.
      *
      * @return int

--- a/src/Illuminate/Support/MessageBag.php
+++ b/src/Illuminate/Support/MessageBag.php
@@ -326,6 +326,16 @@ class MessageBag implements Arrayable, Countable, Jsonable, JsonSerializable, Me
      *
      * @return bool
      */
+    public function isNotEmpty()
+    {
+        return $this->any();
+    }
+
+    /**
+     * Determine if the message bag has any messages.
+     *
+     * @return bool
+     */
     public function any()
     {
         return $this->count() > 0;


### PR DESCRIPTION
I've come to love the `isEmpty` and `isNotEmpty` methods on the collection class.

It's always great when you can guess what methods are available in Laravel - and they are there.

Now that I've grown accustomed to the `isEmpty` method - I assume everywhere I can use that, I can use the complement `isNotEmpty` method. Unfortunately this is not standard across the code base. For example on the `MessageBag` class there is an `isEmpty` and an `any` method. This PR introduces an `isNotEmpty` method where ever the `isEmpty` method is present.

I'm not 100% sure if this should change the contracts, but as 5.5 is nearly here, I thought I'd add it to the contracts and the classes anyway and pull it into 5.5.

I haven't added any tests, would rather know if this is wanted / appropriate first.