### PR TITLE
[5.5] Add dusk blade directive

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -11,6 +11,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
         Concerns\CompilesComments,
         Concerns\CompilesComponents,
         Concerns\CompilesConditionals,
+        Concerns\CompilesDusk,
         Concerns\CompilesEchos,
         Concerns\CompilesIncludes,
         Concerns\CompilesInjections,

--- a/src/Illuminate/View/Compilers/Concerns/CompilesDusk.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesDusk.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Illuminate\View\Compilers\Concerns;
+
+trait CompilesDusk
+{
+    /**
+     * Compile dusk hooks into html "dusk" attributes.
+     *
+     * @param  string  $expression
+     * @return string
+     */
+    protected function compileDusk($expression)
+    {
+        $segments = array_map('trim', explode(',', preg_replace("/[\(\)\\\"\']/", '', $expression)));
+
+        $selector = $segments[0];
+
+        $stringifiedEnvironments = array_map(function ($environment) {
+            return "'{$environment}'";
+        }, array_merge(['testing', 'local'], array_slice($segments, 1)));
+
+        return "<?php echo app()->environment(".implode(', ', $stringifiedEnvironments).") ? 'dusk=\"{$selector}\"' : ''; ?>";
+    }
+}

--- a/tests/View/Blade/BladeDuskTest.php
+++ b/tests/View/Blade/BladeDuskTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Illuminate\Tests\View\Blade;
+
+class BladeDuskTest extends AbstractBladeTestCase
+{
+    public function testDuskIsCompiled()
+    {
+        $this->assertEquals(
+            "<?php echo app()->environment('testing', 'local') ? 'dusk=\"foo\"' : ''; ?>",
+            $this->compiler->compileString("@dusk('foo')")
+        );
+        $this->assertEquals(
+            "<?php echo app()->environment('testing', 'local') ? 'dusk=\"foo\"' : ''; ?>",
+            $this->compiler->compileString("@dusk(\"foo\")")
+        );
+        $this->assertEquals(
+            "<?php echo app()->environment('testing', 'local', 'staging') ? 'dusk=\"foo\"' : ''; ?>",
+            $this->compiler->compileString("@dusk('foo', 'staging')")
+        );
+        $this->assertEquals(
+            "<?php echo app()->environment('testing', 'local', 'staging') ? 'dusk=\"foo\"' : ''; ?>",
+            $this->compiler->compileString("@dusk('foo', \"staging\")")
+        );
+        $this->assertEquals(
+            "<?php echo app()->environment('testing', 'local', 'staging', 'production') ? 'dusk=\"foo\"' : ''; ?>",
+            $this->compiler->compileString("@dusk('foo', 'staging', 'production')")
+        );
+    }
+}


### PR DESCRIPTION
Blade directive for feature referenced in: [this PR](https://github.com/laravel/dusk/pull/343)

```
<div @dusk('foo')>
// renders in local or testing environment to:
<div dusk="foo">
// renders in production:
<div >
```

Optionally other environments can be passed in:

```
<div @dusk('foo', 'bar', 'baz')>
// renders dusk="foo" on 'bar' and 'baz' environments
```