### PR TITLE
[5.4] Ability to set cc and bcc for mail notifications

### DIFF
--- a/src/Illuminate/Notifications/Channels/MailChannel.php
+++ b/src/Illuminate/Notifications/Channels/MailChannel.php
@@ -117,6 +117,14 @@ class MailChannel
         $this->addSender($mailMessage, $message);
 
         $mailMessage->to($this->getRecipients($notifiable, $message));
+
+        if($message->cc){
+            $mailMessage->cc($message->cc[0], Arr::get($message->cc, 1));
+        }
+
+        if($message->bcc){
+            $mailMessage->bcc($message->bcc[0], Arr::get($message->bcc, 1));
+        }
     }
 
     /**

--- a/src/Illuminate/Notifications/Channels/MailChannel.php
+++ b/src/Illuminate/Notifications/Channels/MailChannel.php
@@ -118,11 +118,11 @@ class MailChannel
 
         $mailMessage->to($this->getRecipients($notifiable, $message));
 
-        if($message->cc){
+        if ($message->cc) {
             $mailMessage->cc($message->cc[0], Arr::get($message->cc, 1));
         }
 
-        if($message->bcc){
+        if ($message->bcc) {
             $mailMessage->bcc($message->bcc[0], Arr::get($message->bcc, 1));
         }
     }

--- a/src/Illuminate/Notifications/Messages/MailMessage.php
+++ b/src/Illuminate/Notifications/Messages/MailMessage.php
@@ -40,6 +40,20 @@ class MailMessage extends SimpleMessage
     public $replyTo = [];
 
     /**
+     * The "cc" information for the message.
+     *
+     * @var array
+     */
+    public $cc = [];
+
+    /**
+     * The "bcc" information for the message.
+     *
+     * @var array
+     */
+    public $bcc = [];
+
+    /**
      * The attachments for the message.
      *
      * @var array
@@ -118,6 +132,34 @@ class MailMessage extends SimpleMessage
     public function replyTo($address, $name = null)
     {
         $this->replyTo = [$address, $name];
+
+        return $this;
+    }
+
+    /**
+     * Set the cc address for the mail message.
+     *
+     * @param  string  $address
+     * @param  string|null  $name
+     * @return $this
+     */
+    public function cc($address, $name = null)
+    {
+        $this->cc = [$address, $name];
+
+        return $this;
+    }
+
+    /**
+     * Set the bcc address for the mail message.
+     *
+     * @param  string  $address
+     * @param  string|null  $name
+     * @return $this
+     */
+    public function bcc($address, $name = null)
+    {
+        $this->bcc = [$address, $name];
 
         return $this;
     }


### PR DESCRIPTION
This adds the ability to set a `cc` and `bcc` for a mail notification message.