### PR TITLE
[5.5] add flex-wrap to make pagination more responsive

### DIFF
--- a/src/Illuminate/Pagination/resources/views/bootstrap-4.blade.php
+++ b/src/Illuminate/Pagination/resources/views/bootstrap-4.blade.php
@@ -1,5 +1,5 @@
 @if ($paginator->hasPages())
-    <ul class="pagination">
+    <ul class="pagination flex-wrap">
         {{-- Previous Page Link --}}
         @if ($paginator->onFirstPage())
             <li class="page-item disabled"><span class="page-link">&laquo;</span></li>


### PR DESCRIPTION
Since bootstrap4 doesn't support responsive pagination, detailed discussion can be found here https://github.com/twbs/bootstrap/issues/23504

 so a long pagination would make page width bigger than the screen width. a simple workaround is to make long pagination to another line.