### PR TITLE
Add "strict" option for numeric rule

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1031,11 +1031,18 @@ trait ValidatesAttributes
      *
      * @param  string  $attribute
      * @param  mixed   $value
+     * @param  array  $parameters
      * @return bool
      */
-    public function validateNumeric($attribute, $value)
+    public function validateNumeric($attribute, $value, $parameters)
     {
-        return is_numeric($value);
+        $isNumeric = is_numeric($value);
+
+        if ($isNumeric && !empty($parameters) && $parameters[0] === 'strict') {
+            return !is_nan($value) && !is_infinite($value);
+        }
+
+        return $isNumeric;
     }
 
     /**

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1038,8 +1038,8 @@ trait ValidatesAttributes
     {
         $isNumeric = is_numeric($value);
 
-        if ($isNumeric && !empty($parameters) && $parameters[0] === 'strict') {
-            return !is_nan($value) && !is_infinite($value);
+        if ($isNumeric && ! empty($parameters) && $parameters[0] === 'strict') {
+            return ! is_nan($value) && ! is_infinite($value);
         }
 
         return $isNumeric;


### PR DESCRIPTION
(Now with the correct base branch and more description)

The `numeric` rule validates successful for values like NAN and INF. Although these are valid numeric values by specification (see http://php.net/manual/en/math.constants.php), I think it would be more intuitive when the validator fails for these values (because they are no real numbers).

This PR adds an optional "strict" option to the numeric rule.

```php
Validator::make(['value' => 'numeric:strict']);
```

I was not sure about the naming, so "strict" was my first idea. Maybe something like "real" would be suitable, too.