### PR TITLE
str_before and str_after bug fix

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -38,7 +38,7 @@ class Str
      */
     public static function after($subject, $search)
     {
-        return $search ? array_reverse(explode($search, $subject, 2))[0] : $subject;
+        return $search == "" ? $subject : array_reverse(explode($search, $subject, 2))[0];
     }
 
     /**
@@ -72,7 +72,7 @@ class Str
      */
     public static function before($subject, $search)
     {
-        return $search ? explode($search, $subject)[0] : $subject;
+        return $search == "" ? $subject : explode($search, $subject)[0];
     }
 
     /**

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -95,6 +95,7 @@ class SupportStrTest extends TestCase
         $this->assertEquals('ééé ', Str::before('ééé hannah', 'han'));
         $this->assertEquals('hannah', Str::before('hannah', 'xxxx'));
         $this->assertEquals('hannah', Str::before('hannah', ''));
+        $this->assertEquals('han', Str::before('han0nah', '0'));
     }
 
     public function testStrAfter()
@@ -104,6 +105,7 @@ class SupportStrTest extends TestCase
         $this->assertEquals('nah', Str::after('ééé hannah', 'han'));
         $this->assertEquals('hannah', Str::after('hannah', 'xxxx'));
         $this->assertEquals('hannah', Str::after('hannah', ''));
+        $this->assertEquals('nah', Str::after('han0nah', '0'));
     }
 
     public function testStrContains()


### PR DESCRIPTION
Will fail if passing "0" for the `$search`

Sorry @taylorotwell 

![image](https://user-images.githubusercontent.com/1517011/28073720-3e6dbad8-661c-11e7-80e8-cc46ea600cb0.png)
