### PR TITLE
[5.5] Update docblock to match expectations

### DIFF
--- a/src/Illuminate/Queue/Failed/DatabaseFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/DatabaseFailedJobProvider.php
@@ -77,7 +77,7 @@ class DatabaseFailedJobProvider implements FailedJobProviderInterface
      * Get a single failed job.
      *
      * @param  mixed  $id
-     * @return array
+     * @return object|null
      */
     public function find($id)
     {

--- a/src/Illuminate/Queue/Failed/FailedJobProviderInterface.php
+++ b/src/Illuminate/Queue/Failed/FailedJobProviderInterface.php
@@ -26,7 +26,7 @@ interface FailedJobProviderInterface
      * Get a single failed job.
      *
      * @param  mixed  $id
-     * @return array
+     * @return object|null
      */
     public function find($id);
 

--- a/src/Illuminate/Queue/Failed/NullFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/NullFailedJobProvider.php
@@ -32,7 +32,7 @@ class NullFailedJobProvider implements FailedJobProviderInterface
      * Get a single failed job.
      *
      * @param  mixed  $id
-     * @return array
+     * @return object|null
      */
     public function find($id)
     {


### PR DESCRIPTION
Same as https://github.com/laravel/framework/pull/20980 but without explicit `return null;` on `NullFailedJobProvider`