### PR TITLE
[5.4] Consistent make command class names

### DIFF
--- a/src/Illuminate/Auth/Console/AuthMakeCommand.php
+++ b/src/Illuminate/Auth/Console/AuthMakeCommand.php
@@ -5,7 +5,7 @@ namespace Illuminate\Auth\Console;
 use Illuminate\Console\Command;
 use Illuminate\Console\DetectsApplicationNamespace;
 
-class MakeAuthCommand extends Command
+class AuthMakeCommand extends Command
 {
     use DetectsApplicationNamespace;
 

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -4,7 +4,7 @@ namespace Illuminate\Foundation\Providers;
 
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Queue\Console\TableCommand;
-use Illuminate\Auth\Console\MakeAuthCommand;
+use Illuminate\Auth\Console\AuthMakeCommand;
 use Illuminate\Foundation\Console\UpCommand;
 use Illuminate\Foundation\Console\DownCommand;
 use Illuminate\Auth\Console\ClearResetsCommand;
@@ -190,7 +190,7 @@ class ArtisanServiceProvider extends ServiceProvider
     protected function registerAuthMakeCommand()
     {
         $this->app->singleton('command.auth.make', function ($app) {
-            return new MakeAuthCommand;
+            return new AuthMakeCommand;
         });
     }
 


### PR DESCRIPTION
While I was surfing the code base I notice one make command class name is not consistent with the others.

I think the `MakeAuthCommand` should be `AuthMakeCommand` just to make it consistent.

![screenshot from 2017-07-23 00-32-37](https://user-images.githubusercontent.com/9657132/28494709-45226352-6f3f-11e7-9d9d-bdbc9a375824.png)
