### PR TITLE
Retrive failed jobs in asc order

### DIFF
--- a/src/Illuminate/Queue/Failed/DatabaseFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/DatabaseFailedJobProvider.php
@@ -70,7 +70,7 @@ class DatabaseFailedJobProvider implements FailedJobProviderInterface
      */
     public function all()
     {
-        return $this->getTable()->orderBy('id', 'desc')->get()->all();
+        return $this->getTable()->orderBy('id', 'asc')->get()->all();
     }
 
     /**


### PR DESCRIPTION
Failed jobs are pushed in LIFO manner while using `queue:retry --all` command. This fix will push failed jobs back to queue in FIFO manner similar to regular job push.