### PR TITLE
[5.5] Adding App::isProduction

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -511,6 +511,16 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     }
 
     /**
+     * Determine if application is in production environment.
+     *
+     * @return bool
+     */
+    public function isProduction()
+    {
+        return $this['env'] == 'production';
+    }
+
+    /**
      * Detect the application's current environment.
      *
      * @param  \Closure  $callback


### PR DESCRIPTION
It's common to have a few differences between production and local/staging/testing environments, for example back-up or some jobs. It'd be useful if we'd have an `isProduction` pair next to `isLocal` to avoid bugs originating from string typos (`App::environment() == 'productiom'`).