### PR TITLE
[5.5] add hasReplyTo method to Mailable class

### DIFF
--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -461,6 +461,18 @@ class Mailable implements MailableContract, Renderable
     }
 
     /**
+     * Determine if the given recipient is set on the mailable.
+     *
+     * @param  object|array|string  $address
+     * @param  string|null  $name
+     * @return bool
+     */
+    public function hasReplyTo($address, $name = null)
+    {
+        return $this->hasRecipient($address, $name, 'replyTo');
+    }
+
+    /**
      * Set the recipients of the message.
      *
      * All recipients are stored internally as [['name' => ?, 'address' => ?]]

--- a/tests/Mail/MailMailableTest.php
+++ b/tests/Mail/MailMailableTest.php
@@ -54,6 +54,53 @@ class MailMailableTest extends TestCase
         $this->assertTrue($mailable->hasTo('taylor@laravel.com'));
     }
 
+    public function testMailableSetsReplyToCorrectly()
+    {
+        $mailable = new WelcomeMailableStub;
+        $mailable->replyTo('taylor@laravel.com');
+        $this->assertEquals([['name' => null, 'address' => 'taylor@laravel.com']], $mailable->replyTo);
+        $this->assertTrue($mailable->hasReplyTo('taylor@laravel.com'));
+
+        $mailable = new WelcomeMailableStub;
+        $mailable->replyTo('taylor@laravel.com', 'Taylor Otwell');
+        $this->assertEquals([['name' => 'Taylor Otwell', 'address' => 'taylor@laravel.com']], $mailable->replyTo);
+        $this->assertTrue($mailable->hasReplyTo('taylor@laravel.com', 'Taylor Otwell'));
+        $this->assertTrue($mailable->hasReplyTo('taylor@laravel.com'));
+
+        $mailable = new WelcomeMailableStub;
+        $mailable->replyTo(['taylor@laravel.com']);
+        $this->assertEquals([['name' => null, 'address' => 'taylor@laravel.com']], $mailable->replyTo);
+        $this->assertTrue($mailable->hasReplyTo('taylor@laravel.com'));
+        $this->assertFalse($mailable->hasReplyTo('taylor@laravel.com', 'Taylor Otwell'));
+
+        $mailable = new WelcomeMailableStub;
+        $mailable->replyTo([['name' => 'Taylor Otwell', 'email' => 'taylor@laravel.com']]);
+        $this->assertEquals([['name' => 'Taylor Otwell', 'address' => 'taylor@laravel.com']], $mailable->replyTo);
+        $this->assertTrue($mailable->hasReplyTo('taylor@laravel.com', 'Taylor Otwell'));
+        $this->assertTrue($mailable->hasReplyTo('taylor@laravel.com'));
+
+        $mailable = new WelcomeMailableStub;
+        $mailable->replyTo(new MailableTestUserStub);
+        $this->assertEquals([['name' => 'Taylor Otwell', 'address' => 'taylor@laravel.com']], $mailable->replyTo);
+        $this->assertTrue($mailable->hasReplyTo(new MailableTestUserStub));
+        $this->assertTrue($mailable->hasReplyTo('taylor@laravel.com'));
+
+        $mailable = new WelcomeMailableStub;
+        $mailable->replyTo(collect([new MailableTestUserStub]));
+        $this->assertEquals([['name' => 'Taylor Otwell', 'address' => 'taylor@laravel.com']], $mailable->replyTo);
+        $this->assertTrue($mailable->hasReplyTo(new MailableTestUserStub));
+        $this->assertTrue($mailable->hasReplyTo('taylor@laravel.com'));
+
+        $mailable = new WelcomeMailableStub;
+        $mailable->replyTo(collect([new MailableTestUserStub, new MailableTestUserStub]));
+        $this->assertEquals([
+            ['name' => 'Taylor Otwell', 'address' => 'taylor@laravel.com'],
+            ['name' => 'Taylor Otwell', 'address' => 'taylor@laravel.com'],
+        ], $mailable->replyTo);
+        $this->assertTrue($mailable->hasReplyTo(new MailableTestUserStub));
+        $this->assertTrue($mailable->hasReplyTo('taylor@laravel.com'));
+    }
+
     public function testMailableBuildsViewData()
     {
         $mailable = new WelcomeMailableStub;


### PR DESCRIPTION
All other "setters" have a `hasXXXX` method but there is no`hasReplyTo`. Had to use it today and discovered this haha  

This PR just adds it, the merge target is 5.5 but there are no BC so I don't think it's a problem.
