### PR TITLE
[5.4] Add path method to get the full path of the given file

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -306,6 +306,17 @@ class FilesystemAdapter implements FilesystemContract, CloudFilesystemContract
     }
 
     /**
+     * Get the full path for the file at the given path.
+     *
+     * @param  string  $path
+     * @return string
+     */
+    public function path($path)
+    {
+        return $this->driver->getAdapter()->getPathPrefix().$path;
+    }
+
+    /**
      * Get the URL for the file at the given path.
      *
      * @param  string  $path


### PR DESCRIPTION
For example:

```php
response()->download(Storage::disk('local')->path('file.txt'));
```

Currently you could use the `url()` method:

```php
response()->download(Storage::disk('local')->url('file.txt'));
```

But when you use `Storage::Fake()` the return value of `url()` will be a non-existing file thus `response->download()` will error.