### PR TITLE
[5.5] Replace the force shortcut with factory on the `make:model` command

### DIFF
--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -138,9 +138,9 @@ class ModelMakeCommand extends GeneratorCommand
 
             ['controller', 'c', InputOption::VALUE_NONE, 'Create a new controller for the model'],
 
-            ['factory', 'fa', InputOption::VALUE_NONE, 'Create a new factory for the model'],
+            ['factory', 'f', InputOption::VALUE_NONE, 'Create a new factory for the model'],
 
-            ['force', 'f', InputOption::VALUE_NONE, 'Create the class even if the model already exists.'],
+            ['force', null, InputOption::VALUE_NONE, 'Create the class even if the model already exists.'],
 
             ['migration', 'm', InputOption::VALUE_NONE, 'Create a new migration file for the model.'],
 


### PR DESCRIPTION
I reported an issue in #20793 where a `-fa` was defined for the factory shortcut. Two letter shortcuts won't work.

This removes the `-f` shortcut for `--force` on the `make:model` command and defines the `-f` flag as a shortcut for factory.

As a user I feel like I'd want a factory more than using `--force` and the verbose force is common in other CLI tools. Using `make:model -f` feels more intuitive for the factory and less surprises.

You can see some discussion around it in #20798.

Closes #20793 and #20798.