### PR TITLE
fix bad performance of resolve queueable entity

### DIFF
--- a/src/Illuminate/Queue/Jobs/Job.php
+++ b/src/Illuminate/Queue/Jobs/Job.php
@@ -187,7 +187,7 @@ abstract class Job
      */
     protected function resolveQueueableEntity($value)
     {
-        if (is_string($value) && Str::startsWith($value, '::entity::')) {
+        if (is_string($value) && strpos($value, '::entity::') === 0) {
             list($marker, $type, $id) = explode('|', $value, 3);
 
             return $this->getEntityResolver()->resolve($type, $id);


### PR DESCRIPTION
Illuminate Str startsWith function uses mb_strpos which has a very bad performance when the haystack is huge. When the size of haystack is larger than 100M it will take more than 5 mins. There no need use mb_strpos, I change it to strpos can improve performance significantly.