### PR TITLE
[5.4] Add strict validation support for distinct

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -501,7 +501,13 @@ trait ValidatesAttributes
      */
     protected function validateDistinct($attribute, $value, $parameters)
     {
+        $parameters = $this->parseNamedParameters($parameters);
+
         $attributeName = $this->getPrimaryAttribute($attribute);
+
+        if (isset($parameters) && array_key_exists('strict', $parameters)) {
+            $attributeName = $this->getNestedAttribute($attribute);
+        }
 
         $attributeData = ValidationData::extractDataFromPath(
             ValidationData::getLeadingExplicitAttributePath($attributeName), $this->data

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -406,6 +406,30 @@ class Validator implements ValidatorContract
     }
 
     /**
+     * Get the nested attribute name.
+     *
+     * For example, if "accounts.0.users.1" is given, "accounts.0.users.*" will be returned.
+     *
+     * @param  string  $attribute
+     * @return string
+     */
+    public function getNestedAttribute($attribute)
+    {
+        $keys = $this->getExplicitKeys($attribute);
+
+        if (count($keys) === 1) {
+            return $this->getPrimaryAttribute($attribute);
+        }
+
+        // remove the last result in array
+        array_pop($keys);
+
+        $matches = array_fill(0, count($keys), '/\*/');
+
+        return preg_replace($matches, $keys, $this->getPrimaryAttribute($attribute), 1);
+    }
+
+    /**
      * Replace each field parameter which has asterisks with the given keys.
      *
      * @param  array  $parameters

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1477,6 +1477,15 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['cat' => ['sub' => [['prod' => [['id' => 2]]], ['prod' => [['id' => 2]]]]]], ['cat.sub.*.prod.*.id' => 'distinct']);
         $this->assertFalse($v->passes());
 
+        $v = new Validator($trans, ['cat' => [['prod' => [['id' => 1]]], ['prod' => [['id' => 1]]]]], ['cat.*.prod.*.id' => 'distinct:strict']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['cat' => [['prod' => [['id' => 1], ['id' => 1]]], ['prod' => [['id' => 2], ['id' => 2]]]]], ['cat.*.prod.*.id' => 'distinct:strict']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['cat' => [['prod' => [['id' => 1], ['id' => 2]]], ['prod' => [['id' => 1], ['id' => 2]]]]], ['cat.*.prod.*.id' => 'distinct:strict']);
+        $this->assertTrue($v->passes());
+
         $v = new Validator($trans, ['foo' => ['foo', 'foo']], ['foo.*' => 'distinct'], ['foo.*.distinct' => 'There is a duplication!']);
         $this->assertFalse($v->passes());
         $v->messages()->setFormat(':message');


### PR DESCRIPTION
Currently, the `distinct` validation rule for deeply nested array works like this

Attribute: `accounts.*.users.*.name`

### Validation data set 1:
```
accounts.0.users.0.name = john
accounts.1.users.0.name = john
```
The distinct **validation fails**.

### Validation data set 2:
```
accounts.0.users.0.name = john
accounts.0.users.1.name = john
```
The distinct **validation fails**.

## Requirement:

Lets say we want distinct validation of `name` only for users inside `accounts.0` and not across `accounts.*`

This PR adds a parameter `strict` for distinct validation rule.

Usage: `distinct:strict`

### Validation data set 1:
```
accounts.0.users.0.name = john
accounts.1.users.0.name = john
```
The distinct **validation passes**. (this passes)

### Validation data set 2:
```
accounts.0.users.0.name = john
accounts.0.users.1.name = john
```
The distinct **validation fails**. (as expected)

Note: This is fully backwards compatible and there are no breaking changes.