### PR TITLE
[5.5] revert PR #21214

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1348,7 +1348,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
         // function which we were given. Then, we will sort the returned values and
         // and grab the corresponding values for the sorted keys from this array.
         foreach ($this->items as $key => $value) {
-            $results[$key] = [$callback($value, $key), $key];
+            $results[$key] = $callback($value, $key);
         }
 
         $descending ? arsort($results, $options)

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -798,6 +798,11 @@ class SupportCollectionTest extends TestCase
         $data = $data->sortBy('name');
 
         $this->assertEquals([['name' => 'dayle'], ['name' => 'taylor']], array_values($data->all()));
+
+        $data = new Collection([['name' => 'taylor'], ['name' => 'dayle']]);
+        $data = $data->sortBy('name', SORT_STRING);
+
+        $this->assertEquals([['name' => 'dayle'], ['name' => 'taylor']], array_values($data->all()));
     }
 
     public function testSortByAlwaysReturnsAssoc()
@@ -815,15 +820,6 @@ class SupportCollectionTest extends TestCase
         });
 
         $this->assertEquals([1 => 'dayle', 0 => 'taylor'], $data->all());
-    }
-
-    public function testSortByMaintainsOriginalOrderOfItemsWithIdenticalValues()
-    {
-        $data = new Collection([['name' => 'taylor'], ['name' => 'dayle'], ['name' => 'dayle']]);
-        $data = $data->sortBy('name');
-
-        $this->assertEquals([['name' => 'dayle'], ['name' => 'dayle'], ['name' => 'taylor']], array_values($data->all()));
-        $this->assertEquals([1, 2, 0], $data->keys()->all());
     }
 
     public function testReverse()


### PR DESCRIPTION
As reported in https://github.com/laravel/framework/issues/21253, this PR broke when any of the following options is used:

- SORT_STRING
- SORT_LOCALE_STRING
- SORT_NATURAL