### PR TITLE
[5.5] Dynamically compose template methods (setUp/tearDown) from TestCase traits

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/ComposesTemplateMethods.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/ComposesTemplateMethods.php
@@ -22,7 +22,6 @@ trait ComposesTemplateMethods
         $class = static::class;
 
         if (! isset(static::$traitTemplateMethods[$class])) {
-
             $templateMethods = ['setUp', 'tearDown'];
             static::$traitTemplateMethods[$class] = array_fill_keys($templateMethods, []);
 

--- a/src/Illuminate/Foundation/Testing/Concerns/ComposesTemplateMethods.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/ComposesTemplateMethods.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Illuminate\Foundation\Testing\Concerns;
+
+trait ComposesTemplateMethods
+{
+    /**
+     * Cache of template methods for given test cases.
+     *
+     * @var array
+     */
+    protected static $traitTemplateMethods = [];
+
+    /**
+     * Get a list of template methods from traits.
+     *
+     * @param  string  $template
+     * @return array
+     */
+    protected static function getTraitTemplateMethods($template)
+    {
+        $class = static::class;
+
+        if (!isset(static::$traitTemplateMethods[$class])) {
+
+            $templateMethods = ['setUp', 'tearDown'];
+            static::$traitTemplateMethods[$class] = array_fill_keys($templateMethods, []);
+
+            foreach (class_uses_recursive($class) as $trait) {
+                foreach ($templateMethods as $templateMethod) {
+                    if (method_exists($class, $method = $templateMethod.class_basename($trait))) {
+                        static::$traitTemplateMethods[$class][$templateMethod][] = $method;
+                    }
+                }
+            }
+        }
+
+        return static::$traitTemplateMethods[$class][$template];
+    }
+
+    /**
+     * Call composed template methods for all used traits.
+     *
+     * @param  string  $template
+     * @return void
+     */
+    protected function callTraitTemplateMethods($template)
+    {
+        foreach (static::getTraitTemplateMethods($template) as $method) {
+            $this->$method();
+        }
+    }
+}

--- a/src/Illuminate/Foundation/Testing/Concerns/ComposesTemplateMethods.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/ComposesTemplateMethods.php
@@ -21,7 +21,7 @@ trait ComposesTemplateMethods
     {
         $class = static::class;
 
-        if (!isset(static::$traitTemplateMethods[$class])) {
+        if (! isset(static::$traitTemplateMethods[$class])) {
 
             $templateMethods = ['setUp', 'tearDown'];
             static::$traitTemplateMethods[$class] = array_fill_keys($templateMethods, []);

--- a/src/Illuminate/Foundation/Testing/DatabaseMigrations.php
+++ b/src/Illuminate/Foundation/Testing/DatabaseMigrations.php
@@ -11,7 +11,7 @@ trait DatabaseMigrations
      *
      * @return void
      */
-    public function runDatabaseMigrations()
+    public function setUpDatabaseMigrations()
     {
         $this->artisan('migrate:fresh');
 
@@ -20,5 +20,17 @@ trait DatabaseMigrations
         $this->beforeApplicationDestroyed(function () {
             $this->artisan('migrate:rollback');
         });
+    }
+
+    /**
+     * Define hooks to migrate the database before and after each test.
+     *
+     * @deprecated
+     *
+     * @return void
+     */
+    public function runDatabaseMigrations()
+    {
+        $this->setUpDatabaseMigrations();
     }
 }

--- a/src/Illuminate/Foundation/Testing/DatabaseTransactions.php
+++ b/src/Illuminate/Foundation/Testing/DatabaseTransactions.php
@@ -9,7 +9,7 @@ trait DatabaseTransactions
      *
      * @return void
      */
-    public function beginDatabaseTransaction()
+    public function setUpDatabaseTransactions()
     {
         $database = $this->app->make('db');
 
@@ -25,6 +25,18 @@ trait DatabaseTransactions
                 $connection->disconnect();
             }
         });
+    }
+
+    /**
+     * Handle database transactions on the specified connections.
+     *
+     * @deprecated
+     *
+     * @return void
+     */
+    public function beginDatabaseTransaction()
+    {
+        $this->setUpDatabaseTransactions();
     }
 
     /**

--- a/src/Illuminate/Foundation/Testing/RefreshDatabase.php
+++ b/src/Illuminate/Foundation/Testing/RefreshDatabase.php
@@ -11,11 +11,23 @@ trait RefreshDatabase
      *
      * @return void
      */
