### PR TITLE
[5.5] Update index for faster job access

### DIFF
--- a/src/Illuminate/Queue/Console/stubs/jobs.stub
+++ b/src/Illuminate/Queue/Console/stubs/jobs.stub
@@ -15,14 +15,12 @@ class Create{{tableClassName}}Table extends Migration
     {
         Schema::create('{{table}}', function (Blueprint $table) {
             $table->bigIncrements('id');
-            $table->string('queue');
+            $table->string('queue')->index();
             $table->longText('payload');
             $table->unsignedTinyInteger('attempts');
             $table->unsignedInteger('reserved_at')->nullable();
             $table->unsignedInteger('available_at');
             $table->unsignedInteger('created_at');
-
-            $table->index(['queue', 'reserved_at']);
         });
     }
 


### PR DESCRIPTION
Including `reserved_at` in the index creates so many unique keys (being a timestamp) that MySQL simply ignores the index and uses the PRIMARY key instead.

This PR sets the index to the queue name only, the first field in the where condition of the query pulling jobs, ensuring the index is actually used. This greatly accelerates the query accessing jobs.

An alternative solution would be to leave the queue+reserved index and just add the additional index on the queue field, but there doesn't seem a reason to leave it... unless other db implementations would use it?