### PR TITLE
[5.5] Add factory model creation on different connections

### DIFF
--- a/src/Illuminate/Database/Eloquent/FactoryBuilder.php
+++ b/src/Illuminate/Database/Eloquent/FactoryBuilder.php
@@ -47,6 +47,13 @@ class FactoryBuilder
     protected $activeStates = [];
 
     /**
+     * The database connection on which the model instance should be persisted.
+     *
+     * @var string
+     */
+    protected $connection;
+
+    /**
      * The Faker instance for the builder.
      *
      * @var \Faker\Generator
@@ -106,6 +113,19 @@ class FactoryBuilder
     }
 
     /**
+     * Set the database connection on which the model instance should be persisted.
+     *
+     * @param  string  $name
+     * @return $this
+     */
+    public function connection($name)
+    {
+        $this->connection = $name;
+
+        return $this;
+    }
+
+    /**
      * Create a model and persist it in the database if requested.
      *
      * @param  array  $attributes
@@ -146,7 +166,11 @@ class FactoryBuilder
     protected function store($results)
     {
         $results->each(function ($model) {
-            $model->setConnection($model->newQueryWithoutScopes()->getConnection()->getName());
+            if (isset($this->connection)) {
+                $model->setConnection($this->connection);
+            } else {
+                $model->setConnection($model->newQueryWithoutScopes()->getConnection()->getName());
+            }
 
             $model->save();
         });

--- a/src/Illuminate/Database/Eloquent/FactoryBuilder.php
+++ b/src/Illuminate/Database/Eloquent/FactoryBuilder.php
@@ -166,9 +166,7 @@ class FactoryBuilder
     protected function store($results)
     {
         $results->each(function ($model) {
-            if (isset($this->connection)) {
-                $model->setConnection($this->connection);
-            } else {
+            if (! isset($this->connection)) {
                 $model->setConnection($model->newQueryWithoutScopes()->getConnection()->getName());
             }
 
@@ -251,9 +249,15 @@ class FactoryBuilder
                 throw new InvalidArgumentException("Unable to locate factory with name [{$this->name}] [{$this->class}].");
             }
 
-            return new $this->class(
+            $instance = new $this->class(
                 $this->getRawAttributes($attributes)
             );
+
+            if (isset($this->connection)) {
+                $instance->setConnection($this->connection);
+            }
+
+            return $instance;
         });
     }
 

--- a/tests/Integration/Database/EloquentFactoryBuilderTest.php
+++ b/tests/Integration/Database/EloquentFactoryBuilderTest.php
@@ -179,6 +179,16 @@ class EloquentFactoryBuilderTest extends TestCase
         $this->assertEquals('alternative-connection', $user->getConnectionName());
         $this->assertTrue($user->is($dbUser));
     }
+
+    /** @test */
+    public function making_models_with_a_custom_connection()
+    {
+        $user = factory(FactoryBuildableUser::class)
+            ->connection('alternative-connection')
+            ->make();
+
+        $this->assertEquals('alternative-connection', $user->getConnectionName());
+    }
 }
 
 class FactoryBuildableUser extends Model

--- a/tests/Integration/Database/EloquentFactoryBuilderTest.php
+++ b/tests/Integration/Database/EloquentFactoryBuilderTest.php
@@ -23,6 +23,11 @@ class EloquentFactoryBuilderTest extends TestCase
             'database' => ':memory:',
             'prefix' => '',
         ]);
+        $app['config']->set('database.connections.alternative-connection', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+        ]);
 
         $factory = new Factory($app->make(Generator::class));
 
@@ -61,6 +66,12 @@ class EloquentFactoryBuilderTest extends TestCase
         parent::setUp();
 
         Schema::create('users', function ($table) {
+            $table->increments('id');
+            $table->string('name');
+            $table->string('email');
+        });
+
+        Schema::connection('alternative-connection')->create('users', function ($table) {
             $table->increments('id');
             $table->string('name');
             $table->string('email');
@@ -152,6 +163,21 @@ class EloquentFactoryBuilderTest extends TestCase
             ->each(function ($user) {
                 $this->assertCount(2, $user->servers);
             });
+    }
+
+    /**
+     * @test
+     */
+    public function creating_models_on_custom_connection()
+    {
+        $user = factory(FactoryBuildableUser::class)
+            ->connection('alternative-connection')
+            ->create();
+
+        $dbUser = FactoryBuildableUser::on('alternative-connection')->find(1);
+
+        $this->assertEquals('alternative-connection', $user->getConnectionName());
+        $this->assertTrue($user->is($dbUser));
     }
 }
 


### PR DESCRIPTION
This PR allows for the creation of 'factory models' on other connections than the default.

Example usage:
```php
factory(User::class)->connection('ext-02')->create();
```

Currently, for the same behavior, you would have to `make()` the model, then use `setConnection()` and manually `save()` it.