### PR TITLE
[5.5] Default mail theme: Reset margins on th and td cells to fix Outlook propagation issue

### DIFF
--- a/src/Illuminate/Mail/resources/views/html/themes/default.css
+++ b/src/Illuminate/Mail/resources/views/html/themes/default.css
@@ -182,6 +182,7 @@ img {
 .table th {
     border-bottom: 1px solid #EDEFF2;
     padding-bottom: 8px;
+    margin: 0;
 }
 
 .table td {
@@ -189,6 +190,7 @@ img {
     font-size: 15px;
     line-height: 18px;
     padding: 10px 0;
+    margin: 0;
 }
 
 .content-cell {


### PR DESCRIPTION
Using the `mail::table` component and the default Mail theme, table rows rendered in Outlook appear with a 30px top and bottom margin around them, making them >60 pixel high each.

This is due to the `margin: 30px auto` declaration in the `.table table` selector being propagated to both `.table th` and `.table td` selectors.

This can be fixed by resetting margins in both `.table th`and `.table td` selectors without negative side-effects in other mail clients.

The issue and the fix were both tested and confirmed in Outlook 2016.

Before:
![outlook-before](https://user-images.githubusercontent.com/17774818/31529765-915fd56a-afdb-11e7-9067-ca7acee1d3c1.png)

After applying the fix:
![outlook-after](https://user-images.githubusercontent.com/17774818/31529767-91848d92-afdb-11e7-95e9-5101f567dc72.png)

I might add that there are lots more issues with the default template in Outlook 2016, as some margin declarations are blatantly ignored and would have to be replaced by paddings instead to show any effect. But this should probably be up for discussion in a different pull request.