### PR TITLE
 [5.6] Fallback to Carbon::parse($value) if $value is not in standard format.

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -6,6 +6,7 @@ use LogicException;
 use DateTimeInterface;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
+use InvalidArgumentException;
 use Illuminate\Support\Carbon;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Eloquent\Relations\Relation;
@@ -711,9 +712,16 @@ trait HasAttributes
         // Finally, we will just assume this date is in the format used by default on
         // the database connection and use that format to create the Carbon object
         // that is returned back out to the developers after we convert it here.
-        return Carbon::createFromFormat(
-            $this->getDateFormat(), $value
-        );
+        try {
+            return Carbon::createFromFormat(
+                $this->getDateFormat(), $value
+            );
+        } catch (InvalidArgumentException $exception) {
+
+            // Fallback to Carbon::parse($value) if date format does not match.
+            // So we can get Carbon instance even if $value is not in standard format.
+            return Carbon::parse($value);
+        }
     }
 
     /**

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1516,6 +1516,28 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEquals('1969-07-20 00:00:00', $arr['dateAttribute']);
     }
 
+    public function testModelDateAttributeCastingFallbackToParseOnNotStandardDateFormat()
+    {
+        $model = new EloquentModelCastingStub;
+        $model->setDateFormat('Y-m-d H:i:s');
+        $model->datetimeAttribute = '2017-10-20 10:15:20';
+
+        $this->assertEquals('2017-10-20 10:15:20', $model->datetimeAttribute->toDateTimeString());
+
+        $model->datetimeAttribute = '20.10.2017 10:15:20';
+        $this->assertEquals('2017-10-20 10:15:20', $model->datetimeAttribute->toDateTimeString());
+
+        $model->datetimeAttribute = '10/20/2017 10:15:20';
+        $this->assertEquals('2017-10-20 10:15:20', $model->datetimeAttribute->toDateTimeString());
+
+        $model->setDateFormat('d/m/Y H:i:s');
+        $model->datetimeAttribute = '20/10/2017 10:15:20';
+        $this->assertEquals('2017-10-20 10:15:20', $model->datetimeAttribute->toDateTimeString());
+
+        $model->datetimeAttribute = '2017-10-20 10:15:20';
+        $this->assertEquals('2017-10-20 10:15:20', $model->datetimeAttribute->toDateTimeString());
+    }
+
     public function testModelAttributeCastingPreservesNull()
     {
         $model = new EloquentModelCastingStub;


### PR DESCRIPTION
Same as [#21601](https://github.com/laravel/framework/pull/21601) however, aimed at 5.6.

When we set date-mutable attributes to a model Laravel casts them to Carbon instances. 
But if we try to set a string in not standard format we get an InvalidArgumentException. 
We can specify the format in $dateFormat property, but sometimes we have to handle multiple date formats in one application or and Carbon can easily parse them.