### PR TITLE
[5.5] Custom failed jobs providers

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -1119,6 +1119,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
             'auth.password.broker' => [\Illuminate\Auth\Passwords\PasswordBroker::class, \Illuminate\Contracts\Auth\PasswordBroker::class],
             'queue'                => [\Illuminate\Queue\QueueManager::class, \Illuminate\Contracts\Queue\Factory::class, \Illuminate\Contracts\Queue\Monitor::class],
             'queue.connection'     => [\Illuminate\Contracts\Queue\Queue::class],
+            'queue.failer.manager' => [\Illuminate\Queue\Failed\Manager::class],
             'queue.failer'         => [\Illuminate\Queue\Failed\FailedJobProviderInterface::class],
             'redirect'             => [\Illuminate\Routing\Redirector::class],
             'redis'                => [\Illuminate\Redis\RedisManager::class, \Illuminate\Contracts\Redis\Factory::class],

--- a/src/Illuminate/Queue/Failed/DatabaseFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/DatabaseFailedJobProvider.php
@@ -38,9 +38,9 @@ class DatabaseFailedJobProvider implements FailedJobProviderInterface
      */
     public function __construct(ConnectionResolverInterface $resolver, $database, $table)
     {
-        $this->table = $table;
         $this->resolver = $resolver;
         $this->database = $database;
+        $this->table = $table;
     }
 
     /**

--- a/src/Illuminate/Queue/Failed/Manager.php
+++ b/src/Illuminate/Queue/Failed/Manager.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Illuminate\Queue\Failed;
+
+use Closure;
+
+class Manager
+{
+    /**
+     * The application instance.
+     *
+     * @var \Illuminate\Foundation\Application
+     */
+    protected $app;
+
+    /**
+     * Registered failed job providers.
+     *
+     * @var array
+     */
+    protected $providers = [];
+
+    /**
+     * Create a new queue failed manager instance.
+     *
+     * @param  \Illuminate\Foundation\Application  $app
+     * @return void
+     */
+    public function __construct($app)
+    {
+        $this->app = $app;
+        $this->registerNullFailedJobProvider();
+        $this->registerDatabaseFailedJobProvider();
+    }
+
+    /**
+     * Return a failed job provider instance.
+     * Fallback to null if no provider is set.
+     *
+     * @param string|null $provider
+     * @return \Illuminate\Queue\Failed\FailedJobProviderInterface
+     */
+    public function provider($provider = null)
+    {
+        $provider = $provider ?? $this->app['config']['queue.failed.provider'] ?? 'null';
+        $config = $this->app['config']["queue.failed.{$provider}"] ?? [];
+
+        return isset($this->providers[$provider])
+            ? $this->providers[$provider]($this->app, $config)
+            : $this->providers['null']();
+    }
+
+    /**
+     * Add a provider to providers list.
+     *
+     * @param string  $name
+     * @param Closure $callback
+     * @return void
+     */
+    public function addProvider($name, Closure $callback)
+    {
+        $this->providers[$name] = $callback;
+    }
+
+    /**
+     * Register a new database failed job provider.
+     *
+     * @return Closure
+     */
+    protected function registerDatabaseFailedJobProvider()
+    {
+        $this->addProvider('database', function ($app, $config) {
+            return new DatabaseFailedJobProvider(
+                $app['db'], $config['connection'], $config['table']
+            );
+        });
+    }
+
+    /**
+     * Register null failed job provider.
+     *
+     * @return Closure
+     */
+    protected function registerNullFailedJobProvider()
+    {
+        $this->addProvider('null', function () {
+            return new NullFailedJobProvider();
+        });
+    }
+}

--- a/src/Illuminate/Queue/Failed/Manager.php
+++ b/src/Illuminate/Queue/Failed/Manager.php
@@ -45,7 +45,7 @@ class Manager
         $config = $this->app['config']['queue.failed'];
 
         // Resolve provider with legacy configuration
