### PR TITLE
[5.5] Add support for singular resource routes.

### DIFF
--- a/src/Illuminate/Routing/PendingResourceRegistration.php
+++ b/src/Illuminate/Routing/PendingResourceRegistration.php
@@ -143,6 +143,19 @@ class PendingResourceRegistration
     }
 
     /**
+     * Set the resource to be a singular resource instance.
+     *
+     * @param  bool|string|array  $resources
+     * @return \Illuminate\Routing\PendingResourceRegistration
+     */
+    public function singular($resources = true)
+    {
+        $this->options['singular'] = $resources;
+
+        return $this;
+    }
+
+    /**
      * Handle the object's destruction.
      *
      * @return void

--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -370,7 +370,7 @@ class ResourceRegistrar
     public function getResourceWildcard($value)
     {
         if (in_array($value, $this->singularResources)) {
-            return null;
+            return;
         }
 
         if (isset($this->parameters[$value])) {

--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Routing;
 
+use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 
 class ResourceRegistrar
@@ -107,7 +108,7 @@ class ResourceRegistrar
         if (! empty($options['singular'])) {
             $this->singularResources = array_intersect(
                 $resources,
-                $options['singular'] === true ? [last($resources)] : array_wrap($options['singular'])
+                $options['singular'] === true ? [last($resources)] : Arr::wrap($options['singular'])
             );
         }
 

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -221,6 +221,39 @@ class RouteRegistrarTest extends TestCase
         $this->assertFalse($this->router->getRoutes()->hasNamedRoute('users.edit'));
     }
 
+    public function testUserCanRegisterSingularApiResource()
+    {
+        $this->router->apiResource('user', \Illuminate\Tests\Routing\RouteRegistrarControllerStub::class, ['singular' => true]);
+
+        $this->assertCount(4, $this->router->getRoutes());
+
+        $this->assertFalse($this->router->getRoutes()->hasNamedRoute('user.index'));
+        $this->assertFalse($this->router->getRoutes()->hasNamedRoute('user.create'));
+        $this->assertFalse($this->router->getRoutes()->hasNamedRoute('user.edit'));
+
+        $this->assertEquals('user', $this->router->getRoutes()->getByName('user.show')->uri());
+        $this->assertEquals('user', $this->router->getRoutes()->getByName('user.store')->uri());
+        $this->assertEquals('user', $this->router->getRoutes()->getByName('user.update')->uri());
+        $this->assertEquals('user', $this->router->getRoutes()->getByName('user.destroy')->uri());
+    }
+
+    public function testUserCanSetSingularOnRegisteredApiResource()
+    {
+        $this->router->apiResource('user', \Illuminate\Tests\Routing\RouteRegistrarControllerStub::class)
+                     ->singular();
+
+        $this->assertCount(4, $this->router->getRoutes());
+
+        $this->assertFalse($this->router->getRoutes()->hasNamedRoute('user.index'));
+        $this->assertFalse($this->router->getRoutes()->hasNamedRoute('user.create'));
+        $this->assertFalse($this->router->getRoutes()->hasNamedRoute('user.edit'));
+
+        $this->assertEquals('user', $this->router->getRoutes()->getByName('user.show')->uri());
+        $this->assertEquals('user', $this->router->getRoutes()->getByName('user.store')->uri());
+        $this->assertEquals('user', $this->router->getRoutes()->getByName('user.update')->uri());
+        $this->assertEquals('user', $this->router->getRoutes()->getByName('user.destroy')->uri());
+    }
+
     public function testCanNameRoutesOnRegisteredResource()
     {
         $this->router->resource('users', 'Illuminate\Tests\Routing\RouteRegistrarControllerStub')

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -260,6 +260,19 @@ class RouteRegistrarTest extends TestCase
         $this->seeMiddleware('Illuminate\Tests\Routing\RouteRegistrarMiddlewareStub');
     }
 
+    public function testCanSetSingularOnRegisteredResource()
+    {
+        $this->router->resource('users', 'Illuminate\Tests\Routing\RouteRegistrarControllerStub')
+                     ->singular();
+
+        $this->assertCount(6, $this->router->getRoutes());
+
+        $this->assertEquals('users', $this->router->getRoutes()->getByName('users.show')->uri());
+        $this->assertEquals('users/edit', $this->router->getRoutes()->getByName('users.edit')->uri());
+        $this->assertEquals('users', $this->router->getRoutes()->getByName('users.update')->uri());
+        $this->assertEquals('users', $this->router->getRoutes()->getByName('users.destroy')->uri());
+    }
+
     public function testCanSetRouteName()
     {
         $this->router->as('users.index')->get('users', function () {

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -1097,7 +1097,7 @@ class RoutingRouteTest extends TestCase
         $router = $this->getRouter();
         $router->resource('foo', 'FooController', ['only' => ['index'], 'singular' => true]);
         $routes = $router->getRoutes();
-        $this->assertCount(0, $routes);
+        $this->assertEmpty($routes);
 
         $router = $this->getRouter();
         $router->resource('foo', 'FooController', ['singular' => ['bar']]);

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -1070,6 +1070,111 @@ class RoutingRouteTest extends TestCase
 
         $this->assertEquals('foo/ajouter', $routes->getByName('foo.create')->uri());
         $this->assertEquals('foo/{foo}/modifier', $routes->getByName('foo.edit')->uri());
+
+        ResourceRegistrar::verbs([
+            'create' => 'create',
+            'edit' => 'edit',
+        ]);
+    }
+
+    public function testSingularResourceRouting()
+    {
+        $router = $this->getRouter();
+        $router->resource('foo', 'FooController', ['singular' => true]);
+        $routes = $router->getRoutes();
+        $this->assertCount(6, $routes);
+
+        $router = $this->getRouter();
+        $router->resource('foo', 'FooController', ['singular' => 'foo']);
+        $routes = $router->getRoutes();
+        $this->assertCount(6, $routes);
+
+        $router = $this->getRouter();
+        $router->resource('foo', 'FooController', ['singular' => ['foo']]);
+        $routes = $router->getRoutes();
+        $this->assertCount(6, $routes);
+
+        $router = $this->getRouter();
+        $router->resource('foo', 'FooController', ['only' => ['index'], 'singular' => true]);
+        $routes = $router->getRoutes();
+        $this->assertCount(0, $routes);
+
+        $router = $this->getRouter();
+        $router->resource('foo', 'FooController', ['singular' => ['bar']]);
+        $routes = $router->getRoutes();
+        $this->assertCount(7, $routes);
+
+        $router = $this->getRouter();
+        $router->resource('foo', 'FooController', ['only' => ['show', 'edit', 'update', 'destroy'], 'singular' => true]);
+        $routes = $router->getRoutes();
+
+        $this->assertEquals('foo', $routes->getByName('foo.show')->uri());
+        $this->assertEquals('foo/edit', $routes->getByName('foo.edit')->uri());
+        $this->assertEquals('foo', $routes->getByName('foo.update')->uri());
+        $this->assertEquals('foo', $routes->getByName('foo.destroy')->uri());
+
+        $router = $this->getRouter();
+        $router->resource('foo.bar', 'FooController', ['only' => ['show'], 'singular' => true]);
+        $routes = $router->getRoutes();
+        $routes = $routes->getRoutes();
+
+        $this->assertEquals('foo/{foo}/bar', $routes[0]->uri());
+
+        $router = $this->getRouter();
+        $router->resource('foo.bar', 'FooController', ['only' => ['show'], 'singular' => 'bar']);
+        $routes = $router->getRoutes();
+        $routes = $routes->getRoutes();
+
+        $this->assertEquals('foo/{foo}/bar', $routes[0]->uri());
+
+        $router = $this->getRouter();
+        $router->resource('foo.bar', 'FooController', ['only' => ['show'], 'singular' => ['bar']]);
+        $routes = $router->getRoutes();
+        $routes = $routes->getRoutes();
+
+        $this->assertEquals('foo/{foo}/bar', $routes[0]->uri());
+
+        $router = $this->getRouter();
+        $router->resource('foo.bar', 'FooController', ['only' => ['show'], 'singular' => ['foo']]);
+        $routes = $router->getRoutes();
+        $routes = $routes->getRoutes();
+
+        $this->assertEquals('foo/bar/{bar}', $routes[0]->uri());
+
+        $router = $this->getRouter();
+        $router->resource('foo.bar', 'FooController', ['only' => ['show'], 'singular' => ['foo', 'bar']]);
+        $routes = $router->getRoutes();
+        $routes = $routes->getRoutes();
+
+        $this->assertEquals('foo/bar', $routes[0]->uri());
+
+        $router = $this->getRouter();
+        $router->resource('foo/bar', 'FooController', ['only' => ['show'], 'singular' => true]);
+        $routes = $router->getRoutes();
+        $routes = $routes->getRoutes();
+
+        $this->assertEquals('foo/bar', $routes[0]->uri());
+
+        $router = $this->getRouter();
+        $router->resource('foo/bar.baz', 'FooController', ['only' => ['show'], 'singular' => true]);
+        $routes = $router->getRoutes();
+        $routes = $routes->getRoutes();
+
+        $this->assertEquals('foo/bar/{bar}/baz', $routes[0]->uri());
+
+        $router = $this->getRouter();
+        $router->resource('foo/bar.baz', 'FooController', ['only' => ['show'], 'singular' => ['bar']]);
+        $routes = $router->getRoutes();
+        $routes = $routes->getRoutes();
+
+        $this->assertEquals('foo/bar/baz/{baz}', $routes[0]->uri());
+
+        $router = $this->getRouter();
+        $router->resource('foo/bar.baz', 'FooController', ['only' => ['show'], 'singular' => ['bar', 'baz']]);
+        $routes = $router->getRoutes();
+        $routes = $routes->getRoutes();
+
+        $this->assertEquals('foo/bar/baz', $routes[0]->uri());
     }
 
     public function testResourceRoutingParameters()


### PR DESCRIPTION
I targeted the master branch for 5.5, but this should be a non-breaking change and could be added to 5.4, I believe (without the changes to `PendingResourceRegistration`, which doesn't exist in 5.4).

## Overview

This PR adds the ability to generate resource routes for a singular resource.  This was discussed a long time ago in issue #1192, and received positive feedback, but nothing ever came of it.

Sometimes you need to deal with a resource that does not need to be referenced by the id. For example, you may have a `profile` resource that belongs to the currently authenticated user. Currently, if you wanted to `show` the user's profile, the route would be `/profile/{profile}`. However, since you don't need the id to look up the current user's profile, it would be nice to be able to simply have the `show` route be `/profile`. This is the same for the `edit`, `update`, and `destroy` routes, as well.

The singular resource route generates the following routes:

| Verb | Path | Action | Route Name |
| -- | -- | -- | -- |
| GET | /profile/create | create | profile.create |
| POST | /profile | store | profile.store |
| GET | /profile | show | profile.show |
| GET | /profile/edit | edit | profile.edit |
| PUT/PATCH | /profile | update | profile.update |
| DELETE | /profile | destroy | profile.destroy |

These routes differ from the current resource routes in two ways:
1. The `show`, `edit`, `update`, and `destroy` routes do not need a route parameter.
2. Since this is a singular resource, there is no `index` action.

## How It Works

In order to create a new singular resource route, this PR adds a new `singular` option to the resource route definition. This option can be set to three different values:
1. The boolean `true`. This is mainly for non-nested resource definitions. If it is used on a nested resource definition, only the last resource in the chain will be treated as singular.
2. A string containing the name of the singular resource. This can be used when there is only one resource that is singular in a nested resource definition. The string must contain the name of the singular resource.
3. An array of strings containing the names of the singular resources. This can be used in any scenario, but it must be used when there are multiple singular resources in a nested resource definition.

## Examples

**A singular resource (`/profile`):**
```
// Since there is only one singular resource, and it is the last one,
// all three options work in this scenario.

Route::resource('profile', 'ProfileController', ['only' => ['show'], 'singular' => true]);
Route::resource('profile', 'ProfileController', ['only' => ['show'], 'singular' => 'profile']);
Route::resource('profile', 'ProfileController', ['only' => ['show'], 'singular' => ['profile']]);
```

("only" removed from here on out for brevity)

**A singular resource nested under a plural resource (`/users/{user}/profile`):**
```
// Since there is only one singular resource, and it is the last one,
// all three options work in this scenario.

Route::resource('users.profile', 'ProfileController', ['singular' => true]);
Route::resource('users.profile', 'ProfileController', ['singular' => 'profile']);
Route::resource('users.profile', 'ProfileController', ['singular' => ['profile']]);
```

**A singular resource nested under a singular resource (`/profile/avatar`):**
```
// Since there are multiple resources that are singular, only the array
// syntax can be used to specify all the singular resources.

Route::resource('profile.avatar', 'ProfileAvatarController', ['singular' => ['profile', 'avatar']]);
```

**A plural resource nested under a singular resource (`/profile/phones/{phone}`):**
```
// Since there is a parent resource that is singular, the "true" option cannot be used.
// But since there is only one singular resource, the string option can be used.

Route::resource('profile.phones', 'PhoneController', ['singular' => 'profile']);
Route::resource('profile.phones', 'PhoneController', ['singular' => ['profile']]);
```

**A singular resource nested under a plural resource nested under a singular resource (`/profile/phones/{phone}/type`):**
```
// Since there are multiple resources that are singular, only the array
// syntax can be used to specify all the singular resources.

Route::resource('profile.phones.type', 'PhoneTypeController', ['singular' => ['profile', 'type']]);
```

## [5.5] Fluent Routes

Additonally, a new `singular()` method was added to the fluent route definitions. If nothing is passed in, it will default the `singular` option to `true`, otherwise it sets the `singular` option to whatever is passed in.

**A singular resource defined fluently (`/profile`):**
```
Route::resource('profile', 'ProfileController')->only('show')->singular();
Route::resource('profile', 'ProfileController')->only('show')->singular(true);
Route::resource('profile', 'ProfileController')->only('show')->singular('profile');
Route::resource('profile', 'ProfileController')->only('show')->singular(['profile']);
```

Please let me know if there are any changes that need to be made.

Thanks!