### PR TITLE
[5.6] Refactor & Improve Scheduler Events

### DIFF
--- a/src/Illuminate/Console/Scheduling/CallbackEvent.php
+++ b/src/Illuminate/Console/Scheduling/CallbackEvent.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Console\Scheduling;
 
-use Exception;
 use LogicException;
 use InvalidArgumentException;
 use Illuminate\Contracts\Container\Container;

--- a/src/Illuminate/Console/Scheduling/CallbackEvent.php
+++ b/src/Illuminate/Console/Scheduling/CallbackEvent.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Console\Scheduling;
 
-use Log;
 use Exception;
 use LogicException;
 use InvalidArgumentException;
@@ -120,11 +119,7 @@ class CallbackEvent extends Event
      */
     public function storeOutput($output)
     {
-        try {
-            file_put_contents($this->output, $output.PHP_EOL, $this->shouldAppendOutput ? FILE_APPEND : null);
-        } catch (Exception $e) {
-            Log::error('Unable to store output from event due to: '.$e->getMessage());
-        }
+        file_put_contents($this->output, $output.PHP_EOL, $this->shouldAppendOutput ? FILE_APPEND : null);
 
         return $output;
     }

--- a/src/Illuminate/Console/Scheduling/CallbackEvent.php
+++ b/src/Illuminate/Console/Scheduling/CallbackEvent.php
@@ -48,7 +48,7 @@ class CallbackEvent extends Event
     }
 
     /**
-     * Build the process to run.
+     * Run the given event in the foreground.
      *
      * @param  \Illuminate\Contracts\Container\Container  $container
      * @return mixed
@@ -95,22 +95,6 @@ class CallbackEvent extends Event
     }
 
     /**
-     * Do not allow the event to run in background without a name.
-     *
-     * @return $this
-     */
-    public function runInBackground()
-    {
-        if (! $this->description) {
-            throw new LogicException(
-                "A scheduled event name is required to run in the background. Use the 'name' method before 'runInBackground'."
-            );
-        }
-
-        return parent::runInBackground();
-    }
-
-    /**
      * Do not allow the event to overlap each other.
      *
      * @param  int  $expiresAt
@@ -125,5 +109,21 @@ class CallbackEvent extends Event
         }
 
         return parent::withoutOverlapping($expiresAt);
+    }
+
+    /**
+     * Do not allow the event to run in background without a name.
+     *
+     * @return $this
+     */
+    public function runInBackground()
+    {
+        if (! $this->description) {
+            throw new LogicException(
+                "A scheduled event name is required to run in the background. Use the 'name' method before 'runInBackground'."
+            );
+        }
+
+        return parent::runInBackground();
     }
 }

--- a/src/Illuminate/Console/Scheduling/CallbackEvent.php
+++ b/src/Illuminate/Console/Scheduling/CallbackEvent.php
@@ -68,23 +68,6 @@ class CallbackEvent extends Event
     }
 
     /**
-     * Store any captured output.
-     *
-     * @param  string  $output
-     * @return mixed
-     */
-    public function storeOutput($output)
-    {
-        try {
-            file_put_contents($this->output, $output.PHP_EOL, $this->shouldAppendOutput ? FILE_APPEND : null);
-        } catch (Exception $e) {
-            Log::error('Unable to store output from event due to: '.$e->getMessage());
-        }
-
-        return $output;
-    }
-
-    /**
      * Do not allow the event to overlap each other.
      *
      * @param  int  $expiresAt
@@ -125,5 +108,22 @@ class CallbackEvent extends Event
         }
 
         return parent::runInBackground();
+    }
+
+    /**
+     * Store any captured output.
+     *
+     * @param  string  $output
+     * @return mixed
+     */
+    public function storeOutput($output)
+    {
+        try {
+            file_put_contents($this->output, $output.PHP_EOL, $this->shouldAppendOutput ? FILE_APPEND : null);
+        } catch (Exception $e) {
+            Log::error('Unable to store output from event due to: '.$e->getMessage());
+        }
+
+        return $output;
     }
 }

