### PR TITLE
[5.4] Tweak tests for PHP7.2

### DIFF
--- a/tests/Database/DatabaseEloquentBelongsToManyTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyTest.php
@@ -116,7 +116,7 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
         $this->assertEquals(2, $models[1]->foo[0]->pivot->user_id);
         $this->assertEquals(2, $models[1]->foo[1]->pivot->user_id);
         $this->assertEquals(2, count($models[1]->foo));
-        $this->assertEquals(0, count((array) $models[2]->foo));
+        $this->assertNull($models[2]->foo);
     }
 
     public function testRelationIsProperlyInitialized()

--- a/tests/Database/DatabaseEloquentHasManyTest.php
+++ b/tests/Database/DatabaseEloquentHasManyTest.php
@@ -181,7 +181,7 @@ class DatabaseEloquentHasManyTest extends TestCase
         $this->assertEquals(2, $models[1]->foo[0]->foreign_key);
         $this->assertEquals(2, $models[1]->foo[1]->foreign_key);
         $this->assertEquals(2, count($models[1]->foo));
-        $this->assertEquals(0, count((array) $models[2]->foo));
+        $this->assertNull($models[2]->foo);
     }
 
     public function testCreateManyCreatesARelatedModelForEachRecord()

--- a/tests/Database/DatabaseEloquentHasManyThroughTest.php
+++ b/tests/Database/DatabaseEloquentHasManyThroughTest.php
@@ -98,7 +98,7 @@ class DatabaseEloquentHasManyThroughTest extends TestCase
         $this->assertEquals(2, $models[1]->foo[0]->country_id);
         $this->assertEquals(2, $models[1]->foo[1]->country_id);
         $this->assertEquals(2, count($models[1]->foo));
-        $this->assertEquals(0, count((array) $models[2]->foo));
+        $this->assertNull($models[2]->foo);
     }
 
     public function testModelsAreProperlyMatchedToParentsWithNonPrimaryKey()
@@ -129,7 +129,7 @@ class DatabaseEloquentHasManyThroughTest extends TestCase
         $this->assertEquals(2, $models[1]->foo[0]->country_id);
         $this->assertEquals(2, $models[1]->foo[1]->country_id);
         $this->assertEquals(2, count($models[1]->foo));
-        $this->assertEquals(0, count((array) $models[2]->foo));
+        $this->assertNull($models[2]->foo);
     }
 
     public function testAllColumnsAreSelectedByDefault()


### PR DESCRIPTION
Some of the tests were changed in PR https://github.com/laravel/framework/pull/20258 to be ready for PHP7.2.

I dont think the new tests correctly encapsulate what we are testing for.

Since we know the results returned are expected to be `null` - then lets just test for that. This way we can capture any changes in the future, which could potentially now be hidden with the dynamic typecasting of results in the test.