### PR TITLE
Implement __toString on ViewErrorBag

### DIFF
--- a/src/Illuminate/Support/ViewErrorBag.php
+++ b/src/Illuminate/Support/ViewErrorBag.php
@@ -117,4 +117,14 @@ class ViewErrorBag implements Countable
     {
         $this->put($key, $value);
     }
+    
+    /**
+     * Convert the default bag to its string representation.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return (string) $this->getBag('default');
+    }
 }


### PR DESCRIPTION
Delegates to default bag, as `__call` does.