### PR TITLE
[5.5] Use stored user value to avoid race condition when using id method

### DIFF
--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -204,8 +204,10 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
             return;
         }
 
-        return $this->user()
-                    ? $this->user()->getAuthIdentifier()
+        $user = $this->user();
+
+        return $user
+                    ? $user->getAuthIdentifier()
                     : $this->session->get($this->getName());
     }
 


### PR DESCRIPTION
The first call to _$this->user()_ returns a truthy value, then immediately
returns _null_ in the true branch of the conditional.

This happens very rarely, but it can be mitigated by not using
_$this->user()_ twice in a row.

Storing and using the result from the first call should ensure
consistency in any condition.


```
Symfony\Component\Debug\Exception\FatalThrowableError: Call to a member function getAuthIdentifier() on null in /var/www/html/vendor/laravel/framework/src/Illuminate/Auth/SessionGuard.php:208
```

Please advise if this should be backported to any previous version/branch. We have experienced this with 5.4. I submitted this to 5.5, since it's the default branch atm.