### PR TITLE
[5.5] Setup traits dynamically following a naming convention

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -70,6 +70,8 @@ abstract class TestCase extends BaseTestCase
 
         $this->setUpTraits();
 
+        $this->setUpTraitsDynamically();
+
         foreach ($this->afterApplicationCreatedCallbacks as $callback) {
             call_user_func($callback);
         }
@@ -121,6 +123,24 @@ abstract class TestCase extends BaseTestCase
         }
 
         return $uses;
+    }
+
+    /**
+     * Boot the setUp function of a trait dynamically following
+     * the naming convention: setUpTraitName.
+     *
+     * @return void
+     */
+    protected function setUpTraitsDynamically()
+    {
+        foreach (class_uses_recursive(static::class) as $trait) {
+
+            $method = 'setUp' . class_basename($trait);
+
+            if (method_exists($this, $method)) {
+                call_user_func([$this, $method]);
+            }
+        }
     }
 
     /**

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -134,8 +134,7 @@ abstract class TestCase extends BaseTestCase
     protected function setUpTraitsDynamically()
     {
         foreach (class_uses_recursive(static::class) as $trait) {
-
-            $method = 'setUp' . class_basename($trait);
+            $method = 'setUp'.class_basename($trait);
 
             if (method_exists($this, $method)) {
                 call_user_func([$this, $method]);


### PR DESCRIPTION
Hi everyone,

In my recent projects I started to clean my tests using traits. Whilst doing this I came across the problem of having to set up from multiple used traits. With the current implementation of Laravel I would import the traits, and call some of their methods in the main setUp() function like so:

```php
class ExampleTest extends TestCase
{
    use InteractsWithUser;
    use InteractsWithTeams;

    public function setUp()
    {
        parent::setUp();

        $this->setUpInteractsWithUser();
        $this->setUpInteractsWithTeams();
    }
}
```

As you can see this can become repetitive and could use some naming convention to dynamically call those `setUpTraitName()` functions. This is the purpose of this PR, heavily inspired by the `bootTraitName` convention on Eloquent models. It simply goes through all the traits used by the test class and calls the method `setUpTraitName()` if it exists.

So now all you need to do is use the traits and you're good to go:

```php
class ExampleTest extends TestCase
{
    use InteractsWithUser;
    use InteractsWithTeams;
}
```

I hope you like it as much as I do, otherwise no hard feelings ❤️ 

P.S.: This is my first time contributing to an open source project. I would greatly appreciate some feedback on my contribution in order to improve my next ones. 

🌵 Thanks @JeffreyWay for showing me the way on Laracasts.