### PR TITLE
[5.4] Add now() helper

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -1,5 +1,6 @@
 <?php
 
+use Carbon\Carbon;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Support\Collection;
@@ -637,6 +638,18 @@ if (! function_exists('last')) {
     function last($array)
     {
         return end($array);
+    }
+}
+
+if (! function_exists('now')) {
+    /**
+     * Get the current time as Carbon instance.
+     *
+     * @return Carbon\Carbon
+     */
+    function now()
+    {
+        return Carbon::now();
     }
 }
 

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Support;
 use stdClass;
 use ArrayAccess;
 use Mockery as m;
+use Carbon\Carbon;
 use Illuminate\Support\Str;
 use PHPUnit\Framework\TestCase;
 
@@ -716,6 +717,15 @@ class SupportHelpersTest extends TestCase
         $mock = m::mock();
         $mock->shouldReceive('foo')->once()->andReturn('bar');
         $this->assertEquals($mock, tap($mock)->foo());
+    }
+
+    public function testNow()
+    {
+        Carbon::setTestNow(Carbon::now());
+
+        $this->assertTrue(
+            Carbon::now()->eq(now())
+        );
     }
 }
 


### PR DESCRIPTION
This PR adds a new `now()` helper. This simple function just returns whatever `Carbon::now()` returns. 

_I'm aware that helpers are unlikely to be pulled into the framework itself, but I'm pretty sure that this helper would fit most of the projects out there._

It's super easy to use, looks nice. Plus, it allows me to get the current time without having an import statement at the top (or use this helper inside a view).

Thanks 🌵