### PR TITLE
[5.4] Fix bug in `compileInsert` with empty values with SQLite.

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
@@ -153,6 +153,10 @@ class SQLiteGrammar extends Grammar
         // grammar insert builder because no special syntax is needed for the single
         // row inserts in SQLite. However, if there are multiples, we'll continue.
         if (count($values) == 1) {
+            if (empty(reset($values))) {
+                return "insert into $table default values";
+            }
+
             return parent::compileInsert($query, reset($values));
         }
 


### PR DESCRIPTION
Hi,
When you're trying to perform an insert with empty values with SQLite, a `QueryException` is thrown, with message `SQLSTATE[HY000]: General error: 1 near ")": syntax error (SQL: insert into "foos" () values ())`.

Indeed, the syntax for inserting an empty row is different between SQLite and MySQL.

You can reproduce that with `$model->create();` (with `$timestamps = false` of course to have a perfect empty model). 

With Mysql it works, with SQLite it fails.