### PR TITLE
[5.4] Add macros to \Illuminate\Database\Eloquent\Model

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -382,7 +382,7 @@ trait HasAttributes
         // If the "attribute" exists as a method on the model, we will just assume
         // it is a relationship and will load and return results from the query
         // and hydrate the relationship's value on the "relationships" array.
-        if (method_exists($this, $key)) {
+        if (method_exists($this, $key) || static::hasMacro($key)) {
             return $this->getRelationshipFromMethod($key);
         }
     }

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -29,7 +29,6 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         Concerns\HasTimestamps,
         Concerns\HidesAttributes,
         Concerns\GuardsAttributes;
-
     use Macroable {
         __call as macroCall;
         __callStatic as macroCallStatic;

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -7,6 +7,7 @@ use ArrayAccess;
 use JsonSerializable;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
+use Illuminate\Support\Traits\Macroable;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Routing\UrlRoutable;
@@ -28,6 +29,11 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         Concerns\HasTimestamps,
         Concerns\HidesAttributes,
         Concerns\GuardsAttributes;
+
+    use Macroable {
+        __call as macroCall;
+        __callStatic as macroCallStatic;
+    }
 
     /**
      * The connection name for the model.
@@ -1356,6 +1362,10 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     {
         if (in_array($method, ['increment', 'decrement'])) {
             return $this->$method(...$parameters);
+
+        // Macroable.
+        } elseif (static::hasMacro($method)) {
+            return $this->macroCall($method, $parameters);
         }
 
         return $this->newQuery()->$method(...$parameters);

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1614,6 +1614,15 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertFalse($result);
     }
 
+    public function testMacroableSupport()
+    {
+        EloquentModelStub::macro('testMacro', function () {
+            return false;
+        });
+        $model = new EloquentModelStub;
+        $this->assertFalse($model->testMacro());
+    }
+
     protected function addMockConnection($model)
     {
         $model->setConnectionResolver($resolver = m::mock('Illuminate\Database\ConnectionResolverInterface'));


### PR DESCRIPTION
This feature is useful in real projects and is useful for splitting functional blocks and data model relational coupling.

This change is 100% backward compatible.