### PR TITLE
[5.5] Let In validation parameters contain commas

### DIFF
--- a/src/Illuminate/Validation/Rules/In.php
+++ b/src/Illuminate/Validation/Rules/In.php
@@ -39,8 +39,8 @@ class In
         // Encapsulate strings with double quotes
         // and escape double quotes inside to enable
         // strings containing commas
-        $values = array_map(function($value) {
-            return '"' . str_replace('"', '""', $value) . '"';
+        $values = array_map(function ($value) {
+            return '"'.str_replace('"', '""', $value).'"';
         }, $this->values);
 
         return $this->rule.':'.implode(',', $values);

--- a/src/Illuminate/Validation/Rules/In.php
+++ b/src/Illuminate/Validation/Rules/In.php
@@ -31,9 +31,18 @@ class In
      * Convert the rule to a validation string.
      *
      * @return string
+     *
+     * @see \Illuminate\Validation\ValidationRuleParser::parseParameters
      */
     public function __toString()
     {
-        return $this->rule.':'.implode(',', $this->values);
+        // Encapsulate strings with double quotes
+        // and escape double quotes inside to enable
+        // strings containing commas
+        $values = array_map(function($value) {
+            return '"' . str_replace('"', '""', $value) . '"';
+        }, $this->values);
+
+        return $this->rule.':'.implode(',', $values);
     }
 }

--- a/tests/Validation/ValidationInRuleTest.php
+++ b/tests/Validation/ValidationInRuleTest.php
@@ -12,10 +12,14 @@ class ValidationInRuleTest extends TestCase
     {
         $rule = new In(['Laravel', 'Framework', 'PHP']);
 
-        $this->assertEquals('in:Laravel,Framework,PHP', (string) $rule);
+        $this->assertEquals('in:"Laravel","Framework","PHP"', (string) $rule);
+
+        $rule = new In(['Life, the Universe and Everything', 'this is a "quote"']);
+
+        $this->assertEquals('in:"Life, the Universe and Everything","this is a ""quote"""', (string) $rule);
 
         $rule = Rule::in([1, 2, 3, 4]);
 
-        $this->assertEquals('in:1,2,3,4', (string) $rule);
+        $this->assertEquals('in:"1","2","3","4"', (string) $rule);
     }
 }

--- a/tests/Validation/ValidationInRuleTest.php
+++ b/tests/Validation/ValidationInRuleTest.php
@@ -18,6 +18,10 @@ class ValidationInRuleTest extends TestCase
 
         $this->assertEquals('in:"Life, the Universe and Everything","this is a ""quote"""', (string) $rule);
 
+        $rule = new In(["a,b\nc,d"]);
+
+        $this->assertEquals("in:\"a,b\nc,d\"", (string) $rule);
+
         $rule = Rule::in([1, 2, 3, 4]);
 
         $this->assertEquals('in:"1","2","3","4"', (string) $rule);

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1430,7 +1430,10 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['name' => ['foo,bar', 'qux']], ['name' => 'Array|In:"foo,bar",baz,qux']);
         $this->assertTrue($v->passes());
 
-        $v = new Validator($trans, ['name' => ['f"o"o', 'qux']], ['name' => 'Array|In:"f""o""o",baz,qux']);
+        $v = new Validator($trans, ['name' => 'f"o"o'], ['name' => 'In:"f""o""o",baz,qux']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['name' => "a,b\nc,d"], ['name' => "in:\"a,b\nc,d\""]);
         $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['name' => ['foo', 'bar']], ['name' => 'Alpha|In:foo,bar']);

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1427,6 +1427,12 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['name' => ['foo', 'qux']], ['name' => 'Array|In:foo,baz,qux']);
         $this->assertTrue($v->passes());
 
+        $v = new Validator($trans, ['name' => ['foo,bar', 'qux']], ['name' => 'Array|In:"foo,bar",baz,qux']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['name' => ['f"o"o', 'qux']], ['name' => 'Array|In:"f""o""o",baz,qux']);
+        $this->assertTrue($v->passes());
+
         $v = new Validator($trans, ['name' => ['foo', 'bar']], ['name' => 'Alpha|In:foo,bar']);
         $this->assertFalse($v->passes());
 


### PR DESCRIPTION
Prevoiusly

```php
Rule::in([
    'alpha,beta',
    'gamma,delta'
]);
```

was parsed to `in:alpha,beta,gamma,delta` meaning that 4 values would pass this rule instead of the quite explicitly stated 2 possibilities.

This PR fixes the above bug by enclosing the listed values by double quotes. This is understood by the function `str_getcsv` which is used later on.

Because of introducing extra double quotes, it is necessary to escape existing double quotes (with a double quote, resulting double-double quotes, silly CSV standard...) , this is also implemented here. 