### PR TITLE
[5.5] Clear "select" bindings whenever select columns have been override.

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -188,7 +188,7 @@ abstract class Relation
     {
         return $this->getRelationExistenceQuery(
             $query, $parentQuery, new Expression('count(*)')
-        )->setBindings([], 'select');
+        );
     }
 
     /**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -219,6 +219,8 @@ class Builder
     {
         $this->columns = is_array($columns) ? $columns : func_get_args();
 
+        $this->setBindings([], 'select');
+
         return $this;
     }
 

--- a/tests/Database/DatabaseEloquentHasOneTest.php
+++ b/tests/Database/DatabaseEloquentHasOneTest.php
@@ -177,7 +177,6 @@ class DatabaseEloquentHasOneTest extends TestCase
         $builder->shouldReceive('select')->once()->with(m::type('Illuminate\Database\Query\Expression'))->andReturnSelf();
         $relation->getParent()->shouldReceive('getTable')->andReturn('table');
         $builder->shouldReceive('whereColumn')->once()->with('table.id', '=', 'table.foreign_key')->andReturn($baseQuery);
-        $baseQuery->shouldReceive('setBindings')->once()->with([], 'select');
 
         $relation->getRelationExistenceCountQuery($builder, $builder);
     }

--- a/tests/Integration/Database/QueryBuilderOverrideSelectTest.php
+++ b/tests/Integration/Database/QueryBuilderOverrideSelectTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\QueryBuilderOverrideSelectTest;
+
+use Orchestra\Testbench\TestCase;
+
+/**
+ * @group integration
+ */
+class EloquentWithCountTest extends TestCase
+{
+    protected function getEnvironmentSetUp($app)
+    {
+        $app['config']->set('app.debug', 'true');
+
+        $app['config']->set('database.default', 'testbench');
+
+        $app['config']->set('database.connections.testbench', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+        ]);
+    }
+
+    /**
+     * @test
+     */
+    public function test_query_builder_can_clear_bindings_when_override_select_columns()
+    {
+        $query = app('Illuminate\Database\Query\Builder')
+            ->selectRaw('(select count(*) from posts where status = ?)', [1])
+            ->from('users');
+
+        $this->assertEquals([1], $query->getBindings());
+
+        $query = $query->select()->where('foo', 'bar');
+
+        $this->assertEquals(['bar'], $query->getBindings());
+    }
+}

--- a/tests/Integration/Database/QueryBuilderOverrideSelectTest.php
+++ b/tests/Integration/Database/QueryBuilderOverrideSelectTest.php
@@ -12,14 +12,6 @@ class EloquentWithCountTest extends TestCase
     protected function getEnvironmentSetUp($app)
     {
         $app['config']->set('app.debug', 'true');
-
-        $app['config']->set('database.default', 'testbench');
-
-        $app['config']->set('database.connections.testbench', [
-            'driver' => 'sqlite',
-            'database' => ':memory:',
-            'prefix' => '',
-        ]);
     }
 
     /**


### PR DESCRIPTION
Sorry for not writing a detailed description in last PR #21485 

This PR revert some changes in last fix #21468. And add the code call `->setBindings([], 'select')` when `select()` being called to fix an issue for cases query builder originally have select bindings but later being override cause a binding mismatch issue that lead to error. 

The quickest way to reproduce error is run this in tinker 
```
$query = app('Illuminate\Database\Query\Builder')->selectRaw('(select count(*) from posts where status = ?)', [1])->from('users');
``` 
`$query` will have bindings `[1]`.
if later call 
```
$query->select()->where('foo', 'bar');
``` 
`$query` will have bindings `[1, "bar"]` while it supposed to only have `["bar"]`

@themsaid let me know your thoughts, thanks!

reference: #21472