### PR TITLE
tests : various ways to push a job under QueueFake

### DIFF
--- a/tests/Integration/Queue/QueueFakeTest.php
+++ b/tests/Integration/Queue/QueueFakeTest.php
@@ -14,44 +14,44 @@ class QueueFakeTest extends TestCase
     public function setUp()
     {
         (new BusServiceProvider(app()))->register();
-        CallQueuedHandlerTestJob::$handled = false;
+        CallQueuedHandlerTestJobUnderQueueFake::$handled = false;
     }
 
     public function test_job_through_helper_is_not_fired()
     {
         QueueFacade::fake();
 
-        dispatch(new CallQueuedHandlerTestJob);
+        dispatch(new CallQueuedHandlerTestJobUnderQueueFake);
 
         // job should be puzshed to the QueueFake and not actually handled
-        QueueFacade::assertPushed(CallQueuedHandlerTestJob::class);
-        $this->assertFalse(CallQueuedHandlerTestJob::$handled);
+        QueueFacade::assertPushed(CallQueuedHandlerTestJobUnderQueueFake::class);
+        $this->assertFalse(CallQueuedHandlerTestJobUnderQueueFake::$handled);
     }
 
     public function test_job_through_facade_is_not_fired()
     {
         QueueFacade::fake();
 
-        QueueFacade::push(new CallQueuedHandlerTestJob);
+        QueueFacade::push(new CallQueuedHandlerTestJobUnderQueueFake);
 
         // job should be puzshed to the QueueFake and not actually handled
-        QueueFacade::assertPushed(CallQueuedHandlerTestJob::class);
-        $this->assertFalse(CallQueuedHandlerTestJob::$handled);
+        QueueFacade::assertPushed(CallQueuedHandlerTestJobUnderQueueFake::class);
+        $this->assertFalse(CallQueuedHandlerTestJobUnderQueueFake::$handled);
     }
 
     public function test_job_through_static_is_not_fired()
     {
         QueueFacade::fake();
 
-        CallQueuedHandlerTestJob::dispatch();
+        CallQueuedHandlerTestJobUnderQueueFake::dispatch();
 
         // job should be puzshed to the QueueFake and not actually handled
-        QueueFacade::assertPushed(CallQueuedHandlerTestJob::class);
-        $this->assertFalse(CallQueuedHandlerTestJob::$handled);
+        QueueFacade::assertPushed(CallQueuedHandlerTestJobUnderQueueFake::class);
+        $this->assertFalse(CallQueuedHandlerTestJobUnderQueueFake::$handled);
     }
 }
 
