### PR TITLE
[5.4] Sync Event and CallbackEvent withoutOverlapping functions

### DIFF
--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -516,11 +516,14 @@ class Event
     /**
      * Do not allow the event to overlap each other.
      *
+     * @param  int  $expiresAt
      * @return $this
      */
-    public function withoutOverlapping()
+    public function withoutOverlapping($expiresAt = 1440)
     {
         $this->withoutOverlapping = true;
+
+        $this->expiresAt = $expiresAt;
 
         return $this->then(function () {
             $this->mutex->forget($this);


### PR DESCRIPTION
The signatures for `withoutOverlapping()` in `Event` and `CallbackEvent` are different.

This sync's up the `Event` to match `CallbackEvent`, allowing people to set a cache expiration time on `Event` in the same way as a `CallbackEvent`.

Non-breaking change - will keep current behavior if no value is set. 