### PR TITLE
Added option to add softDelete routes from resource

### DIFF
--- a/src/Illuminate/Routing/PendingResourceRegistration.php
+++ b/src/Illuminate/Routing/PendingResourceRegistration.php
@@ -141,7 +141,7 @@ class PendingResourceRegistration
 
         return $this;
     }
-	
+
     /**
      * Tell the resource to include softDelete routes.
      *

--- a/src/Illuminate/Routing/PendingResourceRegistration.php
+++ b/src/Illuminate/Routing/PendingResourceRegistration.php
@@ -142,7 +142,7 @@ class PendingResourceRegistration
         return $this;
     }
 	
-	/**
+    /**
      * Tell the resource to include softDelete routes.
      *
      * @return \Sjorsvanleeuwen\ExtendedResourceRegistrar\PendingResourceRegistration

--- a/src/Illuminate/Routing/PendingResourceRegistration.php
+++ b/src/Illuminate/Routing/PendingResourceRegistration.php
@@ -141,6 +141,18 @@ class PendingResourceRegistration
 
         return $this;
     }
+	
+	/**
+     * Tell the resource to include softDelete routes.
+     *
+     * @return \Sjorsvanleeuwen\ExtendedResourceRegistrar\PendingResourceRegistration
+     */
+    public function withSoftDeletes()
+    {
+        $this->options['withSoftDeletes'] = true;
+
+        return $this;
+    }
 
     /**
      * Handle the object's destruction.

--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -19,6 +19,13 @@ class ResourceRegistrar
      * @var array
      */
     protected $resourceDefaults = ['index', 'create', 'store', 'show', 'edit', 'update', 'destroy'];
+	
+	/**
+     * The actions for a resourcefull controller with a model with softDeletes.
+     *
+     * @var array
+     */
+    protected $resourceSoftDeletes = ['index', 'trashed', 'create', 'store', 'show', 'edit', 'update', 'destroy', 'restore'];
 
     /**
      * The parameters set for this resource instance.
@@ -49,6 +56,8 @@ class ResourceRegistrar
     protected static $verbs = [
         'create' => 'create',
         'edit' => 'edit',
+		'trashed' => 'trashed',
+        'restore' => 'restore'
     ];
 
     /**
@@ -146,6 +155,10 @@ class ResourceRegistrar
      */
     protected function getResourceMethods($defaults, $options)
     {
+		if (isset($options['withSoftDeletes']) && $options['withSoftDeletes'] == true) {
+            $defaults = $this->resourceSoftDeletes;
+            unset($options['withSoftDeletes']);
+        }
         if (isset($options['only'])) {
             return array_intersect($defaults, (array) $options['only']);
         } elseif (isset($options['except'])) {
@@ -169,6 +182,24 @@ class ResourceRegistrar
         $uri = $this->getResourceUri($name);
 
         $action = $this->getResourceAction($name, $controller, 'index', $options);
+
+        return $this->router->get($uri, $action);
+    }
+	
+	/**
+     * Add the trashed method for a resourceful route.
+     *
+     * @param  string  $name
+     * @param  string  $base
+     * @param  string  $controller
+     * @param  array   $options
+     * @return \Illuminate\Routing\Route
+     */
+    protected function addResourceTrashed($name, $base, $controller, $options)
+    {
+        $uri = $this->getResourceUri($name).'/'.static::$verbs['trashed'];
+
+        $action = $this->getResourceAction($name, $controller, 'trashed', $options);
 
         return $this->router->get($uri, $action);
     }
@@ -279,6 +310,24 @@ class ResourceRegistrar
         $action = $this->getResourceAction($name, $controller, 'destroy', $options);
 
         return $this->router->delete($uri, $action);
+    }
+	
+	/**
+     * Add the restore method for a resourceful route.
+     *
+     * @param  string  $name
+     * @param  string  $base
+     * @param  string  $controller
+     * @param  array   $options
+     * @return \Illuminate\Routing\Route
+     */
+    protected function addResourceRestore($name, $base, $controller, $options)
+    {
+        $uri = $this->getResourceUri($name).'/{'.$base.'}'.static::$verbs['restore'];
+
+        $action = $this->getResourceAction($name, $controller, 'restore', $options);
+
+		return $$this->router->match(['PUT', 'PATCH'], $uri, $action);
     }
 
     /**

--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -20,7 +20,7 @@ class ResourceRegistrar
      */
     protected $resourceDefaults = ['index', 'create', 'store', 'show', 'edit', 'update', 'destroy'];
 	
