### PR TITLE
[5.5] Adding type parameter to alert in Console/Command

### DIFF
--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -477,13 +477,14 @@ class Command extends SymfonyCommand
      * Write a string in an alert box.
      *
      * @param  string  $string
+     * @param  string  $type
      * @return void
      */
-    public function alert($string)
+    public function alert($string, $type = 'comment')
     {
-        $this->comment(str_repeat('*', strlen($string) + 12));
-        $this->comment('*     '.$string.'     *');
-        $this->comment(str_repeat('*', strlen($string) + 12));
+        $this->$type(str_repeat('*', strlen($string) + 12));
+        $this->$type('*     '.$string.'     *');
+        $this->$type(str_repeat('*', strlen($string) + 12));
 
         $this->output->writeln('');
     }


### PR DESCRIPTION
Hello,

i'm proposing to add a $type parameter to alert function in Console/Command,
with a default value of comment.

this way we can do :

```
$this->command->alert('execution successfull', 'info');
```
for success messages for example.

thanks.