### PR TITLE
[5.5] Making "isValid()" testable on the fake UploadedFile

### DIFF
--- a/src/Illuminate/Http/Testing/File.php
+++ b/src/Illuminate/Http/Testing/File.php
@@ -28,6 +28,13 @@ class File extends UploadedFile
     public $sizeToReport;
 
     /**
+     * The upload status of the file.
+     *
+     * @var bool|null
+     */
+    public $isValid = null;
+
+    /**
      * Create a new file instance.
      *
      * @param  string  $name
@@ -111,5 +118,26 @@ class File extends UploadedFile
     protected function tempFilePath()
     {
         return stream_get_meta_data($this->tempFile)['uri'];
+    }
+
+    /**
+     * Set the upload status for the file.
+     *
+     * @param  bool  $status
+     * @return $this
+     */
+    public function setIsValid($status)
+    {
+        $this->isValid = (bool) $status;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isValid()
+    {
+        return is_null($this->isValid) ? parent::isValid() : $this->isValid;
     }
 }


### PR DESCRIPTION
This PR introduces a workaround for testing the `isValid()` boolean result by setting the validation status, I'm not sure if the name `setIsValid` is the right name for it.

This PR affects only `Illuminate\Http\Testing\File`, not `Illuminate\Http\UploadedFile`. The affected `Testing\File` instance is usually a result of `create` or `image` methods on `Illuminate\Http\Testing\FileFactory` which is the result of `Illuminate\Http\UploadedFile::fake()`.

Reason for this PR -instead of mocking and setting the error in the Symfony's `UploadedFile` constructor- is to keep using the benefits of `FileFactory` methods along with the ability to check the validation status.

#### Usage Example:
**MediaController.php**:
```php
    class MediaController extends BaseController
    {
        public function uploadFile(Request $request)
        {
            if(! $request->hasFile('file') {
                return response()
                       ->json(['Error in uploading file'] , 422);
            } else if(! $request->file('file')->isValid())
            { // now the test can reach this area
                return response()
                       ->json(['Teapot != Coffee'] , 418);
            }
            //...
        }
    }
```
**tests/MediaControllerTest.php**:

```php
use Illuminate\Http\UploadedFile;

    public function test_upload_file()
    {
        $response = $this->json('POST', '/media/uploadFile', [
         'file'=> UploadedFile::fake()->image('avatar.jpg')->setIsValid(false)
        ]);
        $response->assertExactJson(['Teapot != Coffee']);
        $response->assertStatus(418);
    }

```

Note:
using this method during the test, `getErrorMessage` will be set to [symfony's unknown error message](https://github.com/symfony/symfony/blob/554303e339c3ba9044d037e5cd0250b2c5a0c3c1/src/Symfony/Component/HttpFoundation/File/UploadedFile.php#L289):
```php
             $request->file('file')->getErrorMessage()
             // = "The file "avatar.jpg" was not uploaded due to an unknown error."
```
