### PR TITLE
[5.5] Add static factory methods to Optional class

### DIFF
--- a/src/Illuminate/Support/Optional.php
+++ b/src/Illuminate/Support/Optional.php
@@ -56,4 +56,37 @@ class Optional
             return $this->value->{$method}(...$parameters);
         }
     }
+
+    /**
+     * Create a new instance with a nullable value.
+     * @param mixed $value
+     * @return self
+     */
+    public static function of($value)
+    {
+        return new self($value);
+    }
+
+    /**
+     * Create a new instance with some value.
+     * @param mixed $value
+     * @return self
+     */
+    public static function some($value)
+    {
+        if (is_null($value)) {
+            throw new \InvalidArgumentException('Null value passed to some() method. Use none() instead.');
+        }
+
+        return new self($value);
+    }
+
+    /**
+     * Create a new instance with no value.
+     * @return self
+     */
+    public static function none()
+    {
+        return new self(null);
+    }
 }

--- a/tests/Support/SupportOptionalTest.php
+++ b/tests/Support/SupportOptionalTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Illuminate\Tests\Support;
+
+use Illuminate\Support\Optional;
+use PHPUnit\Framework\TestCase;
+
+class SupportOptionalTest extends TestCase
+{
+    /**
+     * @param mixed $value
+     * @dataProvider nullableValueProvider
+     */
+    public function testOf($value)
+    {
+        $this->assertEquals(new Optional($value), Optional::of($value));
+    }
+
+    public function nullableValueProvider()
+    {
+        return [
+            [null],
+            [5],
+            [new \stdClass()],
+        ];
+    }
+
+    /**
+     * @param mixed $value
+     * @dataProvider someValueProvider
+     */
+    public function testSome($value)
+    {
+        $this->assertEquals(new Optional($value), Optional::some($value));
+    }
+
+    public function someValueProvider()
+    {
+        return [
+            [5],
+            [new \stdClass()],
+        ];
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Null value passed to some() method. Use none() instead.
+     */
+    public function testSomeThrowsExceptionWhenNullGiven()
+    {
+        Optional::some(null);
+    }
+
+    public function testNone()
+    {
+        $this->assertEquals(new Optional(null), Optional::none());
+    }
+}

--- a/tests/Support/SupportOptionalTest.php
+++ b/tests/Support/SupportOptionalTest.php
@@ -2,8 +2,8 @@
 
 namespace Illuminate\Tests\Support;
 
-use Illuminate\Support\Optional;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Support\Optional;
 
 class SupportOptionalTest extends TestCase
 {


### PR DESCRIPTION
This PR Add ```\Illuminate\Support\Optional``` class three static factory methods for convenience.
* ```Optional::of()```
* ```Optional::some()```
* ```Optional::none()```.

usage

```
use Illuminate\Support\Option;
use App\User;

/**
 * @param int $id
 * @return Optional | User
 */
public function findAdminUser($id)
{
     	$user = User::find($id);
     	if (is_null($user) || !$user->isAdmin()) {
     		return Optional::none();
     	}
     	return Optional::some($user);
}

echo findAdminUser(1)->name;
```
