### PR TITLE
[5.5] Allow notification's template to be changed

### DIFF
--- a/src/Illuminate/Notifications/Messages/MailMessage.php
+++ b/src/Illuminate/Notifications/Messages/MailMessage.php
@@ -217,4 +217,16 @@ class MailMessage extends SimpleMessage
     {
         return array_merge($this->toArray(), $this->viewData);
     }
+
+    /**
+     * Sets the markdown template to render.
+     *
+     * @param string $template
+     */
+    public function template($template)
+    {
+        $this->markdown = $template;
+
+        return $this;
+    }
 }

--- a/src/Illuminate/Notifications/Messages/MailMessage.php
+++ b/src/Illuminate/Notifications/Messages/MailMessage.php
@@ -219,9 +219,10 @@ class MailMessage extends SimpleMessage
     }
 
     /**
-     * Sets the markdown template to render.
+     * Set the markdown template to render.
      *
      * @param string $template
+     * @return $this
      */
     public function template($template)
     {

--- a/tests/Notifications/NotificationMailMessageTest.php
+++ b/tests/Notifications/NotificationMailMessageTest.php
@@ -2,8 +2,8 @@
 
 namespace Illuminate\Tests\Notifications;
 
-use Illuminate\Notifications\Messages\MailMessage;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Notifications\Messages\MailMessage;
 
 class NotificationsMailMessageTest extends TestCase
 {
@@ -20,4 +20,5 @@ class NotificationsMailMessageTest extends TestCase
 
         $this->assertEquals('notifications::foo', $this->message->markdown);
     }
+
 }

--- a/tests/Notifications/NotificationMailMessageTest.php
+++ b/tests/Notifications/NotificationMailMessageTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Illuminate\Tests\Notifications;
+
+use Illuminate\Notifications\Messages\MailMessage;
+use PHPUnit\Framework\TestCase;
+
+class NotificationsMailMessageTest extends TestCase
+{
+    public function setUp()
+    {
+        $this->message = new MailMessage;
+    }
+
+    public function testTemplate()
+    {
+        $this->assertEquals('notifications::email', $this->message->markdown);
+
+        $this->message->template('notifications::foo');
+
+        $this->assertEquals('notifications::foo', $this->message->markdown);
+    }
+}


### PR DESCRIPTION
Right now you can change the default markdown template either by changing the property or by creating another class that extends `MailMessage` and changing it there. This PR would allow something like this:   

```php   
    public function toMail($notifiable)
    {
        return (new MailMessage)
            ->template('emails::foo')
            ->subject('Account Created')
            ->line('Welcome to foo app, bla bla bla')
            ->action('See Dashboard', url('/'))
            ->line('Thanks!');
    }
```   

Not a new feature, but I think it looks way better this way.   

Perhaps we could allow the default markdown template to be published and then the user could change it?