### PR TITLE
[5.5] Allow setting column styles for tables in Artisan commands

### DIFF
--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -385,17 +385,17 @@ class Command extends SymfonyCommand
     public function table($headers, $rows, $tableStyle = 'default', array $columnStyles = [])
     {
         $table = new Table($this->output);
- 
+
         if ($rows instanceof Arrayable) {
             $rows = $rows->toArray();
         }
- 
+
         $table->setHeaders((array) $headers)->setRows($rows)->setStyle($tableStyle);
-         
+
         foreach ($columnStyles as $columnIndex => $columnStyle) {
             $table->setColumnStyle($columnIndex, $columnStyle);
         }
- 
+
         $table->render();
     }
 

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -382,22 +382,22 @@ class Command extends SymfonyCommand
      * @param  array   $columnStyles
      * @return void
      */
-     public function table($headers, $rows, $tableStyle = 'default', array $columnStyles = [])
-     {
-         $table = new Table($this->output);
+    public function table($headers, $rows, $tableStyle = 'default', array $columnStyles = [])
+    {
+        $table = new Table($this->output);
  
-         if ($rows instanceof Arrayable) {
-             $rows = $rows->toArray();
-         }
+        if ($rows instanceof Arrayable) {
+            $rows = $rows->toArray();
+        }
  
-         $table->setHeaders((array) $headers)->setRows($rows)->setStyle($tableStyle);
+        $table->setHeaders((array) $headers)->setRows($rows)->setStyle($tableStyle);
          
-         foreach ($columnStyles as $columnIndex => $columnStyle) {
-             $table->setColumnStyle($columnIndex, $columnStyle);
-         }
+        foreach ($columnStyles as $columnIndex => $columnStyle) {
+            $table->setColumnStyle($columnIndex, $columnStyle);
+        }
  
-         $table->render();
-     }
+        $table->render();
+    }
 
     /**
      * Write a string as information output.

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -378,19 +378,26 @@ class Command extends SymfonyCommand
      *
      * @param  array   $headers
      * @param  \Illuminate\Contracts\Support\Arrayable|array  $rows
-     * @param  string  $style
+     * @param  string  $tableStyle
+     * @param  array   $columnStyles
      * @return void
      */
-    public function table($headers, $rows, $style = 'default')
-    {
-        $table = new Table($this->output);
-
-        if ($rows instanceof Arrayable) {
-            $rows = $rows->toArray();
-        }
-
-        $table->setHeaders((array) $headers)->setRows($rows)->setStyle($style)->render();
-    }
+     public function table($headers, $rows, $tableStyle = 'default', array $columnStyles = [])
+     {
+         $table = new Table($this->output);
+ 
+         if ($rows instanceof Arrayable) {
+             $rows = $rows->toArray();
+         }
+ 
+         $table->setHeaders((array) $headers)->setRows($rows)->setStyle($tableStyle);
+         
+         foreach ($columnStyles as $columnIndex => $columnStyle) {
+             $table->setColumnStyle($columnIndex, $columnStyle);
+         }
+ 
+         $table->render();
+     }
 
     /**
      * Write a string as information output.


### PR DESCRIPTION
The current `table` method in the `Illuminate\Console\Command` class doesn't allow you to set the column style. Because of this, you can't do certain things, like right align items. It is doable, as per [this](http://symfony.com/blog/new-in-symfony-2-8-console-improvements) Symfony blog post. 

This patch makes possible what is described in the blog post by adding a new optional parameter to the end of the `table` method. It takes an array where the key is the column index and the value is either the column style name, or an instance of `Symfony\Component\Console\Helper\TableStyle`.

With the changes in the patch, the equivelent to the example in the blog post looks like this for an Artisan command:

```php
public function handle()
{
    $headers = ['#', 'Path', 'Size'];

    $rows = [
        [1, 'autoload.php', '183'],
        [2, 'ApplicationTest.php', '247,794'],
        [3, 'CommandTest.php', '14,965'],
        [4, 'ListCommandTest.php', '2,369']
    ];

    $rightAligned = new TableStyle();
    $rightAligned->setPadType(STR_PAD_LEFT);

    $columnStyles = [2 => $rightAligned];

    $this->table($headers, $rows, 'default', $columnStyles);
}
```

Artisan command output:

```
+---+---------------------+---------+
| # | Path                |    Size |
+---+---------------------+---------+
| 1 | autoload.php        |     183 |
| 2 | ApplicationTest.php | 247,794 |
| 3 | CommandTest.php     |  14,965 |
| 4 | ListCommandTest.php |   2,369 |
+---+---------------------+---------+
```