### PR TITLE
[5.4] add ability to define reloaded relationships

### DIFF
--- a/src/Illuminate/Queue/SerializesModels.php
+++ b/src/Illuminate/Queue/SerializesModels.php
@@ -41,6 +41,12 @@ trait SerializesModels
                 $this->getPropertyValue($property)
             ));
         }
+
+        if (isset($this->reloadedRelationships)) {
+            foreach ($this->reloadedRelationships as $property => $relationships) {
+                $this->{$property}->load($relationships);
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
Ran into this issue when using Laravel Echo to listen for some broadcast events.

currently when a Model is added to a queue and serialized, the
relationships of the Model are not restored when the Model is
unserialized/refetched from the database.

When you are handling the queued event/job with PHP, it’s not a big
issue. You can either manually load the relationships, or just use them
and they will be fetched when needed.

However, when you are broadcasting the events and listening for them in
Javascript, currently there is no way reload the relationship.  This
addition allows us to define which relationships we would like to be
reloaded when the object is unserialized.

Simply add a `reloadedRelationships` property to your event or job:

```php
class OrderCreated implements ShouldBroadcast
{
    use Dispatchable, InteractsWithSockets, SerializesModels;

    /**
     * @var array
     */
    private $reloadRelationships = [
        'order' => ['user', 'lines'],
    ];

   /**
     * @var \App\Order
     */
    public $order;
```

This will automatically reload the `user` and `lines` relationships on the events `order` property.

This syntax allows us to reload relationships on multiple models, if multiple models exist on the event/job.

I don't really love the name I came up with. Would love some suggestions on it.