### PR TITLE
[5.4] Updating MakesHttpRequests

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -281,7 +281,7 @@ trait MakesHttpRequests
      */
     protected function formatServerHeaderKey($name)
     {
-        if (! Str::startsWith($name, 'HTTP_') && $name != 'CONTENT_TYPE') {
+        if (! Str::startsWith($name, 'HTTP_') && $name != 'CONTENT_TYPE' && $name != 'REMOTE_ADDR') {
             return 'HTTP_'.$name;
         }
 


### PR DESCRIPTION
This is a fix for setting remote ip for http tests with the ->get($url, [ 'REMOTE_ADDR' => $custom_ip ])

see https://github.com/laravel/framework/issues/21350