### PR TITLE
[5.5] Remove hardcoded fields 'id' and 'remember_token' in DatabaseUserProvider

### DIFF
--- a/src/Illuminate/Auth/DatabaseUserProvider.php
+++ b/src/Illuminate/Auth/DatabaseUserProvider.php
@@ -84,7 +84,7 @@ class DatabaseUserProvider implements UserProvider
     public function updateRememberToken(UserContract $user, $token)
     {
         $this->conn->table($this->table)
-                ->where('id', $user->getAuthIdentifier())
+                ->where($user->getAuthIdentifierName(), $user->getAuthIdentifier())
                 ->update(['remember_token' => $token]);
     }
 

--- a/src/Illuminate/Auth/DatabaseUserProvider.php
+++ b/src/Illuminate/Auth/DatabaseUserProvider.php
@@ -68,10 +68,12 @@ class DatabaseUserProvider implements UserProvider
      */
     public function retrieveByToken($identifier, $token)
     {
-        $user = $this->conn->table($this->table)->find($identifier);
+        $user = $this->getGenericUser(
+            $this->conn->table($this->table)->find($identifier)
+        );
 
-        return $user && $user->remember_token && hash_equals($user->remember_token, $token)
-                    ? $this->getGenericUser($user) : null;
+        return $user && $user->getRememberToken() && hash_equals($user->getRememberToken(), $token)
+                    ? $user : null;
     }
 
     /**
@@ -85,7 +87,7 @@ class DatabaseUserProvider implements UserProvider
     {
         $this->conn->table($this->table)
                 ->where($user->getAuthIdentifierName(), $user->getAuthIdentifier())
-                ->update(['remember_token' => $token]);
+                ->update([$user->getRememberTokenName() => $token]);
     }
 
     /**


### PR DESCRIPTION
This PR removes the remaining hardcoded fields id and remember_token in DatabaseUserProvider in order to conform to Authenticatable.