### PR TITLE
[5.5] Show null if a relationship is loaded but has value of null

### DIFF
--- a/src/Illuminate/Http/Resources/Json/Resource.php
+++ b/src/Illuminate/Http/Resources/Json/Resource.php
@@ -151,6 +151,10 @@ class Resource implements ArrayAccess, JsonSerializable, Responsable, UrlRoutabl
                 $value->resource instanceof MissingValue)) {
                 unset($data[$key]);
             }
+
+            if ($value instanceof self && is_null($value->resource)) {
+                $data[$key] = null;
+            }
         }
 
         return $data;

--- a/tests/Integration/Http/Fixtures/Author.php
+++ b/tests/Integration/Http/Fixtures/Author.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Http\Fixtures;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Author extends Model
+{
+    /**
+     * The attributes that aren't mass assignable.
+     *
+     * @var array
+     */
+    protected $guarded = [];
+}

--- a/tests/Integration/Http/Fixtures/AuthorResource.php
+++ b/tests/Integration/Http/Fixtures/AuthorResource.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Http\Fixtures;
+
+use Illuminate\Http\Resources\Json\Resource;
+
+class AuthorResource extends Resource
+{
+    public function toArray($request)
+    {
+        return ['name' => $this->name];
+    }
+}

--- a/tests/Integration/Http/Fixtures/PostResourceWithOptionalRelationship.php
+++ b/tests/Integration/Http/Fixtures/PostResourceWithOptionalRelationship.php
@@ -9,6 +9,7 @@ class PostResourceWithOptionalRelationship extends PostResource
         return [
             'id' => $this->id,
             'comments' => new CommentCollection($this->whenLoaded('comments')),
+            'author' => new AuthorResource($this->whenLoaded('author')),
         ];
     }
 }

--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Integration\Http;
 
+use Illuminate\Tests\Integration\Http\Fixtures\Author;
 use Orchestra\Testbench\TestCase;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Pagination\LengthAwarePaginator;
@@ -106,6 +107,60 @@ class ResourceTest extends TestCase
         $response->assertExactJson([
             'data' => [
                 'id' => 5,
+            ],
+        ]);
+    }
+
+    public function test_resources_may_load_optional_relationships()
+    {
+        Route::get('/', function () {
+            $post = new Post([
+                'id' => 5,
+                'title' => 'Test Title',
+            ]);
+
+            $post->setRelation('author', new Author(['name' => 'jrrmartin']));
+
+            return new PostResourceWithOptionalRelationship($post);
+        });
+
+        $response = $this->withoutExceptionHandling()->get(
+            '/', ['Accept' => 'application/json']
+        );
+
+        $response->assertStatus(200);
+
+        $response->assertExactJson([
+            'data' => [
+                'id' => 5,
+                'author' => ['name' => 'jrrmartin']
+            ],
+        ]);
+    }
+
+    public function test_resources_may_shows_null_for_loaded_relationship_with_value_null()
+    {
+        Route::get('/', function () {
+            $post = new Post([
+                'id' => 5,
+                'title' => 'Test Title',
+            ]);
+
+            $post->setRelation('author', null);
+
+            return new PostResourceWithOptionalRelationship($post);
+        });
+
+        $response = $this->withoutExceptionHandling()->get(
+            '/', ['Accept' => 'application/json']
+        );
+
+        $response->assertStatus(200);
+
+        $response->assertExactJson([
+            'data' => [
+                'id' => 5,
+                'author' => null
             ],
         ]);
     }


### PR DESCRIPTION
Let's say a `Post` belongs to an optional `Author`, so sometimes the `author_id` of a post is `null`.

Having the following in a resource:

```
"author" => AuthorResource::make($this->whenLoaded('author'))
```

In case `author` relationship is not loaded the `author` key won't appear in the response, in case the `author` is loaded and has value the `AuthorResource` will render the array format of the author.

However, in case the relationship **is loaded** but `author_id` = null, ` AuthorResource::make(null)` will throw an exception.

This PR checks if any of the attributes holds a resource whose `$resource` attribute = null and just renders `null` to indicate that this post has no author.

```
"author" => null
```