### PR TITLE
[5.5] Add jump, next, and previous methods to collection

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -684,7 +684,6 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     public function jump($value, $strict = false, $jump = 1)
     {
         if ($value instanceof Model) {
-
             $key = $this->search(function ($item, $key) use ($value) {
                 return $value->is($item);
             });

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -12,6 +12,7 @@ use CachingIterator;
 use JsonSerializable;
 use IteratorAggregate;
 use Illuminate\Support\Debug\Dumper;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Contracts\Support\Arrayable;
@@ -673,6 +674,42 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
+     * Get the item that is a specified number away from the searched item.
+     *
+     * @param  mixed  $value
+     * @param  bool   $strict
+     * @param  int    $jump
+     * @return mixed
+     */
+    public function jump($value, $strict = false, $jump = 1)
+    {
+        if ($value instanceof Model) {
+
+            $key = $this->search(function ($item, $key) use ($value) {
+                return $value->is($item);
+            });
+        }
+
+        else {
+            $key = $this->search($value, $strict);
+        }
+
+        if ($key === false) {
+            return false;
+        }
+
+        $keys = array_keys($this->items);
+
+        $jumpKey = array_search($key, $keys, true) + $jump;
+
+        if ($jumpKey < 0 || $jumpKey >= count($keys)) {
+            return false;
+        }
+
+        return $this->items[$keys[$jumpKey]];
+    }
+
+    /**
      * Key an associative array by a field or using a callback.
      *
      * @param  callable|string  $keyBy
@@ -991,6 +1028,18 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
+     * Get the item after the searched item.
+     *
+     * @param  mixed  $value
+     * @param  bool   $strict
+     * @return mixed
+     */
+    public function next($value, $strict = false)
+    {
+        return $this->jump($value, $strict, 1);
+    }
+
+    /**
      * Create a new collection consisting of every n-th element.
      *
      * @param  int  $step
@@ -1095,6 +1144,18 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
         $this->items = Arr::prepend($this->items, $value, $key);
 
         return $this;
+    }
+
+    /**
+     * Get the item before the searched item.
+     *
+     * @param  mixed   $value
+     * @param  bool    $strict
+     * @return mixed
+     */
+    public function previous($value, $strict = false)
+    {
+        return $this->jump($value, $strict, -1);
     }
 
     /**

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -688,9 +688,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
             $key = $this->search(function ($item, $key) use ($value) {
                 return $value->is($item);
             });
-        }
-
-        else {
+        } else {
             $key = $this->search($value, $strict);
         }
 


### PR DESCRIPTION
resubmission of #20762.

The new `jump` method allows you to move a designated number of items forward or backward from a specific item in the collection.  the `next` and `previous` methods simply go 1 forward or 1 back.

I have addressed all of @sisve's comments from the previous PR.

- I still like these names better.
- Updated type hints to 'mixed'.
- Use a strict check of the key to make sure `0` and an empty string don't break the feature.
- Use `array_search` in strict mode to protect against loosely similar keys.
- The methods return false when there is no match, or if you are beyond the bounds of the collection. It returns `null` if the value is actually `null`.

Have also added the ability to pass in a Model as the search parameter since I see that as one of the main use cases.