### PR TITLE
[5.5] Implicit route binding with UrlRoutable only

### DIFF
--- a/src/Illuminate/Contracts/Routing/UrlRoutable.php
+++ b/src/Illuminate/Contracts/Routing/UrlRoutable.php
@@ -21,8 +21,8 @@ interface UrlRoutable
     /**
      * Retrieve the model for a bound value.
      *
-     * @param  mixed  $value
-     * @return \Illuminate\Database\Eloquent\Model|null
+     * @param  mixed  $routeKey
+     * @return UrlRoutable
      */
-    public function resolveRouteBinding($value);
+    public function resolveRouteBinding($routeKey);
 }

--- a/src/Illuminate/Contracts/Routing/UrlRoutable.php
+++ b/src/Illuminate/Contracts/Routing/UrlRoutable.php
@@ -22,7 +22,7 @@ interface UrlRoutable
      * Retrieve the model for a bound value.
      *
      * @param  mixed  $routeKey
-     * @return UrlRoutable
+     * @return UrlRoutable|null
      */
     public function resolveRouteBinding($routeKey);
 }

--- a/src/Illuminate/Contracts/Routing/UrlRoutable.php
+++ b/src/Illuminate/Contracts/Routing/UrlRoutable.php
@@ -22,7 +22,7 @@ interface UrlRoutable
      * Retrieve the model for a bound value.
      *
      * @param  mixed  $routeKey
-     * @return UrlRoutable|null
+     * @return \Illuminate\Contracts\Routing\UrlRoutable|null
      */
     public function resolveRouteBinding($routeKey);
 }

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1254,7 +1254,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     /**
      * Retrieve the model for a bound value.
      *
-     * @param  mixed  $value
+     * @param  mixed  $routeKey
      * @return \Illuminate\Database\Eloquent\Model|null
      */
     public function resolveRouteBinding($routeKey)

--- a/src/Illuminate/Routing/ImplicitRouteBinding.php
+++ b/src/Illuminate/Routing/ImplicitRouteBinding.php
@@ -3,7 +3,8 @@
 namespace Illuminate\Routing;
 
 use Illuminate\Support\Str;
