### PR TITLE
[5.5] Added option to make new model a pivot model

### DIFF
--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -112,6 +112,10 @@ class ModelMakeCommand extends GeneratorCommand
      */
     protected function getStub()
     {
+        if ($this->option('pivot')) {
+            return __DIR__.'/stubs/pivot.model.stub';
+        }
+
         return __DIR__.'/stubs/model.stub';
     }
 
@@ -145,6 +149,8 @@ class ModelMakeCommand extends GeneratorCommand
             ['migration', 'm', InputOption::VALUE_NONE, 'Create a new migration file for the model.'],
 
             ['resource', 'r', InputOption::VALUE_NONE, 'Indicates if the generated controller should be a resource controller.'],
+
+            ['pivot', 'p', InputOption::VALUE_NONE, 'Indicates if the generated model should be a custom intermediate table model.'],
         ];
     }
 }

--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -148,9 +148,9 @@ class ModelMakeCommand extends GeneratorCommand
 
             ['migration', 'm', InputOption::VALUE_NONE, 'Create a new migration file for the model.'],
 
-            ['resource', 'r', InputOption::VALUE_NONE, 'Indicates if the generated controller should be a resource controller.'],
-
             ['pivot', 'p', InputOption::VALUE_NONE, 'Indicates if the generated model should be a custom intermediate table model.'],
+            
+            ['resource', 'r', InputOption::VALUE_NONE, 'Indicates if the generated controller should be a resource controller.'],
         ];
     }
 }

--- a/src/Illuminate/Foundation/Console/stubs/pivot.model.stub
+++ b/src/Illuminate/Foundation/Console/stubs/pivot.model.stub
@@ -1,0 +1,10 @@
+<?php
+
+namespace DummyNamespace;
+
+use Illuminate\Database\Eloquent\Relations\Pivot;
+
+class DummyClass extends Pivot
+{
+    //
+}


### PR DESCRIPTION
Added an option to make a new model a pivot (custom intermediate table) model via `artisan make:model`.

To do so, one can simply add the `-p|--pivot` flag/option: `artisan make:model -p MyModel`