### PR TITLE
[5.4] Documentation Falsely Suggests Markdown Extra is Available

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "ext-mbstring": "*",
         "ext-openssl": "*",
         "doctrine/inflector": "~1.1",
-        "erusev/parsedown": "~1.6",
+        "erusev/parsedown-extra": "~0.7",
         "league/flysystem": "~1.0",
         "monolog/monolog": "~1.11",
         "mtdowling/cron-expression": "~1.0",

--- a/src/Illuminate/Mail/Markdown.php
+++ b/src/Illuminate/Mail/Markdown.php
@@ -94,7 +94,7 @@ class Markdown
      */
     public static function parse($text)
     {
-        $parsedown = new Parsedown;
+        $parsedown = new ParsedownExtra;
 
         return new HtmlString($parsedown->text($text));
     }

--- a/src/Illuminate/Mail/Markdown.php
+++ b/src/Illuminate/Mail/Markdown.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\Mail;
 
-use Parsedown;
+use ParsedownExtra;
 use Illuminate\Support\Arr;
 use Illuminate\Support\HtmlString;
 use Illuminate\Contracts\View\Factory as ViewFactory;


### PR DESCRIPTION
This is written as a pull request to demonstrate the code changes needed, though upstream needs to fix some things before this can be merged. Please consider this more as a bug report than anything else.

- Laravel Version: 5.4.33
- PHP Version: 7.0.19

### Description:

Looking at the [mail documentation](https://laravel.com/docs/5.4/mail#markdown-mailables), Markdown tables are shown as being usable. This syntax [requires Markdown Extra](https://michelf.ca/projects/php-markdown/extra/#table), not just vanilla Markdown. Laravel currently [depends upon](https://github.com/laravel/framework/blob/5.4/src/Illuminate/Mail/composer.json#L18) [erusev/parsedown](https://github.com/erusev/parsedown), but that package handles only Markdown. For Markdown Extra, Laravel should depend on [erusev/parsedown-extra](https://github.com/erusev/parsedown-extra) and use it [when parsing email](https://github.com/laravel/framework/blob/5.4/src/Illuminate/Mail/Markdown.php#L97).

### Steps To Reproduce:

Create a mailable with a definition list in it and then render it.

    Test List Item
    :    Test List Value
    
    Test List Item 2
    :    Test List Value 2

It should output:

    <dl>
        <dt>Test List Item</dt>
        <dd>Test List Value</dd>
        <dt>Test List Item 2</dt>
        <dd>Test List Value 2</dd>
    </dl>

But instead it outputs:

    <p>Test List Item : Test List Value</p>
    <p>Test List Item 2 : Test List Value 2</p>