### PR TITLE
[POC] [5.6] Allow chaining multiple queue jobs

### DIFF
--- a/src/Illuminate/Bus/ChainLink.php
+++ b/src/Illuminate/Bus/ChainLink.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Illuminate\Bus;
+
+class ChainLink
+{
+    /**
+     * The IDs of the current jobs in the chain.
+     *
+     * @var string[]
+     */
+    public $current = [];
+
+    /**
+     * The IDs of the next jobs in the chain.
+     *
+     * @var string[]
+     */
+    public $next = [];
+
+    /**
+     * The ID of this particular link in the chain.
+     *
+     * @var string
+     */
+    public $jobId;
+
+    /**
+     * The ID of this chain.
+     *
+     * @var string
+     */
+    public $chainId;
+
+    /**
+     * Create a new link in the chain.
+     *
+     * @param string  $jobId
+     * @param string  $chainId
+     */
+    public function __construct($jobId, $chainId)
+    {
+        $this->chainId = $chainId;
+        $this->jobId = $jobId;
+    }
+
+    /**
+     * Set the current jobs' IDs.
+     *
+     * @param  string[]  $current
+     * @return $this
+     */
+    public function current(array $current)
+    {
+        $this->current = $current;
+
+        return $this;
+    }
+
+    /**
+     * Set the next jobs' IDs.
+     *
+     * @param  string[]  $current
+     * @return $this
+     */
+    public function next(array $next)
+    {
+        $this->next = $next;
+
+        return $this;
+    }
+}

--- a/src/Illuminate/Bus/Queueable.php
+++ b/src/Illuminate/Bus/Queueable.php
@@ -26,11 +26,11 @@ trait Queueable
     public $delay;
 
     /**
-     * The jobs that should run if this job is successful.
+     * This job's link in the chain of jobs.
      *
-     * @var array
+     * @var \Illuminate\Bus\ChainLink
      */
-    public $chained = [];
+    public $chain;
 
     /**
      * Set the desired connection for the job.
@@ -69,34 +69,5 @@ trait Queueable
         $this->delay = $delay;
 
         return $this;
-    }
-
-    /**
-     * Set the jobs that should run if this job is successful.
-     *
-     * @param  array  $chain
-     * @return $this
-     */
-    public function chain($chain)
-    {
-        $this->chained = collect($chain)->map(function ($job) {
-            return serialize($job);
-        })->all();
-
-        return $this;
-    }
-
-    /**
-     * Dispatch the next job on the chain.
-     *
-     * @return void
-     */
-    public function dispatchNextJobInChain()
-    {
-        if (! empty($this->chained)) {
-            dispatch(tap(unserialize(array_shift($this->chained)), function ($next) {
-                $next->chained = $this->chained;
-            }));
-        }
     }
 }

