### PR TITLE
[5.5] Assert how many times a mail was sent or a job was pushed to the queue

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -38,7 +38,7 @@ class MailFake implements Mailer
      * Assert if a mailable was sent a number of times based on a truth-test callback.
      *
      * @param  string  $mailable
-     * @param  integer $times
+     * @param  int $times
      * @param  callable|null  $callback
      * @return void
      */

--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -31,6 +31,22 @@ class MailFake implements Mailer
     }
 
     /**
+     * Assert if a mailable was sent a number of times based on a truth-test callback.
+     *
+     * @param  string  $mailable
+     * @param  integer $times
+     * @param  callable|null  $callback
+     * @return void
+     */
+    public function assertSentTimes($mailable, $times = 1, $callback = null)
+    {
+        PHPUnit::assertTrue(
+            ($count = $this->sent($mailable, $callback)->count()) === $times,
+            "The expected [{$mailable}] mailable was sent {$count} times instead of {$times} times."
+        );
+    }
+
+    /**
      * Determine if a mailable was not sent based on a truth-test callback.
      *
      * @param  string  $mailable

--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -24,6 +24,10 @@ class MailFake implements Mailer
      */
     public function assertSent($mailable, $callback = null)
     {
+        if(is_array($mailable)) {
+            return $this->assertSentTimes($mailable[0], $mailable[1], $callback);
+        }
+
         PHPUnit::assertTrue(
             $this->sent($mailable, $callback)->count() > 0,
             "The expected [{$mailable}] mailable was not sent."

--- a/src/Illuminate/Support/Testing/Fakes/QueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/QueueFake.php
@@ -38,7 +38,7 @@ class QueueFake extends QueueManager implements Queue
      * @param  callable|null  $callback
      * @return void
      */
-    public function assertPushed($job, $times, $callback = null)
+    public function assertPushedTimes($job, $times, $callback = null)
     {
         PHPUnit::assertTrue(
             ($count = $this->pushed($job, $callback)->count()) === $times,

--- a/src/Illuminate/Support/Testing/Fakes/QueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/QueueFake.php
@@ -38,7 +38,7 @@ class QueueFake extends QueueManager implements Queue
      * Assert if a job was pushed a number of times based on a truth-test callback.
      *
      * @param  string  $job
-     * @param  integer $times
+     * @param  int $times
      * @param  callable|null  $callback
      * @return void
      */

--- a/src/Illuminate/Support/Testing/Fakes/QueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/QueueFake.php
@@ -31,6 +31,22 @@ class QueueFake extends QueueManager implements Queue
     }
 
     /**
+     * Assert if a job was pushed a number of times based on a truth-test callback.
+     *
+     * @param  string  $job
+     * @param  integer $times
+     * @param  callable|null  $callback
+     * @return void
+     */
+    public function assertPushed($job, $times, $callback = null)
+    {
+        PHPUnit::assertTrue(
+            ($count = $this->pushed($job, $callback)->count()) === $times,
+            "The expected [{$job}] job was pushed {$count} times instead of {$times} times."
+        );
+    }
+
+    /**
      * Assert if a job was pushed based on a truth-test callback.
      *
      * @param  string  $queue

--- a/src/Illuminate/Support/Testing/Fakes/QueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/QueueFake.php
@@ -24,6 +24,10 @@ class QueueFake extends QueueManager implements Queue
      */
     public function assertPushed($job, $callback = null)
     {
+        if(is_array($job)) {
+            return $this->assertPushedTimes($mailable[0], $mailable[1], $callback);
+        }
+
         PHPUnit::assertTrue(
             $this->pushed($job, $callback)->count() > 0,
             "The expected [{$job}] job was not pushed."


### PR DESCRIPTION
Hey guys,  

This is not a huge or important PR, but I think it would be a nice addition. It allows people to assert how many times a job was pushed to the queue or a mail was sent.   

The method names are pretty bad but I couldn't think of anything else and didn't wanna mess with the default implementation.. perhaps check if `$mailable` is an array on the normal methods and call this different ones? like `Mail::assertSent([Foo:class, 3])`  
   

Edit:  

I added a commit that allows you to do this:  

`Mail::assertSent([Foo::class, 2]);`  

Instead of this `Mail::assertSentTimes(Foo::class, 2);`
