### PR TITLE
[5.5] Add new methods to QueueFake and NotificationFake

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
@@ -34,9 +34,29 @@ class NotificationFake implements NotificationFactory
             return;
         }
 
+        if(is_numeric($callback)) {
+            return $this->assertSentToTimes($notifiable, $notification, $callback);
+        }
+
         PHPUnit::assertTrue(
             $this->sent($notifiable, $notification, $callback)->count() > 0,
             "The expected [{$notification}] notification was not sent."
+        );
+    }
+
+    /**
+     * Assert if a notification was sent a number of times.
+     *
+     * @param  mixed  $notifiable
+     * @param  string  $notification
+     * @param  int  $times
+     * @return void
+     */
+    public function assertSentToTimes($notifiable, $notification, $times = 1)
+    {
+        PHPUnit::assertTrue(
+            ($count = $this->sent($notifiable, $notification)->count()) === $times,
+            "The expected [{$notification}] notification was sent {$count} times instead of {$times} times."
         );
     }
 
@@ -62,6 +82,16 @@ class NotificationFake implements NotificationFactory
             $this->sent($notifiable, $notification, $callback)->count() === 0,
             "The unexpected [{$notification}] notification was sent."
         );
+    }
+
+    /**
+     * Assert that no notifications were sent.
+     *
+     * @return void
+     */
+    public function assertNothingSent()
+    {
+        PHPUnit::assertEmpty($this->notifications, 'Notifications were sent unexpectedly.');
     }
 
     /**

--- a/src/Illuminate/Support/Testing/Fakes/QueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/QueueFake.php
@@ -84,6 +84,16 @@ class QueueFake extends QueueManager implements Queue
     }
 
     /**
+     * Assert that no jobs were pushed.
+     *
+     * @return void
+     */
+    public function assertNothingPushed()
+    {
+        PHPUnit::assertEmpty($this->jobs, 'Jobs were pushed unexpectedly.');
+    }
+
+    /**
      * Get all of the jobs matching a truth-test callback.
      *
      * @param  string  $job

--- a/tests/Support/SupportTestingQueueFakeTest.php
+++ b/tests/Support/SupportTestingQueueFakeTest.php
@@ -67,6 +67,19 @@ class QueueFakeTest extends TestCase
 
         $this->fake->assertPushed(JobStub::class, 2);
     }
+
+    /**
+     * @expectedException PHPUnit\Framework\ExpectationFailedException
+     * @expectedExceptionMessage Jobs were pushed unexpectedly.
+     */
+    public function testAssertNothingPushed()
+    {
+        $this->fake->assertNothingPushed();
+
+        $this->fake->push($this->job);
+
+        $this->fake->assertNothingPushed();
+    }
 }
 
 class JobStub


### PR DESCRIPTION
Hey guys — sorry for the PR spam, I imagine this is annoying, but I don't feel I should have sent them together.   

This PR adds the ability to check if a notification was sent a number of times and to check no notifications were sent:  

```php   
Notification::assertSentTo($user, Notification::class, 5);

Notification::assertNothingSent();
```  

And it adds the ability to check that no jobs were pushed to the queue.  

```php  
Queue::assertNothingPushed();
```  

I didn't test `NotificationFake` methods (PR with automated tests https://github.com/laravel/framework/pull/20650) but I can test them in the morning 👍 

