### PR TITLE
[5.5] Add firstOrCreate method to factory builder

### DIFF
--- a/src/Illuminate/Database/Eloquent/FactoryBuilder.php
+++ b/src/Illuminate/Database/Eloquent/FactoryBuilder.php
@@ -157,6 +157,23 @@ class FactoryBuilder
     }
 
     /**
+     * Create or get a collection of models.
+     *
+     * @param array $attributes
+     * @return mixed
+     */
+    public function firstOrCreate(array $attributes = [])
+    {
+        $query = (new $this->class)->where($attributes);
+
+        if ($this->amount === null) {
+            return $query->first() ?? $this->create($attributes);
+        } else {
+            return $query->exists() ? $query->get() : $this->create($attributes);
+        }
+    }
+
+    /**
      * Set the connection name on the results and store them.
      *
      * @param  \Illuminate\Support\Collection  $results


### PR DESCRIPTION
If you want to add item for one time without repeating or if it is unique.

For example : 
```php
factory(\App\User::class)->firstOrCreate(['email' => 'aliraqi.dev@gmail.com']);
```

in this example if you call `php artisan db:seed` more than once no errors will appeary 