### PR TITLE
[5.5] Allow custom pivot accessors

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -97,6 +97,13 @@ class BelongsToMany extends Relation
     protected $using;
 
     /**
+     * The name of the accessor to use for the relationship.
+     *
+     * @var string
+     */
+    protected $accessor = 'pivot';
+
+    /**
      * The count of self joins.
      *
      * @var int
@@ -246,7 +253,7 @@ class BelongsToMany extends Relation
         $dictionary = [];
 
         foreach ($results as $result) {
-            $dictionary[$result->pivot->{$this->foreignPivotKey}][] = $result;
+            $dictionary[$result->{$this->accessor}->{$this->foreignPivotKey}][] = $result;
         }
 
         return $dictionary;
@@ -261,6 +268,19 @@ class BelongsToMany extends Relation
     public function using($class)
     {
         $this->using = $class;
+
+        return $this;
+    }
+
+    /**
+     * Specify the custom pivot accessor to use for the relationship.
+     *
+     * @param  string  $accessor
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
+     */
+    public function as($accessor)
+    {
+        $this->accessor = $accessor;
 
         return $this;
     }
@@ -612,7 +632,7 @@ class BelongsToMany extends Relation
         // and create a new Pivot model, which is basically a dynamic model that we
         // will set the attributes, table, and connections on it so it will work.
         foreach ($models as $model) {
-            $model->setRelation('pivot', $this->newExistingPivot(
+            $model->setRelation($this->accessor, $this->newExistingPivot(
                 $this->migratePivotAttributes($model)
             ));
         }

--- a/tests/Integration/Database/EloquentBelongsToManyTest.php
+++ b/tests/Integration/Database/EloquentBelongsToManyTest.php
@@ -111,7 +111,14 @@ class EloquentBelongsToManyTest extends TestCase
 
         $post->tagsWithCustomPivot()->attach($tag->id);
 
+        $post->tagsWithCustomAccessor()->attach($tag->id);
+
         $this->assertInstanceOf(CustomPivot::class, $post->tagsWithCustomPivot[0]->pivot);
+
+        $this->assertEquals([
+            'post_id' => '1',
+            'tag_id' => '1',
+        ], $post->tagsWithCustomAccessor[0]->tag->toArray());
     }
 
     /**
@@ -578,6 +585,13 @@ class Post extends Model
         return $this->belongsToMany(TagWithCustomPivot::class, 'posts_tags', 'post_id', 'tag_id')
             ->using(CustomPivot::class)
             ->withTimestamps();
+    }
+
+    public function tagsWithCustomAccessor()
+    {
+        return $this->belongsToMany(TagWithCustomPivot::class, 'posts_tags', 'post_id', 'tag_id')
+            ->using(CustomPivot::class)
+            ->as('tag');
     }
 }
 


### PR DESCRIPTION
This adds the ability to define a belongsToMany relation like this:

```
public function podcasts()
{
    return $this->belongsToMany(Podcast::class, 'users_podcasts', 'user_id', 'podcast_id')
        ->as('subscription');
}
```

Now you'll be able to access the pivot data using `$podcast->subscription` instead of `$podcast->pivot`.