### PR TITLE
[5.4] handle a non existing key in array cache store

### DIFF
--- a/src/Illuminate/Cache/ArrayStore.php
+++ b/src/Illuminate/Cache/ArrayStore.php
@@ -50,7 +50,8 @@ class ArrayStore extends TaggableStore implements Store
      */
     public function increment($key, $value = 1)
     {
-        $this->storage[$key] = ((int) $this->storage[$key]) + $value;
+        $this->storage[$key] = ! isset($this->storage[$key])
+                ? $value : ((int) $this->storage[$key]) + $value;
 
         return $this->storage[$key];
     }

--- a/tests/Cache/CacheArrayStoreTest.php
+++ b/tests/Cache/CacheArrayStoreTest.php
@@ -45,6 +45,13 @@ class CacheArrayStoreTest extends TestCase
         $this->assertEquals(2, $store->get('foo'));
     }
 
+    public function testNonExistingKeysCanBeIncremented()
+    {
+        $store = new ArrayStore;
+        $store->increment('foo');
+        $this->assertEquals(1, $store->get('foo'));
+    }
+
     public function testValuesCanBeDecremented()
     {
         $store = new ArrayStore;


### PR DESCRIPTION
To prevent an undefined index error when the cache key doesn't exist while incrementing.