### PR TITLE
[5.5] Bring back the deprecated daemon option in command signature

### DIFF
--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -21,6 +21,7 @@ class WorkCommand extends Command
     protected $signature = 'queue:work
                             {connection? : The name of the queue connection to work}
                             {--queue= : The names of the queues to work}
+                            {--daemon : Run the worker in daemon mode (Deprecated)}
                             {--once : Only process the next job on the queue}
                             {--delay=0 : Amount of time to delay failed jobs}
                             {--force : Force the worker to run even in maintenance mode}
@@ -54,8 +55,6 @@ class WorkCommand extends Command
         parent::__construct();
 
         $this->worker = $worker;
-
-        $this->ignoreValidationErrors();
     }
 
     /**


### PR DESCRIPTION
this `$this->ignoreValidationErrors();` silences the errors that Symfony Console throws when you use the `--daemon` option, however all options after `--daemon` will be ignored.

Seems like we'll need to keep this option here even if it's not used.