### PR TITLE
Remove @mixin \Illuminate\Contracts\Cache\Store contract from Illumin…

### DIFF
--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -17,9 +17,7 @@ use Illuminate\Support\InteractsWithTime;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Cache\Repository as CacheContract;
 
-/**
- * @mixin \Illuminate\Contracts\Cache\Store
- */
+
 class Repository implements CacheContract, ArrayAccess
 {
     use InteractsWithTime;


### PR DESCRIPTION
Should the @mixin docblock be removed as flush() and getPrefix() methods from \Illuminate\Contracts\Cache\Store are not implemented in this Class? My IDE is very upset about this.