### PR TITLE
[5.5] Change parameter name

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2406,13 +2406,13 @@ class Builder
     /**
      * Clone the query without the given properties.
      *
-     * @param  array  $except
+     * @param  array  $properties
      * @return static
      */
-    public function cloneWithout(array $except)
+    public function cloneWithout(array $properties)
     {
-        return tap(clone $this, function ($clone) use ($except) {
-            foreach ($except as $property) {
+        return tap(clone $this, function ($clone) use ($properties) {
+            foreach ($properties as $property) {
                 $clone->{$property} = null;
             }
         });


### PR DESCRIPTION
Today I was checking the `cloneWithout` method and thought that the language is quite uneasy. The docblock says `Clone the query without the given properties`, which means the given `properties` will not be present in the clone.
However the variable is called `$except`, which suggests that the clone will only preserve the provided `$except`

I may be wrong, but I find it easier to think that I will `cloneWithout($these_properties)`.