### PR TITLE
[5.5] Add unwrap to collection

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -73,6 +73,17 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
+     * If the given value is a collection return its items.
+     *
+     * @param  array|static  $value
+     * @return array
+     */
+    public static function unwrap($value)
+    {
+        return $value instanceof self ? $value->all() : $value;
+    }
+
+    /**
      * Create a new collection by invoking the callback a given amount of times.
      *
      * @param  int  $amount

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -60,7 +60,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
-     * If the given value is not a collection, wrap it in one.
+     * Wrap the given value in a collection if applicable.
      *
      * @param  mixed  $value
      * @return static
@@ -73,7 +73,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
-     * If the given value is a collection return its items.
+     * Get the underlying items from the given collection if applicable.
      *
      * @param  array|static  $value
      * @return array

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1057,6 +1057,22 @@ class SupportCollectionTest extends TestCase
         $this->assertInstanceOf(TestCollectionSubclass::class, $collection);
     }
 
+    public function testUnwrapCollection()
+    {
+        $collection = new Collection(['foo']);
+        $this->assertEquals(['foo'], Collection::unwrap($collection));
+    }
+
+    public function testUnwrapCollectionWithArray()
+    {
+        $this->assertEquals(['foo'], Collection::unwrap(['foo']));
+    }
+
+    public function testUnwrapCollectionWithScalar()
+    {
+        $this->assertEquals('foo', Collection::unwrap('foo'));
+    }
+
     public function testTimesMethod()
     {
         $two = Collection::times(2, function ($number) {


### PR DESCRIPTION
Following https://github.com/laravel/framework/pull/20055 

Sometimes the opposite is needed (you need the underlying array of a value that might be a collection or a plain array).