### PR TITLE
[5.6] Add support for collecting DateTimeInterface objects

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1709,7 +1709,9 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
             return $items;
         } elseif ($items instanceof self) {
             return $items->all();
-        } elseif ($items instanceof Arrayable) {
+        } elseif ($items instanceof \DateTimeInterface) {
+        	return [$items];
+		} elseif ($items instanceof Arrayable) {
             return $items->toArray();
         } elseif ($items instanceof Jsonable) {
             return json_decode($items->toJson(), true);

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1710,8 +1710,8 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
         } elseif ($items instanceof self) {
             return $items->all();
         } elseif ($items instanceof \DateTimeInterface) {
-        	return [$items];
-		} elseif ($items instanceof Arrayable) {
+            return [$items];
+        } elseif ($items instanceof Arrayable) {
             return $items->toArray();
         } elseif ($items instanceof Jsonable) {
             return json_decode($items->toJson(), true);

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2356,6 +2356,55 @@ class SupportCollectionTest extends TestCase
 
         $this->assertSame(['michael', 'tom', 'taylor'], $collection->toArray());
     }
+
+	public function testCollectCarbonObject()
+	{
+		$collection = new Collection(new \Illuminate\Support\Carbon());
+		$this->assertEquals(1, $collection->count());
+		$this->assertInstanceOf(\Illuminate\Support\Carbon::class, $collection->first());
+	}
+
+	public function testCollectCarbonObjects()
+	{
+		$collection = new Collection([new \Illuminate\Support\Carbon(), new \Illuminate\Support\Carbon()]);
+		$this->assertEquals(2, $collection->count());
+		$collection->each(function($item) {
+			$this->assertInstanceOf(\Illuminate\Support\Carbon::class, $item);
+		});
+	}
+
+	public function testCollectNativeCarbonObject()
+	{
+		$collection = new Collection(new \Carbon\Carbon());
+		$this->assertEquals(1, $collection->count());
+		$this->assertInstanceOf(\Carbon\Carbon::class, $collection->first());
+	}
+
+	public function testCollectNativeCarbonObjects()
+	{
+		$collection = new Collection([new \Carbon\Carbon(), new \Carbon\Carbon()]);
+		$this->assertEquals(2, $collection->count());
+		$collection->each(function($item) {
+			$this->assertInstanceOf(\Carbon\Carbon::class, $item);
+		});
+	}
+
+	public function testCollectDatetimeObject()
+	{
+		$collection = new Collection(new \Datetime);
+		$this->assertEquals(1, $collection->count());
+		$this->assertInstanceOf(\DateTime::class, $collection->first());
+	}
+
+	public function testCollectDatetimeObjects()
+	{
+		$collection = new Collection([new \Datetime(), new \Datetime()]);
+		$this->assertEquals(2, $collection->count());
+		$collection->each(function($item) {
+			$this->assertInstanceOf(\Datetime::class, $item);
+		});
+	}
+
 }
 
 class TestSupportCollectionHigherOrderItem

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2357,54 +2357,53 @@ class SupportCollectionTest extends TestCase
         $this->assertSame(['michael', 'tom', 'taylor'], $collection->toArray());
     }
 
-	public function testCollectCarbonObject()
-	{
-		$collection = new Collection(new \Illuminate\Support\Carbon());
-		$this->assertEquals(1, $collection->count());
-		$this->assertInstanceOf(\Illuminate\Support\Carbon::class, $collection->first());
-	}
+    public function testCollectCarbonObject()
+    {
+        $collection = new Collection(new \Illuminate\Support\Carbon());
+        $this->assertEquals(1, $collection->count());
+        $this->assertInstanceOf(\Illuminate\Support\Carbon::class, $collection->first());
+    }
 
-	public function testCollectCarbonObjects()
-	{
-		$collection = new Collection([new \Illuminate\Support\Carbon(), new \Illuminate\Support\Carbon()]);
-		$this->assertEquals(2, $collection->count());
-		$collection->each(function($item) {
-			$this->assertInstanceOf(\Illuminate\Support\Carbon::class, $item);
-		});
-	}
+    public function testCollectCarbonObjects()
+    {
+        $collection = new Collection([new \Illuminate\Support\Carbon(), new \Illuminate\Support\Carbon()]);
+        $this->assertEquals(2, $collection->count());
+        $collection->each(function ($item) {
+            $this->assertInstanceOf(\Illuminate\Support\Carbon::class, $item);
+        });
+    }
 
-	public function testCollectNativeCarbonObject()
-	{
-		$collection = new Collection(new \Carbon\Carbon());
-		$this->assertEquals(1, $collection->count());
-		$this->assertInstanceOf(\Carbon\Carbon::class, $collection->first());
-	}
+    public function testCollectNativeCarbonObject()
+    {
+        $collection = new Collection(new \Carbon\Carbon());
+        $this->assertEquals(1, $collection->count());
+        $this->assertInstanceOf(\Carbon\Carbon::class, $collection->first());
+    }
 
-	public function testCollectNativeCarbonObjects()
-	{
-		$collection = new Collection([new \Carbon\Carbon(), new \Carbon\Carbon()]);
-		$this->assertEquals(2, $collection->count());
-		$collection->each(function($item) {
-			$this->assertInstanceOf(\Carbon\Carbon::class, $item);
-		});
-	}
+    public function testCollectNativeCarbonObjects()
+    {
+        $collection = new Collection([new \Carbon\Carbon(), new \Carbon\Carbon()]);
+        $this->assertEquals(2, $collection->count());
+        $collection->each(function ($item) {
+            $this->assertInstanceOf(\Carbon\Carbon::class, $item);
+        });
+    }
 
-	public function testCollectDatetimeObject()
-	{
-		$collection = new Collection(new \Datetime);
-		$this->assertEquals(1, $collection->count());
-		$this->assertInstanceOf(\DateTime::class, $collection->first());
-	}
+    public function testCollectDatetimeObject()
+    {
+        $collection = new Collection(new \Datetime);
+        $this->assertEquals(1, $collection->count());
+        $this->assertInstanceOf(\DateTime::class, $collection->first());
+    }
 
-	public function testCollectDatetimeObjects()
-	{
-		$collection = new Collection([new \Datetime(), new \Datetime()]);
-		$this->assertEquals(2, $collection->count());
-		$collection->each(function($item) {
-			$this->assertInstanceOf(\Datetime::class, $item);
-		});
-	}
-
+    public function testCollectDatetimeObjects()
+    {
+        $collection = new Collection([new \Datetime(), new \Datetime()]);
+        $this->assertEquals(2, $collection->count());
+        $collection->each(function ($item) {
+            $this->assertInstanceOf(\Datetime::class, $item);
+        });
+    }
 }
 
 class TestSupportCollectionHigherOrderItem


### PR DESCRIPTION
Adds support for collecting objects which implements the DateTimeInterface. 

## The problem
- Because Laravel's Carbon implements JsonSerializable, the Collection class will convert the Carbon object into an array of size 3, which isn't really that obvious when using Collection.
- When casting an DateTimeInterface to an array, it will result in it returning an array of size 3.

## The solution
- Change Collection#getArrayableItems so it also looks for instances of DateTimeInterfaces.