### PR TITLE
[5.5] Separate logging configuration to its own concern

### DIFF
--- a/src/Illuminate/Contracts/Logging/Configurator.php
+++ b/src/Illuminate/Contracts/Logging/Configurator.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Illuminate\Contracts\Logging;
+
+interface Configurator
+{
+    /**
+     * Create and configure the logger.
+     *
+     * @return \Illuminate\Contracts\Logging\Log
+     */
+    public function configure();
+}

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -14,6 +14,7 @@ use Illuminate\Log\LogServiceProvider;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Events\EventServiceProvider;
 use Illuminate\Routing\RoutingServiceProvider;
+use Illuminate\Log\Configurator as LogConfigurator;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Illuminate\Contracts\Http\Kernel as HttpKernelContract;
@@ -93,6 +94,13 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
      * @var array
      */
     protected $deferredServices = [];
+
+    /**
+     * The class used to configure logging.
+     *
+     * @var string
+     */
+    protected $logConfigurator = LogConfigurator::class;
 
     /**
      * A custom callback used to configure Monolog.
@@ -1049,6 +1057,29 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     public function getMonologConfigurator()
     {
         return $this->monologConfigurator;
+    }
+
+    /**
+     * Specify a class to be used for configuring the log.
+     *
+     * @param  string  $configurator
+     * @return $this
+     */
+    public function configureLogWith($configurator)
+    {
+        $this->logConfigurator = $configurator;
+
+        return $this;
+    }
+
+    /**
+     * Retrieve the class used for log configuration.
+     *
+     * @return string
+     */
+    public function getLogConfigurator()
+    {
+        return $this->logConfigurator;
     }
 
     /**

--- a/src/Illuminate/Log/Configurator.php
+++ b/src/Illuminate/Log/Configurator.php
@@ -1,0 +1,165 @@
+<?php
+
+namespace Illuminate\Log;
+
+use Monolog\Logger as Monolog;
+use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Contracts\Logging\Configurator as ConfiguratorContract;
+
+class Configurator implements ConfiguratorContract
+{
+    /**
+     * The Illuminate Application instance.
+     *
+     * @var Application
+     */
+    protected $app;
+
+    /**
+     * Create a new Log Configurator.
+     *
+     * @param Application $app
+     */
+    public function __construct(Application $app)
+    {
+        $this->app = $app;
+    }
+
+    /**
+     * Create and configure the logger.
+     *
+     * @return \Illuminate\Contracts\Logging\Log
+     */
+    public function configure()
+    {
+        $log = new Writer(
+            new Monolog($this->channel()), $this->app['events']
+        );
+
+        if ($this->app->hasMonologConfigurator()) {
+            call_user_func($this->app->getMonologConfigurator(), $log->getMonolog());
+        } else {
+            $this->configureHandler($log);
+        }
+
+        return $log;
+    }
+
+    /**
+     * Get the name of the log "channel".
+     *
+     * @return string
+     */
+    protected function channel()
+    {
+        if ($this->app->bound('config') &&
+            $channel = $this->app->make('config')->get('app.log_channel')) {
+            return $channel;
+        }
+
+        return $this->app->bound('env') ? $this->app->environment() : 'production';
+    }
+
+    /**
+     * Configure the Monolog handlers for the application.
+     *
+     * @param  \Illuminate\Log\Writer  $log
+     * @return void
+     */
+    protected function configureHandler(Writer $log)
+    {
+        $this->{'configure'.ucfirst($this->handler()).'Handler'}($log);
+    }
+
+    /**
+     * Configure the Monolog handlers for the application.
+     *
+     * @param  \Illuminate\Log\Writer  $log
+     * @return void
+     */
+    protected function configureSingleHandler(Writer $log)
+    {
+        $log->useFiles(
+            $this->app->storagePath().'/logs/laravel.log',
+            $this->logLevel()
+        );
+    }
+
+    /**
+     * Configure the Monolog handlers for the application.
+     *
+     * @param  \Illuminate\Log\Writer  $log
+     * @return void
+     */
+    protected function configureDailyHandler(Writer $log)
+    {
+        $log->useDailyFiles(
+            $this->app->storagePath().'/logs/laravel.log', $this->maxFiles(),
+            $this->logLevel()
+        );
+    }
+
+    /**
+     * Configure the Monolog handlers for the application.
+     *
+     * @param  \Illuminate\Log\Writer  $log
+     * @return void
+     */
+    protected function configureSyslogHandler(Writer $log)
+    {
+        $log->useSyslog('laravel', $this->logLevel());
+    }
+
+    /**
+     * Configure the Monolog handlers for the application.
+     *
+     * @param  \Illuminate\Log\Writer  $log
+     * @return void
+     */
+    protected function configureErrorlogHandler(Writer $log)
+    {
+        $log->useErrorLog($this->logLevel());
+    }
+
+    /**
+     * Get the default log handler.
+     *
+     * @return string
+     */
+    protected function handler()
+    {
+        if ($this->app->bound('config')) {
+            return $this->app->make('config')->get('app.log', 'single');
+        }
+
+        return 'single';
+    }
+
+    /**
+     * Get the log level for the application.
+     *
+     * @return string
+     */
+    protected function logLevel()
+    {
+        if ($this->app->bound('config')) {
+            return $this->app->make('config')->get('app.log_level', 'debug');
+        }
+
+        return 'debug';
+    }
+
+    /**
+     * Get the maximum number of log files for the application.
+     *
+     * @return int
+     */
+    protected function maxFiles()
+    {
+        if ($this->app->bound('config')) {
+            return $this->app->make('config')->get('app.log_max_files', 5);
+        }
+
+        return 0;
+    }
+}

