### PR TITLE
[5.5] Allow Arrayable for creating new models

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -747,7 +747,7 @@ class Builder
      * @param  array  $attributes
      * @return \Illuminate\Database\Eloquent\Model|$this
      */
-    public function create(array $attributes = [])
+    public function create($attributes = [])
     {
         return tap($this->newModelInstance($attributes), function ($instance) {
             $instance->save();

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -274,6 +274,10 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public function newInstance($attributes = [], $exists = false)
     {
+        if ($attributes instanceof Arrayable) {
+            $attributes = $attributes->toArray();
+        }
+
         // This method just provides a convenient way for us to generate fresh model
         // instances of this current model. It is particularly useful during the
         // hydration of new objects via the Eloquent query builder instances.

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -11,6 +11,7 @@ use DateTimeImmutable;
 use DateTimeInterface;
 use Illuminate\Support\Carbon;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Support\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\InteractsWithTime;
@@ -163,6 +164,14 @@ class DatabaseEloquentModelTest extends TestCase
     {
         $_SERVER['__eloquent.saved'] = false;
         $model = EloquentModelSaveStub::create(['name' => 'taylor']);
+        $this->assertTrue($_SERVER['__eloquent.saved']);
+        $this->assertEquals('taylor', $model->name);
+    }
+
+    public function testCreateMethodWithCollectionSavesNewModel()
+    {
+        $_SERVER['__eloquent.saved'] = false;
+        $model = EloquentModelSaveStub::create(new Collection(['name' => 'taylor']));
         $this->assertTrue($_SERVER['__eloquent.saved']);
         $this->assertEquals('taylor', $model->name);
     }


### PR DESCRIPTION
Type hinting is bad ;-)

More seriously, I wanted to filter some data before sending it to the `::create` method:

```php
Model::create(collect($data)->filter(…)->map(…));
```

But it didn't work because `array` was type hint in the `create` method. I removed the type hint and checked for `Arrayable` to convert the attributes to a plain array before creating the model.

My only concern with this PR is the `instanceof Arrayble` check in `Model::newInstance` performance wise.

The check could be in the `__construct` instead and remove the `array` type hint for `$attributes` in `__construct`.