### PR TITLE
[5.5] Clear CountQuery "select" bindings since we're overriding the columns anyway

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -188,7 +188,7 @@ abstract class Relation
     {
         return $this->getRelationExistenceQuery(
             $query, $parentQuery, new Expression('count(*)')
-        );
+        )->setBindings([], 'select');
     }
 
     /**

--- a/tests/Database/DatabaseEloquentHasOneTest.php
+++ b/tests/Database/DatabaseEloquentHasOneTest.php
@@ -176,7 +176,8 @@ class DatabaseEloquentHasOneTest extends TestCase
 
         $builder->shouldReceive('select')->once()->with(m::type('Illuminate\Database\Query\Expression'))->andReturnSelf();
         $relation->getParent()->shouldReceive('getTable')->andReturn('table');
-        $builder->shouldReceive('whereColumn')->once()->with('table.id', '=', 'table.foreign_key');
+        $builder->shouldReceive('whereColumn')->once()->with('table.id', '=', 'table.foreign_key')->andReturn($baseQuery);
+        $baseQuery->shouldReceive('setBindings')->once()->with([], 'select');
 
         $relation->getRelationExistenceCountQuery($builder, $builder);
     }

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -122,7 +122,12 @@ class FilesystemTest extends TestCase
         file_put_contents($this->tempDir.'/foo/2.txt', '2');
         mkdir($this->tempDir.'/foo/bar');
         $files = new Filesystem;
-        $this->assertEquals([$this->tempDir.'/foo/1.txt', $this->tempDir.'/foo/2.txt'], $files->files($this->tempDir.'/foo'));
+
+        $results = collect($files->files($this->tempDir.'/foo'))->map(function($file){
+            return $file->getPathName();
+        });
+
+        $this->assertEquals([$this->tempDir.'/foo/1.txt', $this->tempDir.'/foo/2.txt'], $results->toArray());
         unset($files);
     }
 

--- a/tests/Integration/Database/EloquentWithCountTest.php
+++ b/tests/Integration/Database/EloquentWithCountTest.php
@@ -53,7 +53,7 @@ class EloquentWithCountTest extends TestCase
         $three = $two->threes()->Create();
 
         $results = Model1::withCount([
-            'twos' => function($query){
+            'twos' => function ($query) {
                 $query->where('id', '>=', 1);
             }
         ]);
@@ -99,8 +99,7 @@ class Model3 extends Model
     {
         parent::boot();
 
-        static::addGlobalScope('app', function($builder)
-        {
+        static::addGlobalScope('app', function ($builder) {
             $builder->where('idz', '>', 0);
         });
     }

--- a/tests/Integration/Database/EloquentWithCountTest.php
+++ b/tests/Integration/Database/EloquentWithCountTest.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\EloquentWithCountTest;
+
+use Orchestra\Testbench\TestCase;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * @group integration
+ */
+class EloquentWithCountTest extends TestCase
+{
+    protected function getEnvironmentSetUp($app)
+    {
+        $app['config']->set('app.debug', 'true');
+
+        $app['config']->set('database.default', 'testbench');
+
+        $app['config']->set('database.connections.testbench', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+        ]);
+    }
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        Schema::create('one', function ($table) {
+            $table->increments('id');
+        });
+
+        Schema::create('two', function ($table) {
+            $table->increments('id');
+            $table->integer('one_id');
+        });
+
+        Schema::create('three', function ($table) {
+            $table->increments('id');
+            $table->integer('two_id');
+        });
+    }
+
+    /**
+     * @test
+     */
+    public function it_basic()
+    {
+        $one = Model1::create();
+        $two = $one->twos()->Create();
+        $three = $two->threes()->Create();
+
+        $results = Model1::withCount([
+            'twos' => function($query){
+                $query->where('id', '>=', 1);
+            }
+        ]);
+
+        $this->assertEquals([
+            ['id' => 1, 'twos_count' => 1]
+        ], $results->get()->toArray());
+    }
+}
+
+class Model1 extends Model
+{
+    public $table = 'one';
+    public $timestamps = false;
+    protected $guarded = ['id'];
+
+    public function twos()
+    {
+        return $this->hasMany(Model2::class, 'one_id');
+    }
+}
+
+class Model2 extends Model
+{
+    public $table = 'two';
+    public $timestamps = false;
+    protected $guarded = ['id'];
+    protected $withCount = ['threes'];
+
+    public function threes()
+    {
+        return $this->hasMany(Model3::class, 'two_id');
+    }
+}
+
+class Model3 extends Model
+{
+    public $table = 'three';
+    public $timestamps = false;
+    protected $guarded = ['id'];
+
+    protected static function boot()
+    {
+        parent::boot();
+
+        static::addGlobalScope('app', function($builder)
+        {
+            $builder->where('idz', '>', 0);
+        });
+    }
+}

--- a/tests/Integration/Database/EloquentWithCountTest.php
+++ b/tests/Integration/Database/EloquentWithCountTest.php
@@ -55,11 +55,11 @@ class EloquentWithCountTest extends TestCase
         $results = Model1::withCount([
             'twos' => function ($query) {
                 $query->where('id', '>=', 1);
-            }
+            },
         ]);
 
         $this->assertEquals([
-            ['id' => 1, 'twos_count' => 1]
+            ['id' => 1, 'twos_count' => 1],
         ], $results->get()->toArray());
     }
 }


### PR DESCRIPTION
We're overriding the columns in the subquery with `new Expression('count(*)')`, in this PR we clear the select bindings since the query won't have the original selects.

In reference to: https://github.com/laravel/framework/issues/21464
In reference to: https://github.com/laravel/framework/pull/21465