### PR TITLE
[5.5] Apply custom pivot model attribute casting on arrays

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -188,7 +188,9 @@ trait InteractsWithPivotTable
             $attributes = $this->addTimestampsToAttachment($attributes, true);
         }
 
-        $updated = $this->newPivotStatementForId($id)->update($attributes);
+        $updated = $this->newPivotStatementForId($id)->update(
+            $this->castAttributes($attributes)
+        );
 
         if ($touch) {
             $this->touchIfTouching();
@@ -258,12 +260,8 @@ trait InteractsWithPivotTable
     {
         list($id, $attributes) = $this->extractAttachIdAndAttributes($key, $value, $attributes);
 
-        $attributes = $this->using
-                ? $this->newPivot()->forceFill($attributes)->getAttributes()
-                : $attributes;
-
         return array_merge(
-            $this->baseAttachRecord($id, $hasTimestamps), $attributes
+            $this->baseAttachRecord($id, $hasTimestamps), $this->castAttributes($attributes)
         );
     }
 
@@ -502,5 +500,18 @@ trait InteractsWithPivotTable
     protected function castKey($key)
     {
         return is_numeric($key) ? (int) $key : (string) $key;
+    }
+
+    /**
+     * Cast the given pivot attributes.
+     *
+     * @param  array $attributes
+     * @return array
+     */
+    protected function castAttributes($attributes)
+    {
+        return $this->using
+                    ? $this->newPivot()->forceFill($attributes)->getAttributes()
+                    : $attributes;
     }
 }

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -236,10 +236,6 @@ trait InteractsWithPivotTable
         // To create the attachment records, we will simply spin through the IDs given
         // and create a new record to insert for each ID. Each ID may actually be a
         // key in the array, with extra attributes to be placed in other columns.
-        $attributes = $this->using
-                ? $this->newPivot()->forceFill($attributes)->getAttributes()
-                : $attributes;
-
         foreach ($ids as $key => $value) {
             $records[] = $this->formatAttachRecord(
                 $key, $value, $attributes, $hasTimestamps
@@ -261,6 +257,10 @@ trait InteractsWithPivotTable
     protected function formatAttachRecord($key, $value, $attributes, $hasTimestamps)
     {
         list($id, $attributes) = $this->extractAttachIdAndAttributes($key, $value, $attributes);
+
+        $attributes = $this->using
+                ? $this->newPivot()->forceFill($attributes)->getAttributes()
+                : $attributes;
 
         return array_merge(
             $this->baseAttachRecord($id, $hasTimestamps), $attributes

--- a/tests/Integration/Database/EloquentCustomPivotCastTest.php
+++ b/tests/Integration/Database/EloquentCustomPivotCastTest.php
@@ -124,6 +124,36 @@ class EloquentCustomPivotCastTest extends TestCase
         $this->assertEquals(['foo' => 'bar'], $project->collaborators[0]->pivot->permissions);
         $this->assertEquals(['baz' => 'bar'], $project->collaborators[1]->pivot->permissions);
     }
+
+    public function test_casts_are_respected_on_sync_array_while_updating_existing()
+    {
+        $user = CustomPivotCastTestUser::forceCreate([
+            'email' => 'taylor@laravel.com',
+        ]);
+
+        $user2 = CustomPivotCastTestUser::forceCreate([
+            'email' => 'mohamed@laravel.com',
+        ]);
+
+        $project = CustomPivotCastTestProject::forceCreate([
+            'name' => 'Test Project',
+        ]);
+
+        $project->collaborators()->attach([
+            $user->id => ['permissions' => ['foo' => 'bar']],
+            $user2->id => ['permissions' => ['baz' => 'bar']],
+        ]);
+
+        $project->collaborators()->sync([
+            $user->id => ['permissions' => ['foo1' => 'bar1']],
+            $user2->id => ['permissions' => ['baz2' => 'bar2']],
+        ]);
+
+        $project = $project->fresh();
+
+        $this->assertEquals(['foo1' => 'bar1'], $project->collaborators[0]->pivot->permissions);
+        $this->assertEquals(['baz2' => 'bar2'], $project->collaborators[1]->pivot->permissions);
+    }
 }
 
 class CustomPivotCastTestUser extends Model

--- a/tests/Integration/Database/EloquentCustomPivotCastTest.php
+++ b/tests/Integration/Database/EloquentCustomPivotCastTest.php
@@ -61,6 +61,30 @@ class EloquentCustomPivotCastTest extends TestCase
         $this->assertEquals(['foo' => 'bar'], $project->collaborators[0]->pivot->permissions);
     }
 
+    public function test_casts_are_respected_on_attach_array()
+    {
+        $user = CustomPivotCastTestUser::forceCreate([
+            'email' => 'taylor@laravel.com',
+        ]);
+
+        $user2 = CustomPivotCastTestUser::forceCreate([
+            'email' => 'mohamed@laravel.com',
+        ]);
+
+        $project = CustomPivotCastTestProject::forceCreate([
+            'name' => 'Test Project',
+        ]);
+
+        $project->collaborators()->attach([
+            $user->id => ['permissions' => ['foo' => 'bar']],
+            $user2->id => ['permissions' => ['baz' => 'bar']],
+        ]);
+        $project = $project->fresh();
+
+        $this->assertEquals(['foo' => 'bar'], $project->collaborators[0]->pivot->permissions);
+        $this->assertEquals(['baz' => 'bar'], $project->collaborators[1]->pivot->permissions);
+    }
+
     public function test_casts_are_respected_on_sync()
     {
         $user = CustomPivotCastTestUser::forceCreate([
@@ -75,6 +99,30 @@ class EloquentCustomPivotCastTest extends TestCase
         $project = $project->fresh();
 
         $this->assertEquals(['foo' => 'bar'], $project->collaborators[0]->pivot->permissions);
+    }
+
+    public function test_casts_are_respected_on_sync_array()
+    {
+        $user = CustomPivotCastTestUser::forceCreate([
+            'email' => 'taylor@laravel.com',
+        ]);
+
+        $user2 = CustomPivotCastTestUser::forceCreate([
+            'email' => 'mohamed@laravel.com',
+        ]);
+
+        $project = CustomPivotCastTestProject::forceCreate([
+            'name' => 'Test Project',
+        ]);
+
+        $project->collaborators()->sync([
+            $user->id => ['permissions' => ['foo' => 'bar']],
+            $user2->id => ['permissions' => ['baz' => 'bar']],
+        ]);
+        $project = $project->fresh();
+
+        $this->assertEquals(['foo' => 'bar'], $project->collaborators[0]->pivot->permissions);
+        $this->assertEquals(['baz' => 'bar'], $project->collaborators[1]->pivot->permissions);
     }
 }
 


### PR DESCRIPTION
Currently attaching/syncing multiple records doesn't trigger the attribute casting on the custom pivot model:

```
$project->collaborators()->attach([
            [$user->id => ['permissions' => ['foo' => 'bar']]],
            [$user2->id => ['permissions' => ['baz' => 'bar']]],
        ]);
```

```

class CustomPivotModel extends Pivot
{
    protected $casts = [
        'permissions' => 'json',
    ];
}

```