### PR TITLE
[5.5] Add support to use subqueries as a where condition on a join clause

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -257,7 +257,7 @@ class Builder
         if ($query instanceof Closure) {
             $callback = $query;
 
-            $callback($query = $this->newQuery());
+            $callback($query = $this->forSubQuery());
         }
 
         // Here, we will parse this query into an SQL string and an array of bindings
@@ -820,13 +820,23 @@ class Builder
         // To create the exists sub-select, we will actually create a query and call the
         // provided callback with the query so the developer may set any of the query
         // conditions they want for the in clause, then we'll put it in this array.
-        call_user_func($callback, $query = $this->newQuery());
+        call_user_func($callback, $query = $this->forSubQuery());
 
         $this->wheres[] = compact('type', 'column', 'query', 'boolean');
 
         $this->addBinding($query->getBindings(), 'where');
 
         return $this;
+    }
+
+    /**
+     * Create a new query instance for sub-query where condition.
+     *
+     * @return \Illuminate\Database\Query\Builder
+     */
+    protected function forSubQuery()
+    {
+        return $this->newQuery();
     }
 
     /**
@@ -1148,7 +1158,7 @@ class Builder
         // Once we have the query instance we can simply execute it so it can add all
         // of the sub-select's conditions to itself, and then we can cache it off
         // in the array of where clauses for the "main" parent query instance.
-        call_user_func($callback, $query = $this->newQuery());
+        call_user_func($callback, $query = $this->forSubQuery());
 
         $this->wheres[] = compact(
             'type', 'column', 'operator', 'query', 'boolean'
@@ -1169,7 +1179,7 @@ class Builder
      */
     public function whereExists(Closure $callback, $boolean = 'and', $not = false)
     {
-        $query = $this->newQuery();
+        $query = $this->forSubQuery();
 
         // Similar to the sub-select clause, we will create a new query instance so
         // the developer may cleanly specify the entire exists query and we will

--- a/src/Illuminate/Database/Query/JoinClause.php
+++ b/src/Illuminate/Database/Query/JoinClause.php
@@ -97,4 +97,14 @@ class JoinClause extends Builder
     {
         return new static($this->parentQuery, $this->type, $this->table);
     }
+
+    /**
+     * Create a new query instance for sub-query where condition.
+     *
+     * @return \Illuminate\Database\Query\Builder
+     */
+    protected function forSubQuery()
+    {
+        return $this->parentQuery->newQuery();
+    }
 }


### PR DESCRIPTION
As reported on issue #19695 when a user tries to use a `->whereIn()` or a `->whereExists()` with a sub-query in a join clause, the query builder does not build the inner query where condition as expected.

Example:

~~~php
<?php

\Route::get( '/test', function () {
    $builder = \DB::table( 'users' )
        ->join( 'password_resets', function ( JoinClause $join ) {
            $join->on( 'users.email', '=', 'password_resets.email' );
            $join->whereIn( 'email', function ( $query ) {
                // dummy example just to demonstrate issue
                $query->select( 'email' )
                    ->from( 'users' )
                    ->where( 'id', '>', 1 );
            } );
        } );

    return $builder->toSql();
} );
~~~

Generates this SQL statment:

~~~sql
select * 
from 
    "users" 
    inner join "password_resets" 
        on "users"."email" = "password_resets"."email" 
        and "email" in (select "email" from "users" on "id" > ?)
~~~

instead of the expected one:

~~~sql
select * 
from 
    "users" 
    inner join "password_resets" 
        on "users"."email" = "password_resets"."email" 
        and "email" in (select "email" from "users" WHERE "id" > ?)
~~~

The is caused due to `JoinClause@newQuery()` method override returns a new `JoinClause` instance instead of a Query `Builder` instance. This makes `Grammar@concatenateWhereClauses()` to compile the nested query where clause not as expected.

I tried to change `JoinClause@newQuery()` method override to return a Query `Builder` instance. But doing so fails the nested where tests within a join clause.

This PR adds a protected method on the Query Builder that returns a new `Builder` instance for sub-queries so that the `JoinClause` class can override it properly.

Tests were added to cover these additional cases.
