### PR TITLE
[5.5] Add config option for whoops blacklist

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -365,6 +365,12 @@ class Handler implements ExceptionHandlerContract
 
             $handler->handleUnconditionally(true);
 
+            foreach (config('whoops.blacklist', []) as $key => $secrets) {
+                foreach ($secrets as $secret) {
+                    $handler->blacklist($key, $secret);
+                }
+            }
+
             $handler->setApplicationPaths(
                 array_flip(Arr::except(
                     array_flip($files->directories(base_path())), [base_path('vendor')]


### PR DESCRIPTION
Sometimes I'm not the only one looking at my development work. As I'm working on a project, I will often show little previews of what I'm working on. Even within my local network, I will have someone checkout my dev site from their machine. It's not always convenient to spin up a test site for these previews. I don't want to expose some secrets to these folks if an exception is thrown, or others who might be looking over my shoulder.

This PR leverages Whoops's built-in blacklisting ability to mask certain variables. It is backward compatible in that if no `config/whoops.php` file exists, the behavior is the same. If you would like this option, then one would just have to create the config file. If the PR is accepted, then perhaps a base config file could be added to the laravel installer too with some sensible defaults.

For example, given this config:

```php
return [
    'blacklist' => [
        '_ENV' => [
            'APP_KEY',
            'DB_PASSWORD',
            'REDIS_PASSWORD',
            'MAIL_PASSWORD',
            'PUSHER_APP_KEY',
            'PUSHER_APP_SECRET',
        ],
        '_SERVER' => [
            'APP_KEY',
            'DB_PASSWORD',
            'REDIS_PASSWORD',
            'MAIL_PASSWORD',
            'PUSHER_APP_KEY',
            'PUSHER_APP_SECRET',
        ],
        '_POST' => [
            'password',
        ],
    ],
];
```

Results in this output:

![whoops exception page](https://i.imgur.com/chrzoPe.png)