### PR TITLE
[5.5] Get all keys from the request which have rules defined

### DIFF
--- a/src/Illuminate/Foundation/Validation/ValidatesRequests.php
+++ b/src/Illuminate/Foundation/Validation/ValidatesRequests.php
@@ -25,7 +25,7 @@ trait ValidatesRequests
 
         $validator->validate();
 
-        return $request->only(collect($validator->getRules())->keys()->map(function ($rule) {
+        return $request->all(collect($validator->getRules())->keys()->map(function ($rule) {
             return str_contains($rule, '.') ? explode('.', $rule)[0] : $rule;
         })->unique()->toArray());
     }
@@ -46,7 +46,7 @@ trait ValidatesRequests
              ->make($request->all(), $rules, $messages, $customAttributes)
              ->validate();
 
-        return $request->only(collect($rules)->keys()->map(function ($rule) {
+        return $request->all(collect($rules)->keys()->map(function ($rule) {
             return str_contains($rule, '.') ? explode('.', $rule)[0] : $rule;
         })->unique()->toArray());
     }


### PR DESCRIPTION
Prior to this PR, this is the behaviour:
```
// in a controller method

$input = $this->validate($request, [
    'something_optional' => ['nullable'],
    'another_key_which_can_default_to_null' => [],
]);

// will error if the key was no provided in the request
if($input['something_optional']) {
    // do something
}
```


I may be mistaken, but I was sure I had seen something (maybe a tweet?) which meant the above would never give me an undefined index.

This means that I can use the validator and get the input (instead of having to do it twice to get optional request keys) and shouldn't cause issues with existing applications
