### PR TITLE
[5.5] Add support for mergeFlatMap

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -945,6 +945,21 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     {
         return new static(array_merge($this->items, $this->getArrayableItems($items)));
     }
+    
+    /**
+     * Merge the collection with the result of a flat map.
+     
+     * @param callable $callback
+     * @return static
+     */
+    public function mergeFlatMap($callback)
+    {
+        return $this->merge(
+            $this->flatMap(function ($item) use ($callback) {
+                return $callback($item);  
+            })
+        );
+    }
 
     /**
      * Create a collection by using this collection for keys and another for its values.

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -948,7 +948,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     
     /**
      * Merge the collection with the result of a flat map.
-     
+     *
      * @param callable $callback
      * @return static
      */

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -518,6 +518,25 @@ class SupportCollectionTest extends TestCase
         $c = new Collection(['name' => 'Hello']);
         $this->assertEquals(['name' => 'World', 'id' => 1], $c->merge(new Collection(['name' => 'World', 'id' => 1]))->all());
     }
+    
+    public function testMergeFlatMap()
+    {
+        $c = new Collection([1,2,3]);
+        
+        $result = $c->mergeFlatMap(function($item) {
+            if ($item == 1) {
+                return [4,5];
+            } else if ($item == 2) {
+                return [6,7];
+            } else if ($item == 3) {
+                return [8];
+            }
+
+            return [];
+        });
+
+        $this->assertEquals([1,2,3,4,5,6,7,8], $result->all());
+    }
 
     public function testUnionNull()
     {


### PR DESCRIPTION
This will allow you to get items / results and merge them in, while retaining the order.

This is useful if you need to do an API call, or similar, based on each item, and retain the order.

For example, generating a file to be imported into a different system, where the order matters, but you need to get all children for a parent.

You'd have all parents, and foreach parent, you can get all the children (however this has to be done), and combine them together. 

Then you can act on it as an ordinary Collection.