### PR TITLE
Rename bcrypt() helper

### DIFF
--- a/src/Illuminate/Foundation/Auth/ResetsPasswords.php
+++ b/src/Illuminate/Foundation/Auth/ResetsPasswords.php
@@ -101,7 +101,7 @@ trait ResetsPasswords
      */
     protected function resetPassword($user, $password)
     {
-        $user->password = bcrypt($password);
+        $user->password = str_hash($password);
 
         $user->setRememberToken(Str::random(60));
 

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -181,7 +181,7 @@ if (! function_exists('base_path')) {
     }
 }
 
-if (! function_exists('bcrypt')) {
+if (! function_exists('str_hash')) {
     /**
      * Hash the given value.
      *
@@ -189,7 +189,7 @@ if (! function_exists('bcrypt')) {
      * @param  array   $options
      * @return string
      */
-    function bcrypt($value, $options = [])
+    function str_hash($value, $options = [])
     {
         return app('hash')->make($value, $options);
     }


### PR DESCRIPTION
As discussed in https://github.com/laravel/internals/issues/695#issuecomment-316386837, this Pull Request renames the `bcrypt()` helper to a more general name, `str_hash()`. This is done because bcrypt may be switched with another algorithm in the near future (PHP7.2 probably).

:key: 