### PR TITLE
[5.5] Merge the given attributes into the response

### DIFF
--- a/src/Illuminate/Http/Resources/Json/Resource.php
+++ b/src/Illuminate/Http/Resources/Json/Resource.php
@@ -255,9 +255,7 @@ class Resource implements ArrayAccess, JsonSerializable, Responsable, UrlRoutabl
      */
     protected function attributes($attributes)
     {
-        return new MergeValue(value(function () use ($attributes) {
-            return $this->resource->only($attributes);
-        }));
+        return new MergeValue($this->resource->only($attributes));
     }
 
     /**

--- a/src/Illuminate/Http/Resources/Json/Resource.php
+++ b/src/Illuminate/Http/Resources/Json/Resource.php
@@ -251,7 +251,7 @@ class Resource implements ArrayAccess, JsonSerializable, Responsable, UrlRoutabl
      * Merge the given attributes.
      *
      * @param  array  $attributes
-     * @return mixed
+     * @return \Illuminate\Http\Resources\MissingValue
      */
     protected function attributes($attributes)
     {

--- a/src/Illuminate/Http/Resources/Json/Resource.php
+++ b/src/Illuminate/Http/Resources/Json/Resource.php
@@ -248,6 +248,19 @@ class Resource implements ArrayAccess, JsonSerializable, Responsable, UrlRoutabl
     }
 
     /**
+     * Merge the given attributes.
+     *
+     * @param  array  $attributes
+     * @return mixed
+     */
+    protected function attributes($attributes)
+    {
+        return new MergeValue(value(function () use ($attributes) {
+            return $this->resource->only($attributes);
+        }));
+    }
+
+    /**
      * Retrieve a relationship if it has been loaded.
      *
      * @param  string  $relationship


### PR DESCRIPTION
Instead of:

```
public function toArray($request)
{
    return [
        'name' => $this->name,
        'email' => $this->email,
        'full_name' => $this->name . ' ' . $this->lastName,
    ];
}
```

You can do:

```
public function toArray($request)
{
    return [
        $this->attributes(['name', 'email']),
        'full_name' => $this->name . ' ' . $this->lastName,
    ];
}
```