### PR TITLE
Add Str::placeholder

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -273,12 +273,7 @@ class Str
      */
     public static function placeholder($subject, array $replace)
     {
-        foreach ($replace as $key => $value)
-        {
-            $subject = str_replace($key, $value, $subject);
-        }
-
-        return $subject;
+        return str_replace(array_keys($replace), array_values($replace), $subject);
     }
 
     /**

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -265,6 +265,23 @@ class Str
     }
 
     /**
+     * Replace the placeholders in a string.
+     *
+     * @param  string  $value
+     * @param  array   $replace
+     * @return string
+     */
+    public static function placeholder($subject, array $replace)
+    {
+        foreach ($replace as $key => $value)
+        {
+            $subject = str_replace($key, $value, $subject);
+        }
+
+        return $subject;
+    }
+
+    /**
      * Get the plural form of an English word.
      *
      * @param  string  $value

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -723,6 +723,20 @@ if (! function_exists('optional')) {
     }
 }
 
+if (! function_exists('str_placeholder')) {
+    /**
+     * Replace the placeholders in a string.
+     *
+     * @param  string  $value
+     * @param  array   $replace
+     * @return string
+     */
+    function str_placeholder($subject, array $replace)
+    {
+        return Str::placeholder($subject, $replace);
+    }
+}
+
 if (! function_exists('preg_replace_array')) {
     /**
      * Replace a given pattern with each value in the array in sequentially.

--- a/src/Illuminate/Validation/Concerns/FormatsMessages.php
+++ b/src/Illuminate/Validation/Concerns/FormatsMessages.php
@@ -260,11 +260,7 @@ trait FormatsMessages
      */
     protected function replaceAttributePlaceholder($message, $value)
     {
-        return str_replace(
-            [':attribute', ':ATTRIBUTE', ':Attribute'],
-            [$value, Str::upper($value), Str::ucfirst($value)],
-            $message
-        );
+        return str_placeholder($message, [':attribute' => $value, ':ATTRIBUTE' => Str::upper($value), ':Attribute' => Str::ucfirst($value)]);
     }
 
     /**

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -199,7 +199,7 @@ class SupportStrTest extends TestCase
     public function testPlaceholder()
     {
         $this->assertEquals('Laravel Framework', Str::placeholder(':name Framework', [':name' => 'Laravel']));
-        $this->assertEquals('Taylor Otwell', Str::placeholder(':first_name :last_name', ['first_name' => 'Taylor', 'last_name' => 'Otwell']));
+        $this->assertEquals('Taylor Otwell', Str::placeholder(':first_name :last_name', [':first_name' => 'Taylor', ':last_name' => 'Otwell']));
     }
 
     public function testRandom()

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -196,6 +196,12 @@ class SupportStrTest extends TestCase
         $this->assertEquals(11, Str::length('foo bar baz'));
     }
 
+    public function testPlaceholder()
+    {
+        $this->assertEquals('Laravel Framework', Str::placeholder(':name Framework', [':name' => 'Laravel']));
+        $this->assertEquals('Taylor Otwell', Str::placeholder(':first_name :last_name', ['first_name' => 'Taylor', 'last_name' => 'Otwell']));
+    }
+
     public function testRandom()
     {
         $this->assertEquals(16, strlen(Str::random()));


### PR DESCRIPTION
This PR adds a function to the `Str` class that replaces placeholders in a string. This makes code more readable because, instead of passing two arrays to the `str_replace` function, you can pass an associative array.

:octocat: