### PR TITLE
[5.5] Fix storage link creation

### DIFF
--- a/src/Illuminate/Foundation/Console/StorageLinkCommand.php
+++ b/src/Illuminate/Foundation/Console/StorageLinkCommand.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Foundation\Console;
 
+use Storage;
 use Illuminate\Console\Command;
 
 class StorageLinkCommand extends Command
@@ -32,7 +33,7 @@ class StorageLinkCommand extends Command
         }
 
         $this->laravel->make('files')->link(
-            storage_path('app/public'), public_path('storage')
+            rtrim(Storage::disk('public')->path(''), '/'), public_path('storage')
         );
 
         $this->info('The [public/storage] directory has been linked.');


### PR DESCRIPTION
There is a bug when custom directory for public storage is used.
If files should be saved on external drive (e.g. /media/disk1), we'll have to change value of disks.public.root in config/filesystems.php file.
Nevertheless php artisan storage:link command works wrong and create link to storage/app/public instead of link, defined in config/filesystems.php