### PR TITLE
[5.1] fix doctrine/inflector version to pull 1.1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "ext-openssl": "*",
         "classpreloader/classpreloader": "~2.0|~3.0",
         "danielstjules/stringy": "~1.8",
-        "doctrine/inflector": "~1.0",
+        "doctrine/inflector": "~1.1.0",
         "jeremeamia/superclosure": "~2.0",
         "league/flysystem": "~1.0",
         "monolog/monolog": "~1.11",


### PR DESCRIPTION
This is a clone of #20227 for the 5.1 branch.