### PR TITLE
[5.5] Accept multiple middleware when defining middleware fluently

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -1195,6 +1195,10 @@ class Router implements RegistrarContract, BindingRegistrar
             return $this->macroCall($method, $parameters);
         }
 
+        if ($method == 'middleware') {
+            return (new RouteRegistrar($this))->attribute($method, is_array($parameters[0]) ? $parameters[0] : $parameters);
+        }
+
         return (new RouteRegistrar($this))->attribute($method, $parameters[0]);
     }
 }

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -28,6 +28,37 @@ class RouteRegistrarTest extends TestCase
         m::close();
     }
 
+    public function testMiddlewareFluentRegistration()
+    {
+        $this->router->middleware(['one', 'two'])->get('users', function () {
+            return 'all-users';
+        });
+
+        $this->seeResponse('all-users', Request::create('users', 'GET'));
+        $this->assertEquals(['one', 'two'], $this->getRoute()->middleware());
+
+        $this->router->middleware('three', 'four')->get('users', function () {
+            return 'all-users';
+        });
+
+        $this->seeResponse('all-users', Request::create('users', 'GET'));
+        $this->assertEquals(['three', 'four'], $this->getRoute()->middleware());
+
+        $this->router->get('users', function () {
+            return 'all-users';
+        })->middleware('five', 'six');
+
+        $this->seeResponse('all-users', Request::create('users', 'GET'));
+        $this->assertEquals(['five', 'six'], $this->getRoute()->middleware());
+
+        $this->router->middleware('seven')->get('users', function () {
+            return 'all-users';
+        });
+
+        $this->seeResponse('all-users', Request::create('users', 'GET'));
+        $this->assertEquals(['seven'], $this->getRoute()->middleware());
+    }
+
     public function testCanRegisterGetRouteWithClosureAction()
     {
         $this->router->middleware('get-middleware')->get('users', function () {


### PR DESCRIPTION
Currently:

```php
Route::middleware('foo', 'bar')->get('/'); // Only 'foo' is registered
Route::get('/')->middleware('foo', 'bar'); // Both middlewares are registered
```

This PR makes both cases behave the same.