### PR TITLE
[5.5] Better `BadMethodCallException` message when dealing with Eloquent

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1369,7 +1369,13 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
             return $this->$method(...$parameters);
         }
 
-        return $this->newQuery()->$method(...$parameters);
+        try {
+            return $this->newQuery()->$method(...$parameters);
+        } catch (\BadMethodCallException $e) {
+            throw new \BadMethodCallException(
+                sprintf('Call to undefined method %s::%s()', get_class($this), $method)
+            );
+        }
     }
 
     /**

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -453,6 +453,28 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEquals('2015-04-17 22:59:01', $model->fromDateTime($value));
     }
 
+    public function testBadMethodCallException()
+    {
+        $conn = m::mock('Illuminate\Database\Connection');
+        $grammar = m::mock('Illuminate\Database\Query\Grammars\Grammar');
+        $processor = m::mock('Illuminate\Database\Query\Processors\Processor');
+        $conn->shouldReceive('getQueryGrammar')->once()->andReturn($grammar);
+        $conn->shouldReceive('getPostProcessor')->once()->andReturn($processor);
+        EloquentModelStub::setConnectionResolver($resolver = m::mock('Illuminate\Database\ConnectionResolverInterface'));
+        $resolver->shouldReceive('connection')->andReturn($conn);
+        $model = new EloquentModelStub;
+
+        try {
+            $model->badMethod();
+        } catch (\BadMethodCallException $e) {
+            $this->assertEquals('Call to undefined method Illuminate\Tests\Database\EloquentModelStub::badMethod()', $e->getMessage());
+
+            return;
+        }
+
+        $this->fail('BadMethodCallException expected.');
+    }
+
     public function testInsertProcess()
     {
         $model = $this->getMockBuilder('Illuminate\Tests\Database\EloquentModelStub')->setMethods(['newQueryWithoutScopes', 'updateTimestamps', 'refresh'])->getMock();


### PR DESCRIPTION
I think for newcomers in Laravel and PHP beginners, the message "Call to undefined method Illuminate\Database\Query\Builder::badMethod()" could be confusing.

Wrapping the call to the builder and throwing a new `BadMethodCallException` with the correct message ("Call to undefined method App\User::badMethod()") could be helpful.

I chose to assert the entire string in the test but I can change it to just asserting that `Illuminate\Tests\Database\EloquentModelStub` is contains in the message.