### PR TITLE
[5.5] WIP | Separate PATCH and PUT routes in requests

### DIFF
--- a/src/Illuminate/Routing/Console/stubs/controller.model.stub
+++ b/src/Illuminate/Routing/Console/stubs/controller.model.stub
@@ -62,6 +62,18 @@ class DummyClass extends Controller
     }
 
     /**
+     * Replace the specified resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \DummyFullModelClass  $DummyModelVariable
+     * @return \Illuminate\Http\Response
+     */
+    public function replace(Request $request, DummyModelClass $DummyModelVariable)
+    {
+        //
+    }
+
+    /**
      * Update the specified resource in storage.
      *
      * @param  \Illuminate\Http\Request  $request
@@ -69,18 +81,6 @@ class DummyClass extends Controller
      * @return \Illuminate\Http\Response
      */
     public function update(Request $request, DummyModelClass $DummyModelVariable)
-    {
-        //
-    }
-
-    /**
-     * Patch the specified resource in storage.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @param  \DummyFullModelClass  $DummyModelVariable
-     * @return \Illuminate\Http\Response
-     */
-    public function patch(Request $request, DummyModelClass $DummyModelVariable)
     {
         //
     }

--- a/src/Illuminate/Routing/Console/stubs/controller.model.stub
+++ b/src/Illuminate/Routing/Console/stubs/controller.model.stub
@@ -74,6 +74,18 @@ class DummyClass extends Controller
     }
 
     /**
+     * Patch the specified resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \DummyFullModelClass  $DummyModelVariable
+     * @return \Illuminate\Http\Response
+     */
+    public function patch(Request $request, DummyModelClass $DummyModelVariable)
+    {
+        //
+    }
+
+    /**
      * Remove the specified resource from storage.
      *
      * @param  \DummyFullModelClass  $DummyModelVariable

--- a/src/Illuminate/Routing/Console/stubs/controller.nested.stub
+++ b/src/Illuminate/Routing/Console/stubs/controller.nested.stub
@@ -68,6 +68,19 @@ class DummyClass extends Controller
     }
 
     /**
+     * Replace the specified resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \ParentDummyFullModelClass  $ParentDummyModelVariable
+     * @param  \DummyFullModelClass  $DummyModelVariable
+     * @return \Illuminate\Http\Response
+     */
+    public function replace(Request $request, ParentDummyModelClass $ParentDummyModelVariable, DummyModelClass $DummyModelVariable)
+    {
+        //
+    }
+
+    /**
      * Update the specified resource in storage.
      *
      * @param  \Illuminate\Http\Request  $request
@@ -76,19 +89,6 @@ class DummyClass extends Controller
      * @return \Illuminate\Http\Response
      */
     public function update(Request $request, ParentDummyModelClass $ParentDummyModelVariable, DummyModelClass $DummyModelVariable)
-    {
-        //
-    }
-
-    /**
-     * Patch the specified resource in storage.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @param  \ParentDummyFullModelClass  $ParentDummyModelVariable
-     * @param  \DummyFullModelClass  $DummyModelVariable
-     * @return \Illuminate\Http\Response
-     */
-    public function patch(Request $request, ParentDummyModelClass $ParentDummyModelVariable, DummyModelClass $DummyModelVariable)
     {
         //
     }

--- a/src/Illuminate/Routing/Console/stubs/controller.nested.stub
+++ b/src/Illuminate/Routing/Console/stubs/controller.nested.stub
@@ -81,6 +81,19 @@ class DummyClass extends Controller
     }
 
     /**
+     * Patch the specified resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \ParentDummyFullModelClass  $ParentDummyModelVariable
+     * @param  \DummyFullModelClass  $DummyModelVariable
+     * @return \Illuminate\Http\Response
+     */
+    public function patch(Request $request, ParentDummyModelClass $ParentDummyModelVariable, DummyModelClass $DummyModelVariable)
+    {
+        //
+    }
+
+    /**
      * Remove the specified resource from storage.
      *
      * @param  \ParentDummyFullModelClass  $ParentDummyModelVariable

--- a/src/Illuminate/Routing/Console/stubs/controller.stub
+++ b/src/Illuminate/Routing/Console/stubs/controller.stub
@@ -61,6 +61,18 @@ class DummyClass extends Controller
     }
 
     /**
+     * Replace the specified resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function replace(Request $request, $id)
+    {
+        //
+    }
+
+    /**
      * Update the specified resource in storage.
      *
      * @param  \Illuminate\Http\Request  $request
@@ -68,18 +80,6 @@ class DummyClass extends Controller
      * @return \Illuminate\Http\Response
      */
     public function update(Request $request, $id)
