### PR TITLE
[5.5] Add changelog for 5.5.12 release

### DIFF
--- a/CHANGELOG-5.5.md
+++ b/CHANGELOG-5.5.md
@@ -1,5 +1,13 @@
 # Release Notes for 5.5.x
 
+## v5.5.12 (2017-09-22)
+
+### Added
+- Added "software" as an uncountable word ([#21324](https://github.com/laravel/framework/pull/21324))
+
+### Fixed
+- Fixed null remember token error on EloquentUserProvider ([#21328](https://github.com/laravel/framework/pull/21328))
+
 ## v5.5.11 (2017-09-21)
 
 ### Fixed


### PR DESCRIPTION
Adds missing changelog for Laravel [`v5.5.12`](https://github.com/laravel/framework/releases/tag/v5.5.12)