### PR TITLE
[5.1] Backport fix

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1272,6 +1272,10 @@ class Validator implements ValidatorContract
             return false;
         }
 
+        if ($this->shouldBlockPhpUpload($value, $parameters)) {
+            return false;
+        }
+
         return $value->getPath() != '' && in_array($value->guessExtension(), $parameters);
     }
 
@@ -1289,7 +1293,29 @@ class Validator implements ValidatorContract
             return false;
         }
 
+        if ($this->shouldBlockPhpUpload($value, $parameters)) {
+            return false;
+        }
+
         return $value->getPath() != '' && in_array($value->getMimeType(), $parameters);
+    }
+
+    /*
+     * Check if PHP uploads are explicitly allowed.
+     *
+     * @param  mixed  $value
+     * @param  array  $parameters
+     * @return bool
+     */
+    protected function shouldBlockPhpUpload($value, $parameters)
+    {
+        if (in_array('php', $parameters)) {
+            return false;
+        }
+
+        return ($value instanceof UploadedFile)
+           ? strtolower($value->getClientOriginalExtension()) === 'php'
+           : strtolower($value->getExtension()) === 'php';
     }
 
     /**

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1176,6 +1176,27 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $v->setFiles(['x' => $file]);
         $this->assertTrue($v->passes());
 
+        $file = $this->getMock('Symfony\Component\HttpFoundation\File\UploadedFile', ['guessExtension', 'getClientOriginalExtension'], $uploadedFile);
+        $file->expects($this->any())->method('guessExtension')->will($this->returnValue('pdf'));
+        $file->expects($this->any())->method('getClientOriginalExtension')->will($this->returnValue('php'));
+        $v = new Validator($trans, [], ['x' => 'mimes:pdf']);
+        $v->setFiles(['x' => $file]);
+        $this->assertFalse($v->passes());
+
+        $file = $this->getMock('Symfony\Component\HttpFoundation\File\UploadedFile', ['guessExtension', 'getClientOriginalExtension'], $uploadedFile);
+        $file->expects($this->any())->method('guessExtension')->will($this->returnValue('pdf'));
+        $file->expects($this->any())->method('getClientOriginalExtension')->will($this->returnValue('pdf'));
+        $v = new Validator($trans, [], ['x' => 'mimes:pdf']);
+        $v->setFiles(['x' => $file]);
+        $this->assertTrue($v->passes());
+
+        $file = $this->getMock('Symfony\Component\HttpFoundation\File\UploadedFile', ['guessExtension', 'getClientOriginalExtension'], $uploadedFile);
+        $file->expects($this->any())->method('guessExtension')->will($this->returnValue('pdf'));
+        $file->expects($this->any())->method('getClientOriginalExtension')->will($this->returnValue('php'));
+        $v = new Validator($trans, [], ['x' => 'mimes:pdf,php']);
+        $v->setFiles(['x' => $file]);
+        $this->assertTrue($v->passes());
+
         $file2 = $this->getMock('Symfony\Component\HttpFoundation\File\UploadedFile', ['guessExtension', 'isValid'], $uploadedFile);
         $file2->expects($this->any())->method('guessExtension')->will($this->returnValue('php'));
         $file2->expects($this->any())->method('isValid')->will($this->returnValue(false));


### PR DESCRIPTION
Backport of security fixes https://github.com/laravel/framework/pull/20392 & https://github.com/laravel/framework/pull/20400

5.1 is still the current LTS - so this should be backported.