### PR TITLE
[5.5] Model can work without updated_at column

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php
@@ -38,7 +38,7 @@ trait HasTimestamps
     {
         $time = $this->freshTimestamp();
 
-        if (! $this->isDirty(static::UPDATED_AT)) {
+        if (! $this->isDirty(static::UPDATED_AT) && $this->isModelHasUpdatedAt()) {
             $this->setUpdatedAt($time);
         }
 
@@ -121,5 +121,15 @@ trait HasTimestamps
     public function getUpdatedAtColumn()
     {
         return static::UPDATED_AT;
+    }
+
+    /**
+     * Determine if model requires "updated at" column updates.
+     *
+     * @return bool
+     */
+    public function isModelHasUpdatedAt()
+    {
+        return !isset($this->withoutUpdatedAt) || !$this->withoutUpdatedAt;
     }
 }

--- a/src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php
@@ -130,6 +130,6 @@ trait HasTimestamps
      */
     public function isModelHasUpdatedAt()
     {
-        return !isset($this->withoutUpdatedAt) || !$this->withoutUpdatedAt;
+        return ! isset($this->withoutUpdatedAt) || ! $this->withoutUpdatedAt;
     }
 }


### PR DESCRIPTION
Related to: https://github.com/laravel/framework/issues/20901 and https://github.com/laravel/framework/pull/19627#issuecomment-313132521

Adds ability to define if model has no `updated_at` column.

If `$withoutUpdatedAt` property exists and `true` - skip handling of `updated_at` column updates.

```php
ModelWithoutUpdatedAt extends Model
{
    public $withoutUpdatedAt = true;
}
```