### PR TITLE
Add mockery expectations to the assertion count

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -147,6 +147,10 @@ abstract class TestCase extends BaseTestCase
         }
 
         if (class_exists('Mockery')) {
+            if ($container = Mockery::getContainer()) {
+                $this->addToAssertionCount($container->mockery_getExpectationCount());
+            }
+
             Mockery::close();
         }
 


### PR DESCRIPTION
Fixes an issue where tests that use mockery expectations that don't have any assertions are marked as risky.

* https://github.com/mockery/mockery/issues/376
* https://github.com/GrahamCampbell/Laravel-TestBench/commit/981289c300ff15e782200b20fa0cfa7b5ae83abd