-class CallQueuedHandlerTestJob
+class CallQueuedHandlerTestJobUnderQueueFake
 {
     use \Illuminate\Queue\InteractsWithQueue, \Illuminate\Foundation\Bus\Dispatchable;
 

--- a/tests/Integration/Queue/QueueFakeTest.php
+++ b/tests/Integration/Queue/QueueFakeTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Queue;
+
+use Orchestra\Testbench\TestCase;
+use Illuminate\Support\Facades\Queue as QueueFacade;
+use Illuminate\Bus\BusServiceProvider;
+
+/**
+ * @group integration
+ */
+class QueueFakeTest extends TestCase
+{
+
+    public function setUp()
+    {
+        (new BusServiceProvider(app()))->register();
+        CallQueuedHandlerTestJob::$handled = false;
+    }
+
+    public function test_job_through_helper_is_not_fired()
+    {
+        QueueFacade::fake();
+
+        dispatch(new CallQueuedHandlerTestJob);
+        
+        // job should be puzshed to the QueueFake and not actually handled
+        QueueFacade::assertPushed(CallQueuedHandlerTestJob::class);
+        $this->assertFalse(CallQueuedHandlerTestJob::$handled);
+    }
+
+    public function test_job_through_facade_is_not_fired()
+    {
+        QueueFacade::fake();
+
+        QueueFacade::push(new CallQueuedHandlerTestJob);
+        
+        // job should be puzshed to the QueueFake and not actually handled
+        QueueFacade::assertPushed(CallQueuedHandlerTestJob::class);
+        $this->assertFalse(CallQueuedHandlerTestJob::$handled);
+    }
+    
+    public function test_job_through_static_is_not_fired()
+    {
+        QueueFacade::fake();
+
+        CallQueuedHandlerTestJob::dispatch();
+
+        // job should be puzshed to the QueueFake and not actually handled
+        QueueFacade::assertPushed(CallQueuedHandlerTestJob::class);
+        $this->assertFalse(CallQueuedHandlerTestJob::$handled);
+    }
+
+}
+
+class CallQueuedHandlerTestJob
+{
+    use \Illuminate\Queue\InteractsWithQueue, \Illuminate\Foundation\Bus\Dispatchable;
+
+    public static $handled = false;
+
+    public function handle()
+    {
+        static::$handled = true;
+    }
+}

--- a/tests/Integration/Queue/QueueFakeTest.php
+++ b/tests/Integration/Queue/QueueFakeTest.php
@@ -3,15 +3,14 @@
 namespace Illuminate\Tests\Integration\Queue;
 
 use Orchestra\Testbench\TestCase;
-use Illuminate\Support\Facades\Queue as QueueFacade;
 use Illuminate\Bus\BusServiceProvider;
+use Illuminate\Support\Facades\Queue as QueueFacade;
 
 /**
  * @group integration
  */
 class QueueFakeTest extends TestCase
 {
-
     public function setUp()
     {
         (new BusServiceProvider(app()))->register();
@@ -23,7 +22,7 @@ class QueueFakeTest extends TestCase
         QueueFacade::fake();
 
         dispatch(new CallQueuedHandlerTestJob);
-        
+
         // job should be puzshed to the QueueFake and not actually handled
         QueueFacade::assertPushed(CallQueuedHandlerTestJob::class);
         $this->assertFalse(CallQueuedHandlerTestJob::$handled);
@@ -34,12 +33,12 @@ class QueueFakeTest extends TestCase
         QueueFacade::fake();
 
         QueueFacade::push(new CallQueuedHandlerTestJob);
-        
+
         // job should be puzshed to the QueueFake and not actually handled
         QueueFacade::assertPushed(CallQueuedHandlerTestJob::class);
         $this->assertFalse(CallQueuedHandlerTestJob::$handled);
     }
-    
+
     public function test_job_through_static_is_not_fired()
     {
         QueueFacade::fake();
@@ -50,7 +49,6 @@ class QueueFakeTest extends TestCase
         QueueFacade::assertPushed(CallQueuedHandlerTestJob::class);
         $this->assertFalse(CallQueuedHandlerTestJob::$handled);
     }
-
 }
 
 class CallQueuedHandlerTestJob


### PR DESCRIPTION
Test cases for #21189.
For now two over three are failing, they are the ones using `dispatch(new CallQueuedHandlerTestJob);` and `CallQueuedHandlerTestJob::dispatch();`

```shell
$ vendor/bin/phpunit -vvv tests/Integration/Queue/QueueFakeTest.php
PHPUnit 6.3.0 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.1.4
Configuration: /somewhere/laravel-framework/phpunit.xml

F.F                                                                 3 / 3 (100%)

Time: 64 ms, Memory: 6.00MB

There were 2 failures:

1) Illuminate\Tests\Integration\Queue\QueueFakeTest::test_job_through_helper_is_not_fired
The expected [Illuminate\Tests\Integration\Queue\CallQueuedHandlerTestJob] job was not pushed.
Failed asserting that false is true.

/somewhere/laravel-framework/src/Illuminate/Support/Testing/Fakes/QueueFake.php:33
/somewhere/laravel-framework/src/Illuminate/Support/Facades/Facade.php:221
/somewhere/laravel-framework/tests/Integration/Queue/QueueFakeTest.php:27

2) Illuminate\Tests\Integration\Queue\QueueFakeTest::test_job_through_static_is_not_fired
The expected [Illuminate\Tests\Integration\Queue\CallQueuedHandlerTestJob] job was not pushed.
Failed asserting that false is true.

/somewhere/laravel-framework/src/Illuminate/Support/Testing/Fakes/QueueFake.php:33
/somewhere/laravel-framework/src/Illuminate/Support/Facades/Facade.php:221
/somewhere/laravel-framework/tests/Integration/Queue/QueueFakeTest.php:47
```