### PR TITLE
[5.5] Fix asking for confirmation two times when running migrate:fresh on production

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/FreshCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/FreshCommand.php
@@ -44,7 +44,7 @@ class FreshCommand extends Command
         $this->call('migrate', [
             '--database' => $database,
             '--path' => $this->input->getOption('path'),
-            '--force' => $this->input->getOption('force'),
+            '--force' => true,
         ]);
 
         if ($this->needsSeeding()) {


### PR DESCRIPTION
When running migrate:fresh on production, the promt shows twice, one for dropping the database, and the other for migrating again. This pull request makes the promt only show once.