### PR TITLE
[5.4] Add whereIn and whereNotIn constraints to Exists rule

### DIFF
--- a/src/Illuminate/Validation/Rules/Exists.php
+++ b/src/Illuminate/Validation/Rules/Exists.php
@@ -28,11 +28,11 @@ class Exists
     protected $wheres = [];
 
     /**
-     * The custom query callback.
+     * The array of custom query callbacks.
      *
-     * @var \Closure|null
+     * @var array
      */
-    protected $using;
+    protected $using = [];
 
     /**
      * Create a new exists rule instance.
@@ -135,7 +135,7 @@ class Exists
      */
     public function using(Closure $callback)
     {
-        $this->using = $callback;
+        $this->using[] = $callback;
 
         return $this;
     }
@@ -159,7 +159,7 @@ class Exists
      */
     public function queryCallbacks()
     {
-        return $this->using ? [$this->using] : [];
+        return $this->using;
     }
 
     /**

--- a/src/Illuminate/Validation/Rules/Exists.php
+++ b/src/Illuminate/Validation/Rules/Exists.php
@@ -100,6 +100,34 @@ class Exists
     }
 
     /**
+     * Set a "where in" constraint on the query.
+     *
+     * @param  string  $column
+     * @param  array  $values
+     * @return $this
+     */
+    public function whereIn($column, array $values)
+    {
+        return $this->where(function($query) use ($column, $values) {
+            $query->whereIn($column, $values);
+        });
+    }
+
+    /**
+     * Set a "where not in" constraint on the query.
+     *
+     * @param  string  $column
+     * @param  array  $values
+     * @return $this
+     */
+    public function whereNotIn($column, array $values)
+    {
+        return $this->where(function($query) use ($column, $values) {
+            $query->whereNotIn($column, $values);
+        });
+    }
+
+    /**
      * Register a custom query callback.
      *
      * @param  \Closure $callback

--- a/src/Illuminate/Validation/Rules/Exists.php
+++ b/src/Illuminate/Validation/Rules/Exists.php
@@ -108,7 +108,7 @@ class Exists
      */
     public function whereIn($column, array $values)
     {
-        return $this->where(function($query) use ($column, $values) {
+        return $this->where(function ($query) use ($column, $values) {
             $query->whereIn($column, $values);
         });
     }
@@ -122,7 +122,7 @@ class Exists
      */
     public function whereNotIn($column, array $values)
     {
-        return $this->where(function($query) use ($column, $values) {
+        return $this->where(function ($query) use ($column, $values) {
             $query->whereNotIn($column, $values);
         });
     }


### PR DESCRIPTION
For me it's pretty useful to have those shortcuts built-in instead of manually adding closure each time. 

We have already `where`, `whereNot`, `whereNull` and `whereNotNull` and adding `whereIn` and `whereNotIn` will be probably also useful in some situations where you need to apply condition with multiple values.