### PR TITLE
[5.5][WIP] Convert all responses to Illuminate Response

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -668,7 +668,7 @@ class Router implements RegistrarContract, BindingRegistrar
             $response = new Response($response->getContent(),
                 $response->getStatusCode(), $response->headers->all()
             );
-        } else {
+        } elseif (! $response instanceof Response) {
             $response = new Response($response);
         }
 

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -2,13 +2,18 @@
 
 namespace Illuminate\Routing;
 
+use ArrayObject;
 use Closure;
+use JsonSerializable;
 use Illuminate\Support\Str;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Collection;
 use Illuminate\Container\Container;
 use Illuminate\Support\Traits\Macroable;
+use Illuminate\Contracts\Support\Jsonable;
+use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Contracts\Routing\BindingRegistrar;
@@ -648,6 +653,15 @@ class Router implements RegistrarContract, BindingRegistrar
             $response = $response->toResponse($request);
         } elseif ($response instanceof PsrResponseInterface) {
             $response = (new HttpFoundationFactory)->createResponse($response);
+        }
+
+        if ($response instanceof Arrayable ||
+            $response instanceof Jsonable ||
+            $response instanceof ArrayObject ||
+            $response instanceof JsonSerializable ||
+            is_array($response)
+        ) {
+            $response = new JsonResponse($response);
         }
 
         if ($response instanceof SymfonyResponse) {

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -664,7 +664,7 @@ class Router implements RegistrarContract, BindingRegistrar
             $response = new JsonResponse($response);
         }
 
-        if ($response instanceof SymfonyResponse) {
+        if ($response instanceof SymfonyResponse && ! $response instanceof Response) {
             $response = new Response($response->getContent(),
                 $response->getStatusCode(), $response->headers->all()
             );

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -3,22 +3,17 @@
 namespace Illuminate\Routing;
 
 use Closure;
-use ArrayObject;
-use JsonSerializable;
 use Illuminate\Support\Str;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Support\Collection;
 use Illuminate\Container\Container;
 use Illuminate\Support\Traits\Macroable;
-use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Contracts\Events\Dispatcher;
-use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Contracts\Routing\BindingRegistrar;
 use Psr\Http\Message\ResponseInterface as PsrResponseInterface;
 use Illuminate\Contracts\Routing\Registrar as RegistrarContract;
-use Symfony\Bridge\PsrHttpMessage\Factory\HttpFoundationFactory;
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 
 class Router implements RegistrarContract, BindingRegistrar

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -2,8 +2,8 @@
 
 namespace Illuminate\Routing;
 
-use ArrayObject;
 use Closure;
+use ArrayObject;
 use JsonSerializable;
 use Illuminate\Support\Str;
 use Illuminate\Http\Request;
@@ -13,8 +13,8 @@ use Illuminate\Support\Collection;
 use Illuminate\Container\Container;
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\Contracts\Support\Jsonable;
-use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Contracts\Routing\BindingRegistrar;
 use Psr\Http\Message\ResponseInterface as PsrResponseInterface;

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -8,7 +8,6 @@ use JsonSerializable;
 use Illuminate\Support\Str;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
-use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Collection;
 use Illuminate\Container\Container;
 use Illuminate\Support\Traits\Macroable;
@@ -542,7 +541,7 @@ class Router implements RegistrarContract, BindingRegistrar
      * Dispatch the request to the application.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @return \Illuminate\Http\Response|\Illuminate\Http\JsonResponse
+     * @return \Illuminate\Http\Response
      */
     public function dispatch(Request $request)
     {
@@ -645,7 +644,7 @@ class Router implements RegistrarContract, BindingRegistrar
      *
      * @param  \Symfony\Component\HttpFoundation\Request  $request
      * @param  mixed  $response
-     * @return \Illuminate\Http\Response|\Illuminate\Http\JsonResponse
+     * @return \Illuminate\Http\Response
      */
     public static function prepareResponse($request, $response)
     {
@@ -654,15 +653,14 @@ class Router implements RegistrarContract, BindingRegistrar
         }
 
         if ($response instanceof PsrResponseInterface) {
-            $response = (new HttpFoundationFactory)->createResponse($response);
-        } elseif (! $response instanceof SymfonyResponse &&
-                   ($response instanceof Arrayable ||
-                    $response instanceof Jsonable ||
-                    $response instanceof ArrayObject ||
-                    $response instanceof JsonSerializable ||
-                    is_array($response))) {
-            $response = new JsonResponse($response);
-        } elseif (! $response instanceof SymfonyResponse) {
+            $response = new Response($response->getBody(),
+                $response->getStatusCode(), $response->getHeaders()
+            );
+        } elseif ($response instanceof SymfonyResponse) {
+            $response = new Response($response->getContent(),
+                $response->getStatusCode(), $response->headers->all()
+            );
+        } else {
             $response = new Response($response);
         }
 

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -14,6 +14,7 @@ use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Contracts\Routing\BindingRegistrar;
 use Psr\Http\Message\ResponseInterface as PsrResponseInterface;
 use Illuminate\Contracts\Routing\Registrar as RegistrarContract;
+use Symfony\Bridge\PsrHttpMessage\Factory\HttpFoundationFactory;
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 
 class Router implements RegistrarContract, BindingRegistrar
@@ -645,13 +646,11 @@ class Router implements RegistrarContract, BindingRegistrar
     {
         if ($response instanceof Responsable) {
             $response = $response->toResponse($request);
+        } elseif ($response instanceof PsrResponseInterface) {
+            $response = (new HttpFoundationFactory)->createResponse($response);
         }
 
-        if ($response instanceof PsrResponseInterface) {
-            $response = new Response($response->getBody(),
-                $response->getStatusCode(), $response->getHeaders()
-            );
-        } elseif ($response instanceof SymfonyResponse) {
+        if ($response instanceof SymfonyResponse) {
             $response = new Response($response->getContent(),
                 $response->getStatusCode(), $response->headers->all()
             );

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -1398,7 +1398,7 @@ class RoutingRouteTest extends TestCase
         $this->assertNotInstanceOf(\Illuminate\Http\JsonResponse::class, $response);
     }
 
-    public function testJsonResponseIsReturned()
+    public function testIlluminateResponseIsReturnedFromArray()
     {
         $router = $this->getRouter();
         $router->get('foo/bar', function () {
@@ -1406,8 +1406,8 @@ class RoutingRouteTest extends TestCase
         });
 
         $response = $router->dispatch(Request::create('foo/bar', 'GET'));
-        $this->assertNotInstanceOf(\Illuminate\Http\Response::class, $response);
-        $this->assertInstanceOf(\Illuminate\Http\JsonResponse::class, $response);
+        $this->assertInstanceOf(\Illuminate\Http\Response::class, $response);
+        $this->assertNotInstanceOf(\Illuminate\Http\JsonResponse::class, $response);
     }
 
     public function testRouteRedirect()


### PR DESCRIPTION
This PR ensures that all response objects passed to middleware is an instance of `Illuminate\Http\Response`.

---

### Update

The version of this PR is not final, we're working on making the transition more easier.