### PR TITLE
[5.5] Fixed json responses

### DIFF
--- a/src/Illuminate/Http/Response.php
+++ b/src/Illuminate/Http/Response.php
@@ -23,10 +23,6 @@ class Response extends BaseResponse
     {
         $this->original = $content;
 
-        if ($this->headers->get('Content-Type') === 'application/json') {
-            $this->headers->remove('Content-Type');
-        }
-
         // If the content is "JSONable" we will set the appropriate header and convert
         // the content to JSON. This is useful when returning something like models
         // from routes that will be automatically transformed to their JSON form.

--- a/tests/Http/HttpResponseTest.php
+++ b/tests/Http/HttpResponseTest.php
@@ -39,10 +39,7 @@ class HttpResponseTest extends TestCase
         $response = new \Illuminate\Http\Response(new JsonSerializableStub);
         $this->assertEquals('{"foo":"bar"}', $response->getContent());
         $this->assertEquals('application/json', $response->headers->get('Content-Type'));
-    }
 
-    public function testResponseHeaderTypeIsReset()
-    {
         $response = new \Illuminate\Http\Response(new ArrayableStub);
         $this->assertEquals('{"foo":"bar"}', $response->getContent());
         $this->assertEquals('application/json', $response->headers->get('Content-Type'));
@@ -50,10 +47,6 @@ class HttpResponseTest extends TestCase
         $response->setContent('{"foo": "bar"}');
         $this->assertEquals('foo', $response->getContent());
         $this->assertEquals('application/json', $response->headers->get('Content-Type'));
-
-        $response->setContent('foo');
-        $this->assertEquals('foo', $response->getContent());
-        $this->assertNotEquals('application/json', $response->headers->get('Content-Type'));
     }
 
     public function testRenderablesAreRendered()

--- a/tests/Http/HttpResponseTest.php
+++ b/tests/Http/HttpResponseTest.php
@@ -47,6 +47,10 @@ class HttpResponseTest extends TestCase
         $this->assertEquals('{"foo":"bar"}', $response->getContent());
         $this->assertEquals('application/json', $response->headers->get('Content-Type'));
 
+        $response->setContent('{"foo": "bar"}');
+        $this->assertEquals('foo', $response->getContent());
+        $this->assertEquals('application/json', $response->headers->get('Content-Type'));
+
         $response->setContent('foo');
         $this->assertEquals('foo', $response->getContent());
         $this->assertNotEquals('application/json', $response->headers->get('Content-Type'));

--- a/tests/Http/HttpResponseTest.php
+++ b/tests/Http/HttpResponseTest.php
@@ -45,7 +45,7 @@ class HttpResponseTest extends TestCase
         $this->assertEquals('application/json', $response->headers->get('Content-Type'));
 
         $response->setContent('{"foo": "bar"}');
-        $this->assertEquals('foo', $response->getContent());
+        $this->assertEquals('{"foo": "bar"}', $response->getContent());
         $this->assertEquals('application/json', $response->headers->get('Content-Type'));
     }
 


### PR DESCRIPTION
The current code breaks the exception handler returning json responses: https://github.com/laravel/framework/blob/5.4/src/Illuminate/Foundation/Exceptions/Handler.php#L223.

Here are the headers before and after:

![image](https://user-images.githubusercontent.com/2829600/28746446-698ee446-7484-11e7-952a-a9e3408aaa33.png)

Clearly this is wrong. The laravel response class should never be removing content types provided by the user!