### PR TITLE
[5.5] isMine() on Model & mine() on Query to check and get result for authenticated user

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1040,6 +1040,17 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     }
 
     /**
+     * Determine if current model is owned by authenticated user.
+     *
+     * @param string $column
+     * @return bool
+     */
+    public function isMine($column = 'user_id')
+    {
+        return $this->$column == auth()->id();
+    }
+
+    /**
      * Get the database connection for the model.
      *
      * @return \Illuminate\Database\Connection

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1444,6 +1444,17 @@ class Builder
     }
 
     /**
+     * Add a "where" clause to limit the result only for the authenticated user.
+     *
+     * @param  string  $column
+     * @return \Illuminate\Database\Query\Builder|static
+     */
+    public function mine($column = 'user_id')
+    {
+        return $this->where($column, auth()->id());
+    }
+
+    /**
      * Put the query's results in random order.
      *
      * @param  string  $seed


### PR DESCRIPTION
I find myself doing lots of checks if current model belongs to a user in views and throughout the app.

```php
$tweet = App\Tweet::find($id);
if( $tweet->user_id == auth()->id() ) {
   ...
}
```

It will be great if we could do it in very laravel way directly from Model
```php
$tweet = App\Tweet::find($id);
if( $tweet->isMine() ) {
   ...
}

// or with a different foriegn key
if( $tweet->isMine('owner_id') ) {
   ...
}
```

And similarly, I can query all the records owned by current user
```php
// get all tweets by authenticated user
App\Tweet::mine()->get()

// with a different foreign key
App\Tweet::mine('owner_id')->get()
```

This PR does just that, I think it will be useful for everyone.