### PR TITLE
[5.5] Improved mysql drop all tables

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -319,6 +319,27 @@ class MySqlGrammar extends Grammar
     }
 
     /**
+     * Compile the SQL needed to drop all tables.
+     *
+     * @param  array  $tables
+     * @return string
+     */
+    public function compileDropAllTables($tables)
+    {
+        return 'drop table '.implode(',', $this->wrapArray($tables));
+    }
+
+    /**
+     * Compile the SQL needed to retrieve all table names.
+     *
+     * @return string
+     */
+    public function compileGetAllTables()
+    {
+        return 'SHOW FULL TABLES WHERE table_type = \'BASE TABLE\'';
+    }
+
+    /**
      * Compile the command to enable foreign key constraints.
      *
      * @return string

--- a/src/Illuminate/Database/Schema/MySqlBuilder.php
+++ b/src/Illuminate/Database/Schema/MySqlBuilder.php
@@ -43,12 +43,36 @@ class MySqlBuilder extends Builder
      */
     public function dropAllTables()
     {
-        $this->disableForeignKeyConstraints();
+        $result = $this->getAllTables();
 
-        foreach ($this->connection->select('SHOW FULL TABLES WHERE table_type = \'BASE TABLE\'') as $table) {
-            $this->drop(get_object_vars($table)[key($table)]);
+        if (empty($result)) {
+            return;
         }
 
+        $tables = [];
+
+        foreach ($result as $row) {
+            $tables[] = get_object_vars($row)[key($row)];
+        }
+
+        $this->disableForeignKeyConstraints();
+
+        $this->connection->statement(
+            $this->grammar->compileDropAllTables($tables)
+        );
+
         $this->enableForeignKeyConstraints();
+    }
+
+    /**
+     * Get all of the table names for the database.
+     *
+     * @return array
+     */
+    protected function getAllTables()
+    {
+        return $this->connection->select(
+            $this->grammar->compileGetAllTables()
+        );
     }
 }

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -778,6 +778,13 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertEquals("alter table `users` add `foo` varchar(255) not null comment 'Escape \\' when using words like it\\'s'", $statements[0]);
     }
 
+    public function testDropAllTables()
+    {
+        $statement = $this->getGrammar()->compileDropAllTables(['alpha', 'beta', 'gamma']);
+
+        $this->assertEquals('drop table `alpha`,`beta`,`gamma`', $statement);
+    }
+
     protected function getConnection()
     {
         return m::mock('Illuminate\Database\Connection');


### PR DESCRIPTION
current implementation runs N queries when database has N number of tables. this PR only run 2 queries to drop all tables.

Previous:
```
SHOW FULL TABLES WHERE table_type = 'BASE TABLE'
DROP TABLE alpha
DROP TABLE beta
DROP TABLE gamma
```
Now:
```
SHOW FULL TABLES WHERE table_type = 'BASE TABLE'
DROP TABLE alpha,beta,gamma
```

this implementation already exists for other database drivers. but mysql missed that somehow.