### PR TITLE
[5.5] Add mov extension and search method in MIME types

### DIFF
--- a/src/Illuminate/Http/Testing/MimeType.php
+++ b/src/Illuminate/Http/Testing/MimeType.php
@@ -747,6 +747,7 @@ class MimeType
         'mp4' => 'video/mp4',
         'mpeg' => 'video/mpeg',
         'ogv' => 'video/ogg',
+        'mov' => 'video/quicktime',
         'qt' => 'video/quicktime',
         'uvh' => 'video/vnd.dece.hd',
         'uvm' => 'video/vnd.dece.mobile',

--- a/src/Illuminate/Http/Testing/MimeType.php
+++ b/src/Illuminate/Http/Testing/MimeType.php
@@ -804,6 +804,17 @@ class MimeType
     }
 
     /**
+     * Search for the extension of a given MIME type.
+     *
+     * @param  string  $mimeType
+     * @return string|null
+     */
+    public static function search($mimeType)
+    {
+        return array_search($mimeType, self::$mimes) ?: null;
+    }
+
+    /**
      * Get the MIME type for a given extension.
      *
      * @param  string  $extension

--- a/tests/Http/HttpMimeTypeTest.php
+++ b/tests/Http/HttpMimeTypeTest.php
@@ -32,4 +32,10 @@ class HttpMimeTypeTest extends TestCase
         $this->assertInternalType('array', MimeType::get());
         $this->assertArraySubset(['jpg' => 'image/jpeg'], MimeType::get());
     }
+
+    public function testSearchExtensionFromMimeType()
+    {
+        $this->assertSame('mov', MimeType::search('video/quicktime'));
+        $this->assertSame(null, MimeType::search('foo/bar'));
+    }
 }


### PR DESCRIPTION
Just add the `mov` video extension in array, and as I said in the previous PR a little method to search for an extension from a MIME type.

```php
MimeType::search('video/quicktime') // mov
MimeType::search('foo/bar') // null
```

Thanks.
