### PR TITLE
[5.6] Add the batch number to `migrate:status` command

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/StatusCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/StatusCommand.php
@@ -56,9 +56,10 @@ class StatusCommand extends BaseCommand
         }
 
         $ran = $this->migrator->getRepository()->getRan();
+        $migrationsBatches = $this->migrator->getRepository()->getMigrationsBatches();
 
-        if (count($migrations = $this->getStatusFor($ran)) > 0) {
-            $this->table(['Ran?', 'Migration'], $migrations);
+        if (count($migrations = $this->getStatusFor($ran, $migrationsBatches)) > 0) {
+            $this->table(['Ran?', 'Migration', 'Batch'], $migrations);
         } else {
             $this->error('No migrations found');
         }
@@ -70,14 +71,14 @@ class StatusCommand extends BaseCommand
      * @param  array  $ran
      * @return \Illuminate\Support\Collection
      */
-    protected function getStatusFor(array $ran)
+    protected function getStatusFor(array $ran, array $migrationsBatches)
     {
         return Collection::make($this->getAllMigrationFiles())
-                    ->map(function ($migration) use ($ran) {
+                    ->map(function ($migration) use ($ran, $migrationsBatches) {
                         $migrationName = $this->migrator->getMigrationName($migration);
 
                         return in_array($migrationName, $ran)
-                                ? ['<info>Y</info>', $migrationName]
+                                ? ['<info>Y</info>', $migrationName, $migrationsBatches[$migrationName]]
                                 : ['<fg=red>N</fg=red>', $migrationName];
                     });
     }

--- a/src/Illuminate/Database/Console/Migrations/StatusCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/StatusCommand.php
@@ -69,6 +69,7 @@ class StatusCommand extends BaseCommand
      * Get the status for the given ran migrations.
      *
      * @param  array  $ran
+     * @param  array  $migrationsBatches
      * @return \Illuminate\Support\Collection
      */
     protected function getStatusFor(array $ran, array $migrationsBatches)

--- a/src/Illuminate/Database/Migrations/DatabaseMigrationRepository.php
+++ b/src/Illuminate/Database/Migrations/DatabaseMigrationRepository.php
@@ -54,6 +54,19 @@ class DatabaseMigrationRepository implements MigrationRepositoryInterface
     }
 
     /**
+     * Get the ran migrations with batch numbers.
+     *
+     * @return array
+     */
+    public function getMigrationsBatches()
+    {
+        return $this->table()
+            ->orderBy('batch', 'asc')
+            ->orderBy('migration', 'asc')
+            ->pluck('batch', 'migration')->all();
+    }
+
+    /**
      * Get list of migrations.
      *
      * @param  int  $steps

--- a/src/Illuminate/Database/Migrations/MigrationRepositoryInterface.php
+++ b/src/Illuminate/Database/Migrations/MigrationRepositoryInterface.php
@@ -12,6 +12,13 @@ interface MigrationRepositoryInterface
     public function getRan();
 
     /**
+     * Get the ran migrations with batch numbers for a given package.
+     *
+     * @return array
+     */
+    public function getMigrationsBatches();
+
+    /**
      * Get list of migrations.
      *
      * @param  int  $steps


### PR DESCRIPTION
adding the batch number to `migrate:status` command

![laravel-migration](https://cloud.githubusercontent.com/assets/1895158/26267980/472ca0d8-3ced-11e7-93da-8100cd3ed03f.png)
