### PR TITLE
[5.4] When user logout clear "remember me" token for the user.

### DIFF
--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -543,7 +543,6 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
     protected function clearRememberToken(AuthenticatableContract $user)
     {
         if ($user->getRememberToken()) {
-
             $user->setRememberToken('');
 
             $this->provider->updateRememberToken($user, '');

--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -542,7 +542,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
      */
     protected function clearRememberToken(AuthenticatableContract $user)
     {
-        if (!empty($user->getRememberToken())) {
+        if (! empty($user->getRememberToken())) {
             $user->setRememberToken('');
 
             $this->provider->updateRememberToken($user, '');

--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -491,7 +491,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
         $this->clearUserDataFromStorage();
 
         if (! is_null($this->user)) {
-            $this->cycleRememberToken($user);
+            $this->clearRememberToken($user);
         }
 
         if (isset($this->events)) {
@@ -532,6 +532,22 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
         $user->setRememberToken($token = Str::random(60));
 
         $this->provider->updateRememberToken($user, $token);
+    }
+
+    /**
+     * Clear the "remember me" token for the user.
+     *
+     * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
+     * @return void
+     */
+    protected function clearRememberToken(AuthenticatableContract $user)
+    {
+        if($user->getRememberToken()) {
+
+            $user->setRememberToken('');
+
+            $this->provider->updateRememberToken($user, '');
+        }
     }
 
     /**

--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -542,7 +542,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
      */
     protected function clearRememberToken(AuthenticatableContract $user)
     {
-        if (empty($user->getRememberToken())) {
+        if (!empty($user->getRememberToken())) {
             $user->setRememberToken('');
 
             $this->provider->updateRememberToken($user, '');

--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -542,7 +542,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
      */
     protected function clearRememberToken(AuthenticatableContract $user)
     {
-        if($user->getRememberToken()) {
+        if ($user->getRememberToken()) {
 
             $user->setRememberToken('');
 

--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -542,7 +542,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
      */
     protected function clearRememberToken(AuthenticatableContract $user)
     {
-        if ($user->getRememberToken()) {
+        if (empty($user->getRememberToken())) {
             $user->setRememberToken('');
 
             $this->provider->updateRememberToken($user, '');

--- a/tests/Auth/AuthGuardTest.php
+++ b/tests/Auth/AuthGuardTest.php
@@ -227,6 +227,7 @@ class AuthGuardTest extends TestCase
         $mock->setCookieJar($cookies = m::mock('Illuminate\Cookie\CookieJar'));
         $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');
         $user->shouldReceive('setRememberToken')->once();
+        $user->shouldReceive('getRememberToken')->once();
         $mock->expects($this->once())->method('getName')->will($this->returnValue('foo'));
         $mock->expects($this->once())->method('getRecallerName')->will($this->returnValue('bar'));
         $mock->expects($this->once())->method('recaller')->will($this->returnValue('non-null-cookie'));
@@ -248,6 +249,7 @@ class AuthGuardTest extends TestCase
         $mock->setCookieJar($cookies = m::mock('Illuminate\Cookie\CookieJar'));
         $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');
         $user->shouldReceive('setRememberToken')->once();
+        $user->shouldReceive('getRememberToken')->once();
         $mock->expects($this->once())->method('getName')->will($this->returnValue('foo'));
         $mock->expects($this->once())->method('recaller')->will($this->returnValue(null));
         $provider->shouldReceive('updateRememberToken')->once();
@@ -266,6 +268,7 @@ class AuthGuardTest extends TestCase
         $mock->setDispatcher($events = m::mock('Illuminate\Contracts\Events\Dispatcher'));
         $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');
         $user->shouldReceive('setRememberToken')->once();
+        $user->shouldReceive('getRememberToken')->once();
         $provider->shouldReceive('updateRememberToken')->once();
         $events->shouldReceive('dispatch')->once()->with(m::type(Authenticated::class));
         $mock->setUser($user);

--- a/tests/Auth/AuthGuardTest.php
+++ b/tests/Auth/AuthGuardTest.php
@@ -226,12 +226,12 @@ class AuthGuardTest extends TestCase
         $mock = $this->getMockBuilder('Illuminate\Auth\SessionGuard')->setMethods(['getName', 'getRecallerName', 'recaller'])->setConstructorArgs(['default', $provider, $session, $request])->getMock();
         $mock->setCookieJar($cookies = m::mock('Illuminate\Cookie\CookieJar'));
         $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');
-        $user->shouldReceive('setRememberToken')->once();
+        $user->shouldReceive('setRememberToken');
         $user->shouldReceive('getRememberToken')->once();
         $mock->expects($this->once())->method('getName')->will($this->returnValue('foo'));
         $mock->expects($this->once())->method('getRecallerName')->will($this->returnValue('bar'));
         $mock->expects($this->once())->method('recaller')->will($this->returnValue('non-null-cookie'));
-        $provider->shouldReceive('updateRememberToken')->once();
+        $provider->shouldReceive('updateRememberToken');
 
         $cookie = m::mock('Symfony\Component\HttpFoundation\Cookie');
         $cookies->shouldReceive('forget')->once()->with('bar')->andReturn($cookie);
@@ -248,11 +248,11 @@ class AuthGuardTest extends TestCase
         $mock = $this->getMockBuilder('Illuminate\Auth\SessionGuard')->setMethods(['getName', 'recaller'])->setConstructorArgs(['default', $provider, $session, $request])->getMock();
         $mock->setCookieJar($cookies = m::mock('Illuminate\Cookie\CookieJar'));
         $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');
-        $user->shouldReceive('setRememberToken')->once();
+        $user->shouldReceive('setRememberToken');
         $user->shouldReceive('getRememberToken')->once();
         $mock->expects($this->once())->method('getName')->will($this->returnValue('foo'));
         $mock->expects($this->once())->method('recaller')->will($this->returnValue(null));
-        $provider->shouldReceive('updateRememberToken')->once();
+        $provider->shouldReceive('updateRememberToken');
 
         $mock->getSession()->shouldReceive('remove')->once()->with('foo');
         $mock->setUser($user);
@@ -267,9 +267,9 @@ class AuthGuardTest extends TestCase
         $mock->expects($this->once())->method('clearUserDataFromStorage');
         $mock->setDispatcher($events = m::mock('Illuminate\Contracts\Events\Dispatcher'));
         $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');
-        $user->shouldReceive('setRememberToken')->once();
+        $user->shouldReceive('setRememberToken');
         $user->shouldReceive('getRememberToken')->once();
-        $provider->shouldReceive('updateRememberToken')->once();
+        $provider->shouldReceive('updateRememberToken');
         $events->shouldReceive('dispatch')->once()->with(m::type(Authenticated::class));
         $mock->setUser($user);
         $events->shouldReceive('dispatch')->once()->with(m::type('Illuminate\Auth\Events\Logout'));


### PR DESCRIPTION
I think need not to regenerate "remember me" token when user logout.
So I added "clearRememberToken" method to "SessionGuard"
Thanks