### PR TITLE
[5.5] Make Request::validate() return value of parent key

### DIFF
--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -172,9 +172,11 @@ class FormRequest extends Request implements ValidatesWhenResolved
      */
     public function validated()
     {
-        return $this->only(array_keys(
-            $this->container->call([$this, 'rules'])
-        ));
+        $rules = $this->container->call([$this, 'rules']);
+
+        return $this->only(collect($rules)->keys()->map(function($rule){
+            return str_contains($rule, '.') ? explode('.', $rule)[0] : $rule;
+        })->unique()->toArray());
     }
 
     /**

--- a/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
@@ -2,9 +2,9 @@
 
 namespace Illuminate\Foundation\Providers;
 
+use Illuminate\Support\Str;
 use Illuminate\Http\Request;
 use Illuminate\Support\AggregateServiceProvider;
-use Illuminate\Support\Str;
 
 class FoundationServiceProvider extends AggregateServiceProvider
 {

--- a/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
@@ -4,6 +4,7 @@ namespace Illuminate\Foundation\Providers;
 
 use Illuminate\Http\Request;
 use Illuminate\Support\AggregateServiceProvider;
+use Illuminate\Support\Str;
 
 class FoundationServiceProvider extends AggregateServiceProvider
 {
@@ -38,7 +39,10 @@ class FoundationServiceProvider extends AggregateServiceProvider
         Request::macro('validate', function (array $rules, ...$params) {
             validator()->validate($this->all(), $rules, ...$params);
 
-            return $this->only(array_keys($rules));
+
+            return $this->only(collect($rules)->keys()->map(function($rule){
+                return Str::contains($rule, '.') ? explode('.', $rule)[0] : $rule;
+            })->unique()->toArray());
         });
     }
 }

--- a/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Foundation\Providers;
 
-use Illuminate\Support\Str;
 use Illuminate\Http\Request;
 use Illuminate\Support\AggregateServiceProvider;
 
@@ -41,7 +40,7 @@ class FoundationServiceProvider extends AggregateServiceProvider
 
 
             return $this->only(collect($rules)->keys()->map(function($rule){
-                return Str::contains($rule, '.') ? explode('.', $rule)[0] : $rule;
+                return str_contains($rule, '.') ? explode('.', $rule)[0] : $rule;
             })->unique()->toArray());
         });
     }

--- a/src/Illuminate/Foundation/Validation/ValidatesRequests.php
+++ b/src/Illuminate/Foundation/Validation/ValidatesRequests.php
@@ -25,9 +25,9 @@ trait ValidatesRequests
 
         $validator->validate();
 
-        return $request->only(
-            array_keys($validator->getRules())
-        );
+        return $request->only(collect($validator->getRules())->keys()->map(function($rule){
+                return str_contains($rule, '.') ? explode('.', $rule)[0] : $rule;
+            })->unique()->toArray());
     }
 
     /**
@@ -46,7 +46,9 @@ trait ValidatesRequests
              ->make($request->all(), $rules, $messages, $customAttributes)
              ->validate();
 
-        return $request->only(array_keys($rules));
+        return $request->only(collect($rules)->keys()->map(function($rule){
+            return str_contains($rule, '.') ? explode('.', $rule)[0] : $rule;
+        })->unique()->toArray());
     }
 
     /**


### PR DESCRIPTION
In reference to the issue in https://github.com/laravel/framework/issues/20973

This PR will make the `Request::validate()` method return values of the parent key only, so if there's a rule `users.*.name`, the method returns the values of the `users` key only.