### PR TITLE
[5.5] Add a from test helper method

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -123,6 +123,17 @@ trait MakesHttpRequests
     }
 
     /**
+     * Set the referer header to simulate a previous request.
+     *
+     * @param  string  $url
+     * @return $this
+     */
+    public function from(string $url)
+    {
+        return $this->withHeader('referer', $url);
+    }
+
+    /**
      * Visit the given URI with a GET request.
      *
      * @param  string  $uri


### PR DESCRIPTION
This adds a method called `from` which can be chained when testing HTTP requests. It's a friendly wrapper that sets the incorrectly spelt `Referer` header. This makes it helpful to test things like validation exceptions that should redirect to the previous page. It's a little more explicit then checking that it redirects to the root URL which it would by default.

```php
$response = $this->from('/register')
    ->post('/register', $invalidAttributes);

$response->assertRedirect('/register');
```