### PR TITLE
[5.5] Don't recreate the SQLite database file

### DIFF
--- a/src/Illuminate/Database/Schema/SQLiteBuilder.php
+++ b/src/Illuminate/Database/Schema/SQLiteBuilder.php
@@ -23,14 +23,12 @@ class SQLiteBuilder extends Builder
     }
 
     /**
-     * Delete the database file & re-create it.
+     * Empty the database file.
      *
      * @return void
      */
     public function refreshDatabaseFile()
     {
-        unlink($this->connection->getDatabaseName());
-
-        touch($this->connection->getDatabaseName());
+        file_put_contents($this->connection->getDatabaseName(), '');
     }
 }


### PR DESCRIPTION
Unlinking and touching the sqlite file will change the permission/owner/group of the database file, which can cause issues in environments like Docker.
Instead, we can just empty the file.

Seems to be a fix for https://github.com/laravel/dusk/issues/359