### PR TITLE
[5.4] Fix 'Too Many Connections' error during testing using `$connectionsToTransact`

### DIFF
--- a/src/Illuminate/Foundation/Testing/DatabaseTransactions.php
+++ b/src/Illuminate/Foundation/Testing/DatabaseTransactions.php
@@ -19,7 +19,10 @@ trait DatabaseTransactions
 
         $this->beforeApplicationDestroyed(function () use ($database) {
             foreach ($this->connectionsToTransact() as $name) {
-                $database->connection($name)->rollBack();
+                $connection = $database->connection($name);
+
+                $connection->rollBack();
+                $connection->disconnect();
             }
         });
     }


### PR DESCRIPTION
Terminate user defined database connections after rollback while using the DatabaseTransactions trait.

_Note: This bug fix is pointed to the 5.4 branch as the corresponding code doesn't exist in the 5.1 release._