### PR TITLE
[5.5] change cron expression at 5 fields

### DIFF
--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -27,7 +27,7 @@ class Event
      *
      * @var string
      */
-    public $expression = '* * * * * *';
+    public $expression = '* * * * *';
 
     /**
      * The timezone the date should be evaluated on.

--- a/tests/Console/ConsoleScheduledEventTest.php
+++ b/tests/Console/ConsoleScheduledEventTest.php
@@ -36,7 +36,7 @@ class ConsoleScheduledEventTest extends TestCase
         $app->shouldReceive('environment')->andReturn('production');
 
         $event = new Event(m::mock('Illuminate\Console\Scheduling\Mutex'), 'php foo');
-        $this->assertEquals('* * * * * *', $event->getExpression());
+        $this->assertEquals('* * * * *', $event->getExpression());
         $this->assertTrue($event->isDue($app));
         $this->assertTrue($event->skip(function () {
             return true;
@@ -46,17 +46,17 @@ class ConsoleScheduledEventTest extends TestCase
         })->filtersPass($app));
 
         $event = new Event(m::mock('Illuminate\Console\Scheduling\Mutex'), 'php foo');
-        $this->assertEquals('* * * * * *', $event->getExpression());
+        $this->assertEquals('* * * * *', $event->getExpression());
         $this->assertFalse($event->environments('local')->isDue($app));
 
         $event = new Event(m::mock('Illuminate\Console\Scheduling\Mutex'), 'php foo');
-        $this->assertEquals('* * * * * *', $event->getExpression());
+        $this->assertEquals('* * * * *', $event->getExpression());
         $this->assertFalse($event->when(function () {
             return false;
         })->filtersPass($app));
 
         $event = new Event(m::mock('Illuminate\Console\Scheduling\Mutex'), 'php foo');
-        $this->assertEquals('* * * * * *', $event->getExpression());
+        $this->assertEquals('* * * * *', $event->getExpression());
         $this->assertFalse($event->when(false)->filtersPass($app));
 
         // chained rules should be commutative
@@ -81,11 +81,11 @@ class ConsoleScheduledEventTest extends TestCase
         Carbon::setTestNow(Carbon::create(2015, 1, 1, 0, 0, 0));
 
         $event = new Event(m::mock('Illuminate\Console\Scheduling\Mutex'), 'php foo');
-        $this->assertEquals('* * * * 4 *', $event->thursdays()->getExpression());
+        $this->assertEquals('* * * * 4', $event->thursdays()->getExpression());
         $this->assertTrue($event->isDue($app));
 
         $event = new Event(m::mock('Illuminate\Console\Scheduling\Mutex'), 'php foo');
-        $this->assertEquals('0 19 * * 3 *', $event->wednesdays()->at('19:00')->timezone('EST')->getExpression());
+        $this->assertEquals('0 19 * * 3', $event->wednesdays()->at('19:00')->timezone('EST')->getExpression());
         $this->assertTrue($event->isDue($app));
     }
 

--- a/tests/Console/Scheduling/EventTest.php
+++ b/tests/Console/Scheduling/EventTest.php
@@ -28,7 +28,7 @@ class EventTest extends TestCase
         $event->runInBackground();
 
         $defaultOutput = (DIRECTORY_SEPARATOR == '\\') ? 'NUL' : '/dev/null';
-        $this->assertSame("(php -i > {$quote}{$defaultOutput}{$quote} 2>&1 ; '".PHP_BINARY."' artisan schedule:finish \"framework/schedule-c65b1c374c37056e0c57fccb0c08d724ce6f5043\") > {$quote}{$defaultOutput}{$quote} 2>&1 &", $event->buildCommand());
+        $this->assertSame("(php -i > {$quote}{$defaultOutput}{$quote} 2>&1 ; '".PHP_BINARY."' artisan schedule:finish \"framework/schedule-eeb46c93d45e928d62aaf684d727e213b7094822\") > {$quote}{$defaultOutput}{$quote} 2>&1 &", $event->buildCommand());
     }
 
     public function testBuildCommandSendOutputTo()

--- a/tests/Console/Scheduling/FrequencyTest.php
+++ b/tests/Console/Scheduling/FrequencyTest.php
@@ -23,99 +23,99 @@ class FrequencyTest extends TestCase
 
     public function testEveryMinute()
     {
-        $this->assertEquals('* * * * * *', $this->event->getExpression());
-        $this->assertEquals('* * * * * *', $this->event->everyMinute()->getExpression());
+        $this->assertEquals('* * * * *', $this->event->getExpression());
+        $this->assertEquals('* * * * *', $this->event->everyMinute()->getExpression());
     }
 
     public function testEveryFiveMinutes()
     {
-        $this->assertEquals('*/5 * * * * *', $this->event->everyFiveMinutes()->getExpression());
+        $this->assertEquals('*/5 * * * *', $this->event->everyFiveMinutes()->getExpression());
     }
 
     public function testDaily()
     {
-        $this->assertEquals('0 0 * * * *', $this->event->daily()->getExpression());
+        $this->assertEquals('0 0 * * *', $this->event->daily()->getExpression());
     }
 
     public function testTwiceDaily()
     {
-        $this->assertEquals('0 3,15 * * * *', $this->event->twiceDaily(3, 15)->getExpression());
+        $this->assertEquals('0 3,15 * * *', $this->event->twiceDaily(3, 15)->getExpression());
     }
 
     public function testOverrideWithHourly()
     {
-        $this->assertEquals('0 * * * * *', $this->event->everyFiveMinutes()->hourly()->getExpression());
-        $this->assertEquals('37 * * * * *', $this->event->hourlyAt(37)->getExpression());
+        $this->assertEquals('0 * * * *', $this->event->everyFiveMinutes()->hourly()->getExpression());
+        $this->assertEquals('37 * * * *', $this->event->hourlyAt(37)->getExpression());
     }
 
     public function testMonthlyOn()
     {
-        $this->assertEquals('0 15 4 * * *', $this->event->monthlyOn(4, '15:00')->getExpression());
+        $this->assertEquals('0 15 4 * *', $this->event->monthlyOn(4, '15:00')->getExpression());
     }
 
     public function testTwiceMonthly()
     {
-        $this->assertEquals('0 0 1,16 * * *', $this->event->twiceMonthly(1, 16)->getExpression());
+        $this->assertEquals('0 0 1,16 * *', $this->event->twiceMonthly(1, 16)->getExpression());
     }
 
     public function testMonthlyOnWithMinutes()
     {
-        $this->assertEquals('15 15 4 * * *', $this->event->monthlyOn(4, '15:15')->getExpression());
+        $this->assertEquals('15 15 4 * *', $this->event->monthlyOn(4, '15:15')->getExpression());
     }
 
     public function testWeekdaysDaily()
     {
-        $this->assertEquals('0 0 * * 1-5 *', $this->event->weekdays()->daily()->getExpression());
+        $this->assertEquals('0 0 * * 1-5', $this->event->weekdays()->daily()->getExpression());
     }
 
     public function testWeekdaysHourly()
     {
-        $this->assertEquals('0 * * * 1-5 *', $this->event->weekdays()->hourly()->getExpression());
+        $this->assertEquals('0 * * * 1-5', $this->event->weekdays()->hourly()->getExpression());
     }
 
     public function testWeekdays()
     {
-        $this->assertEquals('* * * * 1-5 *', $this->event->weekdays()->getExpression());
+        $this->assertEquals('* * * * 1-5', $this->event->weekdays()->getExpression());
     }
 
     public function testSundays()
     {
-        $this->assertEquals('* * * * 0 *', $this->event->sundays()->getExpression());
+        $this->assertEquals('* * * * 0', $this->event->sundays()->getExpression());
     }
 
     public function testMondays()
     {
-        $this->assertEquals('* * * * 1 *', $this->event->mondays()->getExpression());
+        $this->assertEquals('* * * * 1', $this->event->mondays()->getExpression());
     }
 
     public function testTuesdays()
     {
-        $this->assertEquals('* * * * 2 *', $this->event->tuesdays()->getExpression());
+        $this->assertEquals('* * * * 2', $this->event->tuesdays()->getExpression());
     }
 
     public function testWednesdays()
     {
-        $this->assertEquals('* * * * 3 *', $this->event->wednesdays()->getExpression());
+        $this->assertEquals('* * * * 3', $this->event->wednesdays()->getExpression());
     }
 
     public function testThursdays()
     {
-        $this->assertEquals('* * * * 4 *', $this->event->thursdays()->getExpression());
+        $this->assertEquals('* * * * 4', $this->event->thursdays()->getExpression());
     }
 
     public function testFridays()
     {
-        $this->assertEquals('* * * * 5 *', $this->event->fridays()->getExpression());
+        $this->assertEquals('* * * * 5', $this->event->fridays()->getExpression());
     }
 
     public function testSaturdays()
     {
-        $this->assertEquals('* * * * 6 *', $this->event->saturdays()->getExpression());
+        $this->assertEquals('* * * * 6', $this->event->saturdays()->getExpression());
     }
 
     public function testQuarterly()
     {
-        $this->assertEquals('0 0 1 1-12/3 * *', $this->event->quarterly()->getExpression());
+        $this->assertEquals('0 0 1 1-12/3 *', $this->event->quarterly()->getExpression());
     }
 
     public function testFrequencyMacro()
@@ -124,6 +124,6 @@ class FrequencyTest extends TestCase
             return $this->spliceIntoPosition(1, "*/{$x}");
         });
 
-        $this->assertEquals('*/6 * * * * *', $this->event->everyXMinutes(6)->getExpression());
+        $this->assertEquals('*/6 * * * *', $this->event->everyXMinutes(6)->getExpression());
     }
 }


### PR DESCRIPTION
In cron expression expected 5 fields. In this PR was remove the last character * of the base expression and adjust the tests.

Doc: https://github.com/mtdowling/cron-expression

    *    *    *    *    *
    -    -    -    -    -
    |    |    |    |    |
    |    |    |    |    |
    |    |    |    |    +----- day of week (0 - 7) (Sunday=0 or 7)
    |    |    |    +---------- month (1 - 12)
    |    |    +--------------- day of month (1 - 31)
    |    +-------------------- hour (0 - 23)
    +------------------------- min (0 - 59)

