### PR TITLE
[5.5] artisan preset none to remove lodash

### DIFF
--- a/src/Illuminate/Foundation/Console/PresetCommand.php
+++ b/src/Illuminate/Foundation/Console/PresetCommand.php
@@ -15,7 +15,7 @@ class PresetCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'preset { type : The preset type (none, bootstrap, vue, react) }';
+    protected $signature = 'preset { type : The preset type (none, bootstrap, lodash, vue, react) }';
 
     /**
      * The console command description.
@@ -35,7 +35,7 @@ class PresetCommand extends Command
             return call_user_func(static::$macros[$this->argument('type')], $this);
         }
 
-        if (! in_array($this->argument('type'), ['none', 'bootstrap', 'vue', 'react'])) {
+        if (! in_array($this->argument('type'), ['none', 'bootstrap', 'lodash', 'vue', 'react'])) {
             throw new InvalidArgumentException('Invalid preset.');
         }
 
@@ -55,7 +55,7 @@ class PresetCommand extends Command
     }
 
     /**
-     * Install the "fresh" preset.
+     * Install the "bootstrap" preset.
      *
      * @return void
      */
@@ -64,6 +64,19 @@ class PresetCommand extends Command
         Presets\Bootstrap::install();
 
         $this->info('Bootstrap scaffolding installed successfully.');
+        $this->comment('Please run "npm install && npm run dev" to compile your fresh scaffolding.');
+    }
+
+     /**
+     * Install the "lodash" preset.
+     *
+     * @return void
+     */
+    public function lodash()
+    {
+        Presets\Lodash::install();
+
+        $this->info('Lodash scaffolding installed successfully.');
         $this->comment('Please run "npm install && npm run dev" to compile your fresh scaffolding.');
     }
 

--- a/src/Illuminate/Foundation/Console/PresetCommand.php
+++ b/src/Illuminate/Foundation/Console/PresetCommand.php
@@ -67,7 +67,7 @@ class PresetCommand extends Command
         $this->comment('Please run "npm install && npm run dev" to compile your fresh scaffolding.');
     }
 
-     /**
+    /**
      * Install the "lodash" preset.
      *
      * @return void

--- a/src/Illuminate/Foundation/Console/Presets/Lodash.php
+++ b/src/Illuminate/Foundation/Console/Presets/Lodash.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Illuminate\Foundation\Console\Presets;
+
+class Lodash extends Preset
+{
+    /**
+     * Install the preset.
+     *
+     * @return void
+     */
+    public static function install()
+    {
+        static::updatePackages();
+        static::removeNodeModules();
+    }
+
+    /**
+     * Update the given package array.
+     *
+     * @param  array  $packages
+     * @return array
+     */
+    protected static function updatePackageArray(array $packages)
+    {
+        return ['lodash' => '^4.17.4'] + $packages;
+    }
+}

--- a/src/Illuminate/Foundation/Console/Presets/None.php
+++ b/src/Illuminate/Foundation/Console/Presets/None.php
@@ -36,6 +36,7 @@ class None extends Preset
         unset(
             $packages['bootstrap-sass'],
             $packages['jquery'],
+            $packages['lodash'],
             $packages['vue'],
             $packages['babel-preset-react'],
             $packages['react'],


### PR DESCRIPTION
`artisan preset none` should remove lodash.

See discussion here: https://github.com/laravel/laravel/pull/3925

This PR also adds `artisan preset lodash` that adds lodash as dependency.

Comes together with https://github.com/laravel/laravel/pull/4376

PS. Is there any reason why some methods are protected while others are public in this [file](https://github.com/balping/framework/blob/41668852351ac67ee6ab4632e1a96260c77174fe/src/Illuminate/Foundation/Console/PresetCommand.php)?
