### PR TITLE
Revert "[5.4] Add support for callables in model factories attributes"

### DIFF
--- a/src/Illuminate/Database/Eloquent/FactoryBuilder.php
+++ b/src/Illuminate/Database/Eloquent/FactoryBuilder.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Database\Eloquent;
 
+use Closure;
 use Faker\Generator as Faker;
 use InvalidArgumentException;
 use Illuminate\Support\Traits\Macroable;
@@ -264,7 +265,7 @@ class FactoryBuilder
     protected function expandAttributes(array $attributes)
     {
         foreach ($attributes as &$attribute) {
-            if (is_callable($attribute)) {
+            if ($attribute instanceof Closure) {
                 $attribute = $attribute($attributes);
             }
 


### PR DESCRIPTION
This is a breaking change.

Check: https://github.com/laravel/framework/issues/20718
Also: https://github.com/laravel/framework/pull/20692#issuecomment-324465166