### PR TITLE
[5.5] use $attributes property directly instead of getAttributes() method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1019,7 +1019,7 @@ trait HasAttributes
     {
         $dirty = [];
 
-        foreach ($this->getAttributes() as $key => $value) {
+        foreach ($this->attributes as $key => $value) {
             if (! $this->originalIsEquivalent($key, $value)) {
                 $dirty[$key] = $value;
             }


### PR DESCRIPTION
This closes #20902 and provides backwards compatibility for code that overrides the `getAttributes()` method on a model.