### PR TITLE
[5.5] Create higher order "with" proxy

### DIFF
--- a/src/Illuminate/Support/HigherOrderWithProxy.php
+++ b/src/Illuminate/Support/HigherOrderWithProxy.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Illuminate\Support;
+
+class HigherOrderWithProxy
+{
+    /**
+     * The target being proxied.
+     *
+     * @var mixed
+     */
+    public $target;
+
+    /**
+     * Create a new "with" proxy instance.
+     *
+     * @param  mixed  $target
+     * @return void
+     */
+    public function __construct($target)
+    {
+        $this->target = $target;
+    }
+
+    /**
+     * Proxy accessing a property on the target object.
+     *
+     * @param  string  $key
+     * @return mixed
+     */
+    public function __get($key)
+    {
+        if (! is_null($this->target)) {
+            return $this->target->{$key};
+        }
+    }
+
+    /**
+     * Proxy a method call onto the collection items.
+     *
+     * @param  string  $method
+     * @param  array  $params
+     * @return mixed
+     */
+    public function __call($method, $params)
+    {
+        if (! is_null($this->target)) {
+            return $this->target->{$method}(...$params);
+        }
+    }
+}

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -1075,13 +1075,20 @@ if (! function_exists('windows_os')) {
 
 if (! function_exists('with')) {
     /**
-     * Return the given object. Useful for chaining.
+     * Call the given Closure if the given value is not null.
      *
      * @param  mixed  $object
+     * @param  callable|null  $callback
      * @return mixed
      */
-    function with($object)
+    function with($object, callable $callback = null)
     {
-        return $object;
+        if (is_null($callback)) {
+            return $object;
+        }
+
+        if (! is_null($object)) {
+            return $callback($object);
+        }
     }
 }

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Debug\Dumper;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Support\HigherOrderTapProxy;
+use Illuminate\Support\HigherOrderWithProxy;
 
 if (! function_exists('append_config')) {
     /**
@@ -1084,7 +1085,7 @@ if (! function_exists('with')) {
     function with($object, callable $callback = null)
     {
         if (is_null($callback)) {
-            return $object;
+            return new HigherOrderWithProxy($object);
         }
 
         if (! is_null($object)) {

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -755,6 +755,27 @@ class SupportHelpersTest extends TestCase
     {
         throw_if(true, RuntimeException::class, 'Test Message');
     }
+
+    public function testWith()
+    {
+        $object = new SupportTestWith('foo');
+
+        // Only passing the object
+        $this->assertEquals('foo', with($object)->value);
+        $this->assertEquals(['pong', 1], with($object)->ping(1));
+
+        // Also passing a callback
+        $this->assertEquals('foo', with($object, function ($object) {
+            return $object->value;
+        }));
+
+        // Passing null with a callback
+        $this->assertEquals(null, with(null, function () {
+            throw new RuntimeException(
+                'The "with" callback should not be called when the value is null'
+            );
+        }));
+    }
 }
 
 trait SupportTestTraitOne
@@ -802,5 +823,20 @@ class SupportTestArrayAccess implements ArrayAccess
     public function offsetUnset($offset)
     {
         unset($this->attributes[$offset]);
+    }
+}
+
+class SupportTestWith
+{
+    public $value;
+
+    public function __construct($value = null)
+    {
+        $this->value = $value;
+    }
+
+    public function ping(...$params)
+    {
+        return array_merge(['pong'], $params);
     }
 }

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -762,12 +762,16 @@ class SupportHelpersTest extends TestCase
 
         // Only passing the object
         $this->assertEquals('foo', with($object)->value);
-        $this->assertEquals(['pong', 1], with($object)->ping(1));
+        $this->assertEquals(['pong', 1, 2], with($object)->ping(1, 2));
 
         // Also passing a callback
         $this->assertEquals('foo', with($object, function ($object) {
             return $object->value;
         }));
+
+        // Actually passing null
+        $this->assertEquals(null, with(null)->value);
+        $this->assertEquals(null, with(null)->ping(1, 2));
 
         // Passing null with a callback
         $this->assertEquals(null, with(null, function () {


### PR DESCRIPTION
Useful for when you're not sure whether a given value is `null`.

If the value provided is `null`, any method calls or property access on the proxy will safely return `null`.

```php
// This may throw, when there's no logged-in user
$username = auth()->user()->username;

// This won't ever throw
$username = with(auth()->user())->username;
```

Another example would be if you want to delete a model, but it may have already been deleted:

```php
// This may throw, if the post has already been deleted
Post::find(1)->delete();

// This won't ever throw
with(Post::find(1))->delete();
```

---

If you want to do multiple things with the object, a callback will do the trick:

```php
$name = with(auth()->user(), function ($user) {
    return "{$user->first_name} {$user->last_name}";
});
```

...when there's no logged-in user, `$name` will be `null`.