### PR TITLE
[5.5] add allOnQueue and allOnConnection for job chaining

### DIFF
--- a/src/Illuminate/Bus/Queueable.php
+++ b/src/Illuminate/Bus/Queueable.php
@@ -19,6 +19,20 @@ trait Queueable
     public $queue;
 
     /**
+     * The name of the connection the chain should be sent to.
+     *
+     * @var string|null
+     */
+    public $chainConnection;
+
+    /**
+     * The name of the queue the chain should be sent to.
+     *
+     * @var string|null
+     */
+    public $chainQueue;
+
+    /**
      * The number of seconds before the job should be made available.
      *
      * @var \DateTimeInterface|\DateInterval|int|null
@@ -54,6 +68,32 @@ trait Queueable
     public function onQueue($queue)
     {
         $this->queue = $queue;
+
+        return $this;
+    }
+
+    /**
+     * Set the desired connection for the chain.
+     *
+     * @param  string|null  $connection
+     * @return $this
+     */
+    public function allOnConnection($connection)
+    {
+        $this->chainConnection = $connection;
+
+        return $this;
+    }
+
+    /**
+     * Set the desired queue for the chain.
+     *
+     * @param  string|null  $queue
+     * @return $this
+     */
+    public function allOnQueue($queue)
+    {
+        $this->chainQueue = $queue;
 
         return $this;
     }
@@ -96,6 +136,10 @@ trait Queueable
         if (! empty($this->chained)) {
             dispatch(tap(unserialize(array_shift($this->chained)), function ($next) {
                 $next->chained = $this->chained;
+                $next->chainConnection = $this->chainConnection;
+                $next->chainQueue = $this->chainQueue;
+                $next->onConnection($next->connection ?: $this->chainConnection);
+                $next->onQueue($next->queue ?: $this->chainQueue);
             }));
         }
     }

--- a/src/Illuminate/Bus/Queueable.php
+++ b/src/Illuminate/Bus/Queueable.php
@@ -81,6 +81,7 @@ trait Queueable
     public function allOnConnection($connection)
     {
         $this->chainConnection = $connection;
+        $this->connection = $connection;
 
         return $this;
     }
@@ -94,6 +95,7 @@ trait Queueable
     public function allOnQueue($queue)
     {
         $this->chainQueue = $queue;
+        $this->queue = $queue;
 
         return $this;
     }

--- a/src/Illuminate/Foundation/Bus/PendingDispatch.php
+++ b/src/Illuminate/Foundation/Bus/PendingDispatch.php
@@ -51,6 +51,32 @@ class PendingDispatch
     }
 
     /**
+     * Set the desired connection for the chain.
+     *
+     * @param  string|null  $connection
+     * @return $this
+     */
+    public function allOnConnection($connection)
+    {
+        $this->job->allOnConnection($connection);
+
+        return $this;
+    }
+
+    /**
+     * Set the desired queue for the chain.
+     *
+     * @param  string|null  $queue
+     * @return $this
+     */
+    public function allOnQueue($queue)
+    {
+        $this->job->allOnQueue($queue);
+
+        return $this;
+    }
+
+    /**
      * Set the desired delay for the job.
      *
      * @param  \DateTime|int|null  $delay

--- a/tests/Integration/Queue/JobChainingTest.php
+++ b/tests/Integration/Queue/JobChainingTest.php
@@ -136,9 +136,11 @@ class JobChainingTest extends TestCase
 
         $this->assertEquals('some_queue', JobChainingTestFirstJob::$usedQueue);
         $this->assertEquals('sync1', JobChainingTestFirstJob::$usedConnection);
+
         $this->assertEquals('some_queue', JobChainingTestSecondJob::$usedQueue);
-        $this->assertEquals('some_queue', JobChainingTestThirdJob::$usedQueue);
         $this->assertEquals('sync1', JobChainingTestSecondJob::$usedConnection);
+
+        $this->assertEquals('some_queue', JobChainingTestThirdJob::$usedQueue);
         $this->assertEquals('sync1', JobChainingTestThirdJob::$usedConnection);
     }
 
@@ -151,9 +153,11 @@ class JobChainingTest extends TestCase
 
         $this->assertEquals('some_queue', JobChainingTestFirstJob::$usedQueue);
         $this->assertEquals('sync1', JobChainingTestFirstJob::$usedConnection);
+
         $this->assertEquals('another_queue', JobChainingTestSecondJob::$usedQueue);
-        $this->assertEquals('some_queue', JobChainingTestThirdJob::$usedQueue);
         $this->assertEquals('sync2', JobChainingTestSecondJob::$usedConnection);
+
+        $this->assertEquals('some_queue', JobChainingTestThirdJob::$usedQueue);
         $this->assertEquals('sync1', JobChainingTestThirdJob::$usedConnection);
     }
 
@@ -166,8 +170,10 @@ class JobChainingTest extends TestCase
 
         $this->assertEquals('some_queue', JobChainingTestFirstJob::$usedQueue);
         $this->assertEquals('sync1', JobChainingTestFirstJob::$usedConnection);
+
         $this->assertEquals('another_queue', JobChainingTestSecondJob::$usedQueue);
         $this->assertEquals('sync2', JobChainingTestSecondJob::$usedConnection);
+
         $this->assertEquals(null, JobChainingTestThirdJob::$usedQueue);
         $this->assertEquals(null, JobChainingTestThirdJob::$usedConnection);
     }

--- a/tests/Integration/Queue/JobChainingTest.php
+++ b/tests/Integration/Queue/JobChainingTest.php
@@ -134,6 +134,8 @@ class JobChainingTest extends TestCase
             new JobChainingTestThirdJob,
         ]);
 
+        $this->assertEquals('some_queue', JobChainingTestFirstJob::$usedQueue);
+        $this->assertEquals('sync1', JobChainingTestFirstJob::$usedConnection);
         $this->assertEquals('some_queue', JobChainingTestSecondJob::$usedQueue);
         $this->assertEquals('some_queue', JobChainingTestThirdJob::$usedQueue);
         $this->assertEquals('sync1', JobChainingTestSecondJob::$usedConnection);
@@ -147,6 +149,8 @@ class JobChainingTest extends TestCase
             new JobChainingTestThirdJob,
         ]);
 
+        $this->assertEquals('some_queue', JobChainingTestFirstJob::$usedQueue);
+        $this->assertEquals('sync1', JobChainingTestFirstJob::$usedConnection);
         $this->assertEquals('another_queue', JobChainingTestSecondJob::$usedQueue);
         $this->assertEquals('some_queue', JobChainingTestThirdJob::$usedQueue);
         $this->assertEquals('sync2', JobChainingTestSecondJob::$usedConnection);


### PR DESCRIPTION
Having:

```php
JobA::withChain([
    (new JobB())->onQueue('second')->onConnection('connection2'),
    (new JobC()),
])->dispatch()
   ->allOnQueue('first')
   ->allOnConnection('connection1');
```

- JobA will run on `first` queue and on `connection1`.
- JobB on `second` queue and on `connection2`.
- JobC on `first` queue and on `connection1`.

The new `allOnQueue` and `allOnConnection` methods will instruct the dispatcher to use the given queue/connection if no queue/connection was set explicitly on each job.

The old behaviour remains the same thus this PR is not a breaking change.