### PR TITLE
[5.5] Move validated request input extraction into its own method

### DIFF
--- a/src/Illuminate/Foundation/Validation/ValidatesRequests.php
+++ b/src/Illuminate/Foundation/Validation/ValidatesRequests.php
@@ -25,9 +25,7 @@ trait ValidatesRequests
 
         $validator->validate();
 
-        return $request->only(collect($validator->getRules())->keys()->map(function ($rule) {
-            return str_contains($rule, '.') ? explode('.', $rule)[0] : $rule;
-        })->unique()->toArray());
+        return $this->extractInputFromRules($request, $validator->getRules());
     }
 
     /**
@@ -46,6 +44,18 @@ trait ValidatesRequests
              ->make($request->all(), $rules, $messages, $customAttributes)
              ->validate();
 
+        return $this->extractInputFromRules($request, $rules);
+    }
+
+    /**
+     * Get request inputs using validator rules.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  array  $rules
+     * @return array
+     */
+    protected function extractInputFromRules(Request $request, $rules)
+    {
         return $request->only(collect($rules)->keys()->map(function ($rule) {
             return str_contains($rule, '.') ? explode('.', $rule)[0] : $rule;
         })->unique()->toArray());


### PR DESCRIPTION
For my project I want to tweak that from `$request->only(...)` to `$request->all(...)` I could just override both `validateWith` and `validate` methods, but I would rather separate them then only change the bit I care about.

Reasoning:
If either of those methods' internal logic change in the future, my overrides should still work.

The 3 lines I am extracting are duplicated in those two methods, I think there is some general benefit of putting them in a single method.