### PR TITLE
[5.5] fixed a bug in app:name command

### DIFF
--- a/src/Illuminate/Foundation/Console/AppNameCommand.php
+++ b/src/Illuminate/Foundation/Console/AppNameCommand.php
@@ -223,17 +223,17 @@ class AppNameCommand extends Command
      */
     protected function setDatabaseFactoryNamespaces()
     {
-	    $files = Finder::create()
-		                    ->in($this->laravel->databasePath().'/factories')
-		                    ->contains($this->currentRoot)
-		                    ->name('*.php');
+        $files = Finder::create()
+                            ->in($this->laravel->databasePath().'/factories')
+                            ->contains($this->currentRoot)
+                            ->name('*.php');
 
-	    foreach ($files as $file) {
-		    $this->replaceIn(
-			    $file->getRealPath(),
-			    $this->currentRoot, $this->argument('name')
-		    );
-	    }
+        foreach ($files as $file) {
+            $this->replaceIn(
+                $file->getRealPath(),
+                $this->currentRoot, $this->argument('name')
+            );
+        }
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/AppNameCommand.php
+++ b/src/Illuminate/Foundation/Console/AppNameCommand.php
@@ -223,10 +223,17 @@ class AppNameCommand extends Command
      */
     protected function setDatabaseFactoryNamespaces()
     {
-        $this->replaceIn(
-            $this->laravel->databasePath().'/factories/ModelFactory.php',
-            $this->currentRoot, $this->argument('name')
-        );
+	    $files = Finder::create()
+		                    ->in($this->laravel->databasePath().'/factories')
+		                    ->contains($this->currentRoot)
+		                    ->name('*.php');
+
+	    foreach ($files as $file) {
+		    $this->replaceIn(
+			    $file->getRealPath(),
+			    $this->currentRoot, $this->argument('name')
+		    );
+	    }
     }
 
     /**


### PR DESCRIPTION
- Laravel Version: 5.5-dev
- PHP Version: >= 7.0
- Database Driver & Version: -

### Description:
As you see

![screenshot from 2017-08-26 12-53-43](https://user-images.githubusercontent.com/9657132/29740388-f7499422-8a5d-11e7-849f-96f8fbc3f097.png)

the old `ModelFactory.php` has been removed and simplified.

But the `AppNameCommand.php` file is not still updated correspondingly! 

https://github.com/laravel/framework/blob/master/src/Illuminate/Foundation/Console/AppNameCommand.php#L227

![screenshot from 2017-08-26 12-54-29](https://user-images.githubusercontent.com/9657132/29740397-453033b2-8a5e-11e7-8c16-c8fd678ed8d0.png)

### Steps To Reproduce:
 - Create a new Laravel(5.5-dev) app
 - execute `php artisan app:name Test`

See that the `database/factories/UserFactory.php` file is still using `App\User`

Should have been `Test\User`.