### PR TITLE
Add policies method to Gate.

### DIFF
--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -532,4 +532,14 @@ class Gate implements GateContract
     {
         return $this->abilities;
     }
+
+    /**
+     * Get all of the defined policies.
+     *
+     * @return array
+     */
+    public function policies()
+    {
+        return $this->policies;
+    }
 }

--- a/src/Illuminate/Contracts/Auth/Access/Gate.php
+++ b/src/Illuminate/Contracts/Auth/Access/Gate.php
@@ -117,4 +117,11 @@ interface Gate
      * @return array
      */
     public function abilities();
+
+    /**
+     * Get all of the defined policies.
+     *
+     * @return array
+     */
+    public function policies();
 }


### PR DESCRIPTION
I saw Gate has abilities method in order to get all defined abilities. I think adding a method to retrieve all defined policies will be useful. In my case, i need to get all abilities and policies to dynamically grant permissions to users or groups.