### PR TITLE
[5.5] Add ability to set a fallback route

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -106,6 +106,13 @@ class Route
     protected $container;
 
     /**
+     * Determine if the route is a fallback one.
+     *
+     * @var bool
+     */
+    public $isFallback = false;
+
+    /**
      * The validators used by the routes.
      *
      * @var array
@@ -483,6 +490,19 @@ class Route
 
         return $this;
     }
+
+    /**
+     * Mark the route as a fallback route.
+     *
+     * @return $this
+     */
+    public function fallback()
+    {
+        $this->isFallback = true;
+
+        return $this;
+    }
+
 
     /**
      * Get the HTTP verbs the route responds to.

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -503,7 +503,6 @@ class Route
         return $this;
     }
 
-
     /**
      * Get the HTTP verbs the route responds to.
      *

--- a/src/Illuminate/Routing/RouteCollection.php
+++ b/src/Illuminate/Routing/RouteCollection.php
@@ -189,7 +189,9 @@ class RouteCollection implements Countable, IteratorAggregate
      */
     protected function matchAgainstRoutes(array $routes, $request, $includingMethod = true)
     {
-        return Arr::first($routes, function ($value) use ($request, $includingMethod) {
+        return collect($routes)->sort(function ($route) {
+            return $route->isFallback;
+        })->first(function ($value) use ($request, $includingMethod) {
             return $value->matches($request, $includingMethod);
         });
     }

--- a/src/Illuminate/Routing/RouteCollection.php
+++ b/src/Illuminate/Routing/RouteCollection.php
@@ -189,9 +189,7 @@ class RouteCollection implements Countable, IteratorAggregate
      */
     protected function matchAgainstRoutes(array $routes, $request, $includingMethod = true)
     {
-        return collect($routes)->sort(function ($route) {
-            return $route->isFallback;
-        })->first(function ($value) use ($request, $includingMethod) {
+        return collect($routes)->sortBy('isFallback')->first(function ($value) use ($request, $includingMethod) {
             return $value->matches($request, $includingMethod);
         });
     }

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -213,6 +213,19 @@ class Router implements RegistrarContract, BindingRegistrar
     }
 
     /**
+     * Register a new Fallback route with the router.
+     *
+     * @param  \Closure|array|string|null  $action
+     * @return \Illuminate\Routing\Route
+     */
+    public function fallback($action)
+    {
+        $placeholder = 'fallbackPlaceholder';
+
+        return $this->addRoute('GET', "{{$placeholder}}", $action)->where($placeholder, '.*')->fallback();
+    }
+
+    /**
      * Create a redirect from one URI to another.
      *
      * @param string  $uri

--- a/tests/Integration/Routing/FallbackRouteTest.php
+++ b/tests/Integration/Routing/FallbackRouteTest.php
@@ -39,6 +39,7 @@ class FallbackRouteTest extends TestCase
 
         $this->assertContains('one', $this->get('/prefix/one')->getContent());
         $this->assertContains('fallback', $this->get('/prefix/non-existing')->getContent());
+        $this->assertContains('fallback', $this->get('/prefix/non-existing/with/multiple/segments')->getContent());
         $this->assertContains('Page Not Found', $this->get('/non-existing')->getContent());
     }
 

--- a/tests/Integration/Routing/FallbackRouteTest.php
+++ b/tests/Integration/Routing/FallbackRouteTest.php
@@ -17,7 +17,7 @@ class FallbackRouteTest extends TestCase
             return response('fallback', 404);
         });
 
-        Route::get('one', function(){
+        Route::get('one', function () {
             return 'one';
         });
 
@@ -28,12 +28,12 @@ class FallbackRouteTest extends TestCase
 
     public function test_fallback_with_prefix()
     {
-        Route::group(['prefix' => 'prefix'], function(){
+        Route::group(['prefix' => 'prefix'], function () {
             Route::fallback(function () {
                 return response('fallback', 404);
             });
 
-            Route::get('one', function(){
+            Route::get('one', function () {
                 return 'one';
             });
         });
@@ -49,11 +49,11 @@ class FallbackRouteTest extends TestCase
             return response('fallback', 404);
         });
 
-        Route::get('{any}', function(){
+        Route::get('{any}', function () {
             return 'wildcard';
         })->where('any', '.*');
 
-        Route::get('one', function(){
+        Route::get('one', function () {
             return 'one';
         });
 

--- a/tests/Integration/Routing/FallbackRouteTest.php
+++ b/tests/Integration/Routing/FallbackRouteTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Routing;
+
+use Orchestra\Testbench\TestCase;
+use Illuminate\Support\Facades\View;
+use Illuminate\Support\Facades\Route;
+
+/**
+ * @group integration
+ */
+class FallbackRouteTest extends TestCase
+{
+    public function test_basic_fallback()
+    {
+        Route::fallback(function () {
+            return response('fallback', 404);
+        });
+
+        Route::get('one', function(){
+            return 'one';
+        });
+
+        $this->assertContains('one', $this->get('/one')->getContent());
+        $this->assertContains('fallback', $this->get('/non-existing')->getContent());
+        $this->assertEquals(404, $this->get('/non-existing')->getStatusCode());
+    }
+
+    public function test_fallback_with_prefix()
+    {
+        Route::group(['prefix' => 'prefix'], function(){
+            Route::fallback(function () {
+                return response('fallback', 404);
+            });
+
+            Route::get('one', function(){
+                return 'one';
+            });
+        });
+
+        $this->assertContains('one', $this->get('/prefix/one')->getContent());
+        $this->assertContains('fallback', $this->get('/prefix/non-existing')->getContent());
+        $this->assertContains('Page Not Found', $this->get('/non-existing')->getContent());
+    }
+
+    public function test_fallback_with_wildcards()
+    {
+        Route::fallback(function () {
+            return response('fallback', 404);
+        });
+
+        Route::get('{any}', function(){
+            return 'wildcard';
+        })->where('any', '.*');
+
+        Route::get('one', function(){
+            return 'one';
+        });
+
+        $this->assertContains('one', $this->get('/one')->getContent());
+        $this->assertContains('wildcard', $this->get('/non-existing')->getContent());
+        $this->assertEquals(200, $this->get('/non-existing')->getStatusCode());
+    }
+}

--- a/tests/Integration/Routing/FallbackRouteTest.php
+++ b/tests/Integration/Routing/FallbackRouteTest.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Tests\Integration\Routing;
 
 use Orchestra\Testbench\TestCase;
-use Illuminate\Support\Facades\View;
 use Illuminate\Support\Facades\Route;
 
 /**


### PR DESCRIPTION
This was requested in:
- https://github.com/laravel/internals/issues/653
- https://github.com/laravel/internals/issues/780

The idea is to have a catch-all Route that you can use as a fallback if  the request didn't match any of the existing routes, so for example:

- `dashboard/non-existing` will throw a 404 and render the 404 view if no fallback route is used.
- If we use `Route::fallback(function(){  return response()->view('dashboard.404', [], 404); })` the dashboard specific 404 page will be displayed.

In the argument you pass to fallback() you can put a closure or a controller call `DashboardController@notFound`, this will allow you to render a Not Found page with the request passing through all middleware so you have sessions, cookies, etc... available.

So for example in Forge, if a logged in user hit a wrong URL we can display a 404 view but he still has access to the header where he can browse to any of the existing screens.