### PR TITLE
[5.5] changed bcrypt in ResetPassword to Hash::make() 

### DIFF
--- a/src/Illuminate/Foundation/Auth/ResetsPasswords.php
+++ b/src/Illuminate/Foundation/Auth/ResetsPasswords.php
@@ -5,6 +5,7 @@ namespace Illuminate\Foundation\Auth;
 use Illuminate\Support\Str;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Password;
 use Illuminate\Auth\Events\PasswordReset;
 
@@ -101,7 +102,7 @@ trait ResetsPasswords
      */
     protected function resetPassword($user, $password)
     {
-        $user->password = bcrypt($password);
+        $user->password = Hash::make($password);
 
         $user->setRememberToken(Str::random(60));
 


### PR DESCRIPTION
Discussion : https://github.com/laravel/internals/issues/695

Part of this PR was present in #20152 so split it into a seperate PR after the discussion there 