### PR TITLE
[5.5] Add HasNone relationship

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -44,10 +44,10 @@ trait HasRelationships
     ];
 
     /**
-    * Define a void relationship.
-    *
-    * @return \Illuminate\Database\Eloquent\Relations\HasNone
-    */
+     * Define a void relationship.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\HasNone
+     */
     protected function hasNone()
     {
         return new HasNone($this->newQuery(), $this);

--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -44,6 +44,16 @@ trait HasRelationships
     ];
 
     /**
+    * Define a void relationship.
+    *
+    * @return \Illuminate\Database\Eloquent\Relations\HasNone
+    */
+    protected function hasNone()
+    {
+        return new HasNone($this->newQuery(), $this);
+    }
+
+    /**
      * Define a one-to-one relationship.
      *
      * @param  string  $related

--- a/src/Illuminate/Database/Eloquent/Relations/HasNone.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasNone.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Relations;
+
+use Illuminate\Database\Eloquent\Collection;
+
+class HasNone extends Relation
+{
+    /**
+     * Set the base constraints on the relation query.
+     *
+     * @return void
+     */
+    public function addConstraints()
+    {
+        //
+    }
+
+    /**
+     * Set the constraints for an eager load of the relation.
+     *
+     * @param  array  $models
+     * @return void
+     */
+    public function addEagerConstraints(array $models)
+    {
+        //
+    }
+
+    /**
+     * Initialize the relation on a set of models.
+     *
+     * @param  array   $models
+     * @param  string  $relation
+     * @return array
+     */
+    public function initRelation(array $models, $relation)
+    {
+        return $models;
+    }
+
+    /**
+     * Match the eagerly loaded results to their parents.
+     *
+     * @param  array   $models
+     * @param  \Illuminate\Database\Eloquent\Collection  $results
+     * @param  string  $relation
+     * @return array
+     */
+    public function match(array $models, Collection $results, $relation)
+    {
+        return $models;
+    }
+
+    /**
+     * Get the results of the relationship.
+     *
+     * @return void
+     */
+    public function getResults()
+    {
+        //
+    }
+
+    /**
+     * Get the relationship for eager loading.
+     *
+     * @return \Illuminate\Database\Eloquent\Collection
+     */
+    public function getEager()
+    {
+        return new Collection;
+    }
+}

--- a/tests/Database/DatabaseEloquentHasNoneTest.php
+++ b/tests/Database/DatabaseEloquentHasNoneTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Relations\HasNone;
+
+class DatabaseEloquentHasNoneTest extends TestCase
+{
+    protected $builder;
+
+    protected $model;
+
+    public function tearDown()
+    {
+        m::close();
+    }
+
+    public function testRelationIsProperlyInitialized()
+    {
+        $relation = $this->getRelation();
+        $model = m::mock('Illuminate\Database\Eloquent\Model');
+        $models = $relation->initRelation([$model], 'foo');
+
+        $this->assertEquals([$model], $models);
+    }
+
+    public function testModelsAreReturnedWithoutMatches()
+    {
+        $relation = $this->getRelation();
+
+        $model1 = new EloquentHasNoneModelStub;
+        $model1->id = 1;
+        $model2 = new EloquentHasNoneModelStub;
+        $model2->id = 2;
+
+        $models = $relation->match([$model1, $model2], new Collection, 'foo');
+
+        $this->assertEquals([$model1, $model2], $models);
+    }
+
+    protected function getRelation()
+    {
+        $this->model = m::mock('Illuminate\Database\Eloquent\Model');
+        $this->builder = m::mock('Illuminate\Database\Eloquent\Builder');
+        $this->builder->shouldReceive('getModel')->andReturn($this->model);
+
+        return new HasNone($this->builder, $this->model);
+    }
+}
+
+class EloquentHasNoneModelStub extends \Illuminate\Database\Eloquent\Model
+{
+    //
+}


### PR DESCRIPTION
This implements a new `HasNone` relationship that I mentioned a while back in #3467. Effectively this is a relationship that for whatever reason does not exist, and so does not need to be queried. I'll explain some use cases below, but also point out that there is a precedent for a similar feature elsewhere - for example the [`none` method in ActiveRecord](https://apidock.com/rails/v4.0.2/ActiveRecord/QueryMethods/none).

The first use-case is where a model for a certain reason might not have a relationship, so it's pointless for Eloquent to query for it. This is the example I used last time for a `Institution` model which basically represents a given educational institution. If the institution is not a university, it won't have subjects in our application.

```php
public function subjects()
{
    // This doesn't work, results in:
    // Relationship method must return an object of type Illuminate\Database\Eloquent\Relations\Relation
    if ( ! $this->university) {
        return null;
    }

    return $this->hasMany('Subject');
}
```

If you don't return a relationship you'll end up getting an error like `LogicException
App\Institution::subjects must return a relationship instance.`.

The second use-case I've come up for recently basically revolves around using eager-loading wiht a polymoprhic association. Say you have a `Comment` model which has a `commentable` relationship. If you eager-load that `commentable` relationship Laravel is clever enough to query for the different types of `commentable` classes as necessary - but it runs into trouble if you want to also eager-load nested relations.

```php
class Place extends Model
{
    public function comments()
    {
        return $this->morphMany(Comment::class, 'commentable');
    }

    public function photos()
    {
        return $this->hasMany(Photo::class);
    }
}

class Subject extends Model
{
    public function comments()
    {
        return $this->morphMany(Comment::class, 'commentable');
    }

    public function photos()
    {
        // This is the new stuff.
        return $this->hasNone()
    }
}

$comments = Comment::with('commentable.photos');

```

So effectively the `Subject` model here doesn't have any photos. If we tried to eager-load normally with photos it would throw an error. If we tried to do something like `return $this->hasMany(Photo::class)->whereRaw('1 = 0');` then Laravel would still perform the lame database query.

The `return $this->hasNone()` effectively stubs out the entire relationship, and allows eager-loading on nested polymorphic relations without hitting the database.