### PR TITLE
[5.4] FIX: Change version of doctrine/inflector

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "php": ">=5.6.4",
         "ext-mbstring": "*",
         "ext-openssl": "*",
-        "doctrine/inflector": "~1.1",
+        "doctrine/inflector": "1.1",
         "erusev/parsedown": "~1.6",
         "league/flysystem": "~1.0",
         "monolog/monolog": "~1.11",


### PR DESCRIPTION
Doctrine have recently released a new version of doctrine/inflector at version 1.2.

This introduced a breaking change which requires PHP7.1. This pull request changes the composer.json to only use the 1.1 version, as opposed to the new 1.2 release which breaks everything - if you are not using PHP7.1