### PR TITLE
[5.5] Ensure config load order across multiple installations

### DIFF
--- a/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php
+++ b/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php
@@ -90,6 +90,8 @@ class LoadConfiguration
             $files[$directory.basename($file->getRealPath(), '.php')] = $file->getRealPath();
         }
 
+        ksort($files, SORT_NATURAL);
+
         return $files;
     }
 


### PR DESCRIPTION
After reading [this article](https://blog.maqe.com/dont-use-laravel-s-config-inside-config-files-40e2c8207225) it concerned me that the load order of config files could lead to inconsistent behaviour across multiple installations. 

Although I agree with the original author that you shouldn't use `config()` inside config files, I do think that its a reasonable mistake to make, especially if your new to Laravel and there is merit in fixing the issue with consistency. A developer may only realise that the bug exists once it is deployed to a live environment even though it has passed testing in a matching test/dev environment. 

This pull request addresses this issue by naturally sorting the array of config files, ensuring that they are loaded in a deterministic order therefore protecting developers from this subtle bug.