### PR TITLE
[5.5] Add "guestable" feature to gate abilities & policies

### DIFF
--- a/src/Illuminate/Contracts/Auth/Access/Gate.php
+++ b/src/Illuminate/Contracts/Auth/Access/Gate.php
@@ -17,9 +17,10 @@ interface Gate
      *
      * @param  string  $ability
      * @param  callable|string  $callback
+     * @param  array  $options
      * @return $this
      */
-    public function define($ability, $callback);
+    public function define($ability, $callback, array $options = []);
 
     /**
      * Define a policy class for a given class type.
@@ -34,17 +35,19 @@ interface Gate
      * Register a callback to run before all Gate checks.
      *
      * @param  callable  $callback
+     * @param  array  $options
      * @return $this
      */
-    public function before(callable $callback);
+    public function before(callable $callback, array $options = []);
 
     /**
      * Register a callback to run after all Gate checks.
      *
      * @param  callable  $callback
+     * @param  array  $options
      * @return $this
      */
-    public function after(callable $callback);
+    public function after(callable $callback, array $options = []);
 
     /**
      * Determine if the given ability should be granted for the current user.


### PR DESCRIPTION
### Before
Gate immediately denies abilities if there is no authenticated user.

### After
The default behavior is still the same, but now you can mark abilities as `guestable` which will allow guests to call this ability.

### Why is this a valid feature
There're many valid scenarios where this is needed, but I won't give examples which some will argue that it's not considered authorization.

I know that authorization is supposed to be used with users where each user can have something special about him at the time where all guests share the same behavior,

I agree with that, but why not use the gate with guests where yes, the permissions are the same for all guests .. but they are dynamic (say they come from the database).
You're not authorizing each individual guest here per say .. but you're using the gate to check if this public permission is enabled or not. Isn't this a valid use of the `Gate` ?

Also there're situations where the ability should be checked for guests & users but the logic will differ from a guest & an authenticated user (a mixed ability).

Anyway, here's a valid example where I find this feature necessarily :

#### Example : ACL Manager
Lets say I'm building a simple ACL with `permissions` which the admin can enable for either specific users only or all authenticated users or all users & guests.

Without this feature we cannot use the gate for that, We will have to use a custom check for the permissions in the views and use a custom authorization on the controller actions.

But with this feature, we can do this :
```PHP
foreach ($permissions as $permission) {
    Gate::define($permission->name, function($user) {
        if ($permission->users_only) {
            return $user && ($permission->all_users || $user->hasPermission($permission));
        } else {
            return ture;
        }
    }, ['guestable' => true]);
}
```
Then we can use the `@can` directive in the views and normal gate authorization methods in the controller for all permissions without caring about the user or the guest.

## How to use it

### 1- Closure abilities :
We pass an array of options as the third parameter to the `Gate::define()` method containing  the `guestable` key which will default to `false` if we don't pass this parameter.

```PHP
$gate->define('show-article', function ($user, Article $article) {
    // If user is logged-in or not, this ability will be called because we told it so
    return $user || $article->visibility == 'all';
}, ['guestable' => true]);
```

**Note** The same applies for the `before` and `after` filters, If we want them to be called for guests we have to explicitly tell it so, Meaning that if we have a `guestable` ability, Then this ability will be interrupted **only** by the `before` filters which are marked as `guestable`.

**Note** In case of guest, The `$user` parameter will be `null`.

### 2- Policies :

For abilities in policies, We can add an array attribute named `$guestable` containing the names of the abilities which we want to be called with guests :

```PHP
// app/policies/ArticlePolicy.php

namespace App\Policies;

use App\Models\Article;

class ArticlePolicy
{
    /**
     * Array of abilities allowed to be checked for guests
     *
     * @var array
     */
    public $guestable = ['index', 'view'];

    /**
     * Ability to show index page
     *
     * @return bool
     */
    public function index()
    {
        return true;
    }

    /**
     * Ability to view specific article
     *
     * @param  User|Null  $user
     * @param  Article $article
     * @return bool
     */
    public function view($user, Article $article)
    {
        // View all articles for the users, but only articles with 'all' visibility level for guests
        return $user || $article->visibility == 'all';
    }

    /**
     * Ability to edit specific article
     *
     * @param  User  $user
     * @param  Article $article
     * @return bool
     */
    public function edit($user, Article $article)
    {
        return $user->id === $article->user_id;
    }
}
```

**Note** Like closure abilities, If the `before` method is not included in the `$guestable` attribute, It will not be called with guests.


## Changes Notes

### 1- Gate::resource() method

1- added the `index` ability to the default `$abilities` list

2- added an optional third parameter (array of options) containing the key `guestable` which is an array of abilities names to be checked as `guestable`.

It will default to `['guestable' => ['index', 'view']]`

### 2- Can middleware

The `can` middleware  (`Illuminate\Auth\Middleware\Authorize`) has been edited to check for the ability first then throw an `AuthenticationException` exception if it's a guest or `AuthorizationException` if it's a user .. only edited to check for the ability first before trying to authenticate.

### 3- Tests

Tests have been added to cover all changes.

## References 

- Previously rejected PR #16239
- Issue #10568
