### PR TITLE
[5.5] Add inverse side in has/morph one/many relationships

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -379,6 +379,10 @@ trait HasAttributes
             return $this->relations[$key];
         }
 
+        if (isset($this->inverseRelations[$key])) {
+            return $this->inverseRelations[$key];
+        }
+
         // If the "attribute" exists as a method on the model, we will just assume
         // it is a relationship and will load and return results from the query
         // and hydrate the relationship's value on the "relationships" array.

--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -27,6 +27,13 @@ trait HasRelationships
     protected $relations = [];
 
     /**
+     * The loaded inverse relationships for the model.
+     *
+     * @var array
+     */
+    protected $inverseRelations = [];
+
+    /**
      * The relationships that should be touched on save.
      *
      * @var array
@@ -552,6 +559,20 @@ trait HasRelationships
     public function setRelation($relation, $value)
     {
         $this->relations[$relation] = $value;
+
+        return $this;
+    }
+
+    /**
+     * Set the inverse relationship in the model.
+     *
+     * @param  string  $relation
+     * @param  mixed  $value
+     * @return $this
+     */
+    public function setInverseRelation($relation, $value)
+    {
+        $this->inverseRelations[$relation] = $value;
 
         return $this;
     }

--- a/src/Illuminate/Database/Eloquent/Relations/HasMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasMany.php
@@ -13,7 +13,9 @@ class HasMany extends HasOneOrMany
      */
     public function getResults()
     {
-        return $this->query->get();
+        return tap($this->query->get(), function ($results) {
+            $this->setInverseRelation($results);
+        });
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/HasOne.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOne.php
@@ -17,7 +17,13 @@ class HasOne extends HasOneOrMany
      */
     public function getResults()
     {
-        return $this->query->first() ?: $this->getDefaultFor($this->parent);
+        if (! $result = $this->query->first()) {
+            return $this->getDefaultFor($this->parent);
+        }
+
+        $this->setInverseRelation($result);
+
+        return $result;
     }
 
     /**
@@ -57,8 +63,10 @@ class HasOne extends HasOneOrMany
      */
     public function newRelatedInstanceFor(Model $parent)
     {
-        return $this->related->newInstance()->setAttribute(
-            $this->getForeignKeyName(), $parent->{$this->localKey}
-        );
+        return tap($this->related->newInstance(), function ($model) use ($parent) {
+            $model->setAttribute($this->getForeignKeyName(), $parent->getAttribute($this->localKey));
+
+            $this->setInverseRelation($model, $parent);
+        });
     }
 }

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -47,6 +47,39 @@ abstract class HasOneOrMany extends Relation
     }
 
     /**
+     * Assign the inverse side name of the relationship to be populated.
+     *
+     * @param  string  $name
+     * @return $this
+     */
+    public function inversedBy($name)
+    {
+        $this->inverseSide = $name;
+
+        return $this;
+    }
+
+    /**
+     * Set the inverse side of the relationship on the given model.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Collection  $models
+     * @param  \Illuminate\Database\Eloquent\Mode|null  $parent
+     * @return void
+     */
+    protected function setInverseRelation($models, $parent = null)
+    {
+        if (! $this->inverseSide) {
+            return;
+        }
+
+        if ($models instanceof Collection) {
+            $models->each->setRelation($this->inverseSide, $parent ?: $this->parent);
+        } elseif ($models instanceof Model) {
+            $models->setRelation($this->inverseSide, $parent ?: $this->parent);
+        }
+    }
+
+    /**
      * Create and return an un-saved instance of the related model.
      *
      * @param  array  $attributes
@@ -56,6 +89,8 @@ abstract class HasOneOrMany extends Relation
     {
         return tap($this->related->newInstance($attributes), function ($instance) {
             $instance->setAttribute($this->getForeignKeyName(), $this->getParentKey());
+
+            $this->setInverseRelation($instance);
         });
     }
 
@@ -130,9 +165,11 @@ abstract class HasOneOrMany extends Relation
         // matching very convenient and easy work. Then we'll just return them.
         foreach ($models as $model) {
             if (isset($dictionary[$key = $model->getAttribute($this->localKey)])) {
-                $model->setRelation(
-                    $relation, $this->getRelationValue($dictionary, $key, $type)
-                );
+                $related = $this->getRelationValue($dictionary, $key, $type);
+
+                $this->setInverseRelation($related, $model);
+
+                $model->setRelation($relation, $related);
             }
         }
 
@@ -191,6 +228,8 @@ abstract class HasOneOrMany extends Relation
             $instance->setAttribute($this->getForeignKeyName(), $this->getParentKey());
         }
 
+        $this->setInverseRelation($instance);
+
         return $instance;
     }
 
@@ -209,6 +248,8 @@ abstract class HasOneOrMany extends Relation
             $instance->setAttribute($this->getForeignKeyName(), $this->getParentKey());
         }
 
+        $this->setInverseRelation($instance);
+
         return $instance;
     }
 
@@ -223,6 +264,8 @@ abstract class HasOneOrMany extends Relation
     {
         if (is_null($instance = $this->where($attributes)->first())) {
             $instance = $this->create($attributes + $values);
+        } else {
+            $this->setInverseRelation($instance);
         }
 
         return $instance;
@@ -254,6 +297,8 @@ abstract class HasOneOrMany extends Relation
     {
         $model->setAttribute($this->getForeignKeyName(), $this->getParentKey());
 
+        $this->setInverseRelation($model);
+
         return $model->save() ? $model : false;
     }
 
@@ -282,6 +327,8 @@ abstract class HasOneOrMany extends Relation
     {
         return tap($this->related->newInstance($attributes), function ($instance) {
             $instance->setAttribute($this->getForeignKeyName(), $this->getParentKey());
+
+            $this->setInverseRelation($instance);
 
             $instance->save();
         });
@@ -415,5 +462,25 @@ abstract class HasOneOrMany extends Relation
     public function getQualifiedForeignKeyName()
     {
         return $this->foreignKey;
+    }
+
+    /**
+     * Handle dynamic method calls to the relationship.
+     *
+     * @param  string  $method
+     * @param  array   $parameters
+     * @return mixed
+     */
+    public function __call($method, $parameters)
+    {
+        $result = parent::__call($method, $parameters);
+
+        if ($result === $this->query) {
+            return $this;
+        }
+
+        $this->setInverseRelation($result);
+
+        return $result;
     }
 }

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -73,9 +73,9 @@ abstract class HasOneOrMany extends Relation
         }
 
         if ($models instanceof Collection) {
-            $models->each->setRelation($this->inverseSide, $parent ?: $this->parent);
+            $models->each->setInverseRelation($this->inverseSide, $parent ?: $this->parent);
         } elseif ($models instanceof Model) {
-            $models->setRelation($this->inverseSide, $parent ?: $this->parent);
+            $models->setInverseRelation($this->inverseSide, $parent ?: $this->parent);
         }
     }
 

