### PR TITLE
[5.5] Maintain original order of collection items with equal values when using sortBy()

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1348,7 +1348,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
         // function which we were given. Then, we will sort the returned values and
         // and grab the corresponding values for the sorted keys from this array.
         foreach ($this->items as $key => $value) {
-            $results[$key] = $callback($value, $key);
+            $results[$key] = [$callback($value, $key), $key];
         }
 
         $descending ? arsort($results, $options)

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -817,6 +817,15 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals([1 => 'dayle', 0 => 'taylor'], $data->all());
     }
 
+    public function testSortByMaintainsOriginalOrderOfItemsWithIdenticalValues()
+    {
+        $data = new Collection([['name' => 'taylor'], ['name' => 'dayle'], ['name' => 'dayle']]);
+        $data = $data->sortBy('name');
+
+        $this->assertEquals([['name' => 'dayle'], ['name' => 'dayle'], ['name' => 'taylor']], array_values($data->all()));
+        $this->assertEquals([1, 2, 0], $data->keys()->all());
+    }
+
     public function testReverse()
     {
         $data = new Collection(['zaeed', 'alan']);


### PR DESCRIPTION
This PR makes the collection `sortBy()` method perform a **stable sort**, such that it preserves the original order of collection items which have identical values.

### The problem

`sortBy()` relies on [`asort`](http://php.net/manual/en/function.asort.php), which, as @sisve pointed out during [this discussion](https://github.com/laravel/internals/issues/11#issuecomment-329970458) in laravel/internals, includes this warning:

> If two members compare as equal, their relative order in the sorted array is undefined.

So, for example, if you run `sortBy('letter')` on this collection:

```
collect([
    ['letter' => 'b'],
    ['letter' => 'a'],
    ['letter' => 'a'],
]);
```

...the resulting collection swaps the order of the two `'letter' => 'a'` items:

```
Illuminate\Support\Collection {#54
  #items: array:3 [
    2 => array:1 [
      "letter" => "a"
    ]
    1 => array:1 [
      "letter" => "a"
    ]
    0 => array:1 [
      "letter" => "b"
    ]
  ]
}
```

This behavior varies depending on the nature of the collection—sometimes the original order will be maintained, sometimes it won't. 

### Why it matters

This becomes a particular problem when trying to sort a collection by multiple criteria. One way to do so is to chain `sortBy()` clauses in reverse order, i.e. in order to sort by "`foo` then `bar` then `baz`", you _should_ be able to call:

```
$collection->sortBy('baz')->sortBy('bar')->sortBy('foo')
```

...but, because the original position of duplicate values isn't necessarily maintained between each call to `sortBy()`, this will _sometimes_ result in a correct multi-sort, but not _always_. The results are unpredictable.

### The solution

The simplest solution I've found involves using the amusingly-named [Schwartzian Transform](http://notmysock.org/blog/php/schwartzian-transform.html), which basically involves converting each value in the array you're sorting (`['b', 'a', 'a']`) into an array that includes its index (`[['b', 0], ['a', 1], ['a', 2]]`)—which `asort` will handle correctly—and then stripping out those added keys once the sorting is done. Luckily, the way the `sortBy()` method is written, this is easy—we only need to add the keys during the first loop. 

All in all, an additional 8 characters of code...and a much, much longer description. 😄