### PR TITLE
[5.5] Remove branch-alias to missing 5.x-dev branch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -100,11 +100,6 @@
             "Illuminate\\Tests\\": "tests/"
         }
     },
-    "extra": {
-        "branch-alias": {
-            "dev-master": "5.5-dev"
-        }
-    },
     "suggest": {
         "aws/aws-sdk-php": "Required to use the SQS queue driver and SES mail driver (~3.0).",
         "doctrine/dbal": "Required to rename columns and drop SQLite columns (~2.5).",


### PR DESCRIPTION
This will allow projects (between now and release) to be able to use

    "laravel/framework": "dev-master as 5.5.0"

in their composer file.  Since there is no more 5.x-dev branch (seems to be master now), the current branch alias is no longer necessary.

Tweak as necessary, I think you know what the ultimate goal is. :)

PS: changes in `laravel/laravel` will be necessary as well between now and actual release.