### PR TITLE
[5.5] Speed up picking related ids

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -708,11 +708,7 @@ class BelongsToMany extends Relation
      */
     public function allRelatedIds()
     {
-        $related = $this->getRelated();
-
-        return $this->getQuery()->select(
-            $related->getQualifiedKeyName()
-        )->pluck($related->getKeyName());
+        return $this->newPivotQuery()->pluck($this->relatedPivotKey);
     }
 
     /**


### PR DESCRIPTION
Just sending this PR again as didn't get a clear response on the last PR #19993.

With this PR, it avoids an unnecessary join when you only need the related ids for a pivot relation. This will speed up cases where you *only* need the related ids for the pivot table and nothing else - this will speed up touching the relations too.
