### PR TITLE
Added a fromUrl method in Laravel's TestCase

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -78,6 +78,17 @@ trait MakesHttpRequests
     }
 
     /**
+     * Define a url from which the request is being made.
+     *
+     * @param  string  $url
+     * @return $this
+     */
+    public function fromUrl($url)
+    {
+        return $this->withServerVariables(['HTTP_REFERER' => $url]);
+    }
+
+    /**
      * Disable middleware for the test.
      *
      * @param  string|array  $middleware


### PR DESCRIPTION
Added a helper method that allows to do something like this:
```php
// instead of this
$this->withServerVariables(['HTTP_REFERER' => '/login'])->post('/login', [
    //
]);

// do this
$this->fromUrl('/login')->post('/login', [
    //
]);
```

Many people, myself included, find this method crucial for clean code and we find ourselves always writing it in our personal projects. It would be nice to have such method out-of-the-box. It is highly opinionated so I won't be surprised if this doesn't get merged. Just hope to see that in the core.