### PR TITLE
[5.4] Add optional after validation hook method to FormRequest

### DIFF
--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -85,6 +85,10 @@ class FormRequest extends Request implements ValidatesWhenResolved
             $this->withValidator($validator);
         }
 
+        if (method_exists($this, 'after')) {
+            $validator->after([$this, 'after']);
+        }
+
         return $validator;
     }
 


### PR DESCRIPTION
This PR makes is super simple to *optionally* add an after hook in a form request object.

Example:

```php
class TagFormRequest extends FormRequest
{
    ...

    public function after($validator)
    {
        if ($this->prIsRejected()) {
            $validator->errors()->add('after_hook', 'Must add manually');
        }
    }

    ...
}
```

I've personally been using this and it's worked really nicely. Put it out on [Twitter](https://twitter.com/taylorotwell/status/884753989786619904) and had a couple of people mention they also do something similar.

If anyone thinks there is a better way to do this or a better way to implement this would be happy with any feedback / suggestions.

I'm not 100% sure how valuable this will be after 5.5 is released and we have validation classes.