### PR TITLE
[5.5] Show exception class in JSON

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -445,6 +445,7 @@ class Handler implements ExceptionHandlerContract
     {
         return config('app.debug') ? [
             'message' => $e->getMessage(),
+            'exception' => get_class($e),
             'file' => $e->getFile(),
             'line' => $e->getLine(),
             'trace' => $e->getTrace(),


### PR DESCRIPTION
Some exceptions don't have a verbose message, for that reason it might be nice to include the exception class to help developers understand what went wrong.

```
{
  "message": "name",
  "exception": "Illuminate\\Database\\Eloquent\\MassAssignmentException",
  "file": "/Users/mac/sites/laravel-src/laravelcurrent/src/Illuminate/Database/Eloquent/Model.php",
  "line": 237,
  "trace": [
    {
      "file": "/Users/mac/sites/laravel-src/laravelcurrent/src/Illuminate/Database/Eloquent/Model.php",
      "line": 157,
    }
  ]
}
```

Examples of these exceptions:

- MassAssignmentException
- LimiterTimeoutException
- PostTooLargeException
- LockTimeoutException