### PR TITLE
[5.5] Testing: Assert that two models are same

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Foundation\Testing\Concerns;
 
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Testing\Constraints\HasInDatabase;
 use PHPUnit\Framework\Constraint\LogicalNot as ReverseConstraint;
 use Illuminate\Foundation\Testing\Constraints\SoftDeletedInDatabase;
@@ -40,6 +41,21 @@ trait InteractsWithDatabase
         );
 
         $this->assertThat($table, $constraint);
+
+        return $this;
+    }
+
+    /**
+     * Asserts that two models have the same ID and belong to the same table.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model $expected
+     * @param  \Illuminate\Database\Eloquent\Model $actual
+     * @param  string  $message
+     * @return $this
+     */
+    protected function assertModelsSame(Model $expected, Model $actual, $message = '')
+    {
+        $this->assertTrue($expected->is($actual), $message);
 
         return $this;
     }


### PR DESCRIPTION
Helper method for tests which will help us to determine if models are same and stored in same database table.

Instead of:
```php
$this->assertSame($expectedUser->getKey(), $actualUser->getKey());
$this->assertSame($expectedUser->getTable(), $actualUser->getTable());
$this->assertSame($expectedUser->getConnection(), $actualUser->getConnection());
```
We can do:
```php
$this->assertModelsSame($expectedUser, $actualUser);
```

Note: I don't know how to better display error message on assertion fail. Any suggestions what to write there?

Maybe it's better to name it `assertSameModels`?