### PR TITLE
Add 5.5.14 release to changelog

### DIFF
--- a/CHANGELOG-5.5.md
+++ b/CHANGELOG-5.5.md
@@ -1,6 +1,6 @@
 # Release Notes for 5.5.x
 
-## [Unreleased]
+## 5.5.14 (2017-10-03)
 
 ### Added
 - Allow testing anonymous notifiables ([#21379](https://github.com/laravel/framework/pull/21379))


### PR DESCRIPTION
Adds missing changelog for Laravel [`v5.5.14`](https://github.com/laravel/framework/releases/tag/v5.5.14)