### PR TITLE
[5.6] Updated LengthAwarePaginator

### DIFF
--- a/src/Illuminate/Pagination/LengthAwarePaginator.php
+++ b/src/Illuminate/Pagination/LengthAwarePaginator.php
@@ -77,6 +77,7 @@ class LengthAwarePaginator extends AbstractPaginator implements Arrayable, Array
      *
      * @param  string|null  $view
      * @param  array  $data
+     * @param int|null $onEachSide
      * @return \Illuminate\Support\HtmlString
      */
     public function links($view = null, $data = [], $onEachSide = 3)

--- a/src/Illuminate/Pagination/LengthAwarePaginator.php
+++ b/src/Illuminate/Pagination/LengthAwarePaginator.php
@@ -27,7 +27,13 @@ class LengthAwarePaginator extends AbstractPaginator implements Arrayable, Array
      * @var int
      */
     protected $lastPage;
-
+    
+    /**
+    * Number of links to display on each side of pagination
+    *
+    * @var int
+    */
+    public $onEachSide;
     /**
      * Create a new paginator instance.
      *
@@ -73,8 +79,12 @@ class LengthAwarePaginator extends AbstractPaginator implements Arrayable, Array
      * @param  array  $data
      * @return \Illuminate\Support\HtmlString
      */
-    public function links($view = null, $data = [])
+    public function links($view = null, $data = [], $onEachSide = 3)
     {
+        if(!$data){
+            $data = [];
+        }
+        $this->onEachSide = $onEachSide;       
         return $this->render($view, $data);
     }
 

--- a/src/Illuminate/Pagination/LengthAwarePaginator.php
+++ b/src/Illuminate/Pagination/LengthAwarePaginator.php
@@ -27,13 +27,14 @@ class LengthAwarePaginator extends AbstractPaginator implements Arrayable, Array
      * @var int
      */
     protected $lastPage;
-    
+
     /**
     * Number of links to display on each side of pagination
     *
     * @var int
     */
     public $onEachSide;
+
     /**
      * Create a new paginator instance.
      *
@@ -77,15 +78,17 @@ class LengthAwarePaginator extends AbstractPaginator implements Arrayable, Array
      *
      * @param  string|null  $view
      * @param  array  $data
-     * @param int|null $onEachSide
+     * @param  int  $onEachSide
      * @return \Illuminate\Support\HtmlString
      */
     public function links($view = null, $data = [], $onEachSide = 3)
     {
-        if(!$data){
+        if (! $data) {
             $data = [];
         }
-        $this->onEachSide = $onEachSide;       
+
+        $this->onEachSide = $onEachSide;
+
         return $this->render($view, $data);
     }
 

--- a/src/Illuminate/Pagination/UrlWindow.php
+++ b/src/Illuminate/Pagination/UrlWindow.php
@@ -28,7 +28,6 @@ class UrlWindow
      * Create a new URL window instance.
      *
      * @param  \Illuminate\Contracts\Pagination\LengthAwarePaginator  $paginator
-     * @param  int  $onEachSide
      * @return array
      */
     public static function make(PaginatorContract $paginator)

--- a/src/Illuminate/Pagination/UrlWindow.php
+++ b/src/Illuminate/Pagination/UrlWindow.php
@@ -31,9 +31,9 @@ class UrlWindow
      * @param  int  $onEachSide
      * @return array
      */
-    public static function make(PaginatorContract $paginator, $onEachSide = 3)
+    public static function make(PaginatorContract $paginator)
     {
-        return (new static($paginator))->get($onEachSide);
+        return (new static($paginator))->get($paginator->onEachSide);
     }
 
     /**


### PR DESCRIPTION
Updated LengthAwarePaginator so that the links method takes an optional parameter for $onEachSide. This is saved as a property of the object and is referenced in UrlWindow as such, instead of being passed in as a parameter to UrlWindow->make()