### PR TITLE
Make the command make:factory consistent with other make commands.

### DIFF
--- a/src/Illuminate/Database/Console/Factories/FactoryMakeCommand.php
+++ b/src/Illuminate/Database/Console/Factories/FactoryMakeCommand.php
@@ -62,7 +62,7 @@ class FactoryMakeCommand extends GeneratorCommand
     {
         $name = str_replace(
             ['\\', '/'], '', $this->argument('name')
-        ).'Factory';
+        );
 
         return $this->laravel->databasePath()."/factories/{$name}.php";
     }


### PR DESCRIPTION
`make:controller`, `make:seeder`, `make:model` don't append the items name to the created file (i.e. `make:controller ThingController` doesnt make a file named ThingControllerController). Whereas `make:Factory ThingFactory` makes a file named ThingFactoryFactory. This removes the auto-prefix to be consistent with the others.