### PR TITLE
[5.4] Fix typo in Scheduler

### DIFF
--- a/src/Illuminate/Console/Scheduling/Schedule.php
+++ b/src/Illuminate/Console/Scheduling/Schedule.php
@@ -23,7 +23,7 @@ class Schedule
     protected $mutex;
 
     /**
-     * Create a new event instance.
+     * Create a new scheduling instance.
      *
      * @return void
      */

--- a/src/Illuminate/Console/Scheduling/Schedule.php
+++ b/src/Illuminate/Console/Scheduling/Schedule.php
@@ -23,7 +23,7 @@ class Schedule
     protected $mutex;
 
     /**
-     * Create a new scheduling instance.
+     * Create a new schedule instance.
      *
      * @return void
      */


### PR DESCRIPTION
Fix typo. This is the scheduler instance, not the event.