### PR TITLE
[5.5] Bind true as integer 1 while preparing an SQL statement

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -595,6 +595,8 @@ class Connection implements ConnectionInterface
                 $bindings[$key] = $value->format($grammar->getDateFormat());
             } elseif ($value === false) {
                 $bindings[$key] = 0;
+            } elseif ($value === true) {
+                $bindings[$key] = 1;
             }
         }
 

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -593,10 +593,8 @@ class Connection implements ConnectionInterface
             // so we'll just ask the grammar for the format to get from the date.
             if ($value instanceof DateTimeInterface) {
                 $bindings[$key] = $value->format($grammar->getDateFormat());
-            } elseif ($value === false) {
-                $bindings[$key] = 0;
-            } elseif ($value === true) {
-                $bindings[$key] = 1;
+            } elseif (is_bool($value)) {
+                $bindings[$key] = (int) $value;
             }
         }
 


### PR DESCRIPTION
Currently we bind false as 0, doing the same for true will make this more consistent as currently true is converted to string 1.

This causes the issue in https://github.com/laravel/framework/issues/21588, here's a brief about the issue:

> The Laravel database component casts true to string when it binds a value to a statement. When true is casted to string in PHP it becomes '1' (string). The BIT field is binary therefore the database converts the string value '1' to the binary value 0b00110001. The binary value length is 6 which is more then the maximum length of the my_boolean_column field (1), that's why the «Data too long» error occurs.