### PR TITLE
[5.5] limit some relation queries by 1 when eager loading

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
@@ -197,6 +197,16 @@ class BelongsTo extends Relation
     }
 
     /**
+     * Get the relationship for eager loading.
+     *
+     * @return \Illuminate\Database\Eloquent\Collection
+     */
+    public function getEager()
+    {
+        return $this->take(1)->get();
+    }
+
+    /**
      * Update the parent model on the relationship.
      *
      * @param  array  $attributes

--- a/src/Illuminate/Database/Eloquent/Relations/HasOne.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOne.php
@@ -50,6 +50,16 @@ class HasOne extends HasOneOrMany
     }
 
     /**
+     * Get the relationship for eager loading.
+     *
+     * @return \Illuminate\Database\Eloquent\Collection
+     */
+    public function getEager()
+    {
+        return $this->take(1)->get();
+    }
+
+    /**
      * Make a new related instance for the given model.
      *
      * @param  \Illuminate\Database\Eloquent\Model  $parent

--- a/tests/Integration/Database/EloquentBelongsToTest.php
+++ b/tests/Integration/Database/EloquentBelongsToTest.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\EloquentBelongsToTest;
+
+use Illuminate\Support\Carbon;
+use Orchestra\Testbench\TestCase;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * @group integration
+ */
+class EloquentBelongsToTest extends TestCase
+{
+    protected function getEnvironmentSetUp($app)
+    {
+        $app['config']->set('app.debug', 'true');
+
+        $app['config']->set('database.default', 'testbench');
+
+        $app['config']->set('database.connections.testbench', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+        ]);
+    }
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        Schema::create('posts', function ($table) {
+            $table->increments('id');
+            $table->string('title');
+            $table->timestamps();
+        });
+
+        Schema::create('authors', function ($table) {
+            $table->increments('id');
+            $table->integer('post_id');
+            $table->string('name');
+            $table->timestamps();
+        });
+
+        Carbon::setTestNow(null);
+    }
+
+    /**
+     * @test
+     */
+    public function query_is_limited_on_lazy_loading()
+    {
+        Carbon::setTestNow(
+            Carbon::createFromFormat('Y-m-d H:i:s', '2017-10-10 10:10:10')
+        );
+
+        $post = Post::create(['title' => str_random()]);
+
+        $post->author()->create(['name' => str_random()]);
+
+        $author = Author::find(1);
+
+        \DB::enableQueryLog();
+
+        $author->load('post');
+
+        $logs = \DB::getQueryLog();
+
+        $this->assertContains('limit 1', $logs[0]['query']);
+    }
+
+    /**
+     * @test
+     */
+    public function query_is_limited_on_eager_loading()
+    {
+        Carbon::setTestNow(
+            Carbon::createFromFormat('Y-m-d H:i:s', '2017-10-10 10:10:10')
+        );
+
+        $post = Post::create(['title' => str_random()]);
+
+        $post->author()->create(['name' => str_random()]);
+
+        \DB::enableQueryLog();
+
+        Author::with('post')->get();
+
+        $logs = \DB::getQueryLog();
+
+        $this->assertContains('limit 1', $logs[1]['query']);
+    }
+}
+
+class Post extends Model
+{
+    public $table = 'posts';
+    public $timestamps = true;
+    protected $guarded = ['id'];
+
+    public function author()
+    {
+        return $this->hasOne(Author::class);
+    }
+}
+
+class Author extends Model
+{
+    public $table = 'authors';
+    public $timestamps = true;
+    protected $guarded = ['id'];
+
+    public function post()
+    {
+        return $this->belongsTo(Post::class);
+    }
+}

--- a/tests/Integration/Database/EloquentHasOneTest.php
+++ b/tests/Integration/Database/EloquentHasOneTest.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\EloquentHasOneTest;
+
+use Illuminate\Support\Carbon;
+use Orchestra\Testbench\TestCase;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * @group integration
+ */
+class EloquentHasOneTest extends TestCase
+{
+    protected function getEnvironmentSetUp($app)
+    {
+        $app['config']->set('app.debug', 'true');
+
+        $app['config']->set('database.default', 'testbench');
+
+        $app['config']->set('database.connections.testbench', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+        ]);
+    }
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        Schema::create('posts', function ($table) {
+            $table->increments('id');
+            $table->string('title');
+            $table->timestamps();
+        });
+
+        Schema::create('authors', function ($table) {
+            $table->increments('id');
+            $table->integer('post_id');
+            $table->string('name');
+            $table->timestamps();
+        });
+
+        Carbon::setTestNow(null);
+    }
+
+    /**
+     * @test
+     */
+    public function query_is_limited_on_lazy_loading()
+    {
+        Carbon::setTestNow(
+            Carbon::createFromFormat('Y-m-d H:i:s', '2017-10-10 10:10:10')
+        );
+
+        $post = Post::create(['title' => str_random()]);
+
+        $post->author()->create(['name' => str_random()]);
+
+        \DB::enableQueryLog();
+
+        $post->load('author');
+
+        $logs = \DB::getQueryLog();
+
+        $this->assertContains('limit 1', $logs[0]['query']);
+    }
+
+    /**
+     * @test
+     */
+    public function query_is_limited_on_eager_loading()
+    {
+        Carbon::setTestNow(
+            Carbon::createFromFormat('Y-m-d H:i:s', '2017-10-10 10:10:10')
+        );
+
+        $post = Post::create(['title' => str_random()]);
+
+        $post->author()->create(['name' => str_random()]);
+
+        \DB::enableQueryLog();
+
+        Post::with('author')->get();
+
+        $logs = \DB::getQueryLog();
+
+        $this->assertContains('limit 1', $logs[1]['query']);
+    }
+}
+
+class Post extends Model
+{
+    public $table = 'posts';
+    public $timestamps = true;
+    protected $guarded = ['id'];
+
+    public function author()
+    {
+        return $this->hasOne(Author::class);
+    }
+}
+
+class Author extends Model
+{
+    public $table = 'authors';
+    public $timestamps = true;
+    protected $guarded = ['id'];
+
+    public function post()
+    {
+        return $this->belongsTo(Post::class);
+    }
+}


### PR DESCRIPTION
This is an attempt to solve a really old issue: https://github.com/laravel/framework/issues/13387

This PR adds a `limit 1` to the end of the query while eager loading a `HasOne` or a `BelongsTo` relationship, the limit is applied when you query the relation already (e.g. `->product`).