### PR TITLE
[5.5] Fix order of run migrations

### DIFF
--- a/src/Illuminate/Database/Migrations/DatabaseMigrationRepository.php
+++ b/src/Illuminate/Database/Migrations/DatabaseMigrationRepository.php
@@ -63,7 +63,9 @@ class DatabaseMigrationRepository implements MigrationRepositoryInterface
     {
         $query = $this->table()->where('batch', '>=', '1');
 
-        return $query->orderBy('migration', 'desc')->take($steps)->get()->all();
+        return $query->orderBy('batch', 'desc')
+            ->orderBy('migration', 'desc')
+            ->take($steps)->get()->all();
     }
 
     /**


### PR DESCRIPTION
When you run migration 

```
2016_01_01_000000_create_users_table.php
```

first

and then you add package to your application that has migration:

```
2014_01_01_000000_create_projects_table.php
```

and you run this, in database you should have


|Migration                                                           | Batch|
| ------------- |:-------------|
|2016_01_01_000000_create_users_table.php     | 1|
|2014_01_01_000000_create_projects_table.php | 2 |

When you now run 

```
php artisan migrate:rollback
```
because migrations are ordered by migration descending, the `2016_01_01_000000_create_users_table.php` will be rolled back what could be quite surprising. 

That's why the sorting order should by first by batch descending and then by migration descending to rollback migrations in the order they were run.

