### PR TITLE
[5.5] Add "at" Collection method

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -114,6 +114,17 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
+     * Get a single item for a given index from the collection
+     *
+     * @param $index
+     * @return mixed
+     */
+    public function at($index)
+    {
+        return $this->slice($index,1)->first();
+    }
+
+    /**
      * Get the average value of a given key.
      *
      * @param  callable|string|null  $callback

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2365,6 +2365,15 @@ class SupportCollectionTest extends TestCase
 
         $this->assertSame(['michael', 'tom', 'taylor'], $collection->toArray());
     }
+
+    public function testAtReturnsItemFromCollection()
+    {
+        $data = new Collection([1, 2, 3]);
+
+        $this->assertEquals(1, $data->at(0));
+        $this->assertEquals(2, $data->at(1));
+        $this->assertEquals(3, $data->at(-1));
+    }
 }
 
 class TestSupportCollectionHigherOrderItem


### PR DESCRIPTION
The `at` method returns a single item for a provided index (which can be negative or positive) from the collection.