### PR TITLE
[5.5] Fixes application console method `run`

### DIFF
--- a/src/Illuminate/Console/Application.php
+++ b/src/Illuminate/Console/Application.php
@@ -6,9 +6,11 @@ use Closure;
 use Illuminate\Contracts\Events\Dispatcher;
 use Symfony\Component\Process\ProcessUtils;
 use Illuminate\Contracts\Container\Container;
+use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Process\PhpExecutableFinder;
+use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -73,7 +75,15 @@ class Application extends SymfonyApplication implements ApplicationContract
      */
     public function run(InputInterface $input = null, OutputInterface $output = null)
     {
-        $commandName = $this->getCommandName($input);
+        if ($input === null) {
+            $input = new ArgvInput();
+        }
+
+        if ($output === null) {
+            $output = new ConsoleOutput();
+        }
+        
+        $commandName = $this->getCommandName($input ?: new ArgvInput);
 
         $this->events->fire(
             new Events\CommandStarting($commandName, $input, $output)

--- a/src/Illuminate/Console/Application.php
+++ b/src/Illuminate/Console/Application.php
@@ -83,7 +83,7 @@ class Application extends SymfonyApplication implements ApplicationContract
             $output = new ConsoleOutput();
         }
         
-        $commandName = $this->getCommandName($input ?: new ArgvInput);
+        $commandName = $this->getCommandName($input);
 
         $this->events->fire(
             new Events\CommandStarting($commandName, $input, $output)

--- a/src/Illuminate/Console/Application.php
+++ b/src/Illuminate/Console/Application.php
@@ -10,8 +10,8 @@ use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Process\PhpExecutableFinder;
-use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Application as SymfonyApplication;
@@ -82,7 +82,7 @@ class Application extends SymfonyApplication implements ApplicationContract
         if ($output === null) {
             $output = new ConsoleOutput();
         }
-        
+
         $commandName = $this->getCommandName($input);
 
         $this->events->fire(


### PR DESCRIPTION
This PR address an issue introduced on Laravel 5.5.

In the usage of the public method `run`, before we could actually use `null` as input and output. Since the Symfony's method `run` creates a default input and output.

Since now we are managing our `run` method we need to also create default values, in order to don't touch on the API of this method.