### PR TITLE
[5.5] Remove unused parameter from list

### DIFF
--- a/src/Illuminate/Foundation/Http/Kernel.php
+++ b/src/Illuminate/Foundation/Http/Kernel.php
@@ -210,7 +210,7 @@ class Kernel implements KernelContract
                 continue;
             }
 
-            list($name, $parameters) = $this->parseMiddleware($middleware);
+            list($name) = $this->parseMiddleware($middleware);
 
             $instance = $this->app->make($name);
 


### PR DESCRIPTION
Minus 2 opcodes.
Plus 8 bytes to free memory.