### PR TITLE
[5.5] Add Query Builder method "if"

### DIFF
--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -99,11 +99,11 @@ trait BuildsQueries
     /**
      * Apply the basic where if the given "condition" is true.
      *
-     * @param  mixed $condition
-     * @param  string $column
-     * @param  string $operator
-     * @param  mixed $value
-     * @param  string $boolean
+     * @param  mixed  $condition
+     * @param  string  $column
+     * @param  string  $operator
+     * @param  mixed  $value
+     * @param  string  $boolean
      * @return mixed
      */
     public function if($condition, $column, $operator = null, $value = null, $boolean = 'and')

--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -99,14 +99,14 @@ trait BuildsQueries
     /**
      * Apply the basic where if the given "condition" is true.
      * 
-     * @param  mixed $coniditon
+     * @param  mixed $condition
      * @param  string $column
      * @param  string $operator
      * @param  mixed $value
      * @param  string $boolean
      * @return mixed
      */
-    public function if($coniditon, $column, $operator = null, $value = null, $boolean)
+    public function if($condition, $column, $operator = null, $value = null, $boolean = 'and')
     {
         if ($condition) {
             if (func_num_args() === 3) {

--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -97,6 +97,31 @@ trait BuildsQueries
     }
 
     /**
+     * Apply the basic where if the given "condition" is true.
+     * 
+     * @param  mixed $coniditon
+     * @param  string $column
+     * @param  string $operator
+     * @param  mixed $value
+     * @param  string $boolean
+     * @return mixed
+     */
+    public function if($coniditon, $column, $operator = null, $value = null, $boolean)
+    {
+        if ($condition) {
+            if (func_num_args() === 3) {
+                list($value, $operator) = [$operator, '='];
+            } elseif ($this->invalidOperatorAndValue($operator, $value)) {
+                throw new InvalidArgumentException('Illegal operator and value combination.');
+            }
+
+            return $this->where($column, $operator, $value, $boolean);
+        }
+
+        return $this;
+    }
+
+    /**
      * Pass the query to a given callback.
      *
      * @param  \Closure  $callback

--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -98,7 +98,7 @@ trait BuildsQueries
 
     /**
      * Apply the basic where if the given "condition" is true.
-     * 
+     *
      * @param  mixed $condition
      * @param  string $column
      * @param  string $operator

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -147,6 +147,29 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals('select * from "users" where "email" = ?', $builder->toSql());
     }
 
+    public function testEloquentIf()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('id', '=', 1)->if(true, 'email', 'test@test.com');
+        $this->assertEquals('select * from "users" where "id" = ? and "email" = ?', $builder->toSql());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('id', '=', 1)->if(true, 'email', '=', 'test@test.com', 'or');
+        $this->assertEquals('select * from "users" where "id" = ? or "email" = ?', $builder->toSql());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('id', '=', 1)->if(false, 'email', 'test@test.com');
+        $this->assertEquals('select * from "users" where "id" = ?', $builder->toSql());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('id', '=', 1)->if(true, 'email', 'like', 'test%');
+        $this->assertEquals('select * from "users" where "id" = ? and "email" like ?', $builder->toSql());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->if(true, 'id', '>', '1');
+        $this->assertEquals('select * from "users" where "id" > ?', $builder->toSql());
+    }
+
     public function testWhenCallbackWithReturn()
     {
         $callback = function ($query, $condition) {


### PR DESCRIPTION
In some scenes the "when" method don't fit right, so I wrote an if method to solve this problem.

Before:
```
User::when(true, function ($query) {
    $query->where('email', 'xxx@xxx.com');
});
```

After:
```
User::if(true, 'email', 'xxx@xxx.com')
```
