### PR TITLE
Adds a divide method to the collection class

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1239,6 +1239,18 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
+     * Divides the underlying collection array by a denominator.
+     *
+     * @param  int  $denominator
+     * @return static
+     */
+    public function divide($denominator)
+    {
+        return $this->chunk(
+            ceil(count($this->items) / $denominator));
+    }
+
+    /**
      * Sort through each item with a callback.
      *
      * @param  callable|null  $callback


### PR DESCRIPTION
This simple PR creates a very easy way to divide collections by a denominator. 

Example usage, say you need a 3 column layout of an array of items. Simple call `collect([1,2,3,4,5,6,7,8,9])->divide(3)` and now you have a chunked collection by a denominator. 

In the blade template, you can foreach those collections and output the content in one line.

This method simply delegates to the chunk method encapsulating the logic of finding the count of `$this->items` on the controller and makes it very simple to divide a collection.

It won't always divide evenly amongst the denominator so in those cases the last chuck can be shorter by a maximum of number of `$denominator - 1`, example in a 58 item collection divided by 3, you will get a chunk of 20 items, a chunk of 20 items and a chunk of 18 items (or $denominator - 1).