### PR TITLE
Remove superfluous array casting.

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -224,7 +224,7 @@ class Blueprint
      */
     public function dropColumn($columns)
     {
-        $columns = is_array($columns) ? $columns : (array) func_get_args();
+        $columns = is_array($columns) ? $columns : func_get_args();
 
         return $this->addCommand('dropColumn', compact('columns'));
     }


### PR DESCRIPTION
Hello,
this is a pretty trivial change. Today I noticed that the result of a `func_get_args()` function is being cast to an `(array)`, which I believe is not necessary since `func_get_args()` should always return an array, whether or not the function is invoked with parameters or not.

This pull request removes the superfluous array casting.