### PR TITLE
[5.4] Support amount 0 in Arr::random()

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -454,7 +454,7 @@ class Arr
     }
 
     /**
-     * Get a random value from an array.
+     * Get one or a specified number of random values from an array.
      *
      * @param  array  $array
      * @param  int|null  $amount
@@ -475,6 +475,10 @@ class Arr
 
         if (is_null($amount)) {
             return $array[array_rand($array)];
+        }
+
+        if ($amount === 0) {
+            return [];
         }
 
         $keys = array_rand($array, $amount);

--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -464,7 +464,10 @@ class Arr
      */
     public static function random($array, $amount = null)
     {
-        if (($requested = $amount ?: 1) > ($count = count($array))) {
+        $requested = is_null($amount) ? 1 : $amount;
+        $count = count($array);
+
+        if ($requested > $count) {
             throw new InvalidArgumentException(
                 "You requested {$requested} items, but there are only {$count} items in the array."
             );

--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -477,7 +477,7 @@ class Arr
             return $array[array_rand($array)];
         }
 
-        if ($amount === 0) {
+        if ((int) $amount === 0) {
             return [];
         }
 

--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -469,7 +469,7 @@ class Arr
 
         if ($requested > $count) {
             throw new InvalidArgumentException(
-                "You requested {$requested} items, but there are only {$count} items in the array."
+                "You requested {$requested} items, but there are only {$count} items available."
             );
         }
 

--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -465,6 +465,7 @@ class Arr
     public static function random($array, $amount = null)
     {
         $requested = is_null($amount) ? 1 : $amount;
+
         $count = count($array);
 
         if ($requested > $count) {

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1079,10 +1079,6 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      */
     public function random($amount = null)
     {
-        if ($amount === 0) {
-            return new static;
-        }
-
         $requested = is_null($amount) ? 1 : $amount;
         $count = $this->count();
 

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1070,7 +1070,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
-     * Get zero or more items randomly from the collection.
+     * Get one or a specified number of items randomly from the collection.
      *
      * @param  int|null  $amount
      * @return mixed

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -10,7 +10,6 @@ use ArrayIterator;
 use CachingIterator;
 use JsonSerializable;
 use IteratorAggregate;
-use InvalidArgumentException;
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Contracts\Support\Arrayable;
@@ -1079,15 +1078,6 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      */
     public function random($amount = null)
     {
-        $requested = is_null($amount) ? 1 : $amount;
-        $count = $this->count();
-
-        if ($requested > $count) {
-            throw new InvalidArgumentException(
-                "You requested {$requested} items, but there are only {$count} items in the collection."
-            );
-        }
-
         if (is_null($amount)) {
             return Arr::random($this->items);
         }

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1083,7 +1083,10 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
             return new static;
         }
 
-        if (($requested = $amount ?: 1) > ($count = $this->count())) {
+        $requested = is_null($amount) ? 1 : $amount;
+        $count = $this->count();
+
+        if ($requested > $count) {
             throw new InvalidArgumentException(
                 "You requested {$requested} items, but there are only {$count} items in the collection."
             );

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -466,6 +466,31 @@ class SupportArrTest extends TestCase
         $this->assertCount(0, $random);
     }
 
+    public function testRandomThrowsAnErrorWhenRequestingMoreItemsThanAreAvailable()
+    {
+        $exceptions = 0;
+
+        try {
+            Arr::random([]);
+        } catch (\InvalidArgumentException $e) {
+            ++$exceptions;
+        }
+
+        try {
+            Arr::random([], 1);
+        } catch (\InvalidArgumentException $e) {
+            ++$exceptions;
+        }
+
+        try {
+            Arr::random([], 2);
+        } catch (\InvalidArgumentException $e) {
+            ++$exceptions;
+        }
+
+        $this->assertSame(3, $exceptions);
+    }
+
     public function testSet()
     {
         $array = ['products' => ['desk' => ['price' => 100]]];

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -422,21 +422,29 @@ class SupportArrTest extends TestCase
     public function testRandom()
     {
         $random = Arr::random(['foo', 'bar', 'baz']);
-
         $this->assertContains($random, ['foo', 'bar', 'baz']);
 
-        $random = Arr::random(['foo', 'bar', 'baz'], 1);
+        $random = Arr::random(['foo', 'bar', 'baz'], 0);
+        $this->assertInternalType('array', $random);
+        $this->assertCount(0, $random);
 
+        $random = Arr::random(['foo', 'bar', 'baz'], 1);
         $this->assertInternalType('array', $random);
         $this->assertCount(1, $random);
         $this->assertContains($random[0], ['foo', 'bar', 'baz']);
 
         $random = Arr::random(['foo', 'bar', 'baz'], 2);
-
         $this->assertInternalType('array', $random);
         $this->assertCount(2, $random);
         $this->assertContains($random[0], ['foo', 'bar', 'baz']);
         $this->assertContains($random[1], ['foo', 'bar', 'baz']);
+    }
+
+    public function testRandomOnEmptyArray()
+    {
+        $random = Arr::random([], 0);
+        $this->assertInternalType('array', $random);
+        $this->assertCount(0, $random);
     }
 
     public function testSet()

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -421,22 +421,22 @@ class SupportArrTest extends TestCase
 
     public function testRandom()
     {
-        $randomValue = Arr::random(['foo', 'bar', 'baz']);
+        $random = Arr::random(['foo', 'bar', 'baz']);
 
-        $this->assertContains($randomValue, ['foo', 'bar', 'baz']);
+        $this->assertContains($random, ['foo', 'bar', 'baz']);
 
-        $randomValues = Arr::random(['foo', 'bar', 'baz'], 1);
+        $random = Arr::random(['foo', 'bar', 'baz'], 1);
 
-        $this->assertInternalType('array', $randomValues);
-        $this->assertCount(1, $randomValues);
-        $this->assertContains($randomValues[0], ['foo', 'bar', 'baz']);
+        $this->assertInternalType('array', $random);
+        $this->assertCount(1, $random);
+        $this->assertContains($random[0], ['foo', 'bar', 'baz']);
 
-        $randomValues = Arr::random(['foo', 'bar', 'baz'], 2);
+        $random = Arr::random(['foo', 'bar', 'baz'], 2);
 
-        $this->assertInternalType('array', $randomValues);
-        $this->assertCount(2, $randomValues);
-        $this->assertContains($randomValues[0], ['foo', 'bar', 'baz']);
-        $this->assertContains($randomValues[1], ['foo', 'bar', 'baz']);
+        $this->assertInternalType('array', $random);
+        $this->assertCount(2, $random);
+        $this->assertContains($random[0], ['foo', 'bar', 'baz']);
+        $this->assertContains($random[1], ['foo', 'bar', 'baz']);
     }
 
     public function testSet()

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -438,11 +438,30 @@ class SupportArrTest extends TestCase
         $this->assertCount(2, $random);
         $this->assertContains($random[0], ['foo', 'bar', 'baz']);
         $this->assertContains($random[1], ['foo', 'bar', 'baz']);
+
+        $random = Arr::random(['foo', 'bar', 'baz'], '0');
+        $this->assertInternalType('array', $random);
+        $this->assertCount(0, $random);
+
+        $random = Arr::random(['foo', 'bar', 'baz'], '1');
+        $this->assertInternalType('array', $random);
+        $this->assertCount(1, $random);
+        $this->assertContains($random[0], ['foo', 'bar', 'baz']);
+
+        $random = Arr::random(['foo', 'bar', 'baz'], '2');
+        $this->assertInternalType('array', $random);
+        $this->assertCount(2, $random);
+        $this->assertContains($random[0], ['foo', 'bar', 'baz']);
+        $this->assertContains($random[1], ['foo', 'bar', 'baz']);
     }
 
     public function testRandomOnEmptyArray()
     {
         $random = Arr::random([], 0);
+        $this->assertInternalType('array', $random);
+        $this->assertCount(0, $random);
+
+        $random = Arr::random([], '0');
         $this->assertInternalType('array', $random);
         $this->assertCount(0, $random);
     }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -911,6 +911,10 @@ class SupportCollectionTest extends TestCase
     {
         $data = new Collection([1, 2, 3, 4, 5, 6]);
 
+        $random = $data->random();
+        $this->assertInternalType('integer', $random);
+        $this->assertContains($random, $data->all());
+
         $random = $data->random(0);
         $this->assertInstanceOf(Collection::class, $random);
         $this->assertCount(0, $random);
@@ -919,9 +923,9 @@ class SupportCollectionTest extends TestCase
         $this->assertInstanceOf(Collection::class, $random);
         $this->assertCount(1, $random);
 
-        $random = $data->random(3);
+        $random = $data->random(2);
         $this->assertInstanceOf(Collection::class, $random);
-        $this->assertCount(3, $random);
+        $this->assertCount(2, $random);
     }
 
     public function testRandomOnEmptyCollection()
@@ -931,15 +935,6 @@ class SupportCollectionTest extends TestCase
         $random = $data->random(0);
         $this->assertInstanceOf(Collection::class, $random);
         $this->assertCount(0, $random);
-    }
-
-    public function testRandomWithoutArgument()
-    {
-        $data = new Collection([1, 2, 3, 4, 5, 6]);
-
-        $random = $data->random();
-        $this->assertInternalType('integer', $random);
-        $this->assertContains($random, $data->all());
     }
 
     /**

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -953,12 +953,30 @@ class SupportCollectionTest extends TestCase
         $this->assertCount(0, $random);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testRandomThrowsAnErrorWhenRequestingMoreItemsThanAreAvailable()
     {
-        (new Collection)->random();
+        $data = new Collection();
+        $exceptions = 0;
+
+        try {
+            $data->random();
+        } catch (\InvalidArgumentException $e) {
+            ++$exceptions;
+        }
+
+        try {
+            $data->random(1);
+        } catch (\InvalidArgumentException $e) {
+            ++$exceptions;
+        }
+
+        try {
+            $data->random(2);
+        } catch (\InvalidArgumentException $e) {
+            ++$exceptions;
+        }
+
+        $this->assertSame(3, $exceptions);
     }
 
     public function testTakeLast()

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -926,6 +926,18 @@ class SupportCollectionTest extends TestCase
         $random = $data->random(2);
         $this->assertInstanceOf(Collection::class, $random);
         $this->assertCount(2, $random);
+
+        $random = $data->random('0');
+        $this->assertInstanceOf(Collection::class, $random);
+        $this->assertCount(0, $random);
+
+        $random = $data->random('1');
+        $this->assertInstanceOf(Collection::class, $random);
+        $this->assertCount(1, $random);
+
+        $random = $data->random('2');
+        $this->assertInstanceOf(Collection::class, $random);
+        $this->assertCount(2, $random);
     }
 
     public function testRandomOnEmptyCollection()
@@ -933,6 +945,10 @@ class SupportCollectionTest extends TestCase
         $data = new Collection();
 
         $random = $data->random(0);
+        $this->assertInstanceOf(Collection::class, $random);
+        $this->assertCount(0, $random);
+
+        $random = $data->random('0');
         $this->assertInstanceOf(Collection::class, $random);
         $this->assertCount(0, $random);
     }


### PR DESCRIPTION
Follow-up to #20396 and #20402.

To summarize:
* Supports amount 0 in `Arr::random()` for consistency with `Collection::random()`
* Supports "0" as a string, for consistency as the other numbers are accepted as strings.
* A handful of additions to the tests, better this way to prevent any risk of regressions.

<br> ping @browner12