### PR TITLE
[5.4] Use DEV_SERVER_HOST/_PORT env vars as defaults for serve command

### DIFF
--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -81,10 +81,13 @@ class ServeCommand extends Command
      */
     protected function getOptions()
     {
-        return [
-            ['host', null, InputOption::VALUE_OPTIONAL, 'The host address to serve the application on.', '127.0.0.1'],
+        $defaultHost = env('DEV_SERVER_HOST') ?: '127.0.0.1';
+        $defaultPort = intval(env('DEV_SERVER_PORT')) ?: 8000;
 
-            ['port', null, InputOption::VALUE_OPTIONAL, 'The port to serve the application on.', 8000],
+        return [
+            ['host', null, InputOption::VALUE_OPTIONAL, 'The host address to serve the application on.', $defaultHost],
+
+            ['port', null, InputOption::VALUE_OPTIONAL, 'The port to serve the application on.', $defaultPort],
         ];
     }
 }


### PR DESCRIPTION
This PR allows to set values for `DEV_SERVER_HOST` and `DEV_SERVER_PORT` env variables that will be used as defaults by `php artisan serve` command (instead of hardcoded `127.0.0.1` and `8000` values). This patch, of course, respects overriden values passed via `--host` and `--port` options.

This is helpful if you're working with multiple Laravel applications that does not require Homestead/Docker and can be served with built-in dev server, but it's hard to remember what exact host/port combination you were using for each one (especially, if you need multiple apps to be online at the same time).

P.S.: tbh, not sure, are we allowed to use `env` helper function here?