### PR TITLE
Update ValidatesRequests

### DIFF
--- a/src/Illuminate/Foundation/Validation/ValidatesRequests.php
+++ b/src/Illuminate/Foundation/Validation/ValidatesRequests.php
@@ -49,7 +49,7 @@ trait ValidatesRequests
      */
     public function validate($request, array $rules = null, array $messages = [], array $customAttributes = [])
     {
-        if(is_array($request) && $rules == null){
+        if (is_array($request) && $rules == null){
             $rules = $request;
             $request = request();
         }

--- a/src/Illuminate/Foundation/Validation/ValidatesRequests.php
+++ b/src/Illuminate/Foundation/Validation/ValidatesRequests.php
@@ -53,7 +53,7 @@ trait ValidatesRequests
             $rules = $request;
             $request = request();
         }
-        
+
         $validator = $this->getValidationFactory()->make($request->all(), $rules, $messages, $customAttributes);
 
         if ($validator->fails()) {

--- a/src/Illuminate/Foundation/Validation/ValidatesRequests.php
+++ b/src/Illuminate/Foundation/Validation/ValidatesRequests.php
@@ -47,8 +47,13 @@ trait ValidatesRequests
      * @param  array  $customAttributes
      * @return void
      */
-    public function validate(Request $request, array $rules, array $messages = [], array $customAttributes = [])
+    public function validate($request, array $rules = null, array $messages = [], array $customAttributes = [])
     {
+        if(is_array($request) && $rules == null){
+            $rules = $request;
+            $request = request();
+        }
+        
         $validator = $this->getValidationFactory()->make($request->all(), $rules, $messages, $customAttributes);
 
         if ($validator->fails()) {

--- a/src/Illuminate/Foundation/Validation/ValidatesRequests.php
+++ b/src/Illuminate/Foundation/Validation/ValidatesRequests.php
@@ -49,7 +49,7 @@ trait ValidatesRequests
      */
     public function validate($request, array $rules = null, array $messages = [], array $customAttributes = [])
     {
-        if (is_array($request) && $rules == null){
+        if (is_array($request) && $rules == null) {
             $rules = $request;
             $request = request();
         }


### PR DESCRIPTION
Allow to only pass the rules to the validation method.
```
$this-validate([
    'body' => 'required'
]);
```
Without passing the $request every time.