### PR TITLE
[5.5] Don't try to drop Views when executing MySqlBuilder::dropAllTables()

### DIFF
--- a/src/Illuminate/Database/Schema/MySqlBuilder.php
+++ b/src/Illuminate/Database/Schema/MySqlBuilder.php
@@ -45,7 +45,7 @@ class MySqlBuilder extends Builder
     {
         $this->disableForeignKeyConstraints();
 
-        foreach ($this->connection->select('SHOW TABLES') as $table) {
+        foreach ($this->connection->select('SHOW FULL TABLES WHERE table_type = \'BASE TABLE\'') as $table) {
             $this->drop(get_object_vars($table)[key($table)]);
         }
 


### PR DESCRIPTION
The current MySqlBuilder::dropAllTables() function used by migrate:fresh uses "SHOW TABLES" and issues a "DROP TABLE" Query for all returned Values. This causes MySQL errors once a view exists in the database used for Laravel, as Views can only be droped by "DROP VIEW".

Not sure if using Views is a covered Use-Case for Laravel, but figured i might aswell submit a fix for it.


MySQL Documentation at https://dev.mysql.com/doc/refman/5.7/en/show-tables.html on SHOW TABLES: 
"This statement also lists any views in the database. The optional FULL modifier causes SHOW TABLES to display a second output column with values of BASE TABLE for a table and VIEW for a view. "



