### PR TITLE
[5.5] Enforce usage of dispatch over fire.

### DIFF
--- a/src/Illuminate/Contracts/Queue/Job.php
+++ b/src/Illuminate/Contracts/Queue/Job.php
@@ -5,11 +5,11 @@ namespace Illuminate\Contracts\Queue;
 interface Job
 {
     /**
-     * Fire the job.
+     * Dispatch the job.
      *
      * @return void
      */
-    public function fire();
+    public function dispatch();
 
     /**
      * Release the job back into the queue.

--- a/src/Illuminate/Queue/FailingJob.php
+++ b/src/Illuminate/Queue/FailingJob.php
@@ -32,7 +32,7 @@ class FailingJob
 
             $job->failed($e);
         } finally {
-            static::events()->fire(new JobFailed(
+            static::events()->dispatch(new JobFailed(
                 $connectionName, $job, $e ?: new ManuallyFailedException
             ));
         }

--- a/src/Illuminate/Queue/Jobs/Job.php
+++ b/src/Illuminate/Queue/Jobs/Job.php
@@ -67,7 +67,7 @@ abstract class Job
      *
      * @return void
      */
-    public function fire()
+    public function dispatch()
     {
         $payload = $this->payload();
 

--- a/src/Illuminate/Queue/Jobs/JobName.php
+++ b/src/Illuminate/Queue/Jobs/JobName.php
@@ -14,7 +14,7 @@ class JobName
      */
     public static function parse($job)
     {
-        return Str::parseCallback($job, 'fire');
+        return Str::parseCallback($job, 'dispatch');
     }
 
     /**

--- a/src/Illuminate/Queue/SyncQueue.php
+++ b/src/Illuminate/Queue/SyncQueue.php
@@ -39,7 +39,7 @@ class SyncQueue extends Queue implements QueueContract
         try {
             $this->raiseBeforeJobEvent($queueJob);
 
-            $queueJob->fire();
+            $queueJob->dispatch();
 
             $this->raiseAfterJobEvent($queueJob);
         } catch (Exception $e) {
@@ -72,7 +72,7 @@ class SyncQueue extends Queue implements QueueContract
     protected function raiseBeforeJobEvent(Job $job)
     {
         if ($this->container->bound('events')) {
-            $this->container['events']->fire(new Events\JobProcessing($this->connectionName, $job));
+            $this->container['events']->dispatch(new Events\JobProcessing($this->connectionName, $job));
         }
     }
 
@@ -85,7 +85,7 @@ class SyncQueue extends Queue implements QueueContract
     protected function raiseAfterJobEvent(Job $job)
     {
         if ($this->container->bound('events')) {
-            $this->container['events']->fire(new Events\JobProcessed($this->connectionName, $job));
+            $this->container['events']->dispatch(new Events\JobProcessed($this->connectionName, $job));
         }
     }
 
@@ -99,7 +99,7 @@ class SyncQueue extends Queue implements QueueContract
     protected function raiseExceptionOccurredJobEvent(Job $job, $e)
     {
         if ($this->container->bound('events')) {
-            $this->container['events']->fire(new Events\JobExceptionOccurred($this->connectionName, $job, $e));
+            $this->container['events']->dispatch(new Events\JobExceptionOccurred($this->connectionName, $job, $e));
         }
     }
 

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -316,7 +316,7 @@ class Worker
             // Here we will fire off the job and let it process. We will catch any exceptions so
             // they can be reported to the developers logs, etc. Once the job is finished the
             // proper events will be fired to let any listeners know this job has finished.
-            $job->fire();
+            $job->dispatch();
 
             $this->raiseAfterJobEvent($connectionName, $job);
         } catch (Exception $e) {
@@ -429,7 +429,7 @@ class Worker
      */
     protected function raiseBeforeJobEvent($connectionName, $job)
     {
-        $this->events->fire(new Events\JobProcessing(
+        $this->events->dispatch(new Events\JobProcessing(
             $connectionName, $job
         ));
     }
@@ -443,7 +443,7 @@ class Worker
      */
     protected function raiseAfterJobEvent($connectionName, $job)
     {
-        $this->events->fire(new Events\JobProcessed(
+        $this->events->dispatch(new Events\JobProcessed(
             $connectionName, $job
         ));
     }
@@ -458,7 +458,7 @@ class Worker
      */
     protected function raiseExceptionOccurredJobEvent($connectionName, $job, $e)
     {
-        $this->events->fire(new Events\JobExceptionOccurred(
+        $this->events->dispatch(new Events\JobExceptionOccurred(
             $connectionName, $job, $e
         ));
     }
@@ -473,7 +473,7 @@ class Worker
      */
     protected function raiseFailedJobEvent($connectionName, $job, $e)
     {
-        $this->events->fire(new Events\JobFailed(
+        $this->events->dispatch(new Events\JobFailed(
             $connectionName, $job, $e
         ));
     }
@@ -555,7 +555,7 @@ class Worker
      */
     public function stop($status = 0)
     {
-        $this->events->fire(new Events\WorkerStopping);
+        $this->events->dispatch(new Events\WorkerStopping);
 
         exit($status);
     }

--- a/tests/Queue/QueueBeanstalkdJobTest.php
+++ b/tests/Queue/QueueBeanstalkdJobTest.php
@@ -12,14 +12,14 @@ class QueueBeanstalkdJobTest extends TestCase
         m::close();
     }
 
-    public function testFireProperlyCallsTheJobHandler()
+    public function testDispatchProperlyCallsTheJobHandler()
     {
         $job = $this->getJob();
         $job->getPheanstalkJob()->shouldReceive('getData')->once()->andReturn(json_encode(['job' => 'foo', 'data' => ['data']]));
         $job->getContainer()->shouldReceive('make')->once()->with('foo')->andReturn($handler = m::mock('stdClass'));
-        $handler->shouldReceive('fire')->once()->with($job, ['data']);
+        $handler->shouldReceive('dispatch')->once()->with($job, ['data']);
 
-        $job->fire();
+        $job->dispatch();
     }
 
     public function testFailedProperlyCallsTheJobHandler()

--- a/tests/Queue/QueueRedisJobTest.php
+++ b/tests/Queue/QueueRedisJobTest.php
@@ -12,13 +12,13 @@ class QueueRedisJobTest extends TestCase
         m::close();
     }
 
-    public function testFireProperlyCallsTheJobHandler()
+    public function testDispatchProperlyCallsTheJobHandler()
     {
         $job = $this->getJob();
         $job->getContainer()->shouldReceive('make')->once()->with('foo')->andReturn($handler = m::mock('stdClass'));
-        $handler->shouldReceive('fire')->once()->with($job, ['data']);
+        $handler->shouldReceive('dispatch')->once()->with($job, ['data']);
 
-        $job->fire();
+        $job->dispatch();
     }
 
     public function testDeleteRemovesTheJobFromRedis()

--- a/tests/Queue/QueueSqsJobTest.php
+++ b/tests/Queue/QueueSqsJobTest.php
@@ -50,12 +50,12 @@ class QueueSqsJobTest extends TestCase
         m::close();
     }
 
-    public function testFireProperlyCallsTheJobHandler()
+    public function testDispatchProperlyCallsTheJobHandler()
     {
         $job = $this->getJob();
         $job->getContainer()->shouldReceive('make')->once()->with('foo')->andReturn($handler = m::mock('stdClass'));
-        $handler->shouldReceive('fire')->once()->with($job, ['data']);
-        $job->fire();
+        $handler->shouldReceive('dispatch')->once()->with($job, ['data']);
+        $job->dispatch();
     }
 
     public function testDeleteRemovesTheJobFromSqs()

--- a/tests/Queue/QueueSyncQueueTest.php
+++ b/tests/Queue/QueueSyncQueueTest.php
@@ -14,7 +14,7 @@ class QueueSyncQueueTest extends TestCase
         m::close();
     }
 
-    public function testPushShouldFireJobInstantly()
+    public function testPushShouldDispatchJobInstantly()
     {
         unset($_SERVER['__sync.test']);
 
@@ -35,7 +35,7 @@ class QueueSyncQueueTest extends TestCase
         $container = new \Illuminate\Container\Container;
         Container::setInstance($container);
         $events = m::mock('Illuminate\Contracts\Events\Dispatcher');
-        $events->shouldReceive('fire')->times(3);
+        $events->shouldReceive('dispatch')->times(3);
         $container->instance('events', $events);
         $container->instance('Illuminate\Contracts\Events\Dispatcher', $events);
         $sync->setContainer($container);
@@ -65,7 +65,7 @@ class SyncQueueTestEntity implements \Illuminate\Contracts\Queue\QueueableEntity
 
 class SyncQueueTestHandler
 {
-    public function fire($job, $data)
+    public function dispatch($job, $data)
     {
         $_SERVER['__sync.test'] = func_get_args();
     }
@@ -73,7 +73,7 @@ class SyncQueueTestHandler
 
 class FailingSyncQueueTestHandler
 {
-    public function fire($job, $data)
+    public function dispatch($job, $data)
     {
         throw new Exception;
     }


### PR DESCRIPTION
Enforce usage of `dispatch` over `fire` for jobs and queues.