### PR TITLE
[5.6] Remove connection from Migration

### DIFF
--- a/src/Illuminate/Database/Migrations/Migration.php
+++ b/src/Illuminate/Database/Migrations/Migration.php
@@ -4,20 +4,4 @@ namespace Illuminate\Database\Migrations;
 
 abstract class Migration
 {
-    /**
-     * The name of the database connection to use.
-     *
-     * @var string
-     */
-    protected $connection;
-
-    /**
-     * Get the migration connection name.
-     *
-     * @return string
-     */
-    public function getConnection()
-    {
-        return $this->connection;
-    }
 }


### PR DESCRIPTION
I think this is not used anywhere but in theory someone could used it in 5.5 branch so probably it has to go to 5.6