### PR TITLE
[5.5] Revert "Add multibyte functions where needed in Support/Str"

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -118,7 +118,7 @@ class Str
     public static function endsWith($haystack, $needles)
     {
         foreach ((array) $needles as $needle) {
-            if (mb_substr($haystack, -mb_strlen($needle)) === (string) $needle) {
+            if (substr($haystack, -strlen($needle)) === (string) $needle) {
                 return true;
             }
         }
@@ -328,10 +328,10 @@ class Str
             return $subject;
         }
 
-        $position = mb_strpos($subject, $search);
+        $position = strpos($subject, $search);
 
         if ($position !== false) {
-            return mb_substr($subject, 0, $position).$replace.mb_substr($subject, $position + mb_strlen($search));
+            return substr_replace($subject, $replace, $position, strlen($search));
         }
 
         return $subject;
@@ -347,10 +347,10 @@ class Str
      */
     public static function replaceLast($search, $replace, $subject)
     {
-        $position = mb_strrpos($subject, $search);
+        $position = strrpos($subject, $search);
 
         if ($position !== false) {
-            return mb_substr($subject, 0, $position).$replace.mb_substr($subject, $position + mb_strlen($search));
+            return substr_replace($subject, $replace, $position, strlen($search));
         }
 
         return $subject;
@@ -466,7 +466,7 @@ class Str
     public static function startsWith($haystack, $needles)
     {
         foreach ((array) $needles as $needle) {
-            if ($needle !== '' && mb_substr($haystack, 0, mb_strlen($needle)) === (string) $needle) {
+            if ($needle !== '' && substr($haystack, 0, strlen($needle)) === (string) $needle) {
                 return true;
             }
         }


### PR DESCRIPTION
This reverts #21207.
Parsing with the multibyte functions is actually useless.