### PR TITLE
[5.4] Use Instance instead of Deferred Provider

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -721,7 +721,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     {
         $abstract = $this->getAlias($abstract);
 
-        if (isset($this->deferredServices[$abstract])) {
+        if (isset($this->deferredServices[$abstract]) && !isset($this->instances[$abstract])) {
             $this->loadDeferredProvider($abstract);
         }
 

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -721,7 +721,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     {
         $abstract = $this->getAlias($abstract);
 
-        if (isset($this->deferredServices[$abstract]) && !isset($this->instances[$abstract])) {
+        if (isset($this->deferredServices[$abstract]) && ! isset($this->instances[$abstract])) {
             $this->loadDeferredProvider($abstract);
         }
 

--- a/tests/Foundation/FoundationApplicationTest.php
+++ b/tests/Foundation/FoundationApplicationTest.php
@@ -88,6 +88,15 @@ class FoundationApplicationTest extends TestCase
         $this->assertEquals(1, ApplicationDeferredServiceProviderCountStub::$count);
     }
 
+    public function testDeferredServiceDontRunWhenInstanceSet()
+    {
+        $app = new Application;
+        $app->setDeferredServices(['foo' => 'Illuminate\Tests\Foundation\ApplicationDeferredServiceProviderStub']);
+        $app->instance('foo', 'bar');
+        $instance = $app->make('foo');
+        $this->assertEquals($instance, 'bar');
+    }
+
     public function testDeferredServicesAreLazilyInitialized()
     {
         ApplicationDeferredServiceProviderStub::$initialized = false;


### PR DESCRIPTION
When calling app()->instance('foo','bar'), if there's a deferred service provider registered for class foo,
the deferred provider gets called and overrides the instance that was just set.  This means that if you have

app()->bind('foo','foo); // in a deferred service provider

and you run the following as the first reference to 'foo'

app()->instance('foo','bar');
$instance = app()->make('foo');

$instance = 'foo' instead of 'bar'

Added an additional condition to Application->make to check to see if an instance for that $abstract as already been set and skip loading the deferred provider if it does.


This issue tends to crop up most when writing tests, since the call to app()->instance is likely the first time the container will have to resolve the binding and overriding a binding with a particular instance of a Mock is common.  