--- a/src/Illuminate/Console/Scheduling/CallbackEvent.php
+++ b/src/Illuminate/Console/Scheduling/CallbackEvent.php
@@ -85,16 +85,6 @@ class CallbackEvent extends Event
     }
 
     /**
-     * Get the mutex name for the scheduled command.
-     *
-     * @return string
-     */
-    public function mutexName()
-    {
-        return 'schedule-mutex-'.sha1($this->expression.$this->description);
-    }
-
-    /**
      * Do not allow the event to overlap each other.
      *
      * @param  int  $expiresAt
@@ -109,6 +99,16 @@ class CallbackEvent extends Event
         }
 
         return parent::withoutOverlapping($expiresAt);
+    }
+
+    /**
+     * Get the mutex name for the scheduled command.
+     *
+     * @return string
+     */
+    public function mutexName()
+    {
+        return 'schedule-mutex-'.sha1($this->expression.$this->description);
     }
 
     /**

--- a/src/Illuminate/Console/Scheduling/CallbackEvent.php
+++ b/src/Illuminate/Console/Scheduling/CallbackEvent.php
@@ -114,7 +114,7 @@ class CallbackEvent extends Event
      * Store any captured output.
      *
      * @param  string  $output
-     * @return mixed
+     * @return string
      */
     public function storeOutput($output)
     {

--- a/src/Illuminate/Console/Scheduling/CallbackEvent.php
+++ b/src/Illuminate/Console/Scheduling/CallbackEvent.php
@@ -101,11 +101,11 @@ class CallbackEvent extends Event
      */
     public function runInBackground()
     {
-         if (! $this->description) {
-             throw new LogicException(
-                 "A scheduled event name is required to run in the background. Use the 'name' method before 'runInBackground'."
-             );
-         }
+        if (! $this->description) {
+            throw new LogicException(
+                "A scheduled event name is required to run in the background. Use the 'name' method before 'runInBackground'."
+            );
+        }
 
         return parent::runInBackground();
     }

--- a/src/Illuminate/Console/Scheduling/CallbackEvent.php
+++ b/src/Illuminate/Console/Scheduling/CallbackEvent.php
@@ -98,6 +98,8 @@ class CallbackEvent extends Event
      * Do not allow the event to run in background without a name.
      *
      * @return $this
+     *
+     * @throws \LogicException
      */
     public function runInBackground()
     {

--- a/src/Illuminate/Console/Scheduling/CommandBuilder.php
+++ b/src/Illuminate/Console/Scheduling/CommandBuilder.php
@@ -8,27 +8,12 @@ use Symfony\Component\Process\ProcessUtils;
 class CommandBuilder
 {
     /**
-     * Build the command for the given event.
-     *
-     * @param  \Illuminate\Console\Scheduling\Event  $event
-     * @return string
-     */
-    public function buildCommand(Event $event)
-    {
-        if ($event->runInBackground) {
-            return $this->buildBackgroundCommand($event);
-        } else {
-            return $this->buildForegroundCommand($event);
-        }
-    }
-
-    /**
      * Build the command for running the event in the foreground.
      *
      * @param  \Illuminate\Console\Scheduling\Event  $event
      * @return string
      */
-    protected function buildForegroundCommand(Event $event)
+    public function buildForegroundCommand(Event $event)
     {
         $output = ProcessUtils::escapeArgument($event->output);
 
@@ -43,17 +28,14 @@ class CommandBuilder
      * @param  \Illuminate\Console\Scheduling\Event  $event
      * @return string
      */
-    protected function buildBackgroundCommand(Event $event)
+    public function buildBackgroundCommand(Event $event)
     {
-        $output = ProcessUtils::escapeArgument($event->output);
+        $background = Application::formatCommandString('schedule:background').' "'.$event->mutexName().'"';
 
-        $redirect = $event->shouldAppendOutput ? ' >> ' : ' > ';
+        $output = ProcessUtils::escapeArgument($event->getDefaultOutput());
 
-        $finished = Application::formatCommandString('schedule:finish').' "'.$event->mutexName().'"';
-
-        return $this->ensureCorrectUser($event,
-            '('.$event->command.$redirect.$output.' 2>&1 '.(windows_os() ? '&' : ';').' '.$finished.') > '
-            .ProcessUtils::escapeArgument($event->getDefaultOutput()).' 2>&1 &'
+        return $this->ensureCorrectUser(
+            $event, '('.$background. ' > '. $output.' 2>&1) > ' . $output . ' 2>&1 &'
         );
     }
 

--- a/src/Illuminate/Console/Scheduling/CommandBuilder.php
+++ b/src/Illuminate/Console/Scheduling/CommandBuilder.php
@@ -35,7 +35,7 @@ class CommandBuilder
         $output = ProcessUtils::escapeArgument($event->getDefaultOutput());
 
         return $this->ensureCorrectUser(
-            $event, '('.$background. ' > '. $output.' 2>&1) > ' . $output . ' 2>&1 &'
+            $event, '('.$background.' > '.$output.' 2>&1) > '.$output.' 2>&1 &'
         );
     }
 

--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -20,7 +20,7 @@ class Event
      *
      * @var string
      */
-    public $command = null;
+    public $command;
 
     /**
      * The cron expression representing the event's frequency.
@@ -125,7 +125,7 @@ class Event
      *
      * @var string
      */
-    public $description = null;
+    public $description;
 
     /**
      * The mutex implementation.

--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -531,6 +531,7 @@ class Event
     /**
      * Do not allow the event to overlap each other.
      *
+     * @param  int  $expiresAt
      * @return $this
      */
     public function withoutOverlapping($expiresAt = 1440)
@@ -588,7 +589,7 @@ class Event
     }
 
     /**
-     * Alias of then().
+     * Register a callback to be called after the operation.
      *
      * @param  \Closure  $callback
      * @return $this
@@ -612,7 +613,7 @@ class Event
     }
 
     /**
-     * Alias of description().
+     * Set the human-friendly description of the event.
      *
      * @param  string  $description
      * @return $this

--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -92,7 +92,6 @@ class Event
      */
     protected $rejects = [];
 
-
     /**
      * The location that output should be sent to.
      *

--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -149,6 +149,16 @@ class Event
     }
 
     /**
+     * Get the default output depending on the OS.
+     *
+     * @return string
+     */
+    public function getDefaultOutput()
+    {
+        return (DIRECTORY_SEPARATOR == '\\') ? 'NUL' : '/dev/null';
+    }
+
+    /**
      * Run the given event.
      *
      * @param  \Illuminate\Contracts\Container\Container  $container
@@ -164,6 +174,16 @@ class Event
         $this->runInBackground
                     ? $this->runCommandInBackground($container)
                     : $this->runCommandInForeground($container);
+    }
+
+    /**
+     * Get the mutex name for the scheduled command.
+     *
+     * @return string
+     */
+    public function mutexName()
+    {
+        return 'schedule-mutex-'.sha1($this->expression.$this->command);
     }
 
     /**
@@ -568,6 +588,17 @@ class Event
     }
 
     /**
+     * Alias of then().
+     *
+     * @param  \Closure  $callback
+     * @return $this
+     */
+    public function after(Closure $callback)
+    {
+        return $this->then($callback);
+    }
+
+    /**
      * Register a callback to be called after the operation.
      *
      * @param  \Closure  $callback
@@ -581,14 +612,14 @@ class Event
     }
 
     /**
-     * Alias of then().
+     * Alias of description().
      *
-     * @param  \Closure  $callback
+     * @param  string  $description
      * @return $this
      */
-    public function after(Closure $callback)
+    public function name($description)
     {
-        return $this->then($callback);
+        return $this->description($description);
     }
 
     /**
@@ -602,17 +633,6 @@ class Event
         $this->description = $description;
 
         return $this;
-    }
-
-    /**
-     * Alias of description().
-     *
-     * @param  string  $description
-     * @return $this
-     */
-    public function name($description)
-    {
-        return $this->description($description);
     }
 
     /**
@@ -673,25 +693,5 @@ class Event
         $this->mutex = $mutex;
 
         return $this;
-    }
-
-    /**
-     * Get the default output depending on the OS.
-     *
-     * @return string
-     */
-    public function getDefaultOutput()
-    {
-        return (DIRECTORY_SEPARATOR == '\\') ? 'NUL' : '/dev/null';
-    }
-
-    /**
-     * Get the mutex name for the scheduled command.
-     *
-     * @return string
-     */
-    public function mutexName()
-    {
-        return 'schedule-mutex-'.sha1($this->expression.$this->command);
     }
 }

--- a/src/Illuminate/Console/Scheduling/ScheduleBackgroundCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleBackgroundCommand.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Console\Scheduling;
 
+use Illuminate\Support\Arr;
 use Illuminate\Console\Command;
 
 class ScheduleBackgroundCommand extends Command
@@ -66,12 +67,12 @@ class ScheduleBackgroundCommand extends Command
     /**
      * Find the event that matches the id.
      *
-     * @return mixd
+     * @return \Illuminate\Console\Scheduling\Event|null
      */
     protected function findEventMutex()
     {
-        return collect($this->schedule->events())->filter(function ($value) {
+        return Arr::first($this->schedule->events(), (function ($value) {
             return $value->mutexName() === $this->argument('id');
-        })->first();
+        }));
     }
 }

--- a/src/Illuminate/Console/Scheduling/ScheduleBackgroundCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleBackgroundCommand.php
@@ -63,7 +63,7 @@ class ScheduleBackgroundCommand extends Command
     }
 
     /**
-     * Find the event that matches the id
+     * Find the event that matches the id.
      *
      * @return mixd
      */

