### PR TITLE
[5.5] Update FailedJobProviderInterface docblocks to match expectations

### DIFF
--- a/src/Illuminate/Queue/Failed/DatabaseFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/DatabaseFailedJobProvider.php
@@ -77,7 +77,7 @@ class DatabaseFailedJobProvider implements FailedJobProviderInterface
      * Get a single failed job.
      *
      * @param  mixed  $id
-     * @return array
+     * @return object|null
      */
     public function find($id)
     {

--- a/src/Illuminate/Queue/Failed/FailedJobProviderInterface.php
+++ b/src/Illuminate/Queue/Failed/FailedJobProviderInterface.php
@@ -26,7 +26,7 @@ interface FailedJobProviderInterface
      * Get a single failed job.
      *
      * @param  mixed  $id
-     * @return array
+     * @return object|null
      */
     public function find($id);
 

--- a/src/Illuminate/Queue/Failed/NullFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/NullFailedJobProvider.php
@@ -15,7 +15,7 @@ class NullFailedJobProvider implements FailedJobProviderInterface
      */
     public function log($connection, $queue, $payload, $exception)
     {
-        //
+        return null;
     }
 
     /**
@@ -32,11 +32,11 @@ class NullFailedJobProvider implements FailedJobProviderInterface
      * Get a single failed job.
      *
      * @param  mixed  $id
-     * @return array
+     * @return object|null
      */
     public function find($id)
     {
-        //
+        return null;
     }
 
     /**


### PR DESCRIPTION
According to docblock `find` should only return an array, but it actually expects to be [null](https://github.com/laravel/framework/blob/5.5/src/Illuminate/Queue/Console/RetryCommand.php#L34) or an object ([here](https://github.com/laravel/framework/blob/5.5/src/Illuminate/Queue/Console/RetryCommand.php#L70-L72) and [here](https://github.com/laravel/framework/blob/5.5/src/Illuminate/Queue/Console/RetryCommand.php#L32)).

Also update `NullFailedJobProvider` to explicit return `null`.