### PR TITLE
[5.5] (Failing) test for broken withCount when using polymorphic relationship and whereHas

### DIFF
--- a/tests/Database/DatabaseEloquentPolymorphicRelationsIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentPolymorphicRelationsIntegrationTest.php
@@ -2,10 +2,10 @@
 
 namespace Illuminate\Tests\Database;
 
-use PHPUnit\Framework\TestCase;
 use Illuminate\Database\Capsule\Manager as DB;
 use Illuminate\Database\Eloquent\Model as Eloquent;
 use Illuminate\Database\Eloquent\Relations\Relation;
+use PHPUnit\Framework\TestCase;
 
 class DatabaseEloquentPolymorphicRelationsIntegrationTest extends TestCase
 {
@@ -104,6 +104,18 @@ class DatabaseEloquentPolymorphicRelationsIntegrationTest extends TestCase
         $this->assertEquals($post->id, $tag->posts->first()->id);
     }
 
+    public function testWithCount()
+    {
+        $post = EloquentManyToManyPolymorphicTestPostWithCount::create();
+        $tag = EloquentManyToManyPolymorphicTestTagForWithCount::create();
+        $post->tags()->attach($tag->id);
+
+        $firstTagHavingPosts = EloquentManyToManyPolymorphicTestTagForWithCount::whereHas('posts')
+            ->firstOrFail();
+
+        $this->assertTrue($tag->is($firstTagHavingPosts));
+    }
+
     /**
      * Helpers...
      */
@@ -143,6 +155,18 @@ class EloquentManyToManyPolymorphicTestPost extends Eloquent
     }
 }
 
+class EloquentManyToManyPolymorphicTestPostWithCount extends Eloquent
+{
+    protected $table = 'posts';
+    protected $guarded = [];
+    protected $withCount = ["tags as tags_count"];
+
+    public function tags()
+    {
+        return $this->morphToMany('Illuminate\Tests\Database\EloquentManyToManyPolymorphicTestTagForWithCount', 'taggable', 'taggables',null,'eloquent_many_to_many_polymorphic_test_tag_id','');
+    }
+}
+
 class EloquentManyToManyPolymorphicTestImage extends Eloquent
 {
     protected $table = 'images';
@@ -167,5 +191,16 @@ class EloquentManyToManyPolymorphicTestTag extends Eloquent
     public function images()
     {
         return $this->morphedByMany('Illuminate\Tests\Database\EloquentManyToManyPolymorphicTestImage', 'taggable');
+    }
+}
+
+class EloquentManyToManyPolymorphicTestTagForWithCount extends Eloquent
+{
+    protected $table = 'tags';
+    protected $guarded = [];
+
+    public function posts()
+    {
+        return $this->morphedByMany('Illuminate\Tests\Database\EloquentManyToManyPolymorphicTestPostWithCount', 'taggable', 'taggables', 'eloquent_many_to_many_polymorphic_test_tag_id');
     }
 }


### PR DESCRIPTION
This PR adds an Integration Test for using `$withCount` on a model in combination with `whereHas` and polymorphic relationships. It is **currently failing** because the query bindings are wrong as I described and showed in #21116.

I've added another test where the `withCount` method is called before using whereHas with that model to prove that the normal `withCount` method is working while the `$withCount` strategy isn't (in this combination).