### PR TITLE
[5.4] Add class_names helper

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -358,6 +358,27 @@ if (! function_exists('class_basename')) {
     }
 }
 
+if (! function_exists('class_names')) {
+    /**
+     * A simple utility for conditionally joining class names together.
+     *
+     * @param  string|array $classNames
+     * @return string
+     */
+    function class_names()
+    {
+        $classes = array_reduce(func_get_args(), function ($accumulator, $current) {
+            return array_merge($accumulator, is_array($current) ? $current : [$current => true]);
+        }, []);
+
+        $classNames = array_map(function ($expression, $class) {
+            return $expression ? $class : null;
+        }, array_values($classes), array_keys($classes));
+
+        return implode(' ', array_filter($classNames));
+    }
+}
+
 if (! function_exists('class_uses_recursive')) {
     /**
      * Returns all traits used by a class, its subclasses and trait of their traits.

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -317,6 +317,15 @@ class SupportHelpersTest extends TestCase
         $this->assertEquals('Baz', class_basename('Baz'));
     }
 
+    public function testClassNames()
+    {
+        $this->assertEquals('foo bar', class_names(['foo' => true, 'bar' => true]));
+        $this->assertEquals('foo bar', class_names('foo', 'bar'));
+        $this->assertEquals('foo bar', class_names('foo', ['bar' => true]));
+        $this->assertEquals('foo bar', class_names(['foo' => true], ['bar' => true]));
+        $this->assertEquals('foo bar', class_names('foo', ['bar' => true], ['baz' => false]));
+    }
+
     public function testValue()
     {
         $this->assertEquals('foo', value('foo'));


### PR DESCRIPTION
After discussion in the same tweet that spawned https://github.com/laravel/framework/pull/20045 I have opted to submit my `class_names` helper.

This is a PHP port of https://github.com/JedWatson/classnames which I use heavily in my JavaScript code and found it something I'd love to have available in php too.

You can use it like similar

```php
<a href="{{ route('home') }}" class="{{ class_names(['is-active' => request()->routeIs('home')]) }}">Home</a>
```

This will then add the `is-active` class to the anchor tag only if the route we're on matches `home` You can pass as many arguments to the function as you want, a string will automatically be added, but if you pass an array, the keys are the class names, and the values are an expression that when resolved truthy will be added to the class list. Anything that resolves falsy is filtered out.
