### PR TITLE
[5.5] Added 401 response code to AuthenticationException

### DIFF
--- a/src/Illuminate/Auth/AuthenticationException.php
+++ b/src/Illuminate/Auth/AuthenticationException.php
@@ -7,6 +7,13 @@ use Exception;
 class AuthenticationException extends Exception
 {
     /**
+     * Unauthorized Response Code.
+     *
+     * @var int
+     */
+    protected $code = 401;
+
+    /**
      * All of the guards that were checked.
      *
      * @var array


### PR DESCRIPTION
As RFC2616 recomends, authentications errors should return 401 error code:

**10.4.2 401 Unauthorized**

The request requires user authentication. The response MUST include a WWW-Authenticate header field (section 14.47) containing a challenge applicable to the requested resource. The client MAY repeat the request with a suitable Authorization header field (section 14.8).

Similar to 403 Forbidden, but specifically **for use when authentication is required and has failed** or has not yet been provided.