### PR TITLE
[5.5] Eloquent model without updated_at field

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php
@@ -38,8 +38,10 @@ trait HasTimestamps
     {
         $time = $this->freshTimestamp();
 
-        if (! $this->isDirty(static::UPDATED_AT)) {
-            $this->setUpdatedAt($time);
+        if (static::UPDATED_AT !== null) {
+            if (! $this->isDirty(static::UPDATED_AT)) {
+                $this->setUpdatedAt($time);
+            }
         }
 
         if (! $this->exists && ! $this->isDirty(static::CREATED_AT)) {


### PR DESCRIPTION
Since Laravel 5.0 many found a simple method to have eloquent models without updated_at field. Unfortunatelly this is not a thing in Laravel 5.5 anymore ( #19627 #21045 #20901 #20930 ...)

e.g. how it was used before Laravel 5.5

```php
class MyModel extends Model
{
    const UPDATED_AT = null;
}
```

I do understand it's not an official method but since we do lack flexibility on the subject, please, leave this behaviour as it was working before...



