### PR TITLE
pgpool error for reconnect

### DIFF
--- a/src/Illuminate/Database/DetectsLostConnections.php
+++ b/src/Illuminate/Database/DetectsLostConnections.php
@@ -29,6 +29,7 @@ trait DetectsLostConnections
             'Error writing data to the connection',
             'Resource deadlock avoided',
             'Transaction() on null',
+            'child connection forced to terminate due to client_idle_limit',
         ]);
     }
 }


### PR DESCRIPTION
This error is thrown if using pgpool. The application should reconnect if this message is seen.