### PR TITLE
[5.4] On logout, invalidate session instead of regenerating it

### DIFF
--- a/src/Illuminate/Foundation/Auth/AuthenticatesUsers.php
+++ b/src/Illuminate/Foundation/Auth/AuthenticatesUsers.php
@@ -155,9 +155,7 @@ trait AuthenticatesUsers
     {
         $this->guard()->logout();
 
-        $request->session()->flush();
-
-        $request->session()->regenerate();
+        $request->session()->invalidate();
 
         return redirect('/');
     }


### PR DESCRIPTION
Calling `regenerate()` will cause a new session ID to be generated without deleting the old session data, while the request is being terminated the new session store will be saved, leaving the old one un-saved, so `flush()` won't really make any difference.