### PR TITLE
Add translation to email view

### DIFF
--- a/src/Illuminate/Mail/resources/views/html/message.blade.php
+++ b/src/Illuminate/Mail/resources/views/html/message.blade.php
@@ -21,7 +21,7 @@
     {{-- Footer --}}
     @slot('footer')
         @component('mail::footer')
-            &copy; {{ date('Y') }} {{ config('app.name') }}. All rights reserved.
+            &copy; {{ date('Y') }} {{ config('app.name') }}. @lang('mail.all_rights_reserved').
         @endcomponent
     @endslot
 @endcomponent

--- a/src/Illuminate/Notifications/resources/views/email.blade.php
+++ b/src/Illuminate/Notifications/resources/views/email.blade.php
@@ -4,9 +4,9 @@
 # {{ $greeting }}
 @else
 @if ($level == 'error')
-# Whoops!
+# @lang('mail.whoops')
 @else
-# Hello!
+# @lang('mail.hello')
 @endif
 @endif
 
@@ -19,16 +19,16 @@
 {{-- Action Button --}}
 @isset($actionText)
 <?php
-    switch ($level) {
-        case 'success':
-            $color = 'green';
-            break;
-        case 'error':
-            $color = 'red';
-            break;
-        default:
-            $color = 'blue';
-    }
+switch ($level) {
+    case 'success':
+        $color = 'green';
+        break;
+    case 'error':
+        $color = 'red';
+        break;
+    default:
+        $color = 'blue';
+}
 ?>
 @component('mail::button', ['url' => $actionUrl, 'color' => $color])
 {{ $actionText }}
@@ -45,14 +45,13 @@
 @if (! empty($salutation))
 {{ $salutation }}
 @else
-Regards,<br>{{ config('app.name') }}
+@lang('mail.regards'),<br>{{ config('app.name') }}
 @endif
 
 {{-- Subcopy --}}
 @isset($actionText)
 @component('mail::subcopy')
-If you’re having trouble clicking the "{{ $actionText }}" button, copy and paste the URL below
-into your web browser: [{{ $actionUrl }}]({{ $actionUrl }})
+@lang('mail.copy_paste_url', ['actionText' => $actionText]): [{{ $actionUrl }}]({{ $actionUrl }})
 @endcomponent
 @endisset
 @endcomponent


### PR DESCRIPTION
Add translation to the default email view instead of the hard-coded text in order to make it easier to use the MailMessage class without the need to publish the mail components and customize it each time.