### PR TITLE
[5.5] Optional callback for `Arr::sort()`

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -550,10 +550,10 @@ class Arr
      * Sort the array using the given callback or "dot" notation.
      *
      * @param  array  $array
-     * @param  callable|string  $callback
+     * @param  callable|string|null  $callback
      * @return array
      */
-    public static function sort($array, $callback)
+    public static function sort($array, $callback = null)
     {
         return Collection::make($array)->sortBy($callback)->all();
     }

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -282,10 +282,10 @@ if (! function_exists('array_sort')) {
      * Sort the array by the given callback or attribute name.
      *
      * @param  array  $array
-     * @param  callable|string  $callback
+     * @param  callable|string|null  $callback
      * @return array
      */
-    function array_sort($array, $callback)
+    function array_sort($array, $callback = null)
     {
         return Arr::sort($array, $callback);
     }

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -510,6 +510,9 @@ class SupportArrTest extends TestCase
             ['name' => 'Desk'],
         ];
 
+        $sorted = array_values(Arr::sort($unsorted));
+        $this->assertEquals($expected, $sorted);
+
         // sort with closure
         $sortedWithClosure = array_values(Arr::sort($unsorted, function ($value) {
             return $value['name'];


### PR DESCRIPTION
`Arr::sort()` creates a Collection and uses Collection sorting methods where a `$callback` value is not required.

This PR makes `Arr::sort()` work like `Collection::sort()` in that `$callback` is optional.

### Example

```php
$fruits = [
    'banana',
    'pear',
    'apple'
];

// Before
$sorted = Arr::sort($fruits, function($fruit) {
    return $fruit;
});

// After
$sorted = Arr::sort($fruits);

// Result
$sorted == [
    'apple',
    'banana',
    'pear'
];
```