### PR TITLE
[5.5] Inherited Controller Parameters are not Instantiable

### DIFF
--- a/src/Illuminate/Routing/RouteDependencyResolverTrait.php
+++ b/src/Illuminate/Routing/RouteDependencyResolverTrait.php
@@ -90,7 +90,12 @@ trait RouteDependencyResolverTrait
     protected function alreadyInParameters($class, array $parameters)
     {
         return ! is_null(Arr::first($parameters, function ($value) use ($class) {
-            return $value instanceof $class;
+
+            if(is_object($value)) {
+                $value = get_class($value);
+            }
+
+            return $value === $class;
         }));
     }
 

--- a/tests/Routing/RoutingControllerDispatcherTest.php
+++ b/tests/Routing/RoutingControllerDispatcherTest.php
@@ -16,8 +16,6 @@ class RoutingControllerDispatcherTest extends TestCase {
     public function testCanResolveParametersThatInheritFromPreviousParameter()
     {
         $container = new Container();
-        $container->instance(Foo::class, new Foo());
-
         $dispatcher = new ControllerDispatcher($container);
 
         $this->assertCount(3, $dispatcher->resolveMethodDependencies(['id' => 1], new ReflectionMethod(TestController::class, 'example')));

--- a/tests/Routing/RoutingControllerDispatcherTest.php
+++ b/tests/Routing/RoutingControllerDispatcherTest.php
@@ -1,0 +1,42 @@
+<?php
+
+
+namespace Illuminate\Tests\Routing;
+
+
+use Illuminate\Container\Container;
+use Illuminate\Routing\Controller;
+use Illuminate\Routing\ControllerDispatcher;
+use Illuminate\Routing\Route;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+
+class RoutingControllerDispatcherTest extends TestCase {
+
+    public function testCanResolveParametersThatInheritFromPreviousParameter()
+    {
+        $container = new Container();
+        $container->instance(Foo::class, new Foo());
+
+        $dispatcher = new ControllerDispatcher($container);
+
+        $this->assertCount(3, $dispatcher->resolveMethodDependencies(['id' => 1], new ReflectionMethod(TestController::class, 'example')));
+
+        // Alternative way to break test
+//        $instance = new TestController();
+//        $route = new Route(['GET'], '/', []);
+//        $route->parameters = ['id' => 1];
+//
+//        $dispatcher->dispatch(
+//            $route,
+//            $instance,
+//            'example'
+//        );
+    }
+}
+
+class TestController extends Controller{
+    public function example($id, Bar $bar, Foo $foo){}
+}
+class Foo {}
+class Bar extends Foo {}


### PR DESCRIPTION
tl;dr:
Fixes `Argument N passed to XController::show() must be an instance of Y, none given` for parameters that inherit from each other.

Issue:
When injecting controller parameters and one of them inherits from a parameter that occurs earlier in the method interface, the parameter is passed as 'none' where it should be instantiated from the container.