### PR TITLE
[5.3] Fix an issue that doctrine/inflector requires PHP 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "ext-mbstring": "*",
         "ext-openssl": "*",
         "classpreloader/classpreloader": "~3.0",
-        "doctrine/inflector": "~1.0",
+        "doctrine/inflector": "~1.1.0",
         "jeremeamia/superclosure": "~2.2",
         "league/flysystem": "~1.0",
         "monolog/monolog": "~1.11",

--- a/src/Illuminate/Support/composer.json
+++ b/src/Illuminate/Support/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": ">=5.6.4",
         "ext-mbstring": "*",
-        "doctrine/inflector": "~1.0",
+        "doctrine/inflector": "~1.1.0",
         "illuminate/contracts": "5.3.*",
         "paragonie/random_compat": "~1.4|~2.0"
     },


### PR DESCRIPTION
There is an issue related to `doctrine/inflector` as after updating packages the `doctrine/inflector` is upgraded to version 1.2.0 which requires PHP 7.0, however Laravel 5.3 should support PHP 5.6