### PR TITLE
[5.5] remove factory comment

### DIFF
--- a/src/Illuminate/Database/Console/Factories/stubs/factory.stub
+++ b/src/Illuminate/Database/Console/Factories/stubs/factory.stub
@@ -2,17 +2,6 @@
 
 use Faker\Generator as Faker;
 
-/*
-|--------------------------------------------------------------------------
-| Model Factories
-|--------------------------------------------------------------------------
-|
-| This directory should contain each of the model factory definitions for
-| your application. Factories provide a convenient way to generate new
-| model instances for testing / seeding your application's database.
-|
-*/
-
 $factory->define(DummyModel::class, function (Faker $faker) {
     return [
         //


### PR DESCRIPTION
this comment seems like overkill, because it’ll show up in *every*
generated factory.

people can read the docs to learn about factories