### PR TITLE
[5.4] Remove asset helper from mix() helper

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -560,7 +560,7 @@ if (! function_exists('mix')) {
             );
         }
 
-        return new HtmlString(asset($manifestDirectory.$manifest[$path]));
+        return new HtmlString($manifestDirectory.$manifest[$path]);
     }
 }
 


### PR DESCRIPTION
Fix for issue #20164 