### PR TITLE
[5.6] rename bcrypt to hasher and allow null value

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -183,20 +183,6 @@ if (! function_exists('base_path')) {
     }
 }
 
-if (! function_exists('bcrypt')) {
-    /**
-     * Hash the given value.
-     *
-     * @param  string  $value
-     * @param  array   $options
-     * @return string
-     */
-    function bcrypt($value, $options = [])
-    {
-        return app('hash')->make($value, $options);
-    }
-}
-
 if (! function_exists('broadcast')) {
     /**
      * Begin broadcasting an event.
@@ -484,6 +470,24 @@ if (! function_exists('factory')) {
         } else {
             return $factory->of($arguments[0]);
         }
+    }
+}
+
+if (! function_exists('hasher')) {
+    /**
+     * Hash the given value.
+     *
+     * @param  string  $value
+     * @param  array   $options
+     * @return string
+     */
+    function hasher($value = null, $options = [])
+    {
+        if (is_null($value)) {
+            return app('hash');
+        }
+
+        return app('hash')->make($value, $options);
     }
 }
 


### PR DESCRIPTION
the helper, like the Facade, should be implementation agnostic. while we currently do use Bcrypt as our hashing algorithm, it is possibly it will switch to a more updated algo in the future.

also allow passing a `null` value to get the Hasher instance back. this pattern is used in many of the other helpers.  this was originally sent as a separate PR to 5.5, but after a discussion with @Dylan-DPC it was determined this was a BC break.