### PR TITLE
[5.5] Add extension point for custom ControllerDispatcher

### DIFF
--- a/src/Illuminate/Contracts/Routing/ControllerDispatcher.php
+++ b/src/Illuminate/Contracts/Routing/ControllerDispatcher.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Illuminate\Contracts\Routing;
+
+use Illuminate\Routing\Route;
+
+interface ControllerDispatcher
+{
+    /**
+     * Dispatch a request to a given controller and method.
+     *
+     * @param  Route  $route
+     * @param  mixed  $controller
+     * @param  string  $method
+     * @return mixed
+     */
+    public function dispatch(Route $route, $controller, $method);
+
+    /**
+     * Get the middleware for the controller instance.
+     *
+     * @param  \Illuminate\Routing\Controller  $controller
+     * @param  string  $method
+     * @return array
+     */
+    public function getMiddleware($controller, $method);
+}

--- a/src/Illuminate/Routing/Contracts/ControllerDispatcher.php
+++ b/src/Illuminate/Routing/Contracts/ControllerDispatcher.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Illuminate\Contracts\Routing;
+namespace Illuminate\Routing\Contracts;
 
 use Illuminate\Routing\Route;
 

--- a/src/Illuminate/Routing/ControllerDispatcher.php
+++ b/src/Illuminate/Routing/ControllerDispatcher.php
@@ -3,7 +3,7 @@
 namespace Illuminate\Routing;
 
 use Illuminate\Container\Container;
