### PR TITLE
[5.5] Add wrap and unwrap helpers to the Collection class

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -80,6 +80,28 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
+     * If the given value is not an collection, wrap it in one.
+     *
+     * @param  mixed  $value
+     * @return array
+     */
+    public static function wrap($value)
+    {
+        return $value instanceof self ? $value : new static([$value]);
+    }
+
+    /**
+     * If the given value is a collection return its items.
+     *
+     * @param  mixed  $value
+     * @return array
+     */
+    public static function unwrap($value)
+    {
+        return $value instanceof self ? $value->all() : $value;
+    }
+
+    /**
      * Get all of the items in the collection.
      *
      * @return array

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1044,6 +1044,28 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(['foo' => 'bar'], $collection->all());
     }
 
+    public function testWrapCollection()
+    {
+        $collection = Collection::wrap(new Collection(['foo']));
+        $this->assertSame($collection, $collection);
+
+        $collection = Collection::wrap('foo');
+        $this->assertEquals(['foo'], $collection->all());
+
+        $collection = Collection::wrap(new TestArrayableObject);
+        $this->assertEquals(['foo' => 'bar'], $collection->first()->toArray());
+    }
+
+    public function testUnwrapCollection()
+    {
+        $collection = new Collection(['foo']);
+        $this->assertEquals(['foo'], Collection::unwrap($collection));
+
+        $this->assertEquals(['foo'], Collection::unwrap(['foo']));
+
+        $this->assertEquals('foo', Collection::unwrap('foo'));
+    }
+
     public function testConstructMethod()
     {
         $collection = new Collection('foo');


### PR DESCRIPTION
I saw the `array_wrap` helper today and realise it could be useful to have similar helpers for the collections, to normalise the input of methods that accept array and collections without using conditionals. Example:

Replace

```
if ($middlewares instanceof Collection) {
    $middlewares = $middlewares->all();
}
```

With:

```
$middlewares = Collection::unwrap($middlewares);
```

--------------------------------------------------------------------------------

Replace:

`$this->models = $models instanceof Collection ? $models : collect([$models]);`

With:

`$this->models = Collection::wrap($models);`