### PR TITLE
[5.5] Added tests for the make:auth command

### DIFF
--- a/src/Illuminate/Auth/Console/AuthMakeCommand.php
+++ b/src/Illuminate/Auth/Console/AuthMakeCommand.php
@@ -41,6 +41,18 @@ class AuthMakeCommand extends Command
     ];
 
     /**
+     * The tests that need to be exported.
+     *
+     * @var array
+     */
+    protected $tests = [
+        'Feature/Auth/LoginTest.stub' => 'Feature/Auth/LoginTest.php',
+        'Feature/Auth/RegisterTest.stub' => 'Feature/Auth/RegisterTest.php',
+        'Feature/Auth/ForgotPasswordTest.stub' => 'Feature/Auth/ForgotPasswordTest.php',
+        'Feature/Auth/ResetPasswordTest.stub' => 'Feature/Auth/ResetPasswordTest.php',
+    ];
+
+    /**
      * Execute the console command.
      *
      * @return void
@@ -65,25 +77,7 @@ class AuthMakeCommand extends Command
         }
 
         if (! $this->option('no-tests')) {
-            file_put_contents(
-                base_path('tests/Feature/Auth/LoginTest.php'),
-                file_get_contents(__DIR__.'/stubs/make/tests/Feature/Auth/LoginTest.stub')
-            );
-
-            file_put_contents(
-                base_path('tests/Feature/Auth/RegisterTest.php'),
-                file_get_contents(__DIR__.'/stubs/make/tests/Feature/Auth/RegisterTest.stub')
-            );
-
-            file_put_contents(
-                base_path('tests/Feature/Auth/ForgotPasswordTest.php'),
-                file_get_contents(__DIR__.'/stubs/make/tests/Feature/Auth/ForgotPasswordTest.stub')
-            );
-
-            file_put_contents(
-                base_path('tests/Feature/Auth/ResetPasswordTest.php'),
-                file_get_contents(__DIR__.'/stubs/make/tests/Feature/Auth/ResetPasswordTest.stub')
-            );
+            $this->exportTests();
         }
 
         $this->info('Authentication scaffolding generated successfully.');
@@ -128,6 +122,27 @@ class AuthMakeCommand extends Command
             copy(
                 __DIR__.'/stubs/make/views/'.$key,
                 resource_path('views/'.$value)
+            );
+        }
+    }
+
+    /**
+     * Export the authentication tests.
+     *
+     * @return void
+     */
+    public function exportTests()
+    {
+        foreach ($this->tests as $key => $value) {
+            if (file_exists(base_path('tests/'.$value)) && ! $this->option('force')) {
+                if (! $this->confirm("The [{$value}] test already exists. Do you want to replace it?")) {
+                    continue;
+                }
+            }
+
+            copy(
+                __DIR__.'/stubs/make/tests/'.$key,
+                base_path('tests/'.$value)
             );
         }
     }

--- a/src/Illuminate/Auth/Console/AuthMakeCommand.php
+++ b/src/Illuminate/Auth/Console/AuthMakeCommand.php
@@ -98,10 +98,8 @@ class AuthMakeCommand extends Command
             mkdir(resource_path('views/auth/passwords'), 0755, true);
         }
 
-        if (! $this->option('no-tests')) {
-            if (! is_dir(base_path('tests/Feature/Auth'))) {
-                mkdir(base_path('tests/Feature/Auth'), 0755, true);
-            }
+        if (! $this->option('no-tests') && ! is_dir(base_path('tests/Feature/Auth'))) {
+            mkdir(base_path('tests/Feature/Auth'), 0755, true);
         }
     }
 