-    public function refreshDatabase()
+    public function setUpRefreshDatabase()
     {
         $this->usingInMemoryDatabase()
                         ? $this->refreshInMemoryDatabase()
                         : $this->refreshTestDatabase();
+    }
+
+    /**
+     * Define hooks to migrate the database before and after each test.
+     *
+     * @deprecated
+     *
+     * @return void
+     */
+    public function refreshDatabase()
+    {
+        $this->setUpRefreshDatabase();
     }
 
     /**

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -18,7 +18,8 @@ abstract class TestCase extends BaseTestCase
         Concerns\InteractsWithDatabase,
         Concerns\InteractsWithExceptionHandling,
         Concerns\InteractsWithSession,
-        Concerns\MocksApplicationServices;
+        Concerns\MocksApplicationServices,
+        Concerns\ComposesTemplateMethods;
 
     /**
      * The Illuminate application instance.
@@ -98,29 +99,9 @@ abstract class TestCase extends BaseTestCase
      */
     protected function setUpTraits()
     {
-        $uses = array_flip(class_uses_recursive(static::class));
+        $this->callTraitTemplateMethods('setUp');
 
-        if (isset($uses[RefreshDatabase::class])) {
-            $this->refreshDatabase();
-        }
-
-        if (isset($uses[DatabaseMigrations::class])) {
-            $this->runDatabaseMigrations();
-        }
-
-        if (isset($uses[DatabaseTransactions::class])) {
-            $this->beginDatabaseTransaction();
-        }
-
-        if (isset($uses[WithoutMiddleware::class])) {
-            $this->disableMiddlewareForAllTests();
-        }
-
-        if (isset($uses[WithoutEvents::class])) {
-            $this->disableEventsForAllTests();
-        }
-
-        return $uses;
+        return array_flip(class_uses_recursive(static::class));
     }
 
     /**
@@ -130,6 +111,8 @@ abstract class TestCase extends BaseTestCase
      */
     protected function tearDown()
     {
+        $this->callTraitTemplateMethods('tearDown');
+
         if ($this->app) {
             foreach ($this->beforeApplicationDestroyedCallbacks as $callback) {
                 call_user_func($callback);

--- a/src/Illuminate/Foundation/Testing/WithoutEvents.php
+++ b/src/Illuminate/Foundation/Testing/WithoutEvents.php
@@ -11,12 +11,24 @@ trait WithoutEvents
      *
      * @throws \Exception
      */
-    public function disableEventsForAllTests()
+    public function setUpWithoutEvents()
     {
         if (method_exists($this, 'withoutEvents')) {
             $this->withoutEvents();
         } else {
             throw new Exception('Unable to disable events. ApplicationTrait not used.');
         }
+    }
+
+    /**
+     * Prevent all event handles from being executed.
+     *
+     * @deprecated
+     *
+     * @throws \Exception
+     */
+    public function disableEventsForAllTests()
+    {
+        $this->setUpWithoutEvents();
     }
 }

--- a/src/Illuminate/Foundation/Testing/WithoutMiddleware.php
+++ b/src/Illuminate/Foundation/Testing/WithoutMiddleware.php
@@ -11,12 +11,24 @@ trait WithoutMiddleware
      *
      * @throws \Exception
      */
-    public function disableMiddlewareForAllTests()
+    public function setUpWithoutMiddleware()
     {
         if (method_exists($this, 'withoutMiddleware')) {
             $this->withoutMiddleware();
         } else {
             throw new Exception('Unable to disable middleware. MakesHttpRequests trait not used.');
         }
+    }
+
+    /**
+     * Prevent all middleware from being executed for this test class.
+     *
+     * @deprecated
+     *
+     * @throws \Exception
+     */
+    public function disableMiddlewareForAllTests()
+    {
+        $this->setUpWithoutMiddleware();
     }
 }

--- a/tests/Foundation/FoundationComposesTemplateMethodsTest.php
+++ b/tests/Foundation/FoundationComposesTemplateMethodsTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Illuminate\Tests\Foundation;
+
+use Illuminate\Foundation\Testing\Concerns\ComposesTemplateMethods;
+use PHPUnit\Framework\TestCase;
+
+class FoundationComposesTemplateMethodsTest extends TestCase
+{
+    use ComposesTemplateMethods, TestTraitOne, TestTraitTwo;
+
+    public function testCallsComposedSetUpMethods()
+    {
+        $this->callTraitTemplateMethods('setUp');
+
+        $this->assertTrue($this->testTraitOneSetUp);
+        $this->assertTrue($this->testTraitTwoSetUp);
+    }
+
+    public function testCallsComposedTearDownMethods()
+    {
+        $this->callTraitTemplateMethods('tearDown');
+
+        $this->assertFalse($this->testTraitOneSetUp);
+        $this->assertFalse($this->testTraitTwoSetUp);
+    }
+}
+
+trait TestTraitOne
+{
+    public $testTraitOneSetUp;
+
+    public function setUpTestTraitOne()
+    {
+        $this->testTraitOneSetUp = true;
+    }
+
+    public function tearDownTestTraitOne()
+    {
+        $this->testTraitOneSetUp = false;
+    }
+}
+
+trait TestTraitTwo
+{
+    public $testTraitTwoSetUp;
+
+    public function setUpTestTraitTwo()
+    {
+        $this->testTraitTwoSetUp = true;
+    }
+
+    public function tearDownTestTraitTwo()
+    {
+        $this->testTraitTwoSetUp = false;
+    }
+}

--- a/tests/Foundation/FoundationComposesTemplateMethodsTest.php
+++ b/tests/Foundation/FoundationComposesTemplateMethodsTest.php
@@ -2,8 +2,8 @@
 
 namespace Illuminate\Tests\Foundation;
 
-use Illuminate\Foundation\Testing\Concerns\ComposesTemplateMethods;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Foundation\Testing\Concerns\ComposesTemplateMethods;
 
 class FoundationComposesTemplateMethodsTest extends TestCase
 {


### PR DESCRIPTION
The current `TestCase:: setUpTraits` method has a hard-coded list of method calls. This uses `class_uses_recursive` similarly to the way `Model::bootTraits` behaves, calling `setUp<TraitName>` and `tearDown<TraitName>` if they're set.

This means that if you had a test case & trait like:

```php
<?php

trait FooBar
{
    protected $foo;

    public function setUpFooBar()
    {
        $this->foo = 'bar';
    }
}

class MyTest extends TestCase
{
    use FooBar;

    public function testFooBar()
    {
        $this->assertEquals('bar', $this->foo);
    }
}
```

The `$foo` property would automatically set to `"bar"` before each test case.