### PR TITLE
[5.5] flush listeners of custom eloquent events

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
@@ -301,6 +301,10 @@ trait HasEvents
         foreach ($instance->getObservableEvents() as $event) {
             static::$dispatcher->forget("eloquent.{$event}: ".static::class);
         }
+
+        foreach (array_values($instance->dispatchesEvents) as $event) {
+            static::$dispatcher->forget($event);
+        }
     }
 
     /**

--- a/tests/Integration/Database/EloquentModelCustomEventsTest.php
+++ b/tests/Integration/Database/EloquentModelCustomEventsTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\EloquentModelCustomEventsTest;
+
+use Illuminate\Support\Facades\Event;
+use Orchestra\Testbench\TestCase;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * @group integration
+ */
+class EloquentModelCustomEventsTest extends TestCase
+{
+    protected function getEnvironmentSetUp($app)
+    {
+        $app['config']->set('app.debug', 'true');
+
+        $app['config']->set('database.default', 'testbench');
+
+        $app['config']->set('database.connections.testbench', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+        ]);
+    }
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        Schema::create('test_model1', function ($table) {
+            $table->increments('id');
+        });
+
+        Event::listen(CustomEvent::class, function () {
+            $_SERVER['fired_event'] = true;
+        });
+    }
+
+    public function testFlushListenersClearsCustomEvents()
+    {
+        $_SERVER['fired_event'] = false;
+
+        TestModel1::flushEventListeners();
+
+        $user = TestModel1::create();
+
+        $this->assertFalse($_SERVER['fired_event']);
+    }
+
+    public function testCustomEventListenersAreFired()
+    {
+        $_SERVER['fired_event'] = false;
+
+        $user = TestModel1::create();
+
+        $this->assertTrue($_SERVER['fired_event']);
+    }
+}
+
+class TestModel1 extends Model
+{
+    public $dispatchesEvents = ['created' => CustomEvent::class];
+    public $table = 'test_model1';
+    public $timestamps = false;
+    protected $guarded = ['id'];
+}
+
+class CustomEvent
+{
+}

--- a/tests/Integration/Database/EloquentModelCustomEventsTest.php
+++ b/tests/Integration/Database/EloquentModelCustomEventsTest.php
@@ -2,8 +2,8 @@
 
 namespace Illuminate\Tests\Integration\Database\EloquentModelCustomEventsTest;
 
-use Illuminate\Support\Facades\Event;
 use Orchestra\Testbench\TestCase;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Eloquent\Model;
 


### PR DESCRIPTION
Having this in your model:

```
class User extends Model
{
    protected $dispatchesEvents = ['created' => UserCreated::class];
}
```

Currently if you do this in your tests:

```
public function testFlushEventListeners()
    {
        User::flushEventListeners();
        
        $user = factory(User::class)->create();
    }
```

The listeners of the `UserCreated` are still going to be fired, this PR fixes that.