### PR TITLE
[5.5] Fixing __ function DocBlock

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -902,7 +902,7 @@ if (! function_exists('__')) {
      * @param  string  $key
      * @param  array  $replace
      * @param  string  $locale
-     * @return string
+     * @return string|array|null
      */
     function __($key, $replace = [], $locale = null)
     {

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -144,7 +144,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
      * @param  string  $key
      * @param  array  $replace
      * @param  string  $locale
-     * @return string
+     * @return string|array|null
      */
     public function getFromJson($key, array $replace = [], $locale = null)
     {


### PR DESCRIPTION
`getFromJson` falls back to `get`, so it should contain all of `get`'s return types.