### PR TITLE
[5.4] Make pagination support pageName with array notation (#20624)

### DIFF
--- a/src/Illuminate/Pagination/PaginationServiceProvider.php
+++ b/src/Illuminate/Pagination/PaginationServiceProvider.php
@@ -38,7 +38,13 @@ class PaginationServiceProvider extends ServiceProvider
         });
 
         Paginator::currentPageResolver(function ($pageName = 'page') {
-            $page = $this->app['request']->input($pageName);
+            // It is using array notation
+            if(preg_match('/(\w+)\[(\w+)\]/', $pageName, $matches)) {
+                $param = $this->app['request']->input($matches[1]);
+                $page = $param[$matches[2]] ?: null;
+            } else {
+                $page = $this->app['request']->input($pageName);
+            }
 
             if (filter_var($page, FILTER_VALIDATE_INT) !== false && (int) $page >= 1) {
                 return $page;

--- a/src/Illuminate/Pagination/PaginationServiceProvider.php
+++ b/src/Illuminate/Pagination/PaginationServiceProvider.php
@@ -39,7 +39,7 @@ class PaginationServiceProvider extends ServiceProvider
 
         Paginator::currentPageResolver(function ($pageName = 'page') {
             // It is using array notation
-            if(preg_match('/(\w+)\[(\w+)\]/', $pageName, $matches)) {
+            if (preg_match('/(\w+)\[(\w+)\]/', $pageName, $matches)) {
                 $param = $this->app['request']->input($matches[1]);
                 $page = $param[$matches[2]] ?: null;
             } else {


### PR DESCRIPTION
As discussed in #20624, the Paginator page resolver works for keys such as `page`, `my_page` but not for keys using array notation such as `page[published]`, or `page[unpublished]`.

I'm still unsure it is absolutely necessary to support this use case, but if you think it could be somehow useful, I'd be really glad to help. 

I've added a simple check to determine whether the Paginator is using array notation or not, and if it is the case, it retrieves the page number from the proper place.

I'd like to test the page resolving method, and need advices about: 
- Where to place my test, since it's a static method on the Paginator class but defined in a service provider
- How to mock the request, since the resolving method uses `$this->app['request']`

This is my first attempt at contributing to the project, so please feel free to correct me if I'm making any mistake.