### PR TITLE
Add foreignId method to Blueprint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ composer.lock
 Thumbs.db
 /phpunit.xml
 /.idea
+.phpintel/

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -398,6 +398,21 @@ class Blueprint
     }
 
     /**
+     * Makes an unsigned integer column with a foreign key reference.
+     *
+     * @param  string  $column
+     * @param  string  $table
+     * @param  string  $foreignColumn
+     * @return \Illuminate\Support\Fluent
+     */
+    public function foreignId($column, $table, $foreignColumn = 'id')
+    {
+        $this->unsignedInteger($column);
+
+        return $this->foreign($column)->references($foreignColumn)->on($table);
+    }
+
+    /**
      * Create a new auto-incrementing integer (4-byte) column on the table.
      *
      * @param  string  $column


### PR DESCRIPTION
I usually find myself doing this a lot:

```php
$table->integer('category_id')->unsigned();
$table->foreign('category_id')->references('id')->on('categories')->onDelete('cascade');
```

This PR allows you to just do the following:

```php
$table->foreignId('category_id', 'categories')->onDelete('cascade');
```

I'm not sure if the method name is the best it could be, also I'd like for it to be automatic, so you could just do `$table->foreignId('categories')` and it would use the correct column name for that table etc.