### PR TITLE
[5.4] Different abilities share common logic if it allows user.

### DIFF
--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -413,7 +413,6 @@ class Gate implements GateContract
         if (
             method_exists($policy, 'abilities') && 
             method_exists($policy, 'allows') && 
-            !method_exists($policy, $ability) && 
             in_array($ability, $policy->abilities())
         ) {
             return function () use ($user, $ability, $arguments, $policy) {

--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -409,6 +409,18 @@ class Gate implements GateContract
      */
     protected function resolvePolicyCallback($user, $ability, array $arguments, $policy)
     {
+        // If different abilities share common logic if it allows user.
+        if (
+            method_exists($policy, 'abilities') && 
+            method_exists($policy, 'allows') && 
+            !method_exists($policy, $ability) && 
+            in_array($ability, $policy->abilities())
+        ) {
+            return function () use ($user, $ability, $arguments, $policy) {
+                return $policy->allows($user, $ability, $arguments);
+            };
+        }
+        
         return function () use ($user, $ability, $arguments, $policy) {
             // This callback will be responsible for calling the policy's before method and
             // running this policy method if necessary. This is used to when objects are


### PR DESCRIPTION
I think it is a good policy declaration for some abilities that share common logic this way. I prefer this more than using `before()` method, because this is easier to manipulate when you need to `OR` it in other specific abilities. And I think this might be cleaner, shorter way.. I've come to this because I experienced this:

I created an `AdminOnlyPolicy`
```
class AdminOnlyPolicy
{
    use HandlesAuthorization;

    /**
     * Pre-checking.
     *
     * @param  \App\User  $user
     * @param  string $ability
     * @return mixed
     */
    public function before($user, $ability)
    {
        // I felt like this is not clean, because it is a different concern or logic.
        if ($ability == 'update') {     
            return null;                 
        }

       // I felt like this is not clean, because it is a different concern or logic.
       if ($ability == 'view') {     
            return null;
        }

        return $user->is_admin;
    }

    /**
     * Determine whether the user can view the index page of model module.
     *
     * @param  \App\User  $user
     * @return mixed
     */
    public function index($user)
    {
        // nothing here. condition is based from before() method
    }

    /**
     * Determine whether the user can view the model.
     *
     * @param  \App\User  $user
     * @param  mixed  $model
     * @return mixed
     */
    public function view(User $user, $model)
    {
        return $user->is_admin || $user->id == $model->id;   // Calling $user->is_admin seems redundant
    }

    /**
     * Determine whether the user can create models.
     *
     * @param  mixed  $model
     * @return mixed
     */
    public function create(User $user)
    {
        // nothing here. condition is based from before() method
    }

    /**
     * Determine whether the user can update the model.
     *
     * @param  \App\User  $user
     * @param  mixed  $model
     * @return mixed
     */
    public function update(User $user, $model)
    {
        return $user->is_admin || $user->id == $model->id;   // Calling $user->is_admin seems redundant
    }

    /**
     * Determine whether the user can delete the model.
     *
     * @param  \App\User  $user
     * @param  mixed  $model
     * @return mixed
     */
    public function delete(User $user, $model)
    {
        // nothing here. condition is based from before() method
    }
```
So as you can see from above code.. There seems to be redundant code, if you intend that it should share code/logic. Also, in the `before()` method, it is possible to get messy because it can results to multiple if conditions which is supposedly different logic or concerns.. And also, there are methods which contain no code because they just inhereting the method of `before()`.. 

So I think of this better approach.. 

```
class AdminOnlyPolicy
{
    use HandlesAuthorization;

    /**
     * Abilities to allow.
     *
     * @return array
     */
    public function abilities()
    {
        return ['index', 'create', 'delete'];
    }

    /**
     * Determine if this policy allows declared abilities.
     *
     * @param  \App\User  $user
     * @param  string $ability
     * @param  array  $arguments
     * @return bool
     */
    public function allows($user, $ability = null, $arguments = [])
    {
        return $user->is_admin;
    }
    
    /**
     * Determine whether the user can view the model.
     *
     * @param  \App\User  $user
     * @param  mixed  $model
     * @return mixed
     */
    public function view(User $user, $model)
    {
        return $this->allows($user) || $model->isOwnedBy($user);
    }

    /**
     * Determine whether the user can update the model.
     *
     * @param  \App\User  $user
     * @param  mixed  $model
     * @return mixed
     */
    public function update(User $user, $model)
    {
        return $this->allows($user) || $model->isOwnedBy($user);
    }
}
```
So in this code, we gain the ff:
- No empty methods.
- No redundant calls.
- Easier to manipulate or to `OR` common logic to specific ability.
- Cleaner, no clutter of `if` conditions