### PR TITLE
[5.5] Allow for configuration of sticky databases

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -923,7 +923,11 @@ class Connection implements ConnectionInterface
      */
     public function getReadPdo()
     {
-        if ($this->transactions > 0 || $this->recordsModified) {
+        if ($this->transactions > 0) {
+            return $this->getPdo();
+        }
+
+        if ($this->getConfig('sticky') && $this->recordsModified) {
             return $this->getPdo();
         }
 


### PR DESCRIPTION
Allow https://github.com/laravel/framework/pull/20445 to be configurable

I can forsee edge cases where people might not want this functionality (i.e. doing a small write followed by unrelated large read in same request - such as an application that logs all user actions) - so we can easily make it configurable for those that want either behavior.

Also this way we preserve current behavior - because the config will be `null` on existing applications (since the value doesnt exist) - so this reduces risk of strange breaking behavior during a 5.5 upgrade.

Instead I propose to mention this new config option in the 5.5 upgrade guide, for those that *want* to enable it. And meanwhile I can do another PR for laravel/laravel to include it in the default config stack and in the docs.

I'll do the other PR's for you if this gets accepted.