### PR TITLE
[5.5] Properly handle boolean casting for “true” and “false” strings

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -477,7 +477,7 @@ trait HasAttributes
                 return (string) $value;
             case 'bool':
             case 'boolean':
-                return filter_var($value, FILTER_VALIDATE_BOOLEAN);
+                return filter_var($value, FILTER_VALIDATE_BOOLEAN, ['options'	=> [ 'default' => false ]]);
             case 'object':
                 return $this->fromJson($value, true);
             case 'array':

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -477,7 +477,7 @@ trait HasAttributes
                 return (string) $value;
             case 'bool':
             case 'boolean':
-                return (bool) $value;
+                return filter_var($value, FILTER_VALIDATE_BOOLEAN);
             case 'object':
                 return $this->fromJson($value, true);
             case 'array':

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1447,6 +1447,7 @@ class DatabaseEloquentModelTest extends TestCase
         $model->booleanAttribute = 0;
         $model->boolAttributeAsString = 'true';
         $model->booleanAttributeAsString = 'false';
+        $model->defaultBooleanAttribute = 'foobar';
         $model->objectAttribute = ['foo' => 'bar'];
         $obj = new stdClass;
         $obj->foo = 'bar';
@@ -1466,6 +1467,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertInternalType('array', $model->jsonAttribute);
         $this->assertTrue($model->boolAttribute);
         $this->assertFalse($model->booleanAttribute);
+        $this->assertFalse($model->defaultBooleanAttribute);
         $this->assertInternalType('boolean', $model->boolAttributeAsString);
         $this->assertInternalType('boolean', $model->booleanAttributeAsString);
         $this->assertEquals($obj, $model->objectAttribute);
@@ -1491,6 +1493,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertFalse($arr['booleanAttribute']);
         $this->assertTrue($arr['boolAttributeAsString']);
         $this->assertFalse($arr['booleanAttributeAsString']);
+        $this->assertFalse($arr['defaultBooleanAttribute']);
         $this->assertEquals($obj, $arr['objectAttribute']);
         $this->assertEquals(['foo' => 'bar'], $arr['arrayAttribute']);
         $this->assertEquals(['foo' => 'bar'], $arr['jsonAttribute']);
@@ -1997,6 +2000,7 @@ class EloquentModelCastingStub extends Model
         'booleanAttribute' => 'boolean',
         'boolAttributeAsString' => 'bool',
         'booleanAttributeAsString' => 'boolean',
+        'defaultBooleanAttribute' => 'boolean',
         'objectAttribute' => 'object',
         'arrayAttribute' => 'array',
         'jsonAttribute' => 'json',

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1445,6 +1445,8 @@ class DatabaseEloquentModelTest extends TestCase
         $model->stringAttribute = 2.5;
         $model->boolAttribute = 1;
         $model->booleanAttribute = 0;
+        $model->boolAttributeAsString = 'true';
+        $model->booleanAttributeAsString = 'false';
         $model->objectAttribute = ['foo' => 'bar'];
         $obj = new stdClass;
         $obj->foo = 'bar';
@@ -1464,6 +1466,8 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertInternalType('array', $model->jsonAttribute);
         $this->assertTrue($model->boolAttribute);
         $this->assertFalse($model->booleanAttribute);
+        $this->assertInternalType('boolean', $model->boolAttributeAsString);
+        $this->assertInternalType('boolean', $model->booleanAttributeAsString);
         $this->assertEquals($obj, $model->objectAttribute);
         $this->assertEquals(['foo' => 'bar'], $model->arrayAttribute);
         $this->assertEquals(['foo' => 'bar'], $model->jsonAttribute);
@@ -1485,6 +1489,8 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertInternalType('array', $arr['jsonAttribute']);
         $this->assertTrue($arr['boolAttribute']);
         $this->assertFalse($arr['booleanAttribute']);
+        $this->assertTrue($arr['boolAttributeAsString']);
+        $this->assertFalse($arr['booleanAttributeAsString']);
         $this->assertEquals($obj, $arr['objectAttribute']);
         $this->assertEquals(['foo' => 'bar'], $arr['arrayAttribute']);
         $this->assertEquals(['foo' => 'bar'], $arr['jsonAttribute']);
@@ -1989,6 +1995,8 @@ class EloquentModelCastingStub extends Model
         'stringAttribute' => 'string',
         'boolAttribute' => 'bool',
         'booleanAttribute' => 'boolean',
+        'boolAttributeAsString' => 'bool',
+        'booleanAttributeAsString' => 'boolean',
         'objectAttribute' => 'object',
         'arrayAttribute' => 'array',
         'jsonAttribute' => 'json',


### PR DESCRIPTION
Resubmitting to master due to potentially breaking changes from: https://github.com/laravel/framework/pull/20142 per @m1guelpf 
