### PR TITLE
[5.5] Add Redis limiters

### DIFF
--- a/src/Illuminate/Contracts/Redis/LimiterTimeoutException.php
+++ b/src/Illuminate/Contracts/Redis/LimiterTimeoutException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Illuminate\Contracts\Redis;
+
+use Exception;
+
+class LimiterTimeoutException extends Exception
+{
+    //
+}

--- a/src/Illuminate/Redis/Limiters/ConcurrencyLimiter.php
+++ b/src/Illuminate/Redis/Limiters/ConcurrencyLimiter.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace Illuminate\Redis\Limiters;
+
+use Illuminate\Contracts\Redis\LimiterTimeoutException;
+
+class ConcurrencyLimiter
+{
+    /**
+     * The Redis factory implementation.
+     *
+     * @var \Illuminate\Redis\Connections\Connection
+     */
+    protected $redis;
+
+    /**
+     * The name of the limiter.
+     *
+     * @var string
+     */
+    protected $name;
+
+    /**
+     * The allowed number of concurrent tasks.
+     *
+     * @var int
+     */
+    protected $size;
+
+    /**
+     * The number of seconds a slot should be maintained.
+     *
+     * @var int
+     */
+    protected $age;
+
+    /**
+     * Create a new concurrency lock instance.
+     *
+     * @param  \Illuminate\Redis\Connections\Connection  $redis
+     * @param  string  $name
+     * @param  int  $size
+     * @param  int  $age
+     * @return void
+     */
+    public function __construct($redis, $name, $size, $age)
+    {
+        $this->name = $name;
+        $this->size = $size;
+        $this->age = $age;
+        $this->redis = $redis;
+    }
+
+    /**
+     * Attempt to acquire the lock for the given number of seconds.
+     *
+     * @param  int  $timeout
+     * @param  callable|null  $callback
+     * @return bool
+     * @throws \Illuminate\Contracts\Redis\LimiterTimeoutException
+     */
+    public function block($timeout, $callback = null)
+    {
+        $starting = time();
+
+        while (! $slot = $this->acquire()) {
+            if (time() - $timeout >= $starting) {
+                throw new LimiterTimeoutException;
+            }
+
+            usleep(250 * 1000);
+        }
+
+        if (is_callable($callback)) {
+            return tap($callback(), function () use ($slot) {
+                $this->release($slot);
+            });
+        }
+
+        return true;
+    }
+
+    /**
+     * Attempt to acquire the lock.
+     *
+     * @return mixed
+     */
+    private function acquire()
+    {
+        $slots = array_map(function ($i) {
+            return $this->name.$i;
+        }, range(1, $this->size));
+
+        return $this->redis->eval($this->luaScript(), count($slots),
+            ...array_merge($slots, [$this->name, $this->age])
+        );
+    }
+
+    /**
+     * Get the Lua script for acquiring a lock.
+     *
+     * KEYS    - The keys that represent available slots.
+     * ARGV[1] - Lock name
+     * ARGV[2] - Lock age in seconds
+     *
+     * @return string
+     */
+    private function luaScript()
+    {
+        return <<<'LUA'
+for index, value in pairs(redis.call('mget', unpack(KEYS))) do
+    if not value then 
+        redis.call('set', ARGV[1]..index, "1", "EX", ARGV[2])
+        return ARGV[1]..index
+    end
+end
+LUA;
+    }
+
+    /**
+     * Release the lock.
+     *
+     * @return void
+     */
+    protected function release($key)
+    {
+        $this->redis->del($key);
+    }
+}

--- a/src/Illuminate/Redis/Limiters/ConcurrencyLimiter.php
+++ b/src/Illuminate/Redis/Limiters/ConcurrencyLimiter.php
@@ -99,9 +99,9 @@ class ConcurrencyLimiter
     /**
      * Get the Lua script for acquiring a lock.
      *
-     * KEYS    - The keys that represent available slots.
-     * ARGV[1] - Lock name
-     * ARGV[2] - Lock age in seconds
+     * KEYS    - The keys that represent available slots
+     * ARGV[1] - The limiter name
+     * ARGV[2] - The number of seconds the slot should be reserved
      *
      * @return string
      */

