### PR TITLE
[5.5] Feature: configurable logger channel name

### DIFF
--- a/src/Illuminate/Log/LogServiceProvider.php
+++ b/src/Illuminate/Log/LogServiceProvider.php
@@ -47,7 +47,7 @@ class LogServiceProvider extends ServiceProvider
     protected function channel()
     {
         if ($this->app->bound('config')) {
-            if ($channel = $this->app->make('config')->get('app.log_channel', null)) {
+            if ($channel = $this->app->make('config')->get('app.log_channel')) {
                 return $channel;
             }
         }

--- a/src/Illuminate/Log/LogServiceProvider.php
+++ b/src/Illuminate/Log/LogServiceProvider.php
@@ -46,6 +46,12 @@ class LogServiceProvider extends ServiceProvider
      */
     protected function channel()
     {
+        if ($this->app->bound('config')) {
+            if ($channel = $this->app->make('config')->get('app.log_channel', null)) {
+                return $channel;
+            }
+        }
+
         return $this->app->bound('env') ? $this->app->environment() : 'production';
     }
 


### PR DESCRIPTION
Monolog (unfortunately) does not allow post-instantiation of the base logger to change the `Monolog::$name`.  This makes it impossible to change the name away from the environment specified one inside `configureMonologUsing` without a significant amount of code using reflection.

This patch is non-intrusive, and only introduces the ability to use `app.log_channel` if it is set by the user (this is a similar workflow to `app.log_maxfiles`.

References on others having the same problem:
- https://stackoverflow.com/questions/39611693/change-monolog-channel-in-laravel
- https://laracasts.com/discuss/channels/laravel/you-cant-change-monolog-channel-name

Sample code required to change the name after instantiation:
```php
       $this->app->configureMonologUsing(function (Logger $logger) {
            $r = new \ReflectionObject($logger);
            $name = $r->getProperty('name');
            $name->setAccessible(true);
            $name->setValue($logger, env('APP_NAME'));
            ...
```

(If you should require a test, I would be more than happy to create one, but I noticed ServiceProviders don't normally have tests in the test suite.)