### PR TITLE
[5.5] Blade: Make @json directive safe for use in HTML

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesJson.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesJson.php
@@ -5,6 +5,16 @@ namespace Illuminate\View\Compilers\Concerns;
 trait CompilesJson
 {
     /**
+     * Default encoding options.
+     *
+     * To make JSON safe for embedding into HTML, <, >, ', &, and " characters
+     * should be escaped.
+     *
+     * @var int
+     */
+    private $safeEncodingOptions = JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT;
+
+    /**
      * Compile the JSON statement into valid PHP.
      *
      * @param  string  $expression
@@ -14,7 +24,7 @@ trait CompilesJson
     {
         $parts = explode(',', $this->stripParentheses($expression));
 
-        $options = trim($parts[1] ?? 0);
+        $options = trim($parts[1] ?? $this->safeEncodingOptions);
         $depth = trim($parts[2] ?? 512);
 
         return "<?php echo json_encode($parts[0], $options, $depth) ?>";

--- a/src/Illuminate/View/Compilers/Concerns/CompilesJson.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesJson.php
@@ -14,9 +14,8 @@ trait CompilesJson
     {
         $parts = explode(',', $this->stripParentheses($expression));
 
-        $options = $parts[1] ?? 0;
-
-        $depth = $parts[2] ?? 512;
+        $options = trim($parts[1] ?? 0);
+        $depth = trim($parts[2] ?? 512);
 
         return "<?php echo json_encode($parts[0], $options, $depth) ?>";
     }

--- a/tests/View/Blade/BladeJsonTest.php
+++ b/tests/View/Blade/BladeJsonTest.php
@@ -15,7 +15,7 @@ class BladeJsonTest extends AbstractBladeTestCase
     public function testEncodingOptionsCanBeOverwritten()
     {
         $string = 'var foo = @json($var, JSON_HEX_TAG);';
-        $expected = 'var foo = <?php echo json_encode($var,  JSON_HEX_TAG, 512) ?>;';
+        $expected = 'var foo = <?php echo json_encode($var, JSON_HEX_TAG, 512) ?>;';
 
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }

--- a/tests/View/Blade/BladeJsonTest.php
+++ b/tests/View/Blade/BladeJsonTest.php
@@ -4,10 +4,10 @@ namespace Illuminate\Tests\View\Blade;
 
 class BladeJsonTest extends AbstractBladeTestCase
 {
-    public function testStatementIsCompiledWithDefaultEncodingOptions()
+    public function testStatementIsCompiledWithSafeDefaultEncodingOptions()
     {
         $string = 'var foo = @json($var);';
-        $expected = 'var foo = <?php echo json_encode($var, 0, 512) ?>;';
+        $expected = 'var foo = <?php echo json_encode($var, 15, 512) ?>;';
 
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }

--- a/tests/View/Blade/BladeJsonTest.php
+++ b/tests/View/Blade/BladeJsonTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Illuminate\Tests\View\Blade;
+
+class BladeJsonTest extends AbstractBladeTestCase
+{
+    public function testStatementIsCompiledWithDefaultEncodingOptions()
+    {
+        $string = 'var foo = @json($var);';
+        $expected = 'var foo = <?php echo json_encode($var, 0, 512) ?>;';
+
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+
+    public function testEncodingOptionsCanBeOverwritten()
+    {
+        $string = 'var foo = @json($var, JSON_HEX_TAG);';
+        $expected = 'var foo = <?php echo json_encode($var,  JSON_HEX_TAG, 512) ?>;';
+
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+}


### PR DESCRIPTION
As suggested by @ryantology [here](https://github.com/laravel/framework/pull/21004#issuecomment-330584750), the `@json` directive should by default use encoding options that are safe to use in HTML output.

We encountered a similar problem recently in Flarum that we [fixed](https://github.com/flarum/core/commit/ea4d889b76ba03ddf55a77d6333c0a8352b9b854) in a similar, albeit incomplete way. Once we upgrade to Laravel 5.5, we can then use the `@json` directive.

Technically, this is *slightly* breaking backwards-compatible, but doing so for the XSS-safety of the people, so I hope this is okay.

This also adds test and slightly prettifies the compiled output. :)