### PR TITLE
Accept string as parameter in Route::resource()->parameters()

### DIFF
--- a/src/Illuminate/Routing/PendingResourceRegistration.php
+++ b/src/Illuminate/Routing/PendingResourceRegistration.php
@@ -105,10 +105,10 @@ class PendingResourceRegistration
     /**
      * Override the route parameter names.
      *
-     * @param  array  $parameters
+     * @param  array|string  $parameters
      * @return \Illuminate\Routing\PendingResourceRegistration
      */
-    public function parameters(array $parameters)
+    public function parameters($parameters)
     {
         $this->options['parameters'] = $parameters;
 

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -1118,7 +1118,7 @@ class RoutingRouteTest extends TestCase
 
         $router = $this->getRouter();
         $router->resource('foos', 'FooController', ['parameters' => 'singular']);
-        $router->resource('foos.bars', 'FooController', ['parameters' => 'singular']);
+        $router->resource('foos.bars', 'FooController')->parameters('singular');
         $routes = $router->getRoutes();
         $routes = $routes->getRoutes();
 
@@ -1127,6 +1127,13 @@ class RoutingRouteTest extends TestCase
 
         $router = $this->getRouter();
         $router->resource('foos.bars', 'FooController', ['parameters' => ['foos' => 'foo', 'bars' => 'bar']]);
+        $routes = $router->getRoutes();
+        $routes = $routes->getRoutes();
+
+        $this->assertEquals('foos/{foo}/bars/{bar}', $routes[3]->uri());
+
+        $router = $this->getRouter();
+        $router->resource('foos.bars', 'FooController')->parameter('foos', 'foo')->parameter('bars', 'bar');
         $routes = $router->getRoutes();
         $routes = $routes->getRoutes();
 


### PR DESCRIPTION
This PR solves a similar issue as [this one](https://github.com/laravel/framework/pull/20529). Read that first.

According to [this line](https://github.com/laravel/framework/blob/b75aca6a203590068161835945213fd1a39c7080/src/Illuminate/Routing/ResourceRegistrar.php#L334), `parameters` can be a string too.

I also added a test about the `parameter()` chainable method that was lacking.