### PR TITLE
[5.5] Add iteration number to each method of Collection

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -334,8 +334,10 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      */
     public function each(callable $callback)
     {
+        $iteration = 1;
+
         foreach ($this->items as $key => $item) {
-            if ($callback($item, $key) === false) {
+            if ($callback($item, $key, $iteration++) === false) {
                 break;
             }
         }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -568,10 +568,13 @@ class SupportCollectionTest extends TestCase
         $c = new Collection($original = [1, 2, 'foo' => 'bar', 'bam' => 'baz']);
 
         $result = [];
-        $c->each(function ($item, $key) use (&$result) {
+        $iterations = [];
+        $c->each(function ($item, $key, $iteration) use (&$result, &$iterations) {
             $result[$key] = $item;
+            $iterations[$key] = $iteration;
         });
         $this->assertEquals($original, $result);
+        $this->assertEquals(array_combine(array_keys($original), range(1, count($original))), $iterations);
 
         $result = [];
         $c->each(function ($item, $key) use (&$result) {


### PR DESCRIPTION
Sample usage:

```php
User::pluck('name', 'email')->each(function($name, $email, $position) use ($winners, $losers) {
    if ($position < 4) {
        $winners->add($name, $email, $position);
        return true;
    }
    
    $losers->add($name, $email);
});
```

of course collection showed above as `User::pluck('name', 'email')` could be created in much more complex way with ordering or summing some scores, but finally we could get only emails and names without actual keys. 