### PR TITLE
[5.5] Add the queue:once command

### DIFF
--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -48,6 +48,7 @@ use Illuminate\Foundation\Console\PackageDiscoverCommand;
 use Illuminate\Database\Console\Migrations\MigrateCommand;
 use Illuminate\Foundation\Console\NotificationMakeCommand;
 use Illuminate\Database\Console\Factories\FactoryMakeCommand;
+use Illuminate\Queue\Console\OnceCommand as QueueOnceCommand;
 use Illuminate\Queue\Console\WorkCommand as QueueWorkCommand;
 use Illuminate\Database\Console\Migrations\MigrateMakeCommand;
 use Illuminate\Notifications\Console\NotificationTableCommand;
@@ -104,6 +105,7 @@ class ArtisanServiceProvider extends ServiceProvider
         'QueueFlush' => 'command.queue.flush',
         'QueueForget' => 'command.queue.forget',
         'QueueListen' => 'command.queue.listen',
+        'QueueOnce' => 'command.queue.once',
         'QueueRestart' => 'command.queue.restart',
         'QueueRetry' => 'command.queue.retry',
         'QueueWork' => 'command.queue.work',
@@ -652,6 +654,18 @@ class ArtisanServiceProvider extends ServiceProvider
     {
         $this->app->singleton('command.queue.listen', function ($app) {
             return new QueueListenCommand($app['queue.listener']);
+        });
+    }
+
+    /**
+     * Register the command.
+     *
+     * @return void
+     */
+    protected function registerQueueOnceCommand()
+    {
+        $this->app->singleton('command.queue.once', function ($app) {
+            return new QueueOnceCommand($app['queue.worker']);
         });
     }
 

--- a/src/Illuminate/Queue/Console/OnceCommand.php
+++ b/src/Illuminate/Queue/Console/OnceCommand.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Illuminate\Queue\Console;
+
+class OnceCommand extends WorkCommand
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $signature = 'queue:once
+                            {connection? : The name of the queue connection to work}
+                            {--once=1 : Only process the next job on the queue}
+                            {--queue= : The names of the queues to work}
+                            {--delay=0 : Amount of time to delay failed jobs}
+                            {--force : Force the worker to run even in maintenance mode}
+                            {--memory=128 : The memory limit in megabytes}
+                            {--sleep=3 : Number of seconds to sleep when no job is available}
+                            {--timeout=60 : The number of seconds a child process can run}
+                            {--tries=0 : Number of times to attempt a job before logging it failed}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Process a single job on the queue';
+}


### PR DESCRIPTION
I find myself answering a common question on StackOverflow, Slack etc around the difference between queue commands for people new to Laravel.

Currently we have 3 options:

`queue:work` - process queue jobs as a daemon
`queue:work --once` - process a single job on the queue
`queue:listen` - process queue jobs as a loop (i.e. boot the framework each time)

I think it makes more sense to alias out the `once` to its own command - that way you can say:

`queue:work` - process queue jobs as a daemon
`queue:listen` - process queue jobs as a loop (i.e. boot the framework each time)
`queue:once` - process a single job on the queue

This PR leaves the `--once` flag on the work command for those that want it. It is just adding an alias.