### PR TITLE
[5.5] Fix optional() macro __call()

### DIFF
--- a/src/Illuminate/Support/Optional.php
+++ b/src/Illuminate/Support/Optional.php
@@ -4,7 +4,9 @@ namespace Illuminate\Support;
 
 class Optional
 {
-    use Traits\Macroable;
+    use Traits\Macroable {
+        __call as macroCall;
+    }
 
     /**
      * The underlying object.
@@ -48,6 +50,10 @@ class Optional
     {
         if (is_object($this->value)) {
             return $this->value->{$method}(...$parameters);
+        }
+
+        if (static::hasMacro($method)) {
+            return $this->macroCall($method, $parameters);
         }
     }
 }

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -9,6 +9,7 @@ use RuntimeException;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Support\Optional;
 
 class SupportHelpersTest extends TestCase
 {
@@ -766,6 +767,31 @@ class SupportHelpersTest extends TestCase
                 return 10;
             }
         })->something());
+    }
+
+    public function testOptionalIsMacroable()
+    {
+        Optional::macro('present', function () {
+            if (is_object($this->value)) {
+                return $this->value->present();
+            }
+
+            return new Optional(null);
+        });
+
+        $this->assertNull(optional(null)->present()->something());
+
+        $this->assertEquals('$10.00', optional(new class {
+            public function present()
+            {
+                return new class {
+                    public function something()
+                    {
+                        return '$10.00';
+                    }
+                };
+            }
+        })->present()->something());
     }
 
     public function testTransform()


### PR DESCRIPTION
`Optional@__call()` is always called in place of `__call()` pulled in from the Macroable trait.