### PR TITLE
[5.5] Don’t regenerate session in "sendLoginResponse"

### DIFF
--- a/src/Illuminate/Foundation/Auth/AuthenticatesUsers.php
+++ b/src/Illuminate/Foundation/Auth/AuthenticatesUsers.php
@@ -97,8 +97,6 @@ trait AuthenticatesUsers
      */
     protected function sendLoginResponse(Request $request)
     {
-        $request->session()->regenerate();
-
         $this->clearLoginAttempts($request);
 
         return $this->authenticated($request, $this->guard()->user())


### PR DESCRIPTION
The call to `$request->session()->regenerate()` was introduced in 9e68e91cef5df661cd64217c9242cea998a66883, however the session is already being regenerated by `SessionGuard::login()`.

I might be missing an edge case here, not sure, tests are passing.