--- a/src/Illuminate/Console/Scheduling/ScheduleBackgroundCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleBackgroundCommand.php
@@ -56,6 +56,7 @@ class ScheduleBackgroundCommand extends Command
     {
         if (! $event = $this->findEventMutex()) {
             $this->error('No scheduled event could be found that matches the given id.');
+
             return;
         }
 

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -42,11 +42,11 @@ use Illuminate\Foundation\Console\ProviderMakeCommand;
 use Illuminate\Foundation\Console\ClearCompiledCommand;
 use Illuminate\Foundation\Console\EventGenerateCommand;
 use Illuminate\Foundation\Console\VendorPublishCommand;
-use Illuminate\Console\Scheduling\ScheduleFinishCommand;
 use Illuminate\Database\Console\Seeds\SeederMakeCommand;
 use Illuminate\Foundation\Console\PackageDiscoverCommand;
 use Illuminate\Database\Console\Migrations\MigrateCommand;
 use Illuminate\Foundation\Console\NotificationMakeCommand;
+use Illuminate\Console\Scheduling\ScheduleBackgroundCommand;
 use Illuminate\Database\Console\Factories\FactoryMakeCommand;
 use Illuminate\Queue\Console\WorkCommand as QueueWorkCommand;
 use Illuminate\Database\Console\Migrations\MigrateMakeCommand;
@@ -111,7 +111,7 @@ class ArtisanServiceProvider extends ServiceProvider
         'RouteClear' => 'command.route.clear',
         'RouteList' => 'command.route.list',
         'Seed' => 'command.seed',
-        'ScheduleFinish' => ScheduleFinishCommand::class,
+        'ScheduleBackground' => ScheduleBackgroundCommand::class,
         'ScheduleRun' => ScheduleRunCommand::class,
         'StorageLink' => 'command.storage.link',
         'Up' => 'command.up',
@@ -828,9 +828,9 @@ class ArtisanServiceProvider extends ServiceProvider
      *
      * @return void
      */
-    protected function registerScheduleFinishCommand()
+    protected function registerScheduleBackgroundCommand()
     {
-        $this->app->singleton(ScheduleFinishCommand::class);
+        $this->app->singleton(ScheduleBackgroundCommand::class);
     }
 
     /**


### PR DESCRIPTION
I've been doing a lot of digging around the scheduler lately. I started re-writing it for my package to give better monitoring - but I think what I've ended up with is pretty cool and would be better in the framework itself.

This PR gives the following changes to schedulers:

- Closures/Callbacks can now be run in background!
- Closures/Callbacks can now have their output captured (and either emailed or stored)!
- Both Foreground and Background events follow a similar flow (more DRY)
- Background events no longer need `schedule:finish`
- Command and Closure events follow a similar flow (more DRY)
- Better mutex handling should result in less 'lock' scenarios when a command fails (all paths now lead to one place - so we handle `register_shutdown_function` there).

Essentially what occurs is background events are now "bounced" off a `scheduler:background` command in the background, but all that command does is re-run the event in the "foreground" (but on a different process). I drew a diagram to try and illustrate the change in flow:

![flow](https://user-images.githubusercontent.com/1210658/28900628-6f351c08-77ea-11e7-9fc9-c82c4f00c507.png)

This allows us to DRY up the files, and effectively have a single flow for all events. It also means all events can be handled in a single flow, and all of them get the same benefits.

My only question is; is it ok to use `ob_start()` etc to capture the callback output (to allow for emailing etc)? It is working (I tested it) - but I wanted to check if any side effects I'm not considering? That feature can be removed if it clashes with the framework somehow.

I've done lots of actual testing of this code on my project, trying all sorts of combinations of commands, background, mutexs etc - and it all seems to work flawlessly. But would be great if a couple of more people could test, especially if you have funky schedules or commands etc.