### PR TITLE
Add toggle method in Eloquent model

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1512,7 +1512,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public function toggle($attributes)
     {
-        foreach ((array)$attributes as $attribute) {
+        foreach ((array) $attributes as $attribute) {
             $this->setAttribute($attribute, ! $this->getAttribute($attribute));
         }
 

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1503,4 +1503,19 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     {
         $this->bootIfNotBooted();
     }
+
+    /**
+     * Invert the value of each given attribute.
+     *
+     * @param  array  $attributes
+     * @return bool
+     */
+    public function toggle(...$attributes)
+    {
+        foreach ($attributes as $attribute) {
+            $this->setAttribute($attribute, ! $this->getAttribute($attribute));
+        }
+
+        return $this->save();
+    }
 }

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1507,12 +1507,12 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     /**
      * Invert the value of each given attribute.
      *
-     * @param  array  $attributes
+     * @param  string|array  $attributes
      * @return bool
      */
-    public function toggle(...$attributes)
+    public function toggle($attributes)
     {
-        foreach ($attributes as $attribute) {
+        foreach ((array)$attributes as $attribute) {
             $this->setAttribute($attribute, ! $this->getAttribute($attribute));
         }
 

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -1144,7 +1144,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $users = new Collection();
         $this->assertEquals($users->map->fresh(), $users->fresh());
     }
-    
+
     public function testToggleMethodOnModel()
     {
         $payment = EloquentTestPayment::create(['amount' => 500, 'received' => 0]);

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -101,6 +101,13 @@ class DatabaseEloquentIntegrationTest extends TestCase
                 $table->timestamps();
                 $table->softDeletes();
             });
+
+            $this->schema($connection)->create('payments', function ($table) {
+                $table->increments('id');
+                $table->float('amount');
+                $table->boolean('received');
+                $table->timestamps();
+            });
         }
 
         $this->schema($connection)->create('non_incrementing_users', function ($table) {
@@ -1137,6 +1144,17 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $users = new Collection();
         $this->assertEquals($users->map->fresh(), $users->fresh());
     }
+    
+    public function testToggleMethodOnModel()
+    {
+        $payment = EloquentTestPayment::create(['amount' => 500, 'received' => 0]);
+
+        $this->assertFalse($payment->received);
+
+        $payment->toggle('received');
+
+        $this->assertTrue($payment->refresh()->received);
+    }
 
     /**
      * Helpers...
@@ -1367,4 +1385,13 @@ class EloquentTestFriendPivot extends Pivot
     {
         return $this->belongsTo(EloquentTestFriendLevel::class, 'friend_level_id');
     }
+}
+
+class EloquentTestPayment extends Eloquent
+{
+    protected $table = 'payments';
+    protected $guarded = [];
+    protected $casts = [
+        'received' => 'boolean',
+    ];
 }


### PR DESCRIPTION
The `toggle` method allow the user to invert the value of one or many attributes.

Let's say that we have a Post model with a `publish` method who is doing the following

- Setting the `published` attribute to true
- Saving the changes in the DB

```php
class Post extends Model
{
    // ...

    public function publish()
    {
        $this->published = true;

        $this->save();
    }
}
```

With the toggle method, we can simplify the publish method as follow

```php
class Post extends Model
{
    // ...

    public function publish()
    {
        $this->toggle('published');
    }
}
```

The toggle method can also accept an array of attributes

```php
class Post extends Model
{
    // ...

    public function publish()
    {
        $this->toggle(['published', 'locked']);
    }
}
```

Regards.