### PR TITLE
[5.5] add TransactionIsolation DSN key for SQL Server

### DIFF
--- a/src/Illuminate/Database/Connectors/SqlServerConnector.php
+++ b/src/Illuminate/Database/Connectors/SqlServerConnector.php
@@ -130,6 +130,10 @@ class SqlServerConnector extends Connector implements ConnectorInterface
             $arguments['MultipleActiveResultSets'] = 'false';
         }
 
+        if (isset($config['transaction_isolation'])) {
+            $arguments['TransactionIsolation'] = $config['transaction_isolation'];
+        }
+
         return $this->buildConnectString('sqlsrv', $arguments);
     }
 


### PR DESCRIPTION
PDO driver for SQL server provides [additional configuration options](https://docs.microsoft.com/en-us/sql/connect/php/connection-options) for DSN string. One of them is TransactionIsolation. Possible values are listed in [official PDO documentation](http://php.net/manual/en/ref.pdo-sqlsrv.php). This PR makes possible to set desired transaction isolation level for SQL server connection.