### PR TITLE
[5.5] Add Dynamic Enums to Eloquent

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -79,7 +79,7 @@ trait HasAttributes
     protected static $mutatorCache = [];
 
     /**
-     * The dynamic enums on this model
+     * The dynamic enums on this model.
      *
      * @var array
      */
@@ -208,7 +208,7 @@ trait HasAttributes
 
     /**
      * Add dynamic enum attributes to the attributes array.
-     * 
+     *
      * @param  array $attributes
      * @param  array $mutatedAttributes
      * @return array
@@ -930,7 +930,7 @@ trait HasAttributes
     }
 
     /**
-     * Get the corresponding enum options array for an enum
+     * Get the corresponding enum options array for an enum.
      *
      * @param  string $enum
      * @return array
@@ -952,7 +952,7 @@ trait HasAttributes
     }
 
     /**
-     * Get the corresponding enum option value based on the stored key
+     * Get the corresponding enum option value based on the stored key.
      *
      * @param  string $key
      * @param  string $value
@@ -972,7 +972,7 @@ trait HasAttributes
     }
 
     /**
-     * Get the value that should be stored internally for an enum option
+     * Get the value that should be stored internally for an enum option.
      *
      * @param  string $key
      * @param  string $value

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -976,10 +976,14 @@ trait HasAttributes
      *
      * @param  string $key
      * @param  string $value
-     * @return int
+     * @return int|null
      */
     protected function getDynamicEnumInternalValue($key, $value)
     {
+        if (is_null($value)) {
+            return null;
+        }
+
         $value = array_search($value, $this->enums[$key]);
 
         if ($value !== false) {

--- a/src/Illuminate/Database/Eloquent/InvalidEnumValueException.php
+++ b/src/Illuminate/Database/Eloquent/InvalidEnumValueException.php
@@ -9,6 +9,7 @@ class InvalidEnumValueException extends RuntimeException
     public static function make($model, $key, $value)
     {
         $class = get_class($model);
+        
         return new static("Invalid enum value: [{$value}] for enum [{$key}] on model [{$class}]");
     }
 }

--- a/src/Illuminate/Database/Eloquent/InvalidEnumValueException.php
+++ b/src/Illuminate/Database/Eloquent/InvalidEnumValueException.php
@@ -9,7 +9,7 @@ class InvalidEnumValueException extends RuntimeException
     public static function make($model, $key, $value)
     {
         $class = get_class($model);
-        
+
         return new static("Invalid enum value: [{$value}] for enum [{$key}] on model [{$class}]");
     }
 }

--- a/src/Illuminate/Database/Eloquent/InvalidEnumValueException.php
+++ b/src/Illuminate/Database/Eloquent/InvalidEnumValueException.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Illuminate\Database\Eloquent;
+
+use RuntimeException;
+
+class InvalidEnumValueException extends RuntimeException
+{
+    public static function make($model, $key, $value)
+    {
+        $class = get_class($model);
+        return new static("Invalid enum value: [{$value}] for enum [{$key}] on model [{$class}]");
+    }
+}

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -705,14 +705,18 @@ class Blueprint
 
     /**
      * Create a new enum column on the table.
+     * If they don't pass an array, assume they want
+     * a dynamic enum
      *
-     * @param  string  $column
-     * @param  array   $allowed
+     * @param  string      $column
+     * @param  array|null  $allowed
      * @return \Illuminate\Support\Fluent
      */
-    public function enum($column, array $allowed)
+    public function enum($column, array $allowed = null)
     {
-        return $this->addColumn('enum', $column, compact('allowed'));
+        return is_array($allowed) 
+            ? $this->addColumn('enum', $column, compact('allowed'))
+            : $this->unsignedSmallInteger($column);
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -706,7 +706,7 @@ class Blueprint
     /**
      * Create a new enum column on the table.
      * If they don't pass an array, assume they want
-     * a dynamic enum
+     * a dynamic enum.
      *
      * @param  string      $column
      * @param  array|null  $allowed
@@ -714,7 +714,7 @@ class Blueprint
      */
     public function enum($column, array $allowed = null)
     {
-        return is_array($allowed) 
+        return is_array($allowed)
             ? $this->addColumn('enum', $column, compact('allowed'))
             : $this->unsignedSmallInteger($column);
     }

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -463,6 +463,9 @@ class DatabaseEloquentModelTest extends TestCase
         $model->color = 'blue';
         $this->assertEquals('blue', $model->color);
         $this->assertEquals($model->getAttributes(), ['color' => 0]);
+
+        $model->color = null;
+        $this->assertNull($model->color);
         
     }
 

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -453,6 +453,36 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEquals('2015-04-17 22:59:01', $model->fromDateTime($value));
     }
 
