### PR TITLE
[5.5] Make sure sql for virtual columns is added after the unsigned modifier

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -14,7 +14,7 @@ class MySqlGrammar extends Grammar
      * @var array
      */
     protected $modifiers = [
-        'VirtualAs', 'StoredAs', 'Unsigned', 'Charset', 'Collate', 'Nullable',
+        'Unsigned', 'VirtualAs', 'StoredAs', 'Charset', 'Collate', 'Nullable',
         'Default', 'Increment', 'Comment', 'After', 'First',
     ];
 

--- a/src/Illuminate/Validation/ValidationException.php
+++ b/src/Illuminate/Validation/ValidationException.php
@@ -3,8 +3,8 @@
 namespace Illuminate\Validation;
 
 use Exception;
-use Illuminate\Support\Facades\Validator as ValidatorFacade;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Validator as ValidatorFacade;
 
 class ValidationException extends Exception
 {


### PR DESCRIPTION
In reference to https://github.com/laravel/framework/issues/21421

- `$table->integer('total')->unsigned()->virtualAs('a + b + c');`

is converted to : 
- `total int as (a + b + c) unsigned`

which is invalid mysql grammar

It should be converted to 
- `total int unsigned as (a + b + c)`
