### PR TITLE
[5.5] Fix updated at being set in SoftDeletes

### DIFF
--- a/src/Illuminate/Database/Eloquent/SoftDeletes.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletes.php
@@ -66,7 +66,7 @@ trait SoftDeletes
 
         $this->{$this->getDeletedAtColumn()} = $time;
 
-        if ($this->timestamps) {
+        if ($this->timestamps && ! is_null($this->getUpdatedAtColumn())) {
             $this->{$this->getUpdatedAtColumn()} = $time;
 
             $columns[$this->getUpdatedAtColumn()] = $this->fromDateTime($time);


### PR DESCRIPTION
The PR #21178 allows updated at, NOT to be set, when the column is null.
This will not work when the model uses the SoftDeletes trait due to that, updated at will always be set when timestamps is true, no matter what the name of the column is.