### PR TITLE
[5.5] fix for broken queue connections in worker

### DIFF
--- a/src/Illuminate/Queue/DetectsLostConnections.php
+++ b/src/Illuminate/Queue/DetectsLostConnections.php
@@ -19,6 +19,7 @@ trait DetectsLostConnections
 
         return Str::contains($message, [
             'Broken pipe or closed connection',
+            'Channel connection is closed',
         ]);
     }
 }

--- a/src/Illuminate/Queue/DetectsLostConnections.php
+++ b/src/Illuminate/Queue/DetectsLostConnections.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Illuminate\Queue;
+
+use Exception;
+use Illuminate\Support\Str;
+
+trait DetectsLostConnections
+{
+    /**
+     * Determine if the given exception was caused by a lost connection.
+     *
+     * @param  \Exception  $e
+     * @return bool
+     */
+    protected function causedByLostConnection(Exception $e)
+    {
+        $message = $e->getMessage();
+
+        return Str::contains($message, [
+            'Broken pipe or closed connection',
+        ]);
+    }
+}

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -18,7 +18,7 @@ class Worker
     }
 
     /**
-     * The queue manager instance.W
+     * The queue manager instance.
      *
      * @var \Illuminate\Queue\QueueManager
      */

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -11,7 +11,8 @@ use Illuminate\Contracts\Cache\Repository as CacheContract;
 
 class Worker
 {
-    use \Illuminate\Database\DetectsLostConnections, \Illuminate\Queue\DetectsLostConnections {
+    use \Illuminate\Database\DetectsLostConnections, DetectsLostConnections {
+        \Illuminate\Database\DetectsLostConnections::causedByLostConnection insteadof DetectsLostConnections;
         \Illuminate\Database\DetectsLostConnections::causedByLostConnection as causedByLostDbConnection;
         DetectsLostConnections::causedByLostConnection as causedByLostQueueConnection;
     }

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -5,17 +5,19 @@ namespace Illuminate\Queue;
 use Exception;
 use Throwable;
 use Illuminate\Contracts\Events\Dispatcher;
-use Illuminate\Database\DetectsLostConnections;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Symfony\Component\Debug\Exception\FatalThrowableError;
 use Illuminate\Contracts\Cache\Repository as CacheContract;
 
 class Worker
 {
-    use DetectsLostConnections;
+    use \Illuminate\Database\DetectsLostConnections, \Illuminate\Queue\DetectsLostConnections {
+        \Illuminate\Database\DetectsLostConnections::causedByLostConnection as causedByLostDbConnection;
+        DetectsLostConnections::causedByLostConnection as causedByLostQueueConnection;
+    }
 
     /**
-     * The queue manager instance.
+     * The queue manager instance.W
      *
      * @var \Illuminate\Queue\QueueManager
      */
@@ -284,7 +286,7 @@ class Worker
      */
     protected function stopWorkerIfLostConnection($e)
     {
-        if ($this->causedByLostConnection($e)) {
+        if ($this->causedByLostDbConnection($e) || $this->causedByLostQueueConnection($e)) {
             $this->shouldQuit = true;
         }
     }


### PR DESCRIPTION
If queue connection fails queue workers produce errors and never restarts
Ideally we should think how to move Failed connection handler to third parties connection interface or Job class. So third party developers or job task developers can extend it