### PR TITLE
[5.5] Add ability to pass callback to whenLoaded Resource method

### DIFF
--- a/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
+++ b/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
@@ -111,18 +111,34 @@ trait ConditionallyLoadsAttributes
     }
 
     /**
-     * Retrieve a relationship if it has been loaded.
+     * Retrieve a relationship or execute a callback
+     * if the given relationship has been loaded.
      *
      * @param  string  $relationship
+     * @param  mixed  $value
+     * @param  mixed  $default
+     *
      * @return \Illuminate\Http\Resources\MissingValue|mixed
      */
-    protected function whenLoaded($relationship)
+    protected function whenLoaded($relationship, $value = null, $default = null)
     {
-        if ($this->resource->relationLoaded($relationship)) {
+        if (func_num_args() < 3) {
+            $default = new MissingValue;
+        }
+
+        if (!$this->resource->relationLoaded($relationship)) {
+            return $default;
+        }
+
+        if (func_num_args() === 1) {
             return $this->resource->{$relationship};
         }
 
-        return new MissingValue;
+        if($this->resource->{$relationship} === null) {
+            return null;
+        }
+
+        return value($value);
     }
 
     /**

--- a/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
+++ b/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
@@ -126,7 +126,7 @@ trait ConditionallyLoadsAttributes
             $default = new MissingValue;
         }
 
-        if (!$this->resource->relationLoaded($relationship)) {
+        if (! $this->resource->relationLoaded($relationship)) {
             return $default;
         }
 
@@ -134,7 +134,7 @@ trait ConditionallyLoadsAttributes
             return $this->resource->{$relationship};
         }
 
-        if($this->resource->{$relationship} === null) {
+        if ($this->resource->{$relationship} === null) {
             return null;
         }
 

--- a/tests/Integration/Http/Fixtures/PostResourceWithOptionalRelationship.php
+++ b/tests/Integration/Http/Fixtures/PostResourceWithOptionalRelationship.php
@@ -10,6 +10,9 @@ class PostResourceWithOptionalRelationship extends PostResource
             'id' => $this->id,
             'comments' => new CommentCollection($this->whenLoaded('comments')),
             'author' => new AuthorResource($this->whenLoaded('author')),
+            'author_name' => $this->whenLoaded('author', function() {
+                return $this->author->name;
+            }),
         ];
     }
 }

--- a/tests/Integration/Http/Fixtures/PostResourceWithOptionalRelationship.php
+++ b/tests/Integration/Http/Fixtures/PostResourceWithOptionalRelationship.php
@@ -10,7 +10,7 @@ class PostResourceWithOptionalRelationship extends PostResource
             'id' => $this->id,
             'comments' => new CommentCollection($this->whenLoaded('comments')),
             'author' => new AuthorResource($this->whenLoaded('author')),
-            'author_name' => $this->whenLoaded('author', function() {
+            'author_name' => $this->whenLoaded('author', function () {
                 return $this->author->name;
             }),
         ];

--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -185,7 +185,7 @@ class ResourceTest extends TestCase
             'data' => [
                 'id' => 5,
                 'author' => null,
-                'author_name' => null
+                'author_name' => null,
             ],
         ]);
     }

--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -157,6 +157,7 @@ class ResourceTest extends TestCase
             'data' => [
                 'id' => 5,
                 'author' => ['name' => 'jrrmartin'],
+                'author_name' => 'jrrmartin',
             ],
         ]);
     }
@@ -184,6 +185,7 @@ class ResourceTest extends TestCase
             'data' => [
                 'id' => 5,
                 'author' => null,
+                'author_name' => null
             ],
         ]);
     }


### PR DESCRIPTION
Currently, the whenLoaded method for API Resources is only able to return the relationship object.
A similar method, whenPivotLoaded, allows a callback to be passed, which will be added to the returned array.
This PR adds this similar functionality to the whenLoaded method. If a callback is passed, the return value of that callback will be added to the array to be returned. If no callback is passed, the relationship object is returned, as is the current behavior. This should be a fully backward compatible addition.

Behavior when no callback is specified:
```php
/**
 * Transform the resource into an array.
 *
 * @param  \Illuminate\Http\Request
 * @return array
 */
public function toArray($request)
{
    return [
        'id' => $this->id,
        'title' => $this->title,
        'author' => new AuthorResource($this->whenLoaded('author')),
    ];
}

// Would return
[
    'id' => 1,
    'title' => 'Post Title',
    'author' => ['id' => 1, 'name' => 'Taylor Otwell'],
]
```

Behavior when a callback is specified:
```php
/**
 * Transform the resource into an array.
 *
 * @param  \Illuminate\Http\Request
 * @return array
 */
public function toArray($request)
{
    return [
        'id' => $this->id,
        'title' => $this->title,
        'author_name' => $this->whenLoaded('author'), function() {
            return $this->author->name;
        }),
    ];
}

// Would return
[
    'id' => 1,
    'title' => 'Post Title',
    'author_name' => 'Taylor Otwell',
]
```

This isn't the most practical example ever, but being able to pass a callback is very handy for things such as counts or other adjustments to the related object that don't necessarily need to be part of a dedicated Resource object for a model.