### PR TITLE
'with' optional callback

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -1154,13 +1154,14 @@ if (! function_exists('windows_os')) {
 
 if (! function_exists('with')) {
     /**
-     * Return the given object. Useful for chaining.
+     * Return the given object, optionally passed through a callback.
      *
      * @param  mixed  $object
+     * @param  callable|null  $callback
      * @return mixed
      */
-    function with($object)
+    function with($object, $callback = null)
     {
-        return $object;
+        return $callback ? $callback($object) : $object;
     }
 }

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -804,6 +804,18 @@ class SupportHelpersTest extends TestCase
             return 10;
         }));
     }
+
+    public function testWith()
+    {
+        $this->assertEquals('foo', with('foo'));
+    }
+
+    public function testWithWithCallback()
+    {
+        $this->assertEquals('FOO', with('foo', 'strtoupper'));
+
+        $this->assertEquals(2, with(1, function ($n) { return $n + 1; }));
+    }
 }
 
 trait SupportTestTraitOne


### PR DESCRIPTION
Adds an optional callback as 2nd argument to helper `with`, to mutate the value before returning it.

If it's preferred not to overload this function, `thru` may be a good alternative name (same functionality as Lodash function with the same name).