### PR TITLE
[5.5] Add Collection::wrap method

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -60,6 +60,19 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
+     * If the given value is not a collection, wrap it in one.
+     *
+     * @param  mixed  $value
+     * @return static
+     */
+    public static function wrap($value)
+    {
+        return $value instanceof self
+            ? new static($value)
+            : new static(Arr::wrap($value));
+    }
+
+    /**
      * Create a new collection by invoking the callback a given amount of times.
      *
      * @param  int  $amount

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1014,6 +1014,49 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(['foo' => 'bar'], $collection->all());
     }
 
+    public function testWrapWithScalar()
+    {
+        $collection = Collection::wrap('foo');
+        $this->assertEquals(['foo'], $collection->all());
+    }
+
+    public function testWrapWithArray()
+    {
+        $collection = Collection::wrap(['foo']);
+        $this->assertEquals(['foo'], $collection->all());
+    }
+
+    public function testWrapWithArrayable()
+    {
+        $collection = Collection::wrap($o = new TestArrayableObject);
+        $this->assertEquals([$o], $collection->all());
+    }
+
+    public function testWrapWithJsonable()
+    {
+        $collection = Collection::wrap($o = new TestJsonableObject);
+        $this->assertEquals([$o], $collection->all());
+    }
+
+    public function testWrapWithJsonSerialize()
+    {
+        $collection = Collection::wrap($o = new TestJsonSerializeObject);
+        $this->assertEquals([$o], $collection->all());
+    }
+
+    public function testWrapWithCollectionClass()
+    {
+        $collection = Collection::wrap(Collection::make(['foo']));
+        $this->assertEquals(['foo'], $collection->all());
+    }
+
+    public function testWrapWithCollectionSubclass()
+    {
+        $collection = TestCollectionSubclass::wrap(Collection::make(['foo']));
+        $this->assertEquals(['foo'], $collection->all());
+        $this->assertInstanceOf(TestCollectionSubclass::class, $collection);
+    }
+
     public function testTimesMethod()
     {
         $two = Collection::times(2, function ($number) {
@@ -2286,4 +2329,9 @@ class TestCollectionMapIntoObject
     {
         $this->value = $value;
     }
+}
+
+class TestCollectionSubclass extends Collection
+{
+    //
 }


### PR DESCRIPTION
If the given value is not a collection, wrap it in one. This is the collection equivalent to `Arr::wrap`.

If you pass a collection or an array as the value you get a collection with data in the collection or array back. If you pass in anything else you get a collection of one containing that value.

Had the idea while reading the code for PR https://github.com/laravel/framework/pull/20053. It could turn 7 LoC (at the end of `setInverseRelation`) in that PR to this:

`Collection::wrap($models)->each->setRelation($this->inverseSide, $parent);`

No more pesky instanceof check! and it reads rather well too.