### PR TITLE
#17642 - Reset day parameter when using Y-m

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -358,7 +358,6 @@ trait ValidatesAttributes
             return false;
         }
 
-        // Reset the day parameter
         $format = $parameters[0] == 'Y-m' ? '!Y-m' : $parameters[0];
 
         $date = DateTime::createFromFormat($format, $value);

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -358,7 +358,10 @@ trait ValidatesAttributes
             return false;
         }
 
-        $date = DateTime::createFromFormat($parameters[0], $value);
+        // Reset the day parameter
+        $format = $parameters[0] == 'Y-m' ? '!Y-m' : $parameters[0];
+
+        $date = DateTime::createFromFormat($format, $value);
 
         return $date && $date->format($parameters[0]) == $value;
     }

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -2323,6 +2323,10 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['x' => ['Not', 'a', 'date']], ['x' => 'date_format:Y-m-d']);
         $this->assertTrue($v->fails());
 
+        // Set current machine date to 31/xx/xxxx
+        $v = new Validator($trans, ['x' => '2013-02'], ['x' => 'date_format:Y-m']);
+        $this->assertTrue($v->passes());
+
         $v = new Validator($trans, ['x' => '2000-01-01T00:00:00Atlantic/Azores'], ['x' => 'date_format:Y-m-d\TH:i:se']);
         $this->assertTrue($v->passes());
 


### PR DESCRIPTION
This should fix #17642 

Note: this bug only happens when the computers date is set to 31/xx/xxx (or any date not existing in february) 