### PR TITLE
[5.5] Bail when array is provided as key in Session::flash

### DIFF
--- a/src/Illuminate/Session/Store.php
+++ b/src/Illuminate/Session/Store.php
@@ -337,12 +337,8 @@ class Store implements Session
      * @param  mixed   $value
      * @return void
      */
-    public function flash($key, $value = true)
+    public function flash(string $key, $value = true)
     {
-        if (! is_string($key)) {
-            throw new \InvalidArgumentException('Flash key expects a string.');
-        }
-
         $this->put($key, $value);
 
         $this->push('_flash.new', $key);

--- a/src/Illuminate/Session/Store.php
+++ b/src/Illuminate/Session/Store.php
@@ -339,6 +339,10 @@ class Store implements Session
      */
     public function flash($key, $value = true)
     {
+        if (!is_string($key)) {
+            throw new \InvalidArgumentException('Flash key expects a string.');
+        }
+
         $this->put($key, $value);
 
         $this->push('_flash.new', $key);

--- a/src/Illuminate/Session/Store.php
+++ b/src/Illuminate/Session/Store.php
@@ -339,7 +339,7 @@ class Store implements Session
      */
     public function flash($key, $value = true)
     {
-        if (!is_string($key)) {
+        if (! is_string($key)) {
             throw new \InvalidArgumentException('Flash key expects a string.');
         }
 


### PR DESCRIPTION
When someone (accidentally) provides an array as key using `Session::flash()`, the app breaks for users visiting the page until they have cleared their browser cache. It can be hard to identify the problem when there's no exception thrown.

This is my first PR and I don't know if it qualifies, but I thought I'd give it a shot. Feedback is much appreciated.