### PR TITLE
[5.5] Ignore select bindings while building update query

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -741,7 +741,7 @@ class Grammar extends BaseGrammar
      */
     public function prepareBindingsForUpdate(array $bindings, array $values)
     {
-        $bindingsWithoutJoin = Arr::except($bindings, 'join');
+        $bindingsWithoutJoin = Arr::except($bindings, ['join', 'select']);
 
         return array_values(
             array_merge($bindings['join'], $values, Arr::flatten($bindingsWithoutJoin))

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -741,10 +741,10 @@ class Grammar extends BaseGrammar
      */
     public function prepareBindingsForUpdate(array $bindings, array $values)
     {
-        $bindingsWithoutJoin = Arr::except($bindings, ['join', 'select']);
+        $cleanBindings = Arr::except($bindings, ['join', 'select']);
 
         return array_values(
-            array_merge($bindings['join'], $values, Arr::flatten($bindingsWithoutJoin))
+            array_merge($bindings['join'], $values, Arr::flatten($cleanBindings))
         );
     }
 

--- a/tests/Integration/Database/EloquentMorphManyTest.php
+++ b/tests/Integration/Database/EloquentMorphManyTest.php
@@ -4,11 +4,8 @@ namespace Illuminate\Tests\Integration\Database\EloquentMorphManyTest;
 
 use Illuminate\Support\Carbon;
 use Orchestra\Testbench\TestCase;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Collection;
-use Illuminate\Database\Eloquent\Relations\Pivot;
 
 /**
  * @group integration

--- a/tests/Integration/Database/EloquentMorphManyTest.php
+++ b/tests/Integration/Database/EloquentMorphManyTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\EloquentMorphManyTest;
+
+use Illuminate\Support\Carbon;
+use Orchestra\Testbench\TestCase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Relations\Pivot;
+
+/**
+ * @group integration
+ */
+class EloquentMorphManyTest extends TestCase
+{
+    protected function getEnvironmentSetUp($app)
+    {
+        $app['config']->set('app.debug', 'true');
+
+        $app['config']->set('database.default', 'testbench');
+
+        $app['config']->set('database.connections.testbench', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+        ]);
+    }
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        Schema::create('posts', function ($table) {
+            $table->increments('id');
+            $table->string('title');
+            $table->timestamps();
+        });
+
+        Schema::create('comments', function ($table) {
+            $table->increments('id');
+            $table->string('name');
+            $table->integer('commentable_id');
+            $table->string('commentable_type');
+            $table->timestamps();
+        });
+
+        Carbon::setTestNow(null);
+    }
+
+    /**
+     * @test
+     */
+    public function update_model_with_default_withCount()
+    {
+        $post = Post::create(['title' => str_random()]);
+
+        $post->update(['title' => 'new name']);
+
+        $this->assertEquals('new name', $post->title);
+    }
+}
+
+class Post extends Model
+{
+    public $table = 'posts';
+    public $timestamps = true;
+    protected $guarded = ['id'];
+    protected $withCount = ['comments'];
+
+    public function comments()
+    {
+        return $this->morphMany(Comment::class, 'commentable');
+    }
+}
+
+
+class Comment extends Model
+{
+    public $table = 'comments';
+    public $timestamps = true;
+    protected $guarded = ['id'];
+
+    public function commentable()
+    {
+        return $this->morphTo();
+    }
+}


### PR DESCRIPTION
The test with this PR shows an example of a sub select query using the default `withCount` model property, but this basically affects every sub select query.

When building the update query, we use `where` and `join` bindings but we don't use the `select` bindings, so any leftovers in this `select` binding will be used by the final query even though the final query doesn't need it, which will cause incorrect order of bindings.

This PR fixes the following issue: https://github.com/laravel/framework/issues/20640