### PR TITLE
[5.5] Support multiple (api) versions for routing

### DIFF
--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -45,7 +45,7 @@ class RouteListCommand extends Command
      *
      * @var array
      */
-    protected $headers = ['Version','Domain', 'Method', 'URI', 'Name', 'Action', 'Middleware'];
+    protected $headers = ['Version', 'Domain', 'Method', 'URI', 'Name', 'Action', 'Middleware'];
 
     /**
      * Create a new route command instance.

--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -45,7 +45,7 @@ class RouteListCommand extends Command
      *
      * @var array
      */
-    protected $headers = ['Domain', 'Method', 'URI', 'Name', 'Action', 'Middleware'];
+    protected $headers = ['Version','Domain', 'Method', 'URI', 'Name', 'Action', 'Middleware'];
 
     /**
      * Create a new route command instance.
@@ -106,6 +106,7 @@ class RouteListCommand extends Command
     protected function getRouteInformation(Route $route)
     {
         return $this->filterRoute([
+            'version'=> implode('|', $route->version()),
             'host'   => $route->domain(),
             'method' => implode('|', $route->methods()),
             'uri'    => $route->uri(),
@@ -163,6 +164,7 @@ class RouteListCommand extends Command
     {
         if (($this->option('name') && ! Str::contains($route['name'], $this->option('name'))) ||
              $this->option('path') && ! Str::contains($route['uri'], $this->option('path')) ||
+             $this->option('ver') && ! Str::contains($route['version'], $this->option('ver')) ||
              $this->option('method') && ! Str::contains($route['method'], $this->option('method'))) {
             return;
         }
@@ -178,6 +180,8 @@ class RouteListCommand extends Command
     protected function getOptions()
     {
         return [
+            ['ver', null, InputOption::VALUE_OPTIONAL, 'Filter the routes by version.'],
+
             ['method', null, InputOption::VALUE_OPTIONAL, 'Filter the routes by method.'],
 
             ['name', null, InputOption::VALUE_OPTIONAL, 'Filter the routes by name.'],

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -287,6 +287,16 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
     }
 
     /**
+     * Get the client Accept-Version header.
+     *
+     * @return array|string
+     */
+    public function version()
+    {
+        return $this->headers->get('Accept-Version');
+    }
+
+    /**
      * Merge new input into the current request's input array.
      *
      * @param  array  $input

--- a/src/Illuminate/Routing/Matching/VersionValidator.php
+++ b/src/Illuminate/Routing/Matching/VersionValidator.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Illuminate\Routing\Matching;
+
+use Illuminate\Http\Request;
+use Illuminate\Routing\Route;
+
+class VersionValidator implements ValidatorInterface
+{
+    /**
+     * Validate a given rule against a route and request.
+     *
+     * @param  \Illuminate\Routing\Route $route
+     * @param  \Illuminate\Http\Request $request
+     * @return bool
+     */
+
+    public function matches(Route $route, Request $request)
+    {
+        if (empty($route->getVersion()) && ! $request->version()) {
+            return true;
+        }
+
+        return in_array($request->version(), $route->getVersion());
+    }
+}

--- a/src/Illuminate/Routing/Matching/VersionValidator.php
+++ b/src/Illuminate/Routing/Matching/VersionValidator.php
@@ -14,7 +14,6 @@ class VersionValidator implements ValidatorInterface
      * @param  \Illuminate\Http\Request $request
      * @return bool
      */
