### PR TITLE
[5.5] Add multibyte functions where needed in Support/Str

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -118,7 +118,7 @@ class Str
     public static function endsWith($haystack, $needles)
     {
         foreach ((array) $needles as $needle) {
-            if (substr($haystack, -strlen($needle)) === (string) $needle) {
+            if (mb_substr($haystack, -mb_strlen($needle)) === (string) $needle) {
                 return true;
             }
         }
@@ -328,10 +328,10 @@ class Str
             return $subject;
         }
 
-        $position = strpos($subject, $search);
+        $position = mb_strpos($subject, $search);
 
         if ($position !== false) {
-            return substr_replace($subject, $replace, $position, strlen($search));
+            return mb_substr($subject, 0, $position).$replace.mb_substr($subject, $position+mb_strlen($search));
         }
 
         return $subject;
@@ -347,10 +347,10 @@ class Str
      */
     public static function replaceLast($search, $replace, $subject)
     {
-        $position = strrpos($subject, $search);
+        $position = mb_strrpos($subject, $search);
 
         if ($position !== false) {
-            return substr_replace($subject, $replace, $position, strlen($search));
+            return mb_substr($subject, 0, $position).$replace.mb_substr($subject, $position+mb_strlen($search));
         }
 
         return $subject;
@@ -466,7 +466,7 @@ class Str
     public static function startsWith($haystack, $needles)
     {
         foreach ((array) $needles as $needle) {
-            if ($needle !== '' && substr($haystack, 0, strlen($needle)) === (string) $needle) {
+            if ($needle !== '' && mb_substr($haystack, 0, mb_strlen($needle)) === (string) $needle) {
                 return true;
             }
         }

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -331,7 +331,7 @@ class Str
         $position = mb_strpos($subject, $search);
 
         if ($position !== false) {
-            return mb_substr($subject, 0, $position).$replace.mb_substr($subject, $position+mb_strlen($search));
+            return mb_substr($subject, 0, $position).$replace.mb_substr($subject, $position + mb_strlen($search));
         }
 
         return $subject;
@@ -350,7 +350,7 @@ class Str
         $position = mb_strrpos($subject, $search);
 
         if ($position !== false) {
-            return mb_substr($subject, 0, $position).$replace.mb_substr($subject, $position+mb_strlen($search));
+            return mb_substr($subject, 0, $position).$replace.mb_substr($subject, $position + mb_strlen($search));
         }
 
         return $subject;

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -65,6 +65,11 @@ class SupportStrTest extends TestCase
         $this->assertTrue(Str::startsWith(7.123, '7'));
         $this->assertTrue(Str::startsWith(7.123, '7.12'));
         $this->assertFalse(Str::startsWith(7.123, '7.13'));
+        // Test for multibyte string support
+        $this->assertTrue(Str::startsWith('Jönköping', 'Jö'));
+        $this->assertTrue(Str::startsWith('Malmö', 'Malmö'));
+        $this->assertFalse(Str::startsWith('Jönköping', 'Jonko'));
+        $this->assertFalse(Str::startsWith('Malmö', 'Malmo'));
     }
 
     public function testEndsWith()
@@ -84,6 +89,11 @@ class SupportStrTest extends TestCase
         $this->assertTrue(Str::endsWith(0.27, '7'));
         $this->assertTrue(Str::endsWith(0.27, '0.27'));
         $this->assertFalse(Str::endsWith(0.27, '8'));
+        // Test for multibyte string support
+        $this->assertTrue(Str::endsWith('Jönköping', 'öping'));
+        $this->assertTrue(Str::endsWith('Malmö', 'mö'));
+        $this->assertFalse(Str::endsWith('Jönköping', 'oping'));
+        $this->assertFalse(Str::endsWith('Malmö', 'mo'));
     }
 
     public function testStrBefore()
@@ -209,6 +219,9 @@ class SupportStrTest extends TestCase
         $this->assertEquals('foo foobar', Str::replaceFirst('bar', '', 'foobar foobar'));
         $this->assertEquals('foobar foobar', Str::replaceFirst('xxx', 'yyy', 'foobar foobar'));
         $this->assertEquals('foobar foobar', Str::replaceFirst('', 'yyy', 'foobar foobar'));
+        // Test for multibyte string support
+        $this->assertEquals('Jxxxnköping Malmö', Str::replaceFirst('ö', 'xxx', 'Jönköping Malmö'));
+        $this->assertEquals('Jönköping Malmö', Str::replaceFirst('', 'yyy', 'Jönköping Malmö'));
     }
 
     public function testReplaceLast()
@@ -218,6 +231,9 @@ class SupportStrTest extends TestCase
         $this->assertEquals('foobar foo', Str::replaceLast('bar', '', 'foobar foobar'));
         $this->assertEquals('foobar foobar', Str::replaceLast('xxx', 'yyy', 'foobar foobar'));
         $this->assertEquals('foobar foobar', Str::replaceLast('', 'yyy', 'foobar foobar'));
+        // Test for multibyte string support
+        $this->assertEquals('Malmö Jönkxxxping', Str::replaceLast('ö', 'xxx', 'Malmö Jönköping'));
+        $this->assertEquals('Malmö Jönköping', Str::replaceLast('', 'yyy', 'Malmö Jönköping'));
     }
 
     public function testSnake()


### PR DESCRIPTION
This PR updates string support functions to use multibyte-safe versions of `substr` and `strlen`.

Additional test assertions are also added to validate multibyte string operations.

The four methods revised are:

* `Str::endsWith`
* `Str::replaceFirst`
* `Str::replaceLast`
* `Str::startsWith`

Let me know if there are any questions. Thanks!