### PR TITLE
[5.4] fix for requesting 0 randoms on empty collection

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1079,6 +1079,10 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      */
     public function random($amount = null)
     {
+        if ($amount === 0) {
+            return new static;
+        }
+
         if (($requested = $amount ?: 1) > ($count = $this->count())) {
             throw new InvalidArgumentException(
                 "You requested {$requested} items, but there are only {$count} items in the collection."
@@ -1087,10 +1091,6 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
 
         if (is_null($amount)) {
             return Arr::random($this->items);
-        }
-
-        if ($amount === 0) {
-            return new static;
         }
 
         return new static(Arr::random($this->items, $amount));

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -924,6 +924,15 @@ class SupportCollectionTest extends TestCase
         $this->assertCount(3, $random);
     }
 
+    public function testRandomOnEmptyCollection()
+    {
+        $data = new Collection();
+
+        $random = $data->random(0);
+        $this->assertInstanceOf(Collection::class, $random);
+        $this->assertCount(0, $random);
+    }
+
     public function testRandomWithoutArgument()
     {
         $data = new Collection([1, 2, 3, 4, 5, 6]);


### PR DESCRIPTION
previously if you requested 0 random items from an empty collection, it would mistakedly think we were requesting 1 item.

this commit moves the check for a request of zero random items to the beginning, so we don't run into this issue.

also add a test.