### PR TITLE
[5.5] allow `before` and `after` to work with integers

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -38,7 +38,7 @@ class Str
      */
     public static function after($subject, $search)
     {
-        return $search == '' ? $subject : array_reverse(explode($search, $subject, 2))[0];
+        return $search === '' ? $subject : array_reverse(explode($search, $subject, 2))[0];
     }
 
     /**
@@ -72,7 +72,7 @@ class Str
      */
     public static function before($subject, $search)
     {
-        return $search == '' ? $subject : explode($search, $subject)[0];
+        return $search === '' ? $subject : explode($search, $subject)[0];
     }
 
     /**

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -96,6 +96,8 @@ class SupportStrTest extends TestCase
         $this->assertEquals('hannah', Str::before('hannah', 'xxxx'));
         $this->assertEquals('hannah', Str::before('hannah', ''));
         $this->assertEquals('han', Str::before('han0nah', '0'));
+        $this->assertEquals('han', Str::before('han0nah', 0));
+        $this->assertEquals('han', Str::before('han2nah', 2));
     }
 
     public function testStrAfter()
@@ -106,6 +108,8 @@ class SupportStrTest extends TestCase
         $this->assertEquals('hannah', Str::after('hannah', 'xxxx'));
         $this->assertEquals('hannah', Str::after('hannah', ''));
         $this->assertEquals('nah', Str::after('han0nah', '0'));
+        $this->assertEquals('nah', Str::after('han0nah', 0));
+        $this->assertEquals('nah', Str::after('han2nah', 2));
     }
 
     public function testStrContains()


### PR DESCRIPTION
we need to do a strict comparison, because if the user passes an integer this will not function correctly.

while it would be great if people only pass strings to this function, I can imagine people passing integers. with the strict check, everything still works correctly with the strings, but this will just catch that rare occasion that someone passes an integer 0 in.