### PR TITLE
[5.4] Fix scheduler callbacks

### DIFF
--- a/src/Illuminate/Console/Scheduling/CallbackEvent.php
+++ b/src/Illuminate/Console/Scheduling/CallbackEvent.php
@@ -63,7 +63,7 @@ class CallbackEvent extends Event
         register_shutdown_function(function () {
             $this->removeMutex();
         });
-        
+
         parent::callBeforeCallbacks($container);
 
         try {

--- a/src/Illuminate/Console/Scheduling/CallbackEvent.php
+++ b/src/Illuminate/Console/Scheduling/CallbackEvent.php
@@ -63,6 +63,8 @@ class CallbackEvent extends Event
         register_shutdown_function(function () {
             $this->removeMutex();
         });
+        
+        parent::callBeforeCallbacks($container);
 
         try {
             $response = $container->call($this->callback, $this->parameters);


### PR DESCRIPTION
I noticed the scheduler callbacks dont currently call the before callbacks?

I think that is an oversight, as I cant see any reason to not try and call them. I did some local testing - and it works perfectly fine with before callbacks included...