### PR TITLE
Fix Connection::fireConnectionEvent return value docblock

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -778,7 +778,7 @@ class Connection implements ConnectionInterface
      * Fire an event for this connection.
      *
      * @param  string  $event
-     * @return void
+     * @return array|null
      */
     protected function fireConnectionEvent($event)
     {


### PR DESCRIPTION
`dispatch` returns `array|null`, so this method should too