### PR TITLE
[5.5] Add public getter method for MIME types to be able to use them.

### DIFF
--- a/src/Illuminate/Http/Testing/MimeType.php
+++ b/src/Illuminate/Http/Testing/MimeType.php
@@ -788,6 +788,28 @@ class MimeType
     {
         $extension = pathinfo($filename, PATHINFO_EXTENSION);
 
+        return self::getMimeTypeFromExtension($extension);
+    }
+
+    /**
+     * Get the MIME type for a given extension or return all mimes.
+     *
+     * @param  string  $extension
+     * @return string|array
+     */
+    public static function get($extension = null)
+    {
+        return $extension ? self::getMimeTypeFromExtension($extension) : self::$mimes;
+    }
+
+    /**
+     * Get the MIME type for a given extension.
+     *
+     * @param  string  $extension
+     * @return string
+     */
+    protected static function getMimeTypeFromExtension($extension)
+    {
         return self::$mimes[$extension] ?? 'application/octet-stream';
     }
 }

--- a/tests/Http/HttpMimeTypeTest.php
+++ b/tests/Http/HttpMimeTypeTest.php
@@ -7,13 +7,29 @@ use Illuminate\Http\Testing\MimeType;
 
 class HttpMimeTypeTest extends TestCase
 {
-    public function testMimeTypeExistsTrue()
+    public function testMimeTypeFromFileNameExistsTrue()
     {
         $this->assertSame('image/jpeg', MimeType::from('foo.jpg'));
     }
 
-    public function testMimeTypeExistsFalse()
+    public function testMimeTypeFromFileNameExistsFalse()
     {
         $this->assertSame('application/octet-stream', MimeType::from('foo.bar'));
+    }
+
+    public function testMimeTypeFromExtensionExistsTrue()
+    {
+        $this->assertSame('image/jpeg', MimeType::get('jpg'));
+    }
+
+    public function testMimeTypeFromExtensionExistsFalse()
+    {
+        $this->assertSame('application/octet-stream', MimeType::get('bar'));
+    }
+
+    public function testGetAllMimeTypes()
+    {
+        $this->assertInternalType('array', MimeType::get());
+        $this->assertArraySubset(['jpg' => 'image/jpeg'], MimeType::get());
     }
 }


### PR DESCRIPTION
For now, we can't use this array of mimetypes in our apps except from filename, and it's a bit too bad.
This PR adds a simple public method to benefit of it.