### PR TITLE
Fix guest() & auth() blade directives

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
@@ -45,6 +45,7 @@ trait CompilesConditionals
      */
     protected function compileGuest($guard = null)
     {
+        $guard = is_null($guard) ? '()' : $guard;
         return "<?php if(auth()->guard{$guard}->guest()): ?>";
     }
 

--- a/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
@@ -149,7 +149,7 @@ trait CompilesConditionals
      */
     protected function compileAuth($guard = null)
     {
-        $guard = is_null($guard) ? "()" : $guard;
+        $guard = is_null($guard) ? '()' : $guard;
         return "<?php if(auth()->guard{$guard}->guest()): ?>";
     }
 

--- a/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
@@ -107,7 +107,8 @@ trait CompilesConditionals
      */
     protected function compileAuth($guard = null)
     {
-        return "<?php if(auth()->guard{$guard}->check()): ?>";
+        $guard = is_null($guard) ? "()" : $guard;
+        return "<?php if(auth()->guard{$guard}->guest()): ?>";
     }
 
     /**

--- a/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
@@ -24,6 +24,7 @@ trait CompilesConditionals
     protected function compileAuth($guard = null)
     {
         $guard = is_null($guard) ? '()' : $guard;
+
         return "<?php if(auth()->guard{$guard}->check()): ?>";
     }
 
@@ -46,6 +47,7 @@ trait CompilesConditionals
     protected function compileGuest($guard = null)
     {
         $guard = is_null($guard) ? '()' : $guard;
+
         return "<?php if(auth()->guard{$guard}->guest()): ?>";
     }
 

--- a/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
@@ -23,6 +23,7 @@ trait CompilesConditionals
      */
     protected function compileAuth($guard = null)
     {
+        $guard = is_null($guard) ? '()' : $guard;
         return "<?php if(auth()->guard{$guard}->check()): ?>";
     }
 
@@ -137,28 +138,6 @@ trait CompilesConditionals
      * @return string
      */
     protected function compileEndIsset()
-    {
-        return '<?php endif; ?>';
-    }
-
-    /**
-     * Compile the if-auth statements into valid PHP.
-     *
-     * @param  string|null  $guard
-     * @return string
-     */
-    protected function compileAuth($guard = null)
-    {
-        $guard = is_null($guard) ? '()' : $guard;
-        return "<?php if(auth()->guard{$guard}->guest()): ?>";
-    }
-
-    /**
-     * Compile the end-auth statements into valid PHP.
-     *
-     * @return string
-     */
-    protected function compileEndAuth()
     {
         return '<?php endif; ?>';
     }


### PR DESCRIPTION
This PR fixes an error that is thrown if you use `@auth` or `@guest` instead of `@auth()` or `@guest`.

See https://github.com/laravel/framework/issues/20162 for the error report.

:rabbit: 