### PR TITLE
[5.5] Respect abstract classes in kernel->load()

### DIFF
--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -5,6 +5,7 @@ namespace Illuminate\Foundation\Console;
 use Closure;
 use Exception;
 use Throwable;
+use ReflectionClass;
 use Illuminate\Support\Str;
 use Illuminate\Console\Command;
 use Symfony\Component\Finder\Finder;
@@ -218,7 +219,7 @@ class Kernel implements KernelContract
                 Str::after($command->getPathname(), app_path().DIRECTORY_SEPARATOR)
             );
 
-            if (is_subclass_of($command, Command::class)) {
+            if (is_subclass_of($command, Command::class) && ! (new ReflectionClass($command))->isAbstract()) {
                 Artisan::starting(function ($artisan) use ($command) {
                     $artisan->resolve($command);
                 });

--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -5,6 +5,7 @@ namespace Illuminate\Foundation\Console;
 use Closure;
 use Exception;
 use Throwable;
+use ReflectionClass;
 use Illuminate\Support\Str;
 use Illuminate\Console\Command;
 use Symfony\Component\Finder\Finder;
@@ -224,7 +225,9 @@ class Kernel implements KernelContract
                     try {
                         $artisan->resolve($command);
                     } catch (ContainerExceptionInterface $e) {
-                        $this->reportException($e);
+                        if ((new ReflectionClass($command))->isInstantiable()) {
+                            $this->reportException($e);
+                        }
                     }
                 });
             }


### PR DESCRIPTION
If you happen to have an `abstract class BaseCommand extends \Illuminate\Console\Command` inside `app/Console/Commands` folder the whole cli app is broken.

```
$ php artisan
  [Illuminate\Contracts\Container\BindingResolutionException]
  Target [App\Console\Commands\BaseCommand] is not instantiable.
```

This PR fixes this issue.

Note: there is a more strict way to perform a check - http://php.net/manual/en/reflectionclass.isinstantiable.php but it looks like overkill to me