### PR TITLE
[5.5] Add relationship support on joined tables (updated with tests)

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -57,9 +57,11 @@ trait HasRelationships
 
         $foreignKey = $foreignKey ?: $this->getForeignKey();
 
+        $foreignKey = Str::contains($foreignKey, '.') ? $foreignKey : $instance->getTable().'.'.$foreignKey;
+        
         $localKey = $localKey ?: $this->getKeyName();
 
-        return new HasOne($instance->newQuery(), $this, $instance->getTable().'.'.$foreignKey, $localKey);
+        return new HasOne($instance->newQuery(), $this, $foreignKey, $localKey);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -58,7 +58,7 @@ trait HasRelationships
         $foreignKey = $foreignKey ?: $this->getForeignKey();
 
         $foreignKey = Str::contains($foreignKey, '.') ? $foreignKey : $instance->getTable().'.'.$foreignKey;
-        
+
         $localKey = $localKey ?: $this->getKeyName();
 
         return new HasOne($instance->newQuery(), $this, $foreignKey, $localKey);
@@ -223,10 +223,12 @@ trait HasRelationships
 
         $foreignKey = $foreignKey ?: $this->getForeignKey();
 
+        $foreignKey = Str::contains($foreignKey, '.') ? $foreignKey : $instance->getTable().'.'.$foreignKey;
+
         $localKey = $localKey ?: $this->getKeyName();
 
         return new HasMany(
-            $instance->newQuery(), $this, $instance->getTable().'.'.$foreignKey, $localKey
+            $instance->newQuery(), $this, $foreignKey, $localKey
         );
     }
 

--- a/tests/Database/DatabaseEloquentPrefixedRelationsTest.php
+++ b/tests/Database/DatabaseEloquentPrefixedRelationsTest.php
@@ -9,24 +9,64 @@
 namespace Illuminate\Tests\Database;
 use Illuminate\Database\Eloquent\Model;
 use PHPUnit\Framework\TestCase;
