### PR TITLE
Using `fire` instead of `dispatch` according to contract

### DIFF
--- a/src/Illuminate/Queue/FailingJob.php
+++ b/src/Illuminate/Queue/FailingJob.php
@@ -32,7 +32,7 @@ class FailingJob
 
             $job->failed($e);
         } finally {
-            static::events()->fire(new JobFailed(
+            static::events()->dispatch(new JobFailed(
                 $connectionName, $job, $e ?: new ManuallyFailedException
             ));
         }

--- a/src/Illuminate/Queue/SyncQueue.php
+++ b/src/Illuminate/Queue/SyncQueue.php
@@ -72,7 +72,7 @@ class SyncQueue extends Queue implements QueueContract
     protected function raiseBeforeJobEvent(Job $job)
     {
         if ($this->container->bound('events')) {
-            $this->container['events']->fire(new Events\JobProcessing($this->connectionName, $job));
+            $this->container['events']->dispatch(new Events\JobProcessing($this->connectionName, $job));
         }
     }
 
@@ -85,7 +85,7 @@ class SyncQueue extends Queue implements QueueContract
     protected function raiseAfterJobEvent(Job $job)
     {
         if ($this->container->bound('events')) {
-            $this->container['events']->fire(new Events\JobProcessed($this->connectionName, $job));
+            $this->container['events']->dispatch(new Events\JobProcessed($this->connectionName, $job));
         }
     }
 
@@ -99,7 +99,7 @@ class SyncQueue extends Queue implements QueueContract
     protected function raiseExceptionOccurredJobEvent(Job $job, $e)
     {
         if ($this->container->bound('events')) {
-            $this->container['events']->fire(new Events\JobExceptionOccurred($this->connectionName, $job, $e));
+            $this->container['events']->dispatch(new Events\JobExceptionOccurred($this->connectionName, $job, $e));
         }
     }
 

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -429,7 +429,7 @@ class Worker
      */
     protected function raiseBeforeJobEvent($connectionName, $job)
     {
-        $this->events->fire(new Events\JobProcessing(
+        $this->events->dispatch(new Events\JobProcessing(
             $connectionName, $job
         ));
     }
@@ -443,7 +443,7 @@ class Worker
      */
     protected function raiseAfterJobEvent($connectionName, $job)
     {
-        $this->events->fire(new Events\JobProcessed(
+        $this->events->dispatch(new Events\JobProcessed(
             $connectionName, $job
         ));
     }
@@ -458,7 +458,7 @@ class Worker
      */
     protected function raiseExceptionOccurredJobEvent($connectionName, $job, $e)
     {
-        $this->events->fire(new Events\JobExceptionOccurred(
+        $this->events->dispatch(new Events\JobExceptionOccurred(
             $connectionName, $job, $e
         ));
     }
@@ -473,7 +473,7 @@ class Worker
      */
     protected function raiseFailedJobEvent($connectionName, $job, $e)
     {
-        $this->events->fire(new Events\JobFailed(
+        $this->events->dispatch(new Events\JobFailed(
             $connectionName, $job, $e
         ));
     }
@@ -555,7 +555,7 @@ class Worker
      */
     public function stop($status = 0)
     {
-        $this->events->fire(new Events\WorkerStopping);
+        $this->events->dispatch(new Events\WorkerStopping);
 
         exit($status);
     }

--- a/tests/Queue/QueueSyncQueueTest.php
+++ b/tests/Queue/QueueSyncQueueTest.php
@@ -35,7 +35,7 @@ class QueueSyncQueueTest extends TestCase
         $container = new \Illuminate\Container\Container;
         Container::setInstance($container);
         $events = m::mock('Illuminate\Contracts\Events\Dispatcher');
-        $events->shouldReceive('fire')->times(3);
+        $events->shouldReceive('dispatch')->times(3);
         $container->instance('events', $events);
         $container->instance('Illuminate\Contracts\Events\Dispatcher', $events);
         $sync->setContainer($container);

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -41,8 +41,8 @@ class QueueWorkerTest extends TestCase
         $worker = $this->getWorker('default', ['queue' => [$job = new WorkerFakeJob]]);
         $worker->runNextJob('default', 'queue', new WorkerOptions);
         $this->assertTrue($job->fired);
-        $this->events->shouldHaveReceived('fire')->with(Mockery::type(JobProcessing::class))->once();
-        $this->events->shouldHaveReceived('fire')->with(Mockery::type(JobProcessed::class))->once();
+        $this->events->shouldHaveReceived('dispatch')->with(Mockery::type(JobProcessing::class))->once();
+        $this->events->shouldHaveReceived('dispatch')->with(Mockery::type(JobProcessed::class))->once();
     }
 
     public function test_job_can_be_fired_based_on_priority()
@@ -98,8 +98,8 @@ class QueueWorkerTest extends TestCase
         $this->assertEquals(10, $job->releaseAfter);
         $this->assertFalse($job->deleted);
         $this->exceptionHandler->shouldHaveReceived('report')->with($e);
-        $this->events->shouldHaveReceived('fire')->with(Mockery::type(JobExceptionOccurred::class))->once();
-        $this->events->shouldNotHaveReceived('fire', [Mockery::type(JobProcessed::class)]);
+        $this->events->shouldHaveReceived('dispatch')->with(Mockery::type(JobExceptionOccurred::class))->once();
+        $this->events->shouldNotHaveReceived('dispatch', [Mockery::type(JobProcessed::class)]);
     }
 
     public function test_job_is_not_released_if_it_has_exceeded_max_attempts()
@@ -121,9 +121,9 @@ class QueueWorkerTest extends TestCase
         $this->assertTrue($job->deleted);
         $this->assertEquals($e, $job->failedWith);
         $this->exceptionHandler->shouldHaveReceived('report')->with($e);
-        $this->events->shouldHaveReceived('fire')->with(Mockery::type(JobExceptionOccurred::class))->once();
-        $this->events->shouldHaveReceived('fire')->with(Mockery::type(JobFailed::class))->once();
-        $this->events->shouldNotHaveReceived('fire', [Mockery::type(JobProcessed::class)]);
+        $this->events->shouldHaveReceived('dispatch')->with(Mockery::type(JobExceptionOccurred::class))->once();
+        $this->events->shouldHaveReceived('dispatch')->with(Mockery::type(JobFailed::class))->once();
+        $this->events->shouldNotHaveReceived('dispatch', [Mockery::type(JobProcessed::class)]);
     }
 
     public function test_job_is_failed_if_it_has_already_exceeded_max_attempts()
@@ -141,9 +141,9 @@ class QueueWorkerTest extends TestCase
         $this->assertTrue($job->deleted);
         $this->assertInstanceOf(MaxAttemptsExceededException::class, $job->failedWith);
         $this->exceptionHandler->shouldHaveReceived('report')->with(Mockery::type(MaxAttemptsExceededException::class));
-        $this->events->shouldHaveReceived('fire')->with(Mockery::type(JobExceptionOccurred::class))->once();
-        $this->events->shouldHaveReceived('fire')->with(Mockery::type(JobFailed::class))->once();
-        $this->events->shouldNotHaveReceived('fire', [Mockery::type(JobProcessed::class)]);
+        $this->events->shouldHaveReceived('dispatch')->with(Mockery::type(JobExceptionOccurred::class))->once();
+        $this->events->shouldHaveReceived('dispatch')->with(Mockery::type(JobFailed::class))->once();
+        $this->events->shouldNotHaveReceived('dispatch', [Mockery::type(JobProcessed::class)]);
     }
 
     public function test_job_based_max_retries()


### PR DESCRIPTION
We are using `fire` method from a contract but there is no `fire` method. It seems to be `dispatch` method from the contract.

Contract:  `\Illuminate\Contracts\Events\Dispatcher`
Usages:
```
\Illuminate\Queue\Worker
\Illuminate\Queue\SyncQueue
\Illuminate\Queue\FailingJob
```