### PR TITLE
[WIP][5.4] Add --cache to work command

### DIFF
--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -28,7 +28,8 @@ class WorkCommand extends Command
                             {--memory=128 : The memory limit in megabytes}
                             {--sleep=3 : Number of seconds to sleep when no job is available}
                             {--timeout=60 : The number of seconds a child process can run}
-                            {--tries=0 : Number of times to attempt a job before logging it failed}';
+                            {--tries=0 : Number of times to attempt a job before logging it failed}
+                            {--cache= : The name of the cache driver to get the last queue restart timestamp}';
 
     /**
      * The console command description.
@@ -95,7 +96,9 @@ class WorkCommand extends Command
      */
     protected function runWorker($connection, $queue)
     {
-        $this->worker->setCache($this->laravel['cache']->driver());
+        $this->worker->setCache(
+            $this->laravel['cache']->driver($this->option('cache'))
+        );
 
         return $this->worker->{$this->option('once') ? 'runNextJob' : 'daemon'}(
             $connection, $queue, $this->gatherWorkerOptions()


### PR DESCRIPTION
This PR allows the user to define custom cache driver for getting the last restart timestamp:

```
php artisan queue:work --cache=local_redis
```

Currently, it only works with the default cache driver.

