### PR TITLE
[5.5] Fix PHP error in operatorForWhere collection method.

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -481,18 +481,22 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
         return function ($item) use ($key, $operator, $value) {
             $retrieved = data_get($item, $key);
 
-            switch ($operator) {
-                default:
-                case '=':
-                case '==':  return $retrieved == $value;
-                case '!=':
-                case '<>':  return $retrieved != $value;
-                case '<':   return $retrieved < $value;
-                case '>':   return $retrieved > $value;
-                case '<=':  return $retrieved <= $value;
-                case '>=':  return $retrieved >= $value;
-                case '===': return $retrieved === $value;
-                case '!==': return $retrieved !== $value;
+            try {
+                switch ($operator) {
+                    default:
+                    case '=':
+                    case '==':  return $retrieved == $value;
+                    case '!=':
+                    case '<>':  return $retrieved != $value;
+                    case '<':   return $retrieved < $value;
+                    case '>':   return $retrieved > $value;
+                    case '<=':  return $retrieved <= $value;
+                    case '>=':  return $retrieved >= $value;
+                    case '===': return $retrieved === $value;
+                    case '!==': return $retrieved !== $value;
+                }
+            } catch (Exception $e) {
+                return false;
             }
         };
     }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -384,6 +384,19 @@ class SupportCollectionTest extends TestCase
             [['v' => 4]],
             $c->where('v', '>', 3)->values()->all()
         );
+
+        $object = (object) ['foo' => 'bar'];
+
+        $this->assertEquals(
+            [],
+            $c->where('v', $object)->values()->all()
+        );
+
+        $c = new Collection([['v' => 1], ['v' => $object]]);
+        $this->assertEquals(
+            [['v' => $object]],
+            $c->where('v', $object)->values()->all()
+        );
     }
 
     public function testWhereStrict()


### PR DESCRIPTION
Hi,
When you compare thing in collection (`contains`, `every` and `where`), if arguments are not comparable, php will throw an error.

Example: 
```php
collect([['v' => 1], ['v' => new stdClass]])->where('v', 1);
```

<img width="1086" alt="screen shot 2017-09-01 at 11 55 11" src="https://user-images.githubusercontent.com/11351322/29965071-8066644e-8f0c-11e7-8328-f8451fbbb292.png">


This PR fix that, and add some tests to check it.