### PR TITLE
[5.5] Standerize response object

### DIFF
--- a/src/Illuminate/Http/Response.php
+++ b/src/Illuminate/Http/Response.php
@@ -106,7 +106,7 @@ class Response extends BaseResponse
     public function __call($method, $parameters)
     {
         if ($this->baseResponse) {
-            $this->baseResponse->$method(...$parameters);
+            return $this->baseResponse->$method(...$parameters);
         }
     }
 }

--- a/src/Illuminate/Http/Response.php
+++ b/src/Illuminate/Http/Response.php
@@ -14,6 +14,13 @@ class Response extends BaseResponse
     use ResponseTrait;
 
     /**
+     * The base response object.
+     *
+     * @var mixed
+     */
+    public $baseResponse;
+
+    /**
      * Set the content on the response.
      *
      * @param  mixed  $content
@@ -74,5 +81,32 @@ class Response extends BaseResponse
         }
 
         return json_encode($content);
+    }
+
+    /**
+     * Set the base response object.
+     *
+     * @param  mixed  $response
+     * @return $this
+     */
+    public function setBaseResponse($response)
+    {
+        $this->baseResponse = $response;
+
+        return $this;
+    }
+
+    /**
+     * Handle dynamic method calls into the response.
+     *
+     * @param  string  $method
+     * @param  array  $parameters
+     * @return mixed
+     */
+    public function __call($method, $parameters)
+    {
+        if ($this->baseResponse) {
+            $this->baseResponse->$method(...$parameters);
+        }
     }
 }

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -684,11 +684,17 @@ class Router implements RegistrarContract, BindingRegistrar
      */
     private static function createResponseFromBase($response)
     {
-        return (new Response(
+        $new = (new Response(
             $response->getContent(),
             $response->getStatusCode(),
             $response->headers->all()
-        ))->setBaseResponse($response)->withException(null);
+        ))->setBaseResponse($response);
+
+        if (isset($response->exception)) {
+            $new->withException($response->exception);
+        }
+
+        return $new;
     }
 
     /**

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -688,7 +688,7 @@ class Router implements RegistrarContract, BindingRegistrar
             $response->getContent(),
             $response->getStatusCode(),
             $response->headers->all()
-        ))->setBaseResponse($response);
+        ))->setBaseResponse($response)->withException(null);
     }
 
     /**

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -645,7 +645,7 @@ class Router implements RegistrarContract, BindingRegistrar
      *
      * @param  \Symfony\Component\HttpFoundation\Request  $request
      * @param  mixed  $response
-     * @return \Illuminate\Http\Response|\Illuminate\Http\JsonResponse
+     * @return \Illuminate\Http\Response
      */
     public static function prepareResponse($request, $response)
     {
@@ -655,15 +655,18 @@ class Router implements RegistrarContract, BindingRegistrar
 
         if ($response instanceof PsrResponseInterface) {
             $response = (new HttpFoundationFactory)->createResponse($response);
-        } elseif (! $response instanceof SymfonyResponse &&
-                   ($response instanceof Arrayable ||
-                    $response instanceof Jsonable ||
-                    $response instanceof ArrayObject ||
-                    $response instanceof JsonSerializable ||
-                    is_array($response))) {
+        } elseif ($response instanceof Arrayable ||
+            $response instanceof Jsonable ||
+            $response instanceof ArrayObject ||
+            $response instanceof JsonSerializable ||
+            is_array($response)) {
             $response = new JsonResponse($response);
-        } elseif (! $response instanceof SymfonyResponse) {
-            $response = new Response($response);
+        }
+
+        if (! $response instanceof Response) {
+            $response = $response instanceof SymfonyResponse
+                        ? static::createResponseFromBase($response)
+                        : new Response($response);
         }
 
         if ($response->getStatusCode() === Response::HTTP_NOT_MODIFIED) {
@@ -671,6 +674,21 @@ class Router implements RegistrarContract, BindingRegistrar
         }
 
         return $response->prepare($request);
+    }
+
+    /**
+     * Create an illuminate response from a given base response object.
+     *
+     * @param  mixed  $response
+     * @return \Illuminate\Http\Response
+     */
+    private static function createResponseFromBase($response)
+    {
+        return (new Response(
+            $response->getContent(),
+            $response->getStatusCode(),
+            $response->headers->all()
+        ))->setBaseResponse($response);
     }
 
     /**

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -1403,8 +1403,12 @@ class RoutingRouteTest extends TestCase
         });
 
         $response = $router->dispatch(Request::create('foo/bar', 'GET'));
-        $this->assertNotInstanceOf(\Illuminate\Http\Response::class, $response);
-        $this->assertInstanceOf(\Illuminate\Http\JsonResponse::class, $response);
+
+        $response->setEncodingOptions(0);
+
+        $this->assertInstanceOf(\Illuminate\Http\Response::class, $response);
+        $this->assertInstanceOf(\Illuminate\Http\JsonResponse::class, $response->baseResponse);
+        $this->assertEquals(0, $response->getEncodingOptions());
     }
 
     public function testRouteRedirect()

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -1409,6 +1409,7 @@ class RoutingRouteTest extends TestCase
         $this->assertInstanceOf(\Illuminate\Http\Response::class, $response);
         $this->assertInstanceOf(\Illuminate\Http\JsonResponse::class, $response->baseResponse);
         $this->assertEquals(0, $response->getEncodingOptions());
+        $this->assertEquals(['foo', 'bar'], $response->getData());
     }
 
     public function testRouteRedirect()


### PR DESCRIPTION
The aim of this PR is to make sure the return value of `Router::prepareResponse` to always be an instance of `Illuminate\Http\Response`, this way developers can interact with the response object in their middleware knowing what type it is.

It would solve an issue like in: https://github.com/laravel/passport/pull/474