--- a/src/Illuminate/Database/Eloquent/Relations/MorphMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphMany.php
@@ -13,7 +13,9 @@ class MorphMany extends MorphOneOrMany
      */
     public function getResults()
     {
-        return $this->query->get();
+        return tap($this->query->get(), function ($result) {
+            $this->setInverseRelation($result);
+        });
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/MorphOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphOneOrMany.php
@@ -199,6 +199,8 @@ abstract class MorphOneOrMany extends HasOneOrMany
         $model->{$this->getForeignKeyName()} = $this->getParentKey();
 
         $model->{$this->getMorphType()} = $this->morphClass;
+
+        $this->setInverseRelation($model);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -52,6 +52,13 @@ abstract class Relation
     protected static $morphMap = [];
 
     /**
+     * The inverse side of the relationship.
+     *
+     * @var string
+     */
+    protected $inverseSide;
+
+    /**
      * Create a new relation instance.
      *
      * @param  \Illuminate\Database\Eloquent\Builder  $query


### PR DESCRIPTION
This is a more complete proposal of https://github.com/laravel/framework/pull/20011 

This is an idea to fix https://github.com/laravel/framework/issues/20006

By specifying the inverse side of the has many relationship like this:

```
    public function comments()
    {
        return $this->hasMany(Comment::class)->inversedBy('post');
    }
```

Then `$post->comments->first()->post`won't generate an extra SQL and **won't duplicate the post object**, it will be the same! This will help to avoid the N+1 described in the issue. 

This should work with has one, morph one, has many and morph many relations (basically the relations that have inverse side).

I tested with eager and lazy loading and with default, etc. I haven't added unit tests for the core but I've been working with these integration tests: 

https://github.com/sileence/eloquent_push_tests/blob/master/tests/Unit/EloquentInversedByTest.php

