### PR TITLE
[5.5] add JsonSerializable to HtmlString object

### DIFF
--- a/src/Illuminate/Support/HtmlString.php
+++ b/src/Illuminate/Support/HtmlString.php
@@ -2,9 +2,10 @@
 
 namespace Illuminate\Support;
 
+use JsonSerializable;
 use Illuminate\Contracts\Support\Htmlable;
 
-class HtmlString implements Htmlable
+class HtmlString implements Htmlable, JsonSerializable
 {
     /**
      * The HTML string.
@@ -32,6 +33,16 @@ class HtmlString implements Htmlable
     public function toHtml()
     {
         return $this->html;
+    }
+
+    /**
+     * Convert the object into something JSON serializable.
+     *
+     * @return string
+     */
+    public function jsonSerialize()
+    {
+        return $this->toHtml();
     }
 
     /**


### PR DESCRIPTION
This will allow a bit cleaner way of json serialization. Similar like we currently have for collection, response, model, etc..

```php

use Illuminate\Support\HtmlString;

$content = new HtmlString('<p>Hello world</p>');
return json_encode(compact('content'));

```