### PR TITLE
[5.5] null_if() helper function

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -1170,3 +1170,17 @@ if (! function_exists('with')) {
         return $object;
     }
 }
+
+if (! function_exists('null_if')) {
+    /**
+     * Return null if condition is true, otherwise return a value.
+     *
+     * @param  mixed $value
+     * @param  mixed $against
+     * @return mixed
+     */
+    function null_if($value, $against)
+    {
+        return $value === $against ? null : $value;
+    }
+}

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -778,6 +778,15 @@ class SupportHelpersTest extends TestCase
             return 10;
         }));
     }
+
+    public function testNullIf()
+    {
+        $date = '2017-08-27';
+        $this->assertNotNull(null_if($date, '0000-00-00'));
+
+        $date = '0000-00-00';
+        $this->assertNull(null_if($date, '0000-00-00'));
+    }
 }
 
 trait SupportTestTraitOne


### PR DESCRIPTION
I've found it useful on occasion to have a null_if() function, which works in the same way as MySQL's NULLIF(). My main usage was for nullifying invalid dates (mostly 0000-00-00 to null)