### PR TITLE
[5.4] Allow Authorization Header more than one value

### DIFF
--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -52,9 +52,14 @@ trait InteractsWithInput
     public function bearerToken()
     {
         $header = $this->header('Authorization', '');
-
-        if (Str::startsWith($header, 'Bearer ')) {
-            return Str::substr($header, 7);
+        $authorizationHeaders = explode(',', $header);
+        if (count($authorizationHeaders) > 0) {
+            foreach ($authorizationHeaders as $header) {
+                $header = trim($header);
+                if (Str::startsWith($header, 'Bearer ')) {
+                    return Str::substr($header, 7);
+                }
+            }
         }
     }
 

--- a/tests/Auth/AuthTokenGuardTest.php
+++ b/tests/Auth/AuthTokenGuardTest.php
@@ -59,6 +59,19 @@ class AuthTokenGuardTest extends TestCase
         $this->assertEquals(1, $user->id);
     }
 
+    public function testUserCanBeRetrievedByBearerTokenWithMutiAuthorizationHeader()
+    {
+        $provider = Mockery::mock(UserProvider::class);
+        $provider->shouldReceive('retrieveByCredentials')->once()->with(['api_token' => 'foo'])->andReturn((object) ['id' => 1]);
+        $request = Request::create('/', 'GET', [], [], [], ['HTTP_AUTHORIZATION' => 'Basic dXNlcm5hbWU6cGFzc3dvcmQK, Bearer foo']);
+
+        $guard = new TokenGuard($provider, $request);
+
+        $user = $guard->user();
+
+        $this->assertEquals(1, $user->id);
+    }
+
     public function testValidateCanDetermineIfCredentialsAreValid()
     {
         $provider = Mockery::mock(UserProvider::class);


### PR DESCRIPTION
### Background
Adding the token on header with current setup.
```
curl -H "Authorization: Bearer {token}" https://domain.tld/api/action/parms
```

### Motivation
When there is the basic auth on server, the above case doesn't work anymore. As basic auth will have the same header name `Authorization`.

```
❌  curl -u user:pass -H "Authorization: Bearer {token}" https://domain.tld/api/action/parms
❌  curl -H "Authorization: Bearer {token}" https://user:pass@domain.tld/api/action/parms
```

To work around this, i need to put 2 values in header 
```
✅  curl -H "Authorization: Basic {basiauthkey}, Bearer {token}" https://domain.tld/api/action/parms
```

So that It can pass both basic auth and api authorization.