### PR TITLE
[5.5] Use singleton during Schedule creation to allow "resolving" callbacks

### DIFF
--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -97,7 +97,11 @@ class Kernel implements KernelContract
      */
     protected function defineConsoleSchedule()
     {
-        $this->app->instance(Schedule::class, $schedule = new Schedule());
+        $this->app->singleton(Schedule::class, function ($app) {
+            return new Schedule();
+        });
+
+        $schedule = $this->app->make(Schedule::class);
 
         $this->schedule($schedule);
     }

--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -98,7 +98,7 @@ class Kernel implements KernelContract
     protected function defineConsoleSchedule()
     {
         $this->app->singleton(Schedule::class, function ($app) {
-            return new Schedule();
+            return new Schedule;
         });
 
         $schedule = $this->app->make(Schedule::class);


### PR DESCRIPTION
By using `singleton` vs `instance` method it's now possible for packages to hook into resolving process of `Schedule` class. For example adding scheduled events from database would look like this:

```php
// In `boot` method of package Service Provider:
$this->app->resolving(\Illuminate\Console\Scheduling\Schedule::class, function ($schedule) {
  // add schedules here
});
```

Before similar functionality would require code like this:

```php
// In `boot` method of package Service Provider:
if ($this->app->runningInConsole()) {
  // add schedules here
};
```

The problem is checking for Console for every request, including Http ones.