### PR TITLE
Add option to configure MARS on SqlServer Connections

### DIFF
--- a/src/Illuminate/Database/Connectors/SqlServerConnector.php
+++ b/src/Illuminate/Database/Connectors/SqlServerConnector.php
@@ -126,6 +126,10 @@ class SqlServerConnector extends Connector implements ConnectorInterface
             $arguments['TrustServerCertificate'] = $config['trust_server_certificate'];
         }
 
+        if (isset($config['multiple_active_resultsets']) && $config['multiple_active_resultsets'] === false) {
+            $arguments['MultipleActiveResultSets'] = 'false';
+        }
+
         return $this->buildConnectString('sqlsrv', $arguments);
     }
 


### PR DESCRIPTION
As stated in this docs from Microsoft:

https://github.com/Microsoft/msphpsql/wiki/Recommendations-for-improving-the-performance-of-PDO_SQLSRV-and-SQLSRV#1-multiple-active-result-sets-mars

> MARS is enabled by default in both SQLSRV and PDO_SQLSRV drivers. There can be some performance drop when MARS is enabled. Existing code optimized to run in the non-MARS world may show a performance dip when run un-modified with MARS.

This PR adds the ability to disable MARS on a SqlServer connection