### PR TITLE
[5.5] add ability to show input value in validation error messages

### DIFF
--- a/src/Illuminate/Validation/Concerns/FormatsMessages.php
+++ b/src/Illuminate/Validation/Concerns/FormatsMessages.php
@@ -190,7 +190,7 @@ trait FormatsMessages
             $message, $this->getDisplayableAttribute($attribute)
         );
 
-        $message = $this->replaceActualValuePlaceholder($message, $attribute);
+        $message = $this->replaceInputPlaceholder($message, $attribute);
 
         if (isset($this->replacers[Str::snake($rule)])) {
             return $this->callReplacer($message, $attribute, Str::snake($rule), $parameters, $this);
@@ -274,12 +274,12 @@ trait FormatsMessages
      * @param  string  $value
      * @return string
      */
-    protected function replaceActualValuePlaceholder($message, $attribute)
+    protected function replaceInputPlaceholder($message, $attribute)
     {
         $actualValue = $this->getValue($attribute);
 
         if (is_scalar($actualValue) || is_null($actualValue)) {
-            $message = str_replace(':actual_value', $actualValue, $message);
+            $message = str_replace(':input', $actualValue, $message);
         }
 
         return $message;

--- a/src/Illuminate/Validation/Concerns/FormatsMessages.php
+++ b/src/Illuminate/Validation/Concerns/FormatsMessages.php
@@ -268,7 +268,7 @@ trait FormatsMessages
     }
 
     /**
-     * Replace the :attribute placeholder in the given message.
+     * Replace the :actual_value placeholder in the given message.
      *
      * @param  string  $message
      * @param  string  $value

--- a/src/Illuminate/Validation/Concerns/FormatsMessages.php
+++ b/src/Illuminate/Validation/Concerns/FormatsMessages.php
@@ -190,9 +190,7 @@ trait FormatsMessages
             $message, $this->getDisplayableAttribute($attribute)
         );
 
-        if (is_string($this->getValue($attribute)) || is_numeric($this->getValue($attribute))) {
-            $message = str_replace(':actual_value', $this->getValue($attribute), $message);
-        }
+        $message = $this->replaceActualValuePlaceholder($message, $attribute);
 
         if (isset($this->replacers[Str::snake($rule)])) {
             return $this->callReplacer($message, $attribute, Str::snake($rule), $parameters, $this);
@@ -267,6 +265,24 @@ trait FormatsMessages
             [$value, Str::upper($value), Str::ucfirst($value)],
             $message
         );
+    }
+
+    /**
+     * Replace the :attribute placeholder in the given message.
+     *
+     * @param  string  $message
+     * @param  string  $value
+     * @return string
+     */
+    protected function replaceActualValuePlaceholder($message, $attribute)
+    {
+        $actualValue = $this->getValue($attribute);
+
+        if (is_scalar($actualValue) || is_null($actualValue)) {
+            $message = str_replace(':actual_value', $actualValue, $message);
+        }
+
+        return $message;
     }
 
     /**

--- a/src/Illuminate/Validation/Concerns/FormatsMessages.php
+++ b/src/Illuminate/Validation/Concerns/FormatsMessages.php
@@ -190,6 +190,8 @@ trait FormatsMessages
             $message, $this->getDisplayableAttribute($attribute)
         );
 
+        $message = str_replace(':actual_value', $this->getValue($attribute), $message);
+
         if (isset($this->replacers[Str::snake($rule)])) {
             return $this->callReplacer($message, $attribute, Str::snake($rule), $parameters, $this);
         } elseif (method_exists($this, $replacer = "replace{$rule}")) {

--- a/src/Illuminate/Validation/Concerns/FormatsMessages.php
+++ b/src/Illuminate/Validation/Concerns/FormatsMessages.php
@@ -190,7 +190,9 @@ trait FormatsMessages
             $message, $this->getDisplayableAttribute($attribute)
         );
 
-        $message = str_replace(':actual_value', $this->getValue($attribute), $message);
+        if (is_string($this->getValue($attribute)) || is_numeric($this->getValue($attribute))) {
+            $message = str_replace(':actual_value', $this->getValue($attribute), $message);
+        }
 
         if (isset($this->replacers[Str::snake($rule)])) {
             return $this->callReplacer($message, $attribute, Str::snake($rule), $parameters, $this);

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -376,7 +376,6 @@ class ValidationValidatorTest extends TestCase
 
     public function testActualValuesAreReplaced()
     {
-        //required_if:foo,bar
         $trans = $this->getIlluminateArrayTranslator();
         $trans->addLines(['validation.email' => ':actual_value is not a valid email'], 'en');
         $v = new Validator($trans, ['email' => 'a@s'], ['email' => 'email']);

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -374,17 +374,17 @@ class ValidationValidatorTest extends TestCase
         $this->assertEquals('First name is required!', $v->messages()->first('names.0'));
     }
 
-    public function testActualValuesAreReplaced()
+    public function testInputIsReplaced()
     {
         $trans = $this->getIlluminateArrayTranslator();
-        $trans->addLines(['validation.email' => ':actual_value is not a valid email'], 'en');
+        $trans->addLines(['validation.email' => ':input is not a valid email'], 'en');
         $v = new Validator($trans, ['email' => 'a@s'], ['email' => 'email']);
         $this->assertFalse($v->passes());
         $v->messages()->setFormat(':message');
         $this->assertEquals('a@s is not a valid email', $v->messages()->first('email'));
 
         $trans = $this->getIlluminateArrayTranslator();
-        $trans->addLines(['validation.email' => ':actual_value is not a valid email'], 'en');
+        $trans->addLines(['validation.email' => ':input is not a valid email'], 'en');
         $v = new Validator($trans, ['email' => null], ['email' => 'email']);
         $this->assertFalse($v->passes());
         $v->messages()->setFormat(':message');

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -391,7 +391,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertEquals(' is not a valid email', $v->messages()->first('email'));
     }
 
-        public function testDisplayableValuesAreReplaced()
+    public function testDisplayableValuesAreReplaced()
     {
         //required_if:foo,bar
         $trans = $this->getIlluminateArrayTranslator();

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -374,7 +374,18 @@ class ValidationValidatorTest extends TestCase
         $this->assertEquals('First name is required!', $v->messages()->first('names.0'));
     }
 
-    public function testDisplayableValuesAreReplaced()
+    public function testActualValuesAreReplaced()
+    {
+        //required_if:foo,bar
+        $trans = $this->getIlluminateArrayTranslator();
+        $trans->addLines(['validation.email' => ':actual_value is not a valid email'], 'en');
+        $v = new Validator($trans, ['email' => 'a@s'], ['email' => 'email']);
+        $this->assertFalse($v->passes());
+        $v->messages()->setFormat(':message');
+        $this->assertEquals('a@s is not a valid email', $v->messages()->first('email'));
+    }
+
+        public function testDisplayableValuesAreReplaced()
     {
         //required_if:foo,bar
         $trans = $this->getIlluminateArrayTranslator();

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -382,6 +382,13 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
         $v->messages()->setFormat(':message');
         $this->assertEquals('a@s is not a valid email', $v->messages()->first('email'));
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $trans->addLines(['validation.email' => ':actual_value is not a valid email'], 'en');
+        $v = new Validator($trans, ['email' => null], ['email' => 'email']);
+        $this->assertFalse($v->passes());
+        $v->messages()->setFormat(':message');
+        $this->assertEquals(' is not a valid email', $v->messages()->first('email'));
     }
 
         public function testDisplayableValuesAreReplaced()


### PR DESCRIPTION
```
validator(['email' => 'Mohamed'], ['email' => 'email'])->validate();
```

With this PR, you can have the error message of the email rule as `:actual_value is not a valid email`, and the error output will become `Mohamed is not a valid email.`