### PR TITLE
[5.5] Add to and bcc to mailer contract

### DIFF
--- a/src/Illuminate/Contracts/Mail/Mailer.php
+++ b/src/Illuminate/Contracts/Mail/Mailer.php
@@ -5,6 +5,22 @@ namespace Illuminate\Contracts\Mail;
 interface Mailer
 {
     /**
+     * Begin the process of mailing a mailable class instance.
+     *
+     * @param  mixed  $users
+     * @return \Illuminate\Mail\PendingMail
+     */
+    public function to($users);
+
+    /**
+     * Begin the process of mailing a mailable class instance.
+     *
+     * @param  mixed  $users
+     * @return \Illuminate\Mail\PendingMail
+     */
+    public function bcc($users);
+
+    /**
      * Send a new message when only a raw text part.
      *
      * @param  string  $text


### PR DESCRIPTION
Fixes #18361

#19928 was reverted since it broke MailFake.

However we can add ``` bcc ``` and ``` to ```, MailFake implements them:
https://github.com/laravel/framework/blob/master/src/Illuminate/Support/Testing/Fakes/MailFake.php#L110

```php
    /**
     * Begin the process of mailing a mailable class instance.
     *
     * @param  mixed  $users
     * @return \Illuminate\Mail\PendingMail
     */
    public function to($users)
    {
        return (new PendingMailFake($this))->to($users);
    }

    /**
     * Begin the process of mailing a mailable class instance.
     *
     * @param  mixed  $users
     * @return \Illuminate\Mail\PendingMail
     */
    public function bcc($users)
    {
        return (new PendingMailFake($this))->bcc($users);
    }
```

