### PR TITLE
[5.4] Support custom soft deleted_at column in assertion

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
@@ -50,12 +50,13 @@ trait InteractsWithDatabase
      * @param  string  $table
      * @param  array  $data
      * @param  string  $connection
+     * @param  string  $columnName
      * @return $this
      */
-    protected function assertSoftDeleted($table, array $data, $connection = null)
+    protected function assertSoftDeleted($table, array $data, $connection = null, $columnName = 'deleted_at')
     {
         $this->assertThat(
-            $table, new SoftDeletedInDatabase($this->getConnection($connection), $data)
+            $table, new SoftDeletedInDatabase($this->getConnection($connection), $data, $columnName)
         );
 
         return $this;

--- a/src/Illuminate/Foundation/Testing/Constraints/SoftDeletedInDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Constraints/SoftDeletedInDatabase.php
@@ -29,17 +29,28 @@ class SoftDeletedInDatabase extends PHPUnit_Framework_Constraint
     protected $data;
 
     /**
+     * The name of the column used to indicate soft deletion status.
+     *
+     * @var string
+     */
+    protected $columnName;
+
+    /**
      * Create a new constraint instance.
      *
      * @param  \Illuminate\Database\Connection  $database
      * @param  array  $data
+     * @param  string  $columName
      * @return void
      */
-    public function __construct(Connection $database, array $data)
+    public function __construct(Connection $database, array $data, $columnName)
     {
         $this->data = $data;
 
         $this->database = $database;
+
+        $this->columnName = $columnName;
+
     }
 
     /**
@@ -51,7 +62,9 @@ class SoftDeletedInDatabase extends PHPUnit_Framework_Constraint
     public function matches($table)
     {
         return $this->database->table($table)
-                ->where($this->data)->whereNotNull('deleted_at')->count() > 0;
+                ->where($this->data)
+                ->whereNotNull($this->columnName)
+                ->count() > 0;
     }
 
     /**

--- a/src/Illuminate/Foundation/Testing/Constraints/SoftDeletedInDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Constraints/SoftDeletedInDatabase.php
@@ -50,7 +50,6 @@ class SoftDeletedInDatabase extends PHPUnit_Framework_Constraint
         $this->database = $database;
 
         $this->columnName = $columnName;
-
     }
 
     /**

--- a/tests/Foundation/FoundationInteractsWithDatabaseTest.php
+++ b/tests/Foundation/FoundationInteractsWithDatabaseTest.php
@@ -107,6 +107,13 @@ class FoundationInteractsWithDatabaseTest extends TestCase
         $this->assertSoftDeleted($this->table, $this->data);
     }
 
+    public function testSeeSoftDeletedInDatabaseWithCustomColumnFindsResults()
+    {
+        $this->mockCountBuilder(1, 'custom_deleted_at');
+
+        $this->assertSoftDeleted($this->table, $this->data, null, 'custom_deleted_at');
+    }
+
     /**
      * @expectedException \PHPUnit_Framework_ExpectationFailedException
      * @expectedExceptionMessage The table is empty.
@@ -120,13 +127,13 @@ class FoundationInteractsWithDatabaseTest extends TestCase
         $this->assertSoftDeleted($this->table, $this->data);
     }
 
-    protected function mockCountBuilder($countResult)
+    protected function mockCountBuilder($countResult, $columnName = 'deleted_at')
     {
         $builder = m::mock(Builder::class);
 
         $builder->shouldReceive('where')->with($this->data)->andReturnSelf();
 
-        $builder->shouldReceive('whereNotNull')->with('deleted_at')->andReturnSelf();
+        $builder->shouldReceive('whereNotNull')->with($columnName)->andReturnSelf();
 
         $builder->shouldReceive('count')->andReturn($countResult);
 


### PR DESCRIPTION
This adds an additional parameter to `assertSoftDeleted` which allows the passing of a custom column name for when the default `deleted_at` is not used. I feel like it may have been more appropriate as the 3rd argument instead of the 4th but didn't want to make a backwards incompatible change.

It adds an additional test case to ensure the that the correct column name is used if it's passed in.

In response to #20003.