### PR TITLE
[5.5] Update message when creating a migration

### DIFF
--- a/src/Illuminate/Database/Migrations/MigrationCreator.php
+++ b/src/Illuminate/Database/Migrations/MigrationCreator.php
@@ -77,7 +77,7 @@ class MigrationCreator
     protected function ensureMigrationDoesntAlreadyExist($name)
     {
         if (class_exists($className = $this->getClassName($name))) {
-            throw new InvalidArgumentException("A {$className} migration already exists.");
+            throw new InvalidArgumentException("A {$className} class already exists.");
         }
     }
 

--- a/tests/Database/DatabaseMigrationCreatorTest.php
+++ b/tests/Database/DatabaseMigrationCreatorTest.php
@@ -52,7 +52,7 @@ class DatabaseMigrationCreatorTest extends TestCase
 
     /**
      * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage A MigrationCreatorFakeMigration migration already exists.
+     * @expectedExceptionMessage A MigrationCreatorFakeMigration class already exists.
      */
     public function testTableUpdateMigrationWontCreateDuplicateClass()
     {


### PR DESCRIPTION
Recently I try to create a migration and it keeps saying to me that `A {$class} migration already exists.` but there was no migration with that `$class` name. Actually, it was a Seeder.

I know, the message isn't consistent, but, as migrations and seeder aren't namespaces, this PR makes sense?