### PR TITLE
[5.5] Make Optional@__call really macroable

### DIFF
--- a/src/Illuminate/Support/Optional.php
+++ b/src/Illuminate/Support/Optional.php
@@ -48,12 +48,12 @@ class Optional
      */
     public function __call($method, $parameters)
     {
-        if (is_object($this->value)) {
-            return $this->value->{$method}(...$parameters);
-        }
-
         if (static::hasMacro($method)) {
             return $this->macroCall($method, $parameters);
+        }
+
+        if (is_object($this->value)) {
+            return $this->value->{$method}(...$parameters);
         }
     }
 }


### PR DESCRIPTION
We need to firstly check existence of macro and only then proxy `__call` to the value. Otherwise it won't be really macroable (because macros won't work for Optional with value inside).