### PR TITLE
[5.4] allow random to return 0 items

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1089,6 +1089,10 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
             return Arr::random($this->items);
         }
 
+        if ($amount === 0) {
+            return new static;
+        }
+
         return new static(Arr::random($this->items, $amount));
     }
 

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1070,7 +1070,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
-     * Get one or more items randomly from the collection.
+     * Get zero or more items randomly from the collection.
      *
      * @param  int|null  $amount
      * @return mixed

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -911,6 +911,10 @@ class SupportCollectionTest extends TestCase
     {
         $data = new Collection([1, 2, 3, 4, 5, 6]);
 
+        $random = $data->random(0);
+        $this->assertInstanceOf(Collection::class, $random);
+        $this->assertCount(0, $random);
+
         $random = $data->random(1);
         $this->assertInstanceOf(Collection::class, $random);
         $this->assertCount(1, $random);


### PR DESCRIPTION
currently passing in a 0 to the `Collection->random()` method will result in a php error.

this is because it passes the parameter through to the native php `array_rand` function which specifies the 'second argument needs to be between 1 and the number of elements in the array'.

now if we pass in 0, we will catch that early, and simply return an empty static.