### PR TITLE
[5.4] Respect the signature of whereRaw, fix #18952

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -718,7 +718,7 @@ class Builder
      * @param  array   $bindings
      * @return \Illuminate\Database\Query\Builder|static
      */
-    public function orWhereRaw($sql, array $bindings = [])
+    public function orWhereRaw($sql, $bindings = [])
     {
         return $this->whereRaw($sql, $bindings, 'or');
     }


### PR DESCRIPTION
Would lead to
```
FatalThrowableError
Type error: Argument 2 passed to Illuminate\Database\Query\Builder::orWhereRaw() must be of the type array, string given
```
otherwise, when used with a single value.

Fix #18952, closed for no (apparent) reason.