### PR TITLE
[5.5] Add ->post() method to Request

### DIFF
--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -234,7 +234,7 @@ trait InteractsWithInput
     }
 
     /**
-     * Retrieve a post string item from the request.
+     * Retrieve a request payload item from the request.
      *
      * @param  string  $key
      * @param  string|array|null  $default

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -234,6 +234,19 @@ trait InteractsWithInput
     }
 
     /**
+     * Retrieve a post string item from the request.
+     *
+     * @param  string  $key
+     * @param  string|array|null  $default
+     *
+     * @return string|array
+     */
+    public function post($key = null, $default = null)
+    {
+        return $this->retrieveItem('request', $key, $default);
+    }
+
+    /**
      * Determine if a cookie is set on the request.
      *
      * @param  string  $key

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -326,6 +326,15 @@ class HttpRequestTest extends TestCase
         $this->assertEquals('Taylor', $all['name']);
     }
 
+    public function testPostMethod()
+    {
+        $request = Request::create('/', 'POST', ['name' => 'Taylor']);
+        $this->assertEquals('Taylor', $request->post('name'));
+        $this->assertEquals('Bob', $request->post('foo', 'Bob'));
+        $all = $request->post(null);
+        $this->assertEquals('Taylor', $all['name']);
+    }
+
     public function testCookieMethod()
     {
         $request = Request::create('/', 'GET', [], ['name' => 'Taylor']);


### PR DESCRIPTION
The `->post()` method will get all data from the request body (POST body), or when given a `$key`, it'll get that specific value. Using Symfony's public `$request` property on the `Request` object: https://github.com/symfony/http-foundation/blob/master/Request.php#L76-L81