### PR TITLE
[5.5] Fix Basic authentication not working.

### DIFF
--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -336,7 +336,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
      */
     protected function failedBasicResponse()
     {
-        throw new UnauthorizedHttpException('Invalid credentials.');
+        throw new UnauthorizedHttpException('Basic', 'Invalid credentials.');
     }
 
     /**


### PR DESCRIPTION
Fixes #20883. [This commit](https://github.com/laravel/framework/commit/020b407043a755ddb1893a43b8c74e1fe1153a6b) broke it.