### PR TITLE
[5.5] phpredis Fixes

### DIFF
--- a/tests/Redis/RedisConnectionTest.php
+++ b/tests/Redis/RedisConnectionTest.php
@@ -2,8 +2,8 @@
 
 namespace Illuminate\Tests\Redis;
 
-use Illuminate\Redis\RedisManager;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Redis\RedisManager;
 
 class RedisConnectionTest extends TestCase
 {
@@ -37,7 +37,7 @@ class RedisConnectionTest extends TestCase
         foreach ($this->connections() as $redis) {
             $redis->set('one', 'mohamed', 'EX', 5, 'NX');
             $this->assertEquals('mohamed', $redis->get('one'));
-            $this->assertNotEquals(- 1, $redis->ttl('one'));
+            $this->assertNotEquals(-1, $redis->ttl('one'));
 
             // It doesn't override when NX mode
             $redis->set('one', 'taylor', 'EX', 5, 'NX');
@@ -53,8 +53,8 @@ class RedisConnectionTest extends TestCase
 
             $redis->set('three', 'mohamed', 'PX', 5000);
             $this->assertEquals('mohamed', $redis->get('three'));
-            $this->assertNotEquals(- 1, $redis->ttl('three'));
-            $this->assertNotEquals(- 1, $redis->pttl('three'));
+            $this->assertNotEquals(-1, $redis->ttl('three'));
+            $this->assertNotEquals(-1, $redis->pttl('three'));
 
             $redis->flushall();
         }
@@ -108,16 +108,16 @@ class RedisConnectionTest extends TestCase
     {
         foreach ($this->connections() as $redis) {
             $redis->set('one', 'mohamed');
-            $this->assertEquals(- 1, $redis->ttl('one'));
+            $this->assertEquals(-1, $redis->ttl('one'));
             $this->assertEquals(1, $redis->expire('one', 10));
-            $this->assertNotEquals(- 1, $redis->ttl('one'));
+            $this->assertNotEquals(-1, $redis->ttl('one'));
 
             $this->assertEquals(0, $redis->expire('nothing', 10));
 
             $redis->set('two', 'mohamed');
-            $this->assertEquals(- 1, $redis->ttl('two'));
+            $this->assertEquals(-1, $redis->ttl('two'));
             $this->assertEquals(1, $redis->pexpire('two', 10));
-            $this->assertNotEquals(- 1, $redis->pttl('two'));
+            $this->assertNotEquals(-1, $redis->pttl('two'));
 
             $this->assertEquals(0, $redis->pexpire('nothing', 10));
 
@@ -325,7 +325,7 @@ class RedisConnectionTest extends TestCase
         foreach ($this->connections() as $redis) {
             $redis->zadd('set', ['jeffrey' => 1, 'matt' => 5, 'taylor' => 10]);
             $this->assertEquals(['jeffrey', 'matt'], $redis->zrange('set', 0, 1));
-            $this->assertEquals(['jeffrey', 'matt', 'taylor'], $redis->zrange('set', 0, - 1));
+            $this->assertEquals(['jeffrey', 'matt', 'taylor'], $redis->zrange('set', 0, -1));
 
             $this->assertEquals(['jeffrey' => 1, 'matt' => 5], $redis->zrange('set', 0, 1, 'withscores'));
 
@@ -341,7 +341,7 @@ class RedisConnectionTest extends TestCase
         foreach ($this->connections() as $redis) {
             $redis->zadd('set', ['jeffrey' => 1, 'matt' => 5, 'taylor' => 10]);
             $this->assertEquals(['taylor', 'matt'], $redis->ZREVRANGE('set', 0, 1));
-            $this->assertEquals(['taylor', 'matt', 'jeffrey'], $redis->ZREVRANGE('set', 0, - 1));
+            $this->assertEquals(['taylor', 'matt', 'jeffrey'], $redis->ZREVRANGE('set', 0, -1));
 
             $this->assertEquals(['matt' => 5, 'taylor' => 10], $redis->ZREVRANGE('set', 0, 1, 'withscores'));
 
@@ -458,7 +458,7 @@ class RedisConnectionTest extends TestCase
     {
         foreach ($this->connections() as $redis) {
             $redis->zadd('set', ['jeffrey' => 1, 'matt' => 5, 'taylor' => 10, 'adam' => 11]);
-            $redis->ZREMRANGEBYRANK('set', 1, - 1);
+            $redis->ZREMRANGEBYRANK('set', 1, -1);
             $this->assertEquals(1, $redis->zcard('set'));
 
             $redis->flushall();


### PR DESCRIPTION
More fixes to the phpredis wrapper.

- Make sure prefix is respected when raw commands are executed
- Make sure the return value of setNx and hsetNx is an integer like in predis