### PR TITLE
[5.5] Allow marking notifications as unread

### DIFF
--- a/src/Illuminate/Notifications/DatabaseNotification.php
+++ b/src/Illuminate/Notifications/DatabaseNotification.php
@@ -58,6 +58,18 @@ class DatabaseNotification extends Model
     }
 
     /**
+     * Mark the notification as unread.
+     *
+     * @return void
+     */
+    public function markAsUnread()
+    {
+        if (! is_null($this->read_at)) {
+            $this->forceFill(['read_at' => null])->save();
+        }
+    }
+
+    /**
      * Determine if a notification has been read.
      *
      * @return bool

--- a/src/Illuminate/Notifications/DatabaseNotificationCollection.php
+++ b/src/Illuminate/Notifications/DatabaseNotificationCollection.php
@@ -17,4 +17,16 @@ class DatabaseNotificationCollection extends Collection
             $notification->markAsRead();
         });
     }
+
+    /**
+     * Mark all notification as unread.
+     *
+     * @return void
+     */
+    public function markAsUnread()
+    {
+        $this->each(function ($notification) {
+            $notification->markAsUnread();
+        });
+    }
 }

--- a/src/Illuminate/Notifications/DatabaseNotificationCollection.php
+++ b/src/Illuminate/Notifications/DatabaseNotificationCollection.php
@@ -19,7 +19,7 @@ class DatabaseNotificationCollection extends Collection
     }
 
     /**
-     * Mark all notification as unread.
+     * Mark all notifications as unread.
      *
      * @return void
      */


### PR DESCRIPTION
I have a notification area i show notifications to the users.

Some of my users need to mark notifications as unread to return for them later.

I think this is a very common thing, as the vast majority of email services allow for email to be marked as unread, also notifications in most of the websites are allowed to be marked as unread.