### PR TITLE
[5.5] Allow easy ViewFactory override

### DIFF
--- a/src/Illuminate/View/ViewServiceProvider.php
+++ b/src/Illuminate/View/ViewServiceProvider.php
@@ -40,7 +40,7 @@ class ViewServiceProvider extends ServiceProvider
 
             $finder = $app['view.finder'];
 
-            $env = new Factory($resolver, $finder, $app['events']);
+            $env = $this->newFactory($resolver, $finder, $app['events']);
 
             // We will also set the container instance on this view environment since the
             // view composers may be classes registered in the container, which allows
@@ -132,5 +132,18 @@ class ViewServiceProvider extends ServiceProvider
         $resolver->register('blade', function () {
             return new CompilerEngine($this->app['blade.compiler']);
         });
+    }
+
+    /**
+     * Create a new Factory Instance.
+     *
+     * @param  EngineResolver  $resolver
+     * @param  FileViewFinder  $finder
+     * @param  $events
+     * @return Factory
+     */
+    protected function newFactory($resolver, $finder, $events)
+    {
+        return new Factory($resolver, $finder, $events);
     }
 }

--- a/src/Illuminate/View/ViewServiceProvider.php
+++ b/src/Illuminate/View/ViewServiceProvider.php
@@ -137,10 +137,10 @@ class ViewServiceProvider extends ServiceProvider
     /**
      * Create a new Factory Instance.
      *
-     * @param  EngineResolver  $resolver
-     * @param  FileViewFinder  $finder
-     * @param  $events
-     * @return Factory
+     * @param  \Illuminate\View\Engines\EngineResolver  $resolver
+     * @param  \Illuminate\View\ViewFinderInterface  $finder
+     * @param  \Illuminate\Contracts\Events\Dispatcher  $events
+     * @return \Illuminate\View\Factory
      */
     protected function newFactory($resolver, $finder, $events)
     {


### PR DESCRIPTION
In order to implement a data interceptor between any `controller` with any `view`, I had to override the whole `ViewServiceProvider::registerFactory()` method.

Extracting the class instance to it's own method makes it a lot easier to override without having to worry about future changes in the default ViewServiceProvider.