### PR TITLE
[5.4] fix issue with chunkById() when orderByRaw() is used

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1562,7 +1562,7 @@ class Builder
     }
 
     /**
-     * Get an array orders with all orders for an given column removed.
+     * Get an array with all orders with a given column removed.
      *
      * @param  string  $column
      * @return array
@@ -1571,7 +1571,8 @@ class Builder
     {
         return Collection::make($this->orders)
                     ->reject(function ($order) use ($column) {
-                        return $order['column'] === $column;
+                        return isset($order['column'])
+                               ? $order['column'] === $column : false;
                     })->values()->all();
     }
 


### PR DESCRIPTION
When `orderByRaw()` is used the `orders` array of the builder will have a member like:

```
[
    "type" => "Raw"
    "sql" => "name desc"
  ]
```

There's no `column` array key, so the code changes in the PR will prevent an undefined index error when this method is used why chunking by ID.