### PR TITLE
[5.5] Add whereHas related model

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -131,7 +131,7 @@ trait QueriesRelationships
      * @param  int     $count
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
-    public function whereHas($relation,$callback = null, $operator = '>=', $count = 1)
+    public function whereHas($relation, $callback = null, $operator = '>=', $count = 1)
     {
         return $this->has($relation, $operator, $count, 'and', $callback);
     }

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -4,6 +4,7 @@ namespace Illuminate\Database\Eloquent\Concerns;
 
 use Closure;
 use Illuminate\Support\Str;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Query\Expression;
 use Illuminate\Database\Eloquent\Relations\Relation;
@@ -18,11 +19,15 @@ trait QueriesRelationships
      * @param  string  $operator
      * @param  int     $count
      * @param  string  $boolean
-     * @param  \Closure|null  $callback
+     * @param  \Illuminate\Database\Eloquent\Model|\Closure|null  $callback
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
-    public function has($relation, $operator = '>=', $count = 1, $boolean = 'and', Closure $callback = null)
+    public function has($relation, $operator = '>=', $count = 1, $boolean = 'and', $callback = null)
     {
+        if ($callback instanceof Model) {
+            $callback = $this->createHasRelatedCallback($callback);
+        }
+
         if (strpos($relation, '.') !== false) {
             return $this->hasNested($relation, $operator, $count, $boolean, $callback);
         }
@@ -121,12 +126,12 @@ trait QueriesRelationships
      * Add a relationship count / exists condition to the query with where clauses.
      *
      * @param  string  $relation
-     * @param  \Closure|null  $callback
+     * @param  \Illuminate\Database\Eloquent\Model|\Closure|null  $callback
      * @param  string  $operator
      * @param  int     $count
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
-    public function whereHas($relation, Closure $callback = null, $operator = '>=', $count = 1)
+    public function whereHas($relation,$callback = null, $operator = '>=', $count = 1)
     {
         return $this->has($relation, $operator, $count, 'and', $callback);
     }
@@ -306,5 +311,18 @@ trait QueriesRelationships
     protected function canUseExistsForExistenceCheck($operator, $count)
     {
         return ($operator === '>=' || $operator === '<') && $count === 1;
+    }
+
+    /**
+     * Create a relationship callback that scopes the results to only the given model.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @return \Closure
+     */
+    protected function createHasRelatedCallback(Model $model)
+    {
+        return function (Builder $query) use ($model) {
+            $query->whereKey($model->getKey());
+        };
     }
 }

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -817,6 +817,23 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertEquals($nestedSql, $dotSql);
     }
 
+    public function testWhereHasRelatedModel()
+    {
+        $model = new EloquentBuilderTestHavingRelatedModels;
+        $related = new EloquentBuilderTestModelFarRelatedStub(['model_id' => 5552]);
+
+        foreach (['foo', 'foos', 'bar', 'bars'] as $relation) {
+            $builder = $model->whereHas($relation, $related);
+
+            $result = $model->whereHas($relation, function ($q) use ($related) {
+                $q->whereKey($related->model_id);
+            });
+
+            $this->assertEquals($builder->toSql(), $result->toSql());
+            $this->assertEquals($builder->getBindings(), $result->getBindings());
+        }
+    }
+
     public function testSelfHasNestedUsesAlias()
     {
         $model = new EloquentBuilderTestModelSelfRelatedStub;
@@ -1071,6 +1088,35 @@ class EloquentBuilderTestModelCloseRelatedStub extends \Illuminate\Database\Eloq
 
 class EloquentBuilderTestModelFarRelatedStub extends \Illuminate\Database\Eloquent\Model
 {
+    protected $fillable = ['model_id'];
+
+    public function getKeyName()
+    {
+        return 'model_id';
+    }
+}
+
+class EloquentBuilderTestHavingRelatedModels extends \Illuminate\Database\Eloquent\Model
+{
+    public function foo()
+    {
+        return $this->hasOne('Illuminate\Tests\Database\EloquentBuilderTestModelFarRelatedStub');
+    }
+
+    public function foos()
+    {
+        return $this->hasMany('Illuminate\Tests\Database\EloquentBuilderTestModelFarRelatedStub');
+    }
+
+    public function bar()
+    {
+        return $this->belongsTo('Illuminate\Tests\Database\EloquentBuilderTestModelFarRelatedStub');
+    }
+
+    public function bars()
+    {
+        return $this->belongsToMany('Illuminate\Tests\Database\EloquentBuilderTestModelFarRelatedStub');
+    }
 }
 
 class EloquentBuilderTestModelSelfRelatedStub extends \Illuminate\Database\Eloquent\Model


### PR DESCRIPTION
This PR adds support for directly calling whereHas against the related model.

```php
$role = Role::whereName('Editor')->first();

$editors = User::whereHas('role', $role)->get();
```

instead of 

```php
$role = Role::whereName('Editor')->first();

$editors = User::whereHas('role', function ($query) use ($role) {
    $query->where('id', $role->id);
})->get();

```