### PR TITLE
[5.5] Add keys to eachSpread and mapSpread callback

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -351,7 +351,9 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      */
     public function eachSpread(callable $callback)
     {
-        return $this->each(function ($chunk) use ($callback) {
+        return $this->each(function ($chunk, $key) use ($callback) {
+            array_push($chunk, $key);
+
             return $callback(...$chunk);
         });
     }
@@ -837,7 +839,9 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      */
     public function mapSpread(callable $callback)
     {
-        return $this->map(function ($chunk) use ($callback) {
+        return $this->map(function ($chunk, $key) use ($callback) {
+            array_push($chunk, $key);
+
             return $callback(...$chunk);
         });
     }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -587,6 +587,12 @@ class SupportCollectionTest extends TestCase
             return false;
         });
         $this->assertEquals([[1, 'a']], $result);
+
+        $result = [];
+        $c->eachSpread(function ($number, $character, $key) use (&$result) {
+            $result[] = [$number, $character, $key];
+        });
+        $this->assertEquals([[1, 'a', 0], [2, 'b', 1]], $result);
     }
 
     public function testIntersectNull()
@@ -1201,6 +1207,11 @@ class SupportCollectionTest extends TestCase
             return "{$number}-{$character}";
         });
         $this->assertEquals(['1-a', '2-b'], $result->all());
+
+        $result = $c->mapSpread(function ($number, $character, $key) use (&$result) {
+            return "{$number}-{$character}-{$key}";
+        });
+        $this->assertEquals(['1-a-0', '2-b-1'], $result->all());
     }
 
     public function testFlatMap()


### PR DESCRIPTION
This PR adds keys to the callback in `eachSpread` and `mapSpread` so they behave like their `each` and `map` counterparts.

This doesn't break any existing tests, but I think it'd be safest to hold off until 5.5.