### PR TITLE
[5.5] allow loading JSON translations for packages

### DIFF
--- a/src/Illuminate/Contracts/Translation/Loader.php
+++ b/src/Illuminate/Contracts/Translation/Loader.php
@@ -29,7 +29,7 @@ interface Loader
      * @param  string  $path
      * @return void
      */
-    public function addJSONPath($path);
+    public function addJsonPath($path);
 
     /**
      * Get an array of all the registered namespaces.

--- a/src/Illuminate/Contracts/Translation/Loader.php
+++ b/src/Illuminate/Contracts/Translation/Loader.php
@@ -24,6 +24,14 @@ interface Loader
     public function addNamespace($namespace, $hint);
 
     /**
+     * Add a new JSON path to the loader.
+     *
+     * @param  string  $path
+     * @return void
+     */
+    public function addJSONPath($path);
+
+    /**
      * Get an array of all the registered namespaces.
      *
      * @return array

--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -106,7 +106,7 @@ abstract class ServiceProvider
      * @param  string  $path
      * @return void
      */
-    protected function loadJSONTranslationsFrom($path)
+    protected function loadJsonTranslationsFrom($path)
     {
         $this->app['translator']->addJSONPath($path);
     }

--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -101,6 +101,17 @@ abstract class ServiceProvider
     }
 
     /**
+     * Register a JSON translation file path.
+     *
+     * @param  string  $path
+     * @return void
+     */
+    protected function loadJSONTranslationsFrom($path)
+    {
+        $this->app['translator']->addJSONPath($path);
+    }
+
+    /**
      * Register a database migration path.
      *
      * @param  array|string  $paths

--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -108,7 +108,7 @@ abstract class ServiceProvider
      */
     protected function loadJsonTranslationsFrom($path)
     {
-        $this->app['translator']->addJSONPath($path);
+        $this->app['translator']->addJsonPath($path);
     }
 
     /**

--- a/src/Illuminate/Translation/ArrayLoader.php
+++ b/src/Illuminate/Translation/ArrayLoader.php
@@ -50,7 +50,7 @@ class ArrayLoader implements Loader
      * @param  string  $path
      * @return void
      */
-    public function addJSONPath($path)
+    public function addJsonPath($path)
     {
         //
     }

--- a/src/Illuminate/Translation/ArrayLoader.php
+++ b/src/Illuminate/Translation/ArrayLoader.php
@@ -45,6 +45,17 @@ class ArrayLoader implements Loader
     }
 
     /**
+     * Add a new JSON path to the loader.
+     *
+     * @param  string  $path
+     * @return void
+     */
+    public function addJSONPath($path)
+    {
+        //
+    }
+
+    /**
      * Add messages to the loader.
      *
      * @param  string  $locale

--- a/src/Illuminate/Translation/FileLoader.php
+++ b/src/Illuminate/Translation/FileLoader.php
@@ -22,6 +22,13 @@ class FileLoader implements Loader
     protected $path;
 
     /**
+     * All of the paths of JSON files.
+     *
+     * @var string
+     */
+    protected $jsonPaths = [];
+
+    /**
      * All of the namespace hints.
      *
      * @var array
@@ -52,7 +59,7 @@ class FileLoader implements Loader
     public function load($locale, $group, $namespace = null)
     {
         if ($group == '*' && $namespace == '*') {
-            return $this->loadJsonPath($this->path, $locale);
+            return $this->loadJsonPaths($locale);
         }
 
         if (is_null($namespace) || $namespace == '*') {
@@ -121,17 +128,18 @@ class FileLoader implements Loader
     /**
      * Load a locale from the given JSON file path.
      *
-     * @param  string  $path
      * @param  string  $locale
      * @return array
      */
