### PR TITLE
[5.4] Optimize and improve scalability of Arr::last

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -191,7 +191,13 @@ class Arr
     public static function last($array, callable $callback = null, $default = null)
     {
         if (is_null($callback)) {
-            return empty($array) ? value($default) : end($array);
+            if (empty($array)) {
+                return value($default);
+            }
+
+            foreach (array_slice($array, -1) as $item) {
+                return $item;
+            }
         }
 
         return static::first(array_reverse($array, true), $callback, $default);


### PR DESCRIPTION
Similar to #15213. For small arrays it's already faster, and for large arrays it becomes more and more efficient. Still, not O(1)…

```php
function last_v1($array) {
    return end($array);
}

function last_v2($array) {
    foreach (array_slice($array, -1) as $item) {
        return $item;
    }
}

$array = range(1, 5000);
$nb = 1000;

$t1 = microtime(true);
for ($i = $nb; $i--; ) {
    last_v1($array);
}
$t2 = microtime(true);
for ($i = $nb; $i--; ) {
    last_v2($array);
}
$t3 = microtime(true);

echo $t2 - $t1;
echo "\n";
echo $t3 - $t2;
```

Before: 459 ms
After : 55 ms

Refs: https://stackoverflow.com/questions/3687358/whats-the-best-way-to-get-the-last-element-of-an-array-without-deleting-it/41795859#41795859

ping @BePsvPT