### PR TITLE
[5.6] Add custom prefix option on migration

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
@@ -13,6 +13,7 @@ class MigrateMakeCommand extends BaseCommand
      * @var string
      */
     protected $signature = 'make:migration {name : The name of the migration.}
+        {--prefix= : Use custom prefix on migration file instead of default DateTime.}
         {--create= : The table to be created.}
         {--table= : The table to migrate.}
         {--path= : The location where the migration file should be created.}';
@@ -65,6 +66,8 @@ class MigrateMakeCommand extends BaseCommand
         // to be freshly created so we can create the appropriate migrations.
         $name = trim($this->input->getArgument('name'));
 
+        $prefix = $this->input->getOption('prefix');
+
         $table = $this->input->getOption('table');
 
         $create = $this->input->getOption('create') ?: false;
@@ -92,7 +95,7 @@ class MigrateMakeCommand extends BaseCommand
         // Now we are ready to write the migration out to disk. Once we've written
         // the migration out, we will dump-autoload for the entire framework to
         // make sure that the migrations are registered by the class loaders.
-        $this->writeMigration($name, $table, $create);
+        $this->writeMigration($name, $prefix, $table, $create);
 
         $this->composer->dumpAutoloads();
     }
@@ -101,14 +104,15 @@ class MigrateMakeCommand extends BaseCommand
      * Write the migration file to disk.
      *
      * @param  string  $name
+     * @param  string  $prefix
      * @param  string  $table
      * @param  bool    $create
      * @return string
      */
-    protected function writeMigration($name, $table, $create)
+    protected function writeMigration($name, $prefix, $table, $create)
     {
         $file = pathinfo($this->creator->create(
-            $name, $this->getMigrationPath(), $table, $create
+            $name, $this->getMigrationPath(), $prefix, $table, $create
         ), PATHINFO_FILENAME);
 
         $this->line("<info>Created Migration:</info> {$file}");

--- a/src/Illuminate/Database/Migrations/MigrationCreator.php
+++ b/src/Illuminate/Database/Migrations/MigrationCreator.php
@@ -39,12 +39,13 @@ class MigrationCreator
      *
      * @param  string  $name
      * @param  string  $path
+     * @param  string  $prefix
      * @param  string  $table
      * @param  bool    $create
      * @return string
      * @throws \Exception
      */
-    public function create($name, $path, $table = null, $create = false)
+    public function create($name, $path, $prefix = false, $table = null, $create = false)
     {
         $this->ensureMigrationDoesntAlreadyExist($name);
 
@@ -54,7 +55,7 @@ class MigrationCreator
         $stub = $this->getStub($table, $create);
 
         $this->files->put(
-            $path = $this->getPath($name, $path),
+            $path = $this->getPath($prefix, $name, $path),
             $this->populateStub($name, $stub, $table)
         );
 
@@ -84,6 +85,7 @@ class MigrationCreator
     /**
      * Get the migration stub file.
      *
+     * @param  string  $prefix
      * @param  string  $table
      * @param  bool    $create
      * @return string
@@ -140,13 +142,18 @@ class MigrationCreator
     /**
      * Get the full path to the migration.
      *
+     * @param  string  $prefix
      * @param  string  $name
      * @param  string  $path
      * @return string
      */
-    protected function getPath($name, $path)
+    protected function getPath($prefix, $name, $path)
     {
-        return $path.'/'.$this->getDatePrefix().'_'.$name.'.php';
+        if ($prefix) {
+            return $path.'/'.$prefix.'_'.$name.'.php';
+        } else {
+            return $path.'/'.$this->getDatePrefix().'_'.$name.'.php';
+        }
     }
 
     /**


### PR DESCRIPTION
This PR adds option (which is optional) to specify custom prefix for migration file during `make:migration`. That way we can create specify something like this:
`artisan make:migration create_some_table --prefix='01' --create='SomeTable'` which will create `01_create_some_table.php` migration file. Useful for ordering process when we actually migrate.

When not specified, it uses default timestamp as file prefix.