### PR TITLE
[5.5] Add whereIn and whereNotIn constraints to DatabaseRule

### DIFF
--- a/src/Illuminate/Validation/Rules/DatabaseRule.php
+++ b/src/Illuminate/Validation/Rules/DatabaseRule.php
@@ -28,11 +28,11 @@ trait DatabaseRule
     protected $wheres = [];
 
     /**
-     * The custom query callback.
+     * The array of custom query callbacks.
      *
-     * @var \Closure|null
+     * @var array
      */
-    protected $using;
+    protected $using = [];
 
     /**
      * Create a new rule instance.
@@ -100,6 +100,34 @@ trait DatabaseRule
     }
 
     /**
+     * Set a "where in" constraint on the query.
+     *
+     * @param  string  $column
+     * @param  array  $values
+     * @return $this
+     */
+    public function whereIn($column, array $values)
+    {
+        return $this->where(function ($query) use ($column, $values) {
+            $query->whereIn($column, $values);
+        });
+    }
+
+    /**
+     * Set a "where not in" constraint on the query.
+     *
+     * @param  string  $column
+     * @param  array  $values
+     * @return $this
+     */
+    public function whereNotIn($column, array $values)
+    {
+        return $this->where(function ($query) use ($column, $values) {
+            $query->whereNotIn($column, $values);
+        });
+    }
+
+    /**
      * Register a custom query callback.
      *
      * @param  \Closure $callback
@@ -107,7 +135,7 @@ trait DatabaseRule
      */
     public function using(Closure $callback)
     {
-        $this->using = $callback;
+        $this->using[] = $callback;
 
         return $this;
     }
@@ -119,7 +147,7 @@ trait DatabaseRule
      */
     public function queryCallbacks()
     {
-        return $this->using ? [$this->using] : [];
+        return $this->using;
     }
 
     /**

--- a/tests/Validation/ValidationExistsRuleTest.php
+++ b/tests/Validation/ValidationExistsRuleTest.php
@@ -2,12 +2,12 @@
 
 namespace Illuminate\Tests\Validation;
 
-use Illuminate\Validation\DatabasePresenceVerifier;
-use Illuminate\Validation\Rules\Exists;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Validation\Validator;
+use Illuminate\Validation\Rules\Exists;
 use Illuminate\Database\Capsule\Manager as DB;
 use Illuminate\Database\Eloquent\Model as Eloquent;
-use Illuminate\Validation\Validator;
+use Illuminate\Validation\DatabasePresenceVerifier;
 
 class ValidationExistsRuleTest extends TestCase
 {
@@ -29,8 +29,8 @@ class ValidationExistsRuleTest extends TestCase
         $db->setAsGlobal();
 
         $this->createSchema();
-    }    
-    
+    }
+
     public function testItCorrectlyFormatsAStringVersionOfTheRule()
     {
         $rule = new Exists('table');
@@ -116,7 +116,7 @@ class ValidationExistsRuleTest extends TestCase
 
     protected function createSchema()
     {
-        $this->schema('default')->create('users', function($table) {
+        $this->schema('default')->create('users', function ($table) {
             $table->unsignedInteger('id');
             $table->string('type');
         });
@@ -143,7 +143,7 @@ class ValidationExistsRuleTest extends TestCase
     }
 
     /**
-     * Get connection resolver
+     * Get connection resolver.
      *
      * @return \Illuminate\Database\ConnectionResolverInterface
      */
