### PR TITLE
[5.5] Add PHP 7.2 to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ env:
     - setup=basic
 
 matrix:
+  allow_failures:
+    - php: 7.2
   fast_finish: true
   include:
     - php: 7.0.21
@@ -19,7 +21,7 @@ matrix:
     - php: 7.1
       env: setup=lowest
     - php: 7.1
-      env: setup=stable    
+      env: setup=stable
 
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: php
 php:
   - 7.0.21
   - 7.1
+  - 7.2
 
 env:
   global:
@@ -18,7 +19,7 @@ matrix:
     - php: 7.1
       env: setup=lowest
     - php: 7.1
-      env: setup=stable
+      env: setup=stable    
 
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ services:
   - redis-server
 
 before_install:
-  - phpenv config-rm xdebug.ini
+  - if [[ $TRAVIS_PHP_VERSION != 7.2 ]] ; then phpenv config-rm xdebug.ini; fi
   - echo "extension = memcached.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
   - printf "\n" | pecl install -f redis
   - travis_retry composer self-update


### PR DESCRIPTION
This PR adds PHP 7.2 as an allowed failure to travis, we need to fix some things for 5.5 to work with 7.2.

Ps: current test is failing due to #20252