### PR TITLE
Add queue interop based driver. Supports AMQP, Amazon SQS, Kafka, Google PubSub, Redis, STOMP, Gearman, Beanstalk

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -72,6 +72,7 @@
     },
     "require-dev": {
         "aws/aws-sdk-php": "~3.0",
+        "queue-interop/queue-interop": "^0.5",
         "doctrine/dbal": "~2.5",
         "mockery/mockery": "~0.9.4",
         "pda/pheanstalk": "~3.0",
@@ -104,6 +105,7 @@
     },
     "suggest": {
         "aws/aws-sdk-php": "Required to use the SQS queue driver and SES mail driver (~3.0).",
+        "queue-interop/queue-interop": "Required to use the queue interop driver compatible transports",
         "doctrine/dbal": "Required to rename columns and drop SQLite columns (~2.5).",
         "fzaninotto/faker": "Required to use the eloquent factory builder (~1.4).",
         "guzzlehttp/guzzle": "Required to use the Mailgun and Mandrill mail drivers and the ping methods on schedules (~6.0).",

--- a/src/Illuminate/Queue/Connectors/InteropConnector.php
+++ b/src/Illuminate/Queue/Connectors/InteropConnector.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Illuminate\Queue\Connectors;
+
+use Illuminate\Queue\InteropQueue;
+use Interop\Queue\PsrConnectionFactory;
+
+class InteropConnector implements ConnectorInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function connect(array $config)
+    {
+        $config = array_replace([
+            'connection_factory_class' => null,
+            'dsn' => null,
+            'queue' => 'default',
+            'time_to_run' => 0,
+        ], $config);
+
+        if (empty($config['connection_factory_class'])) {
+            throw new \LogicException('The "connection_factory_class" option is required');
+        }
+
+        $factoryClass = $config['connection_factory_class'];
+        if (false == class_exists($factoryClass)) {
+            throw new \LogicException(sprintf('The "connection_factory_class" option "%s" is not a class', $factoryClass));
+        }
+
+        $rc = new \ReflectionClass($factoryClass);
+        if (false == $rc->implementsInterface(PsrConnectionFactory::class)) {
+            throw new \LogicException(sprintf('The "connection_factory_class" option must contain a class that implements "%s" but it is not', PsrConnectionFactory::class));
+        }
+
+        /** @var PsrConnectionFactory $factory */
+        $factory = new $factoryClass($config['dsn'] ? $config['dsn'] : $config);
+
+        return new InteropQueue($factory->createContext(), $config['queue'], $config['time_to_run']);
+    }
+}

