### PR TITLE
[5.5] Add isFromApi method to Request object

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -620,4 +620,16 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
 
         return $this->route($key);
     }
+
+    /**
+     * Check if the request came from an api route.
+     *
+     * @param  int    $index
+     * @param  string $prefix
+     * @return bool
+     */
+    public function isFromApi($index = 1, $prefix = 'api')
+    {
+        return $this->segment($index) == $prefix;
+    }
 }

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -855,4 +855,23 @@ class HttpRequestTest extends TestCase
         $request->setLaravelSession($session);
         $request->flashExcept(['email']);
     }
+
+    public function testIsFromApiMethod()
+    {
+        // Test a default api route
+        $request = Request::create('/api/users', 'GET', []);
+        $this->assertEquals(true, $request->isFromApi());
+
+        // Test that default web route don't match
+        $request = Request::create('/users', 'GET', []);
+        $this->assertEquals(false, $request->isFromApi());
+
+        // Test a custom api route
+        $request = Request::create('my-api/users', 'GET', []);
+        $this->assertEquals(true, $request->isFromApi(1,'my-api'));
+
+        // Test a custom api route in different segment
+        $request = Request::create('/resources/my-api/users', 'GET', []);
+        $this->assertEquals(true, $request->isFromApi(2,'my-api'));
+    }
 }

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -858,7 +858,7 @@ class HttpRequestTest extends TestCase
 
     public function testIsFromApiMethod()
     {
-        // Test a default api route
+        // Test a default api route match
         $request = Request::create('/api/users', 'GET', []);
         $this->assertEquals(true, $request->isFromApi());
 
@@ -868,10 +868,10 @@ class HttpRequestTest extends TestCase
 
         // Test a custom api route
         $request = Request::create('my-api/users', 'GET', []);
-        $this->assertEquals(true, $request->isFromApi(1,'my-api'));
+        $this->assertEquals(true, $request->isFromApi(1, 'my-api'));
 
         // Test a custom api route in different segment
         $request = Request::create('/resources/my-api/users', 'GET', []);
-        $this->assertEquals(true, $request->isFromApi(2,'my-api'));
+        $this->assertEquals(true, $request->isFromApi(2, 'my-api'));
     }
 }


### PR DESCRIPTION
I think this feature is useful when you are using the same controllers for manage API and web requests, maybe you want to know when a user is requesting from an api and return a different set of data that when the request came from the web.

This method bring a clean way for read and implement. For example if you want to return a set of posts in JSON format when someone make a request from an api but return a view when the request came from the web, you can do this.

```php

public index (Request $request)
{
    $posts = Post::paginate();
    if ($request->isFromApi()) {
        return $posts;
    } else {
        return view('posts.index', ['posts' => $posts]);
   }
}
```