### PR TITLE
[5.5] Add ability to exclude specific columns from being in the result collection of Eloquent query

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -7,11 +7,11 @@ use BadMethodCallException;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Pagination\Paginator;
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Concerns\BuildsQueries;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Query\Builder as QueryBuilder;
-use Illuminate\Support\Facades\Schema;
 
 /**
  * @mixin \Illuminate\Database\Query\Builder
@@ -247,7 +247,7 @@ class Builder
 
     /**
      * Exclude one or many columns from being in the result colelction.
-     * 
+     *
      * @param  array $columns
      * @return $this
      */

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -11,6 +11,7 @@ use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Concerns\BuildsQueries;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Query\Builder as QueryBuilder;
+use Illuminate\Support\Facades\Schema;
 
 /**
  * @mixin \Illuminate\Database\Query\Builder
@@ -242,6 +243,22 @@ class Builder
     public function orWhere($column, $operator = null, $value = null)
     {
         return $this->where($column, $operator, $value, 'or');
+    }
+
+    /**
+     * Exclude one or many columns from being in the result colelction.
+     * 
+     * @param  array $columns
+     * @return $this
+     */
+    public function exclude($columns)
+    {
+        $wantedColumns = array_diff(
+                Schema::getColumnListing($this->getModel()['table']),
+                (array) $columns
+            );
+
+        return $this->select($wantedColumns);
     }
 
     /**


### PR DESCRIPTION
Hello,
I was wondering if there's a built-in laravel way to exclude a column or some columns from being selected in the Eloquent query builder and there was not. So I added this method which can be used like the following:

```PHP
App\Team::where('type', 1)->exclude('owner_id')->first();
// OR
App\Team::where('type', 1)->exclude(['owner_id', 'name'])->first();
```
So in the result collection I will get all the attributes and columns of this query except for specific columns in case I don't need them in the result of this query.

Thanks.