### PR TITLE
[5.5] HasOneOrMany and MorphOneOrMany refactor

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -55,8 +55,19 @@ abstract class HasOneOrMany extends Relation
     public function make(array $attributes = [])
     {
         return tap($this->related->newInstance($attributes), function ($instance) {
-            $instance->setAttribute($this->getForeignKeyName(), $this->getParentKey());
+            $this->setForeignAttributesForCreate($instance);
         });
+    }
+
+    /**
+     * Set the foreign key name and key for creating a related model.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @return void
+     */
+    protected function setForeignAttributesForCreate(Model $model)
+    {
+        $model->setAttribute($this->getForeignKeyName(), $this->getParentKey());
     }
 
     /**
@@ -188,7 +199,7 @@ abstract class HasOneOrMany extends Relation
         if (is_null($instance = $this->find($id, $columns))) {
             $instance = $this->related->newInstance();
 
-            $instance->setAttribute($this->getForeignKeyName(), $this->getParentKey());
+            $this->setForeignAttributesForCreate($instance);
         }
 
         return $instance;
@@ -206,7 +217,7 @@ abstract class HasOneOrMany extends Relation
         if (is_null($instance = $this->where($attributes)->first())) {
             $instance = $this->related->newInstance($attributes + $values);
 
-            $instance->setAttribute($this->getForeignKeyName(), $this->getParentKey());
+            $this->setForeignAttributesForCreate($instance);
         }
 
         return $instance;
@@ -252,7 +263,7 @@ abstract class HasOneOrMany extends Relation
      */
     public function save(Model $model)
     {
-        $model->setAttribute($this->getForeignKeyName(), $this->getParentKey());
+        $this->setForeignAttributesForCreate($model);
 
         return $model->save() ? $model : false;
     }
