### PR TITLE
[5.4] Update MigrationCreator

### DIFF
--- a/src/Illuminate/Database/Migrations/MigrationCreator.php
+++ b/src/Illuminate/Database/Migrations/MigrationCreator.php
@@ -77,7 +77,7 @@ class MigrationCreator
     protected function ensureMigrationDoesntAlreadyExist($name)
     {
         if (class_exists($className = $this->getClassName($name))) {
-            throw new InvalidArgumentException("A {$className} migration already exists.");
+            throw new InvalidArgumentException("A {$className} class already exists.");
         }
     }
 

--- a/tests/Database/DatabaseMigrationCreatorTest.php
+++ b/tests/Database/DatabaseMigrationCreatorTest.php
@@ -57,7 +57,7 @@ class DatabaseMigrationCreatorTest extends TestCase
         try {
             $creator->create('migration_creator_fake_migration', 'foo');
         } catch (\Exception $e) {
-            $this->assertEquals($e->getMessage(), 'A MigrationCreatorFakeMigration migration already exists.');
+            $this->assertEquals($e->getMessage(), 'A MigrationCreatorFakeMigration class already exists.');
 
             return;
         }


### PR DESCRIPTION
Recently I try to create a migration and it keeps saying to my that ` A {$class} migration already exists.` but there was no migration with that `$class` name because actually was a Seeder. 

I know, the message isn't consistent, but, as migrations and seeder aren't namespaces, this PR makes sense?