### PR TITLE
Make sure dump is printed last

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -507,6 +507,7 @@ if (! function_exists('dd')) {
      */
     function dd()
     {
+        while (@ob_end_flush());
         array_map(function ($x) {
             (new Dumper)->dump($x);
         }, func_get_args());


### PR DESCRIPTION
If (for some reason) ob_buffers are used dd might be not be last data to be printed out. Flusihing buffer prior dump makes sure dd will placed last.

Syntax is based on php manuals example, even tough @-sings are ….

http://php.net/manual/en/function.ob-end-flush.php