### PR TITLE
[5.5] Add relationship support on joined tables

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -57,9 +57,11 @@ trait HasRelationships
 
         $foreignKey = $foreignKey ?: $this->getForeignKey();
 
+        $foreignKey = Str::contains($foreignKey, '.') ? $foreignKey : $instance->getTable().'.'.$foreignKey;
+        
         $localKey = $localKey ?: $this->getKeyName();
 
-        return new HasOne($instance->newQuery(), $this, $instance->getTable().'.'.$foreignKey, $localKey);
+        return new HasOne($instance->newQuery(), $this, $foreignKey, $localKey);
     }
 
     /**


### PR DESCRIPTION
Added foreign key support for joined tables on a model

We have a model whose relationship to another model is a key in a joined table. Due to an old data structure and legacy systems, this is the only solution we have for joining