### PR TITLE
[5.5] Fix Blade php inline tags when used in combination with Blade php blocks

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -213,7 +213,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
      */
     protected function storePhpBlocks($value)
     {
-        return preg_replace_callback('/(?<!@)@php(.*?)@endphp/s', function ($matches) {
+        return preg_replace_callback('/(?<!@)@php(?![ \t]*\()(.*?)@endphp/s', function ($matches) {
             $this->rawBlocks[] = "<?php{$matches[1]}?>";
 
             return $this->rawPlaceholder;

--- a/tests/View/Blade/BladePhpStatementsTest.php
+++ b/tests/View/Blade/BladePhpStatementsTest.php
@@ -43,4 +43,20 @@ class BladePhpStatementsTest extends AbstractBladeTestCase
 
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
+
+    public function testInlinePhpStatementsWithPhpBlocks()
+    {
+        $string = '@if (isset($team)) @php ($some = true) '
+               .'@else @php($some = false) @endif '
+               .'@php $somethingElse = true; @endphp';
+
+        $expected = '<?php if(isset($team)): ?> '
+                .'<?php ($some = true); ?> '
+                .'<?php else: ?> '
+                .'<?php ($some = false); ?> '
+                .'<?php endif; ?> '
+                .'<?php $somethingElse = true; ?>';
+
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
 }


### PR DESCRIPTION
With this changes only `@php` tags that are not followed by `(` or `    (` are stored. Fixes https://github.com/laravel/framework/issues/20994

https://imgs.xkcd.com/comics/regular_expressions.png