### PR TITLE
Added support for optional to have a default value.

### DIFF
--- a/src/Illuminate/Support/Optional.php
+++ b/src/Illuminate/Support/Optional.php
@@ -16,14 +16,23 @@ class Optional
     protected $value;
 
     /**
+     * The default value returned if the property is unavailable on the underlying object.
+     *
+     * @var mixed
+     */
+    protected $default;
+
+    /**
      * Create a new optional instance.
      *
      * @param  mixed  $value
+     * @param  mixed  $default
      * @return void
      */
-    public function __construct($value)
+    public function __construct($value, $default = null)
     {
         $this->value = $value;
+        $this->default = $default;
     }
 
     /**
@@ -37,6 +46,8 @@ class Optional
         if (is_object($this->value)) {
             return $this->value->{$key};
         }
+
+        return $this->default;
     }
 
     /**
@@ -55,5 +66,7 @@ class Optional
         if (is_object($this->value)) {
             return $this->value->{$method}(...$parameters);
         }
+
+        return $this->default;
     }
 }

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -715,11 +715,12 @@ if (! function_exists('optional')) {
      * Provide access to optional objects.
      *
      * @param  mixed  $value
+     * @param  mixed  $default
      * @return mixed
      */
-    function optional($value)
+    function optional($value, $default = null)
     {
-        return new Optional($value);
+        return new Optional($value, $default);
     }
 }
 

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -769,6 +769,16 @@ class SupportHelpersTest extends TestCase
         })->something());
     }
 
+    public function testOptionalReturnsDefaultForProperty()
+    {
+        $this->assertEquals(10, optional(null, 10)->doesntExist);
+    }
+
+    public function testOptionalReturnsDefaultForMethod()
+    {
+        $this->assertEquals(10, optional(null, 10)->doesntExist());
+    }
+
     public function testOptionalIsMacroable()
     {
         Optional::macro('present', function () {


### PR DESCRIPTION
Found in my projects I was doing a lot of default values for what to do if the optional() method returns null, so I thought I might as well just add it into the method!

Very simple addition, when specifying optional, the method and class constructor now take a second parameter `$default` which allows setting what will be returned if the first argument passed in is not an object.