### PR TITLE
[5.5] Rescue helper

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -742,6 +742,21 @@ if (! function_exists('preg_replace_array')) {
     }
 }
 
+if (! function_exists('rescue')) {
+    function rescue(callable $rescuee, $rescuer)
+    {
+        try {
+            return $rescuee();
+        } catch (Exception $e) {
+            if (is_callable($rescuer)) {
+                return $rescuer();
+            }
+
+            return $rescuer;
+        }
+    }
+}
+
 if (! function_exists('retry')) {
     /**
      * Retry an operation a given number of times.

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -743,16 +743,19 @@ if (! function_exists('preg_replace_array')) {
 }
 
 if (! function_exists('rescue')) {
+    /**
+     * Catch a potential exception and return a default.
+     *
+     * @param  callable  $rescuee
+     * @param  mixed     $rescuer
+     * @return mixed
+     */
     function rescue(callable $rescuee, $rescuer)
     {
         try {
             return $rescuee();
         } catch (Exception $e) {
-            if (is_callable($rescuer)) {
-                return $rescuer();
-            }
-
-            return $rescuer;
+            return is_callable($rescuer) ? $rescuer() : $rescuer;
         }
     }
 }

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -754,7 +754,7 @@ if (! function_exists('rescue')) {
     {
         try {
             return $rescuee();
-        } catch (Exception $e) {
+        } catch (Throwable $e) {
             return is_callable($rescuer) ? $rescuer() : $rescuer;
         }
     }

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Tests\Support;
 
 use stdClass;
-use Exception;
 use ArrayAccess;
 use Mockery as m;
 use RuntimeException;
@@ -812,12 +811,13 @@ class SupportHelpersTest extends TestCase
         }, 'rescued!'), 'no need to rescue');
 
         $testClass = new class {
-            public function test(int $a) {
+            public function test(int $a)
+            {
                 return $a;
             }
         };
 
-        $this->assertEquals(rescue(function () use ($testClass) {
+        $this->assertEquals(rescue(function () use ($testClass){
             $testClass->test([]);
         }, 'rescued!'), 'rescued!');
     }

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Support;
 
 use stdClass;
+use Exception;
 use ArrayAccess;
 use Mockery as m;
 use RuntimeException;
@@ -792,6 +793,23 @@ class SupportHelpersTest extends TestCase
                 };
             }
         })->present()->something());
+    }
+
+    public function testRescue()
+    {
+        $this->assertEquals(rescue(function () {
+            throw new Exception;
+        }, 'rescued!'), 'rescued!');
+
+        $this->assertEquals(rescue(function () {
+            throw new Exception;
+        }, function () {
+            return 'rescued!';
+        }), 'rescued!');
+
+        $this->assertEquals(rescue(function () {
+            return 'no need to rescue';
+        }, 'rescued!'), 'no need to rescue');
     }
 
     public function testTransform()

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -810,6 +810,16 @@ class SupportHelpersTest extends TestCase
         $this->assertEquals(rescue(function () {
             return 'no need to rescue';
         }, 'rescued!'), 'no need to rescue');
+
+        $testClass = new class {
+            public function test(int $a) {
+                return $a;
+            }
+        };
+
+        $this->assertEquals(rescue(function () use ($testClass) {
+            $testClass->test([]);
+        }, 'rescued!'), 'rescued!');
     }
 
     public function testTransform()

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -817,7 +817,7 @@ class SupportHelpersTest extends TestCase
             }
         };
 
-        $this->assertEquals(rescue(function () use ($testClass){
+        $this->assertEquals(rescue(function () use ($testClass) {
             $testClass->test([]);
         }, 'rescued!'), 'rescued!');
     }


### PR DESCRIPTION
Optionals introduced a great helper for one of my favorite pieces of terse ruby syntax, so I thought I'd take a stab at another. 

This rescue helper would allow a terser syntax for a typical try catch pattern that returns a default of some kind. It's held back a bit by PHP's anonymous function syntax, but I still think it's fairly nice. 

```php
return rescue(function () use ($someClass) {
   return $someClass->method();
}, $someClass->backupMethod());
```