### PR TITLE
[5.4] Add ability to use a get{Trait}Dates() function on eloquent model traits

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -765,9 +765,27 @@ trait HasAttributes
     {
         $defaults = [static::CREATED_AT, static::UPDATED_AT];
 
+        $this->getDatesFromTraits($defaults);
+
         return $this->usesTimestamps()
                     ? array_unique(array_merge($this->dates, $defaults))
                     : $this->dates;
+    }
+
+    /**
+     * Get the attributes from traits that should be converted to dates.
+     *
+     * @return array
+     */
+    protected function getDatesFromTraits($defaults)
+    {
+        $class = static::class;
+
+        foreach (class_uses_recursive($class) as $trait) {
+            if (method_exists($class, $method = 'get'.class_basename($trait).'Dates')) {
+                $defaults = array_merge($defaults, $this->{$method}());
+            }
+        }
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/SoftDeletes.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletes.php
@@ -22,6 +22,16 @@ trait SoftDeletes
     }
 
     /**
+     * Get the attributes that should be converted to dates.
+     *
+     * @return array
+     */
+    public function getSoftDeletesDates()
+    {
+        return ['deleted_at'];
+    }
+
+    /**
      * Force a hard delete on a soft deleted model.
      *
      * @return bool|null

--- a/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
@@ -93,6 +93,20 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
     /**
      * Tests...
      */
+    public function testNonSoftDeletingModelDoesNotHaveDeletedAtColumnInGetDates()
+    {
+        $abigail = TestUserWithoutSoftDelete::create(['id' => 1, 'email' =>'abigailotwell@gmail.com']);
+
+        $this->assertNotContains('deleted_at', $abigail->getDates());
+    }
+
+    public function testSoftDeletingModelHasDeletedAtColumnInGetDates()
+    {
+        $taylor = SoftDeletesTestUser::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']);
+
+        $this->assertContains('deleted_at', $taylor->getDates());
+    }
+
     public function testSoftDeletesAreNotRetrieved()
     {
         $this->createUsers();


### PR DESCRIPTION
In the same way that we can use a `boot{Trait}()` method in a trait/concern for an eloquent model, it would be nice to be able to register specific date fields in a trait/concern (i.e. `Publishable` with a `published_at` timestamp column).

The end result of this pull request allows a developer to add a `get{Trait}Dates()` method to their trait/concern that returns an array of timestamp fields.

```php

trait Publishable
{
    public function getPublishableDates()
    {
        return ['published_at'];
    }

    // 
}
```

One benefit is that this solves the problem of wanting to override the `$dates` property in a trait, which of course is not possible.

As an example of this feature in action, I have added a `getSoftDeletesDates()` function to the `SoftDeletes` trait with a couple tests to verify. The major benefit is that there is now no need to worry about adding `$dates = ['deleted_at'];` in the app models.