### PR TITLE
[5.5] Added custom attribute types

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -465,7 +465,16 @@ trait HasAttributes
             return $value;
         }
 
-        switch ($this->getCastType($key)) {
+        $castType = $this->getCastType($key);
+
+        // If the cast type has a cast mutator, we will call that then return what
+        // it returns as the value, which is useful for transforming values on
+        // retrieval from the model to a form that is more useful for usage.
+        if ($this->hasCastMutator($castType)) {
+            return $this->{'cast'.Str::studly($castType).'Value'}($value);
+        }
+
+        switch ($castType) {
             case 'int':
             case 'integer':
                 return (int) $value;
@@ -505,6 +514,17 @@ trait HasAttributes
     protected function getCastType($key)
     {
         return trim(strtolower($this->getCasts()[$key]));
+    }
+
+    /**
+     * Determine if a cast mutator exists for an cast type.
+     *
+     * @param  string  $key
+     * @return bool
+     */
+    public function hasCastMutator($key)
+    {
+        return method_exists($this, 'cast'.Str::studly($key).'Value');
     }
 
     /**

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1516,6 +1516,16 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEquals('1969-07-20 00:00:00', $arr['dateAttribute']);
     }
 
+    public function testModelAttributeCustomCasting()
+    {
+        $model = new EloquentModelCastingStub;
+        $model->customAttribute = 'test';
+
+        $arr = $model->toArray();
+
+        $this->assertEquals('test1', $arr['customAttribute']);
+    }
+
     public function testModelAttributeCastingPreservesNull()
     {
         $model = new EloquentModelCastingStub;
@@ -2008,11 +2018,17 @@ class EloquentModelCastingStub extends Model
         'dateAttribute' => 'date',
         'datetimeAttribute' => 'datetime',
         'timestampAttribute' => 'timestamp',
+        'customAttribute' => 'custom',
     ];
 
     public function jsonAttributeValue()
     {
         return $this->attributes['jsonAttribute'];
+    }
+
+    public function castCustomValue($value)
+    {
+        return $value.'1';
     }
 }
 


### PR DESCRIPTION
For the ability to create custom cast mutators.

In 5.5, a lot of model functionality was transferred to concerns (traits) removing the ability to override various methods in other traits.

This feature provides the ability to override existing casts built-in to Laravel, or define your own using similar naming convention used elsewhere in Laravel.

For example, we have a UUID attribute that is stored as binary in the database. When we use this value though, we need it cast as a string. Currently we would have do this with a defined mutator on each model.

This update would allow us to define a mutator in a trait that we apply to models that have this field. We would create a `castUuidValue` method which takes a value, mutates, and returns the value. In the UUID case we would convert the binary value into a string.

In my personal cases, I use packages for both UUID and JSON cast types which no longer work in 5.5 due to the method collision from the new traits.