### PR TITLE
[5.4] Fix Conflict Variable Name In User Policy Class

### DIFF
--- a/src/Illuminate/Foundation/Console/PolicyMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/PolicyMakeCommand.php
@@ -84,8 +84,9 @@ class PolicyMakeCommand extends GeneratorCommand
             $stub = str_replace('NamespacedDummyModel', $namespaceModel, $stub);
         }
 
-        $stub = str_replace("use {$namespaceModel};\nuse {$namespaceModel};",
-            "use {$namespaceModel};", $stub);
+        $stub = str_replace(
+            "use {$namespaceModel};\nuse {$namespaceModel};", "use {$namespaceModel};", $stub
+        );
 
         $model = class_basename(trim($model, '\\'));
 

--- a/src/Illuminate/Foundation/Console/PolicyMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/PolicyMakeCommand.php
@@ -92,7 +92,9 @@ class PolicyMakeCommand extends GeneratorCommand
 
         $stub = str_replace('DummyModel', $model, $stub);
 
-        $stub = str_replace('dummyModel', Str::camel($model), $stub);
+        $variableName = Str::camel($model) == 'user' : 'model' : Str::camel($model);
+
+        $stub = str_replace('dummyModel', $variableName, $stub);
 
         return str_replace('dummyPluralModel', Str::plural(Str::camel($model)), $stub);
     }

--- a/src/Illuminate/Foundation/Console/PolicyMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/PolicyMakeCommand.php
@@ -92,7 +92,7 @@ class PolicyMakeCommand extends GeneratorCommand
 
         $stub = str_replace('DummyModel', $model, $stub);
 
-        $variableName = Str::camel($model) == 'user' : 'model' : Str::camel($model);
+        $variableName = Str::camel($model) == 'user' ? 'model' : Str::camel($model);
 
         $stub = str_replace('dummyModel', $variableName, $stub);
 


### PR DESCRIPTION
When create policy for user model the methods parameters name will conflict 
So I suggest replace model variable name to $model