### PR TITLE
[5.5] Support failed method in mailables and notifications

### DIFF
--- a/src/Illuminate/Mail/SendQueuedMailable.php
+++ b/src/Illuminate/Mail/SendQueuedMailable.php
@@ -63,6 +63,19 @@ class SendQueuedMailable
     }
 
     /**
+     * Call the failed method on the mailable instance.
+     *
+     * @param  \Exception  $e
+     * @return void
+     */
+    public function failed($e)
+    {
+        if (method_exists($this->mailable, 'failed')) {
+            $this->mailable->failed($e);
+        }
+    }
+
+    /**
      * Prepare the instance for cloning.
      *
      * @return void

--- a/src/Illuminate/Notifications/SendQueuedNotifications.php
+++ b/src/Illuminate/Notifications/SendQueuedNotifications.php
@@ -80,7 +80,6 @@ class SendQueuedNotifications implements ShouldQueue
         }
     }
 
-
     /**
      * Prepare the instance for cloning.
      *

--- a/src/Illuminate/Notifications/SendQueuedNotifications.php
+++ b/src/Illuminate/Notifications/SendQueuedNotifications.php
@@ -68,6 +68,20 @@ class SendQueuedNotifications implements ShouldQueue
     }
 
     /**
+     * Call the failed method on the notification instance.
+     *
+     * @param  \Exception  $e
+     * @return void
+     */
+    public function failed($e)
+    {
+        if (method_exists($this->notification, 'failed')) {
+            $this->notification->failed($e);
+        }
+    }
+
+
+    /**
      * Prepare the instance for cloning.
      *
      * @return void


### PR DESCRIPTION
This PR supports having a `failed($e)` method in your queued Mailables and Notifications, this method will be called if sending the mailable/notification fails.