### PR TITLE
[5.5] Fix for migrate:fresh command being unusable if PostGIS is installed

### DIFF
--- a/src/Illuminate/Database/Schema/PostgresBuilder.php
+++ b/src/Illuminate/Database/Schema/PostgresBuilder.php
@@ -39,7 +39,7 @@ class PostgresBuilder extends Builder
             $row = (array) $row;
             $table = reset($row);
 
-            if (!in_array($table, $excludedTables)) {
+            if (! in_array($table, $excludedTables)) {
                 $tables[] = $table;
             }
         }

--- a/src/Illuminate/Database/Schema/PostgresBuilder.php
+++ b/src/Illuminate/Database/Schema/PostgresBuilder.php
@@ -33,11 +33,15 @@ class PostgresBuilder extends Builder
     public function dropAllTables()
     {
         $tables = [];
+        $excludedTables = ['spatial_ref_sys'];
 
         foreach ($this->getAllTables() as $row) {
             $row = (array) $row;
+            $table = reset($row);
 
-            $tables[] = reset($row);
+            if (!in_array($table, $excludedTables)) {
+                $tables[] = $table;
+            }
         }
 
         if (empty($tables)) {


### PR DESCRIPTION
By excluding the spatial_ref_sys table from being deleted, the `migrate:fresh` command and the `RefreshDatabase` trait for testing become
usable if the PostGIS extension is enabled for a Postgres database.

Fixes: #20972