+    public function testItCastsDynamicEnumValues()
+    {
+        $model = new EloquentDynamicEnumsStub;
+        $model->setRawAttributes(['color' => 1]);
+
+        $this->assertEquals('yellow', $model->color);
+
+        $model->color = 'blue';
+        $this->assertEquals('blue', $model->color);
+        $this->assertEquals($model->getAttributes(), ['color' => 0]);
+        
+    }
+
+    public function testItCastsDynamicEnumValuesInAnArray()
+    {
+        $model = new EloquentDynamicEnumsStub;
+        $model->setRawAttributes(['color' => 1]);
+
+        $this->assertEquals($model->toArray(), ['color' => 'yellow']);
+    }
+
+    /**
+     * @expectedException \Illuminate\Database\Eloquent\InvalidEnumValueException
+     */
+    public function testItThrowsAnErrorOnSaveWithBadEnumValues()
+    {
+        $model = new EloquentDynamicEnumsStub;
+        $model->color = 'green';
+    }
+
     /**
      * @expectedException \BadMethodCallException
      * @expectedExceptionMessage Call to undefined method Illuminate\Tests\Database\EloquentModelStub::badMethod()
@@ -2049,5 +2079,12 @@ class EloquentModelEventObjectStub extends \Illuminate\Database\Eloquent\Model
 {
     protected $dispatchesEvents = [
         'saving' => EloquentModelSavingEventStub::class,
+    ];
+}
+
+class EloquentDynamicEnumsStub extends Model
+{
+    protected $enums = [
+        'color' => ['blue', 'yellow'],
     ];
 }

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -466,7 +466,6 @@ class DatabaseEloquentModelTest extends TestCase
 
         $model->color = null;
         $this->assertNull($model->color);
-        
     }
 
     public function testItCastsDynamicEnumValuesInAnArray()

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -549,6 +549,16 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table `users` add `foo` enum(\'bar\', \'baz\') not null', $statements[0]);
     }
 
+    public function testAddingDynamicEnum()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->enum('foo');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table `users` add `foo` smallint unsigned not null', $statements[0]);
+    }
+
     public function testAddingJson()
     {
         $blueprint = new Blueprint('users');

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -396,6 +396,16 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add column "foo" varchar(255) check ("foo" in (\'bar\', \'baz\')) not null', $statements[0]);
     }
 
+    public function testAddingDynamicEnum()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->enum('foo');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table "users" add column "foo" smallint not null', $statements[0]);
+    }
+
     public function testAddingDate()
     {
         $blueprint = new Blueprint('users');

--- a/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
@@ -340,6 +340,16 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add column "foo" varchar not null', $statements[0]);
     }
 
+    public function testAddingDynamicEnum()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->enum('foo');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table "users" add column "foo" integer not null', $statements[0]);
+    }
+
     public function testAddingJson()
     {
         $blueprint = new Blueprint('users');

--- a/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
@@ -409,6 +409,16 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add "foo" nvarchar(255) not null', $statements[0]);
     }
 
+    public function testAddingDynamicEnum()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->enum('foo');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table "users" add "foo" smallint not null', $statements[0]);
+    }
+
     public function testAddingJson()
     {
         $blueprint = new Blueprint('users');


### PR DESCRIPTION
I've been working with Rails a lot lately and have gotten some good use out of the interesting way that Active Record handles enums. Instead of using the database enum field, Active Record creates an integer field on the table and uses an array on the model to determine the value for the user. 

I don't think this is a solution for all enum usages, but I think it makes for a great compromise between having the db speed and controlled options of an enum, but without being stuck needing to alter the database every time you need to modify the options. 

code could look like this:
```php
class MyModel extends Model
{
  protected $enums = [
    'color' => ['blue', 'yellow'],
  ];
}

$myModel = MyModel::first();
$myModel->color = 'yellow'; // stores 1 on the model and in the database row on save
echo $myModel->color; // yellow

$myModel->color = 'yllow';  // throws an InvalidEnumValueException on assignment
$myModel->color = null; // handles null fine.

// migrations
$table->enum('choices', ['yes', 'no', 'maybe']); // normal enum (current behavior)
$table->enum('choices'); // new "dynamic" enum field
```