### PR TITLE
Model mixes in both Eloquent and Query Builders

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -17,6 +17,7 @@ use Illuminate\Database\ConnectionResolverInterface as Resolver;
 
 /**
  * @mixin \Illuminate\Database\Eloquent\Builder
+ * @mixin \Illuminate\Database\Query\Builder
  */
 abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializable, QueueableEntity, UrlRoutable
 {


### PR DESCRIPTION
Needed to add \Illuminate\Database\Query\Builder
Did not realize that the Eloquent Builder was also calling magic methods of the Query Builder class!!
https://github.com/barryvdh/laravel-ide-helper/issues/541#issuecomment-317264080