### PR TITLE
[5.5] Make sure its a class first before using reflection

### DIFF
--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -214,9 +214,8 @@ class Kernel implements KernelContract
                 Str::after($command->getPathname(), app_path().DIRECTORY_SEPARATOR)
             );
 
-            $reflector = new ReflectionClass($command);
-
-            if (! $reflector->isAbstract() && $reflector->isSubclassOf(Command::class)) {
+            if (is_subclass_of($command, Command::class) &&
+                ! (new ReflectionClass($command))->isAbstract()) {
                 Artisan::starting(function ($artisan) use ($command) {
                     $artisan->resolve($command);
                 });


### PR DESCRIPTION
In this PR we check if the file is a class first before using Relfection, if a non-php class (like a .stub file) is passed to reflection we'll get an error.