### PR TITLE
[5.5] Add driver parameter for new doctrine connection

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -892,10 +892,15 @@ class Connection implements ConnectionInterface
     public function getDoctrineConnection()
     {
         if (is_null($this->doctrineConnection)) {
-            $data = ['pdo' => $this->getPdo(), 'dbname' => $this->getConfig('database')];
+            $driver = $this->getDoctrineDriver();
+            $data = [
+                'pdo' => $this->getPdo(),
+                'dbname' => $this->getConfig('database'),
+                'driver' => $driver->getName(),
+            ];
 
             $this->doctrineConnection = new DoctrineConnection(
-                $data, $this->getDoctrineDriver()
+                $data, $driver
             );
         }
 


### PR DESCRIPTION
Fix sqlite create database missing driver parameter.

Reproduce:

.env
```
DB_CONNECTION=sqlite
```

Code
```php
DB::getDoctrineConnection()->getSchemaManager()->createDatabase(database_path('database.sqlite'));
```

Error message:
```
PHP error:  Undefined index: driver in /vendor/doctrine/dbal/lib/Doctrine/DBAL/Schema/SqliteSchemaManager.php on line 54
```

[Doctrine/DBAL/Schema/SqliteSchemaManager.php#L54](https://github.com/doctrine/dbal/blob/master/lib/Doctrine/DBAL/Schema/SqliteSchemaManager.php#L54)