### PR TITLE
[5.4] Mark all unread notifications as read in one query

### DIFF
--- a/src/Illuminate/Notifications/DatabaseNotificationCollection.php
+++ b/src/Illuminate/Notifications/DatabaseNotificationCollection.php
@@ -13,8 +13,7 @@ class DatabaseNotificationCollection extends Collection
      */
     public function markAsRead()
     {
-        $this->each(function ($notification) {
-            $notification->markAsRead();
-        });
+        DatabaseNotification::whereIn('id', $this->pluck('id')->toArray())
+            ->update(['read_at' => new \Carbon\Carbon]);
     }
 }

--- a/src/Illuminate/Notifications/DatabaseNotificationCollection.php
+++ b/src/Illuminate/Notifications/DatabaseNotificationCollection.php
@@ -14,6 +14,7 @@ class DatabaseNotificationCollection extends Collection
     public function markAsRead()
     {
         DatabaseNotification::whereIn('id', $this->pluck('id')->toArray())
+            ->whereNull('read_at')
             ->update(['read_at' => new \Carbon\Carbon]);
     }
 }


### PR DESCRIPTION
`auth()->user()->unreadNotifications->markAsRead();`

instead of loop and execute a query foreach unread notification .. this approach will only execute one query 