### PR TITLE
[5.4] Eloquent model 'isNot' complement method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1002,6 +1002,17 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     }
 
     /**
+     * Determine if two models do not have the same ID and belong to the same table.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @return bool
+     */
+    public function isNot(Model $model)
+    {
+        return !$this->is($model);
+    }
+
+    /**
      * Get the database connection for the model.
      *
      * @return \Illuminate\Database\Connection

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1002,7 +1002,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     }
 
     /**
-     * Determine if two models do not have the same ID and belong to the same table.
+     * Determine if two models are not the same.
      *
      * @param  \Illuminate\Database\Eloquent\Model  $model
      * @return bool

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1009,7 +1009,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public function isNot(Model $model)
     {
-        return !$this->is($model);
+        return ! $this->is($model);
     }
 
     /**


### PR DESCRIPTION
In Eloquent `$model->is($otherModel)` now has the complement method `$model->isNot($otherModel)`.

In my latest project I added this to my eloquent base model and thought I'd see if there was any interest for the core.