### PR TITLE
[5.5] Add getUrl method

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -1062,6 +1062,16 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     }
 
     /**
+     * Get the current application url.
+     *
+     * @return string
+     */
+    public function getUrl()
+    {
+        return $this['config']->get('app.url');
+    }
+
+    /**
      * Set the current application locale.
      *
      * @param  string  $locale


### PR DESCRIPTION
Current in Laravel we can get the application locale by calling `getLocale` in `app`.

This PR adds `getUrl` method, that returns the current application URL, very useful in routes, views, etc.