### PR TITLE
[5.5] adjust ide-helper hint

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -16,7 +16,6 @@ use Illuminate\Database\Eloquent\Relations\Pivot;
 use Illuminate\Database\Query\Builder as QueryBuilder;
 use Illuminate\Database\ConnectionResolverInterface as Resolver;
 
-
 abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializable, QueueableEntity, UrlRoutable
 {
     use Concerns\HasAttributes,

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -16,10 +16,7 @@ use Illuminate\Database\Eloquent\Relations\Pivot;
 use Illuminate\Database\Query\Builder as QueryBuilder;
 use Illuminate\Database\ConnectionResolverInterface as Resolver;
 
-/**
- * @mixin \Illuminate\Database\Eloquent\Builder
- * @mixin \Illuminate\Database\Query\Builder
- */
+
 abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializable, QueueableEntity, UrlRoutable
 {
     use Concerns\HasAttributes,


### PR DESCRIPTION
From laravel 5.4.29, in the `Illuminate\Database\Eloquent\Model`, added the PHPDoc Param `@mixin \Illuminate\Database\Eloquent\Builder`, and from laravel 5.4.31, in the `Illuminate\Database\Eloquent\Model`, added the PhpDoc Param `@mixin \Illuminate\Database\Query\Builder`.

When `barryvdh/laravel-ide-helper` generates, the two @minin in `Illuminate\Database\Eloquent\Model`  is conflicting with the generated `\Eloquent`, so the generated `\Eloquent` cant work well because one method is static and the other is not. so hope delete the two PHPDoc Param. Now when just @mixin \Eloquent, It is work well. 