### PR TITLE
[5.5] Add array type hinting

### DIFF
--- a/src/Illuminate/Database/QueryException.php
+++ b/src/Illuminate/Database/QueryException.php
@@ -51,7 +51,7 @@ class QueryException extends PDOException
      * @param  \Exception $previous
      * @return string
      */
-    protected function formatMessage($sql, $bindings, $previous)
+    protected function formatMessage($sql, array $bindings, $previous)
     {
         return $previous->getMessage().' (SQL: '.Str::replaceArray('?', $bindings, $sql).')';
     }


### PR DESCRIPTION
Should we add type hinting also for known classes? For example here $previous should be `\Exception` object but type hinting for it is also missing