### PR TITLE
Proxy undefined query builder method calls to the results collection

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -4,7 +4,6 @@ namespace Illuminate\Database\Query;
 
 use Closure;
 use RuntimeException;
-use BadMethodCallException;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
@@ -2444,6 +2443,6 @@ class Builder
 
         $className = static::class;
 
-        throw new BadMethodCallException("Call to undefined method {$className}::{$method}()");
+        return $this->get()->{$method}(...$parameters);
     }
 }

--- a/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
@@ -552,7 +552,7 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
 
     /**
      * @expectedException \BadMethodCallException
-     * @expectedExceptionMessage Call to undefined method Illuminate\Database\Query\Builder::thisMethodDoesNotExist()
+     * @expectedExceptionMessage Method thisMethodDoesNotExist does not exist.
      */
     public function testMorphToWithBadMethodCall()
     {

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1826,11 +1826,13 @@ class DatabaseQueryBuilderTest extends TestCase
 
     /**
      * @expectedException \BadMethodCallException
-     * @expectedExceptionMessage Call to undefined method Illuminate\Database\Query\Builder::noValidMethodHere()
+     * @expectedExceptionMessage Method noValidMethodHere does not exist.
      */
     public function testBuilderThrowsExpectedExceptionWithUndefinedMethod()
     {
         $builder = $this->getBuilder();
+        $builder->getConnection()->shouldReceive('select');
+        $builder->getProcessor()->shouldReceive('processSelect')->andReturn([]);
 
         $builder->noValidMethodHere();
     }
@@ -2020,6 +2022,29 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder = $this->getSqlServerBuilder();
         $builder->select('*')->from('users(1,2)');
         $this->assertEquals('select * from [users](1,2)', $builder->toSql());
+    }
+
+    public function testUnresolvableCallsArePassedToResultsCollection()
+    {
+        $builder = $this->getBuilder();
+        $builder->getProcessor()
+            ->shouldReceive('processSelect')
+            ->andReturn([tap(new \StdClass, function ($item) {
+                $item->first_name = 'Taylor';
+                $item->last_name = 'Otwell';
+            })]);
+        $builder->getConnection()->shouldReceive('select');
+
+        $results = $builder->select('*')->from('users')
+            ->map(function ($user) {
+                return [
+                    'name' => $user->first_name.' '.$user->last_name,
+                ];
+            });
+
+        $this->assertInstanceOf(\Illuminate\Support\Collection::class, $results);
+        $this->assertCount(1, $results);
+        $this->assertEquals(['name' => 'Taylor Otwell'], $results->first());
     }
 
     public function testChunkWithLastChunkComplete()


### PR DESCRIPTION
This PR makes the QB ever so slightly easier to use, by proxying all unknown method calls to the results collection (from calling `get`). This means that:

```
DB::select('*')
    ->from('users')
    ->get()
    ->map(function ($user) {
        $user = (array) $user;
        $user['name'] = $user['first_name'].' '.$user['last_name'];

        return $user;
    });
```
becomes

```
DB::select('*')
    ->from('users')
    ->map(function ($user) {
        $user = (array) $user;
        $user['name'] = $user['first_name'].' '.$user['last_name'];

        return $user;
    });
```

Yes, it's a small thing, but it's a convenience I believe people will find useful.