### PR TITLE
[5.5] fixed ignored prefix while creating indexes

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -105,7 +105,7 @@ class PostgresGrammar extends Grammar
     {
         return sprintf('alter table %s add constraint %s unique (%s)',
             $this->wrapTable($blueprint),
-            $this->wrap($command->index),
+            $this->wrapTable($command->index),
             $this->columnize($command->columns)
         );
     }
@@ -120,7 +120,7 @@ class PostgresGrammar extends Grammar
     public function compileIndex(Blueprint $blueprint, Fluent $command)
     {
         return sprintf('create index %s on %s%s (%s)',
-            $this->wrap($command->index),
+            $this->wrapTable($command->index),
             $this->wrapTable($blueprint),
             $command->algorithm ? ' using '.$command->algorithm : '',
             $this->columnize($command->columns)
@@ -218,7 +218,7 @@ class PostgresGrammar extends Grammar
      */
     public function compileDropPrimary(Blueprint $blueprint, Fluent $command)
     {
-        $index = $this->wrap("{$blueprint->getTable()}_pkey");
+        $index = $this->wrapTable("{$blueprint->getTable()}_pkey");
 
         return 'alter table '.$this->wrapTable($blueprint)." drop constraint {$index}";
     }
@@ -232,7 +232,7 @@ class PostgresGrammar extends Grammar
      */
     public function compileDropUnique(Blueprint $blueprint, Fluent $command)
     {
-        $index = $this->wrap($command->index);
+        $index = $this->wrapTable($command->index);
 
         return "alter table {$this->wrapTable($blueprint)} drop constraint {$index}";
     }
@@ -246,7 +246,7 @@ class PostgresGrammar extends Grammar
      */
     public function compileDropIndex(Blueprint $blueprint, Fluent $command)
     {
-        return "drop index {$this->wrap($command->index)}";
+        return "drop index {$this->wrapTable($command->index)}";
     }
 
     /**
@@ -258,7 +258,7 @@ class PostgresGrammar extends Grammar
      */
     public function compileDropForeign(Blueprint $blueprint, Fluent $command)
     {
-        $index = $this->wrap($command->index);
+        $index = $this->wrapTable($command->index);
 
         return "alter table {$this->wrapTable($blueprint)} drop constraint {$index}";
     }


### PR DESCRIPTION
Reopening initial PR ( #21187 )

Initial issue (https://github.com/CachetHQ/Cachet/issues/2701)
```
I'm trying to get multiple CachetHQ instances running on the same database (postgres), using DB_PREFIX to keep their data separated. The first instance runs fine, but when I try adding a new instance with a different DB_PREFIX I get:

> 
> Initializing Cachet container ...
> Attempting to connect to database ...
> 
> Table foobar_sessions does not exist! ...
> Initializing Cachet database ...
> Clearing settings cache...
> Settings cache cleared!
> Backing up database...
> Dumping database and uploading...
> 
> Successfully dumped pgsql, compressed with gzip and store it to local at /var/www/html/database/backups/2017-09-01 17.13.22
> Backup completed!
> Application key [base64:+WCEmAqrMJ5nTzkRwA8XmMvSQ/P3nd2zbC8Qep9P+pg=] set successfully.
> Configuration cache cleared!
> Configuration cached successfully!
> Route cache cleared!
> Routes cached successfully!
> Copied Directory [/vendor/roumen/feed/src/views] To [/resources/views/vendor/feed]
> Publishing complete for tag []!
> Migration table created successfully.
> 
>                                                                                                                                                                                        
>   [Illuminate\Database\QueryException]                                                                                                                                                 
>   SQLSTATE[42P07]: Duplicate table: 7 ERROR:  relation "components_group_id_index" already exists (SQL: create index "components_group_id_index" on "foobar_components" ("group_id"))  
>                                                                                                                                                                                        
> 
>                                                                                                    
>   [PDOException]                                                                                   
>   SQLSTATE[42P07]: Duplicate table: 7 ERROR:  relation "components_group_id_index" already exists  
> 

```

Further analysis shows that using prefix allows the use of one DB with several (and independant) app instances connected to it (see CachetHQ/Cachet#2701 for one practical example).
All instances need a group of DB objects (tables, indexes, constraints...) dedicated to them.
Example :
```

app1_table1
app1_table2
app1_table3
app1_index1
app1_index2
app1_index3

app2_table1
app2_table2
app2_table3
app2_index1
app2_index2
app2_index3
```

Without the patch, only the following objects will be created using the "php artisan migrate" command:

```
app1_table1
app1_table2
app1_table3
index1
index2
index3

app2_table1
app2_table2
app2_table3
```

Plus, the "migrate" command will ultimately fail when trying to create indexes for prefix app2_ as DB objects index1, index2 and index3 will already be defined (though not indexing the app2 tables).
So, even if index are not tables, they need to be prefixed as well in order to ensure complete separation  of app instances in the database.