### PR TITLE
Cast to object before JSON encoding

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -934,7 +934,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public function toJson($options = 0)
     {
-        $json = json_encode($this->jsonSerialize(), $options);
+        $json = json_encode((object) $this->jsonSerialize(), $options);
 
         if (JSON_ERROR_NONE !== json_last_error()) {
             throw JsonEncodingException::forModel($this, json_last_error_msg());

--- a/src/Illuminate/Support/MessageBag.php
+++ b/src/Illuminate/Support/MessageBag.php
@@ -380,7 +380,7 @@ class MessageBag implements Arrayable, Countable, Jsonable, JsonSerializable, Me
      */
     public function toJson($options = 0)
     {
-        return json_encode($this->jsonSerialize(), $options);
+        return json_encode((object) $this->jsonSerialize(), $options);
     }
 
     /**


### PR DESCRIPTION
Forcing an object cast in 2 `Jsonable` classes (`Eloquent/Model` and `Support/MessageBag`) that are expected to return a JSON object (result of json-encoding an associative array) but will return a JSON array instead if the data array is empty.

Similar to using the [`JSON_FORCE_OBJECT` flag](http://php.net/manual/en/json.constants.php), but unlike that, this implementation will only force an object on the top-level structure, not deeper.