### PR TITLE
[5.6] Add option for custom prefix on migration file

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
@@ -104,6 +104,7 @@ class MigrateMakeCommand extends BaseCommand
      * Write the migration file to disk.
      *
      * @param  string  $name
+     * @param  string  $prefix
      * @param  string  $table
      * @param  bool    $create
      * @return string

--- a/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
@@ -13,6 +13,7 @@ class MigrateMakeCommand extends BaseCommand
      * @var string
      */
     protected $signature = 'make:migration {name : The name of the migration.}
+        {--prefix= : Use custom prefix on migration file instead of default DateTime.}
         {--create= : The table to be created.}
         {--table= : The table to migrate.}
         {--path= : The location where the migration file should be created.}';
@@ -65,6 +66,8 @@ class MigrateMakeCommand extends BaseCommand
         // to be freshly created so we can create the appropriate migrations.
         $name = trim($this->input->getArgument('name'));
 
+        $prefix = $this->input->getOption('prefix');
+
         $table = $this->input->getOption('table');
 
         $create = $this->input->getOption('create') ?: false;
@@ -92,7 +95,7 @@ class MigrateMakeCommand extends BaseCommand
         // Now we are ready to write the migration out to disk. Once we've written
         // the migration out, we will dump-autoload for the entire framework to
         // make sure that the migrations are registered by the class loaders.
-        $this->writeMigration($name, $table, $create);
+        $this->writeMigration($name, $prefix, $table, $create);
 
         $this->composer->dumpAutoloads();
     }
@@ -105,7 +108,7 @@ class MigrateMakeCommand extends BaseCommand
      * @param  bool    $create
      * @return string
      */
-    protected function writeMigration($name, $table, $create)
+    protected function writeMigration($name, $prefix, $table, $create)
     {
         $file = pathinfo($this->creator->create(
             $name, $this->getMigrationPath(), $table, $create

--- a/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
@@ -112,7 +112,7 @@ class MigrateMakeCommand extends BaseCommand
     protected function writeMigration($name, $prefix, $table, $create)
     {
         $file = pathinfo($this->creator->create(
-            $name, $this->getMigrationPath(), $table, $create
+            $name, $this->getMigrationPath(), $prefix, $table, $create
         ), PATHINFO_FILENAME);
 
         $this->line("<info>Created Migration:</info> {$file}");

--- a/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
@@ -13,6 +13,7 @@ class MigrateMakeCommand extends BaseCommand
      * @var string
      */
     protected $signature = 'make:migration {name : The name of the migration.}
+        {--prefix= : Use custom prefix on migration file instead of default DateTime.}
         {--create= : The table to be created.}
         {--table= : The table to migrate.}
         {--path= : The location where the migration file should be created.}';
@@ -65,6 +66,8 @@ class MigrateMakeCommand extends BaseCommand
         // to be freshly created so we can create the appropriate migrations.
         $name = trim($this->input->getArgument('name'));
 
+        $prefix = $this->input->getOption('prefix');
+
         $table = $this->input->getOption('table');
 
         $create = $this->input->getOption('create') ?: false;
@@ -92,7 +95,7 @@ class MigrateMakeCommand extends BaseCommand
         // Now we are ready to write the migration out to disk. Once we've written
         // the migration out, we will dump-autoload for the entire framework to
         // make sure that the migrations are registered by the class loaders.
-        $this->writeMigration($name, $table, $create);
+        $this->writeMigration($name, $prefix, $table, $create);
 
         $this->composer->dumpAutoloads();
     }

--- a/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
@@ -108,7 +108,7 @@ class MigrateMakeCommand extends BaseCommand
      * @param  bool    $create
      * @return string
      */
-    protected function writeMigration($name, $table, $create)
+    protected function writeMigration($name, $prefix, $table, $create)
     {
         $file = pathinfo($this->creator->create(
             $name, $this->getMigrationPath(), $table, $create

--- a/src/Illuminate/Database/Migrations/MigrationCreator.php
+++ b/src/Illuminate/Database/Migrations/MigrationCreator.php
@@ -52,7 +52,7 @@ class MigrationCreator
         // First we will get the stub file for the migration, which serves as a type
         // of template for the migration. Once we have those we will populate the
         // various place-holders, save the file, and run the post create event.
-        $stub = $this->getStub($prefix, $table, $create);
+        $stub = $this->getStub($table, $create);
 
         $this->files->put(
             $path = $this->getPath($prefix, $name, $path),
@@ -90,7 +90,7 @@ class MigrationCreator
      * @param  bool    $create
      * @return string
      */
-    protected function getStub($prefix, $table, $create)
+    protected function getStub($table, $create)
     {
         if (is_null($table)) {
             return $this->files->get($this->stubPath().'/blank.stub');

--- a/src/Illuminate/Database/Migrations/MigrationCreator.php
+++ b/src/Illuminate/Database/Migrations/MigrationCreator.php
@@ -39,22 +39,23 @@ class MigrationCreator
      *
      * @param  string  $name
      * @param  string  $path
+     * @param  string  $prefix
      * @param  string  $table
      * @param  bool    $create
      * @return string
      * @throws \Exception
      */
-    public function create($name, $path, $table = null, $create = false)
+    public function create($name, $path, $prefix = false, $table = null, $create = false)
     {
         $this->ensureMigrationDoesntAlreadyExist($name);
 
         // First we will get the stub file for the migration, which serves as a type
         // of template for the migration. Once we have those we will populate the
         // various place-holders, save the file, and run the post create event.
-        $stub = $this->getStub($table, $create);
+        $stub = $this->getStub($prefix, $table, $create);
 
         $this->files->put(
-            $path = $this->getPath($name, $path),
+            $path = $this->getPath($prefix, $name, $path),
             $this->populateStub($name, $stub, $table)
         );
 
@@ -88,7 +89,7 @@ class MigrationCreator
      * @param  bool    $create
      * @return string
      */
-    protected function getStub($table, $create)
+    protected function getStub($prefix, $table, $create)
     {
         if (is_null($table)) {
             return $this->files->get($this->stubPath().'/blank.stub');
@@ -140,13 +141,18 @@ class MigrationCreator
     /**
      * Get the full path to the migration.
      *
+     * @param  string  $prefix
      * @param  string  $name
      * @param  string  $path
      * @return string
      */
-    protected function getPath($name, $path)
+    protected function getPath($prefix, $name, $path)
     {
-        return $path.'/'.$this->getDatePrefix().'_'.$name.'.php';
+        if ($prefix) {
+            return $path.'/'.$prefix.'_'.$name.'.php';
+        } else {
+            return $path.'/'.$this->getDatePrefix().'_'.$name.'.php';
+        }
     }
 
     /**

--- a/src/Illuminate/Database/Migrations/MigrationCreator.php
+++ b/src/Illuminate/Database/Migrations/MigrationCreator.php
@@ -52,7 +52,7 @@ class MigrationCreator
         // First we will get the stub file for the migration, which serves as a type
         // of template for the migration. Once we have those we will populate the
         // various place-holders, save the file, and run the post create event.
-        $stub = $this->getStub($table, $create);
+        $stub = $this->getStub($prefix, $table, $create);
 
         $this->files->put(
             $path = $this->getPath($prefix, $name, $path),
@@ -85,11 +85,12 @@ class MigrationCreator
     /**
      * Get the migration stub file.
      *
+     * @param  string  $prefix
      * @param  string  $table
      * @param  bool    $create
      * @return string
      */
-    protected function getStub($table, $create)
+    protected function getStub($prefix, $table, $create)
     {
         if (is_null($table)) {
             return $this->files->get($this->stubPath().'/blank.stub');
@@ -148,7 +149,7 @@ class MigrationCreator
      */
     protected function getPath($prefix, $name, $path)
     {
-        if($prefix) {
+        if ($prefix) {
             return $path.'/'.$prefix.'_'.$name.'.php';
         } else {
             return $path.'/'.$this->getDatePrefix().'_'.$name.'.php';

--- a/src/Illuminate/Database/Migrations/MigrationCreator.php
+++ b/src/Illuminate/Database/Migrations/MigrationCreator.php
@@ -148,12 +148,9 @@ class MigrationCreator
      */
     protected function getPath($prefix, $name, $path)
     {
-        if($prefix)
-        {
+        if($prefix) {
             return $path.'/'.$prefix.'_'.$name.'.php';
-        }
-        else
-        {
+        } else {
             return $path.'/'.$this->getDatePrefix().'_'.$name.'.php';
         }
     }

--- a/src/Illuminate/Database/Migrations/MigrationCreator.php
+++ b/src/Illuminate/Database/Migrations/MigrationCreator.php
@@ -39,12 +39,13 @@ class MigrationCreator
      *
      * @param  string  $name
      * @param  string  $path
+     * @param  string  $prefix
      * @param  string  $table
      * @param  bool    $create
      * @return string
      * @throws \Exception
      */
-    public function create($name, $path, $table = null, $create = false)
+    public function create($name, $path, $prefix = false, $table = null, $create = false)
     {
         $this->ensureMigrationDoesntAlreadyExist($name);
 
@@ -54,7 +55,7 @@ class MigrationCreator
         $stub = $this->getStub($table, $create);
 
         $this->files->put(
-            $path = $this->getPath($name, $path),
+            $path = $this->getPath($prefix, $name, $path),
             $this->populateStub($name, $stub, $table)
         );
 
@@ -140,13 +141,21 @@ class MigrationCreator
     /**
      * Get the full path to the migration.
      *
+     * @param  string  $prefix
      * @param  string  $name
      * @param  string  $path
      * @return string
      */
-    protected function getPath($name, $path)
+    protected function getPath($prefix, $name, $path)
     {
-        return $path.'/'.$this->getDatePrefix().'_'.$name.'.php';
+        if($prefix)
+        {
+            return $path.'/'.$prefix.'_'.$name.'.php';
+        }
+        else
+        {
+            return $path.'/'.$this->getDatePrefix().'_'.$name.'.php';
+        }
     }
 
     /**


### PR DESCRIPTION
Laravel uses timestamp as prefix when creating migration file. This creates a problem when we try to actually migrate if we haven't created our DB tables in order as intended. During migration execution process, the files are sorted based on filenames and executed in order. Due to the time stamping our details table might be in higher order than our master table during this process.

One solution is to rename each file by hand to give the order as intended before migration. 

But this PR adds  `--prefix` option on `make:migration` command so that user can specify their custom prefix to migration file for ordering purpose.

For example:

`php artisan make:migration create_cities_table --prefix='00001' --create='Cities'`

will create

`00001_create_cities_table.php` instead of `2017_10_16_100000_create_cities_table.php`

So that user can specify next
`php artisan make:migration create_users_table_who_live_in_that_city --prefix='00002' --create='Users'`

and so on.