### PR TITLE
[5.5] Add view header to the route:list command

### DIFF
--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -45,7 +45,7 @@ class RouteListCommand extends Command
      *
      * @var array
      */
-    protected $headers = ['Domain', 'Method', 'URI', 'Name', 'Action', 'Middleware'];
+    protected $headers = ['Domain', 'Method', 'URI', 'Name', 'Action', 'Middleware', 'View'];
 
     /**
      * Create a new route command instance.
@@ -112,6 +112,7 @@ class RouteListCommand extends Command
             'name'   => $route->getName(),
             'action' => $route->getActionName(),
             'middleware' => $this->getMiddleware($route),
+            'view'   => $route->getViewName()
         ]);
     }
 

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -741,6 +741,16 @@ class Route
     }
 
     /**
+     * Get the view for the route.
+     *
+     * @return string
+     */
+    public function getViewName()
+    {
+        return $this->defaults['view'] ?? null;
+    }
+
+    /**
      * Get all middleware, including the ones from the controller.
      *
      * @return array


### PR DESCRIPTION
Given the `Route::view()` method was introduced with 5.5, I find it would be cool to see which view the route uses with the `route:list` command. What do you think?