### PR TITLE
[5.5] Add 'retrieved' model event

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
@@ -57,7 +57,7 @@ trait HasEvents
             [
                 'creating', 'created', 'updating', 'updated',
                 'deleting', 'deleted', 'saving', 'saved',
-                'restoring', 'restored',
+                'restoring', 'restored', 'retrieved',
             ],
             $this->observables
         );

--- a/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
@@ -275,6 +275,17 @@ trait HasEvents
     }
 
     /**
+     * Register a retrieved model event with the dispatcher.
+     *
+     * @param  \Closure|string  $callback
+     * @return void
+     */
+    public static function retrieved($callback)
+    {
+        static::registerModelEvent('retrieved', $callback);
+    }
+
+    /**
      * Remove all of the event listeners for the model.
      *
      * @return void

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -303,6 +303,8 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 
         $model->setConnection($connection ?: $this->getConnectionName());
 
+        $model->fireModelEvent('retrieved', false);
+
         return $model;
     }
 


### PR DESCRIPTION
As discussed with @taylorotwell at Laracon EU, this simple PR allows Eloquent models to fire a `retrieved` event as soon as their contents are retrieved from the database.

## Use case
This comes from the following use case:

1. I need to do some manipulations with the attributes of a model as soon as this model is retrieved from the database.
2. I also need to do the opposite operation just before the model is saved back to the DB.

The second case is pretty easy: I just need to register an event on my model, for example in its `boot()` method:

```php
// In MyModel.php

protected static function boot()
{
    parent::boot();

    static::saving(function ($model) {
        // Do some stuff...
    });
}
```

However, there is no symmetric way to execute code when an existing model is retrieved from the database.

The currently most straightforward way to implement this behavior is to extend the `newFromBuilder()` method on our custom model, like so:

```php
// In MyModel.php

public function newFromBuilder($attributes = [], $connection = null)
{
    // First, retrieve the model using the original method.
    $model = parent::newFromBuilder($attributes, $connection);

    // Then, we do our custom stuff.
    // ...

    return $model;
}
```

*This works*, but it’s clearly not as elegant nor as practical as just registering a listener on the model.

## What this PR makes possible
This pull request would allow to satisfy the use case, for example, in the following way:

```php
// In MyModel.php

protected static function boot()
{
    parent::boot();

    static::retrieved(function ($model) {
        // Do some stuff...
    });

    static::saving(function ($model) {
        // Do some other stuff...
    });
}
```

Of course, you could also use an observer class instead, or any other working way you could think of.

### Notes
- I don’t propose any `retrieving` event, because I cannot find any use case for it. More importantly, I don’t really see any place where a `retrieving` event would make sense. Just before hydrating the model? Before running the SQL query? I don’t have any satisfying answer;
- Since none of the `*ed` model events have tests (only the `*ing` events require tests), I didn’t add any;
- If this PR is merged, I’ll do another one to update [the docs](https://github.com/laravel/docs).