### PR TITLE
[5.5] Issue when you pass rules for array attributes

### DIFF
--- a/src/Illuminate/Foundation/Validation/ValidatesRequests.php
+++ b/src/Illuminate/Foundation/Validation/ValidatesRequests.php
@@ -4,6 +4,7 @@ namespace Illuminate\Foundation\Validation;
 
 use Illuminate\Http\Request;
 use Illuminate\Contracts\Validation\Factory;
+use Illuminate\Support\Str;
 use Illuminate\Validation\ValidationException;
 
 trait ValidatesRequests
@@ -26,7 +27,7 @@ trait ValidatesRequests
         $validator->validate();
 
         return $request->only(
-            array_keys($validator->getRules())
+            $this->getValidationRuleKeys(array_keys($validator->getRules()))
         );
     }
 
@@ -46,7 +47,7 @@ trait ValidatesRequests
              ->make($request->all(), $rules, $messages, $customAttributes)
              ->validate();
 
-        return $request->only(array_keys($rules));
+        return $request->only($this->getValidationRuleKeys(array_keys($rules)));
     }
 
     /**
@@ -81,5 +82,25 @@ trait ValidatesRequests
     protected function getValidationFactory()
     {
         return app(Factory::class);
+    }
+
+    /**
+     * @param  array  $keys
+     *
+     * @return array
+     */
+    protected function getValidationRuleKeys(array $keys)
+    {
+        $filtered = [];
+
+        foreach ($keys as $key) {
+            if (($position = strpos($key, '.')) !== false) {
+                $filtered[] = Str::substr($key, 0, $position);
+            } else {
+                $filtered[] = $key;
+            }
+        }
+
+        return array_unique($filtered);
     }
 }

--- a/src/Illuminate/Foundation/Validation/ValidatesRequests.php
+++ b/src/Illuminate/Foundation/Validation/ValidatesRequests.php
@@ -94,7 +94,7 @@ trait ValidatesRequests
         $filtered = [];
 
         foreach ($keys as $key) {
-            if (($position = strpos($key, '.')) !== false) {
+            if (($position = mb_strpos($key, '.')) !== false) {
                 $filtered[] = Str::substr($key, 0, $position);
             } else {
                 $filtered[] = $key;


### PR DESCRIPTION
There is an issue with getting data when you pass rules for array attributes. For example, you pass the next rules:
```
[
    'foo' => 'required',
    'bar' => 'required|array',
    'bar.*.title' => 'required|max:255',
    'bar.*.description' => 'required|max:10000',
]
```

And you pass single `bar` in request.
What do you except:
```
[
    'foo' => 'Some Foo',
    'bar' => [
         0 => [
              'title' => 'Bar Title',
              'description' => 'Some Bar Description',
         ],
    ],
]
```

What do you actually get:
```
[
    'foo' => 'Some Foo',
    'bar' => [
         0 => [
              'title' => 'Bar Title',
              'description' => 'Some Bar Description',
         ],
        '*' => [
              'title' => 'Bar Title',
              'description' => 'Some Bar Description',
        ],
    ],
]
```