### PR TITLE
get all request inputs without null inputs

### DIFF
--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -176,6 +176,20 @@ trait InteractsWithInput
     }
 
     /**
+     * Get all of the input and files for the request without null input.
+     *
+     * @param  array|mixed $keys
+     * @return array
+     */
+    public function allWithoutNull($keys = null)
+    {
+        $inputs = $this->all($keys);
+        return Arr::whereRecursive($inputs, function ($value, $key) {
+            return !(null === $value || $value === '' || $value === []);
+        });
+    }
+
+    /**
      * Retrieve an input item from the request.
      *
      * @param  string  $key

--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -594,6 +594,25 @@ class Arr
     }
 
     /**
+     * Filter the array using the given callback Recursively.
+     *
+     * @param  array $array
+     * @param  callable $callback
+     * @return array
+     */
+    public static function whereRecursive(array $array, callable $callback = null)
+    {
+        $array = is_callable($callback) ? static::where($array, $callback) : array_filter($array);
+        foreach ($array as &$value) {
+            if (is_array($value)) {
+                $value = call_user_func(__CLASS__ . '::' . __FUNCTION__, $value, $callback);
+            }
+        }
+
+        return $array;
+    }
+
+    /**
      * If the given value is not an array, wrap it in one.
      *
      * @param  mixed  $value

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -855,4 +855,29 @@ class HttpRequestTest extends TestCase
         $request->setLaravelSession($session);
         $request->flashExcept(['email']);
     }
+
+    public function testAllWithoutNullInputReturnsNestedInputAndFiles()
+    {
+        $file = $this->getMockBuilder('Illuminate\Http\UploadedFile')->setConstructorArgs([__FILE__, 'photo.jpg'])->getMock();
+        $request = Request::create('/?boom=', 'GET', ['foo' => []], [], ['foo' => ['file' => $file, 'anotherFile' => null]]);
+        $this->assertEquals(['foo' => ['file' => $file]], $request->allWithoutNull());
+    }
+
+    public function testAllWithoutNullInputReturnsInputAfterReplace()
+    {
+        $request = Request::create('/?boom=breeze', 'GET', ['foo' => ['bar' => 'baz']]);
+        $request->replace(['foo' => ['bar' => 'baz'], 'boom' => '']);
+        $this->assertEquals(['foo' => ['bar' => 'baz']], $request->allWithoutNull());
+    }
+
+    public function testAllWithoutNullInputWithNumericKeysReturnsInputAfterReplace()
+    {
+        $request1 = Request::create('/', 'POST', [0 => 'A', 1 => 'B', 2 => 'C']);
+        $request1->replace([0 => '', 1 => 'B', 2 => 'C']);
+        $this->assertEquals([1 => 'B', 2 => 'C'], $request1->allWithoutNull());
+
+        $request2 = Request::create('/', 'POST', [1 => 'A', 2 => 'B', 3 => 'C']);
+        $request2->replace([1 => 'A', 2 => '', 3 => 'C']);
+        $this->assertEquals([1 => 'A', 3 => 'C'], $request2->allWithoutNull());
+    }
 }


### PR DESCRIPTION
sometimes we need to get inputs from request without the null inputs to use with models 
`Model::create($request->allWithoutNull()`