### PR TITLE
[5.5] return empty string if database session key was expired

### DIFF
--- a/src/Illuminate/Session/DatabaseSessionHandler.php
+++ b/src/Illuminate/Session/DatabaseSessionHandler.php
@@ -101,6 +101,8 @@ class DatabaseSessionHandler implements SessionHandlerInterface, ExistenceAwareI
 
             return base64_decode($session->payload);
         }
+
+        return '';
     }
 
     /**

--- a/src/Illuminate/Session/DatabaseSessionHandler.php
+++ b/src/Illuminate/Session/DatabaseSessionHandler.php
@@ -93,7 +93,7 @@ class DatabaseSessionHandler implements SessionHandlerInterface, ExistenceAwareI
         if ($this->expired($session)) {
             $this->exists = true;
 
-            return;
+            return '';
         }
 
         if (isset($session->payload)) {


### PR DESCRIPTION
To be consistent with the `SessionHandler` interface:

```
	/**
	 * Read session data
	 * @link http://php.net/manual/en/sessionhandlerinterface.read.php
	 * @param string $session_id The session id to read data for.
	 * @return string <p>
	 * Returns an encoded string of the read data.
	 * If nothing was read, it must return an empty string.
	 * Note this value is returned internally to PHP for processing.
	 * </p>
	 * @since 5.4.0
	 */
	public function read($session_id);
```