### PR TITLE
Added a Notification Channel interface to force channels to implement send()

### DIFF
--- a/src/Illuminate/Notifications/Channels/BroadcastChannel.php
+++ b/src/Illuminate/Notifications/Channels/BroadcastChannel.php
@@ -7,8 +7,9 @@ use Illuminate\Notifications\Notification;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Notifications\Messages\BroadcastMessage;
 use Illuminate\Notifications\Events\BroadcastNotificationCreated;
+use Illuminate\Notifications\NotificationChannelInterface;
 
-class BroadcastChannel
+class BroadcastChannel implements NotificationChannelInterface
 {
     /**
      * The event dispatcher.
@@ -40,7 +41,9 @@ class BroadcastChannel
         $message = $this->getData($notifiable, $notification);
 
         $event = new BroadcastNotificationCreated(
-            $notifiable, $notification, is_array($message) ? $message : $message->data
+            $notifiable,
+            $notification,
+            is_array($message) ? $message : $message->data
         );
 
         if ($message instanceof BroadcastMessage) {

--- a/src/Illuminate/Notifications/Channels/BroadcastChannel.php
+++ b/src/Illuminate/Notifications/Channels/BroadcastChannel.php
@@ -6,8 +6,8 @@ use RuntimeException;
 use Illuminate\Notifications\Notification;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Notifications\Messages\BroadcastMessage;
-use Illuminate\Notifications\Events\BroadcastNotificationCreated;
 use Illuminate\Notifications\NotificationChannelInterface;
+use Illuminate\Notifications\Events\BroadcastNotificationCreated;
 
 class BroadcastChannel implements NotificationChannelInterface
 {

--- a/src/Illuminate/Notifications/Channels/DatabaseChannel.php
+++ b/src/Illuminate/Notifications/Channels/DatabaseChannel.php
@@ -4,8 +4,9 @@ namespace Illuminate\Notifications\Channels;
 
 use RuntimeException;
 use Illuminate\Notifications\Notification;
+use Illuminate\Notifications\NotificationChannelInterface;
 
-class DatabaseChannel
+class DatabaseChannel implements NotificationChannelInterface
 {
     /**
      * Send the given notification.

--- a/src/Illuminate/Notifications/Channels/MailChannel.php
+++ b/src/Illuminate/Notifications/Channels/MailChannel.php
@@ -8,8 +8,9 @@ use Illuminate\Mail\Markdown;
 use Illuminate\Contracts\Mail\Mailer;
 use Illuminate\Contracts\Mail\Mailable;
 use Illuminate\Notifications\Notification;
+use Illuminate\Notifications\NotificationChannelInterface;
 
-class MailChannel
+class MailChannel implements NotificationChannelInterface
 {
     /**
      * The mailer implementation.

--- a/src/Illuminate/Notifications/Channels/NexmoSmsChannel.php
+++ b/src/Illuminate/Notifications/Channels/NexmoSmsChannel.php
@@ -5,8 +5,9 @@ namespace Illuminate\Notifications\Channels;
 use Nexmo\Client as NexmoClient;
 use Illuminate\Notifications\Notification;
 use Illuminate\Notifications\Messages\NexmoMessage;
+use Illuminate\Notifications\NotificationChannelInterface;
 
-class NexmoSmsChannel
+class NexmoSmsChannel implements NotificationChannelInterface
 {
     /**
      * The Nexmo client instance.

--- a/src/Illuminate/Notifications/Channels/SlackWebhookChannel.php
+++ b/src/Illuminate/Notifications/Channels/SlackWebhookChannel.php
@@ -7,8 +7,9 @@ use Illuminate\Notifications\Notification;
 use Illuminate\Notifications\Messages\SlackMessage;
 use Illuminate\Notifications\Messages\SlackAttachment;
 use Illuminate\Notifications\Messages\SlackAttachmentField;
+use Illuminate\Notifications\NotificationChannelInterface;
 
-class SlackWebhookChannel
+class SlackWebhookChannel implements NotificationChannelInterface
 {
     /**
      * The HTTP client instance.

--- a/src/Illuminate/Notifications/Channels/SlackWebhookChannel.php
+++ b/src/Illuminate/Notifications/Channels/SlackWebhookChannel.php
@@ -6,8 +6,8 @@ use GuzzleHttp\Client as HttpClient;
 use Illuminate\Notifications\Notification;
 use Illuminate\Notifications\Messages\SlackMessage;
 use Illuminate\Notifications\Messages\SlackAttachment;
-use Illuminate\Notifications\Messages\SlackAttachmentField;
 use Illuminate\Notifications\NotificationChannelInterface;
+use Illuminate\Notifications\Messages\SlackAttachmentField;
 
 class SlackWebhookChannel implements NotificationChannelInterface
 {

--- a/src/Illuminate/Notifications/NotificationChannelInterface.php
+++ b/src/Illuminate/Notifications/NotificationChannelInterface.php
@@ -1,7 +1,6 @@
 <?php
-namespace Illuminate\Notifications;
 
-use Illuminate\Notifications\Notification;
+namespace Illuminate\Notifications;
 
 interface NotificationChannelInterface
 {

--- a/src/Illuminate/Notifications/NotificationChannelInterface.php
+++ b/src/Illuminate/Notifications/NotificationChannelInterface.php
@@ -1,0 +1,16 @@
+<?php
+namespace Illuminate\Notifications;
+
+use Illuminate\Notifications\Notification;
+
+interface NotificationChannelInterface
+{
+    /**
+     * Send the given notification.
+     *
+     * @param  mixed  $notifiable
+     * @param  \Illuminate\Notifications\Notification  $notification
+     * @return void
+     */
+    public function send($notifiable, Notification $notification);
+}


### PR DESCRIPTION
Notifications require the `public function send($notifiable, Notification $notification); ` method to function, which makes a lot of sense. I think, we should create an interface to force this method to be implemented, as it is typically bad practice to expect classes to implement them correctly.

This also makes our life a bit easier, if we ever require notification channels to implement extra methods in the future. 