### PR TITLE
[5.5] setGlobalTo Mailer method should reset CC and BCC

### DIFF
--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -337,8 +337,8 @@ class Mailer implements MailerContract, MailQueueContract
     protected function setGlobalTo($message)
     {
         $message->to($this->to['address'], $this->to['name'], true);
-        $message->cc($this->to['address'], $this->to['name'], true);
-        $message->bcc($this->to['address'], $this->to['name'], true);
+        $message->cc(null, null, true);
+        $message->bcc(null, null, true);
     }
 
     /**


### PR DESCRIPTION
setGlobalTo Mailer method should reset CC and BCC. Otherwise, this just duplicates emails.