### PR TITLE
[5.5] Supporting Laravel-Mix PR #1246, HMR w/ different Hosts and Ports

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -555,6 +555,12 @@ if (! function_exists('mix')) {
         }
 
         if (file_exists(public_path($manifestDirectory.'/hot'))) {
+            $url = file_get_contents(public_path($manifestDirectory.'/hot'));
+
+            if(Str::startsWith($url, 'http://') || Str::startsWith($url, 'https://')) {
+                return new HtmlString(Str::after($url, ':') . $path);
+            }
+
             return new HtmlString("//localhost:8080{$path}");
         }
 

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -557,8 +557,8 @@ if (! function_exists('mix')) {
         if (file_exists(public_path($manifestDirectory.'/hot'))) {
             $url = file_get_contents(public_path($manifestDirectory.'/hot'));
 
-            if(Str::startsWith($url, 'http://') || Str::startsWith($url, 'https://')) {
-                return new HtmlString(Str::after($url, ':') . $path);
+            if (Str::startsWith($url, 'http://') || Str::startsWith($url, 'https://')) {
+                return new HtmlString(Str::after($url, ':').$path);
             }
 
             return new HtmlString("//localhost:8080{$path}");


### PR DESCRIPTION
This PR changes the 'mix' helper function to take URLs coming from the hot file. This feature is fully backwards compatible.

Supporting Laravel-Mix Pull Request https://github.com/JeffreyWay/laravel-mix/pull/1246, allowing Hot Module Reloading with custom hosts and ports

Please don't merge straight away, I'm awaiting a reply to https://github.com/JeffreyWay/laravel-mix/pull/1246

Let me know if you require tests for the code change