### PR TITLE
[5.4] Add try-catch blade directives

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
@@ -144,4 +144,45 @@ trait CompilesConditionals
     {
         return '<?php endif; ?>';
     }
+
+    /**
+     * Compile the try statement into valid PHP.
+     *
+     * @return string
+     */
+    protected function compileTry()
+    {
+        return "<?php try { ?>";
+    }
+
+    /**
+     * Compile the catch statements into valid PHP.
+     *
+     * @param  string  $expression
+     * @return string
+     */
+    protected function compileCatch($expression)
+    {
+        return "<?php } catch {$expression} { ?>";
+    }
+
+    /**
+     * Compile the finally statement into valid PHP.
+     *
+     * @return string
+     */
+    protected function compileFinally()
+    {
+        return '<?php } finally { ?>';
+    }
+
+    /**
+     * Compile the endtry statement into valid PHP.
+     *
+     * @return string
+     */
+    protected function compileEndTry()
+    {
+        return '<?php } ?>';
+    }
 }

--- a/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
@@ -152,7 +152,7 @@ trait CompilesConditionals
      */
     protected function compileTry()
     {
-        return "<?php try { ?>";
+        return '<?php try { ?>';
     }
 
     /**

--- a/tests/View/Blade/BladeTryCatchFinallyStatementsTest.php
+++ b/tests/View/Blade/BladeTryCatchFinallyStatementsTest.php
@@ -6,7 +6,7 @@ use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Illuminate\View\Compilers\BladeCompiler;
 
-class BladeElseStatementsTest extends TestCase
+class BladeTryCatchFinallyStatementsTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/View/Blade/BladeTryCatchFinallyStatementsTest.php
+++ b/tests/View/Blade/BladeTryCatchFinallyStatementsTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Illuminate\Tests\Blade;
+
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+use Illuminate\View\Compilers\BladeCompiler;
+
+class BladeElseStatementsTest extends TestCase
+{
+    public function tearDown()
+    {
+        m::close();
+    }
+
+    public function testTryCatchStatementsAreCompiled()
+    {
+        $compiler = new BladeCompiler($this->getFiles(), __DIR__);
+        $string = '@try
+breeze
+@catch (\Exception $e)
+boom
+@endtry';
+        $expected = '<?php try { ?>
+breeze
+<?php } catch (\Exception $e) { ?>
+boom
+<?php } ?>';
+        $this->assertEquals($expected, $compiler->compileString($string));
+    }
+
+    public function testTryMultipleCatchStatementsAreCompiled()
+    {
+        $compiler = new BladeCompiler($this->getFiles(), __DIR__);
+        $string = '@try
+breeze
+@catch(\Exception $e)
+boom
+@catch(\Error $e)
+bang
+@endtry';
+        $expected = '<?php try { ?>
+breeze
+<?php } catch (\Exception $e) { ?>
+boom
+<?php } catch (\Error $e) { ?>
+bang
+<?php } ?>';
+        $this->assertEquals($expected, $compiler->compileString($string));
+    }
+
+    public function testTryCatchFinallyStatementsAreCompiled()
+    {
+        $compiler = new BladeCompiler($this->getFiles(), __DIR__);
+        $string = '@try
+breeze
+@catch(\Exception $e)
+boom
+@finally
+bang
+@endtry';
+        $expected = '<?php try { ?>
+breeze
+<?php } catch (\Exception $e) { ?>
+boom
+<?php } finally { ?>
+bang
+<?php } ?>';
+        $this->assertEquals($expected, $compiler->compileString($string));
+    }
+
+    protected function getFiles()
+    {
+        return m::mock('Illuminate\Filesystem\Filesystem');
+    }
+}

--- a/tests/View/Blade/BladeTryCatchFinallyStatementsTest.php
+++ b/tests/View/Blade/BladeTryCatchFinallyStatementsTest.php
@@ -69,6 +69,30 @@ bang
         $this->assertEquals($expected, $compiler->compileString($string));
     }
 
+    public function testTryMultipleCatchFinallyStatementsAreCompiled()
+    {
+        $compiler = new BladeCompiler($this->getFiles(), __DIR__);
+        $string = '@try
+breeze
+@catch(\Exception $e)
+boom
+@catch(\Error $e)
+bang
+@finally
+bang
+@endtry';
+        $expected = '<?php try { ?>
+breeze
+<?php } catch (\Exception $e) { ?>
+boom
+<?php } catch (\Error $e) { ?>
+bang
+<?php } finally { ?>
+bang
+<?php } ?>';
+        $this->assertEquals($expected, $compiler->compileString($string));
+    }
+
     protected function getFiles()
     {
         return m::mock('Illuminate\Filesystem\Filesystem');


### PR DESCRIPTION
Other templating systems include a way to catch exceptions in views (see [Perl's try-catch](http://www.template-toolkit.org/docs/manual/Directives.html#section_TRY_THROW_CATCH_FINAL) and the [Ruby on Rails `try` method](http://api.rubyonrails.org/classes/Object.html#method-i-try)). This pull request would add try-catch ability to Blade templates.

Added are: 
- `@try`
- `@catch()`
- `@finally`
- `@endtry`

Here's two examples in a Blade view. Note that `@catch` takes an argument, identical to the native PHP behavior:

![image](https://user-images.githubusercontent.com/43112/29534533-fa2386ca-867b-11e7-9e85-a7f5398cd81d.png)

![image](https://user-images.githubusercontent.com/43112/29534537-fecd97d8-867b-11e7-969c-aff1cc1b7177.png)

Also included are tests covering these new directives.

Let me know if there are questions or suggestions. Thanks!