### PR TITLE
Add a function to reset the faker unique options

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factory.php
@@ -250,7 +250,7 @@ class Factory implements ArrayAccess
     {
         unset($this->definitions[$offset]);
     }
-    
+
     /**
      * Set the faker unique options.
      *
@@ -259,7 +259,7 @@ class Factory implements ArrayAccess
      */
     public function setFakerUnique($reset = false, $maxRetries = 10000)
     {
-        $this->faker->unique($reset,$maxRetries);
+        $this->faker->unique($reset, $maxRetries);
     }
 
 }

--- a/src/Illuminate/Database/Eloquent/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factory.php
@@ -250,4 +250,15 @@ class Factory implements ArrayAccess
     {
         unset($this->definitions[$offset]);
     }
+    
+    /**
+     * Set the faker unique options
+     *
+     * @param bool $reset
+     * @param int $maxRetries
+     */
+    public function setFakerUnique($reset = false, $maxRetries = 10000){
+        $this->faker->unique($reset,$maxRetries);
+    }
+
 }

--- a/src/Illuminate/Database/Eloquent/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factory.php
@@ -252,12 +252,13 @@ class Factory implements ArrayAccess
     }
     
     /**
-     * Set the faker unique options
+     * Set the faker unique options.
      *
      * @param bool $reset
      * @param int $maxRetries
      */
-    public function setFakerUnique($reset = false, $maxRetries = 10000){
+    public function setFakerUnique($reset = false, $maxRetries = 10000)
+    {
         $this->faker->unique($reset,$maxRetries);
     }
 

--- a/src/Illuminate/Database/Eloquent/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factory.php
@@ -261,5 +261,4 @@ class Factory implements ArrayAccess
     {
         $this->faker->unique($reset, $maxRetries);
     }
-
 }


### PR DESCRIPTION
Add a function to reset the faker unique options cause $faker isn't accessible.

Maybe add another method to the Seeder class in order to reset the fakers unique option.

`use Illuminate\Database\Seeder;
use Illuminate\Database\Eloquent\Factory as EloquentFactory;

class TestTableSeeder extends Seeder
{
    /**
     * Run the database seeds.
     *
     * @return void
     */
    public function run()
    {
        factory(\App\TestClassOne::class,5)->create()->each(function (\App\TestClassOne $obj) {
                // add some other objects
                $properties = factory(App\TestClassTwo::class,5)->make();
                $obj->properties()->saveMany($properties);
                $factory = app(EloquentFactory::class);
                $factory->setFakerUnique(true);
            }
        });
    }
}`


`$factory->define(\App\TestClassTwo::class, function (Faker\Generator $faker) {
    return [
        'uid' => $faker->unique()->randomElement(\App\User::pluck('uid', 'uid')->toArray())
    ];
});`