### PR TITLE
[5.5] Touch parent timestamp only if there are any changes

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -563,11 +563,11 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     {
         $this->fireModelEvent('saved', false);
 
-        $this->syncOriginal();
-
-        if ($options['touch'] ?? true) {
+        if ($this->isDirty() && ($options['touch'] ?? true)) {
             $this->touchOwners();
         }
+
+        $this->syncOriginal();
     }
 
     /**

--- a/tests/Integration/Database/EloquentBelongsToManyTest.php
+++ b/tests/Integration/Database/EloquentBelongsToManyTest.php
@@ -457,8 +457,10 @@ class EloquentBelongsToManyTest extends TestCase
             Carbon::createFromFormat('Y-m-d H:i:s', '2017-10-10 10:10:10')
         );
 
-        $tag->update(['name' => str_random('asd')]);
+        $tag->update(['name' => $tag->name]);
+        $this->assertNotEquals('2017-10-10 10:10:10', $post->fresh()->updated_at->toDateTimeString());
 
+        $tag->update(['name' => str_random()]);
         $this->assertEquals('2017-10-10 10:10:10', $post->fresh()->updated_at->toDateTimeString());
     }
 


### PR DESCRIPTION
Currently even if there are no changes on the child model the parent timestamp gets updated, this PR checks if the model has changes before touching the parent.