### PR TITLE
[5.4] Fix Model->toArray relations override attributes

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -897,7 +897,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public function toArray()
     {
-        return array_merge($this->attributesToArray(), $this->relationsToArray());
+        return $this->attributesToArray() + $this->relationsToArray();
     }
 
     /**


### PR DESCRIPTION
Eager loading relationship attribute conflict with the same name getXxxAttribute when calling toArray (#20743)