### PR TITLE
[5.4] Fix invalid phpdoc on the Queue contract

### DIFF
--- a/src/Illuminate/Contracts/Queue/Queue.php
+++ b/src/Illuminate/Contracts/Queue/Queue.php
@@ -15,7 +15,7 @@ interface Queue
     /**
      * Push a new job onto the queue.
      *
-     * @param  string  $job
+     * @param  string|object  $job
      * @param  mixed   $data
      * @param  string  $queue
      * @return mixed
@@ -26,7 +26,7 @@ interface Queue
      * Push a new job onto the queue.
      *
      * @param  string  $queue
-     * @param  string  $job
+     * @param  string|object  $job
      * @param  mixed   $data
      * @return mixed
      */
@@ -46,7 +46,7 @@ interface Queue
      * Push a new job onto the queue after a delay.
      *
      * @param  \DateTime|int  $delay
-     * @param  string  $job
+     * @param  string|object  $job
      * @param  mixed   $data
      * @param  string  $queue
      * @return mixed
@@ -58,7 +58,7 @@ interface Queue
      *
      * @param  string  $queue
      * @param  \DateTime|int  $delay
-     * @param  string  $job
+     * @param  string|object  $job
      * @param  mixed   $data
      * @return mixed
      */


### PR DESCRIPTION
Backport of https://github.com/laravel/framework/pull/21248