### PR TITLE
[5.5] Ability to determine if queued handler should be pushed to queue

### DIFF
--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -431,7 +431,7 @@ class Dispatcher implements DispatcherContract
             }, func_get_args());
 
             if ($this->mayQueueHandler($class, $arguments)) {
-                $this->queueHandler($class, $method, $arguments);;
+                $this->queueHandler($class, $method, $arguments);
             }
         };
     }

--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -445,7 +445,7 @@ class Dispatcher implements DispatcherContract
      */
     protected function mayQueueHandler($class, $arguments)
     {
-        return ! method_exists($class, 'shouldPushToQueue') ? false
+        return ! method_exists($class, 'shouldPushToQueue') ? true
                     : (new ReflectionClass($class))->newInstanceWithoutConstructor()
                         ->shouldPushToQueue($arguments[0]);
     }


### PR DESCRIPTION
An event that has multiple queued handlers, sometimes a single handler is only desired to run in a certain condition, normally you'd let the handler be queued and when workers run it you can just return null in `handle()` method if it shouldn't be run, but you end up with filling your queues with unnecessary jobs.

This PR adds the ability to add a `shouldPushToQueue()` on the handler class to determine if that queued handler should be pushed to queue or not:

```php
public function shouldPushToQueue($event){
    return $event->user->shouldReceiveOffer();
}
```