### PR TITLE
[5.5] Fix eachSpread mapSpread with nested collections

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -352,7 +352,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     public function eachSpread(callable $callback)
     {
         return $this->each(function ($chunk, $key) use ($callback) {
-            array_push($chunk, $key);
+            $chunk[] = $key;
 
             return $callback(...$chunk);
         });
@@ -844,7 +844,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     public function mapSpread(callable $callback)
     {
         return $this->map(function ($chunk, $key) use ($callback) {
-            array_push($chunk, $key);
+            $chunk[] = $key;
 
             return $callback(...$chunk);
         });

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -606,6 +606,13 @@ class SupportCollectionTest extends TestCase
             $result[] = [$number, $character, $key];
         });
         $this->assertEquals([[1, 'a', 0], [2, 'b', 1]], $result);
+
+        $c = new Collection([new Collection([1, 'a']), new Collection([2, 'b'])]);
+        $result = [];
+        $c->eachSpread(function ($number, $character, $key) use (&$result) {
+            $result[] = [$number, $character, $key];
+        });
+        $this->assertEquals([[1, 'a', 0], [2, 'b', 1]], $result);
     }
 
     public function testIntersectNull()
@@ -1221,6 +1228,12 @@ class SupportCollectionTest extends TestCase
         });
         $this->assertEquals(['1-a', '2-b'], $result->all());
 
+        $result = $c->mapSpread(function ($number, $character, $key) use (&$result) {
+            return "{$number}-{$character}-{$key}";
+        });
+        $this->assertEquals(['1-a-0', '2-b-1'], $result->all());
+
+        $c = new Collection([new Collection([1, 'a']), new Collection([2, 'b'])]);
         $result = $c->mapSpread(function ($number, $character, $key) use (&$result) {
             return "{$number}-{$character}-{$key}";
         });


### PR DESCRIPTION
I recently PR'ed the ability to use the keys in `eachSpread` and `mapSpread`, but it caused a regression when using nested collections (see https://github.com/laravel/framework/commit/2f2886e0d5a162c0b09b0c6755ce1850e8ebaf27#commitcomment-24046152)

This PR fixes that regression and adds some more tests.