### PR TITLE
[5.6] Bumped versions for 5.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -102,7 +102,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "5.5-dev"
+            "dev-master": "5.6-dev"
         }
     },
     "suggest": {

--- a/src/Illuminate/Auth/composer.json
+++ b/src/Illuminate/Auth/composer.json
@@ -15,10 +15,10 @@
     ],
     "require": {
         "php": ">=7.0",
-        "illuminate/contracts": "5.5.*",
-        "illuminate/http": "5.5.*",
-        "illuminate/queue": "5.5.*",
-        "illuminate/support": "5.5.*"
+        "illuminate/contracts": "5.6.*",
+        "illuminate/http": "5.6.*",
+        "illuminate/queue": "5.6.*",
+        "illuminate/support": "5.6.*"
     },
     "autoload": {
         "psr-4": {
@@ -27,13 +27,13 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "5.5-dev"
+            "dev-master": "5.6-dev"
         }
     },
     "suggest": {
-        "illuminate/console": "Required to use the auth:clear-resets command (5.5.*).",
-        "illuminate/queue": "Required to fire login / logout events (5.5.*).",
-        "illuminate/session": "Required to use the session based guard (5.5.*)."
+        "illuminate/console": "Required to use the auth:clear-resets command (5.6.*).",
+        "illuminate/queue": "Required to fire login / logout events (5.6.*).",
+        "illuminate/session": "Required to use the session based guard (5.6.*)."
     },
     "config": {
         "sort-packages": true

--- a/src/Illuminate/Broadcasting/composer.json
+++ b/src/Illuminate/Broadcasting/composer.json
@@ -15,10 +15,10 @@
     ],
     "require": {
         "php": ">=7.0",
-        "illuminate/bus": "5.5.*",
-        "illuminate/contracts": "5.5.*",
-        "illuminate/queue": "5.5.*",
-        "illuminate/support": "5.5.*"
+        "illuminate/bus": "5.6.*",
+        "illuminate/contracts": "5.6.*",
+        "illuminate/queue": "5.6.*",
+        "illuminate/support": "5.6.*"
     },
     "autoload": {
         "psr-4": {
@@ -27,7 +27,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "5.5-dev"
+            "dev-master": "5.6-dev"
         }
     },
     "suggest": {

--- a/src/Illuminate/Bus/composer.json
+++ b/src/Illuminate/Bus/composer.json
@@ -15,9 +15,9 @@
     ],
     "require": {
         "php": ">=7.0",
-        "illuminate/contracts": "5.5.*",
-        "illuminate/pipeline": "5.5.*",
-        "illuminate/support": "5.5.*"
+        "illuminate/contracts": "5.6.*",
+        "illuminate/pipeline": "5.6.*",
+        "illuminate/support": "5.6.*"
     },
     "autoload": {
         "psr-4": {
@@ -26,7 +26,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "5.5-dev"
+            "dev-master": "5.6-dev"
         }
     },
     "config": {

--- a/src/Illuminate/Cache/composer.json
+++ b/src/Illuminate/Cache/composer.json
@@ -15,8 +15,8 @@
     ],
     "require": {
         "php": ">=7.0",
-        "illuminate/contracts": "5.5.*",
-        "illuminate/support": "5.5.*"
+        "illuminate/contracts": "5.6.*",
+        "illuminate/support": "5.6.*"
     },
     "autoload": {
         "psr-4": {
@@ -25,13 +25,13 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "5.5-dev"
+            "dev-master": "5.6-dev"
         }
     },
     "suggest": {
-        "illuminate/database": "Required to use the database cache driver (5.5.*).",
-        "illuminate/filesystem": "Required to use the file cache driver (5.5.*).",
-        "illuminate/redis": "Required to use the redis cache driver (5.5.*)."
+        "illuminate/database": "Required to use the database cache driver (5.6.*).",
+        "illuminate/filesystem": "Required to use the file cache driver (5.6.*).",
+        "illuminate/redis": "Required to use the redis cache driver (5.6.*)."
     },
     "config": {
         "sort-packages": true

--- a/src/Illuminate/Config/composer.json
+++ b/src/Illuminate/Config/composer.json
@@ -15,8 +15,8 @@
     ],
     "require": {
         "php": ">=7.0",
-        "illuminate/contracts": "5.5.*",
-        "illuminate/support": "5.5.*"
+        "illuminate/contracts": "5.6.*",
+        "illuminate/support": "5.6.*"
     },
     "autoload": {
         "psr-4": {
@@ -25,7 +25,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "5.5-dev"
+            "dev-master": "5.6-dev"
         }
     },
     "config": {

--- a/src/Illuminate/Console/composer.json
+++ b/src/Illuminate/Console/composer.json
@@ -15,8 +15,8 @@
     ],
     "require": {
         "php": ">=7.0",
-        "illuminate/contracts": "5.5.*",
-        "illuminate/support": "5.5.*",
+        "illuminate/contracts": "5.6.*",
+        "illuminate/support": "5.6.*",
         "symfony/console": "~3.3"
     },
     "autoload": {
@@ -26,7 +26,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "5.5-dev"
+            "dev-master": "5.6-dev"
         }
     },
     "suggest": {

--- a/src/Illuminate/Container/composer.json
+++ b/src/Illuminate/Container/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "php": ">=7.0",
-        "illuminate/contracts": "5.5.*",
+        "illuminate/contracts": "5.6.*",
         "psr/container": "~1.0"
     },
     "autoload": {
@@ -25,7 +25,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "5.5-dev"
+            "dev-master": "5.6-dev"
         }
     },
     "config": {

--- a/src/Illuminate/Contracts/composer.json
+++ b/src/Illuminate/Contracts/composer.json
@@ -25,7 +25,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "5.5-dev"
+            "dev-master": "5.6-dev"
         }
     },
     "config": {

--- a/src/Illuminate/Cookie/composer.json
+++ b/src/Illuminate/Cookie/composer.json
@@ -15,8 +15,8 @@
     ],
     "require": {
         "php": ">=7.0",
-        "illuminate/contracts": "5.5.*",
-        "illuminate/support": "5.5.*",
+        "illuminate/contracts": "5.6.*",
+        "illuminate/support": "5.6.*",
         "symfony/http-foundation": "~3.3",
         "symfony/http-kernel": "~3.3"
     },
