### PR TITLE
[5.5] Add Descending Sort to collections

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1349,6 +1349,23 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
+     * Sort in descending each item with a callback.
+     *
+     * @param  callable|null  $callback
+     * @return static
+     */
+    public function sortDesc(callable $callback = null)
+    {
+        $items = $this->items;
+
+        $callback
+            ? uasort($items, $callback)
+            : rsort($items);
+
+        return new static($items);
+    }
+
+    /**
      * Sort the collection using the given callback.
      *
      * @param  callable|string  $callback

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -761,6 +761,18 @@ class SupportCollectionTest extends TestCase
         $data = (new Collection(['foo', 'bar-10', 'bar-1']))->sort();
         $this->assertEquals(['bar-1', 'bar-10', 'foo'], $data->values()->all());
     }
+    
+    public function testDescendingSort()
+    {
+        $data = (new Collection([1, 2, 3, 4, 5]))->sortDesc();
+        $this->assertEquals([5, 4, 3, 2, 1], $data->values()->all());
+
+        $data = (new Collection([1, 2, 3, 5, 4, 0, -1, -3, -2, -4, -5]))->sortDesc();
+        $this->assertEquals([5, 4, 3, 2, 1, 0, -1, -2, -3, -4, -5], $data->values()->all());
+
+        $data = (new Collection(['bar-1', 'bar-10', 'foo']))->sortDesc();
+        $this->assertEquals(['foo', 'bar-10', 'bar-1'], $data->values()->all());
+    }
 
     public function testSortWithCallback()
     {


### PR DESCRIPTION
This is a shortcut of using `sort()` and `reverse()` if you want to sort array in descending order.

```php

$numbers = collect([1,2,3,4,5]);

// instead of 
$descSort = $numbers->sort()->reverse();

// use 
$descSort = $numbers->sortDesc();

// Result
[5,4,3,2,1]

```