### PR TITLE
[5.5] Fix invalid phpdoc on the Queue contract

### DIFF
--- a/src/Illuminate/Contracts/Queue/Queue.php
+++ b/src/Illuminate/Contracts/Queue/Queue.php
@@ -15,7 +15,7 @@ interface Queue
     /**
      * Push a new job onto the queue.
      *
-     * @param  string  $job
+     * @param  string|object  $job
      * @param  mixed   $data
      * @param  string  $queue
      * @return mixed
@@ -26,7 +26,7 @@ interface Queue
      * Push a new job onto the queue.
      *
      * @param  string  $queue
-     * @param  string  $job
+     * @param  string|object  $job
      * @param  mixed   $data
      * @return mixed
      */
@@ -46,7 +46,7 @@ interface Queue
      * Push a new job onto the queue after a delay.
      *
      * @param  \DateTimeInterface|\DateInterval|int  $delay
-     * @param  string  $job
+     * @param  string|object  $job
      * @param  mixed   $data
      * @param  string  $queue
      * @return mixed
@@ -58,7 +58,7 @@ interface Queue
      *
      * @param  string  $queue
      * @param  \DateTimeInterface|\DateInterval|int  $delay
-     * @param  string  $job
+     * @param  string|object  $job
      * @param  mixed   $data
      * @return mixed
      */


### PR DESCRIPTION
Deep down inside the queue library there's this method that handles both objects and strings:

```
/**
 * Create a payload array from the given job and data.
 *
 * @param  string  $job
 * @param  mixed   $data
 * @param  string  $queue
 * @return array
 */
protected function createPayloadArray($job, $data = '', $queue = null)
{
    return is_object($job)
                ? $this->createObjectPayload($job)
                : $this->createStringPayload($job, $data);
}
```

I'm not updating that file now because I'm using the GitHub editor. If necessary I can clone my fork and do it.

Fixes Phan errors like this:

```
ContentfulSyncService.php:54 PhanTypeMismatchArgument Argument 1 (job) is SomeClass but \Illuminate\Contracts\Queue\Queue::push() takes string defined at vendor/illuminate/contracts/Queue/Queue.php:23
```