### PR TITLE
[5.5] Fixed null remember token error on EloquentUserProvider

### DIFF
--- a/src/Illuminate/Auth/EloquentUserProvider.php
+++ b/src/Illuminate/Auth/EloquentUserProvider.php
@@ -64,7 +64,9 @@ class EloquentUserProvider implements UserProvider
 
         $model = $model->where($model->getAuthIdentifierName(), $identifier)->first();
 
-        return $model && hash_equals($model->getRememberToken(), $token) ? $model : null;
+        $rememberToken = $model->getRememberToken();
+
+        return $model && $rememberToken && hash_equals($rememberToken, $token) ? $model : null;
     }
 
     /**


### PR DESCRIPTION
I added a check that `$model->getRememberToken()` isn't null before comparing it to `$token` using hash_equals so it doesn't throw an error.