### PR TITLE
[5.5] No need to pass cache to Schedule instance any more

### DIFF
--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -13,7 +13,6 @@ use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Console\Application as Artisan;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Contracts\Foundation\Application;
-use Illuminate\Contracts\Cache\Repository as Cache;
 use Illuminate\Contracts\Console\Kernel as KernelContract;
 use Symfony\Component\Debug\Exception\FatalThrowableError;
 
@@ -97,9 +96,7 @@ class Kernel implements KernelContract
      */
     protected function defineConsoleSchedule()
     {
-        $this->app->instance(
-            Schedule::class, $schedule = new Schedule($this->app[Cache::class])
-        );
+        $this->app->instance(Schedule::class, $schedule = new Schedule());
 
         $this->schedule($schedule);
     }


### PR DESCRIPTION
Cache was removed for Schedule in https://github.com/laravel/framework/pull/18295