### PR TITLE
[5.5] Retrieve the real original content

### DIFF
--- a/src/Illuminate/Http/ResponseTrait.php
+++ b/src/Illuminate/Http/ResponseTrait.php
@@ -49,7 +49,9 @@ trait ResponseTrait
      */
     public function getOriginalContent()
     {
-        return $this->original;
+        $original = $this->original;
+
+        return $original instanceof self ? $original->{__FUNCTION__}() : $original;
     }
 
     /**

--- a/tests/Http/HttpResponseTest.php
+++ b/tests/Http/HttpResponseTest.php
@@ -91,6 +91,14 @@ class HttpResponseTest extends TestCase
         $this->assertSame($arr, $response->getOriginalContent());
     }
 
+    public function testGetOriginalContentRetrievesTheFirstOriginalContent()
+    {
+        $previousResponse = new \Illuminate\Http\Response(['foo' => 'bar']);
+        $response = new \Illuminate\Http\Response($previousResponse);
+
+        $this->assertSame(['foo' => 'bar'], $response->getOriginalContent());
+    }
+
     public function testSetAndRetrieveStatusCode()
     {
         $response = new \Illuminate\Http\Response('foo');


### PR DESCRIPTION
It is possible to build a `Response` from a another `Response`.
In this case we don't want to lose the `original` content.

---

This PR make ensures that the `getOriginalContent` method always return the `original` content of the **first response**.