### PR TITLE
[5.5] Fixed Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,21 @@
 language: php
 
-php:
-  - 7.0.21
-  - 7.1
-  - 7.2
-
 env:
   global:
-    - setup=basic
+    - setup=stable
 
 matrix:
-  allow_failures:
-    - php: 7.2
   fast_finish: true
   include:
     - php: 7.0.21
-      env: setup=lowest
     - php: 7.0.21
-      env: setup=stable
-    - php: 7.1
       env: setup=lowest
     - php: 7.1
-      env: setup=stable
+    - php: 7.1
+      env: setup=lowest
+    - php: 7.2
+    - php: 7.2
+      env: setup=lowest
 
 sudo: false
 
@@ -40,7 +34,6 @@ before_install:
   - travis_retry composer self-update
 
 install:
-  - if [[ $setup = 'basic' ]]; then travis_retry composer install --no-interaction --prefer-dist --no-suggest; fi
   - if [[ $setup = 'stable' ]]; then travis_retry composer update --prefer-dist --no-interaction --prefer-stable --no-suggest; fi
   - if [[ $setup = 'lowest' ]]; then travis_retry composer update --prefer-dist --no-interaction --prefer-lowest --prefer-stable --no-suggest; fi
 

--- a/composer.json
+++ b/composer.json
@@ -75,7 +75,7 @@
         "aws/aws-sdk-php": "~3.0",
         "doctrine/dbal": "~2.5",
         "filp/whoops": "^2.1.4",
-        "mockery/mockery": "~0.9.4",
+        "mockery/mockery": "~1.0",
         "orchestra/testbench-core": "3.5.*",
         "pda/pheanstalk": "~3.0",
         "phpunit/phpunit": "~6.0",


### PR DESCRIPTION
1. Upgrading Mockery to 1.x fixes PHP 7.2 compatibility.
2. PHP 7.2 can now be taken out of allow failures mode on travis.
3. Our basic and stable modes on travis were actually identical, since prefer-stable is set in the composer.json. I've removed the duplicate test runs.