### PR TITLE
Add v5.5.8 release notes

### DIFF
--- a/CHANGELOG-5.5.md
+++ b/CHANGELOG-5.5.md
@@ -1,5 +1,10 @@
 # Release Notes for 5.5.x
 
+## v5.5.8 (2017-09-20)
+
+### Fixed
+- Fixed issue with routes sorting ([#21261](https://github.com/laravel/framework/pull/21261))
+
 ## v5.5.7 (2017-09-19)
 
 ### Fixed


### PR DESCRIPTION
Five hours ago, @themsaid released [`v5.5.8`](https://github.com/laravel/framework/releases/tag/v5.5.8). This pull request adds the release notes to the changelog.

:octocat: