### PR TITLE
[5.5] Add missing import statement for Str

### DIFF
--- a/src/Illuminate/Foundation/Validation/ValidatesRequests.php
+++ b/src/Illuminate/Foundation/Validation/ValidatesRequests.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Foundation\Validation;
 
+use Illuminate\Support\Str;
 use Illuminate\Http\Request;
 use Illuminate\Contracts\Validation\Factory;
 use Illuminate\Validation\ValidationException;


### PR DESCRIPTION
Add missing import statement for the Str facade `use Illuminate\Support\Str;`