### PR TITLE
[5.5] Added get all created connections in RedisManager.

### DIFF
--- a/src/Illuminate/Redis/RedisManager.php
+++ b/src/Illuminate/Redis/RedisManager.php
@@ -118,6 +118,16 @@ class RedisManager implements Factory
     }
 
     /**
+     * Return all of the created connections.
+     *
+     * @return array
+     */
+    public function getConnections()
+    {
+        return $this->connections;
+    }
+
+    /**
      * Pass methods onto the default Redis connection.
      *
      * @param  string  $method


### PR DESCRIPTION
Added a `getConnections()` method to `RedisManager`.

Something we need to reconnect all created connections in RedisManager, this method help us to get all created connections for operation.