### PR TITLE
Only install Whoops in development, by default

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,6 @@
         "ext-openssl": "*",
         "doctrine/inflector": "~1.1.0",
         "erusev/parsedown": "~1.6",
-        "filp/whoops": "~2.0",
         "league/flysystem": "~1.0",
         "monolog/monolog": "~1.12",
         "mtdowling/cron-expression": "~1.0",
@@ -75,6 +74,7 @@
     "require-dev": {
         "aws/aws-sdk-php": "~3.0",
         "doctrine/dbal": "~2.5",
+        "filp/whoops": "~2.0",
         "mockery/mockery": "~0.9.4",
         "orchestra/testbench-core": "3.5.*",
         "pda/pheanstalk": "~3.0",

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -308,7 +308,7 @@ class Handler implements ExceptionHandlerContract
         $statusCode = $this->isHttpException($e) ? $e->getStatusCode() : 500;
 
         try {
-            $content = config('app.debug')
+            $content = config('app.debug') && class_exists(Whoops::class)
                     ? $this->renderExceptionWithWhoops($e)
                     : $this->renderExceptionWithSymfony($e, config('app.debug'));
         } catch (Exception $e) {


### PR DESCRIPTION
Whoops should be encouraged to only be used in Development based environments, otherwise accidentally enabling debug mode on production would be catastrophic. It would expose every env including database passwords, encryption keys, API keys, etc. Mistakes happen. If this happened in a corporate environment, it would ruin a business.

With this PR, it will only be installed by default on development however you are free to add whoops to your `composer.json` in your `require` block, assuming you would like to be an absolute lunatic and install whoops on production 😄 
