### PR TITLE
[5.5] extract AnonymousResourceCollection into class to allow serialization

### DIFF
--- a/src/Illuminate/Http/Resources/Json/AnonymousResourceCollection.php
+++ b/src/Illuminate/Http/Resources/Json/AnonymousResourceCollection.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Illuminate\Http\Resources\Json;
+
+class AnonymousResourceCollection extends ResourceCollection
+{
+    /**
+     * @var string
+     */
+    public $collects;
+
+    /**
+     * Create a new anonymous resource collection.
+     *
+     * @param  mixed  $resource
+     * @param  string  $collects
+     * @return void
+     */
+    public function __construct($resource, $collects)
+    {
+        $this->collects = $collects;
+
+        parent::__construct($resource);
+    }
+}

--- a/src/Illuminate/Http/Resources/Json/Resource.php
+++ b/src/Illuminate/Http/Resources/Json/Resource.php
@@ -78,26 +78,7 @@ class Resource implements ArrayAccess, JsonSerializable, Responsable, UrlRoutabl
      */
     public static function collection($resource)
     {
-        return new class($resource, get_called_class()) extends ResourceCollection {
-            /**
-             * @var string
-             */
-            public $collects;
-
-            /**
-             * Create a new anonymous resource collection.
-             *
-             * @param  mixed  $resource
-             * @param  string  $collects
-             * @return void
-             */
-            public function __construct($resource, $collects)
-            {
-                $this->collects = $collects;
-
-                parent::__construct($resource);
-            }
-        };
+        return new AnonymousResourceCollection($resource, get_called_class());
     }
 
     /**


### PR DESCRIPTION
In reference to https://github.com/laravel/framework/issues/21453

This makes serializing resources created with `Resource::Collection()` possible.