### PR TITLE
[5.5] If applied, this commit adds the timer() helper function

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -1002,6 +1002,25 @@ if (! function_exists('throw_unless')) {
     }
 }
 
+if (! function_exists('timer')) {
+    /**
+     * Returns the execution time of the script.
+     *
+     * @param  mixed  $expression
+     * @return string
+     */
+    function timer($expression = null)
+    {
+        if ($expression instanceof Closure) {
+            $expression();
+        } else {
+            eval(rtrim($expression, ';') . ';');
+        }
+
+        echo microtime(true) - LARAVEL_START . " seconds";
+    }
+}
+
 if (! function_exists('title_case')) {
     /**
      * Convert a value to title case.

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -1014,10 +1014,10 @@ if (! function_exists('timer')) {
         if ($expression instanceof Closure) {
             $expression();
         } else {
-            eval(rtrim($expression, ';') . ';');
+            eval(rtrim($expression, ';').';');
         }
 
-        echo microtime(true) - LARAVEL_START . " seconds";
+        echo microtime(true) - LARAVEL_START .' seconds';
     }
 }
 

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -1017,7 +1017,7 @@ if (! function_exists('timer')) {
             eval(rtrim($expression, ';').';');
         }
 
-        echo microtime(true) - LARAVEL_START .' seconds';
+        echo microtime(true) - LARAVEL_START.' seconds';
     }
 }
 


### PR DESCRIPTION
**Why timer()**
- Because multiple approaches are available to achieve the same output, the better execution time plays a decisive role. So it ends up to `start the timer, subtract and echo the results` loop.

**Uses**
- Can be called without any arguments, to echo the execution time from `LARAVEL_START` till that point.
- A callback or the code can be passed as an argument to include its execution in the result time as well.

**Credits**
- Never thought to make this as a PR until I saw @calebporzio and many other also play around with this idea.
- The code and conditional check of closure is also from Caleb's knowledge base and is taken from his [gist](https://gist.github.com/calebporzio/52cc47ccd8ef75eff33cb45d56b4874b) , so pass all the :kissing_heart: to @calebporzio :smile:  

**Example**

```php
Route::get('/', function () {
    timer(define('TEST', 3)); // echos 0.010795831680298 seconds

    echo "using timer at multiple places to break and measure the difference"; 

    timer(); // echos 0.010809898376465 seconds
    return view('welcome');
});
```
