### PR TITLE
[5.4] Add dropWhile method to Collection

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -276,6 +276,27 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
+     * Returns a new collection containing a slice of the original collection with elements
+     * dropped from the front. Drops items until the provided predicate returns false.
+     *
+     * @param  callable $predicate
+     *
+     * @return static
+     */
+    public function dropWhile(callable $predicate)
+    {
+        $index = $this->search(function ($item) use ($predicate) {
+            return !$predicate($item);
+        });
+
+        if ($index === false) {
+            return new static([]);
+        }
+
+        return $this->slice($index);
+    }
+
+    /**
      * Execute a callback over each item.
      *
      * @param  callable  $callback

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -286,7 +286,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     public function dropWhile(callable $predicate)
     {
         $index = $this->search(function ($item) use ($predicate) {
-            return !$predicate($item);
+            return ! $predicate($item);
         });
 
         if ($index === false) {

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2195,6 +2195,50 @@ class SupportCollectionTest extends TestCase
 
         $this->assertSame(['michael', 'tom', 'taylor'], $collection->toArray());
     }
+
+    public function testDropWhile()
+    {
+        $collection = new Collection([1, 2, 3, 4, 5]);
+
+        $result = $collection->dropWhile(function ($x) {
+            return $x < 3;
+        });
+
+        $this->assertSame([3, 4, 5], $result->values()->toArray());
+    }
+
+    public function testDropWhileWithEmptyList()
+    {
+        $collection = new Collection([]);
+
+        $result = $collection->dropWhile(function ($x) {
+            return $x < 3;
+        });
+
+        $this->assertSame([], $result->values()->toArray());
+    }
+
+    public function testDropWhileWithNoPredicateMatches()
+    {
+        $collection = new Collection([1, 2, 3, 4]);
+
+        $result = $collection->dropWhile(function ($x) {
+            return $x > 5;
+        });
+
+        $this->assertSame([1, 2, 3, 4], $result->values()->toArray());
+    }
+
+    public function testDropWhileWithAllPredicateMatches()
+    {
+        $collection = new Collection([1, 2, 3, 4]);
+
+        $result = $collection->dropWhile(function ($x) {
+            return $x < 5;
+        });
+
+        $this->assertSame([], $result->values()->toArray());
+    }
 }
 
 class TestSupportCollectionHigherOrderItem


### PR DESCRIPTION
Adds a `dropWhile` method to the `Illuminate\Support\Collection` class. `dropWhile` works by returning a new collection containing only a slice of the original collection with elements dropped from the front. The method drops items until the predicate function returns false.

## Example

```php
<?php

$collection = new Collection([3, 4, 1, 5, 2]);

$collection->dropWhile(function ($item) {
     return $item < 5;
})->toArray();

// [5, 2]
```