### PR TITLE
[5.4] Add assertJsonStructureMissing to TestResponse

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -379,6 +379,42 @@ class TestResponse
     }
 
     /**
+     * Assert that the response has not given JSON structure.
+     *
+     * @param  array|null  $structure
+     * @param  array|null  $responseData
+     * @return $this
+     */
+    public function assertJsonMissingStructure(array $structure = null, $responseData = null)
+    {
+        if (is_null($structure)) {
+            return $this->assertJson($this->json());
+        }
+
+        if (is_null($responseData)) {
+            $responseData = $this->decodeResponseJson();
+        }
+
+        foreach ($structure as $key => $value) {
+            if (is_array($value) && $key === '*') {
+                PHPUnit::assertInternalType('array', $responseData);
+
+                foreach ($responseData as $responseDataItem) {
+                    $this->assertJsonMissingStructure($structure['*'], $responseDataItem);
+                }
+            } elseif (is_array($value)) {
+                PHPUnit::assertArrayHasKey($key, $responseData);
+
+                $this->assertJsonMissingStructure($structure[$key], $responseData[$key]);
+            } else {
+                PHPUnit::assertArrayNotHasKey($value, $responseData);
+            }
+        }
+
+        return $this;
+    }
+
+    /**
      * Validate and return the decoded response JSON.
      *
      * @return array

--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -385,7 +385,7 @@ class TestResponse
      * @param  array|null  $responseData
      * @return $this
      */
-    public function assertJsonMissingStructure(array $structure = null, $responseData = null)
+    public function assertJsonStructureMissing(array $structure = null, $responseData = null)
     {
         if (is_null($structure)) {
             return $this->assertJson($this->json());
@@ -400,12 +400,12 @@ class TestResponse
                 PHPUnit::assertInternalType('array', $responseData);
 
                 foreach ($responseData as $responseDataItem) {
-                    $this->assertJsonMissingStructure($structure['*'], $responseDataItem);
+                    $this->assertJsonStructureMissing($structure['*'], $responseDataItem);
                 }
             } elseif (is_array($value)) {
                 PHPUnit::assertArrayHasKey($key, $responseData);
 
-                $this->assertJsonMissingStructure($structure[$key], $responseData[$key]);
+                $this->assertJsonStructureMissing($structure[$key], $responseData[$key]);
             } else {
                 PHPUnit::assertArrayNotHasKey($value, $responseData);
             }

--- a/tests/Foundation/FoundationTestResponseTest.php
+++ b/tests/Foundation/FoundationTestResponseTest.php
@@ -137,24 +137,24 @@ class FoundationTestResponseTest extends TestCase
         $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableMixedResourcesStub));
 
         // Without structure
-        $response->assertJsonMissingStructure();
+        $response->assertJsonStructureMissing();
 
         // At root
-        $response->assertJsonMissingStructure(['foo_bar']);
+        $response->assertJsonStructureMissing(['foo_bar']);
 
         // Nested
-        $response->assertJsonMissingStructure(['foobar' => ['foobar_foo_bar', 'foobar_bar_baz']]);
+        $response->assertJsonStructureMissing(['foobar' => ['foobar_foo_bar', 'foobar_bar_baz']]);
 
         // Wildcard (repeating structure)
-        $response->assertJsonMissingStructure(['bars' => ['*' => ['baz', 'foobar']]]);
+        $response->assertJsonStructureMissing(['bars' => ['*' => ['baz', 'foobar']]]);
 
         // Nested after wildcard
-        $response->assertJsonMissingStructure(['baz' => ['*' => ['baz', 'bar' => ['foobar', 'baz']]]]);
+        $response->assertJsonStructureMissing(['baz' => ['*' => ['baz', 'bar' => ['foobar', 'baz']]]]);
 
         // Wildcard (repeating structure) at root
         $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableSingleResourceStub));
 
-        $response->assertJsonMissingStructure(['*' => ['baz', 'qux', 'quux']]);
+        $response->assertJsonStructureMissing(['*' => ['baz', 'qux', 'quux']]);
     }
 
     public function testMacroable()

--- a/tests/Foundation/FoundationTestResponseTest.php
+++ b/tests/Foundation/FoundationTestResponseTest.php
@@ -132,6 +132,31 @@ class FoundationTestResponseTest extends TestCase
         $response->assertJsonStructure(['*' => ['foo', 'bar', 'foobar']]);
     }
 
+    public function testAssertJsonMissingStructure()
+    {
+        $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableMixedResourcesStub));
+
+        // Without structure
+        $response->assertJsonMissingStructure();
+
+        // At root
+        $response->assertJsonMissingStructure(['foo_bar']);
+
+        // Nested
+        $response->assertJsonMissingStructure(['foobar' => ['foobar_foo_bar', 'foobar_bar_baz']]);
+
+        // Wildcard (repeating structure)
+        $response->assertJsonMissingStructure(['bars' => ['*' => ['baz', 'foobar']]]);
+
+        // Nested after wildcard
+        $response->assertJsonMissingStructure(['baz' => ['*' => ['baz', 'bar' => ['foobar', 'baz']]]]);
+
+        // Wildcard (repeating structure) at root
+        $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableSingleResourceStub));
+
+        $response->assertJsonMissingStructure(['*' => ['baz', 'qux', 'quux']]);
+    }
+
     public function testMacroable()
     {
         TestResponse::macro('foo', function () {


### PR DESCRIPTION
Sometime when you testing an API response, you need to check that a key is not present in JSON response. I added `assertJsonStructureMissing` to `TestResponse` class that do this check.