### PR TITLE
Append dummy for namespaced User model and fix policy stubs

### DIFF
--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -166,8 +166,8 @@ abstract class GeneratorCommand extends Command
     protected function replaceNamespace(&$stub, $name)
     {
         $stub = str_replace(
-            ['DummyNamespace', 'DummyRootNamespace'],
-            [$this->getNamespace($name), $this->rootNamespace()],
+            ['DummyNamespace', 'DummyRootNamespace', 'NamespacedDummyUserModel'],
+            [$this->getNamespace($name), $this->rootNamespace(), config('auth.providers.users.model')],
             $stub
         );
 

--- a/src/Illuminate/Foundation/Console/stubs/policy.plain.stub
+++ b/src/Illuminate/Foundation/Console/stubs/policy.plain.stub
@@ -2,7 +2,7 @@
 
 namespace DummyNamespace;
 
-use DummyRootNamespaceUser;
+use NamespacedDummyUserModel;
 use Illuminate\Auth\Access\HandlesAuthorization;
 
 class DummyClass

--- a/src/Illuminate/Foundation/Console/stubs/policy.stub
+++ b/src/Illuminate/Foundation/Console/stubs/policy.stub
@@ -2,7 +2,7 @@
 
 namespace DummyNamespace;
 
-use DummyRootNamespaceUser;
+use NamespacedDummyUserModel;
 use NamespacedDummyModel;
 use Illuminate\Auth\Access\HandlesAuthorization;
 
@@ -13,7 +13,7 @@ class DummyClass
     /**
      * Determine whether the user can view the dummyModel.
      *
-     * @param  \DummyRootNamespaceUser  $user
+     * @param  \NamespacedDummyUserModel  $user
      * @param  \NamespacedDummyModel  $dummyModel
      * @return mixed
      */
@@ -25,7 +25,7 @@ class DummyClass
     /**
      * Determine whether the user can create dummyPluralModel.
      *
-     * @param  \DummyRootNamespaceUser  $user
+     * @param  \NamespacedDummyUserModel  $user
      * @return mixed
      */
     public function create(User $user)
@@ -36,7 +36,7 @@ class DummyClass
     /**
      * Determine whether the user can update the dummyModel.
      *
-     * @param  \DummyRootNamespaceUser  $user
+     * @param  \NamespacedDummyUserModel  $user
      * @param  \NamespacedDummyModel  $dummyModel
      * @return mixed
      */
@@ -48,7 +48,7 @@ class DummyClass
     /**
      * Determine whether the user can delete the dummyModel.
      *
-     * @param  \DummyRootNamespaceUser  $user
+     * @param  \NamespacedDummyUserModel  $user
      * @param  \NamespacedDummyModel  $dummyModel
      * @return mixed
      */


### PR DESCRIPTION
Before this PR, running `php artisan make:policy`, User model always set as '(RootNamespace)\User'.

This PR make new dummy for User model, based on config 'auth.providers.users.model' and set this dummy for policy stubs.