### PR TITLE
[5.4] Add application version precision

### DIFF
--- a/src/Illuminate/Contracts/Foundation/Application.php
+++ b/src/Illuminate/Contracts/Foundation/Application.php
@@ -9,9 +9,10 @@ interface Application extends Container
     /**
      * Get the version number of the application.
      *
+     * @param null $precision
      * @return string
      */
-    public function version();
+    public function version($precision = null);
 
     /**
      * Get the base path of the Laravel installation.

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -157,10 +157,18 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     /**
      * Get the version number of the application.
      *
+     * @param  null|string $precision
      * @return string
      */
-    public function version()
+    public function version($precision = null)
     {
+        $precision = strtoupper($precision);
+        if ($precision == 'MAJOR') {
+            return (int) static::VERSION;
+        } elseif ($precision == 'MINOR') {
+            return (float) static::VERSION;
+        }
+
         return static::VERSION;
     }
 

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -164,12 +164,14 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     {
         $precision = strtoupper($precision);
         if ($precision == 'MAJOR') {
-            return (int) static::VERSION;
+            $version = (int) static::VERSION;
         } elseif ($precision == 'MINOR') {
-            return (float) static::VERSION;
+            $version = (float) static::VERSION;
+        } else {
+            $version = static::VERSION;
         }
 
-        return static::VERSION;
+        return (string) $version;
     }
 
     /**


### PR DESCRIPTION
Adds application version precision to `app()->version()` method. This allows to change method output depending on your needs. 

Imagine your Laravel version is 5.4.27.

When you need to check somewhere in code that it's Laravel 5:
```php
if (app()->version('MAJOR') == '5') {
    // Do something
}
```

When you need to check somewhere in code that it's Laravel 5.4:
```php
if (app()->version('MINOR') == '5.4') {
    // Do something
}
```

When you need to check somewhere in code that it's Laravel 5.4.27:
```php
if (app()->version('PATCH') == '5.4.27') {
    // Do something
}

if (app()->version() == '5.4.27') {
    // Do something
}
```

[Here is a real usage example](https://github.com/rmariuzzo/Laravel-JS-Localization/blob/bb0b6fb2d46ceaf1fced59e2227b8615f78f722c/src/Mariuzzo/LaravelJsLocalization/LaravelJsLocalizationServiceProvider.php#L44).