### PR TITLE
[5.4] Avoid a problem when adding timestamp columns in dates array

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -765,7 +765,8 @@ trait HasAttributes
     {
         $defaults = [static::CREATED_AT, static::UPDATED_AT];
 
-        return $this->usesTimestamps() ? array_merge($this->dates, $defaults) : $this->dates;
+        return $this->usesTimestamps()
+                    ? array_unique(array_merge($this->dates, $defaults)) : $this->dates;
     }
 
     /**


### PR DESCRIPTION
This change will ensure that date columns will be unique, so that if you add `created_at` and `updated_at` columns in your Model's $dates attribute they won't be parsed twice inside `HasAttributes::addDateAttributesToArray()`.