-    {
-        //
-    }
-
-    /**
-     * Patch the specified resource in storage.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @param  int  $id
-     * @return \Illuminate\Http\Response
-     */
-    public function patch(Request $request, $id)
     {
         //
     }

--- a/src/Illuminate/Routing/Console/stubs/controller.stub
+++ b/src/Illuminate/Routing/Console/stubs/controller.stub
@@ -73,6 +73,18 @@ class DummyClass extends Controller
     }
 
     /**
+     * Patch the specified resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function patch(Request $request, $id)
+    {
+        //
+    }
+
+    /**
      * Remove the specified resource from storage.
      *
      * @param  int  $id

--- a/src/Illuminate/Routing/PendingResourceRegistration.php
+++ b/src/Illuminate/Routing/PendingResourceRegistration.php
@@ -53,7 +53,7 @@ class PendingResourceRegistration
      * Set the methods the controller should apply to.
      *
      * @param  array|string|dynamic  $methods
-     * @return \Illuminate\Routing\PendingResourceRegistration
+     * @return $this
      */
     public function only($methods)
     {
@@ -66,7 +66,7 @@ class PendingResourceRegistration
      * Set the methods the controller should exclude.
      *
      * @param  array|string|dynamic  $methods
-     * @return \Illuminate\Routing\PendingResourceRegistration
+     * @return $this
      */
     public function except($methods)
     {
@@ -79,7 +79,7 @@ class PendingResourceRegistration
      * Set the route names for controller actions.
      *
      * @param  array  $names
-     * @return \Illuminate\Routing\PendingResourceRegistration
+     * @return $this
      */
     public function names(array $names)
     {
@@ -93,7 +93,7 @@ class PendingResourceRegistration
      *
      * @param  string  $method
      * @param  string  $name
-     * @return \Illuminate\Routing\PendingResourceRegistration
+     * @return $this
      */
     public function name($method, $name)
     {
@@ -106,7 +106,7 @@ class PendingResourceRegistration
      * Override the route parameter names.
      *
      * @param  array  $parameters
-     * @return \Illuminate\Routing\PendingResourceRegistration
+     * @return $this
      */
     public function parameters(array $parameters)
     {
@@ -120,7 +120,7 @@ class PendingResourceRegistration
      *
      * @param  string  $previous
      * @param  string  $new
-     * @return \Illuminate\Routing\PendingResourceRegistration
+     * @return $this
      */
     public function parameter($previous, $new)
     {
@@ -133,7 +133,7 @@ class PendingResourceRegistration
      * Set a middleware to the resource.
      *
      * @param  mixed  $middleware
-     * @return \Illuminate\Routing\PendingResourceRegistration
+     * @return $this
      */
     public function middleware($middleware)
     {

--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -18,7 +18,7 @@ class ResourceRegistrar
      *
      * @var array
      */
-    protected $resourceDefaults = ['index', 'create', 'store', 'show', 'edit', 'update', 'patch', 'destroy'];
+    protected $resourceDefaults = ['index', 'create', 'store', 'show', 'edit', 'replace', 'update', 'destroy'];
 
     /**
      * The parameters set for this resource instance.
@@ -246,6 +246,24 @@ class ResourceRegistrar
     }
 
     /**
+     * Add the replace method for a resourceful route.
+     *
+     * @param  string  $name
+     * @param  string  $base
+     * @param  string  $controller
+     * @param  array   $options
+     * @return \Illuminate\Routing\Route
+     */
+    protected function addResourceReplace($name, $base, $controller, $options)
+    {
+        $uri = $this->getResourceUri($name).'/{'.$base.'}';
+
+        $action = $this->getResourceAction($name, $controller, 'replace', $options);
+
+        return $this->router->put($uri, $action);
+    }
+
+    /**
      * Add the update method for a resourceful route.
      *
      * @param  string  $name
@@ -259,24 +277,6 @@ class ResourceRegistrar
         $uri = $this->getResourceUri($name).'/{'.$base.'}';
 
         $action = $this->getResourceAction($name, $controller, 'update', $options);
-
-        return $this->router->put($uri, $action);
-    }
-
-    /**
-     * Add the patch method for a resourceful route.
-     *
-     * @param  string  $name
-     * @param  string  $base
-     * @param  string  $controller
-     * @param  array   $options
-     * @return \Illuminate\Routing\Route
-     */
-    protected function addResourcePatch($name, $base, $controller, $options)
-    {
-        $uri = $this->getResourceUri($name).'/{'.$base.'}';
-
-        $action = $this->getResourceAction($name, $controller, 'patch', $options);
 
         return $this->router->patch($uri, $action);
     }

--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -18,7 +18,7 @@ class ResourceRegistrar
      *
      * @var array
      */
-    protected $resourceDefaults = ['index', 'create', 'store', 'show', 'edit', 'update', 'destroy'];
+    protected $resourceDefaults = ['index', 'create', 'store', 'show', 'edit', 'update', 'patch', 'destroy'];
 
     /**
      * The parameters set for this resource instance.
@@ -260,7 +260,25 @@ class ResourceRegistrar
 
         $action = $this->getResourceAction($name, $controller, 'update', $options);
 
-        return $this->router->match(['PUT', 'PATCH'], $uri, $action);
+        return $this->router->put($uri, $action);
+    }
+
+    /**
+     * Add the patch method for a resourceful route.
+     *
+     * @param  string  $name
+     * @param  string  $base
+     * @param  string  $controller
+     * @param  array   $options
+     * @return \Illuminate\Routing\Route
+     */
+    protected function addResourcePatch($name, $base, $controller, $options)
+    {
+        $uri = $this->getResourceUri($name).'/{'.$base.'}';
+
+        $action = $this->getResourceAction($name, $controller, 'patch', $options);
+
+        return $this->router->patch($uri, $action);
     }
 
     /**

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -302,7 +302,7 @@ class Router implements RegistrarContract, BindingRegistrar
     public function apiResource($name, $controller, array $options = [])
     {
         return $this->resource($name, $controller, array_merge([
-            'only' => ['index', 'show', 'store', 'update', 'patch', 'destroy'],
+            'only' => ['index', 'show', 'store', 'replace', 'update', 'destroy'],
         ], $options));
     }
 

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -302,7 +302,7 @@ class Router implements RegistrarContract, BindingRegistrar
     public function apiResource($name, $controller, array $options = [])
     {
         return $this->resource($name, $controller, array_merge([
-            'only' => ['index', 'show', 'store', 'update', 'destroy'],
+            'only' => ['index', 'show', 'store', 'update', 'patch', 'destroy'],
         ], $options));
     }
 

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -207,8 +207,8 @@ class RouteRegistrarTest extends TestCase
 
         $this->assertCount(3, $this->router->getRoutes());
 
+        $this->assertTrue($this->router->getRoutes()->hasNamedRoute('users.replace'));
         $this->assertTrue($this->router->getRoutes()->hasNamedRoute('users.update'));
-        $this->assertTrue($this->router->getRoutes()->hasNamedRoute('users.patch'));
         $this->assertTrue($this->router->getRoutes()->hasNamedRoute('users.destroy'));
     }
 
@@ -225,19 +225,19 @@ class RouteRegistrarTest extends TestCase
     public function testCanRouteUpdateMethodOnRegisteredResource()
     {
         $this->router->resource('users', \Illuminate\Tests\Routing\RouteRegistrarUpdateControllerStub::class)
-                     ->only(['update']);
+                     ->only(['replace']);
 
         $this->assertCount(1, $this->router->getRoutes());
-        $this->seeResponse('updated', Request::create('users/123', 'PUT'));
+        $this->seeResponse('replaced', Request::create('users/123', 'PUT'));
     }
 
     public function testCanRoutePatchMethodOnRegisteredResource()
     {
         $this->router->resource('users', \Illuminate\Tests\Routing\RouteRegistrarPatchControllerStub::class)
-                     ->only(['patch']);
+                     ->only(['update']);
 
         $this->assertCount(1, $this->router->getRoutes());
-        $this->seeResponse('patched', Request::create('users/123', 'PATCH'));
+        $this->seeResponse('updated', Request::create('users/123', 'PATCH'));
     }
 
     public function testCanRoutePutAndPatchMethodOnRegisteredResource()
@@ -245,7 +245,7 @@ class RouteRegistrarTest extends TestCase
         $this->router->resource('users', \Illuminate\Tests\Routing\RouteRegistrarUpdateControllerStub::class)
                      ->only(['patch', 'update']);
 
-        $this->seeResponse('patched', Request::create('users/123', 'PATCH'));
+        $this->seeResponse('updated', Request::create('users/123', 'PATCH'));
     }
 
     public function testCanNameRoutesOnRegisteredResource()
@@ -360,22 +360,22 @@ class RouteRegistrarControllerStub
 
 class RouteRegistrarUpdateControllerStub
 {
+    public function replace()
+    {
+        return 'replaced';
+    }
+
     public function update()
     {
         return 'updated';
-    }
-
-    public function patch()
-    {
-        return 'patched';
     }
 }
 
 class RouteRegistrarPatchControllerStub
 {
-    public function patch()
+    public function update()
     {
-        return 'patched';
+        return 'updated';
     }
 }
 

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -220,6 +220,8 @@ class RouteRegistrarTest extends TestCase
 
         $this->assertFalse($this->router->getRoutes()->hasNamedRoute('users.create'));
         $this->assertFalse($this->router->getRoutes()->hasNamedRoute('users.edit'));
+        $this->assertTrue($this->router->getRoutes()->hasNamedRoute('users.replace'));
+        $this->assertTrue($this->router->getRoutes()->hasNamedRoute('users.update'));
     }
 
     public function testCanRouteUpdateMethodOnRegisteredResource()

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -205,9 +205,10 @@ class RouteRegistrarTest extends TestCase
         $this->router->resource('users', 'Illuminate\Tests\Routing\RouteRegistrarControllerStub')
                      ->except(['index', 'create', 'store', 'show', 'edit']);
 
-        $this->assertCount(2, $this->router->getRoutes());
+        $this->assertCount(3, $this->router->getRoutes());
 
         $this->assertTrue($this->router->getRoutes()->hasNamedRoute('users.update'));
+        $this->assertTrue($this->router->getRoutes()->hasNamedRoute('users.patch'));
         $this->assertTrue($this->router->getRoutes()->hasNamedRoute('users.destroy'));
     }
 
@@ -215,10 +216,36 @@ class RouteRegistrarTest extends TestCase
     {
         $this->router->apiResource('users', \Illuminate\Tests\Routing\RouteRegistrarControllerStub::class);
 
-        $this->assertCount(5, $this->router->getRoutes());
+        $this->assertCount(6, $this->router->getRoutes());
 
         $this->assertFalse($this->router->getRoutes()->hasNamedRoute('users.create'));
         $this->assertFalse($this->router->getRoutes()->hasNamedRoute('users.edit'));
+    }
+
+    public function testCanRouteUpdateMethodOnRegisteredResource()
+    {
+        $this->router->resource('users', \Illuminate\Tests\Routing\RouteRegistrarUpdateControllerStub::class)
+                     ->only(['update']);
+
+        $this->assertCount(1, $this->router->getRoutes());
+        $this->seeResponse('updated', Request::create('users/123', 'PUT'));
+    }
+
+    public function testCanRoutePatchMethodOnRegisteredResource()
+    {
+        $this->router->resource('users', \Illuminate\Tests\Routing\RouteRegistrarPatchControllerStub::class)
+                     ->only(['patch']);
+
+        $this->assertCount(1, $this->router->getRoutes());
+        $this->seeResponse('patched', Request::create('users/123', 'PATCH'));
+    }
+
+    public function testCanRoutePutAndPatchMethodOnRegisteredResource()
+    {
+        $this->router->resource('users', \Illuminate\Tests\Routing\RouteRegistrarUpdateControllerStub::class)
+                     ->only(['patch', 'update']);
+
+        $this->seeResponse('patched', Request::create('users/123', 'PATCH'));
     }
 
     public function testCanNameRoutesOnRegisteredResource()
@@ -331,6 +358,28 @@ class RouteRegistrarControllerStub
     }
 }
 
+class RouteRegistrarUpdateControllerStub
+{
+    public function update()
+    {
+        return 'updated';
+    }
+
+    public function patch()
+    {
+        return 'patched';
+    }
+}
+
+class RouteRegistrarPatchControllerStub
+{
+    public function patch()
+    {
+        return 'patched';
+    }
+}
+
 class RouteRegistrarMiddlewareStub
 {
+    //
 }

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -1018,7 +1018,7 @@ class RoutingRouteTest extends TestCase
         $router = $this->getRouter();
         $router->resource('foo', 'FooController');
         $routes = $router->getRoutes();
-        $this->assertCount(7, $routes);
+        $this->assertCount(8, $routes);
 
         $router = $this->getRouter();
         $router->resource('foo', 'FooController', ['only' => ['update']]);
@@ -1036,7 +1036,7 @@ class RoutingRouteTest extends TestCase
         $router->resource('foo', 'FooController', ['except' => ['show', 'destroy']]);
         $routes = $router->getRoutes();
 
-        $this->assertCount(5, $routes);
+        $this->assertCount(6, $routes);
 
         $router = $this->getRouter();
         $router->resource('foo-bars', 'FooController', ['only' => ['show']]);
@@ -1083,7 +1083,7 @@ class RoutingRouteTest extends TestCase
         $routes = $routes->getRoutes();
 
         $this->assertEquals('foos/{foo}', $routes[3]->uri());
-        $this->assertEquals('foos/{foo}/bars/{bar}', $routes[10]->uri());
+        $this->assertEquals('foos/{foo}/bars/{bar}', $routes[11]->uri());
 
         ResourceRegistrar::setParameters(['foos' => 'oof', 'bazs' => 'b']);
 
@@ -1104,7 +1104,7 @@ class RoutingRouteTest extends TestCase
         $routes = $routes->getRoutes();
 
         $this->assertEquals('foos/{foo}', $routes[3]->uri());
-        $this->assertEquals('foos/{foo}/bars/{bar}', $routes[10]->uri());
+        $this->assertEquals('foos/{foo}/bars/{bar}', $routes[11]->uri());
 
         $router = $this->getRouter();
         $router->resource('foos.bars', 'FooController', ['parameters' => ['foos' => 'foo', 'bars' => 'bar']]);


### PR DESCRIPTION
Resource Controller are a great feature of Laravel: the update route responds to `PUT` and `PATCH` methods which in most case fine.

However in many cases we want to be able to provide different feature depending on the HTTP verb: 
- a full entity update with `PUT`
- a partial entity update with `PATCH`

_More about PUT/PATCH differences:_

- http://weblog.rubyonrails.org/2012/2/26/edge-rails-patch-is-the-new-primary-http-method-for-updates/
- `PUT` : http://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html#sec9.6
- `PATCH` : http://tools.ietf.org/html/rfc5789

---

At the moment, we have to use some workarounds - one of them coule be:
```php
Route::resource('posts', 'PostController', ['except' => ['update']]);
Route::patch('posts/{post}', '\App\Http\Controllers\PostController@patchUpdate');
Route::put('posts/{post}', '\App\Http\Controllers\PostController@putUpdate');
```

Other solutions might exist, with `Route` macros - In any case no easy out-of-the-box solution exists.

---

This PR introduces the following changes in resource routing:

- The `PATCH/PUT` update route will not be generated anymore
- A `PUT` route will be generated to `...\MyController@replace`
- A `PATCH` route will be generated to `...\MyController@update`

---

**TODO:**

- [x] More tests on options
- [x] Ensure ApiResource also work with patch
- [ ] Provide an easy solution so that people migrating to `5.5`can still use mixed PUT+PATCH routes
