### PR TITLE
[5.5] Add ordinal methods to Collection & "nth" array helper.

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -161,18 +161,41 @@ class Arr
      */
     public static function first($array, callable $callback = null, $default = null)
     {
+        return static::nth($array, 1, $callback, $default);
+    }
+
+    /**
+     * Return the nth element in an array passing a given truth test.
+     *
+     * @param  array  $array
+     * @param  callable|null  $callback
+     * @param  mixed  $default
+     * @return mixed
+     */
+    public static function nth($array, $offset, callable $callback = null, $default = null)
+    {
         if (is_null($callback)) {
             if (empty($array)) {
                 return value($default);
             }
 
+            $matches = 0;
             foreach ($array as $item) {
-                return $item;
+                $matches++;
+
+                if ($matches >= $offset) {
+                    return $item;
+                }
             }
         }
 
+        $matches = 0;
         foreach ($array as $key => $value) {
             if (call_user_func($callback, $value, $key)) {
+                $matches++;
+            }
+
+            if ($matches >= $offset) {
                 return $value;
             }
         }

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -579,6 +579,114 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
+     * Get the second item from the collection.
+     *
+     * @param  callable|null  $callback
+     * @param  mixed  $default
+     * @return mixed
+     */
+    public function second(callable $callback = null, $default = null)
+    {
+        return Arr::nth($this->items, 2, $callback, $default);
+    }
+
+    /**
+     * Get the third item from the collection.
+     *
+     * @param  callable|null  $callback
+     * @param  mixed  $default
+     * @return mixed
+     */
+    public function third(callable $callback = null, $default = null)
+    {
+        return Arr::nth($this->items, 3, $callback, $default);
+    }
+
+    /**
+     * Get the fourth item from the collection.
+     *
+     * @param  callable|null  $callback
+     * @param  mixed  $default
+     * @return mixed
+     */
+    public function fourth(callable $callback = null, $default = null)
+    {
+        return Arr::nth($this->items, 4, $callback, $default);
+    }
+
+    /**
+     * Get the fifth item from the collection.
+     *
+     * @param  callable|null  $callback
+     * @param  mixed  $default
+     * @return mixed
+     */
+    public function fifth(callable $callback = null, $default = null)
+    {
+        return Arr::nth($this->items, 5, $callback, $default);
+    }
+
+    /**
+     * Get the sixth item from the collection.
+     *
+     * @param  callable|null  $callback
+     * @param  mixed  $default
+     * @return mixed
+     */
+    public function sixth(callable $callback = null, $default = null)
+    {
+        return Arr::nth($this->items, 6, $callback, $default);
+    }
+
+    /**
+     * Get the seventh item from the collection.
+     *
+     * @param  callable|null  $callback
+     * @param  mixed  $default
+     * @return mixed
+     */
+    public function seventh(callable $callback = null, $default = null)
+    {
+        return Arr::nth($this->items, 7, $callback, $default);
+    }
+
+    /**
+     * Get the eighth item from the collection.
+     *
+     * @param  callable|null  $callback
+     * @param  mixed  $default
+     * @return mixed
+     */
+    public function eighth(callable $callback = null, $default = null)
+    {
+        return Arr::nth($this->items, 8, $callback, $default);
+    }
+
+    /**
+     * Get the ninth item from the collection.
+     *
+     * @param  callable|null  $callback
+     * @param  mixed  $default
+     * @return mixed
+     */
+    public function ninth(callable $callback = null, $default = null)
+    {
+        return Arr::nth($this->items, 9, $callback, $default);
+    }
+
+    /**
+     * Get the tenth item from the collection.
+     *
+     * @param  callable|null  $callback
+     * @param  mixed  $default
+     * @return mixed
+     */
+    public function tenth(callable $callback = null, $default = null)
+    {
+        return Arr::nth($this->items, 10, $callback, $default);
+    }
+
+    /**
      * Get a flattened array of the items in the collection.
      *
      * @param  int  $depth

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -136,6 +136,18 @@ class SupportArrTest extends TestCase
         $this->assertEquals(100, Arr::first($array));
     }
 
+    public function testNth()
+    {
+        $array = [100, 200, 300, 400, 500];
+
+        $value = Arr::nth($array, 2, function ($value) {
+            return $value >= 200;
+        });
+
+        $this->assertEquals(300, $value);
+        $this->assertEquals(500, Arr::nth($array, 5));
+    }
+
     public function testLast()
     {
         $array = [100, 200, 300];

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -45,6 +45,20 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals('default', $result);
     }
 
+    public function testOrdinalReturnsCorrectItemInCollection()
+    {
+        $c = new Collection([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+        $this->assertEquals(2, $c->second());
+        $this->assertEquals(3, $c->third());
+        $this->assertEquals(4, $c->fourth());
+        $this->assertEquals(5, $c->fifth());
+        $this->assertEquals(6, $c->sixth());
+        $this->assertEquals(7, $c->seventh());
+        $this->assertEquals(8, $c->eighth());
+        $this->assertEquals(9, $c->ninth());
+        $this->assertEquals(10, $c->tenth());
+    }
+
     public function testLastReturnsLastItemInCollection()
     {
         $c = new Collection(['foo', 'bar']);


### PR DESCRIPTION
One of my favorite little features in Rails was the [`.second`, `.third`, etc. ordinal aliases](https://github.com/rails/rails/commit/22af62cf486721ee2e45bb720c42ac2f4121faf4) that were available on arrays. They're nice for more fluent code in some unusual situations, and super handy when debugging things.

```
$collection = collect('foo', 'bar', bar');
$collection->first() // --> 'foo'
$collection->second() // --> 'bar'
$collection->third() // --> 'baz'
```

Since Collection's `first` has some extra parameters for passing a callback or returning a default value, I made an `nth` array helper so other ordinal methods could work the same way.