### PR TITLE
[5.5] Allow single error messages in ValidationException::withMessages

### DIFF
--- a/src/Illuminate/Validation/ValidationException.php
+++ b/src/Illuminate/Validation/ValidationException.php
@@ -69,7 +69,7 @@ class ValidationException extends Exception
     {
         return new static(tap(ValidatorFacade::make([], []), function ($validator) use ($messages) {
             foreach ($messages as $key => $value) {
-                foreach ($value as $message) {
+                foreach (array_wrap($value) as $message) {
                     $validator->errors()->add($key, $message);
                 }
             }


### PR DESCRIPTION
Allows this:

```php
throw ValidationException::withMessages([
    'email' => 'This address is never allowed to be registered',
]);
```

Instead of always having to do this:

```php
throw ValidationException::withMessages([
    'email' => ['This address is never allowed to be registered'],
]);
```