### PR TITLE
[5.5] Avoid json decoding exception trace args

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -449,7 +449,9 @@ class Handler implements ExceptionHandlerContract
             'exception' => get_class($e),
             'file' => $e->getFile(),
             'line' => $e->getLine(),
-            'trace' => $e->getTrace(),
+            'trace' => collect($e->getTrace())->map(function ($trace) {
+                return array_except($trace, ['args']);
+            })->all(),
         ] : [
             'message' => $this->isHttpException($e) ? $e->getMessage() : 'Server Error',
         ];

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -450,7 +450,7 @@ class Handler implements ExceptionHandlerContract
             'file' => $e->getFile(),
             'line' => $e->getLine(),
             'trace' => collect($e->getTrace())->map(function ($trace) {
-                return array_except($trace, ['args']);
+                return Arr::except($trace, ['args']);
             })->all(),
         ] : [
             'message' => $this->isHttpException($e) ? $e->getMessage() : 'Server Error',


### PR DESCRIPTION
As reported in https://github.com/laravel/framework/issues/21146

The exception trace might contain instances that will fail if passed to `json_decode` while rendering the response, this will cause an exception to be thrown preventing a proper response from being produced.

In this PR, we only render the `file`, `line`, `function`, `class`, and `type` from each trace, these values are always strings/integers while `args` might hold objects that are un-decodable.