### PR TITLE
[5.5] Restore Non Static Method Signature to `Illuminate\Routing\Router::prepareResponse`

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -167,7 +167,7 @@ class Handler implements ExceptionHandlerContract
     public function render($request, Exception $e)
     {
         if (method_exists($e, 'render') && $response = $e->render($request)) {
-            return Router::prepareResponse($request, $response);
+            return Router::prepareResponseObject($request, $response);
         } elseif ($e instanceof Responsable) {
             return $e->toResponse($request);
         }

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -651,7 +651,7 @@ class Router implements RegistrarContract, BindingRegistrar
     }
 
     /**
-     * Static version of prepareResponse
+     * Static version of prepareResponse.
      *
      * @param  \Symfony\Component\HttpFoundation\Request  $request
      * @param  mixed  $response

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -645,7 +645,19 @@ class Router implements RegistrarContract, BindingRegistrar
      * @param  mixed  $response
      * @return \Illuminate\Http\Response|\Illuminate\Http\JsonResponse
      */
-    public static function prepareResponse($request, $response)
+    public function prepareResponse($request, $response)
+    {
+        return static::prepareResponseObject($request, $response);
+    }
+
+    /**
+     * Static version of prepareResponse
+     *
+     * @param  \Symfony\Component\HttpFoundation\Request  $request
+     * @param  mixed  $response
+     * @return \Illuminate\Http\Response|\Illuminate\Http\JsonResponse
+     */
+    public static function prepareResponseObject($request, $response)
     {
         if ($response instanceof Responsable) {
             $response = $response->toResponse($request);


### PR DESCRIPTION
> (This is my first pull request to `laravel/framework, if I'm doing something wrong my apologies --
 it's non-intentional!)

This pull request restores the non-static method signature of `Illuminate\Routing\Router::prepareResponseObject` from previous Laravel versions, adds a new static method named `Illuminate\Routing\Router::prepareResponseObject`, and then replaces the one explicit static call to `prepareResponse` in the exception handler. 

**Reason for this Request**: I'm working with/at a company that has a **PHP Extension** (C code compiled into a `.so` file and loaded via a `php.ini` file).  The change in this method signature caused a host of problems that makes the `.so` extension unusable in Laravel 5.5 (happy to discuss these offline). We're working on a fix on our end, but it would be fantastic for our Laravel using customers if we could get the old method signature back.

Also -- acknowledging that the time to bring this up was very likely **before** Laravel 5.5's release. I'm coming into this process late, but we're working hard on our regression tests so this doesn't happy again :)  Thanks for the time/attention!