### PR TITLE
[5.5] WIP | Let Laravel handles Request preconditions

### DIFF
--- a/src/Illuminate/Contracts/Http/ConditionEntity.php
+++ b/src/Illuminate/Contracts/Http/ConditionEntity.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Illuminate\Contracts\Http;
+
+interface ConditionEntity
+{
+    /**
+     * Get the entity tag.
+     *
+     * @return string|null
+     */
+    public function getEtag();
+
+    /**
+     * Get the last modified date.
+     *
+     * @return \DateTime|null
+     */
+    public function getLastModified();
+}

--- a/src/Illuminate/Database/Eloquent/Concerns/HandlesConditions.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HandlesConditions.php
@@ -29,10 +29,8 @@ trait HandlesConditions
      */
     public function getLastModified()
     {
-        if (! $this->exists) {
-            return;
+        if ($this->exists) {
+            return $this->{$this->getUpdatedAtColumn()};
         }
-
-        return $this->{$this->getUpdatedAtColumn()};
     }
 }

--- a/src/Illuminate/Database/Eloquent/Concerns/HandlesConditions.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HandlesConditions.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Concerns;
+
+trait HandlesConditions
+{
+    /**
+     * Get the entity tag.
+     *
+     * @return string|null
+     */
+    public function getEtag()
+    {
+        if (! $this->exists) {
+            return;
+        }
+
+        return sha1(implode('|', [
+            $this->getQueueableId(),
+            $this->getQueueableConnection(),
+            $this->toJson(),
+        ]));
+    }
+
+    /**
+     * Get the last modified date.
+     *
+     * @return mixed
+     */
+    public function getLastModified()
+    {
+        if (! $this->exists) {
+            return;
+        }
+
+        return $this->{$this->getUpdatedAtColumn()};
+    }
+}

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Str;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Routing\UrlRoutable;
+use Illuminate\Contracts\Http\ConditionEntity;
 use Illuminate\Contracts\Queue\QueueableEntity;
 use Illuminate\Database\Eloquent\Relations\Pivot;
 use Illuminate\Database\Query\Builder as QueryBuilder;
@@ -18,9 +19,10 @@ use Illuminate\Database\ConnectionResolverInterface as Resolver;
 /**
  * @mixin \Illuminate\Database\Eloquent\Builder
  */
-abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializable, QueueableEntity, UrlRoutable
+abstract class Model implements ArrayAccess, Arrayable, ConditionEntity, Jsonable, JsonSerializable, QueueableEntity, UrlRoutable
 {
     use Concerns\HasAttributes,
+        Concerns\HandlesConditions,
         Concerns\HasEvents,
         Concerns\HasGlobalScopes,
         Concerns\HasRelationships,

--- a/src/Illuminate/Foundation/Validation/ValidatesRequests.php
+++ b/src/Illuminate/Foundation/Validation/ValidatesRequests.php
@@ -4,6 +4,7 @@ namespace Illuminate\Foundation\Validation;
 
 use Illuminate\Http\Request;
 use Illuminate\Contracts\Validation\Factory;
+use Illuminate\Contracts\Http\ConditionEntity;
 use Illuminate\Validation\ValidationException;
 use Symfony\Component\HttpKernel\Exception\PreconditionFailedHttpException;
 
@@ -78,6 +79,10 @@ trait ValidatesRequests
     {
         if ($entity === null) {
             return $this;
+        }
+
+        if ($entity instanceof ConditionEntity) {
+            return $this->validatePreconditions($request, $entity->getEtag(), $entity->getLastModified());
         }
 
         $etag = method_exists($entity, 'getEtag') ? $entity->getEtag() : null;

--- a/src/Illuminate/Foundation/Validation/ValidatesRequests.php
+++ b/src/Illuminate/Foundation/Validation/ValidatesRequests.php
@@ -58,6 +58,7 @@ trait ValidatesRequests
      * @param  string|null  $eTag
      * @param  string|null  $lastModified
      * @return $this
+     * @throws \Symfony\Component\HttpKernel\Exception\PreconditionFailedHttpException
      */
     public function validatePreconditions(Request $request, $eTag = null, $lastModified = null)
     {

--- a/src/Illuminate/Foundation/Validation/ValidatesRequests.php
+++ b/src/Illuminate/Foundation/Validation/ValidatesRequests.php
@@ -61,6 +61,10 @@ trait ValidatesRequests
      */
     public function validatePreconditions(Request $request, $eTag = null, $lastModified = null)
     {
+        if (in_array($request->getMethod(), ['DELETE', 'PATCH', 'PUT']) === false) {
+            return $this;
+        }
+
         if ($request->passesPreconditions($eTag, $lastModified) === false) {
             throw new PreconditionFailedHttpException;
         }

--- a/src/Illuminate/Foundation/Validation/ValidatesRequests.php
+++ b/src/Illuminate/Foundation/Validation/ValidatesRequests.php
@@ -5,6 +5,7 @@ namespace Illuminate\Foundation\Validation;
 use Illuminate\Http\Request;
 use Illuminate\Contracts\Validation\Factory;
 use Illuminate\Validation\ValidationException;
+use Symfony\Component\HttpKernel\Exception\PreconditionFailedHttpException;
 
 trait ValidatesRequests
 {
@@ -47,6 +48,42 @@ trait ValidatesRequests
              ->validate();
 
         return $request->only(array_keys($rules));
+    }
+
+    /**
+     * Validate the request preconditions.
+     *
+     * @param \Illuminate\Http\Request $request
+     * @param  string|null  $eTag
+     * @param  string|null  $lastModified
+     * @return $this
+     */
+    public function validatePreconditions(Request $request, $eTag = null, $lastModified = null)
+    {
+        if ($request->passesPreconditions($eTag, $lastModified) === false) {
+            throw new PreconditionFailedHttpException;
+        }
+
+        return $this;
+    }
+
+    /**
+     * Validate the request preconditions using an entity.
+     *
+     * @param \Illuminate\Http\Request $request
+     * @param mixed $entity
+     * @return $this
+     */
+    public function validateEntityPreconditions(Request $request, $entity = null)
+    {
+        if ($entity === null) {
+            return $this;
+        }
+
+        $etag = method_exists($entity, 'getEtag') ? $entity->getEtag() : null;
+        $lastModified = method_exists($entity, 'getLastModified') ? $entity->getEtag() : null;
+
+        return $this->validatePreconditions($request, $etag, $lastModified);
     }
 
     /**

--- a/src/Illuminate/Http/Concerns/HandlesPreconditions.php
+++ b/src/Illuminate/Http/Concerns/HandlesPreconditions.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Illuminate\Http\Concerns;
+
+trait HandlesPreconditions
+{
+    /**
+     * Checks if the request passes preconditions.
+     *
+     * @param  string|null  $eTag
+     * @param  string|null  $lastModified
+     * @return bool
+     */
+    public function passesPreconditions($eTag = null, $lastModified = null)
+    {
+        if ($eTag === null && $lastModified === null) {
+            return true;
+        }
+
+        if ($eTag !== null && $eTags = $this->getETags()) {
+            if (in_array($eTag, $eTags) === false && in_array('*', $eTags) === false) {
+                return false;
+            }
+        }
+
+        if ($lastModified !== null && $modifiedSince = $this->headers->get('If-Modified-Since')) {
+            if (strtotime($lastModified) > strtotime($modifiedSince)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -14,7 +14,8 @@ use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 
 class Request extends SymfonyRequest implements Arrayable, ArrayAccess
 {
-    use Concerns\InteractsWithContentTypes,
+    use Concerns\HandlesPreconditions,
+        Concerns\InteractsWithContentTypes,
         Concerns\InteractsWithFlashData,
         Concerns\InteractsWithInput,
         Macroable;

--- a/src/Illuminate/Http/Response.php
+++ b/src/Illuminate/Http/Response.php
@@ -7,9 +7,10 @@ use JsonSerializable;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Renderable;
+use Illuminate\Contracts\Http\ConditionEntity;
 use Symfony\Component\HttpFoundation\Response as BaseResponse;
 
-class Response extends BaseResponse
+class Response extends BaseResponse implements ConditionEntity
 {
     use ResponseTrait;
 

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -822,11 +822,11 @@ class HttpRequestTest extends TestCase
         Carbon::setTestNow($now = Carbon::now('UTC'));
         $request = Request::create('/', 'GET');
         $request->headers->add(['If-Modified-Since' => $now]);
-        $this->assertTrue($request->passesPreconditions(null, $now));
+        $this->assertTrue($request->passesPreconditions(null, $now->toDateTimeString()));
 
         Carbon::setTestNow($now = Carbon::now('UTC'));
         $request = Request::create('/', 'GET');
-        $request->headers->add(['If-Modified-Since' => $now]);
+        $request->headers->add(['If-Modified-Since' => $now->toW3cString()]);
         $this->assertTrue($request->passesPreconditions(null, $now->subMinute()));
 
         Carbon::setTestNow($now = Carbon::now('UTC'));


### PR DESCRIPTION
Implements RFC7232, and handles Precondition failed HTTP 412 exception.
See: https://tools.ietf.org/html/rfc7232#section-4.2

Related to a talk at a previous Berlin 👍 🇩🇪  Laravel Meetup / https://www.meetup.com/laravel-berlin/events/237490869/

---

### Conditions usage

In many case we want to have a better control of the conditions that we have to respect in order to access an entity (in most case a model instance).

This is the reason why if you might probably return a response `eTag` and a `Last-Modified` date in the API response when you are returning a model.
The `eTag` stands for a unique identifier of the current state of the model, with its last modification date.

This simple system enables to return a `Not-Modified 304` response if necessary.

Next time we make a `GET` request we just have to properly populate the request headers, and we will only get a full body response if the model has been updated since the previous call.

---

### Problem

However this system is not available for now when updating or deleting an entity.
This can lead to various issues, as we may try to update a deprecated version of the original entity.

This is even more the case when using jobs with different queues.
We dispatch 10 (`J1`... `J10`) jobs to update a single entity, this jobs might be executed on different queues.

There is no insurance that these 10 jobs will pass in the same order as they've been triggered.
Depending on the queues, the `J10` job could be exectuted before `J2`.

In this situation it is really useful to be able to handle preconditions.

---


### Features

This PR provides the following features.
- `Model` implements `ConditionEntity` (they hold update or delete conditions)
- The `Request` can validate a `ConditionEntity` (`Response`, `Model` or anything else)
- A validator is provided to that we can call `$request->validateEntity($post)` in the controller.

---

**TODO:**
- [ ] Add more tests
- [ ] Let the `ConditionEntity` takes the responsibility to be validated.

