### PR TITLE
[5.4] Add file() method to response factory contact.

### DIFF
--- a/src/Illuminate/Contracts/Routing/ResponseFactory.php
+++ b/src/Illuminate/Contracts/Routing/ResponseFactory.php
@@ -70,6 +70,15 @@ interface ResponseFactory
     public function download($file, $name = null, array $headers = [], $disposition = 'attachment');
 
     /**
+     * Return the raw contents of a binary file.
+     *
+     * @param  \SplFileInfo|string  $file
+     * @param  array  $headers
+     * @return \Symfony\Component\HttpFoundation\BinaryFileResponse
+     */
+    public function file($file, array $headers = [])
+        
+    /**
      * Create a new redirect response to the given path.
      *
      * @param  string  $path

--- a/src/Illuminate/Contracts/Routing/ResponseFactory.php
+++ b/src/Illuminate/Contracts/Routing/ResponseFactory.php
@@ -77,7 +77,7 @@ interface ResponseFactory
      * @return \Symfony\Component\HttpFoundation\BinaryFileResponse
      */
     public function file($file, array $headers = []);
-        
+
     /**
      * Create a new redirect response to the given path.
      *

--- a/src/Illuminate/Contracts/Routing/ResponseFactory.php
+++ b/src/Illuminate/Contracts/Routing/ResponseFactory.php
@@ -76,7 +76,7 @@ interface ResponseFactory
      * @param  array  $headers
      * @return \Symfony\Component\HttpFoundation\BinaryFileResponse
      */
-    public function file($file, array $headers = [])
+    public function file($file, array $headers = []);
         
     /**
      * Create a new redirect response to the given path.


### PR DESCRIPTION
Add missing file() method in ResponseFactory contract to allow using this method according manual https://laravel.com/docs/5.4/responses#file-responses, shoud fix #20473 