-        if(! isset($config['provider'])) {
+        if (! isset($config['provider'])) {
             return $this->legacyProvider($config);
         }
 
@@ -78,8 +78,8 @@ class Manager
     {
         $this->addProvider('database', function ($app, $config) {
             return new DatabaseFailedJobProvider(
-                $app['db'], 
-                $config['connection'] ?? $config['database'], 
+                $app['db'],
+                $config['connection'] ?? $config['database'],
                 $config['table']
             );
         });
@@ -101,7 +101,7 @@ class Manager
      * Resolve failed provider keeping backwards compatibility
      * with older configuration.
      *
-     * @param array 
+     * @param array
      * @return \Illuminate\Queue\Failed\FailedJobProviderInterface
      */
     private function legacyProvider($config)

--- a/tests/Queue/QueueFailedManagerTest.php
+++ b/tests/Queue/QueueFailedManagerTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Illuminate\Tests\Queue;
+
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+use Illuminate\Queue\Failed\Manager;
+use Illuminate\Queue\Failed\NullFailedJobProvider;
+use Illuminate\Database\ConnectionResolverInterface;
+use Illuminate\Queue\Failed\DatabaseFailedJobProvider;
+use Illuminate\Queue\Failed\FailedJobProviderInterface;
+
+class QueueFailedManagerTest extends TestCase
+{
+    public function tearDown()
+    {
+        m::close();
+    }
+
+    public function testCreateManagerWithDefaultProviders()
+    {
+        $app = [
+            'config' => [
+                'queue.failed.provider' => 'null',
+                'queue.failed.database' => ['connection' => 'sqlite', 'table' => 'failed_jobs'],
+            ],
+            'db' => m::mock(ConnectionResolverInterface::class),
+        ];
+
+        $manager = new Manager($app);
+
+        $this->assertInstanceOf(NullFailedJobProvider::class, $manager->provider('null'));
+        $this->assertInstanceOf(DatabaseFailedJobProvider::class, $manager->provider('database'));
+    }
+
+    public function testReturnConfiguredProvider()
+    {
+        $app = [
+            'config' => [
+                'queue.failed.provider' => 'database',
+                'queue.failed.database' => ['connection' => 'sqlite', 'table' => 'failed_jobs'],
+            ],
+            'db' => m::mock(ConnectionResolverInterface::class),
+        ];
+
+        $manager = new Manager($app);
+
+        $this->assertInstanceOf(DatabaseFailedJobProvider::class, $manager->provider());
+    }
+
+    public function testFallbackToNullProviderIfNotConfiguredProperly()
+    {
+        $app = [
+            'config' => [],
+        ];
+
+        $manager = new Manager($app);
+
+        $this->assertInstanceOf(NullFailedJobProvider::class, $manager->provider());
+    }
+
+    public function testAddCustomProvider()
+    {
+        $app = [
+            'config' => [
+                'queue.failed.provider' => 'custom',
+            ],
+        ];
+
+        $customProvider = m::mock(FailedJobProviderInterface::class);
+
+        $manager = new Manager($app);
+        $manager->addProvider('custom', function () use ($customProvider) {
+            return $customProvider;
+        });
+
+        $this->assertSame($customProvider, $manager->provider('custom'));
+        $this->assertSame($customProvider, $manager->provider());
+    }
+
+    public function testReturnNullProviderIfCustomIsNotAdded()
+    {
+        $app = [
+            'config' => [
+                'queue.failed.provider' => 'custom',
+            ],
+        ];
+
+        $manager = new Manager($app);
+
+        $this->assertInstanceOf(NullFailedJobProvider::class, $manager->provider('custom'));
+        $this->assertInstanceOf(NullFailedJobProvider::class, $manager->provider());
+    }
+}

--- a/tests/Queue/QueueFailedManagerTest.php
+++ b/tests/Queue/QueueFailedManagerTest.php
@@ -51,7 +51,7 @@ class QueueFailedManagerTest extends TestCase
 
         $this->assertInstanceOf(DatabaseFailedJobProvider::class, $manager->provider());
     }
-    
+
     public function testKeepBackwardsCompatibilityWithOldConfig()
     {
         $app = [
@@ -59,7 +59,7 @@ class QueueFailedManagerTest extends TestCase
                 'queue.failed' => [
                     'database' => 'sqlite',
                     'table' => 'failed_jobs',
-                ]
+                ],
             ],
             'db' => m::mock(ConnectionResolverInterface::class),
         ];
@@ -76,7 +76,7 @@ class QueueFailedManagerTest extends TestCase
                 'queue.failed' => [
                     'database' => 'sqlite',
                     'table' => null,
-                ]
+                ],
             ],
         ];
 


### PR DESCRIPTION
This make easier swap and add custom queue failed jobs providers as proposed here https://github.com/laravel/internals/issues/751

It involves a minor change on queue failed configuration:

```php
    'failed' => [
        'provider' => 'database',

        'database' => [
            'connection' => env('DB_CONNECTION', 'mysql'),
            'table' => 'failed_jobs',
        ],
    ],
```

If the config is not updated properly, it will fallback to `NullFailedJobProvider`.

Docs (https://github.com/laravel/docs/pull/3573) and skeleton (https://github.com/laravel/laravel/pull/4393) PRs are already open just in case.