-    protected function loadJsonPath($path, $locale)
+    protected function loadJsonPaths($locale)
     {
-        if ($this->files->exists($full = "{$path}/{$locale}.json")) {
-            return json_decode($this->files->get($full), true);
-        }
-
-        return [];
+        return collect(array_merge($this->jsonPaths, [$this->path]))
+            ->reduce(function ($output, $path) use ($locale) {
+                return $this->files->exists($full = "{$path}/{$locale}.json")
+                    ? array_merge($output,
+                        json_decode($this->files->get($full), true)
+                    ) : $output;
+            }, []);
     }
 
     /**
@@ -154,5 +162,16 @@ class FileLoader implements Loader
     public function namespaces()
     {
         return $this->hints;
+    }
+
+    /**
+     * Add a new JSON path to the loader.
+     *
+     * @param  string  $path
+     * @return void
+     */
+    public function addJSONPath($path)
+    {
+        $this->jsonPaths[] = $path;
     }
 }

--- a/src/Illuminate/Translation/FileLoader.php
+++ b/src/Illuminate/Translation/FileLoader.php
@@ -170,7 +170,7 @@ class FileLoader implements Loader
      * @param  string  $path
      * @return void
      */
-    public function addJSONPath($path)
+    public function addJsonPath($path)
     {
         $this->jsonPaths[] = $path;
     }

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -357,9 +357,9 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
      * @param  string  $path
      * @return void
      */
-    public function addJSONPath($path)
+    public function addJsonPath($path)
     {
-        $this->loader->addJSONPath($path);
+        $this->loader->addJsonPath($path);
     }
 
     /**

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -352,6 +352,17 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
     }
 
     /**
+     * Add a new JSON path to the loader.
+     *
+     * @param  string  $path
+     * @return void
+     */
+    public function addJSONPath($path)
+    {
+        $this->loader->addJSONPath($path);
+    }
+
+    /**
      * Parse a key into namespace, group, and item.
      *
      * @param  string  $key

--- a/tests/Translation/TranslationFileLoaderTest.php
+++ b/tests/Translation/TranslationFileLoaderTest.php
@@ -74,7 +74,7 @@ class TranslationFileLoaderTest extends TestCase
     public function testLoadMethodForJSONProperlyCallsLoaderForMultiplePaths()
     {
         $loader = new FileLoader($files = m::mock('Illuminate\Filesystem\Filesystem'), __DIR__);
-        $loader->addJSONPath(__DIR__.'/another');
+        $loader->addJsonPath(__DIR__.'/another');
 
         $files->shouldReceive('exists')->once()->with(__DIR__.'/en.json')->andReturn(true);
         $files->shouldReceive('exists')->once()->with(__DIR__.'/another/en.json')->andReturn(true);

--- a/tests/Translation/TranslationFileLoaderTest.php
+++ b/tests/Translation/TranslationFileLoaderTest.php
@@ -70,4 +70,17 @@ class TranslationFileLoaderTest extends TestCase
 
         $this->assertEquals(['foo' => 'bar'], $loader->load('en', '*', '*'));
     }
+
+    public function testLoadMethodForJSONProperlyCallsLoaderForMultiplePaths()
+    {
+        $loader = new FileLoader($files = m::mock('Illuminate\Filesystem\Filesystem'), __DIR__);
+        $loader->addJSONPath(__DIR__.'/another');
+
+        $files->shouldReceive('exists')->once()->with(__DIR__.'/en.json')->andReturn(true);
+        $files->shouldReceive('exists')->once()->with(__DIR__.'/another/en.json')->andReturn(true);
+        $files->shouldReceive('get')->once()->with(__DIR__.'/en.json')->andReturn('{"foo":"bar"}');
+        $files->shouldReceive('get')->once()->with(__DIR__.'/another/en.json')->andReturn('{"foo":"backagebar", "baz": "backagesplash"}');
+
+        $this->assertEquals(['foo' => 'bar', 'baz' => 'backagesplash'], $loader->load('en', '*', '*'));
+    }
 }


### PR DESCRIPTION
In a package service provider the developer would use:

```php
$this->loadJSONTranslationsFrom(__DIR__.'/translations');
```

Translations in the main json file will override package translation, otherwise package maintainers and users can use translation lines that exist in the package translation file `__('Re-run job')`.