### PR TITLE
Prevent duplicate listener on Eloquent model

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
@@ -113,8 +113,13 @@ trait HasEvents
     {
         if (isset(static::$dispatcher)) {
             $name = static::class;
+            $eventName = "eloquent.{$event}: {$name}";
 
-            static::$dispatcher->listen("eloquent.{$event}: {$name}", $callback);
+            if (in_array($callback, static::$dispatcher->getListeners($eventName))) {
+                return;
+            }
+
+            static::$dispatcher->listen($eventName, $callback);
         }
     }
 


### PR DESCRIPTION
Prevent the same callback from being registered more than once for an event listener registered to an Eloquent model.

I'm not sure what kind of effect this may have actually.
Perhaps there is a use case for having duplicated listeners?

If this is something that seems like a good idea, I'll fix the issues with the tests.