### PR TITLE
[5.5] Reverted broken changes to url routable contract

### DIFF
--- a/src/Illuminate/Contracts/Routing/UrlRoutable.php
+++ b/src/Illuminate/Contracts/Routing/UrlRoutable.php
@@ -17,12 +17,4 @@ interface UrlRoutable
      * @return string
      */
     public function getRouteKeyName();
-
-    /**
-     * Retrieve the model for a bound value.
-     *
-     * @param  mixed  $value
-     * @return \Illuminate\Database\Eloquent\Model|null
-     */
-    public function resolveRouteBinding($value);
 }

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1252,17 +1252,6 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     }
 
     /**
-     * Retrieve the model for a bound value.
-     *
-     * @param  mixed  $value
-     * @return \Illuminate\Database\Eloquent\Model|null
-     */
-    public function resolveRouteBinding($routeKey)
-    {
-        return $this->where($this->getRouteKeyName(), $routeKey)->first();
-    }
-
-    /**
      * Get the default foreign key name for the model.
      *
      * @return string

--- a/src/Illuminate/Routing/RouteBinding.php
+++ b/src/Illuminate/Routing/RouteBinding.php
@@ -65,7 +65,7 @@ class RouteBinding
             // throw a not found exception otherwise we will return the instance.
             $instance = $container->make($class);
 
-            if ($model = $instance->resolveRouteBinding($value)) {
+            if ($model = $instance->where($instance->getRouteKeyName(), $value)->first()) {
                 return $model;
             }
 

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -1600,7 +1600,7 @@ class RouteBindingStub
     }
 }
 
-class RouteModelBindingStub extends Model
+class RouteModelBindingStub
 {
     public function getRouteKeyName()
     {
@@ -1620,7 +1620,7 @@ class RouteModelBindingStub extends Model
     }
 }
 
-class RouteModelBindingNullStub extends Model
+class RouteModelBindingNullStub
 {
     public function getRouteKeyName()
     {

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -465,11 +465,6 @@ class RoutableInterfaceStub implements UrlRoutable
     {
         return 'key';
     }
-
-    public function resolveRouteBinding($routeKey)
-    {
-        return null;
-    }
 }
 
 class InvokableActionStub


### PR DESCRIPTION
Reverting because it introduces a dependency on eloquent on the contracts, and this contract shouldn't know about eloquent, and in fact can't, because there's no composer dependency from the contracts repo on the database component.

Moreover, this breaks the laravel auto presenter package.