### PR TITLE
[5.5] update docblocks

### DIFF
--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -382,7 +382,7 @@ class Filesystem
      *
      * @param  string  $directory
      * @param  bool  $hidden
-     * @return array
+     * @return \Symfony\Component\Finder\SplFileInfo[]
      */
     public function files($directory, $hidden = false)
     {
@@ -397,7 +397,7 @@ class Filesystem
      *
      * @param  string  $directory
      * @param  bool  $hidden
-     * @return array
+     * @return \Symfony\Component\Finder\SplFileInfo[]
      */
     public function allFiles($directory, $hidden = false)
     {


### PR DESCRIPTION
when we return an array of a specific type (object or scalar) we can use this syntax to be more specific, and help out our IDE.

documentation: https://docs.phpdoc.org/references/phpdoc/types.html#arrays

precedence: https://github.com/laravel/framework/blob/5.5/src/Illuminate/Console/Scheduling/Schedule.php#L140