### PR TITLE
[5.5] dont-discover packages

### DIFF
--- a/src/Illuminate/Foundation/PackageManifest.php
+++ b/src/Illuminate/Foundation/PackageManifest.php
@@ -153,10 +153,7 @@ class PackageManifest
 
             $composer = json_decode(file_get_contents($file), true);
 
-            if (array_key_exists('extra', $composer) &&
-                array_key_exists('laravel', $composer['extra']) &&
-                array_key_exists('dont-discover', $composer['extra']['laravel'])
-            ) {
+            if (isset($composer['extra']['laravel']['dont-discover'])) {
                 $ignore[] = $composer['extra']['laravel']['dont-discover'];
             }
         }


### PR DESCRIPTION
Hi, I ran into the following problem when using automatic connected packages:
If I want to inherit some classes from packages for laravel, then I can not disable their automatic registration.