-
-
+use Mockery as m;
+use Illuminate\Database\Capsule\Manager as DB;
 
 class DatabaseEloquentPrefixedRelationsTest extends TestCase
 {
-    public function testPrefixedRelation()
+    public function setUp()
     {
-        $model = new SampleModel();
-        $relation = $model->samplePrefixedRelation();
-        assertEquals($model->foreignTableKey, $relation->getQualifiedForeignKeyName());
+        $db = new DB;
+
+        $db->addConnection([
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+        ]);
+
+        $db->bootEloquent();
+        $db->setAsGlobal();
     }
 
-    public function testNonPrefixedRelation()
+    public function testPrefixedHasOne()
     {
         $model = new SampleModel();
-        $model2 = new SampleModel2;
-        $relation = $model->sampleNonPrefixedRelation();
-        assertEquals($model2->getDefaultRelation(), $relation->getQualifiedForeignKeyName());
+        $relation = $model->samplePrefixedHasOne();
+        $this->assertEquals($model->foreignTableKey, $relation->getQualifiedForeignKeyName());
+    }
+
+    public function testNonPrefixedHasOne()
+    {
+        $model = new SampleModel();
+        $relation = $model->sampleNonPrefixedHasOne();
+        $this->assertEquals('test2.sample_model_id', $relation->getQualifiedForeignKeyName());
+    }
+
+    public function testNonPrefixedHasOneWithKey()
+    {
+        $model = new SampleModel();
+        $relation = $model->sampleNonPrexifedHasOneWithForeignKey();
+        $this->assertEquals('test2.sample_model_id', $relation->getQualifiedForeignKeyName());
+    }
+
+    public function testPrefixedHasMany()
+    {
+        $model = new SampleModel();
+        $relation = $model->samplePrefixedHasMany();
+        $this->assertEquals($model->foreignTableKey, $relation->getQualifiedForeignKeyName());
+    }
+
+    public function testNonPrefixedHasMany()
+    {
+        $model = new SampleModel();
+        $relation = $model->sampleNonPrefixedHasMany();
+        $this->assertEquals('test2.sample_model_id', $relation->getQualifiedForeignKeyName());
+    }
+
+    public function testNonPrefixedHasManyWithKey()
+    {
+        $model = new SampleModel();
+        $relation = $model->sampleNonPrexifedHasManyWithForeignKey();
+        $this->assertEquals('test2.sample_model_id', $relation->getQualifiedForeignKeyName());
     }
 
 
@@ -35,32 +75,40 @@ class DatabaseEloquentPrefixedRelationsTest extends TestCase
 class SampleModel2 extends Model
 {
     protected $table = 'test2';
-    protected $primaryKey = 'id2';
-
-    public function getDefaultRelation()
-    {
-        return $this->table .'.'. $this->primaryKey;
-    }
 }
 
 class SampleModel extends Model
 {
     public $foreignTableKey = 'foreigntable.key';
     public $table = 'test';
-    public $primaryKey = 'id';
 
-    public function samplePrefixedRelation()
+    public function samplePrefixedHasOne()
     {
            return $this->hasOne('Illuminate\Tests\Database\SampleModel2', $this->foreignTableKey,'id');
     }
 
-    public function sampleNonPrefixedRelation()
+    public function sampleNonPrefixedHasOne()
     {
         return $this->hasOne('Illuminate\Tests\Database\SampleModel2');
     }
 
-    public function getDefaultRelation()
+    public function sampleNonPrexifedHasOneWithForeignKey()
     {
+        return $this->hasOne('Illuminate\Tests\Database\SampleModel2', 'sample_model_id','id');
+    }
 
+    public function samplePrefixedHasMany()
+    {
+        return $this->hasOne('Illuminate\Tests\Database\SampleModel2', $this->foreignTableKey,'id');
+    }
+
+    public function sampleNonPrefixedHasMany()
+    {
+        return $this->hasMany('Illuminate\Tests\Database\SampleModel2');
+    }
+
+    public function sampleNonPrexifedHasManyWithForeignKey()
+    {
+        return $this->hasOne('Illuminate\Tests\Database\SampleModel2', 'sample_model_id','id');
     }
 }

--- a/tests/Database/DatabaseEloquentPrefixedRelationsTest.php
+++ b/tests/Database/DatabaseEloquentPrefixedRelationsTest.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Created by IntelliJ IDEA.
+ * User: Cole
+ * Date: 10/18/2017
+ * Time: 9:05 AM
+ */
+
+namespace Illuminate\Tests\Database;
+use Illuminate\Database\Eloquent\Model;
+use PHPUnit\Framework\TestCase;
+
+
+
+class DatabaseEloquentPrefixedRelationsTest extends TestCase
+{
+    public function testPrefixedRelation()
+    {
+        $model = new SampleModel();
+        $relation = $model->samplePrefixedRelation();
+        assertEquals($model->foreignTableKey, $relation->getQualifiedForeignKeyName());
+    }
+
+    public function testNonPrefixedRelation()
+    {
+        $model = new SampleModel();
+        $model2 = new SampleModel2;
+        $relation = $model->sampleNonPrefixedRelation();
+        assertEquals($model2->getDefaultRelation(), $relation->getQualifiedForeignKeyName());
+    }
+
+
+}
+
+class SampleModel2 extends Model
+{
+    protected $table = 'test2';
+    protected $primaryKey = 'id2';
+
+    public function getDefaultRelation()
+    {
+        return $this->table .'.'. $this->primaryKey;
+    }
+}
+
+class SampleModel extends Model
+{
+    public $foreignTableKey = 'foreigntable.key';
+    public $table = 'test';
+    public $primaryKey = 'id';
+
+    public function samplePrefixedRelation()
+    {
+           return $this->hasOne('Illuminate\Tests\Database\SampleModel2', $this->foreignTableKey,'id');
+    }
+
+    public function sampleNonPrefixedRelation()
+    {
+        return $this->hasOne('Illuminate\Tests\Database\SampleModel2');
+    }
+
+    public function getDefaultRelation()
+    {
+
+    }
+}


### PR DESCRIPTION
Added foreign key support for joined tables on a model

We have a model whose relationship to another model is a key in a joined table. Due to an old data structure and legacy systems, this is the only solution we have for joining