--- a/src/Illuminate/Redis/Limiters/DurationLimiter.php
+++ b/src/Illuminate/Redis/Limiters/DurationLimiter.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace Illuminate\Redis\Limiters;
+
+use Illuminate\Contracts\Redis\LimiterTimeoutException;
+
+class DurationLimiter
+{
+    /**
+     * The Redis factory implementation.
+     *
+     * @var \Illuminate\Redis\Connections\Connection
+     */
+    private $redis;
+
+    /**
+     * The unique name of the lock.
+     *
+     * @var string
+     */
+    private $name;
+
+    /**
+     * The allowed number of concurrent tasks.
+     *
+     * @var int
+     */
+    private $size;
+
+    /**
+     * The number of seconds a slot should be maintained.
+     *
+     * @var int
+     */
+    private $duration;
+
+    /**
+     * Create a new concurrency lock instance.
+     *
+     * @param  \Illuminate\Redis\Connections\Connection $redis
+     * @param  string $name
+     * @param  int $size
+     * @param  int $duration
+     * @return void
+     */
+    public function __construct($redis, $name, $size, $duration)
+    {
+        $this->name = $name;
+        $this->size = $size;
+        $this->duration = $duration;
+        $this->redis = $redis;
+    }
+
+    /**
+     * Attempt to acquire the lock for the given number of seconds.
+     *
+     * @param  int $timeout
+     * @param  callable|null $callback
+     * @return bool
+     * @throws \Illuminate\Contracts\Redis\LimiterTimeoutException
+     */
+    public function block($timeout, $callback = null)
+    {
+        $starting = time();
+
+        while (! $this->acquire()) {
+            if ($this->duration > 1 || time() - $timeout >= $starting) {
+                throw new LimiterTimeoutException;
+            }
+
+            usleep(750 * 1000);
+        }
+
+        if (is_callable($callback)) {
+            $callback();
+        }
+
+        return true;
+    }
+
+    /**
+     * Attempt to acquire the lock.
+     *
+     * @return mixed
+     */
+    private function acquire()
+    {
+        return $this->redis->eval($this->luaScript(), 1,
+            $this->name, microtime(true), time(), $this->duration, $this->size
+        );
+    }
+
+    /**
+     * Get the Lua script for acquiring a lock.
+     *
+     * KEYS[1] - The lock name
+     * ARGV[1] - Current time in microseconds
+     * ARGV[2] - Current time in seconds
+     * ARGV[3] - Duration
+     * ARGV[4] - Limit
+     *
+     * @return string
+     */
+    private function luaScript()
+    {
+        return <<<'LUA'
+local endTime = ARGV[2] + ARGV[3]
+
+if redis.call('EXISTS', KEYS[1]) == 0 then
+    redis.call('HMSET', KEYS[1], 'start', ARGV[2], 'end', endTime, 'count', 1)
+    redis.call('EXPIRE', KEYS[1], ARGV[3] * 2)
+    return 1
+end
+
+if ARGV[1] >= redis.call('HGET', KEYS[1], 'start') and ARGV[1] <= redis.call('HGET', KEYS[1], 'end') then
+    return tonumber(redis.call('HINCRBY', KEYS[1], 'count', 1)) <= tonumber(ARGV[4])
+end
+
+redis.call('HMSET', KEYS[1], 'start', ARGV[2], 'end', endTime, 'count', 1)
+redis.call('EXPIRE', KEYS[1], ARGV[3] * 2)
+return 1
+LUA;
+    }
+}

--- a/src/Illuminate/Redis/Limiters/DurationLimiter.php
+++ b/src/Illuminate/Redis/Limiters/DurationLimiter.php
@@ -93,11 +93,11 @@ class DurationLimiter
     /**
      * Get the Lua script for acquiring a lock.
      *
-     * KEYS[1] - The lock name
+     * KEYS[1] - The limiter name
      * ARGV[1] - Current time in microseconds
      * ARGV[2] - Current time in seconds
-     * ARGV[3] - Duration
-     * ARGV[4] - Limit
+     * ARGV[3] - Duration of the bucket
+     * ARGV[4] - Allowed number of tasks
      *
      * @return string
      */

--- a/tests/Redis/ConcurrentLimiterTest.php
+++ b/tests/Redis/ConcurrentLimiterTest.php
@@ -5,6 +5,9 @@ use PHPUnit\Framework\TestCase;
 use Illuminate\Redis\Limiters\ConcurrencyLimiter;
 use Illuminate\Contracts\Redis\LimiterTimeoutException;
 
