### PR TITLE
[5.4] Add support for callables in model factories attributes

### DIFF
--- a/src/Illuminate/Database/Eloquent/FactoryBuilder.php
+++ b/src/Illuminate/Database/Eloquent/FactoryBuilder.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Database\Eloquent;
 
-use Closure;
 use Faker\Generator as Faker;
 use InvalidArgumentException;
 use Illuminate\Support\Traits\Macroable;
@@ -265,7 +264,7 @@ class FactoryBuilder
     protected function expandAttributes(array $attributes)
     {
         foreach ($attributes as &$attribute) {
-            if ($attribute instanceof Closure) {
+            if (is_callable($attribute)) {
                 $attribute = $attribute($attributes);
             }
 


### PR DESCRIPTION
@scrubmx and i were tinkering with the model factories and we discovered that even though there is no support for the usage of any type of callables in the factory definition, this was easy to implement and opens the possibility to interesting patterns. We also found a precedent in https://github.com/laravel/framework/pull/18264 of this behavior so we wanted to give it a shot.

If accepted, this will allow:

Simple callbacks:
```php
$factory->define(App\User::class, function () {
    return [
        'lorem' => function () {
            return 'ipsum';
        },
    ];
});
```

Object method calls:
```php
$factory->define(App\User::class, function () {
    return [
        'lorem' => [new App\Ipsum, 'create'],
    ];
});
```

Static class method calls:
```php
$factory->define(App\User::class, function () {
    return [
        'lorem' => 'App\Ipsum::create',
    ];
});
```

or classes implementing the `__invoke` magic method:
```php
namespace App;

class Ipsum
{
    public function __invoke()
    {
        return 'ipsum';
    }
}

// And then, in the model factories definitions:

$factory->define(App\User::class, function () {
    return [
        'lorem' => new App\Ipsum,
    ];
});
```
