### PR TITLE
[5.5] Basic MailFake tests

### DIFF
--- a/tests/Support/SupportTestingMailFakeTest.php
+++ b/tests/Support/SupportTestingMailFakeTest.php
@@ -3,9 +3,9 @@
 namespace Illuminate\Tests\Support;
 
 use Illuminate\Mail\Mailable;
+use PHPUnit\Framework\TestCase;
 use Illuminate\Support\Testing\Fakes\MailFake;
 use PHPUnit\Framework\ExpectationFailedException;
-use PHPUnit\Framework\TestCase;
 
 class MailFakeTest extends TestCase
 {

--- a/tests/Support/SupportTestingMailFakeTest.php
+++ b/tests/Support/SupportTestingMailFakeTest.php
@@ -20,7 +20,7 @@ class MailFakeTest extends TestCase
     {
         try {
             $this->fake->assertSent(MailableStub::class);
-        } catch(ExpectationFailedException $exception) {
+        } catch (ExpectationFailedException $exception) {
             $this->assertEquals('The expected [Illuminate\Tests\Support\MailableStub] mailable was not sent.
 Failed asserting that false is true.', $exception->getMessage());
         }
@@ -38,7 +38,7 @@ Failed asserting that false is true.', $exception->getMessage());
 
         try {
             $this->fake->assertNotSent(MailableStub::class);
-        } catch(ExpectationFailedException $exception) {
+        } catch (ExpectationFailedException $exception) {
             $this->assertEquals('The unexpected [Illuminate\Tests\Support\MailableStub] mailable was sent.
 Failed asserting that false is true.', $exception->getMessage());
         }
@@ -51,7 +51,7 @@ Failed asserting that false is true.', $exception->getMessage());
 
         try {
             $this->fake->assertSent(MailableStub::class, 1);
-        } catch(ExpectationFailedException $exception) {
+        } catch (ExpectationFailedException $exception) {
             $this->assertEquals('The expected [Illuminate\Tests\Support\MailableStub] mailable was sent 2 times instead of 1 times.
 Failed asserting that false is true.', $exception->getMessage());
         }
@@ -67,7 +67,7 @@ Failed asserting that false is true.', $exception->getMessage());
 
         try {
             $this->fake->assertNothingSent();
-        } catch(ExpectationFailedException $exception) {
+        } catch (ExpectationFailedException $exception) {
             $this->assertEquals('Mailables were sent unexpectedly.
 Failed asserting that an array is empty.', $exception->getMessage());
         }

--- a/tests/Support/SupportTestingMailFakeTest.php
+++ b/tests/Support/SupportTestingMailFakeTest.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Illuminate\Tests\Support;
+
+use Illuminate\Mail\Mailable;
+use Illuminate\Support\Testing\Fakes\MailFake;
+use PHPUnit\Framework\ExpectationFailedException;
+use PHPUnit\Framework\TestCase;
+
+class MailFakeTest extends TestCase
+{
+    public function testAssertSent()
+    {
+        $fake = new MailFake;
+        $mailable = new MailableStub;
+
+        try {
+            $fake->assertSent(MailableStub::class);
+        } catch(ExpectationFailedException $exception) {
+            $this->assertEquals('The expected [Illuminate\Tests\Support\MailableStub] mailable was not sent.
+Failed asserting that false is true.', $exception->getMessage());
+        }
+
+        $fake->to('taylor@laravel.com')->send($mailable);
+
+        $fake->assertSent(MailableStub::class);
+    }
+
+    public function testAssertNotSent()
+    {
+        $fake = new MailFake;
+        $mailable = new MailableStub;
+
+        $fake->assertNotSent(MailableStub::class);
+
+        $fake->to('taylor@laravel.com')->send($mailable);
+
+        try {
+            $fake->assertNotSent(MailableStub::class);
+        } catch(ExpectationFailedException $exception) {
+            $this->assertEquals('The unexpected [Illuminate\Tests\Support\MailableStub] mailable was sent.
+Failed asserting that false is true.', $exception->getMessage());
+        }
+    }
+
+    public function testAssertSentTimes()
+    {
+        $fake = new MailFake;
+        $mailable = new MailableStub;
+
+        $fake->to('taylor@laravel.com')->send($mailable);
+        $fake->to('taylor@laravel.com')->send($mailable);
+
+        try {
+            $fake->assertSent(MailableStub::class, 1);
+        } catch(ExpectationFailedException $exception) {
+            $this->assertEquals('The expected [Illuminate\Tests\Support\MailableStub] mailable was sent 2 times instead of 1 times.
+Failed asserting that false is true.', $exception->getMessage());
+        }
+
+        $fake->assertSent(MailableStub::class, 2);
+    }
+
+    public function testAssertNothingSent()
+    {
+        $fake = new MailFake;
+        $mailable = new MailableStub;
+
+        $fake->assertNothingSent();
+
+        $fake->to('taylor@laravel.com')->send($mailable);
+
+        try {
+            $fake->assertNothingSent();
+        } catch(ExpectationFailedException $exception) {
+            $this->assertEquals('Mailables were sent unexpectedly.
+Failed asserting that an array is empty.', $exception->getMessage());
+        }
+    }
+}
+
+
+class MailableStub extends Mailable
+{
+    public $framework = 'Laravel';
+
+    protected $version = '5.5';
+
+    /**
+     * Build the message.
+     *
+     * @return $this
+     */
+    public function build()
+    {
+        $this->with('first_name', 'Taylor')
+             ->withLastName('Otwell');
+    }
+}

--- a/tests/Support/SupportTestingMailFakeTest.php
+++ b/tests/Support/SupportTestingMailFakeTest.php
@@ -9,34 +9,35 @@ use PHPUnit\Framework\TestCase;
 
 class MailFakeTest extends TestCase
 {
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->fake = new MailFake;
+        $this->mailable = new MailableStub;
+    }
+
     public function testAssertSent()
     {
-        $fake = new MailFake;
-        $mailable = new MailableStub;
-
         try {
-            $fake->assertSent(MailableStub::class);
+            $this->fake->assertSent(MailableStub::class);
         } catch(ExpectationFailedException $exception) {
             $this->assertEquals('The expected [Illuminate\Tests\Support\MailableStub] mailable was not sent.
 Failed asserting that false is true.', $exception->getMessage());
         }
 
-        $fake->to('taylor@laravel.com')->send($mailable);
+        $this->fake->to('taylor@laravel.com')->send($this->mailable);
 
-        $fake->assertSent(MailableStub::class);
+        $this->fake->assertSent(MailableStub::class);
     }
 
     public function testAssertNotSent()
     {
-        $fake = new MailFake;
-        $mailable = new MailableStub;
+        $this->fake->assertNotSent(MailableStub::class);
 
-        $fake->assertNotSent(MailableStub::class);
-
-        $fake->to('taylor@laravel.com')->send($mailable);
+        $this->fake->to('taylor@laravel.com')->send($this->mailable);
 
         try {
-            $fake->assertNotSent(MailableStub::class);
+            $this->fake->assertNotSent(MailableStub::class);
         } catch(ExpectationFailedException $exception) {
             $this->assertEquals('The unexpected [Illuminate\Tests\Support\MailableStub] mailable was sent.
 Failed asserting that false is true.', $exception->getMessage());
@@ -45,33 +46,27 @@ Failed asserting that false is true.', $exception->getMessage());
 
     public function testAssertSentTimes()
     {
-        $fake = new MailFake;
-        $mailable = new MailableStub;
-
-        $fake->to('taylor@laravel.com')->send($mailable);
-        $fake->to('taylor@laravel.com')->send($mailable);
+        $this->fake->to('taylor@laravel.com')->send($this->mailable);
+        $this->fake->to('taylor@laravel.com')->send($this->mailable);
 
         try {
-            $fake->assertSent(MailableStub::class, 1);
+            $this->fake->assertSent(MailableStub::class, 1);
         } catch(ExpectationFailedException $exception) {
             $this->assertEquals('The expected [Illuminate\Tests\Support\MailableStub] mailable was sent 2 times instead of 1 times.
 Failed asserting that false is true.', $exception->getMessage());
         }
 
-        $fake->assertSent(MailableStub::class, 2);
+        $this->fake->assertSent(MailableStub::class, 2);
     }
 
     public function testAssertNothingSent()
     {
-        $fake = new MailFake;
-        $mailable = new MailableStub;
+        $this->fake->assertNothingSent();
 
-        $fake->assertNothingSent();
-
-        $fake->to('taylor@laravel.com')->send($mailable);
+        $this->fake->to('taylor@laravel.com')->send($this->mailable);
 
         try {
-            $fake->assertNothingSent();
+            $this->fake->assertNothingSent();
         } catch(ExpectationFailedException $exception) {
             $this->assertEquals('Mailables were sent unexpectedly.
 Failed asserting that an array is empty.', $exception->getMessage());


### PR DESCRIPTION
I sent some PRs regarding MailFake this week and thought it would be cool to have some basic tests running — I felt a bit lost having to test the methods manually on a laravel app  

I'm not sure if this has been discussed before and it was decided it was not worth it, if it was, I'm really sorry, but I searched and did not find anything   

This PR just adds some basic tests to the assertions present in the `MailFake` class