### PR TITLE
Fixes in Auth/Console

### DIFF
--- a/src/Illuminate/Auth/Console/stubs/make/views/auth/login.stub
+++ b/src/Illuminate/Auth/Console/stubs/make/views/auth/login.stub
@@ -6,6 +6,7 @@
         <div class="col-md-8 col-md-offset-2">
             <div class="panel panel-default">
                 <div class="panel-heading">Login</div>
+
                 <div class="panel-body">
                     <form class="form-horizontal" method="POST" action="{{ route('login') }}">
                         {{ csrf_field() }}

--- a/src/Illuminate/Auth/Console/stubs/make/views/auth/passwords/email.stub
+++ b/src/Illuminate/Auth/Console/stubs/make/views/auth/passwords/email.stub
@@ -6,6 +6,7 @@
         <div class="col-md-8 col-md-offset-2">
             <div class="panel panel-default">
                 <div class="panel-heading">Reset Password</div>
+
                 <div class="panel-body">
                     @if (session('status'))
                         <div class="alert alert-success">

--- a/src/Illuminate/Auth/Console/stubs/make/views/auth/passwords/reset.stub
+++ b/src/Illuminate/Auth/Console/stubs/make/views/auth/passwords/reset.stub
@@ -8,12 +8,6 @@
                 <div class="panel-heading">Reset Password</div>
 
                 <div class="panel-body">
-                    @if (session('status'))
-                        <div class="alert alert-success">
-                            {{ session('status') }}
-                        </div>
-                    @endif
-
                     <form class="form-horizontal" method="POST" action="{{ route('password.request') }}">
                         {{ csrf_field() }}
 

--- a/src/Illuminate/Auth/Console/stubs/make/views/auth/register.stub
+++ b/src/Illuminate/Auth/Console/stubs/make/views/auth/register.stub
@@ -6,6 +6,7 @@
         <div class="col-md-8 col-md-offset-2">
             <div class="panel panel-default">
                 <div class="panel-heading">Register</div>
+
                 <div class="panel-body">
                     <form class="form-horizontal" method="POST" action="{{ route('register') }}">
                         {{ csrf_field() }}

--- a/src/Illuminate/Auth/Console/stubs/make/views/home.stub
+++ b/src/Illuminate/Auth/Console/stubs/make/views/home.stub
@@ -8,6 +8,12 @@
                 <div class="panel-heading">Dashboard</div>
 
                 <div class="panel-body">
+                    @if (session('status'))
+                        <div class="alert alert-success">
+                            {{ session('status') }}
+                        </div>
+                    @endif
+
                     You are logged in!
                 </div>
             </div>


### PR DESCRIPTION
- Fixes success message after password reset.

The passwords/reset stub was handling a success status message stored in session, but there isn't a flow that redirects to that view with said message since the user is authenticated and redirected into the application itself when the password is successfully changed. This commit moves the status message from the passwords/reset.stub to the home.stub so it's clear to the user that his password was changed once he is logged in.

- Fixes spacing between elements for some stubs.

The spacing was inconsistent between views that were using the same element. I just added some spacing to fix it.
