### PR TITLE
[5.5] Removed `alreadyExists` method override

### DIFF
--- a/src/Illuminate/Foundation/Console/EventMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/EventMakeCommand.php
@@ -28,17 +28,6 @@ class EventMakeCommand extends GeneratorCommand
     protected $type = 'Event';
 
     /**
-     * Determine if the class already exists.
-     *
-     * @param  string  $rawName
-     * @return bool
-     */
-    protected function alreadyExists($rawName)
-    {
-        return class_exists($rawName);
-    }
-
-    /**
      * Get the stub file for the generator.
      *
      * @return string

--- a/src/Illuminate/Foundation/Console/ExceptionMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ExceptionMakeCommand.php
@@ -47,17 +47,6 @@ class ExceptionMakeCommand extends GeneratorCommand
     }
 
     /**
-     * Determine if the class already exists.
-     *
-     * @param  string  $rawName
-     * @return bool
-     */
-    protected function alreadyExists($rawName)
-    {
-        return class_exists($this->rootNamespace().'Exceptions\\'.$rawName);
-    }
-
-    /**
      * Get the default namespace for the class.
      *
      * @param  string  $rootNamespace

--- a/src/Illuminate/Foundation/Console/ListenerMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ListenerMakeCommand.php
@@ -75,17 +75,6 @@ class ListenerMakeCommand extends GeneratorCommand
     }
 
     /**
-     * Determine if the class already exists.
-     *
-     * @param  string  $rawName
-     * @return bool
-     */
-    protected function alreadyExists($rawName)
-    {
-        return class_exists($rawName);
-    }
-
-    /**
      * Get the default namespace for the class.
      *
      * @param  string  $rootNamespace


### PR DESCRIPTION
Removed `alreadyExists` method override to make use of the much better `alreadyExists` method of the GeneratorCommand

The issue was discussed here: https://github.com/laravel/framework/issues/21580

The affected commands are `make:event`, `make:listener` and `make:exception`. Currently, these commands allows file overwrite which a dangerous thing to do in whatever case. Based on the code, it checks existence based on `class_exists` instead of checking if the file exists (as the default behavior of the [`Illuminate\Console\GeneratorCommand`](https://github.com/laravel/framework/blob/5.5/src/Illuminate/Console/GeneratorCommand.php#L115)).