### PR TITLE
[5.5] Specify lower case `column_name` (fixes #20190)

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -42,7 +42,7 @@ class MySqlGrammar extends Grammar
      */
     public function compileColumnListing()
     {
-        return 'select column_name from information_schema.columns where table_schema = ? and table_name = ?';
+        return 'select column_name as `column_name` from information_schema.columns where table_schema = ? and table_name = ?';
     }
 
     /**


### PR DESCRIPTION

The `MySqlProcessor` assumes that the result from MySQL contains a [lowercase column called `column_name`](https://github.com/laravel/framework/blob/7f1710a88399feba16aea18f1ed4f9ae76c00183/src/Illuminate/Database/Query/Processors/MySqlProcessor.php#L16).

On my installation, if I run the query from [`compileColumnListing` of MySqlGrammar](https://github.com/laravel/framework/blob/7f1710a88399feba16aea18f1ed4f9ae76c00183/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php#L35)

```sql
select * from information_schema.tables where table_schema = ? and table_name = ?
```

The result contains the column `COLUMN_NAME` in uppercase.

I don't really know where this is changed. In the driver? Maybe it makes sense to change the query in `MySqlGrammar` to ensure the correct case of the result:

```sql
select column_name as "column_name" from information_schema.tables where table_schema = ? and table_name = ?
```

In reference to: https://github.com/laravel/framework/issues/20190