### PR TITLE
[5.5] Added createIfNotExists feature for creating tables

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -172,7 +172,7 @@ class Blueprint
     protected function creating()
     {
         return collect($this->commands)->contains(function ($command) {
-            return $command->name == 'create';
+            return in_array($command->name, ['create', 'createIfNotExists']);
         });
     }
 
@@ -184,6 +184,16 @@ class Blueprint
     public function create()
     {
         return $this->addCommand('create');
+    }
+
+    /**
+     * Indicate that the table needs to be created.
+     *
+     * @return \Illuminate\Support\Fluent
+     */
+    public function createIfNotExists()
+    {
+        return $this->addCommand('createIfNotExists');
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -166,6 +166,22 @@ class Builder
     }
 
     /**
+     * Create a new table on the schema if it doesn't exists.
+     *
+     * @param  string    $table
+     * @param  \Closure  $callback
+     * @return void
+     */
+    public function createIfNotExists($table, Closure $callback)
+    {
+        $this->build(tap($this->createBlueprint($table), function ($blueprint) use ($callback) {
+            $blueprint->createIfNotExists();
+
+            $callback($blueprint);
+        }));
+    }
+
+    /**
      * Drop a table from the schema.
      *
      * @param  string  $table

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -75,6 +75,35 @@ class MySqlGrammar extends Grammar
     }
 
     /**
+     * Compile a create table if not exists command.
+     *
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @param  \Illuminate\Support\Fluent  $command
+     * @param  \Illuminate\Database\Connection  $connection
+     * @return string
+     */
+    public function compileCreateIfNotExists(Blueprint $blueprint, Fluent $command, Connection $connection)
+    {
+        $sql = $this->compileCreateTableIfNotExists(
+            $blueprint, $command, $connection
+        );
+
+        // Once we have the primary SQL, we can add the encoding option to the SQL for
+        // the table.  Then, we can check if a storage engine has been supplied for
+        // the table. If so, we will add the engine declaration to the SQL query.
+        $sql = $this->compileCreateEncoding(
+            $sql, $connection, $blueprint
+        );
+
+        // Finally, we will append the engine configuration onto this SQL statement as
+        // the final thing we do before returning this finished SQL. Once this gets
+        // added the query will be ready to execute against the real connections.
+        return $this->compileCreateEngine(
+            $sql, $connection, $blueprint
+        );
+    }
+
+    /**
      * Create the main create table clause.
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
@@ -85,6 +114,23 @@ class MySqlGrammar extends Grammar
     protected function compileCreateTable($blueprint, $command, $connection)
     {
         return sprintf('%s table %s (%s)',
+            $blueprint->temporary ? 'create temporary' : 'create',
+            $this->wrapTable($blueprint),
+            implode(', ', $this->getColumns($blueprint))
+        );
+    }
+
+    /**
+     * Create the main create table if not exists clause.
+     *
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @param  \Illuminate\Support\Fluent  $command
+     * @param  \Illuminate\Database\Connection  $connection
+     * @return string
+     */
+    protected function compileCreateTableIfNotExists($blueprint, $command, $connection)
+    {
+        return sprintf('%s table if not exists %s (%s)',
             $blueprint->temporary ? 'create temporary' : 'create',
             $this->wrapTable($blueprint),
             implode(', ', $this->getColumns($blueprint))

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -65,6 +65,22 @@ class PostgresGrammar extends Grammar
     }
 
     /**
+     * Compile a create table if not exists command.
+     *
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @param  \Illuminate\Support\Fluent  $command
+     * @return string
+     */
+    public function compileCreateIfNotExists(Blueprint $blueprint, Fluent $command)
+    {
+        return sprintf('%s table if not exists %s (%s)',
+            $blueprint->temporary ? 'create temporary' : 'create',
+            $this->wrapTable($blueprint),
+            implode(', ', $this->getColumns($blueprint))
+        );
+    }
+
+    /**
      * Compile a column addition command.
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint

--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -62,6 +62,24 @@ class SQLiteGrammar extends Grammar
     }
 
     /**
+     * Compile a create table if not exists command.
+     *
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @param  \Illuminate\Support\Fluent  $command
+     * @return string
+     */
+    public function compileCreateIfNotExists(Blueprint $blueprint, Fluent $command)
+    {
+        return sprintf('%s table if not exists %s (%s%s%s)',
+            $blueprint->temporary ? 'create temporary' : 'create',
+            $this->wrapTable($blueprint),
+            implode(', ', $this->getColumns($blueprint)),
+            (string) $this->addForeignKeys($blueprint),
+            (string) $this->addPrimaryKeys($blueprint)
+        );
+    }
+
+    /**
      * Get the foreign key syntax for a table creation statement.
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -59,6 +59,20 @@ class SqlServerGrammar extends Grammar
     }
 
     /**
+     * Compile a create table if not exists command.
+     *
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @param  \Illuminate\Support\Fluent  $command
+     * @return string
+     */
+    public function compileCreateIfNotExists(Blueprint $blueprint, Fluent $command)
+    {
+        $columns = implode(', ', $this->getColumns($blueprint));
+
+        return "if not exists (select * from sys.tables where name='{$blueprint->getTable()}') create table ".$this->wrapTable($blueprint)." ($columns) go";
+    }
+
+    /**
      * Compile a column addition table command.
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint

--- a/src/Illuminate/Support/Facades/Schema.php
+++ b/src/Illuminate/Support/Facades/Schema.php
@@ -4,6 +4,7 @@ namespace Illuminate\Support\Facades;
 
 /**
  * @method static \Illuminate\Database\Schema\Builder create(string $table, \Closure $callback)
+ * @method static \Illuminate\Database\Schema\Builder createIfNotExists(string $table, \Closure $callback)
  * @method static \Illuminate\Database\Schema\Builder drop(string $table)
  * @method static \Illuminate\Database\Schema\Builder dropIfExists(string $table)
  * @method static \Illuminate\Database\Schema\Builder table(string $table, \Closure $callback)


### PR DESCRIPTION
Currently when creating tables through migrations, we use: 

```
Schema::create('foo', function (Blueprint $table) {
    $table->increments('id');
    $table->timestamps();
});
```

This however doesn't check if the table being created already exists. If the table already exists, an exception is thrown. 

This PR adds a new function `createIfNotExists`, which just skips table creation if the specific table already exists:

```
Schema::createIfNotExists('foo', function (Blueprint $table) {
    $table->increments('id');
    $table->timestamps();
});
``` 