### PR TITLE
[5.5] Key collection of values with provided array

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -976,6 +976,17 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
+     * Create a collection by using this collection for values and another for its keys.
+     *
+     * @param  mixed  $keys
+     * @return static
+     */
+    public function keyWith($keys)
+    {
+        return new static(array_combine($this->getArrayableItems($keys), $this->all()));
+    }
+
+    /**
      * Union the collection with the given items.
      *
      * @param  mixed  $items

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1942,6 +1942,35 @@ class SupportCollectionTest extends TestCase
         $this->assertSame($expected, $actual);
     }
 
+    public function testKeyWithArray()
+    {
+        $expected = [
+            1 => 4,
+            2 => 5,
+            3 => 6,
+        ];
+
+        $c = new Collection(array_values($expected));
+        $actual = $c->keyWith(array_keys($expected))->toArray();
+
+        $this->assertSame($expected, $actual);
+    }
+
+    public function testKeyWithCollection()
+    {
+        $expected = [
+            1 => 4,
+            2 => 5,
+            3 => 6,
+        ];
+
+        $keysCollection = new Collection(array_keys($expected));
+        $valueCollection = new Collection(array_values($expected));
+        $actual = $valueCollection->keyWith($keysCollection)->toArray();
+
+        $this->assertSame($expected, $actual);
+    }
+
     public function testConcatWithArray()
     {
         $expected = [


### PR DESCRIPTION
This is the inverse of `$collection->combine($values)` where it allows you to key the collection with the provided values.

I added something like this directly the the partition method and then realised it could be used outside of that, but basically:

``` php
$memberships = Membership::all()->partition('is_main')->keyWith(['main', 'secondary']);

$memberships['main']; // main memberships
$memberships['secondary']; // secondary memberships
```

I know the naming is very close the the already existing `keyBy`, so if anyone has a better name...

---

#weDontNeedThis

``` php
list($main, $secondary) = Membership::all()->partition('is_main');

// or

collect(['main', 'secondary'])->combine(Membership::all()->partition('is_main'));
```

But I can see this being handy to have and I'll certainly use it.