### PR TITLE
[5.6] Let Arr::wrap(null) return empty array

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -594,14 +594,14 @@ class Arr
     }
 
     /**
-     * If the given value is not an array and not null, wrap it in one. Return an empty array if the value is null.
+     * If the given value is not an array and not null, wrap it in one.
      *
      * @param  mixed  $value
      * @return array
      */
     public static function wrap($value)
     {
-        if ($value === null) {
+        if (is_null($value)) {
             return [];
         }
 

--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -601,6 +601,10 @@ class Arr
      */
     public static function wrap($value)
     {
+        if ($value === null) {
+            return [];
+        }
+
         return ! is_array($value) ? [$value] : $value;
     }
 }

--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -594,7 +594,7 @@ class Arr
     }
 
     /**
-     * If the given value is not an array, wrap it in one.
+     * If the given value is not an array and not null, wrap it in one. Return an empty array if the value is null.
      *
      * @param  mixed  $value
      * @return array

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -662,5 +662,6 @@ class SupportArrTest extends TestCase
         $this->assertEquals(['a'], Arr::wrap($string));
         $this->assertEquals($array, Arr::wrap($array));
         $this->assertEquals([$object], Arr::wrap($object));
+        $this->assertEquals([], Arr::wrap(null));
     }
 }


### PR DESCRIPTION
Change `Arr::wrap` function to return an empty array when providing null as argument. This is the same way [Ruby handles it](http://api.rubyonrails.org/v3.1/classes/Array.html) and also more intuitive IMO