### PR TITLE
[5.5] Add make command for custom exceptions

### DIFF
--- a/src/Illuminate/Foundation/Console/ExceptionMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ExceptionMakeCommand.php
@@ -39,11 +39,12 @@ class ExceptionMakeCommand extends GeneratorCommand
             return $this->option('report')
                 ? __DIR__.'/stubs/exception-render-report.stub'
                 : __DIR__.'/stubs/exception-render.stub';
-        } else {
-            return $this->option('report')
-                ? __DIR__.'/stubs/exception-report.stub'
-                : __DIR__.'/stubs/exception.stub';
         }
+        
+        return $this->option('report')
+            ? __DIR__.'/stubs/exception-report.stub'
+            : __DIR__.'/stubs/exception.stub';
+
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/ExceptionMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ExceptionMakeCommand.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Illuminate\Foundation\Console;
+
+use Illuminate\Console\GeneratorCommand;
+use Symfony\Component\Console\Input\InputOption;
+
+class ExceptionMakeCommand extends GeneratorCommand
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'make:exception';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create a new custom exception class';
+
+    /**
+     * The type of class being generated.
+     *
+     * @var string
+     */
+    protected $type = 'Exception';
+
+    /**
+     * Get the stub file for the generator.
+     *
+     * @return string
+     */
+    protected function getStub()
+    {
+        if ($this->option('render')) {
+            return $this->option('report')
+                ? __DIR__.'/stubs/exception-render-report.stub'
+                : __DIR__.'/stubs/exception-render.stub';
+        } else {
+            return $this->option('report')
+                ? __DIR__.'/stubs/exception-report.stub'
+                : __DIR__.'/stubs/exception.stub';
+        }
+    }
+
+    /**
+     * Determine if the class already exists.
+     *
+     * @param  string  $rawName
+     * @return bool
+     */
+    protected function alreadyExists($rawName)
+    {
+        return class_exists($this->rootNamespace().'Exceptions\\'.$rawName);
+    }
+
+    /**
+     * Get the default namespace for the class.
+     *
+     * @param  string  $rootNamespace
+     * @return string
+     */
+    protected function getDefaultNamespace($rootNamespace)
+    {
+        return $rootNamespace.'\Exceptions';
+    }
+
+    /**
+     * Get the console command options.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [
+            ['render', null, InputOption::VALUE_NONE, 'Create the exception with an empty render method.'],
+            ['report', null, InputOption::VALUE_NONE, 'Create the exception with an empty report method.'],
+        ];
+    }
+}

--- a/src/Illuminate/Foundation/Console/stubs/exception-render-report.stub
+++ b/src/Illuminate/Foundation/Console/stubs/exception-render-report.stub
@@ -1,0 +1,30 @@
+<?php
+
+namespace DummyNamespace;
+
+use Exception;
+
+class DummyClass extends Exception
+{
+
+    /**
+     * Render the exception into an HTTP response.
+     *
+     * @param  \Illuminate\Http\Request
+     * @return \Illuminate\Http\Response
+     */
+    public function render($request)
+    {
+        //
+    }
+
+    /**
+     * Report the exception.
+     *
+     * @return void
+     */
+     public function report()
+     {
+        //
+    }
+}

--- a/src/Illuminate/Foundation/Console/stubs/exception-render.stub
+++ b/src/Illuminate/Foundation/Console/stubs/exception-render.stub
@@ -1,0 +1,19 @@
+<?php
+
+namespace DummyNamespace;
+
+use Exception;
+
+class DummyClass extends Exception
+{
+
+    /**
+     * Render an exception into a response.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     */
+    public function render($request)
+    {
+        //
+    }
+}

--- a/src/Illuminate/Foundation/Console/stubs/exception-report.stub
+++ b/src/Illuminate/Foundation/Console/stubs/exception-report.stub
@@ -1,0 +1,19 @@
+<?php
+
+namespace DummyNamespace;
+
+use Exception;
+
+class DummyClass extends Exception
+{
+
+    /**
+     * Report the exception.
+     *
+     * @return void
+     */
+     public function report()
+     {
+        //
+    }
+}

--- a/src/Illuminate/Foundation/Console/stubs/exception.stub
+++ b/src/Illuminate/Foundation/Console/stubs/exception.stub
@@ -1,0 +1,10 @@
+<?php
+
+namespace DummyNamespace;
+
+use Exception;
+
+class DummyClass extends Exception
+{
+
+}

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -42,6 +42,7 @@ use Illuminate\Foundation\Console\ProviderMakeCommand;
 use Illuminate\Foundation\Console\ResourceMakeCommand;
 use Illuminate\Foundation\Console\ClearCompiledCommand;
 use Illuminate\Foundation\Console\EventGenerateCommand;
+use Illuminate\Foundation\Console\ExceptionMakeCommand;
 use Illuminate\Foundation\Console\VendorPublishCommand;
 use Illuminate\Console\Scheduling\ScheduleFinishCommand;
 use Illuminate\Database\Console\Seeds\SeederMakeCommand;
@@ -132,6 +133,7 @@ class ArtisanServiceProvider extends ServiceProvider
         'ControllerMake' => 'command.controller.make',
         'EventGenerate' => 'command.event.generate',
         'EventMake' => 'command.event.make',
+        'ExceptionMake' => 'command.exception.make',
         'FactoryMake' => 'command.factory.make',
         'JobMake' => 'command.job.make',
         'ListenerMake' => 'command.listener.make',
@@ -371,6 +373,18 @@ class ArtisanServiceProvider extends ServiceProvider
     {
         $this->app->singleton('command.environment', function () {
             return new EnvironmentCommand;
+        });
+    }
+
+    /**
+     * Register the command.
+     *
+     * @return void
+     */
+    protected function registerExceptionMakeCommand()
+    {
+        $this->app->singleton('command.exception.make', function ($app) {
+            return new ExceptionMakeCommand($app['files']);
         });
     }
 


### PR DESCRIPTION
Added the ability to create custom exceptions with `php artisan make:exception`. This command will create the Exception inside the Exceptions namespace of the app.

You can also use the flags `--render` and `--report` to generate the methods.