### PR TITLE
[5.5] Add 404 request method and url when using withoutExceptionHandling

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithExceptionHandling.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithExceptionHandling.php
@@ -5,6 +5,7 @@ namespace Illuminate\Foundation\Testing\Concerns;
 use Exception;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Symfony\Component\Console\Application as ConsoleApplication;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 trait InteractsWithExceptionHandling
 {
@@ -49,7 +50,11 @@ trait InteractsWithExceptionHandling
 
             public function render($request, Exception $e)
             {
-                throw $e;
+                if ($e instanceof NotFoundHttpException) {
+                    throw new NotFoundHttpException("{$request->method()} {$request->url()}", null, $e->getCode());
+                } else {
+                    throw $e;
+                }
             }
 
             public function renderForConsole($output, Exception $e)


### PR DESCRIPTION
Whenever a NotFoundHTTPException is thrown, it is helpful to see the request method and url. Helps to debug what route to look at instead of having to first look it up in the test file. I've been using this in my own tests and I love it.

Final result:

```
1) Tests\Feature\Backstage\PublishConcertTest::a_promoter_can_publish_their_own_concert
Symfony\Component\HttpKernel\Exception\NotFoundHttpException: POST http://ticketbeast.app/backstage/published-concerts
```