--- a/src/Illuminate/Foundation/Bus/ChainConductor.php
+++ b/src/Illuminate/Foundation/Bus/ChainConductor.php
@@ -1,0 +1,212 @@
+<?php
+
+namespace Illuminate\Foundation\Bus;
+
+use Ramsey\Uuid\Uuid;
+use Illuminate\Bus\ChainLink;
+use Illuminate\Support\Collection;
+use Illuminate\Database\DatabaseManager;
+
+class ChainConductor
+{
+    /**
+     * The database manager instance.
+     *
+     * @var \Illuminate\Database\DatabaseManager
+     */
+    protected $db;
+
+    /**
+     * Create a chain conductor instance.
+     *
+     * @param \Illuminate\Database\DatabaseManager  $db
+     */
+    public function __construct(DatabaseManager $db)
+    {
+        $this->db = $db;
+    }
+
+    /**
+     * Create a new chain with the given chain of jobs.
+     *
+     * The chain should have a nested collection for each group of parallel jobs.
+     *
+     * @param  \Illuminate\Support\Collection  $chain
+     * @return void
+     */
+    public function createChain(Collection $chain)
+    {
+        $chain = $chain->map->keyBy(function () {
+            return Uuid::uuid4()->toString();
+        });
+
+        $this->populateChainLinks($chain);
+
+        $this->saveChain($chain);
+    }
+
+    /**
+     * Handle a job that has successfully completed execution.
+     *
+     * @param  object  $job
+     * @return void
+     */
+    public function jobCompleted($job)
+    {
+        if (empty($job->chain)) {
+            return;
+        }
+
+        $this->query()->delete($job->chain->jobId);
+
+        if ($this->shouldDispatchNextJobs($job)) {
+            $this->dispatchNextJobs($job);
+        }
+    }
+
+    /**
+     * Handle a job that has failed to successfully execute.
+     *
+     * @param  object  $job
+     * @return void
+     */
+    public function jobFailed($job)
+    {
+        if (! empty($job->chain)) {
+            $this->query()->where('chain_id', $job->chain->chainId)->delete();
+        }
+    }
+
+    /**
+     * Populate the "chain" property on the jobs in the chain.
+     *
+     * @param  \Illuminate\Support\Collection  $chain
+     * @return void
+     */
+    protected function populateChainLinks(Collection $chain)
+    {
+        $chainId = Uuid::uuid4()->toString();
+
+        // This creates the actual chain. Each job's "chain" property
+        // is set to an instance of ChainLink, with information on
+        // the current jobs and the immediately following jobs.
+        $chain->sliding(2)->eachSpread(function ($current, $next) use ($chainId) {
+            foreach ($current as $id => $job) {
+                $job->chain = $this->createChainLink(
+                    $id, $chainId, $current, $next
+                );
+            }
+        });
+
+        // The last link in the chain doesn't need all the information
+        // that the other links need - but it still has to know its
+        // id, as well as the chain id, to delete all when done.
+        $chain->last()->each(function ($job, $id) use ($chainId) {
+            $job->chain = new ChainLink($id, $chainId);
+        });
+    }
+
+    /**
+     * Create an instance of a chain link.
+     *
+     * @param  int  $id
+     * @param  string  $chainId
+     * @param  \Illuminate\Support\Collection  $current
+     * @param  \Illuminate\Support\Collection  $next
+     * @return \Illuminate\Bus\ChainLink
+     */
+    protected function createChainLink($id, $chainId, $current, $next)
+    {
+        return (new ChainLink($id, $chainId))
+                ->current($current->keys()->all())
+                ->next($next->keys()->all());
+    }
+
+    /**
+     * Save the given chain of jobs to the DB.
+     *
+     * @param  \Illuminate\Support\Collection  $chain
+     * @return void
+     */
+    protected function saveChain(Collection $chain)
+    {
+        $this->query()->insert($chain->collapse()->map(function ($job) {
+            return [
+                'id'       => $job->chain->jobId,
+                'chain_id' => $job->chain->chainId,
+                'job'      => serialize($job),
+            ];
+        })->all());
+    }
+
+    /**
+     * Determines whether there are any other concurrent jobs that are not done.
+     *
+     * @param  object  $job
+     * @return bool
+     */
+    protected function hasRemainingConcurrentJobs($job)
+    {
+        return $this->query()->whereIn('id', $job->chain->current)->exists();
+    }
+
+    /**
+     * Determines whether we are ready to dispatch the next link in the chain.
+     *
+     * @param  object  $job
+     * @return bool
+     */
+    protected function shouldDispatchNextJobs($job)
+    {
+        return ! empty($job->chain->next) && ! $this->hasRemainingConcurrentJobs($job);
+    }
+
+    /**
+     * Dispatch the jobs in the chain after the given job.
+     *
+     * @param  object  $job
+     * @return void
+     */
+    protected function dispatchNextJobs($job)
+    {
+        $this->getNextJobs($job)->each(function ($job) {
+            dispatch(unserialize($job));
+        });
+    }
+
+    /**
+     * Get the jobs that are next in the chain.
+     *
+     * @param  object  $job
+     * @return \Illuminate\Support\Collection
+     */
+    protected function getNextJobs($job)
+    {
+        $query = $this->query()->whereIn('id', $job->chain->next);
+
+        return $query->where('reserve_key', $this->reserve($query))->pluck('job');
+    }
+
+    /**
+     * Reserve the jobs in the given query.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @return string
+     */
+    protected function reserve($query)
+    {
+        return tap(Uuid::uuid4()->toString(), function ($key) use ($query) {
+            (clone $query)->whereNull('reserve_key')->update(['reserve_key' => $key]);
+        });
+    }
+
+    /**
+     * Get a query instance for the chained jobs table.
+     *
+     * @return \Illuminate\Database\Query\Builder
+     */
+    protected function query()
+    {
+        return $this->db->table('chained_jobs');
+    }
+}

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -10,6 +10,7 @@ use Illuminate\Foundation\Console\DownCommand;
 use Illuminate\Auth\Console\ClearResetsCommand;
 use Illuminate\Cache\Console\CacheTableCommand;
 use Illuminate\Foundation\Console\ServeCommand;
