### PR TITLE
[5.5] Serialize relationships

### DIFF
--- a/src/Illuminate/Contracts/Database/ModelIdentifier.php
+++ b/src/Illuminate/Contracts/Database/ModelIdentifier.php
@@ -28,17 +28,26 @@ class ModelIdentifier
     public $connection;
 
     /**
+     * The relationships loaded on the model.
+     *
+     * @var array
+     */
+    public $relations;
+
+    /**
      * Create a new model identifier.
      *
      * @param  string  $class
      * @param  mixed  $id
      * @param  mixed  $connection
+     * @param  array  $relations
      * @return void
      */
-    public function __construct($class, $id, $connection)
+    public function __construct($class, $id, $connection, $relations)
     {
         $this->id = $id;
         $this->class = $class;
         $this->connection = $connection;
+        $this->relations = $relations;
     }
 }

--- a/src/Illuminate/Contracts/Queue/QueueableCollection.php
+++ b/src/Illuminate/Contracts/Queue/QueueableCollection.php
@@ -24,4 +24,11 @@ interface QueueableCollection
      * @return string|null
      */
     public function getQueueableConnection();
+
+    /**
+     * Get the relationships of the entities being queued.
+     *
+     * @return array
+     */
+    public function getQueueableRelations();
 }

--- a/src/Illuminate/Contracts/Queue/QueueableEntity.php
+++ b/src/Illuminate/Contracts/Queue/QueueableEntity.php
@@ -17,4 +17,11 @@ interface QueueableEntity
      * @return string|null
      */
     public function getQueueableConnection();
+
+    /**
+     * Get the relationships for the entity.
+     *
+     * @return array
+     */
+    public function getQueueableRelations();
 }

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -419,4 +419,14 @@ class Collection extends BaseCollection implements QueueableCollection
 
         return $connection;
     }
+
+    /**
+     * Get the relationships of the entities being queued.
+     *
+     * @return array
+     */
+    public function getQueueableRelations()
+    {
+        return $this->isNotEmpty() ? $this->first()->getRelations() : [];
+    }
 }

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2,20 +2,20 @@
 
 namespace Illuminate\Database\Eloquent;
 
-use Exception;
 use ArrayAccess;
-use JsonSerializable;
 use BadMethodCallException;
