### PR TITLE
Fix nullable dates

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -678,6 +678,11 @@ trait HasAttributes
      */
     protected function asDateTime($value)
     {
+        // Value can be nullable
+        if (is_null($value)) {
+            return $value;   
+        }
+        
         // If this value is already a Carbon instance, we shall just return it as is.
         // This prevents us having to re-instantiate a Carbon instance when we know
         // it already is one, which wouldn't be fulfilled by the DateTime check.

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -680,9 +680,9 @@ trait HasAttributes
     {
         // Value can be nullable
         if (is_null($value)) {
-            return $value;   
+            return $value;
         }
-        
+
         // If this value is already a Carbon instance, we shall just return it as is.
         // This prevents us having to re-instantiate a Carbon instance when we know
         // it already is one, which wouldn't be fulfilled by the DateTime check.


### PR DESCRIPTION
Carbon throws on `null` value, so we need to return null explicitly. 