### PR TITLE
[5.6] Auto calls parent's constructor on Artisan commands

### DIFF
--- a/src/Illuminate/Console/Application.php
+++ b/src/Illuminate/Console/Application.php
@@ -231,7 +231,7 @@ class Application extends SymfonyApplication implements ApplicationContract
         // After resolve the command via IOC container, Laravel will try to call the constructor
         // of the parent class \Illuminate\Console\Command using reflection. We should ask to
         // the command's instance if the developer have intentionally disabled this action.
-        if ($instance instanceof Command::class && $instance->shouldAutoConstructed()) {
+        if ($instance instanceof Command && $instance->shouldAutoConstructed()) {
             $reflector = new ReflectionObject($instance);
             while ($reflector->getName() !== Command::class) {
                 $reflector = $reflector->getParentClass();

--- a/src/Illuminate/Console/Application.php
+++ b/src/Illuminate/Console/Application.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Console;
 
 use Closure;
+use ReflectionObject;
 use Illuminate\Contracts\Events\Dispatcher;
 use Symfony\Component\Process\ProcessUtils;
 use Illuminate\Contracts\Container\Container;
@@ -225,7 +226,22 @@ class Application extends SymfonyApplication implements ApplicationContract
      */
     public function resolve($command)
     {
-        return $this->add($this->laravel->make($command));
+        $instance = $this->laravel->make($command);
+
+        // After resolve the command via IOC container, Laravel will try to call the constructor
+        // of the parent class \Illuminate\Console\Command using reflection. We should ask to
+        // the command's instance if the developer have intentionally disabled this action.
+        if ($instance instanceof Command::class && $instance->shouldAutoConstructed()) {
+            $reflector = new ReflectionObject($instance);
+            while ($reflector->getName() !== Command::class) {
+                $reflector = $reflector->getParentClass();
+            }
+
+            $reflector->getMethod('__construct')
+                ->invoke($instance);
+        }
+
+        return $this->add($instance);
     }
 
     /**

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -85,8 +85,8 @@ class Command extends SymfonyCommand
     ];
 
     /**
-     * Indicates whether the contructor of the current class
-     * should be called automaticly using reflection.
+     * Indicates whether or not the constructor of the current class
+     * should be called automatically using reflection.
      *
      * @var boolean
      */
@@ -189,8 +189,8 @@ class Command extends SymfonyCommand
     }
 
     /**
-     * Indicates whether the contructor of the current class
-     * should be called automaticly using reflection.
+     * Indicates whether or not the constructor of the current class
+     * should be called automatically using reflection.
      *
      * @return boolean
      */

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -88,7 +88,7 @@ class Command extends SymfonyCommand
      * Indicates whether or not the constructor of the current class
      * should be called automatically using reflection.
      *
-     * @var boolean
+     * @var bool
      */
     protected $autoConstruct = true;
 
@@ -192,7 +192,7 @@ class Command extends SymfonyCommand
      * Indicates whether or not the constructor of the current class
      * should be called automatically using reflection.
      *
-     * @return boolean
+     * @return bool
      */
     public function shouldAutoConstructed()
     {

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -85,6 +85,14 @@ class Command extends SymfonyCommand
     ];
 
     /**
+     * Indicates whether the contructor of the current class
+     * should be called automaticly using reflection.
+     *
+     * @var boolean
+     */
+    protected $autoConstruct = true;
+
+    /**
      * Create a new console command instance.
      *
      * @return void
@@ -178,6 +186,17 @@ class Command extends SymfonyCommand
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         return $this->laravel->call([$this, 'handle']);
+    }
+
+    /**
+     * Indicates whether the contructor of the current class
+     * should be called automaticly using reflection.
+     *
+     * @return boolean
+     */
+    public function shouldAutoConstructed()
+    {
+        return $this->autoConstruct;
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/stubs/console.stub
+++ b/src/Illuminate/Foundation/Console/stubs/console.stub
@@ -27,7 +27,6 @@ class DummyClass extends Command
      */
     public function __construct()
     {
-        parent::__construct();
     }
 
     /**


### PR DESCRIPTION
The PR may be rejected for obvious reasons 😆. But I can't ignore that the call of `parent::__construct()` on every single command with **dependency injection through the constructor** is quite annoying. This PR addresses that exact same problem. 

**Using reflection** could make a bit easier the life of the developer removing this extra line every time that he wants to use dependency injection through the constructor on commands. 😊

Example:

```
class ViewClearCommand extends Command
{
    ...
    /**
     * Create a new config clear command instance.
     *
     * @param  \Illuminate\Filesystem\Filesystem  $files
     * @return void
     */
    public function __construct(Filesystem $files)
    {
        // parent::__construct(); No longer need for this. <-----

        $this->files = $files;
    }
```

The developer may not want this feature. On that case he can set the property `autoConstruct` to `false`, example:

```
class TestCommand extends Command
{
    /**
     * @var bool
     */
    protected $autoConstruct = false;
```