### PR TITLE
[5.5] Updates the Exception Handler in order to allow custom AuthenticationException message

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -216,7 +216,7 @@ class Handler implements ExceptionHandlerContract
     protected function unauthenticated($request, AuthenticationException $exception)
     {
         return $request->expectsJson()
-                    ? response()->json(['message' => 'Unauthenticated.'], 401)
+                    ? response()->json(['message' => $exception->getMessage()], 401)
                     : redirect()->guest(route('login'));
     }
 


### PR DESCRIPTION
Before the PR, in the handler the custom message is overwritten before returning the response.

Example use case: the user account gets disabled while the user is logged in the app and we want to logout the user and throw an exception with an appropriate message.