### PR TITLE
[5.5] Add a `when` validation rule

### DIFF
--- a/src/Illuminate/Contracts/Validation/Validator.php
+++ b/src/Illuminate/Contracts/Validation/Validator.php
@@ -44,4 +44,13 @@ interface Validator extends MessageProvider
      * @return array
      */
     public function errors();
+
+    /**
+     * Validate a given attribute against a rule.
+     *
+     * @param  $attribute
+     * @param  $rule
+     * @return void
+     */
+    public function validateAttribute($attribute, $rule);
 }

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -14,6 +14,7 @@ use InvalidArgumentException;
 use Illuminate\Validation\Rules\Exists;
 use Illuminate\Validation\Rules\Unique;
 use Illuminate\Validation\ValidationData;
+use Illuminate\Contracts\Validation\Validator;
 use Symfony\Component\HttpFoundation\File\File;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 
@@ -1369,6 +1370,24 @@ trait ValidatesAttributes
         $~ixu';
 
         return preg_match($pattern, $value) > 0;
+    }
+
+    /**
+     * Conditionally apply another validation rule.
+     *
+     * @param $attribute
+     * @param $value
+     * @param $parameters
+     * @param \Illuminate\Contracts\Validation\Validator $validator
+     * @return bool
+     */
+    public function validateWhen($attribute, $value, $parameters, Validator $validator)
+    {
+        if (Arr::get($this->attributes(), $parameters[0]) === $parameters[1]) {
+            return $validator->validateAttribute($attribute, $parameters[2]);
+        }
+
+        return true;
     }
 
     /**

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -3607,6 +3607,58 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($rule->called);
     }
 
+    public function testValidateWhenWithSimpleRule()
+    {
+        $v = new Validator($this->getIlluminateArrayTranslator(), [
+            'first' => 'match',
+            'second' => 123,
+        ], [
+            'first' => 'required|string',
+            'second' => 'when:first,match,numeric',
+        ]);
+
+        $this->assertTrue($v->passes());
+    }
+
+    public function testValidateWhenDoesNotRunIfTheConditionIsNotSatisfied()
+    {
+        $v = new Validator($this->getIlluminateArrayTranslator(), [
+            'first' => 'no match',
+            'second' => 'not a number',
+        ], [
+            'first' => 'required|string',
+            'second' => 'when:first,match,number',
+        ]);
+
+        $this->assertTrue($v->passes());
+    }
+
+    public function testValidateWhenCanApplyParameterizedRules()
+    {
+        $v = new Validator($this->getIlluminateArrayTranslator(), [
+            'first' => 'match',
+            'second' => 123,
+        ], [
+            'first' => 'required|string',
+            'second' => 'numeric|when:first,match,min:120',
+        ]);
+
+        $this->assertTrue($v->passes());
+    }
+
+    public function testValidateCorrectlyFailsWhenConditionalRuleFails()
+    {
+        $v = new Validator($this->getIlluminateArrayTranslator(), [
+            'first' => 'match',
+            'second' => 123,
+        ], [
+            'first' => 'required|string',
+            'second' => 'numeric|when:first,match,max:120',
+        ]);
+
+        $this->assertFalse($v->passes());
+    }
+
     protected function getTranslator()
     {
         return m::mock('Illuminate\Contracts\Translation\Translator');


### PR DESCRIPTION
This PR adds a `when` validator, that allows you to arbitrarily apply a rule, given that a condition is satisfied. This is like `required_if`, but for _any_ validation rule, not just `required`.

Example:
```
[
    'first' => 'foo',
    'second' => 123
]
```
with the validation rules
```
[
    'first' => 'required|string',
    'second' => 'numeric|when:first,foo,max:100'
]
```
will conditionally validate `second` to have a max value of 100, *only if* `first` has a value of `foo`.