### PR TITLE
[5.5] allow all parameters to be pass to RouteRegistrar::attribute() by dynamic calls via __call magic method

### DIFF
--- a/src/Illuminate/Routing/RouteRegistrar.php
+++ b/src/Illuminate/Routing/RouteRegistrar.php
@@ -76,6 +76,10 @@ class RouteRegistrar
             throw new InvalidArgumentException("Attribute [{$key}] does not exist.");
         }
 
+        if (count($value) == 1) {
+            $value = $value[0];
+        }
+
         $this->attributes[Arr::get($this->aliases, $key, $key)] = $value;
 
         return $this;
@@ -168,7 +172,7 @@ class RouteRegistrar
         }
 
         if (in_array($method, $this->allowedAttributes)) {
-            return $this->attribute($method, $parameters[0]);
+            return $this->attribute($method, $parameters);
         }
 
         throw new BadMethodCallException("Method [{$method}] does not exist.");

--- a/src/Illuminate/Routing/RouteRegistrar.php
+++ b/src/Illuminate/Routing/RouteRegistrar.php
@@ -76,7 +76,7 @@ class RouteRegistrar
             throw new InvalidArgumentException("Attribute [{$key}] does not exist.");
         }
 
-        if (count($value) == 1) {
+        if (is_array($value) && count($value) == 1) {
             $value = $value[0];
         }
 

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -1148,6 +1148,6 @@ class Router implements RegistrarContract, BindingRegistrar
             return $this->macroCall($method, $parameters);
         }
 
-        return (new RouteRegistrar($this))->attribute($method, $parameters[0]);
+        return (new RouteRegistrar($this))->attribute($method, $parameters);
     }
 }


### PR DESCRIPTION
In this pull request we will be allowed to pass middlewares also as parameters.
currently to apply multiple middlewares to a group looks like this:
`Route::middleware(['middleware1', 'middleware2' etc..])->group(base_path('some_file'));`

This functionallity will be added (you can pass multiple parameters, not only array):
`Route::middleware('middleware1', 'middleware2' etc..)->group(base_path('some_file'));`

All routing tests seems to pass:
![1](https://user-images.githubusercontent.com/16985712/30039062-43d8b4d8-91cc-11e7-8ef5-e16e5fc518b6.jpg)

It also follows the following convention found in the documentations:
![2](https://user-images.githubusercontent.com/16985712/30038982-21095a26-91cb-11e7-8597-e31355e5f295.jpg)

p.s I made some checks but not 100% sure it effects the code somewhere else in the application. please double check it before merging.


 