### PR TITLE
[5.5] Added missing postgres inet operators.

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -16,7 +16,7 @@ class PostgresGrammar extends Grammar
     protected $operators = [
         '=', '<', '>', '<=', '>=', '<>', '!=',
         'like', 'not like', 'between', 'ilike',
-        '&', '|', '#', '<<', '>>',
+        '&', '|', '#', '<<', '>>', '>>=', '=<<',
         '@>', '<@', '?', '?|', '?&', '||', '-', '-', '#-',
     ];
 


### PR DESCRIPTION
This will add two missing Postgres inet operators to the Postgres grammer. This should be backwards compatible to  all other versions.

List of Postgres operators:
https://www.postgresql.org/docs/9.6/static/functions-net.html