### PR TITLE
Don't wrap mix path with asset()

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -560,7 +560,7 @@ if (! function_exists('mix')) {
             );
         }
 
-        return new HtmlString(asset($manifestDirectory.$manifest[$path]));
+        return new HtmlString($manifestDirectory.$manifest[$path]);
     }
 }
 

--- a/tests/Foundation/FoundationHelpersTest.php
+++ b/tests/Foundation/FoundationHelpersTest.php
@@ -68,7 +68,7 @@ class FoundationHelpersTest extends TestCase
         touch(public_path('mix-manifest.json'));
 
         file_put_contents(public_path('mix-manifest.json'), json_encode([
-            '/unversioned.css' => '/versioned.css'
+            '/unversioned.css' => '/versioned.css',
         ]));
 
         $result = mix($file);

--- a/tests/Foundation/FoundationHelpersTest.php
+++ b/tests/Foundation/FoundationHelpersTest.php
@@ -56,4 +56,25 @@ class FoundationHelpersTest extends TestCase
 
         unlink(public_path($file));
     }
+
+    public function testMixDoesNotIncludeHost()
+    {
+        $file = 'unversioned.css';
+
+        app()->singleton('path.public', function () {
+            return __DIR__;
+        });
+
+        touch(public_path('mix-manifest.json'));
+
+        file_put_contents(public_path('mix-manifest.json'), json_encode([
+            '/unversioned.css' => '/versioned.css'
+        ]));
+
+        $result = mix($file);
+
+        $this->assertEquals('/versioned.css', $result);
+
+        unlink(public_path('mix-manifest.json'));
+    }
 }


### PR DESCRIPTION
This removes the `asset` function from wrapping the asset path. I've created a similar fix before (##17727) and it was re-introduced in #19968 which broke one of my apps, and looks like it may have affected some other developers too.

This allows developers to prefix the asset path with whatever host they like and if they choose not to it'll just be a relative path on their own application, so it should work just the same.