### PR TITLE
[5.5] allow to specify the queue while scheduling of queued jobs

### DIFF
--- a/src/Illuminate/Console/Scheduling/Schedule.php
+++ b/src/Illuminate/Console/Scheduling/Schedule.php
@@ -74,12 +74,13 @@ class Schedule
      * Add a new job callback event to the schedule.
      *
      * @param  object|string  $job
+     * @param  string|null  $queue
      * @return \Illuminate\Console\Scheduling\CallbackEvent
      */
-    public function job($job)
+    public function job($job, $queue = null)
     {
-        return $this->call(function () use ($job) {
-            dispatch(is_string($job) ? resolve($job) : $job);
+        return $this->call(function () use ($job, $queue) {
+            dispatch(is_string($job) ? resolve($job) : $job)->onQueue($queue);
         })->name(is_string($job) ? $job : get_class($job));
     }
 


### PR DESCRIPTION
Based on [this idea in laravel/internals/issues/457](https://github.com/laravel/internals/issues/457) and inspired by #18235.

Right now you schedule a job to be queued like this:
```php
# /app/Console/Kernel.php

protected function schedule(Schedule $schedule)
{
    $schedule->job(new UpdatePrices)->hourly();
}
```

My simple addition will allow you to specify the queue:
```php
# /app/Console/Kernel.php

protected function schedule(Schedule $schedule)
{
    $schedule->job(new UpdatePrices, 'update prices')->hourly();
}
```
You'll need this to "categorize" jobs or prioritize queues. This code change is fully backward compatible with current release.