### PR TITLE
[5.5] Blade : add else in the custom if directive

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -387,6 +387,12 @@ class BladeCompiler extends Compiler implements CompilerInterface
                     : "<?php if (\Illuminate\Support\Facades\Blade::check('{$name}')): ?>";
         });
 
+        $this->directive('else'.$name, function ($expression) use ($name) {
+            return $expression
+                ? "<?php elseif (\Illuminate\Support\Facades\Blade::check('{$name}', {$expression})): ?>"
+                : "<?php elseif (\Illuminate\Support\Facades\Blade::check('{$name}')): ?>";
+        });
+
         $this->directive('end'.$name, function () {
             return '<?php endif; ?>';
         });

--- a/tests/View/Blade/BladeCustomTest.php
+++ b/tests/View/Blade/BladeCustomTest.php
@@ -73,4 +73,21 @@ class BladeCustomTest extends AbstractBladeTestCase
 <?php endif; ?>';
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
+
+    public function testCustomIfElseConditions()
+    {
+        $this->compiler->if('custom', function ($anything) {
+            return true;
+        });
+
+        $string = '@custom($user)
+@elsecustom($product)
+@else
+@endcustom';
+        $expected = '<?php if (\Illuminate\Support\Facades\Blade::check(\'custom\', $user)): ?>
+<?php elseif (\Illuminate\Support\Facades\Blade::check(\'custom\', $product)): ?>
+<?php else: ?>
+<?php endif; ?>';
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
 }


### PR DESCRIPTION
This PR adds the`else` in the  [custom if](https://laravel.com/docs/5.5/blade#custom-if-statements) directive to blade.

Example use-case : 

```php
<?php
Blade::if('instanceof', function ($object, $class) {
    return $object instanceof $class;
});
?>
```
(this example can not work as it, but you have the idea)

Actually, we have to use the `@instanceof` this way : 

```blade
@instanceof($object, App\User::class)
   You're a user
@endinstanceof

@instanceof($object, App\Product::class)
   You're a product
@else
  I don't know what you are !
@endinstanceof

```

This PR allows us to write the following

```blade
@instanceof($object, App\User::class)
   You're a user
@elseinstanceof($object, App\Product::class)
   You're a product
@else
   I don't know what you are !
@endinstanceof
```

Tests are provided.