### PR TITLE
Update FilesystemAdapter.php

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -391,9 +391,9 @@ class FilesystemAdapter implements FilesystemContract, CloudFilesystemContract
     public function temporaryUrl($path, $expiration, array $options = [])
     {
         $adapter = $this->driver->getAdapter();
-        
+
         if (method_exists($adapter, 'getTemporaryUrl')) {
-            return $adapter->getTemporaryUrl($path);
+            return $adapter->getTemporaryUrl($path, $expiration, array $options = []);
         } else if (! $adapter instanceof AwsS3Adapter) {
             throw new RuntimeException('This driver does not support creating temporary URLs.');
         }

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -391,12 +391,14 @@ class FilesystemAdapter implements FilesystemContract, CloudFilesystemContract
     public function temporaryUrl($path, $expiration, array $options = [])
     {
         $adapter = $this->driver->getAdapter();
-
-        $client = $adapter->getClient();
-
-        if (! $adapter instanceof AwsS3Adapter) {
+        
+        if (method_exists($adapter, 'getTemporaryUrl')) {
+            return $adapter->getTemporaryUrl($path);
+        } else if (! $adapter instanceof AwsS3Adapter) {
             throw new RuntimeException('This driver does not support creating temporary URLs.');
         }
+
+        $client = $adapter->getClient();
 
         $command = $client->getCommand('GetObject', array_merge([
             'Bucket' => $adapter->getBucket(),

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -393,7 +393,7 @@ class FilesystemAdapter implements FilesystemContract, CloudFilesystemContract
         $adapter = $this->driver->getAdapter();
 
         if (method_exists($adapter, 'getTemporaryUrl')) {
-            return $adapter->getTemporaryUrl($path, $expiration, array $options = []);
+            return $adapter->getTemporaryUrl($path, $expiration, $options);
         } else if (! $adapter instanceof AwsS3Adapter) {
             throw new RuntimeException('This driver does not support creating temporary URLs.');
         }


### PR DESCRIPTION
The current implementation does not allow other adapters a chance to implement a `temporaryUrl()` as the `$adapter->getClient()` gets called in first which is not how it works in all cases (in openstack for eg, there is no `getClient()` on the adapter).

This PR allows for this to be possible.