### PR TITLE
[4.2] Wrap Throwables thrown from custom handlers in FatalThrowableError.

### DIFF
--- a/src/Illuminate/Exception/Handler.php
+++ b/src/Illuminate/Exception/Handler.php
@@ -259,6 +259,7 @@ class Handler {
 			}
 			catch (\Throwable $e)
 			{
+				$e = new FatalThrowableError($e);
 				$response = $this->formatException($e);
 			}
 

--- a/tests/Exception/HandlerTest.php
+++ b/tests/Exception/HandlerTest.php
@@ -41,4 +41,17 @@ class HandlerTest extends PHPUnit_Framework_TestCase
 		$this->assertSame('', $error->getFile(), 'error handler should use correct default path');
 		$this->assertSame(0, $error->getLine(), 'error handler should use correct default line');
 	}
+
+	public function testHandleErrorThrowableThrownDuringCustomHandler()
+	{
+		// Regirster a handler that handles all errors and causes a new PHP 7
+		// Error to be thrown.
+		$this->handler->error(function () {
+			throw new \Error('No cookies for you!');
+		});
+
+		$this->responsePreparer->shouldReceive('prepareResponse')->andReturn('Handled that!');
+		$result = $this->handler->handleException(new \Error('PHP 7 Failure'));
+		$this->assertSame('Handled that!', $result);
+	}
 }


### PR DESCRIPTION
If a custom error handler throws a PHP 7 `Error`, `Handler::formatException()` causes this to happen:

```
PHP Fatal error:  Uncaught TypeError: Argument 1 passed to Illuminate\Exception\Handler::formatException() must be an instance of Exception, instance of Error given, called in /vagrant/vendor/laravel/framework/src/Illuminate/Exception/Handler.php on line 262 and defined in /vagrant/vendor/laravel/framework/src/Illuminate/Exception/Handler.php:328
Stack trace:
#0 /vagrant/vendor/laravel/framework/src/Illuminate/Exception/Handler.php(262): Illuminate\Exception\Handler->formatException(Object(Error))
#1 /vagrant/vendor/laravel/framework/src/Illuminate/Exception/Handler.php(147): Illuminate\Exception\Handler->callCustomHandlers(Object(Error))
#2 /vagrant/vendor/laravel/framework/src/Illuminate/Exception/Handler.php(171): Illuminate\Exception\Handler->handleException(Object(Error))
#3 [internal function]: Illuminate\Exception\Handler->handleUncaughtException(Object(Error))
#4 {main}
  thrown in /vagrant/vendor/laravel/framework/src/Illuminate/Exception/Handler.php on line 328
```

masking what the actual `Error` that happened was.  Simplest solution seemed to be to wrap the `Throwable` in `FatalThrowableError` before passing it along.  That seemed go along with what @GrahamCampbell mentioned in #15994, though that was a different situation.