### PR TITLE
[5.4] Update intersect method to allow booleans

### DIFF
--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -182,11 +182,9 @@ trait InteractsWithInput
     public function intersect($keys)
     {
         return array_filter($this->only(is_array($keys) ? $keys : func_get_args()), function ($input) {
-            if (is_null($input)) {
-                return false;
+            if (! is_null($input)) {
+                return true;
             }
-
-            return true;
         });
     }
 

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -181,7 +181,13 @@ trait InteractsWithInput
      */
     public function intersect($keys)
     {
-        return array_filter($this->only(is_array($keys) ? $keys : func_get_args()));
+        return array_filter($this->only(is_array($keys) ? $keys : func_get_args()), function ($input) {
+            if (is_null($input)) {
+                return false;
+            }
+
+            return true;
+        });
     }
 
     /**

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -278,8 +278,8 @@ class HttpRequestTest extends TestCase
 
     public function testIntersectMethod()
     {
-        $request = Request::create('/', 'GET', ['name' => 'Taylor', 'age' => null]);
-        $this->assertEquals(['name' => 'Taylor'], $request->intersect('name', 'age', 'email'));
+        $request = Request::create('/', 'GET', ['name' => 'Taylor', 'age' => null, 'active' => false]);
+        $this->assertEquals(['name' => 'Taylor', 'active' => false], $request->intersect('name', 'age', 'email', 'active'));
     }
 
     public function testQueryMethod()


### PR DESCRIPTION
Fix for #19991 

Before if you passed a boolean value into `$request->intersect()` it would strip it out - this causes issues when you pass something such as an active state through. This PR fixes that so that it only strips out null values, allowing booleans which equal `false` to pass through