### PR TITLE
[5.5] Add a validator service provider for registering class based rules

### DIFF
--- a/src/Illuminate/Foundation/Support/Providers/ValidatorServiceProvider.php
+++ b/src/Illuminate/Foundation/Support/Providers/ValidatorServiceProvider.php
@@ -2,8 +2,8 @@
 
 namespace Illuminate\Foundation\Support\Providers;
 
-use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\Facades\Validator;
 
 class ValidatorServiceProvider extends ServiceProvider
 {

--- a/src/Illuminate/Foundation/Support/Providers/ValidatorServiceProvider.php
+++ b/src/Illuminate/Foundation/Support/Providers/ValidatorServiceProvider.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Illuminate\Foundation\Support\Providers;
+
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Support\ServiceProvider;
+
+class ValidatorServiceProvider extends ServiceProvider
+{
+    /**
+     * Mappings for custom rules for the application.
+     *
+     * @var array
+     */
+    protected $rules = [];
+
+    /**
+     * Adds application rules to validator.
+     *
+     * @return void
+     */
+    public function bootRules()
+    {
+        foreach ($this->rules as $rule => $class) {
+            $instance = $this->app->make($class);
+
+            Validator::extend($rule, [$instance, 'passes'], $instance->message());
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function boot()
+    {
+        $this->bootRules();
+    }
+}

--- a/src/Illuminate/Foundation/Support/Providers/ValidatorServiceProvider.php
+++ b/src/Illuminate/Foundation/Support/Providers/ValidatorServiceProvider.php
@@ -19,7 +19,7 @@ class ValidatorServiceProvider extends ServiceProvider
      *
      * @return void
      */
-    public function bootRules()
+    public function registerRules()
     {
         foreach ($this->rules as $rule => $class) {
             $instance = $this->app->make($class);
@@ -33,6 +33,6 @@ class ValidatorServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        $this->bootRules();
+        $this->registerRules();
     }
 }


### PR DESCRIPTION
Proposed fix for laravel/internals#717.

Adds a `ValidatorServiceProvider` to make it easy to register class based rules for the application.

Just add a `ValidatorServiceProvider.php` file to your app, have it loaded, and look something like this:
```
<?php

namespace App\Providers;

use Illuminate\Foundation\Support\Providers\ValidatorServiceProvider as ServiceProvider;

class ValidatorServiceProvider extends ServiceProvider
{
    /**
     * A list of custom rules to add to the validator.
     *
     * @var array
     */
    protected $rules = [
        'barcode' => \App\Rules\Barcode::class,
        'country' => \App\Rules\Country::class,
        'country_code' => \App\Rules\CountryCode::class,
    ];
}
```

If this looks good I'll send a PR over to docs.