### PR TITLE
[5.5] Check for vendor views for each paths given in config/view.php

### DIFF
--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -81,8 +81,10 @@ abstract class ServiceProvider
      */
     protected function loadViewsFrom($path, $namespace)
     {
-        if (is_dir($appPath = $this->app->resourcePath().'/views/vendor/'.$namespace)) {
-            $this->app['view']->addNamespace($namespace, $appPath);
+        foreach ($this->app->config['view']['paths'] as $viewPath) {
+            if (is_dir($appPath = $viewPath. '/vendor/'.$namespace)) {
+                $this->app['view']->addNamespace($namespace, $appPath);
+            }
         }
 
         $this->app['view']->addNamespace($namespace, $path);

--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -82,7 +82,7 @@ abstract class ServiceProvider
     protected function loadViewsFrom($path, $namespace)
     {
         foreach ($this->app->config['view']['paths'] as $viewPath) {
-            if (is_dir($appPath = $viewPath. '/vendor/'.$namespace)) {
+            if (is_dir($appPath = $viewPath.'/vendor/'.$namespace)) {
                 $this->app['view']->addNamespace($namespace, $appPath);
             }
         }


### PR DESCRIPTION
Currently I'm working on a project that requires a theme style views environment. There are multiple themes developed by a third party that only has access to themes folder. It's known what packages are used and views are included(e.g. laracasts/flash, backpack etc.). Those views can be different/changed per theme. But not thats not possible in the current situation.

In the current version of Laravel only the local `resources/view/vendor/` folder will be checked for "Package Views". 

## Problem
When having multiple view paths in `config/view.php` or different location of the view path the "Package views" extending will not work. 

Example:
```
// config/view.php
'paths' => [
    resource_path('views'),
    storage_path('themes'),
],
```
Each time the `loadViewsFrom` method will be used it only checks in `resources/views/vendor/$namespace` and it is not loading from `themes/vendor/$namespace`.

Another example:
```
// config/view.php
'paths' => [
    storage_path('themes/theme1'),
],
```
Different location will not be checked for extensions `storage/themes/theme1/vendor/$namespace`.

## Solution
The fix/solution is backwards compatible and can be pushed to earlier version of Laravel aswel. 

Instead of only looking for `$this->app->resourcePath().'/views/vendor/'.$namespace` in the `loadViewsFrom` method, loop through all view paths and check if there is a `vendor/$namespace` within the directory.
```
foreach ($this->app->config['view']['paths'] as $viewPath) {
    if (is_dir($appPath = $viewPath.'/vendor/'.$namespace)) {
        $this->app['view']->addNamespace($namespace, $appPath);
    }
}
```