### PR TITLE
[5.5]  Ensure user is logged before expecting user instance type.

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithAuthentication.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithAuthentication.php
@@ -82,6 +82,11 @@ trait InteractsWithAuthentication
     {
         $expected = $this->app->make('auth')->guard($guard)->user();
 
+        $this->assertNotNull(
+            $expected,
+            'The current user is not authenticated.'
+        );
+
         $this->assertInstanceOf(
             get_class($expected), $user,
             'The currently authenticated user is not who was expected'

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithAuthentication.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithAuthentication.php
@@ -82,10 +82,7 @@ trait InteractsWithAuthentication
     {
         $expected = $this->app->make('auth')->guard($guard)->user();
 
-        $this->assertNotNull(
-            $expected,
-            'The current user is not authenticated.'
-        );
+        $this->assertNotNull($expected, 'The current user is not authenticated.');
 
         $this->assertInstanceOf(
             get_class($expected), $user,


### PR DESCRIPTION
When using the `assertAuthenticatedAs` method, if the user is not logged, the output message was strange. This PR introduce a new check to ensure the user is logged.

Before :
```
Tests\Feature\RegisterControllerTest::testRegisterWithSpecificRole with data set #3 (5)
The currently authenticated user is not who was expected
Failed asserting that Act\User Object (...) is an instance of class "Illuminate\Foundation\Testing\TestCase".
```

After :
```
Tests\Feature\RegisterControllerTest::testRegisterWithSpecificRole with data set #3 (5)
The current user is not authenticated.
```