### PR TITLE
[5.4] new "oncefull" option for queue work command

### DIFF
--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -114,7 +114,7 @@ class WorkCommand extends Command
             $this->option('delay'), $this->option('memory'),
             $this->option('timeout'), $this->option('sleep'),
             $this->option('tries'), $this->option('force'),
-            $this->option('once')
+            $this->option('oncefull')
         );
     }
 

--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -23,6 +23,7 @@ class WorkCommand extends Command
                             {--queue= : The names of the queues to work}
                             {--daemon : Run the worker in daemon mode (Deprecated)}
                             {--once : Only process the next job on the queue}
+                            {--oncefull : Only process until queue is empty}
                             {--delay=0 : Amount of time to delay failed jobs}
                             {--force : Force the worker to run even in maintenance mode}
                             {--memory=128 : The memory limit in megabytes}
@@ -97,7 +98,7 @@ class WorkCommand extends Command
     {
         $this->worker->setCache($this->laravel['cache']->driver());
 
-        return $this->worker->{$this->option('once') ? 'runNextJob' : 'daemon'}(
+        return $this->worker->{$this->option('once')||$this->option('oncefull') ? 'runNextJob' : 'daemon'}(
             $connection, $queue, $this->gatherWorkerOptions()
         );
     }
@@ -112,7 +113,8 @@ class WorkCommand extends Command
         return new WorkerOptions(
             $this->option('delay'), $this->option('memory'),
             $this->option('timeout'), $this->option('sleep'),
-            $this->option('tries'), $this->option('force')
+            $this->option('tries'), $this->option('force'),
+            $this->option('once')
         );
     }
 

--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -98,7 +98,7 @@ class WorkCommand extends Command
     {
         $this->worker->setCache($this->laravel['cache']->driver());
 
-        return $this->worker->{$this->option('once')||$this->option('oncefull') ? 'runNextJob' : 'daemon'}(
+        return $this->worker->{$this->option('once') || $this->option('oncefull') ? 'runNextJob' : 'daemon'}(
             $connection, $queue, $this->gatherWorkerOptions()
         );
     }

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -225,7 +225,7 @@ class Worker
                 $this->runJob($job, $connectionName, $options);
             }
 
-            if ($options->once) {
+            if (! $options->once === false) {
                 break;
             }
         } while ($job);

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -213,16 +213,22 @@ class Worker
      */
     public function runNextJob($connectionName, $queue, WorkerOptions $options)
     {
-        $job = $this->getNextJob(
-            $this->manager->connection($connectionName), $queue
-        );
+        do {
 
-        // If we're able to pull a job off of the stack, we will process it and then return
-        // from this method. If there is no job on the queue, we will "sleep" the worker
-        // for the specified number of seconds, then keep processing jobs after sleep.
-        if ($job) {
-            return $this->runJob($job, $connectionName, $options);
-        }
+            $job = $this->getNextJob(
+                $this->manager->connection($connectionName), $queue
+            );
+
+            // If we're able to pull a job off of the stack, we will process it and then return
+            // from this method. If there is no job on the queue, we will "sleep" the worker
+            // for the specified number of seconds, then keep processing jobs after sleep.
+            if ($job) {
+                $this->runJob($job, $connectionName, $options);
+            }
+
+            if ($options->once) break;
+
+        } while($job);
 
         $this->sleep($options->sleep);
     }

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -225,7 +225,7 @@ class Worker
                 $this->runJob($job, $connectionName, $options);
             }
 
-            if (! $options->once === false) {
+            if (! $options->oncefull) {
                 break;
             }
         } while ($job);

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -226,9 +226,10 @@ class Worker
                 $this->runJob($job, $connectionName, $options);
             }
 
