### PR TITLE
[5.5] Add Missing Abstract Relation Method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -117,6 +117,13 @@ abstract class Relation
     abstract public function initRelation(array $models, $relation);
 
     /**
+     * Get the key for comparing against in "has" query.
+     *
+     * @return string
+     */
+    abstract public function getExistenceCompareKey();
+
+    /**
      * Match the eagerly loaded results to their parents.
      *
      * @param  array   $models


### PR DESCRIPTION
For some reason, this method is not defined (not even as abstract) even though it's called within its self... (Take a look at line 214)