### PR TITLE
[5.5] Add option to get an route action by key

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -698,13 +698,16 @@ class Route
     }
 
     /**
-     * Get the action array for the route.
+     * Get an action or action array for the route.
      *
-     * @return array
+     * @param  string  $action
+     * @return mixed
      */
-    public function getAction()
+    public function getAction($action = null)
     {
-        return $this->action;
+        return array_key_exists($action, $this->action)
+            ? $this->action[$action]
+            : $this->action;
     }
 
     /**

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -700,7 +700,7 @@ class Route
     /**
      * Get an action or action array for the route.
      *
-     * @param  string  $action
+     * @param  string|null  $action
      * @return mixed
      */
     public function getAction($action = null)


### PR DESCRIPTION
With this PR its easier to get an specific route action.

Before you had to use the getAction() method to get the action array from a route and than use the key to get an action like this:
`$route->getAction()['controller'];`

Now you can get the action directly by using:
`$route->getAction('controller');`

Without an valid action key the method returns the action array.