### PR TITLE
[5.5] Auth login throttling fails when decay minutes is more than 1 minute

### DIFF
--- a/src/Illuminate/Foundation/Auth/ThrottlesLogins.php
+++ b/src/Illuminate/Foundation/Auth/ThrottlesLogins.php
@@ -32,7 +32,9 @@ trait ThrottlesLogins
      */
     protected function incrementLoginAttempts(Request $request)
     {
-        $this->limiter()->hit($this->throttleKey($request));
+        $this->limiter()->hit(
+            $this->throttleKey($request), $this->decayMinutes()
+        );
     }
 
     /**


### PR DESCRIPTION
When using a time period longer than 1 minute for the auth login throttler, the rate limiter will only remember hits for 1 minute (the default from `RateLimiter::hit()`), instead of the actual decay minutes value specified in the login controller (the one from `ThrottlesLogins`).

This pull request also passes the custom `decayMinutes` value to the rate limiter to ensure hits are remembered correctly in the cache.