### PR TITLE
[5.5] Change order of checks in JsonResponse

### DIFF
--- a/src/Illuminate/Http/JsonResponse.php
+++ b/src/Illuminate/Http/JsonResponse.php
@@ -57,12 +57,12 @@ class JsonResponse extends BaseJsonResponse
     {
         $this->original = $data;
 
-        if ($data instanceof Arrayable) {
-            $this->data = json_encode($data->toArray(), $this->encodingOptions);
-        } elseif ($data instanceof Jsonable) {
+        if ($data instanceof Jsonable) {
             $this->data = $data->toJson($this->encodingOptions);
         } elseif ($data instanceof JsonSerializable) {
             $this->data = json_encode($data->jsonSerialize(), $this->encodingOptions);
+        } elseif ($data instanceof Arrayable) {
+            $this->data = json_encode($data->toArray(), $this->encodingOptions);
         } else {
             $this->data = json_encode($data, $this->encodingOptions);
         }


### PR DESCRIPTION
As stated in #21079 if you have a class implementing both `Arrayable` and `Jsonable` interface and have different returns for its `toArray()` and `toJson()` methods, the `JsonResponse` will prefer the `toArray()` return over `toJson()` return.

Before #17875, as the check was done inside the `Response`, the `Jsonable` implementation was checked before the `Arrayable`. So if we didn't explicitly returned a `JsonResponse` this wasn't a problem at all.

But after #17875 the `Router` checks the response type and  creates a new `JsonResponse` which have a different logic as described above.

This PR brings the type-checking logic in `JsonResponse` to behave more likely as `Response` (check first for `Jsonable` then for `Arrayable`).

Please refer to #21079 for an example with different implementations of `toArray()` and `toJson()`
