### PR TITLE
[5.5] Allow passing an Arrayable object to the View

### DIFF
--- a/src/Illuminate/View/View.php
+++ b/src/Illuminate/View/View.php
@@ -170,12 +170,13 @@ class View implements ArrayAccess, ViewContract
     /**
      * Add a piece of data to the view.
      *
-     * @param  string|array  $key
+     * @param  string|array|Arrayable  $key
      * @param  mixed   $value
      * @return $this
      */
     public function with($key, $value = null)
     {
+        $key = $key instanceof Arrayable ? $key->toArray() : $key;
         if (is_array($key)) {
             $this->data = array_merge($this->data, $key);
         } else {

--- a/tests/View/ViewTest.php
+++ b/tests/View/ViewTest.php
@@ -20,7 +20,8 @@ class ViewTest extends TestCase
         $view->with('foo', 'bar');
         $view->with(['baz' => 'boom']);
         $view->with(new class implements Arrayable {
-            public function toArray(){
+            public function toArray()
+            {
                 return ['spam' => 'eggs'];
             }
         });

--- a/tests/View/ViewTest.php
+++ b/tests/View/ViewTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\View;
 use Mockery as m;
 use Illuminate\View\View;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Contracts\Support\Arrayable;
 
 class ViewTest extends TestCase
 {
@@ -18,7 +19,12 @@ class ViewTest extends TestCase
         $view = $this->getView();
         $view->with('foo', 'bar');
         $view->with(['baz' => 'boom']);
-        $this->assertEquals(['foo' => 'bar', 'baz' => 'boom'], $view->getData());
+        $view->with(new class implements Arrayable {
+            public function toArray(){
+                return ['spam' => 'eggs'];
+            }
+        });
+        $this->assertEquals(['foo' => 'bar', 'baz' => 'boom', 'spam' => 'eggs'], $view->getData());
 
         $view = $this->getView();
         $view->withFoo('bar')->withBaz('boom');


### PR DESCRIPTION
This change allows you to pass an Arrayable object to the View `with()` method.

This is useful if you have a "property container" object with the properties you want to pass to the view.