### PR TITLE
Added support for associative string replace

### DIFF
--- a/src/Illuminate/Support/Pluralizer.php
+++ b/src/Illuminate/Support/Pluralizer.php
@@ -24,6 +24,7 @@ class Pluralizer
         'equipment',
         'evidence',
         'feedback',
+        'firmware',
         'fish',
         'furniture',
         'gold',

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -321,7 +321,7 @@ class Str
      * @param  string  $subject
      * @return string
      */
-    public static function replaceAssoc(array $searchPairs,$subject)
+    public static function replaceAssoc(array $searchPairs, $subject)
     {
         return str_replace(array_keys($searchPairs), array_values($searchPairs), $subject);
     }

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -315,6 +315,18 @@ class Str
     }
 
     /**
+     * Replace the keys with their corresponding values.
+     *
+     * @param  array   $searchPairs
+     * @param  string  $subject
+     * @return string
+     */
+    public static function replaceAssoc(array $searchPairs,$subject)
+    {
+        return str_replace(array_keys($searchPairs), array_values($searchPairs), $subject);
+    }
+
+    /**
      * Replace the first occurrence of a given value in the string.
      *
      * @param  string  $search

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -933,6 +933,20 @@ if (! function_exists('str_replace_array')) {
     }
 }
 
+if (! function_exists('str_replace_assoc')) {
+    /**
+     * Replace the keys with their corresponding values.
+     *
+     * @param  array   $searchPairs
+     * @param  string  $subject
+     * @return string
+     */
+    function str_replace_assoc(array $searchPairs,$subject)
+    {
+        return Str::replaceAssoc($searchPairs, $subject);
+    }
+}
+
 if (! function_exists('str_replace_first')) {
     /**
      * Replace the first occurrence of a given value in the string.

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -941,7 +941,7 @@ if (! function_exists('str_replace_assoc')) {
      * @param  string  $subject
      * @return string
      */
-    function str_replace_assoc(array $searchPairs,$subject)
+    function str_replace_assoc(array $searchPairs, $subject)
     {
         return Str::replaceAssoc($searchPairs, $subject);
     }

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -218,17 +218,17 @@ class SupportStrTest extends TestCase
             '1' => 'one',
             '2' => 'two',
             '3' => 'three'
-        ],'1 2 3 2 3 1'));
+        ], '1 2 3 2 3 1'));
 
         $this->assertEquals('oranges are color orange', Str::replaceAssoc([
             'apple' => 'orange',
             'red' => 'orange',
-        ],'apples are color red'));
+        ], 'apples are color red'));
 
         $this->assertEquals('Nothing will change in foo', Str::replaceAssoc([
             'foo' => 'bar',
             'bar' => 'foo'
-        ],'Nothing will change in foo'));
+        ], 'Nothing will change in foo'));
     }
 
     public function testReplaceFirst()

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -217,7 +217,7 @@ class SupportStrTest extends TestCase
         $this->assertEquals('one two three two three one', Str::replaceAssoc([
             '1' => 'one',
             '2' => 'two',
-            '3' => 'three'
+            '3' => 'three',
         ], '1 2 3 2 3 1'));
 
         $this->assertEquals('oranges are color orange', Str::replaceAssoc([
@@ -227,7 +227,7 @@ class SupportStrTest extends TestCase
 
         $this->assertEquals('Nothing will change in foo', Str::replaceAssoc([
             'foo' => 'bar',
-            'bar' => 'foo'
+            'bar' => 'foo',
         ], 'Nothing will change in foo'));
     }
 

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -212,6 +212,25 @@ class SupportStrTest extends TestCase
         $this->assertEquals('?/?/?', Str::replaceArray('x', ['foo', 'bar', 'baz'], '?/?/?'));
     }
 
+    public function testReplaceAssoc()
+    {
+        $this->assertEquals('one two three two three one', Str::replaceAssoc([
+            '1' => 'one',
+            '2' => 'two',
+            '3' => 'three'
+        ],'1 2 3 2 3 1'));
+
+        $this->assertEquals('oranges are color orange', Str::replaceAssoc([
+            'apple' => 'orange',
+            'red' => 'orange',
+        ],'apples are color red'));
+
+        $this->assertEquals('Nothing will change in foo', Str::replaceAssoc([
+            'foo' => 'bar',
+            'bar' => 'foo'
+        ],'Nothing will change in foo'));
+    }
+
     public function testReplaceFirst()
     {
         $this->assertEquals('fooqux foobar', Str::replaceFirst('bar', 'qux', 'foobar foobar'));


### PR DESCRIPTION
This is a scratch to my own itch. I create artisan commands that creates classes from stubs. Instead of having to write it this way which is hard to read:
```
$stub = str_replace(['DummyModel','DummyModelRepository'],[$this->argument('model'),$this->argument('repository')], $stub);
```
... I prefer this:
```
$stub = str_replace_assoc([
    'DummyModel' => $this->argument('model'),
    'DummyModelRepository' => $this->argument('repository')
],$stub);
```
