### PR TITLE
[5.4] Queue jobRetry expects object but get an array.

### DIFF
--- a/src/Illuminate/Queue/Console/RetryCommand.php
+++ b/src/Illuminate/Queue/Console/RetryCommand.php
@@ -68,6 +68,7 @@ class RetryCommand extends Command
      */
     protected function retryJob($job)
     {
+        $job = (object) $job;
         $this->laravel['queue']->connection($job->connection)->pushRaw(
             $this->resetAttempts($job->payload), $job->queue
         );


### PR DESCRIPTION
The fuction retryJob in RetryCommand expects an object as first parameter. 
But when you use MongoDB as queue driver, an array will be returned. 

So when you cast the array to an object, the retryJob will succeed instead of fail with the following error:

** exception 'ErrorException' with message 'Trying to get property of non-object' in /var/www/api-usedtrucks/vendor/laravel/framework/src/Illuminate/Queue/Console/RetryCommand.php:71**