### PR TITLE
[5.5] Revert Collection::sortBy to 5.4 behaviour

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1340,7 +1340,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      */
     public function sortBy($callback, $options = SORT_REGULAR, $descending = false)
     {
-        list($values, $results) = [[], []];
+        $results = [];
 
         $callback = $this->valueRetriever($callback);
 
@@ -1348,19 +1348,16 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
         // function which we were given. Then, we will sort the returned values and
         // and grab the corresponding values for the sorted keys from this array.
         foreach ($this->items as $key => $value) {
-            $values[] = $callback($value, $key);
+            $results[$key] = $callback($value, $key);
         }
 
-        $keys = array_keys($this->items);
-
-        $order = $descending ? SORT_DESC : SORT_ASC;
-
-        array_multisort($values, $order, $options, $keys, $order);
+        $descending ? arsort($results, $options)
+            : asort($results, $options);
 
         // Once we have sorted all of the keys in the array, we will loop through them
         // and grab the corresponding model so we can set the underlying items list
         // to the sorted version. Then we'll just return the collection instance.
-        foreach ($keys as $key) {
+        foreach (array_keys($results) as $key) {
             $results[$key] = $this->items[$key];
         }
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -805,45 +805,6 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals([['name' => 'dayle'], ['name' => 'taylor']], array_values($data->all()));
     }
 
-    public function testSortByMaintainsOriginalOrderOfItemsWithIdenticalValues()
-    {
-        $data = new Collection([['name' => 'taylor'], ['name' => 'dayle'], ['name' => 'dayle']]);
-
-        $data = $data->sortBy('name');
-
-        $this->assertEquals([['name' => 'dayle'], ['name' => 'dayle'], ['name' => 'taylor']], array_values($data->all()));
-        $this->assertEquals([1, 2, 0], $data->keys()->all());
-    }
-
-    public function testSortByStringMaintainsOriginalOrderOfItemsWithIdenticalValues()
-    {
-        $data = new Collection([['name' => 'taylor'], ['name' => 'dayle'], ['name' => 'dayle']]);
-
-        $data = $data->sortBy('name', SORT_STRING);
-
-        $this->assertEquals([['name' => 'dayle'], ['name' => 'dayle'], ['name' => 'taylor']], array_values($data->all()));
-        $this->assertEquals([1, 2, 0], $data->keys()->all());
-    }
-
-    public function testSortByNumericMaintainsOriginalOrderOfItemsWithIdenticalValues()
-    {
-        $data = new Collection([['name' => '2'], ['name' => '1'], ['name' => '1']]);
-        $data = $data->sortBy('name', SORT_NUMERIC);
-
-        $this->assertEquals([['name' => '1'], ['name' => '1'], ['name' => '2']], array_values($data->all()));
-        $this->assertEquals([1, 2, 0], $data->keys()->all());
-    }
-
-    public function testSortByNaturalMaintainsOriginalOrderOfItemsWithIdenticalValues()
-    {
-        $data = new Collection([['name' => 'img10.png'], ['name' => 'img1.png'], ['name' => 'img1.png']]);
-
-        $data = $data->sortBy('name', SORT_NATURAL);
-
-        $this->assertEquals([['name' => 'img1.png'], ['name' => 'img1.png'], ['name' => 'img10.png']], array_values($data->all()));
-        $this->assertEquals([1, 2, 0], $data->keys()->all());
-    }
-
     public function testSortByAlwaysReturnsAssoc()
     {
         $data = new Collection(['a' => 'taylor', 'b' => 'dayle']);


### PR DESCRIPTION
That's how the method used to work in 5.4:
https://github.com/laravel/framework/blob/5.4/src/Illuminate/Support/Collection.php#L1259