### PR TITLE
Added additional FileViewFinder error messages for common mistakes.

### DIFF
--- a/src/Illuminate/View/FileViewFinder.php
+++ b/src/Illuminate/View/FileViewFinder.php
@@ -134,27 +134,17 @@ class FileViewFinder implements ViewFinderInterface
             }
         }
         
-        $hasValidViewExtension = in_array( @end(explode('.', $name)), $this->extensions);
+        $hasValidViewExtension = in_array(@end(explode('.', $name)), $this->extensions);
 
-        // The simplest mistake made, is to include the file extensions in the view names.
-        if( $hasValidViewExtension ){
-
-            $msg = '"' . $name . '", You should not specify a file extension as part of a view name';
-
-        // Another mistake is to try and specify .html, .htm files as views
-        // Would be a good idea to include a more exhaustive list of common file types.
-        } else if( !$hasValidViewExtension && in_array( @end(explode('.', $name)), ['html', 'htm', 'xhtml']) ){
-
-            $msg = '".'. @end(explode('.', $name)) . '", is not a valid view extension';
-
-        // Something is wrong, with the path specified, the view name or both, let's give lots of details.
+        if($hasValidViewExtension){
+            $msg = '"'.$name.'", You should not specify a file extension as part of a view name';
+        } elseif (!$hasValidViewExtension && in_array(@end(explode('.', $name)),['html', 'htm', 'xhtml'])){
+            $msg = '".'.@end(explode('.', $name)).'", is not a valid view extension';
         } else {
-
-            $msg =  "View [$name] not found. " . 
-                    "View paths searched: [ " . join(", ", $paths) . " ] ".
-                    "Possible view extensions where: [ " . join(", ", $this->extensions ) . " ]";
+            $msg = "View [$name] not found. ". 
+                   "View paths searched: [ ".join(", ",$paths)." ] ".
+                   "Possible view extensions where: [ ".join(", ",$this->extensions )." ]";
         }
-
         throw new InvalidArgumentException($msg);
     }
 

--- a/src/Illuminate/View/FileViewFinder.php
+++ b/src/Illuminate/View/FileViewFinder.php
@@ -133,8 +133,29 @@ class FileViewFinder implements ViewFinderInterface
                 }
             }
         }
+        
+        $hasValidViewExtension = in_array( @end(explode('.', $name)), $this->extensions);
 
-        throw new InvalidArgumentException("View [$name] not found.");
+        // The simplest mistake made, is to include the file extensions in the view names.
+        if( $hasValidViewExtension ){
+
+            $msg = '"' . $name . '", You should not specify a file extension as part of a view name';
+
+        // Another mistake is to try and specify .html, .htm files as views
+        // Would be a good idea to include a more exhaustive list of common file types.
+        } else if( !$hasValidViewExtension && in_array( @end(explode('.', $name)), ['html', 'htm', 'xhtml']) ){
+
+            $msg = '".'. @end(explode('.', $name)) . '", is not a valid view extension';
+
+        // Something is wrong, with the path specified, the view name or both, let's give lots of details.
+        } else {
+
+            $msg =  "View [$name] not found. " . 
+                    "View paths searched: [ " . join(", ", $paths) . " ] ".
+                    "Possible view extensions where: [ " . join(", ", $this->extensions ) . " ]";
+        }
+
+        throw new InvalidArgumentException($msg);
     }
 
     /**


### PR DESCRIPTION
Added additional error messages to make debugging and troubleshooting much quicker. Specifically addressing three specific error cases.
1) User included ".blade.php", ".php" or ".css" in the view name
2) User included ".html", "xhtml" or "htm" in the view name
3) Supplied view file does not exist, or has something else wrong with it.