### PR TITLE
[5.5] Migrate drop command

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/DropCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/DropCommand.php
@@ -35,9 +35,7 @@ class DropCommand extends Command
             return;
         }
 
-        $this->dropAllTables(
-            $database = $this->input->getOption('database')
-        );
+        $this->dropAllTables($this->input->getOption('database'));
 
         $this->info('Dropped all tables successfully.');
     }

--- a/src/Illuminate/Database/Console/Migrations/DropCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/DropCommand.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Illuminate\Database\Console\Migrations;
+
+use Illuminate\Console\Command;
+use Illuminate\Console\ConfirmableTrait;
+use Symfony\Component\Console\Input\InputOption;
+
+class DropCommand extends Command
+{
+    use ConfirmableTrait;
+
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'migrate:drop';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Drop all database tables';
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        if (! $this->confirmToProceed()) {
+            return;
+        }
+
+        $this->dropAllTables(
+            $database = $this->input->getOption('database')
+        );
+
+        $this->info('Dropped all tables successfully.');
+    }
+
+    /**
+     * Drop all of the database tables.
+     *
+     * @param  string  $database
+     * @return void
+     */
+    protected function dropAllTables($database)
+    {
+        $this->laravel['db']->connection($database)
+                    ->getSchemaBuilder()
+                    ->dropAllTables();
+    }
+
+    /**
+     * Get the console command options.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [
+            ['database', null, InputOption::VALUE_OPTIONAL, 'The database connection to use.'],
+
+            ['force', null, InputOption::VALUE_NONE, 'Force the operation to run when in production.'],
+        ];
+    }
+}

--- a/src/Illuminate/Database/Console/Migrations/FreshCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/FreshCommand.php
@@ -35,17 +35,15 @@ class FreshCommand extends Command
             return;
         }
 
-        $this->dropAllTables(
-            $database = $this->input->getOption('database')
-        );
+        $database = $this->input->getOption('database');
 
-        $this->info('Dropped all tables successfully.');
+        $path = $this->input->getOption('path');
 
-        $this->call('migrate', [
-            '--database' => $database,
-            '--path' => $this->input->getOption('path'),
-            '--force' => $this->input->getOption('force'),
-        ]);
+        $force = $this->input->getOption('force');
+
+        $this->runDrop($database, $force);
+
+        $this->runMigrate($database, $path, $force);
 
         if ($this->needsSeeding()) {
             $this->runSeeder($database);
@@ -53,16 +51,35 @@ class FreshCommand extends Command
     }
 
     /**
-     * Drop all of the database tables.
+     * Run the migrate drop command.
      *
-     * @param  string  $database
+     * @param  string $database
+     * @param bool $force
      * @return void
      */
-    protected function dropAllTables($database)
+    protected function runDrop($database, $force)
     {
-        $this->laravel['db']->connection($database)
-                    ->getSchemaBuilder()
-                    ->dropAllTables();
+        $this->call('migrate:drop', [
+            '--database' => $database,
+            '--force' => $force,
+        ]);
+    }
+
+    /**
+     * Run the migrate command.
+     *
+     * @param  string  $database
+     * @param  string  $path
+     * @param  bool  $force
+     * @return void
+     */
+    protected function runMigrate($database, $path, $force)
+    {
+        $this->call('migrate', [
+            '--database' => $database,
+            '--path' => $path,
+            '--force' => $force,
+        ]);
     }
 
     /**

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -59,6 +59,7 @@ use Illuminate\Queue\Console\RestartCommand as QueueRestartCommand;
 use Illuminate\Queue\Console\ListFailedCommand as ListFailedQueueCommand;
 use Illuminate\Queue\Console\FlushFailedCommand as FlushFailedQueueCommand;
 use Illuminate\Queue\Console\ForgetFailedCommand as ForgetFailedQueueCommand;
+use Illuminate\Database\Console\Migrations\DropCommand as MigrateDropCommand;
 use Illuminate\Database\Console\Migrations\FreshCommand as MigrateFreshCommand;
 use Illuminate\Database\Console\Migrations\ResetCommand as MigrateResetCommand;
 use Illuminate\Database\Console\Migrations\StatusCommand as MigrateStatusCommand;
@@ -96,6 +97,7 @@ class ArtisanServiceProvider extends ServiceProvider
         'MigrateRefresh' => 'command.migrate.refresh',
         'MigrateReset' => 'command.migrate.reset',
         'MigrateRollback' => 'command.migrate.rollback',
+        'MigrateDrop' => 'command.migrate.drop',
         'MigrateStatus' => 'command.migrate.status',
         'Optimize' => 'command.optimize',
         'PackageDiscover' => 'command.package.discover',
@@ -520,6 +522,18 @@ class ArtisanServiceProvider extends ServiceProvider
     {
         $this->app->singleton('command.migrate.rollback', function ($app) {
             return new MigrateRollbackCommand($app['migrator']);
+        });
+    }
+
+    /**
+     * Register the command.
+     *
+     * @return void
+     */
+    protected function registerMigrateDropCommand()
+    {
+        $this->app->singleton('command.migrate.drop', function () {
+            return new MigrateDropCommand;
         });
     }
 

--- a/src/Illuminate/Foundation/Testing/DatabaseMigrations.php
+++ b/src/Illuminate/Foundation/Testing/DatabaseMigrations.php
@@ -18,7 +18,7 @@ trait DatabaseMigrations
         $this->app[Kernel::class]->setArtisan(null);
 
         $this->beforeApplicationDestroyed(function () {
-            $this->artisan('migrate:rollback');
+            $this->artisan('migrate:drop');
         });
     }
 }


### PR DESCRIPTION
This extracts drop tables into a separate command and used drop command instead of rollback in DatabaseMigrations trait to make tests run quickly. Also refactored migrate:fresh command to use use migrate:drop command