### PR TITLE
[5.6] Allow methods to be bound using ::class notation

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -288,8 +288,8 @@ class Container implements ArrayAccess, ContainerContract
      */
     protected function parseBindMethod($method)
     {
-        if(is_array($method)) {
-            return $method[0] . '@' . $method[1];
+        if (is_array($method)) {
+            return $method[0].'@'.$method[1];
         }
 
         return $method;

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -281,7 +281,7 @@ class Container implements ArrayAccess, ContainerContract
     }
 
     /**
-     * Gets the method to be bound in a class@method fashion.
+     * Get the method to be bound in class@method format.
      *
      * @param  array|string $method
      * @return string

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -271,13 +271,28 @@ class Container implements ArrayAccess, ContainerContract
     /**
      * Bind a callback to resolve with Container::call.
      *
-     * @param  string  $method
+     * @param  array|string  $method
      * @param  \Closure  $callback
      * @return void
      */
     public function bindMethod($method, $callback)
     {
-        $this->methodBindings[$method] = $callback;
+        $this->methodBindings[$this->parseBindMethod($method)] = $callback;
+    }
+
+    /**
+     * Gets the method to be bound in a class@method fashion.
+     *
+     * @param  array|string $method
+     * @return string
+     */
+    protected function parseBindMethod($method)
+    {
+        if(is_array($method)) {
+            return $method[0] . '@' . $method[1];
+        }
+
+        return $method;
     }
 
     /**

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -563,6 +563,23 @@ class ContainerTest extends TestCase
         $this->assertEquals(['foo', 'bar'], $result);
     }
 
+    public function testBindMethodAcceptsAnArray()
+    {
+        $container = new Container;
+        $container->bindMethod([\Illuminate\Tests\Container\ContainerTestCallStub::class, 'unresolvable'], function ($stub) {
+            return $stub->unresolvable('foo', 'bar');
+        });
+        $result = $container->call('Illuminate\Tests\Container\ContainerTestCallStub@unresolvable');
+        $this->assertEquals(['foo', 'bar'], $result);
+
+        $container = new Container;
+        $container->bindMethod([\Illuminate\Tests\Container\ContainerTestCallStub::class, 'unresolvable'], function ($stub) {
+            return $stub->unresolvable('foo', 'bar');
+        });
+        $result = $container->call([new ContainerTestCallStub, 'unresolvable']);
+        $this->assertEquals(['foo', 'bar'], $result);
+    }
+
     public function testContainerCanInjectDifferentImplementationsDependingOnContext()
     {
         $container = new Container;


### PR DESCRIPTION
This PR allows something like this to be done:   
```php   
use App\Services\FooService;

...

$this->app->bindMethod([FooService::class, 'handle'], function($foo) {});    
```   

As of right now, you have to do this:   
`$this->app->bindMethod('App\Services\FooService@handle', function($foo) {});`    

I, particularly, prefer to use the `::class` notation. Let me know what you think