### PR TITLE
[5.5] Policy stub fixes: correct User model & var name for `UserPolicy`

### DIFF
--- a/src/Illuminate/Foundation/Console/PolicyMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/PolicyMakeCommand.php
@@ -89,12 +89,16 @@ class PolicyMakeCommand extends GeneratorCommand
         );
 
         $model = class_basename(trim($model, '\\'));
+        $dummyModel = Str::camel($model) === 'user' ? 'model' : Str::camel($model);
+        $dummyUser = class_basename(config('auth.providers.users.model'));
 
         $stub = str_replace('DummyModel', $model, $stub);
 
-        $stub = str_replace('dummyModel', Str::camel($model), $stub);
+        $stub = str_replace('dummyModel', $dummyModel, $stub);
 
-        return str_replace('dummyPluralModel', Str::plural(Str::camel($model)), $stub);
+        $stub = str_replace('DummyUser', $dummyUser, $stub);
+
+        return str_replace('dummyPluralModel', Str::plural($dummyModel), $stub);
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/stubs/policy.stub
+++ b/src/Illuminate/Foundation/Console/stubs/policy.stub
@@ -17,7 +17,7 @@ class DummyClass
      * @param  \NamespacedDummyModel  $dummyModel
      * @return mixed
      */
-    public function view(User $user, DummyModel $dummyModel)
+    public function view(DummyUser $user, DummyModel $dummyModel)
     {
         //
     }
@@ -28,7 +28,7 @@ class DummyClass
      * @param  \NamespacedDummyUserModel  $user
      * @return mixed
      */
-    public function create(User $user)
+    public function create(DummyUser $user)
     {
         //
     }
@@ -40,7 +40,7 @@ class DummyClass
      * @param  \NamespacedDummyModel  $dummyModel
      * @return mixed
      */
-    public function update(User $user, DummyModel $dummyModel)
+    public function update(DummyUser $user, DummyModel $dummyModel)
     {
         //
     }
@@ -52,7 +52,7 @@ class DummyClass
      * @param  \NamespacedDummyModel  $dummyModel
      * @return mixed
      */
-    public function delete(User $user, DummyModel $dummyModel)
+    public function delete(DummyUser $user, DummyModel $dummyModel)
     {
         //
     }


### PR DESCRIPTION
Currently, `User $user` argument in Policy stub does not respect `auth.providers.users.model` config value. This PR replaces default `User` model typehint with correct one from auth config (`DummyUser` in policy stub).

Also, generated policy for `User` model have duplicate `$user` variable in methods signature (one for authenticated user & one for poilcy model instance).

With this change policy for `User` models will be generated with `(User $user, User $model)` signatures instead of `(User $user, User $user)`.