### PR TITLE
[5.4] Add tap method to Model.

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1335,7 +1335,8 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     }
 
     /**
-     * Pass the model to a given callback and then return it
+     * Pass the model to a given callback and then return it.
+     *
      * @param  callable  $callback
      * @return $this
      */

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1335,6 +1335,16 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     }
 
     /**
+     * Pass the model to a given callback and then return it
+     * @param  callable  $callback
+     * @return $this
+     */
+    public function tap($callback = null)
+    {
+        return tap($this, $callback);
+    }
+
+    /**
      * Determine if an attribute or relation exists on the model.
      *
      * @param  string  $key

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1618,7 +1618,7 @@ class DatabaseEloquentModelTest extends TestCase
     {
         $model = new EloquentModelStub;
 
-        $result = $model->tap(function ($tapModel)  use ($model) {
+        $result = $model->tap(function ($tapModel) use ($model) {
             $this->assertEquals($model, $tapModel);
         });
 

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1614,6 +1614,28 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertFalse($result);
     }
 
+    public function testTapMethodCallbackInstance()
+    {
+        $model = new EloquentModelStub;
+
+        $result = $model->tap(function ($tapModel)  use ($model) {
+            $this->assertEquals($model, $tapModel);
+        });
+
+        $this->assertEquals($model, $result);
+    }
+
+    public function testHigherOrderTapMethod()
+    {
+        $_SERVER['__eloquent.saved'] = false;
+        $model = new EloquentModelSaveStub;
+
+        $result = $model->tap()->save()->getTable();
+
+        $this->assertEquals('save_stub', $result);
+        $this->assertTrue($_SERVER['__eloquent.saved']);
+    }
+
     protected function addMockConnection($model)
     {
         $model->setConnectionResolver($resolver = m::mock('Illuminate\Database\ConnectionResolverInterface'));


### PR DESCRIPTION
If you want to do some operations on the model, then update/save it and return it you have to do something like this:

```php
return tap($model->someOperationThatReturnsTheModel(), function ($theModel) use ($request) {
    $theModel->update($request->all());
});
```

So instead of doing that, with this PR you can now do this:

```php
return $model->someOperationThatReturnsTheModel()->tap()->update($request->all());

// or

return $model->someOperationThatReturnsTheModel()->tap(function ($theModel) use ($request) {
    $theModel->update($request->all());
});
```