### PR TITLE
[5.5] Add shortcut to model option in make:factory command

### DIFF
--- a/src/Illuminate/Database/Console/Factories/FactoryMakeCommand.php
+++ b/src/Illuminate/Database/Console/Factories/FactoryMakeCommand.php
@@ -78,7 +78,7 @@ class FactoryMakeCommand extends GeneratorCommand
     protected function getOptions()
     {
         return [
-            ['model', null, InputOption::VALUE_OPTIONAL, 'The name of the model'],
+            ['model', 'm', InputOption::VALUE_OPTIONAL, 'The name of the model'],
         ];
     }
 }


### PR DESCRIPTION
For example : 
```
php artisan make:factory ArticleFactory -m Article
```