--- a/src/Illuminate/Queue/InteropQueue.php
+++ b/src/Illuminate/Queue/InteropQueue.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace Illuminate\Queue;
+
+use Illuminate\Contracts\Queue\Queue as QueueContract;
+use Illuminate\Queue\Jobs\InteropJob;
+use Interop\Queue\PsrContext;
+
+class InteropQueue extends Queue implements QueueContract
+{
+    /**
+     * @var string
+     */
+    protected $queueName;
+
+    /**
+     * @var int
+     */
+    protected $timeToRun;
+    /**
+     * @var PsrContext
+     */
+    private $psrContext;
+
+    /**
+     * @param PsrContext $psrContext
+     * @param string     $queueName
+     * @param int        $timeToRun
+     */
+    public function __construct(PsrContext $psrContext, $queueName, $timeToRun)
+    {
+        $this->psrContext = $psrContext;
+        $this->queueName = $queueName;
+        $this->timeToRun = $timeToRun;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function size($queue = null)
+    {
+        return 0;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function push($job, $data = '', $queue = null)
+    {
+        return $this->pushRaw($this->createPayload($job, $data), $queue);
+    }
+
+    /**
+     * Push a new job onto the queue.
+     *
+     * @param string $queue
+     * @param string $job
+     * @param mixed  $data
+     *
+     * @return mixed
+     */
+    public function pushOn($queue, $job, $data = '')
+    {
+        new \LogicException('to be implemented');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function pushRaw($payload, $queue = null, array $options = [])
+    {
+        return $this->psrContext->createProducer()->send(
+            $this->getQueue($queue),
+            $this->psrContext->createMessage($payload)
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function later($delay, $job, $data = '', $queue = null)
+    {
+        new \LogicException('to be implemented');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function pop($queue = null)
+    {
+        $queue = $this->getQueue($queue);
+
+        $psrConsumer = $this->psrContext->createConsumer($queue);
+        if ($psrMessage = $psrConsumer->receive(1000)) { // 1 sec
+            return new InteropJob(
+                $this->container,
+                $this->psrContext,
+                $psrConsumer,
+                $psrMessage,
+                $this->connectionName
+            );
+        }
+    }
+
+    /**
+     * Get the queue or return the default.
+     *
+     * @param string|null $queue
+     *
+     * @return \Interop\Queue\PsrQueue
+     */
+    public function getQueue($queue = null)
+    {
+        return $this->psrContext->createQueue($queue ?: $this->queueName);
+    }
+
+    /**
+     * @return PsrContext
+     */
+    public function getPsrContext()
+    {
+        return $this->psrContext;
+    }
+
+    /**
+     * @return int
+     */
+    public function getTimeToRun()
+    {
+        return $this->timeToRun;
+    }
+}

--- a/src/Illuminate/Queue/Jobs/InteropJob.php
+++ b/src/Illuminate/Queue/Jobs/InteropJob.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Illuminate\Queue\Jobs;
+
+use Illuminate\Container\Container;
+use Illuminate\Contracts\Queue\Job as JobContract;
+use Interop\Queue\PsrConsumer;
+use Interop\Queue\PsrContext;
+use Interop\Queue\PsrMessage;
+
+class InteropJob extends Job implements JobContract
+{
+    /**
+     * @var PsrContext
+     */
+    private $psrContext;
+
+    /**
+     * @var PsrConsumer
+     */
+    private $psrConsumer;
+
+    /**
+     * @var PsrMessage
+     */
+    private $psrMessage;
+
+    /**
+     * @param Container   $container
+     * @param PsrContext  $psrContext
+     * @param PsrConsumer $psrConsumer
+     * @param PsrMessage  $psrMessage
+     * @param string      $connectionName
+     */
+    public function __construct(Container $container, PsrContext $psrContext, PsrConsumer $psrConsumer, PsrMessage $psrMessage, $connectionName)
+    {
+        $this->container = $container;
+        $this->psrContext = $psrContext;
+        $this->psrConsumer = $psrConsumer;
+        $this->psrMessage = $psrMessage;
+        $this->connectionName = $connectionName;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function delete()
+    {
+        parent::delete();
+
+        $this->psrConsumer->acknowledge($this->psrMessage);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function release($delay = 0)
+    {
+        if ($delay) {
+            throw new \LogicException('To be implemented');
+        }
+
+        $requeueMessage = clone $this->psrMessage;
+        $requeueMessage->setProperty('x-attempts', $this->attempts() + 1);
+
+        $this->psrContext->createProducer()->send($this->psrConsumer->getQueue(), $requeueMessage);
+
+        $this->psrConsumer->acknowledge($this->psrMessage);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getQueue()
+    {
+        return $this->psrConsumer->getQueue()->getQueueName();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function attempts()
+    {
+        return $this->psrMessage->getProperty('x-attempts', 1);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getRawBody()
+    {
+        return $this->psrMessage->getBody();
+    }
+}

--- a/src/Illuminate/Queue/QueueServiceProvider.php
+++ b/src/Illuminate/Queue/QueueServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Queue;
 
+use Illuminate\Queue\Connectors\InteropConnector;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Queue\Connectors\SqsConnector;
 use Illuminate\Queue\Connectors\NullConnector;
@@ -77,7 +78,7 @@ class QueueServiceProvider extends ServiceProvider
      */
     public function registerConnectors($manager)
     {
-        foreach (['Null', 'Sync', 'Database', 'Redis', 'Beanstalkd', 'Sqs'] as $connector) {
+        foreach (['Null', 'Sync', 'Database', 'Redis', 'Beanstalkd', 'Sqs', 'Interop'] as $connector) {
             $this->{"register{$connector}Connector"}($manager);
         }
     }
@@ -157,6 +158,19 @@ class QueueServiceProvider extends ServiceProvider
     {
         $manager->addConnector('sqs', function () {
             return new SqsConnector;
+        });
+    }
+
+    /**
+     * Register the interop queue connector.
+     *
+     * @param  \Illuminate\Queue\QueueManager  $manager
+     * @return void
+     */
+    protected function registerInteropConnector($manager)
+    {
+        $manager->addConnector('interop', function () {
+            return new InteropConnector();
         });
     }
 


### PR DESCRIPTION
The interop driver uses [queue-interop](https://github.com/queue-interop/queue-interop) compatible transports (as of now we have 10th of them). There are many implementations in [enqueue](https://github.com/php-enqueue/enqueue-dev) project.

## Advantages

* Supports message delaying, priorities and expiration
* Use DSN to configure transport. 12 factors friendly.
* It brings support of a lot of MQ transport with few lines of integration code:

    * [AMQP(s)](https://github.com/php-enqueue/enqueue-dev/blob/master/docs/transport/amqp.md) based on [PHP AMQP extension](https://github.com/pdezwart/php-amqp).
    * [AMQP](https://github.com/php-enqueue/enqueue-dev/blob/master/docs/transport/amqp_bunny.md) based on [bunny](https://github.com/jakubkulhan/bunny). 
    * [AMQP(s)](https://github.com/php-enqueue/enqueue-dev/blob/master/docs/transport/amqp_lib.md) based on [php-amqplib](https://github.com/php-amqplib/php-amqplib). 
    * [Beanstalk](https://github.com/php-enqueue/enqueue-dev/blob/master/docs/transport/pheanstalk.md).
    * [STOMP](https://github.com/php-enqueue/enqueue-dev/blob/master/docs/transport/stomp.md)
    * [Amazon SQS](https://github.com/php-enqueue/enqueue-dev/blob/master/docs/transport/sqs.md)
    * [Google PubSub](https://github.com/php-enqueue/enqueue-dev/blob/master/docs/transport/gps.md)
    * [Kafka](https://github.com/php-enqueue/enqueue-dev/blob/master/docs/transport/kafka.md)
    * [Redis](https://github.com/php-enqueue/enqueue-dev/blob/master/docs/transport/redis.md)
    * [Gearman](https://github.com/php-enqueue/enqueue-dev/blob/master/docs/transport/gearman.md)
    * [Doctrine DBAL](https://github.com/php-enqueue/enqueue-dev/blob/master/docs/transport/dbal.md)
    * [Filesystem](https://github.com/php-enqueue/enqueue-dev/blob/master/docs/transport/filesystem.md)
    * [MongoDB](https://github.com/php-enqueue/enqueue-dev/blob/master/docs/transport/mongodb.md)
    * [WAMP](https://github.com/php-enqueue/enqueue-dev/blob/master/docs/transport/wamp.md)
    * [PHP-FPM](https://github.com/makasim/php-fpm-queue)
    * [rabbitmq-cli-consumer-client](https://github.com/makasim/rabbitmq-cli-consumer-client)
    
* Consume messages as they arrive from multiple queues. 
* You can run fewer work processes and reduce memory usages. 
* It uses long pulling whenever possible. It results in zero CPU usages while waiting for messages. 
* You can [monitor](https://github.com/php-enqueue/enqueue-dev/blob/master/docs/monitoring.md) any transport, not only redis 
* Adds extension points
* AMQP friendly. 
* Popular soliution, big and active community around the project
* Supported by a company - Forma-Pro


## Example

* Install the real transport for example `enqueue/fs`

```
composer require enqueue/fs
```

* configure 

```php
<?php

// config/queue.php

return [
    // ....

    'connections' => [
        'interop' => [
            'driver' => 'interop',
            'dsn' => 'file://realpath(__DIR__.'/../storage').'/enqueue',
            // 'dsn' => 'amqp://guest:guest@localhost:5672/%2f'
            // 'dsn' => 'redis:'
        ],
        // ...
    ],
];
```

Use it as any other native driver. I welcome everyone who is interested in MQs to join the queue interop group