### PR TITLE
[5.5] Update MailFake tests to use @expectedException annotations

### DIFF
--- a/tests/Support/SupportTestingMailFakeTest.php
+++ b/tests/Support/SupportTestingMailFakeTest.php
@@ -5,7 +5,6 @@ namespace Illuminate\Tests\Support;
 use Illuminate\Mail\Mailable;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Support\Testing\Fakes\MailFake;
-use PHPUnit\Framework\ExpectationFailedException;
 
 class MailFakeTest extends TestCase
 {
@@ -16,61 +15,57 @@ class MailFakeTest extends TestCase
         $this->mailable = new MailableStub;
     }
 
+    /**
+     * @expectedException PHPUnit\Framework\ExpectationFailedException
+     * @expectedExceptionMessage The expected [Illuminate\Tests\Support\MailableStub] mailable was not sent.
+     */
     public function testAssertSent()
     {
-        try {
-            $this->fake->assertSent(MailableStub::class);
-        } catch (ExpectationFailedException $exception) {
-            $this->assertEquals('The expected [Illuminate\Tests\Support\MailableStub] mailable was not sent.
-Failed asserting that false is true.', $exception->getMessage());
-        }
+        $this->fake->assertSent(MailableStub::class);
 
         $this->fake->to('taylor@laravel.com')->send($this->mailable);
 
         $this->fake->assertSent(MailableStub::class);
     }
 
+    /**
+     * @expectedException PHPUnit\Framework\ExpectationFailedException
+     * @expectedExceptionMessage The unexpected [Illuminate\Tests\Support\MailableStub] mailable was sent.
+     */
     public function testAssertNotSent()
     {
         $this->fake->assertNotSent(MailableStub::class);
 
         $this->fake->to('taylor@laravel.com')->send($this->mailable);
 
-        try {
-            $this->fake->assertNotSent(MailableStub::class);
-        } catch (ExpectationFailedException $exception) {
-            $this->assertEquals('The unexpected [Illuminate\Tests\Support\MailableStub] mailable was sent.
-Failed asserting that false is true.', $exception->getMessage());
-        }
+        $this->fake->assertNotSent(MailableStub::class);
     }
 
+    /**
+     * @expectedException PHPUnit\Framework\ExpectationFailedException
+     * @expectedExceptionMessage The expected [Illuminate\Tests\Support\MailableStub] mailable was sent 2 times instead of 1 times.
+     */
     public function testAssertSentTimes()
     {
         $this->fake->to('taylor@laravel.com')->send($this->mailable);
         $this->fake->to('taylor@laravel.com')->send($this->mailable);
 
-        try {
-            $this->fake->assertSent(MailableStub::class, 1);
-        } catch (ExpectationFailedException $exception) {
-            $this->assertEquals('The expected [Illuminate\Tests\Support\MailableStub] mailable was sent 2 times instead of 1 times.
-Failed asserting that false is true.', $exception->getMessage());
-        }
+        $this->fake->assertSent(MailableStub::class, 1);
 
         $this->fake->assertSent(MailableStub::class, 2);
     }
 
+    /**
+     * @expectedException PHPUnit\Framework\ExpectationFailedException
+     * @expectedExceptionMessage Mailables were sent unexpectedly.
+     */
     public function testAssertNothingSent()
     {
         $this->fake->assertNothingSent();
 
         $this->fake->to('taylor@laravel.com')->send($this->mailable);
 
-        try {
-            $this->fake->assertNothingSent();
-        } catch (ExpectationFailedException $exception) {
-            $this->assertEquals('Mailables were sent unexpectedly.
-Failed asserting that an array is empty.', $exception->getMessage());
-        }
+        $this->fake->assertNothingSent();
     }
 }
 


### PR DESCRIPTION
Had completely forgotten about this. Way cleaner.  

Tks @lucasmichot 