### PR TITLE
[5.4] Fix JoinClause's whereIn when using a subquery

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -16,6 +16,7 @@ use Illuminate\Database\ConnectionInterface;
 use Illuminate\Database\Concerns\BuildsQueries;
 use Illuminate\Database\Query\Grammars\Grammar;
 use Illuminate\Database\Query\Processors\Processor;
+use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 
 class Builder
 {
@@ -725,10 +726,17 @@ class Builder
     {
         $type = $not ? 'NotIn' : 'In';
 
+        // If the value is an eloquent builder instance we will assume the developer wants to
+        // look for any values that exists within this given query. So we will access the
+        // internal query builder which will then be used as a subquery.
+        if ($values instanceof EloquentBuilder) {
+            $values = $values->getQuery();
+        }
+
         // If the value is a query builder instance we will assume the developer wants to
         // look for any values that exists within this given query. So we will add the
         // query accordingly so that this query is properly executed when it is run.
-        if ($values instanceof static) {
+        if ($values instanceof self) {
             return $this->whereInExistingQuery(
                 $column, $values, $boolean, $not
             );

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -726,9 +726,6 @@ class Builder
     {
         $type = $not ? 'NotIn' : 'In';
 
-        // If the value is an eloquent builder instance we will assume the developer wants to
-        // look for any values that exists within this given query. So we will access the
-        // internal query builder which will then be used as a subquery.
         if ($values instanceof EloquentBuilder) {
             $values = $values->getQuery();
         }


### PR DESCRIPTION
### Description:

You should be able to pass an existing Builder to `whereIn` of a `JoinClause`, but this doesn't work because the [`if ($values instanceof static)`](https://github.com/laravel/framework/blob/5.4/src/Illuminate/Database/Query/Builder.php#L731) doesn't catch the expected case when you pass a `Builder` because it's not an instance of `JoinClause`. 

`TypeError: Argument 1 passed to Illuminate\Database\Grammar::parameterize() must be of the type array, object given`

### Steps To Reproduce:

```php

/** @var Illuminate\Database\Query $query */
$query = $this->getFieldQuery(); 

Account::join('other_table', function (JoinClause $join) use ($query) {
    return $join->on('other_table.field', '=', 'accounts.field')
                ->whereIn('other_table.field', $query);
});
```

