### PR TITLE
Add DatabaseTruncations as Alternative to DatabaseMigrations

### DIFF
--- a/src/Illuminate/Foundation/Testing/DatabaseTruncations.php
+++ b/src/Illuminate/Foundation/Testing/DatabaseTruncations.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Illuminate\Foundation\Testing;
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+trait DatabaseTruncations
+{
+    /**
+     * Truncates all tables except for `migrations` table.
+     *
+     * @return void
+     */
+    protected function truncateTables()
+    {
+        Schema::disableForeignKeyConstraints();
+
+        $tableNames = collect(array_map('reset', DB::select('SHOW TABLES')))
+            ->reject(function ($table) {
+                return $table == 'migrations';
+            })
+            ->each(function ($table) {
+                DB::table($table)->truncate();
+            });
+
+        Schema::enableForeignKeyConstraints();
+    }
+}

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -130,6 +130,10 @@ abstract class TestCase extends BaseTestCase
      */
     protected function tearDown()
     {
+        if (isset($uses[DatabaseTruncations::class])) {
+            $this->truncateTables();
+        }
+
         if ($this->app) {
             foreach ($this->beforeApplicationDestroyedCallbacks as $callback) {
                 call_user_func($callback);


### PR DESCRIPTION
Added another database reset strategy which is using truncation.

This is useful when running Dusk tests which currently only works with DatabaseMigrations.

By switching Dusk tests to DatabaseTruncations it might speed up the database reset process.

DatabaseTruncations will run during `tearDown` process.

Probably it is possible to integrate this into `RefreshDatabase` trait where it will run
truncations for Dusk tests.