### PR TITLE
[5.5] Refactor resolve method to make more readable

### DIFF
--- a/src/Illuminate/Http/Resources/Json/Resource.php
+++ b/src/Illuminate/Http/Resources/Json/Resource.php
@@ -92,12 +92,12 @@ class Resource implements ArrayAccess, JsonSerializable, Responsable, UrlRoutabl
         );
 
         if ($data instanceof Arrayable) {
-            $data = $this->filter($data->toArray());
+            $data = $data->toArray();
         } elseif ($data instanceof JsonSerializable) {
-            $data = $this->filter($data->jsonSerialize());
+            $data = $data->jsonSerialize();
         }
 
-        return $this->filter($data);
+        return $this->filter((array) $data);
     }
 
     /**

--- a/src/Illuminate/Http/Resources/Json/Resource.php
+++ b/src/Illuminate/Http/Resources/Json/Resource.php
@@ -92,9 +92,9 @@ class Resource implements ArrayAccess, JsonSerializable, Responsable, UrlRoutabl
         );
 
         if ($data instanceof Arrayable) {
-            return $this->filter($data->toArray());
+            $data = $this->filter($data->toArray());
         } elseif ($data instanceof JsonSerializable) {
-            return $this->filter($data->jsonSerialize());
+            $data = $this->filter($data->jsonSerialize());
         }
 
         return $this->filter($data);

--- a/src/Illuminate/Http/Resources/Json/Resource.php
+++ b/src/Illuminate/Http/Resources/Json/Resource.php
@@ -91,12 +91,12 @@ class Resource implements ArrayAccess, JsonSerializable, Responsable, UrlRoutabl
             $request = $request ?: Container::getInstance()->make('request')
         );
 
-        if (is_array($data)) {
-            $data = $data;
-        } elseif ($data instanceof Arrayable || $data instanceof Collection) {
-            $data = $data->toArray();
-        } elseif ($data instanceof JsonSerializable) {
-            $data = $data->jsonSerialize();
+        if ($data instanceof Arrayable || $data instanceof Collection) {
+            return $this->filter((array) $data->toArray());
+        }
+
+        if ($data instanceof JsonSerializable) {
+            return $this->filter((array) $data->jsonSerialize());
         }
 
         return $this->filter((array) $data);

--- a/src/Illuminate/Http/Resources/Json/Resource.php
+++ b/src/Illuminate/Http/Resources/Json/Resource.php
@@ -91,15 +91,15 @@ class Resource implements ArrayAccess, JsonSerializable, Responsable, UrlRoutabl
             $request = $request ?: Container::getInstance()->make('request')
         );
 
-        if ($data instanceof Arrayable || $data instanceof Collection) {
-            return $this->filter((array) $data->toArray());
+        if ($data instanceof Arrayable) {
+            return $this->filter($data->toArray());
         }
 
         if ($data instanceof JsonSerializable) {
-            return $this->filter((array) $data->jsonSerialize());
+            return $this->filter($data->jsonSerialize());
         }
 
-        return $this->filter((array) $data);
+        return $this->filter($data);
     }
 
     /**

--- a/src/Illuminate/Http/Resources/Json/Resource.php
+++ b/src/Illuminate/Http/Resources/Json/Resource.php
@@ -93,9 +93,7 @@ class Resource implements ArrayAccess, JsonSerializable, Responsable, UrlRoutabl
 
         if ($data instanceof Arrayable) {
             return $this->filter($data->toArray());
-        }
-
-        if ($data instanceof JsonSerializable) {
+        } elseif ($data instanceof JsonSerializable) {
             return $this->filter($data->jsonSerialize());
         }
 


### PR DESCRIPTION
In the pull request I have altered the `resolve` method within the `Resource` class. It seems a bit odd in my opinion to be setting a variable to itself `$data = $data`. Therefore I have altered this slightly to remove it and make it more readable (in my opinion)
