### PR TITLE
[5.5] Remove useless where clause on HasMany constraint

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/HasMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasMany.php
@@ -17,6 +17,18 @@ class HasMany extends HasOneOrMany
     }
 
     /**
+     * Set the base constraints on the relation query.
+     *
+     * @return void
+     */
+    public function addConstraints()
+    {
+        if (static::$constraints) {
+            $this->query->where($this->foreignKey, '=', $this->getParentKey());
+        }
+    }
+
+    /**
      * Initialize the relation on a set of models.
      *
      * @param  array   $models


### PR DESCRIPTION
**How to reproduce:**

Set the following kind of relationship: `User` has many `Post`

Then execute:

```php
$user = User::first();
dd($user->posts()->toSql());
```

You will have the following query:

```sql
select * from `posts` where `posts`.`user_id` = ? and `posts`.`user_id` is not null
```

I believe the last where clause is useless, or at least, I am not able to think of any use case where it is useful at the moment... Any ideas?

This patch remove the `where is not null` clause by overriding the `HasOneOrMany::addConstraint` method.

**Original method from the extended class:**

```php
    /**
     * Set the base constraints on the relation query.
     *
     * @return void
     */
    public function addConstraints()
    {
        if (static::$constraints) {
            $this->query->where($this->foreignKey, '=', $this->getParentKey());

            $this->query->whereNotNull($this->foreignKey); // This line is removed on the overridden method
        }
    }
```