### PR TITLE
[5.4] Revert breaking change

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -740,7 +740,7 @@ class BelongsToMany extends Relation
      * @param  bool   $touch
      * @return \Illuminate\Database\Eloquent\Model
      */
-    public function create(array $attributes = [], array $joining = [], $touch = true)
+    public function create(array $attributes, array $joining = [], $touch = true)
     {
         $instance = $this->related->newInstance($attributes);
 


### PR DESCRIPTION
https://github.com/laravel/framework/pull/20321 silently breaks packages that extend the BelongsToMany relationship class in a minor release!

Like laravel-mongodb:

https://github.com/jenssegers/laravel-mongodb/blob/master/src/Jenssegers/Mongodb/Relations/BelongsToMany.php#L94

Or the couchbase driver:

https://github.com/ORT-Interactive-GmbH/laravel-couchbase/blob/42a2fd6fcaa53a614900945ecf7895e1ac67ee23/src/Mpociot/Couchbase/Relations/BelongsToMany.php#L117

---

Original breaking change report from @mpociot in https://github.com/laravel/framework/pull/20321#issuecomment-319918377