### PR TITLE
[5.2] Fix Environment variables sometimes return null when use ajax

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -325,9 +325,9 @@ if (! function_exists('env')) {
      */
     function env($key, $default = null)
     {
-        $value = getenv($key);
+        $value = Dotenv::findEnvironmentVariable($key);
 
-        if ($value === false) {
+        if (is_null($value)) {
             return value($default);
         }
 


### PR DESCRIPTION
When use ajax get some data, env() will return null. 
It will occur 2 requests:
first request,  "Dotenv" class read .env file,  read $_SERVER, it's empty,  save config value to $_ENV,  function env() can read $_ENV value. 
second request, "Dotenv" class read .env file, read $_SERVER, it's not empty, will donot save config value to  $_ENV, so function env() return null.
 
so, env() function will read $_SERVER first, if empty, read env. 

It exist version 5.1, 5.2， I don't know it exist or not in other versions.

other link bugs:  #8191
