### PR TITLE
[5.5] Blueprint Geo Spatial index 

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -142,7 +142,7 @@ class Blueprint
     protected function addFluentIndexes()
     {
         foreach ($this->columns as $column) {
-            foreach (['primary', 'unique', 'index'] as $index) {
+            foreach (['primary', 'unique', 'index', 'spatialIndex'] as $index) {
                 // If the index has been specified on the given column, but is simply equal
                 // to "true" (boolean), no name has been specified for this index so the
                 // index method can be called without a name and it will generate one.
@@ -383,6 +383,18 @@ class Blueprint
     public function index($columns, $name = null, $algorithm = null)
     {
         return $this->indexCommand('index', $columns, $name, $algorithm);
+    }
+
+    /**
+     * Specify a spatial index for the table.
+     *
+     * @param  string|array  $columns
+     * @param  string        $name
+     * @return \Illuminate\Support\Fluent
+     */
+    public function spatialIndex($columns, $name = null)
+    {
+        return $this->indexCommand('spatialIndex', $columns, $name);
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -194,6 +194,18 @@ class MySqlGrammar extends Grammar
     }
 
     /**
+     * Compile a spatial index key command.
+     *
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @param  \Illuminate\Support\Fluent  $command
+     * @return string
+     */
+    public function compileSpatialIndex(Blueprint $blueprint, Fluent $command)
+    {
+        return $this->compileKey($blueprint, $command, 'spatial index');
+    }
+
+    /**
      * Compile an index creation command.
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -291,6 +291,26 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table `users` add index `baz` using hash(`foo`, `bar`)', $statements[0]);
     }
 
+    public function testAddingSpatialIndex()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->spatialIndex('foo', 'baz');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table `users` add spatial index `baz`(`foo`)', $statements[0]);
+    }
+
+    public function testAddingFluentSpatialIndex()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->point('foo')->spatialIndex('baz');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(2, $statements);
+        $this->assertEquals('alter table `users` add spatial index `baz`(`foo`)', $statements[1]);
+    }
+
     public function testAddingForeignKey()
     {
         $blueprint = new Blueprint('users');


### PR DESCRIPTION
This PR continues #21056 and introduces spatial indexes in your migrations with the `spatialIndex` blueprint method.

*Note: At this moment I've implemented only MySQL grammar `SPATIAL INDEX` support.*

```php
$table->spatialIndex('column_name');
// or
$table->point('column_name')->spatialIndex();
```

Example:
```php
public function up()
{
    Schema::table('conferences', function (Blueprint $table) {
        $table->increments('id');
        $table->point('coordinates')->spatialIndex();
    });
}
```

You can drop it using default `$table->dropIndex('column_name')` command.

### MySQL

Note about spatial indexes from the [MySQL documentation](https://dev.mysql.com/doc/refman/5.7/en/creating-spatial-indexes.html):

> For [`MyISAM`](https://dev.mysql.com/doc/refman/5.7/en/myisam-storage-engine.html) and (as of MySQL 5.7.5) `InnoDB` tables, MySQL can create spatial indexes using syntax similar to that for creating regular indexes, but using the `SPATIAL` keyword. Columns in spatial indexes must be declared `NOT NULL`.

MySQL `SPATIAL INDEX` creates an R-tree index. For storage engines that support nonspatial indexing of spatial columns, the engine creates a B-tree index. A B-tree index on spatial values is useful for exact-value lookups, but not for range scans.

- Available only for `MyISAM` and `InnoDB` tables. Specifying `SPATIAL INDEX` for other storage engines results in an error.
- Indexed columns must be NOT NULL.
- Column prefix lengths are prohibited. The full width of each column is indexed.

### PostgreSQL

Accordingly to [PostGIS Spatial Indexing article](http://revenant.ca/www/postgis/workshop/indexing.html):

> The `USING GIST` clause tells PostgreSQL to use the generic index structure (GIST) when building the index. This is important because the default index type is the B-Ttree. B-Tree indices are not lossy (inexact) in the way a GIST index can be. This means that while the GIST index only indexes the bounding box of the geometry, the B-Tree must index the entire geometry, which can often be larger than the index can cope with. If you receive an error that looks like `ERROR: index row requires 11340 bytes, maximum size is 8191` when creating your index, you have likely neglected to add the `USING GIST` clause.