### PR TITLE
[5.5] Updates output property visibility on Artisan command events

### DIFF
--- a/src/Illuminate/Console/Events/CommandFinished.php
+++ b/src/Illuminate/Console/Events/CommandFinished.php
@@ -26,7 +26,7 @@ class CommandFinished
      *
      * @var \Symfony\Component\Console\Output\OutputInterface|null
      */
-    protected $output;
+    public $output;
 
     /**
      * The command exit code.

--- a/src/Illuminate/Console/Events/CommandStarting.php
+++ b/src/Illuminate/Console/Events/CommandStarting.php
@@ -26,7 +26,7 @@ class CommandStarting
      *
      * @var \Symfony\Component\Console\Output\OutputInterface|null
      */
-    protected $output;
+    public $output;
 
     /**
      * Create a new event instance.


### PR DESCRIPTION
This PR addresses the events `CommandStarting`and `CommandFinished` making the `output` implementation accessible via a listener.

With this change, the listener can output information before and after every command execution.