### PR TITLE
[5.5] Add breaking changes related to precision to changelog

### DIFF
--- a/CHANGELOG-5.5.md
+++ b/CHANGELOG-5.5.md
@@ -80,7 +80,8 @@
 
 ### Database
 - ⚠️ Added `dropAllTables()` to schema builder ([#18484](https://github.com/laravel/framework/pull/18484), [d910bc8](https://github.com/laravel/framework/commit/d910bc8039f3cec2d906797818984e825601a3f5), [#19644](https://github.com/laravel/framework/pull/19644), [#19645](https://github.com/laravel/framework/pull/19645))
-- Added precision to `dateTime` and `timestamp` column types ([#18847](https://github.com/laravel/framework/pull/18847), [f85f6db](https://github.com/laravel/framework/commit/f85f6db7c00a43ae45d963d089458477cf3e44b3), [#18962](https://github.com/laravel/framework/pull/18962))
+- Added precision to `dateTime` and `timestamp` column types ([#18847](https://github.com/laravel/framework/pull/18847), [f85f6db](https://github.com/laravel/framework/commit/f85f6db7c00a43ae45d963d089458477cf3e44b3))
+- ⚠️ SQL Server changed to use datetime2 column type ([#18962](https://github.com/laravel/framework/pull/18962)) 
 - Pass page number to `chunk()` callback ([#19316](https://github.com/laravel/framework/pull/19316))
 - Improve memory usage in `chunk()` and `chunkById()` ([#19345](https://github.com/laravel/framework/pull/19345), [#19369](https://github.com/laravel/framework/pull/19369), [#19368](https://github.com/laravel/framework/pull/19368))
 - Fixed `compileColumnListing()` when using PostgreSQL with multiple schemas ([#19553](https://github.com/laravel/framework/pull/19553))

--- a/CHANGELOG-5.5.md
+++ b/CHANGELOG-5.5.md
@@ -79,6 +79,8 @@
 - ⚠️ Removed `Controller::missingMethod()` ([bf5d221](https://github.com/laravel/framework/commit/bf5d221037d9857a74020f2623839e282035a420))
 
 ### Database
+- ⚠️ Dropped support for MySQL 5.5 ([#18847](https://github.com/laravel/framework/pull/18847))
+- ⚠️ Dropped support for SQL Server 2005 and older ([#18962](https://github.com/laravel/framework/pull/18962))
 - ⚠️ Added `dropAllTables()` to schema builder ([#18484](https://github.com/laravel/framework/pull/18484), [d910bc8](https://github.com/laravel/framework/commit/d910bc8039f3cec2d906797818984e825601a3f5), [#19644](https://github.com/laravel/framework/pull/19644), [#19645](https://github.com/laravel/framework/pull/19645))
 - Added precision to `dateTime` and `timestamp` column types ([#18847](https://github.com/laravel/framework/pull/18847), [f85f6db](https://github.com/laravel/framework/commit/f85f6db7c00a43ae45d963d089458477cf3e44b3))
 - ⚠️ SQL Server changed to use datetime2 column type ([#18962](https://github.com/laravel/framework/pull/18962)) 


### PR DESCRIPTION
Related: https://github.com/laravel/framework/pull/18962

I'll argue that this is a breaking change and should be noted as such. This is regards to migrations, which I believe is very important to be stable over long timespans.

I have several years worth of migrations, and this change will change the behavior/result of every existing already migration. Executing the migrations in 5.5 will result in a different schema than when I executed in a 5.4 installation. Thus I think this should be documented as a breaking change that needs to be highlighted for SQL Server users.

I will need to rewrite my migrations to use explicit sql commands to keep the old behavior. This is also an indication that it is a breaking change.

TL:DR; I consider this a breaking change.