### PR TITLE
[5.5] Fix docblock for Str::is()

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -143,7 +143,7 @@ class Str
     /**
      * Determine if a given string matches a given pattern.
      *
-     * @param  string  $pattern
+     * @param  string|array  $pattern
      * @param  string  $value
      * @return bool
      */


### PR DESCRIPTION
Commit ceb59c14748504e9f900674419fddda5ba37838e added the ability for `Str::is()` to handle multiple patterns instead of just one, but the docblock has not been updated to reflect this change.