### PR TITLE
[5.5] Fix phpdoc

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -144,7 +144,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
     }
 
     /**
-     * Get the current encoded path info for the request.
+     * Get the current decoded path info for the request.
      *
      * @return string
      */


### PR DESCRIPTION
> Get the current **decoded** path info for the request.
> public function decodedPath()

I'm thinking about `rawurldecode` may be changed to `urldecode` ❓ 