### PR TITLE
[5.5] Keep track of model changes after serialization

### DIFF
--- a/src/Illuminate/Contracts/Database/ModelIdentifier.php
+++ b/src/Illuminate/Contracts/Database/ModelIdentifier.php
@@ -32,7 +32,7 @@ class ModelIdentifier
      *
      * @var array
      */
-    public $changes;
+    public $changes = [];
 
     /**
      * Create a new model identifier.

--- a/src/Illuminate/Contracts/Database/ModelIdentifier.php
+++ b/src/Illuminate/Contracts/Database/ModelIdentifier.php
@@ -28,6 +28,13 @@ class ModelIdentifier
     public $connection;
 
     /**
+     * The changes applied to the model.
+     *
+     * @var array
+     */
+    public $changes;
+
+    /**
      * Create a new model identifier.
      *
      * @param  string  $class
@@ -40,5 +47,28 @@ class ModelIdentifier
         $this->id = $id;
         $this->class = $class;
         $this->connection = $connection;
+    }
+
+    /**
+     * Set the changes applied to the mode;.
+     *
+     * @param  array  $changes
+     * @return $this
+     */
+    public function setChanges($changes)
+    {
+        $this->changes = $changes;
+
+        return $this;
+    }
+
+    /**
+     * The changes applied to the model.
+     *
+     * @return array
+     */
+    public function getChanges()
+    {
+        return $this->changes;
     }
 }

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -878,6 +878,19 @@ trait HasAttributes
     }
 
     /**
+     * Set the array of model changes.
+     *
+     * @param  array  $changes
+     * @return $this
+     */
+    public function setChanges(array $changes)
+    {
+        $this->changes = $changes;
+
+        return $this;
+    }
+
+    /**
      * Get the model's original attribute values.
      *
      * @param  string|null  $key

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -593,9 +593,9 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         if (count($dirty) > 0) {
             $this->setKeysForSaveQuery($query)->update($dirty);
 
-            $this->fireModelEvent('updated', false);
-
             $this->syncChanges();
+            
+            $this->fireModelEvent('updated', false);
         }
 
         return true;

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -594,7 +594,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
             $this->setKeysForSaveQuery($query)->update($dirty);
 
             $this->syncChanges();
-            
+
             $this->fireModelEvent('updated', false);
         }
 

--- a/src/Illuminate/Queue/SerializesAndRestoresModelIdentifiers.php
+++ b/src/Illuminate/Queue/SerializesAndRestoresModelIdentifiers.php
@@ -26,11 +26,11 @@ trait SerializesAndRestoresModelIdentifiers
         }
 
         if ($value instanceof QueueableEntity) {
-            return new ModelIdentifier(
+            return (new ModelIdentifier(
                 get_class($value),
                 $value->getQueueableId(),
                 $value->getQueueableConnection()
-            );
+            ))->setChanges($value->getChanges());
         }
 
         return $value;
@@ -51,7 +51,7 @@ trait SerializesAndRestoresModelIdentifiers
         return is_array($value->id)
                 ? $this->restoreCollection($value)
                 : $this->getQueryForModelRestoration((new $value->class)->setConnection($value->connection))
-                    ->useWritePdo()->findOrFail($value->id);
+                    ->useWritePdo()->findOrFail($value->id)->setChanges($value->changes);
     }
 
     /**

--- a/tests/Integration/Queue/ModelSerializationTest.php
+++ b/tests/Integration/Queue/ModelSerializationTest.php
@@ -48,6 +48,28 @@ class ModelSerializationTest extends TestCase
     /**
      * @test
      */
+    public function it_keeps_model_changes()
+    {
+        $user = ModelSerializationTestUser::create([
+            'email' => 'mohamed@laravel.com',
+        ]);
+
+        $user->update([
+            'email' => 'taylor@laravel.com',
+        ]);
+
+        $serialized = serialize(new ModelSerializationTestClass($user));
+
+        $unSerialized = unserialize($serialized);
+
+        $this->assertEquals('testbench', $unSerialized->user->getConnectionName());
+        $this->assertEquals('taylor@laravel.com', $unSerialized->user->email);
+        $this->assertEquals(['email' => 'taylor@laravel.com'], $unSerialized->user->getChanges());
+    }
+
+    /**
+     * @test
+     */
     public function it_serialize_user_on_default_connection()
     {
         $user = ModelSerializationTestUser::create([


### PR DESCRIPTION
This change will store a `changes` attribute inside the `ModelIdentifier`, so when a model is unserialized inside a queued job/listener/notification people can still access the model `changes` attribute.