### PR TITLE
Validation rule for UUID

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1471,4 +1471,38 @@ trait ValidatesAttributes
             throw new InvalidArgumentException("Validation rule $rule requires at least $count parameters.");
         }
     }
+
+    /**
+     * Validate that an attribute is valid UUID as explained in "UUID 4122 RFC".
+     *
+     * @param  string  $attribute
+     * @param  mixed   $value
+     * @param  array   $parameters
+     * @return bool
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function validateUuid($attribute, $value, $parameters)
+    {
+        $pattern = '/^[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}$/i';
+
+        $patterns = [
+            0 => '/^[0]{8}-[0]{4}-[0]{4}-[0]{4}-[0]{12}$/i',
+            1 => '/^[0-9A-F]{8}-[0-9A-F]{4}-[1][0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i',
+            2 => '/^[0-9A-F]{8}-[0-9A-F]{4}-[2][0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i',
+            3 => '/^[0-9A-F]{8}-[0-9A-F]{4}-[3][0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i',
+            4 => '/^[0-9A-F]{8}-[0-9A-F]{4}-[4][0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i',
+            5 => '/^[0-9A-F]{8}-[0-9A-F]{4}-[5][0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i',
+        ];
+
+        if (count($parameters)) {
+            if (! Arr::has($patterns, $parameters[0])) {
+                throw new \InvalidArgumentException('UUID version is unsupported.');
+            }
+
+            $pattern = Arr::get($patterns, $parameters[0]);
+        }
+
+        return is_string($value) && preg_match($pattern, $value);
+    }
 }

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -3803,4 +3803,75 @@ class ValidationValidatorTest extends TestCase
             new \Illuminate\Translation\ArrayLoader, 'en'
         );
     }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage UUID version is unsupported.
+     */
+    public function testValidateUuidThrowOnInvalidArgument()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+
+        $v = new Validator($trans, ['x' => 'cd940696-643c-42ca-815d-a5ea0ed7bd3e'], ['x' => 'uuid:6']);
+        $v->validate();
+    }
+
+    public function testValidateUuid()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+
+        $v = new Validator($trans, ['x' => ''], ['x' => 'required|uuid']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, [], ['x' => 'uuid']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => null], ['x' => 'uuid']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['x' => 'string does not contains UUID'], ['x' => 'uuid']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['x' => '1fa4a050-b0de-11e7-abc4-cec278b6b50a'], ['x' => 'uuid']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => '1fa4a050-b0de-11e7-FAIL-cec278b6b50a'], ['x' => 'uuid']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['x' => '00000000-0000-0000-0000-000000000000'], ['x' => 'uuid']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => '00000000-0000-0000-0000-000000000000'], ['x' => 'uuid:0']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => '00000000-0000-0000-0000-000000000000'], ['x' => 'uuid:1']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['x' => '54ffc0fa-27c3-1243-885e-0761b9e7bddd'], ['x' => 'uuid:1']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => '54ffc0fa-27c3-2243-885e-0761b9e7bddd'], ['x' => 'uuid:1']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['x' => '54ffc0fa-27c3-2243-885e-0761b9e7bddd'], ['x' => 'uuid:2']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => '54ffc0fa-27c3-3243-885e-0761b9e7bddd'], ['x' => 'uuid:2']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['x' => '54ffc0fa-27c3-3243-885e-0761b9e7bddd'], ['x' => 'uuid:3']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => '54ffc0fa-27c3-4243-885e-0761b9e7bddd'], ['x' => 'uuid:3']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['x' => '54ffc0fa-27c3-4243-885e-0761b9e7bddd'], ['x' => 'uuid:4']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => '54ffc0fa-27c3-5243-885e-0761b9e7bddd'], ['x' => 'uuid:4']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['x' => '54ffc0fa-27c3-5243-885e-0761b9e7bddd'], ['x' => 'uuid:5']);
+        $this->assertTrue($v->passes());
+    }
 }


### PR DESCRIPTION
Support versions 1..5, as explained in [4122 RFC, chapter 4.1.3](https://tools.ietf.org/html/rfc4122#section-4.1.3) and nil UUID, as explained in [4122 RFC, chapter 4.1.7](https://tools.ietf.org/html/rfc4122#section-4.1.7)

Examples:
- uuid
- uuid:1
- uuid:5