### PR TITLE
[5.5] Fix problems with commands load in Windows

### DIFF
--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -215,7 +215,7 @@ class Kernel implements KernelContract
             $command = $namespace.str_replace(
                 ['/', '.php'],
                 ['\\', ''],
-                Str::after($command->getPathname(), app_path().'/')
+                Str::after($command->getPathname(), app_path().DIRECTORY_SEPARATOR)
             );
 
             if (is_subclass_of($command, Command::class)) {


### PR DESCRIPTION
Backslash broke last param passed to function on windows `Str::after()`

> "C:\Develope\php\laravel\app\Console/Commands\TestCommand.php"
> "C:\Develope\php\laravel\app/"
