### PR TITLE
[5.5] Offer autowire with PSR-11 compliant container

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -6,8 +6,8 @@ use Closure;
 use ArrayAccess;
 use LogicException;
 use ReflectionClass;
-use ReflectionParameter;
 use ReflectionException;
+use ReflectionParameter;
 use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Contracts\Container\Container as ContainerContract;
 

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -7,6 +7,7 @@ use ArrayAccess;
 use LogicException;
 use ReflectionClass;
 use ReflectionParameter;
+use ReflectionException;
 use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Contracts\Container\Container as ContainerContract;
 
@@ -160,7 +161,13 @@ class Container implements ArrayAccess, ContainerContract
      */
     public function has($id)
     {
-        return $this->bound($id);
+        try {
+            $this->resolve($id);
+
+            return true;
+        } catch (ReflectionException $e) {
+            return false;
+        }
     }
 
     /**

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -161,6 +161,10 @@ class Container implements ArrayAccess, ContainerContract
      */
     public function has($id)
     {
+        if ($this->bound($id) || $this->resolved($id)) {
+            return true;
+        }
+
         try {
             $this->resolve($id);
 

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -993,6 +993,18 @@ class ContainerTest extends TestCase
         $container = new Container;
         $container->get('Taylor');
     }
+
+    public function testContainerKnowsAutowiredObjects()
+    {
+        $container = new Container;
+        $this->assertTrue($container->has(ContainerConcreteStub::class));
+    }
+
+    public function testUnknownEntry()
+    {
+        $container = new Container;
+        $this->assertFalse($container->has('Laravel'));
+    }
 }
 
 class ContainerConcreteStub


### PR DESCRIPTION
This is a simpler alternative for #21327. After reading through https://github.com/laravel/internals/issues/803 I see that my interpretation of https://github.com/laravel/framework/pull/19822 may have been a little bit flawed. PSR-11 leaves room of the implementation details to the concrete class. `has` doesn't necessarily needs to `return false` for auto-wire objects because Laravel Container does offer auto-wire. It is better consistency to also offer auto-wiring with `has` and `get`.