### PR TITLE
[5.4][PHP-7.2] Make addNestedWhereQuery PHP 7.2 compatible

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -99,7 +99,7 @@ class Builder
      *
      * @var array
      */
-    public $wheres;
+    public $wheres = [];
 
     /**
      * The groupings for the query.
@@ -469,7 +469,7 @@ class Builder
      */
     public function mergeWheres($wheres, $bindings)
     {
-        $this->wheres = array_merge((array) $this->wheres, (array) $wheres);
+        $this->wheres = array_merge($this->wheres, (array) $wheres);
 
         $this->bindings['where'] = array_values(
             array_merge($this->bindings['where'], (array) $bindings)


### PR DESCRIPTION
In PHP 7.2, `count()` can only be called on arrays and `Countable`

The old code did do this in `addNestedWhereQuery`:
```PHP
        if (count($query->wheres)) {
```
Which could translate to `if (count(NULL)) {` which will produce:
` ErrorException: count(): Parameter must be an array or an object that implements Countable`

Because the phpdoc says it's supposed to be an array and I saw another place having an explicit `(array)`-cast, my approach was to simply ensure it's an array by default and don't have special cases for `NULL` case anymore