### PR TITLE
[5.5] Fix InvalidArgumentException for not standard date formats

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -6,6 +6,7 @@ use LogicException;
 use DateTimeInterface;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
+use InvalidArgumentException;
 use Illuminate\Support\Carbon;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Eloquent\Relations\Relation;
@@ -708,8 +709,19 @@ trait HasAttributes
             return Carbon::createFromFormat('Y-m-d', $value)->startOfDay();
         }
 
-	    // Finally, we will just parse this date.
-	    return Carbon::parse($value);
+	    // Finally, we will just assume this date is in the format used by default on
+	    // the database connection and use that format to create the Carbon object
+	    // that is returned back out to the developers after we convert it here.
+	    try {
+		    return Carbon::createFromFormat(
+			    $this->getDateFormat(), $value
+		    );
+	    } catch (InvalidArgumentException $exception) {
+
+		    // Fallback to Carbon::parse($value) if date format does not match.
+		    // So we can get Carbon instance even if $value is not in standard format.
+			return Carbon::parse($value);
+	    }
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -708,12 +708,8 @@ trait HasAttributes
             return Carbon::createFromFormat('Y-m-d', $value)->startOfDay();
         }
 
-        // Finally, we will just assume this date is in the format used by default on
-        // the database connection and use that format to create the Carbon object
-        // that is returned back out to the developers after we convert it here.
-        return Carbon::createFromFormat(
-            $this->getDateFormat(), $value
-        );
+	    // Finally, we will just parse this date.
+	    return Carbon::parse($value);
     }
 
     /**

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1516,6 +1516,28 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEquals('1969-07-20 00:00:00', $arr['dateAttribute']);
     }
 
+    public function testModelDateAttributeCastingFallbackToParseOnNotStandardDateFormat()
+    {
+        $model = new EloquentModelCastingStub;
+	    $model->setDateFormat('Y-m-d H:i:s');
+        $model->datetimeAttribute = '2017-10-20 10:15:20';
+
+        $this->assertEquals('2017-10-20 10:15:20', $model->datetimeAttribute->toDateTimeString());
+
+	    $model->datetimeAttribute = '20.10.2017 10:15:20';
+	    $this->assertEquals('2017-10-20 10:15:20', $model->datetimeAttribute->toDateTimeString());
+
+	    $model->datetimeAttribute = '10/20/2017 10:15:20';
+	    $this->assertEquals('2017-10-20 10:15:20', $model->datetimeAttribute->toDateTimeString());
+
+	    $model->setDateFormat('d/m/Y H:i:s');
+	    $model->datetimeAttribute = '20/10/2017 10:15:20';
+	    $this->assertEquals('2017-10-20 10:15:20', $model->datetimeAttribute->toDateTimeString());
+
+	    $model->datetimeAttribute = '2017-10-20 10:15:20';
+	    $this->assertEquals('2017-10-20 10:15:20', $model->datetimeAttribute->toDateTimeString());
+    }
+
     public function testModelAttributeCastingPreservesNull()
     {
         $model = new EloquentModelCastingStub;


### PR DESCRIPTION
When we set date-mutable attributes to a model laravel casts them to Carbon instances, but if we try to set a string with not standard format we get an InvalidArgumentException. We can specify the format in `$dateFormat` property, but sometimes we have to handle multiple date formats in one application and Carbon can easily parse them.