### PR TITLE
Allow setting HttpOnly flag in the XSRF token cookie

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
+++ b/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
@@ -156,7 +156,7 @@ class VerifyCsrfToken
         $response->headers->setCookie(
             new Cookie(
                 'XSRF-TOKEN', $request->session()->token(), Carbon::now()->getTimestamp() + 60 * $config['lifetime'],
-                $config['path'], $config['domain'], $config['secure'], false, false, $config['same_site'] ?? null
+                $config['path'], $config['domain'], $config['secure'], $config['http_only'], false, $config['same_site'] ?? null
             )
         );
 


### PR DESCRIPTION
It overrides the PHP default settings, if the config option is not ... perhaps turn to PHP default?

This PR will at least use the config env of the session so its settable. 