### PR TITLE
[5.6] Queue Jobs updates

### DIFF
--- a/src/Illuminate/Contracts/Queue/Job.php
+++ b/src/Illuminate/Contracts/Queue/Job.php
@@ -112,4 +112,18 @@ interface Job
      * @return string
      */
     public function getRawBody();
+
+    /**
+     * Get the decoded body of the job.
+     *
+     * @return array
+     */
+    public function payload();
+
+    /**
+     * Get the job identifier.
+     *
+     * @return string
+     */
+    public function getJobId();
 }

--- a/src/Illuminate/Queue/Jobs/Job.php
+++ b/src/Illuminate/Queue/Jobs/Job.php
@@ -63,6 +63,13 @@ abstract class Job
     abstract public function getRawBody();
 
     /**
+     * Get the job identifier.
+     *
+     * @return string
+     */
+    abstract public function getJobId();
+
+    /**
      * Fire the job.
      *
      * @return void


### PR DESCRIPTION
- updated to include common methods in the abstract Job class
- added the required getJobId to the abstract class
   this method is used in all existing Illuminate/Queue/Jobs/* classes
   also allows better code completion via the addition in the Contract.

Taylor said not update on a point release...
https://github.com/laravel/framework/pull/21298
requesting on 5.6 release...