### PR TITLE
[5.5] prevent reloading default relationships while lazy eager loading

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -368,7 +368,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public function load($relations)
     {
-        $query = $this->newQuery()->with(
+        $query = $this->newQueryWithoutRelationships()->with(
             is_string($relations) ? func_get_args() : $relations
         );
 
@@ -819,8 +819,30 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public function newQuery()
     {
-        $builder = $this->newQueryWithoutScopes();
+        return $this->registerGlobalScopes($this->newQueryWithoutScopes());
+    }
 
+    /**
+     * Get a new query builder with no relationships loaded.
+     *
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function newQueryWithoutRelationships()
+    {
+        return $this->registerGlobalScopes(
+            $this->newEloquentBuilder($this->newBaseQueryBuilder())
+                 ->setModel($this)
+        );
+    }
+
+    /**
+     * Register the global scopes for this builder instance.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder  $builder
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function registerGlobalScopes($builder)
+    {
         foreach ($this->getGlobalScopes() as $identifier => $scope) {
             $builder->withGlobalScope($identifier, $scope);
         }

--- a/tests/Integration/Database/EloquentLazyEagerLoadingTest.php
+++ b/tests/Integration/Database/EloquentLazyEagerLoadingTest.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\EloquentLazyEagerLoadingTest;
+
+use Orchestra\Testbench\TestCase;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * @group integration
+ */
+class EloquentLazyEagerLoadingTest extends TestCase
+{
+    protected function getEnvironmentSetUp($app)
+    {
+        $app['config']->set('app.debug', 'true');
+
+        $app['config']->set('database.default', 'testbench');
+
+        $app['config']->set('database.connections.testbench', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+        ]);
+    }
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        Schema::create('one', function ($table) {
+            $table->increments('id');
+        });
+
+        Schema::create('two', function ($table) {
+            $table->increments('id');
+            $table->integer('one_id');
+        });
+
+        Schema::create('three', function ($table) {
+            $table->increments('id');
+            $table->integer('one_id');
+        });
+    }
+
+    /**
+     * @test
+     */
+    public function it_basic()
+    {
+        $one = Model1::create();
+        $one->twos()->create();
+        $one->threes()->create();
+
+        $model = Model1::find($one->id);
+
+        $this->assertTrue($model->relationLoaded('twos'));
+        $this->assertFalse($model->relationLoaded('threes'));
+
+        \DB::enableQueryLog();
+
+        $model->load('threes');
+
+        $this->assertCount(1, \DB::getQueryLog());
+
+        $this->assertTrue($model->relationLoaded('threes'));
+    }
+}
+
+class Model1 extends Model
+{
+    public $table = 'one';
+    public $timestamps = false;
+    protected $guarded = ['id'];
+    protected $with = ['twos'];
+
+    public function twos()
+    {
+        return $this->hasMany(Model2::class, 'one_id');
+    }
+
+    public function threes()
+    {
+        return $this->hasMany(Model3::class, 'one_id');
+    }
+}
+
+class Model2 extends Model
+{
+    public $table = 'two';
+    public $timestamps = false;
+    protected $guarded = ['id'];
+
+    public function one()
+    {
+        return $this->belongsTo(Model1::class, 'one_id');
+    }
+}
+
+class Model3 extends Model
+{
+    public $table = 'three';
+    public $timestamps = false;
+    protected $guarded = ['id'];
+
+    public function one()
+    {
+        return $this->belongsTo(Model1::class, 'one_id');
+    }
+}


### PR DESCRIPTION
Model1 has a `$with` property that loads the relationship with Model2

```
class Model1 extends Model
{
    protected $with = ['twos'];

    public function twos()
    {
        return $this->hasMany(Model2::class, 'one_id');
    }

    public function threes()
    {
        return $this->hasMany(Model3::class, 'one_id');
    }
}
```

So if we do `Model1::find(1)`, a query to load the `twos` relationship will run as well, now if we do `$model1->load('threes')` a query to load the `threes` relationship will run but also the query to load the `twos` relationship will run again.

The current behaviour is causing extra queries to run each time we lazy eager load a relationship, all relations registered with `$with` or `$withCount` will run too.

This PR fixes that by using a new `newQueryWithoutRelationships` methods to create a builder instance without registering the default relationships on the query, and use this new method inside the `load()` method.

This solves the issue reported in: https://github.com/laravel/framework/issues/21653