### PR TITLE
[5.5] Don't try to load abstract console command classes

### DIFF
--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -5,6 +5,7 @@ namespace Illuminate\Foundation\Console;
 use Closure;
 use Exception;
 use Throwable;
+use ReflectionClass;
 use Illuminate\Support\Str;
 use Illuminate\Console\Command;
 use Symfony\Component\Finder\Finder;
@@ -218,7 +219,7 @@ class Kernel implements KernelContract
                 Str::after($command->getPathname(), app_path().DIRECTORY_SEPARATOR)
             );
 
-            if (is_subclass_of($command, Command::class)) {
+            if (is_subclass_of($command, Command::class) && (new ReflectionClass($command))->isInstantiable()) {
                 Artisan::starting(function ($artisan) use ($command) {
                     $artisan->resolve($command);
                 });


### PR DESCRIPTION
This prevents Artisan failing with an error if there is an abstract subclass of `Illuminate\Console\Command` in the Commands/ directory.

```
  [Illuminate\Contracts\Container\BindingResolutionException]
  Target [App\Console\Commands\Download\DownloadCommand] is not instantiable.
```