### PR TITLE
[5.4] fix rate limiter cache leak

### DIFF
--- a/src/Illuminate/Cache/RateLimiter.php
+++ b/src/Illuminate/Cache/RateLimiter.php
@@ -73,9 +73,15 @@ class RateLimiter
      */
     public function hit($key, $decayMinutes = 1)
     {
-        $this->cache->add($key, 0, $decayMinutes);
+        $added = $this->cache->add($key, 0, $decayMinutes);
 
-        return (int) $this->cache->increment($key);
+        $hits = (int) $this->cache->increment($key);
+
+        if (! $added && $hits == 1) {
+            $this->cache->put($key, 1, $decayMinutes);
+        }
+
+        return $hits;
     }
 
     /**

--- a/tests/Cache/CacheRateLimiterTest.php
+++ b/tests/Cache/CacheRateLimiterTest.php
@@ -39,8 +39,19 @@ class CacheRateLimiterTest extends TestCase
     public function testHitProperlyIncrementsAttemptCount()
     {
         $cache = m::mock(Cache::class);
-        $cache->shouldReceive('add')->once()->with('key', 0, 1);
-        $cache->shouldReceive('increment')->once()->with('key');
+        $cache->shouldReceive('add')->once()->with('key', 0, 1)->andReturn(true);
+        $cache->shouldReceive('increment')->once()->with('key')->andReturn(1);
+        $rateLimiter = new RateLimiter($cache);
+
+        $rateLimiter->hit('key', 1);
+    }
+
+    public function testHitHasNoMemoryLeak()
+    {
+        $cache = m::mock(Cache::class);
+        $cache->shouldReceive('add')->once()->with('key', 0, 1)->andReturn(false);
+        $cache->shouldReceive('increment')->once()->with('key')->andReturn(1);
+        $cache->shouldReceive('put')->once()->with('key', 1, 1);
         $rateLimiter = new RateLimiter($cache);
 
         $rateLimiter->hit('key', 1);


### PR DESCRIPTION
The added if-block detects and fix the leak. The leak is still possible when the added if-block fails, although practically unlikely.