### PR TITLE
[5.5] Add chainability to Optional class

### DIFF
--- a/src/Illuminate/Support/Optional.php
+++ b/src/Illuminate/Support/Optional.php
@@ -25,6 +25,34 @@ class Optional
     }
 
     /**
+     * Check if Optional has a value.
+     *
+     * @return bool
+     */
+    public function hasValue()
+    {
+        return is_object($this->value);
+    }
+
+    /**
+     * Check if Optional is empty.
+     *
+     * @return bool
+     */
+    public function empty()
+    {
+        return ! $this->hasValue();
+    }
+
+    /**
+     * Get underlying value.
+     */
+    public function value()
+    {
+        return $this->value;
+    }
+
+    /**
      * Dynamically access a property on the underlying object.
      *
      * @param  string  $key
@@ -32,8 +60,24 @@ class Optional
      */
     public function __get($key)
     {
-        if (is_object($this->value)) {
-            return $this->value->{$key};
+        if ($this->hasValue()) {
+            return new self($this->value->{$key});
+        }
+
+        return $this;
+    }
+
+    /**
+     * Dynamically set a property on the underlying object.
+     *
+     * @param  string  $key
+     * @param  mixed   $value
+     * @return mixed
+     */
+    public function __set($key, $value)
+    {
+        if ($this->hasValue()) {
+            $this->value->{$key} = $value;
         }
     }
 
@@ -46,8 +90,10 @@ class Optional
      */
     public function __call($method, $parameters)
     {
-        if (is_object($this->value)) {
-            return $this->value->{$method}(...$parameters);
+        if ($this->hasValue()) {
+            return new self($this->value->{$method}(...$parameters));
         }
+
+        return $this;
     }
 }

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -758,14 +758,25 @@ class SupportHelpersTest extends TestCase
 
     public function testOptional()
     {
-        $this->assertNull(optional(null)->something());
+        $null = optional(null);
+        $this->assertTrue($null->empty());
+        $this->assertNull($null->something()->value());
 
-        $this->assertEquals(10, optional(new class {
+        $withValue = optional(new class {
+            public function chain()
+            {
+                return $this;
+            }
+
             public function something()
             {
                 return 10;
             }
-        })->something());
+        });
+
+        $this->assertTrue($withValue->hasValue());
+        $this->assertEquals(10, $withValue->something()->value());
+        $this->assertEquals(10, $withValue->chain()->something()->value());
     }
 
     public function testTransform()


### PR DESCRIPTION
This change will make `Optional` class chainable. So, things like `$optional->foo->bar` and `$optional->foo()->bar()` won't throw any exception.
Also, it will be more similar to `Option`/`Maybe` monads from FP world, which is also cool.
Yes, there is breaking change (we need to call ->value() at the end), but it isn't too late for it. We could get bunch of new possibilities with it.