--- a/src/Illuminate/Log/LogServiceProvider.php
+++ b/src/Illuminate/Log/LogServiceProvider.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Log;
 
-use Monolog\Logger as Monolog;
 use Illuminate\Support\ServiceProvider;
 
 class LogServiceProvider extends ServiceProvider
@@ -15,145 +14,9 @@ class LogServiceProvider extends ServiceProvider
     public function register()
     {
         $this->app->singleton('log', function () {
-            return $this->createLogger();
+            $configurator = $this->app->getLogConfigurator();
+
+            return (new $configurator($this->app))->configure();
         });
-    }
-
-    /**
-     * Create the logger.
-     *
-     * @return \Illuminate\Log\Writer
-     */
-    public function createLogger()
-    {
-        $log = new Writer(
-            new Monolog($this->channel()), $this->app['events']
-        );
-
-        if ($this->app->hasMonologConfigurator()) {
-            call_user_func($this->app->getMonologConfigurator(), $log->getMonolog());
-        } else {
-            $this->configureHandler($log);
-        }
-
-        return $log;
-    }
-
-    /**
-     * Get the name of the log "channel".
-     *
-     * @return string
-     */
-    protected function channel()
-    {
-        if ($this->app->bound('config') &&
-            $channel = $this->app->make('config')->get('app.log_channel')) {
-            return $channel;
-        }
-
-        return $this->app->bound('env') ? $this->app->environment() : 'production';
-    }
-
-    /**
-     * Configure the Monolog handlers for the application.
-     *
-     * @param  \Illuminate\Log\Writer  $log
-     * @return void
-     */
-    protected function configureHandler(Writer $log)
-    {
-        $this->{'configure'.ucfirst($this->handler()).'Handler'}($log);
-    }
-
-    /**
-     * Configure the Monolog handlers for the application.
-     *
-     * @param  \Illuminate\Log\Writer  $log
-     * @return void
-     */
-    protected function configureSingleHandler(Writer $log)
-    {
-        $log->useFiles(
-            $this->app->storagePath().'/logs/laravel.log',
-            $this->logLevel()
-        );
-    }
-
-    /**
-     * Configure the Monolog handlers for the application.
-     *
-     * @param  \Illuminate\Log\Writer  $log
-     * @return void
-     */
-    protected function configureDailyHandler(Writer $log)
-    {
-        $log->useDailyFiles(
-            $this->app->storagePath().'/logs/laravel.log', $this->maxFiles(),
-            $this->logLevel()
-        );
-    }
-
-    /**
-     * Configure the Monolog handlers for the application.
-     *
-     * @param  \Illuminate\Log\Writer  $log
-     * @return void
-     */
-    protected function configureSyslogHandler(Writer $log)
-    {
-        $log->useSyslog('laravel', $this->logLevel());
-    }
-
-    /**
-     * Configure the Monolog handlers for the application.
-     *
-     * @param  \Illuminate\Log\Writer  $log
-     * @return void
-     */
-    protected function configureErrorlogHandler(Writer $log)
-    {
-        $log->useErrorLog($this->logLevel());
-    }
-
-    /**
-     * Get the default log handler.
-     *
-     * @return string
-     */
-    protected function handler()
-    {
-        if ($this->app->bound('config')) {
-            return $this->app->make('config')->get('app.log', 'single');
-        }
-
-        return 'single';
-    }
-
-    /**
-     * Get the log level for the application.
-     *
-     * @return string
-     */
-    protected function logLevel()
-    {
-        if ($this->app->bound('config')) {
-            return $this->app->make('config')->get('app.log_level', 'debug');
-        }
-
-        return 'debug';
-    }
-
-    /**
-     * Get the maximum number of log files for the application.
-     *
-     * @return int
-     */
-    protected function maxFiles()
-    {
-        if ($this->app->bound('config')) {
-            return $this->app->make('config')->get('app.log_max_files', 5);
-        }
-
-        return 0;
     }
 }

