### PR TITLE
[5.5] Update Mailable to expose buildView and callbacks in send as public functions.

### DIFF
--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -117,12 +117,23 @@ class Mailable implements MailableContract, Renderable
         Container::getInstance()->call([$this, 'build']);
 
         $mailer->send($this->buildView(), $this->buildViewData(), function ($message) {
-            $this->buildFrom($message)
-                 ->buildRecipients($message)
-                 ->buildSubject($message)
-                 ->buildAttachments($message)
-                 ->runCallbacks($message);
+            $this->prepareMessage($message);
         });
+    }
+
+    /**
+     * Prepare the message details before sending.
+     *
+     * @param  \Illuminate\Mail\Message  $message
+     * @return $this
+     */
+    public function prepareMessage($message)
+    {
+        $this->buildFrom($message)
+             ->buildRecipients($message)
+             ->buildSubject($message)
+             ->buildAttachments($message)
+             ->runCallbacks($message);
     }
 
     /**
@@ -183,7 +194,7 @@ class Mailable implements MailableContract, Renderable
      *
      * @return array|string
      */
-    protected function buildView()
+    public function buildView()
     {
         if (isset($this->markdown)) {
             return $this->buildMarkdownView();


### PR DESCRIPTION
This pull request will allow packages like MailThief to be able to render and prepare the parts of a Mailable more easily.

I am in the process of preparing a pull request for MailThief to support laravel 5.5. I hope to expose `buildView()` as public. And, I also hope to add a new public function that calls everything from the anonymous callback located in the `send()` method.

https://github.com/laravel/framework/blob/5.5/src/Illuminate/Mail/Mailable.php#L120-L124

```php
$this->buildFrom($message)
   ->buildRecipients($message)
   ->buildSubject($message)
   ->buildAttachments($message)
   ->runCallbacks($message);
```

In particular, I need to be able to do something like the following (where`$view` is the Mailable).

https://github.com/wells/mailthief/blob/a3aa432c9c07b27c38743841f4c2bf6534218efd/src/MailThief.php#L157-L169

```php
$message = Message::fromView($view->buildView(), $view->buildViewData());
$message->delay = $delay;
$this->prepareMessage($message, function ($message) use ($view) {
    $view->prepareMessage($message);
});
$this->later[] = $message;
```