-use Illuminate\Database\Eloquent\Model;
+use Illuminate\Contracts\Routing\UrlRoutable;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 
 class ImplicitRouteBinding
 {
@@ -18,22 +19,26 @@ class ImplicitRouteBinding
     {
         $parameters = $route->parameters();
 
-        foreach ($route->signatureParameters(Model::class) as $parameter) {
+        foreach ($route->signatureParameters(UrlRoutable::class) as $parameter) {
             if (! $parameterName = static::getParameterName($parameter->name, $parameters)) {
                 continue;
             }
 
             $parameterValue = $parameters[$parameterName];
 
-            if ($parameterValue instanceof Model) {
+            if ($parameterValue instanceof UrlRoutable) {
                 continue;
             }
 
-            $model = $container->make($parameter->getClass()->name);
+            $instance = $container->make($parameter->getClass()->name);
 
-            $route->setParameter($parameterName, $model->where(
-                $model->getRouteKeyName(), $parameterValue
-            )->firstOrFail());
+            
+
+            if (! $model = $instance->resolveRouteBinding($parameterValue)) {
+                throw (new ModelNotFoundException)->setModel($parameter->getClass());
+            }
+
+            $route->setParameter($parameterName, $model);
         }
     }
 

--- a/src/Illuminate/Routing/ImplicitRouteBinding.php
+++ b/src/Illuminate/Routing/ImplicitRouteBinding.php
@@ -32,8 +32,6 @@ class ImplicitRouteBinding
 
             $instance = $container->make($parameter->getClass()->name);
 
-            
-
             if (! $model = $instance->resolveRouteBinding($parameterValue)) {
                 throw (new ModelNotFoundException)->setModel($parameter->getClass());
             }

--- a/src/Illuminate/Routing/RouteSignatureParameters.php
+++ b/src/Illuminate/Routing/RouteSignatureParameters.php
@@ -22,7 +22,7 @@ class RouteSignatureParameters
                         : (new ReflectionFunction($action['uses']))->getParameters();
 
         return is_null($subClass) ? $parameters : array_filter($parameters, function ($p) use ($subClass) {
-            return $p->getClass() && $p->getClass()->isSubclassOf($subClass);
+            return $p->getClass() && ($p->getClass()->isSubclassOf($subClass) || $p->getClass()->implementsInterface($subClass));
         });
     }
 

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -17,8 +17,8 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Auth\Middleware\Authorize;
 use Illuminate\Routing\ResourceRegistrar;
 use Illuminate\Contracts\Routing\Registrar;
-use Illuminate\Contracts\Routing\UrlRoutable;
 use Illuminate\Auth\Middleware\Authenticate;
+use Illuminate\Contracts\Routing\UrlRoutable;
 use Symfony\Component\HttpFoundation\Response;
 use Illuminate\Routing\Middleware\SubstituteBindings;
 

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -17,6 +17,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Auth\Middleware\Authorize;
 use Illuminate\Routing\ResourceRegistrar;
 use Illuminate\Contracts\Routing\Registrar;
+use Illuminate\Contracts\Routing\UrlRoutable;
 use Illuminate\Auth\Middleware\Authenticate;
 use Symfony\Component\HttpFoundation\Response;
 use Illuminate\Routing\Middleware\SubstituteBindings;
@@ -1308,6 +1309,21 @@ class RoutingRouteTest extends TestCase
         $this->assertEquals('taylor', $router->dispatch(Request::create('foo/taylor', 'GET'))->getContent());
     }
 
+    public function testImplicitBindingsWithUrlRoutableInterface()
+    {
+        $phpunit = $this;
+        $router = $this->getRouter();
+        $router->get('foo/{bar}', [
+            'middleware' => SubstituteBindings::class,
+            'uses' => function (RoutingTestUrlRoutableModel $bar) use ($phpunit) {
+                $phpunit->assertInstanceOf(RoutingTestUrlRoutableModel::class, $bar);
+
+                return $bar->value;
+            },
+        ]);
+        $this->assertEquals('taylor', $router->dispatch(Request::create('foo/taylor', 'GET'))->getContent());
+    }
+
     public function testImplicitBindingsWithOptionalParameterWithExistingKeyInUri()
     {
         $phpunit = $this;
@@ -1684,6 +1700,26 @@ class RoutingTestUserModel extends Model
 
     public function firstOrFail()
     {
+        return $this;
+    }
+}
+
+class RoutingTestUrlRoutableModel implements UrlRoutable
+{
+    public function getRouteKeyName()
+    {
+        return 'id';
+    }
+
+    public function getRouteKey()
+    {
+        return $this->id;
+    }
+
+    public function resolveRouteBinding($value)
+    {
+        $this->value = $value;
+
         return $this;
     }
 }


### PR DESCRIPTION
This is an improvement on https://github.com/laravel/framework/pull/20521

Although @GrahamCampbell is wrong in https://github.com/laravel/framework/pull/20535 about `UrlRoutable`'s dependence on eloquent, he has a point in a way little bit different.

He's right about that `UrlRoutable@resolveRouteBinding` should be able to return anything, not just eloquent. There's no restriction in the interface itself, however there are restrictions in other parts of the framework.

This PR replaces checks of `Model` with checks of `UrlRoutable` in `ImplicitRouteBinding`.

From now the following is possible:

```php
Route::get('/posts/{post}', function(\App\Post $post){
	return $post->id;
});
```

```php
<?php

namespace App;

class Post implements \Illuminate\Contracts\Routing\UrlRoutable
{
    public $id;

    public function getRouteKey(){
    	return $this->id;
    }
    
    public function getRouteKeyName(){
    	return 'id';
    }
    
    public function resolveRouteBinding($id){
    	$post = new Post;

    	$post->id = $id;

    	return $post;
    }
}
```

Now this `Post` model implements `ImplicitRouteBinding` and `resolveRouteBinding` clearly **doesn't return eloquent**!