### PR TITLE
[5.5] [Security] Close `remember_me` Timing Attack Vector

### DIFF
--- a/src/Illuminate/Auth/DatabaseUserProvider.php
+++ b/src/Illuminate/Auth/DatabaseUserProvider.php
@@ -72,7 +72,7 @@ class DatabaseUserProvider implements UserProvider
                         ->where('id', $identifier)
                         ->first();
 
-        return hash_equals($user->remember_token, $token) ? $this->getGenericUser($user) : null;
+        return $user && hash_equals($user->remember_token, $token) ? $this->getGenericUser($user) : null;
     }
 
     /**

--- a/src/Illuminate/Auth/DatabaseUserProvider.php
+++ b/src/Illuminate/Auth/DatabaseUserProvider.php
@@ -70,10 +70,9 @@ class DatabaseUserProvider implements UserProvider
     {
         $user = $this->conn->table($this->table)
                         ->where('id', $identifier)
-                        ->where('remember_token', $token)
                         ->first();
 
-        return $this->getGenericUser($user);
+        return hash_equals($user->remember_token, $token) ? $this->getGenericUser($user) : null;
     }
 
     /**

--- a/src/Illuminate/Auth/EloquentUserProvider.php
+++ b/src/Illuminate/Auth/EloquentUserProvider.php
@@ -63,7 +63,7 @@ class EloquentUserProvider implements UserProvider
         $model = $this->createModel()->newQuery()
             ->where($model->getAuthIdentifierName(), $identifier)
             ->first();
-        
+
         return $model && hash_equals($model->getRememberToken(), $token) ? $model : null;
     }
 

--- a/src/Illuminate/Auth/EloquentUserProvider.php
+++ b/src/Illuminate/Auth/EloquentUserProvider.php
@@ -60,12 +60,11 @@ class EloquentUserProvider implements UserProvider
      */
     public function retrieveByToken($identifier, $token)
     {
-        $model = $this->createModel();
-
-        return $model->newQuery()
+        $model = $this->createModel()->newQuery()
             ->where($model->getAuthIdentifierName(), $identifier)
-            ->where($model->getRememberTokenName(), $token)
             ->first();
+        
+        return $model && hash_equals($model->getRememberToken(), $token) ? $model : null;
     }
 
     /**


### PR DESCRIPTION
The current `remember_me` token verification process leaves the application open to a [timing attack](http://blog.ircmaxell.com/2014/11/its-all-about-time.html).

Since the default is for the token to be stored as a cookie and for cookies to be encrypted, an attacker would have to know the application secret to exploit this. However, should a custom guard be used or cookies not be encrypted, it becomes possible to tease this value out.

The proposed change switches to comparing the token using a constant-time comparison. This makes it impossible to learn the value of the token by timing responses, independently of guard or encryption settings.