### PR TITLE
[5.5] Allow where and dynamicWhere to handle arrays

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -636,7 +636,7 @@ class Builder
     }
 
     /**
-     * Determine if the given operator is used to determine not equals
+     * Determine if the given operator is used to determine not equals.
      *
      * @param  string  $operator
      * @return bool

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -546,6 +546,10 @@ class Builder
             $value = new Expression($value ? 'true' : 'false');
         }
 
+        if (is_array($value) || $value instanceof Arrayable) {
+            return $this->whereIn($column, $value, $boolean, $this->notEqualOperator($operator));
+        }
+
         // Now that we are working with just a simple query we can put the elements
         // in our array and add the query binding to our array of bindings that
         // will be bound to each SQL statements when it is finally executed.
@@ -629,6 +633,17 @@ class Builder
     {
         return ! in_array(strtolower($operator), $this->operators, true) &&
                ! in_array(strtolower($operator), $this->grammar->getOperators(), true);
+    }
+
+    /**
+     * Determine if the given operator is used to determine not equals
+     *
+     * @param  string  $operator
+     * @return bool
+     */
+    protected function notEqualOperator($operator)
+    {
+        return in_array($operator, ['<>', '!=']);
     }
 
     /**

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Database;
 
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Support\Collection;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Database\Query\Expression as Raw;
@@ -265,6 +266,43 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->select('*')->from('users')->where('id', '=', 1);
         $this->assertEquals('select * from "users" where "id" = ?', $builder->toSql());
         $this->assertEquals([0 => 1], $builder->getBindings());
+    }
+
+    public function testArrayWheres()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('id', [1, 2, 3]);
+        $this->assertEquals('select * from "users" where "id" in (?, ?, ?)', $builder->toSql());
+        $this->assertEquals([0 => 1, 1 => 2, 2 => 3], $builder->getBindings());
+    }
+
+    public function testArrayNotWheres()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('id', '<>', [1, 2, 3]);
+        $this->assertEquals('select * from "users" where "id" not in (?, ?, ?)', $builder->toSql());
+        $this->assertEquals([0 => 1, 1 => 2, 2 => 3], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('id', '!=', [1, 2, 3]);
+        $this->assertEquals('select * from "users" where "id" not in (?, ?, ?)', $builder->toSql());
+        $this->assertEquals([0 => 1, 1 => 2, 2 => 3], $builder->getBindings());
+    }
+
+    public function testCollectionWheres()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('id', Collection::make([1, 2, 3]));
+        $this->assertEquals('select * from "users" where "id" in (?, ?, ?)', $builder->toSql());
+        $this->assertEquals([0 => 1, 1 => 2, 2 => 3], $builder->getBindings());
+    }
+
+    public function testArrayDynamicWheres()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereId([1, 2, 3]);
+        $this->assertEquals('select * from "users" where "id" in (?, ?, ?)', $builder->toSql());
+        $this->assertEquals([0 => 1, 1 => 2, 2 => 3], $builder->getBindings());
     }
 
     public function testMySqlWrappingProtectsQuotationMarks()


### PR DESCRIPTION
Currently if you pass an array as the value of where, you get strange behavior:

```php
User::whereName(['brandon', 'matt'])->get();
select * from `users` where `name` = 'brandon'
```
or much worse
```php
User::whereName(['brandon', 'matt'])->whereId(5)->get();
select * from `users` where `name` = 'brandon' and `id` = 'matt'
```

This PR would assume the user was interested in a whereIn query instead and handle that automatically. 
```php
User::whereName(['brandon', 'matt'])->get();
select * from `users` where `name` in ('brandon', 'matt')
// OR
User::where('name', '<>', ['brandon', 'matt'])->get();
select * from `users` where `name` not in ('brandon', 'matt')
```