-            if ($options->once) break;
-
-        } while($job);
+            if ($options->once) {
+                break;
+            }
+        } while ($job);
 
         $this->sleep($options->sleep);
     }

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -214,7 +214,6 @@ class Worker
     public function runNextJob($connectionName, $queue, WorkerOptions $options)
     {
         do {
-
             $job = $this->getNextJob(
                 $this->manager->connection($connectionName), $queue
             );

--- a/src/Illuminate/Queue/WorkerOptions.php
+++ b/src/Illuminate/Queue/WorkerOptions.php
@@ -63,7 +63,7 @@ class WorkerOptions
      * @param  int  $maxTries
      * @param  bool  $force
      */
-    public function __construct($delay = 0, $memory = 128, $timeout = 60, $sleep = 3, $maxTries = 0, $force = false , $once = false)
+    public function __construct($delay = 0, $memory = 128, $timeout = 60, $sleep = 3, $maxTries = 0, $force = false, $once = false)
     {
         $this->delay = $delay;
         $this->sleep = $sleep;

--- a/src/Illuminate/Queue/WorkerOptions.php
+++ b/src/Illuminate/Queue/WorkerOptions.php
@@ -47,6 +47,13 @@ class WorkerOptions
     public $force;
 
     /**
+     * Indicates if the worker should run in only once.
+     *
+     * @var bool
+     */
+    public $once;
+
+    /**
      * Create a new worker options instance.
      *
      * @param  int  $delay
@@ -56,7 +63,7 @@ class WorkerOptions
      * @param  int  $maxTries
      * @param  bool  $force
      */
-    public function __construct($delay = 0, $memory = 128, $timeout = 60, $sleep = 3, $maxTries = 0, $force = false)
+    public function __construct($delay = 0, $memory = 128, $timeout = 60, $sleep = 3, $maxTries = 0, $force = false , $once = false)
     {
         $this->delay = $delay;
         $this->sleep = $sleep;
@@ -64,5 +71,6 @@ class WorkerOptions
         $this->memory = $memory;
         $this->timeout = $timeout;
         $this->maxTries = $maxTries;
+        $this->once = $once;
     }
 }

--- a/src/Illuminate/Queue/WorkerOptions.php
+++ b/src/Illuminate/Queue/WorkerOptions.php
@@ -63,7 +63,7 @@ class WorkerOptions
      * @param  int  $maxTries
      * @param  bool  $force
      */
-    public function __construct($delay = 0, $memory = 128, $timeout = 60, $sleep = 3, $maxTries = 0, $force = false, $once = false)
+    public function __construct($delay = 0, $memory = 128, $timeout = 60, $sleep = 3, $maxTries = 0, $force = false, $once = null)
     {
         $this->delay = $delay;
         $this->sleep = $sleep;

--- a/src/Illuminate/Queue/WorkerOptions.php
+++ b/src/Illuminate/Queue/WorkerOptions.php
@@ -47,11 +47,11 @@ class WorkerOptions
     public $force;
 
     /**
-     * Indicates if the worker should run in only once.
+     * Indicates if the worker should run until queue empty.
      *
      * @var bool
      */
-    public $once;
+    public $oncefull;
 
     /**
      * Create a new worker options instance.
@@ -63,7 +63,7 @@ class WorkerOptions
      * @param  int  $maxTries
      * @param  bool  $force
      */
-    public function __construct($delay = 0, $memory = 128, $timeout = 60, $sleep = 3, $maxTries = 0, $force = false, $once = null)
+    public function __construct($delay = 0, $memory = 128, $timeout = 60, $sleep = 3, $maxTries = 0, $force = false, $oncefull = false)
     {
         $this->delay = $delay;
         $this->sleep = $sleep;
@@ -71,6 +71,6 @@ class WorkerOptions
         $this->memory = $memory;
         $this->timeout = $timeout;
         $this->maxTries = $maxTries;
-        $this->once = $once;
+        $this->oncefull = $oncefull;
     }
 }


### PR DESCRIPTION
similar to "once" option this will also exit, but after running through all items in the current queue. this is useful when processing the queue periodically from laravel schedular rather then daemon process

Signed-off-by: Siddharth <siddharth@kstych.com>