### PR TITLE
[5.5] Write line in console with custom colors and options

### DIFF
--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -414,7 +414,11 @@ class Command extends SymfonyCommand
      */
     public function line($string, $style = null, $verbosity = null)
     {
-        $styled = $style ? "<$style>$string</$style>" : $string;
+        if ($style && str_contains($style, '=')) {
+            $styled = "<$style>$string</>";
+        } else {
+            $styled = $style ? "<$style>$string</$style>" : $string;
+        }
 
         $this->output->writeln($styled, $this->parseVerbosity($verbosity));
     }

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Console;
 
 use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Support\Str;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\NullOutput;
@@ -414,10 +415,10 @@ class Command extends SymfonyCommand
      */
     public function line($string, $style = null, $verbosity = null)
     {
-        if ($style && str_contains($style, '=')) {
-            $styled = "<$style>$string</>";
+        if ($style) {
+            $styled = Str::contains($style, '=') ? "<$style>$string</>" : "<$style>$string</$style>";
         } else {
-            $styled = $style ? "<$style>$string</$style>" : $string;
+            $styled = $string;
         }
 
         $this->output->writeln($styled, $this->parseVerbosity($verbosity));

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -2,8 +2,8 @@
 
 namespace Illuminate\Console;
 
-use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Str;
+use Illuminate\Contracts\Support\Arrayable;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\NullOutput;


### PR DESCRIPTION
With this change is possible print line in console with custom colors and options.

This feature is described at the end of this document: http://symfony.com/doc/master/console/coloring.html  

Now, with this change I can do this:
```php
$this->line('String with custom style', 'bg=yellow;options=bold');
```
The other alternative without this change is this:
```php
// ...
use Symfony\Component\Console\Formatter\OutputFormatterStyle;
// ...
public function handle()
{
     $style = new OutputFormatterStyle('red', 'yellow', array('bold', 'blink'));
     $this->output->getFormatter()->setStyle('fire', $style);
     $this->line('String with custom style', 'fire');
```

Anyway, I think it's an interesting functionality.