### PR TITLE
[5.4] Adding MessageSelectorTest to Translation test suite and refactoring MessageSelector

### DIFF
--- a/src/Illuminate/Translation/MessageSelector.php
+++ b/src/Illuminate/Translation/MessageSelector.php
@@ -26,7 +26,7 @@ class MessageSelector
 
         $pluralIndex = $this->getPluralIndex($locale, $number);
 
-        if (count($segments) == 1 || !isset($segments[$pluralIndex])) {
+        if (count($segments) == 1 || ! isset($segments[$pluralIndex])) {
             return $segments[0];
         }
 
@@ -43,7 +43,7 @@ class MessageSelector
     private function extract($segments, $number)
     {
         foreach ($segments as $part) {
-            if (!is_null($line = $this->extractFromString($part, $number))) {
+            if (! is_null($line = $this->extractFromString($part, $number))) {
                 return $line;
             }
         }
@@ -123,13 +123,13 @@ class MessageSelector
                 return (($number % 10 == 1) && ($number % 100 != 11)) ? 0 : ((($number % 10 >= 2) && ($number % 10 <= 4) && (($number % 100 < 10) || ($number % 100 >= 20))) ? 1 : 2);
             case strpos('cs|sk', $countryCode) !== false:
                 return ($number == 1) ? 0 : ((($number >= 2) && ($number <= 4)) ? 1 : 2);
-            default :
+            default:
                 return $this->getUniquePluralIndex($countryCode, $number);
         }
     }
 
     /**
-     * Get the index to use for countries with unique pluralization pattern
+     * Get the index to use for countries with unique pluralization pattern.
      *
      * @param string $countryCode
      * @param int $number

--- a/src/Illuminate/Translation/MessageSelector.php
+++ b/src/Illuminate/Translation/MessageSelector.php
@@ -9,9 +9,9 @@ class MessageSelector
     /**
      * Select a proper translation string based on the given number.
      *
-     * @param  string  $line
-     * @param  int  $number
-     * @param  string  $locale
+     * @param  string $line
+     * @param  int $number
+     * @param  string $locale
      * @return mixed
      */
     public function choose($line, $number, $locale)
@@ -26,7 +26,7 @@ class MessageSelector
 
         $pluralIndex = $this->getPluralIndex($locale, $number);
 
-        if (count($segments) == 1 || ! isset($segments[$pluralIndex])) {
+        if (count($segments) == 1 || !isset($segments[$pluralIndex])) {
             return $segments[0];
         }
 
@@ -36,14 +36,14 @@ class MessageSelector
     /**
      * Extract a translation string using inline conditions.
      *
-     * @param  array  $segments
-     * @param  int  $number
+     * @param  array $segments
+     * @param  int $number
      * @return mixed
      */
     private function extract($segments, $number)
     {
         foreach ($segments as $part) {
-            if (! is_null($line = $this->extractFromString($part, $number))) {
+            if (!is_null($line = $this->extractFromString($part, $number))) {
                 return $line;
             }
         }
@@ -52,8 +52,8 @@ class MessageSelector
     /**
      * Get the translation string if the condition matches.
      *
-     * @param  string  $part
-     * @param  int  $number
+     * @param  string $part
+     * @param  int $number
      * @return mixed
      */
     private function extractFromString($part, $number)
@@ -86,7 +86,7 @@ class MessageSelector
     /**
      * Strip the inline conditions from each segment, just leaving the text.
      *
-     * @param  array  $segments
+     * @param  array $segments
      * @return array
      */
     private function stripConditions($segments)
@@ -103,307 +103,60 @@ class MessageSelector
      * is subject to the new BSD license (http://framework.zend.com/license/new-bsd)
      * Copyright (c) 2005-2010 - Zend Technologies USA Inc. (http://www.zend.com)
      *
-     * @param  string  $locale
-     * @param  int  $number
+     * @param  string $locale
+     * @param  int $number
      * @return int
      */
     public function getPluralIndex($locale, $number)
     {
-        switch ($locale) {
-            case 'az':
-            case 'az_AZ':
-            case 'bo':
-            case 'bo_CN':
-            case 'bo_IN':
-            case 'dz':
-            case 'dz_BT':
-            case 'id':
-            case 'id_ID':
-            case 'ja':
-            case 'ja_JP':
-            case 'jv':
-            case 'ka':
-            case 'ka_GE':
-            case 'km':
-            case 'km_KH':
-            case 'kn':
-            case 'kn_IN':
-            case 'ko':
-            case 'ko_KR':
-            case 'ms':
-            case 'ms_MY':
-            case 'th':
-            case 'th_TH':
-            case 'tr':
-            case 'tr_CY':
-            case 'tr_TR':
-            case 'vi':
-            case 'vi_VN':
-            case 'zh':
-            case 'zh_CN':
-            case 'zh_HK':
-            case 'zh_SG':
-            case 'zh_TW':
-                return 0;
-            case 'af':
-            case 'af_ZA':
-            case 'bn':
-            case 'bn_BD':
-            case 'bn_IN':
-            case 'bg':
-            case 'bg_BG':
-            case 'ca':
-            case 'ca_AD':
-            case 'ca_ES':
-            case 'ca_FR':
-            case 'ca_IT':
-            case 'da':
-            case 'da_DK':
-            case 'de':
-            case 'de_AT':
-            case 'de_BE':
-            case 'de_CH':
-            case 'de_DE':
-            case 'de_LI':
-            case 'de_LU':
-            case 'el':
-            case 'el_CY':
-            case 'el_GR':
-            case 'en':
-            case 'en_AG':
-            case 'en_AU':
-            case 'en_BW':
-            case 'en_CA':
-            case 'en_DK':
-            case 'en_GB':
-            case 'en_HK':
-            case 'en_IE':
-            case 'en_IN':
-            case 'en_NG':
-            case 'en_NZ':
-            case 'en_PH':
-            case 'en_SG':
-            case 'en_US':
-            case 'en_ZA':
-            case 'en_ZM':
-            case 'en_ZW':
-            case 'eo':
-            case 'eo_US':
-            case 'es':
-            case 'es_AR':
-            case 'es_BO':
-            case 'es_CL':
-            case 'es_CO':
-            case 'es_CR':
-            case 'es_CU':
-            case 'es_DO':
-            case 'es_EC':
-            case 'es_ES':
-            case 'es_GT':
-            case 'es_HN':
-            case 'es_MX':
-            case 'es_NI':
-            case 'es_PA':
-            case 'es_PE':
-            case 'es_PR':
-            case 'es_PY':
-            case 'es_SV':
-            case 'es_US':
-            case 'es_UY':
-            case 'es_VE':
-            case 'et':
-            case 'et_EE':
-            case 'eu':
-            case 'eu_ES':
-            case 'eu_FR':
-            case 'fa':
-            case 'fa_IR':
-            case 'fi':
-            case 'fi_FI':
-            case 'fo':
-            case 'fo_FO':
-            case 'fur':
-            case 'fur_IT':
-            case 'fy':
-            case 'fy_DE':
-            case 'fy_NL':
-            case 'gl':
-            case 'gl_ES':
-            case 'gu':
-            case 'gu_IN':
-            case 'ha':
-            case 'ha_NG':
-            case 'he':
-            case 'he_IL':
-            case 'hu':
-            case 'hu_HU':
-            case 'is':
-            case 'is_IS':
-            case 'it':
-            case 'it_CH':
-            case 'it_IT':
-            case 'ku':
-            case 'ku_TR':
-            case 'lb':
-            case 'lb_LU':
-            case 'ml':
-            case 'ml_IN':
-            case 'mn':
-            case 'mn_MN':
-            case 'mr':
-            case 'mr_IN':
-            case 'nah':
-            case 'nb':
-            case 'nb_NO':
-            case 'ne':
-            case 'ne_NP':
-            case 'nl':
-            case 'nl_AW':
-            case 'nl_BE':
-            case 'nl_NL':
-            case 'nn':
-            case 'nn_NO':
-            case 'no':
-            case 'om':
-            case 'om_ET':
-            case 'om_KE':
-            case 'or':
-            case 'or_IN':
-            case 'pa':
-            case 'pa_IN':
-            case 'pa_PK':
-            case 'pap':
-            case 'pap_AN':
-            case 'pap_AW':
-            case 'pap_CW':
-            case 'ps':
-            case 'ps_AF':
-            case 'pt':
-            case 'pt_BR':
-            case 'pt_PT':
-            case 'so':
-            case 'so_DJ':
-            case 'so_ET':
-            case 'so_KE':
-            case 'so_SO':
-            case 'sq':
-            case 'sq_AL':
-            case 'sq_MK':
-            case 'sv':
-            case 'sv_FI':
-            case 'sv_SE':
-            case 'sw':
-            case 'sw_KE':
-            case 'sw_TZ':
-            case 'ta':
-            case 'ta_IN':
-            case 'ta_LK':
-            case 'te':
-            case 'te_IN':
-            case 'tk':
-            case 'tk_TM':
-            case 'ur':
-            case 'ur_IN':
-            case 'ur_PK':
-            case 'zu':
-            case 'zu_ZA':
+        $countryCode = strtok($locale, '_');
+        switch (true) {
+            case strpos('af|bn|bg|ca|da|de|el|en|eo|es|et|eu|fa|fi|fo|fur|fy', $countryCode) !== false:
+            case strpos('gl|gu|ha|he|hu|is|it|ku|lb|ml|mn|mr|nah|nb|ne|nl|nn', $countryCode) !== false:
+            case strpos('no|om|or|pa|pap|ps|pt|so|sq|sv|sw|ta|te|tk|ur|zu', $countryCode) !== false:
                 return ($number == 1) ? 0 : 1;
-            case 'am':
-            case 'am_ET':
-            case 'bh':
-            case 'fil':
-            case 'fil_PH':
-            case 'fr':
-            case 'fr_BE':
-            case 'fr_CA':
-            case 'fr_CH':
-            case 'fr_FR':
-            case 'fr_LU':
-            case 'gun':
-            case 'hi':
-            case 'hi_IN':
-            case 'hy':
-            case 'hy_AM':
-            case 'ln':
-            case 'ln_CD':
-            case 'mg':
-            case 'mg_MG':
-            case 'nso':
-            case 'nso_ZA':
-            case 'ti':
-            case 'ti_ER':
-            case 'ti_ET':
-            case 'wa':
-            case 'wa_BE':
-            case 'xbr':
+            case strpos('az|bo|dz|id|ja|jv|ka|km|kn|ko|ms|th|tr|vi|zh', $countryCode) !== false:
+                return 0;
+            case strpos('am|bh|fil|fr|gun|hi|hy|ln|mg|nso|ti|wa|xbr', $countryCode) !== false:
                 return (($number == 0) || ($number == 1)) ? 0 : 1;
-            case 'be':
-            case 'be_BY':
-            case 'bs':
-            case 'bs_BA':
-            case 'hr':
-            case 'hr_HR':
-            case 'ru':
-            case 'ru_RU':
-            case 'ru_UA':
-            case 'sr':
-            case 'sr_ME':
-            case 'sr_RS':
-            case 'uk':
-            case 'uk_UA':
+            case strpos('be|bs|hr|ru|sr|uk', $countryCode) !== false:
                 return (($number % 10 == 1) && ($number % 100 != 11)) ? 0 : ((($number % 10 >= 2) && ($number % 10 <= 4) && (($number % 100 < 10) || ($number % 100 >= 20))) ? 1 : 2);
-            case 'cs':
-            case 'cs_CZ':
-            case 'sk':
-            case 'sk_SK':
+            case strpos('cs|sk', $countryCode) !== false:
                 return ($number == 1) ? 0 : ((($number >= 2) && ($number <= 4)) ? 1 : 2);
+            default :
+                return $this->getUniquePluralIndex($countryCode, $number);
+        }
+    }
+
+    /**
+     * Get the index to use for countries with unique pluralization pattern
+     *
+     * @param string $countryCode
+     * @param int $number
+     * @return int
+     */
+    private function getUniquePluralIndex($countryCode, $number)
+    {
+        switch ($countryCode) {
             case 'ga':
-            case 'ga_IE':
                 return ($number == 1) ? 0 : (($number == 2) ? 1 : 2);
             case 'lt':
-            case 'lt_LT':
                 return (($number % 10 == 1) && ($number % 100 != 11)) ? 0 : ((($number % 10 >= 2) && (($number % 100 < 10) || ($number % 100 >= 20))) ? 1 : 2);
             case 'sl':
-            case 'sl_SI':
                 return ($number % 100 == 1) ? 0 : (($number % 100 == 2) ? 1 : ((($number % 100 == 3) || ($number % 100 == 4)) ? 2 : 3));
             case 'mk':
-            case 'mk_MK':
                 return ($number % 10 == 1) ? 0 : 1;
             case 'mt':
-            case 'mt_MT':
                 return ($number == 1) ? 0 : ((($number == 0) || (($number % 100 > 1) && ($number % 100 < 11))) ? 1 : ((($number % 100 > 10) && ($number % 100 < 20)) ? 2 : 3));
             case 'lv':
-            case 'lv_LV':
                 return ($number == 0) ? 0 : ((($number % 10 == 1) && ($number % 100 != 11)) ? 1 : 2);
             case 'pl':
-            case 'pl_PL':
                 return ($number == 1) ? 0 : ((($number % 10 >= 2) && ($number % 10 <= 4) && (($number % 100 < 12) || ($number % 100 > 14))) ? 1 : 2);
             case 'cy':
-            case 'cy_GB':
                 return ($number == 1) ? 0 : (($number == 2) ? 1 : ((($number == 8) || ($number == 11)) ? 2 : 3));
             case 'ro':
-            case 'ro_RO':
                 return ($number == 1) ? 0 : ((($number == 0) || (($number % 100 > 0) && ($number % 100 < 20))) ? 1 : 2);
             case 'ar':
-            case 'ar_AE':
-            case 'ar_BH':
-            case 'ar_DZ':
-            case 'ar_EG':
-            case 'ar_IN':
-            case 'ar_IQ':
-            case 'ar_JO':
-            case 'ar_KW':
-            case 'ar_LB':
-            case 'ar_LY':
-            case 'ar_MA':
-            case 'ar_OM':
-            case 'ar_QA':
-            case 'ar_SA':
-            case 'ar_SD':
-            case 'ar_SS':
-            case 'ar_SY':
-            case 'ar_TN':
-            case 'ar_YE':
                 return ($number == 0) ? 0 : (($number == 1) ? 1 : (($number == 2) ? 2 : ((($number % 100 >= 3) && ($number % 100 <= 10)) ? 3 : ((($number % 100 >= 11) && ($number % 100 <= 99)) ? 4 : 5))));
             default:
                 return 0;

--- a/tests/Translation/MessageSelectorTest.php
+++ b/tests/Translation/MessageSelectorTest.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace Illuminate\Tests\Translation;
+
+use PHPUnit\Framework\TestCase;
+use Illuminate\Translation\MessageSelector;
+
+class MessageSelectorTest extends TestCase
+{
+    public function testChooseUsingPipe()
+    {
+        $messageSelector = new MessageSelector();
+        $line = 'There is one apple|There are many apples';
+
+        $traduction = $messageSelector->choose($line, 1, 'en_EN');
+        $this->assertEquals('There is one apple', $traduction);
+
+        $traduction = $messageSelector->choose($line, 5, 'en_EN');
+        $this->assertEquals('There are many apples', $traduction);
+    }
+
+    public function testChooseUsingPipeAndRange()
+    {
+        $messageSelector = new MessageSelector();
+        $line = '{0} There are none|[1,19] There are some|[20,*] There are many';
+
+        $traduction = $messageSelector->choose($line, 0, 'en_EN');
+        $this->assertEquals('There are none', $traduction);
+
+        $traduction = $messageSelector->choose($line, 5, 'en_EN');
+        $this->assertEquals('There are some', $traduction);
+
+        $traduction = $messageSelector->choose($line, 50, 'en_EN');
+        $this->assertEquals('There are many', $traduction);
+    }
+
+    public function getPluralIndexTestData()
+    {
+        /**
+         * Some locales of each cases with number and expected result
+         */
+        return $testData = [
+            'az_AZ' => [
+                'number' => 0,
+                'expected_result' => 0
+            ],
+            'bn_BD' => [
+                'number' => 0,
+                'expected_result' => 1
+            ],
+            'zu_ZA' => [
+                'number' => 1,
+                'expected_result' => 0
+            ],
+            'fi' => [
+                'number' => 2,
+                'expected_result' => 1
+            ],
+            'fil_PH' => [
+                'number' => 1,
+                'expected_result' => 0
+            ],
+            'wa_BE' => [
+                'number' => 2,
+                'expected_result' => 1
+            ],
+            'hr_HR' => [
+                'number' => 21,
+                'expected_result' => 0
+            ],
+            'uk_UA' => [
+                'number' => 10,
+                'expected_result' => 2
+            ],
+            'cs_CZ' => [
+                'number' => 5,
+                'expected_result' => 2
+            ],
+            'ga_IE' => [
+                'number' => 2,
+                'expected_result' => 1
+            ],
+            'lt_LT' => [
+                'number' => 81,
+                'expected_result' => 0
+            ],
+            'sl_SI' => [
+                'number' => 5,
+                'expected_result' => 3
+            ],
+            'mk_MK' => [
+                'number' => 91,
+                'expected_result' => 0
+            ],
+            'mt_MT' => [
+                'number' => 20,
+                'expected_result' => 3
+            ],
+            'lv_LV' => [
+                'number' => 51,
+                'expected_result' => 1
+            ],
+            'pl_PL' => [
+                'number' => 25,
+                'expected_result' => 2
+            ],
+            'cy_GB' => [
+                'number' => 8,
+                'expected_result' => 2
+            ],
+            'ro_RO' => [
+                'number' => 19,
+                'expected_result' => 1
+            ],
+            'ar_AE' => [
+                'number' => 4,
+                'expected_result' => 3
+            ],
+            'not_EXIST' => [
+                'number' => 7,
+                'expected_result' => 0
+            ]
+        ];
+    }
+
+    public function testGetPluralIndex()
+    {
+        $messageSelector = new MessageSelector();
+        foreach ($this->getPluralIndexTestData() as $locale => $testData) {
+            $plural = $messageSelector->getPluralIndex($locale, $testData['number']);
+            $this->assertEquals($testData['expected_result'], $plural);
+        }
+    }
+}

--- a/tests/Translation/MessageSelectorTest.php
+++ b/tests/Translation/MessageSelectorTest.php
@@ -36,90 +36,90 @@ class MessageSelectorTest extends TestCase
 
     public function getPluralIndexTestData()
     {
-        /**
+        /*
          * Some locales of each cases with number and expected result
          */
         return $testData = [
             'az_AZ' => [
                 'number' => 0,
-                'expected_result' => 0
+                'expected_result' => 0,
             ],
             'bn_BD' => [
                 'number' => 0,
-                'expected_result' => 1
+                'expected_result' => 1,
             ],
             'zu_ZA' => [
                 'number' => 1,
-                'expected_result' => 0
+                'expected_result' => 0,
             ],
             'fi' => [
                 'number' => 2,
-                'expected_result' => 1
+                'expected_result' => 1,
             ],
             'fil_PH' => [
                 'number' => 1,
-                'expected_result' => 0
+                'expected_result' => 0,
             ],
             'wa_BE' => [
                 'number' => 2,
-                'expected_result' => 1
+                'expected_result' => 1,
             ],
             'hr_HR' => [
                 'number' => 21,
-                'expected_result' => 0
+                'expected_result' => 0,
             ],
             'uk_UA' => [
                 'number' => 10,
-                'expected_result' => 2
+                'expected_result' => 2,
             ],
             'cs_CZ' => [
                 'number' => 5,
-                'expected_result' => 2
+                'expected_result' => 2,
             ],
             'ga_IE' => [
                 'number' => 2,
-                'expected_result' => 1
+                'expected_result' => 1,
             ],
             'lt_LT' => [
                 'number' => 81,
-                'expected_result' => 0
+                'expected_result' => 0,
             ],
             'sl_SI' => [
                 'number' => 5,
-                'expected_result' => 3
+                'expected_result' => 3,
             ],
             'mk_MK' => [
                 'number' => 91,
-                'expected_result' => 0
+                'expected_result' => 0,
             ],
             'mt_MT' => [
                 'number' => 20,
-                'expected_result' => 3
+                'expected_result' => 3,
             ],
             'lv_LV' => [
                 'number' => 51,
-                'expected_result' => 1
+                'expected_result' => 1,
             ],
             'pl_PL' => [
                 'number' => 25,
-                'expected_result' => 2
+                'expected_result' => 2,
             ],
             'cy_GB' => [
                 'number' => 8,
-                'expected_result' => 2
+                'expected_result' => 2,
             ],
             'ro_RO' => [
                 'number' => 19,
-                'expected_result' => 1
+                'expected_result' => 1,
             ],
             'ar_AE' => [
                 'number' => 4,
-                'expected_result' => 3
+                'expected_result' => 3,
             ],
             'not_EXIST' => [
                 'number' => 7,
-                'expected_result' => 0
-            ]
+                'expected_result' => 0,
+            ],
         ];
     }
 


### PR DESCRIPTION
Hello,

i've created a new MessageSelectorTest class with the objective to refactor the getPluralIndex method of the class MessageSelector in the Translation. The test cover all the methods of MessageSelector.

I've replaced the numerous cases by few strpos checks, to improve readability, testing and maintenance. I've also created a getUniquePluralIndex private function, used for countries that have a unique pattern of pluralization, so i don't have to use strpos for them, it runs faster then.

i've also done performance checks to verify that my changes dont overload the translation process :

| Locale | Execution Time After | Execution Time Before | Difference|
| :-------------: | :-------------: | :-------------: | :-------------: |
| `az_AZ`  | 9.05E-6  | 4.05E-6 | -5.0E-6  |
| `bn_BD`  | 4.05E-6 | 9.05E-6 | +5.0E-6  |
| `zu_ZA` | 5.0E-6 | 1.69E-5  | +1.19E-5  |
| `fi` | 4.05E-6  | 6.91E-6 | +2.86E-6  |
| `fil_PH` | 7.15E-6 | 1.28E-5 | +5.72E-6  |
| `wa_BE` | 5.96E-6 | 1.31E-5  | +7.15E-6  |
| `hr_HR`  | 8.1E-6  | 1.4E-5 | +5.96E-6  |
| `uk_UA`  | 8.1E-6 | 1.4E-5 | +5.96E-6  |
| `zs_CZ` | 8.1E-6 | 1.31E-5  | +5.0E-6  |
| `ga_IE` | 8.1E-6  | 1.40E-5 | +5.96E-6  |
| `ar_AE` | 9.05E-6 | 1.28E-5 | +5.72E-6  |

it seems to improve performance a little bit.
i've also executed all the tests on php 5.6 and it seems to work fine :+1: 

> OK (2716 tests, 6209 assertions)



Tell me what you think of my changes, if they have drawbacks etc...
I'm new to this repo, so perhaps i've made some mistakes.

thanks.




