### PR TITLE
[5.5] Add handleExceptions

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithExceptionHandling.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithExceptionHandling.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Foundation\Testing\Concerns;
 
 use Exception;
+use Illuminate\Validation\ValidationException;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Symfony\Component\Console\Application as ConsoleApplication;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -37,11 +38,41 @@ trait InteractsWithExceptionHandling
      */
     protected function withoutExceptionHandling()
     {
+        return $this->turnOffExceptionHandling();
+    }
+
+    /**
+     * @param  array  $exceptions
+     * @return $this
+     */
+    protected function handleExceptions(array $exceptions)
+    {
+        return $this->turnOffExceptionHandling($exceptions);
+    }
+
+    protected function handleValidationException()
+    {
+        return $this->handleExceptions([ValidationException::class]);
+    }
+
+    /**
+     * Disable exception handling for the test.
+     *
+     * @param  array  $except
+     * @return $this
+     */
+    protected function turnOffExceptionHandling(array $except = [])
+    {
         $this->previousExceptionHandler = app(ExceptionHandler::class);
 
-        $this->app->instance(ExceptionHandler::class, new class implements ExceptionHandler {
-            public function __construct()
+        $this->app->instance(ExceptionHandler::class, new class($this->previousExceptionHandler, $except) implements ExceptionHandler {
+            protected $except;
+            protected $previousHandler;
+
+            public function __construct($previousHandler, $except = [])
             {
+                $this->previousHandler = $previousHandler;
+                $this->except = $except;
             }
 
             public function report(Exception $e)
@@ -54,6 +85,12 @@ trait InteractsWithExceptionHandling
                     throw new NotFoundHttpException(
                         "{$request->method()} {$request->url()}", null, $e->getCode()
                     );
+                }
+
+                foreach ($this->except as $class) {
+                    if ($e instanceof $class) {
+                        return $this->previousHandler->render($request, $e);
+                    }
                 }
 
                 throw $e;


### PR DESCRIPTION
This method allows to deactivate the exception handling except for the given exceptions, that way, continuing with: https://github.com/laravel/framework/pull/20724 I can have a test like:

```
        $this->handleValidationException()->post('profile', [
            'twitter' => '@{sileence}'
        ])
        ->assertSessionHasErrors('twitter');
```

And if an exception is thrown (other than a validation exception) then I will get the error in the console. 

This way it is possible to get the best of both worlds?

Going further maybe I could add a handleExceptedException to throw an exception if the expected exception is not thrown (PHPUnit style)?

Or have some kind of wrapper like:

```
        $this->expectValidationErrors(['twitter'], function () {
            $this->post('profile', [
                'twitter' => '@{sileence}'
            ]);
        });
```
