### PR TITLE
[5.5] Cache\DatabaseStore, function forever unlimit

### DIFF
--- a/src/Illuminate/Cache/DatabaseStore.php
+++ b/src/Illuminate/Cache/DatabaseStore.php
@@ -73,7 +73,7 @@ class DatabaseStore implements Store
         // If this cache expiration date is past the current time, we will remove this
         // item from the cache. Then we will return a null value since the cache is
         // expired. We will use "Carbon" to make this comparison with the column.
-        if ($this->currentTime() >= $cache->expiration) {
+        if ($this->currentTime() >= $cache->expiration && $cache->expiration > 0) {
             $this->forget($key);
 
             return;
@@ -199,7 +199,7 @@ class DatabaseStore implements Store
      */
     public function forever($key, $value)
     {
-        $this->put($key, $value, 5256000);
+        $this->put($key, $value, 0);
     }
 
     /**

--- a/tests/Cache/CacheDatabaseStoreTest.php
+++ b/tests/Cache/CacheDatabaseStoreTest.php
@@ -77,7 +77,7 @@ class CacheDatabaseStoreTest extends TestCase
     public function testForeverCallsStoreItemWithReallyLongTime()
     {
         $store = $this->getMockBuilder('Illuminate\Cache\DatabaseStore')->setMethods(['put'])->setConstructorArgs($this->getMocks())->getMock();
-        $store->expects($this->once())->method('put')->with($this->equalTo('foo'), $this->equalTo('bar'), $this->equalTo(5256000));
+        $store->expects($this->once())->method('put')->with($this->equalTo('foo'), $this->equalTo('bar'), $this->equalTo(0));
         $store->forever('foo', 'bar');
     }
 


### PR DESCRIPTION
I have observed that this function forget the key passed 10 years, I have modified it to use the value `0` in the `expiration` field as unlimited