### PR TITLE
Add RedirectsUsers to SendPasswordResetEmails

### DIFF
--- a/src/Illuminate/Foundation/Auth/SendsPasswordResetEmails.php
+++ b/src/Illuminate/Foundation/Auth/SendsPasswordResetEmails.php
@@ -7,6 +7,8 @@ use Illuminate\Support\Facades\Password;
 
 trait SendsPasswordResetEmails
 {
+    use RedirectsUsers;
+
     /**
      * Display the form to request a password reset link.
      *
@@ -58,7 +60,8 @@ trait SendsPasswordResetEmails
      */
     protected function sendResetLinkResponse($response)
     {
-        return back()->with('status', trans($response));
+        return redirect($this->redirectPath())
+                            ->with('status', trans($response));
     }
 
     /**


### PR DESCRIPTION
AuthenticatesUsers, RegistersUsers and ResetsPasswords all employ RedirectsUsers for redirection on success. This adds the same functionality to SendPasswordResetEmails for consistency.