### PR TITLE
Added setConnection() line to Model save() method.

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -154,7 +154,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         $this->syncOriginal();
 
         $this->fill($attributes);
-        
+
         $this->setConnection($this->getConnection()->getName());
     }
 

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -520,7 +520,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         // which is typically an auto-increment value managed by the database.
         else {
             $saved = $this->performInsert($query);
-            if (!$this->getConnectionName()) {
+            if (! $this->getConnectionName()) {
                 $this->setConnection($query->getConnection()->getName());
             }
         }

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -154,8 +154,6 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         $this->syncOriginal();
 
         $this->fill($attributes);
-
-        $this->setConnection($this->getConnection()->getName());
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -520,6 +520,9 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         // which is typically an auto-increment value managed by the database.
         else {
             $saved = $this->performInsert($query);
+            if (!$this->getConnectionName()) {
+                $this->setConnection($query->getConnection()->getName());
+            }
         }
 
         // If the model is successfully saved, we need to do a few more things once

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -154,6 +154,8 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         $this->syncOriginal();
 
         $this->fill($attributes);
+        
+        $this->setConnection($this->getConnection()->getName());
     }
 
     /**


### PR DESCRIPTION
Currently _setConnection()_ never gets called if a model is created using _new_ instead of _create_. This causes _is_ and _contains_ to fail when used with a new model. Possibly fixes #20408.