### PR TITLE
[5.5] Make Route Macroable

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Http\Request;
 use Illuminate\Container\Container;
+use Illuminate\Support\Traits\Macroable;
 use Illuminate\Routing\Matching\UriValidator;
 use Illuminate\Routing\Matching\HostValidator;
 use Illuminate\Routing\Matching\MethodValidator;
@@ -18,7 +19,7 @@ use Illuminate\Routing\Contracts\ControllerDispatcher as ControllerDispatcherCon
 
 class Route
 {
-    use RouteDependencyResolverTrait;
+    use RouteDependencyResolverTrait, Macroable;
 
     /**
      * The URI pattern the route responds to.

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -19,7 +19,7 @@ use Illuminate\Routing\Contracts\ControllerDispatcher as ControllerDispatcherCon
 
 class Route
 {
-    use RouteDependencyResolverTrait, Macroable;
+    use Macroable, RouteDependencyResolverTrait;
 
     /**
      * The URI pattern the route responds to.

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -308,6 +308,25 @@ class RoutingRouteTest extends TestCase
         $this->assertEquals('OK', $router->dispatch(Request::create('webhook', 'GET'))->getContent());
         $this->assertEquals('OK', $router->dispatch(Request::create('webhook', 'POST'))->getContent());
     }
+    
+    public function testRouteMacro()
+    {
+        $router = $this->getRouter();
+        
+        Route::macro('breadcrumb', function ($breadcrumb) {
+            $this->action['breadcrumb'] = $breadcrumb;
+            
+            return $this;
+        });
+        
+        $router->get('foo', function () {
+            return 'bar';
+        })->breadcrumb('fooBreadcrumb')->name('foo');
+        
+        $router->getRoutes()->refreshNameLookups();
+        
+        $this->assertEquals('fooBreadcrumb', $router->getRoutes()->getByName('foo')->getAction()['breadcrumb']);
+    }
 
     public function testClassesCanBeInjectedIntoRoutes()
     {


### PR DESCRIPTION
This PR adds the macroable trait to the Illuminate/Routing/Route class.

In our last project we used a custom route action to generate breadcrumbs like this:

        Route::get('', ['uses' => 'IndexController@index', 'breadcrumb' => 'Homepage']);

But with a route macro for breadcrumbs we can write it this way:

        Route::get('', 'IndexController@index')->breadcrumb('Homepage');

The related macro:

        Route::macro('breadcrumb', function ($breadcrumb) {
            $this->action['breadcrumb'] = $breadcrumb;
            
            return $this;
        });