### PR TITLE
[5.5] Allow to replace asterisks into real parameter values for Exists rule

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -171,11 +171,11 @@ class Validator implements ValidatorContract
     ];
 
     /**
-     * The validation rules which depend on other fields as parameters and should have replaced 
+     * The validation rules which depend on other fields as parameters and should have replaced
      * array parameters with real values.
      *
      * @var array
-     */    
+     */
     protected $dependantReplaceParametersRules = [
         'Exists',
     ];
@@ -384,12 +384,12 @@ class Validator implements ValidatorContract
     {
         $replacedParameters = $this->replaceAsterisksInParameters($parameters, $keys);
 
-        if (!$this->shouldReplaceParametersWithValues($rule)) {
+        if (! $this->shouldReplaceParametersWithValues($rule)) {
             return $replacedParameters;
         }
         // For all data arguments try to verify if they are set in input and if they are,
         // immediately use valid value from input otherwise leave it unchanged
-        for ($i=3, $c = count($parameters); $i<$c; $i+=2) {
+        for ($i = 3, $c = count($parameters); $i < $c; $i += 2) {
             $parameters[$i] = Arr::get($this->data, $replacedParameters[$i], $parameters[$i]);
         }
 
@@ -404,7 +404,7 @@ class Validator implements ValidatorContract
      */
     protected function dependsOnOtherFields($rule)
     {
-        return in_array($rule, $this->dependentRules) 
+        return in_array($rule, $this->dependentRules)
             || $this->shouldReplaceParametersWithValues($rule);
     }
 

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -171,6 +171,16 @@ class Validator implements ValidatorContract
     ];
 
     /**
+     * The validation rules which depend on other fields as parameters and should have replaced 
+     * array parameters with real values.
+     *
+     * @var array
+     */    
+    protected $dependantReplaceParametersRules = [
+        'Exists',
+    ];
+
+    /**
      * The size related validation rules.
      *
      * @var array
@@ -329,7 +339,7 @@ class Validator implements ValidatorContract
         // If so, we will replace any asterisks found in the parameters with the correct keys.
         if (($keys = $this->getExplicitKeys($attribute)) &&
             $this->dependsOnOtherFields($rule)) {
-            $parameters = $this->replaceAsterisksInParameters($parameters, $keys);
+            $parameters = $this->getReplacedParameters($parameters, $keys, $rule);
         }
 
         $value = $this->getValue($attribute);
@@ -362,6 +372,31 @@ class Validator implements ValidatorContract
     }
 
     /**
+     * Get replaced parameters.
+     *
+     * @param array  $parameters
+     * @param array  $keys
+     * @param string  $rule
+     *
+     * @return array
+     */
+    protected function getReplacedParameters(array $parameters, array $keys, $rule)
+    {
+        $replacedParameters = $this->replaceAsterisksInParameters($parameters, $keys);
+
+        if (!$this->shouldReplaceParametersWithValues($rule)) {
+            return $replacedParameters;
+        }
+        // For all data arguments try to verify if they are set in input and if they are,
+        // immediately use valid value from input otherwise leave it unchanged
+        for ($i=3, $c = count($parameters); $i<$c; $i+=2) {
+            $parameters[$i] = Arr::get($this->data, $replacedParameters[$i], $parameters[$i]);
+        }
+
+        return $parameters;
+    }
+
+    /**
      * Determine if the given rule depends on other fields.
      *
      * @param  string  $rule
@@ -369,7 +404,19 @@ class Validator implements ValidatorContract
      */
     protected function dependsOnOtherFields($rule)
     {
-        return in_array($rule, $this->dependentRules);
+        return in_array($rule, $this->dependentRules) 
+            || $this->shouldReplaceParametersWithValues($rule);
+    }
+
+    /**
+     * Determine if the given rule should have replaced asterisk parameters.
+     *
+     * @param  string  $rule
+     * @return bool
+     */
+    protected function shouldReplaceParametersWithValues($rule)
+    {
+        return in_array($rule, $this->dependantReplaceParametersRules);
     }
 
     /**

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1623,7 +1623,7 @@ class ValidationValidatorTest extends TestCase
     public function testValidationExistsParametersAreReplacedWhenPossible()
     {
         $trans = $this->getIlluminateArrayTranslator();
-        $v = new Validator($trans, ['tasks' => [['company_id' => 1, 'user_id' => 2]]], 
+        $v = new Validator($trans, ['tasks' => [['company_id' => 1, 'user_id' => 2]]],
             ['tasks.*.user_id' => 'Exists:users,id,company_id,tasks.*.company_id']);
         $mock = m::mock('Illuminate\Validation\PresenceVerifierInterface');
         $mock->shouldReceive('setConnection')->once()->with(null);
@@ -1632,14 +1632,14 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['tasks' => [['company_id' => 1, 'user_id' => 2]]],
-            ['tasks.*.user_id' => (new Exists('users', 'id'))->where('company_id','tasks.*.company_id')]);
+            ['tasks.*.user_id' => (new Exists('users', 'id'))->where('company_id', 'tasks.*.company_id')]);
         $mock = m::mock('Illuminate\Validation\PresenceVerifierInterface');
         $mock->shouldReceive('setConnection')->once()->with(null);
         $mock->shouldReceive('getCount')->once()->with('users', 'id', '2', null, null, ['company_id' => 1])->andReturn(true);
         $v->setPresenceVerifier($mock);
         $this->assertTrue($v->passes());
 
-        $v = new Validator($trans, ['tasks' => [['company_id' => 1, 'user_id' => 2]]], 
+        $v = new Validator($trans, ['tasks' => [['company_id' => 1, 'user_id' => 2]]],
             ['tasks.*.user_id' => 'Exists:users,id,company_id,tasks.*.not_existing_key']);
         $mock = m::mock('Illuminate\Validation\PresenceVerifierInterface');
         $mock->shouldReceive('setConnection')->once()->with(null);
@@ -1648,7 +1648,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['tasks' => [['company_id' => 1, 'user_id' => 2]]],
-            ['tasks.*.user_id' => (new Exists('users', 'id'))->where('company_id','tasks.*.not_existing_key')]);
+            ['tasks.*.user_id' => (new Exists('users', 'id'))->where('company_id', 'tasks.*.not_existing_key')]);
         $mock = m::mock('Illuminate\Validation\PresenceVerifierInterface');
         $mock->shouldReceive('setConnection')->once()->with(null);
         $mock->shouldReceive('getCount')->once()->with('users', 'id', '2', null, null, ['company_id' => 'tasks.*.not_existing_key'])->andReturn(true);
@@ -1662,17 +1662,17 @@ class ValidationValidatorTest extends TestCase
         $mock->shouldReceive('getCount')->once()->with('users', 'id', '2', null, null, ['company_id' => 1])->andReturn(true);
         $mock->shouldReceive('getCount')->once()->with('types', 'type', 'user', null, null, ['user_id' => 2])->andReturn(true);
         $mock->shouldReceive('getCount')->once()->with('users', 'id', '4', null, null, ['company_id' => 3])->andReturn(true);
-        $mock->shouldReceive('getCount')->once()->with('types', 'type', 'admin', null, null, ['user_id' => 4])->andReturn(true);        
+        $mock->shouldReceive('getCount')->once()->with('types', 'type', 'admin', null, null, ['user_id' => 4])->andReturn(true);
         $v->setPresenceVerifier($mock);
         $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['tasks' => [['company_id' => [1, 2, 3], 'user_id' => 2]]],
-            ['tasks.*.user_id' => (new Exists('users', 'id'))->where('company_id','tasks.*.company_id')]);
+            ['tasks.*.user_id' => (new Exists('users', 'id'))->where('company_id', 'tasks.*.company_id')]);
         $mock = m::mock('Illuminate\Validation\PresenceVerifierInterface');
         $mock->shouldReceive('setConnection')->once()->with(null);
         $mock->shouldReceive('getCount')->once()->with('users', 'id', '2', null, null, ['company_id' => [1, 2, 3]])->andReturn(true);
         $v->setPresenceVerifier($mock);
-        $this->assertTrue($v->passes());        
+        $this->assertTrue($v->passes());
     }
 
     public function testValidateIp()


### PR DESCRIPTION
As far as I know it's not possible to use rule like this:

```
[
    'activities.*.ticket_id' => [
          Rule::unique('tickets', 'id')->where('project_id', 'activities.*.project_id'),
     ]
]
```

for data like this:

```
[
    'activities' => [
        [
            'project_id' => 1,
            'ticket_id' => 2,
        ],
        [
            'project_id' => 5,
            'ticket_id' => 7,
        ],
    ],
];
```

What you need to do now something like this:

```
foreach ($this->input('activities') as $key => $activity) {
    $rules['activities.' . $key . '.ticket_id'][] =
        Rule::exists('tickets', 'id')->where('project_id', $activity['project_id']);
}
```

what is not very convenient. 

I believe this could be applied also for other rules (`Unique` for example) but I believe some extra work should be done for `Unique` rule because of this PR: https://github.com/laravel/framework/pull/12612


This is of course breaking change, if someone really needs to search for  column with `activities.*.project_id` value and have same key, the key value will be used instead of simple string.