### PR TITLE
[5.5] Enhance Mailable queueing

### DIFF
--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -165,7 +165,7 @@ class Mailable implements MailableContract, Renderable
     }
 
     /**
-     * Create job to be queued
+     * Create job to be queued.
      *
      * @return SendQueuedMailable
      */

--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -142,7 +142,7 @@ class Mailable implements MailableContract, Renderable
         $queueName = property_exists($this, 'queue') ? $this->queue : null;
 
         return $queue->connection($connection)->pushOn(
-            $queueName ?: null, new SendQueuedMailable($this)
+            $queueName ?: null, $this->createJob()
         );
     }
 
@@ -160,8 +160,18 @@ class Mailable implements MailableContract, Renderable
         $queueName = property_exists($this, 'queue') ? $this->queue : null;
 
         return $queue->connection($connection)->laterOn(
-            $queueName ?: null, $delay, new SendQueuedMailable($this)
+            $queueName ?: null, $delay, $this->createJob()
         );
+    }
+
+    /**
+     * Create job to be queued
+     *
+     * @return SendQueuedMailable
+     */
+    protected function createJob()
+    {
+        return new SendQueuedMailable($this);
     }
 
     /**


### PR DESCRIPTION
It is impossible to enhance or change queue job in Mailable now. 

For example it would be nice to add [failed](https://laravel.com/docs/5.5/queues#dealing-with-failed-jobs) method to Job to handle job failures. But it is impossible now.

With job factory method we can use any custom Job for Mailables. It will be possible to add [failed](https://laravel.com/docs/5.5/queues#dealing-with-failed-jobs) method.