### PR TITLE
[5.6] Use early returns in else method

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -432,7 +432,9 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     {
         if ($value) {
             return $callback($this);
-        } elseif ($default) {
+        }
+
+        if ($default) {
             return $default($this);
         }
 


### PR DESCRIPTION
Then when method should be using early returns instead of if/else