### PR TITLE
Add return type declaration for improved debugging.

### DIFF
--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -74,11 +74,11 @@ class Filesystem
      * Get the returned value of a file.
      *
      * @param  string  $path
-     * @return mixed
+     * @return array
      *
      * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
      */
-    public function getRequire($path)
+    public function getRequire($path): array
     {
         if ($this->isFile($path)) {
             return require $path;


### PR DESCRIPTION
- if this method returns anything but an array, it will throw an unhelpful exception

Prevents 
```
ErrorException: array_merge(): Argument #2 is not an array 
```

on 

src/Illuminate/Foundation/ProviderRepository.php:95