### PR TITLE
[5.5] Protect user from potentially trashing unintended environment

### DIFF
--- a/src/Illuminate/Foundation/Testing/RefreshDatabase.php
+++ b/src/Illuminate/Foundation/Testing/RefreshDatabase.php
@@ -2,8 +2,8 @@
 
 namespace Illuminate\Foundation\Testing;
 
-use Illuminate\Contracts\Console\Kernel;
 use RuntimeException;
+use Illuminate\Contracts\Console\Kernel;
 
 trait RefreshDatabase
 {

--- a/src/Illuminate/Foundation/Testing/RefreshDatabase.php
+++ b/src/Illuminate/Foundation/Testing/RefreshDatabase.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Foundation\Testing;
 
 use Illuminate\Contracts\Console\Kernel;
+use RuntimeException;
 
 trait RefreshDatabase
 {
@@ -49,6 +50,10 @@ trait RefreshDatabase
      */
     protected function refreshTestDatabase()
     {
+        if ($this->app->configurationIsCached()) {
+            throw new RuntimeException('Configuration cache detected. Variables in phpunit.xml did not take effect.');
+        }
+
         if (! RefreshDatabaseState::$migrated) {
             $this->artisan('migrate:fresh');
 


### PR DESCRIPTION
Today I learned (in the kind-of-hard way) that if you run `php artisan config:cache` and then try to run any phpunit test, your variables on `phpunit.xml` will not take effect. At first, I thought it was just me being 100% stupid, but it raised a question: Isn't the expected behavior that `phpunit.xml` environment variables should take precedence at all costs during tests?
I'm not 100% hoping this gets merged, but it may at least bring awareness to a possible issue.