### PR TITLE
[5.5] Cache: allows DateInterface and DateInterval

### DIFF
--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -3,8 +3,9 @@
 namespace Illuminate\Cache;
 
 use Closure;
-use DateTime;
 use ArrayAccess;
+use DateInterval;
+use DateTimeInterface;
 use BadMethodCallException;
 use Illuminate\Support\Carbon;
 use Illuminate\Cache\Events\CacheHit;
@@ -159,7 +160,7 @@ class Repository implements CacheContract, ArrayAccess
      *
      * @param  string  $key
      * @param  mixed   $value
-     * @param  \DateTime|float|int  $minutes
+     * @param  \DateTimeInterface|\DateInterval|float|int  $minutes
      * @return void
      */
     public function put($key, $value, $minutes = null)
@@ -179,7 +180,7 @@ class Repository implements CacheContract, ArrayAccess
      * Store multiple items in the cache for a given number of minutes.
      *
      * @param  array  $values
-     * @param  float|int  $minutes
+     * @param  \DateTimeInterface|\DateInterval|float|int  $minutes
      * @return void
      */
     public function putMany(array $values, $minutes)
@@ -198,7 +199,7 @@ class Repository implements CacheContract, ArrayAccess
      *
      * @param  string  $key
      * @param  mixed   $value
-     * @param  \DateTime|float|int  $minutes
+     * @param  \DateTimeInterface|\DateInterval|float|int  $minutes
      * @return bool
      */
     public function add($key, $value, $minutes)
@@ -270,7 +271,7 @@ class Repository implements CacheContract, ArrayAccess
      * Get an item from the cache, or store the default value.
      *
      * @param  string  $key
-     * @param  \DateTime|float|int  $minutes
+     * @param  \DateTimeInterface|\DateInterval|float|int  $minutes
      * @param  \Closure  $callback
      * @return mixed
      */
@@ -477,13 +478,17 @@ class Repository implements CacheContract, ArrayAccess
     /**
      * Calculate the number of minutes with the given duration.
      *
-     * @param  \DateTime|float|int  $duration
+     * @param  \DateTimeInterface|\DateInterval|float|int  $duration
      * @return float|int|null
      */
     protected function getMinutes($duration)
     {
-        if ($duration instanceof DateTime) {
-            $duration = Carbon::now()->diffInSeconds(Carbon::instance($duration), false) / 60;
+        if ($duration instanceof DateInterval) {
+            $duration = Carbon::now()->add($duration);
+        }
+
+        if ($duration instanceof DateTimeInterface) {
+            $duration = Carbon::now()->diffInSeconds(Carbon::createFromTimestamp($duration->getTimestamp()), false) / 60;
         }
 
         return (int) ($duration * 60) > 0 ? $duration : null;

--- a/src/Illuminate/Contracts/Cache/Repository.php
+++ b/src/Illuminate/Contracts/Cache/Repository.php
@@ -37,7 +37,7 @@ interface Repository
      *
      * @param  string  $key
      * @param  mixed   $value
-     * @param  \DateTime|float|int  $minutes
+     * @param  \DateTimeInterface|\DateInterval|float|int  $minutes
      * @return void
      */
     public function put($key, $value, $minutes);
@@ -47,7 +47,7 @@ interface Repository
      *
      * @param  string  $key
      * @param  mixed   $value
-     * @param  \DateTime|float|int  $minutes
+     * @param  \DateTimeInterface|\DateInterval|float|int  $minutes
      * @return bool
      */
     public function add($key, $value, $minutes);
@@ -83,7 +83,7 @@ interface Repository
      * Get an item from the cache, or store the default value.
      *
      * @param  string  $key
-     * @param  \DateTime|float|int  $minutes
+     * @param  \DateTimeInterface|\DateInterval|float|int  $minutes
      * @param  \Closure  $callback
      * @return mixed
      */

--- a/tests/Cache/CacheRepositoryTest.php
+++ b/tests/Cache/CacheRepositoryTest.php
@@ -2,7 +2,10 @@
 
 namespace Illuminate\Tests\Cache;
 
+use DateTime;
+use DateInterval;
 use Mockery as m;
+use DateTimeImmutable;
 use Illuminate\Support\Carbon;
 use PHPUnit\Framework\TestCase;
 
@@ -134,6 +137,32 @@ class CacheRepositoryTest extends TestCase
         $store->shouldReceive('add')->once()->with('k', 'v', 60)->andReturn(true);
         $repository = new \Illuminate\Cache\Repository($store);
         $this->assertTrue($repository->add('k', 'v', 60));
+    }
+
+    public function dataProviderTestGetMinutes()
+    {
+        return [
+            [Carbon::now()->addMinutes(5)],
+            [(new DateTime('2017-07-25 12:13:14 UTC'))->modify('+5 minutes')],
+            [(new DateTimeImmutable('2017-07-25 12:13:14 UTC'))->modify('+5 minutes')],
+            [new DateInterval('PT5M')],
+            [5],
+        ];
+    }
+
+    /**
+     * @dataProvider dataProviderTestGetMinutes
+     * @param mixed $duration
+     */
+    public function testGetMinutes($duration)
+    {
+        Carbon::setTestNow(Carbon::parse('2017-07-25 12:13:14 UTC'));
+
+        $repo = $this->getRepository();
+        $repo->getStore()->shouldReceive('put')->with($key = 'foo', $value = 'bar', 5);
+        $repo->put($key, $value, $duration);
+
+        Carbon::setTestNow();
     }
 
     public function testRegisterMacroWithNonStaticCall()


### PR DESCRIPTION
At the moment when using the Cache repository, we can only pass an instance of `\DateTime` or an integer for the duration.

---

This is therefore impossible to use `\DateTimeImmutable` for example.
Also we sometimes wish to use a `\DateInterval`.

---

This PR allows to use any kind of `\DateInterface`, `\DateInterval` and integers