### PR TITLE
[5.5] [Proposal] Allow artisan commands to accept multiple databases

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/FreshCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/FreshCommand.php
@@ -35,9 +35,31 @@ class FreshCommand extends Command
             return;
         }
 
-        $this->dropAllTables(
-            $database = $this->input->getOption('database')
-        );
+        if ($this->hasOption('database') && (strpos(',', $this->option('database')) !== false)) {
+            foreach (explode(',', $this->option('database')) as $database) {
+                $this->freshMigrations($database);
+            }
+        } else {
+            $this->freshMigrations(
+                $this->option('database')
+            );
+        }
+    }
+
+    /**
+     * Remove all table from database & run all migrations.
+     *
+     * @param string $database
+     *
+     * @return void
+     */
+    protected function freshMigrations($database)
+    {
+        if (! empty($database)) {
+            $this->output->writeln("<comment>Dropping all tables from database</comment>: {$database}");
+        }
+
+        $this->dropAllTables($database);
 
         $this->info('Dropped all tables successfully.');
 

--- a/src/Illuminate/Database/Console/Migrations/RefreshCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/RefreshCommand.php
@@ -38,7 +38,9 @@ class RefreshCommand extends Command
         // Next we'll gather some of the options so that we can have the right options
         // to pass to the commands. This includes options such as which database to
         // use and the path to use for the migration. Then we'll run the command.
-        $database = $this->input->getOption('database');
+        $database = $this->hasOption('database') ?
+            explode(',', $this->input->getOption('database')) :
+            $this->input->getOption('database');
 
         $path = $this->input->getOption('path');
 
@@ -49,6 +51,25 @@ class RefreshCommand extends Command
         // only rollback and remigrate the latest four migrations instead of all.
         $step = $this->input->getOption('step') ?: 0;
 
+        if (is_array($database)) {
+            foreach ($database as $db) {
+                $this->refreshMigrations($db, $path, $step, $force);
+            }
+        } else {
+            $this->refreshMigrations($database, $path, $step, $force);
+        }
+    }
+
+    /**
+     * Rollback & migrate all migrations.
+     *
+     * @param string $database
+     * @param string $path
+     * @param string $step
+     * @param string $force
+     */
+    protected function refreshMigrations($database, $path, $step, $force)
+    {
         if ($step > 0) {
             $this->runRollback($database, $path, $step, $force);
         } else {

--- a/src/Illuminate/Database/Console/Migrations/ResetCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/ResetCommand.php
@@ -55,7 +55,31 @@ class ResetCommand extends BaseCommand
             return;
         }
 
-        $this->migrator->setConnection($this->option('database'));
+        if ($this->hasOption('database') && (strpos(',', $this->option('database')) !== false)) {
+            foreach (explode(',', $this->option('database')) as $database) {
+                $this->resetMigrations($database);
+            }
+        } else {
+            $this->resetMigrations(
+                $this->option('database')
+            );
+        }
+    }
+
+    /**
+     * Revert all migrations.
+     *
+     * @param string $database
+     *
+     * @return void
+     */
+    protected function resetMigrations($database)
+    {
+        $this->migrator->setConnection($database);
+
+        if (! empty($database)) {
+            $this->output->writeln("<comment>Reverting all migrations for database</comment>: {$database}");
+        }
 
         // First, we'll make sure that the migration table actually exists before we
         // start trying to rollback and re-run all of the migrations. If it's not

--- a/src/Illuminate/Database/Console/Migrations/RollbackCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/RollbackCommand.php
@@ -55,7 +55,31 @@ class RollbackCommand extends BaseCommand
             return;
         }
 
