### PR TITLE
[5.5] don't reload pivot relationship on refresh

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -978,9 +978,9 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
             return $this;
         }
 
-        $this->load(array_keys($this->relations));
-
         $this->setRawAttributes(static::findOrFail($this->getKey())->attributes);
+
+        $this->load(collect($this->relations)->except('pivot')->keys()->toArray());
 
         return $this;
     }

--- a/tests/Integration/Database/EloquentBelongsToManyTest.php
+++ b/tests/Integration/Database/EloquentBelongsToManyTest.php
@@ -99,6 +99,37 @@ class EloquentBelongsToManyTest extends TestCase
     /**
      * @test
      */
+    public function refresh_on_other_model_works()
+    {
+        $post = Post::create(['title' => str_random()]);
+        $tag = Tag::create(['name' => $tagName = str_random()]);
+
+        $post->tags()->sync([
+            $tag->id,
+        ]);
+
+        $post->load('tags');
+
+        $loadedTag = $post->tags()->first();
+
+        $tag->update(['name' => 'newName']);
+
+        $this->assertEquals($tagName, $loadedTag->name);
+
+        $this->assertEquals($tagName, $post->tags[0]->name);
+
+        $loadedTag->refresh();
+
+        $this->assertEquals('newName', $loadedTag->name);
+
+        $post->refresh();
+
+        $this->assertEquals('newName', $post->tags[0]->name);
+    }
+
+    /**
+     * @test
+     */
     public function custom_pivot_class()
     {
         Carbon::setTestNow(


### PR DESCRIPTION
Having a ManyToMany relationship between posts and tags;

```
$tag = $post->tags()->first();
```

If we do `$tag->refresh()` an exception is thrown because Eloquent will try to load a relationship with name `pivot` which doesn't exist, in the PR we just exclude that key from the list of relationships to reload.

We also load the model attributes before loading the relationships to catch any changes in relationship keys before trying to load the relationship again.