@@ -171,7 +171,7 @@ class ValidationExistsRuleTest extends TestCase
 }
 
 /**
- * Eloquent Models
+ * Eloquent Models.
  */
 class EloquentTestUser extends Eloquent
 {

--- a/tests/Validation/ValidationExistsRuleTest.php
+++ b/tests/Validation/ValidationExistsRuleTest.php
@@ -2,18 +2,180 @@
 
 namespace Illuminate\Tests\Validation;
 
+use Illuminate\Validation\DatabasePresenceVerifier;
+use Illuminate\Validation\Rules\Exists;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Database\Capsule\Manager as DB;
+use Illuminate\Database\Eloquent\Model as Eloquent;
+use Illuminate\Validation\Validator;
 
 class ValidationExistsRuleTest extends TestCase
 {
+    /**
+     * Setup the database schema.
+     *
+     * @return void
+     */
+    public function setUp()
+    {
+        $db = new DB;
+
+        $db->addConnection([
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+        ]);
+
+        $db->bootEloquent();
+        $db->setAsGlobal();
+
+        $this->createSchema();
+    }    
+    
     public function testItCorrectlyFormatsAStringVersionOfTheRule()
     {
-        $rule = new \Illuminate\Validation\Rules\Exists('table');
+        $rule = new Exists('table');
         $rule->where('foo', 'bar');
         $this->assertEquals('exists:table,NULL,foo,bar', (string) $rule);
 
-        $rule = new \Illuminate\Validation\Rules\Exists('table', 'column');
+        $rule = new Exists('table', 'column');
         $rule->where('foo', 'bar');
         $this->assertEquals('exists:table,column,foo,bar', (string) $rule);
     }
+
+    public function testItChoosesValidRecordsUsingWhereInRule()
+    {
+        $rule = new Exists('users', 'id');
+        $rule->whereIn('type', ['foo', 'bar']);
+
+        EloquentTestUser::create(['id' => '1', 'type' => 'foo']);
+        EloquentTestUser::create(['id' => '2', 'type' => 'bar']);
+        EloquentTestUser::create(['id' => '3', 'type' => 'baz']);
+        EloquentTestUser::create(['id' => '4', 'type' => 'other']);
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, [], ['id' => $rule]);
+        $v->setPresenceVerifier(new DatabasePresenceVerifier(Eloquent::getConnectionResolver()));
+
+        $v->setData(['id' => 1]);
+        $this->assertTrue($v->passes());
+        $v->setData(['id' => 2]);
+        $this->assertTrue($v->passes());
+        $v->setData(['id' => 3]);
+        $this->assertFalse($v->passes());
+        $v->setData(['id' => 4]);
+        $this->assertFalse($v->passes());
+    }
+
+    public function testItChoosesValidRecordsUsingWhereNotInRule()
+    {
+        $rule = new Exists('users', 'id');
+        $rule->whereNotIn('type', ['foo', 'bar']);
+
+        EloquentTestUser::create(['id' => '1', 'type' => 'foo']);
+        EloquentTestUser::create(['id' => '2', 'type' => 'bar']);
+        EloquentTestUser::create(['id' => '3', 'type' => 'baz']);
+        EloquentTestUser::create(['id' => '4', 'type' => 'other']);
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, [], ['id' => $rule]);
+        $v->setPresenceVerifier(new DatabasePresenceVerifier(Eloquent::getConnectionResolver()));
+
+        $v->setData(['id' => 1]);
+        $this->assertFalse($v->passes());
+        $v->setData(['id' => 2]);
+        $this->assertFalse($v->passes());
+        $v->setData(['id' => 3]);
+        $this->assertTrue($v->passes());
+        $v->setData(['id' => 4]);
+        $this->assertTrue($v->passes());
+    }
+
+    public function testItChoosesValidRecordsUsingWhereNotInAndWhereNotInRulesTogether()
+    {
+        $rule = new Exists('users', 'id');
+        $rule->whereIn('type', ['foo', 'bar', 'baz'])->whereNotIn('type', ['foo', 'bar']);
+
+        EloquentTestUser::create(['id' => '1', 'type' => 'foo']);
+        EloquentTestUser::create(['id' => '2', 'type' => 'bar']);
+        EloquentTestUser::create(['id' => '3', 'type' => 'baz']);
+        EloquentTestUser::create(['id' => '4', 'type' => 'other']);
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, [], ['id' => $rule]);
+        $v->setPresenceVerifier(new DatabasePresenceVerifier(Eloquent::getConnectionResolver()));
+
+        $v->setData(['id' => 1]);
+        $this->assertFalse($v->passes());
+        $v->setData(['id' => 2]);
+        $this->assertFalse($v->passes());
+        $v->setData(['id' => 3]);
+        $this->assertTrue($v->passes());
+        $v->setData(['id' => 4]);
+        $this->assertFalse($v->passes());
+    }
+
+    protected function createSchema()
+    {
+        $this->schema('default')->create('users', function($table) {
+            $table->unsignedInteger('id');
+            $table->string('type');
+        });
+    }
+
+    /**
+     * Get a schema builder instance.
+     *
+     * @return \Illuminate\Database\Schema\Builder
+     */
+    protected function schema($connection = 'default')
+    {
+        return $this->connection($connection)->getSchemaBuilder();
+    }
+
+    /**
+     * Get a database connection instance.
+     *
+     * @return \Illuminate\Database\Connection
+     */
+    protected function connection($connection = 'default')
+    {
+        return $this->getConnectionResolver()->connection($connection);
+    }
+
+    /**
+     * Get connection resolver
+     *
+     * @return \Illuminate\Database\ConnectionResolverInterface
+     */
+    protected function getConnectionResolver()
+    {
+        return Eloquent::getConnectionResolver();
+    }
+
+    /**
+     * Tear down the database schema.
+     *
+     * @return void
+     */
+    public function tearDown()
+    {
+        $this->schema('default')->drop('users');
+    }
+
+    public function getIlluminateArrayTranslator()
+    {
+        return new \Illuminate\Translation\Translator(
+            new \Illuminate\Translation\ArrayLoader, 'en'
+        );
+    }
+}
+
+/**
+ * Eloquent Models
+ */
+class EloquentTestUser extends Eloquent
+{
+    protected $table = 'users';
+    protected $guarded = [];
+    public $timestamps = false;
 }


### PR DESCRIPTION
Allow to use multiple callbacks and allow to use `whereIn` and `whereNotIn` constraints. 

Before it was not possible to use multiple callbacks - the later was always overriding the previous one so this might be breaking in case someone added multiple callbacks and now all of them will start working.