### PR TITLE
Accept string as parameter in Route::resource()->names()

### DIFF
--- a/src/Illuminate/Routing/PendingResourceRegistration.php
+++ b/src/Illuminate/Routing/PendingResourceRegistration.php
@@ -78,10 +78,10 @@ class PendingResourceRegistration
     /**
      * Set the route names for controller actions.
      *
-     * @param  array  $names
+     * @param  array|string  $names
      * @return \Illuminate\Routing\PendingResourceRegistration
      */
-    public function names(array $names)
+    public function names($names)
     {
         $this->options['names'] = $names;
 

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -223,6 +223,9 @@ class RouteRegistrarTest extends TestCase
 
     public function testCanNameRoutesOnRegisteredResource()
     {
+        $this->router->resource('comments', 'Illuminate\Tests\Routing\RouteRegistrarControllerStub')
+                     ->only('create', 'store')->names('reply');
+
         $this->router->resource('users', 'Illuminate\Tests\Routing\RouteRegistrarControllerStub')
                      ->only('create', 'store')->names([
                          'create' => 'user.build',
@@ -234,6 +237,8 @@ class RouteRegistrarTest extends TestCase
                     ->name('create', 'posts.make')
                     ->name('destroy', 'posts.remove');
 
+        $this->assertTrue($this->router->getRoutes()->hasNamedRoute('reply.create'));
+        $this->assertTrue($this->router->getRoutes()->hasNamedRoute('reply.store'));
         $this->assertTrue($this->router->getRoutes()->hasNamedRoute('user.build'));
         $this->assertTrue($this->router->getRoutes()->hasNamedRoute('user.save'));
         $this->assertTrue($this->router->getRoutes()->hasNamedRoute('posts.make'));


### PR DESCRIPTION
According to [this line](https://github.com/laravel/framework/blob/b75aca6a203590068161835945213fd1a39c7080/src/Illuminate/Routing/ResourceRegistrar.php#L379) it  makes sense for option `names` to be a string. If it is a string, routes will be named with that prefix, ie. `customname.create`, `customname.show`, etc.


Currently it is possible to set `names` to be a string through the options array:

```php
Route::resource('/comments', 'ReplyController', ['names' => 'reply'] );
```

It should be possible to do the same using the chainable `names()` method:

```php
Route::resource('/comments', 'ReplyController' )->names('reply');
```