### PR TITLE
[5.5] "php artisan make:model --unguard"

### DIFF
--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -148,7 +148,7 @@ class ModelMakeCommand extends GeneratorCommand
 
             ['resource', 'r', InputOption::VALUE_NONE, 'Indicates if the generated controller should be a resource controller.'],
             
-            ['unguard', 'u', InputOption::VALUE_NONE, 'Sets $guarded to an empty array, making all attributes mass assignable.'],
+            ['unguard', 'u', InputOption::VALUE_NONE, 'Sets all attributes as mass assignable.'],
         ];
     }
 }

--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -147,7 +147,7 @@ class ModelMakeCommand extends GeneratorCommand
             ['migration', 'm', InputOption::VALUE_NONE, 'Create a new migration file for the model.'],
 
             ['resource', 'r', InputOption::VALUE_NONE, 'Indicates if the generated controller should be a resource controller.'],
-            
+
             ['unguard', 'u', InputOption::VALUE_NONE, 'Sets all attributes as mass assignable.'],
         ];
     }

--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -112,7 +112,9 @@ class ModelMakeCommand extends GeneratorCommand
      */
     protected function getStub()
     {
-        return __DIR__.'/stubs/model.stub';
+        return $this->option('unguard')
+            ? __DIR__.'/stubs/model-unguarded.stub'
+            : __DIR__.'/stubs/model.stub';
     }
 
     /**
@@ -145,6 +147,8 @@ class ModelMakeCommand extends GeneratorCommand
             ['migration', 'm', InputOption::VALUE_NONE, 'Create a new migration file for the model.'],
 
             ['resource', 'r', InputOption::VALUE_NONE, 'Indicates if the generated controller should be a resource controller.'],
+            
+            ['unguard', 'u', InputOption::VALUE_NONE, 'Sets $guarded to an empty array, making all attributes mass assignable.'],
         ];
     }
 }

--- a/src/Illuminate/Foundation/Console/stubs/model-unguarded.stub
+++ b/src/Illuminate/Foundation/Console/stubs/model-unguarded.stub
@@ -1,0 +1,15 @@
+<?php
+
+namespace DummyNamespace;
+
+use Illuminate\Database\Eloquent\Model;
+
+class DummyClass extends Model
+{
+    /**
+     * The attributes that aren't mass assignable.
+     *
+     * @var array
+     */
+    protected $guarded = [];
+}


### PR DESCRIPTION
Inspired by @freekmurze's [tweet](https://twitter.com/freekmurze/status/907623198845489155)…

![inspiration](https://user-images.githubusercontent.com/1914481/30410260-4dd8e876-994d-11e7-91f8-dda1ddc1579d.png)

…this PR adds an "unguard" option to the "make:model" command…

<img width="681" alt="help" src="https://user-images.githubusercontent.com/1914481/30410322-b1dcedae-994d-11e7-9d58-0bf1dfd502b0.png">

…which if passed…

<img width="559" alt="command" src="https://user-images.githubusercontent.com/1914481/30410445-76bc7e46-994e-11e7-82cc-e4641004e200.png">

…sets the generated model's `$guarded` property to an empty array:

![model](https://user-images.githubusercontent.com/1914481/30410495-c7fba1a6-994e-11e7-89d6-de75e729495a.png)

🤓👍