### PR TITLE
[5.5] Completed BelongsToMany Parent Key Change

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -194,7 +194,7 @@ class BelongsToMany extends Relation
      */
     public function addEagerConstraints(array $models)
     {
-        $this->query->whereIn($this->getQualifiedForeignPivotKeyName(), $this->getKeys($models));
+        $this->query->whereIn($this->getQualifiedForeignPivotKeyName(), $this->getKeys($models, $this->parentKey));
     }
 
     /**
@@ -229,7 +229,7 @@ class BelongsToMany extends Relation
         // children back to their parent using the dictionary and the keys on the
         // the parent models. Then we will return the hydrated models back out.
         foreach ($models as $model) {
-            if (isset($dictionary[$key = $model->getKey()])) {
+            if (isset($dictionary[$key = $model->{$this->parentKey}])) {
                 $model->setRelation(
                     $relation, $this->related->newCollection($dictionary[$key])
                 );

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -293,7 +293,7 @@ trait InteractsWithPivotTable
     {
         $record[$this->relatedPivotKey] = $id;
 
-        $record[$this->foreignPivotKey] = $this->parent->getKey();
+        $record[$this->foreignPivotKey] = $this->parent->{$this->parentKey};
 
         // If the record needs to have creation and update timestamps, we will make
         // them by calling the parent model's "freshTimestamp" method which will
@@ -439,7 +439,7 @@ trait InteractsWithPivotTable
             call_user_func_array([$query, 'whereIn'], $arguments);
         }
 
-        return $query->where($this->foreignPivotKey, $this->parent->getKey());
+        return $query->where($this->foreignPivotKey, $this->parent->{$this->parentKey});
     }
 
     /**


### PR DESCRIPTION
This resolves the issue where BelongsToMany.php makes use of parentKey, but this concern (InteractsWithPivotTable) does not make use of parentKey at all, and instead still uses the old $this->parent->getKey() rather than $this->parent->{$this->parentKey}

This references this change illuminate/database@e4f8884 which has been superceded by illuminate/database@00c2c5a

This also includes a change to the BelongsToMany Relation to allow for the correct loading of Eager Loaded relations by making use of the parentKey for parent models.