### PR TITLE
[5.5] Add  get method in the Relation class

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/HasMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasMany.php
@@ -13,7 +13,9 @@ class HasMany extends HasOneOrMany
      */
     public function getResults()
     {
-        return $this->query->get();
+        return tap($this->query->get(), function ($results) {
+            $this->setInverseRelation($results);
+        });
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/HasOne.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOne.php
@@ -17,7 +17,13 @@ class HasOne extends HasOneOrMany
      */
     public function getResults()
     {
-        return $this->query->first() ?: $this->getDefaultFor($this->parent);
+        if (! $result = $this->query->first()) {
+            return $this->getDefaultFor($this->parent);
+        }
+
+        $this->setInverseRelation($result);
+
+        return $result;
     }
 
     /**
@@ -57,8 +63,10 @@ class HasOne extends HasOneOrMany
      */
     public function newRelatedInstanceFor(Model $parent)
     {
-        return $this->related->newInstance()->setAttribute(
-            $this->getForeignKeyName(), $parent->{$this->localKey}
-        );
+        return tap($this->related->newInstance(), function ($model) use ($parent) {
+            $model->setAttribute($this->getForeignKeyName(), $parent->getAttribute($this->localKey));
+
+            $this->setInverseRelation($model, $parent);
+        });
     }
 }

--- a/src/Illuminate/Database/Eloquent/Relations/MorphMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphMany.php
@@ -13,7 +13,9 @@ class MorphMany extends MorphOneOrMany
      */
     public function getResults()
     {
-        return $this->query->get();
+        return tap($this->query->get(), function ($result) {
+            $this->setInverseRelation($result);
+        });
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/MorphOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphOneOrMany.php
@@ -199,6 +199,8 @@ abstract class MorphOneOrMany extends HasOneOrMany
         $model->{$this->getForeignKeyName()} = $this->getParentKey();
 
         $model->{$this->getMorphType()} = $this->morphClass;
+
+        $this->setInverseRelation($model);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -141,6 +141,17 @@ abstract class Relation
     }
 
     /**
+     * Execute the query as a "select" statement.
+     *
+     * @param  array  $columns
+     * @return \Illuminate\Database\Eloquent\Collection
+     */
+    public function get($columns = ['*'])
+    {
+        return $this->query->get($columns);
+    }
+
+    /**
      * Touch all of the related models for the relationship.
      *
      * @return void

--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -52,6 +52,13 @@ abstract class Relation
     protected static $morphMap = [];
 
     /**
+     * The inverse side of the relationship.
+     *
+     * @var string
+     */
+    protected $inverseSide;
+
+    /**
      * Create a new relation instance.
      *
      * @param  \Illuminate\Database\Eloquent\Builder  $query
@@ -353,6 +360,8 @@ abstract class Relation
         if ($result === $this->query) {
             return $this;
         }
+
+        $this->setInverseRelation($result);
 
         return $result;
     }


### PR DESCRIPTION
This PR is a micro optimisation on one side, but on the other side I think it is good to be explicit here since the `BelongsToMany`class is actually "overriding" the (non-declared) get method. 

For example I thought I could change this:

```
    public function getEager()
    {
        return $this->get();
    }
```

To this:

```
    public function getEager()
    {
        return $this->query->get();
    }
```

Since `get()`was just a call to a "magic method"

But this actually caused 2 tests to fail because `get` is (re)declared in `BelongsToMany`.