### PR TITLE
[5.6] Snake case numbers

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -450,7 +450,7 @@ class Str
         if (! ctype_lower($value)) {
             $value = preg_replace('/\s+/u', '', ucwords($value));
 
-            $value = static::lower(preg_replace('/(.)(?=[A-Z])/u', '$1'.$delimiter, $value));
+            $value = static::lower(preg_replace('/([^0-9])(?=[A-Z0-9])/u', '$1'.$delimiter, $value));
         }
 
         return static::$snakeCache[$key][$delimiter] = $value;

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -450,7 +450,7 @@ class Str
         if (! ctype_lower($value)) {
             $value = preg_replace('/\s+/u', '', ucwords($value));
 
-            $value = static::lower(preg_replace('/([^0-9])(?=[A-Z0-9])/u', '$1'.$delimiter, $value));
+            $value = static::lower(preg_replace('/([^0-9])(?=[A-Z0-9])|([0-9])(?=[A-Z])/u', '$1$2'.$delimiter, $value));
         }
 
         return static::$snakeCache[$key][$delimiter] = $value;

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -251,6 +251,7 @@ class SupportStrTest extends TestCase
 
         // ensure expected behavior for numbers
         $this->assertEquals('laravel_php_framework_v_2', Str::snake('LaravelPhpFrameworkV2'));
+        $this->assertEquals('laravel_php_framework_v_2_more', Str::snake('LaravelPhpFrameworkV2More'));
         $this->assertEquals('laravel_php_framework_v_234', Str::snake('LaravelPhpFrameworkV234'));
         $this->assertEquals('laravel_php_framework_v_234', Str::snake('LaravelPhpFrameworkV2 3 4'));
     }

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -254,6 +254,7 @@ class SupportStrTest extends TestCase
         $this->assertEquals('laravel_php_framework_v_2_more', Str::snake('LaravelPhpFrameworkV2More'));
         $this->assertEquals('laravel_php_framework_v_234', Str::snake('LaravelPhpFrameworkV234'));
         $this->assertEquals('laravel_php_framework_v_234', Str::snake('LaravelPhpFrameworkV2 3 4'));
+        $this->assertEquals('laravel_php_framework_v_234_more', Str::snake('LaravelPhpFrameworkV234More'));
     }
 
     public function testStudly()

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -248,6 +248,11 @@ class SupportStrTest extends TestCase
         $this->assertEquals('laravel_php_framework_', Str::snake('LaravelPhpFramework_', '_'));
         $this->assertEquals('laravel_php_framework', Str::snake('laravel php Framework'));
         $this->assertEquals('laravel_php_frame_work', Str::snake('laravel php FrameWork'));
+
+        // ensure expected behavior for numbers
+        $this->assertEquals('laravel_php_framework_v_2', Str::snake('LaravelPhpFrameworkV2'));
+        $this->assertEquals('laravel_php_framework_v_234', Str::snake('LaravelPhpFrameworkV234'));
+        $this->assertEquals('laravel_php_framework_v_234', Str::snake('LaravelPhpFrameworkV2 3 4'));
     }
 
     public function testStudly()


### PR DESCRIPTION
See #21599.

My brief benchmarking even suggests that this method is slightly faster. (Using ten rounds of 5000 times running the test cases each on my local machine)

New Snake took 1.39498326778413s/round on average
Old snake took 1.48209123611449s/round on average

Time: 30.3 seconds, Memory: 30.00MB