### PR TITLE
[5.5] Job Expiration

### DIFF
--- a/src/Illuminate/Contracts/Queue/Job.php
+++ b/src/Illuminate/Contracts/Queue/Job.php
@@ -63,6 +63,13 @@ interface Job
     public function maxTries();
 
     /**
+     * The timestamp of job expiration.
+     *
+     * @return int|null
+     */
+    public function expiration();
+
+    /**
      * The number of seconds the job can run.
      *
      * @return int|null

--- a/src/Illuminate/Events/CallQueuedListener.php
+++ b/src/Illuminate/Events/CallQueuedListener.php
@@ -40,6 +40,13 @@ class CallQueuedListener implements ShouldQueue
     public $tries;
 
     /**
+     * The timestamp of job expiration.
+     *
+     * @var int
+     */
+    public $expiration;
+
+    /**
      * The number of seconds the job can run before timing out.
      *
      * @var int

--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -504,6 +504,8 @@ class Dispatcher implements DispatcherContract
         return tap($job, function ($job) use ($listener) {
             $job->tries = $listener->tries ?? null;
             $job->timeout = $listener->timeout ?? null;
+            $job->expiration = method_exists($listener, 'retryUntil')
+                               ? $listener->retryUntil() : null;
         });
     }
 

--- a/src/Illuminate/Queue/Jobs/Job.php
+++ b/src/Illuminate/Queue/Jobs/Job.php
@@ -198,6 +198,16 @@ abstract class Job
     }
 
     /**
+     * The timestamp of job expiration.
+     *
+     * @return int|null
+     */
+    public function expiration()
+    {
+        return $this->payload()['expiration'] ?? null;
+    }
+
+    /**
      * The number of seconds the job can run.
      *
      * @return int|null

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Queue;
 
+use DateTimeInterface;
 use Illuminate\Container\Container;
 use Illuminate\Support\InteractsWithTime;
 
@@ -121,11 +122,30 @@ abstract class Queue
             'job' => 'Illuminate\Queue\CallQueuedHandler@call',
             'maxTries' => $job->tries ?? null,
             'timeout' => $job->timeout ?? null,
+            'expiration' => $this->getJobExpiration($job),
             'data' => [
                 'commandName' => get_class($job),
                 'command' => serialize(clone $job),
             ],
         ];
+    }
+
+    /**
+     * Get the expiration time for  an object-based queue handler.
+     *
+     * @param  mixed  $job
+     * @return mixed
+     */
+    public function getJobExpiration($job)
+    {
+        if (! method_exists($job, 'retryUntil')) {
+            return;
+        }
+
+        $expiration = $job->retryUntil();
+
+        return $expiration instanceof DateTimeInterface
+             ? $expiration->getTimestamp() : $expiration;
     }
 
     /**

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -138,11 +138,11 @@ abstract class Queue
      */
     public function getJobExpiration($job)
     {
-        if (! method_exists($job, 'retryUntil')) {
+        if (! method_exists($job, 'retryUntil') && ! $job->expiration) {
             return;
         }
 
-        $expiration = $job->retryUntil();
+        $expiration = $job->expiration ?? $job->retryUntil();
 
         return $expiration instanceof DateTimeInterface
              ? $expiration->getTimestamp() : $expiration;

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -382,7 +382,7 @@ class Worker
 
         $expiration = $job->expiration();
 
-        if ($job->expiration() && $job->expiration() > now()->getTimestamp()) {
+        if ($expiration && now()->getTimestamp() <= $expiration) {
             return;
         }
 

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -2,9 +2,9 @@
 
 namespace Illuminate\Tests\Queue;
 
-use Illuminate\Support\Carbon;
 use Mockery;
 use RuntimeException;
+use Illuminate\Support\Carbon;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Container\Container;
 use Illuminate\Queue\WorkerOptions;

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -120,6 +120,7 @@ class QueueWorkerTest extends TestCase
 
         $this->assertNull($job->releaseAfter);
         $this->assertTrue($job->deleted);
+        $this->assertEquals($e, $job->failedWith);
         $this->exceptionHandler->shouldHaveReceived('report')->with($e);
         $this->events->shouldHaveReceived('dispatch')->with(Mockery::type(JobExceptionOccurred::class))->once();
         $this->events->shouldHaveReceived('dispatch')->with(Mockery::type(JobFailed::class))->once();
@@ -137,12 +138,12 @@ class QueueWorkerTest extends TestCase
             throw $e;
         });
 
-        $job->expiration = now()->addSeconds(2)->getTimestamp();
+        $job->expiration = now()->addSeconds(1)->getTimestamp();
 
         $job->attempts = 0;
 
         Carbon::setTestNow(
-            now()->addSeconds(2)
+            now()->addSeconds(1)
         );
 
         $worker = $this->getWorker('default', ['queue' => [$job]]);
@@ -150,6 +151,7 @@ class QueueWorkerTest extends TestCase
 
         $this->assertNull($job->releaseAfter);
         $this->assertTrue($job->deleted);
+        $this->assertEquals($e, $job->failedWith);
         $this->exceptionHandler->shouldHaveReceived('report')->with($e);
         $this->events->shouldHaveReceived('dispatch')->with(Mockery::type(JobExceptionOccurred::class))->once();
         $this->events->shouldHaveReceived('dispatch')->with(Mockery::type(JobFailed::class))->once();

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -180,7 +180,7 @@ class QueueWorkerTest extends TestCase
 
     public function test_job_is_failed_if_it_has_already_expired()
     {
-        $job = new WorkerFakeJob(function ($job){
+        $job = new WorkerFakeJob(function ($job) {
             $job->attempts++;
         });
 


### PR DESCRIPTION
This PR gives the ability to define an expiration time for a job so it fails after all retries fail during this time:

```php
class TestJob implements ShouldQueue
{
    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;

    public function handle()
    {
        //...
    }

    public function retryUntil()
    {
        return now()->addSeconds(10);
    }
}
```