### PR TITLE
[5.5] Implement iterable Gate::check() and Gate::any()

### DIFF
--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -221,19 +221,35 @@ class Gate implements GateContract
     }
 
     /**
-     * Determine if the given ability should be granted for the current user.
+     * Determine if all of the given abilities should be granted for the current user.
      *
-     * @param  string  $ability
+     * @param  iterable|string  $abilities
      * @param  array|mixed  $arguments
      * @return bool
      */
-    public function check($ability, $arguments = [])
+    public function check($abilities, $arguments = [])
     {
-        try {
-            return (bool) $this->raw($ability, $arguments);
-        } catch (AuthorizationException $e) {
-            return false;
-        }
+        return collect($abilities)->every(function ($ability) use ($arguments) {
+            try {
+                return (bool) $this->raw($ability, $arguments);
+            } catch (AuthorizationException $e) {
+                return false;
+            }
+        });
+    }
+
+    /**
+     * Determine if any one of the given abilities should be granted for the current user.
+     *
+     * @param  iterable|string  $abilities
+     * @param  array|mixed  $arguments
+     * @return bool
+     */
+    public function any($abilities, $arguments = [])
+    {
+        return collect($abilities)->contains(function ($ability) use ($arguments) {
+            return $this->check($ability, $arguments);
+        });
     }
 
     /**

--- a/src/Illuminate/Contracts/Auth/Access/Gate.php
+++ b/src/Illuminate/Contracts/Auth/Access/Gate.php
@@ -65,13 +65,22 @@ interface Gate
     public function denies($ability, $arguments = []);
 
     /**
-     * Determine if the given ability should be granted.
+     * Determine if all of the given abilities should be granted for the current user.
      *
-     * @param  string  $ability
+     * @param  iterable|string  $abilities
      * @param  array|mixed  $arguments
      * @return bool
      */
-    public function check($ability, $arguments = []);
+    public function check($abilities, $arguments = []);
+
+    /**
+     * Determine if any one of the given abilities should be granted for the current user.
+     *
+     * @param  iterable|string  $abilities
+     * @param  array|mixed  $arguments
+     * @return bool
+     */
+    public function any($abilities, $arguments = []);
 
     /**
      * Determine if the given ability should be granted for the current user.

--- a/tests/Auth/AuthAccessGateTest.php
+++ b/tests/Auth/AuthAccessGateTest.php
@@ -319,6 +319,60 @@ class GateTest extends TestCase
             return (object) ['id' => 1, 'isAdmin' => $isAdmin];
         });
     }
+
+    public function test_any_ability_check_passes_if_all_pass()
+    {
+        $gate = $this->getBasicGate();
+
+        $gate->policy(AccessGateTestDummy::class, AccessGateTestPolicyWithAllPermissions::class);
+
+        $this->assertTrue($gate->any(['edit', 'update'], new AccessGateTestDummy));
+    }
+
+    public function test_any_ability_check_passes_if_at_least_one_passes()
+    {
+        $gate = $this->getBasicGate();
+
+        $gate->policy(AccessGateTestDummy::class, AccessGateTestPolicyWithMixedPermissions::class);
+
+        $this->assertTrue($gate->any(['edit', 'update'], new AccessGateTestDummy));
+    }
+
+    public function test_any_ability_check_fails_if_none_pass()
+    {
+        $gate = $this->getBasicGate();
+
+        $gate->policy(AccessGateTestDummy::class, AccessGateTestPolicyWithNoPermissions::class);
+
+        $this->assertFalse($gate->any(['edit', 'update'], new AccessGateTestDummy));
+    }
+
+    public function test_every_ability_check_passes_if_all_pass()
+    {
+        $gate = $this->getBasicGate();
+
+        $gate->policy(AccessGateTestDummy::class, AccessGateTestPolicyWithAllPermissions::class);
+
+        $this->assertTrue($gate->check(['edit', 'update'], new AccessGateTestDummy));
+    }
+
+    public function test_every_ability_check_fails_if_at_least_one_fails()
+    {
+        $gate = $this->getBasicGate();
+
+        $gate->policy(AccessGateTestDummy::class, AccessGateTestPolicyWithMixedPermissions::class);
+
+        $this->assertFalse($gate->check(['edit', 'update'], new AccessGateTestDummy));
+    }
+
+    public function test_every_ability_check_fails_if_none_pass()
+    {
+        $gate = $this->getBasicGate();
+
+        $gate->policy(AccessGateTestDummy::class, AccessGateTestPolicyWithNoPermissions::class);
+
+        $this->assertFalse($gate->check(['edit', 'update'], new AccessGateTestDummy));
+    }
 }
 
 class AccessGateTestClass
@@ -418,6 +472,45 @@ class AccessGateTestCustomResource
     }
 
     public function bar($user)
+    {
+        return true;
+    }
+}
+
+class AccessGateTestPolicyWithMixedPermissions
+{
+    public function edit($user, AccessGateTestDummy $dummy)
+    {
+        return false;
+    }
+
+    public function update($user, AccessGateTestDummy $dummy)
+    {
+        return true;
+    }
+}
+
+class AccessGateTestPolicyWithNoPermissions
+{
+    public function edit($user, AccessGateTestDummy $dummy)
+    {
+        return false;
+    }
+
+    public function update($user, AccessGateTestDummy $dummy)
+    {
+        return false;
+    }
+}
+
+class AccessGateTestPolicyWithAllPermissions
+{
+    public function edit($user, AccessGateTestDummy $dummy)
+    {
+        return true;
+    }
+
+    public function update($user, AccessGateTestDummy $dummy)
     {
         return true;
     }


### PR DESCRIPTION
### Premise
This is a simplified version of PR #19900, which adds two new capabilities to the Gate class:
- updates check() method to allow an array or collection of abilities to test that every ability passes.
- adds an any() method that takes an array or collection of abilities and checks if any one of those abilities passes.

In conjunction with the new `Blade::if` shorthand methods, this will make checking multiple abilities for a model in one go very simple.

### Background
The initial PR was unable to be resolved as we couldn't come up with a good method name that succinctly captured the intent and different to the `@can` Blade directive, or the `can()` method in the `Authorizable` trait. Should a suitable name for the `Gate::any()` method be found, a subsequent PR will implement it as a new Blade directive and method on the `Authorizable` trait, as well as update the `@can` directive and `can()` method.

### Examples
```php
Blade::if('canEvery', function ($abilities, $arguments) {
    return app(Gate::class)->forUser(auth()->user())
        ->check($abilities, $arguments);
});

Blade::if('canAny', function ($abilities, $arguments) {
    return app(Gate::class)->forUser(auth()->user())
        ->any($abilities, $arguments);
});
```