### PR TITLE
Include runningUnitTests in Application Contract

### DIFF
--- a/src/Illuminate/Contracts/Foundation/Application.php
+++ b/src/Illuminate/Contracts/Foundation/Application.php
@@ -33,6 +33,13 @@ interface Application extends Container
      * @return bool
      */
     public function runningInConsole();
+    
+     /**
+     * Determine if we are running unit tests.
+     *
+     * @return bool
+     */
+    public function runningUnitTests();
 
     /**
      * Determine if the application is currently down for maintenance.


### PR DESCRIPTION
I could not come up with alternative implementations of this interface not requiring this extra method signature, and currently it's annoying to type-hint the contract because my IDE will complain about non-existing method.