### PR TITLE
Update unit-test.stub to use RefreshDatabase trait

### DIFF
--- a/src/Illuminate/Foundation/Console/stubs/unit-test.stub
+++ b/src/Illuminate/Foundation/Console/stubs/unit-test.stub
@@ -3,8 +3,7 @@
 namespace DummyNamespace;
 
 use Tests\TestCase;
-use Illuminate\Foundation\Testing\DatabaseMigrations;
-use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 
 class DummyClass extends TestCase
 {


### PR DESCRIPTION
Since `Illuminate\Foundation\Testing\RefreshDatabase` is used by default now, this stub should reflect it and match the test.stub.