### PR TITLE
[5.4] Mix() wont throw an exception in production mode.

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -558,7 +558,7 @@ if (! function_exists('mix')) {
                           'webpack.mix.js output paths and try again.';
 
             if (app()->environment() === 'production') {
-                \Log::info($mixMessage);
+                app('log')->info($mixMessage);
 
                 return $path;
             }

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -555,6 +555,7 @@ if (! function_exists('mix')) {
 
         if (! isset($manifest[$path])) {
             if (app()->environment() === 'production') {
+                \Log::info('Unable to locate Mix file: '.$path.'. Please check your webpack.mix.js output paths and try again.');
                 return $path;
             }
 

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -554,6 +554,10 @@ if (! function_exists('mix')) {
         $manifest = $manifests[$manifestPath];
 
         if (! isset($manifest[$path])) {
+            if (app()->environment() === 'production') {
+                return $path;
+            }
+
             throw new Exception(
                 "Unable to locate Mix file: {$path}. Please check your ".
                 'webpack.mix.js output paths and try again.'

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -557,7 +557,7 @@ if (! function_exists('mix')) {
             $mixMessage = "Unable to locate Mix file: {$path}. Please check your ".
                           'webpack.mix.js output paths and try again.';
 
-            if (app()->environment() === 'production') {
+            if (! app('config')->get('app.debug')) {
                 app('log')->info($mixMessage);
 
                 return $path;

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -563,7 +563,7 @@ if (! function_exists('mix')) {
                 return $path;
             }
 
-            throw new Exception( $mixMessage );
+            throw new Exception($mixMessage);
         }
 
         return new HtmlString($manifestDirectory.$manifest[$path]);

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -554,15 +554,16 @@ if (! function_exists('mix')) {
         $manifest = $manifests[$manifestPath];
 
         if (! isset($manifest[$path])) {
+            $mixMessage = "Unable to locate Mix file: {$path}. Please check your ".
+                          'webpack.mix.js output paths and try again.';
+
             if (app()->environment() === 'production') {
-                \Log::info('Unable to locate Mix file: '.$path.'. Please check your webpack.mix.js output paths and try again.');
+                \Log::info($mixMessage);
+
                 return $path;
             }
 
-            throw new Exception(
-                "Unable to locate Mix file: {$path}. Please check your ".
-                'webpack.mix.js output paths and try again.'
-            );
+            throw new Exception( $mixMessage );
         }
 
         return new HtmlString($manifestDirectory.$manifest[$path]);


### PR DESCRIPTION
Return $path if env is in production mode. Otherwise, throw an exception.

ref #20355