### PR TITLE
[5.5] Fix bug when use SoftDeletes and no column updated_at `cons UPDATED_AT = null;`

### DIFF
--- a/src/Illuminate/Database/Eloquent/SoftDeletes.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletes.php
@@ -66,7 +66,7 @@ trait SoftDeletes
 
         $this->{$this->getDeletedAtColumn()} = $time;
 
-        if ($this->timestamps) {
+        if ($this->timestamps && $this->getUpdatedAtColumn() != null) {
             $this->{$this->getUpdatedAtColumn()} = $time;
 
             $columns[$this->getUpdatedAtColumn()] = $this->fromDateTime($time);

--- a/tests/Database/DatabaseSoftDeletingTraitTest.php
+++ b/tests/Database/DatabaseSoftDeletingTraitTest.php
@@ -28,6 +28,21 @@ class DatabaseSoftDeletingTraitTest extends TestCase
         $this->assertInstanceOf(\Illuminate\Support\Carbon::class, $model->deleted_at);
     }
 
+    public function testDeleteSetsSoftDeletedWithUpdatedAtColumnIsNull()
+    {
+
+        $model = m::mock('Illuminate\Tests\Database\DatabaseSoftDeletingWithUpdatedAtIsNullTraitStub');
+        $model->shouldDeferMissing();
+        $model->shouldReceive('newQueryWithoutScopes')->andReturn($query = m::mock('stdClass'));
+        $query->shouldReceive('where')->once()->with('id', 1)->andReturn($query);
+        $query->shouldReceive('update')->once()->with([
+            'deleted_at' => 'date-time',
+        ]);
+        $model->delete();
+
+        $this->assertInstanceOf(\Illuminate\Support\Carbon::class, $model->deleted_at);
+    }
+
     public function testRestore()
     {
         $model = m::mock('Illuminate\Tests\Database\DatabaseSoftDeletingTraitStub');
@@ -58,6 +73,61 @@ class DatabaseSoftDeletingTraitStub
     public $deleted_at;
     public $updated_at;
     public $timestamps = true;
+
+    public function newQuery()
+    {
+        //
+    }
+
+    public function getKey()
+    {
+        return 1;
+    }
+
+    public function getKeyName()
+    {
+        return 'id';
+    }
+
+    public function save()
+    {
+        //
+    }
+
+    public function delete()
+    {
+        return $this->performDeleteOnModel();
+    }
+
+    public function fireModelEvent()
+    {
+        //
+    }
+
+    public function freshTimestamp()
+    {
+        return \Illuminate\Support\Carbon::now();
+    }
+
+    public function fromDateTime()
+    {
+        return 'date-time';
+    }
+
+    public function getUpdatedAtColumn()
+    {
+        return defined('static::UPDATED_AT') ? static::UPDATED_AT : 'updated_at';
+    }
+}
+
+class DatabaseSoftDeletingWithUpdatedAtIsNullTraitStub
+{
+    use \Illuminate\Database\Eloquent\SoftDeletes;
+    public $deleted_at;
+    public $updated_at;
+    public $timestamps = true;
+
+    const UPDATED_AT = null;
 
     public function newQuery()
     {

--- a/tests/Database/DatabaseSoftDeletingTraitTest.php
+++ b/tests/Database/DatabaseSoftDeletingTraitTest.php
@@ -30,7 +30,6 @@ class DatabaseSoftDeletingTraitTest extends TestCase
 
     public function testDeleteSetsSoftDeletedWithUpdatedAtColumnIsNull()
     {
-
         $model = m::mock('Illuminate\Tests\Database\DatabaseSoftDeletingWithUpdatedAtIsNullTraitStub');
         $model->shouldDeferMissing();
         $model->shouldReceive('newQueryWithoutScopes')->andReturn($query = m::mock('stdClass'));


### PR DESCRIPTION
I always had a problem with this, When I have no `updated_at` column and use `SoftDeletes`.

> Type error: Too few arguments to function Illuminate\Database\Eloquent\Model::setAttribute(), 1 passed in /...path_to_directory.../vendor/laravel/framework/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php on line 525 and exactly 2 expected 

With set this in Model.

```
    use SoftDeletes;

    const UPDATED_AT = null;

    /**
    * Set the value of the "updated at" attribute.
    *
    * @param  mixed  $value
    * @return $this
    */
    public function setUpdatedAt($value)
    {
        return $this;
    }
```