### PR TITLE
[5.5] Add expire time to S3 FileSystem

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -306,9 +306,10 @@ class FilesystemAdapter implements FilesystemContract, CloudFilesystemContract
      * Get the URL for the file at the given path.
      *
      * @param  string  $path
+     * @param  string  $expires
      * @return string
      */
-    public function url($path)
+    public function url($path, $expires = null)
     {
         $adapter = $this->driver->getAdapter();
 

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -306,7 +306,11 @@ class FilesystemAdapter implements FilesystemContract, CloudFilesystemContract
      * Get the URL for the file at the given path.
      *
      * @param  string  $path
-     * @param  string  $expires
+     * @param  int|string|\DateTime $expires The time at which the URL should
+     *                                      expire. This can be a Unix
+     *                                      timestamp, a PHP DateTime object,
+     *                                      or a string that can be evaluated
+     *                                      by strtotime().
      * @return string
      */
     public function url($path, $expires = null)
@@ -329,7 +333,11 @@ class FilesystemAdapter implements FilesystemContract, CloudFilesystemContract
      *
      * @param  \League\Flysystem\AwsS3v3\AwsS3Adapter  $adapter
      * @param  string  $path
-     * @param  string  $expires
+     * @param  int|string|\DateTime $expires The time at which the URL should
+     *                                      expire. This can be a Unix
+     *                                      timestamp, a PHP DateTime object,
+     *                                      or a string that can be evaluated
+     *                                      by strtotime().
      * @return string
      */
     protected function getAwsUrl($adapter, $path, $expires)


### PR DESCRIPTION
Added expire time to AWS S3 url method

so you're now able to add expire time to you're generated URL

``Storage::disk('s3')->url('filename', '+10 seconds');``

PS: weak a breaking-chang