### PR TITLE
[5.4] Improve Queue's InvalidPayloadException error message

### DIFF
--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -87,7 +87,7 @@ abstract class Queue
 
         if (JSON_ERROR_NONE !== json_last_error()) {
             throw new InvalidPayloadException(
-                'Unable to JSON encode payload.  Error code: '.json_last_error()
+                'Unable to JSON encode payload. Error code: '.json_last_error()
             );
         }
 

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -86,7 +86,9 @@ abstract class Queue
         $payload = json_encode($this->createPayloadArray($job, $data, $queue));
 
         if (JSON_ERROR_NONE !== json_last_error()) {
-            throw new InvalidPayloadException;
+            throw new InvalidPayloadException(
+                'Unable to JSON encode payload.  Error code: '.json_last_error()
+            );
         }
 
         return $payload;


### PR DESCRIPTION
Currently the queue can throw an `InvalidPayloadException` with just the `last_json_error()` number in the message.

<img width="506" alt="screen shot 2017-07-19 at 1 33 45 pm" src="https://user-images.githubusercontent.com/24803032/28350060-c6ce2b6a-6c89-11e7-8158-bdffa44cb33e.png">

I had to jump into the Queue source to understand what was actually the issue happening here. I thought perhaps we could simply give a little more context to the error. The message itself may not be exactly what should be in there - suggestions welcomed - but I think it would be good to present more info. The suggested message is:

<img width="364" alt="screen shot 2017-07-19 at 1 56 53 pm" src="https://user-images.githubusercontent.com/24803032/28350146-39ce6d5a-6c8a-11e7-8131-537570f3726d.png">

Maybe this is more obvious to more experienced dev's then myself and isn't needed.