### PR TITLE
[5.4] Ability to simplify query building with whereIsset and orWhereIsset

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -947,7 +947,7 @@ class Builder
         );
 
         return isset($value)
-            ? $this->where(... func_get_args())
+            ? $this->where(...func_get_args())
             : $this;
     }
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -928,6 +928,48 @@ class Builder
     }
 
     /**
+     * Add an "where" statement to the query if value is set.
+     *
+     * @param  string|array|\Closure  $column
+     * @param  string  $operator
+     * @param  mixed   $value
+     * @param  string  $boolean
+     * @return $this
+     */
+    public function whereIsset($column, $operator = null, $value = null, $boolean = 'and')
+    {
+        if (is_array($column)) {
+            return $this->addArrayOfWheres($column, $boolean, 'whereIsset');
+        }
+
+        list($value, $operator) = $this->prepareValueAndOperator(
+            $value, $operator, func_num_args() == 2
+        );
+
+        return isset($value)
+            ? $this->where(... func_get_args())
+            : $this;
+    }
+
+    /**
+     * Add an "or where" statement to the query if value is set.
+     *
+     * @param  string|array|\Closure  $column
+     * @param  string  $operator
+     * @param  mixed   $value
+     *
+     * @return Builder
+     */
+    public function orWhereIsset($column, $operator = null, $value = null)
+    {
+        list($value, $operator) = $this->prepareValueAndOperator(
+            $value, $operator, func_num_args() == 2
+        );
+
+        return $this->whereIsset($column, $operator, $value, 'or');
+    }
+
+    /**
      * Add a where not between statement to the query.
      *
      * @param  string  $column

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -438,7 +438,7 @@ class DatabaseQueryBuilderTest extends TestCase
             ['email', 'test'],
             ['id', '<=', 1],
             ['is_admin', false],
-            ['created_at','=', null],
+            ['created_at', '=', null],
         ];
 
         $builder = $this->getBuilder();

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -444,7 +444,6 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereIsset($request);
         $this->assertSame('select * from "users" where ("email" = ? and "id" <= ? and "is_admin" = ?)', $builder->toSql());
-
     }
 
     public function testBasicOrWheres()


### PR DESCRIPTION
In my project I often write something like this

```php
if ($name) {
    $query->where('name', $name);
}
if ($number) {
    $query->where('number', $number);
}
// .. 
if ($position) {
    $query->orWhere('position', $position);
}
```

With this pull request it can be simplified to

```php
$query->whereIsset('name', $name)
    ->whereIsset('number', $number);
// ..
    ->orWhereIsset('position', $position);
```

Perhaps it will be better if I rename the method to "whereValueIsset". What do you think ?