### PR TITLE
[5.5] Handle asterisks parameters in Unique and Exists rules

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -661,7 +661,7 @@ trait ValidatesAttributes
     protected function prepareUniqueId($id)
     {
         if (preg_match('/\[(.*)\]/', $id, $matches)) {
-            $id = $this->getValue($matches[1]);
+            $id = $matches[1];
         }
 
         if (strtolower($id) == 'null') {

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -421,21 +421,21 @@ class Validator implements ValidatorContract
         $arrayParameter = false;
 
         // if it's array parameter with array notation ex. [users.*.id] we cut off brackets
-        if (Str::startsWith($parameter,'[') && Str::endsWith($parameter,']')) {
+        if (Str::startsWith($parameter, '[') && Str::endsWith($parameter, ']')) {
             $arrayParameter = true;
             $parameter = mb_substr($parameter, 1, -1);
             $replacedParameter = mb_substr($replacedParameter, 1, -1);
         }
 
         $value = Arr::get($this->data, $replacedParameter, $parameter);
-        
+
         // if value is array but [users.*.id] notation is used this is not what we expect so return
-        // parameter without any modification 
+        // parameter without any modification
         if (is_array($value) && $arrayParameter) {
             return $value;
         }
 
-        return $arrayParameter ? '['.$value .']' : $value;
+        return $arrayParameter ? '['.$value.']' : $value;
     }
 
     /**

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -171,11 +171,11 @@ class Validator implements ValidatorContract
     ];
 
     /**
-     * The validation rules which depend on other fields as parameters and should have replaced 
+     * The validation rules which depend on other fields as parameters and should have replaced
      * array parameters with real values.
      *
      * @var array
-     */    
+     */
     protected $dependantReplaceParametersRules = [
         'Exists',
     ];
@@ -384,12 +384,12 @@ class Validator implements ValidatorContract
     {
         $replacedParameters = $this->replaceAsterisksInParameters($parameters, $keys);
 
-        if (!$this->shouldReplaceParametersWithValues($rule)) {
+        if (! $this->shouldReplaceParametersWithValues($rule)) {
             return $replacedParameters;
         }
         // For all data arguments try to verify if they are set in input and if they are,
         // immediately use valid value from input otherwise leave it unchanged
-        for ($i=3, $c = count($parameters); $i<$c; $i+=2) {
+        for ($i = 3, $c = count($parameters); $i < $c; $i += 2) {
             $parameters[$i] = Arr::get($this->data, $replacedParameters[$i], $parameters[$i]);
         }
 
@@ -404,7 +404,7 @@ class Validator implements ValidatorContract
      */
     protected function dependsOnOtherFields($rule)
     {
-        return in_array($rule, $this->dependentRules) 
+        return in_array($rule, $this->dependentRules)
             || $this->shouldReplaceParametersWithValues($rule);
     }
 

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -171,6 +171,16 @@ class Validator implements ValidatorContract
     ];
 
     /**
+     * The validation rules which depend on other fields as parameters and should have replaced 
+     * array parameters with real values.
+     *
+     * @var array
+     */    
+    protected $dependantReplaceParametersRules = [
+        'Exists',
+    ];
+
+    /**
      * The size related validation rules.
      *
      * @var array
@@ -329,7 +339,7 @@ class Validator implements ValidatorContract
         // If so, we will replace any asterisks found in the parameters with the correct keys.
         if (($keys = $this->getExplicitKeys($attribute)) &&
             $this->dependsOnOtherFields($rule)) {
-            $parameters = $this->replaceAsterisksInParameters($parameters, $keys);
+            $parameters = $this->getReplacedParameters($parameters, $keys, $rule);
         }
 
         $value = $this->getValue($attribute);
@@ -362,6 +372,31 @@ class Validator implements ValidatorContract
     }
 
     /**
+     * Get replaced parameters.
+     *
+     * @param array  $parameters
+     * @param array  $keys
+     * @param string  $rule
+     *
+     * @return array
+     */
+    protected function getReplacedParameters(array $parameters, array $keys, $rule)
+    {
+        $replacedParameters = $this->replaceAsterisksInParameters($parameters, $keys);
+
+        if (!$this->shouldReplaceParametersWithValues($rule)) {
+            return $replacedParameters;
+        }
+        // For all data arguments try to verify if they are set in input and if they are,
+        // immediately use valid value from input otherwise leave it unchanged
+        for ($i=3, $c = count($parameters); $i<$c; $i+=2) {
+            $parameters[$i] = Arr::get($this->data, $replacedParameters[$i], $parameters[$i]);
+        }
+
+        return $parameters;
+    }
+
+    /**
      * Determine if the given rule depends on other fields.
      *
      * @param  string  $rule
@@ -369,7 +404,19 @@ class Validator implements ValidatorContract
      */
     protected function dependsOnOtherFields($rule)
     {
-        return in_array($rule, $this->dependentRules);
+        return in_array($rule, $this->dependentRules) 
+            || $this->shouldReplaceParametersWithValues($rule);
+    }
+
+    /**
+     * Determine if the given rule should have replaced asterisk parameters.
+     *
+     * @param  string  $rule
+     * @return bool
+     */
+    protected function shouldReplaceParametersWithValues($rule)
+    {
+        return in_array($rule, $this->dependantReplaceParametersRules);
     }
 
     /**

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1576,7 +1576,7 @@ class ValidationValidatorTest extends TestCase
         $mock->shouldReceive('getCount')->once()->with('users', 'id', '2', null, 'id', ['company_id' => [1, 2, 3]])->andReturn(1);
         $v->setPresenceVerifier($mock);
         $this->assertFalse($v->passes());
-    }    
+    }
 
     public function testValidateUniqueAndExistsSendsCorrectFieldNameToDBWithArrays()
     {

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1623,7 +1623,7 @@ class ValidationValidatorTest extends TestCase
     public function testValidationExistsParametersAreReplacedWhenPossible()
     {
         $trans = $this->getIlluminateArrayTranslator();
-        $v = new Validator($trans, ['tasks' => [['company_id' => 1, 'user_id' => 2]]], 
+        $v = new Validator($trans, ['tasks' => [['company_id' => 1, 'user_id' => 2]]],
             ['tasks.*.user_id' => 'Exists:users,id,company_id,tasks.*.company_id']);
         $mock = m::mock('Illuminate\Validation\PresenceVerifierInterface');
         $mock->shouldReceive('setConnection')->once()->with(null);
@@ -1632,14 +1632,14 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['tasks' => [['company_id' => 1, 'user_id' => 2]]],
-            ['tasks.*.user_id' => (new Exists('users', 'id'))->where('company_id','tasks.*.company_id')]);
+            ['tasks.*.user_id' => (new Exists('users', 'id'))->where('company_id', 'tasks.*.company_id')]);
         $mock = m::mock('Illuminate\Validation\PresenceVerifierInterface');
         $mock->shouldReceive('setConnection')->once()->with(null);
         $mock->shouldReceive('getCount')->once()->with('users', 'id', '2', null, null, ['company_id' => 1])->andReturn(true);
         $v->setPresenceVerifier($mock);
         $this->assertTrue($v->passes());
 
-        $v = new Validator($trans, ['tasks' => [['company_id' => 1, 'user_id' => 2]]], 
+        $v = new Validator($trans, ['tasks' => [['company_id' => 1, 'user_id' => 2]]],
             ['tasks.*.user_id' => 'Exists:users,id,company_id,tasks.*.not_existing_key']);
         $mock = m::mock('Illuminate\Validation\PresenceVerifierInterface');
         $mock->shouldReceive('setConnection')->once()->with(null);
@@ -1648,7 +1648,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['tasks' => [['company_id' => 1, 'user_id' => 2]]],
-            ['tasks.*.user_id' => (new Exists('users', 'id'))->where('company_id','tasks.*.not_existing_key')]);
+            ['tasks.*.user_id' => (new Exists('users', 'id'))->where('company_id', 'tasks.*.not_existing_key')]);
         $mock = m::mock('Illuminate\Validation\PresenceVerifierInterface');
         $mock->shouldReceive('setConnection')->once()->with(null);
         $mock->shouldReceive('getCount')->once()->with('users', 'id', '2', null, null, ['company_id' => 'tasks.*.not_existing_key'])->andReturn(true);
@@ -1662,17 +1662,17 @@ class ValidationValidatorTest extends TestCase
         $mock->shouldReceive('getCount')->once()->with('users', 'id', '2', null, null, ['company_id' => 1])->andReturn(true);
         $mock->shouldReceive('getCount')->once()->with('types', 'type', 'user', null, null, ['user_id' => 2])->andReturn(true);
         $mock->shouldReceive('getCount')->once()->with('users', 'id', '4', null, null, ['company_id' => 3])->andReturn(true);
-        $mock->shouldReceive('getCount')->once()->with('types', 'type', 'admin', null, null, ['user_id' => 4])->andReturn(true);        
+        $mock->shouldReceive('getCount')->once()->with('types', 'type', 'admin', null, null, ['user_id' => 4])->andReturn(true);
         $v->setPresenceVerifier($mock);
         $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['tasks' => [['company_id' => [1, 2, 3], 'user_id' => 2]]],
-            ['tasks.*.user_id' => (new Exists('users', 'id'))->where('company_id','tasks.*.company_id')]);
+            ['tasks.*.user_id' => (new Exists('users', 'id'))->where('company_id', 'tasks.*.company_id')]);
         $mock = m::mock('Illuminate\Validation\PresenceVerifierInterface');
         $mock->shouldReceive('setConnection')->once()->with(null);
         $mock->shouldReceive('getCount')->once()->with('users', 'id', '2', null, null, ['company_id' => [1, 2, 3]])->andReturn(true);
         $v->setPresenceVerifier($mock);
-        $this->assertTrue($v->passes());        
+        $this->assertTrue($v->passes());
     }
 
     public function testValidateIp()


### PR DESCRIPTION
This is follow up of https://github.com/laravel/framework/pull/20778

About tests - tests for those are written in the same way as other validation tests. Almost all the tests are using mocks just to verify whether valid parameters are passed to some methods. If you think Database integration tests would be better I can add them.

I've extended this PR comparing to previous PR with handling also Unique rule, so now for both rules should be possible to automatically resolve parameters like  `activities.*.project_id` into real values to avoid running strange loops in FormRequest for example.