### PR TITLE
[5.4] Add assertExactJsonStructure to TestResponse

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -343,6 +343,57 @@ class TestResponse
     }
 
     /**
+     * Assert that the response has exact given JSON structure.
+     *
+     * @param  array|null  $structure
+     * @param  array|null  $responseData
+     * @return $this
+     */
+    public function assertExactJsonStructure(array $structure, $responseData = null)
+    {
+        if (is_null($responseData)) {
+            $responseData = $this->decodeResponseJson();
+        }
+
+        foreach ($structure as $key => $value) {
+            if (is_array($value) && $key === '*') {
+                PHPUnit::assertInternalType('array', $responseData);
+
+                foreach ($responseData as $responseDataItem) {
+                    $this->assertJsonStructure($value, $responseDataItem);
+                }
+            } elseif (is_array($value)) {
+                PHPUnit::assertArrayHasKey($key, $responseData);
+
+                $this->assertJsonStructure($value, $responseData[$key]);
+            } else {
+                PHPUnit::assertArrayHasKey($value, $responseData);
+
+                if (is_array($responseData[$value])) {
+                    // It's ok if the value of $responseData[$value] is a sequential array
+                    PHPUnit::assertEquals(array_values($responseData[$value]), $responseData[$value]);
+                }
+            }
+        }
+
+
+        array_walk($structure, function (&$item, $key) {
+            if (!is_int($key)) {
+                $item = $key;
+            }
+        });
+        $structure = array_flip($structure);
+
+        // Skip checking root keys if structure root key is '*'
+        if (array_keys($structure) != ['*']) {
+            // At the end we check response root keys is exactly match with structure root keys
+            PHPUnit::assertEquals(array_keys($structure), array_keys($responseData));
+        }
+
+        return $this;
+    }
+
+    /**
      * Assert that the response has a given JSON structure.
      *
      * @param  array|null  $structure

--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -376,9 +376,8 @@ class TestResponse
             }
         }
 
-
         array_walk($structure, function (&$item, $key) {
-            if (!is_int($key)) {
+            if (! is_int($key)) {
                 $item = $key;
             }
         });

--- a/tests/Foundation/FoundationTestResponseTest.php
+++ b/tests/Foundation/FoundationTestResponseTest.php
@@ -118,13 +118,13 @@ class FoundationTestResponseTest extends TestCase
                 'foobar_bar',
             ],
             'bars'   => [
-                '*' => ['bar', 'foo']
+                '*' => ['bar', 'foo'],
             ],
             'baz'    => [
                 '*' => [
                     'foo',
-                    'bar' => ['foo', 'bar']
-                ]
+                    'bar' => ['foo', 'bar'],
+                ],
             ],
         ]);
 

--- a/tests/Foundation/FoundationTestResponseTest.php
+++ b/tests/Foundation/FoundationTestResponseTest.php
@@ -107,6 +107,33 @@ class FoundationTestResponseTest extends TestCase
         $response->assertJsonFragment(['foo' => 'bar 0', 'bar' => ['foo' => 'bar 0', 'bar' => 'foo 0']]);
     }
 
+    public function testAssertExactJsonStructure()
+    {
+        $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableMixedResourcesStub));
+
+        $response->assertExactJsonStructure([
+            'foo',
+            'foobar' => [
+                'foobar_foo',
+                'foobar_bar',
+            ],
+            'bars'   => [
+                '*' => ['bar', 'foo']
+            ],
+            'baz'    => [
+                '*' => [
+                    'foo',
+                    'bar' => ['foo', 'bar']
+                ]
+            ],
+        ]);
+
+        // Wildcard (repeating structure) at root
+        $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableSingleResourceStub));
+
+        $response->assertExactJsonStructure(['*' => ['foo', 'bar', 'foobar']]);
+    }
+
     public function testAssertJsonStructure()
     {
         $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableMixedResourcesStub));


### PR DESCRIPTION
This assertion is requested in discussion under PR #17700.

This assertion is for testing exact structure matching.