### PR TITLE
Eloquent Static Methods Definition

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -17,6 +17,7 @@ use Illuminate\Database\ConnectionResolverInterface as Resolver;
 
 /**
  * @mixin \Illuminate\Database\Eloquent\Builder
+ * @mixin \Eloquent
  */
 abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializable, QueueableEntity, UrlRoutable
 {


### PR DESCRIPTION
# PROBLEM:
The addition of `@mixin \Illuminate\Database\Eloquent\Builder` fails to provide the model instance the proper routes to the static methods.  This is due to the __callStatic method allowing access to all methods on the model without any definition for it.
## SOLUTION 1:
The `/** @mixin \Eloquent */` mixin that fixes the same issue for individual Eloquent/Model instances.  This work-around (used by the laravel-ide-helper) provides the definition for the static method calls for Eloquent/Models.
## SOLUTION 2:
We could add a @method DocComment for each of the valid static methods, since some would fail if called statically.
If this is the prefered method, I can get that done in a short amount of time.

# Possible concerns:
### SOLUTION 1. 
this is not a laravel mixin, but it is lightweight and affective.
### SOLUTION 2.
 this solution would add a lot of text to the docs for the model and would need to be maintained.