### PR TITLE
Enclose APP_KEY value in quotes

### DIFF
--- a/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
+++ b/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
@@ -92,7 +92,7 @@ class KeyGenerateCommand extends Command
     {
         file_put_contents($this->laravel->environmentFilePath(), preg_replace(
             $this->keyReplacementPattern(),
-            'APP_KEY='.$key,
+            'APP_KEY="'.$key.'"',
             file_get_contents($this->laravel->environmentFilePath())
         ));
     }
@@ -104,8 +104,8 @@ class KeyGenerateCommand extends Command
      */
     protected function keyReplacementPattern()
     {
-        $escaped = preg_quote('='.$this->laravel['config']['app.key'], '/');
+        $escaped = preg_quote($this->laravel['config']['app.key'], '/');
 
-        return "/^APP_KEY{$escaped}/m";
+        return "/^APP_KEY\=\"?{$escaped}\"?/m";
     }
 }


### PR DESCRIPTION
In principle, the .env file is an INI format. Parsing that file to add e.g. database credentials during setup can fail due to invalid characters in the APP_KEY value because they are currently not enclosed in quotes.