### PR TITLE
[5.5] Add and stop middleware methods

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -2,24 +2,24 @@
 
 namespace Illuminate\Routing;
 
-use ArrayObject;
 use Closure;
-use Illuminate\Container\Container;
-use Illuminate\Contracts\Events\Dispatcher;
-use Illuminate\Contracts\Routing\BindingRegistrar;
-use Illuminate\Contracts\Routing\Registrar as RegistrarContract;
-use Illuminate\Contracts\Support\Arrayable;
-use Illuminate\Contracts\Support\Jsonable;
-use Illuminate\Contracts\Support\Responsable;
-use Illuminate\Http\JsonResponse;
+use ArrayObject;
+use JsonSerializable;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
-use Illuminate\Support\Arr;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Str;
+use Illuminate\Container\Container;
 use Illuminate\Support\Traits\Macroable;
-use JsonSerializable;
+use Illuminate\Contracts\Support\Jsonable;
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Contracts\Support\Responsable;
+use Illuminate\Contracts\Routing\BindingRegistrar;
 use Psr\Http\Message\ResponseInterface as PsrResponseInterface;
+use Illuminate\Contracts\Routing\Registrar as RegistrarContract;
 use Symfony\Bridge\PsrHttpMessage\Factory\HttpFoundationFactory;
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -411,9 +411,7 @@ class Router implements RegistrarContract, BindingRegistrar
     protected function addRoute($methods, $uri, $action)
     {
         return tap($this->routes->add($this->createRoute($methods, $uri, $action)), function($route) {
-            if(! empty($this->currentMiddlewares)) {
-                $route->middleware(Arr::flatten($this->currentMiddlewares));
-            }
+            $route->middleware(Arr::flatten($this->currentMiddlewares));    
         });
     }
 

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -265,6 +265,52 @@ class RouteRegistrarTest extends TestCase
         $this->seeMiddleware('Illuminate\Tests\Routing\RouteRegistrarMiddlewareStub');
     }
 
+    public function testCanStartAndStopMiddlewares()
+    {
+        $this->router->startMiddleware('Illuminate\Tests\Routing\RouteRegistrarMiddlewareStub');
+
+        $this->router->get('users', function () {
+            return 'all-users';
+        });
+
+        $this->router->stopMiddleware();
+
+        $this->seeMiddleware('Illuminate\Tests\Routing\RouteRegistrarMiddlewareStub');
+
+        $this->router->get('foo', function () {
+            return 'all-users';
+        });
+
+        $this->assertEmpty($this->getRoute()->middleware());
+    }
+
+    public function testCanStartAndStopAnArrayOfMiddlewares()
+    {
+        $this->router->startMiddleware(['Illuminate\Tests\Routing\RouteRegistrarMiddlewareStub', 'foo']);
+        $this->router->startMiddleware(['bar', 'baz']);
+        $this->router->startMiddleware('laravel');
+
+        $this->router->get('users', function () {
+            return 'all-users';
+        });
+
+        $this->router->stopMiddleware();
+        $this->router->stopMiddleware();
+        $this->router->stopMiddleware();
+
+        $this->seeResponse('all-users', Request::create('users', 'GET'));
+        $this->assertEquals('Illuminate\Tests\Routing\RouteRegistrarMiddlewareStub', $this->getRoute()->middleware()[0]);
+        $this->assertEquals('foo', $this->getRoute()->middleware()[1]);
+        $this->assertEquals('bar', $this->getRoute()->middleware()[2]);
+        $this->assertEquals('baz', $this->getRoute()->middleware()[3]);
+
+        $this->router->get('foo', function () {
+            return 'all-users';
+        });
+
+        $this->assertEmpty($this->getRoute()->middleware());
+    }
+
     public function testCanSetRouteName()
     {
         $this->router->as('users.index')->get('users', function () {

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -311,6 +311,18 @@ class RouteRegistrarTest extends TestCase
         $this->assertEmpty($this->getRoute()->middleware());
     }
 
+    public function testCanStartAndStopMiddlewaresOnAResource()
+    {
+        $this->router->startMiddleware('Illuminate\Tests\Routing\RouteRegistrarMiddlewareStub');
+        $this->router->resource('users', 'Illuminate\Tests\Routing\RouteRegistrarControllerStub');
+        $this->router->stopMiddleware();
+
+        $this->seeMiddleware('Illuminate\Tests\Routing\RouteRegistrarMiddlewareStub');
+
+        $this->router->resource('foo', 'Illuminate\Tests\Routing\RouteRegistrarControllerStub');
+        $this->assertEmpty($this->getRoute()->middleware());
+    }                   
+
     public function testCanSetRouteName()
     {
         $this->router->as('users.index')->get('users', function () {


### PR DESCRIPTION
Hey guys   

Just an idea -- I was thinking about a `Route::startMiddleware('foo')`. So, for instance, you could do something like this:   

```php   
Route::startMiddleware('auth');

Route::startMiddleware('cors');

Route::get('cors');

Route::stopMiddleware();

Route::get('foo', 'FooController@index');

Route:stopMiddleware();   

Route::get('users', 'UsersController@index');
```     

`cors` would have `auth` and `cors` middlewares applied.   
`foo` would have `auth` middleware applied.   
`users` would have no middlewares.

The `foo` route would have the `auth`  middleware applied. As far as I know the only way to do thi right now is using the `group` method, right?  

Sorry if something like this already exists — wasn't aware!   