+use Illuminate\Queue\Console\ChainTableCommand;
 use Illuminate\Foundation\Console\PresetCommand;
 use Illuminate\Queue\Console\FailedTableCommand;
 use Illuminate\Foundation\Console\AppNameCommand;
@@ -143,6 +144,7 @@ class ArtisanServiceProvider extends ServiceProvider
         'PolicyMake' => 'command.policy.make',
         'ProviderMake' => 'command.provider.make',
         'QueueFailedTable' => 'command.queue.failed-table',
+        'QueueChainTable' => 'command.queue.chain-table',
         'QueueTable' => 'command.queue.table',
         'RequestMake' => 'command.request.make',
         'RuleMake' => 'command.rule.make',
@@ -604,6 +606,18 @@ class ArtisanServiceProvider extends ServiceProvider
     {
         $this->app->singleton('command.provider.make', function ($app) {
             return new ProviderMakeCommand($app['files']);
+        });
+    }
+
+    /**
+     * Register the command.
+     *
+     * @return void
+     */
+    protected function registerQueueChainTableCommand()
+    {
+        $this->app->singleton('command.queue.chain-table', function ($app) {
+            return new ChainTableCommand($app['files'], $app['composer']);
         });
     }
 

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -4,6 +4,7 @@ use Illuminate\Support\HtmlString;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Bus\Dispatcher;
 use Illuminate\Contracts\Auth\Access\Gate;
+use Illuminate\Foundation\Bus\ChainConductor;
 use Illuminate\Contracts\Routing\UrlGenerator;
 use Illuminate\Foundation\Bus\PendingDispatch;
 use Illuminate\Contracts\Routing\ResponseFactory;
@@ -369,14 +370,14 @@ if (! function_exists('decrypt')) {
 
 if (! function_exists('dispatch')) {
     /**
-     * Dispatch a job to its appropriate handler.
+     * Dispatch a jobs to their appropriate handler.
      *
-     * @param  mixed  $job
+     * @param  array|object  $jobs
      * @return \Illuminate\Foundation\Bus\PendingDispatch
      */
-    function dispatch($job)
+    function dispatch($jobs)
     {
-        return new PendingDispatch($job);
+        return new PendingDispatch($jobs, app(ChainConductor::class));
     }
 }
 

--- a/src/Illuminate/Queue/CallQueuedHandler.php
+++ b/src/Illuminate/Queue/CallQueuedHandler.php
@@ -50,7 +50,11 @@ class CallQueuedHandler
         );
 
         if (! $job->hasFailed() && ! $job->isReleased()) {
-            $this->ensureNextJobInChainIsDispatched($command);
+            // This does not belong here, obviously. We should
+            // instead add it to some service provider, and
+            // do this from within a JobProccessed event.
+            app(\Illuminate\Foundation\Bus\ChainConductor::class)
+                ->jobCompleted($command);
         }
 
         if (! $job->isDeletedOrReleased()) {
@@ -93,19 +97,6 @@ class CallQueuedHandler
     }
 
     /**
-     * Ensure the next job in the chain is dispatched if applicable.
-     *
-     * @param  mixed  $command
-     * @return void
-     */
-    protected function ensureNextJobInChainIsDispatched($command)
-    {
-        if (method_exists($command, 'dispatchNextJobInChain')) {
-            $command->dispatchNextJobInChain();
-        }
-    }
-
-    /**
      * Handle a model not found exception.
      *
      * @param  \Illuminate\Contracts\Queue\Job  $job
@@ -144,6 +135,12 @@ class CallQueuedHandler
     public function failed(array $data, $e)
     {
         $command = unserialize($data['command']);
+
+        // This does not belong here, obviously. We should
+        // instead add it to some service provider, and
+        // do this from within a JobFailed event.
+        app(\Illuminate\Foundation\Bus\ChainConductor::class)
+            ->jobFailed($command);
 
         if (method_exists($command, 'failed')) {
             $command->failed($e);

--- a/src/Illuminate/Queue/Console/ChainTableCommand.php
+++ b/src/Illuminate/Queue/Console/ChainTableCommand.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Illuminate\Queue\Console;
+
+use Illuminate\Support\Str;
+use Illuminate\Console\Command;
+use Illuminate\Support\Composer;
+use Illuminate\Filesystem\Filesystem;
+
+class ChainTableCommand extends Command
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'queue:chain-table';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create a migration for the chained jobs database table';
+
+    /**
+     * The filesystem instance.
+     *
+     * @var \Illuminate\Filesystem\Filesystem
+     */
+    protected $files;
+
+    /**
+     * @var \Illuminate\Support\Composer
+     */
+    protected $composer;
+
+    /**
+     * Create a new failed queue jobs table command instance.
+     *
+     * @param  \Illuminate\Filesystem\Filesystem  $files
+     * @param  \Illuminate\Support\Composer    $composer
+     * @return void
+     */
+    public function __construct(Filesystem $files, Composer $composer)
+    {
+        parent::__construct();
+
+        $this->files = $files;
+        $this->composer = $composer;
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function fire()
+    {
+        $table = 'chained_jobs';
+
+        $this->replaceMigration(
+            $this->createBaseMigration($table), $table, Str::studly($table)
+        );
+
+        $this->info('Migration created successfully!');
+
+        $this->composer->dumpAutoloads();
+    }
+
+    /**
+     * Create a base migration file for the table.
+     *
+     * @param  string  $table
+     * @return string
+     */
+    protected function createBaseMigration($table)
+    {
+        return $this->laravel['migration.creator']->create(
+            'create_'.$table.'_table', $this->laravel->databasePath().'/migrations'
+        );
+    }
+
+    /**
+     * Replace the generated migration with the failed job table stub.
+     *
+     * @param  string  $path
+     * @param  string  $table
+     * @param  string  $tableClassName
+     * @return void
+     */
+    protected function replaceMigration($path, $table, $tableClassName)
+    {
+        $stub = str_replace(
+            ['{{table}}', '{{tableClassName}}'],
+            [$table, $tableClassName],
+            $this->files->get(__DIR__.'/stubs/chained_jobs.stub')
+        );
+
+        $this->files->put($path, $stub);
+    }
+}

