### PR TITLE
[5.5] Add `replace` method to the Collection class 

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1198,6 +1198,20 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
+     * Replace all occurrences of the search item with the replacement item.
+     *
+     * @param  mixed  $search
+     * @param  mixed  $replace
+     * @return static
+     */
+    public function replace($search, $replace)
+    {
+        return $this->map(function ($item) use ($search, $replace) {
+            return $item == $search ? $replace : $item;
+        });
+    }
+
+    /**
      * Reverse items order.
      *
      * @return static

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2235,6 +2235,13 @@ class SupportCollectionTest extends TestCase
 
         $this->assertSame(['michael', 'tom', 'taylor'], $collection->toArray());
     }
+
+    public function testReplace()
+    {
+        $collection = new Collection(['jeffrey', 'tom', 'adam', 'tom']);
+
+        $this->assertSame(['jeffrey', 'taylor', 'adam', 'taylor'], $collection->replace('tom', 'taylor')->toArray());
+    }
 }
 
 class TestSupportCollectionHigherOrderItem


### PR DESCRIPTION
Simple implementation of a `replace` method which replace all occurrences of an item to another.

### Other possible features to add to the PR if requested

I kept this implementation really simple because I wanted to know it's a feature wanted by the framework. But we could add more sugar:

#### Strict mode

```php
collect([1, '1', 2])->replace(1, 3, true);

// [3, '1', 2]
```

#### Callbacks

```php
collect([1, 2, 3, 4])->replace(function($value) {
   return ($value % 2) == 0;
}, function($value) {
    return $value * 2;
});

// [1, 4, 3, 8]
```

```php
collect([
    collect([1, 2, 3]),
    collect([2, 1, 2]),
])->replace(function($collection) {
   return $collection->contains(3);
}, collect());

// [ [], [2, 1, 2] ]
```