### PR TITLE
[5.4] migrate to target

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
@@ -68,6 +68,7 @@ class MigrateCommand extends BaseCommand
         $this->migrator->run($this->getMigrationPaths(), [
             'pretend' => $this->option('pretend'),
             'step' => $this->option('step'),
+            'target' => $this->option('target'),
         ]);
 
         // Once the migrator has run we will grab the note output and send it out to

--- a/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
@@ -19,7 +19,8 @@ class MigrateCommand extends BaseCommand
                 {--path= : The path of migrations files to be executed.}
                 {--pretend : Dump the SQL queries that would be run.}
                 {--seed : Indicates if the seed task should be re-run.}
-                {--step : Force the migrations to be run so they can be rolled back individually.}';
+                {--step : Force the migrations to be run so they can be rolled back individually.}
+                {--target : Run the operation until the target is reached. }';
 
     /**
      * The console command description.

--- a/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
@@ -20,7 +20,7 @@ class MigrateCommand extends BaseCommand
                 {--pretend : Dump the SQL queries that would be run.}
                 {--seed : Indicates if the seed task should be re-run.}
                 {--step : Force the migrations to be run so they can be rolled back individually.}
-                {--target : Run the operation until the target is reached. }';
+                {--target= : Run the operation until the target is reached. }';
 
     /**
      * The console command description.

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -94,6 +94,8 @@ class Migrator
         $target = Arr::get($options, 'target', false);
 
         if($target) {
+            $errortarget = false;
+            // check if target exists, get the realpath of the target
             if(isset($files[$target])) {
                 $targetpath = $files[$target];
                 $key = array_search($targetpath, $migrations);
@@ -101,10 +103,18 @@ class Migrator
                     //remove migrations from the stack after the target
                     array_splice($migrations, $key + 1);
                 } else {
-                    $this->note('<info>Could not find target : '. $target . '</info> ');
+                    $errortarget = true;
                 }
             } else {
+                $errortarget = true;
+            }
+
+            // target not found, show error message
+            // clear the migrations array, so no migrations can be done
+            if($errortarget) {
+                // on error, clear the migrations array, so that nothing gets migrated
                 $this->note('<info>Could not find target : '. $target . '</info> ');
+                $migrations = array();
             }
         }
 

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -85,9 +85,25 @@ class Migrator
         // run each of the outstanding migrations against a database connection.
         $files = $this->getMigrationFiles($paths);
 
-        $this->requireFiles($migrations = $this->pendingMigrations(
+        $migrations = $this->pendingMigrations(
             $files, $this->repository->getRan()
-        ));
+        );
+
+        // Next we see if migrations should run until a certain point
+        // Remove migrations from the stack if target is used, after the given target
+        $target = Arr::get($options, 'target', false);
+        if($target) {
+            $key = array_search($target, $migrations);
+            if($key !== false) {
+                //remove migrations from the stack after the target
+                array_splice($migrations, $key + 1);
+            } else {
+                $this->note('<info>Migration target ' . $target . ' not found.</info>');
+                $migrations = array();
+            }
+        }
+
+        $this->requireFiles($migrations);
 
         // Once we have all these migrations that are outstanding we are ready to run
         // we will go ahead and run them "up". This will execute each migration as

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -92,14 +92,19 @@ class Migrator
         // Next we see if migrations should run until a certain point
         // Remove migrations from the stack if target is used, after the given target
         $target = Arr::get($options, 'target', false);
+
         if($target) {
-            $key = array_search($target, $migrations);
-            if($key !== false) {
-                //remove migrations from the stack after the target
-                array_splice($migrations, $key + 1);
+            if(isset($files[$target])) {
+                $targetpath = $files[$target];
+                $key = array_search($targetpath, $migrations);
+                if ($key !== false) {
+                    //remove migrations from the stack after the target
+                    array_splice($migrations, $key + 1);
+                } else {
+                    $this->note('<info>Could not find target : '. $target . '</info> ');
+                }
             } else {
-                $this->note('<info>Migration target ' . $target . ' not found.</info>');
-                $migrations = array();
+                $this->note('<info>Could not find target : '. $target . '</info> ');
             }
         }
 

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -93,10 +93,10 @@ class Migrator
         // Remove migrations from the stack if target is used, after the given target
         $target = Arr::get($options, 'target', false);
 
-        if($target) {
+        if ($target) {
             $errortarget = false;
             // check if target exists, get the realpath of the target
-            if(isset($files[$target])) {
+            if (isset($files[$target])) {
                 $targetpath = $files[$target];
                 $key = array_search($targetpath, $migrations);
                 if ($key !== false) {
@@ -111,10 +111,10 @@ class Migrator
 
             // target not found, show error message
             // clear the migrations array, so no migrations can be done
-            if($errortarget) {
+            if ($errortarget) {
                 // on error, clear the migrations array, so that nothing gets migrated
-                $this->note('<info>Could not find target : '. $target . '</info> ');
-                $migrations = array();
+                $this->note('<info>Could not find target : '.$target.'</info> ');
+                $migrations = [];
             }
         }
 

--- a/tests/Database/DatabaseMigrationMigrateCommandTest.php
+++ b/tests/Database/DatabaseMigrationMigrateCommandTest.php
@@ -22,7 +22,7 @@ class DatabaseMigrationMigrateCommandTest extends TestCase
         $command->setLaravel($app);
         $migrator->shouldReceive('paths')->once()->andReturn([]);
         $migrator->shouldReceive('setConnection')->once()->with(null);
-        $migrator->shouldReceive('run')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => false, 'step' => false]);
+        $migrator->shouldReceive('run')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => false, 'step' => false, 'target' => false]);
         $migrator->shouldReceive('getNotes')->andReturn([]);
         $migrator->shouldReceive('repositoryExists')->once()->andReturn(true);
 
@@ -38,7 +38,7 @@ class DatabaseMigrationMigrateCommandTest extends TestCase
         $command->setLaravel($app);
         $migrator->shouldReceive('paths')->once()->andReturn([]);
         $migrator->shouldReceive('setConnection')->once()->with(null);
-        $migrator->shouldReceive('run')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => false, 'step' => false]);
+        $migrator->shouldReceive('run')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => false, 'step' => false, 'target' => false]);
         $migrator->shouldReceive('getNotes')->andReturn([]);
         $migrator->shouldReceive('repositoryExists')->once()->andReturn(false);
         $command->expects($this->once())->method('call')->with($this->equalTo('migrate:install'), $this->equalTo(['--database' => null]));
@@ -54,7 +54,7 @@ class DatabaseMigrationMigrateCommandTest extends TestCase
         $command->setLaravel($app);
         $migrator->shouldReceive('paths')->once()->andReturn([]);
         $migrator->shouldReceive('setConnection')->once()->with(null);
-        $migrator->shouldReceive('run')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => true, 'step' => false]);
+        $migrator->shouldReceive('run')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => true, 'step' => false, 'target' => false]);
         $migrator->shouldReceive('getNotes')->andReturn([]);
         $migrator->shouldReceive('repositoryExists')->once()->andReturn(true);
 
@@ -69,7 +69,7 @@ class DatabaseMigrationMigrateCommandTest extends TestCase
         $command->setLaravel($app);
         $migrator->shouldReceive('paths')->once()->andReturn([]);
         $migrator->shouldReceive('setConnection')->once()->with('foo');
-        $migrator->shouldReceive('run')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => false, 'step' => false]);
+        $migrator->shouldReceive('run')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => false, 'step' => false, 'target' => false]);
         $migrator->shouldReceive('getNotes')->andReturn([]);
         $migrator->shouldReceive('repositoryExists')->once()->andReturn(true);
 
@@ -84,11 +84,26 @@ class DatabaseMigrationMigrateCommandTest extends TestCase
         $command->setLaravel($app);
         $migrator->shouldReceive('paths')->once()->andReturn([]);
         $migrator->shouldReceive('setConnection')->once()->with(null);
-        $migrator->shouldReceive('run')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => false, 'step' => true]);
+        $migrator->shouldReceive('run')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => false, 'step' => true, 'target' => false]);
         $migrator->shouldReceive('getNotes')->andReturn([]);
         $migrator->shouldReceive('repositoryExists')->once()->andReturn(true);
 
         $this->runCommand($command, ['--step' => true]);
+    }
+
+    public function testTargetMayBeSet()
+    {
+        $command = new MigrateCommand($migrator = m::mock('Illuminate\Database\Migrations\Migrator'), __DIR__.'/vendor');
+        $app = new ApplicationDatabaseMigrationStub(['path.database' => __DIR__]);
+        $app->useDatabasePath(__DIR__);
+        $command->setLaravel($app);
+        $migrator->shouldReceive('paths')->once()->andReturn([]);
+        $migrator->shouldReceive('setConnection')->once()->with(null);
+        $migrator->shouldReceive('run')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => false, 'step' => false, 'target' => true]);
+        $migrator->shouldReceive('getNotes')->andReturn([]);
+        $migrator->shouldReceive('repositoryExists')->once()->andReturn(true);
+
+        $this->runCommand($command, ['--target' => true]);
     }
 
     protected function runCommand($command, $input = [])


### PR DESCRIPTION
Added an option to run migrations to a target.
This way migrations can be tested better.

it is not used to skip migrations.

```
php artisan migrate --target={target_migration}
```
other options and rollback still work as intended

