### PR TITLE
Fix serialize/unserialize issues with DatabaseStore caching and speci…

### DIFF
--- a/src/Illuminate/Cache/DatabaseStore.php
+++ b/src/Illuminate/Cache/DatabaseStore.php
@@ -78,7 +78,7 @@ class DatabaseStore implements Store
             return;
         }
 
-        return unserialize($cache->value);
+        return unserialize(base64_decode($cache->value));
     }
 
     /**
@@ -93,7 +93,7 @@ class DatabaseStore implements Store
     {
         $key = $this->prefix.$key;
 
-        $value = serialize($value);
+        $value = base64_encode(serialize($value));
 
         $expiration = $this->getTime() + (int) ($minutes * 60);
 

--- a/src/Illuminate/Cache/DatabaseStore.php
+++ b/src/Illuminate/Cache/DatabaseStore.php
@@ -157,7 +157,7 @@ class DatabaseStore implements Store
 
             $cache = is_array($cache) ? (object) $cache : $cache;
 
-            $current = unserialize($cache->value);
+            $current = unserialize(base64_decode($cache->value));
 
             // Here we'll call this callback function that was given to the function which
             // is used to either increment or decrement the function. We use a callback
@@ -172,7 +172,7 @@ class DatabaseStore implements Store
             // since database cache values are encrypted by default with secure storage
             // that can't be easily read. We will return the new value after storing.
             $this->table()->where('key', $prefixed)->update([
-                'value' => serialize($new),
+                'value' => base64_encode(serialize($new)),
             ]);
 
             return $new;

--- a/tests/Cache/CacheDatabaseStoreTest.php
+++ b/tests/Cache/CacheDatabaseStoreTest.php
@@ -43,7 +43,7 @@ class CacheDatabaseStoreTest extends TestCase
         $table = m::mock('stdClass');
         $store->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($table);
         $table->shouldReceive('where')->once()->with('key', '=', 'prefixfoo')->andReturn($table);
-        $table->shouldReceive('first')->once()->andReturn((object) ['value' => serialize('bar'), 'expiration' => 999999999999999]);
+        $table->shouldReceive('first')->once()->andReturn((object) ['value' => base64_encode(serialize('bar')), 'expiration' => 999999999999999]);
 
         $this->assertEquals('bar', $store->get('foo'));
     }
@@ -54,7 +54,7 @@ class CacheDatabaseStoreTest extends TestCase
         $table = m::mock('stdClass');
         $store->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($table);
         $store->expects($this->once())->method('getTime')->will($this->returnValue(1));
-        $table->shouldReceive('insert')->once()->with(['key' => 'prefixfoo', 'value' => serialize('bar'), 'expiration' => 61]);
+        $table->shouldReceive('insert')->once()->with(['key' => 'prefixfoo', 'value' => base64_encode(serialize('bar')), 'expiration' => 61]);
 
         $store->put('foo', 'bar', 1);
     }
@@ -65,11 +65,11 @@ class CacheDatabaseStoreTest extends TestCase
         $table = m::mock('stdClass');
         $store->getConnection()->shouldReceive('table')->with('table')->andReturn($table);
         $store->expects($this->once())->method('getTime')->will($this->returnValue(1));
-        $table->shouldReceive('insert')->once()->with(['key' => 'prefixfoo', 'value' => serialize('bar'), 'expiration' => 61])->andReturnUsing(function () {
+        $table->shouldReceive('insert')->once()->with(['key' => 'prefixfoo', 'value' => base64_encode(serialize('bar')), 'expiration' => 61])->andReturnUsing(function () {
             throw new Exception;
         });
         $table->shouldReceive('where')->once()->with('key', 'prefixfoo')->andReturn($table);
-        $table->shouldReceive('update')->once()->with(['value' => serialize('bar'), 'expiration' => 61]);
+        $table->shouldReceive('update')->once()->with(['value' => base64_encode(serialize('bar')), 'expiration' => 61]);
 
         $store->put('foo', 'bar', 1);
     }
@@ -118,7 +118,7 @@ class CacheDatabaseStoreTest extends TestCase
         $table->shouldReceive('first')->once()->andReturn(null);
         $this->assertFalse($store->increment('foo'));
 
-        $cache->value = serialize('bar');
+        $cache->value = base64_encode(serialize('bar'));
         $store->getConnection()->shouldReceive('transaction')->once()->with(m::type('Closure'))->andReturnUsing(function ($closure) {
             return $closure();
         });
@@ -128,7 +128,7 @@ class CacheDatabaseStoreTest extends TestCase
         $table->shouldReceive('first')->once()->andReturn($cache);
         $this->assertFalse($store->increment('foo'));
 
-        $cache->value = serialize(2);
+        $cache->value = base64_encode(serialize(2));
         $store->getConnection()->shouldReceive('transaction')->once()->with(m::type('Closure'))->andReturnUsing(function ($closure) {
             return $closure();
         });
@@ -138,7 +138,7 @@ class CacheDatabaseStoreTest extends TestCase
         $table->shouldReceive('first')->once()->andReturn($cache);
         $store->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($table);
         $table->shouldReceive('where')->once()->with('key', 'prefixfoo')->andReturn($table);
-        $table->shouldReceive('update')->once()->with(['value' => serialize(3)]);
+        $table->shouldReceive('update')->once()->with(['value' => base64_encode(serialize(3))]);
         $this->assertEquals(3, $store->increment('foo'));
     }
 
@@ -157,7 +157,7 @@ class CacheDatabaseStoreTest extends TestCase
         $table->shouldReceive('first')->once()->andReturn(null);
         $this->assertFalse($store->decrement('foo'));
 
-        $cache->value = serialize('bar');
+        $cache->value = base64_encode(serialize('bar'));
         $store->getConnection()->shouldReceive('transaction')->once()->with(m::type('Closure'))->andReturnUsing(function ($closure) {
             return $closure();
         });
@@ -167,7 +167,7 @@ class CacheDatabaseStoreTest extends TestCase
         $table->shouldReceive('first')->once()->andReturn($cache);
         $this->assertFalse($store->decrement('foo'));
 
-        $cache->value = serialize(3);
+        $cache->value = base64_encode(serialize(3));
         $store->getConnection()->shouldReceive('transaction')->once()->with(m::type('Closure'))->andReturnUsing(function ($closure) {
             return $closure();
         });
@@ -177,7 +177,7 @@ class CacheDatabaseStoreTest extends TestCase
         $table->shouldReceive('first')->once()->andReturn($cache);
         $store->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($table);
         $table->shouldReceive('where')->once()->with('key', 'prefixbar')->andReturn($table);
-        $table->shouldReceive('update')->once()->with(['value' => serialize(2)]);
+        $table->shouldReceive('update')->once()->with(['value' => base64_encode(serialize(2))]);
         $this->assertEquals(2, $store->decrement('bar'));
     }
 


### PR DESCRIPTION
This pull request fixes PHP's issues with serialize/unserialize which are also used in the DatabaseStore caching.
The fix adds base64_encode and base64_decode as described here http://php.net/manual/en/function.serialize.php
The bug is reproduced when unserializing and special characters like ", ', :, or ; exist in any of the serialized values.