+/**
+ * @group redislimiters
+ */
 class ConcurrentLimiterTest extends TestCase
 {
     public $redis;

--- a/tests/Redis/ConcurrentLimiterTest.php
+++ b/tests/Redis/ConcurrentLimiterTest.php
@@ -1,0 +1,170 @@
+<?php
+
+use Predis\Client;
+use PHPUnit\Framework\TestCase;
+use Illuminate\Redis\Limiters\ConcurrencyLimiter;
+use Illuminate\Contracts\Redis\LimiterTimeoutException;
+
+class ConcurrentLimiterTest extends TestCase
+{
+    public $redis;
+
+    public function setup()
+    {
+        parent::setup();
+
+        $this->redis()->flushall();
+    }
+
+    /**
+     * @test
+     */
+    public function it_locks_tasks_when_no_slot_available()
+    {
+        $store = [];
+
+        foreach (range(1, 2) as $i) {
+            (new ConcurrencyLimiterMockThatDoesntRelease($this->redis(), 'key', 2, 5))->block(2, function () use (&$store, $i) {
+                $store[] = $i;
+            });
+        }
+
+        try {
+            (new ConcurrencyLimiterMockThatDoesntRelease($this->redis(), 'key', 2, 5))->block(0, function () use (&$store) {
+                $store[] = 3;
+            });
+        } catch (\Throwable $e) {
+            $this->assertInstanceOf(LimiterTimeoutException::class, $e);
+        }
+
+        (new ConcurrencyLimiterMockThatDoesntRelease($this->redis(), 'other_key', 2, 5))->block(2, function () use (&$store) {
+            $store[] = 4;
+        });
+
+        $this->assertEquals([1, 2, 4], $store);
+    }
+
+    /**
+     * @test
+     */
+    public function it_releases_lock_after_task_finishes()
+    {
+        $store = [];
+
+        foreach (range(1, 4) as $i) {
+            (new ConcurrencyLimiter($this->redis(), 'key', 2, 5))->block(2, function () use (&$store, $i) {
+                $store[] = $i;
+            });
+        }
+
+        $this->assertEquals([1, 2, 3, 4], $store);
+    }
+
+    /**
+     * @test
+     */
+    public function it_releases_lock_if_task_took_too_long()
+    {
+        $store = [];
+
+        $lock = (new ConcurrencyLimiterMockThatDoesntRelease($this->redis(), 'key', 1, 1));
+
+        $lock->block(2, function () use (&$store) {
+            $store[] = 1;
+        });
+
+        try {
+            $lock->block(0, function () use (&$store) {
+                $store[] = 2;
+            });
+        } catch (\Throwable $e) {
+            $this->assertInstanceOf(LimiterTimeoutException::class, $e);
+        }
+
+        usleep(1.2 * 1000000);
+
+        $lock->block(0, function () use (&$store) {
+            $store[] = 3;
+        });
+
+        $this->assertEquals([1, 3], $store);
+    }
+
+    /**
+     * @test
+     */
+    public function it_fails_immediately_or_retries_for_a_while_based_on_a_given_timeout()
+    {
+        $store = [];
+
+        $lock = (new ConcurrencyLimiterMockThatDoesntRelease($this->redis(), 'key', 1, 2));
+
+        $lock->block(2, function () use (&$store) {
+            $store[] = 1;
+        });
+
+        try {
+            $lock->block(0, function () use (&$store) {
+                $store[] = 2;
+            });
+        } catch (\Throwable $e) {
+            $this->assertInstanceOf(LimiterTimeoutException::class, $e);
+        }
+
+        $lock->block(3, function () use (&$store) {
+            $store[] = 3;
+        });
+
+        $this->assertEquals([1, 3], $store);
+    }
+
+    /**
+     * @test
+     */
+    public function it_fails_after_retry_timeout()
+    {
+        $store = [];
+
+        $lock = (new ConcurrencyLimiterMockThatDoesntRelease($this->redis(), 'key', 1, 10));
+
+        $lock->block(2, function () use (&$store) {
+            $store[] = 1;
+        });
+
+        try {
+            $lock->block(2, function () use (&$store) {
+                $store[] = 2;
+            });
+        } catch (\Throwable $e) {
+            $this->assertInstanceOf(LimiterTimeoutException::class, $e);
+        }
+
+        $this->assertEquals([1], $store);
+    }
+
+
+    /**
+     * @return Client
+     */
+    public function redis()
+    {
+        return $this->redis ?
+            $this->redis :
+            $this->redis = (new \Illuminate\Redis\RedisManager('predis', [
+                'default' => [
+                    'host' => '127.0.0.1',
+                    'password' => null,
+                    'port' => 6379,
+                    'database' => 0,
+                ],
+            ]))->connection();
+    }
+}
+
+class ConcurrencyLimiterMockThatDoesntRelease extends ConcurrencyLimiter
+{
+    protected function release($Key)
+    {
+        //
+    }
+}

--- a/tests/Redis/ConcurrentLimiterTest.php
+++ b/tests/Redis/ConcurrentLimiterTest.php
@@ -142,7 +142,6 @@ class ConcurrentLimiterTest extends TestCase
         $this->assertEquals([1], $store);
     }
 
-
     /**
      * @return Client
      */

--- a/tests/Redis/DurationLimiterTest.php
+++ b/tests/Redis/DurationLimiterTest.php
@@ -98,7 +98,6 @@ class DurationLimiterTest extends TestCase
         }
     }
 
-
     /**
      * @return Client
      */

