### PR TITLE
[5.4] Use the same behaviour of select() on get()

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1689,7 +1689,7 @@ class Builder
         $original = $this->columns;
 
         if (is_null($original)) {
-            $this->columns = $columns;
+            $this->columns = is_array($columns) ? $columns : func_get_args();
         }
 
         $results = $this->processor->processSelect($this, $this->runSelect());

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -42,6 +42,21 @@ class DatabaseQueryBuilderTest extends TestCase
 
         $this->assertEquals('select * from "users"', $builder->toSql());
         $this->assertNull($builder->columns);
+
+        $builder->getConnection()->shouldReceive('select')->once()->andReturnUsing(function ($sql) {
+            $this->assertEquals('select "foo" from "users"', $sql);
+        });
+        $builder->from('users')->get('foo');
+
+        $builder->getConnection()->shouldReceive('select')->once()->andReturnUsing(function ($sql) {
+            $this->assertEquals('select "foo", "bar" from "users"', $sql);
+        });
+        $builder->from('users')->get('foo', 'bar');
+
+        $builder->getConnection()->shouldReceive('select')->once()->andReturnUsing(function ($sql) {
+            $this->assertEquals('select "foo", "bar" from "users"', $sql);
+        });
+        $builder->from('users')->get(['foo', 'bar']);
     }
 
     public function testBasicSelectUseWritePdo()


### PR DESCRIPTION
Using `select()` it's possible to pass either a string or array:

https://github.com/laravel/framework/blob/5.4/src/Illuminate/Database/Query/Builder.php#L219

So, now it's gonna be possible use `get()` this way:

```php
$rows = DB::table('foo')->get('id');
```