### PR TITLE
[5.5] Add Tests Demonstrating and Fixes for Error on Retrieving a User By Token With a Bad Identifier

### DIFF
--- a/src/Illuminate/Auth/DatabaseUserProvider.php
+++ b/src/Illuminate/Auth/DatabaseUserProvider.php
@@ -70,9 +70,7 @@ class DatabaseUserProvider implements UserProvider
     {
         $user = $this->conn->table($this->table)->find($identifier);
 
-        $rememberToken = $user->remember_token;
-
-        return $user && $rememberToken && hash_equals($rememberToken, $token)
+        return $user && $user->remember_token && hash_equals($user->remember_token, $token)
                     ? $this->getGenericUser($user) : null;
     }
 

--- a/src/Illuminate/Auth/EloquentUserProvider.php
+++ b/src/Illuminate/Auth/EloquentUserProvider.php
@@ -64,9 +64,13 @@ class EloquentUserProvider implements UserProvider
 
         $model = $model->where($model->getAuthIdentifierName(), $identifier)->first();
 
+        if (!$model) {
+            return null;
+        }
+
         $rememberToken = $model->getRememberToken();
 
-        return $model && $rememberToken && hash_equals($rememberToken, $token) ? $model : null;
+        return $rememberToken && hash_equals($rememberToken, $token) ? $model : null;
     }
 
     /**

--- a/src/Illuminate/Auth/EloquentUserProvider.php
+++ b/src/Illuminate/Auth/EloquentUserProvider.php
@@ -64,7 +64,7 @@ class EloquentUserProvider implements UserProvider
 
         $model = $model->where($model->getAuthIdentifierName(), $identifier)->first();
 
-        if (!$model) {
+        if (! $model) {
             return null;
         }
 

--- a/tests/Auth/AuthDatabaseUserProviderTest.php
+++ b/tests/Auth/AuthDatabaseUserProviderTest.php
@@ -55,6 +55,18 @@ class AuthDatabaseUserProviderTest extends TestCase
         $this->assertEquals(new GenericUser((array) $mockUser), $user);
     }
 
+    public function testRetrieveTokenWithBadIdentifierReturnsNull()
+    {
+        $conn = m::mock('Illuminate\Database\Connection');
+        $conn->shouldReceive('table')->once()->with('foo')->andReturn($conn);
+        $conn->shouldReceive('find')->once()->with(1)->andReturn(null);
+        $hasher = m::mock('Illuminate\Contracts\Hashing\Hasher');
+        $provider = new DatabaseUserProvider($conn, $hasher, 'foo');
+        $user = $provider->retrieveByToken(1, 'a');
+
+        $this->assertNull($user);
+    }
+
     public function testRetrieveByBadTokenReturnsNull()
     {
         $mockUser = new \stdClass();

--- a/tests/Auth/AuthEloquentUserProviderTest.php
+++ b/tests/Auth/AuthEloquentUserProviderTest.php
@@ -43,6 +43,19 @@ class AuthEloquentUserProviderTest extends TestCase
         $this->assertEquals($mockUser, $user);
     }
 
+    public function testRetrieveTokenWithBadIdentifierReturnsNull()
+    {
+        $provider = $this->getProviderMock();
+        $mock = m::mock('stdClass');
+        $mock->shouldReceive('getAuthIdentifierName')->once()->andReturn('id');
+        $mock->shouldReceive('where')->once()->with('id', 1)->andReturn($mock);
+        $mock->shouldReceive('first')->once()->andReturn(null);
+        $provider->expects($this->once())->method('createModel')->will($this->returnValue($mock));
+        $user = $provider->retrieveByToken(1, 'a');
+
+        $this->assertNull($user);
+    }
+
     public function testRetrieveByBadTokenReturnsNull()
     {
         $mockUser = m::mock('stdClass');


### PR DESCRIPTION
This addresses the issue that @SebastianS90 pointed out and adds tests to demonstrate it.