### PR TITLE
[5.5] Auto register commands in app/console/commands

### DIFF
--- a/src/Illuminate/Console/ShouldAutoRegister.php
+++ b/src/Illuminate/Console/ShouldAutoRegister.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Illuminate\Console;
+
+interface ShouldAutoRegister
+{
+    //
+}

--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -5,8 +5,8 @@ namespace Illuminate\Foundation\Console;
 use Closure;
 use Exception;
 use Throwable;
-use Illuminate\Console\Command;
 use Symfony\Component\Finder\Finder;
+use Illuminate\Console\ShouldAutoRegister;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Console\Application as Artisan;
@@ -310,7 +310,7 @@ class Kernel implements KernelContract
                     str_after($command->getPathname(), app_path().'/')
                 );
 
-            if (is_subclass_of($command, Command::class)) {
+            if (class_implements($command, ShouldAutoRegister::class)) {
                 $this->artisan->resolve($command);
             }
         }

--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -5,6 +5,7 @@ namespace Illuminate\Foundation\Console;
 use Closure;
 use Exception;
 use Throwable;
+use Symfony\Component\Finder\Finder;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Console\Application as Artisan;
@@ -82,9 +83,27 @@ class Kernel implements KernelContract
         $this->app = $app;
         $this->events = $events;
 
+        $this->autoRegisterCommands();
+
         $this->app->booted(function () {
             $this->defineConsoleSchedule();
         });
+    }
+
+    /**
+     * Auto register commands
+     *
+     * @return void
+     */
+    protected function autoRegisterCommands()
+    {
+        $files = (new Finder)->in(app_path('Console/Commands/'))->files();
+
+        $namespace = $this->app->getNamespace();
+
+        foreach ($files as $file) {
+            $this->commands[] = $namespace.'Console\\Commands\\'.$file->getBaseName('.php');
+        }
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -101,12 +101,10 @@ class Kernel implements KernelContract
             return;
         }
 
-        $files = (new Finder)->in($commands)->files();
-
         $namespace = $this->app->getNamespace();
 
-        foreach ($files as $file) {
-            $this->commands[] = $namespace.'Console\\Commands\\'.$file->getBaseName('.php');
+        foreach ((new Finder)->in($commands)->files() as $command) {
+            $this->commands[] = $namespace.'Console\\Commands\\'.$command->getBaseName('.php');
         }
     }
 

--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -4,8 +4,8 @@ namespace Illuminate\Foundation\Console;
 
 use Closure;
 use Exception;
-use Illuminate\Console\Command;
 use Throwable;
+use Illuminate\Console\Command;
 use Symfony\Component\Finder\Finder;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Contracts\Events\Dispatcher;

--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -97,7 +97,11 @@ class Kernel implements KernelContract
      */
     protected function autoRegisterCommands()
     {
-        $files = (new Finder)->in(app_path('Console/Commands/'))->files();
+        if (! is_dir($commands = app_path('Console/Commands/'))) {
+            return;
+        }
+
+        $files = (new Finder)->in($commands)->files();
 
         $namespace = $this->app->getNamespace();
 

--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -91,7 +91,7 @@ class Kernel implements KernelContract
     }
 
     /**
-     * Auto register commands
+     * Auto register commands.
      *
      * @return void
      */


### PR DESCRIPTION
I always find it annoying having to include the console commands in Kernel's `commands` class property after creating the command using `make:command`, this PR is an attempt to auto register commands residing inside `app/console/commands`.

- The auto-registerer will find commands in sub directories as well.
- Commands that aren't sub classes of `Illuminate\Console\Command` are excluded.