### PR TITLE
fix: phpdoc error of $column parameter of orWhere method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -217,7 +217,7 @@ class Builder
     /**
      * Add an "or where" clause to the query.
      *
-     * @param  string|\Closure  $column
+     * @param  string|array|\Closure  $column
      * @param  string  $operator
      * @param  mixed  $value
      * @return \Illuminate\Database\Eloquent\Builder|static


### PR DESCRIPTION
The PHPDoc of $column in `Illuminate\Database\Eloquent\Builder::orWhere()` is `@param  string|\Closure  $column`, which is inconsistent with `where()` method: `@param  string|array|\Closure  $column`.

Since `orWhere()` method call `where()` method, it should be consistent with `where()` method.

This pull request fixes this.