### PR TITLE
Allow commands from other namespaces to be auto registered

### DIFF
--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -209,14 +209,12 @@ class Kernel implements KernelContract
             return;
         }
 
-        $namespace = $this->app->getNamespace();
-
         foreach ((new Finder)->in($paths)->files() as $command) {
-            $command = $namespace.str_replace(
+            $command = ucfirst(str_replace(
                 ['/', '.php'],
                 ['\\', ''],
-                Str::after($command->getPathname(), app_path().DIRECTORY_SEPARATOR)
-            );
+                Str::after($command->getPathname(), base_path().DIRECTORY_SEPARATOR)
+            ));
 
             if (is_subclass_of($command, Command::class)) {
                 Artisan::starting(function ($artisan) use ($command) {


### PR DESCRIPTION
If you have multiple namespaces in the autoload section of your composer.json, the `load('path/to/commands')` method won't register any commands beyond the first namespace.

`getNamespace()` will return the first namespace found in the autoload section of `composer.json`, usually `App\`.