### PR TITLE
[5.5] Added 401 response code to AuthenticationException

### DIFF
--- a/CHANGELOG-5.4.md
+++ b/CHANGELOG-5.4.md
@@ -1,5 +1,16 @@
 # Release Notes for 5.4.x
 
+## [Unreleased]
+
+### Changed
+- Moved `tap()` method from `Builder` to `BuildsQueries` ([#20384](https://github.com/laravel/framework/pull/20384))
+- Made Blade `or` operator case-insensitive ([#20425](https://github.com/laravel/framework/pull/20425))
+- Support `$amount = 0` in `Arr::random()` ([#20439](https://github.com/laravel/framework/pull/20439))
+
+### Fixed
+- Fixed bug when using empty values in `SQLiteGrammar::compileInsert()` ([#20424](https://github.com/laravel/framework/pull/20424))
+
+
 ## v5.4.32 (2017-08-03)
 
 ### Added

--- a/CHANGELOG-5.4.md
+++ b/CHANGELOG-5.4.md
@@ -1,5 +1,21 @@
 # Release Notes for 5.4.x
 
+## v5.4.32 (2017-08-03)
+
+### Added
+- Added `FilesystemAdapter::path()` method  ([#20395](https://github.com/laravel/framework/pull/20395))
+
+### Changed
+- Allow `Collection::random()` to return `0` items ([#20396](https://github.com/laravel/framework/pull/20396), [#20402](https://github.com/laravel/framework/pull/20402))
+- Accept options on `FilesystemAdapter::temporaryUrl()` ([#20394](https://github.com/laravel/framework/pull/20394))
+- Sync `withoutOverlapping` method on `Event` and `CallbackEvent` ([#20389](https://github.com/laravel/framework/pull/20389))
+- Prevent PHP file uploads by default unless explicitly allowed ([#20392](https://github.com/laravel/framework/pull/20392), [#20400](https://github.com/laravel/framework/pull/20400))
+- Allow other filesystem adapter to implement `temporaryUrl()` ([#20398](https://github.com/laravel/framework/pull/20398))
+
+### Fixed
+- Reverted breaking change on `BelongsToMany::create()` ([#20407](https://github.com/laravel/framework/pull/20407))
+
+
 ## v5.4.31 (2017-08-02)
 
 ### Added

--- a/src/Illuminate/Auth/AuthenticationException.php
+++ b/src/Illuminate/Auth/AuthenticationException.php
@@ -7,6 +7,13 @@ use Exception;
 class AuthenticationException extends Exception
 {
     /**
+    * Unauthorized Response Code
+    *
+    * @var int
+    */
+    protected $code = 401;
+
+    /**
      * All of the guards that were checked.
      *
      * @var array

--- a/src/Illuminate/Auth/AuthenticationException.php
+++ b/src/Illuminate/Auth/AuthenticationException.php
@@ -7,10 +7,10 @@ use Exception;
 class AuthenticationException extends Exception
 {
     /**
-    * Unauthorized Response Code
-    *
-    * @var int
-    */
+     * Unauthorized Response Code
+     *
+     * @var int
+     */
     protected $code = 401;
 
     /**

--- a/src/Illuminate/Auth/AuthenticationException.php
+++ b/src/Illuminate/Auth/AuthenticationException.php
@@ -7,7 +7,7 @@ use Exception;
 class AuthenticationException extends Exception
 {
     /**
-     * Unauthorized Response Code
+     * Unauthorized Response Code.
      *
      * @var int
      */

--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -95,6 +95,17 @@ trait BuildsQueries
     }
 
     /**
+     * Pass the query to a given callback.
+     *
+     * @param  \Closure  $callback
+     * @return \Illuminate\Database\Query\Builder
+     */
+    public function tap($callback)
+    {
+        return $this->when(true, $callback);
+    }
+
+    /**
      * Apply the callback's query changes if the given "value" is false.
      *
      * @param  mixed  $value

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -217,7 +217,7 @@ class Builder
     /**
      * Add an "or where" clause to the query.
      *
-     * @param  string|\Closure  $column
+     * @param  string|array|\Closure  $column
      * @param  string  $operator
      * @param  mixed  $value
      * @return \Illuminate\Database\Eloquent\Builder|static

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -460,17 +460,6 @@ class Builder
     }
 
     /**
-     * Pass the query to a given callback.
-     *
-     * @param  \Closure  $callback
-     * @return \Illuminate\Database\Query\Builder
-     */
-    public function tap($callback)
-    {
-        return $this->when(true, $callback);
-    }
-
-    /**
      * Merge an array of where clauses and bindings.
      *
      * @param  array  $wheres

--- a/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
@@ -153,6 +153,10 @@ class SQLiteGrammar extends Grammar
         // grammar insert builder because no special syntax is needed for the single
         // row inserts in SQLite. However, if there are multiples, we'll continue.
         if (count($values) == 1) {
+            if (empty(reset($values))) {
+                return "insert into $table default values";
+            }
+
             return parent::compileInsert($query, reset($values));
         }
 

--- a/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
@@ -153,11 +153,9 @@ class SQLiteGrammar extends Grammar
         // grammar insert builder because no special syntax is needed for the single
         // row inserts in SQLite. However, if there are multiples, we'll continue.
         if (count($values) == 1) {
-            if (empty(reset($values))) {
-                return "insert into $table default values";
-            }
-
-            return parent::compileInsert($query, reset($values));
+            return empty(reset($values))
+                    ? "insert into $table default values"
+                    : parent::compileInsert($query, reset($values));
         }
 
         $names = $this->columnize(array_keys(reset($values)));

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -778,18 +778,18 @@ if (! function_exists('trans')) {
     /**
      * Translate the given message.
      *
-     * @param  string  $id
+     * @param  string  $key
      * @param  array   $replace
      * @param  string  $locale
      * @return \Illuminate\Contracts\Translation\Translator|string|array|null
      */
-    function trans($id = null, $replace = [], $locale = null)
+    function trans($key = null, $replace = [], $locale = null)
     {
-        if (is_null($id)) {
+        if (is_null($key)) {
             return app('translator');
         }
 
-        return app('translator')->trans($id, $replace, $locale);
+        return app('translator')->trans($key, $replace, $locale);
     }
 }
 
@@ -797,15 +797,15 @@ if (! function_exists('trans_choice')) {
     /**
      * Translates the given message based on a count.
      *
-     * @param  string  $id
+     * @param  string  $key
      * @param  int|array|\Countable  $number
      * @param  array   $replace
      * @param  string  $locale
      * @return string
      */
-    function trans_choice($id, $number, array $replace = [], $locale = null)
+    function trans_choice($key, $number, array $replace = [], $locale = null)
     {
-        return app('translator')->transChoice($id, $number, $replace, $locale);
+        return app('translator')->transChoice($key, $number, $replace, $locale);
     }
 }
 

--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -457,14 +457,14 @@ class Arr
      * Get one or a specified number of random values from an array.
      *
      * @param  array  $array
-     * @param  int|null  $amount
+     * @param  int|null  $number
      * @return mixed
      *
      * @throws \InvalidArgumentException
      */
-    public static function random($array, $amount = null)
+    public static function random($array, $number = null)
     {
-        $requested = is_null($amount) ? 1 : $amount;
+        $requested = is_null($number) ? 1 : $number;
 
         $count = count($array);
 
@@ -474,15 +474,15 @@ class Arr
             );
         }
 
-        if (is_null($amount)) {
+        if (is_null($number)) {
             return $array[array_rand($array)];
         }
 
-        if ((int) $amount === 0) {
+        if ((int) $number === 0) {
             return [];
         }
 
-        $keys = array_rand($array, $amount);
+        $keys = array_rand($array, $number);
 
         $results = [];
 

--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -454,7 +454,7 @@ class Arr
     }
 
     /**
-     * Get a random value from an array.
+     * Get one or a specified number of random values from an array.
      *
      * @param  array  $array
      * @param  int|null  $amount
@@ -464,14 +464,22 @@ class Arr
      */
     public static function random($array, $amount = null)
     {
-        if (($requested = $amount ?: 1) > ($count = count($array))) {
+        $requested = is_null($amount) ? 1 : $amount;
+
+        $count = count($array);
+
+        if ($requested > $count) {
             throw new InvalidArgumentException(
-                "You requested {$requested} items, but there are only {$count} items in the array."
+                "You requested {$requested} items, but there are only {$count} items available."
             );
         }
 
         if (is_null($amount)) {
             return $array[array_rand($array)];
+        }
+
+        if ((int) $amount === 0) {
+            return [];
         }
 
         $keys = array_rand($array, $amount);

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -58,23 +58,23 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
-     * Create a new collection by invoking the callback a given amount of times.
+     * Create a new collection by invoking the callback a given number of times.
      *
-     * @param  int  $amount
+     * @param  int  $number
      * @param  callable  $callback
      * @return static
      */
-    public static function times($amount, callable $callback = null)
+    public static function times($number, callable $callback = null)
     {
-        if ($amount < 1) {
+        if ($number < 1) {
             return new static;
         }
 
         if (is_null($callback)) {
-            return new static(range(1, $amount));
+            return new static(range(1, $number));
         }
 
-        return (new static(range(1, $amount)))->map($callback);
+        return (new static(range(1, $number)))->map($callback);
     }
 
     /**
@@ -1071,18 +1071,18 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Get one or a specified number of items randomly from the collection.
      *
-     * @param  int|null  $amount
+     * @param  int|null  $number
      * @return mixed
      *
      * @throws \InvalidArgumentException
      */
-    public function random($amount = null)
+    public function random($number = null)
     {
-        if (is_null($amount)) {
+        if (is_null($number)) {
             return Arr::random($this->items);
         }
 
-        return new static(Arr::random($this->items, $amount));
+        return new static(Arr::random($this->items, $number));
     }
 
     /**

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -10,7 +10,6 @@ use ArrayIterator;
 use CachingIterator;
 use JsonSerializable;
 use IteratorAggregate;
-use InvalidArgumentException;
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Contracts\Support\Arrayable;
@@ -1070,7 +1069,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
-     * Get zero or more items randomly from the collection.
+     * Get one or a specified number of items randomly from the collection.
      *
      * @param  int|null  $amount
      * @return mixed
@@ -1079,16 +1078,6 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      */
     public function random($amount = null)
     {
-        if ($amount === 0) {
-            return new static;
-        }
-
-        if (($requested = $amount ?: 1) > ($count = $this->count())) {
-            throw new InvalidArgumentException(
-                "You requested {$requested} items, but there are only {$count} items in the collection."
-            );
-        }
-
         if (is_null($amount)) {
             return Arr::random($this->items);
         }

--- a/src/Illuminate/View/Compilers/Concerns/CompilesEchos.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesEchos.php
@@ -100,6 +100,6 @@ trait CompilesEchos
      */
     public function compileEchoDefaults($value)
     {
-        return preg_replace('/^(?=\$)(.+?)(?:\s+or\s+)(.+?)$/s', 'isset($1) ? $1 : $2', $value);
+        return preg_replace('/^(?=\$)(.+?)(?:\s+or\s+)(.+?)$/si', 'isset($1) ? $1 : $2', $value);
     }
 }

--- a/src/Illuminate/View/Engines/EngineResolver.php
+++ b/src/Illuminate/View/Engines/EngineResolver.php
@@ -38,7 +38,7 @@ class EngineResolver
     }
 
     /**
-     * Resolver an engine instance by name.
+     * Resolve an engine instance by name.
      *
      * @param  string  $engine
      * @return \Illuminate\View\Engines\EngineInterface

--- a/tests/Database/DatabaseConcernsBuildsQueriesTraitTest.php
+++ b/tests/Database/DatabaseConcernsBuildsQueriesTraitTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use PHPUnit\Framework\TestCase;
+use Illuminate\Database\Concerns\BuildsQueries;
+
+class DatabaseConcernsBuildsQueriesTraitTest extends TestCase
+{
+    public function testTapCallbackInstance()
+    {
+        $mock = $this->getMockForTrait(BuildsQueries::class);
+        $mock->tap(function ($builder) use ($mock) {
+            $this->assertEquals($mock, $builder);
+        });
+    }
+}

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -421,22 +421,74 @@ class SupportArrTest extends TestCase
 
     public function testRandom()
     {
-        $randomValue = Arr::random(['foo', 'bar', 'baz']);
+        $random = Arr::random(['foo', 'bar', 'baz']);
+        $this->assertContains($random, ['foo', 'bar', 'baz']);
 
-        $this->assertContains($randomValue, ['foo', 'bar', 'baz']);
+        $random = Arr::random(['foo', 'bar', 'baz'], 0);
+        $this->assertInternalType('array', $random);
+        $this->assertCount(0, $random);
 
-        $randomValues = Arr::random(['foo', 'bar', 'baz'], 1);
+        $random = Arr::random(['foo', 'bar', 'baz'], 1);
+        $this->assertInternalType('array', $random);
+        $this->assertCount(1, $random);
+        $this->assertContains($random[0], ['foo', 'bar', 'baz']);
 
-        $this->assertInternalType('array', $randomValues);
-        $this->assertCount(1, $randomValues);
-        $this->assertContains($randomValues[0], ['foo', 'bar', 'baz']);
+        $random = Arr::random(['foo', 'bar', 'baz'], 2);
+        $this->assertInternalType('array', $random);
+        $this->assertCount(2, $random);
+        $this->assertContains($random[0], ['foo', 'bar', 'baz']);
+        $this->assertContains($random[1], ['foo', 'bar', 'baz']);
 
-        $randomValues = Arr::random(['foo', 'bar', 'baz'], 2);
+        $random = Arr::random(['foo', 'bar', 'baz'], '0');
+        $this->assertInternalType('array', $random);
+        $this->assertCount(0, $random);
 
-        $this->assertInternalType('array', $randomValues);
-        $this->assertCount(2, $randomValues);
-        $this->assertContains($randomValues[0], ['foo', 'bar', 'baz']);
-        $this->assertContains($randomValues[1], ['foo', 'bar', 'baz']);
+        $random = Arr::random(['foo', 'bar', 'baz'], '1');
+        $this->assertInternalType('array', $random);
+        $this->assertCount(1, $random);
+        $this->assertContains($random[0], ['foo', 'bar', 'baz']);
+
+        $random = Arr::random(['foo', 'bar', 'baz'], '2');
+        $this->assertInternalType('array', $random);
+        $this->assertCount(2, $random);
+        $this->assertContains($random[0], ['foo', 'bar', 'baz']);
+        $this->assertContains($random[1], ['foo', 'bar', 'baz']);
+    }
+
+    public function testRandomOnEmptyArray()
+    {
+        $random = Arr::random([], 0);
+        $this->assertInternalType('array', $random);
+        $this->assertCount(0, $random);
+
+        $random = Arr::random([], '0');
+        $this->assertInternalType('array', $random);
+        $this->assertCount(0, $random);
+    }
+
+    public function testRandomThrowsAnErrorWhenRequestingMoreItemsThanAreAvailable()
+    {
+        $exceptions = 0;
+
+        try {
+            Arr::random([]);
+        } catch (\InvalidArgumentException $e) {
+            ++$exceptions;
+        }
+
+        try {
+            Arr::random([], 1);
+        } catch (\InvalidArgumentException $e) {
+            ++$exceptions;
+        }
+
+        try {
+            Arr::random([], 2);
+        } catch (\InvalidArgumentException $e) {
+            ++$exceptions;
+        }
+
+        $this->assertSame(3, $exceptions);
     }
 
     public function testSet()

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -911,6 +911,10 @@ class SupportCollectionTest extends TestCase
     {
         $data = new Collection([1, 2, 3, 4, 5, 6]);
 
+        $random = $data->random();
+        $this->assertInternalType('integer', $random);
+        $this->assertContains($random, $data->all());
+
         $random = $data->random(0);
         $this->assertInstanceOf(Collection::class, $random);
         $this->assertCount(0, $random);
@@ -919,9 +923,21 @@ class SupportCollectionTest extends TestCase
         $this->assertInstanceOf(Collection::class, $random);
         $this->assertCount(1, $random);
 
-        $random = $data->random(3);
+        $random = $data->random(2);
         $this->assertInstanceOf(Collection::class, $random);
-        $this->assertCount(3, $random);
+        $this->assertCount(2, $random);
+
+        $random = $data->random('0');
+        $this->assertInstanceOf(Collection::class, $random);
+        $this->assertCount(0, $random);
+
+        $random = $data->random('1');
+        $this->assertInstanceOf(Collection::class, $random);
+        $this->assertCount(1, $random);
+
+        $random = $data->random('2');
+        $this->assertInstanceOf(Collection::class, $random);
+        $this->assertCount(2, $random);
     }
 
     public function testRandomOnEmptyCollection()
@@ -931,23 +947,36 @@ class SupportCollectionTest extends TestCase
         $random = $data->random(0);
         $this->assertInstanceOf(Collection::class, $random);
         $this->assertCount(0, $random);
+
+        $random = $data->random('0');
+        $this->assertInstanceOf(Collection::class, $random);
+        $this->assertCount(0, $random);
     }
 
-    public function testRandomWithoutArgument()
-    {
-        $data = new Collection([1, 2, 3, 4, 5, 6]);
-
-        $random = $data->random();
-        $this->assertInternalType('integer', $random);
-        $this->assertContains($random, $data->all());
-    }
-
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testRandomThrowsAnErrorWhenRequestingMoreItemsThanAreAvailable()
     {
-        (new Collection)->random();
+        $data = new Collection();
+        $exceptions = 0;
+
+        try {
+            $data->random();
+        } catch (\InvalidArgumentException $e) {
+            ++$exceptions;
+        }
+
+        try {
+            $data->random(1);
+        } catch (\InvalidArgumentException $e) {
+            ++$exceptions;
+        }
+
+        try {
+            $data->random(2);
+        } catch (\InvalidArgumentException $e) {
+            ++$exceptions;
+        }
+
+        $this->assertSame(3, $exceptions);
     }
 
     public function testTakeLast()


### PR DESCRIPTION
As RFC2616 recomends, authentications errors should return 401 error code:

10.4.2 401 Unauthorized

The request requires user authentication. The response MUST include a WWW-Authenticate header field (section 14.47) containing a challenge applicable to the requested resource. The client MAY repeat the request with a suitable Authorization header field (section 14.8).

Similar to 403 Forbidden, but specifically **for use when authentication is required and has failed** or has not yet been provided.