### PR TITLE
[5.5] Automatically give request and route parameters to view routes

### DIFF
--- a/src/Illuminate/Routing/ViewController.php
+++ b/src/Illuminate/Routing/ViewController.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Routing;
 
+use Illuminate\Http\Request;
 use Illuminate\Contracts\View\Factory as ViewFactory;
 
 class ViewController extends Controller
@@ -14,25 +15,39 @@ class ViewController extends Controller
     protected $view;
 
     /**
+     * The default data for the view.
+     * 
+     * @var array;
+     */
+    protected $data;
+
+    /**
      * Create a new controller instance.
      *
      * @param  \Illuminate\Contracts\View\Factory  $view
+     * @param  \Illuminate\Routing\Route           $route
+     * @param  \Illuminate\Http\Request            $request
      * @return void
      */
-    public function __construct(ViewFactory $view)
+    public function __construct(ViewFactory $view, Route $route, Request $request)
     {
         $this->view = $view;
+        $this->data = $route->parameters + compact('request');
     }
 
     /**
      * Invoke the controller method.
      *
-     * @param  string  $view
-     * @param  array  $data
+     * @param  \Illuminate\Routing\Route  $route
      * @return \Illuminate\Contracts\View\View
      */
-    public function __invoke($view, $data)
+    public function __invoke(Route $route)
     {
+        $view = $route->defaults['view'];
+        $data = $route->defaults['data'];
+
+        $data = array_merge($this->data, $data);
+
         return $this->view->make($view, $data);
     }
 }

--- a/src/Illuminate/Routing/ViewController.php
+++ b/src/Illuminate/Routing/ViewController.php
@@ -16,7 +16,7 @@ class ViewController extends Controller
 
     /**
      * The default data for the view.
-     * 
+     *
      * @var array;
      */
     protected $data;
@@ -46,7 +46,7 @@ class ViewController extends Controller
         $view = $route->defaults['view'];
         $data = $route->defaults['data'];
 
-        $data = array_merge($this->data, $data);
+        $data = array_merge($data, $this->data);
 
         return $this->view->make($view, $data);
     }

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -1435,6 +1435,24 @@ class RoutingRouteTest extends TestCase
         $this->assertEquals('Hello Taylor!', $router->dispatch(Request::create('hello/Taylor', 'GET'))->getContent());
     }
 
+    public function testRouteViewWithOptionalParameters()
+    {
+        $container = new Container;
+        $factory = m::mock('Illuminate\View\Factory');
+        $router = new Router(new Dispatcher, $container);
+        $container->bind(ViewFactory::class, function () use ($factory) {
+            return $factory;
+        });
+        $container->singleton(Registrar::class, function () use ($router) {
+            return $router;
+        });
+
+        $router->view('hello/{name?}', 'pages.greeting', ['name' => 'He-Who-Must-Not-Be-Named']);
+
+        $factory->shouldReceive('make')->once()->with('pages.greeting', m::subset(['name' => 'He-Who-Must-Not-Be-Named']))->andReturn('Hello He-Who-Must-Not-Be-Named!');
+        $this->assertEquals('Hello He-Who-Must-Not-Be-Named!', $router->dispatch(Request::create('hello', 'GET'))->getContent());
+    }
+
     protected function getRouter()
     {
         $container = new Container;

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -1403,7 +1403,7 @@ class RoutingRouteTest extends TestCase
     {
         $container = new Container;
         $factory = m::mock('Illuminate\View\Factory');
-        $factory->shouldReceive('make')->once()->with('pages.contact', ['foo' => 'bar'])->andReturn('Contact us');
+        $factory->shouldReceive('make')->once()->with('pages.contact', m::subset(['foo' => 'bar']))->andReturn('Contact us');
         $router = new Router(new Dispatcher, $container);
         $container->bind(ViewFactory::class, function () use ($factory) {
             return $factory;
@@ -1415,6 +1415,24 @@ class RoutingRouteTest extends TestCase
         $router->view('contact', 'pages.contact', ['foo' => 'bar']);
 
         $this->assertEquals('Contact us', $router->dispatch(Request::create('contact', 'GET'))->getContent());
+    }
+
+    public function testRouteViewWithParameters()
+    {
+        $container = new Container;
+        $factory = m::mock('Illuminate\View\Factory');
+        $factory->shouldReceive('make')->once()->with('pages.greeting', m::subset(['name' => 'Taylor']))->andReturn('Hello Taylor!');
+        $router = new Router(new Dispatcher, $container);
+        $container->bind(ViewFactory::class, function () use ($factory) {
+            return $factory;
+        });
+        $container->singleton(Registrar::class, function () use ($router) {
+            return $router;
+        });
+
+        $router->view('hello/{name}', 'pages.greeting');
+
+        $this->assertEquals('Hello Taylor!', $router->dispatch(Request::create('hello/Taylor', 'GET'))->getContent());
     }
 
     protected function getRouter()


### PR DESCRIPTION
Now when you make a route like so:

```php
Route::view('/hello/{name}', 'pages.greeting');
```

You can simply use that route parameter in the view like so:

```html
<h1>Hello {{ $name }}!</h1>
```

And if you have route model binding set up (not implicitly), then you can even do this:

```php
Route::view('/users/{user}', 'users.profile');
```

```html
<h1>Here's your profile {{ $user->name }}</h1>
```

And finally the `request` object is also available by default. In case you'd like to easily access anything passed in the query part of the url for example.

```html
<h1>Hello {{ $request['name'] }}!</h1>
```

Though I'm willing to remove the `request` object if Taylor thinks we should just use the global function for that.

### edit

Oh and you can also use this to provide `default` data.

```php
Route::view('/hello/{name?}', 'pages.greeting', ['name' => 'He-Who-Must-Not-Be-Named']);
```

Which means the `$name` in the view would either be whatever is passed as the route parameter or if that's not available then it is `"He-Who-Must-Not-Be-Named"`.