### PR TITLE
[5.5] Alphabetize vendor:publish options

### DIFF
--- a/src/Illuminate/Foundation/Console/VendorPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/VendorPublishCommand.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Foundation\Console;
 
+use Illuminate\Support\Arr;
 use Illuminate\Console\Command;
 use League\Flysystem\MountManager;
 use Illuminate\Filesystem\Filesystem;
@@ -126,8 +127,8 @@ class VendorPublishCommand extends Command
     {
         return array_merge(
             ['<comment>Publish files from all providers and tags listed below</comment>'],
-            preg_filter('/^/', '<comment>Provider: </comment>', ServiceProvider::publishableProviders()),
-            preg_filter('/^/', '<comment>Tag: </comment>', ServiceProvider::publishableGroups())
+            preg_filter('/^/', '<comment>Provider: </comment>', Arr::sort(ServiceProvider::publishableProviders())),
+            preg_filter('/^/', '<comment>Tag: </comment>', Arr::sort(ServiceProvider::publishableGroups()))
         );
     }
 


### PR DESCRIPTION
This orders the `vendor:publish` options alphabetically so that it's easier to find the one you want when the list starts to get long.