### PR TITLE
Preserve Model->exists on newInstances

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -275,7 +275,9 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         // hydration of new objects via the Eloquent query builder instances.
         $model = new static((array) $attributes);
 
-        $model->exists = $exists;
+        // Refactored to preserve model's "exists" property where set and 
+        // not explicitly supplied in this method call.
+        $model->exists = is_null($exists) ? $this->exists : boolval($exists);
 
         $model->setConnection(
             $this->getConnectionName()


### PR DESCRIPTION
As far as I can tell, the only method on the Builder to get a Model instance, is through the ->make() method. But this method, did not preserve the "exists" state, so I traced it back to the Builder->newModelInstance method, through to  the Model->newInstance method. 

I made a simple toggle, to first try and use the optional "exists" argument, or fallback to the current $this->exists value. I could not test this, but it does work in my usecase.

This will allow my own Models to rely on the "exists" property and other dependant methods such as refresh, update and fresh etc.