### PR TITLE
[5.5] Maintain original order of collection items with equal values when using sortBy()

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1348,16 +1348,17 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
         // function which we were given. Then, we will sort the returned values and
         // and grab the corresponding values for the sorted keys from this array.
         foreach ($this->items as $key => $value) {
-            $results[$key] = $callback($value, $key);
+            $values[] = $callback($value, $key);
         }
 
-        $descending ? arsort($results, $options)
-                    : asort($results, $options);
+        $keys = array_keys($this->items);
+        $order = $descending ? SORT_DESC : SORT_ASC;
+        array_multisort($values, $order, $options, $keys, $order);
 
         // Once we have sorted all of the keys in the array, we will loop through them
         // and grab the corresponding model so we can set the underlying items list
         // to the sorted version. Then we'll just return the collection instance.
-        foreach (array_keys($results) as $key) {
+        foreach ($keys as $key) {
             $results[$key] = $this->items[$key];
         }
 

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1340,6 +1340,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      */
     public function sortBy($callback, $options = SORT_REGULAR, $descending = false)
     {
+        $values = [];
         $results = [];
 
         $callback = $this->valueRetriever($callback);

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -795,9 +795,48 @@ class SupportCollectionTest extends TestCase
     public function testSortByString()
     {
         $data = new Collection([['name' => 'taylor'], ['name' => 'dayle']]);
-        $data = $data->sortBy('name');
+        $data = $data->sortBy('name', SORT_STRING);
 
         $this->assertEquals([['name' => 'dayle'], ['name' => 'taylor']], array_values($data->all()));
+    }
+
+    public function testSortByMaintainsOriginalOrderOfItemsWithIdenticalValues()
+    {
+        $data = new Collection([['name' => 'taylor'], ['name' => 'dayle'], ['name' => 'dayle']]);
+
+        $data = $data->sortBy('name');
+
+        $this->assertEquals([['name' => 'dayle'], ['name' => 'dayle'], ['name' => 'taylor']], array_values($data->all()));
+        $this->assertEquals([1, 2, 0], $data->keys()->all());
+    }
+
+    public function testSortByStringMaintainsOriginalOrderOfItemsWithIdenticalValues()
+    {
+        $data = new Collection([['name' => 'taylor'], ['name' => 'dayle'], ['name' => 'dayle']]);
+
+        $data = $data->sortBy('name', SORT_STRING);
+
+        $this->assertEquals([['name' => 'dayle'], ['name' => 'dayle'], ['name' => 'taylor']], array_values($data->all()));
+        $this->assertEquals([1, 2, 0], $data->keys()->all());
+    }
+
+    public function testSortByNumericMaintainsOriginalOrderOfItemsWithIdenticalValues()
+    {
+        $data = new Collection([['name' => '2'], ['name' => '1'], ['name' => '1']]);
+        $data = $data->sortBy('name', SORT_NUMERIC);
+
+        $this->assertEquals([['name' => '1'], ['name' => '1'], ['name' => '2']], array_values($data->all()));
+        $this->assertEquals([1, 2, 0], $data->keys()->all());
+    }
+
+    public function testSortByNaturalMaintainsOriginalOrderOfItemsWithIdenticalValues()
+    {
+        $data = new Collection([['name' => 'img10.png'], ['name' => 'img1.png'], ['name' => 'img1.png']]);
+
+        $data = $data->sortBy('name', SORT_NATURAL);
+
+        $this->assertEquals([['name' => 'img1.png'], ['name' => 'img1.png'], ['name' => 'img10.png']], array_values($data->all()));
+        $this->assertEquals([1, 2, 0], $data->keys()->all());
     }
 
     public function testSortByAlwaysReturnsAssoc()


### PR DESCRIPTION
(Revisits https://github.com/laravel/framework/pull/21214, which was reverted in https://github.com/laravel/framework/pull/21255)

This PR implements stable sort for `sortBy()`, as discussed in https://github.com/laravel/framework/pull/21214, but approaches it another way that doesn't break when passed sort options like `SORT_STRING`, `SORT_NUMBER', `SORT_NATURAL`, etc.

**The result:** `sortBy()` will now preserve the original order of collection items which have identical values, _and_ will work correctly with all sort options.

Fixes https://github.com/laravel/framework/issues/21253

---

Coincidentally, the instability of `sortBy()` also seems to be the cause of issues arising from the recent addition of route fallbacks, which ended up re-sorting routes in an unpredictable manner. So this PR should have the side-effect of fixing https://github.com/laravel/framework/issues/21257 and https://github.com/laravel/framework/issues/21258.

---
