### PR TITLE
[5.5] Cast consistancy

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/Grammar.php
@@ -224,7 +224,7 @@ abstract class Grammar extends BaseGrammar
 
         return is_bool($value)
                     ? "'".(int) $value."'"
-                    : "'".strval($value)."'";
+                    : "'".(string) $value."'";
     }
 
     /**

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -669,7 +669,7 @@ trait ValidatesAttributes
         }
 
         if (filter_var($id, FILTER_VALIDATE_INT) !== false) {
-            $id = intval($id);
+            $id = (int) $id;
         }
 
         return $id;

--- a/src/Illuminate/Validation/ValidationRuleParser.php
+++ b/src/Illuminate/Validation/ValidationRuleParser.php
@@ -111,7 +111,7 @@ class ValidationRuleParser
             return $rule;
         }
 
-        return strval($rule);
+        return (string) $rule;
     }
 
     /**


### PR DESCRIPTION
Cast consistancy: use (int) and (string)

Might be worth adding `modernize_types_casting` to StyleCI laravel preset