### PR TITLE
[5.5] Add followingRedirects() method

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -410,6 +410,8 @@ trait MakesHttpRequests
             $response = $this->get($response->headers->get('Location'));
         }
 
+        $this->followRedirects = false;
+
         return $response;
     }
 

--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -26,6 +26,13 @@ trait MakesHttpRequests
     protected $serverVariables = [];
 
     /**
+     * Whether redirects should be followed.
+     *
+     * @var bool
+     */
+    protected $followRedirects = false;
+
+    /**
      * Define additional headers to be sent with the request.
      *
      * @param  array $headers
@@ -99,6 +106,18 @@ trait MakesHttpRequests
                 }
             });
         }
+
+        return $this;
+    }
+
+    /**
+     * Automatically follow any redirects returned from the response.
+     *
+     * @return $this
+     */
+    public function followingRedirects()
+    {
+        $this->followRedirects = true;
 
         return $this;
     }
@@ -294,6 +313,10 @@ trait MakesHttpRequests
             $request = Request::createFromBase($symfonyRequest)
         );
 
+        if ($this->followRedirects) {
+            $response = $this->followRedirects($response);
+        }
+
         $kernel->terminate($request, $response);
 
         return $this->createTestResponse($response);
@@ -373,6 +396,21 @@ trait MakesHttpRequests
         }
 
         return $files;
+    }
+
+    /**
+     * Follow a redirect chain until a non-redirect is received.
+     *
+     * @param  \Illuminate\Http\Response  $response
+     * @return \Illuminate\Http\Response
+     */
+    protected function followRedirects($response)
+    {
+        while ($response->isRedirect()) {
+            $response = $this->get($response->headers->get('Location'));
+        }
+
+        return $response;
     }
 
     /**


### PR DESCRIPTION
This adds a test helper method called `followingRedirects()` that will instruct the the test case to follow any redirect responses automatically. It can be chained prior to making a HTTP request and it's named to read more sentence-like.

```php
$response = $this->followingRedirects()->post('/login', ['email' => 'john@example.com']);

$response->assertSee('Welcome back, John.');
```

From memory a similar test helper used to exist in an earlier iteration of Laravel's test suite, so this is just returning the functionality. It was prompted by #18016.