### PR TITLE
[5.5] Parse ISO 8601 in dates attributes

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -738,7 +738,7 @@ trait HasAttributes
      * Determine if the given value is is according to the ISO 8601 spec.
      *  YYYY-MM-DDThh:mm:ss
      *  YYYY-MM-DDThh:mm:ssTZD
-     *  YYYY-MM-DDThh:mm:ss.sTZD
+     *  YYYY-MM-DDThh:mm:ss.sTZD.
      *
      * @param  string  $value
      * @return bool

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -708,6 +708,13 @@ trait HasAttributes
             return Carbon::createFromFormat('Y-m-d', $value)->startOfDay();
         }
 
+        // If the value is according to the ISO 8601 spec.we will instantiate the
+        // Carbon instances from that format. This is useful for dates that come
+        // from the default Js format.
+        if ($this->isIso8601DateFormat($value)) {
+            return Carbon::createFromFormat('Y-m-d\TH:i:s+', $value);
+        }
+
         // Finally, we will just assume this date is in the format used by default on
         // the database connection and use that format to create the Carbon object
         // that is returned back out to the developers after we convert it here.
@@ -725,6 +732,20 @@ trait HasAttributes
     protected function isStandardDateFormat($value)
     {
         return preg_match('/^(\d{4})-(\d{1,2})-(\d{1,2})$/', $value);
+    }
+
+    /**
+     * Determine if the given value is is according to the ISO 8601 spec.
+     *  YYYY-MM-DDThh:mm:ss
+     *  YYYY-MM-DDThh:mm:ssTZD
+     *  YYYY-MM-DDThh:mm:ss.sTZD
+     *
+     * @param  string  $value
+     * @return bool
+     */
+    protected function isIso8601DateFormat($value)
+    {
+        return preg_match('/^\d{4}-\d\d-\d\dT\d\d:\d\d:\d\d(\.\d+)?(([+-]\d\d:\d\d)|Z)?$/', $value);
     }
 
     /**


### PR DESCRIPTION
Allows to parse iso 8601 dates in eloquent dates attributes

Real world example:

When working with js dates (for example in a custom date component in vue), maybe you want to save the v-model value as a javascript date object, instead the "user friendly value" of the input for example.

Some developers use the iso string generated by js date object (date.toISOString()) and actually i use a vuejs timepicker component that use this format as default value., the problem is that currently is not compatible with the date parser function in eloquent models (returns: InvalidArgumentException with message 'Unexpected data found. Trailing data')

One solution is to format the date before send it, but i think should be a standard "parseable" format considering that is the common javascript date format.

