### PR TITLE
[5.5] Collection's methods using `valueRetriever` can have optional key

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -360,14 +360,14 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Determine if all items in the collection pass the given test.
      *
-     * @param  string|callable  $key
+     * @param  string|callable|null  $key
      * @param  mixed  $operator
      * @param  mixed  $value
      * @return bool
      */
-    public function every($key, $operator = null, $value = null)
+    public function every($key = null, $operator = null, $value = null)
     {
-        if (func_num_args() == 1) {
+        if (func_num_args() <= 1) {
             $callback = $this->valueRetriever($key);
 
             foreach ($this->items as $k => $v) {
@@ -633,11 +633,11 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Group an associative array by a field or using a callback.
      *
-     * @param  callable|string  $groupBy
+     * @param  callable|string |null $groupBy
      * @param  bool  $preserveKeys
      * @return static
      */
-    public function groupBy($groupBy, $preserveKeys = false)
+    public function groupBy($groupBy = null, $preserveKeys = false)
     {
         $groupBy = $this->valueRetriever($groupBy);
 
@@ -667,10 +667,10 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Key an associative array by a field or using a callback.
      *
-     * @param  callable|string  $keyBy
+     * @param  callable|string|null  $keyBy
      * @return static
      */
-    public function keyBy($keyBy)
+    public function keyBy($keyBy = null)
     {
         $keyBy = $this->valueRetriever($keyBy);
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -865,6 +865,12 @@ class SupportCollectionTest extends TestCase
             return $item === null;
         }));
 
+        $c = new Collection([true, true]);
+        $this->assertTrue($c->every());
+
+        $c = new Collection([null, true]);
+        $this->assertFalse($c->every());
+
         $c = new Collection([['active' => true], ['active' => true]]);
         $this->assertTrue($c->every('active'));
         $this->assertTrue($c->every->active);
@@ -1352,6 +1358,21 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals([1 => [['rating' => 1, 'url' => '1'], ['rating' => 1, 'url' => '1']], 2 => [['rating' => 2, 'url' => '2']]], $result->toArray());
     }
 
+    public function testGroupByValue()
+    {
+        $data = new Collection([
+            'foo',
+            'foo',
+            'bar',
+        ]);
+
+        $result = $data->groupBy();
+        $this->assertEquals([
+            'foo' => ['foo', 'foo'],
+            'bar' => ['bar'],
+        ], $result->toArray());
+    }
+
     public function testGroupByAttributePreservingKeys()
     {
         $data = new Collection([10 => ['rating' => 1, 'url' => '1'],  20 => ['rating' => 1, 'url' => '1'],  30 => ['rating' => 2, 'url' => '2']]);
@@ -1462,6 +1483,22 @@ class SupportCollectionTest extends TestCase
             return $item['rating'] * 2;
         });
         $this->assertEquals([2 => ['rating' => 1, 'name' => '1'], 4 => ['rating' => 2, 'name' => '2'], 6 => ['rating' => 3, 'name' => '3']], $result->all());
+    }
+
+    public function testKeyByValue()
+    {
+        $data = new Collection([
+            'foo',
+            'bar',
+            'baz',
+        ]);
+
+        $result = $data->keyBy();
+        $this->assertEquals([
+            'foo' => 'foo',
+            'bar' => 'bar',
+            'baz' => 'baz',
+        ], $result->all());
     }
 
     public function testKeyByClosure()


### PR DESCRIPTION
When the key is null, the `valueRetriever` is already returning the identity function (always return the pure value of the item in the collection).

So without changing any code, just making optional the keys for some functions, we can get new behaviours (described in the new tests).