### PR TITLE
[5.5] Implement __toString on ViewErrorBag

### DIFF
--- a/src/Illuminate/Support/ViewErrorBag.php
+++ b/src/Illuminate/Support/ViewErrorBag.php
@@ -117,4 +117,14 @@ class ViewErrorBag implements Countable
     {
         $this->put($key, $value);
     }
+    
+    /**
+     * Convert the default bag to its string representation.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return (string) $this->getBag('default');
+    }
 }

--- a/src/Illuminate/Support/ViewErrorBag.php
+++ b/src/Illuminate/Support/ViewErrorBag.php
@@ -117,7 +117,7 @@ class ViewErrorBag implements Countable
     {
         $this->put($key, $value);
     }
-    
+
     /**
      * Convert the default bag to its string representation.
      *


### PR DESCRIPTION
(Recycling #21078, with better explanation)

The intention here is being able to convert the shared variable `$errors` to its JSON representation.
It seemed to me that, if `__call` delegates method calls to the default bag, a `__toString` implementation should too.

For instance when passing the errors from Blade to a Vue form component, this enables to do just  `<vue-form :errors="{{ $errors }}">`.
