### PR TITLE
Fixed stable sortBy() not sorting correctly when chained

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1351,7 +1351,9 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
             $values[] = $callback($value, $key);
         }
 
-        $keys = array_keys($this->items);
+        $items = array_values($this->items);
+        $keys = array_keys($items);
+        $resultKeys = array_combine($keys, array_keys($this->items));
 
         $order = $descending ? SORT_DESC : SORT_ASC;
 
@@ -1361,7 +1363,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
         // and grab the corresponding model so we can set the underlying items list
         // to the sorted version. Then we'll just return the collection instance.
         foreach ($keys as $key) {
-            $results[$key] = $this->items[$key];
+            $results[$resultKeys[$key]] = $items[$key];
         }
 
         return new static($results);

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -805,6 +805,31 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals([['name' => 'dayle'], ['name' => 'taylor']], array_values($data->all()));
     }
 
+    public function testChainedSortByMaintainsOriginalOrderOfItemsWithIdenticalValues()
+    {
+        $data = new Collection(
+            [
+                ['name' => 'Ann', 'grade' => 'B'],
+                ['name' => 'Boris', 'grade' => 'B'],
+                ['name' => 'Dave', 'grade' => 'A'],
+                ['name' => 'Cathy', 'grade' => 'A'],
+            ]
+        );
+
+        $data = $data->sortBy('name')->sortBy('grade');
+
+        $this->assertEquals(
+            [
+                ['name' => 'Cathy', 'grade' => 'A'],
+                ['name' => 'Dave', 'grade' => 'A'],
+                ['name' => 'Ann', 'grade' => 'B'],
+                ['name' => 'Boris', 'grade' => 'B'],
+            ],
+            array_values($data->all())
+        );
+        $this->assertEquals([3, 2, 0, 1], $data->keys()->all());
+    }
+
     public function testSortByMaintainsOriginalOrderOfItemsWithIdenticalValues()
     {
         $data = new Collection([['name' => 'taylor'], ['name' => 'dayle'], ['name' => 'dayle']]);


### PR DESCRIPTION
This pull request is related to https://github.com/laravel/framework/pull/21270 and https://github.com/laravel/framework/pull/21214).

## Problem

Suppose we have a collection like this:
```
$grades = collect([
    ['name' => 'Ann', 'grade' => 'B'],
    ['name' => 'Boris', 'grade' => 'B'],
    ['name' => 'Dave', 'grade' => 'A'],
    ['name' => 'Cathy', 'grade' => 'A'],
]);
```

We want everything sorted by grade first; if the grades are equal, we want to sort by name. In Laravel 5.4, we could do this:

```
$grades->sortBy('name')->sortBy('grade');
```

Because of how sortBy was changed to work stable with duplicate entries in 5.5 (cfr. pull requests mentioned earlier), this doesn't work anymore.

The result from the chained sortBy() methods is this in Laravel 5.5:

```
Illuminate\Support\Collection {#14
  #items: array:4 [
    0 => array:2 [
      "name" => "Dave"
      "grade" => "A"
    ]
    1 => array:2 [
      "name" => "Cathy"
      "grade" => "A"
    ]
    2 => array:2 [
      "name" => "Ann"
      "grade" => "B"
    ]
    3 => array:2 [
      "name" => "Boris"
      "grade" => "B"
    ]
  ]
}
```

This is not the expected behaviour: Cathy should come before Dave.

## Cause

The cause of this becomes clear when we look at the keys of the array between the two sort operations. After performing the `sortBy('name')`, this is the collection:

```
Illuminate\Support\Collection {#16
  #items: array:4 [
    0 => array:2 [
      "name" => "Ann"
      "grade" => "B"
    ]
    1 => array:2 [
      "name" => "Boris"
      "grade" => "B"
    ]
    3 => array:2 [
      "name" => "Cathy"
      "grade" => "A"
    ]
    2 => array:2 [
      "name" => "Dave"
      "grade" => "A"
    ]
  ]
}
```

When we try to sort by grade now, it will see the grade of Cathy and Dave as equal and sort based on theirs keys instead (this was introduced by the stable sort).

## Solution 

One possible solution to this is to add a `->values()` call in the chain:

```
$grades->sortBy('name')->values()->sortBy('grade');
```

This will reset the keys, resulting in key '2' for Cathy and key '3' for Dave.

I've used this idea to try and implement a fix for this issue. Instead of using `$this->items` directly, I use the values of `$this->items`. The keys for these values are used in the `array_multisort` call to make sure we don't lose the stable sort. 

However, the keys of the values array, are not the original keys (which we want to keep too, especially when working with associative arrays). This is why I keep the `$resultKeys` variable containing the mapping from the keys of the values array to the original keys.