### PR TITLE
[5.5] Allow Whoops customization.

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -369,7 +369,7 @@ class Handler implements ExceptionHandlerContract
                 ))
             );
 
-            $this->customizeWhoopsHandler($handler);
+            $this->customizeWhoopsPage($handler);
         });
     }
 
@@ -483,7 +483,8 @@ class Handler implements ExceptionHandlerContract
      * @param  \Whoops\Handler\PrettyPageHandler  $handler
      * @return void
      */
-    protected function customizeWhoopsHandler($handler) {
+    protected function customizeWhoopsPage($handler)
+    {
         //
     }
 }

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -368,6 +368,8 @@ class Handler implements ExceptionHandlerContract
                     array_flip($files->directories(base_path())), [base_path('vendor')]
                 ))
             );
+
+            $this->customizeWhoopsHandler($handler);
         });
     }
 
@@ -473,5 +475,15 @@ class Handler implements ExceptionHandlerContract
     protected function isHttpException(Exception $e)
     {
         return $e instanceof HttpException;
+    }
+
+    /**
+     * Allow to customize Whoops Handler.
+     *
+     * @param  \Whoops\Handler\PrettyPageHandler  $handler
+     * @return void
+     */
+    protected function customizeWhoopsHandler($handler) {
+        //
     }
 }


### PR DESCRIPTION
Hi, a little PR today, to allow user to customize the Whoops page.

For now, If you want to customize whoops, you need to overwrite the entire `whoopsHandler`method. 

Example here: https://medium.com/@DCzajkowski/how-to-make-laravels-exception-handler-even-better-e20b2e4e8fd4

With this PR, you can add all your wanted customization in a new `customizeWhoopsPage` method, in your `\App\Exceptions\Handler`.

An example:

With this little piece of code in your standard `\App\Exceptions\Handler`:
<img width="603" alt="screen shot 2017-08-09 at 14 25 19" src="https://user-images.githubusercontent.com/11351322/29121385-a1d4d31e-7d0e-11e7-944c-6f4382a72a85.png">

You can have:
![screen shot 2017-08-09 at 14 21 55](https://user-images.githubusercontent.com/11351322/29121389-a6ad2a26-7d0e-11e7-9a26-b45524945e7c.png)

Hope it will be ok for you.
Matt'