-        $this->migrator->setConnection($this->option('database'));
+        if ($this->hasOption('database') && (strpos(',', $this->option('database')) !== false)) {
+            foreach (explode(',', $this->option('database')) as $database) {
+                $this->rollbackMigrations($database);
+            }
+        } else {
+            $this->rollbackMigrations(
+                $this->option('database')
+            );
+        }
+    }
+
+    /**
+     * Rollback migrations for database.
+     *
+     * @param string $database
+     *
+     * @return void
+     */
+    protected function rollbackMigrations($database)
+    {
+        $this->migrator->setConnection($database);
+
+        if (! empty($database)) {
+            $this->output->writeln("<comment>Rolling back migrations for database</comment>: {$database}");
+        }
 
         $this->migrator->rollback(
             $this->getMigrationPaths(), [

--- a/tests/Database/DatabaseMigrationMigrateCommandTest.php
+++ b/tests/Database/DatabaseMigrationMigrateCommandTest.php
@@ -76,6 +76,21 @@ class DatabaseMigrationMigrateCommandTest extends TestCase
         $this->runCommand($command, ['--database' => 'foo']);
     }
 
+    public function testMigrateCommandWithMultipleDatabases()
+    {
+        $command = new MigrateCommand($migrator = m::mock('Illuminate\Database\Migrations\Migrator'), __DIR__.'/vendor');
+        $app = new ApplicationDatabaseMigrationStub(['path.database' => __DIR__]);
+        $app->useDatabasePath(__DIR__);
+        $command->setLaravel($app);
+        $migrator->shouldReceive('paths')->once()->andReturn([]);
+        $migrator->shouldReceive('setConnection')->once()->with('foo,bar');
+        $migrator->shouldReceive('run')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => false, 'step' => false]);
+        $migrator->shouldReceive('getNotes')->andReturn([]);
+        $migrator->shouldReceive('repositoryExists')->once()->andReturn(true);
+
+        $this->runCommand($command, ['--database' => 'foo,bar']);
+    }
+
     public function testStepMayBeSet()
     {
         $command = new MigrateCommand($migrator = m::mock('Illuminate\Database\Migrations\Migrator'), __DIR__.'/vendor');

--- a/tests/Database/DatabaseMigrationResetCommandTest.php
+++ b/tests/Database/DatabaseMigrationResetCommandTest.php
@@ -44,6 +44,21 @@ class DatabaseMigrationResetCommandTest extends TestCase
         $this->runCommand($command, ['--pretend' => true, '--database' => 'foo']);
     }
 
+    public function testResetCommandCanBePretendedWithMultipleDatabases()
+    {
+        $command = new ResetCommand($migrator = m::mock('Illuminate\Database\Migrations\Migrator'));
+        $app = new ApplicationDatabaseResetStub(['path.database' => __DIR__]);
+        $app->useDatabasePath(__DIR__);
+        $command->setLaravel($app);
+        $migrator->shouldReceive('paths')->once()->andReturn([]);
+        $migrator->shouldReceive('setConnection')->once()->with('foo,bar');
+        $migrator->shouldReceive('repositoryExists')->once()->andReturn(true);
+        $migrator->shouldReceive('reset')->once()->with([__DIR__.'/migrations'], true);
+        $migrator->shouldReceive('getNotes')->andReturn([]);
+
+        $this->runCommand($command, ['--pretend' => true, '--database' => 'foo,bar']);
+    }
+
     protected function runCommand($command, $input = [])
     {
         return $command->run(new \Symfony\Component\Console\Input\ArrayInput($input), new \Symfony\Component\Console\Output\NullOutput);

--- a/tests/Database/DatabaseMigrationRollbackCommandTest.php
+++ b/tests/Database/DatabaseMigrationRollbackCommandTest.php
@@ -56,6 +56,20 @@ class DatabaseMigrationRollbackCommandTest extends TestCase
         $this->runCommand($command, ['--pretend' => true, '--database' => 'foo']);
     }
 
+    public function testRollbackCommandWithMultipleDatabases()
+    {
+        $command = new RollbackCommand($migrator = m::mock('Illuminate\Database\Migrations\Migrator'));
+        $app = new ApplicationDatabaseRollbackStub(['path.database' => __DIR__]);
+        $app->useDatabasePath(__DIR__);
+        $command->setLaravel($app);
+        $migrator->shouldReceive('paths')->once()->andReturn([]);
+        $migrator->shouldReceive('setConnection')->once()->with('foo,bar');
+        $migrator->shouldReceive('rollback')->once()->with([__DIR__.'/migrations'], true);
+        $migrator->shouldReceive('getNotes')->andReturn([]);
+
+        $this->runCommand($command, ['--database' => 'foo,bar']);
+    }
+
     public function testRollbackCommandCanBePretendedWithStepOption()
     {
         $command = new RollbackCommand($migrator = m::mock('Illuminate\Database\Migrations\Migrator'));


### PR DESCRIPTION
Currently, whenever we run migration commands in Laravel. We need to specify the specific database configuration by using the `--database` option. Often times, we have multiple database configuration on which we want to run migrations. So we have to run the following commands multiple times:

```
php artisan migrate --database=foo
php artisan migrate --database=bar
php artisan migrate --database=baz
```

This PR will allow us to use a single command to run across multiple database configurations:

```
php artisan migrate --database=foo,bar,baz
```

I don't know whether in its current implementation is acceptable to be merged in 5.5. Looking forward to your feedback