### PR TITLE
[5.5] Fix choice for non-tty terminals

### DIFF
--- a/src/Illuminate/Foundation/Console/VendorPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/VendorPublishCommand.php
@@ -110,7 +110,7 @@ class VendorPublishCommand extends Command
             $choices = $this->publishableChoices()
         );
 
-        if ($choice == $choices[0]) {
+        if ($choice == $choices[0] || $choice === null) {
             return;
         }
 

--- a/src/Illuminate/Foundation/Console/VendorPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/VendorPublishCommand.php
@@ -110,7 +110,7 @@ class VendorPublishCommand extends Command
             $choices = $this->publishableChoices()
         );
 
-        if ($choice == $choices[0] || $choice === null) {
+        if ($choice == $choices[0] || is_null($choice)) {
             return;
         }
 


### PR DESCRIPTION
Some terminals (like "Command Line Tools Console" in PhpStrom) does not support any features and skip waiting the answer of the method `choice()`. By the default it returns `null` which leads to error:

```
~/artisan vendor:publish -vvv


[ErrorException]     
  Undefined offset: 1  
                       

Exception trace:
 () at ~/vendor/laravel/framework/src/Illuminate/Foundation/Console/VendorPublishCommand.php:142
 Illuminate\Foundation\Bootstrap\HandleExceptions->handleError() at ~/vendor/laravel/framework/src/Illuminate/Foundation/Console/VendorPublishCommand.php:142
 Illuminate\Foundation\Console\VendorPublishCommand->parseChoice() at ~/vendor/laravel/framework/src/Illuminate/Foundation/Console/VendorPublishCommand.php:117
 Illuminate\Foundation\Console\VendorPublishCommand->promptForProviderOrTag() at ~/vendor/laravel/framework/src/Illuminate/Foundation/Console/VendorPublishCommand.php:97
 Illuminate\Foundation\Console\VendorPublishCommand->determineWhatShouldBePublished() at ~/vendor/laravel/framework/src/Illuminate/Foundation/Console/VendorPublishCommand.php:72
 Illuminate\Foundation\Console\VendorPublishCommand->handle() at n/a:n/a
 call_user_func_array() at ~/vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php:29
 Illuminate\Container\BoundMethod::Illuminate\Container\{closure}() at ~/vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php:87
 Illuminate\Container\BoundMethod::callBoundMethod() at ~/vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php:31
 Illuminate\Container\BoundMethod::call() at ~/vendor/laravel/framework/src/Illuminate/Container/Container.php:549
 Illuminate\Container\Container->call() at ~/vendor/laravel/framework/src/Illuminate/Console/Command.php:180
 Illuminate\Console\Command->execute() at ~/vendor/symfony/console/Command/Command.php:276
 Symfony\Component\Console\Command\Command->run() at ~/vendor/laravel/framework/src/Illuminate/Console/Command.php:167
 Illuminate\Console\Command->run() at ~/vendor/symfony/console/Application.php:934
 Symfony\Component\Console\Application->doRunCommand() at ~/vendor/symfony/console/Application.php:231
 Symfony\Component\Console\Application->doRun() at ~/vendor/symfony/console/Application.php:132
 Symfony\Component\Console\Application->run() at ~/vendor/laravel/framework/src/Illuminate/Console/Application.php:82
 Illuminate\Console\Application->run() at ~/vendor/laravel/framework/src/Illuminate/Foundation/Console/Kernel.php:125
 Illuminate\Foundation\Console\Kernel->handle() at ~/artisan:37
```

This pull request fixes this error by selecting the default `0` option.