### PR TITLE
[5.5] return $this  from Validator::setCustomMessages

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -942,11 +942,13 @@ class Validator implements ValidatorContract
      * Set the custom messages for the validator.
      *
      * @param  array  $messages
-     * @return void
+     * @return $this
      */
     public function setCustomMessages(array $messages)
     {
         $this->customMessages = array_merge($this->customMessages, $messages);
+
+        return $this;
     }
 
     /**


### PR DESCRIPTION
- setAttributeNames
- addCustomAttributes
- setValueNames

Return $this currently, this helps with using the validator fluently.