### PR TITLE
Adding mp3 to mime type property

### DIFF
--- a/src/Illuminate/Http/Testing/MimeType.php
+++ b/src/Illuminate/Http/Testing/MimeType.php
@@ -600,6 +600,7 @@ class MimeType
         'adp' => 'audio/adpcm',
         'au' => 'audio/basic',
         'mid' => 'audio/midi',
+        'mp3' => 'audio/mpeg',
         'mp4a' => 'audio/mp4',
         'mpga' => 'audio/mpeg',
         'oga' => 'audio/ogg',


### PR DESCRIPTION
I have a need to test uploading mp3's. The current implementation defaults an mp3 to `application/octet-stream` which won't pass validation. For this type of audio file.