### PR TITLE
fix(validation): Correction of string validation. String validation b…

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1311,7 +1311,7 @@ trait ValidatesAttributes
      */
     public function validateString($attribute, $value)
     {
-        return is_string($value);
+        return is_null($value) || is_string($value);
     }
 
     /**


### PR DESCRIPTION
The "string" validation has a function similar to the "required" rule, and it is not possible to escape an empty field that is not required