### PR TITLE
[5.4] Specify the inverse side of has many relationships

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/HasMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasMany.php
@@ -13,7 +13,15 @@ class HasMany extends HasOneOrMany
      */
     public function getResults()
     {
-        return $this->query->get();
+        $results = $this->query->get();
+
+        if ($this->inverseSide) {
+            $results->each(function ($model) {
+                $model->setRelation($this->inverseSide, $this->parent);
+            });
+        }
+
+        return $results;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -23,6 +23,13 @@ abstract class HasOneOrMany extends Relation
     protected $localKey;
 
     /**
+     * The inverse side of the relationship.
+     *
+     * @var string
+     */
+    protected $inverseSide;
+
+    /**
      * The count of self joins.
      *
      * @var int
@@ -44,6 +51,19 @@ abstract class HasOneOrMany extends Relation
         $this->foreignKey = $foreignKey;
 
         parent::__construct($query, $parent);
+    }
+
+    /**
+     * Set the inverse side of the relationship.
+     *
+     * @param  string  $name
+     * @return $this
+     */
+    public function inversedBy($name)
+    {
+        $this->inverseSide = $name;
+
+        return $this;
     }
 
     /**


### PR DESCRIPTION
This is an idea to fix https://github.com/laravel/framework/issues/20006

By specifying the inverse side of the has many relationship like this:

```
    public function comments()
    {
        return $this->hasMany(Comment::class)->inversedBy('post');
    }
```

Then `$post->comments->first()->post`won't generate an extra SQL and this will help to avoid the N+1 described in the issue. 
