### PR TITLE
[5.5] Blade Extension Class Support

### DIFF
--- a/src/Illuminate/Contracts/View/BladeExtension.php
+++ b/src/Illuminate/Contracts/View/BladeExtension.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Illuminate\Contracts\View;
+
+interface BladeExtension
+{
+    /**
+     * Get custom directives this extension defines
+     * @return array
+     */
+    public function getDirectives();
+
+    /**
+     * Get custom conditional directives
+     * @return array
+     */
+    public function getConditionals();
+}

--- a/src/Illuminate/Foundation/Console/BladeExtensionMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/BladeExtensionMakeCommand.php
@@ -51,6 +51,22 @@ class BladeExtensionMakeCommand extends GeneratorCommand
     }
 
     /**
+     * Get the desired class name from the input.
+     *
+     * @return string
+     */
+    protected function getNameInput()
+    {
+        $name = trim($this->argument('name'));
+
+        if (Str::endsWith($name, 'Extension')) {
+            return $name;
+        }
+
+        return sprintf("%sExtension", $name);
+    }
+
+    /**
      * Get the console command options.
      *
      * @return array

--- a/src/Illuminate/Foundation/Console/BladeExtensionMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/BladeExtensionMakeCommand.php
@@ -27,7 +27,7 @@ class BladeExtensionMakeCommand extends GeneratorCommand
      *
      * @var string
      */
-    protected $type = 'BladeExtension';
+    protected $type = 'Blade Extension';
 
     /**
      * Get the stub file for the generator.

--- a/src/Illuminate/Foundation/Console/BladeExtensionMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/BladeExtensionMakeCommand.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Illuminate\Foundation\Console;
+
+use Illuminate\Support\Str;
+use Illuminate\Console\GeneratorCommand;
+use Symfony\Component\Console\Input\InputOption;
+
+class BladeExtensionMakeCommand extends GeneratorCommand
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'make:blade';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create a custom blade extension class';
+
+    /**
+     * The type of class being generated.
+     *
+     * @var string
+     */
+    protected $type = 'BladeExtension';
+
+    /**
+     * Get the stub file for the generator.
+     *
+     * @return string
+     */
+    protected function getStub()
+    {
+        return __DIR__.'/stubs/blade-extension.stub';
+    }
+
+    /**
+     * Get the default namespace for the class.
+     *
+     * @param  string  $rootNamespace
+     * @return string
+     */
+    protected function getDefaultNamespace($rootNamespace)
+    {
+        return $rootNamespace.'\Blade';
+    }
+
+    /**
+     * Get the console command options.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [];
+    }
+}

--- a/src/Illuminate/Foundation/Console/stubs/blade-extension.stub
+++ b/src/Illuminate/Foundation/Console/stubs/blade-extension.stub
@@ -1,0 +1,34 @@
+<?php
+
+namespace DummyNamespace;
+
+use Illuminate\Contracts\View\BladeExtension;
+
+class DummyClass implements BladeExtension
+{
+    /**
+     * Get custom directives this extension provides
+     *
+     * @example
+     * return ['foo' => [$this, 'doFoo']]
+     *
+     * @return array
+     */
+    public function getDirectives()
+    {
+        return [];
+    }
+
+    /**
+     * Get custom conditional directives this extension provides
+     *
+     * @example
+     * return ['bar' => [$this, 'isBar']]
+     *
+     * @return array
+     */
+    public function getConditionals()
+    {
+        return [];
+    }
+}

--- a/src/Illuminate/Foundation/Console/stubs/blade-extension.stub
+++ b/src/Illuminate/Foundation/Console/stubs/blade-extension.stub
@@ -4,7 +4,7 @@ namespace DummyNamespace;
 
 use Illuminate\Contracts\View\BladeExtension;
 
