### PR TITLE
[5.5] Add blade default & defaults directives

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -11,6 +11,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
         Concerns\CompilesComments,
         Concerns\CompilesComponents,
         Concerns\CompilesConditionals,
+        Concerns\CompilesDefaults,
         Concerns\CompilesEchos,
         Concerns\CompilesIncludes,
         Concerns\CompilesInjections,

--- a/src/Illuminate/View/Compilers/Concerns/CompilesDefaults.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesDefaults.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Illuminate\View\Compilers\Concerns;
+
+trait CompilesDefaults
+{
+    /*
+     * Compile the default statements into valid PHP.
+     *
+     * @param  string $expression
+     * @return string
+     */
+    protected function compileDefault($expression)
+    {
+        $segments = explode(',', trim($expression, '()'));
+
+        $variable = preg_replace("/[\(\)\\\"\']/", '', $segments[0]);
+
+        $value = trim($segments[1]);
+
+        return "<?php \${$variable} = \${$variable} ?? {$value}; ?>";
+    }
+
+    /*
+     * Compile the defaults statements into valid PHP.
+     *
+     * @param  string $defaults
+     * @return string
+     */
+    protected function compileDefaults($defaults)
+    {
+        return '<?php foreach ('.$defaults.' as $variable => $value) {'.PHP_EOL.
+            '$$variable = $$variable ?? $value;'.PHP_EOL.
+        '} ?>';
+    }
+}


### PR DESCRIPTION
I often have views with optional variables, mostly when dealing with components or partials. This PR adds a `default` and `defaults` directive which allows you to define default value to variables that aren't set.

```blade
@default('foo', 'Bar')

@defaults([
    'foo' => 'Bar',
])
```