### PR TITLE
[5.5] Add a str_hash() helper

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -791,6 +791,20 @@ if (! function_exists('storage_path')) {
     }
 }
 
+if (! function_exists('str_hash')) {
+    /**
+     * Hash the given value.
+     *
+     * @param  string  $value
+     * @param  array   $options
+     * @return string
+     */
+    function str_hash($value, $options = [])
+    {
+        return app('hash')->make($value, $options);
+    }
+}
+
 if (! function_exists('trans')) {
     /**
      * Translate the given message.


### PR DESCRIPTION
This PR adds the new helper that will replace `bcrypt()` in the future, as  [requested by Taylor in my last PR](https://github.com/laravel/framework/pull/20152#issuecomment-316452060).

@taylorotwell Should I also deprecate (adding a `@deprecated` docblock & triggering a deprecated error) `bcrypt()` or are we leaving this for another Laravel release?