### PR TITLE
[5.5] Ability to chains an array of jobs via helper

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -384,6 +384,19 @@ if (! function_exists('dispatch')) {
     }
 }
 
+if (! function_exists('dispatch_chain')) {
+    /**
+     * Dispatch a chain of jobs to its appropriate handlers.
+     *
+     * @param  array  $jobs
+     * @return \Illuminate\Foundation\Bus\PendingDispatch
+     */
+    function dispatch_chain(array $jobs)
+    {
+        return dispatch(array_shift($jobs))->chain($jobs);
+    }
+}
+
 if (! function_exists('dispatch_now')) {
     /**
      * Dispatch a command to its appropriate handler in the current process.

--- a/tests/Integration/Queue/JobChainingTest.php
+++ b/tests/Integration/Queue/JobChainingTest.php
@@ -73,6 +73,17 @@ class JobChainingTest extends TestCase
         $this->assertTrue(JobChainingTestSecondJob::$ran);
     }
 
+    public function test_jobs_can_be_chained_on_success_using_chain_helper()
+    {
+        dispatch_chain([
+            new JobChainingTestFirstJob,
+            new JobChainingTestSecondJob,
+        ]);
+
+        $this->assertTrue(JobChainingTestFirstJob::$ran);
+        $this->assertTrue(JobChainingTestSecondJob::$ran);
+    }
+
     public function test_jobs_can_be_chained_via_queue()
     {
         Queue::connection('sync')->push((new JobChainingTestFirstJob)->chain([


### PR DESCRIPTION
I often have a collection or an array of jobs that I need to chain and what I end up doing is
`dispatch(array_shift($jobs))->chain($jobs); // Or something similar`
I think it would be helpful just to be able to
`dispatch_chain($jobs);`