### PR TITLE
[5.4] Fix make:policy Command

### DIFF
--- a/src/Illuminate/Foundation/Console/PolicyMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/PolicyMakeCommand.php
@@ -82,6 +82,11 @@ class PolicyMakeCommand extends GeneratorCommand
             $stub = str_replace('NamespacedDummyModel', $this->laravel->getNamespace().$model, $stub);
         }
 
+        $namspaceModel = $this->laravel->getNamespace().$model;
+
+        $stub = str_replace("use {$namspaceModel};\nuse {$namspaceModel};",
+            "use {$namspaceModel};", $stub);
+
         $model = class_basename(trim($model, '\\'));
 
         $stub = str_replace('DummyModel', $model, $stub);


### PR DESCRIPTION
When create the User policy  `php artisan make:policy UserPolicy -m User` 
will duplicate the `App\User` class imports
 
![screenshot](http://i.imgur.com/3Iyay28.png)
