### PR TITLE
[5.4] Move "tap" method to BuildsQueries trait.

### DIFF
--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -95,6 +95,17 @@ trait BuildsQueries
     }
 
     /**
+     * Pass the query to a given callback.
+     *
+     * @param  \Closure  $callback
+     * @return \Illuminate\Database\Query\Builder
+     */
+    public function tap($callback)
+    {
+        return $this->when(true, $callback);
+    }
+
+    /**
      * Apply the callback's query changes if the given "value" is false.
      *
      * @param  mixed  $value

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -460,17 +460,6 @@ class Builder
     }
 
     /**
-     * Pass the query to a given callback.
-     *
-     * @param  \Closure  $callback
-     * @return \Illuminate\Database\Query\Builder
-     */
-    public function tap($callback)
-    {
-        return $this->when(true, $callback);
-    }
-
-    /**
      * Merge an array of where clauses and bindings.
      *
      * @param  array  $wheres

--- a/tests/Database/DatabaseConcernsBuildsQueriesTraitTest.php
+++ b/tests/Database/DatabaseConcernsBuildsQueriesTraitTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use Illuminate\Database\Concerns\BuildsQueries;
+use PHPUnit\Framework\TestCase;
+
+class DatabaseConcernsBuildsQueriesTraitTest extends TestCase
+{
+    public function testTapCallbackInstance()
+    {
+        $mock = $this->getMockForTrait(BuildsQueries::class);
+        $mock->tap(function ($builder) use ($mock) {
+            $this->assertEquals($mock, $builder);
+        });
+    }
+}

--- a/tests/Database/DatabaseConcernsBuildsQueriesTraitTest.php
+++ b/tests/Database/DatabaseConcernsBuildsQueriesTraitTest.php
@@ -2,8 +2,8 @@
 
 namespace Illuminate\Tests\Database;
 
-use Illuminate\Database\Concerns\BuildsQueries;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Database\Concerns\BuildsQueries;
 
 class DatabaseConcernsBuildsQueriesTraitTest extends TestCase
 {


### PR DESCRIPTION
Method `tap` was moved from `Illuminate\Database\Query\Builder` to `Illuminate\Database\Concerns\BuildsQueries` trait.

Eloquent builder `when` and `tap` methods passes different builder instances to the callback.
`when` passes current eloquent builder to the callback, but `tap` method uses `Illuminate\Database\Query\Builder` as callback argument.

For example:
```php

>>> (new User)->newQuery()->tap(function($builder) { dd(get_class($builder)); });
"Illuminate\Database\Query\Builder"

>>> (new User)->newQuery()->when(true, function($builder) { dd(get_class($builder)); });
"Illuminate\Database\Eloquent\Builder"
```

So, we can't use one **type hint** callback for when/tap methods, like (class callback case will illustrate this better): 

```php
class SomeBuilderCallback
{
   public function __invoke(Illuminate\Database\Eloquent\Builder $builder)
   {
       // do stuff
   }
}

// In one part of application
User::when($condition, new SomeBuilderCallback);

// In other part
User::tap(new SomeBuilderCallback); // will fail
```


