### PR TITLE
[5.5] Track model changes after persisting to database

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -29,6 +29,13 @@ trait HasAttributes
     protected $original = [];
 
     /**
+     * The changed model attribute's.
+     *
+     * @var array
+     */
+    protected $changes = [];
+
+    /**
      * The attributes that should be cast to native types.
      *
      * @var array
@@ -925,6 +932,18 @@ trait HasAttributes
     }
 
     /**
+     * Sync the changed attributes.
+     *
+     * @return $this
+     */
+    public function syncChanges()
+    {
+        $this->changes = $this->getDirty();
+
+        return $this;
+    }
+
+    /**
      * Determine if the model or given attribute(s) have been modified.
      *
      * @param  array|string|null  $attributes
@@ -983,6 +1002,16 @@ trait HasAttributes
         }
 
         return $dirty;
+    }
+
+    /**
+     * Get the attributes that was changed.
+     *
+     * @return array
+     */
+    public function getChanges()
+    {
+        return $this->changes;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -29,7 +29,7 @@ trait HasAttributes
     protected $original = [];
 
     /**
-     * The changed model attribute's.
+     * The changed model attributes.
      *
      * @var array
      */
@@ -984,6 +984,32 @@ trait HasAttributes
     public function isClean($attributes = null)
     {
         return ! $this->isDirty(...func_get_args());
+    }
+
+    /**
+     * Determine if the model or given attribute(s) have been modified.
+     *
+     * @param  array|string|null  $attributes
+     * @return bool
+     */
+    public function isChanged($attributes = null)
+    {
+        $changes = $this->getChanges();
+
+        if (is_null($attributes)) {
+            return count($changes) > 0;
+        }
+
+        $attributes = is_array($attributes)
+            ? $attributes : func_get_args();
+
+        foreach ($attributes as $attribute) {
+            if (array_key_exists($attribute, $changes)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -594,6 +594,8 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
             $this->setKeysForSaveQuery($query)->update($dirty);
 
             $this->fireModelEvent('updated', false);
+
+            $this->syncChanges();
         }
 
         return true;

--- a/tests/Integration/Database/EloquentModelTest.php
+++ b/tests/Integration/Database/EloquentModelTest.php
@@ -63,16 +63,22 @@ class EloquentModelTest extends TestCase
 
         $this->assertEmpty($user->getDirty());
         $this->assertEmpty($user->getChanges());
+        $this->assertFalse($user->isDirty());
+        $this->assertFalse($user->isChanged());
 
         $user->name = $name = str_random();
 
         $this->assertEquals(['name' => $name], $user->getDirty());
         $this->assertEmpty($user->getChanges());
+        $this->assertTrue($user->isDirty());
+        $this->assertFalse($user->isChanged());
 
         $user->save();
 
         $this->assertEmpty($user->getDirty());
         $this->assertEquals(['name' => $name], $user->getChanges());
+        $this->assertTrue($user->isChanged());
+        $this->assertTrue($user->isChanged('name'));
     }
 }
 

--- a/tests/Integration/Database/EloquentModelTest.php
+++ b/tests/Integration/Database/EloquentModelTest.php
@@ -28,15 +28,21 @@ class EloquentModelTest extends TestCase
     {
         parent::setUp();
 
-        Schema::create('users', function ($table) {
+        Schema::create('test_model1', function ($table) {
             $table->increments('id');
             $table->timestamp('nullable_date')->nullable();
+        });
+
+        Schema::create('test_model2', function ($table) {
+            $table->increments('id');
+            $table->string('name');
+            $table->string('title');
         });
     }
 
     public function test_user_can_update_nullable_date()
     {
-        $user = EloquentModelTestModel::create([
+        $user = TestModel1::create([
             'nullable_date' => null,
         ]);
 
@@ -48,12 +54,39 @@ class EloquentModelTest extends TestCase
         $user->save();
         $this->assertEquals($now->toDateString(), $user->nullable_date->toDateString());
     }
+
+    public function test_attribute_changes()
+    {
+        $user = TestModel2::create([
+            'name' => str_random(), 'title' => str_random(),
+        ]);
+
+        $this->assertEmpty($user->getDirty());
+        $this->assertEmpty($user->getChanges());
+
+        $user->name = $name = str_random();
+
+        $this->assertEquals(['name' => $name], $user->getDirty());
+        $this->assertEmpty($user->getChanges());
+
+        $user->save();
+
+        $this->assertEmpty($user->getDirty());
+        $this->assertEquals(['name' => $name], $user->getChanges());
+    }
 }
 
-class EloquentModelTestModel extends Model
+class TestModel1 extends Model
 {
-    public $table = 'users';
+    public $table = 'test_model1';
     public $timestamps = false;
     protected $guarded = ['id'];
     protected $dates = ['nullable_date'];
+}
+
+class TestModel2 extends Model
+{
+    public $table = 'test_model2';
+    public $timestamps = false;
+    protected $guarded = ['id'];
 }


### PR DESCRIPTION
Currently:
```php
$user->name = 'new name';

// This returns the name attribute with its new value
$user->getDirty();

$user->save();

// Now that the user is saved getDirty() will return an empty array
$user->getDirty();
```

What Changed:

```php
$user->name = 'new name';

$user->save();

// getChanges() will return an array of the name attribute with its new value
$user->getChanges();
```

This allows for doing some useful checks after model is saved, for example if a `Server` was activated we want to send notification to customer.

```php
$server->update(request()->all());

if($server->isChanged('active') && $server->active){
   Notification::send(....);
}
```