### PR TITLE
[5.5] Add Detection of `dont-discover` in Packages

### DIFF
--- a/src/Illuminate/Foundation/PackageManifest.php
+++ b/src/Illuminate/Foundation/PackageManifest.php
@@ -118,6 +118,10 @@ class PackageManifest
 
         $this->write(collect($packages)->mapWithKeys(function ($package) {
             return [$this->format($package['name']) => $package['extra']['laravel'] ?? []];
+        })->each(function ($configuration) use (&$ignore) {
+            if ($configuration['dont-discover'] ?? false) {
+                $ignore += $configuration['dont-discover'];
+            }
         })->reject(function ($configuration, $package) use ($ignore, $ignoreAll) {
             return $ignoreAll || in_array($package, $ignore);
         })->filter()->all());

--- a/tests/Foundation/fixtures/vendor/composer/installed.json
+++ b/tests/Foundation/fixtures/vendor/composer/installed.json
@@ -11,7 +11,10 @@
         "providers": "foo",
         "aliases": {
           "Foo": "Foo\\Facade"
-        }
+        },
+        "dont-discover": [
+            "vendor_a/package_d"
+        ]
       }
     }
   },
@@ -29,5 +32,15 @@
   {
     "name": "vendor_a/package_c",
     "type": "library"
+  },
+  {
+    "name": "vendor_a/package_d",
+    "extra": {
+      "laravel": {
+        "providers": [
+          "bazinga"
+        ]
+      }
+    }
   }
 ]


### PR DESCRIPTION
# `dont-discover` In Packages
## Goal
Allow packages to declare other packages as non-discoverable in order to prevent conflicts.

## Problem
Packages that have auto-discoverable packages as dependencies, and which purpose it is to extend those packages, can be over-riden (depending on load order) by their auto-discovered dependency. Most of the time this is not an issue, but is very much an issue when the alias being declared are the same. This is necessary so that the extending package can act as a drop-in replacement of the dependency package.

## Solution
Allow packages to declare `dont-discover` packages in their `composer.json` to prevent from being over-riden.