### PR TITLE
[5.5] Fix ErrorException: Undefined variable: model

### DIFF
--- a/src/Illuminate/Auth/EloquentUserProvider.php
+++ b/src/Illuminate/Auth/EloquentUserProvider.php
@@ -64,7 +64,7 @@ class EloquentUserProvider implements UserProvider
             ->where($model->getAuthIdentifierName(), $identifier)
             ->first();
 
-        return !is_null($model) && $model->exists && hash_equals($model->getRememberToken(), $token) ? $model : null;
+        return ! is_null($model) && $model->exists && hash_equals($model->getRememberToken(), $token) ? $model : null;
     }
 
     /**

--- a/src/Illuminate/Auth/EloquentUserProvider.php
+++ b/src/Illuminate/Auth/EloquentUserProvider.php
@@ -64,7 +64,7 @@ class EloquentUserProvider implements UserProvider
             ->where($model->getAuthIdentifierName(), $identifier)
             ->first();
 
-        return $model && hash_equals($model->getRememberToken(), $token) ? $model : null;
+        return !is_null($model) && $model->exists && hash_equals($model->getRememberToken(), $token) ? $model : null;
     }
 
     /**


### PR DESCRIPTION
When updating to Laravel `v5.5.10`, I get an ErrorException because the variable `$model` isn't defined. This should fix it.

:octocat: