### PR TITLE
[5.4] Add @errors blade directive

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -443,7 +443,7 @@ if (! function_exists('has_errors')) {
     function has_errors($key = null, $bag = null)
     {
         $errors = session('errors');
-        if (if (is_null($errors) || ! $errors->any())) {
+        if (is_null($errors) || ! $errors->any()) {
             return false;
         } elseif ($key !== null) {
             return is_null($bag) ? $errors->has($key) : $errors->$bag->has($key);

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -443,7 +443,7 @@ if (! function_exists('has_errors')) {
     function has_errors($key = null, $bag = null)
     {
         $errors = session('errors');
-        if (is_null($errors)) {
+        if (is_null($errors) && ! session('errors')->any()) {
             return false;
         } elseif ($key !== null) {
             return is_null($bag) ? $errors->has($key) : $errors->$bag->has($key);

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -432,14 +432,14 @@ if (! function_exists('encrypt')) {
     }
 }
 
-if (! function_exists('errors')) {
+if (! function_exists('has_errors')) {
     /**
      * Returns true if session has errors, and optionally key-specific errors.
      *
      * @param  string|null  $key
      * @return bool
      */
-    function errors($key = null)
+    function has_errors($key = null)
     {
         $errors = session('errors');
         if (is_null($errors)) {

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -446,7 +446,7 @@ if (! function_exists('has_errors')) {
         if (is_null($errors)) {
             return false;
         } elseif ($key !== null) {
-            return is_null($bag) ? $errors->has($key):$errors->$bag->has($key);
+            return is_null($bag) ? $errors->has($key) : $errors->$bag->has($key);
         }
 
         return true;

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -437,15 +437,16 @@ if (! function_exists('has_errors')) {
      * Returns true if session has errors, and optionally key-specific errors.
      *
      * @param  string|null  $key
+     * @param  string|null  $bag
      * @return bool
      */
-    function has_errors($key = null)
+    function has_errors($key = null, $bag = null)
     {
         $errors = session('errors');
         if (is_null($errors)) {
             return false;
         } elseif ($key !== null) {
-            return $errors->has($key);
+            return is_null($bag) ? $errors->has($key):$errors->$bag->has($key);
         }
 
         return true;

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -432,27 +432,6 @@ if (! function_exists('encrypt')) {
     }
 }
 
-if (! function_exists('has_errors')) {
-    /**
-     * Returns true if session has errors, and optionally key-specific errors.
-     *
-     * @param  string|null  $key
-     * @param  string|null  $bag
-     * @return bool
-     */
-    function has_errors($key = null, $bag = null)
-    {
-        $errors = session('errors');
-        if (is_null($errors) || ! $errors->any()) {
-            return false;
-        } elseif ($key !== null) {
-            return is_null($bag) ? $errors->has($key) : $errors->$bag->has($key);
-        }
-
-        return true;
-    }
-}
-
 if (! function_exists('event')) {
     /**
      * Dispatch an event and call the listeners.
@@ -488,6 +467,27 @@ if (! function_exists('factory')) {
         } else {
             return $factory->of($arguments[0]);
         }
+    }
+}
+
+if (! function_exists('has_errors')) {
+    /**
+     * Returns true if session has errors, and optionally key-specific errors.
+     *
+     * @param  string|null  $key
+     * @param  string|null  $bag
+     * @return bool
+     */
+    function has_errors($key = null, $bag = null)
+    {
+        $errors = session('errors');
+        if (is_null($errors) || ! $errors->any()) {
+            return false;
+        } elseif ($key !== null) {
+            return is_null($bag) ? $errors->has($key) : $errors->$bag->has($key);
+        }
+
+        return true;
     }
 }
 

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -481,7 +481,7 @@ if (! function_exists('has_errors')) {
     function has_errors($key = null, $bag = null)
     {
         $errors = session('errors');
-        if (is_null($errors) || ! $errors->any()) {
+        if (is_null($errors) || ! $errors->getBag($bag ?: 'default')->any()) {
             return false;
         } elseif ($key !== null) {
             return is_null($bag) ? $errors->has($key) : $errors->$bag->has($key);

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -443,7 +443,7 @@ if (! function_exists('has_errors')) {
     function has_errors($key = null, $bag = null)
     {
         $errors = session('errors');
-        if (is_null($errors) && ! session('errors')->any()) {
+        if (if (is_null($errors) || ! $errors->any())) {
             return false;
         } elseif ($key !== null) {
             return is_null($bag) ? $errors->has($key) : $errors->$bag->has($key);

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -442,11 +442,9 @@ if (! function_exists('errors')) {
     function errors($key = null)
     {
         $errors = session('errors');
-        if (is_null($errors))
-        {
+        if (is_null($errors)) {
             return false;
-        } else if ($key !== null)
-        {
+        } elseif ($key !== null) {
             return $errors->has($key);
         }
 

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -432,6 +432,28 @@ if (! function_exists('encrypt')) {
     }
 }
 
+if (! function_exists('errors')) {
+    /**
+     * Returns true if session has errors, and optionally key-specific errors.
+     *
+     * @param  string|null  $key
+     * @return bool
+     */
+    function errors($key = null)
+    {
+        $errors = session('errors');
+        if (is_null($errors))
+        {
+            return false;
+        } else if ($key !== null)
+        {
+            return $errors->has($key);
+        }
+
+        return true;
+    }
+}
+
 if (! function_exists('event')) {
     /**
      * Dispatch an event and call the listeners.

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -478,13 +478,13 @@ if (! function_exists('has_errors')) {
      * @param  string|null  $bag
      * @return bool
      */
-    function has_errors($key = null, $bag = null)
+    function has_errors($key = null, $bag = 'default')
     {
         $errors = session('errors');
-        if (is_null($errors) || ! $errors->getBag($bag ?: 'default')->any()) {
+        if (is_null($errors) || ! $errors->getBag($bag)->any()) {
             return false;
         } elseif ($key !== null) {
-            return is_null($bag) ? $errors->has($key) : $errors->$bag->has($key);
+            return $errors->getBag($bag)->has($key);
         }
 
         return true;

--- a/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
@@ -119,4 +119,25 @@ trait CompilesConditionals
     {
         return '<?php endif; ?>';
     }
+    
+    /**
+     * Compile the if-errors statements into valid PHP.
+     *
+     * @param  string|null  $key
+     * @return string
+     */
+    protected function compileErrors($key = null)
+    {
+        return "<?php if(is_null(session('errors')) ? false:{$key} !== null ? session('errors')->has({$key}):true): ?>"
+    }
+    
+    /**
+     * Compile the end-errors statements into valid PHP.
+     *
+     * @return string
+     */
+    protected function compileEndErrors()
+    {
+        return '<?php endif; ?>';
+    }
 }

--- a/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
@@ -128,7 +128,7 @@ trait CompilesConditionals
      */
     protected function compileErrors($key = null)
     {
-        return "<?php if(is_null(session('errors')) ? false:{$key} !== null ? session('errors')->has({$key}):true): ?>"
+        return "<?php if(is_null(session('errors')) ? false:{$key} !== null ? session('errors')->has({$key}):true): ?>";
     }
     
     /**

--- a/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
@@ -126,9 +126,9 @@ trait CompilesConditionals
      * @param  string|null  $key
      * @return string
      */
-    protected function compileErrors($key = null)
+    protected function compileErrors($expression = null)
     {
-        return "<?php if(errors({$key})): ?>";
+        return "<?php if(errors{$expression}): ?>";
     }
 
     /**

--- a/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
@@ -142,27 +142,6 @@ trait CompilesConditionals
     }
 
     /**
-     * Compile the if-auth statements into valid PHP.
-     *
-     * @param  string|null  $guard
-     * @return string
-     */
-    protected function compileAuth($guard = null)
-    {
-        return "<?php if(auth()->guard{$guard}->check()): ?>";
-    }
-
-    /**
-     * Compile the end-auth statements into valid PHP.
-     *
-     * @return string
-     */
-    protected function compileEndAuth()
-    {
-        return '<?php endif; ?>';
-    }
-
-    /**
      * Compile the if-errors statements into valid PHP.
      *
      * @param  string|null  $key

--- a/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
@@ -144,12 +144,12 @@ trait CompilesConditionals
     /**
      * Compile the if-errors statements into valid PHP.
      *
-     * @param  string|null  $key
+     * @param  string|null  $expression
      * @return string
      */
     protected function compileErrors($expression = null)
     {
-        return "<?php if(errors{$expression}): ?>";
+        return "<?php if(has_errors{$expression}): ?>";
     }
 
     /**

--- a/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
@@ -128,7 +128,7 @@ trait CompilesConditionals
      */
     protected function compileErrors($key = null)
     {
-        return "<?php if(is_null(session('errors')) ? false:{$key} !== null ? session('errors')->has({$key}):true): ?>";
+        return "<?php if(errors({$key})): ?>";
     }
 
     /**

--- a/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
@@ -119,7 +119,7 @@ trait CompilesConditionals
     {
         return '<?php endif; ?>';
     }
-    
+
     /**
      * Compile the if-errors statements into valid PHP.
      *
@@ -130,7 +130,7 @@ trait CompilesConditionals
     {
         return "<?php if(is_null(session('errors')) ? false:{$key} !== null ? session('errors')->has({$key}):true): ?>";
     }
-    
+
     /**
      * Compile the end-errors statements into valid PHP.
      *

--- a/tests/View/Blade/BladeIfIErrorsStatementsTest.php
+++ b/tests/View/Blade/BladeIfIErrorsStatementsTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Illuminate\Tests\Blade;
+
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+use Illuminate\View\Compilers\BladeCompiler;
+
+class BladeIfErrorsStatementsTest extends TestCase
+{
+    public function tearDown()
+    {
+        m::close();
+    }
+
+    public function testIfStatementsAreCompiled()
+    {
+        $compiler = new BladeCompiler($this->getFiles(), __DIR__);
+        $string = '@errors ($key, $bag)
+breeze
+@enderrors';
+        $expected = '<?php if(has_errors($key, $bag)): ?>
+breeze
+<?php endif; ?>';
+        $this->assertEquals($expected, $compiler->compileString($string));
+    }
+
+    protected function getFiles()
+    {
+        return m::mock('Illuminate\Filesystem\Filesystem');
+    }
+}


### PR DESCRIPTION
This Pull Requests adds an @errors blade directive.

![](https://pbs.twimg.com/media/DEiqgoWUIAAUko5.jpg:large)
![](https://pbs.twimg.com/media/DEiqiYuUMAE23IR.jpg:large)
![](https://pbs.twimg.com/media/DEiqmmhUQAA9FCx.jpg:large)

Original idea by @paulredmond in Twitter.

## Structure

I feel like the oneliner of the implementation is very big. Would it be better to create a errors() helper and move the logic there?
ping @themsaid @taylorotwell 