### PR TITLE
[5.5] Remove useless condition.

### DIFF
--- a/src/Illuminate/Broadcasting/BroadcastManager.php
+++ b/src/Illuminate/Broadcasting/BroadcastManager.php
@@ -83,9 +83,7 @@ class BroadcastManager implements FactoryContract
 
         $request = $request ?: $this->app['request'];
 
-        if ($request->hasHeader('X-Socket-ID')) {
-            return $request->header('X-Socket-ID');
-        }
+        return $request->header('X-Socket-ID');
     }
 
     /**


### PR DESCRIPTION
Remove useless condition.

As `\Illuminate\Http\Concerns\InteractsWithInput::hasHeader` already calls `\Illuminate\Http\Concerns\InteractsWithInput::header`.