### PR TITLE
[5.4] Add FileSystem temporaryUrl() method for aws

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -370,6 +370,31 @@ class FilesystemAdapter implements FilesystemContract, CloudFilesystemContract
     }
 
     /**
+     * Get a temporary URL for the file at the given path.
+     *
+     * @param  string $path
+     * @param  \DateTime  $expiration
+     * @return string
+     */
+    public function temporaryUrl($path, $expiration)
+    {
+        $adapter = $this->driver->getAdapter();
+
+        $client = $adapter->getClient();
+
+        if (! $adapter instanceof AwsS3Adapter) {
+            throw new RuntimeException('This driver does not support retrieving temporary URLs.');
+        }
+
+        $command = $client->getCommand('GetObject', [
+            'Bucket' => $adapter->getBucket(),
+            'Key' => $adapter->getPathPrefix().$path
+        ]);
+
+        return (string) $client->createPresignedRequest($command, $expiration)->getUri();
+    }
+
+    /**
      * Get an array of all files in a directory.
      *
      * @param  string|null  $directory

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -388,7 +388,7 @@ class FilesystemAdapter implements FilesystemContract, CloudFilesystemContract
 
         $command = $client->getCommand('GetObject', [
             'Bucket' => $adapter->getBucket(),
-            'Key' => $adapter->getPathPrefix().$path
+            'Key' => $adapter->getPathPrefix().$path,
         ]);
 
         return (string) $client->createPresignedRequest($command, $expiration)->getUri();

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -372,7 +372,7 @@ class FilesystemAdapter implements FilesystemContract, CloudFilesystemContract
     /**
      * Get a temporary URL for the file at the given path.
      *
-     * @param  string $path
+     * @param  string  $path
      * @param  \DateTime  $expiration
      * @return string
      */


### PR DESCRIPTION
Gives the ability to generate temporary links for a given file:

```
Storage::disk('s3')->temporaryUrl("path/to/file", Carbon::now()->addMinutes(10))
```