### PR TITLE
Make request accessible in password reset responses

### DIFF
--- a/src/Illuminate/Foundation/Auth/ResetsPasswords.php
+++ b/src/Illuminate/Foundation/Auth/ResetsPasswords.php
@@ -52,7 +52,7 @@ trait ResetsPasswords
         // the application's home authenticated view. If there is an error we can
         // redirect them back to where they came from with their error message.
         return $response == Password::PASSWORD_RESET
-                    ? $this->sendResetResponse($response)
+                    ? $this->sendResetResponse($request, $response)
                     : $this->sendResetFailedResponse($request, $response);
     }
 
@@ -116,10 +116,11 @@ trait ResetsPasswords
     /**
      * Get the response for a successful password reset.
      *
+     * @param  \Illuminate\Http\Request
      * @param  string  $response
      * @return \Illuminate\Http\RedirectResponse|\Illuminate\Http\JsonResponse
      */
-    protected function sendResetResponse($response)
+    protected function sendResetResponse(Request $request, $response)
     {
         return redirect($this->redirectPath())
                             ->with('status', trans($response));

--- a/src/Illuminate/Foundation/Auth/SendsPasswordResetEmails.php
+++ b/src/Illuminate/Foundation/Auth/SendsPasswordResetEmails.php
@@ -35,7 +35,7 @@ trait SendsPasswordResetEmails
         );
 
         return $response == Password::RESET_LINK_SENT
-                    ? $this->sendResetLinkResponse($response)
+                    ? $this->sendResetLinkResponse($request, $response)
                     : $this->sendResetLinkFailedResponse($request, $response);
     }
 
@@ -53,10 +53,11 @@ trait SendsPasswordResetEmails
     /**
      * Get the response for a successful password reset link.
      *
+     * @param  \Illuminate\Http\Request
      * @param  string  $response
      * @return \Illuminate\Http\RedirectResponse|\Illuminate\Http\JsonResponse
      */
-    protected function sendResetLinkResponse($response)
+    protected function sendResetLinkResponse(Request $request, $response)
     {
         return back()->with('status', trans($response));
     }


### PR DESCRIPTION
It's necessary to access `$request` for customization of `sendResetResponse()` in `\Illuminate\Foundation\Auth\ResetsPasswords` and `sendResetLinkResponse()` in `\Illuminate\Foundation\Auth\SendsPasswordResetEmails`.