### PR TITLE
Log a debug statement when using env() when the config is cached.

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -602,6 +602,10 @@ if (! function_exists('env')) {
      */
     function env($key, $default = null)
     {
+        if (app()->configurationIsCached()) {
+            app('log')->debug(sprintf("The env('%s') method has been called but the config is cached.", $key));
+        }
+
         $value = getenv($key);
 
         if ($value === false) {


### PR DESCRIPTION
The [Configuration Caching section in the docs](https://laravel.com/docs/5.5/configuration#configuration-caching) states:

> If you execute the `config:cache` command during your deployment process, you should be sure that you are only calling the `env` function from within your configuration files.

This is a great tip, but its pretty easy to miss. We just got tripped up by this.

Perhaps we can write something in the logs that would have made our mistake easier to find.