### PR TITLE
[5.5] Ability to build a response using a fallback route name

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -1115,7 +1115,8 @@ class Router implements RegistrarContract, BindingRegistrar
      * @param  string  $name
      * @return mixed
      */
-    public function respondWith($name){
+    public function respondWith($name)
+    {
         return $this->buildResponse($this->currentRequest,
             tap($this->routes->getByName($name))->bind($this->currentRequest)
         );

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -572,20 +572,7 @@ class Router implements RegistrarContract, BindingRegistrar
      */
     public function dispatchToRoute(Request $request)
     {
-        // First we will find a route that matches this request. We will also set the
-        // route resolver on the request so middlewares assigned to the route will
-        // receive access to this route instance for checking of the parameters.
-        $route = $this->findRoute($request);
-
-        $request->setRouteResolver(function () use ($route) {
-            return $route;
-        });
-
-        $this->events->dispatch(new Events\RouteMatched($route, $request));
-
-        $response = $this->runRouteWithinStack($route, $request);
-
-        return $this->prepareResponse($request, $response);
+        return $this->buildResponse($this->findRoute($request), $request);
     }
 
     /**
@@ -601,6 +588,26 @@ class Router implements RegistrarContract, BindingRegistrar
         $this->container->instance(Route::class, $route);
 
         return $route;
+    }
+
+    /**
+     * Return the response for the given route.
+     *
+     * @param  Route  $route
+     * @param  Request  $request
+     * @return mixed
+     */
+    protected function buildResponse(Route $route, Request $request)
+    {
+        $request->setRouteResolver(function () use ($route) {
+            return $route;
+        });
+
+        $this->events->dispatch(new Events\RouteMatched($route, $request));
+
+        return $this->prepareResponse($request,
+            $this->runRouteWithinStack($route, $request)
+        );
     }
 
     /**
@@ -1100,6 +1107,19 @@ class Router implements RegistrarContract, BindingRegistrar
         $this->post('password/email', 'Auth\ForgotPasswordController@sendResetLinkEmail')->name('password.email');
         $this->get('password/reset/{token}', 'Auth\ResetPasswordController@showResetForm')->name('password.reset');
         $this->post('password/reset', 'Auth\ResetPasswordController@reset');
+    }
+
+    /**
+     * Return a response out of the given route.
+     *
+     * @param  string  $name
+     * @param  \Illuminate\Http\Request  $request
+     * @return mixed
+     */
+    public function respondWith($name, $request){
+        $route = tap($this->routes->getByName($name))->bind($request);
+
+        return $this->buildResponse($route, $request);
     }
 
     /**

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -572,7 +572,7 @@ class Router implements RegistrarContract, BindingRegistrar
      */
     public function dispatchToRoute(Request $request)
     {
-        return $this->buildResponse($this->findRoute($request), $request);
+        return $this->buildResponse($request, $this->findRoute($request));
     }
 
     /**
@@ -597,7 +597,7 @@ class Router implements RegistrarContract, BindingRegistrar
      * @param  Request  $request
      * @return mixed
      */
-    protected function buildResponse(Route $route, Request $request)
+    protected function buildResponse(Request $request, Route $route)
     {
         $request->setRouteResolver(function () use ($route) {
             return $route;
@@ -1113,13 +1113,12 @@ class Router implements RegistrarContract, BindingRegistrar
      * Return a response out of the given route.
      *
      * @param  string  $name
-     * @param  \Illuminate\Http\Request  $request
      * @return mixed
      */
-    public function respondWith($name, $request){
-        $route = tap($this->routes->getByName($name))->bind($request);
-
-        return $this->buildResponse($route, $request);
+    public function respondWith($name){
+        return $this->buildResponse($this->currentRequest,
+            tap($this->routes->getByName($name))->bind($this->currentRequest)
+        );
     }
 
     /**

--- a/tests/Integration/Routing/FallbackRouteTest.php
+++ b/tests/Integration/Routing/FallbackRouteTest.php
@@ -79,7 +79,7 @@ class FallbackRouteTest extends TestCase
         })->name('testFallbackRoute');
 
         Route::get('one', function () {
-            return Route::respondWith('testFallbackRoute', request());
+            return Route::respondWith('testFallbackRoute');
         });
 
         $this->assertContains('fallback', $this->get('/non-existing')->getContent());

--- a/tests/Integration/Routing/FallbackRouteTest.php
+++ b/tests/Integration/Routing/FallbackRouteTest.php
@@ -72,6 +72,20 @@ class FallbackRouteTest extends TestCase
         $this->assertEquals(404, $this->get('/non-existing')->getStatusCode());
     }
 
+    public function test_respond_with_named_fallback_route()
+    {
+        Route::fallback(function () {
+            return response('fallback', 404);
+        })->name('testFallbackRoute');
+
+        Route::get('one', function () {
+            return Route::respondWith('testFallbackRoute', request());
+        });
+
+        $this->assertContains('fallback', $this->get('/non-existing')->getContent());
+        $this->assertContains('fallback', $this->get('/one')->getContent());
+    }
+
     public function test_no_fallbacks()
     {
         Route::get('one', function () {


### PR DESCRIPTION
Having:

```php
Route::fallback('ServersController@notFound')->name('notFoundServer');
```

In your exception handler or inside another route you can do:

```php
return Route::respondWith('notFoundServer');
```

This will run the `ServersController@notFound` action and return its response.

This is useful for when you want to catch a `ModelNotFound` exception and return a fallback route instead of the `404.blade.php` view.