### PR TITLE
[5.5] Updated Console/Kernel autoloading of commands to ignore abstract classes

### DIFF
--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -5,6 +5,7 @@ namespace Illuminate\Foundation\Console;
 use Closure;
 use Exception;
 use Throwable;
+use ReflectionClass;
 use Illuminate\Support\Str;
 use Illuminate\Console\Command;
 use Symfony\Component\Finder\Finder;
@@ -209,7 +210,9 @@ class Kernel implements KernelContract
                 Str::after($command->getPathname(), app_path().DIRECTORY_SEPARATOR)
             );
 
-            if (is_subclass_of($command, Command::class)) {
+            $reflector = new ReflectionClass($command);
+
+            if (! $reflector->isAbstract() && $reflector->isSubclassOf(Command::class)) {
                 Artisan::starting(function ($artisan) use ($command) {
                     $artisan->resolve($command);
                 });


### PR DESCRIPTION
The new Laravel 5.5 auto loading of console commands is great.

Unfortunately it didn't work in my app, as I use an abstract class that extends `Illuminate\Console\Command`, so the `is_subclass_of($command, Command::class)` was resolving that abstract class causing a `Illuminate\Contracts\Container\BindingResolutionException` exception.

This PR changes the conditional to use `ReflectionClass` and the `isAbstract` and `isSubclassOf` methods, fixing this issue.

PS. My abstract console class is extended by custom migration classes that are necessary for our multi-tenant / multi-database migrations, while the base migrator commands act on our primary database.


