### PR TITLE
Make make:model -fa behave correctly

### DIFF
--- a/src/Illuminate/Database/Console/Factories/FactoryMakeCommand.php
+++ b/src/Illuminate/Database/Console/Factories/FactoryMakeCommand.php
@@ -49,7 +49,7 @@ class FactoryMakeCommand extends GeneratorCommand
         $model = $this->qualifyClass($this->argument('name'));
 
         if ($this->argument('model')) {
-            $model = $this->qualifyClass($this->argument("model"));
+            $model = $this->qualifyClass($this->argument('model'));
         }
 
         return str_replace(

--- a/src/Illuminate/Database/Console/Factories/FactoryMakeCommand.php
+++ b/src/Illuminate/Database/Console/Factories/FactoryMakeCommand.php
@@ -48,7 +48,7 @@ class FactoryMakeCommand extends GeneratorCommand
     {
         $model = $this->qualifyClass($this->argument('name'));
 
-        if ($this->argument('model') !== '') {
+        if ($this->argument('model')) {
             $model = $this->qualifyClass($this->argument("model"));
         }
 

--- a/src/Illuminate/Database/Console/Factories/FactoryMakeCommand.php
+++ b/src/Illuminate/Database/Console/Factories/FactoryMakeCommand.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Database\Console\Factories;
 
 use Illuminate\Console\GeneratorCommand;
+use Symfony\Component\Console\Input\InputArgument;
 
 class FactoryMakeCommand extends GeneratorCommand
 {
@@ -47,6 +48,10 @@ class FactoryMakeCommand extends GeneratorCommand
     {
         $model = $this->qualifyClass($this->argument('name'));
 
+        if ($this->argument('model') !== '') {
+            $model = $this->qualifyClass($this->argument("model"));
+        }
+
         return str_replace(
             'DummyModel', $model, parent::buildClass($name)
         );
@@ -66,4 +71,14 @@ class FactoryMakeCommand extends GeneratorCommand
 
         return $this->laravel->databasePath()."/factories/{$name}.php";
     }
+
+    protected function getArguments()
+    {
+        return [
+            parent::getArguments()[0],
+            ['model', InputArgument::OPTIONAL, 'The name of the model to create']
+        ];
+    }
+
+
 }

--- a/src/Illuminate/Database/Console/Factories/FactoryMakeCommand.php
+++ b/src/Illuminate/Database/Console/Factories/FactoryMakeCommand.php
@@ -76,9 +76,7 @@ class FactoryMakeCommand extends GeneratorCommand
     {
         return [
             parent::getArguments()[0],
-            ['model', InputArgument::OPTIONAL, 'The name of the model to create']
+            ['model', InputArgument::OPTIONAL, 'The name of the model to create'],
         ];
     }
-
-
 }

--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -69,7 +69,7 @@ class ModelMakeCommand extends GeneratorCommand
     {
         $this->call('make:factory', [
             'name' => $this->argument('name').'Factory',
-            'model' => $this->argument('name')
+            'model' => $this->argument('name'),
         ]);
     }
 

--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -69,6 +69,7 @@ class ModelMakeCommand extends GeneratorCommand
     {
         $this->call('make:factory', [
             'name' => $this->argument('name').'Factory',
+            'model' => $this->argument('name')
         ]);
     }
 


### PR DESCRIPTION
Currently, invoking `make:model -fa Car` creates the factory class `CarFactory.php`, which ultimately creates `App\CarFactory::class`. 



So, it wants to create itself instead of the corresponding model.

To fix this, i've added an optional argument `model` to `make:factory`, which specifies the model to create.

Further, `make:model -fa` now calls `make:factory` with the correct arguments.

Let me now what you think.

Happy crafting 🔨