### PR TITLE
[5.5] Add new json blade directive

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -14,6 +14,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
         Concerns\CompilesEchos,
         Concerns\CompilesIncludes,
         Concerns\CompilesInjections,
+        Concerns\CompilesJson,
         Concerns\CompilesLayouts,
         Concerns\CompilesLoops,
         Concerns\CompilesRawPhp,

--- a/src/Illuminate/View/Compilers/Concerns/CompilesJson.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesJson.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Illuminate\View\Compilers\Concerns;
+
+trait CompilesJson
+{
+    /**
+     * Compile the json statement into valid PHP.
+     *
+     * @param string $expression
+     * @param int $options
+     * @param int $depth
+     * @return string
+     */
+    protected function compileJson($expression, $options = 0, $depth = 512)
+    {
+        return "<?php echo json_encode($expression, $options, $depth) ?>";
+    }
+}


### PR DESCRIPTION
This PR introduces a new `@json` directive for Blade. The purpose behind this new directive is to make it easier to inject PHP data structures into JS code while being IDE error free. 

Alternatives to this approach like `{!! $json !!}` or `{!! json_encode($data) !!}` raise syntax errors in some IDEs (PhpStorm) but `@json($data)` doesn't.

Usage example:
`let foo = @json($foo);`