### PR TITLE
[5.2] fix doctrine/inflector version to pull 1.1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "ext-mbstring": "*",
         "ext-openssl": "*",
         "classpreloader/classpreloader": "~3.0",
-        "doctrine/inflector": "~1.0",
+        "doctrine/inflector": "~1.1.0",
         "jeremeamia/superclosure": "~2.2",
         "league/flysystem": "~1.0",
         "monolog/monolog": "~1.11",


### PR DESCRIPTION
This is a clone of #20227 for the 5.2 branch.