@@ -281,7 +292,7 @@ abstract class HasOneOrMany extends Relation
     public function create(array $attributes = [])
     {
         return tap($this->related->newInstance($attributes), function ($instance) {
-            $instance->setAttribute($this->getForeignKeyName(), $this->getParentKey());
+            $this->setForeignAttributesForCreate($instance);
 
             $instance->save();
         });

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -60,7 +60,7 @@ abstract class HasOneOrMany extends Relation
     }
 
     /**
-     * Set the foreign key name and key for creating a related model.
+     * Set the foreign ID for creating a related model.
      *
      * @param  \Illuminate\Database\Eloquent\Model  $model
      * @return void

--- a/src/Illuminate/Database/Eloquent/Relations/MorphOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphOneOrMany.php
@@ -41,22 +41,6 @@ abstract class MorphOneOrMany extends HasOneOrMany
     }
 
     /**
-     * Create and return an un-saved instance of the related model.
-     *
-     * @param  array  $attributes
-     * @return \Illuminate\Database\Eloquent\Model
-     */
-    public function make(array $attributes = [])
-    {
-        return tap($this->related->newInstance($attributes), function ($instance) {
-            // When saving a polymorphic relationship, we need to set not only the foreign
-            // key, but also the foreign key type, which is typically the class name of
-            // the parent model. This makes the polymorphic item unique in the table.
-            $this->setForeignAttributesForCreate($instance);
-        });
-    }
-
-    /**
      * Set the base constraints on the relation query.
      *
      * @return void
@@ -84,48 +68,6 @@ abstract class MorphOneOrMany extends HasOneOrMany
     }
 
     /**
-     * Find a related model by its primary key or return new instance of the related model.
-     *
-     * @param  mixed  $id
-     * @param  array  $columns
-     * @return \Illuminate\Support\Collection|\Illuminate\Database\Eloquent\Model
-     */
-    public function findOrNew($id, $columns = ['*'])
-    {
-        if (is_null($instance = $this->find($id, $columns))) {
-            $instance = $this->related->newInstance();
-
-            // When saving a polymorphic relationship, we need to set not only the foreign
-            // key, but also the foreign key type, which is typically the class name of
-            // the parent model. This makes the polymorphic item unique in the table.
-            $this->setForeignAttributesForCreate($instance);
-        }
-
-        return $instance;
-    }
-
-    /**
-     * Get the first related model record matching the attributes or instantiate it.
-     *
-     * @param  array  $attributes
-     * @param  array  $values
-     * @return \Illuminate\Database\Eloquent\Model
-     */
-    public function firstOrNew(array $attributes, array $values = [])
-    {
-        if (is_null($instance = $this->where($attributes)->first())) {
-            $instance = $this->related->newInstance($attributes + $values);
-
-            // When saving a polymorphic relationship, we need to set not only the foreign
-            // key, but also the foreign key type, which is typically the class name of
-            // the parent model. This makes the polymorphic item unique in the table.
-            $this->setForeignAttributesForCreate($instance);
-        }
-
-        return $instance;
-    }
-
-    /**
      * Attach a model instance to the parent model.
      *
      * @param  \Illuminate\Database\Eloquent\Model  $model
@@ -136,24 +78,6 @@ abstract class MorphOneOrMany extends HasOneOrMany
         $model->setAttribute($this->getMorphType(), $this->morphClass);
 
         return parent::save($model);
-    }
-
-    /**
-     * Create a new instance of the related model.
-     *
-     * @param  array  $attributes
-     * @return \Illuminate\Database\Eloquent\Model
-     */
-    public function create(array $attributes = [])
-    {
-        return tap($this->related->newInstance($attributes), function ($instance) {
-            // When saving a polymorphic relationship, we need to set not only the foreign
-            // key, but also the foreign key type, which is typically the class name of
-            // the parent model. This makes the polymorphic item unique in the table.
-            $this->setForeignAttributesForCreate($instance);
-
-            $instance->save();
-        });
     }
 
     /**

--- a/tests/Database/DatabaseEloquentHasManyTest.php
+++ b/tests/Database/DatabaseEloquentHasManyTest.php
@@ -7,6 +7,7 @@ use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Model;
 
 class DatabaseEloquentHasManyTest extends TestCase
 {
@@ -45,10 +46,10 @@ class DatabaseEloquentHasManyTest extends TestCase
     {
         $relation = $this->getRelation();
         $relation->getQuery()->shouldReceive('find')->once()->with('foo', ['*'])->andReturn(null);
-        $relation->getRelated()->shouldReceive('newInstance')->once()->with()->andReturn($model = m::mock('stdClass'));
+        $relation->getRelated()->shouldReceive('newInstance')->once()->with()->andReturn($model = m::mock(Model::class));
         $model->shouldReceive('setAttribute')->once()->with('foreign_key', 1);
 
-        $this->assertInstanceOf(stdClass::class, $relation->findOrNew('foo'));
+        $this->assertInstanceOf(Model::class, $relation->findOrNew('foo'));
     }
 
     public function testFirstOrNewMethodFindsFirstModel()
@@ -153,12 +154,12 @@ class DatabaseEloquentHasManyTest extends TestCase
         $relation = $this->getRelation();
         $relation->getQuery()->shouldReceive('where')->once()->with(['foo'])->andReturn($relation->getQuery());
         $relation->getQuery()->shouldReceive('first')->once()->with()->andReturn(null);
-        $relation->getRelated()->shouldReceive('newInstance')->once()->with(['foo'])->andReturn($model = m::mock('stdClass'));
+        $relation->getRelated()->shouldReceive('newInstance')->once()->with(['foo'])->andReturn($model = m::mock(Model::class));
         $model->shouldReceive('save')->once()->andReturn(true);
         $model->shouldReceive('fill')->once()->with(['bar']);
         $model->shouldReceive('setAttribute')->once()->with('foreign_key', 1);
 
-        $this->assertInstanceOf(stdClass::class, $relation->updateOrCreate(['foo'], ['bar']));
+        $this->assertInstanceOf(Model::class, $relation->updateOrCreate(['foo'], ['bar']));
     }
 
     public function testUpdateMethodUpdatesModelsWithTimestamps()

--- a/tests/Database/DatabaseEloquentHasManyTest.php
+++ b/tests/Database/DatabaseEloquentHasManyTest.php
@@ -5,9 +5,9 @@ namespace Illuminate\Tests\Database;
 use stdClass;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Relations\HasMany;
-use Illuminate\Database\Eloquent\Model;
 
 class DatabaseEloquentHasManyTest extends TestCase
 {


### PR DESCRIPTION
This is further changes in HasOneOrMany and MorphOneOrMany that let to remove other duplicated methods.

Reviewing is welcome just to make sure nothing won't be broken.