### PR TITLE
[5.5] Add range collection method

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1552,10 +1552,10 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
-     * Create a new collection with a range of values, with optional step.
+     * Create a new collection with a range of elements, with optional step.
      *
-     * @param  int  $start
-     * @param  int  $end
+     * @param  mixed  $start
+     * @param  mixed  $end
      * @param  float|int  $step    
      * @return static
      */

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1552,6 +1552,19 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
+     * Create a new collection with a range of values, with optional step.
+     *
+     * @param  int  $start
+     * @param  int  $end
+     * @param  float|int  $step    
+     * @return static
+     */
+    public static function range($start, $end, $step = 1)
+    {
+        return new static(range($start, $end, $step));
+    }
+
+    /**
      * Get the collection of items as a plain array.
      *
      * @return array

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1556,7 +1556,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      *
      * @param  mixed  $start
      * @param  mixed  $end
-     * @param  float|int  $step    
+     * @param  float|int  $step
      * @return static
      */
     public static function range($start, $end, $step = 1)

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1774,6 +1774,14 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals([1, 2, 3, 4, 5], $c->all());
     }
 
+    public function testRangeCollection()
+    {
+        $this->assertEquals([0,1,2,3,4],Collection::range(0,4)->all());
+        $this->assertEquals([0,2,4,6,8],Collection::range(0,8,2)->all());
+        $this->assertEquals([0,100,200,300,400],Collection::range(0,499,100)->all());
+        $this->assertEquals([-2,-1,0,1,2],Collection::range(-2,2)->all());
+    }
+
     public function testGettingMaxItemsFromCollection()
     {
         $c = new Collection([(object) ['foo' => 10], (object) ['foo' => 20]]);

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1776,10 +1776,12 @@ class SupportCollectionTest extends TestCase
 
     public function testRangeCollection()
     {
-        $this->assertEquals([0,1,2,3,4],Collection::range(0,4)->all());
-        $this->assertEquals([0,2,4,6,8],Collection::range(0,8,2)->all());
-        $this->assertEquals([0,100,200,300,400],Collection::range(0,499,100)->all());
-        $this->assertEquals([-2,-1,0,1,2],Collection::range(-2,2)->all());
+        $this->assertEquals([0, 1, 2, 3, 4], Collection::range(0, 4)->all());
+        $this->assertEquals([0, 2, 4, 6, 8], Collection::range(0, 8, 2)->all());
+        $this->assertEquals([-2, -1, 0, 1, 2], Collection::range(-2, 2)->all());
+        $this->assertEquals([4, 3, 2, 1, 0], Collection::range(4, 0)->all());
+        $this->assertEquals([-1, -.5, 0, .5, 1], Collection::range(-1, 1, .5)->all());
+        $this->assertEquals(['a', 'c', 'e', 'g'], Collection::range('a', 'h', 2)->all());
     }
 
     public function testGettingMaxItemsFromCollection()


### PR DESCRIPTION
This PR adds a static collection method `range`, which mirrors the native [PHP array function](https://secure.php.net/manual/en/function.range.php) of the same name. 

The existing method `Collection::times(n)` works for an integer range of `1..n`, but the full functionality of PHP's `range` includes a `start`, `end`, and optional `step` parameter, and works with number or character sequences. Range also accepts integer or float step values.

Using this new method:

```php
Collection::range(0, 100, 25); // [0, 25, 50, 75, 100]
Collection::range(5, 0); // [5, 4, 3, 2, 1, 0]
Collection::range('A', 'C'); // ['A', 'B', 'C']
```

Thanks, and let me know if you have any questions or suggestions.