-	/**
+    /**
      * The actions for a resourcefull controller with a model with softDeletes.
      *
      * @var array
@@ -56,7 +56,7 @@ class ResourceRegistrar
     protected static $verbs = [
         'create' => 'create',
         'edit' => 'edit',
-		'trashed' => 'trashed',
+        'trashed' => 'trashed',
         'restore' => 'restore'
     ];
 
@@ -155,7 +155,7 @@ class ResourceRegistrar
      */
     protected function getResourceMethods($defaults, $options)
     {
-		if (isset($options['withSoftDeletes']) && $options['withSoftDeletes'] == true) {
+        if (isset($options['withSoftDeletes']) && $options['withSoftDeletes'] == true) {
             $defaults = $this->resourceSoftDeletes;
             unset($options['withSoftDeletes']);
         }
@@ -186,7 +186,7 @@ class ResourceRegistrar
         return $this->router->get($uri, $action);
     }
 	
-	/**
+    /**
      * Add the trashed method for a resourceful route.
      *
      * @param  string  $name
@@ -312,7 +312,7 @@ class ResourceRegistrar
         return $this->router->delete($uri, $action);
     }
 	
-	/**
+    /**
      * Add the restore method for a resourceful route.
      *
      * @param  string  $name
@@ -327,7 +327,7 @@ class ResourceRegistrar
 
         $action = $this->getResourceAction($name, $controller, 'restore', $options);
 
-		return $$this->router->match(['PUT', 'PATCH'], $uri, $action);
+        return $$this->router->match(['PUT', 'PATCH'], $uri, $action);
     }
 
     /**

--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -19,7 +19,7 @@ class ResourceRegistrar
      * @var array
      */
     protected $resourceDefaults = ['index', 'create', 'store', 'show', 'edit', 'update', 'destroy'];
-	
+
     /**
      * The actions for a resourcefull controller with a model with softDeletes.
      *
@@ -57,7 +57,7 @@ class ResourceRegistrar
         'create' => 'create',
         'edit' => 'edit',
         'trashed' => 'trashed',
-        'restore' => 'restore'
+        'restore' => 'restore',
     ];
 
     /**
@@ -185,7 +185,7 @@ class ResourceRegistrar
 
         return $this->router->get($uri, $action);
     }
-	
+
     /**
      * Add the trashed method for a resourceful route.
      *
@@ -311,7 +311,7 @@ class ResourceRegistrar
 
         return $this->router->delete($uri, $action);
     }
-	
+
     /**
      * Add the restore method for a resourceful route.
      *

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -316,7 +316,7 @@ class Router implements RegistrarContract, BindingRegistrar
     {
 		$only = ['index', 'show', 'store', 'update', 'destroy'];
         if (isset($options['withSoftDeletes'])) {
-            $only = $only + ['trashed', 'restore'];
+        $only = $only + ['trashed', 'restore'];
             unset($options['withSoftDeletes']);
         }
         return $this->resource($name, $controller, array_merge([

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -314,11 +314,12 @@ class Router implements RegistrarContract, BindingRegistrar
      */
     public function apiResource($name, $controller, array $options = [])
     {
-		$only = ['index', 'show', 'store', 'update', 'destroy'];
+        $only = ['index', 'show', 'store', 'update', 'destroy'];
         if (isset($options['withSoftDeletes'])) {
-        $only = $only + ['trashed', 'restore'];
+            $only = $only + ['trashed', 'restore'];
             unset($options['withSoftDeletes']);
         }
+
         return $this->resource($name, $controller, array_merge([
             'only' => $only,
         ], $options));

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -314,8 +314,13 @@ class Router implements RegistrarContract, BindingRegistrar
      */
     public function apiResource($name, $controller, array $options = [])
     {
+		$only = ['index', 'show', 'store', 'update', 'destroy'];
+        if (isset($options['withSoftDeletes'])) {
+            $only = $only + ['trashed', 'restore'];
+            unset($options['withSoftDeletes']);
+        }
         return $this->resource($name, $controller, array_merge([
-            'only' => ['index', 'show', 'store', 'update', 'destroy'],
+            'only' => $only,
         ], $options));
     }
 


### PR DESCRIPTION
Laravel allows models tohave softdeletes to not really remove from the database but just add a flag with date that the resource is removed.
This contribution allows a developer to create a resource route that supports softdeletes out of the box like so:
```php
Route::resource('foo', 'FooController')->withSoftDeletes();
```