### PR TITLE
[5.5] Add doctrine/instantiator to fix tests on PHP 7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
         "ext-mbstring": "*",
         "ext-openssl": "*",
         "doctrine/inflector": "~1.1",
+        "doctrine/instantiator": "~1.0|~1.1",
         "erusev/parsedown": "~1.6",
         "league/flysystem": "~1.0",
         "monolog/monolog": "~1.12",


### PR DESCRIPTION
Fixes the issue as described here #20255. There is a PR for inclusion in `php-mock-objects` package [here](https://github.com/sebastianbergmann/phpunit-mock-objects/pull/370), but as @sebastianbergmann response that appropriate package should be pulled in anyway.

When i run my tests on PHP 7 Linode server, the tests fail because `doctrine/instantiator` to be used is still 1.1 which requires PHP 7.1. This PR fixes the error, by allowing Laravel to pull in the requisite version automatically. 