### PR TITLE
`package:discover` prints an incorrect list of packages

### DIFF
--- a/src/Illuminate/Foundation/PackageManifest.php
+++ b/src/Illuminate/Foundation/PackageManifest.php
@@ -116,7 +116,7 @@ class PackageManifest
 
         $ignoreAll = in_array('*', $ignore = $this->packagesToIgnore());
 
-        $this->write(collect($packages)->mapWithKeys(function ($package) {
+        $this->write($this->manifest = collect($packages)->mapWithKeys(function ($package) {
             return [$this->format($package['name']) => $package['extra']['laravel'] ?? []];
         })->each(function ($configuration) use (&$ignore) {
             $ignore += $configuration['dont-discover'] ?? [];


### PR DESCRIPTION
This fixes #21538.

This updates the cached `$manifest` array after it's built, so that the console command can print the correct list of packages.