### PR TITLE
[5.5] Throttle requests with Redis

### DIFF
--- a/src/Illuminate/Redis/Limiters/DurationLimiter.php
+++ b/src/Illuminate/Redis/Limiters/DurationLimiter.php
@@ -36,15 +36,15 @@ class DurationLimiter
 
     /**
      * The timestamp of the end of the current duration.
-     * 
-     * @var integer
+     *
+     * @var int
      */
     public $decaysAt;
 
     /**
      * The number of remaining slots.
-     * 
-     * @var integer
+     *
+     * @var int
      */
     public $remaining;
 
@@ -104,7 +104,7 @@ class DurationLimiter
         );
 
         $this->decaysAt = $results[1];
-        
+
         $this->remaining = max(0, $results[2]);
 
         return (bool) $results[0];

--- a/src/Illuminate/Redis/Limiters/DurationLimiter.php
+++ b/src/Illuminate/Redis/Limiters/DurationLimiter.php
@@ -35,6 +35,20 @@ class DurationLimiter
     private $decay;
 
     /**
+     * The timestamp of the end of the current duration.
+     * 
+     * @var integer
+     */
+    public $decaysAt;
+
+    /**
+     * The number of remaining slots.
+     * 
+     * @var integer
+     */
+    public $remaining;
+
+    /**
      * Create a new duration limiter instance.
      *
      * @param  \Illuminate\Redis\Connections\Connection $redis
@@ -81,13 +95,19 @@ class DurationLimiter
     /**
      * Attempt to acquire the lock.
      *
-     * @return mixed
+     * @return bool
      */
