### PR TITLE
Update Builder.php

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -561,12 +561,12 @@ class Builder
      */
     protected function addArrayOfWheres($column, $boolean, $method = 'where')
     {
-        return $this->whereNested(function ($query) use ($column, $method) {
+        return $this->whereNested(function ($query) use ($column, $method, $boolean) {
             foreach ($column as $key => $value) {
                 if (is_numeric($key) && is_array($value)) {
                     $query->{$method}(...array_values($value));
                 } else {
-                    $query->$method($key, '=', $value);
+                    $query->$method($key, '=', $value, $boolean);
                 }
             }
         }, $boolean);


### PR DESCRIPTION
Fixed $boolean parameter being ignored by "where" function, when the $column parameter is an array.

In detail: the following code should produce a query with "or" conditions:

..->where(["col1"=>"val1","col2"=>"val2"],null,null,"or");

But, it produced the query with "and" conditions - ignoring the last parameter "or" and taking it as "and" (default value)