### PR TITLE
[5.5] Add Route::default

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -248,7 +248,7 @@ class Router implements RegistrarContract, BindingRegistrar
      * @param  \Closure|array|string|null  $action
      * @return \Illuminate\Routing\Route
      */
-    public function fallback($action = null)
+    public function default($action = null)
     {
         return $this->addRoute(['GET', 'HEAD'], '{any}', $action)->where('any', '.*');
     }

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -243,6 +243,17 @@ class Router implements RegistrarContract, BindingRegistrar
     }
 
     /**
+     * Register a new route responding to all URIs.
+     *
+     * @param  \Closure|array|string|null  $action
+     * @return \Illuminate\Routing\Route
+     */
+    public function fallback($action = null)
+    {
+        return $this->addRoute(['GET', 'HEAD'], '{any}', $action)->where('any', '.*');
+    }
+
+    /**
      * Register a new route with the given verbs.
      *
      * @param  array|string  $methods

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -1420,10 +1420,32 @@ class RoutingRouteTest extends TestCase
         $this->assertEquals(302, $response->getStatusCode());
     }
 
-    public function testRouteFallBack()
+    public function testRouteDefault()
     {
         $router = $this->getRouter();
-        $router->fallback(function () {
+        $router->default(function () {
+            return 'SPA view';
+        });
+
+        $response = $router->dispatch(Request::create('any-uri-here', 'GET'));
+
+        $this->assertSame('SPA view', $response->getContent());
+
+        $response = $router->dispatch(Request::create('uri/with/segments/also/work', 'GET'));
+
+        $this->assertSame('SPA view', $response->getContent());
+    }
+
+    public function testRouteDefaultWithOtherRoutes()
+    {
+        $router = $this->getRouter();
+        $router->get('/', function () {
+            return 'Should not reach here';
+        });
+        $router->post('{post}', function () {
+            return 'Should not reach here';
+        })->where('any', '.*');
+        $router->default(function () {
             return 'SPA view';
         });
 

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -1420,6 +1420,22 @@ class RoutingRouteTest extends TestCase
         $this->assertEquals(302, $response->getStatusCode());
     }
 
+    public function testRouteFallBack()
+    {
+        $router = $this->getRouter();
+        $router->fallback(function () {
+            return 'SPA view';
+        });
+
+        $response = $router->dispatch(Request::create('any-uri-here', 'GET'));
+
+        $this->assertSame('SPA view', $response->getContent());
+
+        $response = $router->dispatch(Request::create('uri/with/segments/also/work', 'GET'));
+
+        $this->assertSame('SPA view', $response->getContent());
+    }
+
     protected function getRouter()
     {
         $container = new Container;


### PR DESCRIPTION
Useful to build SPAs or simply add a default route.

Before:

```
Route::get('{any}', function () {
    return view('welcome');
})->where('any', '.*');
```

After:

```
Route::fallback(function () {
    return view('welcome');
});
```

I got this idea during the Evan You talk in Laracon EU :)