### PR TITLE
[5.5] Let table headers be less strict

### DIFF
--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -381,7 +381,7 @@ class Command extends SymfonyCommand
      * @param  string  $style
      * @return void
      */
-    public function table(array $headers, $rows, $style = 'default')
+    public function table($headers, $rows, $style = 'default')
     {
         $table = new Table($this->output);
 
@@ -389,7 +389,7 @@ class Command extends SymfonyCommand
             $rows = $rows->toArray();
         }
 
-        $table->setHeaders($headers)->setRows($rows)->setStyle($style)->render();
+        $table->setHeaders((array) $headers)->setRows($rows)->setStyle($style)->render();
     }
 
     /**


### PR DESCRIPTION
We don't need to be so strict for the `$headers` parameter, thus we can pass some `Arrayable`, `ArrayAccess` variables, etc...