### PR TITLE
[5.5] docblock magic methods

### DIFF
--- a/src/Illuminate/Support/Facades/Route.php
+++ b/src/Illuminate/Support/Facades/Route.php
@@ -3,21 +3,25 @@
 namespace Illuminate\Support\Facades;
 
 /**
- * @method static \Illuminate\Routing\Route get(string $uri, \Closure|array|string|null $action = null)
- * @method static \Illuminate\Routing\Route post(string $uri, \Closure|array|string|null $action = null)
- * @method static \Illuminate\Routing\Route put(string $uri, \Closure|array|string|null $action = null)
- * @method static \Illuminate\Routing\Route delete(string $uri, \Closure|array|string|null $action = null)
- * @method static \Illuminate\Routing\Route patch(string $uri, \Closure|array|string|null $action = null)
- * @method static \Illuminate\Routing\Route options(string $uri, \Closure|array|string|null $action = null)
- * @method static \Illuminate\Routing\Route any(string $uri, \Closure|array|string|null $action = null)
- * @method static \Illuminate\Routing\Route match(array|string $methods, string $uri, \Closure|array|string|null $action = null)
- * @method static \Illuminate\Routing\Route prefix(string  $prefix)
+ * @method static \Illuminate\Support\Facades\Route get(string $uri, \Closure|array|string|null $action = null)
+ * @method static \Illuminate\Support\Facades\Route post(string $uri, \Closure|array|string|null $action = null)
+ * @method static \Illuminate\Support\Facades\Route put(string $uri, \Closure|array|string|null $action = null)
+ * @method static \Illuminate\Support\Facades\Route delete(string $uri, \Closure|array|string|null $action = null)
+ * @method static \Illuminate\Support\Facades\Route patch(string $uri, \Closure|array|string|null $action = null)
+ * @method static \Illuminate\Support\Facades\Route options(string $uri, \Closure|array|string|null $action = null)
+ * @method static \Illuminate\Support\Facades\Route any(string $uri, \Closure|array|string|null $action = null)
+ * @method static \Illuminate\Support\Facades\Route match(array|string $methods, string $uri, \Closure|array|string|null $action = null)
+ * @method static \Illuminate\Support\Facades\Route prefix(string  $prefix)
  * @method static \Illuminate\Routing\PendingResourceRegistration resource(string $name, string $controller, array $options = [])
  * @method static \Illuminate\Routing\PendingResourceRegistration apiResource(string $name, string $controller, array $options = [])
- * @method static void group(array $attributes, \Closure|string $callback)
- * @method static \Illuminate\Routing\Route middleware(array|string|null $middleware)
- * @method static \Illuminate\Routing\Route substituteBindings(\Illuminate\Routing\Route $route)
- * @method static void substituteImplicitBindings(\Illuminate\Routing\Route $route)
+ * @method static \Illuminate\Support\Facades\Route middleware(array|string|null $middleware)
+ * @method static \Illuminate\Support\Facades\Route substituteBindings(\Illuminate\Support\Facades\Route $route)
+ * @method static void substituteImplicitBindings(\Illuminate\Support\Facades\Route $route)
+ * @method \Illuminate\Support\Facades\Route as(string $value)
+ * @method \Illuminate\Support\Facades\Route domain(string $value)
+ * @method \Illuminate\Support\Facades\Route name(string $value)
+ * @method \Illuminate\Support\Facades\Route namespace(string $value)
+ * @method \Illuminate\Routing\Route group(string $value)
  *
  * @see \Illuminate\Routing\Router
  */


### PR DESCRIPTION
defining/updating for the magic methods.
also updated to return values of the facade itself.
this allows for proper ide support including chaining within the RouteServiceProvider

    protected function mapWebRoutes()
    {
        Route::middleware('web')
            ->namespace($this->namespace)
            ->group(base_path('routes/web.php'));
    }
