### PR TITLE
[5.5] Add dusk blade directive

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -11,6 +11,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
         Concerns\CompilesComments,
         Concerns\CompilesComponents,
         Concerns\CompilesConditionals,
+        Concerns\CompilesDusk,
         Concerns\CompilesEchos,
         Concerns\CompilesIncludes,
         Concerns\CompilesInjections,

--- a/src/Illuminate/View/Compilers/Concerns/CompilesDusk.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesDusk.php
@@ -5,21 +5,14 @@ namespace Illuminate\View\Compilers\Concerns;
 trait CompilesDusk
 {
     /**
-     * Compile dusk hooks into html "dusk" attributes.
+     * Compile dusk hooks into empty strings. This is needed
+     * because Dusk doesn't register itself in production.
      *
      * @param  string  $expression
      * @return string
      */
     protected function compileDusk($expression)
     {
-        $segments = array_map('trim', explode(',', preg_replace("/[\(\)\\\"\']/", '', $expression)));
-
-        $selector = $segments[0];
-
-        $stringifiedEnvironments = array_map(function ($environment) {
-            return "'{$environment}'";
-        }, array_merge(['testing', 'local'], array_slice($segments, 1)));
-
-        return "<?php echo app()->environment(".implode(', ', $stringifiedEnvironments).") ? 'dusk=\"{$selector}\"' : ''; ?>";
+        return '';
     }
 }

--- a/src/Illuminate/View/Compilers/Concerns/CompilesDusk.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesDusk.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Illuminate\View\Compilers\Concerns;
+
+trait CompilesDusk
+{
+    /**
+     * Compile dusk hooks into html "dusk" attributes.
+     *
+     * @param  string  $expression
+     * @return string
+     */
+    protected function compileDusk($expression)
+    {
+        $segments = array_map('trim', explode(',', preg_replace("/[\(\)\\\"\']/", '', $expression)));
+
+        $selector = $segments[0];
+
+        $stringifiedEnvironments = array_map(function ($environment) {
+            return "'{$environment}'";
+        }, array_merge(['testing', 'local'], array_slice($segments, 1)));
+
+        return "<?php echo app()->environment(".implode(', ', $stringifiedEnvironments).") ? 'dusk=\"{$selector}\"' : ''; ?>";
+    }
+}

--- a/tests/View/Blade/BladeDuskTest.php
+++ b/tests/View/Blade/BladeDuskTest.php
@@ -6,25 +6,6 @@ class BladeDuskTest extends AbstractBladeTestCase
 {
     public function testDuskIsCompiled()
     {
-        $this->assertEquals(
-            "<?php echo app()->environment('testing', 'local') ? 'dusk=\"foo\"' : ''; ?>",
-            $this->compiler->compileString("@dusk('foo')")
-        );
-        $this->assertEquals(
-            "<?php echo app()->environment('testing', 'local') ? 'dusk=\"foo\"' : ''; ?>",
-            $this->compiler->compileString("@dusk(\"foo\")")
-        );
-        $this->assertEquals(
-            "<?php echo app()->environment('testing', 'local', 'staging') ? 'dusk=\"foo\"' : ''; ?>",
-            $this->compiler->compileString("@dusk('foo', 'staging')")
-        );
-        $this->assertEquals(
-            "<?php echo app()->environment('testing', 'local', 'staging') ? 'dusk=\"foo\"' : ''; ?>",
-            $this->compiler->compileString("@dusk('foo', \"staging\")")
-        );
-        $this->assertEquals(
-            "<?php echo app()->environment('testing', 'local', 'staging', 'production') ? 'dusk=\"foo\"' : ''; ?>",
-            $this->compiler->compileString("@dusk('foo', 'staging', 'production')")
-        );
+        $this->assertEquals('', $this->compiler->compileString("@dusk('foo')"));
     }
 }

--- a/tests/View/Blade/BladeDuskTest.php
+++ b/tests/View/Blade/BladeDuskTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Illuminate\Tests\View\Blade;
+
+class BladeDuskTest extends AbstractBladeTestCase
+{
+    public function testDuskIsCompiled()
+    {
+        $this->assertEquals(
+            "<?php echo app()->environment('testing', 'local') ? 'dusk=\"foo\"' : ''; ?>",
+            $this->compiler->compileString("@dusk('foo')")
+        );
+        $this->assertEquals(
+            "<?php echo app()->environment('testing', 'local') ? 'dusk=\"foo\"' : ''; ?>",
+            $this->compiler->compileString("@dusk(\"foo\")")
+        );
+        $this->assertEquals(
+            "<?php echo app()->environment('testing', 'local', 'staging') ? 'dusk=\"foo\"' : ''; ?>",
+            $this->compiler->compileString("@dusk('foo', 'staging')")
+        );
+        $this->assertEquals(
+            "<?php echo app()->environment('testing', 'local', 'staging') ? 'dusk=\"foo\"' : ''; ?>",
+            $this->compiler->compileString("@dusk('foo', \"staging\")")
+        );
+        $this->assertEquals(
+            "<?php echo app()->environment('testing', 'local', 'staging', 'production') ? 'dusk=\"foo\"' : ''; ?>",
+            $this->compiler->compileString("@dusk('foo', 'staging', 'production')")
+        );
+    }
+}


### PR DESCRIPTION
This PR is a compliment to an open dusk PR: https://github.com/laravel/dusk/pull/347

It prevents the `@dusk` directive from being ignored in production because `DuskServiceProvider` isn't loaded in production.

```
<div @dusk('foo')></div> // production markup without this PR 
<div ></div> // with PR
```