### PR TITLE
[5.4] Signal alarm after timeout passes

### DIFF
--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -141,7 +141,7 @@ class Worker
 
             $timeout = $this->timeoutForJob($job, $options);
 
-            pcntl_alarm($timeout > 0 ? $timeout + $options->sleep : 0);
+            pcntl_alarm($timeout > 0 ? $timeout : 0);
         }
     }
 


### PR DESCRIPTION
This might cause the job to be run twice since a new job can start after the queue `retry_after` passes while the current worker isn't killed yet because of the extra `sleep` time.