### PR TITLE
[5.6] Ensure expected behavior for numbers in snake case helper

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -450,7 +450,7 @@ class Str
         if (! ctype_lower($value)) {
             $value = preg_replace('/\s+/u', '', ucwords($value));
 
-            $value = static::lower(preg_replace('/(.)(?=[A-Z])/u', '$1'.$delimiter, $value));
+            $value = static::lower(preg_replace('/([^0-9])(?=[A-Z0-9])/u', '$1'.$delimiter, $value));
         }
 
         return static::$snakeCache[$key][$delimiter] = $value;

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -248,6 +248,11 @@ class SupportStrTest extends TestCase
         $this->assertEquals('laravel_php_framework_', Str::snake('LaravelPhpFramework_', '_'));
         $this->assertEquals('laravel_php_framework', Str::snake('laravel php Framework'));
         $this->assertEquals('laravel_php_frame_work', Str::snake('laravel php FrameWork'));
+
+        // ensure expected behavior for numbers
+        $this->assertEquals('laravel_php_framework_v_2', Str::snake('LaravelPhpFrameworkV2'));
+        $this->assertEquals('laravel_php_framework_v_234', Str::snake('LaravelPhpFrameworkV234'));
+        $this->assertEquals('laravel_php_framework_v_234', Str::snake('LaravelPhpFrameworkV2 3 4'));
     }
 
     public function testStudly()


### PR DESCRIPTION
Same as #21598, however aimed at 5.6.

Right now mutators in eloquent don't work as expected, e.g. when having a field `foo_bar_2` in the database.

The snake case helper makes the model look for an attribute `foo_bar2` which it cannot find. Thus, the transformation to array does not work as expected, although directly accessing the attribute does work.
Consider this example:
```php
<?php

use Illuminate\Database\Eloquent\Model;

class FooBarModel extends Model {
    protected $fillable = ['foo_bar_2'];

    public function getFooBar2Attribute ($value) {
        return $value . ' # FOOBAR'; // Just some random mutation
    }
}

$fb = new FooBarModel([ 'foo_bar_2' => 'VALUE' ]);
$fb->foo_bar_2; // "VALUE # FOOBAR" -- as expected
$fb->toArray(); // [ "foo_bar_2" => "VALUE" ] -- not as expected
```

It's not specifically by design. Mutators are to be picked up by the `toArray` method, as can be seen here: https://github.com/laravel/framework/blob/5.5/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php#L94-L96