### PR TITLE
[5.4] Edit methods signatures on Http/UploadedFile

### DIFF
--- a/src/Illuminate/Http/UploadedFile.php
+++ b/src/Illuminate/Http/UploadedFile.php
@@ -26,7 +26,7 @@ class UploadedFile extends SymfonyUploadedFile
      * Store the uploaded file on a filesystem disk.
      *
      * @param  string  $path
-     * @param  array  $options
+     * @param  array|string  $options
      * @return string|false
      */
     public function store($path, $options = [])
@@ -38,7 +38,7 @@ class UploadedFile extends SymfonyUploadedFile
      * Store the uploaded file on a filesystem disk with public visibility.
      *
      * @param  string  $path
-     * @param  array  $options
+     * @param  array|string  $options
      * @return string|false
      */
     public function storePublicly($path, $options = [])
@@ -55,7 +55,7 @@ class UploadedFile extends SymfonyUploadedFile
      *
      * @param  string  $path
      * @param  string  $name
-     * @param  array  $options
+     * @param  array|string  $options
      * @return string|false
      */
     public function storePubliclyAs($path, $name, $options = [])
@@ -72,7 +72,7 @@ class UploadedFile extends SymfonyUploadedFile
      *
      * @param  string  $path
      * @param  string  $name
-     * @param  array  $options
+     * @param  array|string  $options
      * @return string|false
      */
     public function storeAs($path, $name, $options = [])


### PR DESCRIPTION
on Http/UploadedFile, the public methods `store`,  `storePublicly`, `storePubliclyAs`, `storeAs`, have the parameter `array $options` while it accepts a `string` (short fort `['disk'=>'the-string']`) so it will be parsed anyway by [parseOptions](https://github.com/laravel/framework/blob/504bcffdb0b8ca23c5382067633318a699868ab5/src/Illuminate/Http/UploadedFile.php#L111) which have the signature `array|string $options`.

Now it's all `array|string $options`.

