### PR TITLE
[5.5] Use fill instead of forceFill while storing pivot attributes

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -511,7 +511,7 @@ trait InteractsWithPivotTable
     protected function castAttributes($attributes)
     {
         return $this->using
-                    ? $this->newPivot()->forceFill($attributes)->getAttributes()
+                    ? $this->newPivot()->fill($attributes)->getAttributes()
                     : $attributes;
     }
 }


### PR DESCRIPTION
This change allows CustomModels to control fillable attributes. By default all attributes are fillable in the `Pivot` built-in class.