### PR TITLE
MailFake does not support Mail::later

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -157,6 +157,21 @@ class MailFake implements Mailer
     }
 
     /**
+     * Queue a new e-mail message for sending after (n) seconds.
+     *
+     * @param  int  $delay
+     * @param  string|array  $view
+     * @param  array  $data
+     * @param  \Closure|string  $callback
+     * @param  string|null  $queue
+     * @return mixed
+     */
+    public function later($delay, $view, array $data = [], $callback = null, $queue = null)
+    {
+        $this->send($view);
+    }
+
+    /**
      * Get the array of failed recipients.
      *
      * @return array


### PR DESCRIPTION
`Mail::fake` does not support `Mail::later`, so errors out during testing. 

`Call to undefined method Illuminate\Support\Testing\Fakes\MailFake::later()`

This simply implements `MailFake::later` to match `MailFake::queue`

Please advise if you'd like a different branch targeted. 