### PR TITLE
Revert "[5.4] fix doctrine/inflector version to pull 1.1.0 (#20227)"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "php": ">=5.6.4",
         "ext-mbstring": "*",
         "ext-openssl": "*",
-        "doctrine/inflector": "~1.1.0",
+        "doctrine/inflector": "~1.0",
         "erusev/parsedown": "~1.6",
         "league/flysystem": "~1.0",
         "monolog/monolog": "~1.11",

--- a/src/Illuminate/Support/composer.json
+++ b/src/Illuminate/Support/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": ">=5.6.4",
         "ext-mbstring": "*",
-        "doctrine/inflector": "~1.1.0",
+        "doctrine/inflector": "~1.0",
         "illuminate/contracts": "5.4.*",
         "paragonie/random_compat": "~1.4|~2.0"
     },


### PR DESCRIPTION
Tries to solve https://github.com/laravel/framework/issues/20214 with another approach.

As was tested [here](https://github.com/laravel/framework/pull/20241#issuecomment-317564201) composer correctly handle doctrine/inflector version with the `~1.0` constraint.

Consider PR https://github.com/laravel/installer/pull/68 before merging/closing this.