### PR TITLE
[5.5] Support In-Model Event Observer Methods

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
@@ -119,6 +119,24 @@ trait HasEvents
     }
 
     /**
+     * Register model event observers within the model.
+     *
+     * @return void
+     */
+    protected static function registerInModelEventObservers()
+    {
+        $class = static::class;
+
+        $instance = new static;
+
+        foreach ($instance->getObservableEvents() as $event) {
+            if (method_exists($instance, 'on'.ucfirst($event))) {
+                static::registerModelEvent($event, $class.'@on'.ucfirst($event));
+            }
+        }
+    }
+
+    /**
      * Fire the given event for the model.
      *
      * @param  string  $event

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -183,6 +183,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     protected static function boot()
     {
         static::bootTraits();
+        static::registerInModelEventObservers();
     }
 
     /**

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1281,6 +1281,15 @@ class DatabaseEloquentModelTest extends TestCase
         EloquentModelStub::flushEventListeners();
     }
 
+    public function testInModelObserversAreAttachedToModels()
+    {
+        EloquentInModelEventObjectStub::setEventDispatcher($events = m::mock('Illuminate\Contracts\Events\Dispatcher', ['fire' => 'return value true']));
+        $events->shouldReceive('listen')->once()->with('eloquent.saving: Illuminate\Tests\Database\EloquentInModelEventObjectStub', 'Illuminate\Tests\Database\EloquentInModelEventObjectStub@onSaving');
+        $events->shouldReceive('listen')->once()->with('eloquent.creating: Illuminate\Tests\Database\EloquentInModelEventObjectStub', 'Illuminate\Tests\Database\EloquentInModelEventObjectStub@onCreating');
+        $events->shouldReceive('forget');
+        EloquentInModelEventObjectStub::flushEventListeners();
+    }
+
     public function testSetObservableEvents()
     {
         $class = new EloquentModelStub;
@@ -2063,4 +2072,17 @@ class EloquentModelEventObjectStub extends \Illuminate\Database\Eloquent\Model
     protected $dispatchesEvents = [
         'saving' => EloquentModelSavingEventStub::class,
     ];
+}
+
+class EloquentInModelEventObjectStub extends EloquentModelStub
+{
+    public function onCreating(EloquentInModelEventObjectStub $model)
+    {
+        return true;
+    }
+
+    public function onSaving(EloquentInModelEventObjectStub $model)
+    {
+        return true;
+    }
 }


### PR DESCRIPTION
**Improvement:**

Support for model event observer methods from within the model.

**Why?**

Observers are certainly appropriate for more involved model eventing, however, I'm not a fan of creating a new class and registering an observer for a simple check on a single observable event.

**Implementation:**

This solution allows the auto-registration of observer methods defined within the model for methods that match the pattern `on[ObservableEvent]`.

I chose to prefix the method name with `on` because the model events already exist as static function on the models.

This is what it looks like in the model:

```php
<?php

class User extends Model
{
    public function onSaving(User $user)
    {
        return $user->locked == false;
    }
}

```
