### PR TITLE
[5.5] Use php built-in functions to cast Eloquent models' attributes

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -468,16 +468,16 @@ trait HasAttributes
         switch ($this->getCastType($key)) {
             case 'int':
             case 'integer':
-                return (int) $value;
+                return intval($value);
             case 'real':
             case 'float':
             case 'double':
-                return (float) $value;
+                return floatval($value);
             case 'string':
-                return (string) $value;
+                return strval($value);
             case 'bool':
             case 'boolean':
-                return (bool) $value;
+                return boolval($value);
             case 'object':
                 return $this->fromJson($value, true);
             case 'array':


### PR DESCRIPTION
This PR uses PHP built-in functions ([`intval`](http://php.net/manual/pt_BR/function.intval.php), [`boolval`](http://php.net/manual/pt_BR/function.boolval.php), [`floatval`](http://php.net/manual/pt_BR/function.floatval.php) and [`strval`](http://php.net/manual/pt_BR/function.strval.php)) instead of [native Type Casting](http://php.net/manual/en/language.types.type-juggling.php#language.types.typecasting) when casting attributes in Eloquent models.

I used [`testModelAttributesAreCastedWhenPresentInCastsArray`](https://github.com/laravel/framework/blob/5.5/tests/Database/DatabaseEloquentModelTest.php#L1450) to check this PR.