### PR TITLE
Added `equals` rule (working not like `same`)

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -19,1340 +19,1500 @@ use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 trait ValidatesAttributes
 {
-    /**
-     * Validate that an attribute was "accepted".
-     *
-     * This validation rule implies the attribute is "required".
-     *
-     * @param  string  $attribute
-     * @param  mixed   $value
-     * @return bool
-     */
-    public function validateAccepted($attribute, $value)
-    {
-        $acceptable = ['yes', 'on', '1', 1, true, 'true'];
-
-        return $this->validateRequired($attribute, $value) && in_array($value, $acceptable, true);
-    }
-
-    /**
-     * Validate that an attribute is an active URL.
-     *
-     * @param  string  $attribute
-     * @param  mixed   $value
-     * @return bool
-     */
-    public function validateActiveUrl($attribute, $value)
-    {
-        if (! is_string($value)) {
-            return false;
-        }
-
-        if ($url = parse_url($value, PHP_URL_HOST)) {
-            try {
-                return count(dns_get_record($url, DNS_A | DNS_AAAA)) > 0;
-            } catch (Exception $e) {
-                return false;
-            }
-        }
-
-        return false;
-    }
-
-    /**
-     * "Break" on first validation fail.
-     *
-     * Always returns true, just lets us put "bail" in rules.
-     *
-     * @return bool
-     */
-    public function validateBail()
-    {
-        return true;
-    }
-
-    /**
-     * Validate the date is before a given date.
-     *
-     * @param  string  $attribute
-     * @param  mixed   $value
-     * @param  array   $parameters
-     * @return bool
-     */
-    public function validateBefore($attribute, $value, $parameters)
-    {
-        $this->requireParameterCount(1, $parameters, 'before');
-
-        return $this->compareDates($attribute, $value, $parameters, '<');
-    }
-
-    /**
-     * Validate the date is before or equal a given date.
-     *
-     * @param  string  $attribute
-     * @param  mixed   $value
-     * @param  array   $parameters
-     * @return bool
-     */
-    public function validateBeforeOrEqual($attribute, $value, $parameters)
-    {
-        $this->requireParameterCount(1, $parameters, 'before_or_equal');
-
-        return $this->compareDates($attribute, $value, $parameters, '<=');
-    }
-
-    /**
-     * Validate the date is after a given date.
-     *
-     * @param  string  $attribute
-     * @param  mixed   $value
-     * @param  array   $parameters
-     * @return bool
-     */
-    public function validateAfter($attribute, $value, $parameters)
-    {
-        $this->requireParameterCount(1, $parameters, 'after');
-
-        return $this->compareDates($attribute, $value, $parameters, '>');
-    }
-
-    /**
-     * Validate the date is equal or after a given date.
-     *
-     * @param  string  $attribute
-     * @param  mixed   $value
-     * @param  array   $parameters
-     * @return bool
-     */
-    public function validateAfterOrEqual($attribute, $value, $parameters)
-    {
-        $this->requireParameterCount(1, $parameters, 'after_or_equal');
-
-        return $this->compareDates($attribute, $value, $parameters, '>=');
-    }
-
-    /**
-     * Compare a given date against another using an operator.
-     *
-     * @param  string  $attribute
-     * @param  mixed  $value
-     * @param  array  $parameters
-     * @param  string  $operator
-     * @return bool
-     */
-    protected function compareDates($attribute, $value, $parameters, $operator)
-    {
-        if (! is_string($value) && ! is_numeric($value) && ! $value instanceof DateTimeInterface) {
-            return false;
-        }
-
-        if ($format = $this->getDateFormat($attribute)) {
-            return $this->checkDateTimeOrder(
-                $format, $value, $this->getValue($parameters[0]) ?: $parameters[0], $operator
-            );
-        }
-
-        if (! $date = $this->getDateTimestamp($parameters[0])) {
-            $date = $this->getDateTimestamp($this->getValue($parameters[0]));
-        }
-
-        return $this->compare($this->getDateTimestamp($value), $date, $operator);
-    }
-
-    /**
-     * Get the date format for an attribute if it has one.
-     *
-     * @param  string  $attribute
-     * @return string|null
-     */
-    protected function getDateFormat($attribute)
-    {
-        if ($result = $this->getRule($attribute, 'DateFormat')) {
-            return $result[1][0];
-        }
-    }
-
-    /**
-     * Get the date timestamp.
-     *
-     * @param  mixed  $value
-     * @return int
-     */
-    protected function getDateTimestamp($value)
-    {
-        return $value instanceof DateTimeInterface ? $value->getTimestamp() : strtotime($value);
-    }
-
-    /**
-     * Given two date/time strings, check that one is after the other.
-     *
-     * @param  string  $format
-     * @param  string  $first
-     * @param  string  $second
-     * @param  string  $operator
-     * @return bool
-     */
-    protected function checkDateTimeOrder($format, $first, $second, $operator)
-    {
-        $first = $this->getDateTimeWithOptionalFormat($format, $first);
-
-        $second = $this->getDateTimeWithOptionalFormat($format, $second);
-
-        return ($first && $second) && ($this->compare($first, $second, $operator));
-    }
-
-    /**
-     * Get a DateTime instance from a string.
-     *
-     * @param  string  $format
-     * @param  string  $value
-     * @return \DateTime|null
-     */
-    protected function getDateTimeWithOptionalFormat($format, $value)
-    {
-        if ($date = DateTime::createFromFormat('!'.$format, $value)) {
-            return $date;
-        }
-
-        try {
-            return new DateTime($value);
-        } catch (Exception $e) {
-            //
-        }
-    }
-
-    /**
-     * Validate that an attribute contains only alphabetic characters.
-     *
-     * @param  string  $attribute
-     * @param  mixed   $value
-     * @return bool
-     */
-    public function validateAlpha($attribute, $value)
-    {
-        return is_string($value) && preg_match('/^[\pL\pM]+$/u', $value);
-    }
-
-    /**
-     * Validate that an attribute contains only alpha-numeric characters, dashes, and underscores.
-     *
-     * @param  string  $attribute
-     * @param  mixed   $value
-     * @return bool
-     */
-    public function validateAlphaDash($attribute, $value)
-    {
-        if (! is_string($value) && ! is_numeric($value)) {
-            return false;
-        }
-
-        return preg_match('/^[\pL\pM\pN_-]+$/u', $value) > 0;
-    }
-
-    /**
-     * Validate that an attribute contains only alpha-numeric characters.
-     *
-     * @param  string  $attribute
-     * @param  mixed   $value
-     * @return bool
-     */
-    public function validateAlphaNum($attribute, $value)
-    {
-        if (! is_string($value) && ! is_numeric($value)) {
-            return false;
-        }
-
-        return preg_match('/^[\pL\pM\pN]+$/u', $value) > 0;
-    }
-
-    /**
-     * Validate that an attribute is an array.
-     *
-     * @param  string  $attribute
-     * @param  mixed   $value
-     * @return bool
-     */
-    public function validateArray($attribute, $value)
-    {
-        return is_array($value);
-    }
-
-    /**
-     * Validate the size of an attribute is between a set of values.
-     *
-     * @param  string  $attribute
-     * @param  mixed   $value
-     * @param  array   $parameters
-     * @return bool
-     */
-    public function validateBetween($attribute, $value, $parameters)
-    {
-        $this->requireParameterCount(2, $parameters, 'between');
-
-        $size = $this->getSize($attribute, $value);
-
-        return $size >= $parameters[0] && $size <= $parameters[1];
-    }
-
-    /**
-     * Validate that an attribute is a boolean.
-     *
-     * @param  string  $attribute
-     * @param  mixed   $value
-     * @return bool
-     */
-    public function validateBoolean($attribute, $value)
-    {
-        $acceptable = [true, false, 0, 1, '0', '1'];
-
-        return in_array($value, $acceptable, true);
-    }
-
-    /**
-     * Validate that an attribute has a matching confirmation.
-     *
-     * @param  string  $attribute
-     * @param  mixed   $value
-     * @return bool
-     */
-    public function validateConfirmed($attribute, $value)
-    {
-        return $this->validateSame($attribute, $value, [$attribute.'_confirmation']);
-    }
-
-    /**
-     * Validate that an attribute is a valid date.
-     *
-     * @param  string  $attribute
-     * @param  mixed   $value
-     * @return bool
-     */
-    public function validateDate($attribute, $value)
-    {
-        if ($value instanceof DateTimeInterface) {
-            return true;
-        }
-
-        if ((! is_string($value) && ! is_numeric($value)) || strtotime($value) === false) {
-            return false;
-        }
-
-        $date = date_parse($value);
-
-        return checkdate($date['month'], $date['day'], $date['year']);
-    }
-
-    /**
-     * Validate that an attribute matches a date format.
-     *
-     * @param  string  $attribute
-     * @param  mixed   $value
-     * @param  array   $parameters
-     * @return bool
-     */
-    public function validateDateFormat($attribute, $value, $parameters)
-    {
-        $this->requireParameterCount(1, $parameters, 'date_format');
-
-        if (! is_string($value) && ! is_numeric($value)) {
-            return false;
-        }
-
-        $format = $parameters[0];
-
-        $date = DateTime::createFromFormat('!'.$format, $value);
-
-        return $date && $date->format($format) == $value;
-    }
-
-    /**
-     * Validate that an attribute is equal to another date.
-     *
-     * @param  string  $attribute
-     * @param  mixed   $value
-     * @param  array   $parameters
-     * @return bool
-     */
-    public function validateDateEquals($attribute, $value, $parameters)
-    {
-        $this->requireParameterCount(1, $parameters, 'date_equals');
-
-        return $this->compareDates($attribute, $value, $parameters, '=');
-    }
-
-    /**
-     * Validate that an attribute is different from another attribute.
-     *
-     * @param  string  $attribute
-     * @param  mixed   $value
-     * @param  array   $parameters
-     * @return bool
-     */
-    public function validateDifferent($attribute, $value, $parameters)
-    {
-        $this->requireParameterCount(1, $parameters, 'different');
-
-        foreach ($parameters as $parameter) {
-            $other = Arr::get($this->data, $parameter);
-
-            if (is_null($other) || $value === $other) {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
-    /**
-     * Validate that an attribute has a given number of digits.
-     *
-     * @param  string  $attribute
-     * @param  mixed   $value
-     * @param  array   $parameters
-     * @return bool
-     */
-    public function validateDigits($attribute, $value, $parameters)
-    {
-        $this->requireParameterCount(1, $parameters, 'digits');
-
-        return ! preg_match('/[^0-9]/', $value)
-                    && strlen((string) $value) == $parameters[0];
-    }
-
-    /**
-     * Validate that an attribute is between a given number of digits.
-     *
-     * @param  string  $attribute
-     * @param  mixed   $value
-     * @param  array   $parameters
-     * @return bool
-     */
-    public function validateDigitsBetween($attribute, $value, $parameters)
-    {
-        $this->requireParameterCount(2, $parameters, 'digits_between');
-
-        $length = strlen((string) $value);
-
-        return ! preg_match('/[^0-9]/', $value)
-                    && $length >= $parameters[0] && $length <= $parameters[1];
-    }
-
-    /**
-     * Validate the dimensions of an image matches the given values.
-     *
-     * @param  string $attribute
-     * @param  mixed $value
-     * @param  array $parameters
-     * @return bool
-     */
-    public function validateDimensions($attribute, $value, $parameters)
-    {
-        if (! $this->isValidFileInstance($value) || ! $sizeDetails = @getimagesize($value->getRealPath())) {
-            return false;
-        }
-
-        $this->requireParameterCount(1, $parameters, 'dimensions');
-
-        list($width, $height) = $sizeDetails;
-
-        $parameters = $this->parseNamedParameters($parameters);
-
-        if ($this->failsBasicDimensionChecks($parameters, $width, $height) ||
-            $this->failsRatioCheck($parameters, $width, $height)) {
-            return false;
-        }
-
-        return true;
-    }
-
-    /**
-     * Test if the given width and height fail any conditions.
-     *
-     * @param  array  $parameters
-     * @param  int  $width
-     * @param  int  $height
-     * @return bool
-     */
-    protected function failsBasicDimensionChecks($parameters, $width, $height)
-    {
-        return (isset($parameters['width']) && $parameters['width'] != $width) ||
-               (isset($parameters['min_width']) && $parameters['min_width'] > $width) ||
-               (isset($parameters['max_width']) && $parameters['max_width'] < $width) ||
-               (isset($parameters['height']) && $parameters['height'] != $height) ||
-               (isset($parameters['min_height']) && $parameters['min_height'] > $height) ||
-               (isset($parameters['max_height']) && $parameters['max_height'] < $height);
-    }
-
-    /**
-     * Determine if the given parameters fail a dimension ratio check.
-     *
-     * @param  array  $parameters
-     * @param  int  $width
-     * @param  int  $height
-     * @return bool
-     */
-    protected function failsRatioCheck($parameters, $width, $height)
-    {
-        if (! isset($parameters['ratio'])) {
-            return false;
-        }
-
-        list($numerator, $denominator) = array_replace(
-            [1, 1], array_filter(sscanf($parameters['ratio'], '%f/%d'))
-        );
-
-        $precision = 1 / max($width, $height);
-
-        return abs($numerator / $denominator - $width / $height) > $precision;
-    }
-
-    /**
-     * Validate an attribute is unique among other values.
-     *
-     * @param  string  $attribute
-     * @param  mixed   $value
-     * @param  array   $parameters
-     * @return bool
-     */
-    public function validateDistinct($attribute, $value, $parameters)
-    {
-        $attributeName = $this->getPrimaryAttribute($attribute);
-
-        $attributeData = ValidationData::extractDataFromPath(
-            ValidationData::getLeadingExplicitAttributePath($attributeName), $this->data
-        );
-
-        $pattern = str_replace('\*', '[^.]+', preg_quote($attributeName, '#'));
-
-        $data = Arr::where(Arr::dot($attributeData), function ($value, $key) use ($attribute, $pattern) {
-            return $key != $attribute && (bool) preg_match('#^'.$pattern.'\z#u', $key);
-        });
-
-        return ! in_array($value, array_values($data));
-    }
-
-    /**
-     * Validate that an attribute is a valid e-mail address.
-     *
-     * @param  string  $attribute
-     * @param  mixed   $value
-     * @return bool
-     */
-    public function validateEmail($attribute, $value)
-    {
-        return filter_var($value, FILTER_VALIDATE_EMAIL) !== false;
-    }
-
-    /**
-     * Validate the existence of an attribute value in a database table.
-     *
-     * @param  string  $attribute
-     * @param  mixed   $value
-     * @param  array   $parameters
-     * @return bool
-     */
-    public function validateExists($attribute, $value, $parameters)
-    {
-        $this->requireParameterCount(1, $parameters, 'exists');
-
-        list($connection, $table) = $this->parseTable($parameters[0]);
-
-        // The second parameter position holds the name of the column that should be
-        // verified as existing. If this parameter is not specified we will guess
-        // that the columns being "verified" shares the given attribute's name.
-        $column = $this->getQueryColumn($parameters, $attribute);
-
-        $expected = (is_array($value)) ? count($value) : 1;
-
-        return $this->getExistCount(
-            $connection, $table, $column, $value, $parameters
-        ) >= $expected;
-    }
-
-    /**
-     * Get the number of records that exist in storage.
-     *
-     * @param  mixed   $connection
-     * @param  string  $table
-     * @param  string  $column
-     * @param  mixed   $value
-     * @param  array   $parameters
-     * @return int
-     */
-    protected function getExistCount($connection, $table, $column, $value, $parameters)
-    {
-        $verifier = $this->getPresenceVerifierFor($connection);
-
-        $extra = $this->getExtraConditions(
-            array_values(array_slice($parameters, 2))
-        );
-
-        if ($this->currentRule instanceof Exists) {
-            $extra = array_merge($extra, $this->currentRule->queryCallbacks());
-        }
-
-        return is_array($value)
-                ? $verifier->getMultiCount($table, $column, $value, $extra)
-                : $verifier->getCount($table, $column, $value, null, null, $extra);
-    }
-
-    /**
-     * Validate the uniqueness of an attribute value on a given database table.
-     *
-     * If a database column is not specified, the attribute will be used.
-     *
-     * @param  string  $attribute
-     * @param  mixed   $value
-     * @param  array   $parameters
-     * @return bool
-     */
-    public function validateUnique($attribute, $value, $parameters)
-    {
-        $this->requireParameterCount(1, $parameters, 'unique');
-
-        list($connection, $table) = $this->parseTable($parameters[0]);
-
-        // The second parameter position holds the name of the column that needs to
-        // be verified as unique. If this parameter isn't specified we will just
-        // assume that this column to be verified shares the attribute's name.
-        $column = $this->getQueryColumn($parameters, $attribute);
-
-        list($idColumn, $id) = [null, null];
-
-        if (isset($parameters[2])) {
-            list($idColumn, $id) = $this->getUniqueIds($parameters);
-        }
-
-        // The presence verifier is responsible for counting rows within this store
-        // mechanism which might be a relational database or any other permanent
-        // data store like Redis, etc. We will use it to determine uniqueness.
-        $verifier = $this->getPresenceVerifierFor($connection);
-
-        $extra = $this->getUniqueExtra($parameters);
-
-        if ($this->currentRule instanceof Unique) {
-            $extra = array_merge($extra, $this->currentRule->queryCallbacks());
-        }
-
-        return $verifier->getCount(
-            $table, $column, $value, $id, $idColumn, $extra
-        ) == 0;
-    }
-
-    /**
-     * Get the excluded ID column and value for the unique rule.
-     *
-     * @param  array  $parameters
-     * @return array
-     */
-    protected function getUniqueIds($parameters)
-    {
-        $idColumn = $parameters[3] ?? 'id';
-
-        return [$idColumn, $this->prepareUniqueId($parameters[2])];
-    }
-
-    /**
-     * Prepare the given ID for querying.
-     *
-     * @param  mixed  $id
-     * @return int
-     */
-    protected function prepareUniqueId($id)
-    {
-        if (preg_match('/\[(.*)\]/', $id, $matches)) {
-            $id = $this->getValue($matches[1]);
-        }
-
-        if (strtolower($id) == 'null') {
-            $id = null;
-        }
-
-        if (filter_var($id, FILTER_VALIDATE_INT) !== false) {
-            $id = (int) $id;
-        }
-
-        return $id;
-    }
-
-    /**
-     * Get the extra conditions for a unique rule.
-     *
-     * @param  array  $parameters
-     * @return array
-     */
-    protected function getUniqueExtra($parameters)
-    {
-        if (isset($parameters[4])) {
-            return $this->getExtraConditions(array_slice($parameters, 4));
-        }
-
-        return [];
-    }
-
-    /**
-     * Parse the connection / table for the unique / exists rules.
-     *
-     * @param  string  $table
-     * @return array
-     */
-    protected function parseTable($table)
-    {
-        return Str::contains($table, '.') ? explode('.', $table, 2) : [null, $table];
-    }
-
-    /**
-     * Get the column name for an exists / unique query.
-     *
-     * @param  array  $parameters
-     * @param  string  $attribute
-     * @return bool
-     */
-    protected function getQueryColumn($parameters, $attribute)
-    {
-        return isset($parameters[1]) && $parameters[1] !== 'NULL'
-                    ? $parameters[1] : $this->guessColumnForQuery($attribute);
-    }
-
-    /**
-     * Guess the database column from the given attribute name.
-     *
-     * @param  string  $attribute
-     * @return string
-     */
-    public function guessColumnForQuery($attribute)
-    {
-        if (in_array($attribute, Arr::collapse($this->implicitAttributes))
-                && ! is_numeric($last = last(explode('.', $attribute)))) {
-            return $last;
-        }
-
-        return $attribute;
-    }
-
-    /**
-     * Get the extra conditions for a unique / exists rule.
-     *
-     * @param  array  $segments
-     * @return array
-     */
-    protected function getExtraConditions(array $segments)
-    {
-        $extra = [];
-
-        $count = count($segments);
-
-        for ($i = 0; $i < $count; $i += 2) {
-            $extra[$segments[$i]] = $segments[$i + 1];
-        }
-
-        return $extra;
-    }
-
-    /**
-     * Validate the given value is a valid file.
-     *
-     * @param  string  $attribute
-     * @param  mixed   $value
-     * @return bool
-     */
-    public function validateFile($attribute, $value)
-    {
-        return $this->isValidFileInstance($value);
-    }
-
-    /**
-     * Validate the given attribute is filled if it is present.
-     *
-     * @param  string  $attribute
-     * @param  mixed   $value
-     * @return bool
-     */
-    public function validateFilled($attribute, $value)
-    {
-        if (Arr::has($this->data, $attribute)) {
-            return $this->validateRequired($attribute, $value);
-        }
-
-        return true;
-    }
-
-    /**
-     * Validate the MIME type of a file is an image MIME type.
-     *
-     * @param  string  $attribute
-     * @param  mixed   $value
-     * @return bool
-     */
-    public function validateImage($attribute, $value)
-    {
-        return $this->validateMimes($attribute, $value, ['jpeg', 'png', 'gif', 'bmp', 'svg']);
-    }
-
-    /**
-     * Validate an attribute is contained within a list of values.
-     *
-     * @param  string  $attribute
-     * @param  mixed   $value
-     * @param  array   $parameters
-     * @return bool
-     */
-    public function validateIn($attribute, $value, $parameters)
-    {
-        if (is_array($value) && $this->hasRule($attribute, 'Array')) {
-            foreach ($value as $element) {
-                if (is_array($element)) {
-                    return false;
-                }
-            }
-
-            return count(array_diff($value, $parameters)) == 0;
-        }
-
-        return ! is_array($value) && in_array((string) $value, $parameters);
-    }
-
-    /**
-     * Validate that the values of an attribute is in another attribute.
-     *
-     * @param  string  $attribute
-     * @param  mixed   $value
-     * @param  array   $parameters
-     * @return bool
-     */
-    public function validateInArray($attribute, $value, $parameters)
-    {
-        $this->requireParameterCount(1, $parameters, 'in_array');
-
-        $explicitPath = ValidationData::getLeadingExplicitAttributePath($parameters[0]);
-
-        $attributeData = ValidationData::extractDataFromPath($explicitPath, $this->data);
-
-        $otherValues = Arr::where(Arr::dot($attributeData), function ($value, $key) use ($parameters) {
-            return Str::is($parameters[0], $key);
-        });
-
-        return in_array($value, $otherValues);
-    }
-
-    /**
-     * Validate that an attribute is an integer.
-     *
-     * @param  string  $attribute
-     * @param  mixed   $value
-     * @return bool
-     */
-    public function validateInteger($attribute, $value)
-    {
-        return filter_var($value, FILTER_VALIDATE_INT) !== false;
-    }
-
-    /**
-     * Validate that an attribute is a valid IP.
-     *
-     * @param  string  $attribute
-     * @param  mixed   $value
-     * @return bool
-     */
-    public function validateIp($attribute, $value)
-    {
-        return filter_var($value, FILTER_VALIDATE_IP) !== false;
-    }
-
-    /**
-     * Validate that an attribute is a valid IPv4.
-     *
-     * @param  string  $attribute
-     * @param  mixed   $value
-     * @return bool
-     */
-    public function validateIpv4($attribute, $value)
-    {
-        return filter_var($value, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) !== false;
-    }
-
-    /**
-     * Validate that an attribute is a valid IPv6.
-     *
-     * @param  string  $attribute
-     * @param  mixed   $value
-     * @return bool
-     */
-    public function validateIpv6($attribute, $value)
-    {
-        return filter_var($value, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) !== false;
-    }
-
-    /**
-     * Validate the attribute is a valid JSON string.
-     *
-     * @param  string  $attribute
-     * @param  mixed   $value
-     * @return bool
-     */
-    public function validateJson($attribute, $value)
-    {
-        if (! is_scalar($value) && ! method_exists($value, '__toString')) {
-            return false;
-        }
-
-        json_decode($value);
-
-        return json_last_error() === JSON_ERROR_NONE;
-    }
-
-    /**
-     * Validate the size of an attribute is less than a maximum value.
-     *
-     * @param  string  $attribute
-     * @param  mixed   $value
-     * @param  array   $parameters
-     * @return bool
-     */
-    public function validateMax($attribute, $value, $parameters)
-    {
-        $this->requireParameterCount(1, $parameters, 'max');
-
-        if ($value instanceof UploadedFile && ! $value->isValid()) {
-            return false;
-        }
-
-        return $this->getSize($attribute, $value) <= $parameters[0];
-    }
-
-    /**
-     * Validate the guessed extension of a file upload is in a set of file extensions.
-     *
-     * @param  string  $attribute
-     * @param  mixed  $value
-     * @param  array   $parameters
-     * @return bool
-     */
-    public function validateMimes($attribute, $value, $parameters)
-    {
-        if (! $this->isValidFileInstance($value)) {
-            return false;
-        }
-
-        if ($this->shouldBlockPhpUpload($value, $parameters)) {
-            return false;
-        }
-
-        return $value->getPath() !== '' && in_array($value->guessExtension(), $parameters);
-    }
-
-    /**
-     * Validate the MIME type of a file upload attribute is in a set of MIME types.
-     *
-     * @param  string  $attribute
-     * @param  mixed  $value
-     * @param  array  $parameters
-     * @return bool
-     */
-    public function validateMimetypes($attribute, $value, $parameters)
-    {
-        if (! $this->isValidFileInstance($value)) {
-            return false;
-        }
-
-        if ($this->shouldBlockPhpUpload($value, $parameters)) {
-            return false;
-        }
-
-        return $value->getPath() !== '' &&
-                (in_array($value->getMimeType(), $parameters) ||
-                 in_array(explode('/', $value->getMimeType())[0].'/*', $parameters));
-    }
-
-    /**
-     * Check if PHP uploads are explicitly allowed.
-     *
-     * @param  mixed  $value
-     * @param  array  $parameters
-     * @return bool
-     */
-    protected function shouldBlockPhpUpload($value, $parameters)
-    {
-        if (in_array('php', $parameters)) {
-            return false;
-        }
-
-        return ($value instanceof UploadedFile)
-           ? strtolower($value->getClientOriginalExtension()) === 'php'
-           : strtolower($value->getExtension()) === 'php';
-    }
-
-    /**
-     * Validate the size of an attribute is greater than a minimum value.
-     *
-     * @param  string  $attribute
-     * @param  mixed   $value
-     * @param  array   $parameters
-     * @return bool
-     */
-    public function validateMin($attribute, $value, $parameters)
-    {
-        $this->requireParameterCount(1, $parameters, 'min');
-
-        return $this->getSize($attribute, $value) >= $parameters[0];
-    }
-
-    /**
-     * "Indicate" validation should pass if value is null.
-     *
-     * Always returns true, just lets us put "nullable" in rules.
-     *
-     * @return bool
-     */
-    public function validateNullable()
-    {
-        return true;
-    }
-
-    /**
-     * Validate an attribute is not contained within a list of values.
-     *
-     * @param  string  $attribute
-     * @param  mixed   $value
-     * @param  array   $parameters
-     * @return bool
-     */
-    public function validateNotIn($attribute, $value, $parameters)
-    {
-        return ! $this->validateIn($attribute, $value, $parameters);
-    }
-
-    /**
-     * Validate that an attribute is numeric.
-     *
-     * @param  string  $attribute
-     * @param  mixed   $value
-     * @return bool
-     */
-    public function validateNumeric($attribute, $value)
-    {
-        return is_numeric($value);
-    }
-
-    /**
-     * Validate that an attribute exists even if not filled.
-     *
-     * @param  string  $attribute
-     * @param  mixed   $value
-     * @return bool
-     */
-    public function validatePresent($attribute, $value)
-    {
-        return Arr::has($this->data, $attribute);
-    }
-
-    /**
-     * Validate that an attribute passes a regular expression check.
-     *
-     * @param  string  $attribute
-     * @param  mixed   $value
-     * @param  array   $parameters
-     * @return bool
-     */
-    public function validateRegex($attribute, $value, $parameters)
-    {
-        if (! is_string($value) && ! is_numeric($value)) {
-            return false;
-        }
-
-        $this->requireParameterCount(1, $parameters, 'regex');
-
-        return preg_match($parameters[0], $value) > 0;
-    }
-
-    /**
-     * Validate that a required attribute exists.
-     *
-     * @param  string  $attribute
-     * @param  mixed   $value
-     * @return bool
-     */
-    public function validateRequired($attribute, $value)
-    {
-        if (is_null($value)) {
-            return false;
-        } elseif (is_string($value) && trim($value) === '') {
-            return false;
-        } elseif ((is_array($value) || $value instanceof Countable) && count($value) < 1) {
-            return false;
-        } elseif ($value instanceof File) {
-            return (string) $value->getPath() !== '';
-        }
-
-        return true;
-    }
-
-    /**
-     * Validate that an attribute exists when another attribute has a given value.
-     *
-     * @param  string  $attribute
-     * @param  mixed   $value
-     * @param  mixed   $parameters
-     * @return bool
-     */
-    public function validateRequiredIf($attribute, $value, $parameters)
-    {
-        $this->requireParameterCount(2, $parameters, 'required_if');
-
-        $other = Arr::get($this->data, $parameters[0]);
-
-        $values = array_slice($parameters, 1);
-
-        if (is_bool($other)) {
-            $values = $this->convertValuesToBoolean($values);
-        }
-
-        if (in_array($other, $values)) {
-            return $this->validateRequired($attribute, $value);
-        }
-
-        return true;
-    }
-
-    /**
-     * Convert the given values to boolean if they are string "true" / "false".
-     *
-     * @param  array  $values
-     * @return array
-     */
-    protected function convertValuesToBoolean($values)
-    {
-        return array_map(function ($value) {
-            if ($value === 'true') {
-                return true;
-            } elseif ($value === 'false') {
-                return false;
-            }
-
-            return $value;
-        }, $values);
-    }
-
-    /**
-     * Validate that an attribute exists when another attribute does not have a given value.
-     *
-     * @param  string  $attribute
-     * @param  mixed  $value
-     * @param  mixed  $parameters
-     * @return bool
-     */
-    public function validateRequiredUnless($attribute, $value, $parameters)
-    {
-        $this->requireParameterCount(2, $parameters, 'required_unless');
-
-        $data = Arr::get($this->data, $parameters[0]);
-
-        $values = array_slice($parameters, 1);
-
-        if (! in_array($data, $values)) {
-            return $this->validateRequired($attribute, $value);
-        }
-
-        return true;
-    }
-
-    /**
-     * Validate that an attribute exists when any other attribute exists.
-     *
-     * @param  string  $attribute
-     * @param  mixed   $value
-     * @param  mixed   $parameters
-     * @return bool
-     */
-    public function validateRequiredWith($attribute, $value, $parameters)
-    {
-        if (! $this->allFailingRequired($parameters)) {
-            return $this->validateRequired($attribute, $value);
-        }
-
-        return true;
-    }
-
-    /**
-     * Validate that an attribute exists when all other attributes exists.
-     *
-     * @param  string  $attribute
-     * @param  mixed   $value
-     * @param  mixed   $parameters
-     * @return bool
-     */
-    public function validateRequiredWithAll($attribute, $value, $parameters)
-    {
-        if (! $this->anyFailingRequired($parameters)) {
-            return $this->validateRequired($attribute, $value);
-        }
-
-        return true;
-    }
-
-    /**
-     * Validate that an attribute exists when another attribute does not.
-     *
-     * @param  string  $attribute
-     * @param  mixed   $value
-     * @param  mixed   $parameters
-     * @return bool
-     */
-    public function validateRequiredWithout($attribute, $value, $parameters)
-    {
-        if ($this->anyFailingRequired($parameters)) {
-            return $this->validateRequired($attribute, $value);
-        }
-
-        return true;
-    }
-
-    /**
-     * Validate that an attribute exists when all other attributes do not.
-     *
-     * @param  string  $attribute
-     * @param  mixed   $value
-     * @param  mixed   $parameters
-     * @return bool
-     */
-    public function validateRequiredWithoutAll($attribute, $value, $parameters)
-    {
-        if ($this->allFailingRequired($parameters)) {
-            return $this->validateRequired($attribute, $value);
-        }
-
-        return true;
-    }
-
-    /**
-     * Determine if any of the given attributes fail the required test.
-     *
-     * @param  array  $attributes
-     * @return bool
-     */
-    protected function anyFailingRequired(array $attributes)
-    {
-        foreach ($attributes as $key) {
-            if (! $this->validateRequired($key, $this->getValue($key))) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    /**
-     * Determine if all of the given attributes fail the required test.
-     *
-     * @param  array  $attributes
-     * @return bool
-     */
-    protected function allFailingRequired(array $attributes)
-    {
-        foreach ($attributes as $key) {
-            if ($this->validateRequired($key, $this->getValue($key))) {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
-    /**
-     * Validate that two attributes match.
-     *
-     * @param  string  $attribute
-     * @param  mixed   $value
-     * @param  array   $parameters
-     * @return bool
-     */
-    public function validateSame($attribute, $value, $parameters)
-    {
-        $this->requireParameterCount(1, $parameters, 'same');
-
-        $other = Arr::get($this->data, $parameters[0]);
-
-        return $value === $other;
-    }
-
-    /**
-     * Validate the size of an attribute.
-     *
-     * @param  string  $attribute
-     * @param  mixed   $value
-     * @param  array   $parameters
-     * @return bool
-     */
-    public function validateSize($attribute, $value, $parameters)
-    {
-        $this->requireParameterCount(1, $parameters, 'size');
-
-        return $this->getSize($attribute, $value) == $parameters[0];
-    }
-
-    /**
-     * "Validate" optional attributes.
-     *
-     * Always returns true, just lets us put sometimes in rules.
-     *
-     * @return bool
-     */
-    public function validateSometimes()
-    {
-        return true;
-    }
-
-    /**
-     * Validate that an attribute is a string.
-     *
-     * @param  string  $attribute
-     * @param  mixed   $value
-     * @return bool
-     */
-    public function validateString($attribute, $value)
-    {
-        return is_string($value);
-    }
-
-    /**
-     * Validate that an attribute is a valid timezone.
-     *
-     * @param  string  $attribute
-     * @param  mixed   $value
-     * @return bool
-     */
-    public function validateTimezone($attribute, $value)
-    {
-        try {
-            new DateTimeZone($value);
-        } catch (Exception $e) {
-            return false;
-        } catch (Throwable $e) {
-            return false;
-        }
-
-        return true;
-    }
-
-    /**
-     * Validate that an attribute is a valid URL.
-     *
-     * @param  string  $attribute
-     * @param  mixed   $value
-     * @return bool
-     */
-    public function validateUrl($attribute, $value)
-    {
-        if (! is_string($value)) {
-            return false;
-        }
-
-        /*
-         * This pattern is derived from Symfony\Component\Validator\Constraints\UrlValidator (2.7.4).
-         *
-         * (c) Fabien Potencier <fabien@symfony.com> http://symfony.com
-         */
-        $pattern = '~^
+	/**
+	 * Validate that an attribute was "accepted".
+	 * This validation rule implies the attribute is "required".
+	 *
+	 * @param  string $attribute
+	 * @param  mixed $value
+	 *
+	 * @return bool
+	 */
+	public function validateAccepted($attribute, $value)
+	{
+		$acceptable = ['yes', 'on', '1', 1, true, 'true'];
+
+		return $this->validateRequired($attribute, $value) && in_array($value, $acceptable, true);
+	}
+
+
+	/**
+	 * Validate that an attribute is an active URL.
+	 *
+	 * @param  string $attribute
+	 * @param  mixed $value
+	 *
+	 * @return bool
+	 */
+	public function validateActiveUrl($attribute, $value)
+	{
+		if (! is_string($value)) {
+			return false;
+		}
+
+		if ($url = parse_url($value, PHP_URL_HOST)) {
+			try {
+				return count(dns_get_record($url, DNS_A | DNS_AAAA)) > 0;
+			} catch (Exception $e) {
+				return false;
+			}
+		}
+
+		return false;
+	}
+
+
+	/**
+	 * "Break" on first validation fail.
+	 * Always returns true, just lets us put "bail" in rules.
+	 *
+	 * @return bool
+	 */
+	public function validateBail()
+	{
+		return true;
+	}
+
+
+	/**
+	 * Validate the date is before a given date.
+	 *
+	 * @param  string $attribute
+	 * @param  mixed $value
+	 * @param  array $parameters
+	 *
+	 * @return bool
+	 */
+	public function validateBefore($attribute, $value, $parameters)
+	{
+		$this->requireParameterCount(1, $parameters, 'before');
+
+		return $this->compareDates($attribute, $value, $parameters, '<');
+	}
+
+
+	/**
+	 * Validate the date is before or equal a given date.
+	 *
+	 * @param  string $attribute
+	 * @param  mixed $value
+	 * @param  array $parameters
+	 *
+	 * @return bool
+	 */
+	public function validateBeforeOrEqual($attribute, $value, $parameters)
+	{
+		$this->requireParameterCount(1, $parameters, 'before_or_equal');
+
+		return $this->compareDates($attribute, $value, $parameters, '<=');
+	}
+
+
+	/**
+	 * Validate the date is after a given date.
+	 *
+	 * @param  string $attribute
+	 * @param  mixed $value
+	 * @param  array $parameters
+	 *
+	 * @return bool
+	 */
+	public function validateAfter($attribute, $value, $parameters)
+	{
+		$this->requireParameterCount(1, $parameters, 'after');
+
+		return $this->compareDates($attribute, $value, $parameters, '>');
+	}
+
+
+	/**
+	 * Validate the date is equal or after a given date.
+	 *
+	 * @param  string $attribute
+	 * @param  mixed $value
+	 * @param  array $parameters
+	 *
+	 * @return bool
+	 */
+	public function validateAfterOrEqual($attribute, $value, $parameters)
+	{
+		$this->requireParameterCount(1, $parameters, 'after_or_equal');
+
+		return $this->compareDates($attribute, $value, $parameters, '>=');
+	}
+
+
+	/**
+	 * Compare a given date against another using an operator.
+	 *
+	 * @param  string $attribute
+	 * @param  mixed $value
+	 * @param  array $parameters
+	 * @param  string $operator
+	 *
+	 * @return bool
+	 */
+	protected function compareDates($attribute, $value, $parameters, $operator)
+	{
+		if (! is_string($value) && ! is_numeric($value) && ! $value instanceof DateTimeInterface) {
+			return false;
+		}
+
+		if ($format = $this->getDateFormat($attribute)) {
+			return $this->checkDateTimeOrder(
+				$format, $value, $this->getValue($parameters[0]) ?: $parameters[0], $operator
+			);
+		}
+
+		if (! $date = $this->getDateTimestamp($parameters[0])) {
+			$date = $this->getDateTimestamp($this->getValue($parameters[0]));
+		}
+
+		return $this->compare($this->getDateTimestamp($value), $date, $operator);
+	}
+
+
+	/**
+	 * Get the date format for an attribute if it has one.
+	 *
+	 * @param  string $attribute
+	 *
+	 * @return string|null
+	 */
+	protected function getDateFormat($attribute)
+	{
+		if ($result = $this->getRule($attribute, 'DateFormat')) {
+			return $result[1][0];
+		}
+	}
+
+
+	/**
+	 * Get the date timestamp.
+	 *
+	 * @param  mixed $value
+	 *
+	 * @return int
+	 */
+	protected function getDateTimestamp($value)
+	{
+		return $value instanceof DateTimeInterface ? $value->getTimestamp() : strtotime($value);
+	}
+
+
+	/**
+	 * Given two date/time strings, check that one is after the other.
+	 *
+	 * @param  string $format
+	 * @param  string $first
+	 * @param  string $second
+	 * @param  string $operator
+	 *
+	 * @return bool
+	 */
+	protected function checkDateTimeOrder($format, $first, $second, $operator)
+	{
+		$first = $this->getDateTimeWithOptionalFormat($format, $first);
+
+		$second = $this->getDateTimeWithOptionalFormat($format, $second);
+
+		return ($first && $second) && ($this->compare($first, $second, $operator));
+	}
+
+
+	/**
+	 * Get a DateTime instance from a string.
+	 *
+	 * @param  string $format
+	 * @param  string $value
+	 *
+	 * @return \DateTime|null
+	 */
+	protected function getDateTimeWithOptionalFormat($format, $value)
+	{
+		if ($date = DateTime::createFromFormat('!' . $format, $value)) {
+			return $date;
+		}
+
+		try {
+			return new DateTime($value);
+		} catch (Exception $e) {
+			//
+		}
+	}
+
+
+	/**
+	 * Validate that an attribute contains only alphabetic characters.
+	 *
+	 * @param  string $attribute
+	 * @param  mixed $value
+	 *
+	 * @return bool
+	 */
+	public function validateAlpha($attribute, $value)
+	{
+		return is_string($value) && preg_match('/^[\pL\pM]+$/u', $value);
+	}
+
+
+	/**
+	 * Validate that an attribute contains only alpha-numeric characters, dashes, and underscores.
+	 *
+	 * @param  string $attribute
+	 * @param  mixed $value
+	 *
+	 * @return bool
+	 */
+	public function validateAlphaDash($attribute, $value)
+	{
+		if (! is_string($value) && ! is_numeric($value)) {
+			return false;
+		}
+
+		return preg_match('/^[\pL\pM\pN_-]+$/u', $value) > 0;
+	}
+
+
+	/**
+	 * Validate that an attribute contains only alpha-numeric characters.
+	 *
+	 * @param  string $attribute
+	 * @param  mixed $value
+	 *
+	 * @return bool
+	 */
+	public function validateAlphaNum($attribute, $value)
+	{
+		if (! is_string($value) && ! is_numeric($value)) {
+			return false;
+		}
+
+		return preg_match('/^[\pL\pM\pN]+$/u', $value) > 0;
+	}
+
+
+	/**
+	 * Validate that an attribute is an array.
+	 *
+	 * @param  string $attribute
+	 * @param  mixed $value
+	 *
+	 * @return bool
+	 */
+	public function validateArray($attribute, $value)
+	{
+		return is_array($value);
+	}
+
+
+	/**
+	 * Validate the size of an attribute is between a set of values.
+	 *
+	 * @param  string $attribute
+	 * @param  mixed $value
+	 * @param  array $parameters
+	 *
+	 * @return bool
+	 */
+	public function validateBetween($attribute, $value, $parameters)
+	{
+		$this->requireParameterCount(2, $parameters, 'between');
+
+		$size = $this->getSize($attribute, $value);
+
+		return $size >= $parameters[0] && $size <= $parameters[1];
+	}
+
+
+	/**
+	 * Validate that an attribute is a boolean.
+	 *
+	 * @param  string $attribute
+	 * @param  mixed $value
+	 *
+	 * @return bool
+	 */
+	public function validateBoolean($attribute, $value)
+	{
+		$acceptable = [true, false, 0, 1, '0', '1'];
+
+		return in_array($value, $acceptable, true);
+	}
+
+
+	/**
+	 * Validate that an attribute has a matching confirmation.
+	 *
+	 * @param  string $attribute
+	 * @param  mixed $value
+	 *
+	 * @return bool
+	 */
+	public function validateConfirmed($attribute, $value)
+	{
+		return $this->validateSame($attribute, $value, [$attribute . '_confirmation']);
+	}
+
+
+	/**
+	 * Validate that an attribute is a valid date.
+	 *
+	 * @param  string $attribute
+	 * @param  mixed $value
+	 *
+	 * @return bool
+	 */
+	public function validateDate($attribute, $value)
+	{
+		if ($value instanceof DateTimeInterface) {
+			return true;
+		}
+
+		if ((! is_string($value) && ! is_numeric($value)) || strtotime($value) === false) {
+			return false;
+		}
+
+		$date = date_parse($value);
+
+		return checkdate($date['month'], $date['day'], $date['year']);
+	}
+
+
+	/**
+	 * Validate that an attribute matches a date format.
+	 *
+	 * @param  string $attribute
+	 * @param  mixed $value
+	 * @param  array $parameters
+	 *
+	 * @return bool
+	 */
+	public function validateDateFormat($attribute, $value, $parameters)
+	{
+		$this->requireParameterCount(1, $parameters, 'date_format');
+
+		if (! is_string($value) && ! is_numeric($value)) {
+			return false;
+		}
+
+		$format = $parameters[0];
+
+		$date = DateTime::createFromFormat('!' . $format, $value);
+
+		return $date && $date->format($format) == $value;
+	}
+
+
+	/**
+	 * Validate that an attribute is equal to another date.
+	 *
+	 * @param  string $attribute
+	 * @param  mixed $value
+	 * @param  array $parameters
+	 *
+	 * @return bool
+	 */
+	public function validateDateEquals($attribute, $value, $parameters)
+	{
+		$this->requireParameterCount(1, $parameters, 'date_equals');
+
+		return $this->compareDates($attribute, $value, $parameters, '=');
+	}
+
+
+	/**
+	 * Validate that an attribute is different from another attribute.
+	 *
+	 * @param  string $attribute
+	 * @param  mixed $value
+	 * @param  array $parameters
+	 *
+	 * @return bool
+	 */
+	public function validateDifferent($attribute, $value, $parameters)
+	{
+		$this->requireParameterCount(1, $parameters, 'different');
+
+		foreach ($parameters as $parameter) {
+			$other = Arr::get($this->data, $parameter);
+
+			if (is_null($other) || $value === $other) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+
+	/**
+	 * Validate that an attribute has a given number of digits.
+	 *
+	 * @param  string $attribute
+	 * @param  mixed $value
+	 * @param  array $parameters
+	 *
+	 * @return bool
+	 */
+	public function validateDigits($attribute, $value, $parameters)
+	{
+		$this->requireParameterCount(1, $parameters, 'digits');
+
+		return ! preg_match('/[^0-9]/', $value)
+			&& strlen((string)$value) == $parameters[0];
+	}
+
+
+	/**
+	 * Validate that an attribute is between a given number of digits.
+	 *
+	 * @param  string $attribute
+	 * @param  mixed $value
+	 * @param  array $parameters
+	 *
+	 * @return bool
+	 */
+	public function validateDigitsBetween($attribute, $value, $parameters)
+	{
+		$this->requireParameterCount(2, $parameters, 'digits_between');
+
+		$length = strlen((string)$value);
+
+		return ! preg_match('/[^0-9]/', $value)
+			&& $length >= $parameters[0] && $length <= $parameters[1];
+	}
+
+
+	/**
+	 * Validate the dimensions of an image matches the given values.
+	 *
+	 * @param  string $attribute
+	 * @param  mixed $value
+	 * @param  array $parameters
+	 *
+	 * @return bool
+	 */
+	public function validateDimensions($attribute, $value, $parameters)
+	{
+		if (! $this->isValidFileInstance($value) || ! $sizeDetails = @getimagesize($value->getRealPath())) {
+			return false;
+		}
+
+		$this->requireParameterCount(1, $parameters, 'dimensions');
+
+		list($width, $height) = $sizeDetails;
+
+		$parameters = $this->parseNamedParameters($parameters);
+
+		if ($this->failsBasicDimensionChecks($parameters, $width, $height) ||
+			$this->failsRatioCheck($parameters, $width, $height)) {
+			return false;
+		}
+
+		return true;
+	}
+
+
+	/**
+	 * Test if the given width and height fail any conditions.
+	 *
+	 * @param  array $parameters
+	 * @param  int $width
+	 * @param  int $height
+	 *
+	 * @return bool
+	 */
+	protected function failsBasicDimensionChecks($parameters, $width, $height)
+	{
+		return (isset($parameters['width']) && $parameters['width'] != $width) ||
+			(isset($parameters['min_width']) && $parameters['min_width'] > $width) ||
+			(isset($parameters['max_width']) && $parameters['max_width'] < $width) ||
+			(isset($parameters['height']) && $parameters['height'] != $height) ||
+			(isset($parameters['min_height']) && $parameters['min_height'] > $height) ||
+			(isset($parameters['max_height']) && $parameters['max_height'] < $height);
+	}
+
+
+	/**
+	 * Determine if the given parameters fail a dimension ratio check.
+	 *
+	 * @param  array $parameters
+	 * @param  int $width
+	 * @param  int $height
+	 *
+	 * @return bool
+	 */
+	protected function failsRatioCheck($parameters, $width, $height)
+	{
+		if (! isset($parameters['ratio'])) {
+			return false;
+		}
+
+		list($numerator, $denominator) = array_replace(
+			[1, 1], array_filter(sscanf($parameters['ratio'], '%f/%d'))
+		);
+
+		$precision = 1 / max($width, $height);
+
+		return abs($numerator / $denominator - $width / $height) > $precision;
+	}
+
+
+	/**
+	 * Validate an attribute is unique among other values.
+	 *
+	 * @param  string $attribute
+	 * @param  mixed $value
+	 * @param  array $parameters
+	 *
+	 * @return bool
+	 */
+	public function validateDistinct($attribute, $value, $parameters)
+	{
+		$attributeName = $this->getPrimaryAttribute($attribute);
+
+		$attributeData = ValidationData::extractDataFromPath(
+			ValidationData::getLeadingExplicitAttributePath($attributeName), $this->data
+		);
+
+		$pattern = str_replace('\*', '[^.]+', preg_quote($attributeName, '#'));
+
+		$data = Arr::where(Arr::dot($attributeData), function ($value, $key) use ($attribute, $pattern) {
+			return $key != $attribute && (bool)preg_match('#^' . $pattern . '\z#u', $key);
+		});
+
+		return ! in_array($value, array_values($data));
+	}
+
+
+	/**
+	 * Validate that an attribute is a valid e-mail address.
+	 *
+	 * @param  string $attribute
+	 * @param  mixed $value
+	 *
+	 * @return bool
+	 */
+	public function validateEmail($attribute, $value)
+	{
+		return filter_var($value, FILTER_VALIDATE_EMAIL) !== false;
+	}
+
+
+	/**
+	 * Validate that an attribute is equal to given.
+	 *
+	 * @param  string $attribute
+	 * @param  mixed $value
+	 * @param  array $parameters
+	 *
+	 * @return bool
+	 */
+	public function validateEquals($attribute, $value, $parameters)
+	{
+		$this->requireParameterCount(1, $parameters, 'equals');
+
+		return $value == $parameters[0];
+	}
+
+
+	/**
+	 * Validate the existence of an attribute value in a database table.
+	 *
+	 * @param  string $attribute
+	 * @param  mixed $value
+	 * @param  array $parameters
+	 *
+	 * @return bool
+	 */
+	public function validateExists($attribute, $value, $parameters)
+	{
+		$this->requireParameterCount(1, $parameters, 'exists');
+
+		list($connection, $table) = $this->parseTable($parameters[0]);
+
+		// The second parameter position holds the name of the column that should be
+		// verified as existing. If this parameter is not specified we will guess
+		// that the columns being "verified" shares the given attribute's name.
+		$column = $this->getQueryColumn($parameters, $attribute);
+
+		$expected = (is_array($value)) ? count($value) : 1;
+
+		return $this->getExistCount(
+				$connection, $table, $column, $value, $parameters
+			) >= $expected;
+	}
+
+
+	/**
+	 * Get the number of records that exist in storage.
+	 *
+	 * @param  mixed $connection
+	 * @param  string $table
+	 * @param  string $column
+	 * @param  mixed $value
+	 * @param  array $parameters
+	 *
+	 * @return int
+	 */
+	protected function getExistCount($connection, $table, $column, $value, $parameters)
+	{
+		$verifier = $this->getPresenceVerifierFor($connection);
+
+		$extra = $this->getExtraConditions(
+			array_values(array_slice($parameters, 2))
+		);
+
+		if ($this->currentRule instanceof Exists) {
+			$extra = array_merge($extra, $this->currentRule->queryCallbacks());
+		}
+
+		return is_array($value)
+			? $verifier->getMultiCount($table, $column, $value, $extra)
+			: $verifier->getCount($table, $column, $value, null, null, $extra);
+	}
+
+
+	/**
+	 * Validate the uniqueness of an attribute value on a given database table.
+	 * If a database column is not specified, the attribute will be used.
+	 *
+	 * @param  string $attribute
+	 * @param  mixed $value
+	 * @param  array $parameters
+	 *
+	 * @return bool
+	 */
+	public function validateUnique($attribute, $value, $parameters)
+	{
+		$this->requireParameterCount(1, $parameters, 'unique');
+
+		list($connection, $table) = $this->parseTable($parameters[0]);
+
+		// The second parameter position holds the name of the column that needs to
+		// be verified as unique. If this parameter isn't specified we will just
+		// assume that this column to be verified shares the attribute's name.
+		$column = $this->getQueryColumn($parameters, $attribute);
+
+		list($idColumn, $id) = [null, null];
+
+		if (isset($parameters[2])) {
+			list($idColumn, $id) = $this->getUniqueIds($parameters);
+		}
+
+		// The presence verifier is responsible for counting rows within this store
+		// mechanism which might be a relational database or any other permanent
+		// data store like Redis, etc. We will use it to determine uniqueness.
+		$verifier = $this->getPresenceVerifierFor($connection);
+
+		$extra = $this->getUniqueExtra($parameters);
+
+		if ($this->currentRule instanceof Unique) {
+			$extra = array_merge($extra, $this->currentRule->queryCallbacks());
+		}
+
+		return $verifier->getCount(
+				$table, $column, $value, $id, $idColumn, $extra
+			) == 0;
+	}
+
+
+	/**
+	 * Get the excluded ID column and value for the unique rule.
+	 *
+	 * @param  array $parameters
+	 *
+	 * @return array
+	 */
+	protected function getUniqueIds($parameters)
+	{
+		$idColumn = $parameters[3] ?? 'id';
+
+		return [$idColumn, $this->prepareUniqueId($parameters[2])];
+	}
+
+
+	/**
+	 * Prepare the given ID for querying.
+	 *
+	 * @param  mixed $id
+	 *
+	 * @return int
+	 */
+	protected function prepareUniqueId($id)
+	{
+		if (preg_match('/\[(.*)\]/', $id, $matches)) {
+			$id = $this->getValue($matches[1]);
+		}
+
+		if (strtolower($id) == 'null') {
+			$id = null;
+		}
+
+		if (filter_var($id, FILTER_VALIDATE_INT) !== false) {
+			$id = (int)$id;
+		}
+
+		return $id;
+	}
+
+
+	/**
+	 * Get the extra conditions for a unique rule.
+	 *
+	 * @param  array $parameters
+	 *
+	 * @return array
+	 */
+	protected function getUniqueExtra($parameters)
+	{
+		if (isset($parameters[4])) {
+			return $this->getExtraConditions(array_slice($parameters, 4));
+		}
+
+		return [];
+	}
+
+
+	/**
+	 * Parse the connection / table for the unique / exists rules.
+	 *
+	 * @param  string $table
+	 *
+	 * @return array
+	 */
+	protected function parseTable($table)
+	{
+		return Str::contains($table, '.') ? explode('.', $table, 2) : [null, $table];
+	}
+
+
+	/**
+	 * Get the column name for an exists / unique query.
+	 *
+	 * @param  array $parameters
+	 * @param  string $attribute
+	 *
+	 * @return bool
+	 */
+	protected function getQueryColumn($parameters, $attribute)
+	{
+		return isset($parameters[1]) && $parameters[1] !== 'NULL'
+			? $parameters[1] : $this->guessColumnForQuery($attribute);
+	}
+
+
+	/**
+	 * Guess the database column from the given attribute name.
+	 *
+	 * @param  string $attribute
+	 *
+	 * @return string
+	 */
+	public function guessColumnForQuery($attribute)
+	{
+		if (in_array($attribute, Arr::collapse($this->implicitAttributes))
+			&& ! is_numeric($last = last(explode('.', $attribute)))) {
+			return $last;
+		}
+
+		return $attribute;
+	}
+
+
+	/**
+	 * Get the extra conditions for a unique / exists rule.
+	 *
+	 * @param  array $segments
+	 *
+	 * @return array
+	 */
+	protected function getExtraConditions(array $segments)
+	{
+		$extra = [];
+
+		$count = count($segments);
+
+		for ($i = 0; $i < $count; $i += 2) {
+			$extra[$segments[$i]] = $segments[$i + 1];
+		}
+
+		return $extra;
+	}
+
+
+	/**
+	 * Validate the given value is a valid file.
+	 *
+	 * @param  string $attribute
+	 * @param  mixed $value
+	 *
+	 * @return bool
+	 */
+	public function validateFile($attribute, $value)
+	{
+		return $this->isValidFileInstance($value);
+	}
+
+
+	/**
+	 * Validate the given attribute is filled if it is present.
+	 *
+	 * @param  string $attribute
+	 * @param  mixed $value
+	 *
+	 * @return bool
+	 */
+	public function validateFilled($attribute, $value)
+	{
+		if (Arr::has($this->data, $attribute)) {
+			return $this->validateRequired($attribute, $value);
+		}
+
+		return true;
+	}
+
+
+	/**
+	 * Validate the MIME type of a file is an image MIME type.
+	 *
+	 * @param  string $attribute
+	 * @param  mixed $value
+	 *
+	 * @return bool
+	 */
+	public function validateImage($attribute, $value)
+	{
+		return $this->validateMimes($attribute, $value, ['jpeg', 'png', 'gif', 'bmp', 'svg']);
+	}
+
+
+	/**
+	 * Validate an attribute is contained within a list of values.
+	 *
+	 * @param  string $attribute
+	 * @param  mixed $value
+	 * @param  array $parameters
+	 *
+	 * @return bool
+	 */
+	public function validateIn($attribute, $value, $parameters)
+	{
+		if (is_array($value) && $this->hasRule($attribute, 'Array')) {
+			foreach ($value as $element) {
+				if (is_array($element)) {
+					return false;
+				}
+			}
+
+			return count(array_diff($value, $parameters)) == 0;
+		}
+
+		return ! is_array($value) && in_array((string)$value, $parameters);
+	}
+
+
+	/**
+	 * Validate that the values of an attribute is in another attribute.
+	 *
+	 * @param  string $attribute
+	 * @param  mixed $value
+	 * @param  array $parameters
+	 *
+	 * @return bool
+	 */
+	public function validateInArray($attribute, $value, $parameters)
+	{
+		$this->requireParameterCount(1, $parameters, 'in_array');
+
+		$explicitPath = ValidationData::getLeadingExplicitAttributePath($parameters[0]);
+
+		$attributeData = ValidationData::extractDataFromPath($explicitPath, $this->data);
+
+		$otherValues = Arr::where(Arr::dot($attributeData), function ($value, $key) use ($parameters) {
+			return Str::is($parameters[0], $key);
+		});
+
+		return in_array($value, $otherValues);
+	}
+
+
+	/**
+	 * Validate that an attribute is an integer.
+	 *
+	 * @param  string $attribute
+	 * @param  mixed $value
+	 *
+	 * @return bool
+	 */
+	public function validateInteger($attribute, $value)
+	{
+		return filter_var($value, FILTER_VALIDATE_INT) !== false;
+	}
+
+
+	/**
+	 * Validate that an attribute is a valid IP.
+	 *
+	 * @param  string $attribute
+	 * @param  mixed $value
+	 *
+	 * @return bool
+	 */
+	public function validateIp($attribute, $value)
+	{
+		return filter_var($value, FILTER_VALIDATE_IP) !== false;
+	}
+
+
+	/**
+	 * Validate that an attribute is a valid IPv4.
+	 *
+	 * @param  string $attribute
+	 * @param  mixed $value
+	 *
+	 * @return bool
+	 */
+	public function validateIpv4($attribute, $value)
+	{
+		return filter_var($value, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) !== false;
+	}
+
+
+	/**
+	 * Validate that an attribute is a valid IPv6.
+	 *
+	 * @param  string $attribute
+	 * @param  mixed $value
+	 *
+	 * @return bool
+	 */
+	public function validateIpv6($attribute, $value)
+	{
+		return filter_var($value, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) !== false;
+	}
+
+
+	/**
+	 * Validate the attribute is a valid JSON string.
+	 *
+	 * @param  string $attribute
+	 * @param  mixed $value
+	 *
+	 * @return bool
+	 */
+	public function validateJson($attribute, $value)
+	{
+		if (! is_scalar($value) && ! method_exists($value, '__toString')) {
+			return false;
+		}
+
+		json_decode($value);
+
+		return json_last_error() === JSON_ERROR_NONE;
+	}
+
+
+	/**
+	 * Validate the size of an attribute is less than a maximum value.
+	 *
+	 * @param  string $attribute
+	 * @param  mixed $value
+	 * @param  array $parameters
+	 *
+	 * @return bool
+	 */
+	public function validateMax($attribute, $value, $parameters)
+	{
+		$this->requireParameterCount(1, $parameters, 'max');
+
+		if ($value instanceof UploadedFile && ! $value->isValid()) {
+			return false;
+		}
+
+		return $this->getSize($attribute, $value) <= $parameters[0];
+	}
+
+
+	/**
+	 * Validate the guessed extension of a file upload is in a set of file extensions.
+	 *
+	 * @param  string $attribute
+	 * @param  mixed $value
+	 * @param  array $parameters
+	 *
+	 * @return bool
+	 */
+	public function validateMimes($attribute, $value, $parameters)
+	{
+		if (! $this->isValidFileInstance($value)) {
+			return false;
+		}
+
+		if ($this->shouldBlockPhpUpload($value, $parameters)) {
+			return false;
+		}
+
+		return $value->getPath() !== '' && in_array($value->guessExtension(), $parameters);
+	}
+
+
+	/**
+	 * Validate the MIME type of a file upload attribute is in a set of MIME types.
+	 *
+	 * @param  string $attribute
+	 * @param  mixed $value
+	 * @param  array $parameters
+	 *
+	 * @return bool
+	 */
+	public function validateMimetypes($attribute, $value, $parameters)
+	{
+		if (! $this->isValidFileInstance($value)) {
+			return false;
+		}
+
+		if ($this->shouldBlockPhpUpload($value, $parameters)) {
+			return false;
+		}
+
+		return $value->getPath() !== '' &&
+			(in_array($value->getMimeType(), $parameters) ||
+				in_array(explode('/', $value->getMimeType())[0] . '/*', $parameters));
+	}
+
+
+	/**
+	 * Check if PHP uploads are explicitly allowed.
+	 *
+	 * @param  mixed $value
+	 * @param  array $parameters
+	 *
+	 * @return bool
+	 */
+	protected function shouldBlockPhpUpload($value, $parameters)
+	{
+		if (in_array('php', $parameters)) {
+			return false;
+		}
+
+		return ($value instanceof UploadedFile)
+			? strtolower($value->getClientOriginalExtension()) === 'php'
+			: strtolower($value->getExtension()) === 'php';
+	}
+
+
+	/**
+	 * Validate the size of an attribute is greater than a minimum value.
+	 *
+	 * @param  string $attribute
+	 * @param  mixed $value
+	 * @param  array $parameters
+	 *
+	 * @return bool
+	 */
+	public function validateMin($attribute, $value, $parameters)
+	{
+		$this->requireParameterCount(1, $parameters, 'min');
+
+		return $this->getSize($attribute, $value) >= $parameters[0];
+	}
+
+
+	/**
+	 * "Indicate" validation should pass if value is null.
+	 * Always returns true, just lets us put "nullable" in rules.
+	 *
+	 * @return bool
+	 */
+	public function validateNullable()
+	{
+		return true;
+	}
+
+
+	/**
+	 * Validate an attribute is not contained within a list of values.
+	 *
+	 * @param  string $attribute
+	 * @param  mixed $value
+	 * @param  array $parameters
+	 *
+	 * @return bool
+	 */
+	public function validateNotIn($attribute, $value, $parameters)
+	{
+		return ! $this->validateIn($attribute, $value, $parameters);
+	}
+
+
+	/**
+	 * Validate that an attribute is numeric.
+	 *
+	 * @param  string $attribute
+	 * @param  mixed $value
+	 *
+	 * @return bool
+	 */
+	public function validateNumeric($attribute, $value)
+	{
+		return is_numeric($value);
+	}
+
+
+	/**
+	 * Validate that an attribute exists even if not filled.
+	 *
+	 * @param  string $attribute
+	 * @param  mixed $value
+	 *
+	 * @return bool
+	 */
+	public function validatePresent($attribute, $value)
+	{
+		return Arr::has($this->data, $attribute);
+	}
+
+
+	/**
+	 * Validate that an attribute passes a regular expression check.
+	 *
+	 * @param  string $attribute
+	 * @param  mixed $value
+	 * @param  array $parameters
+	 *
+	 * @return bool
+	 */
+	public function validateRegex($attribute, $value, $parameters)
+	{
+		if (! is_string($value) && ! is_numeric($value)) {
+			return false;
+		}
+
+		$this->requireParameterCount(1, $parameters, 'regex');
+
+		return preg_match($parameters[0], $value) > 0;
+	}
+
+
+	/**
+	 * Validate that a required attribute exists.
+	 *
+	 * @param  string $attribute
+	 * @param  mixed $value
+	 *
+	 * @return bool
+	 */
+	public function validateRequired($attribute, $value)
+	{
+		if (is_null($value)) {
+			return false;
+		} elseif (is_string($value) && trim($value) === '') {
+			return false;
+		} elseif ((is_array($value) || $value instanceof Countable) && count($value) < 1) {
+			return false;
+		} elseif ($value instanceof File) {
+			return (string)$value->getPath() !== '';
+		}
+
+		return true;
+	}
+
+
+	/**
+	 * Validate that an attribute exists when another attribute has a given value.
+	 *
+	 * @param  string $attribute
+	 * @param  mixed $value
+	 * @param  mixed $parameters
+	 *
+	 * @return bool
+	 */
+	public function validateRequiredIf($attribute, $value, $parameters)
+	{
+		$this->requireParameterCount(2, $parameters, 'required_if');
+
+		$other = Arr::get($this->data, $parameters[0]);
+
+		$values = array_slice($parameters, 1);
+
+		if (is_bool($other)) {
+			$values = $this->convertValuesToBoolean($values);
+		}
+
+		if (in_array($other, $values)) {
+			return $this->validateRequired($attribute, $value);
+		}
+
+		return true;
+	}
+
+
+	/**
+	 * Convert the given values to boolean if they are string "true" / "false".
+	 *
+	 * @param  array $values
+	 *
+	 * @return array
+	 */
+	protected function convertValuesToBoolean($values)
+	{
+		return array_map(function ($value) {
+			if ($value === 'true') {
+				return true;
+			} elseif ($value === 'false') {
+				return false;
+			}
+
+			return $value;
+		}, $values);
+	}
+
+
+	/**
+	 * Validate that an attribute exists when another attribute does not have a given value.
+	 *
+	 * @param  string $attribute
+	 * @param  mixed $value
+	 * @param  mixed $parameters
+	 *
+	 * @return bool
+	 */
+	public function validateRequiredUnless($attribute, $value, $parameters)
+	{
+		$this->requireParameterCount(2, $parameters, 'required_unless');
+
+		$data = Arr::get($this->data, $parameters[0]);
+
+		$values = array_slice($parameters, 1);
+
+		if (! in_array($data, $values)) {
+			return $this->validateRequired($attribute, $value);
+		}
+
+		return true;
+	}
+
+
+	/**
+	 * Validate that an attribute exists when any other attribute exists.
+	 *
+	 * @param  string $attribute
+	 * @param  mixed $value
+	 * @param  mixed $parameters
+	 *
+	 * @return bool
+	 */
+	public function validateRequiredWith($attribute, $value, $parameters)
+	{
+		if (! $this->allFailingRequired($parameters)) {
+			return $this->validateRequired($attribute, $value);
+		}
+
+		return true;
+	}
+
+
+	/**
+	 * Validate that an attribute exists when all other attributes exists.
+	 *
+	 * @param  string $attribute
+	 * @param  mixed $value
+	 * @param  mixed $parameters
+	 *
+	 * @return bool
+	 */
+	public function validateRequiredWithAll($attribute, $value, $parameters)
+	{
+		if (! $this->anyFailingRequired($parameters)) {
+			return $this->validateRequired($attribute, $value);
+		}
+
+		return true;
+	}
+
+
+	/**
+	 * Validate that an attribute exists when another attribute does not.
+	 *
+	 * @param  string $attribute
+	 * @param  mixed $value
+	 * @param  mixed $parameters
+	 *
+	 * @return bool
+	 */
+	public function validateRequiredWithout($attribute, $value, $parameters)
+	{
+		if ($this->anyFailingRequired($parameters)) {
+			return $this->validateRequired($attribute, $value);
+		}
+
+		return true;
+	}
+
+
+	/**
+	 * Validate that an attribute exists when all other attributes do not.
+	 *
+	 * @param  string $attribute
+	 * @param  mixed $value
+	 * @param  mixed $parameters
+	 *
+	 * @return bool
+	 */
+	public function validateRequiredWithoutAll($attribute, $value, $parameters)
+	{
+		if ($this->allFailingRequired($parameters)) {
+			return $this->validateRequired($attribute, $value);
+		}
+
+		return true;
+	}
+
+
+	/**
+	 * Determine if any of the given attributes fail the required test.
+	 *
+	 * @param  array $attributes
+	 *
+	 * @return bool
+	 */
+	protected function anyFailingRequired(array $attributes)
+	{
+		foreach ($attributes as $key) {
+			if (! $this->validateRequired($key, $this->getValue($key))) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+
+	/**
+	 * Determine if all of the given attributes fail the required test.
+	 *
+	 * @param  array $attributes
+	 *
+	 * @return bool
+	 */
+	protected function allFailingRequired(array $attributes)
+	{
+		foreach ($attributes as $key) {
+			if ($this->validateRequired($key, $this->getValue($key))) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+
+	/**
+	 * Validate that two attributes match.
+	 *
+	 * @param  string $attribute
+	 * @param  mixed $value
+	 * @param  array $parameters
+	 *
+	 * @return bool
+	 */
+	public function validateSame($attribute, $value, $parameters)
+	{
+		$this->requireParameterCount(1, $parameters, 'same');
+
+		$other = Arr::get($this->data, $parameters[0]);
+
+		return $value === $other;
+	}
+
+
+	/**
+	 * Validate the size of an attribute.
+	 *
+	 * @param  string $attribute
+	 * @param  mixed $value
+	 * @param  array $parameters
+	 *
+	 * @return bool
+	 */
+	public function validateSize($attribute, $value, $parameters)
+	{
+		$this->requireParameterCount(1, $parameters, 'size');
+
+		return $this->getSize($attribute, $value) == $parameters[0];
+	}
+
+
+	/**
+	 * "Validate" optional attributes.
+	 * Always returns true, just lets us put sometimes in rules.
+	 *
+	 * @return bool
+	 */
+	public function validateSometimes()
+	{
+		return true;
+	}
+
+
+	/**
+	 * Validate that an attribute is a string.
+	 *
+	 * @param  string $attribute
+	 * @param  mixed $value
+	 *
+	 * @return bool
+	 */
+	public function validateString($attribute, $value)
+	{
+		return is_string($value);
+	}
+
+
+	/**
+	 * Validate that an attribute is a valid timezone.
+	 *
+	 * @param  string $attribute
+	 * @param  mixed $value
+	 *
+	 * @return bool
+	 */
+	public function validateTimezone($attribute, $value)
+	{
+		try {
+			new DateTimeZone($value);
+		} catch (Exception $e) {
+			return false;
+		} catch (Throwable $e) {
+			return false;
+		}
+
+		return true;
+	}
+
+
+	/**
+	 * Validate that an attribute is a valid URL.
+	 *
+	 * @param  string $attribute
+	 * @param  mixed $value
+	 *
+	 * @return bool
+	 */
+	public function validateUrl($attribute, $value)
+	{
+		if (! is_string($value)) {
+			return false;
+		}
+
+		/*
+		 * This pattern is derived from Symfony\Component\Validator\Constraints\UrlValidator (2.7.4).
+		 *
+		 * (c) Fabien Potencier <fabien@symfony.com> http://symfony.com
+		 */
+		$pattern = '~^
             ((aaa|aaas|about|acap|acct|acr|adiumxtra|afp|afs|aim|apt|attachment|aw|barion|beshare|bitcoin|blob|bolo|callto|cap|chrome|chrome-extension|cid|coap|coaps|com-eventbrite-attendee|content|crid|cvs|data|dav|dict|dlna-playcontainer|dlna-playsingle|dns|dntp|dtn|dvb|ed2k|example|facetime|fax|feed|feedready|file|filesystem|finger|fish|ftp|geo|gg|git|gizmoproject|go|gopher|gtalk|h323|ham|hcp|http|https|iax|icap|icon|im|imap|info|iotdisco|ipn|ipp|ipps|irc|irc6|ircs|iris|iris.beep|iris.lwz|iris.xpc|iris.xpcs|itms|jabber|jar|jms|keyparc|lastfm|ldap|ldaps|magnet|mailserver|mailto|maps|market|message|mid|mms|modem|ms-help|ms-settings|ms-settings-airplanemode|ms-settings-bluetooth|ms-settings-camera|ms-settings-cellular|ms-settings-cloudstorage|ms-settings-emailandaccounts|ms-settings-language|ms-settings-location|ms-settings-lock|ms-settings-nfctransactions|ms-settings-notifications|ms-settings-power|ms-settings-privacy|ms-settings-proximity|ms-settings-screenrotation|ms-settings-wifi|ms-settings-workplace|msnim|msrp|msrps|mtqp|mumble|mupdate|mvn|news|nfs|ni|nih|nntp|notes|oid|opaquelocktoken|pack|palm|paparazzi|pkcs11|platform|pop|pres|prospero|proxy|psyc|query|redis|rediss|reload|res|resource|rmi|rsync|rtmfp|rtmp|rtsp|rtsps|rtspu|secondlife|service|session|sftp|sgn|shttp|sieve|sip|sips|skype|smb|sms|smtp|snews|snmp|soap.beep|soap.beeps|soldat|spotify|ssh|steam|stun|stuns|submit|svn|tag|teamspeak|tel|teliaeid|telnet|tftp|things|thismessage|tip|tn3270|turn|turns|tv|udp|unreal|urn|ut2004|vemmi|ventrilo|videotex|view-source|wais|webcal|ws|wss|wtai|wyciwyg|xcon|xcon-userid|xfire|xmlrpc\.beep|xmlrpc.beeps|xmpp|xri|ymsgr|z39\.50|z39\.50r|z39\.50s))://                                 # protocol
             (([\pL\pN-]+:)?([\pL\pN-]+)@)?          # basic auth
             (
@@ -1368,107 +1528,116 @@ trait ValidatesAttributes
             (/?|/\S+|\?\S*|\#\S*)                   # a /, nothing, a / with something, a query or a fragment
         $~ixu';
 
-        return preg_match($pattern, $value) > 0;
-    }
+		return preg_match($pattern, $value) > 0;
+	}
 
-    /**
-     * Get the size of an attribute.
-     *
-     * @param  string  $attribute
-     * @param  mixed   $value
-     * @return mixed
-     */
-    protected function getSize($attribute, $value)
-    {
-        $hasNumeric = $this->hasRule($attribute, $this->numericRules);
 
-        // This method will determine if the attribute is a number, string, or file and
-        // return the proper size accordingly. If it is a number, then number itself
-        // is the size. If it is a file, we take kilobytes, and for a string the
-        // entire length of the string will be considered the attribute size.
-        if (is_numeric($value) && $hasNumeric) {
-            return $value;
-        } elseif (is_array($value)) {
-            return count($value);
-        } elseif ($value instanceof File) {
-            return $value->getSize() / 1024;
-        }
+	/**
+	 * Get the size of an attribute.
+	 *
+	 * @param  string $attribute
+	 * @param  mixed $value
+	 *
+	 * @return mixed
+	 */
+	protected function getSize($attribute, $value)
+	{
+		$hasNumeric = $this->hasRule($attribute, $this->numericRules);
 
-        return mb_strlen($value);
-    }
+		// This method will determine if the attribute is a number, string, or file and
+		// return the proper size accordingly. If it is a number, then number itself
+		// is the size. If it is a file, we take kilobytes, and for a string the
+		// entire length of the string will be considered the attribute size.
+		if (is_numeric($value) && $hasNumeric) {
+			return $value;
+		} elseif (is_array($value)) {
+			return count($value);
+		} elseif ($value instanceof File) {
+			return $value->getSize() / 1024;
+		}
 
-    /**
-     * Check that the given value is a valid file instance.
-     *
-     * @param  mixed  $value
-     * @return bool
-     */
-    public function isValidFileInstance($value)
-    {
-        if ($value instanceof UploadedFile && ! $value->isValid()) {
-            return false;
-        }
+		return mb_strlen($value);
+	}
 
-        return $value instanceof File;
-    }
 
-    /**
-     * Determine if a comparison passes between the given values.
-     *
-     * @param  mixed  $first
-     * @param  mixed  $second
-     * @param  string  $operator
-     * @return bool
-     */
-    protected function compare($first, $second, $operator)
-    {
-        switch ($operator) {
-            case '<':
-                return $first < $second;
-            case '>':
-                return $first > $second;
-            case '<=':
-                return $first <= $second;
-            case '>=':
-                return $first >= $second;
-            case '=':
-                return $first == $second;
-            default:
-                throw new InvalidArgumentException;
-        }
-    }
+	/**
+	 * Check that the given value is a valid file instance.
+	 *
+	 * @param  mixed $value
+	 *
+	 * @return bool
+	 */
+	public function isValidFileInstance($value)
+	{
+		if ($value instanceof UploadedFile && ! $value->isValid()) {
+			return false;
+		}
 
-    /**
-     * Parse named parameters to $key => $value items.
-     *
-     * @param  array  $parameters
-     * @return array
-     */
-    protected function parseNamedParameters($parameters)
-    {
-        return array_reduce($parameters, function ($result, $item) {
-            list($key, $value) = array_pad(explode('=', $item, 2), 2, null);
+		return $value instanceof File;
+	}
 
-            $result[$key] = $value;
 
-            return $result;
-        });
-    }
+	/**
+	 * Determine if a comparison passes between the given values.
+	 *
+	 * @param  mixed $first
+	 * @param  mixed $second
+	 * @param  string $operator
+	 *
+	 * @return bool
+	 */
+	protected function compare($first, $second, $operator)
+	{
+		switch ($operator) {
+			case '<':
+				return $first < $second;
+			case '>':
+				return $first > $second;
+			case '<=':
+				return $first <= $second;
+			case '>=':
+				return $first >= $second;
+			case '=':
+				return $first == $second;
+			default:
+				throw new InvalidArgumentException;
+		}
+	}
 
-    /**
-     * Require a certain number of parameters to be present.
-     *
-     * @param  int    $count
-     * @param  array  $parameters
-     * @param  string  $rule
-     * @return void
-     *
-     * @throws \InvalidArgumentException
-     */
-    protected function requireParameterCount($count, $parameters, $rule)
-    {
-        if (count($parameters) < $count) {
-            throw new InvalidArgumentException("Validation rule $rule requires at least $count parameters.");
-        }
-    }
+
+	/**
+	 * Parse named parameters to $key => $value items.
+	 *
+	 * @param  array $parameters
+	 *
+	 * @return array
+	 */
+	protected function parseNamedParameters($parameters)
+	{
+		return array_reduce($parameters, function ($result, $item) {
+			list($key, $value) = array_pad(explode('=', $item, 2), 2, null);
+
+			$result[$key] = $value;
+
+			return $result;
+		});
+	}
+
+
+	/**
+	 * Require a certain number of parameters to be present.
+	 *
+	 * @param  int $count
+	 * @param  array $parameters
+	 * @param  string $rule
+	 *
+	 * @return void
+	 * @throws \InvalidArgumentException
+	 */
+	protected function requireParameterCount($count, $parameters, $rule)
+	{
+		if (count($parameters) < $count) {
+			throw new InvalidArgumentException("Validation rule $rule requires at least $count parameters.");
+		}
+	}
 }

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -19,1500 +19,1355 @@ use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 trait ValidatesAttributes
 {
-	/**
-	 * Validate that an attribute was "accepted".
-	 * This validation rule implies the attribute is "required".
-	 *
-	 * @param  string $attribute
-	 * @param  mixed $value
-	 *
-	 * @return bool
-	 */
-	public function validateAccepted($attribute, $value)
-	{
-		$acceptable = ['yes', 'on', '1', 1, true, 'true'];
-
-		return $this->validateRequired($attribute, $value) && in_array($value, $acceptable, true);
-	}
-
-
-	/**
-	 * Validate that an attribute is an active URL.
-	 *
-	 * @param  string $attribute
-	 * @param  mixed $value
-	 *
-	 * @return bool
-	 */
-	public function validateActiveUrl($attribute, $value)
-	{
-		if (! is_string($value)) {
-			return false;
-		}
-
-		if ($url = parse_url($value, PHP_URL_HOST)) {
-			try {
-				return count(dns_get_record($url, DNS_A | DNS_AAAA)) > 0;
-			} catch (Exception $e) {
-				return false;
-			}
-		}
-
-		return false;
-	}
-
-
-	/**
-	 * "Break" on first validation fail.
-	 * Always returns true, just lets us put "bail" in rules.
-	 *
-	 * @return bool
-	 */
-	public function validateBail()
-	{
-		return true;
-	}
-
-
-	/**
-	 * Validate the date is before a given date.
-	 *
-	 * @param  string $attribute
-	 * @param  mixed $value
-	 * @param  array $parameters
-	 *
-	 * @return bool
-	 */
-	public function validateBefore($attribute, $value, $parameters)
-	{
-		$this->requireParameterCount(1, $parameters, 'before');
-
-		return $this->compareDates($attribute, $value, $parameters, '<');
-	}
-
-
-	/**
-	 * Validate the date is before or equal a given date.
-	 *
-	 * @param  string $attribute
-	 * @param  mixed $value
-	 * @param  array $parameters
-	 *
-	 * @return bool
-	 */
-	public function validateBeforeOrEqual($attribute, $value, $parameters)
-	{
-		$this->requireParameterCount(1, $parameters, 'before_or_equal');
-
-		return $this->compareDates($attribute, $value, $parameters, '<=');
-	}
-
-
-	/**
-	 * Validate the date is after a given date.
-	 *
-	 * @param  string $attribute
-	 * @param  mixed $value
-	 * @param  array $parameters
-	 *
-	 * @return bool
-	 */
-	public function validateAfter($attribute, $value, $parameters)
-	{
-		$this->requireParameterCount(1, $parameters, 'after');
-
-		return $this->compareDates($attribute, $value, $parameters, '>');
-	}
-
-
-	/**
-	 * Validate the date is equal or after a given date.
-	 *
-	 * @param  string $attribute
-	 * @param  mixed $value
-	 * @param  array $parameters
-	 *
-	 * @return bool
-	 */
-	public function validateAfterOrEqual($attribute, $value, $parameters)
-	{
-		$this->requireParameterCount(1, $parameters, 'after_or_equal');
-
-		return $this->compareDates($attribute, $value, $parameters, '>=');
-	}
-
-
-	/**
-	 * Compare a given date against another using an operator.
-	 *
-	 * @param  string $attribute
-	 * @param  mixed $value
-	 * @param  array $parameters
-	 * @param  string $operator
-	 *
-	 * @return bool
-	 */
-	protected function compareDates($attribute, $value, $parameters, $operator)
-	{
-		if (! is_string($value) && ! is_numeric($value) && ! $value instanceof DateTimeInterface) {
-			return false;
-		}
-
-		if ($format = $this->getDateFormat($attribute)) {
-			return $this->checkDateTimeOrder(
-				$format, $value, $this->getValue($parameters[0]) ?: $parameters[0], $operator
-			);
-		}
-
-		if (! $date = $this->getDateTimestamp($parameters[0])) {
-			$date = $this->getDateTimestamp($this->getValue($parameters[0]));
-		}
-
-		return $this->compare($this->getDateTimestamp($value), $date, $operator);
-	}
-
-
-	/**
-	 * Get the date format for an attribute if it has one.
-	 *
-	 * @param  string $attribute
-	 *
-	 * @return string|null
-	 */
-	protected function getDateFormat($attribute)
-	{
-		if ($result = $this->getRule($attribute, 'DateFormat')) {
-			return $result[1][0];
-		}
-	}
-
-
-	/**
-	 * Get the date timestamp.
-	 *
-	 * @param  mixed $value
-	 *
-	 * @return int
-	 */
-	protected function getDateTimestamp($value)
-	{
-		return $value instanceof DateTimeInterface ? $value->getTimestamp() : strtotime($value);
-	}
-
-
-	/**
-	 * Given two date/time strings, check that one is after the other.
-	 *
-	 * @param  string $format
-	 * @param  string $first
-	 * @param  string $second
-	 * @param  string $operator
-	 *
-	 * @return bool
-	 */
-	protected function checkDateTimeOrder($format, $first, $second, $operator)
-	{
-		$first = $this->getDateTimeWithOptionalFormat($format, $first);
-
-		$second = $this->getDateTimeWithOptionalFormat($format, $second);
-
-		return ($first && $second) && ($this->compare($first, $second, $operator));
-	}
-
-
-	/**
-	 * Get a DateTime instance from a string.
-	 *
-	 * @param  string $format
-	 * @param  string $value
-	 *
-	 * @return \DateTime|null
-	 */
-	protected function getDateTimeWithOptionalFormat($format, $value)
-	{
-		if ($date = DateTime::createFromFormat('!' . $format, $value)) {
-			return $date;
-		}
-
-		try {
-			return new DateTime($value);
-		} catch (Exception $e) {
-			//
-		}
-	}
-
-
-	/**
-	 * Validate that an attribute contains only alphabetic characters.
-	 *
-	 * @param  string $attribute
-	 * @param  mixed $value
-	 *
-	 * @return bool
-	 */
-	public function validateAlpha($attribute, $value)
-	{
-		return is_string($value) && preg_match('/^[\pL\pM]+$/u', $value);
-	}
-
-
-	/**
-	 * Validate that an attribute contains only alpha-numeric characters, dashes, and underscores.
-	 *
-	 * @param  string $attribute
-	 * @param  mixed $value
-	 *
-	 * @return bool
-	 */
-	public function validateAlphaDash($attribute, $value)
-	{
-		if (! is_string($value) && ! is_numeric($value)) {
-			return false;
-		}
-
-		return preg_match('/^[\pL\pM\pN_-]+$/u', $value) > 0;
-	}
-
-
-	/**
-	 * Validate that an attribute contains only alpha-numeric characters.
-	 *
-	 * @param  string $attribute
-	 * @param  mixed $value
-	 *
-	 * @return bool
-	 */
-	public function validateAlphaNum($attribute, $value)
-	{
-		if (! is_string($value) && ! is_numeric($value)) {
-			return false;
-		}
-
-		return preg_match('/^[\pL\pM\pN]+$/u', $value) > 0;
-	}
-
-
-	/**
-	 * Validate that an attribute is an array.
-	 *
-	 * @param  string $attribute
-	 * @param  mixed $value
-	 *
-	 * @return bool
-	 */
-	public function validateArray($attribute, $value)
-	{
-		return is_array($value);
-	}
-
-
-	/**
-	 * Validate the size of an attribute is between a set of values.
-	 *
-	 * @param  string $attribute
-	 * @param  mixed $value
-	 * @param  array $parameters
-	 *
-	 * @return bool
-	 */
-	public function validateBetween($attribute, $value, $parameters)
-	{
-		$this->requireParameterCount(2, $parameters, 'between');
-
-		$size = $this->getSize($attribute, $value);
-
-		return $size >= $parameters[0] && $size <= $parameters[1];
-	}
-
-
-	/**
-	 * Validate that an attribute is a boolean.
-	 *
-	 * @param  string $attribute
-	 * @param  mixed $value
-	 *
-	 * @return bool
-	 */
-	public function validateBoolean($attribute, $value)
-	{
-		$acceptable = [true, false, 0, 1, '0', '1'];
-
-		return in_array($value, $acceptable, true);
-	}
-
-
-	/**
-	 * Validate that an attribute has a matching confirmation.
-	 *
-	 * @param  string $attribute
-	 * @param  mixed $value
-	 *
-	 * @return bool
-	 */
-	public function validateConfirmed($attribute, $value)
-	{
-		return $this->validateSame($attribute, $value, [$attribute . '_confirmation']);
-	}
-
-
-	/**
-	 * Validate that an attribute is a valid date.
-	 *
-	 * @param  string $attribute
-	 * @param  mixed $value
-	 *
-	 * @return bool
-	 */
-	public function validateDate($attribute, $value)
-	{
-		if ($value instanceof DateTimeInterface) {
-			return true;
-		}
-
-		if ((! is_string($value) && ! is_numeric($value)) || strtotime($value) === false) {
-			return false;
-		}
-
-		$date = date_parse($value);
-
-		return checkdate($date['month'], $date['day'], $date['year']);
-	}
-
-
-	/**
-	 * Validate that an attribute matches a date format.
-	 *
-	 * @param  string $attribute
-	 * @param  mixed $value
-	 * @param  array $parameters
-	 *
-	 * @return bool
-	 */
-	public function validateDateFormat($attribute, $value, $parameters)
-	{
-		$this->requireParameterCount(1, $parameters, 'date_format');
-
-		if (! is_string($value) && ! is_numeric($value)) {
-			return false;
-		}
-
-		$format = $parameters[0];
-
-		$date = DateTime::createFromFormat('!' . $format, $value);
-
-		return $date && $date->format($format) == $value;
-	}
-
-
-	/**
-	 * Validate that an attribute is equal to another date.
-	 *
-	 * @param  string $attribute
-	 * @param  mixed $value
-	 * @param  array $parameters
-	 *
-	 * @return bool
-	 */
-	public function validateDateEquals($attribute, $value, $parameters)
-	{
-		$this->requireParameterCount(1, $parameters, 'date_equals');
-
-		return $this->compareDates($attribute, $value, $parameters, '=');
-	}
-
-
-	/**
-	 * Validate that an attribute is different from another attribute.
-	 *
-	 * @param  string $attribute
-	 * @param  mixed $value
-	 * @param  array $parameters
-	 *
-	 * @return bool
-	 */
-	public function validateDifferent($attribute, $value, $parameters)
-	{
-		$this->requireParameterCount(1, $parameters, 'different');
-
-		foreach ($parameters as $parameter) {
-			$other = Arr::get($this->data, $parameter);
-
-			if (is_null($other) || $value === $other) {
-				return false;
-			}
-		}
-
-		return true;
-	}
-
-
-	/**
-	 * Validate that an attribute has a given number of digits.
-	 *
-	 * @param  string $attribute
-	 * @param  mixed $value
-	 * @param  array $parameters
-	 *
-	 * @return bool
-	 */
-	public function validateDigits($attribute, $value, $parameters)
-	{
-		$this->requireParameterCount(1, $parameters, 'digits');
-
-		return ! preg_match('/[^0-9]/', $value)
-			&& strlen((string)$value) == $parameters[0];
-	}
-
-
-	/**
-	 * Validate that an attribute is between a given number of digits.
-	 *
-	 * @param  string $attribute
-	 * @param  mixed $value
-	 * @param  array $parameters
-	 *
-	 * @return bool
-	 */
-	public function validateDigitsBetween($attribute, $value, $parameters)
-	{
-		$this->requireParameterCount(2, $parameters, 'digits_between');
-
-		$length = strlen((string)$value);
-
-		return ! preg_match('/[^0-9]/', $value)
-			&& $length >= $parameters[0] && $length <= $parameters[1];
-	}
-
-
-	/**
-	 * Validate the dimensions of an image matches the given values.
-	 *
-	 * @param  string $attribute
-	 * @param  mixed $value
-	 * @param  array $parameters
-	 *
-	 * @return bool
-	 */
-	public function validateDimensions($attribute, $value, $parameters)
-	{
-		if (! $this->isValidFileInstance($value) || ! $sizeDetails = @getimagesize($value->getRealPath())) {
-			return false;
-		}
-
-		$this->requireParameterCount(1, $parameters, 'dimensions');
-
-		list($width, $height) = $sizeDetails;
-
-		$parameters = $this->parseNamedParameters($parameters);
-
-		if ($this->failsBasicDimensionChecks($parameters, $width, $height) ||
-			$this->failsRatioCheck($parameters, $width, $height)) {
-			return false;
-		}
-
-		return true;
-	}
-
-
-	/**
-	 * Test if the given width and height fail any conditions.
-	 *
-	 * @param  array $parameters
-	 * @param  int $width
-	 * @param  int $height
-	 *
-	 * @return bool
-	 */
-	protected function failsBasicDimensionChecks($parameters, $width, $height)
-	{
-		return (isset($parameters['width']) && $parameters['width'] != $width) ||
-			(isset($parameters['min_width']) && $parameters['min_width'] > $width) ||
-			(isset($parameters['max_width']) && $parameters['max_width'] < $width) ||
-			(isset($parameters['height']) && $parameters['height'] != $height) ||
-			(isset($parameters['min_height']) && $parameters['min_height'] > $height) ||
-			(isset($parameters['max_height']) && $parameters['max_height'] < $height);
-	}
-
-
-	/**
-	 * Determine if the given parameters fail a dimension ratio check.
-	 *
-	 * @param  array $parameters
-	 * @param  int $width
-	 * @param  int $height
-	 *
-	 * @return bool
-	 */
-	protected function failsRatioCheck($parameters, $width, $height)
-	{
-		if (! isset($parameters['ratio'])) {
-			return false;
-		}
-
-		list($numerator, $denominator) = array_replace(
-			[1, 1], array_filter(sscanf($parameters['ratio'], '%f/%d'))
-		);
-
-		$precision = 1 / max($width, $height);
-
-		return abs($numerator / $denominator - $width / $height) > $precision;
-	}
-
-
-	/**
-	 * Validate an attribute is unique among other values.
-	 *
-	 * @param  string $attribute
-	 * @param  mixed $value
-	 * @param  array $parameters
-	 *
-	 * @return bool
-	 */
-	public function validateDistinct($attribute, $value, $parameters)
-	{
-		$attributeName = $this->getPrimaryAttribute($attribute);
-
-		$attributeData = ValidationData::extractDataFromPath(
-			ValidationData::getLeadingExplicitAttributePath($attributeName), $this->data
-		);
-
-		$pattern = str_replace('\*', '[^.]+', preg_quote($attributeName, '#'));
-
-		$data = Arr::where(Arr::dot($attributeData), function ($value, $key) use ($attribute, $pattern) {
-			return $key != $attribute && (bool)preg_match('#^' . $pattern . '\z#u', $key);
-		});
-
-		return ! in_array($value, array_values($data));
-	}
-
-
-	/**
-	 * Validate that an attribute is a valid e-mail address.
-	 *
-	 * @param  string $attribute
-	 * @param  mixed $value
-	 *
-	 * @return bool
-	 */
-	public function validateEmail($attribute, $value)
-	{
-		return filter_var($value, FILTER_VALIDATE_EMAIL) !== false;
-	}
-
-
-	/**
-	 * Validate that an attribute is equal to given.
-	 *
-	 * @param  string $attribute
-	 * @param  mixed $value
-	 * @param  array $parameters
-	 *
-	 * @return bool
-	 */
-	public function validateEquals($attribute, $value, $parameters)
-	{
-		$this->requireParameterCount(1, $parameters, 'equals');
-
-		return $value == $parameters[0];
-	}
-
-
-	/**
-	 * Validate the existence of an attribute value in a database table.
-	 *
-	 * @param  string $attribute
-	 * @param  mixed $value
-	 * @param  array $parameters
-	 *
-	 * @return bool
-	 */
-	public function validateExists($attribute, $value, $parameters)
-	{
-		$this->requireParameterCount(1, $parameters, 'exists');
-
-		list($connection, $table) = $this->parseTable($parameters[0]);
-
-		// The second parameter position holds the name of the column that should be
-		// verified as existing. If this parameter is not specified we will guess
-		// that the columns being "verified" shares the given attribute's name.
-		$column = $this->getQueryColumn($parameters, $attribute);
-
-		$expected = (is_array($value)) ? count($value) : 1;
-
-		return $this->getExistCount(
-				$connection, $table, $column, $value, $parameters
-			) >= $expected;
-	}
-
-
-	/**
-	 * Get the number of records that exist in storage.
-	 *
-	 * @param  mixed $connection
-	 * @param  string $table
-	 * @param  string $column
-	 * @param  mixed $value
-	 * @param  array $parameters
-	 *
-	 * @return int
-	 */
-	protected function getExistCount($connection, $table, $column, $value, $parameters)
-	{
-		$verifier = $this->getPresenceVerifierFor($connection);
-
-		$extra = $this->getExtraConditions(
-			array_values(array_slice($parameters, 2))
-		);
-
-		if ($this->currentRule instanceof Exists) {
-			$extra = array_merge($extra, $this->currentRule->queryCallbacks());
-		}
-
-		return is_array($value)
-			? $verifier->getMultiCount($table, $column, $value, $extra)
-			: $verifier->getCount($table, $column, $value, null, null, $extra);
-	}
-
-
-	/**
-	 * Validate the uniqueness of an attribute value on a given database table.
-	 * If a database column is not specified, the attribute will be used.
-	 *
-	 * @param  string $attribute
-	 * @param  mixed $value
-	 * @param  array $parameters
-	 *
-	 * @return bool
-	 */
-	public function validateUnique($attribute, $value, $parameters)
-	{
-		$this->requireParameterCount(1, $parameters, 'unique');
-
-		list($connection, $table) = $this->parseTable($parameters[0]);
-
-		// The second parameter position holds the name of the column that needs to
-		// be verified as unique. If this parameter isn't specified we will just
-		// assume that this column to be verified shares the attribute's name.
-		$column = $this->getQueryColumn($parameters, $attribute);
-
-		list($idColumn, $id) = [null, null];
-
-		if (isset($parameters[2])) {
-			list($idColumn, $id) = $this->getUniqueIds($parameters);
-		}
-
-		// The presence verifier is responsible for counting rows within this store
-		// mechanism which might be a relational database or any other permanent
-		// data store like Redis, etc. We will use it to determine uniqueness.
-		$verifier = $this->getPresenceVerifierFor($connection);
-
-		$extra = $this->getUniqueExtra($parameters);
-
-		if ($this->currentRule instanceof Unique) {
-			$extra = array_merge($extra, $this->currentRule->queryCallbacks());
-		}
-
-		return $verifier->getCount(
-				$table, $column, $value, $id, $idColumn, $extra
-			) == 0;
-	}
-
-
-	/**
-	 * Get the excluded ID column and value for the unique rule.
-	 *
-	 * @param  array $parameters
-	 *
-	 * @return array
-	 */
-	protected function getUniqueIds($parameters)
-	{
-		$idColumn = $parameters[3] ?? 'id';
-
-		return [$idColumn, $this->prepareUniqueId($parameters[2])];
-	}
-
-
-	/**
-	 * Prepare the given ID for querying.
-	 *
-	 * @param  mixed $id
-	 *
-	 * @return int
-	 */
-	protected function prepareUniqueId($id)
-	{
-		if (preg_match('/\[(.*)\]/', $id, $matches)) {
-			$id = $this->getValue($matches[1]);
-		}
-
-		if (strtolower($id) == 'null') {
-			$id = null;
-		}
-
-		if (filter_var($id, FILTER_VALIDATE_INT) !== false) {
-			$id = (int)$id;
-		}
-
-		return $id;
-	}
-
-
-	/**
-	 * Get the extra conditions for a unique rule.
-	 *
-	 * @param  array $parameters
-	 *
-	 * @return array
-	 */
-	protected function getUniqueExtra($parameters)
-	{
-		if (isset($parameters[4])) {
-			return $this->getExtraConditions(array_slice($parameters, 4));
-		}
-
-		return [];
-	}
-
-
-	/**
-	 * Parse the connection / table for the unique / exists rules.
-	 *
-	 * @param  string $table
-	 *
-	 * @return array
-	 */
-	protected function parseTable($table)
-	{
-		return Str::contains($table, '.') ? explode('.', $table, 2) : [null, $table];
-	}
-
-
-	/**
-	 * Get the column name for an exists / unique query.
-	 *
-	 * @param  array $parameters
-	 * @param  string $attribute
-	 *
-	 * @return bool
-	 */
-	protected function getQueryColumn($parameters, $attribute)
-	{
-		return isset($parameters[1]) && $parameters[1] !== 'NULL'
-			? $parameters[1] : $this->guessColumnForQuery($attribute);
-	}
-
-
-	/**
-	 * Guess the database column from the given attribute name.
-	 *
-	 * @param  string $attribute
-	 *
-	 * @return string
-	 */
-	public function guessColumnForQuery($attribute)
-	{
-		if (in_array($attribute, Arr::collapse($this->implicitAttributes))
-			&& ! is_numeric($last = last(explode('.', $attribute)))) {
-			return $last;
-		}
-
-		return $attribute;
-	}
-
-
-	/**
-	 * Get the extra conditions for a unique / exists rule.
-	 *
-	 * @param  array $segments
-	 *
-	 * @return array
-	 */
-	protected function getExtraConditions(array $segments)
-	{
-		$extra = [];
-
-		$count = count($segments);
-
-		for ($i = 0; $i < $count; $i += 2) {
-			$extra[$segments[$i]] = $segments[$i + 1];
-		}
-
-		return $extra;
-	}
-
-
-	/**
-	 * Validate the given value is a valid file.
-	 *
-	 * @param  string $attribute
-	 * @param  mixed $value
-	 *
-	 * @return bool
-	 */
-	public function validateFile($attribute, $value)
-	{
-		return $this->isValidFileInstance($value);
-	}
-
-
-	/**
-	 * Validate the given attribute is filled if it is present.
-	 *
-	 * @param  string $attribute
-	 * @param  mixed $value
-	 *
-	 * @return bool
-	 */
-	public function validateFilled($attribute, $value)
-	{
-		if (Arr::has($this->data, $attribute)) {
-			return $this->validateRequired($attribute, $value);
-		}
-
-		return true;
-	}
-
-
-	/**
-	 * Validate the MIME type of a file is an image MIME type.
-	 *
-	 * @param  string $attribute
-	 * @param  mixed $value
-	 *
-	 * @return bool
-	 */
-	public function validateImage($attribute, $value)
-	{
-		return $this->validateMimes($attribute, $value, ['jpeg', 'png', 'gif', 'bmp', 'svg']);
-	}
-
-
-	/**
-	 * Validate an attribute is contained within a list of values.
-	 *
-	 * @param  string $attribute
-	 * @param  mixed $value
-	 * @param  array $parameters
-	 *
-	 * @return bool
-	 */
-	public function validateIn($attribute, $value, $parameters)
-	{
-		if (is_array($value) && $this->hasRule($attribute, 'Array')) {
-			foreach ($value as $element) {
-				if (is_array($element)) {
-					return false;
-				}
-			}
-
-			return count(array_diff($value, $parameters)) == 0;
-		}
-
-		return ! is_array($value) && in_array((string)$value, $parameters);
-	}
-
-
-	/**
-	 * Validate that the values of an attribute is in another attribute.
-	 *
-	 * @param  string $attribute
-	 * @param  mixed $value
-	 * @param  array $parameters
-	 *
-	 * @return bool
-	 */
-	public function validateInArray($attribute, $value, $parameters)
-	{
-		$this->requireParameterCount(1, $parameters, 'in_array');
-
-		$explicitPath = ValidationData::getLeadingExplicitAttributePath($parameters[0]);
-
-		$attributeData = ValidationData::extractDataFromPath($explicitPath, $this->data);
-
-		$otherValues = Arr::where(Arr::dot($attributeData), function ($value, $key) use ($parameters) {
-			return Str::is($parameters[0], $key);
-		});
-
-		return in_array($value, $otherValues);
-	}
-
-
-	/**
-	 * Validate that an attribute is an integer.
-	 *
-	 * @param  string $attribute
-	 * @param  mixed $value
-	 *
-	 * @return bool
-	 */
-	public function validateInteger($attribute, $value)
-	{
-		return filter_var($value, FILTER_VALIDATE_INT) !== false;
-	}
-
-
-	/**
-	 * Validate that an attribute is a valid IP.
-	 *
-	 * @param  string $attribute
-	 * @param  mixed $value
-	 *
-	 * @return bool
-	 */
-	public function validateIp($attribute, $value)
-	{
-		return filter_var($value, FILTER_VALIDATE_IP) !== false;
-	}
-
-
-	/**
-	 * Validate that an attribute is a valid IPv4.
-	 *
-	 * @param  string $attribute
-	 * @param  mixed $value
-	 *
-	 * @return bool
-	 */
-	public function validateIpv4($attribute, $value)
-	{
-		return filter_var($value, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) !== false;
-	}
-
-
-	/**
-	 * Validate that an attribute is a valid IPv6.
-	 *
-	 * @param  string $attribute
-	 * @param  mixed $value
-	 *
-	 * @return bool
-	 */
-	public function validateIpv6($attribute, $value)
-	{
-		return filter_var($value, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) !== false;
-	}
-
-
-	/**
-	 * Validate the attribute is a valid JSON string.
-	 *
-	 * @param  string $attribute
-	 * @param  mixed $value
-	 *
-	 * @return bool
-	 */
-	public function validateJson($attribute, $value)
-	{
-		if (! is_scalar($value) && ! method_exists($value, '__toString')) {
-			return false;
-		}
-
-		json_decode($value);
-
-		return json_last_error() === JSON_ERROR_NONE;
-	}
-
-
-	/**
-	 * Validate the size of an attribute is less than a maximum value.
-	 *
-	 * @param  string $attribute
-	 * @param  mixed $value
-	 * @param  array $parameters
-	 *
-	 * @return bool
-	 */
-	public function validateMax($attribute, $value, $parameters)
-	{
-		$this->requireParameterCount(1, $parameters, 'max');
-
-		if ($value instanceof UploadedFile && ! $value->isValid()) {
-			return false;
-		}
-
-		return $this->getSize($attribute, $value) <= $parameters[0];
-	}
-
-
-	/**
-	 * Validate the guessed extension of a file upload is in a set of file extensions.
-	 *
-	 * @param  string $attribute
-	 * @param  mixed $value
-	 * @param  array $parameters
-	 *
-	 * @return bool
-	 */
-	public function validateMimes($attribute, $value, $parameters)
-	{
-		if (! $this->isValidFileInstance($value)) {
-			return false;
-		}
-
-		if ($this->shouldBlockPhpUpload($value, $parameters)) {
-			return false;
-		}
-
-		return $value->getPath() !== '' && in_array($value->guessExtension(), $parameters);
-	}
-
-
-	/**
-	 * Validate the MIME type of a file upload attribute is in a set of MIME types.
-	 *
-	 * @param  string $attribute
-	 * @param  mixed $value
-	 * @param  array $parameters
-	 *
-	 * @return bool
-	 */
-	public function validateMimetypes($attribute, $value, $parameters)
-	{
-		if (! $this->isValidFileInstance($value)) {
-			return false;
-		}
-
-		if ($this->shouldBlockPhpUpload($value, $parameters)) {
-			return false;
-		}
-
-		return $value->getPath() !== '' &&
-			(in_array($value->getMimeType(), $parameters) ||
-				in_array(explode('/', $value->getMimeType())[0] . '/*', $parameters));
-	}
-
-
-	/**
-	 * Check if PHP uploads are explicitly allowed.
-	 *
-	 * @param  mixed $value
-	 * @param  array $parameters
-	 *
-	 * @return bool
-	 */
-	protected function shouldBlockPhpUpload($value, $parameters)
-	{
-		if (in_array('php', $parameters)) {
-			return false;
-		}
-
-		return ($value instanceof UploadedFile)
-			? strtolower($value->getClientOriginalExtension()) === 'php'
-			: strtolower($value->getExtension()) === 'php';
-	}
-
-
-	/**
-	 * Validate the size of an attribute is greater than a minimum value.
-	 *
-	 * @param  string $attribute
-	 * @param  mixed $value
-	 * @param  array $parameters
-	 *
-	 * @return bool
-	 */
-	public function validateMin($attribute, $value, $parameters)
-	{
-		$this->requireParameterCount(1, $parameters, 'min');
-
-		return $this->getSize($attribute, $value) >= $parameters[0];
-	}
-
-
-	/**
-	 * "Indicate" validation should pass if value is null.
-	 * Always returns true, just lets us put "nullable" in rules.
-	 *
-	 * @return bool
-	 */
-	public function validateNullable()
-	{
-		return true;
-	}
-
-
-	/**
-	 * Validate an attribute is not contained within a list of values.
-	 *
-	 * @param  string $attribute
-	 * @param  mixed $value
-	 * @param  array $parameters
-	 *
-	 * @return bool
-	 */
-	public function validateNotIn($attribute, $value, $parameters)
-	{
-		return ! $this->validateIn($attribute, $value, $parameters);
-	}
-
-
-	/**
-	 * Validate that an attribute is numeric.
-	 *
-	 * @param  string $attribute
-	 * @param  mixed $value
-	 *
-	 * @return bool
-	 */
-	public function validateNumeric($attribute, $value)
-	{
-		return is_numeric($value);
-	}
-
-
-	/**
-	 * Validate that an attribute exists even if not filled.
-	 *
-	 * @param  string $attribute
-	 * @param  mixed $value
-	 *
-	 * @return bool
-	 */
-	public function validatePresent($attribute, $value)
-	{
-		return Arr::has($this->data, $attribute);
-	}
-
-
-	/**
-	 * Validate that an attribute passes a regular expression check.
-	 *
-	 * @param  string $attribute
-	 * @param  mixed $value
-	 * @param  array $parameters
-	 *
-	 * @return bool
-	 */
-	public function validateRegex($attribute, $value, $parameters)
-	{
-		if (! is_string($value) && ! is_numeric($value)) {
-			return false;
-		}
-
-		$this->requireParameterCount(1, $parameters, 'regex');
-
-		return preg_match($parameters[0], $value) > 0;
-	}
-
-
-	/**
-	 * Validate that a required attribute exists.
-	 *
-	 * @param  string $attribute
-	 * @param  mixed $value
-	 *
-	 * @return bool
-	 */
-	public function validateRequired($attribute, $value)
-	{
-		if (is_null($value)) {
-			return false;
-		} elseif (is_string($value) && trim($value) === '') {
-			return false;
-		} elseif ((is_array($value) || $value instanceof Countable) && count($value) < 1) {
-			return false;
-		} elseif ($value instanceof File) {
-			return (string)$value->getPath() !== '';
-		}
-
-		return true;
-	}
-
-
-	/**
-	 * Validate that an attribute exists when another attribute has a given value.
-	 *
-	 * @param  string $attribute
-	 * @param  mixed $value
-	 * @param  mixed $parameters
-	 *
-	 * @return bool
-	 */
-	public function validateRequiredIf($attribute, $value, $parameters)
-	{
-		$this->requireParameterCount(2, $parameters, 'required_if');
-
-		$other = Arr::get($this->data, $parameters[0]);
-
-		$values = array_slice($parameters, 1);
-
-		if (is_bool($other)) {
-			$values = $this->convertValuesToBoolean($values);
-		}
-
-		if (in_array($other, $values)) {
-			return $this->validateRequired($attribute, $value);
-		}
-
-		return true;
-	}
-
-
-	/**
-	 * Convert the given values to boolean if they are string "true" / "false".
-	 *
-	 * @param  array $values
-	 *
-	 * @return array
-	 */
-	protected function convertValuesToBoolean($values)
-	{
-		return array_map(function ($value) {
-			if ($value === 'true') {
-				return true;
-			} elseif ($value === 'false') {
-				return false;
-			}
-
-			return $value;
-		}, $values);
-	}
-
-
-	/**
-	 * Validate that an attribute exists when another attribute does not have a given value.
-	 *
-	 * @param  string $attribute
-	 * @param  mixed $value
-	 * @param  mixed $parameters
-	 *
-	 * @return bool
-	 */
-	public function validateRequiredUnless($attribute, $value, $parameters)
-	{
-		$this->requireParameterCount(2, $parameters, 'required_unless');
-
-		$data = Arr::get($this->data, $parameters[0]);
-
-		$values = array_slice($parameters, 1);
-
-		if (! in_array($data, $values)) {
-			return $this->validateRequired($attribute, $value);
-		}
-
-		return true;
-	}
-
-
-	/**
-	 * Validate that an attribute exists when any other attribute exists.
-	 *
-	 * @param  string $attribute
-	 * @param  mixed $value
-	 * @param  mixed $parameters
-	 *
-	 * @return bool
-	 */
-	public function validateRequiredWith($attribute, $value, $parameters)
-	{
-		if (! $this->allFailingRequired($parameters)) {
-			return $this->validateRequired($attribute, $value);
-		}
-
-		return true;
-	}
-
-
-	/**
-	 * Validate that an attribute exists when all other attributes exists.
-	 *
-	 * @param  string $attribute
-	 * @param  mixed $value
-	 * @param  mixed $parameters
-	 *
-	 * @return bool
-	 */
-	public function validateRequiredWithAll($attribute, $value, $parameters)
-	{
-		if (! $this->anyFailingRequired($parameters)) {
-			return $this->validateRequired($attribute, $value);
-		}
-
-		return true;
-	}
-
-
-	/**
-	 * Validate that an attribute exists when another attribute does not.
-	 *
-	 * @param  string $attribute
-	 * @param  mixed $value
-	 * @param  mixed $parameters
-	 *
-	 * @return bool
-	 */
-	public function validateRequiredWithout($attribute, $value, $parameters)
-	{
-		if ($this->anyFailingRequired($parameters)) {
-			return $this->validateRequired($attribute, $value);
-		}
-
-		return true;
-	}
-
-
-	/**
-	 * Validate that an attribute exists when all other attributes do not.
-	 *
-	 * @param  string $attribute
-	 * @param  mixed $value
-	 * @param  mixed $parameters
-	 *
-	 * @return bool
-	 */
-	public function validateRequiredWithoutAll($attribute, $value, $parameters)
-	{
-		if ($this->allFailingRequired($parameters)) {
-			return $this->validateRequired($attribute, $value);
-		}
-
-		return true;
-	}
-
-
-	/**
-	 * Determine if any of the given attributes fail the required test.
-	 *
-	 * @param  array $attributes
-	 *
-	 * @return bool
-	 */
-	protected function anyFailingRequired(array $attributes)
-	{
-		foreach ($attributes as $key) {
-			if (! $this->validateRequired($key, $this->getValue($key))) {
-				return true;
-			}
-		}
-
-		return false;
-	}
-
-
-	/**
-	 * Determine if all of the given attributes fail the required test.
-	 *
-	 * @param  array $attributes
-	 *
-	 * @return bool
-	 */
-	protected function allFailingRequired(array $attributes)
-	{
-		foreach ($attributes as $key) {
-			if ($this->validateRequired($key, $this->getValue($key))) {
-				return false;
-			}
-		}
-
-		return true;
-	}
-
-
-	/**
-	 * Validate that two attributes match.
-	 *
-	 * @param  string $attribute
-	 * @param  mixed $value
-	 * @param  array $parameters
-	 *
-	 * @return bool
-	 */
-	public function validateSame($attribute, $value, $parameters)
-	{
-		$this->requireParameterCount(1, $parameters, 'same');
-
-		$other = Arr::get($this->data, $parameters[0]);
-
-		return $value === $other;
-	}
-
-
-	/**
-	 * Validate the size of an attribute.
-	 *
-	 * @param  string $attribute
-	 * @param  mixed $value
-	 * @param  array $parameters
-	 *
-	 * @return bool
-	 */
-	public function validateSize($attribute, $value, $parameters)
-	{
-		$this->requireParameterCount(1, $parameters, 'size');
-
-		return $this->getSize($attribute, $value) == $parameters[0];
-	}
-
-
-	/**
-	 * "Validate" optional attributes.
-	 * Always returns true, just lets us put sometimes in rules.
-	 *
-	 * @return bool
-	 */
-	public function validateSometimes()
-	{
-		return true;
-	}
-
-
-	/**
-	 * Validate that an attribute is a string.
-	 *
-	 * @param  string $attribute
-	 * @param  mixed $value
-	 *
-	 * @return bool
-	 */
-	public function validateString($attribute, $value)
-	{
-		return is_string($value);
-	}
-
-
-	/**
-	 * Validate that an attribute is a valid timezone.
-	 *
-	 * @param  string $attribute
-	 * @param  mixed $value
-	 *
-	 * @return bool
-	 */
-	public function validateTimezone($attribute, $value)
-	{
-		try {
-			new DateTimeZone($value);
-		} catch (Exception $e) {
-			return false;
-		} catch (Throwable $e) {
-			return false;
-		}
-
-		return true;
-	}
-
-
-	/**
-	 * Validate that an attribute is a valid URL.
-	 *
-	 * @param  string $attribute
-	 * @param  mixed $value
-	 *
-	 * @return bool
-	 */
-	public function validateUrl($attribute, $value)
-	{
-		if (! is_string($value)) {
-			return false;
-		}
-
-		/*
-		 * This pattern is derived from Symfony\Component\Validator\Constraints\UrlValidator (2.7.4).
-		 *
-		 * (c) Fabien Potencier <fabien@symfony.com> http://symfony.com
-		 */
-		$pattern = '~^
+    /**
+     * Validate that an attribute was "accepted".
+     *
+     * This validation rule implies the attribute is "required".
+     *
+     * @param  string  $attribute
+     * @param  mixed   $value
+     * @return bool
+     */
+    public function validateAccepted($attribute, $value)
+    {
+        $acceptable = ['yes', 'on', '1', 1, true, 'true'];
+
+        return $this->validateRequired($attribute, $value) && in_array($value, $acceptable, true);
+    }
+
+    /**
+     * Validate that an attribute is an active URL.
+     *
+     * @param  string  $attribute
+     * @param  mixed   $value
+     * @return bool
+     */
+    public function validateActiveUrl($attribute, $value)
+    {
+        if (! is_string($value)) {
+            return false;
+        }
+
+        if ($url = parse_url($value, PHP_URL_HOST)) {
+            try {
+                return count(dns_get_record($url, DNS_A | DNS_AAAA)) > 0;
+            } catch (Exception $e) {
+                return false;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * "Break" on first validation fail.
+     *
+     * Always returns true, just lets us put "bail" in rules.
+     *
+     * @return bool
+     */
+    public function validateBail()
+    {
+        return true;
+    }
+
+    /**
+     * Validate the date is before a given date.
+     *
+     * @param  string  $attribute
+     * @param  mixed   $value
+     * @param  array   $parameters
+     * @return bool
+     */
+    public function validateBefore($attribute, $value, $parameters)
+    {
+        $this->requireParameterCount(1, $parameters, 'before');
+
+        return $this->compareDates($attribute, $value, $parameters, '<');
+    }
+
+    /**
+     * Validate the date is before or equal a given date.
+     *
+     * @param  string  $attribute
+     * @param  mixed   $value
+     * @param  array   $parameters
+     * @return bool
+     */
+    public function validateBeforeOrEqual($attribute, $value, $parameters)
+    {
+        $this->requireParameterCount(1, $parameters, 'before_or_equal');
+
+        return $this->compareDates($attribute, $value, $parameters, '<=');
+    }
+
+    /**
+     * Validate the date is after a given date.
+     *
+     * @param  string  $attribute
+     * @param  mixed   $value
+     * @param  array   $parameters
+     * @return bool
+     */
+    public function validateAfter($attribute, $value, $parameters)
+    {
+        $this->requireParameterCount(1, $parameters, 'after');
+
+        return $this->compareDates($attribute, $value, $parameters, '>');
+    }
+
+    /**
+     * Validate the date is equal or after a given date.
+     *
+     * @param  string  $attribute
+     * @param  mixed   $value
+     * @param  array   $parameters
+     * @return bool
+     */
+    public function validateAfterOrEqual($attribute, $value, $parameters)
+    {
+        $this->requireParameterCount(1, $parameters, 'after_or_equal');
+
+        return $this->compareDates($attribute, $value, $parameters, '>=');
+    }
+
+    /**
+     * Compare a given date against another using an operator.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  array  $parameters
+     * @param  string  $operator
+     * @return bool
+     */
+    protected function compareDates($attribute, $value, $parameters, $operator)
+    {
+        if (! is_string($value) && ! is_numeric($value) && ! $value instanceof DateTimeInterface) {
+            return false;
+        }
+
+        if ($format = $this->getDateFormat($attribute)) {
+            return $this->checkDateTimeOrder(
+                $format, $value, $this->getValue($parameters[0]) ?: $parameters[0], $operator
+            );
+        }
+
+        if (! $date = $this->getDateTimestamp($parameters[0])) {
+            $date = $this->getDateTimestamp($this->getValue($parameters[0]));
+        }
+
+        return $this->compare($this->getDateTimestamp($value), $date, $operator);
+    }
+
+    /**
+     * Get the date format for an attribute if it has one.
+     *
+     * @param  string  $attribute
+     * @return string|null
+     */
+    protected function getDateFormat($attribute)
+    {
+        if ($result = $this->getRule($attribute, 'DateFormat')) {
+            return $result[1][0];
+        }
+    }
+
+    /**
+     * Get the date timestamp.
+     *
+     * @param  mixed  $value
+     * @return int
+     */
+    protected function getDateTimestamp($value)
+    {
+        return $value instanceof DateTimeInterface ? $value->getTimestamp() : strtotime($value);
+    }
+
+    /**
+     * Given two date/time strings, check that one is after the other.
+     *
+     * @param  string  $format
+     * @param  string  $first
+     * @param  string  $second
+     * @param  string  $operator
+     * @return bool
+     */
+    protected function checkDateTimeOrder($format, $first, $second, $operator)
+    {
+        $first = $this->getDateTimeWithOptionalFormat($format, $first);
+
+        $second = $this->getDateTimeWithOptionalFormat($format, $second);
+
+        return ($first && $second) && ($this->compare($first, $second, $operator));
+    }
+
+    /**
+     * Get a DateTime instance from a string.
+     *
+     * @param  string  $format
+     * @param  string  $value
+     * @return \DateTime|null
+     */
+    protected function getDateTimeWithOptionalFormat($format, $value)
+    {
+        if ($date = DateTime::createFromFormat('!'.$format, $value)) {
+            return $date;
+        }
+
+        try {
+            return new DateTime($value);
+        } catch (Exception $e) {
+            //
+        }
+    }
+
+    /**
+     * Validate that an attribute contains only alphabetic characters.
+     *
+     * @param  string  $attribute
+     * @param  mixed   $value
+     * @return bool
+     */
+    public function validateAlpha($attribute, $value)
+    {
+        return is_string($value) && preg_match('/^[\pL\pM]+$/u', $value);
+    }
+
+    /**
+     * Validate that an attribute contains only alpha-numeric characters, dashes, and underscores.
+     *
+     * @param  string  $attribute
+     * @param  mixed   $value
+     * @return bool
+     */
+    public function validateAlphaDash($attribute, $value)
+    {
+        if (! is_string($value) && ! is_numeric($value)) {
+            return false;
+        }
+
+        return preg_match('/^[\pL\pM\pN_-]+$/u', $value) > 0;
+    }
+
+    /**
+     * Validate that an attribute contains only alpha-numeric characters.
+     *
+     * @param  string  $attribute
+     * @param  mixed   $value
+     * @return bool
+     */
+    public function validateAlphaNum($attribute, $value)
+    {
+        if (! is_string($value) && ! is_numeric($value)) {
+            return false;
+        }
+
+        return preg_match('/^[\pL\pM\pN]+$/u', $value) > 0;
+    }
+
+    /**
+     * Validate that an attribute is an array.
+     *
+     * @param  string  $attribute
+     * @param  mixed   $value
+     * @return bool
+     */
+    public function validateArray($attribute, $value)
+    {
+        return is_array($value);
+    }
+
+    /**
+     * Validate the size of an attribute is between a set of values.
+     *
+     * @param  string  $attribute
+     * @param  mixed   $value
+     * @param  array   $parameters
+     * @return bool
+     */
+    public function validateBetween($attribute, $value, $parameters)
+    {
+        $this->requireParameterCount(2, $parameters, 'between');
+
+        $size = $this->getSize($attribute, $value);
+
+        return $size >= $parameters[0] && $size <= $parameters[1];
+    }
+
+    /**
+     * Validate that an attribute is a boolean.
+     *
+     * @param  string  $attribute
+     * @param  mixed   $value
+     * @return bool
+     */
+    public function validateBoolean($attribute, $value)
+    {
+        $acceptable = [true, false, 0, 1, '0', '1'];
+
+        return in_array($value, $acceptable, true);
+    }
+
+    /**
+     * Validate that an attribute has a matching confirmation.
+     *
+     * @param  string  $attribute
+     * @param  mixed   $value
+     * @return bool
+     */
+    public function validateConfirmed($attribute, $value)
+    {
+        return $this->validateSame($attribute, $value, [$attribute.'_confirmation']);
+    }
+
+    /**
+     * Validate that an attribute is a valid date.
+     *
+     * @param  string  $attribute
+     * @param  mixed   $value
+     * @return bool
+     */
+    public function validateDate($attribute, $value)
+    {
+        if ($value instanceof DateTimeInterface) {
+            return true;
+        }
+
+        if ((! is_string($value) && ! is_numeric($value)) || strtotime($value) === false) {
+            return false;
+        }
+
+        $date = date_parse($value);
+
+        return checkdate($date['month'], $date['day'], $date['year']);
+    }
+
+    /**
+     * Validate that an attribute matches a date format.
+     *
+     * @param  string  $attribute
+     * @param  mixed   $value
+     * @param  array   $parameters
+     * @return bool
+     */
+    public function validateDateFormat($attribute, $value, $parameters)
+    {
+        $this->requireParameterCount(1, $parameters, 'date_format');
+
+        if (! is_string($value) && ! is_numeric($value)) {
+            return false;
+        }
+
+        $format = $parameters[0];
+
+        $date = DateTime::createFromFormat('!'.$format, $value);
+
+        return $date && $date->format($format) == $value;
+    }
+
+    /**
+     * Validate that an attribute is equal to another date.
+     *
+     * @param  string  $attribute
+     * @param  mixed   $value
+     * @param  array   $parameters
+     * @return bool
+     */
+    public function validateDateEquals($attribute, $value, $parameters)
+    {
+        $this->requireParameterCount(1, $parameters, 'date_equals');
+
+        return $this->compareDates($attribute, $value, $parameters, '=');
+    }
+
+    /**
+     * Validate that an attribute is different from another attribute.
+     *
+     * @param  string  $attribute
+     * @param  mixed   $value
+     * @param  array   $parameters
+     * @return bool
+     */
+    public function validateDifferent($attribute, $value, $parameters)
+    {
+        $this->requireParameterCount(1, $parameters, 'different');
+
+        foreach ($parameters as $parameter) {
+            $other = Arr::get($this->data, $parameter);
+
+            if (is_null($other) || $value === $other) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Validate that an attribute has a given number of digits.
+     *
+     * @param  string  $attribute
+     * @param  mixed   $value
+     * @param  array   $parameters
+     * @return bool
+     */
+    public function validateDigits($attribute, $value, $parameters)
+    {
+        $this->requireParameterCount(1, $parameters, 'digits');
+
+        return ! preg_match('/[^0-9]/', $value)
+                    && strlen((string) $value) == $parameters[0];
+    }
+
+    /**
+     * Validate that an attribute is between a given number of digits.
+     *
+     * @param  string  $attribute
+     * @param  mixed   $value
+     * @param  array   $parameters
+     * @return bool
+     */
+    public function validateDigitsBetween($attribute, $value, $parameters)
+    {
+        $this->requireParameterCount(2, $parameters, 'digits_between');
+
+        $length = strlen((string) $value);
+
+        return ! preg_match('/[^0-9]/', $value)
+                    && $length >= $parameters[0] && $length <= $parameters[1];
+    }
+
+    /**
+     * Validate the dimensions of an image matches the given values.
+     *
+     * @param  string $attribute
+     * @param  mixed $value
+     * @param  array $parameters
+     * @return bool
+     */
+    public function validateDimensions($attribute, $value, $parameters)
+    {
+        if (! $this->isValidFileInstance($value) || ! $sizeDetails = @getimagesize($value->getRealPath())) {
+            return false;
+        }
+
+        $this->requireParameterCount(1, $parameters, 'dimensions');
+
+        list($width, $height) = $sizeDetails;
+
+        $parameters = $this->parseNamedParameters($parameters);
+
+        if ($this->failsBasicDimensionChecks($parameters, $width, $height) ||
+            $this->failsRatioCheck($parameters, $width, $height)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Test if the given width and height fail any conditions.
+     *
+     * @param  array  $parameters
+     * @param  int  $width
+     * @param  int  $height
+     * @return bool
+     */
+    protected function failsBasicDimensionChecks($parameters, $width, $height)
+    {
+        return (isset($parameters['width']) && $parameters['width'] != $width) ||
+               (isset($parameters['min_width']) && $parameters['min_width'] > $width) ||
+               (isset($parameters['max_width']) && $parameters['max_width'] < $width) ||
+               (isset($parameters['height']) && $parameters['height'] != $height) ||
+               (isset($parameters['min_height']) && $parameters['min_height'] > $height) ||
+               (isset($parameters['max_height']) && $parameters['max_height'] < $height);
+    }
+
+    /**
+     * Determine if the given parameters fail a dimension ratio check.
+     *
+     * @param  array  $parameters
+     * @param  int  $width
+     * @param  int  $height
+     * @return bool
+     */
+    protected function failsRatioCheck($parameters, $width, $height)
+    {
+        if (! isset($parameters['ratio'])) {
+            return false;
+        }
+
+        list($numerator, $denominator) = array_replace(
+            [1, 1], array_filter(sscanf($parameters['ratio'], '%f/%d'))
+        );
+
+        $precision = 1 / max($width, $height);
+
+        return abs($numerator / $denominator - $width / $height) > $precision;
+    }
+
+    /**
+     * Validate an attribute is unique among other values.
+     *
+     * @param  string  $attribute
+     * @param  mixed   $value
+     * @param  array   $parameters
+     * @return bool
+     */
+    public function validateDistinct($attribute, $value, $parameters)
+    {
+        $attributeName = $this->getPrimaryAttribute($attribute);
+
+        $attributeData = ValidationData::extractDataFromPath(
+            ValidationData::getLeadingExplicitAttributePath($attributeName), $this->data
+        );
+
+        $pattern = str_replace('\*', '[^.]+', preg_quote($attributeName, '#'));
+
+        $data = Arr::where(Arr::dot($attributeData), function ($value, $key) use ($attribute, $pattern) {
+            return $key != $attribute && (bool) preg_match('#^'.$pattern.'\z#u', $key);
+        });
+
+        return ! in_array($value, array_values($data));
+    }
+
+    /**
+     * Validate that an attribute is a valid e-mail address.
+     *
+     * @param  string  $attribute
+     * @param  mixed   $value
+     * @return bool
+     */
+    public function validateEmail($attribute, $value)
+    {
+        return filter_var($value, FILTER_VALIDATE_EMAIL) !== false;
+    }
+
+    /**
+     * Validate that an attribute is equal to given.
+     *
+     * @param  string  $attribute
+     * @param  mixed   $value
+     * @param  array   $parameters
+     * @return bool
+     */
+    public function validateEquals($attribute, $value, $parameters)
+    {
+	    $this->requireParameterCount(1, $parameters, 'equals');
+
+        return $value == $parameters[0];
+    }
+
+    /**
+     * Validate the existence of an attribute value in a database table.
+     *
+     * @param  string  $attribute
+     * @param  mixed   $value
+     * @param  array   $parameters
+     * @return bool
+     */
+    public function validateExists($attribute, $value, $parameters)
+    {
+        $this->requireParameterCount(1, $parameters, 'exists');
+
+        list($connection, $table) = $this->parseTable($parameters[0]);
+
+        // The second parameter position holds the name of the column that should be
+        // verified as existing. If this parameter is not specified we will guess
+        // that the columns being "verified" shares the given attribute's name.
+        $column = $this->getQueryColumn($parameters, $attribute);
+
+        $expected = (is_array($value)) ? count($value) : 1;
+
+        return $this->getExistCount(
+            $connection, $table, $column, $value, $parameters
+        ) >= $expected;
+    }
+
+    /**
+     * Get the number of records that exist in storage.
+     *
+     * @param  mixed   $connection
+     * @param  string  $table
+     * @param  string  $column
+     * @param  mixed   $value
+     * @param  array   $parameters
+     * @return int
+     */
+    protected function getExistCount($connection, $table, $column, $value, $parameters)
+    {
+        $verifier = $this->getPresenceVerifierFor($connection);
+
+        $extra = $this->getExtraConditions(
+            array_values(array_slice($parameters, 2))
+        );
+
+        if ($this->currentRule instanceof Exists) {
+            $extra = array_merge($extra, $this->currentRule->queryCallbacks());
+        }
+
+        return is_array($value)
+                ? $verifier->getMultiCount($table, $column, $value, $extra)
+                : $verifier->getCount($table, $column, $value, null, null, $extra);
+    }
+
+    /**
+     * Validate the uniqueness of an attribute value on a given database table.
+     *
+     * If a database column is not specified, the attribute will be used.
+     *
+     * @param  string  $attribute
+     * @param  mixed   $value
+     * @param  array   $parameters
+     * @return bool
+     */
+    public function validateUnique($attribute, $value, $parameters)
+    {
+        $this->requireParameterCount(1, $parameters, 'unique');
+
+        list($connection, $table) = $this->parseTable($parameters[0]);
+
+        // The second parameter position holds the name of the column that needs to
+        // be verified as unique. If this parameter isn't specified we will just
+        // assume that this column to be verified shares the attribute's name.
+        $column = $this->getQueryColumn($parameters, $attribute);
+
+        list($idColumn, $id) = [null, null];
+
+        if (isset($parameters[2])) {
+            list($idColumn, $id) = $this->getUniqueIds($parameters);
+        }
+
+        // The presence verifier is responsible for counting rows within this store
+        // mechanism which might be a relational database or any other permanent
+        // data store like Redis, etc. We will use it to determine uniqueness.
+        $verifier = $this->getPresenceVerifierFor($connection);
+
+        $extra = $this->getUniqueExtra($parameters);
+
+        if ($this->currentRule instanceof Unique) {
+            $extra = array_merge($extra, $this->currentRule->queryCallbacks());
+        }
+
+        return $verifier->getCount(
+            $table, $column, $value, $id, $idColumn, $extra
+        ) == 0;
+    }
+
+    /**
+     * Get the excluded ID column and value for the unique rule.
+     *
+     * @param  array  $parameters
+     * @return array
+     */
+    protected function getUniqueIds($parameters)
+    {
+        $idColumn = $parameters[3] ?? 'id';
+
+        return [$idColumn, $this->prepareUniqueId($parameters[2])];
+    }
+
+    /**
+     * Prepare the given ID for querying.
+     *
+     * @param  mixed  $id
+     * @return int
+     */
+    protected function prepareUniqueId($id)
+    {
+        if (preg_match('/\[(.*)\]/', $id, $matches)) {
+            $id = $this->getValue($matches[1]);
+        }
+
+        if (strtolower($id) == 'null') {
+            $id = null;
+        }
+
+        if (filter_var($id, FILTER_VALIDATE_INT) !== false) {
+            $id = (int) $id;
+        }
+
+        return $id;
+    }
+
+    /**
+     * Get the extra conditions for a unique rule.
+     *
+     * @param  array  $parameters
+     * @return array
+     */
+    protected function getUniqueExtra($parameters)
+    {
+        if (isset($parameters[4])) {
+            return $this->getExtraConditions(array_slice($parameters, 4));
+        }
+
+        return [];
+    }
+
+    /**
+     * Parse the connection / table for the unique / exists rules.
+     *
+     * @param  string  $table
+     * @return array
+     */
+    protected function parseTable($table)
+    {
+        return Str::contains($table, '.') ? explode('.', $table, 2) : [null, $table];
+    }
+
+    /**
+     * Get the column name for an exists / unique query.
+     *
+     * @param  array  $parameters
+     * @param  string  $attribute
+     * @return bool
+     */
+    protected function getQueryColumn($parameters, $attribute)
+    {
+        return isset($parameters[1]) && $parameters[1] !== 'NULL'
+                    ? $parameters[1] : $this->guessColumnForQuery($attribute);
+    }
+
+    /**
+     * Guess the database column from the given attribute name.
+     *
+     * @param  string  $attribute
+     * @return string
+     */
+    public function guessColumnForQuery($attribute)
+    {
+        if (in_array($attribute, Arr::collapse($this->implicitAttributes))
+                && ! is_numeric($last = last(explode('.', $attribute)))) {
+            return $last;
+        }
+
+        return $attribute;
+    }
+
+    /**
+     * Get the extra conditions for a unique / exists rule.
+     *
+     * @param  array  $segments
+     * @return array
+     */
+    protected function getExtraConditions(array $segments)
+    {
+        $extra = [];
+
+        $count = count($segments);
+
+        for ($i = 0; $i < $count; $i += 2) {
+            $extra[$segments[$i]] = $segments[$i + 1];
+        }
+
+        return $extra;
+    }
+
+    /**
+     * Validate the given value is a valid file.
+     *
+     * @param  string  $attribute
+     * @param  mixed   $value
+     * @return bool
+     */
+    public function validateFile($attribute, $value)
+    {
+        return $this->isValidFileInstance($value);
+    }
+
+    /**
+     * Validate the given attribute is filled if it is present.
+     *
+     * @param  string  $attribute
+     * @param  mixed   $value
+     * @return bool
+     */
+    public function validateFilled($attribute, $value)
+    {
+        if (Arr::has($this->data, $attribute)) {
+            return $this->validateRequired($attribute, $value);
+        }
+
+        return true;
+    }
+
+    /**
+     * Validate the MIME type of a file is an image MIME type.
+     *
+     * @param  string  $attribute
+     * @param  mixed   $value
+     * @return bool
+     */
+    public function validateImage($attribute, $value)
+    {
+        return $this->validateMimes($attribute, $value, ['jpeg', 'png', 'gif', 'bmp', 'svg']);
+    }
+
+    /**
+     * Validate an attribute is contained within a list of values.
+     *
+     * @param  string  $attribute
+     * @param  mixed   $value
+     * @param  array   $parameters
+     * @return bool
+     */
+    public function validateIn($attribute, $value, $parameters)
+    {
+        if (is_array($value) && $this->hasRule($attribute, 'Array')) {
+            foreach ($value as $element) {
+                if (is_array($element)) {
+                    return false;
+                }
+            }
+
+            return count(array_diff($value, $parameters)) == 0;
+        }
+
+        return ! is_array($value) && in_array((string) $value, $parameters);
+    }
+
+    /**
+     * Validate that the values of an attribute is in another attribute.
+     *
+     * @param  string  $attribute
+     * @param  mixed   $value
+     * @param  array   $parameters
+     * @return bool
+     */
+    public function validateInArray($attribute, $value, $parameters)
+    {
+        $this->requireParameterCount(1, $parameters, 'in_array');
+
+        $explicitPath = ValidationData::getLeadingExplicitAttributePath($parameters[0]);
+
+        $attributeData = ValidationData::extractDataFromPath($explicitPath, $this->data);
+
+        $otherValues = Arr::where(Arr::dot($attributeData), function ($value, $key) use ($parameters) {
+            return Str::is($parameters[0], $key);
+        });
+
+        return in_array($value, $otherValues);
+    }
+
+    /**
+     * Validate that an attribute is an integer.
+     *
+     * @param  string  $attribute
+     * @param  mixed   $value
+     * @return bool
+     */
+    public function validateInteger($attribute, $value)
+    {
+        return filter_var($value, FILTER_VALIDATE_INT) !== false;
+    }
+
+    /**
+     * Validate that an attribute is a valid IP.
+     *
+     * @param  string  $attribute
+     * @param  mixed   $value
+     * @return bool
+     */
+    public function validateIp($attribute, $value)
+    {
+        return filter_var($value, FILTER_VALIDATE_IP) !== false;
+    }
+
+    /**
+     * Validate that an attribute is a valid IPv4.
+     *
+     * @param  string  $attribute
+     * @param  mixed   $value
+     * @return bool
+     */
+    public function validateIpv4($attribute, $value)
+    {
+        return filter_var($value, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) !== false;
+    }
+
+    /**
+     * Validate that an attribute is a valid IPv6.
+     *
+     * @param  string  $attribute
+     * @param  mixed   $value
+     * @return bool
+     */
+    public function validateIpv6($attribute, $value)
+    {
+        return filter_var($value, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) !== false;
+    }
+
+    /**
+     * Validate the attribute is a valid JSON string.
+     *
+     * @param  string  $attribute
+     * @param  mixed   $value
+     * @return bool
+     */
+    public function validateJson($attribute, $value)
+    {
+        if (! is_scalar($value) && ! method_exists($value, '__toString')) {
+            return false;
+        }
+
+        json_decode($value);
+
+        return json_last_error() === JSON_ERROR_NONE;
+    }
+
+    /**
+     * Validate the size of an attribute is less than a maximum value.
+     *
+     * @param  string  $attribute
+     * @param  mixed   $value
+     * @param  array   $parameters
+     * @return bool
+     */
+    public function validateMax($attribute, $value, $parameters)
+    {
+        $this->requireParameterCount(1, $parameters, 'max');
+
+        if ($value instanceof UploadedFile && ! $value->isValid()) {
+            return false;
+        }
+
+        return $this->getSize($attribute, $value) <= $parameters[0];
+    }
+
+    /**
+     * Validate the guessed extension of a file upload is in a set of file extensions.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  array   $parameters
+     * @return bool
+     */
+    public function validateMimes($attribute, $value, $parameters)
+    {
+        if (! $this->isValidFileInstance($value)) {
+            return false;
+        }
+
+        if ($this->shouldBlockPhpUpload($value, $parameters)) {
+            return false;
+        }
+
+        return $value->getPath() !== '' && in_array($value->guessExtension(), $parameters);
+    }
+
+    /**
+     * Validate the MIME type of a file upload attribute is in a set of MIME types.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  array  $parameters
+     * @return bool
+     */
+    public function validateMimetypes($attribute, $value, $parameters)
+    {
+        if (! $this->isValidFileInstance($value)) {
+            return false;
+        }
+
+        if ($this->shouldBlockPhpUpload($value, $parameters)) {
+            return false;
+        }
+
+        return $value->getPath() !== '' &&
+                (in_array($value->getMimeType(), $parameters) ||
+                 in_array(explode('/', $value->getMimeType())[0].'/*', $parameters));
+    }
+
+    /**
+     * Check if PHP uploads are explicitly allowed.
+     *
+     * @param  mixed  $value
+     * @param  array  $parameters
+     * @return bool
+     */
+    protected function shouldBlockPhpUpload($value, $parameters)
+    {
+        if (in_array('php', $parameters)) {
+            return false;
+        }
+
+        return ($value instanceof UploadedFile)
+           ? strtolower($value->getClientOriginalExtension()) === 'php'
+           : strtolower($value->getExtension()) === 'php';
+    }
+
+    /**
+     * Validate the size of an attribute is greater than a minimum value.
+     *
+     * @param  string  $attribute
+     * @param  mixed   $value
+     * @param  array   $parameters
+     * @return bool
+     */
+    public function validateMin($attribute, $value, $parameters)
+    {
+        $this->requireParameterCount(1, $parameters, 'min');
+
+        return $this->getSize($attribute, $value) >= $parameters[0];
+    }
+
+    /**
+     * "Indicate" validation should pass if value is null.
+     *
+     * Always returns true, just lets us put "nullable" in rules.
+     *
+     * @return bool
+     */
+    public function validateNullable()
+    {
+        return true;
+    }
+
+    /**
+     * Validate an attribute is not contained within a list of values.
+     *
+     * @param  string  $attribute
+     * @param  mixed   $value
+     * @param  array   $parameters
+     * @return bool
+     */
+    public function validateNotIn($attribute, $value, $parameters)
+    {
+        return ! $this->validateIn($attribute, $value, $parameters);
+    }
+
+    /**
+     * Validate that an attribute is numeric.
+     *
+     * @param  string  $attribute
+     * @param  mixed   $value
+     * @return bool
+     */
+    public function validateNumeric($attribute, $value)
+    {
+        return is_numeric($value);
+    }
+
+    /**
+     * Validate that an attribute exists even if not filled.
+     *
+     * @param  string  $attribute
+     * @param  mixed   $value
+     * @return bool
+     */
+    public function validatePresent($attribute, $value)
+    {
+        return Arr::has($this->data, $attribute);
+    }
+
+    /**
+     * Validate that an attribute passes a regular expression check.
+     *
+     * @param  string  $attribute
+     * @param  mixed   $value
+     * @param  array   $parameters
+     * @return bool
+     */
+    public function validateRegex($attribute, $value, $parameters)
+    {
+        if (! is_string($value) && ! is_numeric($value)) {
+            return false;
+        }
+
+        $this->requireParameterCount(1, $parameters, 'regex');
+
+        return preg_match($parameters[0], $value) > 0;
+    }
+
+    /**
+     * Validate that a required attribute exists.
+     *
+     * @param  string  $attribute
+     * @param  mixed   $value
+     * @return bool
+     */
+    public function validateRequired($attribute, $value)
+    {
+        if (is_null($value)) {
+            return false;
+        } elseif (is_string($value) && trim($value) === '') {
+            return false;
+        } elseif ((is_array($value) || $value instanceof Countable) && count($value) < 1) {
+            return false;
+        } elseif ($value instanceof File) {
+            return (string) $value->getPath() !== '';
+        }
+
+        return true;
+    }
+
+    /**
+     * Validate that an attribute exists when another attribute has a given value.
+     *
+     * @param  string  $attribute
+     * @param  mixed   $value
+     * @param  mixed   $parameters
+     * @return bool
+     */
+    public function validateRequiredIf($attribute, $value, $parameters)
+    {
+        $this->requireParameterCount(2, $parameters, 'required_if');
+
+        $other = Arr::get($this->data, $parameters[0]);
+
+        $values = array_slice($parameters, 1);
+
+        if (is_bool($other)) {
+            $values = $this->convertValuesToBoolean($values);
+        }
+
+        if (in_array($other, $values)) {
+            return $this->validateRequired($attribute, $value);
+        }
+
+        return true;
+    }
+
+    /**
+     * Convert the given values to boolean if they are string "true" / "false".
+     *
+     * @param  array  $values
+     * @return array
+     */
+    protected function convertValuesToBoolean($values)
+    {
+        return array_map(function ($value) {
+            if ($value === 'true') {
+                return true;
+            } elseif ($value === 'false') {
+                return false;
+            }
+
+            return $value;
+        }, $values);
+    }
+
+    /**
+     * Validate that an attribute exists when another attribute does not have a given value.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  mixed  $parameters
+     * @return bool
+     */
+    public function validateRequiredUnless($attribute, $value, $parameters)
+    {
+        $this->requireParameterCount(2, $parameters, 'required_unless');
+
+        $data = Arr::get($this->data, $parameters[0]);
+
+        $values = array_slice($parameters, 1);
+
+        if (! in_array($data, $values)) {
+            return $this->validateRequired($attribute, $value);
+        }
+
+        return true;
+    }
+
+    /**
+     * Validate that an attribute exists when any other attribute exists.
+     *
+     * @param  string  $attribute
+     * @param  mixed   $value
+     * @param  mixed   $parameters
+     * @return bool
+     */
+    public function validateRequiredWith($attribute, $value, $parameters)
+    {
+        if (! $this->allFailingRequired($parameters)) {
+            return $this->validateRequired($attribute, $value);
+        }
+
+        return true;
+    }
+
+    /**
+     * Validate that an attribute exists when all other attributes exists.
+     *
+     * @param  string  $attribute
+     * @param  mixed   $value
+     * @param  mixed   $parameters
+     * @return bool
+     */
+    public function validateRequiredWithAll($attribute, $value, $parameters)
+    {
+        if (! $this->anyFailingRequired($parameters)) {
+            return $this->validateRequired($attribute, $value);
+        }
+
+        return true;
+    }
+
+    /**
+     * Validate that an attribute exists when another attribute does not.
+     *
+     * @param  string  $attribute
+     * @param  mixed   $value
+     * @param  mixed   $parameters
+     * @return bool
+     */
+    public function validateRequiredWithout($attribute, $value, $parameters)
+    {
+        if ($this->anyFailingRequired($parameters)) {
+            return $this->validateRequired($attribute, $value);
+        }
+
+        return true;
+    }
+
+    /**
+     * Validate that an attribute exists when all other attributes do not.
+     *
+     * @param  string  $attribute
+     * @param  mixed   $value
+     * @param  mixed   $parameters
+     * @return bool
+     */
+    public function validateRequiredWithoutAll($attribute, $value, $parameters)
+    {
+        if ($this->allFailingRequired($parameters)) {
+            return $this->validateRequired($attribute, $value);
+        }
+
+        return true;
+    }
+
+    /**
+     * Determine if any of the given attributes fail the required test.
+     *
+     * @param  array  $attributes
+     * @return bool
+     */
+    protected function anyFailingRequired(array $attributes)
+    {
+        foreach ($attributes as $key) {
+            if (! $this->validateRequired($key, $this->getValue($key))) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Determine if all of the given attributes fail the required test.
+     *
+     * @param  array  $attributes
+     * @return bool
+     */
+    protected function allFailingRequired(array $attributes)
+    {
+        foreach ($attributes as $key) {
+            if ($this->validateRequired($key, $this->getValue($key))) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Validate that two attributes match.
+     *
+     * @param  string  $attribute
+     * @param  mixed   $value
+     * @param  array   $parameters
+     * @return bool
+     */
+    public function validateSame($attribute, $value, $parameters)
+    {
+        $this->requireParameterCount(1, $parameters, 'same');
+
+        $other = Arr::get($this->data, $parameters[0]);
+
+        return $value === $other;
+    }
+
+    /**
+     * Validate the size of an attribute.
+     *
+     * @param  string  $attribute
+     * @param  mixed   $value
+     * @param  array   $parameters
+     * @return bool
+     */
+    public function validateSize($attribute, $value, $parameters)
+    {
+        $this->requireParameterCount(1, $parameters, 'size');
+
+        return $this->getSize($attribute, $value) == $parameters[0];
+    }
+
+    /**
+     * "Validate" optional attributes.
+     *
+     * Always returns true, just lets us put sometimes in rules.
+     *
+     * @return bool
+     */
+    public function validateSometimes()
+    {
+        return true;
+    }
+
+    /**
+     * Validate that an attribute is a string.
+     *
+     * @param  string  $attribute
+     * @param  mixed   $value
+     * @return bool
+     */
+    public function validateString($attribute, $value)
+    {
+        return is_string($value);
+    }
+
+    /**
+     * Validate that an attribute is a valid timezone.
+     *
+     * @param  string  $attribute
+     * @param  mixed   $value
+     * @return bool
+     */
+    public function validateTimezone($attribute, $value)
+    {
+        try {
+            new DateTimeZone($value);
+        } catch (Exception $e) {
+            return false;
+        } catch (Throwable $e) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Validate that an attribute is a valid URL.
+     *
+     * @param  string  $attribute
+     * @param  mixed   $value
+     * @return bool
+     */
+    public function validateUrl($attribute, $value)
+    {
+        if (! is_string($value)) {
+            return false;
+        }
+
+        /*
+         * This pattern is derived from Symfony\Component\Validator\Constraints\UrlValidator (2.7.4).
+         *
+         * (c) Fabien Potencier <fabien@symfony.com> http://symfony.com
+         */
+        $pattern = '~^
             ((aaa|aaas|about|acap|acct|acr|adiumxtra|afp|afs|aim|apt|attachment|aw|barion|beshare|bitcoin|blob|bolo|callto|cap|chrome|chrome-extension|cid|coap|coaps|com-eventbrite-attendee|content|crid|cvs|data|dav|dict|dlna-playcontainer|dlna-playsingle|dns|dntp|dtn|dvb|ed2k|example|facetime|fax|feed|feedready|file|filesystem|finger|fish|ftp|geo|gg|git|gizmoproject|go|gopher|gtalk|h323|ham|hcp|http|https|iax|icap|icon|im|imap|info|iotdisco|ipn|ipp|ipps|irc|irc6|ircs|iris|iris.beep|iris.lwz|iris.xpc|iris.xpcs|itms|jabber|jar|jms|keyparc|lastfm|ldap|ldaps|magnet|mailserver|mailto|maps|market|message|mid|mms|modem|ms-help|ms-settings|ms-settings-airplanemode|ms-settings-bluetooth|ms-settings-camera|ms-settings-cellular|ms-settings-cloudstorage|ms-settings-emailandaccounts|ms-settings-language|ms-settings-location|ms-settings-lock|ms-settings-nfctransactions|ms-settings-notifications|ms-settings-power|ms-settings-privacy|ms-settings-proximity|ms-settings-screenrotation|ms-settings-wifi|ms-settings-workplace|msnim|msrp|msrps|mtqp|mumble|mupdate|mvn|news|nfs|ni|nih|nntp|notes|oid|opaquelocktoken|pack|palm|paparazzi|pkcs11|platform|pop|pres|prospero|proxy|psyc|query|redis|rediss|reload|res|resource|rmi|rsync|rtmfp|rtmp|rtsp|rtsps|rtspu|secondlife|service|session|sftp|sgn|shttp|sieve|sip|sips|skype|smb|sms|smtp|snews|snmp|soap.beep|soap.beeps|soldat|spotify|ssh|steam|stun|stuns|submit|svn|tag|teamspeak|tel|teliaeid|telnet|tftp|things|thismessage|tip|tn3270|turn|turns|tv|udp|unreal|urn|ut2004|vemmi|ventrilo|videotex|view-source|wais|webcal|ws|wss|wtai|wyciwyg|xcon|xcon-userid|xfire|xmlrpc\.beep|xmlrpc.beeps|xmpp|xri|ymsgr|z39\.50|z39\.50r|z39\.50s))://                                 # protocol
             (([\pL\pN-]+:)?([\pL\pN-]+)@)?          # basic auth
             (
@@ -1528,116 +1383,107 @@ trait ValidatesAttributes
             (/?|/\S+|\?\S*|\#\S*)                   # a /, nothing, a / with something, a query or a fragment
         $~ixu';
 
-		return preg_match($pattern, $value) > 0;
-	}
+        return preg_match($pattern, $value) > 0;
+    }
 
+    /**
+     * Get the size of an attribute.
+     *
+     * @param  string  $attribute
+     * @param  mixed   $value
+     * @return mixed
+     */
+    protected function getSize($attribute, $value)
+    {
+        $hasNumeric = $this->hasRule($attribute, $this->numericRules);
 
-	/**
-	 * Get the size of an attribute.
-	 *
-	 * @param  string $attribute
-	 * @param  mixed $value
-	 *
-	 * @return mixed
-	 */
-	protected function getSize($attribute, $value)
-	{
-		$hasNumeric = $this->hasRule($attribute, $this->numericRules);
+        // This method will determine if the attribute is a number, string, or file and
+        // return the proper size accordingly. If it is a number, then number itself
+        // is the size. If it is a file, we take kilobytes, and for a string the
+        // entire length of the string will be considered the attribute size.
+        if (is_numeric($value) && $hasNumeric) {
+            return $value;
+        } elseif (is_array($value)) {
+            return count($value);
+        } elseif ($value instanceof File) {
+            return $value->getSize() / 1024;
+        }
 
-		// This method will determine if the attribute is a number, string, or file and
-		// return the proper size accordingly. If it is a number, then number itself
-		// is the size. If it is a file, we take kilobytes, and for a string the
-		// entire length of the string will be considered the attribute size.
-		if (is_numeric($value) && $hasNumeric) {
-			return $value;
-		} elseif (is_array($value)) {
-			return count($value);
-		} elseif ($value instanceof File) {
-			return $value->getSize() / 1024;
-		}
+        return mb_strlen($value);
+    }
 
-		return mb_strlen($value);
-	}
+    /**
+     * Check that the given value is a valid file instance.
+     *
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function isValidFileInstance($value)
+    {
+        if ($value instanceof UploadedFile && ! $value->isValid()) {
+            return false;
+        }
 
+        return $value instanceof File;
+    }
 
-	/**
-	 * Check that the given value is a valid file instance.
-	 *
-	 * @param  mixed $value
-	 *
-	 * @return bool
-	 */
-	public function isValidFileInstance($value)
-	{
-		if ($value instanceof UploadedFile && ! $value->isValid()) {
-			return false;
-		}
+    /**
+     * Determine if a comparison passes between the given values.
+     *
+     * @param  mixed  $first
+     * @param  mixed  $second
+     * @param  string  $operator
+     * @return bool
+     */
+    protected function compare($first, $second, $operator)
+    {
+        switch ($operator) {
+            case '<':
+                return $first < $second;
+            case '>':
+                return $first > $second;
+            case '<=':
+                return $first <= $second;
+            case '>=':
+                return $first >= $second;
+            case '=':
+                return $first == $second;
+            default:
+                throw new InvalidArgumentException;
+        }
+    }
 
-		return $value instanceof File;
-	}
+    /**
+     * Parse named parameters to $key => $value items.
+     *
+     * @param  array  $parameters
+     * @return array
+     */
+    protected function parseNamedParameters($parameters)
+    {
+        return array_reduce($parameters, function ($result, $item) {
+            list($key, $value) = array_pad(explode('=', $item, 2), 2, null);
 
+            $result[$key] = $value;
 
-	/**
-	 * Determine if a comparison passes between the given values.
-	 *
-	 * @param  mixed $first
-	 * @param  mixed $second
-	 * @param  string $operator
-	 *
-	 * @return bool
-	 */
-	protected function compare($first, $second, $operator)
-	{
-		switch ($operator) {
-			case '<':
-				return $first < $second;
-			case '>':
-				return $first > $second;
-			case '<=':
-				return $first <= $second;
-			case '>=':
-				return $first >= $second;
-			case '=':
-				return $first == $second;
-			default:
-				throw new InvalidArgumentException;
-		}
-	}
+            return $result;
+        });
+    }
 
-
-	/**
-	 * Parse named parameters to $key => $value items.
-	 *
-	 * @param  array $parameters
-	 *
-	 * @return array
-	 */
-	protected function parseNamedParameters($parameters)
-	{
-		return array_reduce($parameters, function ($result, $item) {
-			list($key, $value) = array_pad(explode('=', $item, 2), 2, null);
-
-			$result[$key] = $value;
-
-			return $result;
-		});
-	}
-
-
-	/**
-	 * Require a certain number of parameters to be present.
-	 *
-	 * @param  int $count
-	 * @param  array $parameters
-	 * @param  string $rule
-	 *
-	 * @return void
-	 * @throws \InvalidArgumentException
-	 */
-	protected function requireParameterCount($count, $parameters, $rule)
-	{
-		if (count($parameters) < $count) {
-			throw new InvalidArgumentException("Validation rule $rule requires at least $count parameters.");
-		}
-	}
+    /**
+     * Require a certain number of parameters to be present.
+     *
+     * @param  int    $count
+     * @param  array  $parameters
+     * @param  string  $rule
+     * @return void
+     *
+     * @throws \InvalidArgumentException
+     */
+    protected function requireParameterCount($count, $parameters, $rule)
+    {
+        if (count($parameters) < $count) {
+            throw new InvalidArgumentException("Validation rule $rule requires at least $count parameters.");
+        }
+    }
 }

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1678,6 +1678,16 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->passes());
     }
 
+    public function testValidateEquals()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['foo' => 'bar'], ['foo' => 'equals:foo']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'bar'], ['foo' => 'equals:bar']);
+        $this->assertTrue($v->passes());
+    }
+
     /**
      * @dataProvider validUrls
      */


### PR DESCRIPTION
This PR is duplicate of this closed https://github.com/laravel/framework/pull/21512

But @taylorotwell   same compares with other field value, this PR allow to compare with user defined value.
The only way for now is use `in:value`. Now we can define rule like this 
`'phone' => 'equals:123456789'`

