### PR TITLE
[5.5] Assign BelongsTo relation via attribute using relation name

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -560,7 +560,6 @@ trait HasAttributes
             return $this->fillJsonAttribute($key, $value);
         }
 
-
         $this->attributes[$key] = $value;
 
         return $this;

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -542,6 +542,8 @@ trait HasAttributes
             $relation = $this->$key();
 
             if ($relation instanceof BelongsTo) {
+                $this->setRelation($key, $value);
+
                 $key = $relation->getForeignKey();
                 $value = $value->getAttributeFromArray($relation->getOwnerKey());
             }


### PR DESCRIPTION
Adam Wathan in his 2017 Laracon US talk added mutators to assign models for a `BelongsTo` relationship by passing only the models. (Relevant part: https://www.youtube.com/watch?time_continue=1589&v=MF0jFKvS4SI)

It transformed this...

```
class SubscriptionsController extends Controller
{
    public function store()
    {
        $podcast = Podcast::published()->findOrFail(request('podcast_id'));

        $subscription = Subscription::create([
            'user_id' => Auth::user()->id,
            'podcast_id' => $podcast->id,
        ]);

        return $subscription;
    }
}
```

Into:

```
class SubscriptionsController extends Controller
{
    public function store()
    {
        $podcast = Podcast::published()->findOrFail(request('podcast_id'));

        $subscription = Subscription::create([
            'user' => Auth::user(),
            'podcast' => $podcast,
        ]);

        return $subscription;
    }
}

...

class Subscription extends Model
{
    protected $guarded = [];
    public function user()
    {
        return $this->belongsTo(User::class);
    }
    public function podcast()
    {
        return $this->belongsTo(Podcast::class);
    }
    public function setUserAttribute($user)
    {
        $this->user_id = $user->getKey();
        $this->setRelation('user', $user);
    }
    public function setPodcastAttribute($podcast)
    {
        $this->podcast_id = $podcast->getKey();
        $this->setRelation('podcast', $podcast);
    }
}
```

This PR adds support for the above without the need for a custom mutator. It assigns the correct column auto-magically ('Belongs To'  is the ONLY relationship supported.)

I wrote this test locally, which passes, but did not include one with the PR. (Sorry!)

```
    /** @test */
    public function test_assigning_through_relation_name()
    {
        $user = factory('App\User')->create();

        $subscription = \App\Subscription::create([
            'user' => $user,
        ]);

        $this->assertEquals($user->id, $subscription->user_id);

        $this->assertTrue($subscription->relationLoaded('user'));
        $this->assertEquals($user->id, $subscription->user->id);

        $this->assertEquals($user->id, $subscription->refresh()->user->id);
    }
```

I ensured that if you had a mutator set `setUserAttribute`, the mutator would be called instead of this code. Let me know your thoughts!
