### PR TITLE
Add opt() helper as ternary shorthand

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -1071,3 +1071,18 @@ if (! function_exists('with')) {
         return $object;
     }
 }
+
+if (! function_exists('opt')) {
+    /**
+     * Functional equivalent of ternary operator. Useful shorthand in Blade templates.
+     *
+     * @param  mixed  $condition
+     * @param  mixed  $object
+     * @param  mixed  $object
+     * @return mixed
+     */
+    function opt($condition, $a, $b = null)
+    {
+        return $condition ? $a : $b;
+    }
+}

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -736,6 +736,13 @@ class SupportHelpersTest extends TestCase
     {
         throw_if(true, RuntimeException::class, 'Test Message');
     }
+
+    public function testOpt()
+    {
+        $this->assertEquals('a', opt(true, 'a', 'b'));
+        $this->assertEquals('b', opt(false, 'a', 'b'));
+        $this->assertNull(opt(false, 'a'));
+    }
 }
 
 trait SupportTestTraitOne


### PR DESCRIPTION
Grew tired of using the ternary operator, especially in Blade templates for simply things like outputting the class name.

```php
<div class="{{ $expression ? 'some-class' : '' }}">
```

`opt()` is a helper that wraps the ternary operator and makes the third argument optional, allowing you to write the following instead:

```php
<div class="{{ opt($expression, 'some-class') }}">
```

"opt" is a synonym for "choose". Figured it was a concise name, but open to others. More discussion on Twitter - https://twitter.com/gonedark/status/885567499953221633