### PR TITLE
[5.5] Use listensFor instead of hears for event listener self-registration 

### DIFF
--- a/src/Illuminate/Foundation/Console/EventGenerateCommand.php
+++ b/src/Illuminate/Foundation/Console/EventGenerateCommand.php
@@ -41,7 +41,7 @@ class EventGenerateCommand extends Command
     }
 
     /**
-     * Generate the dynamic listeners which have "hears" properties.
+     * Generate the dynamic listeners which have "listensFor" properties.
      *
      * @param  object  $provider
      * @return void
@@ -55,7 +55,7 @@ class EventGenerateCommand extends Command
                 continue;
             }
 
-            foreach ($listener::$hears as $event) {
+            foreach ($listener::$listensFor as $event) {
                 $this->makeEventAndListeners($event, [$listener]);
             }
         }

--- a/src/Illuminate/Foundation/Console/stubs/listener-duck.stub
+++ b/src/Illuminate/Foundation/Console/stubs/listener-duck.stub
@@ -12,7 +12,7 @@ class DummyClass
      *
      * @var array
      */
-    public static $hears = [
+    public static $listensFor = [
         //
     ];
 

--- a/src/Illuminate/Foundation/Console/stubs/listener-queued-duck.stub.php
+++ b/src/Illuminate/Foundation/Console/stubs/listener-queued-duck.stub.php
@@ -14,7 +14,7 @@ class DummyClass implements ShouldQueue
      *
      * @var array
      */
-    public static $hears = [
+    public static $listensFor = [
         //
     ];
 

--- a/src/Illuminate/Foundation/Support/Providers/EventServiceProvider.php
+++ b/src/Illuminate/Foundation/Support/Providers/EventServiceProvider.php
@@ -64,7 +64,7 @@ class EventServiceProvider extends ServiceProvider
         return array_merge_recursive(collect($this->listeners)->filter(function ($listener) {
             return class_exists($listener, false);
         })->flatMap(function ($listener) {
-            return collect($listener::$hears)->map(function ($event) use ($listener) {
+            return collect($listener::$listensFor)->map(function ($event) use ($listener) {
                 return ['event' => $event, 'listeners' => [$listener]];
             })->all();
         })->groupBy('event')->map(function ($listeners) {


### PR DESCRIPTION
I love the new feature introduced in #19917 and I wanted to make a naming suggestion, but I didn't see it until it was merged. There was a bit of discussion on that PR, but I'm sure Taylor and Mohammed get enough alerts without reading through closed PRs so I figured opening a new one would be the best way to propose it.

Here's my reasoning for the change copied from that thread: The reason I prefer `$listensFor` instead of `$hears` is that `$listensFor` is more active; it describes something that the object is actively doing, whereas `$hears` feels more passive. If I say I "_hear_" a particular sound, you would assume that I happen to be in the area when some sound is occurring. If I say I "_listen for_" a particular sound, you would assume that I am actively attentive while waiting for that sound to occur. We're setting up objects that specifically listen for certain events (and actively wait for them to occur), not just that hear the event activity around them.

@adamwathan , would love to hear your thoughts since you introduced the feature. Of course, close away if this seems too pedantic, but I find naming to worth a discussion since it's both difficult and important. I'll still use and enjoy the feature regardless, but I might scoff a bit when I add my listeners array :smile: