### PR TITLE
[5.5] Add option to not preserve keys during reverse.

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1201,6 +1201,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Reverse items order.
      *
+     * @param  bool  $preserve
      * @return static
      */
     public function reverse($preserve = true)

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1203,9 +1203,9 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      *
      * @return static
      */
-    public function reverse()
+    public function reverse($preserve = true)
     {
-        return new static(array_reverse($this->items, true));
+        return new static(array_reverse($this->items, $preserve));
     }
 
     /**


### PR DESCRIPTION
There are circumstances where I don't wish to preserve the keys during a reverse of a collection.

Consider the following when using a for loop with iterator index:
$col = collect(['foo', 'bar', 'baz']);

$col[0]; // foo expected

$col = $col->reverse();
$col[0]; // also foo because keys are preserved. unexpected.