### PR TITLE
[5.4] Edit translation helper functions signature

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -778,18 +778,18 @@ if (! function_exists('trans')) {
     /**
      * Translate the given message.
      *
-     * @param  string  $id
+     * @param  string  $key
      * @param  array   $replace
      * @param  string  $locale
      * @return \Illuminate\Contracts\Translation\Translator|string|array|null
      */
-    function trans($id = null, $replace = [], $locale = null)
+    function trans($key = null, $replace = [], $locale = null)
     {
-        if (is_null($id)) {
+        if (is_null($key)) {
             return app('translator');
         }
 
-        return app('translator')->trans($id, $replace, $locale);
+        return app('translator')->trans($key, $replace, $locale);
     }
 }
 
@@ -797,15 +797,15 @@ if (! function_exists('trans_choice')) {
     /**
      * Translates the given message based on a count.
      *
-     * @param  string  $id
+     * @param  string  $key
      * @param  int|array|\Countable  $number
      * @param  array   $replace
      * @param  string  $locale
      * @return string
      */
-    function trans_choice($id, $number, array $replace = [], $locale = null)
+    function trans_choice($key, $number, array $replace = [], $locale = null)
     {
-        return app('translator')->transChoice($id, $number, $replace, $locale);
+        return app('translator')->transChoice($key, $number, $replace, $locale);
     }
 }
 


### PR DESCRIPTION
id => key.

So, `trans` signature now match the implementation [src/Illuminate/Translation/Translator.php](https://github.com/laravel/framework/blob/591e89828b8cbecf52cdaaff091a43d296cb1d84/src/Illuminate/Translation/Translator.php#L98) and the contract [src/Illuminate/Contracts/Translation/Translator.php](https://github.com/laravel/framework/blob/591e89828b8cbecf52cdaaff091a43d296cb1d84/src/Illuminate/Contracts/Translation/Translator.php#L15).

And `trans_choice`: [src/Illuminate/Translation/Translator.php](https://github.com/laravel/framework/blob/591e89828b8cbecf52cdaaff091a43d296cb1d84/src/Illuminate/Translation/Translator.php#L183) and [src/Illuminate/Contracts/Translation/Translator.php](https://github.com/laravel/framework/blob/591e89828b8cbecf52cdaaff091a43d296cb1d84/src/Illuminate/Contracts/Translation/Translator.php#L26).
