### PR TITLE
[5.5] Add an everyFifteenMinutes function to the ManagesFrequencies trait t…

### DIFF
--- a/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
+++ b/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
@@ -346,7 +346,7 @@ trait ManagesFrequencies
     {
         return $this->spliceIntoPosition(1, '*/10');
     }
-    
+
     /**
      * Schedule the event to run every fifteen minutes.
      *

--- a/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
+++ b/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
@@ -346,7 +346,7 @@ trait ManagesFrequencies
     {
         return $this->spliceIntoPosition(1, '*/10');
     }
-		
+    
     /**
      * Schedule the event to run every fifteen minutes.
      *

--- a/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
+++ b/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
@@ -346,7 +346,7 @@ trait ManagesFrequencies
     {
         return $this->spliceIntoPosition(1, '*/10');
     }
-	
+		
     /**
      * Schedule the event to run every fifteen minutes.
      *

--- a/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
+++ b/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
@@ -346,6 +346,16 @@ trait ManagesFrequencies
     {
         return $this->spliceIntoPosition(1, '*/10');
     }
+	
+    /**
+     * Schedule the event to run every fifteen minutes.
+     *
+     * @return $this
+     */
+    public function everyFifteenMinutes()
+    {
+        return $this->spliceIntoPosition(1, '*/15');
+    }
 
     /**
      * Schedule the event to run every thirty minutes.


### PR DESCRIPTION
I often want to schedule things to run four times an hour (every 15 minutes).

I know that using ->cron('*/15 * * * * *') is an option, but would rather use an everyFifteenMinutes function, like the existing everyMinute, everyFiveMinutes, everyTenMinutes, everyThirtyMinutes, etc.

I saw a few people ask for this, so thought it'd be a nice simple PR to add to the framework.


