### PR TITLE
[5.4] Allow associate on MorphTo to accept null value

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -194,9 +194,9 @@ class MorphTo extends BelongsTo
      */
     public function associate($model)
     {
-        $this->parent->setAttribute($this->foreignKey, $model->getKey());
+        $this->parent->setAttribute($this->foreignKey, $model instanceof Model ? $model->getKey() : null);
 
-        $this->parent->setAttribute($this->morphType, $model->getMorphClass());
+        $this->parent->setAttribute($this->morphType, $model instanceof Model ? $model->getMorphClass() : null);
 
         return $this->parent->setRelation($this->relation, $model);
     }

--- a/tests/Database/DatabaseEloquentMorphToTest.php
+++ b/tests/Database/DatabaseEloquentMorphToTest.php
@@ -57,6 +57,20 @@ class DatabaseEloquentMorphToTest extends TestCase
         $relation->associate($associate);
     }
 
+    public function testAssociateMethodIgnoresNullValue()
+    {
+        $parent = m::mock('Illuminate\Database\Eloquent\Model');
+        $parent->shouldReceive('getAttribute')->once()->with('foreign_key')->andReturn('foreign.value');
+
+        $relation = $this->getRelationAssociate($parent);
+
+        $parent->shouldReceive('setAttribute')->once()->with('foreign_key', null);
+        $parent->shouldReceive('setAttribute')->once()->with('morph_type', null);
+        $parent->shouldReceive('setRelation')->once()->with('relation', null);
+
+        $relation->associate(null);
+    }
+
     public function testDissociateMethodDeletesUnsetsKeyAndTypeOnModel()
     {
         $parent = m::mock('Illuminate\Database\Eloquent\Model');


### PR DESCRIPTION
This will make the MorphTo match the signature of BelongsTo.
BelongsTo can accept a null value on associate.
MorphTo would fail due that getKey() would not exists on null.
This should be possible also due to that is it possible to generate migrations with nullable polymorphic relations

Part of #21318

Example:

```php
$model->user()->associate($user);
$model->customer()->associate($customer);
if ($morph_relation) {
    $model->morphRelation()->associate($morph_relation);
}
```

Can be turned into

```php
$model->user()->associate($user);
$model->customer()->associate($customer);
$model->morphRelation()->associate($morph_relation);
```