### PR TITLE
[5.5] Fix error when use command php artisan preset none from command php artisan preset react

### DIFF
--- a/src/Illuminate/Foundation/Console/Presets/None.php
+++ b/src/Illuminate/Foundation/Console/Presets/None.php
@@ -46,6 +46,16 @@ class None extends Preset
     }
 
     /**
+     * Update the Webpack configuration.
+     *
+     * @return void
+     */
+    protected static function updateWebpackConfiguration()
+    {
+        copy(__DIR__.'/none-stubs/webpack.mix.js', base_path('webpack.mix.js'));
+    }
+
+    /**
      * Write the stubs for the Sass and JavaScript files.
      *
      * @return void

--- a/src/Illuminate/Foundation/Console/Presets/none-stubs/webpack.mix.js
+++ b/src/Illuminate/Foundation/Console/Presets/none-stubs/webpack.mix.js
@@ -1,0 +1,15 @@
+let mix = require('laravel-mix');
+
+/*
+ |--------------------------------------------------------------------------
+ | Mix Asset Management
+ |--------------------------------------------------------------------------
+ |
+ | Mix provides a clean, fluent API for defining some Webpack build steps
+ | for your Laravel application. By default, we are compiling the Sass
+ | file for the application as well as bundling up all the JS files.
+ |
+ */
+
+mix.js('resources/assets/js/app.js', 'public/js')
+   .sass('resources/assets/sass/app.scss', 'public/css');


### PR DESCRIPTION
When i don't want to use react and i use command `$ php artisan preset none`. I have a problem
webpack.min.js don't change. `mix.react('resources/assets/js/app.js', 'public/js')` and i think should come back `mix.js('resources/assets/js/app.js', 'public/js')` with command `$ php artisan preset none`