### PR TITLE
[5.5] Maintain queue and connection on chained jobs

### DIFF
--- a/src/Illuminate/Bus/Queueable.php
+++ b/src/Illuminate/Bus/Queueable.php
@@ -96,6 +96,8 @@ trait Queueable
         if (! empty($this->chained)) {
             dispatch(tap(unserialize(array_shift($this->chained)), function ($next) {
                 $next->chained = $this->chained;
+                $next->onConnection($this->connection);
+                $next->onQueue($this->queue);
             }));
         }
     }

--- a/src/Illuminate/Bus/Queueable.php
+++ b/src/Illuminate/Bus/Queueable.php
@@ -96,8 +96,8 @@ trait Queueable
         if (! empty($this->chained)) {
             dispatch(tap(unserialize(array_shift($this->chained)), function ($next) {
                 $next->chained = $this->chained;
-                $next->onConnection($this->connection);
-                $next->onQueue($this->queue);
+                $next->onConnection($next->connection ?: $this->connection);
+                $next->onQueue($next->queue ?: $this->queue);
             }));
         }
     }

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -122,7 +122,12 @@ class FilesystemTest extends TestCase
         file_put_contents($this->tempDir.'/foo/2.txt', '2');
         mkdir($this->tempDir.'/foo/bar');
         $files = new Filesystem;
-        $this->assertEquals([$this->tempDir.'/foo/1.txt', $this->tempDir.'/foo/2.txt'], $files->files($this->tempDir.'/foo'));
+
+        $results = collect($files->files($this->tempDir.'/foo'))->map(function($file){
+            return $file->getPathName();
+        });
+
+        $this->assertEquals([$this->tempDir.'/foo/1.txt', $this->tempDir.'/foo/2.txt'], $results->toArray());
         unset($files);
     }
 

--- a/tests/Integration/Queue/JobChainingTest.php
+++ b/tests/Integration/Queue/JobChainingTest.php
@@ -111,6 +111,16 @@ class JobChainingTest extends TestCase
         $this->assertTrue(JobChainingTestFirstJob::$ran);
         $this->assertFalse(JobChainingTestThirdJob::$ran);
     }
+
+    public function test_chain_jobs_use_same_config()
+    {
+        JobChainingTestFirstJob::dispatch()->onQueue('some_queue')->onConnection('sync')->chain([
+            new JobChainingTestSecondJob,
+        ]);
+
+        $this->assertEquals('some_queue', JobChainingTestSecondJob::$usedQueue);
+        $this->assertEquals('sync', JobChainingTestSecondJob::$usedConnection);
+    }
 }
 
 class JobChainingTestFirstJob implements ShouldQueue
@@ -118,10 +128,14 @@ class JobChainingTestFirstJob implements ShouldQueue
     use Dispatchable, Queueable;
 
     public static $ran = false;
+    public static $usedQueue = null;
+    public static $usedConnection = null;
 
     public function handle()
     {
         static::$ran = true;
+        static::$usedQueue = $this->queue;
+        static::$usedConnection = $this->connection;
     }
 }
 
@@ -130,10 +144,14 @@ class JobChainingTestSecondJob implements ShouldQueue
     use Dispatchable, Queueable;
 
     public static $ran = false;
+    public static $usedQueue = null;
+    public static $usedConnection = null;
 
     public function handle()
     {
         static::$ran = true;
+        static::$usedQueue = $this->queue;
+        static::$usedConnection = $this->connection;
     }
 }
 
@@ -142,10 +160,15 @@ class JobChainingTestThirdJob implements ShouldQueue
     use Dispatchable, Queueable;
 
     public static $ran = false;
+    public static $usedQueue = null;
+    public static $usedConnection = null;
 
     public function handle()
     {
         static::$ran = true;
+        static::$usedQueue = $this->queue;
+        static::$usedConnection = $this->connection;
+
     }
 }
 

--- a/tests/Integration/Queue/JobChainingTest.php
+++ b/tests/Integration/Queue/JobChainingTest.php
@@ -121,6 +121,16 @@ class JobChainingTest extends TestCase
         $this->assertEquals('some_queue', JobChainingTestSecondJob::$usedQueue);
         $this->assertEquals('sync', JobChainingTestSecondJob::$usedConnection);
     }
+
+    public function test_chain_jobs_use_own_config()
+    {
+        JobChainingTestFirstJob::dispatch()->onQueue('some_queue')->onConnection('sync')->chain([
+            (new JobChainingTestSecondJob)->onQueue('another_queue'),
+        ]);
+
+        $this->assertEquals('another_queue', JobChainingTestSecondJob::$usedQueue);
+        $this->assertEquals('sync', JobChainingTestSecondJob::$usedConnection);
+    }
 }
 
 class JobChainingTestFirstJob implements ShouldQueue

--- a/tests/Integration/Queue/JobChainingTest.php
+++ b/tests/Integration/Queue/JobChainingTest.php
@@ -168,7 +168,6 @@ class JobChainingTestThirdJob implements ShouldQueue
         static::$ran = true;
         static::$usedQueue = $this->queue;
         static::$usedConnection = $this->connection;
-
     }
 }
 


### PR DESCRIPTION
While doing:

```php
JobA::withChain([
       ( new JobB() ),
       ( new JobB() )
])->dispatch()
  ->onConnection('custom-connection')
  ->onQueue('custom-queue');
```

The selected connection and queue won't be used for chained jobs, only JobA. This PR fixes that.

If you explicitly define a queue/connection on a job, it'll be used instead of the main one.

```php
JobA::withChain([
       (new JobB())->onQueue('some_queue'),
       new JobB()
])->dispatch()
  ->onConnection('custom-connection')
  ->onQueue('custom-queue');
```

Here JobB will run on `some_queue` while the rest of the jobs will run on `custom-queue`