### PR TITLE
[5.5] Add View::either method

### DIFF
--- a/src/Illuminate/View/Factory.php
+++ b/src/Illuminate/View/Factory.php
@@ -245,6 +245,23 @@ class Factory implements FactoryContract
     }
 
     /**
+     * Get the evaluated view contents for the given view, or for a fallback
+     * view if the given view doesn't exist.
+     *
+     * @param  string  $view
+     * @param  string  $fallback
+     * @param  array   $data
+     * @param  array   $mergeData
+     * @return \Illuminate\Contracts\View\View
+     */
+    public function either($view, $fallback, $data = [], $mergeData = [])
+    {
+        $view = $this->exists($view) ? $view : $fallback;
+
+        return $this->make($view, $data, $mergeData);
+    }
+
+    /**
      * Get the appropriate view engine for the given path.
      *
      * @param  string  $path


### PR DESCRIPTION
Adds a `View::either` method. `either` returns and instance of the first view if it exists, or the second if it doesn't.

```php
return view()->either("categories.{$category->slug}", 'categories.default', compact('category'));
```

Wrote this, then realized it didn't solve my current use case, but thought I might as well PR anyway 😅 