### PR TITLE
Allow fallback translations on attribute validation

### DIFF
--- a/src/Illuminate/Validation/Concerns/FormatsMessages.php
+++ b/src/Illuminate/Validation/Concerns/FormatsMessages.php
@@ -248,7 +248,7 @@ trait FormatsMessages
      */
     protected function getAttributeFromTranslations($name)
     {
-        return $this->translator->trans('validation.attributes.' . $name);
+        return $this->translator->trans('validation.attributes.'.$name);
     }
 
     /**

--- a/src/Illuminate/Validation/Concerns/FormatsMessages.php
+++ b/src/Illuminate/Validation/Concerns/FormatsMessages.php
@@ -248,7 +248,7 @@ trait FormatsMessages
      */
     protected function getAttributeFromTranslations($name)
     {
-        return Arr::get($this->translator->trans('validation.attributes'), $name);
+        return $this->translator->trans('validation.attributes.' . $name);
     }
 
     /**


### PR DESCRIPTION
Currently when using Custom Validation Attributes, fallback translations are not supported. So every locale file within the app must contain an array of EVERY attribute translation, even if they are just duplicates of the fallback language.

I propose that instead of considering just the attribute translations defined within the active locale's translation file, the translation system could offer fallback translations also.

Consider the following translations:

**resources/lang/en/validation.php**
```
'attributes' => [
    'email' => 'Email Address',
    'favourite_band' => 'Favourite Band',
]
```

**resources/lang/fr/validation.php**
```
'attributes' => [
    'email' => 'Adresse E-mail',
]
```

Note the missing "favourite_band" attribute translation in FR. Currently the consequences of failed Form Request Validation is as follows...

Perfect validation errors in "en" locale:
- "The Email Address field is required."
- "The Favourite Band field is required."

Only partial translations in "fr" locale:
- "Le champ Adresse E-mail est obligatoire."
- "Le champ favourite_band est obligatoire."

Not very clean. By using my proposal, the consequences would be as follows...

Still perfect validation errors in "en" locale:
- "The Email Address field is required."
- "The Favourite Band field is required."

Missing attributes fallback to default "en" value in "fr" locale:
- "Le champ Adresse E-mail est obligatoire."
- "Le champ Favourite Band est obligatoire."