### PR TITLE
[5.5] Fix getQualifiedParentKey on BelongsToMany

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -930,7 +930,7 @@ class BelongsToMany extends Relation
      */
     public function getQualifiedParentKeyName()
     {
-        return $this->table.'.'.$this->parentKey;
+        return $this->parent->getTable().'.'.$this->parentKey;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -922,6 +922,16 @@ class BelongsToMany extends Relation
     {
         return $this->table.'.'.$this->relatedPivotKey;
     }
+    
+    /**
+     * Get the fully qualified parent key name for the relation.
+     *
+     * @return string
+     */
+    public function getQualifiedParentKeyName()
+    {
+        return $this->table.'.'.$this->parentKey;
+    }
 
     /**
      * Get the intermediate table for the relationship.

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -922,7 +922,7 @@ class BelongsToMany extends Relation
     {
         return $this->table.'.'.$this->relatedPivotKey;
     }
-    
+
     /**
      * Get the fully qualified parent key name for the relation.
      *


### PR DESCRIPTION
This is a continuation of the fixes from https://github.com/laravel/framework/pull/21044

Example Code:

```
// Contained within TemporaryProfile
public function services()
{
    return $this->belongsToMany(Service::class, 'user_profile_services', 'user_id', 'service_id', 'user_id');
}

//Query
TemporaryProfile::has('services')
```

The services belongsToMany relation has a parentKey specified as `user_id`, the below SQL query shows that it still wants to use user_temporary_profiles.`id` as opposed to user_temporary_profiles.`user_id`

> select * from user_temporary_profiles where exists (select * from services inner join user_profile_services on services.id = user_profile_services.service_id where user_temporary_profiles.**id** = user_profile_services.user_id)

> select * from user_temporary_profiles where exists (select * from services inner join user_profile_services on services.id = user_profile_services.service_id where user_temporary_profiles.**user_id** = user_profile_services.user_id)

Without this fix, queries using any of the has methods will return incorrect results as the query is trying to make use of the default getQualifiedKeyName on the parent (See https://github.com/laravel/framework/blob/5.5/src/Illuminate/Database/Eloquent/Relations/Relation.php#L262)