### PR TITLE
[5.5] Do not use now helper, as Queue package is not aware of Foundation.

### DIFF
--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -4,6 +4,7 @@ namespace Illuminate\Queue;
 
 use Exception;
 use Throwable;
+use Illuminate\Support\Carbon;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Database\DetectsLostConnections;
 use Illuminate\Contracts\Debug\ExceptionHandler;
@@ -382,7 +383,7 @@ class Worker
 
         $timeoutAt = $job->timeoutAt();
 
-        if ($timeoutAt && now()->getTimestamp() <= $timeoutAt) {
+        if ($timeoutAt && Carbon::now()->getTimestamp() <= $timeoutAt) {
             return;
         }
 
@@ -410,7 +411,7 @@ class Worker
     {
         $maxTries = ! is_null($job->maxTries()) ? $job->maxTries() : $maxTries;
 
-        if ($job->timeoutAt() && $job->timeoutAt() <= now()->getTimestamp()) {
+        if ($job->timeoutAt() && $job->timeoutAt() <= Carbon::now()->getTimestamp()) {
             $this->failJob($connectionName, $job, $e);
         }
 

--- a/tests/Integration/Http/ThrottleRequestsTest.php
+++ b/tests/Integration/Http/ThrottleRequestsTest.php
@@ -53,7 +53,7 @@ class ThrottleRequestsTest extends TestCase
             $this->assertEquals(2, $e->getHeaders()['X-RateLimit-Limit']);
             $this->assertEquals(0, $e->getHeaders()['X-RateLimit-Remaining']);
             $this->assertEquals(2, $e->getHeaders()['Retry-After']);
-            $this->assertEquals(now()->timestamp + 2, $e->getHeaders()['X-RateLimit-Reset']);
+            $this->assertEquals(Carbon::now()->addSeconds(2)->getTimestamp(), $e->getHeaders()['X-RateLimit-Reset']);
         }
     }
 }

--- a/tests/Integration/Http/ThrottleRequestsWithRedisTest.php
+++ b/tests/Integration/Http/ThrottleRequestsWithRedisTest.php
@@ -43,7 +43,7 @@ class ThrottleRequestsWithRedisTest extends TestCase
             $this->assertEquals(2, $e->getHeaders()['X-RateLimit-Limit']);
             $this->assertEquals(0, $e->getHeaders()['X-RateLimit-Remaining']);
             $this->assertTrue(in_array($e->getHeaders()['Retry-After'], [2, 3]));
-            $this->assertTrue(in_array($e->getHeaders()['X-RateLimit-Reset'], [now()->timestamp + 2, now()->timestamp + 3]));
+            $this->assertTrue(in_array($e->getHeaders()['X-RateLimit-Reset'], [Carbon::now()->getTimestamp() + 2, Carbon::now()->timestamp + 3]));
         }
     }
 }

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -143,7 +143,7 @@ class QueueWorkerTest extends TestCase
         $job->attempts = 0;
 
         Carbon::setTestNow(
-            now()->addSeconds(1)
+            Carbon::now()->addSeconds(1)
         );
 
         $worker = $this->getWorker('default', ['queue' => [$job]]);
@@ -184,12 +184,12 @@ class QueueWorkerTest extends TestCase
             $job->attempts++;
         });
 
-        $job->timeoutAt = now()->addSeconds(2)->getTimestamp();
+        $job->timeoutAt = Carbon::now()->addSeconds(2)->getTimestamp();
 
         $job->attempts = 1;
 
         Carbon::setTestNow(
-            now()->addSeconds(3)
+            Carbon::now()->addSeconds(3)
         );
 
         $worker = $this->getWorker('default', ['queue' => [$job]]);


### PR DESCRIPTION
Do not use now helper, as Queue package is not aware of Foundation.
Also prefer Carbon in tests.

