### PR TITLE
Unify validation exception formatting.

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -63,6 +63,16 @@ class Handler implements ExceptionHandlerContract
     ];
 
     /**
+     * A list of the inputs that are never flashed for validation exceptions.
+     *
+     * @var array
+     */
+    protected $dontFlash = [
+        'password',
+        'password_confirmation',
+    ];
+
+    /**
      * Create a new exception handler instance.
      *
      * @param  \Illuminate\Contracts\Container\Container  $container
@@ -222,13 +232,14 @@ class Handler implements ExceptionHandlerContract
      */
     protected function invalid($request, ValidationException $exception)
     {
-        return redirect()->back()->withInput($request->except([
-            'password',
-            'password_confirmation',
-        ]))->withErrors(
-            $exception->validator->errors()->messages(),
-            $exception->errorBag
-        );
+        $url = $exception->redirectTo ?? url()->previous();
+
+        return redirect($url)
+                ->withInput($request->except($this->dontFlash))
+                ->withErrors(
+                    $exception->validator->errors()->messages(),
+                    $exception->errorBag
+                );
     }
 
     /**
@@ -242,7 +253,7 @@ class Handler implements ExceptionHandlerContract
     {
         return response()->json([
             'message' => $exception->getMessage(),
-            'errors' => $exception->validator->errors()->messages(),
+            'errors' => $exception->errors()
         ], 422);
     }
 

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -253,7 +253,7 @@ class Handler implements ExceptionHandlerContract
     {
         return response()->json([
             'message' => $exception->getMessage(),
-            'errors' => $exception->errors()
+            'errors' => $exception->errors(),
         ], 422);
     }
 

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -41,7 +41,7 @@ class Handler implements ExceptionHandlerContract
     protected $container;
 
     /**
-     * A list of the exception types that should not be reported.
+     * A list of the exception types that are not reported.
      *
      * @var array
      */
@@ -247,7 +247,7 @@ class Handler implements ExceptionHandlerContract
      *
      * @param  \Illuminate\Http\Request  $request
      * @param  \Illuminate\Validation\ValidationException  $exception
-     * @return \Illuminate\Http\Response
+     * @return \Illuminate\Http\JsonResponse
      */
     protected function invalidJson($request, ValidationException $exception)
     {

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -237,7 +237,7 @@ class Handler implements ExceptionHandlerContract
         return redirect($url)
                 ->withInput($request->except($this->dontFlash))
                 ->withErrors(
-                    $exception->validator->errors()->messages(),
+                    $exception->errors(),
                     $exception->errorBag
                 );
     }

