### PR TITLE
[5.4] Improvements to Artisan 'vendor:publish' command.

### DIFF
--- a/src/Illuminate/Foundation/Console/VendorPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/VendorPublishCommand.php
@@ -19,6 +19,14 @@ class VendorPublishCommand extends Command
     protected $files;
 
     /**
+     * Boolean describing the status of files. Initially set to false, it changes
+     * to true if any file is successfully published.
+     *
+     * @var boolean
+     */
+    protected $published;
+
+    /**
      * The console command signature.
      *
      * @var string
@@ -45,6 +53,8 @@ class VendorPublishCommand extends Command
         parent::__construct();
 
         $this->files = $files;
+
+        $this->published = false;
     }
 
     /**
@@ -71,9 +81,15 @@ class VendorPublishCommand extends Command
     {
         foreach ($this->pathsToPublish($tag) as $from => $to) {
             $this->publishItem($from, $to);
+
+            $this->published = true;
         }
 
-        $this->info('Publishing complete.');
+        if ($this->published) {
+            $this->info('Publishing complete.');
+        } else {
+            $this->error('Nothing to publish.');
+        }
     }
 
     /**
@@ -122,6 +138,8 @@ class VendorPublishCommand extends Command
             $this->files->copy($from, $to);
 
             $this->status($from, $to, 'File');
+        } else {
+            $this->didntCopyStatus($from, $to, 'File');
         }
     }
 
@@ -186,4 +204,22 @@ class VendorPublishCommand extends Command
 
         $this->line('<info>Copied '.$type.'</info> <comment>['.$from.']</comment> <info>To</info> <comment>['.$to.']</comment>');
     }
+
+    /**
+     * Write a 'didn't copy' status message to the console.
+     *
+     * @param  string  $from
+     * @param  string  $to
+     * @param  string  $type
+     * @return void
+     */
+    protected function didntCopyStatus($from, $to, $type)
+    {
+        $from = str_replace(base_path(), '', realpath($from));
+
+        $to = str_replace(base_path(), '', realpath($to));
+
+        $this->warn('Did not copy '.strtolower($type).' ['.$from.'] to ['.$to.'] as file already exists and "--force" was not specified.');
+    }
+
 }


### PR DESCRIPTION
When using Artisan's `vendor:publish` command on a package with no instructions, I received a 'false positive' where it looked like an asset had been published, when it hadn't. This PR clarifies the output such that it will tell you if a package was not published due to an incorrect name or lack of `--force` attribute.

Incorrect name:
```
$ ./artisan vendor:publish --provider="Person\Package\PackageServiceProvideeeeee"
Nothing to publish.
```

Correct name (same output as previous):
```
$ ./artisan vendor:publish --provider="Person\Package\PackageServiceProvider"
Copied File [/vendor/spatie/laravel-permission/config/permission.php] To [/config/permission.php]
Publishing complete.
```

Published again:
```
$ ./artisan vendor:publish --provider="Person\Package\PackageServiceProvider"
Did not copy file [/vendor/spatie/laravel-permission/config/permission.php] to [/config/permission.php] as file already exists and "--force" was not specified.
Publishing complete.
```
