### PR TITLE
[5.5] Let the Model datetime value accept many formats

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -6,6 +6,7 @@ use LogicException;
 use DateTimeInterface;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
+use InvalidArgumentException;
 use Illuminate\Support\Carbon;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Eloquent\Relations\Relation;
@@ -711,9 +712,11 @@ trait HasAttributes
         // Finally, we will just assume this date is in the format used by default on
         // the database connection and use that format to create the Carbon object
         // that is returned back out to the developers after we convert it here.
-        return Carbon::createFromFormat(
-            $this->getDateFormat(), $value
-        );
+        try {
+            return Carbon::createFromFormat($this->getDateFormat(), $value);
+        } catch (InvalidArgumentException $e) {
+            return Carbon::parse($value);
+        }
     }
 
     /**

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1493,6 +1493,37 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEquals(-14173440, $arr['timestampAttribute']);
     }
 
+    /**
+     * @expectedException \Exception
+     * @expectedExceptionMessage DateTime::__construct(): Failed to parse time string (FOOBAR) at position 0
+     */
+    public function testModelDatesAttributesCanNotBeParsed()
+    {
+        $model = new EloquentModelCastingStub;
+        $model->setDateFormat('Y-m-d H:i:s');
+
+        $model->datetimeAttribute = 'FOOBAR';
+    }
+
+    public function testModelDatesAttributesCanBeParsedWithManyFormats()
+    {
+        $model = new EloquentModelCastingStub;
+        $model->setDateFormat('Y-m-d H:i:s');
+
+        $date = Carbon::create(2017, 07, 28, 13, 14, 15);
+        $model->datetimeAttribute = $date;
+        $this->assertSame($model->datetimeAttribute->getTimestamp(), $date->getTimestamp());
+
+        $model->datetimeAttribute = $date->toW3cString();
+        $this->assertSame($model->datetimeAttribute->getTimestamp(), $date->getTimestamp());
+
+        $model->datetimeAttribute = $date->toIso8601String();
+        $this->assertSame($model->datetimeAttribute->getTimestamp(), $date->getTimestamp());
+
+        $model->datetimeAttribute = $date->toAtomString();
+        $this->assertSame($model->datetimeAttribute->getTimestamp(), $date->getTimestamp());
+    }
+
     public function testModelDateAttributeCastingResetsTime()
     {
         $model = new EloquentModelCastingStub;


### PR DESCRIPTION
We sometimes want set a model date using a custom format.
Unfortunately if the value does not respect the grammar specific format or the one which is set for this model, the set will fail.

This PR allows to set a datetime field using virtually any format in the case we could not use the model format, starting with the most common ones:

    const ATOM = 'Y-m-d\TH:i:sP';
    const COOKIE = 'l, d-M-y H:i:s T';
    const ISO8601 = 'Y-m-d\TH:i:sO';
    const RFC822 = 'D, d M y H:i:s O';
    const RFC850 = 'l, d-M-y H:i:s T';
    const RFC1036 = 'D, d M y H:i:s O';
    const RFC1123 = 'D, d M Y H:i:s O';
    const RFC2822 = 'D, d M Y H:i:s O';
    const RFC3339 = 'Y-m-d\TH:i:sP';
    const RSS = 'D, d M Y H:i:s O';
    const W3C = 'Y-m-d\TH:i:sP';

At the very end if the value cannot be parsed we will throw an exception.

---

Related to https://github.com/laravel/internals/issues/669 & https://github.com/laravel/framework/pull/20273