--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -60,13 +60,6 @@ class FormRequest extends Request implements ValidatesWhenResolved
     protected $errorBag = 'default';
 
     /**
-     * The input keys that should not be flashed on redirect.
-     *
-     * @var array
-     */
-    protected $dontFlash = ['password', 'password_confirmation'];
-
-    /**
      * Get the validator instance for the request.
      *
      * @return \Illuminate\Contracts\Validation\Validator
@@ -122,51 +115,9 @@ class FormRequest extends Request implements ValidatesWhenResolved
      */
     protected function failedValidation(Validator $validator)
     {
-        throw new ValidationException($validator, $this->response(
-            $this->formatErrors($validator)
-        ));
-    }
-
-    /**
-     * Get the proper failed validation response for the request.
-     *
-     * @param  array  $errors
-     * @return \Symfony\Component\HttpFoundation\Response
-     */
-    public function response(array $errors)
-    {
-        if ($this->expectsJson()) {
-            return $this->jsonResponse($errors);
-        }
-
-        return $this->redirector->to($this->getRedirectUrl())
-                        ->withInput($this->except($this->dontFlash))
-                        ->withErrors($errors, $this->errorBag);
-    }
-
-    /**
-     * Get the proper failed validation JSON response for the request.
-     *
-     * @param  array  $errors
-     * @return \Illuminate\Http\JsonResponse
-     */
-    public function jsonResponse(array $errors)
-    {
-        return new JsonResponse([
-            'message' => 'The given data was invalid.',
-            'errors' => $errors,
-        ], 422);
-    }
-
-    /**
-     * Format the errors from the given Validator instance.
-     *
-     * @param  \Illuminate\Contracts\Validation\Validator  $validator
-     * @return array
-     */
-    protected function formatErrors(Validator $validator)
-    {
-        return $validator->getMessageBag()->toArray();
+        throw (new ValidationException($validator))
+                    ->errorBag($this->errorBag)
+                    ->redirectTo($this->getRedirectUrl());
     }
 
     /**

--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Foundation\Http;
 
 use Illuminate\Http\Request;
-use Illuminate\Http\JsonResponse;
 use Illuminate\Routing\Redirector;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Validation\Validator;

--- a/src/Illuminate/Validation/ValidationException.php
+++ b/src/Illuminate/Validation/ValidationException.php
@@ -28,6 +28,13 @@ class ValidationException extends Exception
     public $errorBag;
 
     /**
+     * The path the client should be redirected to.
+     *
+     * @var string
+     */
+    public $redirectTo;
+
+    /**
      * Create a new exception instance.
      *
      * @param  \Illuminate\Contracts\Validation\Validator  $validator
@@ -42,6 +49,42 @@ class ValidationException extends Exception
         $this->response = $response;
         $this->errorBag = $errorBag;
         $this->validator = $validator;
+    }
+
+    /**
+     * Get all of the validation error messages.
+     *
+     * @return array
+     */
+    public function errors()
+    {
+        return $this->validator->errors()->messages();
+    }
+
+    /**
+     * Set the error bag on the exception.
+     *
+     * @param  string  $errorBag
+     * @return $this
+     */
+    public function errorBag($errorBag)
+    {
+        $this->errorBag = $errorBag;
+
+        return $this;
+    }
+
+    /**
+     * Set the URL to redirect to on a validation error.
+     *
+     * @param  string  $url
+     * @return string
+     */
+    public function redirectTo($url)
+    {
+        $this->redirectTo = $url;
+
+        return $this;
     }
 
     /**

--- a/tests/Foundation/FoundationFormRequestTest.php
+++ b/tests/Foundation/FoundationFormRequestTest.php
@@ -10,7 +10,6 @@ use Illuminate\Container\Container;
 use Illuminate\Routing\UrlGenerator;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Foundation\Http\FormRequest;
-use Illuminate\Validation\ValidationException;
 use Illuminate\Contracts\Translation\Translator;
 use Illuminate\Validation\Factory as ValidationFactory;
 use Illuminate\Contracts\Validation\Factory as ValidationFactoryContract;
@@ -55,7 +54,6 @@ class FoundationFormRequestTest extends TestCase
     {
         $this->createRequest([], FoundationTestFormRequestForbiddenStub::class)->validate();
     }
-
 
     public function test_prepare_for_validation_runs_before_validation()
     {

--- a/tests/Foundation/FoundationFormRequestTest.php
+++ b/tests/Foundation/FoundationFormRequestTest.php
@@ -56,23 +56,6 @@ class FoundationFormRequestTest extends TestCase
         $this->createRequest([], FoundationTestFormRequestForbiddenStub::class)->validate();
     }
 
-    public function test_redirect_response_is_properly_created_with_given_errors()
-    {
-        $request = $this->createRequest();
-
-        $this->mocks['redirect']->shouldReceive('withInput')->andReturnSelf();
-
-        $this->mocks['redirect']
-             ->shouldReceive('withErrors')
-             ->with(['name' => ['error']], 'default')
-             ->andReturnSelf();
-
-        $e = $this->catchException(ValidationException::class, function () use ($request) {
-            $request->validate();
-        });
-
-        $this->assertInstanceOf(RedirectResponse::class, $e->getResponse());
-    }
 
     public function test_prepare_for_validation_runs_before_validation()
     {


### PR DESCRIPTION
This unifies all validation error formatting into the exception handler
and out of Form Request. “Don’t Flash” is typically a global concept
that always applies to a list of fields for all pages in the
applications, so seemed to make sense to specify in one place instead
of each form.

Total control of the Form Request error response can still be gained by
overriding failedValidation and throwing a HttpResponseException with
whatever response you want.

This would mean in Laravel 5.5 all validation JSON responses would be customized in a single location within your application's exception handler:

```php
    /**
     * Convert a validation exception into a JSON response.
     *
     * @param  \Illuminate\Http\Request  $request
     * @param  \Illuminate\Validation\ValidationException  $exception
     * @return \Illuminate\Http\Response
     */
    protected function invalidJson($request, ValidationException $exception)
    {
        return response()->json([
            'message' => $exception->getMessage(),
            'errors' => $exception->errors(),
        ], 422);
    }
```