### PR TITLE
Fixed bug #20943  'before' method isn't called

### DIFF
--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -434,10 +434,6 @@ class Gate implements GateContract
      */
     protected function resolvePolicyCallback($user, $ability, array $arguments, $policy)
     {
-        if (! is_callable([$policy, $this->formatAbilityToMethod($ability)])) {
-            return false;
-        }
-
         return function () use ($user, $ability, $arguments, $policy) {
             // This callback will be responsible for calling the policy's before method and
             // running this policy method if necessary. This is used to when objects are


### PR DESCRIPTION
The deleted lines is asking all abilities to be written into callable methods in policy classes.

e.g. in the policy class bellow:
```
class Policy
{
    public function before(User $user, $ability)
    {
        //
        dd('The \`before\`method is called.');
    }

    public function someAbility(User $user, Class $object)
    {
        //
    }
}
```

when we authorize in a controller `$this->authorize('someAbility', $someObject)`, we may get "The \`before\`method is called"; 
when we authorize in a controller `$this->authorize('otherAbility')`, we may get `AccessDeniedHttpException`.

This PR solves this problem.