### PR TITLE
[5.4] Fix visibility of testing helper

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -24,7 +24,7 @@ trait MakesHttpRequests
      * @param  array  $server
      * @return $this
      */
-    protected function withServerVariables(array $server)
+    public function withServerVariables(array $server)
     {
         $this->serverVariables = $server;
 


### PR DESCRIPTION
The `withServerVariables()` method (in the `MakesHttpRequests` testing concern), which is `protected`, isn’t used anywhere in the codebase. This seems to indicate it is supposed to be public and called by external code, similarly to the `withoutMiddleware()` method of the same trait.