### PR TITLE
[5.4] Resolve double spending scheduled event on multiple servers

### DIFF
--- a/src/Illuminate/Console/Scheduling/CacheMutex.php
+++ b/src/Illuminate/Console/Scheduling/CacheMutex.php
@@ -56,6 +56,8 @@ class CacheMutex implements Mutex
      */
     public function forget(Event $event)
     {
-        $this->cache->forget($event->mutexName());
+        $this->cache->put(
+            $event->mutexName(), true, 0.125
+        );
     }
 }

--- a/tests/Console/Scheduling/CacheOverlappingStrategyTest.php
+++ b/tests/Console/Scheduling/CacheOverlappingStrategyTest.php
@@ -75,7 +75,7 @@ class CacheMutexTest extends TestCase
     {
         $cacheMutex = $this->cacheMutex;
 
-        $this->cacheRepository->shouldReceive('forget');
+        $this->cacheRepository->shouldReceive('put');
 
         $event = new Event($this->cacheMutex, 'command');
 


### PR DESCRIPTION
# Problem
When having multiple servers running the scheduler. If a job takes only a couple of hundred of milliseconds to execute, the withoutOverlap won't stop a second server to take the same event.

# Solution
Adding an artificial delay after job completion of a couple of second will resolve this.

A cron can only at least be launched every minute, the seconds added won't influence the normal working of the scheduler.