### PR TITLE
[5.5] Optional opinionated view names for controller

### DIFF
--- a/src/Illuminate/Routing/Controller.php
+++ b/src/Illuminate/Routing/Controller.php
@@ -67,4 +67,28 @@ abstract class Controller
     {
         throw new BadMethodCallException("Method [{$method}] does not exist.");
     }
+    
+    /**
+     * Returns the view in a folder with same structure as namespace, function name as the name
+     *
+     * @param  array   $vars
+     * @return \Illuminate\Contracts\View\View
+     */
+    public function view($vars=[])
+    {
+        $class    = strtolower(debug_backtrace()[1]['class']);
+        $function = strtolower(debug_backtrace()[1]['function']);
+
+        //transform namespace to folder structure
+        $dir = preg_replace('/controller$/', '',
+            str_replace('app.http.controllers.', '',
+                str_replace('\\', '.', $class)
+            )
+        );
+
+        //function becomes filename
+        $defaultView = $dir . '.' . $function;
+
+        return view($defaultView,$vars);
+    }
 }


### PR DESCRIPTION
Controllers typically go like this:

```
<?php
namespace App\Http\Controllers\Admin;

class SomethingController extends Controller
{
    public function index()
    {
        $var1 = 'hello';
        return view('admin.something.index', compact('var1'));
    }
}
```

namespace same as view folder name 
function same as view filename

So why not?

```
<?php
namespace App\Http\Controllers\Admin;

class SomethingController extends Controller
{
    public function index()
    {
        $var1 = 'hello';
        return $this->view(compact('var1'));
    }
}

```

When no variables are present it would look very compact. 
Default view for this example would be 

**views/admin/something/index.blade.php**

```
<?php
namespace App\Http\Controllers\Admin;

class SomethingController extends Controller
{
    public function index()
    {
        return $this->view();
    }
}

```

Less typing = more fun