### PR TITLE
[5.5] Fix migration pluralization in make:model command for special cases

### DIFF
--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -80,7 +80,7 @@ class ModelMakeCommand extends GeneratorCommand
      */
     protected function createMigration()
     {
-        $table = Str::plural(Str::snake(class_basename($this->argument('name'))));
+        $table = Str::snake(Str::plural(class_basename($this->argument('name'))));
 
         $this->call('make:migration', [
             'name' => "create_{$table}_table",


### PR DESCRIPTION
Fix migration pluralization in make:model command for special cases like a CamelCased 'MetaData' model.

At the moment `php artisan make:model MetaData --migration` will generate a migration for 'meta_data**s**' table whereas Eloquent looks for a 'meta_data' table.

This fix enables you to name your model 'MetaData' instead of 'Metadata' and still have a correctly pluralized table migration for 'meta_data' generated.