-    protected function acquire()
+    public function acquire()
     {
-        return $this->redis->eval($this->luaScript(), 1,
+        $results = $this->redis->eval($this->luaScript(), 1,
             $this->name, microtime(true), time(), $this->decay, $this->maxLocks
         );
+
+        $this->decaysAt = $results[1];
+        
+        $this->remaining = max(0, $results[2]);
+
+        return (bool) $results[0];
     }
 
     /**
@@ -110,14 +130,18 @@ local function reset()
 end
 
 if redis.call('EXISTS', KEYS[1]) == 0 then
-    return reset()
+    return {reset(), ARGV[2] + ARGV[3], ARGV[4] - 1}
 end
 
 if ARGV[1] >= redis.call('HGET', KEYS[1], 'start') and ARGV[1] <= redis.call('HGET', KEYS[1], 'end') then
-    return tonumber(redis.call('HINCRBY', KEYS[1], 'count', 1)) <= tonumber(ARGV[4])
+    return {
+        tonumber(redis.call('HINCRBY', KEYS[1], 'count', 1)) <= tonumber(ARGV[4]),
+        redis.call('HGET', KEYS[1], 'end'),
+        ARGV[4] - redis.call('HGET', KEYS[1], 'count')
+    }
 end
 
-return reset()
+return {reset(), ARGV[2] + ARGV[3], ARGV[4] - 1}
 LUA;
     }
 }

--- a/src/Illuminate/Routing/Middleware/ThrottleRequestsWithRedis.php
+++ b/src/Illuminate/Routing/Middleware/ThrottleRequestsWithRedis.php
@@ -1,0 +1,216 @@
+<?php
+
+namespace Illuminate\Routing\Middleware;
+
+use Closure;
+use RuntimeException;
+use Illuminate\Support\Str;
+use Illuminate\Support\InteractsWithTime;
+use Illuminate\Redis\Limiters\DurationLimiter;
+use Symfony\Component\HttpFoundation\Response;
+use Illuminate\Contracts\Redis\Factory as Redis;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+class ThrottleRequestsWithRedis
+{
+    use InteractsWithTime;
+
+    /**
+     * The Redis factory implementation.
+     *
+     * @var \Illuminate\Contracts\Redis\Factory
+     */
+    protected $redis;
+
+    /**
+     * The timestamp of the end of the current duration.
+     *
+     * @var integer
+     */
+    public $decaysAt;
+
+    /**
+     * The number of remaining slots.
+     *
+     * @var integer
+     */
+    public $remaining;
+
+    /**
+     * Create a new request throttler.
+     *
+     * @param  \Illuminate\Contracts\Redis\Factory  $redis
+     * @return void
+     */
+    public function __construct(Redis $redis)
+    {
+        $this->redis = $redis;
+    }
+
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @param  int|string  $maxAttempts
+     * @param  float|int  $decayMinutes
+     * @return mixed
+     * @throws \Symfony\Component\HttpKernel\Exception\HttpException
+     */
+    public function handle($request, Closure $next, $maxAttempts = 60, $decayMinutes = 1)
+    {
+        $key = $this->resolveRequestSignature($request);
+
+        $maxAttempts = $this->resolveMaxAttempts($request, $maxAttempts);
+
+        if ($this->tooManyAttempts($key, $maxAttempts, $decayMinutes)) {
+            throw $this->buildException($key, $maxAttempts);
+        }
+
+        $response = $next($request);
+
+        return $this->addHeaders(
+            $response, $maxAttempts,
+            $this->calculateRemainingAttempts($key, $maxAttempts)
+        );
+    }
+
+    /**
+     * Resolve the number of attempts if the user is authenticated or not.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  int|string  $maxAttempts
+     * @return int
+     */
+    protected function resolveMaxAttempts($request, $maxAttempts)
+    {
+        if (Str::contains($maxAttempts, '|')) {
+            $maxAttempts = explode('|', $maxAttempts, 2)[$request->user() ? 1 : 0];
+        }
+
+        return (int) $maxAttempts;
+    }
+
+    /**
+     * Resolve request signature.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return string
+     * @throws \RuntimeException
+     */
+    protected function resolveRequestSignature($request)
+    {
+        if ($user = $request->user()) {
+            return sha1($user->getAuthIdentifier());
+        }
+
+        if ($route = $request->route()) {
+            return sha1($route->getDomain().'|'.$request->ip());
+        }
+
+        throw new RuntimeException(
+            'Unable to generate the request signature. Route unavailable.'
+        );
+    }
+
+    /**
+     * Create a 'too many attempts' exception.
+     *
+     * @param  string  $key
+     * @param  int  $maxAttempts
+     * @return \Symfony\Component\HttpKernel\Exception\HttpException
+     */
+    protected function buildException($key, $maxAttempts)
+    {
+        $retryAfter = $this->decaysAt - $this->currentTime();
+
+        $headers = $this->getHeaders(
+            $maxAttempts,
+            $this->calculateRemainingAttempts($key, $maxAttempts, $retryAfter),
+            $retryAfter
+        );
+
+        return new HttpException(
+            429, 'Too Many Attempts.', null, $headers
+        );
+    }
+
+    /**
+     * Add the limit header information to the given response.
+     *
+     * @param  \Symfony\Component\HttpFoundation\Response  $response
+     * @param  int  $maxAttempts
+     * @param  int  $remainingAttempts
+     * @param  int|null  $retryAfter
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    protected function addHeaders(Response $response, $maxAttempts, $remainingAttempts, $retryAfter = null)
+    {
+        $response->headers->add(
+            $this->getHeaders($maxAttempts, $remainingAttempts, $retryAfter)
+        );
+
+        return $response;
+    }
+
+    /**
+     * Get the limit headers information.
+     *
+     * @param  int  $maxAttempts
+     * @param  int  $remainingAttempts
+     * @param  int|null  $retryAfter
+     * @return array
+     */
+    protected function getHeaders($maxAttempts, $remainingAttempts, $retryAfter = null)
+    {
+        $headers = [
+            'X-RateLimit-Limit' => $maxAttempts,
+            'X-RateLimit-Remaining' => $remainingAttempts,
+        ];
+
+        if (! is_null($retryAfter)) {
+            $headers['Retry-After'] = $retryAfter;
+            $headers['X-RateLimit-Reset'] = $this->availableAt($retryAfter);
+        }
+
+        return $headers;
+    }
+
+    /**
+     * Calculate the number of remaining attempts.
+     *
+     * @param  string  $key
+     * @param  int  $maxAttempts
+     * @param  int|null  $retryAfter
+     * @return int
+     */
+    protected function calculateRemainingAttempts($key, $maxAttempts, $retryAfter = null)
+    {
+        if (is_null($retryAfter)) {
+            return $this->remaining;
+        }
+
+        return 0;
+    }
+
+    /**
+     * Determine if the given key has been "accessed" too many times.
+     *
+     * @param  string  $key
+     * @param  int  $maxAttempts
+     * @param  int  $decayMinutes
+     * @return mixed
+     */
+    protected function tooManyAttempts($key, $maxAttempts, $decayMinutes)
+    {
+        $limiter = (new DurationLimiter($this->redis, $key, $maxAttempts, $decayMinutes * 60));
+
+        $attempt = $limiter->acquire();
+
+        $this->decaysAt = $limiter->decaysAt;
+
+        $this->remaining = $limiter->remaining;
+
+        return !$attempt;
+    }
+}

