### PR TITLE
[5.5] Cast to object before json_encoding

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -930,7 +930,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public function toJson($options = 0)
     {
-        $json = json_encode($this->jsonSerialize(), $options);
+        $json = json_encode((object) $this->jsonSerialize(), $options);
 
         if (JSON_ERROR_NONE !== json_last_error()) {
             throw JsonEncodingException::forModel($this, json_last_error_msg());

--- a/src/Illuminate/Support/MessageBag.php
+++ b/src/Illuminate/Support/MessageBag.php
@@ -380,7 +380,7 @@ class MessageBag implements Arrayable, Countable, Jsonable, JsonSerializable, Me
      */
     public function toJson($options = 0)
     {
-        return json_encode($this->jsonSerialize(), $options);
+        return json_encode((object) $this->jsonSerialize(), $options);
     }
 
     /**


### PR DESCRIPTION
Both `Support\MessageBag` and `Eloquent\Model` hold their data as an associative array, and their JSON representation is the simple the "`json_encode`-ing" of that array. It's an implicit contract that a key-value structure is returned.

However, when that array is empty, the resulting JSON is `[]` instead of the expected `{}`. Thus, that contract is broken, from the point of view of the consumer of the json string.

Consider  (related and following up to #21605 ) a Vue component to which I'm passing a model and the validation errors.

```
<user-form :model="{{ $user }}"
           :errors="{{ $errors }}"
></user-form>
```

While the component expects an object, if the error bag (or, less likely, the model) is empty, an empty array is effectively passed. This change ensures the resulting JSON represents an object.