### PR TITLE
[5.5] Allow default headers to be sent with requests

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -19,6 +19,13 @@ trait MakesHttpRequests
     protected $serverVariables = [];
 
     /**
+     * Additional headers for the request.
+     *
+     * @var array
+     */
+    protected $defaultHeaders = [];
+
+    /**
      * Define a set of server variables to be sent with the requests.
      *
      * @param  array  $server

--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -79,7 +79,7 @@ trait MakesHttpRequests
 
     /**
      * Removes all the predefined headers to be sent with the requests.
-     * 
+     *
      * @return $this
      */
     public function cleanRequestHeaders()
@@ -312,7 +312,7 @@ trait MakesHttpRequests
      */
     protected function transformHeadersToServerVars(array $headers)
     {
-        return collect($this->getHeaders($headers))->mapWithKeys(function ($value, $name) {
+        return collect($this->mergeDefaultHeaders($headers))->mapWithKeys(function ($value, $name) {
             $name = strtr(strtoupper($name), '-', '_');
 
             return [$this->formatServerHeaderKey($name) => $value];
@@ -321,11 +321,11 @@ trait MakesHttpRequests
 
     /**
      * Merges the given headers and the default request headers.
-     * 
+     *
      * @param  array  $headers
      * @return array
      */
-    protected function getHeaders(array $headers)
+    protected function mergeDefaultHeaders(array $headers)
     {
         return array_merge($headers, $this->defaultHeaders);
     }

--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -78,6 +78,20 @@ trait MakesHttpRequests
     }
 
     /**
+     * Adds a header to be sent with the requests.
+     *
+     * @param  string $name
+     * @param  string $value
+     * @return $this
+     */
+    public function withHeader(string $name, string $value)
+    {
+        $this->defaultHeaders[$name] = $value;
+
+        return $this;
+    }
+
+    /**
      * Removes all the predefined headers to be sent with the requests.
      *
      * @return $this

--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -70,7 +70,7 @@ trait MakesHttpRequests
      * @param array $headers
      * @return $this
      */
-    public function addRequestHeaders(array $headers)
+    public function withHeaders(array $headers)
     {
         $this->defaultHeaders = $headers;
 
@@ -82,7 +82,7 @@ trait MakesHttpRequests
      *
      * @return $this
      */
-    public function cleanRequestHeaders()
+    public function cleanHeaders()
     {
         $this->defaultHeaders = [];
 

--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -78,6 +78,18 @@ trait MakesHttpRequests
     }
 
     /**
+     * Removes all the predefined headers to be sent with the requests.
+     * 
+     * @return $this
+     */
+    public function cleanRequestHeaders()
+    {
+        $this->defaultHeaders = [];
+
+        return $this;
+    }
+
+    /**
      * Visit the given URI with a GET request.
      *
      * @param  string  $uri

--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -58,6 +58,19 @@ trait MakesHttpRequests
     }
 
     /**
+     * Define a set of headers to be sent with the requests.
+     *
+     * @param array $headers
+     * @return $this
+     */
+    public function addRequestHeaders(array $headers)
+    {
+        $this->defaultHeaders = $headers;
+
+        return $this;
+    }
+
+    /**
      * Visit the given URI with a GET request.
      *
      * @param  string  $uri
@@ -280,11 +293,22 @@ trait MakesHttpRequests
      */
     protected function transformHeadersToServerVars(array $headers)
     {
-        return collect($headers)->mapWithKeys(function ($value, $name) {
+        return collect($this->getHeaders($headers))->mapWithKeys(function ($value, $name) {
             $name = strtr(strtoupper($name), '-', '_');
 
             return [$this->formatServerHeaderKey($name) => $value];
         })->all();
+    }
+
+    /**
+     * Merges the given headers and the default request headers.
+     * 
+     * @param  array  $headers
+     * @return array
+     */
+    protected function getHeaders(array $headers)
+    {
+        return array_merge($headers, $this->defaultHeaders);
     }
 
     /**

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -146,6 +146,10 @@ abstract class TestCase extends BaseTestCase
             $this->serverVariables = [];
         }
 
+        if (property_exists($this, 'defaultHeaders')) {
+            $this->defaultHeaders = [];
+        }
+
         if (class_exists('Mockery')) {
             Mockery::close();
         }


### PR DESCRIPTION
This PR allows default headers to be sent with the requests. So, instead of having to override the `call` method or having to use something as   

```php   
$this->withServerVariables([
    'HTTP_FOO' => 'bar'
]);

$this->get('/');
```   

You can do    

```php   
$this->withHeaders([
    'foo' => 'bar'
]);

$this->get('/');
```   

You can also clean the headers with `$this->cleanHeaders();`

I've been having to send default headers quite a lot on an app and thought it would be cool to have it on the core. let me know what you all think