-use Illuminate\Contracts\Routing\ControllerDispatcher as ControllerDispatcherContract;
+use Illuminate\Routing\Contracts\ControllerDispatcher as ControllerDispatcherContract;
 
 class ControllerDispatcher implements ControllerDispatcherContract
 {

--- a/src/Illuminate/Routing/ControllerDispatcher.php
+++ b/src/Illuminate/Routing/ControllerDispatcher.php
@@ -3,8 +3,9 @@
 namespace Illuminate\Routing;
 
 use Illuminate\Container\Container;
+use Illuminate\Contracts\Routing\ControllerDispatcher as ControllerDispatcherContract;
 
-class ControllerDispatcher
+class ControllerDispatcher implements ControllerDispatcherContract
 {
     use RouteDependencyResolverTrait;
 
@@ -54,7 +55,7 @@ class ControllerDispatcher
      * @param  string  $method
      * @return array
      */
-    public static function getMiddleware($controller, $method)
+    public function getMiddleware($controller, $method)
     {
         if (! method_exists($controller, 'getMiddleware')) {
             return [];

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -754,7 +754,8 @@ class Route
      *
      * @return ControllerDispatcherContract
      */
-    public function controllerDispatcher() {
+    public function controllerDispatcher()
+    {
         if ($this->container->bound(ControllerDispatcherContract::class)) {
             return $this->container->make(ControllerDispatcherContract::class);
         }

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -14,7 +14,7 @@ use Illuminate\Routing\Matching\HostValidator;
 use Illuminate\Routing\Matching\MethodValidator;
 use Illuminate\Routing\Matching\SchemeValidator;
 use Illuminate\Http\Exceptions\HttpResponseException;
-use Illuminate\Contracts\Routing\ControllerDispatcher as ControllerDispatcherContract;
+use Illuminate\Routing\Contracts\ControllerDispatcher as ControllerDispatcherContract;
 
 class Route
 {

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -14,6 +14,7 @@ use Illuminate\Routing\Matching\HostValidator;
 use Illuminate\Routing\Matching\MethodValidator;
 use Illuminate\Routing\Matching\SchemeValidator;
 use Illuminate\Http\Exceptions\HttpResponseException;
+use Illuminate\Contracts\Routing\ControllerDispatcher as ControllerDispatcherContract;
 
 class Route
 {
@@ -199,7 +200,7 @@ class Route
      */
     protected function runController()
     {
-        return (new ControllerDispatcher($this->container))->dispatch(
+        return $this->controllerDispatcher()->dispatch(
             $this, $this->getController(), $this->getControllerMethod()
         );
     }
@@ -743,9 +744,22 @@ class Route
             return [];
         }
 
-        return ControllerDispatcher::getMiddleware(
+        return $this->controllerDispatcher()->getMiddleware(
             $this->getController(), $this->getControllerMethod()
         );
+    }
+
+    /**
+     * Get the dispatcher for the route's controller.
+     *
+     * @return ControllerDispatcherContract
+     */
+    public function controllerDispatcher() {
+        if ($this->container->bound(ControllerDispatcherContract::class)) {
+            return $this->container->make(ControllerDispatcherContract::class);
+        }
+
+        return new ControllerDispatcher($this->container);
     }
 
     /**

--- a/src/Illuminate/Routing/RoutingServiceProvider.php
+++ b/src/Illuminate/Routing/RoutingServiceProvider.php
@@ -9,7 +9,7 @@ use Psr\Http\Message\ServerRequestInterface;
 use Symfony\Bridge\PsrHttpMessage\Factory\DiactorosFactory;
 use Illuminate\Contracts\View\Factory as ViewFactoryContract;
 use Illuminate\Contracts\Routing\ResponseFactory as ResponseFactoryContract;
-use Illuminate\Contracts\Routing\ControllerDispatcher as ControllerDispatcherContract;
+use Illuminate\Routing\Contracts\ControllerDispatcher as ControllerDispatcherContract;
 
 class RoutingServiceProvider extends ServiceProvider
 {

--- a/src/Illuminate/Routing/RoutingServiceProvider.php
+++ b/src/Illuminate/Routing/RoutingServiceProvider.php
@@ -9,6 +9,7 @@ use Psr\Http\Message\ServerRequestInterface;
 use Symfony\Bridge\PsrHttpMessage\Factory\DiactorosFactory;
 use Illuminate\Contracts\View\Factory as ViewFactoryContract;
 use Illuminate\Contracts\Routing\ResponseFactory as ResponseFactoryContract;
+use Illuminate\Contracts\Routing\ControllerDispatcher as ControllerDispatcherContract;
 
 class RoutingServiceProvider extends ServiceProvider
 {
@@ -30,6 +31,8 @@ class RoutingServiceProvider extends ServiceProvider
         $this->registerPsrResponse();
 
         $this->registerResponseFactory();
+
+        $this->registerControllerDispatcher();
     }
 
     /**
@@ -146,6 +149,18 @@ class RoutingServiceProvider extends ServiceProvider
     {
         $this->app->singleton(ResponseFactoryContract::class, function ($app) {
             return new ResponseFactory($app[ViewFactoryContract::class], $app['redirect']);
+        });
+    }
+
+    /**
+     * Register the controller dispatcher.
+     *
+     * @return void
+     */
+    protected function registerControllerDispatcher()
+    {
+        $this->app->singleton(ControllerDispatcherContract::class, function ($app) {
+            return new ControllerDispatcher($app);
         });
     }
 }


### PR DESCRIPTION
This introduces an extension point to write a custom dispatcher. This allows me to write a custom resolving logic that can use functionality not originally available in Laravel; like handling of nullable type hints (PHP 7.1) and optional route parameters. Laravel currently [calls app::make on those parameters](https://github.com/laravel/framework/blob/ebd86d7d2ff4e34b24a0dd84d10bb77c13130222/src/Illuminate/Routing/RouteDependencyResolverTrait.php#L77), even if they are neither bound, nor buildable

#### Changes

1. Added Illuminate\Contracts\Routing\ControllerDispatcher
2. Changed ControllerDispatcher::getMiddleware from static to an instance method.
3. Added Route::controllerDispatcher() that resolves the dispatcher if bound, and falls back to the original if a dispatcher isn't bound.

Point 1 and 2 are breaking changes if someone has already replaced their dispatcher by replacing the Route (hardcoded `new ControllerDispatcher` in [runController](https://github.com/laravel/framework/blob/ebd86d7d2ff4e34b24a0dd84d10bb77c13130222/src/Illuminate/Routing/Route.php#L202)) and the Router (hardcoded `new Route` in [newRoute](https://github.com/laravel/framework/blob/ebd86d7d2ff4e34b24a0dd84d10bb77c13130222/src/Illuminate/Routing/Router.php#L461)).

Point 2 isn't necessary for my use-case, but seemed to be within the scope of the ControllerDispatcher contract.