### PR TITLE
[5.5] Re-use implicit binding resolving logic that is already present on model

### DIFF
--- a/src/Illuminate/Broadcasting/Broadcasters/Broadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/Broadcaster.php
@@ -149,11 +149,13 @@ abstract class Broadcaster implements BroadcasterContract
                 continue;
             }
 
-            $model = $parameter->getClass()->newInstance();
+            $instance = $parameter->getClass()->newInstance();
 
-            return $model->where($model->getRouteKeyName(), $value)->firstOr(function () {
+            if (! $model = $instance->resolveRouteBinding($value)) {
                 throw new AccessDeniedHttpException;
-            });
+            }
+
+            return $model;
         }
 
         return $value;

--- a/src/Illuminate/Routing/ImplicitRouteBinding.php
+++ b/src/Illuminate/Routing/ImplicitRouteBinding.php
@@ -35,7 +35,7 @@ class ImplicitRouteBinding
             if (! $model = $instance->resolveRouteBinding($parameterValue)) {
                 throw (new ModelNotFoundException)->setModel($parameter->getClass());
             }
- 
+
             $route->setParameter($parameterName, $model);
         }
     }

--- a/src/Illuminate/Routing/ImplicitRouteBinding.php
+++ b/src/Illuminate/Routing/ImplicitRouteBinding.php
@@ -4,6 +4,7 @@ namespace Illuminate\Routing;
 
 use Illuminate\Support\Str;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 
 class ImplicitRouteBinding
 {
@@ -29,11 +30,13 @@ class ImplicitRouteBinding
                 continue;
             }
 
-            $model = $container->make($parameter->getClass()->name);
+            $instance = $container->make($parameter->getClass()->name);
 
-            $route->setParameter($parameterName, $model->where(
-                $model->getRouteKeyName(), $parameterValue
-            )->firstOrFail());
+            if (! $model = $instance->resolveRouteBinding($parameterValue)) {
+                throw (new ModelNotFoundException)->setModel($parameter->getClass());
+            }
+ 
+            $route->setParameter($parameterName, $model);
         }
     }
 

--- a/tests/Broadcasting/BroadcasterTest.php
+++ b/tests/Broadcasting/BroadcasterTest.php
@@ -104,8 +104,7 @@ class BroadcasterTestEloquentModelStub extends Model
         return $this;
     }
 
-    public function firstOr()
-    {
+    public function first(){
         return "model.{$this->value}.instance";
     }
 }
@@ -124,8 +123,8 @@ class BroadcasterTestEloquentModelNotFoundStub extends Model
         return $this;
     }
 
-    public function firstOr($callback)
+    public function first()
     {
-        return call_user_func($callback);
+        return null;
     }
 }

--- a/tests/Broadcasting/BroadcasterTest.php
+++ b/tests/Broadcasting/BroadcasterTest.php
@@ -104,7 +104,8 @@ class BroadcasterTestEloquentModelStub extends Model
         return $this;
     }
 
-    public function first(){
+    public function first()
+    {
         return "model.{$this->value}.instance";
     }
 }


### PR DESCRIPTION
This was my original intention in https://github.com/laravel/framework/pull/20521

However I was inattentive there: when I moved the resolving logic to eloquent model, I made only one replacement, while 3 could have been done. (+ I was wrong on calling that implicit binding while that was about explicit binding without callback function, ie. `Route::model`)

This PR fixes that by reusing the resolving logic already being present in eloquent's `resolveRouteBinding`

Note that all three occurrences used to implement *exactly the same* logic, so this PR, together with the merged [original](https://github.com/laravel/framework/pull/20521) one, removes code repetition too.

There was [another related PR](https://github.com/laravel/framework/pull/20537) where Taylor Otwell said

> We're not changing anything else about this

But I hope he meant the controversy around `UrlRoutable`. This PR has nothing to do with that, it simply removes duplicated code and completes my original intention of making it possible to alter implicit route model binding resolution by overriding a method on a model.
