### PR TITLE
Add Str::start() and str_start helper function

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -354,6 +354,20 @@ class Str
     }
 
     /**
+     * Begin a string with a single instance of a given value.
+     *
+     * @param  string  $value
+     * @param  string  $prefix
+     * @return string
+     */
+    public static function start($value, $prefix)
+    {
+        $quoted = preg_quote($prefix, '/');
+
+        return $prefix.preg_replace('/^(?:'.$quoted.')+/u', '', $value);
+    }
+
+    /**
      * Convert the given string to upper-case.
      *
      * @param  string  $value

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -920,6 +920,20 @@ if (! function_exists('str_slug')) {
     }
 }
 
+if (! function_exists('str_start')) {
+    /**
+     * Begin a string with a single instance of a given value.
+     *
+     * @param  string  $value
+     * @param  string  $prefix
+     * @return string
+     */
+    function str_start($value, $prefix)
+    {
+        return Str::start($value, $prefix);
+    }
+}
+
 if (! function_exists('studly_case')) {
     /**
      * Convert a value to studly caps case.

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -275,6 +275,13 @@ class SupportHelpersTest extends TestCase
         $this->assertEquals('test/string/', Str::finish('test/string//', '/'));
     }
 
+    public function testStrStart()
+    {
+        $this->assertEquals('/test/string', Str::start('test/string', '/'));
+        $this->assertEquals('/test/string', Str::start('/test/string', '/'));
+        $this->assertEquals('/test/string', Str::start('//test/string', '/'));
+    }
+
     public function testSnakeCase()
     {
         $this->assertEquals('foo_bar', Str::snake('fooBar'));


### PR DESCRIPTION
What's life if you can't PR string helper functions - amiright?

With some naming help from twitter and @adamwathan, I planned on PRing `str_prefix` and `str_suffix` (Those were the helper functions @DanielCoulbourne  and I talked about on the podcast) as a cure for the common and gnarly looking `ltrim($path, '/').'/'` and `rtrim($path, '/').'/'`, but upon writing up tests discovered `str_finish` *face palm*

I often need this sort of thing when dealing with urls and paths. Hopefully the need is felt. 

Long live the string helper!