### PR TITLE
remove duplicate collection/array length check

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1079,9 +1079,9 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      */
     public function random($amount = null)
     {
-        try{
+        try {
             return Arr::random($this->items, $amount);
-        } catch(InvalidArgumentException $e) {
+        } catch (InvalidArgumentException $e) {
             throw new InvalidArgumentException(
                 "You requested {$requested} items, but there are only {$count} items in the collection.",
                 $e->getCode(),

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1080,7 +1080,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     public function random($amount = null)
     {
         try {
-            return Arr::random($this->items, $amount);
+            return new static(Arr::random($this->items, $amount));
         } catch (InvalidArgumentException $e) {
             throw new InvalidArgumentException(
                 "You requested {$amount} items, but there are only {$this->count()} items in the collection.",

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1083,7 +1083,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
             return Arr::random($this->items, $amount);
         } catch (InvalidArgumentException $e) {
             throw new InvalidArgumentException(
-                "You requested {$amount} items, but there are only {$count} items in the collection.",
+                "You requested {$amount} items, but there are only {$this->count()} items in the collection.",
                 $e->getCode(),
                 $e
             );

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1083,7 +1083,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
             return Arr::random($this->items, $amount);
         } catch (InvalidArgumentException $e) {
             throw new InvalidArgumentException(
-                "You requested {$requested} items, but there are only {$count} items in the collection.",
+                "You requested {$amount} items, but there are only {$count} items in the collection.",
                 $e->getCode(),
                 $e
             );

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1079,17 +1079,15 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      */
     public function random($amount = null)
     {
-        if (($requested = $amount ?: 1) > ($count = $this->count())) {
+        try{
+            return Arr::random($this->items, $amount);
+        } catch(InvalidArgumentException $e) {
             throw new InvalidArgumentException(
-                "You requested {$requested} items, but there are only {$count} items in the collection."
+                "You requested {$requested} items, but there are only {$count} items in the collection.",
+                $e->getCode(),
+                $e
             );
         }
-
-        if (is_null($amount)) {
-            return Arr::random($this->items);
-        }
-
-        return new static(Arr::random($this->items, $amount));
     }
 
     /**


### PR DESCRIPTION
Remove the duplicate length check code that appears to be there so that the `InvalidArgumentException` message can be different, the check for is_null is handled in `Arr::random`, it does not need to be here either, you can pass it straight through to the underlying function.