### PR TITLE
[5.4] Allow float input for collection take() method

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1331,13 +1331,17 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
-     * Take the first or last {$limit} items.
+     * Take the first or last {$limit} items. With float, takes 100 * $limit items (i.e. a percentage of the count of the items)
      *
-     * @param  int  $limit
+     * @param  float|int  $limit
      * @return static
      */
     public function take($limit)
     {
+        if (is_float($limit)) {
+            // Percentage
+            $limit = ceil($this->count() * $limit);
+        }
         if ($limit < 0) {
             return $this->slice($limit, abs($limit));
         }

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1331,7 +1331,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
-     * Take the first or last {$limit} items. With float, takes 100 * $limit items (i.e. a percentage of the count of the items)
+     * Take the first or last {$limit} items. With float, takes 100 * $limit items (i.e. a percentage of the count of the items).
      *
      * @param  float|int  $limit
      * @return static

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -907,6 +907,24 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(['taylor', 'dayle'], $data->all());
     }
 
+    public function testTakeAsPercentage()
+    {
+        // Take 40% from the beginning
+        $data = new Collection(['taylor', 'dayle', 'shawn', 'adam', 'mohamed']);
+        $data = $data->take(.4);
+        $this->assertEquals(['taylor', 'dayle'], $data->all());
+
+        // Take 1% from the beginning (rounding up)
+        $data = new Collection(['taylor', 'dayle', 'shawn', 'adam', 'mohamed']);
+        $data = $data->take(.01);
+        $this->assertEquals(['taylor'], $data->all());
+
+        // Take 40% from the end
+        $data = new Collection(['taylor', 'dayle', 'shawn', 'adam', 'mohamed']);
+        $data = $data->take(-.4);
+        $this->assertEquals([3 => 'adam', 4 => 'mohamed'], $data->all());
+    }
+
     public function testRandom()
     {
         $data = new Collection([1, 2, 3, 4, 5, 6]);


### PR DESCRIPTION
There isn't currently a way to easily take a percentage of items from a collection.

This PR adds functionality to the existing `take()` method, allowing a float input. If a float is given, it's treated as a decimal percentage (e.g. 0.1 == 10%) and that percentage of items is returned. Negative floats are also supported.

**As an alternative**, this might work better as a new method entirely (e.g. `takePercentage()`) which could accept integer percentage values. 

Thanks, all!