### PR TITLE
[Proposal][5.5] Handling events only once

### DIFF
--- a/src/Illuminate/Contracts/Events/Dispatcher.php
+++ b/src/Illuminate/Contracts/Events/Dispatcher.php
@@ -14,6 +14,15 @@ interface Dispatcher
     public function listen($events, $listener);
 
     /**
+     * Register an event listener and mark it as expendable.
+     *
+     * @param  string|array  $events
+     * @param  mixed  $listener
+     * @return void
+     */
+    public function once($events, $listener);
+
+    /**
      * Determine if a given event has listeners.
      *
      * @param  string  $eventName

--- a/src/Illuminate/Support/Testing/Fakes/EventFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/EventFake.php
@@ -119,6 +119,18 @@ class EventFake implements Dispatcher
     }
 
     /**
+     * Register an event listener and mark it as expendable.
+     *
+     * @param  string|array  $events
+     * @param  mixed  $listener
+     * @return void
+     */
+    public function once($events, $listener)
+    {
+        //
+    }
+
+    /**
      * Determine if a given event has listeners.
      *
      * @param  string  $eventName

--- a/tests/Events/EventsDispatcherTest.php
+++ b/tests/Events/EventsDispatcherTest.php
@@ -245,6 +245,39 @@ class EventsDispatcherTest extends TestCase
 
         $this->assertFalse($d->shouldBroadcast([$event]));
     }
+
+    public function testListenOnce()
+    {
+        $_SERVER['__event.test'] = 0;
+
+        $d = new Dispatcher;
+        $d->once('foo', function () {
+            $_SERVER['__event.test']++;
+        });
+
+        $d->fire('foo');
+        $d->fire('foo');
+
+        $this->assertEquals(1, $_SERVER['__event.test']);
+    }
+
+    public function testListenOnceWithMultipleListeners()
+    {
+        $_SERVER['__event.test'] = 0;
+
+        $d = new Dispatcher;
+        $d->once('foo', function () {
+            $_SERVER['__event.test']++;
+        });
+        $d->once('foo', function () {
+            $_SERVER['__event.test']++;
+        });
+
+        $d->fire('foo');
+        $d->fire('foo');
+
+        $this->assertEquals(2, $_SERVER['__event.test']);
+    }
 }
 
 class TestDispatcherQueuedHandler implements \Illuminate\Contracts\Queue\ShouldQueue


### PR DESCRIPTION
Add `Dispatcher::once` to register an event as expendable.
Once the event dispatched, call `forget` to remove the listener(s).