### PR TITLE
[5.5] Prevent raw blocks from being restore in the wrong order

### DIFF
--- a/tests/View/Blade/BladeCommentsTest.php
+++ b/tests/View/Blade/BladeCommentsTest.php
@@ -24,4 +24,12 @@ this is a comment
 
         $this->assertEmpty($this->compiler->compileString($string));
     }
+
+    public function testRawBlocksDontGetMixedUpWhenSomeAreRemovedByBladeComments()
+    {
+        $string = '{{-- @verbatim Block #1 @endverbatim --}} @php "Block #2" @endphp';
+        $expected = ' <?php "Block #2" ?>';
+
+        $this->assertSame($expected, $this->compiler->compileString($string));
+    }
 }


### PR DESCRIPTION
There is a possibility that multiple raw blocks (`@verbatim` and/or `@php`) are rendered incorrectly if part of that code is commented with Blade (as Blade comments mean the raw placeholder will be removed too leaving the raw placeholders / blocks out of sync).

My solution was to give each raw placeholder an unique identifier, another idea would be to compile the Blade comments first but that could have other implications as we want to ignore the Blade code inside `@verbatim` and `@php` and also support the raw PHP tags as well.