### PR TITLE
[5.5] Guess the --create option in make:migration

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
@@ -78,6 +78,14 @@ class MigrateMakeCommand extends BaseCommand
             $create = true;
         }
 
+        if (! $table) {
+            if (preg_match('/^create_(\w+)_table$/', $name, $matches)) {
+                $table = $matches[1];
+
+                $create = true;
+            }
+        }
+
         // Now we are ready to write the migration out to disk. Once we've written
         // the migration out, we will dump-autoload for the entire framework to
         // make sure that the migrations are registered by the class loaders.

--- a/tests/Database/DatabaseMigrationMakeCommandTest.php
+++ b/tests/Database/DatabaseMigrationMakeCommandTest.php
@@ -59,6 +59,21 @@ class DatabaseMigrationMakeCommandTest extends TestCase
         $this->runCommand($command, ['name' => 'create_foo', '--create' => 'users']);
     }
 
+    public function testBasicCreateGivesCreatorProperArgumentsWhenCreateTablePatternIsFound()
+    {
+        $command = new MigrateMakeCommand(
+            $creator = m::mock('Illuminate\Database\Migrations\MigrationCreator'),
+            m::mock('Illuminate\Support\Composer')->shouldIgnoreMissing(),
+            __DIR__.'/vendor'
+        );
+        $app = new \Illuminate\Foundation\Application;
+        $app->useDatabasePath(__DIR__);
+        $command->setLaravel($app);
+        $creator->shouldReceive('create')->once()->with('create_users_table', __DIR__.DIRECTORY_SEPARATOR.'migrations', 'users', true);
+
+        $this->runCommand($command, ['name' => 'create_users_table']);
+    }
+
     public function testCanSpecifyPathToCreateMigrationsIn()
     {
         $command = new MigrateMakeCommand(


### PR DESCRIPTION
This is probably a silly PR but I always find myself writing this:

```
art mak:mig create_users_table --create=users
art mak:mig create_products_table --create=products
art mak:mig create_product_categories_table --create=product_categories
art mak:mig create_another_table_with_really_long_name_table --create=another_table_with_really_long_name
```

So maybe we can have the `make:migration` command guess the table to create for us?