### PR TITLE
[5.4] add `next` and `previous` methods to collection

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -906,6 +906,30 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
+     * Get the item after the searched item.
+     *
+     * @param  string  $value
+     * @param  bool    $strict
+     * @return mixed|null
+     */
+    public function next($value, $strict = false)
+    {
+        if (!$key = $this->search($value, $strict)) {
+            return null;
+        }
+
+        $keys = array_keys($this->items);
+
+        $nextKey = array_search($key, $keys) + 1;
+
+        if ($nextKey >= count($keys)) {
+            return null;
+        }
+
+        return $this->items[$keys[$nextKey]];
+    }
+
+    /**
      * Create a new collection consisting of every n-th element.
      *
      * @param  int  $step
@@ -1010,6 +1034,30 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
         $this->items = Arr::prepend($this->items, $value, $key);
 
         return $this;
+    }
+
+    /**
+     * Get the item before the searched item.
+     *
+     * @param  string  $value
+     * @param  bool    $strict
+     * @return mixed|null
+     */
+    public function previous($value, $strict = false)
+    {
+        if (!$key = $this->search($value, $strict)) {
+            return null;
+        }
+
+        $keys = array_keys($this->items);
+
+        $previousKey = array_search($key, $keys) - 1;
+
+        if ($previousKey < 0) {
+            return null;
+        }
+
+        return $this->items[$keys[$previousKey]];
     }
 
     /**

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -914,7 +914,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      */
     public function next($value, $strict = false)
     {
-        if (!$key = $this->search($value, $strict)) {
+        if (! $key = $this->search($value, $strict)) {
             return null;
         }
 
@@ -1045,7 +1045,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      */
     public function previous($value, $strict = false)
     {
-        if (!$key = $this->search($value, $strict)) {
+        if (! $key = $this->search($value, $strict)) {
             return null;
         }
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2195,6 +2195,64 @@ class SupportCollectionTest extends TestCase
 
         $this->assertSame(['michael', 'tom', 'taylor'], $collection->toArray());
     }
+
+    public function testNext()
+    {
+        $collection = new Collection(['wind' => 'blows', 'rain' => 'falls', 'fire' => 'burns', 1 => 'leeloo', 5 => 'korben']);
+
+        $fire = $collection->next('falls');
+        $five = $collection->next('leeloo');
+
+        $this->assertSame('burns', $fire);
+        $this->assertSame('korben', $five);
+    }
+
+    public function testNextReturnsNullAtTheEnd()
+    {
+        $collection = new Collection(['wind' => 'blows', 'rain' => 'falls', 'fire' => 'burns', 1 => 'leeloo', 5 => 'korben']);
+
+        $next = $collection->next('korben');
+
+        $this->assertNull($next);
+    }
+
+    public function testNextReturnsNullWhenValueIsNotFound()
+    {
+        $collection = new Collection(['wind' => 'blows', 'rain' => 'falls', 'fire' => 'burns', 1 => 'leeloo', 5 => 'korben']);
+
+        $next = $collection->next('dne');
+
+        $this->assertNull($next);
+    }
+
+    public function testPrevious()
+    {
+        $collection = new Collection(['wind' => 'blows', 'rain' => 'falls', 'fire' => 'burns', 1 => 'leeloo', 5 => 'korben']);
+
+        $wind = $collection->previous('falls');
+        $fire = $collection->previous('leeloo');
+
+        $this->assertSame('blows', $wind);
+        $this->assertSame('burns', $fire);
+    }
+
+    public function testPreviousReturnsNullAtTheBeginning()
+    {
+        $collection = new Collection(['wind' => 'blows', 'rain' => 'falls', 'fire' => 'burns', 1 => 'leeloo', 5 => 'korben']);
+
+        $previous = $collection->previous('blows');
+
+        $this->assertNull($previous);
+    }
+
+    public function testPreviousReturnsNullWhenValueIsNotFound()
+    {
+        $collection = new Collection(['wind' => 'blows', 'rain' => 'falls', 'fire' => 'burns', 1 => 'leeloo', 5 => 'korben']);
+
+        $previous = $collection->previous('dne');
+
+        $this->assertNull($previous);
+    }
 }
 
 class TestSupportCollectionHigherOrderItem


### PR DESCRIPTION
I have a page where managers of a team can view a list of the users on their team. Each user has a corresponding button to edit or delete them.  If I edit one of the users, and then need to make similar changes on all the other users, I must first go back to the list view, and then click into the new user.   I'd like an quicker way to navigate to the next or previous user in the list.   I cannot simply add or subtract 1 from the user ID because they may not be sequential.

---

This PR adds to new methods to the Collection that allow you to search for an item in a Collection and then return the previous or next item in the Collection.

```php

$users = collect(['Andy', 'Taylor', 'Mohamed']);

$users->next('Taylor'); --> returns Mohamed

$users->previous('Taylor') --> returns Andy
```

---

In order to account for associative and numeric keys, I create a numerically indexed array of the keys of the items.  This allows me to simply add or subtract 1 to find the next or previous key that I should use on the items.

---

Both methods also have checks to make sure you have not reached the beginning or end of the array, and both check to make sure your search result returns something.  If either of these fail, the methods will return `null`.

---

We simply pass through to the `search` method, so you can use either a value or a callback to search, and you may also pass the strict flag if you'd like.