### PR TITLE
[5.5] Allow @json options to be 0

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesJson.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesJson.php
@@ -21,9 +21,9 @@ trait CompilesJson
     {
         $parts = explode(',', $this->stripParentheses($expression));
 
-        $options = trim($parts[1] ?? $this->encodingOptions);
+        $options = isset($parts[1]) ? trim($parts[1]) : $this->encodingOptions;
 
-        $depth = trim($parts[2] ?? 512);
+        $depth = isset($parts[2]) ? trim($parts[2]) : 512;
 
         return "<?php echo json_encode($parts[0], $options, $depth) ?>";
     }


### PR DESCRIPTION
Currently we set the @json helper's `$options` if it is evaluated to false; however, it makes it impossible to set 0 for it.

For example in the current behavior `@json($array,0)` means the same as `@json($array)`, which will have a default `$options` set (which is obviously not what the coder intends to do).