-
     public function matches(Route $route, Request $request)
     {
         if (empty($route->getVersion()) && ! $request->version()) {

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -14,6 +14,7 @@ use Illuminate\Routing\Matching\UriValidator;
 use Illuminate\Routing\Matching\HostValidator;
 use Illuminate\Routing\Matching\MethodValidator;
 use Illuminate\Routing\Matching\SchemeValidator;
+use Illuminate\Routing\Matching\VersionValidator;
 use Illuminate\Http\Exceptions\HttpResponseException;
 use Illuminate\Routing\Contracts\ControllerDispatcher as ControllerDispatcherContract;
 
@@ -597,6 +598,33 @@ class Route
     }
 
     /**
+     * Get or set the version for the route.
+     *
+     * @param  string|null $version
+     * @return $this|array
+     */
+    public function version($version = null)
+    {
+        if (is_null($version)) {
+            return $this->getVersion();
+        }
+
+        $this->action['version'] = $version;
+
+        return $this;
+    }
+
+    /**
+     * Get the version defined for the route.
+     *
+     * @return array
+     */
+    public function getVersion()
+    {
+        return isset($this->action['version']) ? Arr::wrap($this->action['version']) : [];
+    }
+
+    /**
      * Get the URI associated with the route.
      *
      * @return string
@@ -828,6 +856,7 @@ class Route
         return static::$validators = [
             new UriValidator, new MethodValidator,
             new SchemeValidator, new HostValidator,
+            new VersionValidator,
         ];
     }
 

--- a/src/Illuminate/Routing/RouteCollection.php
+++ b/src/Illuminate/Routing/RouteCollection.php
@@ -64,7 +64,7 @@ class RouteCollection implements Countable, IteratorAggregate
      */
     protected function addToCollections($route)
     {
-        $domainAndUri = $route->getDomain().$route->uri().implode(",", $route->version());
+        $domainAndUri = $route->getDomain().$route->uri().implode(',', $route->version());
 
         foreach ($route->methods() as $method) {
             $this->routes[$method][$domainAndUri] = $route;

--- a/src/Illuminate/Routing/RouteCollection.php
+++ b/src/Illuminate/Routing/RouteCollection.php
@@ -64,7 +64,7 @@ class RouteCollection implements Countable, IteratorAggregate
      */
     protected function addToCollections($route)
     {
-        $domainAndUri = $route->getDomain().$route->uri();
+        $domainAndUri = $route->getDomain().$route->uri().implode(",",$route->version());
 
         foreach ($route->methods() as $method) {
             $this->routes[$method][$domainAndUri] = $route;

--- a/src/Illuminate/Routing/RouteCollection.php
+++ b/src/Illuminate/Routing/RouteCollection.php
@@ -64,7 +64,7 @@ class RouteCollection implements Countable, IteratorAggregate
      */
     protected function addToCollections($route)
     {
-        $domainAndUri = $route->getDomain().$route->uri().implode(",",$route->version());
+        $domainAndUri = $route->getDomain().$route->uri().implode(",", $route->version());
 
         foreach ($route->methods() as $method) {
             $this->routes[$method][$domainAndUri] = $route;

--- a/src/Illuminate/Routing/RouteRegistrar.php
+++ b/src/Illuminate/Routing/RouteRegistrar.php
@@ -38,7 +38,7 @@ class RouteRegistrar
      * @var array
      */
     protected $allowedAttributes = [
-        'as', 'domain', 'middleware', 'name', 'namespace', 'prefix',
+        'as', 'domain', 'middleware', 'name', 'namespace', 'prefix', 'version',
     ];
 
     /**

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -1018,6 +1018,16 @@ class Router implements RegistrarContract, BindingRegistrar
     }
 
     /**
+     * Get the current route version.
+     *
+     * @return array|null
+     */
+    public function currentRouteVersion()
+    {
+        return $this->current() ? $this->current()->getVersion() : null;
+    }
+
+    /**
      * Alias for the "currentRouteNamed" method.
      *
      * @param  dynamic  $patterns

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -217,6 +217,14 @@ class HttpRequestTest extends TestCase
         $this->assertEquals('Laravel', $request->userAgent());
     }
 
+    public function testVersionMethod()
+    {
+        $request = Request::create('/', 'GET');
+        $this->assertNull($request->version());
+        $request->headers->set('Accept-Version', '2');
+        $this->assertEquals('2', $request->version());
+    }
+
     public function testHasMethod()
     {
         $request = Request::create('/', 'GET', ['name' => 'Taylor', 'age' => '', 'city' => null]);

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -559,6 +559,18 @@ class RoutingRouteTest extends TestCase
         $this->assertEquals('hello', $router->dispatch(Request::create('http://api.foo.bar/foo/bar', 'GET'))->getContent());
     }
 
+    public function testMatchesVersionRequests()
+    {
+        $request = Request::create('foo/bar', 'POST');
+        $route = new Route('POST', 'foo/bar', ['version' => ['v1', 'v2'], function () {
+        }]);
+        $this->assertFalse($route->matches($request));
+        $request->headers->set('Accept-Version', 'v2');
+        $this->assertTrue($route->matches($request));
+        $request->headers->set('Accept-Version', 'v3');
+        $this->assertFalse($route->matches($request));
+    }
+
     public function testMatchesMethodAgainstRequests()
     {
         /*


### PR DESCRIPTION
Support multiple (api) versions for routing

- Added `Route::version()`, `Route::getVersion()`, `Router::currentRouteVersion()`, `Request::version()`
- Added `VersionValidator` Routing Matching

Define an custom http header to request a specific version. The header name is `Accept-Version`, `v1` is version. Example: 

```
Accept-Version: v1
```

You may use the `version` method before defining the group. Example: 

```php

Route::version('v1')->group(function () {
    Route::post('/', function () {
        // 
    });
});

Route::group([
    'version' => 'v1'
], function () {
	//
});

```

If you would like a group to respond to multiple versions you can simply pass an array of versions. Example: 

```php

Route::version(['v1', 'v2'])->group(function () {
    Route::post('/', function () {
        // 
    });
});
```
