### PR TITLE
[5.5] Recommend stable psr http bridge

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -119,7 +119,7 @@
         "pusher/pusher-php-server": "Required to use the Pusher broadcast driver (~2.0).",
         "symfony/css-selector": "Required to use some of the crawler integration testing tools (~3.3).",
         "symfony/dom-crawler": "Required to use most of the crawler integration testing tools (~3.3).",
-        "symfony/psr-http-message-bridge": "Required to psr7 bridging features (0.2.*)."
+        "symfony/psr-http-message-bridge": "Required to psr7 bridging features (~1.0)."
     },
     "config": {
         "sort-packages": true

--- a/src/Illuminate/Routing/composer.json
+++ b/src/Illuminate/Routing/composer.json
@@ -38,7 +38,7 @@
     },
     "suggest": {
         "illuminate/console": "Required to use the make commands (5.5.*).",
-        "symfony/psr-http-message-bridge": "Required to psr7 bridging features (0.2.*)."
+        "symfony/psr-http-message-bridge": "Required to psr7 bridging features (~1.0)."
     },
     "config": {
         "sort-packages": true


### PR DESCRIPTION
1.0 has been out since last year, and as far as I'm aware works just fine. We should recommend that version, instead of 0.2.