-class DummyClass implements BladeExtension
+class DummyClassExtension implements BladeExtension
 {
     /**
      * Get custom directives this extension provides

--- a/src/Illuminate/Foundation/Console/stubs/blade-extension.stub
+++ b/src/Illuminate/Foundation/Console/stubs/blade-extension.stub
@@ -7,7 +7,7 @@ use Illuminate\Contracts\View\BladeExtension;
 class DummyClass implements BladeExtension
 {
     /**
-     * Get custom directives this extension provides
+     * Define custom blade directives
      *
      * @example
      * return ['foo' => [$this, 'doFoo']]
@@ -20,7 +20,7 @@ class DummyClass implements BladeExtension
     }
 
     /**
-     * Get custom conditional directives this extension provides
+     * Define custom conditional blade directives
      *
      * @example
      * return ['bar' => [$this, 'isBar']]

--- a/src/Illuminate/Foundation/Console/stubs/blade-extension.stub
+++ b/src/Illuminate/Foundation/Console/stubs/blade-extension.stub
@@ -4,7 +4,7 @@ namespace DummyNamespace;
 
 use Illuminate\Contracts\View\BladeExtension;
 
-class DummyClassExtension implements BladeExtension
+class DummyClass implements BladeExtension
 {
     /**
      * Get custom directives this extension provides

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -209,7 +209,7 @@ class ArtisanServiceProvider extends ServiceProvider
     protected function registerBladeExtensionMakeCommand()
     {
         $this->app->singleton('command.blade.make', function ($app) {
-            return new BladeExtensionMakeCommand;
+            return new BladeExtensionMakeCommand($app['files']);
         });
     }
 

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -47,6 +47,7 @@ use Illuminate\Database\Console\Seeds\SeederMakeCommand;
 use Illuminate\Foundation\Console\PackageDiscoverCommand;
 use Illuminate\Database\Console\Migrations\MigrateCommand;
 use Illuminate\Foundation\Console\NotificationMakeCommand;
+use Illuminate\Foundation\Console\BladeExtensionMakeCommand;
 use Illuminate\Database\Console\Factories\FactoryMakeCommand;
 use Illuminate\Queue\Console\WorkCommand as QueueWorkCommand;
 use Illuminate\Database\Console\Migrations\MigrateMakeCommand;
@@ -125,6 +126,7 @@ class ArtisanServiceProvider extends ServiceProvider
      */
     protected $devCommands = [
         'AppName' => 'command.app.name',
+        'BladeExtensionMake' => 'command.blade.make',
         'AuthMake' => 'command.auth.make',
         'CacheTable' => 'command.cache.table',
         'ConsoleMake' => 'command.console.make',
@@ -201,6 +203,13 @@ class ArtisanServiceProvider extends ServiceProvider
     {
         $this->app->singleton('command.auth.make', function ($app) {
             return new MakeAuthCommand;
+        });
+    }
+
+    protected function registerBladeExtensionMakeCommand()
+    {
+        $this->app->singleton('command.blade.make', function ($app) {
+            return new BladeExtensionMakeCommand;
         });
     }
 

--- a/src/Illuminate/View/ViewServiceProvider.php
+++ b/src/Illuminate/View/ViewServiceProvider.php
@@ -12,6 +12,16 @@ use Illuminate\View\Compilers\BladeCompiler;
 class ViewServiceProvider extends ServiceProvider
 {
     /**
+     * Bootstrap the application services.
+     *
+     * @return void
+     */
+    public function boot()
+    {
+        $this->defineCustomBladeExtensions();
+    }
+
+    /**
      * Register the service provider.
      *
      * @return void
@@ -132,5 +142,18 @@ class ViewServiceProvider extends ServiceProvider
         $resolver->register('blade', function () {
             return new CompilerEngine($this->app['blade.compiler']);
         });
+    }
+
+    public function defineCustomBladeExtensions()
+    {
+        foreach ($this->app->tagged('blade.extension') as $extension) {
+            foreach ($extension->getDirectives() as $name => $callable) {
+                $this->app['blade.compiler']->directive($name, $callable);
+            }
+
+            foreach ($extension->getConditionals() as $name => $callable) {
+                $this->app['blade.compiler']->if($name, $callable);
+            }
+        }
     }
 }


### PR DESCRIPTION
A simple blade extension system to laravel/framework which allows a Blade extension class to be defined and registered in the container. This will also allow you to inject services from the container easily.

I mentioned it in laravel/internals#682

Basically this allows you to group related Blade directives in a class and through tagging the Laravel framework could register all the blade directives and conditionals automatically. Registered providers could then tag an extension and Laravel would wire it up in blade.

Here's a basic example of what an extension class might look like:

```php
<?php

namespace App\Blade;

use Illuminate\Contracts\View\BladeExtension;

/**
 * Example blade extension class for grouping extensions
 */
class ExampleBladeExtension implements BladeExtension
{
    public function getDirectives()
    {
        return [
            'truncate' => [$this, 'truncate']
        ];
    }

    public function getConditionals()
    {
        return [
            'prod' => [$this, 'isProduction']
        ];
    }

    public function isProduction()
    {
        return app()->environment('production');
    }

    /**
     * @see https://zaengle.com/blog/exploring-laravels-custom-blade-directives
     */
    public function truncate($expression)
    {
        list($string, $length) = explode(',',str_replace(['(',')',' '], '', $expression));

        return "<?php echo e(strlen({$string}) > {$length} ? substr({$string},0,{$length}).'...' : {$string}); ?>";
    }
}
```

You can create it with `php artisan make:blade ExampleBladeExtension`.

Here's how you'd wire it up in your provider:

```php
// Service container available to extensions
$this->app->bind(ExampleExtension::class, function ($app) {
    return new ExampleExtension($app['foo']);
});

$this->app->tag([ExampleExtension::class], 'blade.extension');
```