### PR TITLE
[5.5] Fix minimum value of last_page field in paginator

### DIFF
--- a/src/Illuminate/Pagination/LengthAwarePaginator.php
+++ b/src/Illuminate/Pagination/LengthAwarePaginator.php
@@ -46,7 +46,7 @@ class LengthAwarePaginator extends AbstractPaginator implements Arrayable, Array
 
         $this->total = $total;
         $this->perPage = $perPage;
-        $this->lastPage = (int) ceil($total / $perPage);
+        $this->lastPage = max((int) ceil($total / $perPage), 1);
         $this->path = $this->path != '/' ? rtrim($this->path, '/') : $this->path;
         $this->currentPage = $this->setCurrentPage($currentPage, $this->pageName);
         $this->items = $items instanceof Collection ? $items : Collection::make($items);

--- a/tests/Pagination/LengthAwarePaginatorTest.php
+++ b/tests/Pagination/LengthAwarePaginatorTest.php
@@ -34,6 +34,17 @@ class LengthAwarePaginatorTest extends TestCase
         $this->assertEquals(['item1', 'item2', 'item3', 'item4'], $this->p->items());
     }
 
+    public function testLengthAwarePaginatorSetCorrectInformationWithNoItems()
+    {
+        $paginator = new LengthAwarePaginator([], 0, 2, 1);
+
+        $this->assertEquals(1, $paginator->lastPage());
+        $this->assertEquals(1, $paginator->currentPage());
+        $this->assertFalse($paginator->hasPages());
+        $this->assertFalse($paginator->hasMorePages());
+        $this->assertEmpty($paginator->items());
+    }
+
     public function testLengthAwarePaginatorCanGenerateUrls()
     {
         $this->p->setPath('http://website.com');


### PR DESCRIPTION
Hi. Assuming we have a Product model and no products in the database, this:

```php
public function index()
{
    return Product::paginate();
}
```

Will output:

```php
{
    "current_page": 1,
    "data": [],
    "from": null,
    "last_page": 0,
    ...
}
```

Seems strange that the [last_page] field is less than the [current_page] field. I've added a failing test and code to make the minimum value of [last_page] 1.