### PR TITLE
[5.5] update docblocks

### DIFF
--- a/src/Illuminate/Cookie/CookieJar.php
+++ b/src/Illuminate/Cookie/CookieJar.php
@@ -42,7 +42,7 @@ class CookieJar implements JarContract
     /**
      * All of the cookies queued for sending.
      *
-     * @var array
+     * @var \Symfony\Component\HttpFoundation\Cookie[]
      */
     protected $queued = [];
 
@@ -184,7 +184,7 @@ class CookieJar implements JarContract
     /**
      * Get the cookies which have been queued for the next request.
      *
-     * @return array
+     * @return \Symfony\Component\HttpFoundation\Cookie[]
      */
     public function getQueuedCookies()
     {


### PR DESCRIPTION
queued cookies are an array of `Cookies`

documentation: https://docs.phpdoc.org/references/phpdoc/types.html#arrays

precedence: https://github.com/laravel/framework/blob/5.5/src/Illuminate/Console/Scheduling/Schedule.php#L140