### PR TITLE
[5.5] Allow MailFake to assert mailables were queued

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -153,7 +153,7 @@ class MailFake implements Mailer
             return true;
         };
 
-        return $this->mailablesOf($mailable, true)->filter(function ($mailable) use ($callback) {
+        return $this->queuedMailablesOf($mailable)->filter(function ($mailable) use ($callback) {
             return $callback($mailable);
         });
     }
@@ -173,14 +173,24 @@ class MailFake implements Mailer
      * Get all of the mailed mailables for a given type.
      *
      * @param  string  $type
-     * @param  bool $queued
      * @return \Illuminate\Support\Collection
      */
-    protected function mailablesOf($type, $queued = false)
+    protected function mailablesOf($type)
     {
-        $mailables = $queued ? $this->queuedMailables : $this->mailables;
+        return collect($this->mailables)->filter(function ($mailable) use ($type) {
+            return $mailable instanceof $type;
+        });
+    }
 
-        return collect($mailables)->filter(function ($mailable) use ($type) {
+    /**
+     * Get all of the mailed mailables for a given type.
+     *
+     * @param  string  $type
+     * @return \Illuminate\Support\Collection
+     */
+    protected function queuedMailablesOf($type)
+    {
+        return collect($this->queuedMailables)->filter(function ($mailable) use ($type) {
             return $mailable instanceof $type;
         });
     }
@@ -248,7 +258,7 @@ class MailFake implements Mailer
     public function queue($view, array $data = [], $callback = null, $queue = null)
     {
         if (! $view instanceof Mailable) {
-            throw new InvalidArgumentException('Only mailables may be queued.');
+            return;
         }
 
         $this->queuedMailables[] = $view;

--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -4,6 +4,7 @@ namespace Illuminate\Support\Testing\Fakes;
 
 use Illuminate\Contracts\Mail\Mailer;
 use Illuminate\Contracts\Mail\Mailable;
+use Illuminate\Contracts\Queue\ShouldQueue;
 use PHPUnit\Framework\Assert as PHPUnit;
 
 class MailFake implements Mailer
@@ -184,7 +185,7 @@ class MailFake implements Mailer
      */
     public function hasQueued($mailable)
     {
-        return $this->mailablesOf($mailable, true)->count() > 0;
+        return $this->queuedMailablesOf($mailable)->count() > 0;
     }
 
     /**
@@ -259,6 +260,10 @@ class MailFake implements Mailer
     {
         if (! $view instanceof Mailable) {
             return;
+        }
+
+        if ($view instanceof ShouldQueue) {
+            return $this->queue($view, $data, $callback);
         }
 
         $this->mailables[] = $view;

--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -4,8 +4,8 @@ namespace Illuminate\Support\Testing\Fakes;
 
 use Illuminate\Contracts\Mail\Mailer;
 use Illuminate\Contracts\Mail\Mailable;
-use Illuminate\Contracts\Queue\ShouldQueue;
 use PHPUnit\Framework\Assert as PHPUnit;
+use Illuminate\Contracts\Queue\ShouldQueue;
 
 class MailFake implements Mailer
 {

--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -173,7 +173,7 @@ class MailFake implements Mailer
      * Get all of the mailed mailables for a given type.
      *
      * @param  string  $type
-     * @param  boolean $queued
+     * @param  bool $queued
      * @return \Illuminate\Support\Collection
      */
     protected function mailablesOf($type, $queued = false)

--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Support\Testing\Fakes;
 
-use InvalidArgumentException;
 use Illuminate\Contracts\Mail\Mailer;
 use Illuminate\Contracts\Mail\Mailable;
 use PHPUnit\Framework\Assert as PHPUnit;

--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -173,6 +173,7 @@ class MailFake implements Mailer
      * Get all of the mailed mailables for a given type.
      *
      * @param  string  $type
+     * @param  boolean $queued
      * @return \Illuminate\Support\Collection
      */
     protected function mailablesOf($type, $queued = false)

--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -19,6 +19,7 @@ class MailFake implements Mailer
 
     /**
      * All of the mailables that have been queued;
+     *
      * @var array
      */
     protected $queuedMailables = [];
@@ -85,7 +86,7 @@ class MailFake implements Mailer
      * @param  callable|null  $callback
      * @return void
      */
-    public function assertNotSent($mailable, $callback = null)
+    public function assertNotQueued($mailable, $callback = null)
     {
         PHPUnit::assertTrue(
             $this->queued($mailable, $callback)->count() === 0,
@@ -100,7 +101,7 @@ class MailFake implements Mailer
      */
     public function assertNothingQueued()
     {
-        PHPUnit::assertEmpty($this->mailables, 'Mailables were queued unexpectedly.');
+        PHPUnit::assertEmpty($this->queuedMailables, 'Mailables were queued unexpectedly.');
     }
 
     /**

--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -5,7 +5,7 @@ namespace Illuminate\Support\Testing\Fakes;
 use InvalidArgumentException;
 use Illuminate\Contracts\Mail\Mailable;
 use Illuminate\Contracts\Mail\Mailer;
-use Illuminate\Mail\MailableContract;
+use Illuminate\Contracts\Mail\Mailable as MailableContract;
 use PHPUnit\Framework\Assert as PHPUnit;
 
 class MailFake implements Mailer
@@ -250,7 +250,7 @@ class MailFake implements Mailer
         if (! $view instanceof MailableContract) {
             throw new InvalidArgumentException('Only mailables may be queued.');
         }
-
+        
         $this->queuedMailables[] = $view;
     }
 

--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -86,14 +86,33 @@ class MailFake implements Mailer
      * Assert if a mailable was queued based on a truth-test callback.
      *
      * @param  string  $mailable
-     * @param  callable|null  $callback
+     * @param  callable|int|null  $callback
      * @return void
      */
     public function assertQueued($mailable, $callback = null)
     {
+        if (is_numeric($callback)) {
+            return $this->assertQueuedTimes($mailable, $callback);
+        }
+
         PHPUnit::assertTrue(
             $this->queued($mailable, $callback)->count() > 0,
             "The expected [{$mailable}] mailable was not queued."
+        );
+    }
+
+    /**
+     * Assert if a mailable was queued a number of times.
+     *
+     * @param  string  $mailable
+     * @param  int  $times
+     * @return void
+     */
+    protected function assertQueuedTimes($mailable, $times = 1)
+    {
+        PHPUnit::assertTrue(
+            ($count = $this->queued($mailable)->count()) === $times,
+            "The expected [{$mailable}] mailable was queued {$count} times instead of {$times} times."
         );
     }
 

--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -3,9 +3,8 @@
 namespace Illuminate\Support\Testing\Fakes;
 
 use InvalidArgumentException;
-use Illuminate\Contracts\Mail\Mailable;
 use Illuminate\Contracts\Mail\Mailer;
-use Illuminate\Contracts\Mail\Mailable as MailableContract;
+use Illuminate\Contracts\Mail\Mailable;
 use PHPUnit\Framework\Assert as PHPUnit;
 
 class MailFake implements Mailer
@@ -18,7 +17,7 @@ class MailFake implements Mailer
     protected $mailables = [];
 
     /**
-     * All of the mailables that have been queued;
+     * All of the mailables that have been queued.
      *
      * @var array
      */
@@ -247,10 +246,10 @@ class MailFake implements Mailer
      */
     public function queue($view, array $data = [], $callback = null, $queue = null)
     {
-        if (! $view instanceof MailableContract) {
+        if (! $view instanceof Mailable) {
             throw new InvalidArgumentException('Only mailables may be queued.');
         }
-        
+
         $this->queuedMailables[] = $view;
     }
 

--- a/src/Illuminate/Support/Testing/Fakes/PendingMailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/PendingMailFake.php
@@ -48,6 +48,6 @@ class PendingMailFake extends PendingMail
      */
     public function queue(Mailable $mailable)
     {
-        return $this->sendNow($mailable);
+        return $this->mailer->queue($mailable);
     }
 }

--- a/tests/Support/SupportTestingMailFakeTest.php
+++ b/tests/Support/SupportTestingMailFakeTest.php
@@ -59,6 +59,35 @@ Failed asserting that false is true.', $exception->getMessage());
         $this->fake->assertSent(MailableStub::class, 2);
     }
 
+    public function testAssertQueued()
+    {
+        try {
+            $this->fake->assertQueued(MailableStub::class);
+        } catch (ExpectationFailedException $exception) {
+            $this->assertEquals('The expected [Illuminate\Tests\Support\MailableStub] mailable was not queued.
+Failed asserting that false is true.', $exception->getMessage());
+        }
+
+        $this->fake->to('taylor@laravel.com')->queue($this->mailable);
+
+        $this->fake->assertQueued(MailableStub::class);
+    }
+
+    public function testAssertQueuedTimes()
+    {
+        $this->fake->to('taylor@laravel.com')->queue($this->mailable);
+        $this->fake->to('taylor@laravel.com')->queue($this->mailable);
+
+        try {
+            $this->fake->assertQueued(MailableStub::class, 1);
+        } catch (ExpectationFailedException $exception) {
+            $this->assertEquals('The expected [Illuminate\Tests\Support\MailableStub] mailable was queued 2 times instead of 1 times.
+Failed asserting that false is true.', $exception->getMessage());
+        }
+
+        $this->fake->assertQueued(MailableStub::class, 2);
+    }
+
     public function testAssertNothingSent()
     {
         $this->fake->assertNothingSent();

--- a/tests/Support/SupportTestingMailFakeTest.php
+++ b/tests/Support/SupportTestingMailFakeTest.php
@@ -4,9 +4,9 @@ namespace Illuminate\Tests\Support;
 
 use Illuminate\Mail\Mailable;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Support\Testing\Fakes\MailFake;
 use PHPUnit\Framework\ExpectationFailedException;
-use Illuminate\Contracts\Queue\ShouldQueue;
 
 class MailFakeTest extends TestCase
 {
@@ -89,7 +89,7 @@ Failed asserting that false is true.', $exception->getMessage());
         $this->fake->assertQueued(MailableStub::class, 2);
     }
 
-    public function testSendQueuesAMailable()
+    public function testSendQueuesAMailableThatShouldBeQueued()
     {
         $this->fake->to('taylor@laravel.com')->send(new QueueableMailableStub);
 

--- a/tests/Support/SupportTestingMailFakeTest.php
+++ b/tests/Support/SupportTestingMailFakeTest.php
@@ -6,6 +6,7 @@ use Illuminate\Mail\Mailable;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Support\Testing\Fakes\MailFake;
 use PHPUnit\Framework\ExpectationFailedException;
+use Illuminate\Contracts\Queue\ShouldQueue;
 
 class MailFakeTest extends TestCase
 {
@@ -88,6 +89,20 @@ Failed asserting that false is true.', $exception->getMessage());
         $this->fake->assertQueued(MailableStub::class, 2);
     }
 
+    public function testSendQueuesAMailable()
+    {
+        $this->fake->to('taylor@laravel.com')->send(new QueueableMailableStub);
+
+        try {
+            $this->fake->assertSent(QueueableMailableStub::class);
+        } catch (ExpectationFailedException $exception) {
+            $this->assertEquals('The expected [Illuminate\Tests\Support\QueueableMailableStub] mailable was not sent.
+Failed asserting that false is true.', $exception->getMessage());
+        }
+
+        $this->fake->assertQueued(QueueableMailableStub::class);
+    }
+
     public function testAssertNothingSent()
     {
         $this->fake->assertNothingSent();
@@ -104,6 +119,24 @@ Failed asserting that an array is empty.', $exception->getMessage());
 }
 
 class MailableStub extends Mailable
+{
+    public $framework = 'Laravel';
+
+    protected $version = '5.5';
+
+    /**
+     * Build the message.
+     *
+     * @return $this
+     */
+    public function build()
+    {
+        $this->with('first_name', 'Taylor')
+             ->withLastName('Otwell');
+    }
+}
+
+class QueueableMailableStub extends Mailable implements ShouldQueue
 {
     public $framework = 'Laravel';
 


### PR DESCRIPTION
Hey everyone,  

Right now when you queue a mailable you have to either assert it was `sent` (it was not, as it was queued) or you have to assert `Illuminate\Mail\SendQueuedMailable` was pushed on to the queue.  

This PR gives queued mailables their own property and allows assertions to be made, such as `assertWasQueued($mailable)`.    

Let me know what you guys think!