### PR TITLE
[5.5] Make Redis tests skippable if Redis is not available

### DIFF
--- a/tests/Integration/Http/ThrottleRequestsTest.php
+++ b/tests/Integration/Http/ThrottleRequestsTest.php
@@ -13,17 +13,6 @@ use Illuminate\Routing\Middleware\ThrottleRequests;
  */
 class ThrottleRequestsTest extends TestCase
 {
-    protected function getEnvironmentSetUp($app)
-    {
-        $app['config']->set('cache.default', 'redis');
-    }
-
-    public function setup()
-    {
-        parent::setup();
-        resolve('redis')->flushall();
-    }
-
     public function tearDown()
     {
         parent::tearDown();

--- a/tests/Redis/ConcurrentLimiterTest.php
+++ b/tests/Redis/ConcurrentLimiterTest.php
@@ -1,6 +1,7 @@
 <?php
 
-use Predis\Client;
+namespace Illuminate\Tests\Redis;
+
 use PHPUnit\Framework\TestCase;
 use Illuminate\Redis\Limiters\ConcurrencyLimiter;
 use Illuminate\Contracts\Redis\LimiterTimeoutException;
@@ -10,13 +11,13 @@ use Illuminate\Contracts\Redis\LimiterTimeoutException;
  */
 class ConcurrentLimiterTest extends TestCase
 {
-    public $redis;
+    use InteractsWithRedis;
 
     public function setup()
     {
         parent::setup();
 
-        $this->redis()->flushall();
+        $this->setUpRedis();
     }
 
     /**
@@ -145,21 +146,9 @@ class ConcurrentLimiterTest extends TestCase
         $this->assertEquals([1], $store);
     }
 
-    /**
-     * @return Client
-     */
-    public function redis()
+    private function redis()
     {
-        return $this->redis ?
-            $this->redis :
-            $this->redis = (new \Illuminate\Redis\RedisManager('predis', [
-                'default' => [
-                    'host' => '127.0.0.1',
-                    'password' => null,
-                    'port' => 6379,
-                    'database' => 0,
-                ],
-            ]))->connection();
+        return $this->redis['predis']->connection();
     }
 }
 

--- a/tests/Redis/DurationLimiterTest.php
+++ b/tests/Redis/DurationLimiterTest.php
@@ -1,6 +1,7 @@
 <?php
 
-use Predis\Client;
+namespace Illuminate\Tests\Redis;
+
 use PHPUnit\Framework\TestCase;
 use Illuminate\Redis\Limiters\DurationLimiter;
 use Illuminate\Contracts\Redis\LimiterTimeoutException;
@@ -10,13 +11,13 @@ use Illuminate\Contracts\Redis\LimiterTimeoutException;
  */
 class DurationLimiterTest extends TestCase
 {
-    public $redis;
+    use InteractsWithRedis;
 
     public function setup()
     {
         parent::setup();
 
-        $this->redis()->flushall();
+        $this->setUpRedis();
     }
 
     /**
@@ -79,20 +80,8 @@ class DurationLimiterTest extends TestCase
         $this->assertEquals([1, 3], $store);
     }
 
-    /**
-     * @return Client
-     */
-    public function redis()
+    private function redis()
     {
-        return $this->redis ?
-            $this->redis :
-            $this->redis = (new \Illuminate\Redis\RedisManager('predis', [
-                'default' => [
-                    'host' => '127.0.0.1',
-                    'password' => null,
-                    'port' => 6379,
-                    'database' => 0,
-                ],
-            ]))->connection();
+        return $this->redis['predis']->connection();
     }
 }


### PR DESCRIPTION
* Use default cache store in `ThrottleRequestsTest`
* Check for Redis availability in `ThrottleRequestsWithRedisTest` using `InteractsWithRedis` trait
* Use Redis connection setup from `InteractsWithRedis` trait in Redis limiters tests.

This allows for these Redis tests to be skipped when no Redis server was found at the default host/port.