### PR TITLE
[5.5] Fix example component tag name

### DIFF
--- a/src/Illuminate/Foundation/Console/Presets/vue-stubs/app.js
+++ b/src/Illuminate/Foundation/Console/Presets/vue-stubs/app.js
@@ -15,7 +15,7 @@ window.Vue = require('vue');
  * or customize the JavaScript scaffolding to fit your unique needs.
  */
 
-Vue.component('example', require('./components/ExampleComponent.vue'));
+Vue.component('example-component', require('./components/ExampleComponent.vue'));
 
 const app = new Vue({
     el: '#app'


### PR DESCRIPTION
Fixed the tag name of the example component as poined out by @bbashy here: https://github.com/laravel/framework/pull/21685#issuecomment-336927565