### PR TITLE
[5.6] Add console command to compile all views.

### DIFF
--- a/src/Illuminate/Foundation/Console/ViewCacheCommand.php
+++ b/src/Illuminate/Foundation/Console/ViewCacheCommand.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Illuminate\Foundation\Console;
+
+use RuntimeException;
+use Illuminate\Console\Command;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\View\Engines\CompilerEngine;
+
+class ViewCacheCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'view:cache
+                    {--f|force : Compile all views regardless of their timestamp}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Compile all view files';
+
+    /**
+     * The filesystem instance.
+     *
+     * @var \Illuminate\Filesystem\Filesystem
+     */
+    protected $files;
+
+    /**
+     * Create a new config clear command instance.
+     *
+     * @param  \Illuminate\Filesystem\Filesystem  $files
+     * @return void
+     */
+    public function __construct(Filesystem $files)
+    {
+        parent::__construct();
+
+        $this->files = $files;
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        $force = $this->option('force');
+
+        $paths = $this->laravel['config']['view.paths'];
+        if (! $paths) {
+            throw new RuntimeException('View path not found.');
+        }
+
+        $factory = view();
+
+        foreach ($paths as $path) {
+            foreach ($this->files->allFiles($path) as $file) {
+                $path = $file->getRealPath();
+
+                $engine = $factory->getEngineFromPath($path);
+                if (! ($engine instanceof CompilerEngine)) {
+                    continue;
+                }
+
+                $compiler = $engine->getCompiler();
+                if ($force || $compiler->isExpired($path)) {
+                    $compiler->compile($path);
+                    $this->info('Compiled view: '.$path, 'v');
+                }
+            }
+        }
+
+        $this->info('Views cached successfully!', 'normal');
+    }
+}


### PR DESCRIPTION
Right now the directories for views cache and bootstrap/cache are the only ones that need to be both writable by apache and executable by php. By compiling the views ahead of time, the views cache folder can be made read-only, improving the security. Also this has the added benefit of making the views first render faster.