--- a/tests/Log/LogConfiguratorTest.php
+++ b/tests/Log/LogConfiguratorTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Illuminate\Tests\Log;
+
+use Mockery as m;
+use Monolog\Logger;
+use Illuminate\Log\Writer;
+use PHPUnit\Framework\TestCase;
+use Illuminate\Log\Configurator;
+use Illuminate\Foundation\Application;
+use Illuminate\Contracts\Config\Repository;
+use Illuminate\Contracts\Events\Dispatcher;
+
+class LogConfiguratorTest extends TestCase
+{
+    public function test_it_configures_a_single_logger()
+    {
+        $configurator = new Configurator($app = m::mock(Application::class));
+
+        $app->shouldReceive('hasMonologConfigurator')->once()->andReturn(false);
+        $app->shouldReceive('bound')->with('config')->andReturn(true);
+        $app->shouldReceive('make')->with('config')->andReturn($config = m::mock(Repository::class));
+        $config->shouldReceive('get')->with('app.log', 'single')->once()->andReturn('single');
+        $config->shouldReceive('get')->with('app.log_channel')->once()->andReturn('test');
+        $app->shouldReceive('offsetGet')->with('events')->andReturn(m::mock(Dispatcher::class));
+        $app->shouldReceive('storagePath')->andReturn('/test');
+        $config->shouldReceive('get')->with('app.log_level', 'debug')->once()->andReturn('debug');
+
+        $this->assertInstanceOf(Writer::class, $configurator->configure());
+    }
+
+    public function test_it_configures_a_daily_logger()
+    {
+        $configurator = new Configurator($app = m::mock(Application::class));
+
+        $app->shouldReceive('hasMonologConfigurator')->once()->andReturn(false);
+        $app->shouldReceive('bound')->with('config')->andReturn(true);
+        $app->shouldReceive('make')->with('config')->andReturn($config = m::mock(Repository::class));
+        $config->shouldReceive('get')->with('app.log', 'single')->once()->andReturn('daily');
+        $config->shouldReceive('get')->with('app.log_channel')->once()->andReturn('test');
+        $app->shouldReceive('offsetGet')->with('events')->andReturn(m::mock(Dispatcher::class));
+        $app->shouldReceive('storagePath')->andReturn('/test');
+        $config->shouldReceive('get')->with('app.log_level', 'debug')->once()->andReturn('debug');
+        $config->shouldReceive('get')->with('app.log_max_files', 5)->once()->andReturn(0);
+
+        $this->assertInstanceOf(Writer::class, $configurator->configure());
+    }
+
+    public function test_it_uses_the_monolog_configurator_if_specified()
+    {
+        $configurator = new Configurator($app = m::mock(Application::class));
+
+        $app->shouldReceive('hasMonologConfigurator')->once()->andReturn(true);
+        $app->shouldReceive('bound')->with('config')->andReturn(true);
+        $app->shouldReceive('make')->with('config')->andReturn($config = m::mock(Repository::class));
+        $app->shouldReceive('offsetGet')->with('events')->andReturn(m::mock(Dispatcher::class));
+        $config->shouldReceive('get')->with('app.log_channel')->once()->andReturn('test');
+
+        $app->shouldReceive('getMonologConfigurator')->once()->andReturn(function ($monolog) {
+            $this->assertInstanceOf(Logger::class, $monolog);
+        });
+
+        $this->assertInstanceOf(Writer::class, $configurator->configure());
+    }
+}


### PR DESCRIPTION
This PR aims to solve a problem I, and probably other developers, have faced in many projects: the lacking ability to customise the logger completely. Yes, we have `$app->configureMonologUsing()` which is great when you always want to configure monolog a certain way. However, if you want to i.e keep the default single/daily log, but add a JsonFormatter, you have to jump through hoops to reimplement what the `configureSingleHandler` already does.

To solve this, and to make Laravel's logging _slightly_ more testable, I've separated logging configuration into its own class, which can be overridden from `bootstrap/app.php` by simply calling

```
$app->configureLogWith(CustomConfigurator::class);
```

All original functionality is maintained, but now in a separate location. This will require no changes from the user, since behaviour is only changed if the configurator is overridden.