### PR TITLE
[5.5] Added __debugInfo to Eloquent model and collections.

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1457,4 +1457,14 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     {
         $this->bootIfNotBooted();
     }
+
+    /**
+     * Get attributes for debugging functions like var_dump/dd/dump.
+     *
+     * @return array
+     */
+    public function __debugInfo()
+    {
+        return $this->toArray();
+    }
 }

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1734,4 +1734,14 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
 
         return new HigherOrderCollectionProxy($this, $key);
     }
+
+    /**
+     * Get attributes for debugging functions like var_dump/dd/dump.
+     *
+     * @return array
+     */
+    public function __debugInfo()
+    {
+        return $this->all();
+    }
 }


### PR DESCRIPTION
In 98% cases when we try to dump eloquent model or collection we want to see attributes for model and items for collection case.
Now we must write `dd($collection->all())` or `dd($model->toArray())`. 

(Yes, I know about `dd` and `dump` methods in `Collection`) ;)

This PR adds [__debugInfo()](http://php.net/manual/en/language.oop5.magic.php#object.debuginfo) method into model and collection, which can be very useful for debugging.

And we can call

```php
dd($collection);
```

or 

```php
dd($model);
```

