### PR TITLE
sliceLoop and Redis Queue dynamic prefix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ composer.lock
 Thumbs.db
 /phpunit.xml
 /.idea
+test.php

--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -2,11 +2,11 @@
 
 namespace Illuminate\Queue;
 
+use Illuminate\Contracts\Queue\Queue as QueueContract;
+use Illuminate\Contracts\Redis\Factory as Redis;
+use Illuminate\Queue\Jobs\RedisJob;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
-use Illuminate\Queue\Jobs\RedisJob;
-use Illuminate\Contracts\Redis\Factory as Redis;
-use Illuminate\Contracts\Queue\Queue as QueueContract;
 
 class RedisQueue extends Queue implements QueueContract
 {
@@ -41,10 +41,10 @@ class RedisQueue extends Queue implements QueueContract
     /**
      * Create a new Redis queue instance.
      *
-     * @param  \Illuminate\Contracts\Redis\Factory  $redis
-     * @param  string  $default
-     * @param  string  $connection
-     * @param  int  $retryAfter
+     * @param  \Illuminate\Contracts\Redis\Factory $redis
+     * @param  string $default
+     * @param  string $connection
+     * @param  int $retryAfter
      * @return void
      */
     public function __construct(Redis $redis, $default = 'default', $connection = null, $retryAfter = 60)
@@ -58,7 +58,7 @@ class RedisQueue extends Queue implements QueueContract
     /**
      * Get the size of the queue.
      *
-     * @param  string  $queue
+     * @param  string $queue
      * @return int
      */
     public function size($queue = null)
@@ -66,16 +66,16 @@ class RedisQueue extends Queue implements QueueContract
         $queue = $this->getQueue($queue);
 
         return $this->getConnection()->eval(
-            LuaScripts::size(), 3, $queue, $queue.':delayed', $queue.':reserved'
+            LuaScripts::size(), 3, $queue, $queue . ':delayed', $queue . ':reserved'
         );
     }
 
     /**
      * Push a new job onto the queue.
      *
-     * @param  object|string  $job
-     * @param  mixed   $data
-     * @param  string  $queue
+     * @param  object|string $job
+     * @param  mixed $data
+     * @param  string $queue
      * @return mixed
      */
     public function push($job, $data = '', $queue = null)
@@ -86,9 +86,9 @@ class RedisQueue extends Queue implements QueueContract
     /**
      * Push a raw payload onto the queue.
      *
-     * @param  string  $payload
-     * @param  string  $queue
-     * @param  array   $options
+     * @param  string $payload
+     * @param  string $queue
+     * @param  array $options
      * @return mixed
      */
     public function pushRaw($payload, $queue = null, array $options = [])
@@ -101,10 +101,10 @@ class RedisQueue extends Queue implements QueueContract
     /**
      * Push a new job onto the queue after a delay.
      *
-     * @param  \DateTime|int  $delay
-     * @param  object|string  $job
-     * @param  mixed   $data
-     * @param  string  $queue
+     * @param  \DateTime|int $delay
+     * @param  object|string $job
+     * @param  mixed $data
+     * @param  string $queue
      * @return mixed
      */
     public function later($delay, $job, $data = '', $queue = null)
