### PR TITLE
[5.6] Updated to use new release of cron-expression

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "erusev/parsedown": "~1.6",
         "league/flysystem": "~1.0",
         "monolog/monolog": "~1.12",
-        "mtdowling/cron-expression": "~1.0",
+        "dragonmantank/cron-expression": "~2.0",
         "nesbot/carbon": "~1.20",
         "psr/container": "~1.0",
         "psr/simple-cache": "^1.0",

--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -27,7 +27,7 @@ class Event
      *
      * @var string
      */
-    public $expression = '* * * * * *';
+    public $expression = '* * * * *';
 
     /**
      * The timezone the date should be evaluated on.

--- a/tests/Console/ConsoleScheduledEventTest.php
+++ b/tests/Console/ConsoleScheduledEventTest.php
@@ -36,7 +36,7 @@ class ConsoleScheduledEventTest extends TestCase
         $app->shouldReceive('environment')->andReturn('production');
 
         $event = new Event(m::mock('Illuminate\Console\Scheduling\Mutex'), 'php foo');
-        $this->assertEquals('* * * * * *', $event->getExpression());
+        $this->assertEquals('* * * * *', $event->getExpression());
         $this->assertTrue($event->isDue($app));
         $this->assertTrue($event->skip(function () {
             return true;
@@ -46,17 +46,17 @@ class ConsoleScheduledEventTest extends TestCase
         })->filtersPass($app));
 
         $event = new Event(m::mock('Illuminate\Console\Scheduling\Mutex'), 'php foo');
-        $this->assertEquals('* * * * * *', $event->getExpression());
+        $this->assertEquals('* * * * *', $event->getExpression());
         $this->assertFalse($event->environments('local')->isDue($app));
 
         $event = new Event(m::mock('Illuminate\Console\Scheduling\Mutex'), 'php foo');
-        $this->assertEquals('* * * * * *', $event->getExpression());
+        $this->assertEquals('* * * * *', $event->getExpression());
         $this->assertFalse($event->when(function () {
             return false;
         })->filtersPass($app));
 
         $event = new Event(m::mock('Illuminate\Console\Scheduling\Mutex'), 'php foo');
-        $this->assertEquals('* * * * * *', $event->getExpression());
+        $this->assertEquals('* * * * *', $event->getExpression());
         $this->assertFalse($event->when(false)->filtersPass($app));
 
         // chained rules should be commutative
@@ -81,11 +81,11 @@ class ConsoleScheduledEventTest extends TestCase
         Carbon::setTestNow(Carbon::create(2015, 1, 1, 0, 0, 0));
 
         $event = new Event(m::mock('Illuminate\Console\Scheduling\Mutex'), 'php foo');
-        $this->assertEquals('* * * * 4 *', $event->thursdays()->getExpression());
+        $this->assertEquals('* * * * 4', $event->thursdays()->getExpression());
         $this->assertTrue($event->isDue($app));
 
         $event = new Event(m::mock('Illuminate\Console\Scheduling\Mutex'), 'php foo');
-        $this->assertEquals('0 19 * * 3 *', $event->wednesdays()->at('19:00')->timezone('EST')->getExpression());
+        $this->assertEquals('0 19 * * 3', $event->wednesdays()->at('19:00')->timezone('EST')->getExpression());
         $this->assertTrue($event->isDue($app));
     }
 

--- a/tests/Console/Scheduling/EventTest.php
+++ b/tests/Console/Scheduling/EventTest.php
@@ -28,7 +28,7 @@ class EventTest extends TestCase
         $event->runInBackground();
 
         $defaultOutput = (DIRECTORY_SEPARATOR == '\\') ? 'NUL' : '/dev/null';
-        $this->assertSame("(php -i > {$quote}{$defaultOutput}{$quote} 2>&1 ; '".PHP_BINARY."' artisan schedule:finish \"framework/schedule-c65b1c374c37056e0c57fccb0c08d724ce6f5043\") > {$quote}{$defaultOutput}{$quote} 2>&1 &", $event->buildCommand());
+        $this->assertSame("(php -i > {$quote}{$defaultOutput}{$quote} 2>&1 ; '".PHP_BINARY."' artisan schedule:finish \"framework/schedule-eeb46c93d45e928d62aaf684d727e213b7094822\") > {$quote}{$defaultOutput}{$quote} 2>&1 &", $event->buildCommand());
     }
 
     public function testBuildCommandSendOutputTo()

--- a/tests/Console/Scheduling/FrequencyTest.php
+++ b/tests/Console/Scheduling/FrequencyTest.php
@@ -23,99 +23,99 @@ class FrequencyTest extends TestCase
 
     public function testEveryMinute()
     {
-        $this->assertEquals('* * * * * *', $this->event->getExpression());
-        $this->assertEquals('* * * * * *', $this->event->everyMinute()->getExpression());
+        $this->assertEquals('* * * * *', $this->event->getExpression());
+        $this->assertEquals('* * * * *', $this->event->everyMinute()->getExpression());
     }
 
     public function testEveryFiveMinutes()
     {
-        $this->assertEquals('*/5 * * * * *', $this->event->everyFiveMinutes()->getExpression());
+        $this->assertEquals('*/5 * * * *', $this->event->everyFiveMinutes()->getExpression());
     }
 
     public function testDaily()
     {
-        $this->assertEquals('0 0 * * * *', $this->event->daily()->getExpression());
+        $this->assertEquals('0 0 * * *', $this->event->daily()->getExpression());
     }
 
     public function testTwiceDaily()
     {
-        $this->assertEquals('0 3,15 * * * *', $this->event->twiceDaily(3, 15)->getExpression());
+        $this->assertEquals('0 3,15 * * *', $this->event->twiceDaily(3, 15)->getExpression());
     }
 
     public function testOverrideWithHourly()
     {
-        $this->assertEquals('0 * * * * *', $this->event->everyFiveMinutes()->hourly()->getExpression());
-        $this->assertEquals('37 * * * * *', $this->event->hourlyAt(37)->getExpression());
+        $this->assertEquals('0 * * * *', $this->event->everyFiveMinutes()->hourly()->getExpression());
+        $this->assertEquals('37 * * * *', $this->event->hourlyAt(37)->getExpression());
     }
 
     public function testMonthlyOn()
     {
-        $this->assertEquals('0 15 4 * * *', $this->event->monthlyOn(4, '15:00')->getExpression());
+        $this->assertEquals('0 15 4 * *', $this->event->monthlyOn(4, '15:00')->getExpression());
     }
 
     public function testTwiceMonthly()
     {
-        $this->assertEquals('0 0 1,16 * * *', $this->event->twiceMonthly(1, 16)->getExpression());
+        $this->assertEquals('0 0 1,16 * *', $this->event->twiceMonthly(1, 16)->getExpression());
     }
 
     public function testMonthlyOnWithMinutes()
     {
-        $this->assertEquals('15 15 4 * * *', $this->event->monthlyOn(4, '15:15')->getExpression());
+        $this->assertEquals('15 15 4 * *', $this->event->monthlyOn(4, '15:15')->getExpression());
     }
 
     public function testWeekdaysDaily()
     {
-        $this->assertEquals('0 0 * * 1-5 *', $this->event->weekdays()->daily()->getExpression());
+        $this->assertEquals('0 0 * * 1-5', $this->event->weekdays()->daily()->getExpression());
     }
 
     public function testWeekdaysHourly()
     {
-        $this->assertEquals('0 * * * 1-5 *', $this->event->weekdays()->hourly()->getExpression());
+        $this->assertEquals('0 * * * 1-5', $this->event->weekdays()->hourly()->getExpression());
     }
 
     public function testWeekdays()
     {
-        $this->assertEquals('* * * * 1-5 *', $this->event->weekdays()->getExpression());
+        $this->assertEquals('* * * * 1-5', $this->event->weekdays()->getExpression());
     }
 
     public function testSundays()
     {
-        $this->assertEquals('* * * * 0 *', $this->event->sundays()->getExpression());
+        $this->assertEquals('* * * * 0', $this->event->sundays()->getExpression());
     }
 
     public function testMondays()
     {
-        $this->assertEquals('* * * * 1 *', $this->event->mondays()->getExpression());
+        $this->assertEquals('* * * * 1', $this->event->mondays()->getExpression());
     }
 
     public function testTuesdays()
     {
-        $this->assertEquals('* * * * 2 *', $this->event->tuesdays()->getExpression());
+        $this->assertEquals('* * * * 2', $this->event->tuesdays()->getExpression());
     }
 
     public function testWednesdays()
     {
-        $this->assertEquals('* * * * 3 *', $this->event->wednesdays()->getExpression());
+        $this->assertEquals('* * * * 3', $this->event->wednesdays()->getExpression());
     }
 
     public function testThursdays()
     {
-        $this->assertEquals('* * * * 4 *', $this->event->thursdays()->getExpression());
+        $this->assertEquals('* * * * 4', $this->event->thursdays()->getExpression());
     }
 
     public function testFridays()
     {
-        $this->assertEquals('* * * * 5 *', $this->event->fridays()->getExpression());
+        $this->assertEquals('* * * * 5', $this->event->fridays()->getExpression());
     }
 
     public function testSaturdays()
     {
-        $this->assertEquals('* * * * 6 *', $this->event->saturdays()->getExpression());
+        $this->assertEquals('* * * * 6', $this->event->saturdays()->getExpression());
     }
 
     public function testQuarterly()
     {
-        $this->assertEquals('0 0 1 1-12/3 * *', $this->event->quarterly()->getExpression());
+        $this->assertEquals('0 0 1 1-12/3 *', $this->event->quarterly()->getExpression());
     }
 
     public function testFrequencyMacro()
@@ -124,6 +124,6 @@ class FrequencyTest extends TestCase
             return $this->spliceIntoPosition(1, "*/{$x}");
         });
 
-        $this->assertEquals('*/6 * * * * *', $this->event->everyXMinutes(6)->getExpression());
+        $this->assertEquals('*/6 * * * *', $this->event->everyXMinutes(6)->getExpression());
     }
 }


### PR DESCRIPTION
This updates the Laravel Framework to support the new 2.x branch of `cron-expression`. 

I looked through the test set to fix what I could find that relies on the library, and the only test I could not fix was `Illuminate\Tests\Console\Scheduling\EventTest::testBuildCommand` ... I'm just not exactly sure how all that is managed, so the hash it generates is different than what the test expects. If I missed any other tests, let me know and I'll gladly update this PR. Most of the test changes are because `cron-expression` has dropped support for the Year place. 

This is in response to mtdowling/cron-expression#153 and #19532. More detail on the package name change can be found at http://ctankersley.com/2017/10/12/cron-expression-update/