### PR TITLE
Add whereNotNested() to query builder

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1020,7 +1020,7 @@ class Builder
 
         $whereGroup->wheres = $whereSlice;
 
-        return ['type' => 'Nested', 'query' => $whereGroup, 'boolean' => $boolean];
+        return ['type' => 'Nested', 'query' => $whereGroup, 'boolean' => $boolean, 'not' => false];
     }
 
     /**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1093,13 +1093,26 @@ class Builder
      *
      * @param  \Closure $callback
      * @param  string   $boolean
+     * @param  bool     $not
      * @return \Illuminate\Database\Query\Builder|static
      */
-    public function whereNested(Closure $callback, $boolean = 'and')
+    public function whereNested(Closure $callback, $boolean = 'and', $not = false)
     {
         call_user_func($callback, $query = $this->forNestedWhere());
 
-        return $this->addNestedWhereQuery($query, $boolean);
+        return $this->addNestedWhereQuery($query, $boolean, $not);
+    }
+
+    /**
+     * Add a nested "where not" statement to the query.
+     *
+     * @param  \Closure $callback
+     * @param  string   $boolean
+     * @return \Illuminate\Database\Query\Builder|static
+     */
+    public function whereNotNested(Closure $callback, $boolean = 'and')
+    {
+        return $this->whereNested($callback, $boolean, true);
     }
 
     /**
@@ -1117,14 +1130,15 @@ class Builder
      *
      * @param  \Illuminate\Database\Query\Builder|static $query
      * @param  string  $boolean
+     * @param  bool    $not
      * @return $this
      */
-    public function addNestedWhereQuery($query, $boolean = 'and')
+    public function addNestedWhereQuery($query, $boolean = 'and', $not = false)
     {
         if (count($query->wheres)) {
             $type = 'Nested';
 
-            $this->wheres[] = compact('type', 'query', 'boolean');
+            $this->wheres[] = compact('type', 'query', 'boolean', 'not');
 
             $this->addBinding($query->getBindings(), 'where');
         }

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -432,7 +432,9 @@ class Grammar extends BaseGrammar
         // if it is a normal query we need to take the leading "where" of queries.
         $offset = $query instanceof JoinClause ? 3 : 6;
 
-        return '('.substr($this->compileWheres($where['query']), $offset).')';
+        $negation = ($where['not'] ?? false) ? 'not ' : '';
+
+        return  "{$negation}(".substr($this->compileWheres($where['query']), $offset).')';
     }
 
     /**

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -909,6 +909,16 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => 'foo', 1 => 'bar', 2 => 25], $builder->getBindings());
     }
 
+    public function testWhereNotNested()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereNotNested(function ($q) {
+            $q->where('email', '=', 'foo')->where('name', '=', 'bar');
+        });
+        $this->assertEquals('select * from "users" where not ("email" = ? and "name" = ?)', $builder->toSql());
+        $this->assertEquals([0 => 'foo', 1 => 'bar'], $builder->getBindings());
+    }
+
     public function testFullSubSelects()
     {
         $builder = $this->getBuilder();


### PR DESCRIPTION
Adds ability to create negated nested groups.
Ex: select * from users where not (`foo` = ? and `bar` = ?)