### PR TITLE
[5.5] Force handle function for commands

### DIFF
--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -177,9 +177,7 @@ class Command extends SymfonyCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $method = method_exists($this, 'handle') ? 'handle' : 'fire';
-
-        return $this->laravel->call([$this, $method]);
+        return $this->laravel->call([$this, 'handle']);
     }
 
     /**


### PR DESCRIPTION
Recently PR https://github.com/laravel/framework/pull/19827 was pulled into 5.5. This PR changes all the core artisan console commands to always use `handle()` instead of `fire()`.

While this doesnt seem like a big change - it will have unintended on all packages or classes that do any sort of extension of a core artisan command. Further - it could actually be a silent failure on upgrades in certain situations.

Consider this pseudo artisan command scenario:

```
Class CoreInspire
{
    public function fire()
    {
         echo 'Original';
    }
}

Class MyInspire extends CoreInspire
{
     public function fire()
     {
           echo 'New';
     }
}
```

In Laravel <=5.4 you would get `New` printed on the screen as expected.

But in Laravel 5.5 - you will now get `Original` with no errors. That is because `fire()` has been renamed to `handle()` in the `CoreInspire` (example) class, and calls to function `handle()` take priority.

Obviously you can change all your packages/classes that extend a core artisan command to now use `handle()` - but at the moment it is possible they will silently stop being extended (depending on the quality of your test suites).

If we are going to go down this route - then we might as well remove any reference to `fire()` in the base artisan console command class - and have it *explicitly* listed as a breaking change in the 5.5 upgrade path to rename any artisan commands containing `fire()` to now be `handle()`.

The alternative is we leave it to accept both `fire()` and `handle()` - but then if we are doing that, what is the point of having this breaking change in some situations in the first place? Either we should go all the way, or not at all IMO.

