### PR TITLE
[5.4] Clear the Carbon mock during tear down

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Foundation\Testing;
 
 use Mockery;
+use Carbon\Carbon;
 use Illuminate\Support\Facades\Facade;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Console\Application as Artisan;
@@ -142,6 +143,10 @@ abstract class TestCase extends BaseTestCase
 
         if (class_exists('Mockery')) {
             Mockery::close();
+        }
+
+        if (Carbon::hasTestNow()) {
+            Carbon::setTestNow();
         }
 
         $this->afterApplicationCreatedCallbacks = [];


### PR DESCRIPTION
I found that the `Carbon\Carbon` mock was not being clear after each test execution, causing some random tests failures.

This is fixed in https://github.com/laravel/framework/pull/19934 but i think that 5.4 users can also benefit from this.