### PR TITLE
[5.5] Throw BadMethodCallException when attempting to resolve a policy that is not defined on the gate

### DIFF
--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -4,6 +4,7 @@ namespace Illuminate\Auth\Access;
 
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
+use BadMethodCallException;
 use InvalidArgumentException;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Auth\Access\Gate as GateContract;
@@ -367,6 +368,8 @@ class Gate implements GateContract
      * @param  string  $ability
      * @param  array  $arguments
      * @return callable
+     *
+     * @throws \BadMethodCallException
      */
     protected function resolveAuthCallback($user, $ability, array $arguments)
     {
@@ -380,9 +383,7 @@ class Gate implements GateContract
             return $this->abilities[$ability];
         }
 
-        return function () {
-            return false;
-        };
+        throw new BadMethodCallException("Could not resolve policy for ability '$ability' - did you define this on the Gate?");
     }
 
     /**

--- a/tests/Auth/AuthAccessGateTest.php
+++ b/tests/Auth/AuthAccessGateTest.php
@@ -287,6 +287,16 @@ class GateTest extends TestCase
         $gate->authorize('create', new AccessGateTestDummy);
     }
 
+    /**
+     * @expectedException \BadMethodCallException
+     */
+    public function test_undefined_policy_throws_exception()
+    {
+        $gate = $this->getBasicGate();
+
+        $gate->authorize('blah');
+    }
+
     public function test_authorize_returns_allowed_response()
     {
         $gate = $this->getBasicGate(true);


### PR DESCRIPTION
This is in reference to [this internals discussion](https://github.com/laravel/internals/issues/442) which Taylor gave 👍 

At the moment, if you check authorization on an "undefined" ability, it'll just return false:

```php
$result = Gate::check('func_doesnt_exist_on_policy_and_ability_not_defined', $user);
```

This creates the illusion that the check went through and returned false, when in actual fact it couldn't be checked because the function doesn't exist on the policy and the ability is not even defined. By forcing an exception, it'll ensure that policies are properly defined on the Gate.