### PR TITLE
[5.5] Add Tests for User Providers and Null-Check DatabaseUserProvider

### DIFF
--- a/src/Illuminate/Auth/DatabaseUserProvider.php
+++ b/src/Illuminate/Auth/DatabaseUserProvider.php
@@ -70,7 +70,9 @@ class DatabaseUserProvider implements UserProvider
     {
         $user = $this->conn->table($this->table)->find($identifier);
 
-        return $user && hash_equals($user->remember_token, $token)
+        $rememberToken = $user->remember_token;
+
+        return $user && $rememberToken && hash_equals($rememberToken, $token)
                     ? $this->getGenericUser($user) : null;
     }
 

--- a/tests/Auth/AuthDatabaseUserProviderTest.php
+++ b/tests/Auth/AuthDatabaseUserProviderTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Auth;
 
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Auth\GenericUser;
 use Illuminate\Auth\DatabaseUserProvider;
 
 class AuthDatabaseUserProviderTest extends TestCase
@@ -35,6 +36,36 @@ class AuthDatabaseUserProviderTest extends TestCase
         $hasher = m::mock('Illuminate\Contracts\Hashing\Hasher');
         $provider = new DatabaseUserProvider($conn, $hasher, 'foo');
         $user = $provider->retrieveById(1);
+
+        $this->assertNull($user);
+    }
+
+    public function testRetrieveByTokenReturnsUser()
+    {
+        $mockUser = new \stdClass();
+        $mockUser->remember_token = 'a';
+
+        $conn = m::mock('Illuminate\Database\Connection');
+        $conn->shouldReceive('table')->once()->with('foo')->andReturn($conn);
+        $conn->shouldReceive('find')->once()->with(1)->andReturn($mockUser);
+        $hasher = m::mock('Illuminate\Contracts\Hashing\Hasher');
+        $provider = new DatabaseUserProvider($conn, $hasher, 'foo');
+        $user = $provider->retrieveByToken(1, 'a');
+
+        $this->assertEquals(new GenericUser((array )$mockUser), $user);
+    }
+
+    public function testRetrieveByBadTokenReturnsNull()
+    {
+        $mockUser = new \stdClass();
+        $mockUser->remember_token = null;
+
+        $conn = m::mock('Illuminate\Database\Connection');
+        $conn->shouldReceive('table')->once()->with('foo')->andReturn($conn);
+        $conn->shouldReceive('find')->once()->with(1)->andReturn($mockUser);
+        $hasher = m::mock('Illuminate\Contracts\Hashing\Hasher');
+        $provider = new DatabaseUserProvider($conn, $hasher, 'foo');
+        $user = $provider->retrieveByToken(1, 'a');
 
         $this->assertNull($user);
     }

--- a/tests/Auth/AuthDatabaseUserProviderTest.php
+++ b/tests/Auth/AuthDatabaseUserProviderTest.php
@@ -52,7 +52,7 @@ class AuthDatabaseUserProviderTest extends TestCase
         $provider = new DatabaseUserProvider($conn, $hasher, 'foo');
         $user = $provider->retrieveByToken(1, 'a');
 
-        $this->assertEquals(new GenericUser((array )$mockUser), $user);
+        $this->assertEquals(new GenericUser((array) $mockUser), $user);
     }
 
     public function testRetrieveByBadTokenReturnsNull()

--- a/tests/Auth/AuthEloquentUserProviderTest.php
+++ b/tests/Auth/AuthEloquentUserProviderTest.php
@@ -27,6 +27,38 @@ class AuthEloquentUserProviderTest extends TestCase
         $this->assertEquals('bar', $user);
     }
 
+    public function testRetrieveByTokenReturnsUser()
+    {
+        $mockUser = m::mock('stdClass');
+        $mockUser->shouldReceive('getRememberToken')->once()->andReturn('a');
+
+        $provider = $this->getProviderMock();
+        $mock = m::mock('stdClass');
+        $mock->shouldReceive('getAuthIdentifierName')->once()->andReturn('id');
+        $mock->shouldReceive('where')->once()->with('id', 1)->andReturn($mock);
+        $mock->shouldReceive('first')->once()->andReturn($mockUser);
+        $provider->expects($this->once())->method('createModel')->will($this->returnValue($mock));
+        $user = $provider->retrieveByToken(1, 'a');
+
+        $this->assertEquals($mockUser, $user);
+    }
+
+    public function testRetrieveByBadTokenReturnsNull()
+    {
+        $mockUser = m::mock('stdClass');
+        $mockUser->shouldReceive('getRememberToken')->once()->andReturn(null);
+
+        $provider = $this->getProviderMock();
+        $mock = m::mock('stdClass');
+        $mock->shouldReceive('getAuthIdentifierName')->once()->andReturn('id');
+        $mock->shouldReceive('where')->once()->with('id', 1)->andReturn($mock);
+        $mock->shouldReceive('first')->once()->andReturn($mockUser);
+        $provider->expects($this->once())->method('createModel')->will($this->returnValue($mock));
+        $user = $provider->retrieveByToken(1, 'a');
+
+        $this->assertNull($user);
+    }
+
     public function testRetrieveByCredentialsReturnsUser()
     {
         $provider = $this->getProviderMock();


### PR DESCRIPTION
I'm sure you're not happy to see another PR from me so soon, but the `DatabaseUserProvider` should be subject to the same null issue that the EloquentUserProvider is and I don't want to let that stand.

This PR applies the fix from #21328 to the DatabaseUserProvider and covers both `retrieveByToken` calls with tests. I don't know how these methods weren't tested in the first place, but again, I should have verified that the tests actually existed and checked null values before sending that last PR.