@@ -27,7 +27,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "5.5-dev"
+            "dev-master": "5.6-dev"
         }
     },
     "config": {

--- a/src/Illuminate/Database/composer.json
+++ b/src/Illuminate/Database/composer.json
@@ -16,9 +16,9 @@
     ],
     "require": {
         "php": ">=7.0",
-        "illuminate/container": "5.5.*",
-        "illuminate/contracts": "5.5.*",
-        "illuminate/support": "5.5.*"
+        "illuminate/container": "5.6.*",
+        "illuminate/contracts": "5.6.*",
+        "illuminate/support": "5.6.*"
     },
     "autoload": {
         "psr-4": {
@@ -27,16 +27,16 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "5.5-dev"
+            "dev-master": "5.6-dev"
         }
     },
     "suggest": {
         "doctrine/dbal": "Required to rename columns and drop SQLite columns (~2.5).",
         "fzaninotto/faker": "Required to use the eloquent factory builder (~1.4).",
-        "illuminate/console": "Required to use the database commands (5.5.*).",
-        "illuminate/events": "Required to use the observers with Eloquent (5.5.*).",
-        "illuminate/filesystem": "Required to use the migrations (5.5.*).",
-        "illuminate/pagination": "Required to paginate the result set (5.5.*)."
+        "illuminate/console": "Required to use the database commands (5.6.*).",
+        "illuminate/events": "Required to use the observers with Eloquent (5.6.*).",
+        "illuminate/filesystem": "Required to use the migrations (5.6.*).",
+        "illuminate/pagination": "Required to paginate the result set (5.6.*)."
     },
     "config": {
         "sort-packages": true

--- a/src/Illuminate/Encryption/composer.json
+++ b/src/Illuminate/Encryption/composer.json
@@ -17,8 +17,8 @@
         "php": ">=7.0",
         "ext-mbstring": "*",
         "ext-openssl": "*",
-        "illuminate/contracts": "5.5.*",
-        "illuminate/support": "5.5.*"
+        "illuminate/contracts": "5.6.*",
+        "illuminate/support": "5.6.*"
     },
     "autoload": {
         "psr-4": {
@@ -27,7 +27,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "5.5-dev"
+            "dev-master": "5.6-dev"
         }
     },
     "config": {

--- a/src/Illuminate/Events/composer.json
+++ b/src/Illuminate/Events/composer.json
@@ -15,9 +15,9 @@
     ],
     "require": {
         "php": ">=7.0",
-        "illuminate/container": "5.5.*",
-        "illuminate/contracts": "5.5.*",
-        "illuminate/support": "5.5.*"
+        "illuminate/container": "5.6.*",
+        "illuminate/contracts": "5.6.*",
+        "illuminate/support": "5.6.*"
     },
     "autoload": {
         "psr-4": {
@@ -26,7 +26,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "5.5-dev"
+            "dev-master": "5.6-dev"
         }
     },
     "config": {

--- a/src/Illuminate/Filesystem/composer.json
+++ b/src/Illuminate/Filesystem/composer.json
@@ -15,8 +15,8 @@
     ],
     "require": {
         "php": ">=7.0",
-        "illuminate/contracts": "5.5.*",
-        "illuminate/support": "5.5.*",
+        "illuminate/contracts": "5.6.*",
+        "illuminate/support": "5.6.*",
         "symfony/finder": "~3.3"
     },
     "autoload": {
@@ -26,7 +26,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "5.5-dev"
+            "dev-master": "5.6-dev"
         }
     },
     "suggest": {

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -29,7 +29,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
      *
      * @var string
      */
-    const VERSION = '5.5.0';
+    const VERSION = '5.6-dev';
 
     /**
      * The base path for the Laravel installation.

--- a/src/Illuminate/Hashing/composer.json
+++ b/src/Illuminate/Hashing/composer.json
@@ -15,8 +15,8 @@
     ],
     "require": {
         "php": ">=7.0",
-        "illuminate/contracts": "5.5.*",
-        "illuminate/support": "5.5.*"
+        "illuminate/contracts": "5.6.*",
+        "illuminate/support": "5.6.*"
     },
     "autoload": {
         "psr-4": {
@@ -25,7 +25,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "5.5-dev"
+            "dev-master": "5.6-dev"
         }
     },
     "config": {

--- a/src/Illuminate/Http/composer.json
+++ b/src/Illuminate/Http/composer.json
@@ -15,8 +15,8 @@
     ],
     "require": {
         "php": ">=7.0",
-        "illuminate/session": "5.5.*",
-        "illuminate/support": "5.5.*",
+        "illuminate/session": "5.6.*",
+        "illuminate/support": "5.6.*",
         "symfony/http-foundation": "~3.3",
         "symfony/http-kernel": "~3.3"
     },
@@ -27,7 +27,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "5.5-dev"
+            "dev-master": "5.6-dev"
         }
     },
     "config": {

--- a/src/Illuminate/Log/composer.json
+++ b/src/Illuminate/Log/composer.json
@@ -15,8 +15,8 @@
     ],
     "require": {
         "php": ">=7.0",
-        "illuminate/contracts": "5.5.*",
-        "illuminate/support": "5.5.*",
+        "illuminate/contracts": "5.6.*",
+        "illuminate/support": "5.6.*",
         "monolog/monolog": "~1.11"
     },
     "autoload": {
@@ -26,7 +26,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "5.5-dev"
+            "dev-master": "5.6-dev"
         }
     },
     "config": {

--- a/src/Illuminate/Mail/composer.json
+++ b/src/Illuminate/Mail/composer.json
@@ -16,9 +16,9 @@
     "require": {
         "php": ">=7.0",
         "erusev/parsedown": "~1.6",
-        "illuminate/container": "5.5.*",
-        "illuminate/contracts": "5.5.*",
-        "illuminate/support": "5.5.*",
+        "illuminate/container": "5.6.*",
+        "illuminate/contracts": "5.6.*",
+        "illuminate/support": "5.6.*",
         "psr/log": "~1.0",
         "swiftmailer/swiftmailer": "~6.0",
         "tijsverkoyen/css-to-inline-styles": "~2.2"
@@ -30,7 +30,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "5.5-dev"
+            "dev-master": "5.6-dev"
         }
     },
     "suggest": {

--- a/src/Illuminate/Notifications/composer.json
+++ b/src/Illuminate/Notifications/composer.json
@@ -15,14 +15,14 @@
     ],
     "require": {
         "php": ">=7.0",
-        "illuminate/broadcasting": "5.5.*",
-        "illuminate/bus": "5.5.*",
-        "illuminate/container": "5.5.*",
-        "illuminate/contracts": "5.5.*",
-        "illuminate/filesystem": "5.5.*",
-        "illuminate/mail": "5.5.*",
-        "illuminate/queue": "5.5.*",
-        "illuminate/support": "5.5.*",
+        "illuminate/broadcasting": "5.6.*",
+        "illuminate/bus": "5.6.*",
+        "illuminate/container": "5.6.*",
+        "illuminate/contracts": "5.6.*",
+        "illuminate/filesystem": "5.6.*",
+        "illuminate/mail": "5.6.*",
+        "illuminate/queue": "5.6.*",
+        "illuminate/support": "5.6.*",
         "ramsey/uuid": "~3.0"
     },
     "autoload": {
@@ -32,12 +32,12 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "5.5-dev"
+            "dev-master": "5.6-dev"
         }
     },
     "suggest": {
         "guzzlehttp/guzzle": "Required to use the Slack transport (~6.0)",
-        "illuminate/database": "Required to use the database transport (5.5.*).",
+        "illuminate/database": "Required to use the database transport (5.6.*).",
         "nexmo/client": "Required to use the Nexmo transport (~1.0)."
     },
     "config": {

--- a/src/Illuminate/Pagination/composer.json
+++ b/src/Illuminate/Pagination/composer.json
@@ -15,8 +15,8 @@
     ],
     "require": {
         "php": ">=7.0",
-        "illuminate/contracts": "5.5.*",
-        "illuminate/support": "5.5.*"
+        "illuminate/contracts": "5.6.*",
+        "illuminate/support": "5.6.*"
     },
     "autoload": {
         "psr-4": {
@@ -25,7 +25,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "5.5-dev"
+            "dev-master": "5.6-dev"
         }
     },
     "config": {

--- a/src/Illuminate/Pipeline/composer.json
+++ b/src/Illuminate/Pipeline/composer.json
@@ -15,8 +15,8 @@
     ],
     "require": {
         "php": ">=7.0",
-        "illuminate/contracts": "5.5.*",
-        "illuminate/support": "5.5.*"
+        "illuminate/contracts": "5.6.*",
+        "illuminate/support": "5.6.*"
     },
     "autoload": {
         "psr-4": {
@@ -25,7 +25,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "5.5-dev"
+            "dev-master": "5.6-dev"
         }
     },
     "config": {

--- a/src/Illuminate/Queue/composer.json
+++ b/src/Illuminate/Queue/composer.json
@@ -15,12 +15,12 @@
     ],
     "require": {
         "php": ">=7.0",
-        "illuminate/console": "5.5.*",
-        "illuminate/container": "5.5.*",
-        "illuminate/contracts": "5.5.*",
-        "illuminate/database": "5.5.*",
-        "illuminate/filesystem": "5.5.*",
-        "illuminate/support": "5.5.*",
+        "illuminate/console": "5.6.*",
+        "illuminate/container": "5.6.*",
+        "illuminate/contracts": "5.6.*",
+        "illuminate/database": "5.6.*",
+        "illuminate/filesystem": "5.6.*",
+        "illuminate/support": "5.6.*",
         "symfony/debug": "~3.3",
         "symfony/process": "~3.3"
     },
@@ -31,12 +31,12 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "5.5-dev"
+            "dev-master": "5.6-dev"
         }
     },
     "suggest": {
         "aws/aws-sdk-php": "Required to use the SQS queue driver (~3.0).",
-        "illuminate/redis": "Required to use the Redis queue driver (5.5.*).",
+        "illuminate/redis": "Required to use the Redis queue driver (5.6.*).",
         "pda/pheanstalk": "Required to use the Beanstalk queue driver (~3.0)."
     },
     "config": {

--- a/src/Illuminate/Redis/composer.json
+++ b/src/Illuminate/Redis/composer.json
@@ -15,8 +15,8 @@
     ],
     "require": {
         "php": ">=7.0",
-        "illuminate/contracts": "5.5.*",
-        "illuminate/support": "5.5.*",
+        "illuminate/contracts": "5.6.*",
+        "illuminate/support": "5.6.*",
         "predis/predis": "~1.0"
     },
     "autoload": {
@@ -26,7 +26,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "5.5-dev"
+            "dev-master": "5.6-dev"
         }
     },
     "config": {

--- a/src/Illuminate/Routing/composer.json
+++ b/src/Illuminate/Routing/composer.json
@@ -15,12 +15,12 @@
     ],
     "require": {
         "php": ">=7.0",
-        "illuminate/container": "5.5.*",
-        "illuminate/contracts": "5.5.*",
-        "illuminate/http": "5.5.*",
-        "illuminate/pipeline": "5.5.*",
-        "illuminate/session": "5.5.*",
-        "illuminate/support": "5.5.*",
+        "illuminate/container": "5.6.*",
+        "illuminate/contracts": "5.6.*",
+        "illuminate/http": "5.6.*",
+        "illuminate/pipeline": "5.6.*",
+        "illuminate/session": "5.6.*",
+        "illuminate/support": "5.6.*",
         "symfony/debug": "~3.3",
         "symfony/http-foundation": "~3.3",
         "symfony/http-kernel": "~3.3",
@@ -33,11 +33,11 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "5.5-dev"
+            "dev-master": "5.6-dev"
         }
     },
     "suggest": {
-        "illuminate/console": "Required to use the make commands (5.5.*).",
+        "illuminate/console": "Required to use the make commands (5.6.*).",
         "symfony/psr-http-message-bridge": "Required to psr7 bridging features (0.2.*)."
     },
     "config": {

--- a/src/Illuminate/Session/composer.json
+++ b/src/Illuminate/Session/composer.json
@@ -15,9 +15,9 @@
     ],
     "require": {
         "php": ">=7.0",
-        "illuminate/contracts": "5.5.*",
-        "illuminate/filesystem": "5.5.*",
-        "illuminate/support": "5.5.*",
+        "illuminate/contracts": "5.6.*",
+        "illuminate/filesystem": "5.6.*",
+        "illuminate/support": "5.6.*",
         "symfony/finder": "~3.3",
         "symfony/http-foundation": "~3.3"
     },
@@ -28,11 +28,11 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "5.5-dev"
+            "dev-master": "5.6-dev"
         }
     },
     "suggest": {
-        "illuminate/console": "Required to use the session:table command (5.5.*)."
+        "illuminate/console": "Required to use the session:table command (5.6.*)."
     },
     "config": {
         "sort-packages": true

--- a/src/Illuminate/Support/composer.json
+++ b/src/Illuminate/Support/composer.json
@@ -17,7 +17,7 @@
         "php": ">=7.0",
         "ext-mbstring": "*",
         "doctrine/inflector": "~1.1",
-        "illuminate/contracts": "5.5.*",
+        "illuminate/contracts": "5.6.*",
         "nesbot/carbon": "^1.20"
     },
     "replace": {
@@ -33,7 +33,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "5.5-dev"
+            "dev-master": "5.6-dev"
         }
     },
     "suggest": {

--- a/src/Illuminate/Translation/composer.json
+++ b/src/Illuminate/Translation/composer.json
@@ -15,9 +15,9 @@
     ],
     "require": {
         "php": ">=7.0",
-        "illuminate/contracts": "5.5.*",
-        "illuminate/filesystem": "5.5.*",
-        "illuminate/support": "5.5.*"
+        "illuminate/contracts": "5.6.*",
+        "illuminate/filesystem": "5.6.*",
+        "illuminate/support": "5.6.*"
     },
     "autoload": {
         "psr-4": {
@@ -26,7 +26,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "5.5-dev"
+            "dev-master": "5.6-dev"
         }
     },
     "config": {

--- a/src/Illuminate/Validation/composer.json
+++ b/src/Illuminate/Validation/composer.json
@@ -15,10 +15,10 @@
     ],
     "require": {
         "php": ">=7.0",
-        "illuminate/container": "5.5.*",
-        "illuminate/contracts": "5.5.*",
-        "illuminate/support": "5.5.*",
-        "illuminate/translation": "5.5.*",
+        "illuminate/container": "5.6.*",
+        "illuminate/contracts": "5.6.*",
+        "illuminate/support": "5.6.*",
+        "illuminate/translation": "5.6.*",
         "symfony/http-foundation": "~3.3"
     },
     "autoload": {
@@ -28,11 +28,11 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "5.5-dev"
+            "dev-master": "5.6-dev"
         }
     },
     "suggest": {
-        "illuminate/database": "Required to use the database presence verifier (5.5.*)."
+        "illuminate/database": "Required to use the database presence verifier (5.6.*)."
     },
     "config": {
         "sort-packages": true

--- a/src/Illuminate/View/composer.json
+++ b/src/Illuminate/View/composer.json
@@ -15,11 +15,11 @@
     ],
     "require": {
         "php": ">=7.0",
-        "illuminate/container": "5.5.*",
-        "illuminate/contracts": "5.5.*",
-        "illuminate/events": "5.5.*",
-        "illuminate/filesystem": "5.5.*",
-        "illuminate/support": "5.5.*",
+        "illuminate/container": "5.6.*",
+        "illuminate/contracts": "5.6.*",
+        "illuminate/events": "5.6.*",
+        "illuminate/filesystem": "5.6.*",
+        "illuminate/support": "5.6.*",
         "symfony/debug": "~3.3"
     },
     "autoload": {
@@ -29,7 +29,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "5.5-dev"
+            "dev-master": "5.6-dev"
         }
     },
     "config": {

--- a/tests/Console/ConsoleApplicationTest.php
+++ b/tests/Console/ConsoleApplicationTest.php
@@ -47,7 +47,7 @@ class ConsoleApplicationTest extends TestCase
 
     protected function getMockConsole(array $methods)
     {
-        $app = m::mock('Illuminate\Contracts\Foundation\Application', ['version' => '5.5']);
+        $app = m::mock('Illuminate\Contracts\Foundation\Application', ['version' => '5.6']);
         $events = m::mock('Illuminate\Contracts\Events\Dispatcher', ['dispatch' => null]);
 
         $console = $this->getMockBuilder('Illuminate\Console\Application')->setMethods($methods)->setConstructorArgs([

--- a/tests/Support/SupportTestingMailFakeTest.php
+++ b/tests/Support/SupportTestingMailFakeTest.php
@@ -111,7 +111,7 @@ class MailableStub extends Mailable
 {
     public $framework = 'Laravel';
 
-    protected $version = '5.5';
+    protected $version = '5.6';
 
     /**
      * Build the message.
@@ -129,7 +129,7 @@ class QueueableMailableStub extends Mailable implements ShouldQueue
 {
     public $framework = 'Laravel';
 
-    protected $version = '5.5';
+    protected $version = '5.6';
 
     /**
      * Build the message.


### PR DESCRIPTION
I've intentionally not bumped the minimum symfony versions for now. I wonder if the best option for Laravel 5.6 will be to actually go Symfony 4.x only, since Laravel 5.5 is LTS, and is `~3.3`, so will eventually end up on Symfony 3.4 LTS.