### PR TITLE
Make Password Rest Mail Translatable

### DIFF
--- a/src/Illuminate/Auth/Notifications/ResetPassword.php
+++ b/src/Illuminate/Auth/Notifications/ResetPassword.php
@@ -45,8 +45,8 @@ class ResetPassword extends Notification
     public function toMail($notifiable)
     {
         return (new MailMessage)
-            ->line('You are receiving this email because we received a password reset request for your account.')
-            ->action('Reset Password', url(config('app.url').route('password.reset', $this->token, false)))
-            ->line('If you did not request a password reset, no further action is required.');
+            ->line(trans('passwords.request.mail'))
+            ->action(trans('passwords.request.action'), url(config('app.url').route('password.reset', $this->token, false)))
+            ->line(trans('passwords.request.no-action'));
     }
 }


### PR DESCRIPTION
if password reset email get translatable, there is no need make new notification and overwrite the 
`sendPasswordResetNotification()` in  `User` Model

PR for translation files sent