### PR TITLE
[5.5] definition for Job interface

### DIFF
--- a/src/Illuminate/Contracts/Queue/Job.php
+++ b/src/Illuminate/Contracts/Queue/Job.php
@@ -2,6 +2,11 @@
 
 namespace Illuminate\Contracts\Queue;
 
+/**
+ * @mixin \Illuminate\Queue\Jobs\Job
+ *
+ * @method int getJobId()
+ */
 interface Job
 {
     /**


### PR DESCRIPTION
defining methods available via @mixin 

also "patch" for 5.5 to show that getJobId() is standard, 5.6 includes the methods.

https://github.com/laravel/framework/pull/21298
https://github.com/laravel/framework/pull/21303