### PR TITLE
[5.5] Let \Illuminate\Auth\Events\Failed also accept the current request.

### DIFF
--- a/src/Illuminate/Auth/Events/Attempting.php
+++ b/src/Illuminate/Auth/Events/Attempting.php
@@ -23,6 +23,7 @@ class Attempting
      *
      * @param  array  $credentials
      * @param  bool  $remember
+     * @return void
      */
     public function __construct($credentials, $remember)
     {

--- a/src/Illuminate/Auth/Events/Failed.php
+++ b/src/Illuminate/Auth/Events/Failed.php
@@ -30,10 +30,10 @@ class Failed
      *
      * @param  \Illuminate\Contracts\Auth\Authenticatable|null  $user
      * @param  array  $credentials
-     * @param  \Illuminate\Http\Request  $request
+     * @param  \Illuminate\Http\Request|null  $request
      * @return void
      */
-    public function __construct($user, $credentials, $request)
+    public function __construct($user, $credentials, $request = null)
     {
         $this->user = $user;
         $this->credentials = $credentials;

--- a/src/Illuminate/Auth/Events/Failed.php
+++ b/src/Illuminate/Auth/Events/Failed.php
@@ -19,14 +19,24 @@ class Failed
     public $credentials;
 
     /**
+     * The request.
+     *
+     * @var \Illuminate\Http\Request
+     */
+    protected $request;
+
+    /**
      * Create a new event instance.
      *
      * @param  \Illuminate\Contracts\Auth\Authenticatable|null  $user
      * @param  array  $credentials
+     * @param  \Illuminate\Http\Request  $request
+     * @return void
      */
-    public function __construct($user, $credentials)
+    public function __construct($user, $credentials, $request)
     {
         $this->user = $user;
         $this->credentials = $credentials;
+        $this->request = $request;
     }
 }

--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -600,7 +600,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
     protected function fireFailedEvent($user, array $credentials)
     {
         if (isset($this->events)) {
-            $this->events->dispatch(new Events\Failed($user, $credentials));
+            $this->events->dispatch(new Events\Failed($user, $credentials, $this->getRequest()));
         }
     }
 


### PR DESCRIPTION
Let `\Illuminate\Auth\Events\Failed` event also accept the current request.