### PR TITLE
Display name using v-pre in auth scaffolding

### DIFF
--- a/src/Illuminate/Auth/Console/stubs/make/views/layouts/app.stub
+++ b/src/Illuminate/Auth/Console/stubs/make/views/layouts/app.stub
@@ -47,7 +47,7 @@
                             <li><a href="{{ route('register') }}">Register</a></li>
                         @else
                             <li class="dropdown">
-                                <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">
+                                <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false" v-pre>
                                     {{ Auth::user()->name }} <span class="caret"></span>
                                 </a>
 


### PR DESCRIPTION
**Issue**

The default auth scaffolding displays the user's name HTML escaped, but if the user has used curly braces the default Vue setup will try to interpolate it. This could lead to the user executing javascript or breaking the page rendering entirely. I don't believe this is a security vulnerability since it will only happen to the currently authenticated user, but a good example should be set for users.

**Steps to Reproduce**

1. Create a new Laravel project
2. Run `php artisan auth:make`
3. Register a user named `{{ breaksPage }}` or `{{ alert('Hello World') }}`

**Solution**

Use the `v-pre` Vue directive on the element displaying the name.