### PR TITLE
[5.6] Added new method rotate in collection class

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1212,7 +1212,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
-     * Roate the items in the collection
+     * Roate the items in the collection.
      *
      * @param  int  $offset
      * @return static
@@ -1223,7 +1223,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
 
         $offset %= $count;
 
-        if($offset < 0) {
+        if ($offset < 0) {
             $offset += $count;
         }
 

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1219,6 +1219,10 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      */
     public function rotate($offset)
     {
+        if ($this->isEmpty()) {
+            return new static;
+        }
+
         $count = $this->count();
 
         $offset %= $count;

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1212,6 +1212,25 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
+     * Roate the items in the collection
+     *
+     * @param  int  $offset
+     * @return static
+     */
+    public function rotate($offset)
+    {
+        $count = $this->count();
+
+        $offset %= $count;
+
+        if($offset < 0) {
+            $offset += $count;
+        }
+
+        return new static($this->slice($offset)->merge($this->take($offset)));
+    }
+
+    /**
      * Search the collection for a given value and return the corresponding key if successful.
      *
      * @param  mixed  $value

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2325,6 +2325,30 @@ class SupportCollectionTest extends TestCase
 
         $this->assertSame(['michael', 'tom', 'taylor'], $collection->toArray());
     }
+
+    public function testRotateOffset()
+    {
+        $collection = new Collection([1, 2, 3, 4, 5, 6]);
+        $this->assertEquals([3, 4, 5, 6, 1, 2], $collection->rotate(2)->toArray());
+    }
+
+    public function testRotateNegativeOffset()
+    {
+        $collection = new Collection([1, 2, 3, 4, 5, 6]);
+        $this->assertEquals([5, 6, 1, 2, 3, 4], $collection->rotate(-2)->toArray());
+    }
+
+    public function testRotateOffsetWithKeys()
+    {
+        $collection = new Collection(['first' => 1, 'second' => 2, 'third' => 3, 'fourth' => 4, 'fifth' => 5]);
+        $this->assertEquals(['fourth' => 4, 'fifth' => 5, 'first' => 1, 'second' => 2, 'third' => 3], $collection->rotate(3)->toArray());
+    }
+
+    public function testRotateNegativeOffsetWithKeys()
+    {
+        $collection = new Collection(['first' => 1, 'second' => 2, 'third' => 3, 'fourth' => 4, 'fifth' => 5]);
+        $this->assertEquals(['third' => 3, 'fourth' => 4, 'fifth' => 5, 'first' => 1, 'second' => 2], $collection->rotate(-3)->toArray());
+    }
 }
 
 class TestSupportCollectionHigherOrderItem


### PR DESCRIPTION
This is the PR for adding the new method `rotate` in collection class.

It is similar to the one that ruby has.

**rotate()**

Roate the items in the given collection
```

$collection = collect([1, 2, 3, 4, 5, 6]);

$rotate = $collection->rotate(1);

$rotate->all();

// [2, 3, 4, 5, 6, 1]
```


```
$collection = collect([ "one" => 1, "two" => 2, "three" => 3, "four" => 4]);

$rotate = $collection->rotate(2);

$rotate->all();

// [  "three" => 3, "four" => 4, "one" => 1, "two" => 2]
```
