### PR TITLE
[5.4] Make job fail only if it not failed already

### DIFF
--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -343,9 +343,11 @@ class Worker
             // First, we will go ahead and mark the job as failed if it will exceed the maximum
             // attempts it is allowed to run the next time we process it. If so we will just
             // go ahead and mark it as failed now so we do not have to release this again.
-            $this->markJobAsFailedIfWillExceedMaxAttempts(
-                $connectionName, $job, (int) $options->maxTries, $e
-            );
+            if (! $job->hasFailed()) {
+                $this->markJobAsFailedIfWillExceedMaxAttempts(
+                    $connectionName, $job, (int) $options->maxTries, $e
+                );
+            }
 
             $this->raiseExceptionOccurredJobEvent(
                 $connectionName, $job, $e


### PR DESCRIPTION
This will prevent calling statsJob on an already failed and therefore deleted job, which would create another exception.

In case of beanstalk queue driver this will make queue worker to correctly report MaxAttemptsExceededException instead of Pheanstalk ServerException.