### PR TITLE
[5.5] Add whereIn and whereNotIn constraints to DatabaseRule

### DIFF
--- a/src/Illuminate/Validation/Rules/DatabaseRule.php
+++ b/src/Illuminate/Validation/Rules/DatabaseRule.php
@@ -28,11 +28,11 @@ trait DatabaseRule
     protected $wheres = [];
 
     /**
-     * The custom query callback.
+     * The array of custom query callbacks.
      *
-     * @var \Closure|null
+     * @var array
      */
-    protected $using;
+    protected $using = [];
 
     /**
      * Create a new rule instance.
@@ -100,6 +100,34 @@ trait DatabaseRule
     }
 
     /**
+     * Set a "where in" constraint on the query.
+     *
+     * @param  string  $column
+     * @param  array  $values
+     * @return $this
+     */
+    public function whereIn($column, array $values)
+    {
+        return $this->where(function ($query) use ($column, $values) {
+            $query->whereIn($column, $values);
+        });
+    }
+
+    /**
+     * Set a "where not in" constraint on the query.
+     *
+     * @param  string  $column
+     * @param  array  $values
+     * @return $this
+     */
+    public function whereNotIn($column, array $values)
+    {
+        return $this->where(function ($query) use ($column, $values) {
+            $query->whereNotIn($column, $values);
+        });
+    }
+
+    /**
      * Register a custom query callback.
      *
      * @param  \Closure $callback
@@ -107,7 +135,7 @@ trait DatabaseRule
      */
     public function using(Closure $callback)
     {
-        $this->using = $callback;
+        $this->using[] = $callback;
 
         return $this;
     }
@@ -119,7 +147,7 @@ trait DatabaseRule
      */
     public function queryCallbacks()
     {
-        return $this->using ? [$this->using] : [];
+        return $this->using;
     }
 
     /**


### PR DESCRIPTION
Allow to use multiple callbacks and allow to use `whereIn` and `whereNotIn` constraints. 

Before it was not possible to use multiple callbacks - the later was always overriding the previous one so this might be breaking in case someone added multiple callbacks and now all of them will start working.