### PR TITLE
Reference component view data passed in as an array

### DIFF
--- a/src/Illuminate/View/Concerns/ManagesComponents.php
+++ b/src/Illuminate/View/Concerns/ManagesComponents.php
@@ -75,6 +75,7 @@ trait ManagesComponents
         return array_merge(
             $this->componentData[count($this->componentStack)],
             ['slot' => new HtmlString(trim(ob_get_clean()))],
+            ['_data' => $this->componentData[count($this->componentStack)]],
             $this->slots[count($this->componentStack)]
         );
     }


### PR DESCRIPTION
To get all the component blade data that are passed in, like a magic variable `$_data` for easy access. Will be useful especially in building blade component, resemblance to Vue component when receiving non props attribute. 

So that we can make use of the blade component to do something like below:


![image](https://user-images.githubusercontent.com/4320720/29493239-26bdfe70-85c5-11e7-9514-b0032ed05352.png)

If `$_data` might not be unique enough to avoid conflict, can rename to something else more unique.