### PR TITLE
[5.5] An easy way to route notifications on the go

### DIFF
--- a/src/Illuminate/Notifications/Channels/SlackWebhookChannel.php
+++ b/src/Illuminate/Notifications/Channels/SlackWebhookChannel.php
@@ -37,7 +37,6 @@ class SlackWebhookChannel
      */
     public function send($notifiable, Notification $notification)
     {
-        dd($notifiable->routeNotificationFor('slack'));
         if (! $url = $notifiable->routeNotificationFor('slack')) {
             return;
         }

--- a/src/Illuminate/Notifications/Channels/SlackWebhookChannel.php
+++ b/src/Illuminate/Notifications/Channels/SlackWebhookChannel.php
@@ -37,6 +37,7 @@ class SlackWebhookChannel
      */
     public function send($notifiable, Notification $notification)
     {
+        dd($notifiable->routeNotificationFor('slack'));
         if (! $url = $notifiable->routeNotificationFor('slack')) {
             return;
         }

--- a/src/Illuminate/Notifications/InstantNotifiable.php
+++ b/src/Illuminate/Notifications/InstantNotifiable.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Notifications;
 
+use Illuminate\Contracts\Notifications\Dispatcher;
+
 class InstantNotifiable
 {
     /**
@@ -10,6 +12,17 @@ class InstantNotifiable
      * @var array
      */
     public $routes;
+
+    /**
+     * Send the given notification.
+     *
+     * @param  mixed  $instance
+     * @return void
+     */
+    public function notify($instance)
+    {
+        app(Dispatcher::class)->send($this, $instance);
+    }
 
     /**
      * Get the notification routing information for the given driver.

--- a/src/Illuminate/Notifications/InstantNotifiable.php
+++ b/src/Illuminate/Notifications/InstantNotifiable.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Illuminate\Notifications;
+
+class InstantNotifiable
+{
+    /**
+     * The array of routes a notification should be sent to.
+     *
+     * @var array
+     */
+    public $routes;
+
+    /**
+     * Get the notification routing information for the given driver.
+     *
+     * @param  string  $driver
+     * @return mixed
+     */
+    public function routeNotificationFor($driver)
+    {
+        return $this->routes[$driver] ?? null;
+    }
+
+    /**
+     * Register the given route.
+     *
+     * @param  mixed  $route
+     * @param  string  $channel
+     * @return $this
+     */
+    public function addRoute($route, $channel)
+    {
+        $this->routes[$channel] = $route;
+
+        return $this;
+    }
+}

--- a/src/Illuminate/Notifications/NotificationSender.php
+++ b/src/Illuminate/Notifications/NotificationSender.php
@@ -154,7 +154,7 @@ class NotificationSender
                 $notification->id = $notificationId;
 
                 $this->bus->dispatch(
-                    (new SendQueuedNotifications($this->formatNotifiables($notifiable), $notification, [$channel]))
+                    (new SendQueuedNotifications($notifiable, $notification, [$channel]))
                             ->onConnection($notification->connection)
                             ->onQueue($notification->queue)
                             ->delay($notification->delay)

--- a/tests/Integration/Notifications/SendingNotificationsViaInstantNotifiableTest.php
+++ b/tests/Integration/Notifications/SendingNotificationsViaInstantNotifiableTest.php
@@ -1,0 +1,59 @@
+<?php
+
+use Orchestra\Testbench\TestCase;
+use Illuminate\Notifications\Notification;
+use Illuminate\Notifications\InstantNotifiable;
+use Illuminate\Support\Facades\Notification as NotificationFacade;
+
+/**
+ * @group integration
+ */
+class SendingNotificationsViaInstantNotifiableTest extends TestCase
+{
+    public $mailer;
+
+    protected function getEnvironmentSetUp($app)
+    {
+        $app['config']->set('app.debug', 'true');
+    }
+
+    public function test_mail_is_sent()
+    {
+        $notifiable = (new InstantNotifiable())
+            ->addRoute('enzo', 'testchannel')
+            ->addRoute('enzo@deepblue.com', 'anothertestchannel');
+
+        NotificationFacade::send(
+            $notifiable,
+            new TestMailNotificationForInstantNotifiable()
+        );
+
+        $this->assertEquals([
+            'enzo', 'enzo@deepblue.com',
+        ], $_SERVER['__notifiable.route']);
+    }
+}
+
+class TestMailNotificationForInstantNotifiable extends Notification
+{
+    public function via($notifiable)
+    {
+        return [TestCustomChannel::class, AnotherTestCustomChannel::class];
+    }
+}
+
+class TestCustomChannel
+{
+    public function send($notifiable, $notification)
+    {
+        $_SERVER['__notifiable.route'][] = $notifiable->routeNotificationFor('testchannel');
+    }
+}
+
+class AnotherTestCustomChannel
+{
+    public function send($notifiable, $notification)
+    {
+        $_SERVER['__notifiable.route'][] = $notifiable->routeNotificationFor('anothertestchannel');
+    }
+}


### PR DESCRIPTION
This PR allows for the following:

```php
(new InstantNotifiable())
            ->addRoute('enzo@deepblue.com', 'mail')
            ->addRoute('https://slack-webhook...', 'slack')
            ->notify(new TestNotification())
```

Sometimes you need to use an existing notification class to send to a non-existing entity, like a specific slack webhook that doesn't belong to any notifiable, or global email address that doesn't belong to any notifiable.