### PR TITLE
[5.4] Cast id to string before use as an array key

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -129,7 +129,7 @@ abstract class HasOneOrMany extends Relation
         // link them up with their children using the keyed dictionary to make the
         // matching very convenient and easy work. Then we'll just return them.
         foreach ($models as $model) {
-            if (isset($dictionary[$key = $model->getAttribute($this->localKey)])) {
+            if (isset($dictionary[$key = (string) $model->getAttribute($this->localKey)])) {
                 $model->setRelation(
                     $relation, $this->getRelationValue($dictionary, $key, $type)
                 );


### PR DESCRIPTION
This fix allow to use Id as an object with implemented __toString method.

There are some cases where you want to use your custom object to be representation of your database table id. For example Uuid.

If you want to make sure all id are correct you can create getAttribute wrappers as such:

```php
public function getIdAttribute() 
{
    return Uuid::fromString($this->attributes['id'];
}

public function setIdAttribute(Uuid $id) 
{
    $this->attributes['id'] = $id;
}
```

It works fine since (One | Many)ToMany relation.
Code below will try to use object as an array key which will cause fatal error.
```php
if (isset($dictionary[$key = $model->getAttribute($this->localKey)])) {
```

We can safely fix this with object to string casting. I'll not break backwards compatibility and will allow programmers to use object representation of an id.