### PR TITLE
[5.4] Updated the error respone for failed login

### DIFF
--- a/src/Illuminate/Foundation/Auth/AuthenticatesUsers.php
+++ b/src/Illuminate/Foundation/Auth/AuthenticatesUsers.php
@@ -124,7 +124,7 @@ trait AuthenticatesUsers
      */
     protected function sendFailedLoginResponse(Request $request)
     {
-        $errors = [$this->username() => trans('auth.failed')];
+        $errors = [$this->username() => [trans('auth.failed')]];
 
         if ($request->expectsJson()) {
             return response()->json($errors, 422);


### PR DESCRIPTION
I noticed that the built in authentication will return the JSON error message as a string instead of an array of error messages like the normal validation does. 

This is simple enough to handle on the frontend but figured standardizing it like other validation errors would be best.