### PR TITLE
[5.4] if handler can't report exception just render it

### DIFF
--- a/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
+++ b/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
@@ -77,7 +77,11 @@ class HandleExceptions
             $e = new FatalThrowableError($e);
         }
 
-        $this->getExceptionHandler()->report($e);
+        try {
+            $this->getExceptionHandler()->report($e);
+        } catch (Exception $e) {
+            //
+        }
 
         if ($this->app->runningInConsole()) {
             $this->renderForConsole($e);


### PR DESCRIPTION
In case the exception handler can't log the exception, we'll render the exception (coming from the failure to log). Otherwise there's no feedback(response) coming to the user when such failure happens.

To replicate the issue you can:

```
chmod ug+r,ug-w storage/logs/laravel.log
```

And then throw an exception.


Issue reported in: https://github.com/laravel/framework/issues/19973