### PR TITLE
[5.4] add getMorphedModel to Relation class

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -328,9 +328,9 @@ abstract class Relation
     }
 
     /**
-     * Return the model associated to a custom polymorphic type.
+     * Get the model associated with a custom polymorphic type.
      *
-     * @param string $alias
+     * @param  string  $alias
      * @return string|null
      */
     public static function getMorphedModel($alias)

--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -328,6 +328,19 @@ abstract class Relation
     }
 
     /**
+     * Return the model associated to a custom polymorphic type.
+     *
+     * @param string $alias
+     * @return string|null
+     */
+    public static function getMorphedModel($alias)
+    {
+        return array_key_exists($alias, self::$morphMap)
+            ? self::$morphMap[$alias]
+            : null;
+    }
+
+    /**
      * Handle dynamic method calls to the relationship.
      *
      * @param  string  $method


### PR DESCRIPTION
I couldn't found a way to do it with the current classes or methods. What this method does is to retrieve the model class that will be used before a related model is created. It's useful for example like this:

```
// app/Providers/AppServiceProvider.php

Relation::morphMap([
    'posts' => 'App\Post',
    'videos' => 'App\Video',
]);

// any place on your application

$morphedClass = Relation::getMorphedModel($comment->commentable_type); // posts to App\Post

$morphedModel = $morphedClass::createFromComment($comment); // did this way because Post and Video have different initial/default values
```