### PR TITLE
[5.5] Add wrap and unwrap helpers to the Collection class

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -80,6 +80,28 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
+     * If the given value is not an collection, wrap it in one.
+     *
+     * @param  mixed  $value
+     * @return static
+     */
+    public static function wrap($value)
+    {
+        return $value instanceof self ? $value : new static(Arr::wrap($value));
+    }
+
+    /**
+     * If the given value is a collection return its items.
+     *
+     * @param  array|static  $value
+     * @return array
+     */
+    public static function unwrap($value)
+    {
+        return $value instanceof self ? $value->all() : $value;
+    }
+
+    /**
      * Get all of the items in the collection.
      *
      * @return array

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1044,6 +1044,31 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(['foo' => 'bar'], $collection->all());
     }
 
+    public function testWrapCollection()
+    {
+        $collection = Collection::wrap(new Collection(['foo']));
+        $this->assertEquals(['foo'], $collection->all());
+
+        $collection = Collection::wrap(['foo']);
+        $this->assertEquals(['foo'], $collection->all());
+
+        $collection = Collection::wrap('foo');
+        $this->assertEquals(['foo'], $collection->all());
+
+        $collection = Collection::wrap(new TestArrayableObject);
+        $this->assertEquals(['foo' => 'bar'], $collection->first()->toArray());
+    }
+
+    public function testUnwrapCollection()
+    {
+        $collection = new Collection(['foo']);
+        $this->assertEquals(['foo'], Collection::unwrap($collection));
+
+        $this->assertEquals(['foo'], Collection::unwrap(['foo']));
+
+        $this->assertEquals('foo', Collection::unwrap('foo'));
+    }
+
     public function testConstructMethod()
     {
         $collection = new Collection('foo');


### PR DESCRIPTION
Based on https://github.com/laravel/framework/pull/19970

Wrap method works as follow:

If the given value is a collection then it returns it. Otherwise it wraps the given value in an array using `Arr::wrap` and then it wraps it in a new collection.

The main difference VS `collect($value)` is that objects that implement `Arrayable` or `Jsonable` will be assigned as the first item in the new collection instead of being extracted.