### PR TITLE
[5.5] Fix typo in HasAttributes trait

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -314,7 +314,7 @@ trait HasAttributes
         }
 
         // Here we will determine if the model base class itself contains this given key
-        // since we do not want to treat any of those methods are relationships since
+        // since we do not want to treat any of those methods as relationships since
         // they are all intended as helper methods and none of these are relations.
         if (method_exists(self::class, $key)) {
             return;


### PR DESCRIPTION
Fix a typo in the HasAttributes trait.

:octocat: