### PR TITLE
[5.5] Implement a getKey for AnonymousNotifiable

### DIFF
--- a/src/Illuminate/Notifications/AnonymousNotifiable.php
+++ b/src/Illuminate/Notifications/AnonymousNotifiable.php
@@ -48,4 +48,14 @@ class AnonymousNotifiable
     {
         return $this->routes[$driver] ?? null;
     }
+
+    /**
+     * Get the value of the notifiable's primary key.
+     *
+     * @return mixed
+     */
+    public function getKey()
+    {
+        //
+    }
 }


### PR DESCRIPTION
The getKey method is called on a notifiable in multiple places when you fake Notifications:

- https://github.com/laravel/framework/blob/5.5/src/Illuminate/Support/Testing/Fakes/NotificationFake.php#L143
- https://github.com/laravel/framework/blob/5.5/src/Illuminate/Support/Testing/Fakes/NotificationFake.php#L144
- https://github.com/laravel/framework/blob/5.5/src/Illuminate/Support/Testing/Fakes/NotificationFake.php#L178

This PR adds the method so PHP won't error when it gets called.