### PR TITLE
[5.4] fix for broken rabbitmq connections in worker

### DIFF
--- a/src/Illuminate/Database/DetectsLostConnections.php
+++ b/src/Illuminate/Database/DetectsLostConnections.php
@@ -29,6 +29,7 @@ trait DetectsLostConnections
             'Error writing data to the connection',
             'Resource deadlock avoided',
             'Transaction() on null',
+            'Broken pipe or closed connection',
         ]);
     }
 }


### PR DESCRIPTION
If rabbitmq connection fails queue workers produce a lot of such errors and never restart