### PR TITLE
[5.4] Make blade 'or' keyword case insensitive

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesEchos.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesEchos.php
@@ -100,6 +100,6 @@ trait CompilesEchos
      */
     public function compileEchoDefaults($value)
     {
-        return preg_replace('/^(?=\$)(.+?)(?:\s+or\s+)(.+?)$/s', 'isset($1) ? $1 : $2', $value);
+        return preg_replace('/^(?=\$)(.+?)(?:\s+or\s+)(.+?)$/si', 'isset($1) ? $1 : $2', $value);
     }
 }


### PR DESCRIPTION
This will make the 'or' keyword case insensitive.
So `{{ $email or old('email') }}` will work the same as `{{ $email OR old('email') }}`.
Currently, the latter is evaluated to boolean.