### PR TITLE
[5.5] Allow testing anonymous notifiables

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
@@ -178,6 +178,7 @@ class NotificationFake implements NotificationFactory
             $this->notifications[get_class($notifiable)][$notifiable->getKey()][get_class($notification)][] = [
                 'notification' => $notification,
                 'channels' => $notification->via($notifiable),
+                'notifiable' => $notifiable,
             ];
         }
     }

--- a/tests/Integration/Notifications/SendingNotificationsViaAnonymousNotifiableTest.php
+++ b/tests/Integration/Notifications/SendingNotificationsViaAnonymousNotifiableTest.php
@@ -48,9 +48,11 @@ class SendingNotificationsViaAnonymousNotifiableTest extends TestCase
             new TestMailNotificationForAnonymousNotifiable()
         );
 
-        NotificationFacade::assertSentTo(new AnonymousNotifiable(), TestMailNotificationForAnonymousNotifiable::class, function($notification, $channels, $notifiable){
-            return $notifiable->routes['testchannel'] == 'enzo' && $notifiable->routes['anothertestchannel'] == 'enzo@deepblue.com';
-        });
+        NotificationFacade::assertSentTo(new AnonymousNotifiable(), TestMailNotificationForAnonymousNotifiable::class,
+            function ($notification, $channels, $notifiable) {
+                return $notifiable->routes['testchannel'] == 'enzo' && $notifiable->routes['anothertestchannel'] == 'enzo@deepblue.com';
+            }
+        );
     }
 }
 

--- a/tests/Integration/Notifications/SendingNotificationsViaAnonymousNotifiableTest.php
+++ b/tests/Integration/Notifications/SendingNotificationsViaAnonymousNotifiableTest.php
@@ -34,6 +34,24 @@ class SendingNotificationsViaAnonymousNotifiableTest extends TestCase
             'enzo', 'enzo@deepblue.com',
         ], $_SERVER['__notifiable.route']);
     }
+
+    public function test_faking()
+    {
+        NotificationFacade::fake();
+
+        $notifiable = (new AnonymousNotifiable())
+            ->route('testchannel', 'enzo')
+            ->route('anothertestchannel', 'enzo@deepblue.com');
+
+        NotificationFacade::send(
+            $notifiable,
+            new TestMailNotificationForAnonymousNotifiable()
+        );
+
+        NotificationFacade::assertSentTo(new AnonymousNotifiable(), TestMailNotificationForAnonymousNotifiable::class, function($notification, $channels, $notifiable){
+            return $notifiable->routes['testchannel'] == 'enzo' && $notifiable->routes['anothertestchannel'] == 'enzo@deepblue.com';
+        });
+    }
 }
 
 class TestMailNotificationForAnonymousNotifiable extends Notification


### PR DESCRIPTION
Storing the notifiable in the fake notifications array will give us the change to do something like:

```php
Notification::assertSentTo(new AnonymousNotifiable(), Notification::class, function($notification, $channels, $notifiable){
            return $notifiable->routes['mail'] == 'mail@yahoo.com';
        });
```