### PR TITLE
Extend the Arr::wrap() method.

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -605,7 +605,7 @@ class Arr
         if (is_array($value)) {
             return $value;
         }
-        
+
         return is_null($key) ? [$value] : [$key => $value];
     }
 }

--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -597,10 +597,15 @@ class Arr
      * If the given value is not an array, wrap it in one.
      *
      * @param  mixed  $value
+     * @param  string|null  $key
      * @return array
      */
-    public static function wrap($value)
+    public static function wrap($value, $key = null)
     {
-        return ! is_array($value) ? [$value] : $value;
+        if (is_array($value)) {
+            return $value;
+        }
+        
+        return is_null($key) ? [$value] : [$key => $value];
     }
 }

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -659,8 +659,12 @@ class SupportArrTest extends TestCase
         $array = ['a'];
         $object = new stdClass;
         $object->value = 'a';
+        $key = 't';
         $this->assertEquals(['a'], Arr::wrap($string));
         $this->assertEquals($array, Arr::wrap($array));
         $this->assertEquals([$object], Arr::wrap($object));
+        $this->assertEquals(['t' => 'a'], Arr::wrap($string, $key));
+        $this->assertEquals($array, Arr::wrap($array, $key));
+        $this->assertEquals(['t' => $object], Arr::wrap($object, $key));
     }
 }


### PR DESCRIPTION
This can wrap a non-array value into an associative array.