--- a/src/Illuminate/Queue/Console/stubs/chained_jobs.stub
+++ b/src/Illuminate/Queue/Console/stubs/chained_jobs.stub
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class Create{{tableClassName}}Table extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('{{table}}', function (Blueprint $table) {
+            $table->string('id', 36)->index();
+            $table->string('chain_id', 36)->index();
+            $table->string('reserve_key', 36)->nullable()->index();
+            $table->text('job');
+            $table->timestamp('created_at')->useCurrent();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('{{table}}');
+    }
+}

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1240,6 +1240,21 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
+     * Create overlapping chunks of the given size, by passing a "sliding window" over them.
+     *
+     * @param  int  $size
+     * @return static
+     */
+    public function sliding($size)
+    {
+        $chunks = $this->count() - $size + 1;
+
+        return static::times($chunks, function ($number) use ($size) {
+            return $this->slice($number - 1, $size);
+        });
+    }
+
+    /**
      * Shuffle the items in the collection.
      *
      * @param  int  $seed


### PR DESCRIPTION
The code here is a (fully functional) proof of concept, so it's not fully fleshed out and has no tests.

---

To test, run `php artisan queue:chain-table` to publish the queue chain table migration. Then run `php artisan migrate` to actually create the table. Now you're ready to start chaining like a boss :sunglasses: 

---

Allows you to chain a job after multiple jobs run in parallel. For example:

```php
dispatch([new SomeJob(1), new SomeJob(2), new SomeJob(3)])->chain(
    new RunsAfterOthersHaveCompleted(),
);
```

All 3 `SomeJob`s will run in parallel. When they're done, the final one will run.

---

You can construct these chains as complex as you need them to be. At each step, you can have as many parallel jobs as needed. Here's another example:

```php
dispatch([new SomeJob(1), new SomeJob(2)])->chain(
    [new SomeOtherJob(1), new SomeOtherJob(2)],
    [new YetAnotherJob(1), new YetAnotherJob(2)]
);
```

The `SomeJob`s will run in parallel. When done, the `SomeOtherJob`s will run in parallel. Finally, all `YetAnotherJob`s will run in parallel.

If you're familiar with JS promises, the above is similar to this:

```js
Promise.all([someJob(1), someJob(2)])
       .then(() => Promise.all([someOtherJob(1), someOtherJob(2)]))
       .then(() => Promise.all([yetAnotherJob(1), yetAnotherJob(2)]));
```

---

This PR is a resubmission of #19515, with the race condition fixed.