### PR TITLE
[5.5] Move route model binding resolution logic to model

### DIFF
--- a/src/Illuminate/Contracts/Routing/UrlRoutable.php
+++ b/src/Illuminate/Contracts/Routing/UrlRoutable.php
@@ -19,7 +19,7 @@ interface UrlRoutable
     public function getRouteKeyName();
 
     /**
-     * Retrieve model for route model binding
+     * Retrieve model for route model binding.
      *
      * @param  mixed  $routeKey
      * @return null|\Illuminate\Database\Eloquent\Model

--- a/src/Illuminate/Contracts/Routing/UrlRoutable.php
+++ b/src/Illuminate/Contracts/Routing/UrlRoutable.php
@@ -17,4 +17,12 @@ interface UrlRoutable
      * @return string
      */
     public function getRouteKeyName();
+
+    /**
+     * Retrieve model for route model binding
+     *
+     * @param  mixed  $routeKey
+     * @return null|\Illuminate\Database\Eloquent\Model
+     */
+    public function resolveRouteBinding($routeKey);
 }

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1252,6 +1252,17 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     }
 
     /**
+     * Retrieve model for route model binding
+     *
+     * @param  mixed  $routeKey
+     * @return null|\Illuminate\Database\Eloquent\Model
+     */
+    public function resolveRouteBinding($routeKey)
+    {
+        return $this->where($this->getRouteKeyName(), $routeKey)->first();
+    }
+
+    /**
      * Get the default foreign key name for the model.
      *
      * @return string

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1252,7 +1252,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     }
 
     /**
-     * Retrieve model for route model binding
+     * Retrieve model for route model binding.
      *
      * @param  mixed  $routeKey
      * @return null|\Illuminate\Database\Eloquent\Model

--- a/src/Illuminate/Routing/RouteBinding.php
+++ b/src/Illuminate/Routing/RouteBinding.php
@@ -65,7 +65,7 @@ class RouteBinding
             // throw a not found exception otherwise we will return the instance.
             $instance = $container->make($class);
 
-            if ($model = $instance->where($instance->getRouteKeyName(), $value)->first()) {
+            if ($model = $instance->resolveRouteBinding($value)) {
                 return $model;
             }
 

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -1593,7 +1593,7 @@ class RouteBindingStub
     }
 }
 
-class RouteModelBindingStub
+class RouteModelBindingStub extends Model
 {
     public function getRouteKeyName()
     {
@@ -1613,7 +1613,7 @@ class RouteModelBindingStub
     }
 }
 
-class RouteModelBindingNullStub
+class RouteModelBindingNullStub extends Model
 {
     public function getRouteKeyName()
     {

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -465,6 +465,11 @@ class RoutableInterfaceStub implements UrlRoutable
     {
         return 'key';
     }
+
+    public function resolveRouteBinding($routeKey)
+    {
+        return null;
+    }
 }
 
 class InvokableActionStub


### PR DESCRIPTION
This PR moves the one-liner implicit binding resolution logic from `Illuminate\Routing\RouteBinding@forModel` to `Illuminate\Database\Eloquent\Model@resolveRouteBinding` while adding the above method to `UrlRoutable` interface.

Since interface `UrlRoutable` exists, I think it is adequate to let a `UrlRoutable` class (Model) to 'find itself'.

The motivation for this is to simplify the process of *Customizing The Resolution Logic*, without having to explicitly bind the custom resolution function in RouteServiceProvider. With this PR, a simple override on a model would solve the issue. The possibility of having traits on models that can handle route model resolution would be a great benefit.

This PR doesn't alter *explicit* route model binding! It only adds a possibility to customize *implicit*  route model resolution logic.