### PR TITLE
[5.5] fixed failing test

### DIFF
--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -475,7 +475,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     /**
      * @expectedException \Illuminate\Database\Eloquent\RelationNotFoundException
-     * @expectedExceptionMessage Call to undefined relationship [invalid] on model [Mockery_18_Illuminate_Database_Eloquent_Model].
+     * @expectedExceptionMessage Call to undefined relationship [invalid] on model [Mockery_2_Illuminate_Database_Eloquent_Model].
      */
     public function testGetRelationThrowsException()
     {


### PR DESCRIPTION
was getting this error: 

```
Failed asserting that exception message 'Call to undefined relationship [invalid] on model [Mockery_2_Illuminate_Database_Eloquent_Model].' contains 'Call to undefined relationship [invalid] on model [Mockery_18_Illuminate_Database_Eloquent_Model].'.
```

so changed it to _2 and tests pass.. weird.. 

the bug was created by #19873 