### PR TITLE
[5.6] Add New Collection::filterKeys Method

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -418,6 +418,14 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
+     * Return new filtered Collection that matches given keys.
+     */
+    public function filterKeys($keys)
+    {
+        return new static(array_intersect_key($this->items, array_flip($keys)));
+    }
+
+    /**
      * Apply the callback if the value is truthy.
      *
      * @param  bool  $value

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2301,6 +2301,24 @@ class SupportCollectionTest extends TestCase
 
         $this->assertSame(['michael', 'tom', 'taylor'], $collection->toArray());
     }
+
+    public function testFilterKeysWithMatching()
+    {
+        $collection = new Collection(['a' => 'foo', 'b' => 'bar', 'c' => 'baz']);
+
+        $filteredCollection = $collection->filterKeys(['a', 'c']);
+
+        $this->assertSame(['a' => 'foo', 'c' => 'baz'], $filteredCollection->toArray());
+    }
+
+    public function testFilterKeysWithoutMatching()
+    {
+        $collection = new Collection(['a' => 'foo', 'b' => 'bar', 'c' => 'baz']);
+
+        $filteredCollection = $collection->filterKeys(['y', 'z']);
+
+        $this->assertEquals([], $filteredCollection->toArray());
+    }
 }
 
 class TestSupportCollectionHigherOrderItem


### PR DESCRIPTION
Introduces new Collection method named `filterKeys` which accepts a list of keys.
It returns new filtered Collection that matches the given keys.

```php

$collection = new Collection(['a' => 'foo', 'b' => 'bar', 'c' => 'baz']);
$filteredCollection = $collection->filterKeys(['a', 'c']);
echo $filteredCollection->toArray(); // ['a' => 'foo', 'c' => 'baz'];

```