### PR TITLE
[5.5] Respect casts declaration on update for custom pivot models

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -184,6 +184,10 @@ trait InteractsWithPivotTable
      */
     public function updateExistingPivot($id, array $attributes, $touch = true)
     {
+        $attributes = $this->using
+                ? $this->newPivot()->forceFill($attributes)->getAttributes()
+                : $attributes;
+
         if (in_array($this->updatedAt(), $this->pivotColumns)) {
             $attributes = $this->addTimestampsToAttachment($attributes, true);
         }

--- a/tests/Integration/Database/EloquentCustomPivotCastTest.php
+++ b/tests/Integration/Database/EloquentCustomPivotCastTest.php
@@ -76,6 +76,24 @@ class EloquentCustomPivotCastTest extends TestCase
 
         $this->assertEquals(['foo' => 'bar'], $project->collaborators[0]->pivot->permissions);
     }
+
+    public function test_casts_are_respected_on_sync_update()
+    {
+        $user = CustomPivotCastTestUser::forceCreate([
+            'email' => 'taylor@laravel.com',
+        ]);
+
+        $project = CustomPivotCastTestProject::forceCreate([
+            'name' => 'Test Project',
+        ]);
+
+        $project->collaborators()->attach($user, ['permissions' => ['foo' => 'bar']]);
+
+        $project->collaborators()->sync([$user->id => ['permissions' => ['foo' => 'baz']]]);
+        $project = $project->fresh();
+
+        $this->assertEquals(['foo' => 'baz'], $project->collaborators[0]->pivot->permissions);
+    }
 }
 
 class CustomPivotCastTestUser extends Model


### PR DESCRIPTION
The changes introduced in https://github.com/laravel/framework/pull/19335 work ok when attaching new records but the same changes are also required when updating existing records as casts are not correctly respected on updates.