### PR TITLE
[5.6] Include job ID in the output of the queue:work Artisan command

### DIFF
--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -168,8 +168,9 @@ class WorkCommand extends Command
     protected function writeStatus(Job $job, $status, $type)
     {
         $this->output->writeln(sprintf(
-            "<{$type}>[%s] %s</{$type}> %s",
+            "<{$type}>[%s][%s] %s</{$type}> %s",
             Carbon::now()->format('Y-m-d H:i:s'),
+            $job->getJobId(),
             str_pad("{$status}:", 11), $job->resolveName()
         ));
     }


### PR DESCRIPTION
Recently, when working on a project that required a queue, I was trying to debug my app and track down certain jobs. The `queue:work` Artisan command didn't print out the job id, so it was a little harder for me to figure out what was going on. This PR adds the job ID to the command. Currently the output of the `queue:work` command looks like this:

```
[2017-09-15 14:44:08] Processing: App\Jobs\FooBarJob
[2017-09-15 14:44:08] Processed:  App\Jobs\FooBarJob
```

With this PR, the output looks like this:

```
[2017-09-15 14:44:08][917] Processing: App\Jobs\FooBarJob
[2017-09-15 14:44:08][917] Processed:  App\Jobs\FooBarJob
```

Please note how the job ID is just after the timestamp. I made this PR against master because it might break some apps that parse the output of this command. For example, if you were using the grep functionality in Logstash. So it would be better to save it for Laravel 5.6.