### PR TITLE
Fix TestResponse::assertSeeText() HTML decoding bug

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -206,7 +206,7 @@ class TestResponse
      */
     public function assertSeeText($value)
     {
-        PHPUnit::assertContains($value, strip_tags($this->getContent()));
+        PHPUnit::assertContains($value, html_entity_decode(strip_tags($this->getContent()), ENT_QUOTES));
 
         return $this;
     }

--- a/tests/Foundation/FoundationTestResponseTest.php
+++ b/tests/Foundation/FoundationTestResponseTest.php
@@ -54,6 +54,19 @@ class FoundationTestResponseTest extends TestCase
         $response->assertSeeText('foobar');
     }
 
+    public function testAssertSeeTextEscapesSpecialChars()
+    {
+        $baseResponse = tap(new Response, function ($response) {
+            $response->setContent(\Mockery::mock(View::class, [
+                'render' => 'foo&#039;s b&auml;r',
+            ]));
+        });
+
+        $response = TestResponse::fromBaseResponse($baseResponse);
+
+        $response->assertSeeText("foo's bär");
+    }
+
     public function testAssertHeader()
     {
         $baseResponse = tap(new Response, function ($response) {


### PR DESCRIPTION
Fix a bug where TestResponse::assertSeeText() won't decode HTML
encoded characters before assertion.

For example:
```
foo&#039;s b&auml;r
```

would not match the expected
```
foo's bär
```