### PR TITLE
[5.5] Fixing the doc comments

### DIFF
--- a/src/Illuminate/Contracts/Validation/Validator.php
+++ b/src/Illuminate/Contracts/Validation/Validator.php
@@ -41,7 +41,7 @@ interface Validator extends MessageProvider
     /**
      * Get all of the validation error messages.
      *
-     * @return array
+     * @return \Illuminate\Support\MessageBag
      */
     public function errors();
 }


### PR DESCRIPTION
Fixing the `@return` type for the `Illuminate\Contracts\Validation@errors()` method.