### PR TITLE
[5.5] Fix Collection::contains() when the found value is null

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -217,7 +217,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     {
         if (func_num_args() == 1) {
             if ($this->useAsCallable($key)) {
-                return ! is_null($this->first($key));
+                return $this->first($key, '__placeholder') != '__placeholder';
             }
 
             return in_array($key, $this->items);

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -218,7 +218,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     {
         if (func_num_args() == 1) {
             if ($this->useAsCallable($key)) {
-                $placeholder = new stdClass();
+                $placeholder = new stdClass;
 
                 return $this->first($key, $placeholder) !== $placeholder;
             }

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Support;
 
+use stdClass;
 use Countable;
 use Exception;
 use ArrayAccess;
@@ -217,7 +218,9 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     {
         if (func_num_args() == 1) {
             if ($this->useAsCallable($key)) {
-                return $this->first($key, '__placeholder') != '__placeholder';
+                $placeholder = new stdClass();
+
+                return $this->first($key, $placeholder) !== $placeholder;
             }
 
             return in_array($key, $this->items);

--- a/src/Illuminate/Validation/ValidationException.php
+++ b/src/Illuminate/Validation/ValidationException.php
@@ -3,8 +3,8 @@
 namespace Illuminate\Validation;
 
 use Exception;
-use Illuminate\Support\Facades\Validator as ValidatorFacade;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Validator as ValidatorFacade;
 
 class ValidationException extends Exception
 {

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1561,6 +1561,14 @@ class SupportCollectionTest extends TestCase
 
         $this->assertTrue($c->contains->a);
         $this->assertFalse($c->contains->b);
+
+        $c = new Collection([
+            null, 1, 2
+        ]);
+
+        $this->assertTrue($c->contains(function ($value) {
+            return is_null($value);
+        }));
     }
 
     public function testContainsStrict()

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1563,7 +1563,7 @@ class SupportCollectionTest extends TestCase
         $this->assertFalse($c->contains->b);
 
         $c = new Collection([
-            null, 1, 2
+            null, 1, 2,
         ]);
 
         $this->assertTrue($c->contains(function ($value) {


### PR DESCRIPTION
As reported in https://github.com/laravel/framework/issues/21406

Currently `Collection::contains()` uses `Collection::first()`, if `first()` returned null `contains` will return false even if null is the desired value.