### PR TITLE
return hasher when value is null

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -191,8 +191,12 @@ if (! function_exists('bcrypt')) {
      * @param  array   $options
      * @return string
      */
-    function bcrypt($value, $options = [])
+    function bcrypt($value = null, $options = [])
     {
+        if (is_null($value)) {
+            return app('hash');
+        }
+
         return app('hash')->make($value, $options);
     }
 }


### PR DESCRIPTION
this allows us to use the other methods on the Hasher (`check`, `needsRehash`).

similar to many of the other helper function that simply return the object if no value is passed.