### PR TITLE
[5.5] Include current attempt in callback within a database transaction

### DIFF
--- a/src/Illuminate/Database/Concerns/ManagesTransactions.php
+++ b/src/Illuminate/Database/Concerns/ManagesTransactions.php
@@ -26,7 +26,7 @@ trait ManagesTransactions
             // catch any exception we can rollback this transaction so that none of this
             // gets actually persisted to a database or stored in a permanent fashion.
             try {
-                return tap($callback($this), function ($result) {
+                return tap($callback($this, $currentAttempt), function ($result) {
                     $this->commit();
                 });
             }


### PR DESCRIPTION
This gives access to the current attempt without breaking existing behaviour. Valuable if you want to log every failed attempt and not just the thrown exception.