### PR TITLE
[5.5] Fix class name in generated class file

### DIFF
--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -80,6 +80,8 @@ abstract class GeneratorCommand extends Command
      */
     protected function qualifyClass($name)
     {
+        $name = ltrim(ltrim($name, '\\'), '/');
+        
         $rootNamespace = $this->rootNamespace();
 
         if (Str::startsWith($name, $rootNamespace)) {

--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -80,7 +80,7 @@ abstract class GeneratorCommand extends Command
      */
     protected function qualifyClass($name)
     {
-        $name = ltrim(ltrim($name, '\\'), '/');
+        $name = ltrim($name, '\\/');
         
         $rootNamespace = $this->rootNamespace();
 


### PR DESCRIPTION
This fixes the class name in a generated class file if the class name begins with a slash.

If a class name used in a make command starts with a slash the generated file will have the slash in the class name creating a syntax error in class file. For example, "php artisan make:model \Foo" will generate a file with the class name \Foo (i.e. namespace App; ....  class \Foo { ..... } ).  

Although a user would see the invalid class name in the generated file when they edit it to add their content, it seems more appropriate for the generator to create syntactically correct files.

Removing the beginning slash in the GeneratorCommand::qualifyClass() method generates a file with a valid class name. 
