### PR TITLE
[5.5] Unify bootstrap preset with the laravel/laravel repo

### DIFF
--- a/src/Illuminate/Foundation/Console/Presets/bootstrap-stubs/app.scss
+++ b/src/Illuminate/Foundation/Console/Presets/bootstrap-stubs/app.scss
@@ -1,9 +1,9 @@
 
 // Fonts
-@import url(https://fonts.googleapis.com/css?family=Raleway:300,400,600);
+@import url("https://fonts.googleapis.com/css?family=Raleway:300,400,600");
 
 // Variables
 @import "variables";
 
 // Bootstrap
-@import "node_modules/bootstrap-sass/assets/stylesheets/bootstrap";
+@import "~bootstrap-sass/assets/stylesheets/bootstrap";


### PR DESCRIPTION
Unified the bootstrap preset stubs with the main repository.

Made the same changes as here: https://github.com/laravel/laravel/pull/4287 and here: https://github.com/laravel/laravel/pull/4368.