### PR TITLE
[5.5] fix table prefix add to database name when using database.table

### DIFF
--- a/src/Illuminate/Database/Grammar.php
+++ b/src/Illuminate/Database/Grammar.php
@@ -59,7 +59,7 @@ abstract class Grammar
         // the pieces so we can wrap each of the segments of the expression on it
         // own, and then joins them both back together with the "as" connector.
         if (strpos(strtolower($value), ' as ') !== false) {
-            return $this->wrapAliasedValue($value, $prefixAlias, $hasDatabaseName = false);
+            return $this->wrapAliasedValue($value, $prefixAlias, $hasDatabaseName);
         }
 
         return $this->wrapSegments(explode('.', $value), $hasDatabaseName);

--- a/src/Illuminate/Database/Grammar.php
+++ b/src/Illuminate/Database/Grammar.php
@@ -59,7 +59,7 @@ abstract class Grammar
         // the pieces so we can wrap each of the segments of the expression on it
         // own, and then joins them both back together with the "as" connector.
         if (strpos(strtolower($value), ' as ') !== false) {
-            return $this->wrapAliasedValue($value, $prefixAlias);
+            return $this->wrapAliasedValue($value, $prefixAlias, $hasDatabaseName = false);
         }
 
         return $this->wrapSegments(explode('.', $value), $hasDatabaseName);
@@ -70,9 +70,10 @@ abstract class Grammar
      *
      * @param  string  $value
      * @param  bool  $prefixAlias
+     * @param  bool  $hasDatabaseName
      * @return string
      */
-    protected function wrapAliasedValue($value, $prefixAlias = false)
+    protected function wrapAliasedValue($value, $prefixAlias = false, $hasDatabaseName = false)
     {
         $segments = preg_split('/\s+as\s+/i', $value);
 
@@ -84,7 +85,7 @@ abstract class Grammar
         }
 
         return $this->wrap(
-            $segments[0]).' as '.$this->wrapValue($segments[1]
+            $segments[0], $prefixAlias, $hasDatabaseName).' as '.$this->wrapValue($segments[1]
         );
     }
 

--- a/src/Illuminate/Database/Grammar.php
+++ b/src/Illuminate/Database/Grammar.php
@@ -32,11 +32,13 @@ abstract class Grammar
      */
     public function wrapTable($table)
     {
-        if (! $this->isExpression($table)) {
+        // When the value of $table has database name,such as database.table,we should not
+        // add a tablePrefix to database name.
+        if (strpos($table, '.') == false) {
             return $this->wrap($this->tablePrefix.$table, true);
+        } else {
+            return $this->wrap($table, true, true);
         }
-
-        return $this->getValue($table);
     }
 
     /**
@@ -44,9 +46,10 @@ abstract class Grammar
      *
      * @param  \Illuminate\Database\Query\Expression|string  $value
      * @param  bool    $prefixAlias
+     * @param  bool    $hasDatabaseName
      * @return string
      */
-    public function wrap($value, $prefixAlias = false)
+    public function wrap($value, $prefixAlias = false, $hasDatabaseName = false)
     {
         if ($this->isExpression($value)) {
             return $this->getValue($value);
@@ -59,7 +62,7 @@ abstract class Grammar
             return $this->wrapAliasedValue($value, $prefixAlias);
         }
 
-        return $this->wrapSegments(explode('.', $value));
+        return $this->wrapSegments(explode('.', $value), $hasDatabaseName);
     }
 
     /**
@@ -89,12 +92,17 @@ abstract class Grammar
      * Wrap the given value segments.
      *
      * @param  array  $segments
+     * @param  bool   $hasDatabaseName
      * @return string
      */
-    protected function wrapSegments($segments)
+    protected function wrapSegments($segments, $hasDatabaseName = false)
     {
-        return collect($segments)->map(function ($segment, $key) use ($segments) {
-            return $key == 0 && count($segments) > 1
+        // The value of $segments has two forms : database.table or table.column,we should
+        // distinguish them.
+        $table_key = $hasDatabaseName ? 1 : 0;
+
+        return collect($segments)->map(function ($segment, $key) use ($segments, $table_key) {
+            return $key == $table_key && count($segments) > 1
                             ? $this->wrapTable($segment)
                             : $this->wrapValue($segment);
         })->implode('.');

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -130,6 +130,22 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals('select * from "public"."users"', $builder->toSql());
     }
 
+    public function testTableWithDatabaseWrapping()
+    {
+        $builder = $this->getBuilder();
+        $builder->getGrammar()->setTablePrefix('prefix_');
+        $builder->select('*')->from('public.users');
+        $this->assertEquals('select * from "public"."prefix_users"', $builder->toSql());
+    }
+
+    public function testTableWithDatabaseAsWrapping()
+    {
+        $builder = $this->getBuilder();
+        $builder->getGrammar()->setTablePrefix('prefix_');
+        $builder->select('*')->from('public.users as people');
+        $this->assertEquals('select * from "public"."prefix_users" as "prefix_people"', $builder->toSql());
+    }
+
     public function testWhenCallback()
     {
         $callback = function ($query, $condition) {


### PR DESCRIPTION
When we use the table prefix like this:
```php
DB::connection()->getGrammar()->setTablePrefix('prefix_');
$sql = DB::table('public.user')->toSql();
``` 
we can get the result:
```php
select * from "prefix_prefix_public"."user"
```
which is wrong.