### PR TITLE
[5.5] Add get method in the Relation class

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -141,6 +141,17 @@ abstract class Relation
     }
 
     /**
+     * Execute the query as a "select" statement.
+     *
+     * @param  array  $columns
+     * @return \Illuminate\Database\Eloquent\Collection
+     */
+    public function get($columns = ['*'])
+    {
+        return $this->query->get($columns);
+    }
+
+    /**
      * Touch all of the related models for the relationship.
      *
      * @return void


### PR DESCRIPTION
(Reopened)

This PR is a micro optimisation on one side, but on the other side I think it is good to be explicit here since the `BelongsToMany`class is actually "overriding" the (non-declared) get method. 

For example I thought I could change this:

```
    public function getEager()
    {
        return $this->get();
    }
```

To this:

```
    public function getEager()
    {
        return $this->query->get();
    }
```

Since `get()`was just a call to a "magic method"

But this actually caused 2 tests to fail because `get` is (re)declared in `BelongsToMany`.