### PR TITLE
[5.5] New Carbon helper

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -249,6 +249,32 @@ if (! function_exists('cache')) {
     }
 }
 
+if (! function_exists('carbon')) {
+    /**
+     * Create a new Carbon instance for the given datetime or return a new instance.
+     *
+     * @param  \DateTime|string|null $datetime
+     * @param  \DateTimeZone|string|null $tz
+     * @return \Illuminate\Support\Carbon
+     */
+    function carbon($datetime = null, $tz = null)
+    {
+        if (is_null($datetime)) {
+            return new Carbon(null, $tz);
+        }
+
+        if ($datetime instanceof \DateTime) {
+            if (is_null($tz)) {
+                return Carbon::instance($datetime);
+            }
+
+            return Carbon::instance($datetime)->setTimezone($tz);
+        }
+
+        return new Carbon($datetime, $tz);
+    }
+}
+
 if (! function_exists('config')) {
     /**
      * Get / set the specified configuration value.

--- a/tests/Foundation/FoundationHelpersTest.php
+++ b/tests/Foundation/FoundationHelpersTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Foundation;
 
 use Mockery as m;
+use Illuminate\Support\Carbon;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Foundation\Application;
 
@@ -41,6 +42,45 @@ class FoundationHelpersTest extends TestCase
     public function testCacheThrowsAnExceptionIfAnExpirationIsNotProvided()
     {
         cache(['foo' => 'bar']);
+    }
+
+    public function testCarbon()
+    {
+        // carbon()
+        $this->assertInstanceOf('Illuminate\Support\Carbon', carbon());
+
+        // carbon('string', 'timezone')
+        $this->assertEquals(13, carbon('2017-10-13 22:00:00')->day);
+        $this->assertEquals('2017', carbon('first day of october 2017')->year);
+        $this->assertFalse(carbon('today', 'America/Sao_Paulo')->utc);
+        $this->assertFalse(carbon(null, 'America/Sao_Paulo')->utc);
+
+        // carbon(\DateTime)
+        $this->assertEquals(
+            '22',
+            carbon(\DateTime::createFromFormat('Y-m-d H', '2017-10-13 22'))->hour
+        );
+        $this->assertFalse(
+            carbon(new \DateTime('now', new \DateTimeZone('America/Sao_Paulo')))->utc
+        );
+        $this->assertFalse(
+            carbon(new \DateTime('now'), new \DateTimeZone('America/Sao_Paulo'))->utc
+        );
+
+        // Carbon helpers
+        $this->assertEquals(Carbon::yesterday(), carbon()->yesterday());
+        $this->assertEquals(Carbon::tomorrow(), carbon()->tomorrow());
+
+        // Relative phrases
+        $this->assertEquals(
+            Carbon::now()->addMonth()->month, carbon('next month')->month
+        );
+
+        // Addition and Subtraction
+        $this->assertEquals(
+            Carbon::tomorrow()->addWeek(),
+            carbon()->tomorrow()->addWeek()
+        );
     }
 
     public function testUnversionedElixir()


### PR DESCRIPTION
Recently, two new helpers were added to Laravel: `now` and `today`. My first reaction was to add another two ones: `tomorrow` and `yesterday`, but it didn't sound the best to do. So, encouraged by that, I've created a new helper: **`carbon`**.

This helper will make the work with `Carbon` a lot easier, especially in `views`, removing the need of importing `Carbon` every time.

This supports:

- Datetime: `carbon(\DateTime::createFromFormat('Y-m-d H', '2017-10-13 22'))`;
- String: `carbon('2017-10-13 22:00:00')`;
- Timezone: `carbon('tomorrow', 'America/Sao_Paulo')`;
- Relative phrases from `Carbon`: `carbon('next month')`;
- `Carbon` helpers: `carbon()->yesterday()`.

References: [laravel/internals#828](https://github.com/laravel/internals/issues/828)