### PR TITLE
[5.5] Adding tableFromModel to Command.php

### DIFF
--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -403,12 +403,16 @@ class Command extends SymfonyCommand
      */
     public function tableFromModel($model, $attributes = null, $style = 'default')
     {
-        if(!$attributes){
-            $attributes = collect($model->first()->getAttributes())->keys()->toArray();
+        if(!$model instanceof Model){
+            if($attributes){
+                $model = $model::all($attributes);
+            } else {
+                $model = $model::all();
+            }
         }
 
-        if(!$model instanceof Model){
-            $model = $model::all($attributes);
+        if(!$attributes){
+            $attributes = collect($model->first()->getAttributes())->keys()->toArray();
         }
 
         $this->table($attributes, $model, $style);

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -404,11 +404,7 @@ class Command extends SymfonyCommand
     public function tableFromModel($model, $attributes = null, $style = 'default')
     {
         if(!$model instanceof Model){
-            if($attributes){
-                $model = $model::all($attributes);
-            } else {
-                $model = $model::all();
-            }
+            $model = $model::all($attributes ?? ['*']);
         }
 
         if(!$attributes){

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -398,9 +398,10 @@ class Command extends SymfonyCommand
      *
      * @param  \Illuminate\Database\Eloquent\Model|string $model
      * @param  array|null $attributes
+     * @param  string $style
      * @return void
      */
-    public function tableFromModel($model, $attributes = null)
+    public function tableFromModel($model, $attributes = null, $style = 'default')
     {
         if(!$attributes){
             $attributes = collect($model->first()->getAttributes())->keys()->toArray();
@@ -410,7 +411,7 @@ class Command extends SymfonyCommand
             $model = $model::all($attributes);
         }
 
-        $this->table($attributes, $model);
+        $this->table($attributes, $model, $style);
     }
 
     /**

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Console;
 
 use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Database\Eloquent\Model;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\NullOutput;
@@ -390,6 +391,32 @@ class Command extends SymfonyCommand
         }
 
         $table->setHeaders((array) $headers)->setRows($rows)->setStyle($style)->render();
+    }
+
+    /**
+     * Format input to textual table from model.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model|string $model
+     * @param  array|null $fields
+     * @return void
+     */
+    public function tableFromModel($model, $fields = null)
+    {
+        if(!$model instanceof Model){
+            $model = $model::all();
+        }
+
+        if(!$fields){
+            $fields = collect($model->first()->getAttributes())->keys()->toArray();
+        }
+
+        $this->table($fields, $model->map(function($model) use($fields){
+            $return = [];
+            foreach($fields as $field){
+                $return[] = $model->$field;
+            }
+            return $return;
+        }));
     }
 
     /**

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -397,22 +397,22 @@ class Command extends SymfonyCommand
      * Format input to textual table from model.
      *
      * @param  \Illuminate\Database\Eloquent\Model|string $model
-     * @param  array|null $fields
+     * @param  array|null $attributes
      * @return void
      */
-    public function tableFromModel($model, $fields = null)
+    public function tableFromModel($model, $attributes = null)
     {
         if(!$model instanceof Model){
             $model = $model::all();
         }
 
-        if(!$fields){
-            $fields = collect($model->first()->getAttributes())->keys()->toArray();
+        if(!$attributes){
+            $attributes = collect($model->first()->getAttributes())->keys()->toArray();
         }
 
-        $this->table($fields, $model->map(function($model) use($fields){
+        $this->table($attributes, $model->map(function($model) use($attributes){
             $return = [];
-            foreach($fields as $field){
+            foreach($attributes as $field){
                 $return[] = $model->$field;
             }
             return $return;

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -402,21 +402,15 @@ class Command extends SymfonyCommand
      */
     public function tableFromModel($model, $attributes = null)
     {
-        if(!$model instanceof Model){
-            $model = $model::all();
-        }
-
         if(!$attributes){
             $attributes = collect($model->first()->getAttributes())->keys()->toArray();
         }
 
-        $this->table($attributes, $model->map(function($model) use($attributes){
-            $return = [];
-            foreach($attributes as $field){
-                $return[] = $model->$field;
-            }
-            return $return;
-        }));
+        if(!$model instanceof Model){
+            $model = $model::all($attributes);
+        }
+
+        $this->table($attributes, $model);
     }
 
     /**


### PR DESCRIPTION
Sometimes, we want to review our model to see the data that we need for our next input. 

For example, before I create a new lecture, I want to see all of my `Tutorial` data first to see which tutorial that I have to assign the new lecture into.

The code is simple `$this->tableFromModel(Tutorial::class, ['id', 'title'])`.

The output:

![image](https://user-images.githubusercontent.com/8213031/30534410-51b51d32-9c88-11e7-8d8b-4b26816339c8.png)
