### PR TITLE
[5.5] setModel parameter should be the model name

### DIFF
--- a/src/Illuminate/Routing/ImplicitRouteBinding.php
+++ b/src/Illuminate/Routing/ImplicitRouteBinding.php
@@ -33,7 +33,7 @@ class ImplicitRouteBinding
             $instance = $container->make($parameter->getClass()->name);
 
             if (! $model = $instance->resolveRouteBinding($parameterValue)) {
-                throw (new ModelNotFoundException)->setModel($parameter->getClass());
+                throw (new ModelNotFoundException)->setModel($parameter->getClass()->name);
             }
 
             $route->setParameter($parameterName, $model);


### PR DESCRIPTION
Addresses #20888 

### Details:
In all other cases throughout the framework where setModel is called on ModelNotFoundException, the string name of the model is passed. Here, in ImplicitRouteBinding, a ReflectionClass object is passed.

### Before:
When calling 'getModel' on the exception object, a ReflectionClass object will be returned.

### After:
$exception->getModel will return the string name of the model, just as it does elsewhere in the framework.