### PR TITLE
[5.4] Add options to temporaryUrl()

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -374,9 +374,10 @@ class FilesystemAdapter implements FilesystemContract, CloudFilesystemContract
      *
      * @param  string  $path
      * @param  \DateTimeInterface  $expiration
+     * @param  array  $options
      * @return string
      */
-    public function temporaryUrl($path, $expiration)
+    public function temporaryUrl($path, $expiration, array $options = [])
     {
         $adapter = $this->driver->getAdapter();
 
@@ -386,10 +387,10 @@ class FilesystemAdapter implements FilesystemContract, CloudFilesystemContract
             throw new RuntimeException('This driver does not support creating temporary URLs.');
         }
 
-        $command = $client->getCommand('GetObject', [
+        $command = $client->getCommand('GetObject', array_merge([
             'Bucket' => $adapter->getBucket(),
             'Key' => $adapter->getPathPrefix().$path,
-        ]);
+        ], $options));
 
         return (string) $client->createPresignedRequest(
             $command, $expiration


### PR DESCRIPTION
This allows users to specify [additional `GetObject` arguments](http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectGET.html) such as:

```
[
    'ResponseContentDisposition' => 'attachment; filename="foobar.zip"',
]
```