### PR TITLE
[5.5] Fix make:model factory option behavior

### DIFF
--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -138,7 +138,7 @@ class ModelMakeCommand extends GeneratorCommand
 
             ['controller', 'c', InputOption::VALUE_NONE, 'Create a new controller for the model'],
 
-            ['factory', 'fa', InputOption::VALUE_NONE, 'Create a new factory for the model'],
+            ['factory', 's', InputOption::VALUE_NONE, 'Create a new factory for the model'],
 
             ['force', 'f', InputOption::VALUE_NONE, 'Create the class even if the model already exists.'],
 


### PR DESCRIPTION
As pointed out in #20793 by @paulredmond, when we run the command:

```
php artisan make:model -fa Category
```
it performs all tasks that are done by `all` option for `make:model` command, but it should simply create a model & a factory.

This PR achieves the desired behavior by renaming the `factory` option to `s` (could be better short code. But i used `s` because it is indirectly a seeder to a table).
