### PR TITLE
[5.4] Loop variables added to @each directive of blade

### DIFF
--- a/src/Illuminate/View/Concerns/ManagesLoops.php
+++ b/src/Illuminate/View/Concerns/ManagesLoops.php
@@ -87,4 +87,14 @@ trait ManagesLoops
     {
         return $this->loopsStack;
     }
+
+    /**
+     * Reset the loop stack.
+     *
+     * @return void
+     */
+    public function resetLoopStack()
+    {
+        $this->loopsStack = [];
+    }
 }

--- a/src/Illuminate/View/Factory.php
+++ b/src/Illuminate/View/Factory.php
@@ -182,6 +182,8 @@ class Factory implements FactoryContract
                     $view, ['key' => $key, $iterator => $value, 'loop' => $this->getLastLoop()]
                 )->render();
             }
+
+            $this->resetLoopStack();
         }
 
         // If there is no data in the array, we will render the contents of the empty

--- a/src/Illuminate/View/Factory.php
+++ b/src/Illuminate/View/Factory.php
@@ -173,9 +173,13 @@ class Factory implements FactoryContract
         // an instance of the partial view to the final result HTML passing in the
         // iterated value of this data array, allowing the views to access them.
         if (count($data) > 0) {
+            $this->addLoop($data);
+
             foreach ($data as $key => $value) {
+                $this->incrementLoopIndices();
+
                 $result .= $this->make(
-                    $view, ['key' => $key, $iterator => $value]
+                    $view, ['key' => $key, $iterator => $value, 'loop' => $this->getLastLoop()]
                 )->render();
             }
         }

--- a/tests/View/ViewFactoryTest.php
+++ b/tests/View/ViewFactoryTest.php
@@ -56,6 +56,7 @@ class ViewFactoryTest extends TestCase
             $this->assertEquals($data[$arg['key']], $arg['value']);
             $this->assertArrayHasKey('loop', $arg);
             $this->assertTrue($arg['loop'] instanceof \stdClass);
+
             return true;
         }))->andReturn($mockView1 = m::mock('StdClass'));
 
@@ -64,6 +65,7 @@ class ViewFactoryTest extends TestCase
             $this->assertEquals($data[$arg['key']], $arg['value']);
             $this->assertArrayHasKey('loop', $arg);
             $this->assertTrue($arg['loop'] instanceof \stdClass);
+
             return true;
         }))->andReturn($mockView2 = m::mock('StdClass'));
 

--- a/tests/View/ViewFactoryTest.php
+++ b/tests/View/ViewFactoryTest.php
@@ -48,12 +48,29 @@ class ViewFactoryTest extends TestCase
     public function testRenderEachCreatesViewForEachItemInArray()
     {
         $factory = m::mock('Illuminate\View\Factory[make]', $this->getFactoryArgs());
-        $factory->shouldReceive('make')->once()->with('foo', ['key' => 'bar', 'value' => 'baz'])->andReturn($mockView1 = m::mock('StdClass'));
-        $factory->shouldReceive('make')->once()->with('foo', ['key' => 'breeze', 'value' => 'boom'])->andReturn($mockView2 = m::mock('StdClass'));
+
+        $data = ['bar' => 'baz', 'breeze' => 'boom'];
+
+        $factory->shouldReceive('make')->once()->with('foo', m::on(function ($arg) use ($data) {
+            $this->assertArrayHasKey($arg['key'], $data);
+            $this->assertEquals($data[$arg['key']], $arg['value']);
+            $this->assertArrayHasKey('loop', $arg);
+            $this->assertTrue($arg['loop'] instanceof \stdClass);
+            return true;
+        }))->andReturn($mockView1 = m::mock('StdClass'));
+
+        $factory->shouldReceive('make')->once()->with('foo', m::on(function ($arg) use ($data) {
+            $this->assertArrayHasKey($arg['key'], $data);
+            $this->assertEquals($data[$arg['key']], $arg['value']);
+            $this->assertArrayHasKey('loop', $arg);
+            $this->assertTrue($arg['loop'] instanceof \stdClass);
+            return true;
+        }))->andReturn($mockView2 = m::mock('StdClass'));
+
         $mockView1->shouldReceive('render')->once()->andReturn('dayle');
         $mockView2->shouldReceive('render')->once()->andReturn('rees');
 
-        $result = $factory->renderEach('foo', ['bar' => 'baz', 'breeze' => 'boom'], 'value');
+        $result = $factory->renderEach('foo', $data, 'value');
 
         $this->assertEquals('daylerees', $result);
     }


### PR DESCRIPTION
Related with [#19909](https://github.com/laravel/framework/pull/19909)

Reset method added to reset the loop stack.