### PR TITLE
Change the BladeCompiler::if type-hint to callable like directive

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -358,7 +358,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
      * @param  \Closure  $callback
      * @return void
      */
-    public function if($name, Closure $callback)
+    public function if($name, callable $callback)
     {
         $this->conditions[$name] = $callback;
 

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\View\Compilers;
 
-use Closure;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -355,7 +355,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
      * Register an "if" statement directive.
      *
      * @param  string  $name
-     * @param  \Closure  $callback
+     * @param  callable  $callback
      * @return void
      */
     public function if($name, callable $callback)


### PR DESCRIPTION
I proposed a feature in laravel/internals#682 and noticed that the `Blade::if()` signature doesn't allow `callable` like `Blade::directive()` does.

I've updated the `Blade::if()` method to a `callable` type-hint to allow more flexibility in how you define a conditional directive.