### PR TITLE
[5.5] Add the ability to handle nested levels in collection.

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -281,7 +281,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Dump the collection.
      *
-     * @return void
+     * @return static
      */
     public function dump()
     {

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -38,25 +38,47 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     ];
 
     /**
-     * Create a new collection.
+     * Create a new collection. If $nested, will create a collection for all traversable nested levels.
      *
      * @param  mixed  $items
+     * @param  bool  $nested
      * @return void
      */
-    public function __construct($items = [])
+    public function __construct($items = [], $nested = false)
     {
         $this->items = $this->getArrayableItems($items);
+
+        if ($nested) {
+            $this->items = $this->parseNested()->all();
+        }
+    }
+
+    /**
+     * Convert all nested levels of traversable items to collections.
+     *
+     * @return static
+     */
+    public function parseNested()
+    {
+        return $this->map(function ($value) {
+            if (is_array($value) || $value instanceof Traversable) {
+                return $value instanceof self ? $value->parseNested() : (new static($value))->parseNested();
+            }
+
+            return $value;
+        });
     }
 
     /**
      * Create a new collection instance if the value isn't one already.
      *
      * @param  mixed  $items
+     * @param  bool  $nested
      * @return static
      */
-    public static function make($items = [])
+    public static function make($items = [], $nested = false)
     {
-        return new static($items);
+        return new static($items, $nested);
     }
 
     /**

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2250,7 +2250,7 @@ class SupportCollectionTest extends TestCase
                     'bar' => ['foo', 'bar'],
                 ]),
 
-            ]
+            ],
         ];
 
         $basicCollection = new Collection($nestedArray);
@@ -2264,7 +2264,7 @@ class SupportCollectionTest extends TestCase
                 '2ndLevelArrayableObj' => new TestArrayableObject(),
                 '2ndLevelSubCollection' => new TestCollectionSubclass([
                     'foo' => new TestArrayableObject(),
-                    'bar' => new TestCollectionSubclass(['foo', 'bar'])
+                    'bar' => new TestCollectionSubclass(['foo', 'bar']),
                 ]),
             ]),
         ]);

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2235,6 +2235,43 @@ class SupportCollectionTest extends TestCase
 
         $this->assertSame(['michael', 'tom', 'taylor'], $collection->toArray());
     }
+
+    public function testNestedCollection()
+    {
+        $nestedArray = [
+            '1stLevel' => [
+                '2ndLevel' => [
+                    '3rdLevel' => 'value',
+                    '3rdLevelObj' => (object) ['foo' => 'bar'],
+                ],
+                '2ndLevelArrayableObj' => new TestArrayableObject(),
+                '2ndLevelSubCollection' => new TestCollectionSubclass([
+                    'foo' => new TestArrayableObject(),
+                    'bar' => ['foo', 'bar'],
+                ]),
+
+            ]
+        ];
+
+        $basicCollection = new Collection($nestedArray);
+
+        $nestedCollection = new Collection([
+            '1stLevel' => new Collection([
+                '2ndLevel'    => new Collection([
+                    '3rdLevel'    => 'value',
+                    '3rdLevelObj' => (object) ['foo' => 'bar'],
+                ]),
+                '2ndLevelArrayableObj' => new TestArrayableObject(),
+                '2ndLevelSubCollection' => new TestCollectionSubclass([
+                    'foo' => new TestArrayableObject(),
+                    'bar' => new TestCollectionSubclass(['foo', 'bar'])
+                ]),
+            ]),
+        ]);
+
+        $this->assertEquals($basicCollection, new Collection($nestedArray, false));
+        $this->assertEquals($nestedCollection, new Collection($nestedArray, true));
+    }
 }
 
 class TestSupportCollectionHigherOrderItem


### PR DESCRIPTION
Hi,
With this PR, we can now manage nested arrays and traversables in collection.
Before, only the first level of an array was converted to a collection, it can be painful when you're trying to chain many operations on many levels.

I had the problem myself, and I've seen many posts about that in forums like laracast or stackoverflow, so I think this should be handled in the core.

Thank you for your time and your work.

### Example:
```php
$nestedArray = [
    '1stLevel' => [
        '2ndLevel' => [
            '3rdLevel' => [
                'value'
            ]
        ]
    ]
];
```
#### Before : 
```php
$c = collect($nestedArray);
$c->get('1stLevel'); // array

$c->each(function ($value, $key) {
    dump($key, gettype($value)); // '1stLevel', array
    return (new Collection($value))->each(function ($value, $key) {
        dump($key, gettype($value)); // '2ndLevel', array
        (new Collection($value))->each(function ($value, $key) {
            dump($key, gettype($value)); // '3rdLevel', array
            (new Collection($value))->each(function ($value) {
                dump(gettype($value)); // string
            });
        });
    });
});
```

#### After:
```php
$c = collect($nestedArray)->parseNested();
$c->get('1stLevel'); // Collection

$c->each(function ($value, $key) {
    dump($key, get_class($value)); // '1stLevel', Collection
    return $value->each(function ($value, $key) {
        dump($key, get_class($value)); // '2ndLevel', Collection
        $value->each(function ($value, $key) {
            dump($key, get_class($value)); // '3rdLevel', Collection
            $value->each(function ($value) {
                dump(gettype($value)); // string
            });
        });
    });
});
```

### Bonus:
You can also declare a `$nested` boolean when you create the collection:
```php
(new Collection($nestedArray))->get('1stLevel'); // array
(new Collection($nestedArray, true))->get('1stLevel'); // Collection
```
I wondered about this: this can be cool, but if you think we shouldn't change the constructor, no problem I can edit and leave only the `parseNested` method.