### PR TITLE
[5.5] Make the requests throttler less aggressive

### DIFF
--- a/tests/Integration/Http/ThrottleRequestsTest.php
+++ b/tests/Integration/Http/ThrottleRequestsTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Http;
+
+use Illuminate\Support\Carbon;
+use Orchestra\Testbench\TestCase;
+use Illuminate\Support\Facades\Route;
+use Illuminate\Routing\Middleware\ThrottleRequests;
+
+/**
+ * @group integration
+ */
+class ThrottleRequestsTest extends TestCase
+{
+    protected function getEnvironmentSetUp($app)
+    {
+        $app['config']->set('cache.default', 'redis');
+    }
+
+    public function setup()
+    {
+        parent::setup();
+
+        resolve('redis')->flushall();
+    }
+
+    public function test_lock_opens_immediately_after_decay()
+    {
+        Route::get('/', function () {
+            return 'yes';
+        })->middleware(ThrottleRequests::class.':2,1');
+
+        $response = $this->withoutExceptionHandling()->get('/');
+        $this->assertEquals('yes', $response->getContent());
+        $this->assertEquals(2, $response->headers->get('X-RateLimit-Limit'));
+        $this->assertEquals(1, $response->headers->get('X-RateLimit-Remaining'));
+
+        $response = $this->withoutExceptionHandling()->get('/');
+        $this->assertEquals('yes', $response->getContent());
+        $this->assertEquals(2, $response->headers->get('X-RateLimit-Limit'));
+        $this->assertEquals(0, $response->headers->get('X-RateLimit-Remaining'));
+
+        Carbon::setTestNow(
+            Carbon::now()->addSeconds(58)
+        );
+
+        try{
+            $response = $this->withoutExceptionHandling()->get('/');
+        }catch(\Throwable $e){
+            $this->assertEquals(429, $e->getStatusCode());
+            $this->assertEquals(2, $e->getHeaders()['X-RateLimit-Limit']);
+            $this->assertEquals(0, $e->getHeaders()['X-RateLimit-Remaining']);
+            $this->assertEquals(2, $e->getHeaders()['Retry-After']);
+            $this->assertEquals(now()->timestamp + 2, $e->getHeaders()['X-RateLimit-Reset']);
+        }
+    }
+}

--- a/tests/Integration/Http/ThrottleRequestsTest.php
+++ b/tests/Integration/Http/ThrottleRequestsTest.php
@@ -44,9 +44,9 @@ class ThrottleRequestsTest extends TestCase
             Carbon::now()->addSeconds(58)
         );
 
-        try{
+        try {
             $response = $this->withoutExceptionHandling()->get('/');
-        }catch(\Throwable $e){
+        } catch (\Throwable $e) {
             $this->assertEquals(429, $e->getStatusCode());
             $this->assertEquals(2, $e->getHeaders()['X-RateLimit-Limit']);
             $this->assertEquals(0, $e->getHeaders()['X-RateLimit-Remaining']);

--- a/tests/Integration/Http/ThrottleRequestsTest.php
+++ b/tests/Integration/Http/ThrottleRequestsTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Http;
+
+use Illuminate\Routing\Middleware\ThrottleRequests;
+use JsonSerializable;
+use Orchestra\Testbench\TestCase;
+use Illuminate\Support\Facades\Route;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Http\Resources\Json\Resource;
+use Illuminate\Pagination\LengthAwarePaginator;
+use Illuminate\Http\Resources\Json\ResourceCollection;
+
+/**
+ * @group integration
+ */
+class ThrottleRequestsTest extends TestCase
+{
+    protected function getEnvironmentSetUp($app)
+    {
+        $app['config']->set('cache.default', 'redis');
+    }
+
+    public function setup()
+    {
+        parent::setup();
+
+        resolve('redis')->flushall();
+    }
+
+    public function test_resources_may_be_converted_to_json()
+    {
+        Route::get('/', function () {
+            return 'yes';
+        })->middleware(ThrottleRequests::class.':2,1');
+
+        $response = $this->withoutExceptionHandling()->get('/');
+        $this->assertEquals('yes', $response->getContent());
+        $this->assertEquals(2, $response->headers->get('X-RateLimit-Limit'));
+        $this->assertEquals(1, $response->headers->get('X-RateLimit-Remaining'));
+
+        $response = $this->withoutExceptionHandling()->get('/');
+        $this->assertEquals('yes', $response->getContent());
+        $this->assertEquals(2, $response->headers->get('X-RateLimit-Limit'));
+        $this->assertEquals(0, $response->headers->get('X-RateLimit-Remaining'));
+
+        try{
+            $response = $this->withoutExceptionHandling()->get('/');
+        }catch(\Throwable $e){
+            $this->assertEquals(429, $e->getStatusCode());
+            $this->assertEquals(2, $e->getHeaders()['X-RateLimit-Limit']);
+            $this->assertEquals(0, $e->getHeaders()['X-RateLimit-Remaining']);
+            $this->assertEquals(60, $e->getHeaders()['Retry-After']);
+        }
+    }
+}


### PR DESCRIPTION
Currently if you have 10 requests per minute and at second :59 of the minute you hit the limit you'll have to wait another 1 minute until the lock is released.

In this PR the bucket is reset at the end of the duration set for the limiter, so if you hit the limit at :59 you can send a new request at :00 again.