### PR TITLE
remove `illuminate/exception` replacement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,6 @@
         "illuminate/database": "self.version",
         "illuminate/encryption": "self.version",
         "illuminate/events": "self.version",
-        "illuminate/exception": "self.version",
         "illuminate/filesystem": "self.version",
         "illuminate/hashing": "self.version",
         "illuminate/http": "self.version",


### PR DESCRIPTION
as far as I can tell, `illuminate/exception` is no longer provided in the framework.  the subtree has not had an update since 2014.

I came across this discrepancy when I was looking into all the subtrees.  Taylor, would you be willing to do a Medium article about how the subtrees work. Mostly interested in how they get updated, and why one does not exist for `Illuminate/Foundation`.  This would help clear up some confusion in Slack Internals.

Thanks,