### PR TITLE
[5.5] More consistent PSR-11 implementation

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -165,7 +165,7 @@ class Container implements ArrayAccess, ContainerContract
 
     /**
      * Determine if a given class exist and can be instantiated.
-     * 
+     *
      * @param  string  $concrete
      * @return bool
      */
@@ -180,9 +180,9 @@ class Container implements ArrayAccess, ContainerContract
 
     /**
      * Determine if the given abstract is instantiable.
-     * 
+     *
      * @param  string  $concrete
-     * @return bool           
+     * @return bool    
      */
     protected function isInstantiable($concrete)
     {

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -182,7 +182,7 @@ class Container implements ArrayAccess, ContainerContract
      * Determine if the given abstract is instantiable.
      *
      * @param  string  $concrete
-     * @return bool    
+     * @return bool
      */
     protected function isInstantiable($concrete)
     {

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -164,14 +164,14 @@ class Container implements ArrayAccess, ContainerContract
     }
 
     /**
-     * Determine if a given class exist and can be instantiated
+     * Determine if a given class exist and can be instantiated.
      * 
      * @param  string  $concrete
-     * @return boolean     
+     * @return bool
      */
     protected function isResolvable($concrete)
     {
-        if(! class_exists($concrete) && ! interface_exists($concrete)) {
+        if (! class_exists($concrete) && ! interface_exists($concrete)) {
             return false;
         }
 
@@ -179,7 +179,7 @@ class Container implements ArrayAccess, ContainerContract
     }
 
     /**
-     * Determine if the given abstract is instantiable
+     * Determine if the given abstract is instantiable.
      * 
      * @param  string  $concrete
      * @return bool           

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -160,7 +160,35 @@ class Container implements ArrayAccess, ContainerContract
      */
     public function has($id)
     {
-        return $this->bound($id);
+        return $this->bound($id) || $this->isResolvable($id);
+    }
+
+    /**
+     * Determine if a given class exist and can be instantiated
+     * 
+     * @param  string  $concrete
+     * @return boolean     
+     */
+    protected function isResolvable($concrete)
+    {
+        if(! class_exists($concrete) && ! interface_exists($concrete)) {
+            return false;
+        }
+
+        return $this->isInstantiable($concrete);
+    }
+
+    /**
+     * Determine if the given abstract is instantiable
+     * 
+     * @param  string  $concrete
+     * @return bool           
+     */
+    protected function isInstantiable($concrete)
+    {
+        $reflector = new ReflectionClass($concrete);
+
+        return $reflector->isInstantiable();
     }
 
     /**
@@ -749,16 +777,16 @@ class Container implements ArrayAccess, ContainerContract
             return $concrete($this, $this->getLastParameterOverride());
         }
 
-        $reflector = new ReflectionClass($concrete);
-
         // If the type is not instantiable, the developer is attempting to resolve
         // an abstract type such as an Interface of Abstract Class and there is
         // no binding registered for the abstractions so we need to bail out.
-        if (! $reflector->isInstantiable()) {
+        if (! $this->isInstantiable($concrete)) {
             return $this->notInstantiable($concrete);
         }
 
         $this->buildStack[] = $concrete;
+
+        $reflector = new ReflectionClass($concrete);
 
         $constructor = $reflector->getConstructor();
 


### PR DESCRIPTION
This modify the behavior of the container `has()` method to return `true` if a class that has not been explicitly bound to the container can still be resolved by it. 

PSR-11 doesn't impose an explicit binding of concrete class beforehand, so we can consider returning `true` for any concrete class that can be actually resolved as it's a better reflection of how laravel's container works internally.

See discussion in laravel internals : https://github.com/laravel/internals/issues/803

