### PR TITLE
[5.6] Look up in the JSON fallback translation file

### DIFF
--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -89,7 +89,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
     }
 
     /**
-     * Get the translation for a given key.
+     * Get the translation for a given key using the typical translation files.
      *
      * @param  string  $key
      * @param  array   $replace
@@ -102,7 +102,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
     }
 
     /**
-     * Get the translation for the given key.
+     * Get the translation for the given key using the typical translation files.
      *
      * @param  string  $key
      * @param  array   $replace
@@ -139,7 +139,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
     }
 
     /**
-     * Get the translation for a given key from the JSON translation files.
+     * Get the translation for a given key.
      *
      * @param  string  $key
      * @param  array  $replace
@@ -153,9 +153,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
         // For JSON translations, there is only one file per locale, so we will simply load
         // that file and then we will be ready to check the array for the key. These are
         // only one level deep so we do not need to do any fancy searching through it.
-        $this->load('*', '*', $locale);
-
-        $line = $this->loaded['*']['*'][$locale][$key] ?? null;
+        $line = $this->fromJson($key, $locale);
 
         // If we can't find a translation for the JSON key, we will attempt to translate it
         // using the typical translation file. This way developers can always just use a
@@ -285,6 +283,20 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
         return (new Collection($replace))->sortBy(function ($value, $key) {
             return mb_strlen($key) * -1;
         })->all();
+    }
+
+    /**
+     * Get the translation for a given key from the JSON translation files.
+     *
+     * @param  string  $key
+     * @param  string  $locale
+     * @return string
+     */
+    protected function fromJson($key, $locale)
+    {
+        $this->load('*', '*', $locale);
+
+        return $this->loaded['*']['*'][$locale][$key] ?? null;
     }
 
     /**

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -164,6 +164,11 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
             if ($fallback !== $key) {
                 return $fallback;
             }
+
+            // If we still can't find a translation using the typical translation file for the
+            // current language and the fallback language, we will try in a last attempt to
+            // find the given key in the JSON translation file for the fallback language.
+            $line = $this->fromJson($key, $this->fallback);
         }
 
         return $this->makeReplacements($line ?: $key, $replace);

--- a/tests/Translation/TranslationTranslatorTest.php
+++ b/tests/Translation/TranslationTranslatorTest.php
@@ -159,6 +159,17 @@ class TranslationTranslatorTest extends TestCase
         $this->assertEquals('foo baz', $t->getFromJson('foo :message', ['message' => 'baz']));
     }
 
+    public function testGetJsonForNonExistingJsonKeyReturnsTheJsonKeyOfTheFallbackLanguage()
+    {
+        $t = new \Illuminate\Translation\Translator($this->getLoader(), 'en');
+        $t->setFallback('it');
+        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
+        $t->getLoader()->shouldReceive('load')->once()->with('en', 'foo', '*')->andReturn([]);
+        $t->getLoader()->shouldReceive('load')->once()->with('it', 'foo', '*')->andReturn([]);
+        $t->getLoader()->shouldReceive('load')->once()->with('it', '*', '*')->andReturn(['foo' => 'one']);
+        $this->assertEquals('one', $t->getFromJson('foo'));
+    }
+
     protected function getLoader()
     {
         return m::mock(\Illuminate\Contracts\Translation\Loader::class);

--- a/tests/Translation/TranslationTranslatorTest.php
+++ b/tests/Translation/TranslationTranslatorTest.php
@@ -146,6 +146,7 @@ class TranslationTranslatorTest extends TestCase
         $t = new \Illuminate\Translation\Translator($this->getLoader(), 'en');
         $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
         $t->getLoader()->shouldReceive('load')->once()->with('en', 'Foo that bar', '*')->andReturn([]);
+        $t->getLoader()->shouldReceive('load')->once()->with($t->getFallback(), '*', '*')->andReturn([]);
         $this->assertEquals('Foo that bar', $t->getFromJson('Foo that bar'));
     }
 
@@ -154,6 +155,7 @@ class TranslationTranslatorTest extends TestCase
         $t = new \Illuminate\Translation\Translator($this->getLoader(), 'en');
         $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
         $t->getLoader()->shouldReceive('load')->once()->with('en', 'foo :message', '*')->andReturn([]);
+        $t->getLoader()->shouldReceive('load')->once()->with($t->getFallback(), '*', '*')->andReturn([]);
         $this->assertEquals('foo baz', $t->getFromJson('foo :message', ['message' => 'baz']));
     }
 


### PR DESCRIPTION
For a given translation key, no lookup is actually being made in the JSON file for the fallback language. This PR adds this behaviour.

Now the lookup order for a given key is:

1. in the JSON translation file
2. in the typical translation file
3. in the typical translation file for the fallback language
4. with this pull request in the **JSON translation file for the fallback language**

(I still have to commit some tests)