### PR TITLE
Fixed wrong input parameters intersection

### DIFF
--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -181,7 +181,12 @@ trait InteractsWithInput
      */
     public function intersect($keys)
     {
-        return array_filter($this->only(is_array($keys) ? $keys : func_get_args()));
+        return array_filter(
+            $this->only(is_array($keys) ? $keys : func_get_args()),
+            function ($value) {
+                return ! is_null($value);
+            }
+        );
     }
 
     /**

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -278,8 +278,13 @@ class HttpRequestTest extends TestCase
 
     public function testIntersectMethod()
     {
-        $request = Request::create('/', 'GET', ['name' => 'Taylor', 'age' => null]);
-        $this->assertEquals(['name' => 'Taylor'], $request->intersect('name', 'age', 'email'));
+        $request = Request::create('/', 'GET', [
+            'name' => 'Taylor', 'age' => null, 'accepted' => false, 'agreed' => 0,
+        ]);
+        $this->assertEquals(
+            ['name' => 'Taylor', 'accepted' => false, 'agreed' => 0],
+            $request->intersect('name', 'age', 'accepted', 'agreed', 'email')
+        );
     }
 
     public function testQueryMethod()


### PR DESCRIPTION
I discovered an small annoyance while working with Request. Trying to intersect an allowed list of parameters against the input data seams to work wrong. 

Confusion is that the `intersect` method is returning a result array _without_ original input parameters, which are _listed as allowed_, when the values of this input parameters come as _0_ (zero) or _false_. 

The error is caused by default behavior of `array_filter` function - it throws away anything is equal to false (always converting checking value to boolean), when is called with a single argument. 

As `intersect` internally use the `only` method, the solution is that we just need to filter out _only exact_ `NULL` values, but leave `false` / `0` / `"0"` / `""`.

This PR fixes up this issue. 

Thanks!