### PR TITLE
[5.5] Add sliceConsecutive($size) method to Collection

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1276,6 +1276,31 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
+     * Returns collection of every consecutive slice of certain size.
+     *
+     * @param  int  $size
+     * @return static
+     */
+    public function sliceConsecutive($size)
+    {
+        if ($size <= 0) {
+            return new static;
+        }
+
+        if ($size >= $this->count()) {
+            return $this;
+        }
+
+        $chunks = [];
+
+        for ($i = 0; $i <= $this->count() - $size; $i++) {
+            $chunks [] = $this->slice($i, $size)->values();
+        }
+
+        return new static($chunks);
+    }
+
+    /**
      * Split a collection into a certain number of groups.
      *
      * @param  int  $numberOfGroups

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1288,7 +1288,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
         }
 
         if ($size >= $this->count()) {
-            return $this;
+            return new static([$this]);
         }
 
         $chunks = [];

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2301,6 +2301,57 @@ class SupportCollectionTest extends TestCase
 
         $this->assertSame(['michael', 'tom', 'taylor'], $collection->toArray());
     }
+
+    public function testSliceConsecutive()
+    {
+        $data = new Collection([1, 2, 3, 4, 5]);
+        $data = $data->sliceConsecutive(3);
+
+        $this->assertInstanceOf(Collection::class, $data);
+        $this->assertInstanceOf(Collection::class, $data[0]);
+        $this->assertCount(3, $data);
+        $this->assertEquals([1, 2, 3], $data[0]->toArray());
+        $this->assertEquals([2, 3, 4], $data[1]->toArray());
+        $this->assertEquals([3, 4, 5], $data[2]->toArray());
+    }
+
+    public function testSliceConsecutiveWithSizeEqualCount()
+    {
+        $data = new Collection([1, 2, 3, 4, 5]);
+        $data = $data->sliceConsecutive(5);
+
+        $this->assertInstanceOf(Collection::class, $data);
+        $this->assertCount(5, $data);
+        $this->assertEquals([1, 2, 3, 4, 5], $data->toArray());
+    }
+
+    public function testSliceConsecutiveWithSizeLargerThanCount()
+    {
+        $data = new Collection([1, 2, 3, 4, 5]);
+        $data = $data->sliceConsecutive(10);
+
+        $this->assertInstanceOf(Collection::class, $data);
+        $this->assertCount(5, $data);
+        $this->assertEquals([1, 2, 3, 4, 5], $data->toArray());
+    }
+
+    public function testSliceConsecutiveWithNegativeSize()
+    {
+        $data = new Collection([1, 2, 3, 4, 5]);
+        $data = $data->sliceConsecutive(-1);
+
+        $this->assertInstanceOf(Collection::class, $data);
+        $this->assertCount(0, $data);
+    }
+
+    public function testSliceConsecutiveWithZeroSize()
+    {
+        $data = new Collection([1, 2, 3, 4, 5]);
+        $data = $data->sliceConsecutive(0);
+
+        $this->assertInstanceOf(Collection::class, $data);
+        $this->assertCount(0, $data);
+    }
 }
 
 class TestSupportCollectionHigherOrderItem

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2321,8 +2321,8 @@ class SupportCollectionTest extends TestCase
         $data = $data->sliceConsecutive(5);
 
         $this->assertInstanceOf(Collection::class, $data);
-        $this->assertCount(5, $data);
-        $this->assertEquals([1, 2, 3, 4, 5], $data->toArray());
+        $this->assertCount(1, $data);
+        $this->assertEquals([1, 2, 3, 4, 5], $data[0]->toArray());
     }
 
     public function testSliceConsecutiveWithSizeLargerThanCount()
@@ -2331,8 +2331,8 @@ class SupportCollectionTest extends TestCase
         $data = $data->sliceConsecutive(10);
 
         $this->assertInstanceOf(Collection::class, $data);
-        $this->assertCount(5, $data);
-        $this->assertEquals([1, 2, 3, 4, 5], $data->toArray());
+        $this->assertCount(1, $data);
+        $this->assertEquals([1, 2, 3, 4, 5], $data[0]->toArray());
     }
 
     public function testSliceConsecutiveWithNegativeSize()


### PR DESCRIPTION
The method returns each consecutive slice of fixed size, like this:

```php
$data = new Collection([1, 2, 3, 4, 5]);
$data->sliceConsecutive(3)

[ [1, 2, 3], [2, 3, 4], [3, 4, 5] ]

$data->sliceConsecutive(5) // or 6 and more

[ [1, 2, 3, 4, 5] ]

$data->sliceConsecutive(0)

[  ]
```

Note: Collections are replaced with arrays for brevity