### PR TITLE
[5.5] Simplify "app" function.

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -107,9 +107,7 @@ if (! function_exists('app')) {
             return Container::getInstance();
         }
 
-        return empty($parameters)
-            ? Container::getInstance()->make($abstract)
-            : Container::getInstance()->makeWith($abstract, $parameters);
+        return Container::getInstance()->make($abstract, $parameters);
     }
 }
 


### PR DESCRIPTION
While the `$parameters` in `Container::make` had back, we can use it without condition.