### PR TITLE
[5.5] Fix misleading behavior in `Route::getAction()`

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -698,7 +698,7 @@ class Route
     }
 
     /**
-     * Get the action array or one of its property for the route.
+     * Get the action array or one of its properties for the route.
      *
      * @param  string|null  $key
      * @return mixed

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -698,16 +698,14 @@ class Route
     }
 
     /**
-     * Get an action or action array for the route.
+     * Get the action array or one of its property for the route.
      *
-     * @param  string|null  $action
+     * @param  string|null  $key
      * @return mixed
      */
-    public function getAction($action = null)
+    public function getAction($key = null)
     {
-        return array_key_exists($action, $this->action)
-            ? $this->action[$action]
-            : $this->action;
+        return Arr::get($this->action, $key);
     }
 
     /**

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -296,6 +296,20 @@ class RoutingRouteTest extends TestCase
         $this->assertEquals('foo.bar', $router->currentRouteName());
     }
 
+    public function testRouteGetAction()
+    {
+        $router = $this->getRouter();
+
+        $route = $router->get('foo', function () {
+            return 'foo';
+        })->name('foo');
+
+        $this->assertTrue(is_array($route->getAction()));
+        $this->assertArrayHasKey('as', $route->getAction());
+        $this->assertEquals('foo', $route->getAction('as'));
+        $this->assertNull($route->getAction('unknown_property'));
+    }
+
     public function testMacro()
     {
         $router = $this->getRouter();


### PR DESCRIPTION
Patch for the following PR https://github.com/laravel/framework/pull/20975

> Pretty cool. However, am I the only one bothered by the fact that it is returning the action array if the key is not found?
> 
> Wouldn't it be more appropriate to return null instead as we expect a very specific property?
> 
> I find this misleading, especially if using it in a condition.
> Eg: if ($route->getAction('controller')), even if there is no controllers it will return true...

As a bonus I added some tests.