@@ -115,15 +115,15 @@ class RedisQueue extends Queue implements QueueContract
     /**
      * Push a raw job onto the queue after a delay.
      *
-     * @param  \DateTime|int  $delay
-     * @param  string  $payload
-     * @param  string  $queue
+     * @param  \DateTime|int $delay
+     * @param  string $payload
+     * @param  string $queue
      * @return mixed
      */
     protected function laterRaw($delay, $payload, $queue = null)
     {
         $this->getConnection()->zadd(
-            $this->getQueue($queue).':delayed', $this->availableAt($delay), $payload
+            $this->getQueue($queue) . ':delayed', $this->availableAt($delay), $payload
         );
 
         return Arr::get(json_decode($payload, true), 'id');
@@ -132,9 +132,9 @@ class RedisQueue extends Queue implements QueueContract
     /**
      * Create a payload string from the given job and data.
      *
-     * @param  string  $job
-     * @param  mixed   $data
-     * @param  string  $queue
+     * @param  string $job
+     * @param  mixed $data
+     * @param  string $queue
      * @return array
      */
     protected function createPayloadArray($job, $data = '', $queue = null)
@@ -148,7 +148,7 @@ class RedisQueue extends Queue implements QueueContract
     /**
      * Pop the next job off of the queue.
      *
-     * @param  string  $queue
+     * @param  string $queue
      * @return \Illuminate\Contracts\Queue\Job|null
      */
     public function pop($queue = null)
@@ -168,23 +168,23 @@ class RedisQueue extends Queue implements QueueContract
     /**
      * Migrate any delayed or expired jobs onto the primary queue.
      *
-     * @param  string  $queue
+     * @param  string $queue
      * @return void
      */
     protected function migrate($queue)
     {
-        $this->migrateExpiredJobs($queue.':delayed', $queue);
+        $this->migrateExpiredJobs($queue . ':delayed', $queue);
 
-        if (! is_null($this->retryAfter)) {
-            $this->migrateExpiredJobs($queue.':reserved', $queue);
+        if (!is_null($this->retryAfter)) {
+            $this->migrateExpiredJobs($queue . ':reserved', $queue);
         }
     }
 
     /**
      * Migrate the delayed jobs that are ready to the regular queue.
      *
-     * @param  string  $from
-     * @param  string  $to
+     * @param  string $from
+     * @param  string $to
      * @return array
      */
     public function migrateExpiredJobs($from, $to)
@@ -197,13 +197,13 @@ class RedisQueue extends Queue implements QueueContract
     /**
      * Retrieve the next job from the queue.
      *
-     * @param  string  $queue
+     * @param  string $queue
      * @return array
      */
     protected function retrieveNextJob($queue)
     {
         return $this->getConnection()->eval(
-            LuaScripts::pop(), 2, $queue, $queue.':reserved',
+            LuaScripts::pop(), 2, $queue, $queue . ':reserved',
             $this->availableAt($this->retryAfter)
         );
     }
@@ -211,21 +211,21 @@ class RedisQueue extends Queue implements QueueContract
     /**
      * Delete a reserved job from the queue.
      *
-     * @param  string  $queue
-     * @param  \Illuminate\Queue\Jobs\RedisJob  $job
+     * @param  string $queue
+     * @param  \Illuminate\Queue\Jobs\RedisJob $job
      * @return void
      */
     public function deleteReserved($queue, $job)
     {
-        $this->getConnection()->zrem($this->getQueue($queue).':reserved', $job->getReservedJob());
+        $this->getConnection()->zrem($this->getQueue($queue) . ':reserved', $job->getReservedJob());
     }
 
     /**
      * Delete a reserved job from the reserved queue and release it.
      *
-     * @param  string  $queue
-     * @param  \Illuminate\Queue\Jobs\RedisJob  $job
-     * @param  int  $delay
+     * @param  string $queue
+     * @param  \Illuminate\Queue\Jobs\RedisJob $job
+     * @param  int $delay
      * @return void
      */
     public function deleteAndRelease($queue, $job, $delay)
@@ -233,7 +233,7 @@ class RedisQueue extends Queue implements QueueContract
         $queue = $this->getQueue($queue);
 
         $this->getConnection()->eval(
-            LuaScripts::release(), 2, $queue.':delayed', $queue.':reserved',
+            LuaScripts::release(), 2, $queue . ':delayed', $queue . ':reserved',
             $job->getReservedJob(), $this->availableAt($delay)
         );
     }
@@ -251,12 +251,12 @@ class RedisQueue extends Queue implements QueueContract
     /**
      * Get the queue or return the default.
      *
-     * @param  string|null  $queue
+     * @param  string|null $queue
      * @return string
      */
     protected function getQueue($queue)
     {
-        return 'queues:'.($queue ?: $this->default);
+        return config('cache.prefix', 'laravel') . ':' . 'queues:' . ($queue ?: $this->default);
     }
 
     /**

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -2,18 +2,22 @@
 
 namespace Illuminate\Support;
 
-use Countable;
-use Exception;
 use ArrayAccess;
-use Traversable;
 use ArrayIterator;
 use CachingIterator;
-use JsonSerializable;
-use IteratorAggregate;
-use Illuminate\Support\Traits\Macroable;
-use Illuminate\Contracts\Support\Jsonable;
+use Countable;
+use Exception;
 use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Contracts\Support\Jsonable;
+use Illuminate\Support\Traits\Macroable;
+use IteratorAggregate;
+use JsonSerializable;
+use Traversable;
 
+/**
+ * Class Collection
+ * @package Illuminate\Support
+ */
 class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate, Jsonable, JsonSerializable
 {
     use Macroable;
@@ -38,7 +42,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Create a new collection.
      *
-     * @param  mixed  $items
+     * @param  mixed $items
      * @return void
      */
     public function __construct($items = [])
@@ -49,7 +53,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Create a new collection instance if the value isn't one already.
      *
-     * @param  mixed  $items
+     * @param  mixed $items
      * @return static
      */
     public static function make($items = [])
@@ -60,8 +64,8 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Create a new collection by invoking the callback a given number of times.
      *
-     * @param  int  $number
-     * @param  callable  $callback
+     * @param  int $number
+     * @param  callable $callback
      * @return static
      */
     public static function times($number, callable $callback = null)
@@ -90,7 +94,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Get the average value of a given key.
      *
-     * @param  callable|string|null  $callback
+     * @param  callable|string|null $callback
      * @return mixed
      */
     public function avg($callback = null)
@@ -103,7 +107,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Alias for the "avg" method.
      *
-     * @param  callable|string|null  $callback
+     * @param  callable|string|null $callback
      * @return mixed
      */
     public function average($callback = null)
@@ -126,9 +130,9 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
         }
 
         $values = with(isset($key) ? $this->pluck($key) : $this)
-                    ->sort()->values();
+            ->sort()->values();
 
-        $middle = (int) ($count / 2);
+        $middle = (int)($count / 2);
 
         if ($count % 2) {
             return $values->get($middle);
@@ -142,7 +146,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Get the mode of a given key.
      *
-     * @param  mixed  $key
+     * @param  mixed $key
      * @return array|null
      */
     public function mode($key = null)
@@ -183,16 +187,16 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Determine if an item exists in the collection.
      *
-     * @param  mixed  $key
-     * @param  mixed  $operator
-     * @param  mixed  $value
+     * @param  mixed $key
+     * @param  mixed $operator
+     * @param  mixed $value
      * @return bool
      */
     public function contains($key, $operator = null, $value = null)
     {
         if (func_num_args() == 1) {
             if ($this->useAsCallable($key)) {
-                return ! is_null($this->first($key));
+                return !is_null($this->first($key));
             }
 
             return in_array($key, $this->items);
@@ -210,8 +214,8 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Determine if an item exists in the collection using strict comparison.
      *
-     * @param  mixed  $key
-     * @param  mixed  $value
+     * @param  mixed $key
+     * @param  mixed $value
      * @return bool
      */
     public function containsStrict($key, $value = null)
@@ -223,7 +227,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
         }
 
         if ($this->useAsCallable($key)) {
-            return ! is_null($this->first($key));
+            return !is_null($this->first($key));
         }
 
         return in_array($key, $this->items, true);
@@ -232,7 +236,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Cross join with the given lists, returning all possible permutations.
      *
-     * @param  mixed  ...$lists
+     * @param  mixed ...$lists
      * @return static
      */
     public function crossJoin(...$lists)
@@ -245,7 +249,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Get the items in the collection that are not present in the given items.
      *
-     * @param  mixed  $items
+     * @param  mixed $items
      * @return static
      */
     public function diff($items)
@@ -256,7 +260,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Get the items in the collection whose keys and values are not present in the given items.
      *
-     * @param  mixed  $items
+     * @param  mixed $items
      * @return static
      */
     public function diffAssoc($items)
@@ -267,7 +271,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Get the items in the collection whose keys are not present in the given items.
      *
-     * @param  mixed  $items
+     * @param  mixed $items
      * @return static
      */
     public function diffKeys($items)
@@ -278,7 +282,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Execute a callback over each item.
      *
-     * @param  callable  $callback
+     * @param  callable $callback
      * @return $this
      */
     public function each(callable $callback)
@@ -295,7 +299,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Execute a callback over each nested chunk of items.
      *
-     * @param  callable  $callback
+     * @param  callable $callback
      * @return static
      */
     public function eachSpread(callable $callback)
@@ -308,9 +312,9 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Determine if all items in the collection pass the given test.
      *
-     * @param  string|callable  $key
-     * @param  mixed  $operator
-     * @param  mixed  $value
+     * @param  string|callable $key
+     * @param  mixed $operator
+     * @param  mixed $value
      * @return bool
      */
     public function every($key, $operator = null, $value = null)
@@ -319,7 +323,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
             $callback = $this->valueRetriever($key);
 
             foreach ($this->items as $k => $v) {
-                if (! $callback($v, $k)) {
+                if (!$callback($v, $k)) {
                     return false;
                 }
             }
@@ -339,7 +343,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Get all items except for those with the specified keys.
      *
-     * @param  mixed  $keys
+     * @param  mixed $keys
      * @return static
      */
     public function except($keys)
@@ -352,7 +356,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Run a filter over each of the items.
      *
-     * @param  callable|null  $callback
+     * @param  callable|null $callback
      * @return static
      */
     public function filter(callable $callback = null)
@@ -367,9 +371,9 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Apply the callback if the value is truthy.
      *
-     * @param  bool  $value
-     * @param  callable  $callback
-     * @param  callable  $default
+     * @param  bool $value
+     * @param  callable $callback
+     * @param  callable $default
      * @return mixed
      */
     public function when($value, callable $callback, callable $default = null)
@@ -386,22 +390,22 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Apply the callback if the value is falsy.
      *
-     * @param  bool  $value
-     * @param  callable  $callback
-     * @param  callable  $default
+     * @param  bool $value
+     * @param  callable $callback
+     * @param  callable $default
      * @return mixed
      */
     public function unless($value, callable $callback, callable $default = null)
     {
-        return $this->when(! $value, $callback, $default);
+        return $this->when(!$value, $callback, $default);
     }
 
     /**
      * Filter items by the given key value pair.
      *
-     * @param  string  $key
-     * @param  mixed  $operator
-     * @param  mixed  $value
+     * @param  string $key
+     * @param  mixed $operator
+     * @param  mixed $value
      * @return static
      */
     public function where($key, $operator, $value = null)
@@ -418,9 +422,9 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Get an operator checker callback.
      *
-     * @param  string  $key
-     * @param  string  $operator
-     * @param  mixed  $value
+     * @param  string $key
+     * @param  string $operator
+     * @param  mixed $value
      * @return \Closure
      */
     protected function operatorForWhere($key, $operator, $value)
@@ -431,15 +435,23 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
             switch ($operator) {
                 default:
                 case '=':
-                case '==':  return $retrieved == $value;
+                case '==':
+                    return $retrieved == $value;
                 case '!=':
-                case '<>':  return $retrieved != $value;
-                case '<':   return $retrieved < $value;
-                case '>':   return $retrieved > $value;
-                case '<=':  return $retrieved <= $value;
-                case '>=':  return $retrieved >= $value;
-                case '===': return $retrieved === $value;
-                case '!==': return $retrieved !== $value;
+                case '<>':
+                    return $retrieved != $value;
+                case '<':
+                    return $retrieved < $value;
+                case '>':
+                    return $retrieved > $value;
+                case '<=':
+                    return $retrieved <= $value;
+                case '>=':
+                    return $retrieved >= $value;
+                case '===':
+                    return $retrieved === $value;
+                case '!==':
+                    return $retrieved !== $value;
             }
         };
     }
@@ -447,8 +459,8 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Filter items by the given key value pair using strict comparison.
      *
-     * @param  string  $key
-     * @param  mixed  $value
+     * @param  string $key
+     * @param  mixed $value
      * @return static
      */
     public function whereStrict($key, $value)
@@ -459,9 +471,9 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Filter items by the given key value pair.
      *
-     * @param  string  $key
-     * @param  mixed  $values
-     * @param  bool  $strict
+     * @param  string $key
+     * @param  mixed $values
+     * @param  bool $strict
      * @return static
      */
     public function whereIn($key, $values, $strict = false)
@@ -476,8 +488,8 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Filter items by the given key value pair using strict comparison.
      *
-     * @param  string  $key
-     * @param  mixed  $values
+     * @param  string $key
+     * @param  mixed $values
      * @return static
      */
     public function whereInStrict($key, $values)
@@ -488,9 +500,9 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Filter items by the given key value pair.
      *
-     * @param  string  $key
-     * @param  mixed  $values
-     * @param  bool  $strict
+     * @param  string $key
+     * @param  mixed $values
+     * @param  bool $strict
      * @return static
      */
     public function whereNotIn($key, $values, $strict = false)
@@ -505,8 +517,8 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Filter items by the given key value pair using strict comparison.
      *
-     * @param  string  $key
-     * @param  mixed  $values
+     * @param  string $key
+     * @param  mixed $values
      * @return static
      */
     public function whereNotInStrict($key, $values)
@@ -517,8 +529,8 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Get the first item from the collection.
      *
-     * @param  callable|null  $callback
-     * @param  mixed  $default
+     * @param  callable|null $callback
+     * @param  mixed $default
      * @return mixed
      */
     public function first(callable $callback = null, $default = null)
@@ -529,7 +541,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Get a flattened array of the items in the collection.
      *
-     * @param  int  $depth
+     * @param  int $depth
      * @return static
      */
     public function flatten($depth = INF)
@@ -550,12 +562,12 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Remove an item from the collection by key.
      *
-     * @param  string|array  $keys
+     * @param  string|array $keys
      * @return $this
      */
     public function forget($keys)
     {
-        foreach ((array) $keys as $key) {
+        foreach ((array)$keys as $key) {
             $this->offsetUnset($key);
         }
 
@@ -565,8 +577,8 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Get an item from the collection by key.
      *
-     * @param  mixed  $key
-     * @param  mixed  $default
+     * @param  mixed $key
+     * @param  mixed $default
      * @return mixed
      */
     public function get($key, $default = null)
@@ -581,8 +593,8 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Group an associative array by a field or using a callback.
      *
-     * @param  callable|string  $groupBy
-     * @param  bool  $preserveKeys
+     * @param  callable|string $groupBy
+     * @param  bool $preserveKeys
      * @return static
      */
     public function groupBy($groupBy, $preserveKeys = false)
@@ -594,14 +606,14 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
         foreach ($this->items as $key => $value) {
             $groupKeys = $groupBy($value, $key);
 
-            if (! is_array($groupKeys)) {
+            if (!is_array($groupKeys)) {
                 $groupKeys = [$groupKeys];
             }
 
             foreach ($groupKeys as $groupKey) {
-                $groupKey = is_bool($groupKey) ? (int) $groupKey : $groupKey;
+                $groupKey = is_bool($groupKey) ? (int)$groupKey : $groupKey;
 
-                if (! array_key_exists($groupKey, $results)) {
+                if (!array_key_exists($groupKey, $results)) {
                     $results[$groupKey] = new static;
                 }
 
@@ -615,7 +627,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Key an associative array by a field or using a callback.
      *
-     * @param  callable|string  $keyBy
+     * @param  callable|string $keyBy
      * @return static
      */
     public function keyBy($keyBy)
@@ -628,7 +640,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
             $resolvedKey = $keyBy($item, $key);
 
             if (is_object($resolvedKey)) {
-                $resolvedKey = (string) $resolvedKey;
+                $resolvedKey = (string)$resolvedKey;
             }
 
             $results[$resolvedKey] = $item;
@@ -640,7 +652,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Determine if an item exists in the collection by key.
      *
-     * @param  mixed  $key
+     * @param  mixed $key
      * @return bool
      */
     public function has($key)
@@ -651,8 +663,8 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Concatenate values of a given key as a string.
      *
-     * @param  string  $value
-     * @param  string  $glue
+     * @param  string $value
+     * @param  string $glue
      * @return string
      */
     public function implode($value, $glue = null)
@@ -669,7 +681,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Intersect the collection with the given items.
      *
-     * @param  mixed  $items
+     * @param  mixed $items
      * @return static
      */
     public function intersect($items)
@@ -680,7 +692,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Intersect the collection with the given items by key.
      *
-     * @param  mixed  $items
+     * @param  mixed $items
      * @return static
      */
     public function intersectKey($items)
@@ -705,18 +717,18 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      */
     public function isNotEmpty()
     {
-        return ! $this->isEmpty();
+        return !$this->isEmpty();
     }
 
     /**
      * Determine if the given value is callable, but not a string.
      *
-     * @param  mixed  $value
+     * @param  mixed $value
      * @return bool
      */
     protected function useAsCallable($value)
     {
-        return ! is_string($value) && is_callable($value);
+        return !is_string($value) && is_callable($value);
     }
 
     /**
@@ -732,8 +744,8 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Get the last item from the collection.
      *
-     * @param  callable|null  $callback
-     * @param  mixed  $default
+     * @param  callable|null $callback
+     * @param  mixed $default
      * @return mixed
      */
     public function last(callable $callback = null, $default = null)
@@ -744,8 +756,8 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Get the values of a given key.
      *
-     * @param  string|array  $value
-     * @param  string|null  $key
+     * @param  string|array $value
+     * @param  string|null $key
      * @return static
      */
     public function pluck($value, $key = null)
@@ -756,7 +768,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Run a map over each of the items.
      *
-     * @param  callable  $callback
+     * @param  callable $callback
      * @return static
      */
     public function map(callable $callback)
@@ -771,7 +783,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Run a map over each nested chunk of items.
      *
-     * @param  callable  $callback
+     * @param  callable $callback
      * @return static
      */
     public function mapSpread(callable $callback)
@@ -786,7 +798,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      *
      * The callback should return an associative array with a single key/value pair.
      *
-     * @param  callable  $callback
+     * @param  callable $callback
      * @return static
      */
     public function mapToGroups(callable $callback)
@@ -805,7 +817,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      *
      * The callback should return an associative array with a single key/value pair.
      *
-     * @param  callable  $callback
+     * @param  callable $callback
      * @return static
      */
     public function mapWithKeys(callable $callback)
@@ -826,7 +838,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Map a collection and flatten the result by a single level.
      *
-     * @param  callable  $callback
+     * @param  callable $callback
      * @return static
      */
     public function flatMap(callable $callback)
@@ -837,7 +849,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Get the max value of a given key.
      *
-     * @param  callable|string|null  $callback
+     * @param  callable|string|null $callback
      * @return mixed
      */
     public function max($callback = null)
@@ -845,7 +857,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
         $callback = $this->valueRetriever($callback);
 
         return $this->filter(function ($value) {
-            return ! is_null($value);
+            return !is_null($value);
         })->reduce(function ($result, $item) use ($callback) {
             $value = $callback($item);
 
@@ -856,7 +868,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Merge the collection with the given items.
      *
-     * @param  mixed  $items
+     * @param  mixed $items
      * @return static
      */
     public function merge($items)
@@ -867,7 +879,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Create a collection by using this collection for keys and another for its values.
      *
-     * @param  mixed  $values
+     * @param  mixed $values
      * @return static
      */
     public function combine($values)
@@ -878,7 +890,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Union the collection with the given items.
      *
-     * @param  mixed  $items
+     * @param  mixed $items
      * @return static
      */
     public function union($items)
@@ -889,7 +901,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Get the min value of a given key.
      *
-     * @param  callable|string|null  $callback
+     * @param  callable|string|null $callback
      * @return mixed
      */
     public function min($callback = null)
@@ -897,7 +909,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
         $callback = $this->valueRetriever($callback);
 
         return $this->filter(function ($value) {
-            return ! is_null($value);
+            return !is_null($value);
         })->reduce(function ($result, $item) use ($callback) {
             $value = $callback($item);
 
@@ -908,8 +920,8 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Create a new collection consisting of every n-th element.
      *
-     * @param  int  $step
-     * @param  int  $offset
+     * @param  int $step
+     * @param  int $offset
      * @return static
      */
     public function nth($step, $offset = 0)
@@ -932,7 +944,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Get the items with the specified keys.
      *
-     * @param  mixed  $keys
+     * @param  mixed $keys
      * @return static
      */
     public function only($keys)
@@ -949,8 +961,8 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * "Paginate" the collection by slicing it into a smaller collection.
      *
-     * @param  int  $page
-     * @param  int  $perPage
+     * @param  int $page
+     * @param  int $perPage
      * @return static
      */
     public function forPage($page, $perPage)
@@ -961,7 +973,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Partition the collection into two arrays using the given callback or key.
      *
-     * @param  callable|string  $callback
+     * @param  callable|string $callback
      * @return static
      */
     public function partition($callback)
@@ -971,7 +983,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
         $callback = $this->valueRetriever($callback);
 
         foreach ($this->items as $key => $item) {
-            $partitions[(int) ! $callback($item)][$key] = $item;
+            $partitions[(int)!$callback($item)][$key] = $item;
         }
 
         return new static($partitions);
@@ -1001,8 +1013,8 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Push an item onto the beginning of the collection.
      *
-     * @param  mixed  $value
-     * @param  mixed  $key
+     * @param  mixed $value
+     * @param  mixed $key
      * @return $this
      */
     public function prepend($value, $key = null)
@@ -1015,7 +1027,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Push an item onto the end of the collection.
      *
-     * @param  mixed  $value
+     * @param  mixed $value
      * @return $this
      */
     public function push($value)
@@ -1028,7 +1040,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Push all of the given items onto the collection.
      *
-     * @param  \Traversable  $source
+     * @param  \Traversable $source
      * @return self
      */
     public function concat($source)
@@ -1045,8 +1057,8 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Get and remove an item from the collection.
      *
-     * @param  mixed  $key
-     * @param  mixed  $default
+     * @param  mixed $key
+     * @param  mixed $default
      * @return mixed
      */
     public function pull($key, $default = null)
@@ -1057,8 +1069,8 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Put an item in the collection by key.
      *
-     * @param  mixed  $key
-     * @param  mixed  $value
+     * @param  mixed $key
+     * @param  mixed $value
      * @return $this
      */
     public function put($key, $value)
@@ -1071,7 +1083,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Get one or a specified number of items randomly from the collection.
      *
-     * @param  int|null  $number
+     * @param  int|null $number
      * @return mixed
      *
      * @throws \InvalidArgumentException
@@ -1088,8 +1100,8 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Reduce the collection to a single value.
      *
-     * @param  callable  $callback
-     * @param  mixed  $initial
+     * @param  callable $callback
+     * @param  mixed $initial
      * @return mixed
      */
     public function reduce(callable $callback, $initial = null)
@@ -1100,14 +1112,14 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Create a collection of all elements that do not pass a given truth test.
      *
-     * @param  callable|mixed  $callback
+     * @param  callable|mixed $callback
      * @return static
      */
     public function reject($callback)
     {
         if ($this->useAsCallable($callback)) {
             return $this->filter(function ($value, $key) use ($callback) {
-                return ! $callback($value, $key);
+                return !$callback($value, $key);
             });
         }
 
@@ -1129,13 +1141,13 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Search the collection for a given value and return the corresponding key if successful.
      *
-     * @param  mixed  $value
-     * @param  bool  $strict
+     * @param  mixed $value
+     * @param  bool $strict
      * @return mixed
      */
     public function search($value, $strict = false)
     {
-        if (! $this->useAsCallable($value)) {
+        if (!$this->useAsCallable($value)) {
             return array_search($value, $this->items, $strict);
         }
 
@@ -1161,7 +1173,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Shuffle the items in the collection.
      *
-     * @param  int  $seed
+     * @param  int $seed
      * @return static
      */
     public function shuffle($seed = null)
@@ -1184,8 +1196,8 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Slice the underlying collection array.
      *
-     * @param  int  $offset
-     * @param  int  $length
+     * @param  int $offset
+     * @param  int $length
      * @return static
      */
     public function slice($offset, $length = null)
@@ -1193,10 +1205,40 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
         return new static(array_slice($this->items, $offset, $length, true));
     }
 
+
+    /**
+     *
+     * Run closure on each slice.
+     *
+     * @param int $sliceSize
+     * @param \Closure $closure
+     * @return $this
+     */
+    public function sliceLoop($sliceSize = 100, \Closure $closure)
+    {
+        $step = 0;
+
+        do {
+            $slice = $this->slice($sliceSize * $step++, $sliceSize);
+
+            if ($slice->isEmpty()) {
+                return $this;
+            }
+
+            if ($closure($slice, $this, $step) === false) {
+                return $this;
+            }
+
+        } while ($slice->isNotEmpty());
+
+        return $this;
+    }
+
+
     /**
      * Split a collection into a certain number of groups.
      *
-     * @param  int  $numberOfGroups
+     * @param  int $numberOfGroups
      * @return static
      */
     public function split($numberOfGroups)
@@ -1213,7 +1255,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Chunk the underlying collection array.
      *
-     * @param  int  $size
+     * @param  int $size
      * @return static
      */
     public function chunk($size)
@@ -1234,7 +1276,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Sort through each item with a callback.
      *
-     * @param  callable|null  $callback
+     * @param  callable|null $callback
      * @return static
      */
     public function sort(callable $callback = null)
@@ -1251,9 +1293,9 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Sort the collection using the given callback.
      *
-     * @param  callable|string  $callback
-     * @param  int  $options
-     * @param  bool  $descending
+     * @param  callable|string $callback
+     * @param  int $options
+     * @param  bool $descending
      * @return static
      */
     public function sortBy($callback, $options = SORT_REGULAR, $descending = false)
@@ -1270,7 +1312,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
         }
 
         $descending ? arsort($results, $options)
-                    : asort($results, $options);
+            : asort($results, $options);
 
         // Once we have sorted all of the keys in the array, we will loop through them
         // and grab the corresponding model so we can set the underlying items list
@@ -1285,8 +1327,8 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Sort the collection in descending order using the given callback.
      *
-     * @param  callable|string  $callback
-     * @param  int  $options
+     * @param  callable|string $callback
+     * @param  int $options
      * @return static
      */
     public function sortByDesc($callback, $options = SORT_REGULAR)
@@ -1297,9 +1339,9 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Splice a portion of the underlying collection array.
      *
-     * @param  int  $offset
-     * @param  int|null  $length
-     * @param  mixed  $replacement
+     * @param  int $offset
+     * @param  int|null $length
+     * @param  mixed $replacement
      * @return static
      */
     public function splice($offset, $length = null, $replacement = [])
@@ -1314,7 +1356,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Get the sum of the given values.
      *
-     * @param  callable|string|null  $callback
+     * @param  callable|string|null $callback
      * @return mixed
      */
     public function sum($callback = null)
@@ -1333,7 +1375,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Take the first or last {$limit} items.
      *
-     * @param  int  $limit
+     * @param  int $limit
      * @return static
      */
     public function take($limit)
@@ -1348,7 +1390,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Pass the collection to the given callback and then return it.
      *
-     * @param  callable  $callback
+     * @param  callable $callback
      * @return $this
      */
     public function tap(callable $callback)
@@ -1361,7 +1403,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Transform each item in the collection using a callback.
      *
-     * @param  callable  $callback
+     * @param  callable $callback
      * @return $this
      */
     public function transform(callable $callback)
@@ -1374,8 +1416,8 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Return only unique items from the collection array.
      *
-     * @param  string|callable|null  $key
-     * @param  bool  $strict
+     * @param  string|callable|null $key
+     * @param  bool $strict
      * @return static
      */
     public function unique($key = null, $strict = false)
@@ -1400,7 +1442,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Return only unique items from the collection array using strict comparison.
      *
-     * @param  string|callable|null  $key
+     * @param  string|callable|null $key
      * @return static
      */
     public function uniqueStrict($key = null)
@@ -1421,7 +1463,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Get a value retrieving callback.
      *
-     * @param  string  $value
+     * @param  string $value
      * @return callable
      */
     protected function valueRetriever($value)
@@ -1492,7 +1534,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Get the collection of items as JSON.
      *
-     * @param  int  $options
+     * @param  int $options
      * @return string
      */
     public function toJson($options = 0)
@@ -1513,7 +1555,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Get a CachingIterator instance.
      *
-     * @param  int  $flags
+     * @param  int $flags
      * @return \CachingIterator
      */
     public function getCachingIterator($flags = CachingIterator::CALL_TOSTRING)
@@ -1544,7 +1586,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Determine if an item exists at an offset.
      *
-     * @param  mixed  $key
+     * @param  mixed $key
      * @return bool
      */
     public function offsetExists($key)
@@ -1555,7 +1597,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Get an item at a given offset.
      *
-     * @param  mixed  $key
+     * @param  mixed $key
      * @return mixed
      */
     public function offsetGet($key)
@@ -1566,8 +1608,8 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Set the item at a given offset.
      *
-     * @param  mixed  $key
-     * @param  mixed  $value
+     * @param  mixed $key
+     * @param  mixed $value
      * @return void
      */
     public function offsetSet($key, $value)
@@ -1582,7 +1624,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Unset the item at a given offset.
      *
-     * @param  string  $key
+     * @param  string $key
      * @return void
      */
     public function offsetUnset($key)
@@ -1603,7 +1645,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Results array of items from Collection or Arrayable.
      *
-     * @param  mixed  $items
+     * @param  mixed $items
      * @return array
      */
     protected function getArrayableItems($items)
@@ -1622,13 +1664,13 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
             return iterator_to_array($items);
         }
 
-        return (array) $items;
+        return (array)$items;
     }
 
     /**
      * Add a method to the list of proxied methods.
      *
-     * @param  string  $method
+     * @param  string $method
      * @return void
      */
     public static function proxy($method)
@@ -1639,14 +1681,14 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Dynamically access collection proxies.
      *
-     * @param  string  $key
+     * @param  string $key
      * @return mixed
      *
      * @throws \Exception
      */
     public function __get($key)
     {
-        if (! in_array($key, static::$proxies)) {
+        if (!in_array($key, static::$proxies)) {
             throw new Exception("Property [{$key}] does not exist on this collection instance.");
         }
 


### PR DESCRIPTION
1. Added sliceLoop() method in Collection. This method accept Closure and slice size. Closure is called with current slice collection, entire collection and current step parameters. In our project, we use a lot this functionality because is more fast to use than using chunks or something else.

2. Updated getQueue() method of RedisQueue in order to add a dynamic prefix for queue key. This is useful when are two Laravel apps on same server and use same Redis Server.


 