### PR TITLE
[5.4] Add an "irreplicable" property to Eloquent models

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasReplication.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasReplication.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Concerns;
+
+use Illuminate\Support\Arr;
+
+trait HasReplication
+{
+    /**
+     * The attributes that aren't replicable.
+     *
+     * @var array
+     */
+    protected $irreplicable = [];
+
+    /**
+     * Get the irreplicable attributes for the model.
+     *
+     * @return array
+     */
+    public function getIrreplicable()
+    {
+        return $this->irreplicable;
+    }
+
+    /**
+     * Set the irreplicable attributes for the model.
+     *
+     * @param  array  $irreplicable
+     * @return $this
+     */
+    public function irreplicable(array $irreplicable)
+    {
+        $this->irreplicable = $irreplicable;
+
+        return $this;
+    }
+
+    /**
+     * Get the irreplicable default attributes for the model.
+     *
+     * @return array
+     */
+    protected function getIrreplicableDefaults()
+    {
+        return [
+            $this->getKeyName(),
+            $this->getCreatedAtColumn(),
+            $this->getUpdatedAtColumn(),
+        ];
+    }
+
+    /**
+     * Determine if the given attribute may be replicated.
+     *
+     * @param  string  $key
+     * @return bool
+     */
+    public function isReplicable($key)
+    {
+        $irreplicable = array_merge($this->irreplicable, $this->getIrreplicableDefaults());
+
+        return ! in_array($key, $irreplicable);
+    }
+
+    /**
+     * Clone the model into a new, non-existing instance.
+     *
+     * @param  array|null  $except
+     * @return \Illuminate\Database\Eloquent\Model
+     */
+    public function replicate(array $except = null)
+    {
+        $irreplicable = array_merge($this->irreplicable, $this->getIrreplicableDefaults());
+
+        $attributes = Arr::except(
+            $this->attributes, $except ? array_unique(array_merge($except, $irreplicable)) : $irreplicable
+        );
+
+        return tap(new static, function ($instance) use ($attributes) {
+            $instance->setRawAttributes($attributes);
+
+            $instance->setRelations($this->relations);
+        });
+    }
+}

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -22,6 +22,7 @@ use Illuminate\Database\ConnectionResolverInterface as Resolver;
 abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializable, QueueableEntity, UrlRoutable
 {
     use Concerns\HasAttributes,
+        Concerns\HasReplication,
         Concerns\HasEvents,
         Concerns\HasGlobalScopes,
         Concerns\HasRelationships,
@@ -961,31 +962,6 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         $this->load(array_keys($this->relations));
 
         $this->setRawAttributes(static::findOrFail($this->getKey())->attributes);
-    }
-
-    /**
-     * Clone the model into a new, non-existing instance.
-     *
-     * @param  array|null  $except
-     * @return \Illuminate\Database\Eloquent\Model
-     */
-    public function replicate(array $except = null)
-    {
-        $defaults = [
-            $this->getKeyName(),
-            $this->getCreatedAtColumn(),
-            $this->getUpdatedAtColumn(),
-        ];
-
-        $attributes = Arr::except(
-            $this->attributes, $except ? array_unique(array_merge($except, $defaults)) : $defaults
-        );
-
-        return tap(new static, function ($instance) use ($attributes) {
-            $instance->setRawAttributes($attributes);
-
-            $instance->setRelations($this->relations);
-        });
     }
 
     /**

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1310,6 +1310,25 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertNull($replicated->updated_at);
     }
 
+    public function testReplicateCreatesANewModelWithoutIrreplicableAttributes()
+    {
+        $model = new EloquentModelStub;
+        $model->id = 'id';
+        $model->foo = 'bar';
+        $model->created_at = new DateTime;
+        $model->updated_at = new DateTime;
+        $model->irreplicable(['foo']);
+        $replicated = $model->replicate();
+
+        $this->assertFalse($model->isReplicable('id'));
+        $this->assertFalse($model->isReplicable('foo'));
+
+        $this->assertNull($replicated->id);
+        $this->assertNull($replicated->foo);
+        $this->assertNull($replicated->created_at);
+        $this->assertNull($replicated->updated_at);
+    }
+
     public function testIncrementOnExistingModelCallsQueryAndSetsAttribute()
     {
         $model = m::mock('Illuminate\Tests\Database\EloquentModelStub[newQuery]');


### PR DESCRIPTION
Adding an `irreplicable` property to Eloquent models allows to declare attributes we never want to copy on model replication, example:

```php
use Illuminate\Foundation\Auth\User as Authenticatable;

class User extends Authenticatable
{
    /**
     * The attributes that are mass assignable.
     *
     * @var array
     */
    protected $fillable = [
        'name', 'email', 'password',
    ];
    
    /**
     * The attributes that should be hidden for arrays.
     *
     * @var array
     */
    protected $hidden = [
        'password', 'remember_token',
    ];

    /**
     * The attributes that aren't replicable.
     *
     * @var array
     */
    protected $irreplicable = [
        'password', 'remember_token',
    ];
}
```

```php
$user = User::first();

// "password" and "remember_token" are null, in addition
// to "id", "created_at" and "updated_at".
$replicate = $user->replicate();
```