### PR TITLE
[5.5] Enable user quota in the User model

### DIFF
--- a/src/Illuminate/Auth/HandlesRequestLimit.php
+++ b/src/Illuminate/Auth/HandlesRequestLimit.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Illuminate\Auth;
+
+/**
+ * @property  int|float quota
+ */
+trait HandlesRequestLimit
+{
+    /**
+     * Set the user request limit.
+     *
+     * @param  float|int $quota
+     * @return $this
+     */
+    public function setRequestLimit($quota)
+    {
+        $this->quota = (int) $quota;
+
+        return $this;
+    }
+
+    /**
+     * Get the user request request limit.
+     *
+     * @return int
+     */
+    public function getRequestLimit()
+    {
+        return $this->quota ?? 60;
+    }
+}

--- a/src/Illuminate/Contracts/Auth/HasRequestThrottleLimit.php
+++ b/src/Illuminate/Contracts/Auth/HasRequestThrottleLimit.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Illuminate\Contracts\Auth;
+
+interface HasRequestThrottleLimit
+{
+    /**
+     * Get the user request limit.
+     *
+     * @return int
+     */
+    public function getRequestLimit();
+}

--- a/src/Illuminate/Foundation/Auth/User.php
+++ b/src/Illuminate/Foundation/Auth/User.php
@@ -4,8 +4,10 @@ namespace Illuminate\Foundation\Auth;
 
 use Illuminate\Auth\Authenticatable;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Auth\HandlesRequestLimit;
 use Illuminate\Auth\Passwords\CanResetPassword;
 use Illuminate\Foundation\Auth\Access\Authorizable;
+use Illuminate\Contracts\Auth\HasRequestThrottleLimit;
 use Illuminate\Contracts\Auth\Authenticatable as AuthenticatableContract;
 use Illuminate\Contracts\Auth\Access\Authorizable as AuthorizableContract;
 use Illuminate\Contracts\Auth\CanResetPassword as CanResetPasswordContract;
@@ -13,7 +15,8 @@ use Illuminate\Contracts\Auth\CanResetPassword as CanResetPasswordContract;
 class User extends Model implements
     AuthenticatableContract,
     AuthorizableContract,
-    CanResetPasswordContract
+    CanResetPasswordContract,
+    HasRequestThrottleLimit
 {
-    use Authenticatable, Authorizable, CanResetPassword;
+    use Authenticatable, Authorizable, CanResetPassword, HandlesRequestLimit;
 }

--- a/src/Illuminate/Routing/Middleware/ThrottleRequests.php
+++ b/src/Illuminate/Routing/Middleware/ThrottleRequests.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Str;
 use Illuminate\Support\Carbon;
 use Illuminate\Cache\RateLimiter;
 use Symfony\Component\HttpFoundation\Response;
+use Illuminate\Contracts\Auth\HasRequestThrottleLimit;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 
 class ThrottleRequests
@@ -69,8 +70,12 @@ class ThrottleRequests
      */
     protected function resolveMaxAttempts($request, $maxAttempts)
     {
-        if (Str::contains($maxAttempts, '|')) {
-            $maxAttempts = explode('|', $maxAttempts, 2)[$request->user() ? 1 : 0];
+        $user = $request->user();
+
+        if ($user && $user instanceof HasRequestThrottleLimit) {
+            $maxAttempts = $user->getRequestLimit();
+        } elseif (Str::contains($maxAttempts, '|')) {
+            $maxAttempts = explode('|', $maxAttempts, 2)[$user ? 1 : 0];
         }
 
         return (int) $maxAttempts;


### PR DESCRIPTION
Let the User model determine which quota to use when it is authenticated.
If the quota is not set in the model, the 2nd or/then the 1st quota argument will be taken into consideration.