### PR TITLE
Revert "[5.5] Add Request::pick()"

### DIFF
--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -185,27 +185,6 @@ trait InteractsWithInput
      * @param  array|mixed  $keys
      * @return array
      */
-    public function pick($keys)
-    {
-        $keys = is_array($keys) ? $keys : func_get_args();
-
-        $results = [];
-
-        $input = $this->all();
-
-        foreach ($keys as $key) {
-            Arr::set($results, $key, data_get($input, $key));
-        }
-
-        return $results;
-    }
-
-    /**
-     * Get a subset containing the provided keys with values from the input data.
-     *
-     * @param  array|mixed  $keys
-     * @return array
-     */
     public function only($keys)
     {
         $results = [];

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -319,17 +319,6 @@ class HttpRequestTest extends TestCase
         $this->assertEquals([], $request->only('developer.skills'));
     }
 
-    public function testPickMethod()
-    {
-        $request = Request::create('/', 'GET', ['name' => 'Taylor', 'age' => null]);
-        $this->assertEquals(['name' => 'Taylor', 'age' => null, 'email' => null], $request->pick('name', 'age', 'email'));
-
-        $request = Request::create('/', 'GET', ['developer' => ['name' => 'Taylor', 'age' => null]]);
-        $this->assertEquals(['developer' => ['name' => 'Taylor', 'skills' => null]], $request->pick('developer.name', 'developer.skills'));
-        $this->assertEquals(['developer' => ['age' => null]], $request->pick('developer.age'));
-        $this->assertEquals([], $request->only('developer.skills'));
-    }
-
     public function testExceptMethod()
     {
         $request = Request::create('/', 'GET', ['name' => 'Taylor', 'age' => 25]);


### PR DESCRIPTION
Since `Request::all()` can now accept keys, and would work exactly like `Request::pick()`.