### PR TITLE
[5.5] dont use global scope while touching parent timestamp

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -174,7 +174,7 @@ abstract class Relation
      */
     public function rawUpdate(array $attributes = [])
     {
-        return $this->query->update($attributes);
+        return $this->query->withoutGlobalScopes()->update($attributes);
     }
 
     /**

--- a/tests/Database/DatabaseEloquentRelationTest.php
+++ b/tests/Database/DatabaseEloquentRelationTest.php
@@ -33,6 +33,7 @@ class DatabaseEloquentRelationTest extends TestCase
         $builder->shouldReceive('getModel')->andReturn($related = m::mock(\stdClass::class));
         $builder->shouldReceive('whereNotNull');
         $builder->shouldReceive('where');
+        $builder->shouldReceive('withoutGlobalScopes')->andReturn($builder);
         $relation = new HasOne($builder, $parent, 'foreign_key', 'id');
         $related->shouldReceive('getTable')->andReturn('table');
         $related->shouldReceive('getUpdatedAtColumn')->andReturn('updated_at');

--- a/tests/Integration/Database/EloquentTouchParentWithGlobalScopeTest.php
+++ b/tests/Integration/Database/EloquentTouchParentWithGlobalScopeTest.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\EloquentTouchParentWithGlobalScopeTest;
+
+use Illuminate\Support\Carbon;
+use Orchestra\Testbench\TestCase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Relations\Pivot;
+
+/**
+ * @group integration
+ */
+class EloquentTouchParentWithGlobalScopeTest extends TestCase
+{
+    protected function getEnvironmentSetUp($app)
+    {
+        $app['config']->set('app.debug', 'true');
+
+        $app['config']->set('database.default', 'testbench');
+
+        $app['config']->set('database.connections.testbench', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+        ]);
+    }
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        Schema::create('posts', function ($table) {
+            $table->increments('id');
+            $table->string('title');
+            $table->timestamps();
+        });
+
+        Schema::create('comments', function ($table) {
+            $table->increments('id');
+            $table->integer('post_id');
+            $table->string('title');
+            $table->timestamps();
+        });
+
+        Carbon::setTestNow(null);
+    }
+
+    /**
+     * @test
+     */
+    public function basic_create_and_retrieve()
+    {
+        $post = Post::create(['title' => str_random(), 'updated_at' => '2016-10-10 10:10:10']);
+
+        $this->assertEquals('2016-10-10', $post->fresh()->updated_at->toDateString());
+
+        $post->comments()->create(['title' => str_random()]);
+
+        $this->assertNotEquals('2016-10-10', $post->fresh()->updated_at->toDateString());
+    }
+}
+
+class Post extends Model
+{
+    public $table = 'posts';
+    public $timestamps = true;
+    protected $guarded = ['id'];
+
+    public function comments()
+    {
+        return $this->hasMany(Comment::class, 'post_id');
+    }
+
+    static function boot()
+    {
+        parent::boot();
+
+        static::addGlobalScope('age', function ($builder) {
+            $builder->join('comments', 'comments.post_id', '=', 'posts.id');
+        });
+    }
+}
+
+class Comment extends Model
+{
+    public $table = 'comments';
+    public $timestamps = true;
+    protected $guarded = ['id'];
+    protected $touches = ['post'];
+
+    public function post()
+    {
+        return $this->belongsTo(Post::class, 'post_id');
+    }
+}

--- a/tests/Integration/Database/EloquentTouchParentWithGlobalScopeTest.php
+++ b/tests/Integration/Database/EloquentTouchParentWithGlobalScopeTest.php
@@ -4,11 +4,8 @@ namespace Illuminate\Tests\Integration\Database\EloquentTouchParentWithGlobalSco
 
 use Illuminate\Support\Carbon;
 use Orchestra\Testbench\TestCase;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Collection;
-use Illuminate\Database\Eloquent\Relations\Pivot;
 
 /**
  * @group integration
@@ -74,7 +71,7 @@ class Post extends Model
         return $this->hasMany(Comment::class, 'post_id');
     }
 
-    static function boot()
+    public static function boot()
     {
         parent::boot();
 


### PR DESCRIPTION
While touching the parent model timestamps we shouldn't use global scope in the query, this PR fixes that.