--- a/tests/Redis/DurationLimiterTest.php
+++ b/tests/Redis/DurationLimiterTest.php
@@ -1,0 +1,118 @@
+<?php
+
+use Predis\Client;
+use PHPUnit\Framework\TestCase;
+use Illuminate\Redis\Limiters\DurationLimiter;
+use Illuminate\Contracts\Redis\LimiterTimeoutException;
+
+class DurationLimiterTest extends TestCase
+{
+    public $redis;
+
+    public function setup()
+    {
+        parent::setup();
+
+        $this->redis()->flushall();
+    }
+
+    /**
+     * @test
+     */
+    public function it_locks_tasks_when_no_slot_available()
+    {
+        $store = [];
+
+        (new DurationLimiter($this->redis(), 'key', 2, 2))->block(2, function () use (&$store) {
+            $store[] = 1;
+        });
+
+        (new DurationLimiter($this->redis(), 'key', 2, 2))->block(2, function () use (&$store) {
+            $store[] = 2;
+        });
+
+        try {
+            (new DurationLimiter($this->redis(), 'key', 2, 2))->block(2, function () use (&$store) {
+                $store[] = 3;
+            });
+        } catch (\Throwable $e) {
+            $this->assertInstanceOf(LimiterTimeoutException::class, $e);
+        }
+
+        $this->assertEquals([1, 2], $store);
+
+        sleep(2);
+
+        (new DurationLimiter($this->redis(), 'key', 2, 2))->block(0, function () use (&$store) {
+            $store[] = 3;
+        });
+
+        $this->assertEquals([1, 2, 3], $store);
+    }
+
+    /**
+     * @test
+     */
+    public function it_fails_immediately_or_retries_for_a_while_based_on_a_given_timeout()
+    {
+        $store = [];
+
+        (new DurationLimiter($this->redis(), 'key', 1, 1))->block(2, function () use (&$store) {
+            $store[] = 1;
+        });
+
+        try {
+            (new DurationLimiter($this->redis(), 'key', 1, 1))->block(0, function () use (&$store) {
+                $store[] = 2;
+            });
+        } catch (\Throwable $e) {
+            $this->assertInstanceOf(LimiterTimeoutException::class, $e);
+        }
+
+        (new DurationLimiter($this->redis(), 'key', 1, 1))->block(2, function () use (&$store) {
+            $store[] = 3;
+        });
+
+        $this->assertEquals([1, 3], $store);
+    }
+
+    /**
+     * @test
+     */
+    public function it_doesnt_retry_if_duration_more_than_1_second()
+    {
+        $store = [];
+
+        (new DurationLimiter($this->redis(), 'key', 1, 60))->block(2, function () use (&$store) {
+            $store[] = 1;
+        });
+
+        try {
+            $this->assertEquals([1], $store);
+
+            (new DurationLimiter($this->redis(), 'key', 1, 60))->block(120, function () use (&$store) {
+                $store[] = 3;
+            });
+        } catch (\Throwable $e) {
+            $this->assertInstanceOf(LimiterTimeoutException::class, $e);
+        }
+    }
+
+
+    /**
+     * @return Client
+     */
+    public function redis()
+    {
+        return $this->redis ?
+            $this->redis :
+            $this->redis = (new \Illuminate\Redis\RedisManager('predis', [
+                'default' => [
+                    'host' => '127.0.0.1',
+                    'password' => null,
+                    'port' => 6379,
+                    'database' => 0,
+                ],
+            ]))->connection();
+    }
+}

--- a/tests/Redis/DurationLimiterTest.php
+++ b/tests/Redis/DurationLimiterTest.php
@@ -5,6 +5,9 @@ use PHPUnit\Framework\TestCase;
 use Illuminate\Redis\Limiters\DurationLimiter;
 use Illuminate\Contracts\Redis\LimiterTimeoutException;
 
+/**
+ * @group redislimiters
+ */
 class DurationLimiterTest extends TestCase
 {
     public $redis;


### PR DESCRIPTION
This PR adds two types of limiters:

- Concurrency Limiter: it ensures that only x number of tasks are running at the same time
- Duration Limiter: it ensures that only x number of tasks are running in a specified duration of time

These limiters can be used in a middleware to throttle access to certain routes, or in a queued job to limit hitting a 3rd party service or even prevent a race condition of two processes trying to update a single resource and would cause a race condition.

```php
(new ConcurrencyLimiter($redis, 'site-ssl-123', 1, 10))->block(5, function(){
     // Do work that touches your nginx file
})
```

The code above will ensure only a single task is touching the nginx file, it can be added in multiple places in your code and it'll protect your file from race conditions.

In case no available slots, the limiter will try again for 5 seconds before an exception is thrown.

If a slot was reserved for more than 10 seconds it'll be automatically freed so it can be used by another task.