### PR TITLE
[5.4] Backport str_before helper

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -65,6 +65,18 @@ class Str
 
         return preg_replace('/[^\x20-\x7E]/u', '', $value);
     }
+    
+    /**
+     * Get the portion of a string before a given value.
+     *
+     * @param  string  $subject
+     * @param  string  $search
+     * @return string
+     */
+    public static function before($subject, $search)
+    {
+        return $search === '' ? $subject : explode($search, $subject)[0];
+    }
 
     /**
      * Convert a value to camel case.

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -65,7 +65,7 @@ class Str
 
         return preg_replace('/[^\x20-\x7E]/u', '', $value);
     }
-    
+
     /**
      * Get the portion of a string before a given value.
      *

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -762,6 +762,20 @@ if (! function_exists('str_after')) {
     }
 }
 
+if (! function_exists('str_before')) {
+    /**
+     * Get the portion of a string before a given value.
+     *
+     * @param  string  $subject
+     * @param  string  $search
+     * @return string
+     */
+    function str_before($subject, $search)
+    {
+        return Str::before($subject, $search);
+    }
+}
+
 if (! function_exists('str_contains')) {
     /**
      * Determine if a given string contains a given substring.

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -75,6 +75,15 @@ class SupportStrTest extends TestCase
         $this->assertTrue(Str::endsWith(0.27, '0.27'));
         $this->assertFalse(Str::endsWith(0.27, '8'));
     }
+    
+    public function testStrBefore()
+    {
+        $this->assertEquals('han', Str::before('hannah', 'nah'));
+        $this->assertEquals('ha', Str::before('hannah', 'n'));
+        $this->assertEquals('ééé ', Str::before('ééé hannah', 'han'));
+        $this->assertEquals('hannah', Str::before('hannah', 'xxxx'));
+        $this->assertEquals('hannah', Str::before('hannah', ''));
+    }
 
     public function testStrAfter()
     {

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -75,7 +75,7 @@ class SupportStrTest extends TestCase
         $this->assertTrue(Str::endsWith(0.27, '0.27'));
         $this->assertFalse(Str::endsWith(0.27, '8'));
     }
-    
+
     public function testStrBefore()
     {
         $this->assertEquals('han', Str::before('hannah', 'nah'));


### PR DESCRIPTION
Fixes #20125

It's currently on the docs for the 5.4: https://laravel.com/docs/5.4/helpers#method-str-before

However it exists only on 5.5, maybe you'd prefer to remove it from the docs...