--- a/src/Illuminate/Routing/Middleware/ThrottleRequestsWithRedis.php
+++ b/src/Illuminate/Routing/Middleware/ThrottleRequestsWithRedis.php
@@ -25,14 +25,14 @@ class ThrottleRequestsWithRedis
     /**
      * The timestamp of the end of the current duration.
      *
-     * @var integer
+     * @var int
      */
     public $decaysAt;
 
     /**
      * The number of remaining slots.
      *
-     * @var integer
+     * @var int
      */
     public $remaining;
 

--- a/tests/Integration/Http/ThrottleRequestsWithRedisTest.php
+++ b/tests/Integration/Http/ThrottleRequestsWithRedisTest.php
@@ -5,32 +5,22 @@ namespace Illuminate\Tests\Integration\Http;
 use Illuminate\Support\Carbon;
 use Orchestra\Testbench\TestCase;
 use Illuminate\Support\Facades\Route;
-use Illuminate\Routing\Middleware\ThrottleRequests;
+use Illuminate\Routing\Middleware\ThrottleRequestsWithRedis;
 
 /**
  * @group integration
  */
-class ThrottleRequestsTest extends TestCase
+class ThrottleRequestsWithRedisTest extends TestCase
 {
-    protected function getEnvironmentSetUp($app)
-    {
-        $app['config']->set('cache.default', 'redis');
-    }
-
-    public function setup()
-    {
-        parent::setup();
-
-        resolve('redis')->flushall();
-    }
-
     public function test_lock_opens_immediately_after_decay()
     {
         Carbon::setTestNow(null);
         
+        resolve('redis')->flushall();
+
         Route::get('/', function () {
             return 'yes';
-        })->middleware(ThrottleRequests::class.':2,1');
+        })->middleware(ThrottleRequestsWithRedis::class.':2,1');
 
         $response = $this->withoutExceptionHandling()->get('/');
         $this->assertEquals('yes', $response->getContent());
@@ -52,8 +42,8 @@ class ThrottleRequestsTest extends TestCase
             $this->assertEquals(429, $e->getStatusCode());
             $this->assertEquals(2, $e->getHeaders()['X-RateLimit-Limit']);
             $this->assertEquals(0, $e->getHeaders()['X-RateLimit-Remaining']);
-            $this->assertEquals(2, $e->getHeaders()['Retry-After']);
-            $this->assertEquals(now()->timestamp + 2, $e->getHeaders()['X-RateLimit-Reset']);
+            $this->assertTrue(in_array($e->getHeaders()['Retry-After'], [2,3]));
+            $this->assertTrue(in_array($e->getHeaders()['X-RateLimit-Reset'], [now()->timestamp + 2, now()->timestamp + 3]));
         }
     }
 }

--- a/tests/Integration/Http/ThrottleRequestsWithRedisTest.php
+++ b/tests/Integration/Http/ThrottleRequestsWithRedisTest.php
@@ -15,7 +15,7 @@ class ThrottleRequestsWithRedisTest extends TestCase
     public function test_lock_opens_immediately_after_decay()
     {
         Carbon::setTestNow(null);
-        
+
         resolve('redis')->flushall();
 
         Route::get('/', function () {
@@ -42,7 +42,7 @@ class ThrottleRequestsWithRedisTest extends TestCase
             $this->assertEquals(429, $e->getStatusCode());
             $this->assertEquals(2, $e->getHeaders()['X-RateLimit-Limit']);
             $this->assertEquals(0, $e->getHeaders()['X-RateLimit-Remaining']);
-            $this->assertTrue(in_array($e->getHeaders()['Retry-After'], [2,3]));
+            $this->assertTrue(in_array($e->getHeaders()['Retry-After'], [2, 3]));
             $this->assertTrue(in_array($e->getHeaders()['X-RateLimit-Reset'], [now()->timestamp + 2, now()->timestamp + 3]));
         }
     }


### PR DESCRIPTION
The normal Request throttler needs more roundtrips to Redis to achieve its purpose, this one is more efficient and more accurate since the whole process is atomic.

- Normal throttle sends 5 commands to Redis.
- This one only sends 1

With a great number of requests to the application this could exhaust resources.