### PR TITLE
[5.4] Mailables that defined a delay property will honor it

### DIFF
--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -132,6 +132,10 @@ class Mailable implements MailableContract
      */
     public function queue(Queue $queue)
     {
+        if (property_exists($this, 'delay')) {
+            return $this->later($this->delay, $queue);
+        }
+
         $connection = property_exists($this, 'connection') ? $this->connection : null;
 
         $queueName = property_exists($this, 'queue') ? $this->queue : null;


### PR DESCRIPTION
This commit allows Mailables implementing `ShouldQueue` to define the `$delay` property in the Mailable class. This will allow to run `Mail::queue(new ExampleMailable));` and honor the delay.

I know you can just use the `Mail::later()` that will respect the defined value (or assigned with `$mailable->delay($delay)`) but if we're already implementing the `ShouldQueue` contract and even the generated Mailable class with the command makes use of the `Queueable` I don't see a reason why you should be forced to use `later()`.

This also allows to add a delay to any mailable class without having to specifically find where exactly we're sending the email. 