### PR TITLE
[5.4] Use the correct user model namespace in make:policy Command

### DIFF
--- a/src/Illuminate/Foundation/Console/PolicyMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/PolicyMakeCommand.php
@@ -54,7 +54,7 @@ class PolicyMakeCommand extends GeneratorCommand
      */
     protected function replaceUserModelNamespace($stub)
     {
-        return str_replace('App\User', config('auth.providers.users.model'), $stub);
+        return str_replace($this->rootNamespace().'User', config('auth.providers.users.model'), $stub);
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/PolicyMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/PolicyMakeCommand.php
@@ -50,7 +50,7 @@ class PolicyMakeCommand extends GeneratorCommand
      * Replace the user model for the given stub.
      *
      * @param  string  $stub
-     * @return string  mixed
+     * @return string
      */
     protected function replaceUserModelNamespace($stub)
     {

--- a/src/Illuminate/Foundation/Console/PolicyMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/PolicyMakeCommand.php
@@ -39,7 +39,7 @@ class PolicyMakeCommand extends GeneratorCommand
     {
         $stub = parent::buildClass($name);
 
-        $stub = $this->replaceModelUserNamespace($stub);
+        $stub = $this->replaceUserModelNamespace($stub);
 
         $model = $this->option('model');
 
@@ -52,7 +52,7 @@ class PolicyMakeCommand extends GeneratorCommand
      * @param  string  $stub
      * @return string  mixed
      */
-    protected function replaceModelUserNamespace($stub)
+    protected function replaceUserModelNamespace($stub)
     {
         return str_replace('App\User', config('auth.providers.users.model'), $stub);
     }

--- a/src/Illuminate/Foundation/Console/PolicyMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/PolicyMakeCommand.php
@@ -38,7 +38,7 @@ class PolicyMakeCommand extends GeneratorCommand
     protected function buildClass($name)
     {
         $stub = parent::buildClass($name);
-        
+
         $stub = $this->replaceUserModelNamespace($stub);
 
         $model = $this->option('model');
@@ -62,17 +62,17 @@ class PolicyMakeCommand extends GeneratorCommand
     }
 
     /**
-     * Get the default namespace for the user model
+     * Get the default namespace for the user model.
      *
      * @return string
      */
     public function getDefaultUserNamespace()
     {
-        return $this->rootNamespace() . 'User';
+        return $this->rootNamespace().'User';
     }
 
     /**
-     * Get the real namespace for the user model
+     * Get the real namespace for the user model.
      *
      * @return string
      */

--- a/src/Illuminate/Foundation/Console/PolicyMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/PolicyMakeCommand.php
@@ -39,9 +39,22 @@ class PolicyMakeCommand extends GeneratorCommand
     {
         $stub = parent::buildClass($name);
 
+        $stub = $this->replaceModelUserNamespace($stub);
+
         $model = $this->option('model');
 
         return $model ? $this->replaceModel($stub, $model) : $stub;
+    }
+
+    /**
+     * Replace the user model for the given stub.
+     *
+     * @param  string  $stub
+     * @return string  mixed
+     */
+    protected function replaceModelUserNamespace($stub)
+    {
+        return str_replace('App\User', config('auth.providers.users.model'), $stub);
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/PolicyMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/PolicyMakeCommand.php
@@ -38,7 +38,7 @@ class PolicyMakeCommand extends GeneratorCommand
     protected function buildClass($name)
     {
         $stub = parent::buildClass($name);
-
+        
         $stub = $this->replaceUserModelNamespace($stub);
 
         $model = $this->option('model');
@@ -47,14 +47,38 @@ class PolicyMakeCommand extends GeneratorCommand
     }
 
     /**
-     * Replace the user model for the given stub.
+     * Replace the user model namespace for the given stub.
      *
      * @param  string  $stub
      * @return string
      */
     protected function replaceUserModelNamespace($stub)
     {
-        return str_replace($this->rootNamespace().'User', config('auth.providers.users.model'), $stub);
+        if ($this->getDefaultUserNamespace() != $this->getRealUserNamespace()) {
+            return str_replace($this->getDefaultUserNamespace(), $this->getRealUserNamespace(), $stub);
+        }
+
+        return $stub;
+    }
+
+    /**
+     * Get the default namespace for the user model
+     *
+     * @return string
+     */
+    public function getDefaultUserNamespace()
+    {
+        return $this->rootNamespace() . 'User';
+    }
+
+    /**
+     * Get the real namespace for the user model
+     *
+     * @return string
+     */
+    public function getRealUserNamespace()
+    {
+        return config('auth.providers.users.model');
     }
 
     /**


### PR DESCRIPTION
I've been creating new policies this days in a project where my models are under app/Models directory. 

Every policy I created I needed to modify the namespace of the user's model.

I remembered that this information is available through the auth configuration file and ended up with this.

I want to thank @JosephSilber who taught me a lot on this Gates & Policies stuff.