### PR TITLE
trans helper return type doc

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -781,7 +781,7 @@ if (! function_exists('trans')) {
      * @param  string  $id
      * @param  array   $replace
      * @param  string  $locale
-     * @return \Illuminate\Contracts\Translation\Translator|string
+     * @return \Illuminate\Contracts\Translation\Translator|string|array|null
      */
     function trans($id = null, $replace = [], $locale = null)
     {


### PR DESCRIPTION
Matching the return types for the `trans` method in the Translator class.