### PR TITLE
[5.6] Fix add user defined primary key constraint name in postgres grammar

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -89,9 +89,11 @@ class PostgresGrammar extends Grammar
      */
     public function compilePrimary(Blueprint $blueprint, Fluent $command)
     {
-        $columns = $this->columnize($command->columns);
-
-        return 'alter table '.$this->wrapTable($blueprint)." add primary key ({$columns})";
+        return sprintf('alter table %s add constraint %s primary key (%s)',
+            $this->wrapTable($blueprint),
+            $this->wrap($command->index),
+            $this->columnize($command->columns)
+        );
     }
 
     /**
@@ -218,9 +220,7 @@ class PostgresGrammar extends Grammar
      */
     public function compileDropPrimary(Blueprint $blueprint, Fluent $command)
     {
-        $index = $this->wrap("{$blueprint->getTable()}_pkey");
-
-        return 'alter table '.$this->wrapTable($blueprint)." drop constraint {$index}";
+        return $this->dropConstraint($blueprint, $command->index);
     }
 
     /**
@@ -232,9 +232,22 @@ class PostgresGrammar extends Grammar
      */
     public function compileDropUnique(Blueprint $blueprint, Fluent $command)
     {
-        $index = $this->wrap($command->index);
+        return $this->dropConstraint($blueprint, $command->index);
+    }
 
-        return "alter table {$this->wrapTable($blueprint)} drop constraint {$index}";
+    /**
+     * Compile a drop constraint command.
+     *
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @param  string  $name
+     * @return string
+     */
+    protected function dropConstraint(Blueprint $blueprint, string $name)
+    {
+        return sprintf('alter table %s drop constraint %s',
+            $this->wrapTable($blueprint),
+            $this->wrap($name)
+        );
     }
 
     /**

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -101,7 +101,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(2, $statements);
-        $this->assertEquals('alter table "users" drop constraint "users_'.implode("_", $columns).'_primary"', $statements[1]);
+        $this->assertEquals('alter table "users" drop constraint "users_'.implode('_', $columns).'_primary"', $statements[1]);
     }
 
     public function testDropUnique()

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -101,7 +101,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(2, $statements);
-        $this->assertEquals('alter table "users" drop constraint "users_' . implode("_", $columns) . '_primary"', $statements[1]);
+        $this->assertEquals('alter table "users" drop constraint "users_'.implode("_", $columns).'_primary"', $statements[1]);
     }
 
     public function testDropUnique()

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -80,11 +80,28 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
     public function testDropPrimary()
     {
         $blueprint = new Blueprint('users');
-        $blueprint->dropPrimary();
+        $blueprint->dropPrimary('id');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" drop constraint "users_pkey"', $statements[0]);
+        $this->assertEquals('alter table "users" drop constraint "id"', $statements[0]);
+    }
+
+    public function testDropPrimaryWithColumns()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->dropPrimary(['id']);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table "users" drop constraint "users_id_primary"', $statements[0]);
+
+        $columns = ['id', 'code'];
+        $blueprint->dropPrimary($columns);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(2, $statements);
+        $this->assertEquals('alter table "users" drop constraint "users_' . implode("_", $columns) . '_primary"', $statements[1]);
     }
 
     public function testDropUnique()
@@ -154,7 +171,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add primary key ("foo")', $statements[0]);
+        $this->assertEquals('alter table "users" add constraint "users_foo_primary" primary key ("foo")', $statements[0]);
     }
 
     public function testAddingUniqueKey()


### PR DESCRIPTION
### Present behaviour

`` $table->primary('id', 'pk_tablename_id'); ``

Creates a primary key with index name of **tablename_pkey** in postgres as no ``constraint`` keyword is not used in creating or altering table with a constraint name. i.e, **pk_tablename_id**.

### Expected behaviour

Create a primary index with name ``pk_tablename_id``

### With this PR behaviour will be

`` $table->primary('id'); ``

Results in creating an primary index with given name or laravel generated name.
Ex: pk_tablename_id or tablename_id_primary _(if no constraint name is given)_

## It is a breaking change, in this scenario
If a migration had created before this PR and dropping a ``primary`` index after this PR results in unexpected constraint names. So giving PR to master not to 5.5