### PR TITLE
[5.5] Move console commands auto discovery to the bootstrap method

### DIFF
--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -116,12 +116,6 @@ class Kernel implements KernelContract
         try {
             $this->bootstrap();
 
-            if (! $this->commandsLoaded) {
-                $this->commands();
-
-                $this->commandsLoaded = true;
-            }
-
             return $this->getArtisan()->run($input, $output);
         } catch (Exception $e) {
             $this->reportException($e);
@@ -249,12 +243,6 @@ class Kernel implements KernelContract
     {
         $this->bootstrap();
 
-        if (! $this->commandsLoaded) {
-            $this->commands();
-
-            $this->commandsLoaded = true;
-        }
-
         return $this->getArtisan()->call($command, $parameters, $outputBuffer);
     }
 
@@ -303,6 +291,12 @@ class Kernel implements KernelContract
     {
         if (! $this->app->hasBeenBootstrapped()) {
             $this->app->bootstrapWith($this->bootstrappers());
+        }
+
+        if (! $this->commandsLoaded) {
+            $this->commands();
+
+            $this->commandsLoaded = true;
         }
 
         // If we are calling an arbitrary command from within the application, we'll load


### PR DESCRIPTION
This makes auto discovery work for all Kernel methods, for example `Kernel::all()` now doesn't show the auto-discovered commands.

It also DRYs some.