### PR TITLE
[5.5] Ability to create view name aliases

### DIFF
--- a/src/Illuminate/View/Factory.php
+++ b/src/Illuminate/View/Factory.php
@@ -214,7 +214,7 @@ class Factory implements FactoryContract
     }
 
     /**
-     * Add a view alias
+     * Add a view alias.
      *
      * @param string|array $aliases
      * @param null|string  $name

--- a/src/Illuminate/View/Factory.php
+++ b/src/Illuminate/View/Factory.php
@@ -214,6 +214,23 @@ class Factory implements FactoryContract
     }
 
     /**
+     * Add a view alias
+     *
+     * @param string|array $aliases
+     * @param null|string  $name
+     *
+     * @return $this
+     */
+    public function addAlias($aliases, $name = null)
+    {
+        ViewName::addAliases(
+            is_array($aliases) ? $aliases : [$aliases => $name]
+        );
+
+        return $this;
+    }
+
+    /**
      * Normalize a view name.
      *
      * @param  string $name

--- a/src/Illuminate/View/ViewName.php
+++ b/src/Illuminate/View/ViewName.php
@@ -5,6 +5,13 @@ namespace Illuminate\View;
 class ViewName
 {
     /**
+     * View name aliases
+     *
+     * @var array
+     */
+    protected static $aliases = [];
+
+    /**
      * Normalize the given event name.
      *
      * @param  string  $name
@@ -12,6 +19,8 @@ class ViewName
      */
     public static function normalize($name)
     {
+        $name = static::resolveAlias($name);
+
         $delimiter = ViewFinderInterface::HINT_PATH_DELIMITER;
 
         if (strpos($name, $delimiter) === false) {
@@ -21,5 +30,29 @@ class ViewName
         list($namespace, $name) = explode($delimiter, $name);
 
         return $namespace.$delimiter.str_replace('/', '.', $name);
+    }
+
+    /**
+     * Add a view name alias
+     *
+     * @param $aliases array
+     *
+     * @return array
+     */
+    public static function addAliases($aliases)
+    {
+        static::$aliases = array_merge(static::$aliases, $aliases);
+    }
+
+    /**
+     * Resolve view name by alias
+     *
+     * @param $name
+     *
+     * @return mixed
+     */
+    protected static function resolveAlias($name)
+    {
+        return static::$aliases[$name] ?? $name;
     }
 }

--- a/src/Illuminate/View/ViewName.php
+++ b/src/Illuminate/View/ViewName.php
@@ -5,7 +5,7 @@ namespace Illuminate\View;
 class ViewName
 {
     /**
-     * View name aliases
+     * View name aliases.
      *
      * @var array
      */
@@ -33,7 +33,7 @@ class ViewName
     }
 
     /**
-     * Add a view name alias
+     * Add a view name alias.
      *
      * @param $aliases array
      *
@@ -45,7 +45,7 @@ class ViewName
     }
 
     /**
-     * Resolve view name by alias
+     * Resolve view name by alias.
      *
      * @param $name
      *

--- a/tests/View/ViewFactoryTest.php
+++ b/tests/View/ViewFactoryTest.php
@@ -620,6 +620,23 @@ class ViewFactoryTest extends TestCase
         $this->assertNull($factory->getLoopStack()[0]['last']);
     }
 
+    public function testMakeNormalizesAliases()
+    {
+        $factory = $this->getFactory();
+        $factory->getFinder()->shouldReceive('find')->once()->with('path.to.foo')->andReturn('path.php');
+        $factory->getFinder()->shouldReceive('find')->once()->with('path.to.bar')->andReturn('path.php');
+        $factory->getEngineResolver()->shouldReceive('resolve')->twice()->with('php')->andReturn($engine = m::mock(\Illuminate\Contracts\View\Engine::class));
+        $factory->setDispatcher(new \Illuminate\Events\Dispatcher);
+
+        $factory->addAlias('foo', 'path.to.foo');
+        $factory->addAlias(['bar' => 'path.to.bar']);
+
+        $foo = $factory->make('foo');
+        $bar = $factory->make('bar');
+        $this->assertSame('path.to.foo', $foo->getName());
+        $this->assertSame('path.to.bar', $bar->getName());
+    }
+
     protected function getFactory()
     {
         return new Factory(


### PR DESCRIPTION
This gives the ability to use aliases within views and blade directives.

For example adding
```php
View::addAlias('@panel', 'admin.layout.components.panel');
```

means we could use the following syntax within blade

```blade
@component('@panel')
...
@endcomponent
```

Aliases do not have to start with an `@` - but prefixing with a symbol could be a good way to differentiate between an alias and a top level view.