### PR TITLE
Add email to ResetPassword Notification.

### DIFF
--- a/src/Illuminate/Auth/Notifications/ResetPassword.php
+++ b/src/Illuminate/Auth/Notifications/ResetPassword.php
@@ -39,14 +39,15 @@ class ResetPassword extends Notification
     /**
      * Build the mail representation of the notification.
      *
-     * @param  mixed  $notifiable
+     * @param \Illuminate\Contracts\Auth\CanResetPassword $user
+     *
      * @return \Illuminate\Notifications\Messages\MailMessage
      */
-    public function toMail($notifiable)
+    public function toMail($user)
     {
         return (new MailMessage)
             ->line('You are receiving this email because we received a password reset request for your account.')
-            ->action('Reset Password', url(config('app.url').route('password.reset', $this->token, false)))
+            ->action('Reset Password', url(config('app.url').route('password.reset', ['token' => $this->token, 'email' => $user->getEmailForPasswordReset()], false)))
             ->line('If you did not request a password reset, no further action is required.');
     }
 }


### PR DESCRIPTION
Hi,

In `src/Illuminate/Foundation/Auth/ResetsPasswords.php`, we can see that the password reset link should have an email field in its query:
https://github.com/laravel/framework/blob/8427c704124c2b96bfae4312a68ff1dfcf135f61/src/Illuminate/Foundation/Auth/ResetsPasswords.php#L25-L29

It was missing in the notification:
https://github.com/laravel/framework/blob/8427c704124c2b96bfae4312a68ff1dfcf135f61/src/Illuminate/Auth/Notifications/ResetPassword.php#L49

This PR adds it.