### PR TITLE
[5.4] Fix flatMap() returning BaseCollection while result has models

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -139,6 +139,21 @@ class Collection extends BaseCollection implements QueueableCollection
     }
 
     /**
+     * Map a collection and flatten the result by a single level.
+     *
+     * @param  callable  $callback
+     * @return \Illuminate\Support\Collection|static
+     */
+    public function flatMap(callable $callback)
+    {
+        $result = parent::map($callback)->collapse();
+
+        return ! $result->count() || $result->contains(function ($item) {
+            return ! $item instanceof Model;
+        }) ? $result : new static($result);
+    }
+
+    /**
      * Reload a fresh model instance from the database for all the entities.
      *
      * @param  array|string  $with

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -131,7 +131,7 @@ class Collection extends BaseCollection implements QueueableCollection
      */
     public function map(callable $callback)
     {
-        $result = parent::map($callback);
+        $result = parent::flatMap($callback);
 
         return $result->contains(function ($item) {
             return ! $item instanceof Model;

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -131,7 +131,7 @@ class Collection extends BaseCollection implements QueueableCollection
      */
     public function map(callable $callback)
     {
-        $result = parent::flatMap($callback);
+        $result = parent::map($callback);
 
         return $result->contains(function ($item) {
             return ! $item instanceof Model;
@@ -146,7 +146,7 @@ class Collection extends BaseCollection implements QueueableCollection
      */
     public function flatMap(callable $callback)
     {
-        $result = parent::map($callback)->collapse();
+        $result = parent::flatMap($callback);
 
         return ! $result->count() || $result->contains(function ($item) {
             return ! $item instanceof Model;

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -224,6 +224,48 @@ class DatabaseEloquentCollectionTest extends TestCase
         $this->assertEquals(BaseCollection::class, get_class($c));
     }
 
+    public function testFlatMap()
+    {
+        $one = m::mock('Illuminate\Database\Eloquent\Model');
+        $two = m::mock('Illuminate\Database\Eloquent\Model');
+        $oneChildren = new Collection($oneChildrenArray = [
+            m::mock('Illuminate\Database\Eloquent\Model'),
+            m::mock('Illuminate\Database\Eloquent\Model'),
+        ]);
+
+        $twoChildren = new Collection($twoChildrenArray = [
+            m::mock('Illuminate\Database\Eloquent\Model'),
+            m::mock('Illuminate\Database\Eloquent\Model'),
+        ]);
+
+        $c = new Collection([$one, $two]);
+
+        $cAfterMap = $c->flatMap(function ($item, $i) use($oneChildren, $twoChildren){
+            return $i == 0 ? $oneChildren : $twoChildren;
+        });
+
+        $this->assertEquals(array_merge($oneChildrenArray, $twoChildrenArray), $cAfterMap->all());
+        $this->assertInstanceOf(Collection::class, $cAfterMap);
+    }
+
+    public function testFlatMappingToNonModelsReturnsABaseCollection()
+    {
+        $one = m::mock('Illuminate\Database\Eloquent\Model');
+        $two = m::mock('Illuminate\Database\Eloquent\Model');
+        $oneChildren = new Collection($oneChildrenArray = [1,2]);
+
+        $twoChildren = new Collection($twoChildrenArray = [3,4]);
+
+        $c = new Collection([$one, $two]);
+
+        $cAfterMap = $c->flatMap(function ($item, $i) use($oneChildren, $twoChildren){
+            return $i == 0 ? $oneChildren : $twoChildren;
+        });
+
+        $this->assertEquals(array_merge($oneChildrenArray, $twoChildrenArray), $cAfterMap->all());
+        $this->assertInstanceOf(BaseCollection::class, $cAfterMap);
+    }
+
     public function testCollectionDiffsWithGivenCollection()
     {
         $one = m::mock('Illuminate\Database\Eloquent\Model');

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -240,7 +240,7 @@ class DatabaseEloquentCollectionTest extends TestCase
 
         $c = new Collection([$one, $two]);
 
-        $cAfterMap = $c->flatMap(function ($item, $i) use($oneChildren, $twoChildren){
+        $cAfterMap = $c->flatMap(function ($item, $i) use ($oneChildren, $twoChildren) {
             return $i == 0 ? $oneChildren : $twoChildren;
         });
 
@@ -252,13 +252,13 @@ class DatabaseEloquentCollectionTest extends TestCase
     {
         $one = m::mock('Illuminate\Database\Eloquent\Model');
         $two = m::mock('Illuminate\Database\Eloquent\Model');
-        $oneChildren = new Collection($oneChildrenArray = [1,2]);
+        $oneChildren = new Collection($oneChildrenArray = [1, 2]);
 
-        $twoChildren = new Collection($twoChildrenArray = [3,4]);
+        $twoChildren = new Collection($twoChildrenArray = [3, 4]);
 
         $c = new Collection([$one, $two]);
 
-        $cAfterMap = $c->flatMap(function ($item, $i) use($oneChildren, $twoChildren){
+        $cAfterMap = $c->flatMap(function ($item, $i) use ($oneChildren, $twoChildren) {
             return $i == 0 ? $oneChildren : $twoChildren;
         });
 


### PR DESCRIPTION
```
User::all()->flatMap(function($user){
    return $user->friends;
});
```

Even though friends is a relationship that returns an Eloquent Collection, flatMap() would currently still return a support collection. this PR fixes that.