### PR TITLE
[5.5] Allow having "dot macros"

### DIFF
--- a/src/Illuminate/Foundation/Console/PresetCommand.php
+++ b/src/Illuminate/Foundation/Console/PresetCommand.php
@@ -32,7 +32,7 @@ class PresetCommand extends Command
     public function handle()
     {
         if (static::hasMacro($this->argument('type'))) {
-            return call_user_func(static::$macros[$this->argument('type')], $this);
+            return call_user_func(array_get(static::$macros, $this->argument('type')), $this);
         }
 
         if (! in_array($this->argument('type'), ['none', 'bootstrap', 'vue', 'react'])) {

--- a/src/Illuminate/Support/Traits/Macroable.php
+++ b/src/Illuminate/Support/Traits/Macroable.php
@@ -27,7 +27,7 @@ trait Macroable
      */
     public static function macro($name, $macro)
     {
-        static::$macros[$name] = $macro;
+        array_add(static::$macros, $name, $macro);
     }
 
     /**
@@ -57,7 +57,7 @@ trait Macroable
      */
     public static function hasMacro($name)
     {
-        return isset(static::$macros[$name]);
+        return array_has(static::$macros, $name);
     }
 
     /**
@@ -75,11 +75,11 @@ trait Macroable
             throw new BadMethodCallException("Method {$method} does not exist.");
         }
 
-        if (static::$macros[$method] instanceof Closure) {
-            return call_user_func_array(Closure::bind(static::$macros[$method], null, static::class), $parameters);
+        if (array_get(static::$macros, $method) instanceof Closure) {
+            return call_user_func_array(Closure::bind(array_get(static::$macros, $method), null, static::class), $parameters);
         }
 
-        return call_user_func_array(static::$macros[$method], $parameters);
+        return call_user_func_array(array_get(static::$macros, $method), $parameters);
     }
 
     /**
@@ -97,7 +97,7 @@ trait Macroable
             throw new BadMethodCallException("Method {$method} does not exist.");
         }
 
-        $macro = static::$macros[$method];
+        $macro = array_get(static::$macros, $method);
 
         if ($macro instanceof Closure) {
             return call_user_func_array($macro->bindTo($this, static::class), $parameters);


### PR DESCRIPTION
This pull request adds the option to register "dot macros". This is useful, for example, on the preset command, where now I could macro a bulma function and a bulma.auth function for the auth views.