### PR TITLE
[5.6] Rename Support\Optional class for more naming consistency

### DIFF
--- a/src/Illuminate/Support/HigherOrderOptionalProxy.php
+++ b/src/Illuminate/Support/HigherOrderOptionalProxy.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\Support;
 
-class Optional
+class HigherOrderOptionalProxy
 {
     use Traits\Macroable;
 

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -2,11 +2,11 @@
 
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
-use Illuminate\Support\Optional;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Debug\Dumper;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Support\HigherOrderTapProxy;
+use Illuminate\Support\HigherOrderOptionalProxy;
 
 if (! function_exists('append_config')) {
     /**
@@ -723,7 +723,7 @@ if (! function_exists('optional')) {
      */
     function optional($value)
     {
-        return new Optional($value);
+        return new HigherOrderOptionalProxy($value);
     }
 }
 


### PR DESCRIPTION
Rename `Illuminate\Support\Optional` to `Illuminate\Support\HigherOrderOptionalProxy`