### PR TITLE
[5.5] Reset the index after a MissingValue while resolving resource

### DIFF
--- a/src/Illuminate/Http/Resources/Json/Resource.php
+++ b/src/Illuminate/Http/Resources/Json/Resource.php
@@ -150,6 +150,7 @@ class Resource implements ArrayAccess, JsonSerializable, Responsable, UrlRoutabl
                 ($value instanceof self &&
                 $value->resource instanceof MissingValue)) {
                 unset($data[$key]);
+                $index--;
             }
 
             if ($value instanceof self && is_null($value->resource)) {

--- a/tests/Integration/Http/Fixtures/PostResourceWithOptionalMerging.php
+++ b/tests/Integration/Http/Fixtures/PostResourceWithOptionalMerging.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Http\Fixtures;
+
+use Illuminate\Http\Resources\Json\Resource;
+
+class PostResourceWithOptionalMerging extends Resource
+{
+    public function toArray($request)
+    {
+        return [
+            'id' => $this->id,
+            $this->mergeWhen(false, ['first' => 'value']),
+            $this->mergeWhen(true, ['second' => 'value']),
+        ];
+    }
+}

--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Integration\Http;
 
+use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithOptionalMerging;
 use Orchestra\Testbench\TestCase;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Pagination\LengthAwarePaginator;
@@ -85,6 +86,28 @@ class ResourceTest extends TestCase
                 'id' => 5,
                 'second' => 'value',
                 'third' => 'value',
+            ],
+        ]);
+    }
+
+    public function test_resources_may_have_optional_Merges()
+    {
+        Route::get('/', function () {
+            return new PostResourceWithOptionalMerging(new Post([
+                'id' => 5,
+            ]));
+        });
+
+        $response = $this->withoutExceptionHandling()->get(
+            '/', ['Accept' => 'application/json']
+        );
+
+        $response->assertStatus(200);
+
+        $response->assertExactJson([
+            'data' => [
+                'id' => 5,
+                'second' => 'value',
             ],
         ]);
     }


### PR DESCRIPTION
In reference to https://github.com/laravel/framework/issues/21122:

```
public function toArray($request)
    {
        return [
            'id' => $this->id,
            $this->mergeWhen(false, ['first' => 'value']),
            $this->mergeWhen(true, ['second' => 'value']),
        ];
    }
```

While filtering, the second element will be removed from the $data, thus we need to reset the index.