### PR TITLE
[5.5] Prepare CallQueuedListener for cloning

### DIFF
--- a/src/Illuminate/Events/CallQueuedListener.php
+++ b/src/Illuminate/Events/CallQueuedListener.php
@@ -138,4 +138,16 @@ class CallQueuedListener implements ShouldQueue
     {
         return $this->class;
     }
+
+    /**
+     * Prepare the instance for cloning.
+     *
+     * @return void
+     */
+    public function __clone()
+    {
+        $this->data = array_map(function ($data) {
+            return is_object($data) ? clone $data : $data;
+        }, $this->data);
+    }
 }


### PR DESCRIPTION
This will prevent converting models in the event object to `ModelIdentifier` for extra work after the job is pushed and serialized.