### PR TITLE
load commands from folder residing inside custom packages

### DIFF
--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -3,6 +3,8 @@
 namespace Illuminate\Support;
 
 use Illuminate\Console\Application as Artisan;
+use Symfony\Component\Finder\Finder;
+use Illuminate\Console\Command;
 
 abstract class ServiceProvider
 {
@@ -114,6 +116,40 @@ abstract class ServiceProvider
             }
         });
     }
+    
+    /**
+     * Register all of the commands in the given directory.
+     *
+     * @param  array|string  $paths
+     * @return void
+     */
+    protected function loadCommandsFrom($paths, $namespace)
+    {
+        $paths = array_unique(is_array($paths) ? $paths : (array) $paths);
+
+        $paths = array_filter($paths, function ($path) {
+            return is_dir($path);
+        });
+
+        if (empty($paths)) {
+            return;
+        }
+
+        foreach ((new Finder)->in($paths)->files() as $command) {
+
+            $command = $namespace.str_replace(
+                    ['/', '.php'],
+                    ['\\', ''],
+                    basename($command)
+                );
+
+            if (is_subclass_of($command, Command::class)) {
+                Artisan::starting(function ($artisan) use ($command) {
+                    $artisan->resolve($command);
+                });
+            }
+        }
+    }    
 
     /**
      * Register paths to be published by the publish command.


### PR DESCRIPTION
For more than a year now I've used packages (or modules as I call them) as part of my workflow.

Inside my modules I have a ServiceProvider which makes use of mergeConfigFrom, loadRoutesFrom, loadViewsFrom, loadMigrationsFrom, etc

My custom modules often include their own console commands and until now I've had to declare them manually

In Laravel 5.5 you can now scan a folder for all commands which is a very neat and time-saving addition.

I'm proposing that we add this functionality to the ServiceProvider so people like me can benefit from it

My modules are always under `base_path('modules/vendorname/packagename/')`

I require them in my composer.json and then add them under repositories as such:

```
    "repositories": {
        "vendorname/packagename": {
            "type": "path",
            "url": "./modules/vendorname/packagename"
        },
}
```

I've tested the above code in my module's service provider like so:

```
$this->loadCommandsFrom($this->modulePath . "/src/Console/Commands", $this->moduleNamespace . "\\Console\\Commands\\");
```

where `$this->modulePath = base_path('modules/vendorname/packagename')`
and `$this->moduleNamespace = "Vendorname\\Packagename"`

and it works, it scans all my commands without having to declare them one at a time