### PR TITLE
[5.4] Add subqueries as first parameter to joins

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -250,14 +250,8 @@ class Builder
      */
     public function selectSub($query, $as)
     {
-        // If the given query is a Closure, we will execute it while passing in a new
-        // query instance to the Closure. This will give the developer a chance to
-        // format and work with the query before we cast it to a raw SQL string.
-        if ($query instanceof Closure) {
-            $callback = $query;
-
-            $callback($query = $this->newQuery());
-        }
+        // parse the query.
+        $query = $this->getQueryFromClosure($query);
 
         // Here, we will parse this query into an SQL string and an array of bindings
         // so we can add it to the query builder using the selectRaw method so the
@@ -267,6 +261,23 @@ class Builder
         return $this->selectRaw(
             '('.$query.') as '.$this->grammar->wrap($as), $bindings
         );
+    }
+
+    /**
+     * @param $query
+     * @return Builder
+     */
+    protected function getQueryFromClosure($query)
+    {
+        // If the given query is a Closure, we will execute it while passing in a new
+        // query instance to the Closure. This will give the developer a chance to
+        // format and work with the query before we cast it to a raw SQL string.
+        if ($query instanceof Closure) {
+            $callback = $query;
+
+            $callback($query = $this->newQuery());
+        }
+        return $query;
     }
 
     /**
@@ -341,6 +352,11 @@ class Builder
      */
     public function join($table, $first, $operator = null, $second = null, $type = 'inner', $where = false)
     {
+        // If the table is a closure or an instance of Builder it will be
+        // parsed as a subquery with the table name the subquery queries
+        // from as the 'as' value for the subquery.
+        $table = $this->parseJoinWithSubQuery($table);
+
         $join = new JoinClause($this, $type, $table);
 
         // If the first "column" of the join is really a Closure instance the developer
@@ -382,20 +398,54 @@ class Builder
      */
     public function joinSub($query, $as, $first, $operator, $second, $type = 'inner')
     {
-        if ($query instanceof Closure)
-        {
-            $callback = $query;
+        $table = $this->parseJoinWithSubQuery($query, $as);
 
-            $callback($query = $this->newQuery());
+        return $this->join($table, $first, $operator, $second, $type);
+    }
+
+    /**
+     * @param $table
+     *
+     * @param null $as
+     * @return Expression
+     */
+    protected function parseJoinWithSubQuery($table, $as = null)
+    {
+        if ($table instanceof self || $table instanceof Closure) {
+
+            // If the given query is a Closure, we will execute it while passing in a new
+            // query instance to the Closure. This will give the developer a chance to
+            // format and work with the query before we cast it to a raw SQL string.
+            $query = $this->getQueryFromClosure($table);
+
+            // if the given as name is null, we will extract the table name from the
+            // query, giving the developer the possibility to just use the existing
+            // join methods, with a closure or builder object as first parameter.
+            $as = is_null($as) ? $query->from : $as;
+
+            // build the resulting subquery and merge the bindings of the given query into
+            // the base query.
+            $table = $this->mergeJoinWithSubQuery($query, $as);
         }
 
+        return $table;
+    }
+
+    /**
+     * @param $query
+     * @param $as
+     *
+     * @return \Illuminate\Database\Query\Expression
+     */
+    protected function mergeJoinWithSubQuery(Builder $query, $as)
+    {
         $table = new Expression(
             '(' . $query->toSql() . ') as ' . $this->grammar->wrap($as)
         );
 
         $this->mergeBindings($query);
 
-        return $this->join($table, $first, $operator, $second, $type);
+        return $table;
     }
 
     /**
@@ -617,7 +667,7 @@ class Builder
             'type', 'column', 'operator', 'value', 'boolean'
         );
 
-        if (! $value instanceof Expression) {
+        if (!$value instanceof Expression) {
             $this->addBinding($value, 'where');
         }
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -369,6 +369,36 @@ class Builder
     }
 
     /**
+     * Add a join clause to the query using a sub query.
+     *
+     * @param        $query
+     * @param        $as
+     * @param        $first
+     * @param        $operator
+     * @param        $second
+     * @param string $type
+     *
+     * @return \Illuminate\Database\Query\Builder
+     */
+    public function joinSub($query, $as, $first, $operator, $second, $type = 'inner')
+    {
+        if ($query instanceof Closure)
+        {
+            $callback = $query;
+
+            $callback($query = $this->newQuery());
+        }
+
+        $table = new Expression(
+            '(' . $query->toSql() . ') as ' . $this->grammar->wrap($as)
+        );
+
+        $this->mergeBindings($query);
+
+        return $this->join($table, $first, $operator, $second, $type);
+    }
+
+    /**
      * Add a "join where" clause to the query.
      *
      * @param  string  $table
@@ -412,6 +442,22 @@ class Builder
     }
 
     /**
+     * Add a left join clause to the query using a sub query.
+     *
+     * @param $query
+     * @param $as
+     * @param $first
+     * @param $operator
+     * @param $second
+     *
+     * @return \Illuminate\Database\Query\Builder
+     */
+    public function leftJoinSub($query, $as, $first, $operator, $second)
+    {
+        return $this->joinSub($query, $as, $first, $operator, $second, 'left');
+    }
+
+    /**
      * Add a right join to the query.
      *
      * @param  string  $table
@@ -437,6 +483,22 @@ class Builder
     public function rightJoinWhere($table, $first, $operator, $second)
     {
         return $this->joinWhere($table, $first, $operator, $second, 'right');
+    }
+
+    /**
+     * Add a right join clause to the query using a sub query.
+     *
+     * @param $query
+     * @param $as
+     * @param $first
+     * @param $operator
+     * @param $second
+     *
+     * @return \Illuminate\Database\Query\Builder
+     */
+    public function rightJoinSub($query, $as, $first, $operator, $second)
+    {
+        return $this->joinSub($query, $as, $first, $operator, $second, 'right');
     }
 
     /**

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1101,6 +1101,52 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals(['admin'], $builder->getBindings());
     }
 
+    public function testBasicJoinRaw()
+    {
+        $builder = $this->getBuilder();
+        $sub = $this->getBuilder();
+        $sub->select('*')
+            ->from('contracts')
+            ->where('role', '=', 'admin');
+
+        $builder->select('*')
+                ->from('users')
+                ->joinSub($sub, 'contracts', 'users.id', '=', 'contracts.id');
+
+        $this->assertEquals('select * from "users" inner join (select * from "contracts" where "role" = ?) as "contracts" on "users"."id" = "contracts"."id"', $builder->toSql());
+        $this->assertEquals(['admin'], $builder->getBindings());
+    }
+
+    public function testBasicLeftJoinRaw(){
+        $builder = $this->getBuilder();
+        $sub = $this->getBuilder();
+        $sub->select('*')
+            ->from('contracts')
+            ->where('role', '=', 'admin');
+
+        $builder->select('*')
+                ->from('users')
+                ->leftJoinSub($sub, 'contracts', 'users.id', '=', 'contracts.id');
+
+        $this->assertEquals('select * from "users" left join (select * from "contracts" where "role" = ?) as "contracts" on "users"."id" = "contracts"."id"', $builder->toSql());
+        $this->assertEquals(['admin'], $builder->getBindings());
+    }
+
+    public function testBasicRightJoinRaw(){
+        $builder = $this->getBuilder();
+        $sub = $this->getBuilder();
+        $sub->select('*')
+            ->from('contracts')
+            ->where('role', '=', 'admin');
+
+        $builder->select('*')
+                ->from('users')
+                ->rightJoinSub($sub, 'contracts', 'users.id', '=', 'contracts.id');
+
+        $this->assertEquals('select * from "users" right join (select * from "contracts" where "role" = ?) as "contracts" on "users"."id" = "contracts"."id"', $builder->toSql());
+        $this->assertEquals(['admin'], $builder->getBindings());
+    }
+
     public function testRawExpressionsInSelect()
     {
         $builder = $this->getBuilder();


### PR DESCRIPTION
This allows for preforming subqueries before making a join.

The following statement
```SQL
select * from "users" left join (select * from "contracts" where "role" = ?) as "contracts" on "users"."id" = "contracts"."id"
```
is currently a bit cumbersome to write, as the first argument to any of the join methods only accepts a string or the result of `DB::raw()`. This results in manually parsing a builder object to a sub query inside a `DB::raw()`, or, even worse, pasting a complete query as string into the first parameter.

__Examples__:

Before:
```PHP
<?php

$sub = new Builder();
$sub->select('*')
            ->from('contracts')
            ->where('role', '=', 'admin');

$builder = new Builder();
$builder->select('*')
                ->from('users')
                ->leftJoin(DB::raw('(' . $sub->toSql() . ') as contracts'), 'users.id', '=', 'contracts.id')
                ->mergeBindings($sub);
```

Note, we also need to remember to merge the bindings with this approach.

What this Pull Requests enables:
```PHP
<?php
// with closure
$builder = new Builder();
$builder->select('*')
                ->from('users')
                ->leftJoin(function($q){
                    $q->select('*')->from('contracts')->where('role', '=', 'admin');
                }, 'users.id', '=', 'contracts.id');

// with builder object
$sub = new Builder();
$sub->select('*')
            ->from('contracts')
            ->where('role', '=', 'admin');

$builder = new Builder();
$builder->select('*')
                ->from('users')
                ->leftJoin($sub, 'users.id', '=', 'contracts.id');
```
Making it much more readable and merging the bindings behind the scenes.

Next to changing the join method to accept a Builder or closure as first argument I've added the following explicit methods, making it also possible to provide a different value for `as` inside the query. The default value for `as` is the name of the table the subquery selects from.

- `Builder::joinSub($query, $as, $first, $operator, $second, $type = 'inner')`
- `Builder::leftJoinSub($query, $as, $first, $operator, $second)`
- `Builder::rightJoinSub($query, $as, $first, $operator, $second)`