--- a/src/Illuminate/Auth/Console/AuthMakeCommand.php
+++ b/src/Illuminate/Auth/Console/AuthMakeCommand.php
@@ -111,15 +111,10 @@ class AuthMakeCommand extends Command
     protected function exportViews()
     {
         foreach ($this->views as $key => $value) {
-            if (file_exists(resource_path('views/'.$value)) && ! $this->option('force')) {
-                if (! $this->confirm("The [{$value}] view already exists. Do you want to replace it?")) {
-                    continue;
-                }
-            }
-
-            copy(
+            $this->exportStub(
                 __DIR__.'/stubs/make/views/'.$key,
-                resource_path('views/'.$value)
+                resource_path($filename = 'views/'.$value),
+                $filename
             );
         }
     }
@@ -132,17 +127,31 @@ class AuthMakeCommand extends Command
     public function exportTests()
     {
         foreach ($this->tests as $key => $value) {
-            if (file_exists(base_path('tests/'.$value)) && ! $this->option('force')) {
-                if (! $this->confirm("The [{$value}] test already exists. Do you want to replace it?")) {
-                    continue;
-                }
-            }
-
-            copy(
+            $this->exportStub(
                 __DIR__.'/stubs/make/tests/'.$key,
-                base_path('tests/'.$value)
+                base_path($filename = 'tests/'.$value),
+                $filename
             );
         }
+    }
+
+    /**
+     * Export a stub from the source location to the given location.
+     *
+     * @param  string  $source
+     * @param  string  $destination
+     * @param  string  $filename
+     * @return void
+     */
+    protected function exportStub($source, $destination, $filename)
+    {
+        if (file_exists($destination) && ! $this->option('force')) {
+            if (! $this->confirm("The [{$filename}] file already exists. Do you want to replace it?")) {
+                return;
+            }
+        }
+
+        copy($source, $destination);
     }
 
     /**

--- a/src/Illuminate/Auth/Console/AuthMakeCommand.php
+++ b/src/Illuminate/Auth/Console/AuthMakeCommand.php
@@ -16,7 +16,8 @@ class AuthMakeCommand extends Command
      */
     protected $signature = 'make:auth
                     {--views : Only scaffold the authentication views}
-                    {--force : Overwrite existing views by default}';
+                    {--force : Overwrite existing views by default}
+                    {--no-tests : Do not generate tests}';
 
     /**
      * The console command description.
@@ -63,6 +64,28 @@ class AuthMakeCommand extends Command
             );
         }
 
+        if (! $this->option('no-tests')) {
+            file_put_contents(
+                base_path('tests/Feature/Auth/LoginTest.php'),
+                file_get_contents(__DIR__.'/stubs/make/tests/Feature/Auth/LoginTest.stub')
+            );
+
+            file_put_contents(
+                base_path('tests/Feature/Auth/RegisterTest.php'),
+                file_get_contents(__DIR__.'/stubs/make/tests/Feature/Auth/RegisterTest.stub')
+            );
+
+            file_put_contents(
+                base_path('tests/Feature/Auth/ForgotPasswordTest.php'),
+                file_get_contents(__DIR__.'/stubs/make/tests/Feature/Auth/ForgotPasswordTest.stub')
+            );
+
+            file_put_contents(
+                base_path('tests/Feature/Auth/ResetPasswordTest.php'),
+                file_get_contents(__DIR__.'/stubs/make/tests/Feature/Auth/ResetPasswordTest.stub')
+            );
+        }
+
         $this->info('Authentication scaffolding generated successfully.');
     }
 
@@ -79,6 +102,12 @@ class AuthMakeCommand extends Command
 
         if (! is_dir(resource_path('views/auth/passwords'))) {
             mkdir(resource_path('views/auth/passwords'), 0755, true);
+        }
+
+        if (! $this->option('no-tests')) {
+            if (! is_dir(base_path('tests/Feature/Auth'))) {
+                mkdir(base_path('tests/Feature/Auth'), 0755, true);
+            }
         }
     }
 

--- a/src/Illuminate/Auth/Console/stubs/make/tests/Feature/Auth/ForgotPasswordTest.stub
+++ b/src/Illuminate/Auth/Console/stubs/make/tests/Feature/Auth/ForgotPasswordTest.stub
@@ -1,0 +1,69 @@
+<?php
+
+namespace Tests\Feature\Auth;
+
+use App\User;
+use Tests\TestCase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Notification;
+use Illuminate\Auth\Notifications\ResetPassword;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+class ForgotPasswordTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function fromPage($uri)
+    {
+        return $this->withServerVariables(['HTTP_REFERER' => $uri]);
+    }
+
+    public function testUserCanViewAnEmailPasswordForm()
+    {
+        $response = $this->get(route('password.request'));
+
+        $response->assertSuccessful();
+        $response->assertViewIs('auth.passwords.email');
+    }
+
+    public function testUserCannotViewAnEmailPasswordFormWhenAuthenticated()
+    {
+        $user = factory(User::class)->make();
+
+        $response = $this->actingAs($user)->get(route('password.request'));
+
+        $response->assertRedirect(route('home'));
+    }
+
+    public function testUserReceivesAnEmailWithAPasswordResetLink()
+    {
+        Notification::fake();
+
+        $user = factory(User::class)->create([
+            'email' => 'john@example.com',
+        ]);
+
+        $response = $this->post(route('password.email'), [
+            'email' => 'john@example.com',
+        ]);
+
+        $this->assertNotNull($token = DB::table('password_resets')->first());
+        Notification::assertSentTo($user, ResetPassword::class, function ($notification, $channels) use ($token) {
+            return Hash::check($notification->token, $token->token) === true;
+        });
+    }
+
+    public function testUserDoesNotReceiveEmailWhenNotRegistered()
+    {
+        Notification::fake();
+
+        $response = $this->fromPage(route('password.email'))->post(route('password.email'), [
+            'email' => 'nobody@example.com',
+        ]);
+
+        $response->assertRedirect(route('password.email'));
+        $response->assertSessionHasErrors('email');
+        Notification::assertNotSentTo(factory(User::class)->make(['email' => 'nobody@example.com']), ResetPassword::class);
+    }
+}

--- a/src/Illuminate/Auth/Console/stubs/make/tests/Feature/Auth/LoginTest.stub
+++ b/src/Illuminate/Auth/Console/stubs/make/tests/Feature/Auth/LoginTest.stub
@@ -1,0 +1,98 @@
+<?php
+
+namespace Tests\Feature\Auth;
+
+use App\User;
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+class LoginTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function fromPage($uri)
+    {
+        return $this->withServerVariables(['HTTP_REFERER' => $uri]);
+    }
+
+    public function testUserCanViewALoginForm()
+    {
+        $response = $this->get(route('login'));
+
+        $response->assertSuccessful();
+        $response->assertViewIs('auth.login');
+    }
+
+    public function testUserCannotViewALoginFormWhenAuthenticated()
+    {
+        $user = factory(User::class)->make();
+        $response = $this->actingAs($user)->get(route('login'));
+
+        $response->assertRedirect(route('home'));
+    }
+
+    public function testUserCanLoginWithCorrectCredentials()
+    {
+        $user = factory(User::class)->create([
+            'password' => bcrypt($password = 'i-love-laravel'),
+        ]);
+
+        $response = $this->post(route('login'), [
+            'email' => $user->email,
+            'password' => $password,
+        ]);
+
+        $response->assertRedirect(route('home'));
+        $this->assertAuthenticatedAs($user);
+    }
+
+    public function testUserCannotLoginWithIncorrectPassword()
+    {
+        $user = factory(User::class)->create([
+            'password' => bcrypt('i-love-laravel'),
+        ]);
+
+        $response = $this->fromPage(route('login'))->post(route('login'), [
+            'email' => $user->email,
+            'password' => 'invalid-password',
+        ]);
+
+        $response->assertRedirect(route('login'));
+        $response->assertSessionHasErrors('email');
+        $this->assertTrue(session()->hasOldInput('email'));
+        $this->assertFalse(session()->hasOldInput('password'));
+        $this->assertGuest();
+    }
+
+    public function testUserCannotLoginWithEmailThatDoesNotExist()
+    {
+        $response = $this->fromPage(route('login'))->post(route('login'), [
+            'email' => 'nobody@example.com',
+            'password' => 'invalid-password',
+        ]);
+
+        $response->assertRedirect(route('login'));
+        $response->assertSessionHasErrors('email');
+        $this->assertTrue(session()->hasOldInput('email'));
+        $this->assertFalse(session()->hasOldInput('password'));
+        $this->assertGuest();
+    }
+
+    public function testUserCanLogout()
+    {
+        $this->be(factory(User::class)->create());
+
+        $response = $this->post(route('logout'));
+
+        $response->assertRedirect('/');
+        $this->assertGuest();
+    }
+
+    public function testUserCannotLogoutWhenNotAuthenticated()
+    {
+        $response = $this->post(route('logout'));
+
+        $response->assertRedirect('/');
+        $this->assertGuest();
+    }
+}

--- a/src/Illuminate/Auth/Console/stubs/make/tests/Feature/Auth/RegisterTest.stub
+++ b/src/Illuminate/Auth/Console/stubs/make/tests/Feature/Auth/RegisterTest.stub
@@ -42,15 +42,12 @@ class RegisterTest extends TestCase
             'password_confirmation' => 'i-love-laravel',
         ]);
 
-        $users = User::all();
-        $user = $users->first();
-
         $response->assertRedirect(route('home'));
-        $this->assertCount(1, $users);
+        $this->assertCount(1, $users = User::all());
+        $this->assertAuthenticatedAs($user = $users->first());
         $this->assertEquals('John Doe', $user->name);
         $this->assertEquals('john@example.com', $user->email);
         $this->assertTrue(Hash::check('i-love-laravel', $user->password));
-        $this->assertAuthenticatedAs($user);
     }
 
     public function testUserCannotRegisterWithoutName()
@@ -62,9 +59,7 @@ class RegisterTest extends TestCase
             'password_confirmation' => 'i-love-laravel',
         ]);
 
-        $users = User::all();
-
-        $this->assertCount(0, $users);
+        $this->assertCount(0, User::all());
         $response->assertRedirect(route('register'));
         $response->assertSessionHasErrors('name');
         $this->assertTrue(session()->hasOldInput('email'));
@@ -81,9 +76,7 @@ class RegisterTest extends TestCase
             'password_confirmation' => 'i-love-laravel',
         ]);
 
-        $users = User::all();
-
-        $this->assertCount(0, $users);
+        $this->assertCount(0, User::all());
         $response->assertRedirect(route('register'));
         $response->assertSessionHasErrors('email');
         $this->assertTrue(session()->hasOldInput('name'));
@@ -120,9 +113,7 @@ class RegisterTest extends TestCase
             'password_confirmation' => '',
         ]);
 
-        $users = User::all();
-
-        $this->assertCount(0, $users);
+        $this->assertCount(0, User::all());
         $response->assertRedirect(route('register'));
         $response->assertSessionHasErrors('password');
         $this->assertTrue(session()->hasOldInput('name'));
@@ -140,9 +131,7 @@ class RegisterTest extends TestCase
             'password_confirmation' => '',
         ]);
 
-        $users = User::all();
-
-        $this->assertCount(0, $users);
+        $this->assertCount(0, User::all());
         $response->assertRedirect(route('register'));
         $response->assertSessionHasErrors('password');
         $this->assertTrue(session()->hasOldInput('name'));
@@ -160,9 +149,7 @@ class RegisterTest extends TestCase
             'password_confirmation' => 'i-love-symfony',
         ]);
 
-        $users = User::all();
-
-        $this->assertCount(0, $users);
+        $this->assertCount(0, User::all());
         $response->assertRedirect(route('register'));
         $response->assertSessionHasErrors('password');
         $this->assertTrue(session()->hasOldInput('name'));

--- a/src/Illuminate/Auth/Console/stubs/make/tests/Feature/Auth/RegisterTest.stub
+++ b/src/Illuminate/Auth/Console/stubs/make/tests/Feature/Auth/RegisterTest.stub
@@ -1,0 +1,172 @@
+<?php
+
+namespace Tests\Feature\Auth;
+
+use App\User;
+use Tests\TestCase;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+class RegisterTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function fromPage($uri)
+    {
+        return $this->withServerVariables(['HTTP_REFERER' => $uri]);
+    }
+
+    public function testUserCanViewARegistrationForm()
+    {
+        $response = $this->get(route('register'));
+
+        $response->assertSuccessful();
+        $response->assertViewIs('auth.register');
+    }
+
+    public function testUserCannotViewARegistrationFormWhenAuthenticated()
+    {
+        $user = factory(User::class)->make();
+
+        $response = $this->actingAs($user)->get(route('register'));
+
+        $response->assertRedirect(route('home'));
+    }
+
+    public function testUserCanRegister()
+    {
+        $response = $this->post(route('register'), [
+            'name' => 'John Doe',
+            'email' => 'john@example.com',
+            'password' => 'i-love-laravel',
+            'password_confirmation' => 'i-love-laravel',
+        ]);
+
+        $users = User::all();
+
+        $response->assertRedirect(route('home'));
+        $this->assertCount(1, $users);
+        $this->assertEquals('John Doe', $users->first()->name);
+        $this->assertEquals('john@example.com', $users->first()->email);
+        $this->assertTrue(Hash::check('i-love-laravel', $users->first()->password));
+        $this->assertAuthenticatedAs(User::where('email', 'john@example.com')->first());
+    }
+
+    public function testUserCannotRegisterWithoutName()
+    {
+        $response = $this->fromPage(route('register'))->post(route('register'), [
+            'name' => '',
+            'email' => 'john@example.com',
+            'password' => 'i-love-laravel',
+            'password_confirmation' => 'i-love-laravel',
+        ]);
+
+        $users = User::all();
+
+        $this->assertCount(0, $users);
+        $response->assertRedirect(route('register'));
+        $response->assertSessionHasErrors('name');
+        $this->assertTrue(session()->hasOldInput('email'));
+        $this->assertFalse(session()->hasOldInput('password'));
+        $this->assertGuest();
+    }
+
+    public function testUserCannotRegisterWithoutEmail()
+    {
+        $response = $this->fromPage(route('register'))->post(route('register'), [
+            'name' => 'John Doe',
+            'email' => '',
+            'password' => 'i-love-laravel',
+            'password_confirmation' => 'i-love-laravel',
+        ]);
+
+        $users = User::all();
+
+        $this->assertCount(0, $users);
+        $response->assertRedirect(route('register'));
+        $response->assertSessionHasErrors('email');
+        $this->assertTrue(session()->hasOldInput('name'));
+        $this->assertFalse(session()->hasOldInput('password'));
+        $this->assertGuest();
+    }
+
+    public function testUserCannotRegisterWithInvalidEmail()
+    {
+        $response = $this->fromPage(route('register'))->post(route('register'), [
+            'name' => 'John Doe',
+            'email' => 'invalid-email',
+            'password' => 'i-love-laravel',
+            'password_confirmation' => 'i-love-laravel',
+        ]);
+
+        $users = User::all();
+
+        $this->assertCount(0, $users);
+        $response->assertRedirect(route('register'));
+        $response->assertSessionHasErrors('email');
+        $this->assertTrue(session()->hasOldInput('name'));
+        $this->assertTrue(session()->hasOldInput('email'));
+        $this->assertFalse(session()->hasOldInput('password'));
+        $this->assertGuest();
+    }
+
+    public function testUserCannotRegisterWithoutPassword()
+    {
+        $response = $this->fromPage(route('register'))->post(route('register'), [
+            'name' => 'John Doe',
+            'email' => 'john@example.com',
+            'password' => '',
+            'password_confirmation' => '',
+        ]);
+
+        $users = User::all();
+
+        $this->assertCount(0, $users);
+        $response->assertRedirect(route('register'));
+        $response->assertSessionHasErrors('password');
+        $this->assertTrue(session()->hasOldInput('name'));
+        $this->assertTrue(session()->hasOldInput('email'));
+        $this->assertFalse(session()->hasOldInput('password'));
+        $this->assertGuest();
+    }
+
+    public function testUserCannotRegisterWithoutPasswordConfirmation()
+    {
+        $response = $this->fromPage(route('register'))->post(route('register'), [
+            'name' => 'John Doe',
+            'email' => 'john@example.com',
+            'password' => 'i-love-laravel',
+            'password_confirmation' => '',
+        ]);
+
+        $users = User::all();
+
+        $this->assertCount(0, $users);
+        $response->assertRedirect(route('register'));
+        $response->assertSessionHasErrors('password');
+        $this->assertTrue(session()->hasOldInput('name'));
+        $this->assertTrue(session()->hasOldInput('email'));
+        $this->assertFalse(session()->hasOldInput('password'));
+        $this->assertGuest();
+    }
+
+    public function testUserCannotRegisterWithPasswordsNotMatching()
+    {
+        $response = $this->fromPage(route('register'))->post(route('register'), [
+            'name' => 'John Doe',
+            'email' => 'john@example.com',
+            'password' => 'i-love-laravel',
+            'password_confirmation' => 'i-love-symfony',
+        ]);
+
+        $users = User::all();
+
+        $this->assertCount(0, $users);
+        $response->assertRedirect(route('register'));
+        $response->assertSessionHasErrors('password');
+        $this->assertTrue(session()->hasOldInput('name'));
+        $this->assertTrue(session()->hasOldInput('email'));
+        $this->assertFalse(session()->hasOldInput('password'));
+        $this->assertGuest();
+    }
+}

--- a/src/Illuminate/Auth/Console/stubs/make/tests/Feature/Auth/RegisterTest.stub
+++ b/src/Illuminate/Auth/Console/stubs/make/tests/Feature/Auth/RegisterTest.stub
@@ -43,13 +43,14 @@ class RegisterTest extends TestCase
         ]);
 
         $users = User::all();
+        $user = $users->first();
 
         $response->assertRedirect(route('home'));
         $this->assertCount(1, $users);
-        $this->assertEquals('John Doe', $users->first()->name);
-        $this->assertEquals('john@example.com', $users->first()->email);
-        $this->assertTrue(Hash::check('i-love-laravel', $users->first()->password));
-        $this->assertAuthenticatedAs(User::where('email', 'john@example.com')->first());
+        $this->assertEquals('John Doe', $user->name);
+        $this->assertEquals('john@example.com', $user->email);
+        $this->assertTrue(Hash::check('i-love-laravel', $user->password));
+        $this->assertAuthenticatedAs($user);
     }
 
     public function testUserCannotRegisterWithoutName()

--- a/src/Illuminate/Auth/Console/stubs/make/tests/Feature/Auth/RegisterTest.stub
+++ b/src/Illuminate/Auth/Console/stubs/make/tests/Feature/Auth/RegisterTest.stub
@@ -93,9 +93,29 @@ class RegisterTest extends TestCase
             'password_confirmation' => 'i-love-laravel',
         ]);
 
-        $users = User::all();
+        $this->assertCount(0, User::all());
+        $response->assertRedirect(route('register'));
+        $response->assertSessionHasErrors('email');
+        $this->assertTrue(session()->hasOldInput('name'));
+        $this->assertTrue(session()->hasOldInput('email'));
+        $this->assertFalse(session()->hasOldInput('password'));
+        $this->assertGuest();
+    }
 
-        $this->assertCount(0, $users);
+    public function testUserCannotRegisterWithEmailThatAlreadyExists()
+    {
+        $existingUser = factory(User::class)->create([
+            'email' => 'john@example.com',
+        ]);
+
+        $response = $this->fromPage(route('register'))->post(route('register'), [
+            'name' => 'John Doe',
+            'email' => $existingUser->email,
+            'password' => 'i-love-laravel',
+            'password_confirmation' => 'i-love-laravel',
+        ]);
+
+        $this->assertCount(1, User::all());
         $response->assertRedirect(route('register'));
         $response->assertSessionHasErrors('email');
         $this->assertTrue(session()->hasOldInput('name'));

--- a/src/Illuminate/Auth/Console/stubs/make/tests/Feature/Auth/ResetPasswordTest.stub
+++ b/src/Illuminate/Auth/Console/stubs/make/tests/Feature/Auth/ResetPasswordTest.stub
@@ -1,0 +1,82 @@
+<?php
+
+namespace Tests\Feature\Auth;
+
+use App\User;
+use Tests\TestCase;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Password;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+class ResetPasswordTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function getValidToken($user)
+    {
+        return Password::broker()->createToken($user);
+    }
+
+    protected function getInvalidToken()
+    {
+        return 'invalid-token';
+    }
+
+    protected function fromPage($uri)
+    {
+        return $this->withServerVariables(['HTTP_REFERER' => $uri]);
+    }
+
+    public function testUserCanViewAPasswordResetForm()
+    {
+        $user = factory(User::class)->create();
+
+        $response = $this->get(route('password.reset', $this->getValidToken($user)));
+
+        $response->assertSuccessful();
+        $response->assertViewIs('auth.passwords.reset');
+    }
+
+    public function testUserCannotViewAPasswordResetFormWhenAuthenticated()
+    {
+        $user = factory(User::class)->create();
+
+        $response = $this->actingAs($user)->get(route('password.reset', $this->getValidToken($user)));
+
+        $response->assertRedirect(route('home'));
+    }
+
+    public function testUserCanResetPasswordWithCorrectToken()
+    {
+        $user = factory(User::class)->create();
+
+        $response = $this->post('/password/reset', [
+            'token' => $this->getValidToken($user),
+            'email' => $user->email,
+            'password' => 'new-awesome-password',
+            'password_confirmation' => 'new-awesome-password',
+        ]);
+
+        $response->assertRedirect(route('home'));
+        $this->assertEquals($user->email, $user->fresh()->email);
+        $this->assertTrue(Hash::check('new-awesome-password', $user->fresh()->password));
+    }
+
+    public function testUserCannotResetPasswordWithIncorrectToken()
+    {
+        $user = factory(User::class)->create([
+            'password' => bcrypt('old-password'),
+        ]);
+
+        $response = $this->fromPage(route('password.reset', $this->getInvalidToken()))->post('/password/reset', [
+            'token' => $this->getInvalidToken(),
+            'email' => $user->email,
+            'password' => 'new-awesome-password',
+            'password_confirmation' => 'new-awesome-password',
+        ]);
+
+        $response->assertRedirect(route('password.reset', $this->getInvalidToken()));
+        $this->assertEquals($user->email, $user->fresh()->email);
+        $this->assertTrue(Hash::check('old-password', $user->fresh()->password));
+    }
+}

--- a/src/Illuminate/Auth/Console/stubs/make/tests/Feature/Auth/ResetPasswordTest.stub
+++ b/src/Illuminate/Auth/Console/stubs/make/tests/Feature/Auth/ResetPasswordTest.stub
@@ -79,4 +79,47 @@ class ResetPasswordTest extends TestCase
         $this->assertEquals($user->email, $user->fresh()->email);
         $this->assertTrue(Hash::check('old-password', $user->fresh()->password));
     }
+
+    public function testUserCannotResetPasswordWithoutProvidingANewPassword()
+    {
+        $user = factory(User::class)->create([
+            'password' => bcrypt('old-password'),
+        ]);
+
+        $response = $this->fromPage(route('password.reset', $token = $this->getValidToken($user)))->post('/password/reset', [
+            'token' => $this->getInvalidToken(),
+            'email' => $user->email,
+            'password' => '',
+            'password_confirmation' => '',
+        ]);
+
+        $response->assertRedirect(route('password.reset', $token));
+        $response->assertSessionHasErrors('password');
+        $this->assertTrue(session()->hasOldInput('email'));
+        $this->assertFalse(session()->hasOldInput('password'));
+        $this->assertEquals($user->email, $user->fresh()->email);
+        $this->assertTrue(Hash::check('old-password', $user->fresh()->password));
+        $this->assertGuest();
+    }
+
+    public function testUserCannotResetPasswordWithoutProvingAnEmail()
+    {
+        $user = factory(User::class)->create([
+            'password' => bcrypt('old-password'),
+        ]);
+
+        $response = $this->fromPage(route('password.reset', $token = $this->getValidToken($user)))->post('/password/reset', [
+            'token' => $this->getInvalidToken(),
+            'email' => '',
+            'password' => 'new-awesome-password',
+            'password_confirmation' => 'new-awesome-password',
+        ]);
+
+        $response->assertRedirect(route('password.reset', $token));
+        $response->assertSessionHasErrors('email');
+        $this->assertFalse(session()->hasOldInput('password'));
+        $this->assertEquals($user->email, $user->fresh()->email);
+        $this->assertTrue(Hash::check('old-password', $user->fresh()->password));
+        $this->assertGuest();
+    }
 }

--- a/src/Illuminate/Auth/Console/stubs/make/tests/Feature/Auth/ResetPasswordTest.stub
+++ b/src/Illuminate/Auth/Console/stubs/make/tests/Feature/Auth/ResetPasswordTest.stub
@@ -60,6 +60,7 @@ class ResetPasswordTest extends TestCase
         $response->assertRedirect(route('home'));
         $this->assertEquals($user->email, $user->fresh()->email);
         $this->assertTrue(Hash::check('new-awesome-password', $user->fresh()->password));
+        $this->assertAuthenticatedAs($user);
     }
 
     public function testUserCannotResetPasswordWithIncorrectToken()
@@ -78,6 +79,7 @@ class ResetPasswordTest extends TestCase
         $response->assertRedirect(route('password.reset', $this->getInvalidToken()));
         $this->assertEquals($user->email, $user->fresh()->email);
         $this->assertTrue(Hash::check('old-password', $user->fresh()->password));
+        $this->assertGuest();
     }
 
     public function testUserCannotResetPasswordWithoutProvidingANewPassword()


### PR DESCRIPTION
![](http://i.imgur.com/7IPTuEw.png)

## Description
As mentioned in [laravel/internals](https://github.com/laravel/internals/issues/734), I have created tests that should be published when running the `php artisan make:auth` command.
Closes [#734](https://github.com/laravel/internals/issues/734) and [#658](https://github.com/laravel/internals/issues/658).

## Changes
### Basic idea
When running `php artisan make:auth` command, four new stubs, containing tests for the authentication, will be added to the `tests/Feature/Auth` folder.

### Flags
There has been one `--no-tests` flag added for those, who do not want tests to be generated.

## Demo
You can play around with the tests, by adding this into your `composer.json` file:
```json
"repositories": [
    {
        "type": "vcs",
        "url": "https://github.com/DCzajkowski/framework"
    }
],
```
and changing Laravel version to:
```json
"laravel/framework": "dev-master",
```

Then connect to the database or add this to your `phpunit.xml` file:
```xml
<env name="DB_CONNECTION" value="sqlite"/>
<env name="DB_DATABASE" value=":memory:"/>
```