### PR TITLE
Allow Blade to comment raw PHP

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -100,7 +100,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
      *
      * @var string
      */
-    protected $rawPlaceholder = '@__raw-block__@';
+    protected $rawPlaceholder = '@__raw_block_#__@';
 
     /**
      * Array to temporary store the raw blocks found in the template.
@@ -158,7 +158,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
     public function compileString($value)
     {
         if (strpos($value, '@verbatim') !== false) {
-            $value = $this->storeVerbatimBlocks($value);
+            $value = $this->storeRawBlocks($value, 'verbatim');
         }
 
         $this->footer = [];
@@ -166,7 +166,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
         $result = $this->convertPhpTagsToBladeSyntax($value);
 
         if (strpos($result, '@php') !== false) {
-            $result = $this->storePhpBlocks($result);
+            $result = $this->storeRawBlocks($result, 'php');
         }
 
         foreach ($this->compilers as $type) {
@@ -188,32 +188,20 @@ class BladeCompiler extends Compiler implements CompilerInterface
     }
 
     /**
-     * Store the verbatim blocks and replace them with a temporary placeholder.
+     * Store the verbatim and PHP blocks and replace them with a temporary placeholder.
      *
      * @param  string  $value
+     * @param  string  $tag
      * @return string
      */
-    protected function storeVerbatimBlocks($value)
+    protected function storeRawBlocks($value, $tag)
     {
-        return preg_replace_callback('/(?<!@)@verbatim(.*?)@endverbatim/s', function ($matches) {
-            $this->rawBlocks[] = $matches[1];
+        return preg_replace_callback("/(?<!@)@{$tag}(.*?)@end{$tag}/s", function ($matches) use ($tag) {
+            $this->rawBlocks[] = $tag == 'php' ? "<?php{$matches[1]}?>" : $matches[1];
 
-            return $this->rawPlaceholder;
-        }, $value);
-    }
+            end($this->rawBlocks);
 
-    /**
-     * Store the PHP blocks and replace them with a temporary placeholder.
-     *
-     * @param  string  $value
-     * @return string
-     */
-    protected function storePhpBlocks($value)
-    {
-        return preg_replace_callback('/(?<!@)@php(.*?)@endphp/s', function ($matches) {
-            $this->rawBlocks[] = "<?php{$matches[1]}?>";
-
-            return $this->rawPlaceholder;
+            return str_replace('#', key($this->rawBlocks), $this->rawPlaceholder);
         }, $value);
     }
 
@@ -253,8 +241,10 @@ class BladeCompiler extends Compiler implements CompilerInterface
      */
     protected function restoreRawContent($result)
     {
-        $result = preg_replace_callback('/'.preg_quote($this->rawPlaceholder).'/', function () {
-            return array_shift($this->rawBlocks);
+        $placeholderRegex = str_replace('#', '(\d+)', preg_quote($this->rawPlaceholder));
+
+        $result = preg_replace_callback("/{$placeholderRegex}/", function ($matches) {
+            return $this->rawBlocks[$matches[1]];
         }, $result);
 
         $this->rawBlocks = [];

--- a/tests/View/Blade/BladeCommentsTest.php
+++ b/tests/View/Blade/BladeCommentsTest.php
@@ -31,4 +31,12 @@ this is a comment
 
         $this->assertEmpty($this->compiler->compileString($string));
     }
+
+    public function testRawBlocksDontGetMixedUpWhenSomeAreRemovedByBladeComments()
+    {
+        $string = '{{-- @verbatim Block #1 @endverbatim --}} @php "Block #2" @endphp';
+        $expected = ' <?php "Block #2" ?>';
+
+        $this->assertSame($expected, $this->compiler->compileString($string));
+    }
 }

--- a/tests/View/Blade/BladeCommentsTest.php
+++ b/tests/View/Blade/BladeCommentsTest.php
@@ -24,4 +24,11 @@ this is a comment
 
         $this->assertEmpty($this->compiler->compileString($string));
     }
+
+    public function testPhpCodeInsideCommentsIsNotCompiled()
+    {
+        $string = '{{-- <?php echo "No one will see this"; ?> --}}';
+
+        $this->assertEmpty($this->compiler->compileString($string));
+    }
 }

--- a/tests/View/Blade/BladePhpStatementsTest.php
+++ b/tests/View/Blade/BladePhpStatementsTest.php
@@ -29,6 +29,27 @@ class BladePhpStatementsTest extends AbstractBladeTestCase
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
+    public function testRawPhpStatementsAreConvertedToBladeSyntax()
+    {
+        $string = '<?php echo "Hello world"; ?>';
+        $expected = '@php echo "Hello world"; @endphp';
+        $this->assertEquals($expected, $this->compiler->convertPhpTagsToBladeSyntax($string));
+
+        $string = "<?php
+            echo 'Hello world';
+        ?>
+        
+        Content here";
+
+        $expected = "@php
+            echo 'Hello world';
+        @endphp
+        
+        Content here";
+
+        $this->assertEquals($expected, $this->compiler->convertPhpTagsToBladeSyntax($string));
+    }
+
     public function testVerbatimAndPhpStatementsDontGetMixedUp()
     {
         $string = "@verbatim {{ Hello, I'm not blade! }}"


### PR DESCRIPTION
This is a fix for: https://github.com/laravel/framework/issues/20060

Right now Blade cannot comment a fragment of Blade code that contains raw PHP, for example:

```
    {{--
        @foreach (['some', 'things'] as $thing)


            <?php echo 'Hi!' ?>


        @endforeach
    --}}
```

Because the `token_get_all` function splits the Blade comments in 2 different strings, they end up being ignored by the Blade Compiler. 

So the idea of this PR is to transform the raw PHP tags to Blade in that way everything can be compiled as a whole and the above code can produce the expected result. 