### PR TITLE
Add test for mix() return value

### DIFF
--- a/tests/Foundation/FoundationHelpersTest.php
+++ b/tests/Foundation/FoundationHelpersTest.php
@@ -56,4 +56,25 @@ class FoundationHelpersTest extends TestCase
 
         unlink(public_path($file));
     }
+
+    public function testMixDoesNotIncludeHost()
+    {
+        $file = 'unversioned.css';
+
+        app()->singleton('path.public', function () {
+            return __DIR__;
+        });
+
+        touch(public_path('mix-manifest.json'));
+
+        file_put_contents(public_path('mix-manifest.json'), json_encode([
+            '/unversioned.css' => '/versioned.css',
+        ]));
+
+        $result = mix($file);
+
+        $this->assertEquals('/versioned.css', $result);
+
+        unlink(public_path('mix-manifest.json'));
+    }
 }


### PR DESCRIPTION
Hope I'm not being annoying here, just offering test coverage for the return value of the `mix()` helper now that the `asset()` helper has been removed again (#20197). It would just provide some confidence that it isn't broken again as it's happened twice already.