+use Exception;
+use Illuminate\Contracts\Queue\QueueableCollection;
+use Illuminate\Contracts\Queue\QueueableEntity;
+use Illuminate\Contracts\Routing\UrlRoutable;
+use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Contracts\Support\Jsonable;
+use Illuminate\Database\ConnectionResolverInterface as Resolver;
+use Illuminate\Database\Eloquent\Relations\Pivot;
+use Illuminate\Database\Query\Builder as QueryBuilder;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
-use Illuminate\Contracts\Support\Jsonable;
-use Illuminate\Contracts\Support\Arrayable;
-use Illuminate\Contracts\Routing\UrlRoutable;
-use Illuminate\Contracts\Queue\QueueableEntity;
-use Illuminate\Database\Eloquent\Relations\Pivot;
-use Illuminate\Contracts\Queue\QueueableCollection;
-use Illuminate\Database\Query\Builder as QueryBuilder;
-use Illuminate\Database\ConnectionResolverInterface as Resolver;
+use JsonSerializable;
 
 /**
  * @mixin \Illuminate\Database\Eloquent\Builder
@@ -1260,20 +1260,17 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     {
         $relations = [];
 
-        foreach ($this->getRelations() as $key => $relation){
-
+        foreach ($this->getRelations() as $key => $relation) {
             $relations[] = $key;
 
-            if ($relation instanceof QueueableCollection)
-            {
-                foreach($relation->getQueueableRelations() as $collectionKey => $collectionValue){
+            if ($relation instanceof QueueableCollection) {
+                foreach ($relation->getQueueableRelations() as $collectionKey => $collectionValue) {
                     $relations[] = $key . '.' . $collectionKey;
                 }
             }
 
-            if ($relation instanceof QueueableEntity)
-            {
-                foreach($relation->getQueueableRelations() as $entityKey => $entityValue){
+            if ($relation instanceof QueueableEntity) {
+                foreach ($relation->getQueueableRelations() as $entityKey => $entityValue) {
                     $relations[] = $key . '.' . $entityValue;
                 }
             }

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -13,6 +13,7 @@ use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Routing\UrlRoutable;
 use Illuminate\Contracts\Queue\QueueableEntity;
 use Illuminate\Database\Eloquent\Relations\Pivot;
+use Illuminate\Contracts\Queue\QueueableCollection;
 use Illuminate\Database\Query\Builder as QueryBuilder;
 use Illuminate\Database\ConnectionResolverInterface as Resolver;
 
@@ -1248,6 +1249,37 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     public function getQueueableConnection()
     {
         return $this->getConnectionName();
+    }
+
+    /**
+     * Get the queueable relationships for the entity.
+     *
+     * @return array
+     */
+    public function getQueueableRelations()
+    {
+        $relations = [];
+
+        foreach ($this->getRelations() as $key => $relation){
+
+            $relations[] = $key;
+
+            if ($relation instanceof QueueableCollection)
+            {
+                foreach($relation->getQueueableRelations() as $collectionKey => $collectionValue){
+                    $relations[] = $key . '.' . $collectionKey;
+                }
+            }
+
+            if ($relation instanceof QueueableEntity)
+            {
+                foreach($relation->getQueueableRelations() as $entityKey => $entityValue){
+                    $relations[] = $key . '.' . $entityValue;
+                }
+            }
+        }
+
+        return $relations;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2,20 +2,20 @@
 
 namespace Illuminate\Database\Eloquent;
 
-use ArrayAccess;
-use BadMethodCallException;
 use Exception;
-use Illuminate\Contracts\Queue\QueueableCollection;
-use Illuminate\Contracts\Queue\QueueableEntity;
-use Illuminate\Contracts\Routing\UrlRoutable;
-use Illuminate\Contracts\Support\Arrayable;
-use Illuminate\Contracts\Support\Jsonable;
-use Illuminate\Database\ConnectionResolverInterface as Resolver;
-use Illuminate\Database\Eloquent\Relations\Pivot;
-use Illuminate\Database\Query\Builder as QueryBuilder;
+use ArrayAccess;
+use JsonSerializable;
+use BadMethodCallException;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
-use JsonSerializable;
+use Illuminate\Contracts\Support\Jsonable;
+use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Contracts\Routing\UrlRoutable;
+use Illuminate\Contracts\Queue\QueueableEntity;
+use Illuminate\Database\Eloquent\Relations\Pivot;
+use Illuminate\Contracts\Queue\QueueableCollection;
+use Illuminate\Database\Query\Builder as QueryBuilder;
+use Illuminate\Database\ConnectionResolverInterface as Resolver;
 
 /**
  * @mixin \Illuminate\Database\Eloquent\Builder
@@ -1265,13 +1265,13 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 
             if ($relation instanceof QueueableCollection) {
                 foreach ($relation->getQueueableRelations() as $collectionKey => $collectionValue) {
-                    $relations[] = $key . '.' . $collectionKey;
+                    $relations[] = $key.'.'.$collectionKey;
                 }
             }
 
             if ($relation instanceof QueueableEntity) {
                 foreach ($relation->getQueueableRelations() as $entityKey => $entityValue) {
-                    $relations[] = $key . '.' . $entityValue;
+                    $relations[] = $key.'.'.$entityValue;
                 }
             }
         }

--- a/tests/Integration/Queue/ModelSerializationTest.php
+++ b/tests/Integration/Queue/ModelSerializationTest.php
@@ -154,7 +154,6 @@ class ModelSerializationTest extends TestCase
 
         Line::create(['order_id' => $order->id, 'product_id' => $product1->id]);
         Line::create(['order_id' => $order->id, 'product_id' => $product2->id]);
-        Line::create(['order_id' => $order->id, 'product_id' => $product1->id]);
 
         $order->load('lines');
 
@@ -176,7 +175,6 @@ class ModelSerializationTest extends TestCase
 
         Line::create(['order_id' => $order->id, 'product_id' => $product1->id]);
         Line::create(['order_id' => $order->id, 'product_id' => $product2->id]);
-        Line::create(['order_id' => $order->id, 'product_id' => $product1->id]);
 
         $order->load('lines', 'lines.product');
 

--- a/tests/Integration/Queue/ModelSerializationTest.php
+++ b/tests/Integration/Queue/ModelSerializationTest.php
@@ -56,7 +56,6 @@ class ModelSerializationTest extends TestCase
 
         Schema::create('products', function ($table) {
             $table->increments('id');
-
         });
     }
 

--- a/tests/Queue/QueueSyncQueueTest.php
+++ b/tests/Queue/QueueSyncQueueTest.php
@@ -61,6 +61,11 @@ class SyncQueueTestEntity implements \Illuminate\Contracts\Queue\QueueableEntity
     {
         //
     }
+
+    public function getQueueableRelations()
+    {
+        //
+    }
 }
 
 class SyncQueueTestHandler


### PR DESCRIPTION
Previous attempt: https://github.com/laravel/framework/pull/20602

Currently when you serialize a model (usually to place on a queue), and then unserialize, the model is reloaded fine, but the relationships are not.  My previous solution was to have the user define on the queued object which relationships to reload.  Taylor wanted something more automatic, so this PR will examine the model while it is being serialized and add the currently loaded relationships to the `ModelIdentifier`.  Then, when the object is unserialized, will automatically reload all of the previously loaded relationships.

Some things to consider:

- Is there a situation where the user would not want to reload relationships? If so, do we provide a toggle for them to turn it off?
- I did not restore `Collection` relationships in this PR. I want to make sure this works and is accepted first, and then go back to add. Should be straightforward since all of the pieces are already there.
- Do I need to make the `$relations` parameter of the `ModelIdentifier` constructor optional?  If I don't, am I technically making a BC break on a minor release?

Thanks!