### PR TITLE
[5.5] Add mergeWith method to Collection

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -940,6 +940,28 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
+     * Merge the collection with the given items.
+     * Items on the same key will be merge using the callback.
+     *
+     * @param  mixed  $items
+     * @param  callable  $callback
+     * @return static
+     */
+    public function mergeWith($items, callable $callback)
+    {
+        $items = $this->getArrayableItems($items);
+
+        return $this->merge($items)
+            ->map(function ($value, $key) use ($callback, $items) {
+                if ($this->has($key) && array_key_exists($key, $items)) {
+                    return $callback($this->get($key), $value, $key);
+                }
+
+                return $value;
+            });
+    }
+
+    /**
      * Create a collection by using this collection for keys and another for its values.
      *
      * @param  mixed  $values

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -506,6 +506,43 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(['name' => 'World', 'id' => 1], $c->merge(new Collection(['name' => 'World', 'id' => 1]))->all());
     }
 
+    public function testMergeWithCallback()
+    {
+        $initial = new Collection(['foo' => 1, 'bar' => 40]);
+        $other = new Collection(['bar' => 2, 'baz' => 1337]);
+
+        $result = $initial->mergeWith($other, function ($a, $b) {
+            return $a + $b;
+        })->all();
+
+        $this->assertEquals([
+            'foo' => 1,
+            'bar' => 40 + 2,
+            'baz' => 1337,
+        ], $result);
+    }
+
+    public function testMergeWithCallbackWithArrays()
+    {
+        $initial = new Collection([
+            'individuals' => ['Taylor', 'Adam'],
+            'companies' => ['Laravel'],
+        ]);
+        $other = new Collection([
+            'individuals' => ['Jeffrey'],
+            'companies' => ['Laracasts'],
+        ]);
+
+        $result = $initial->mergeWith($other, function ($a, $b) {
+            return array_merge($a, $b);
+        })->all();
+
+        $this->assertEquals([
+            'individuals' => ['Taylor', 'Adam', 'Jeffrey'],
+            'companies' => ['Laravel', 'Laracasts'],
+        ], $result);
+    }
+
     public function testUnionNull()
     {
         $c = new Collection(['name' => 'Hello']);


### PR DESCRIPTION
The `merge` method erase the value of the original collection in case of duplicated keys. The `union` method prefer the original collection's value in case of duplicated keys.

This `mergeWith` method provides a way to specify a custom callback / strategy in case of duplicated keys. It's very useful in statistics where you want to add the two values of the same date. Or for groups of values like:

```php
$initial = new Collection([
    'individuals' => ['Taylor', 'Adam'],
    'companies' => ['Laravel'],
]);
$other = new Collection([
    'individuals' => ['Jeffrey'],
    'companies' => ['Laracasts'],
]);

$result = $initial->mergeWith($other, function ($a, $b) {
    return array_merge($a, $b);
})->all();

$this->assertEquals([
    'individuals' => ['Taylor', 'Adam', 'Jeffrey'],
    'companies' => ['Laravel', 'Laracasts'],
], $result);
```