### PR TITLE
[5.5] Added ability to pass an ID to exists() in QueryBuilder

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -68,7 +68,7 @@ class Builder
      */
     protected $passthru = [
         'insert', 'insertGetId', 'getBindings', 'toSql',
-        'exists', 'count', 'min', 'max', 'avg', 'sum', 'getConnection',
+        'count', 'min', 'max', 'avg', 'sum', 'getConnection',
     ];
 
     /**
@@ -345,6 +345,21 @@ class Builder
         }
 
         return $this->newModelInstance();
+    }
+
+    /**
+     * Determine if a records exists by its primary key.
+     *
+     * @param  mixed  $id
+     * @return bool
+     */
+    public function exists($id = null)
+    {
+        if(! is_null($id)) {
+            $this->whereKey($id);
+        }
+
+        return $this->query->exists();
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -348,13 +348,15 @@ class Builder
     }
 
     /**
-     * Determine if a records exists by its primary key.
+     * Determine if a record exists by its primary key.
      *
      * @param  mixed  $id
      * @return bool
      */
     public function exists($id = null)
     {
+        // if an array of ids is passed, this returns true
+        // when any one of the ids exist.
         if (! is_null($id)) {
             $this->whereKey($id);
         }

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -355,7 +355,7 @@ class Builder
      */
     public function exists($id = null)
     {
-        if(! is_null($id)) {
+        if (! is_null($id)) {
             $this->whereKey($id);
         }
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1922,12 +1922,20 @@ class Builder
     }
 
     /**
-     * Determine if any rows exist for the current query.
+     * Determine if any rows exist for the current query and/or by id.
      *
+     * @param  int  $id
      * @return bool
      */
-    public function exists()
+    public function exists($id = null)
     {
+        // If an ID is passed to the method, we will set the where clause to check the
+        // ID to let developers simply and quickly check if a single row exists in
+        // the database without manually specifying the "where" clauses on the query.
+        if (! is_null($id)) {
+            $this->where('id', '=', $id);
+        }
+
         $results = $this->connection->select(
             $this->grammar->compileExists($this), $this->getBindings(), ! $this->useWritePdo
         );


### PR DESCRIPTION
This small change adds the same functionality as find and delete QueryBuilder methods to exists.

Before:

`ModelX::where('id', '=', 1)->exists()`

After:

`ModelX::exists(1)`