### PR TITLE
[5.5] Use table aliases when calling a self-referencing HasManyThrough

### DIFF
--- a/CHANGELOG-5.5.md
+++ b/CHANGELOG-5.5.md
@@ -1,5 +1,17 @@
 # Release Notes for 5.5.x
 
+## [Unreleased]
+
+### Added
+- Added `MakesHttpRequests::followingRedirects()` method ([#21771](https://github.com/laravel/framework/pull/21771))
+- Added `MakesHttpRequests::from()` method ([#21788](https://github.com/laravel/framework/pull/21788))
+- Added `notifyNow()` method to notifiables ([#21795](https://github.com/laravel/framework/pull/21795))
+- Added `TestResponse::assertCookieExpired()` method ([#21793](https://github.com/laravel/framework/pull/21793))
+
+### Fixed
+- Excluding `spatial_ref_sys` table from `migrate:fresh` ([#21778](https://github.com/laravel/framework/pull/21778))
+
+
 ## v5.5.18 (2017-10-19)
 
 ### Added

--- a/CHANGELOG-5.5.md
+++ b/CHANGELOG-5.5.md
@@ -7,9 +7,16 @@
 - Added `MakesHttpRequests::from()` method ([#21788](https://github.com/laravel/framework/pull/21788))
 - Added `notifyNow()` method to notifiables ([#21795](https://github.com/laravel/framework/pull/21795))
 - Added `TestResponse::assertCookieExpired()` method ([#21793](https://github.com/laravel/framework/pull/21793))
+- Added `TestResponse::assertCookieMissing()` method ([#21803](https://github.com/laravel/framework/pull/21803))
+
+### Changed
+- Allow the distinct validation rule to optionally ignore case ([#21757](https://github.com/laravel/framework/pull/21757))
 
 ### Fixed
 - Excluding `spatial_ref_sys` table from `migrate:fresh` ([#21778](https://github.com/laravel/framework/pull/21778))
+- Fixed issue with `SessionGuard` setting the logged in user after firing the `Authenticated` event ([#21790](https://github.com/laravel/framework/pull/21790))
+- Fixed issue with `Model::refresh()` when model has a global scope ([#21815](https://github.com/laravel/framework/pull/21815))
+- Fixed scheduling a non-queuable job ([#21820](https://github.com/laravel/framework/pull/21820))
 
 
 ## v5.5.18 (2017-10-19)

--- a/CHANGELOG-5.5.md
+++ b/CHANGELOG-5.5.md
@@ -1,6 +1,6 @@
 # Release Notes for 5.5.x
 
-## [Unreleased]
+## v5.5.19 (2017-10-25)
 
 ### Added
 - Added `MakesHttpRequests::followingRedirects()` method ([#21771](https://github.com/laravel/framework/pull/21771))

--- a/src/Illuminate/Auth/Console/stubs/make/views/layouts/app.stub
+++ b/src/Illuminate/Auth/Console/stubs/make/views/layouts/app.stub
@@ -20,7 +20,7 @@
                 <div class="navbar-header">
 
                     <!-- Collapsed Hamburger -->
-                    <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#app-navbar-collapse">
+                    <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#app-navbar-collapse" aria-expanded="false">
                         <span class="sr-only">Toggle Navigation</span>
                         <span class="icon-bar"></span>
                         <span class="icon-bar"></span>
@@ -47,11 +47,11 @@
                             <li><a href="{{ route('register') }}">Register</a></li>
                         @else
                             <li class="dropdown">
-                                <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">
+                                <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false" aria-haspopup="true">
                                     {{ Auth::user()->name }} <span class="caret"></span>
                                 </a>
 
-                                <ul class="dropdown-menu" role="menu">
+                                <ul class="dropdown-menu">
                                     <li>
                                         <a href="{{ route('logout') }}"
                                             onclick="event.preventDefault();

--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -127,11 +127,9 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
         // First we will try to load the user using the identifier in the session if
         // one exists. Otherwise we will check for a "remember me" cookie in this
         // request, and if one exists, attempt to retrieve the user using that.
-        $user = null;
-
         if (! is_null($id)) {
-            if ($user = $this->provider->retrieveById($id)) {
-                $this->fireAuthenticatedEvent($user);
+            if ($this->user = $this->provider->retrieveById($id)) {
+                $this->fireAuthenticatedEvent($this->user);
             }
         }
 
@@ -140,17 +138,17 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
         // the application. Once we have a user we can return it to the caller.
         $recaller = $this->recaller();
 
-        if (is_null($user) && ! is_null($recaller)) {
-            $user = $this->userFromRecaller($recaller);
+        if (is_null($this->user) && ! is_null($recaller)) {
+            $this->user = $this->userFromRecaller($recaller);
 
-            if ($user) {
-                $this->updateSession($user->getAuthIdentifier());
+            if ($this->user) {
+                $this->updateSession($this->user->getAuthIdentifier());
 
-                $this->fireLoginEvent($user, true);
+                $this->fireLoginEvent($this->user, true);
             }
         }
 
-        return $this->user = $user;
+        return $this->user;
     }
 
     /**

--- a/src/Illuminate/Broadcasting/BroadcastManager.php
+++ b/src/Illuminate/Broadcasting/BroadcastManager.php
@@ -65,7 +65,7 @@ class BroadcastManager implements FactoryContract
         $attributes = $attributes ?: ['middleware' => ['web']];
 
         $this->app['router']->group($attributes, function ($router) {
-            $router->post('/broadcasting/auth', BroadcastController::class.'@authenticate');
+            $router->post('/broadcasting/auth', '\\'.BroadcastController::class.'@authenticate');
         });
     }
 

--- a/src/Illuminate/Console/Scheduling/Schedule.php
+++ b/src/Illuminate/Console/Scheduling/Schedule.php
@@ -4,6 +4,7 @@ namespace Illuminate\Console\Scheduling;
 
 use Illuminate\Console\Application;
 use Illuminate\Container\Container;
+use Illuminate\Contracts\Queue\ShouldQueue;
 use Symfony\Component\Process\ProcessUtils;
 
 class Schedule
@@ -80,7 +81,13 @@ class Schedule
     public function job($job, $queue = null)
     {
         return $this->call(function () use ($job, $queue) {
-            dispatch(is_string($job) ? resolve($job) : $job)->onQueue($queue);
+            $job = is_string($job) ? resolve($job) : $job;
+
+            if ($job instanceof ShouldQueue) {
+                dispatch($job)->onQueue($queue);
+            } else {
+                dispatch_now($job);
+            }
         })->name(is_string($job) ? $job : get_class($job));
     }
 

--- a/src/Illuminate/Database/Console/Factories/stubs/factory.stub
+++ b/src/Illuminate/Database/Console/Factories/stubs/factory.stub
@@ -2,8 +2,6 @@
 
 use Faker\Generator as Faker;
 
-/* @var Illuminate\Database\Eloquent\Factory $factory */
-
 $factory->define(DummyModel::class, function (Faker $faker) {
     return [
         //

--- a/src/Illuminate/Database/Console/Factories/stubs/factory.stub
+++ b/src/Illuminate/Database/Console/Factories/stubs/factory.stub
@@ -2,6 +2,8 @@
 
 use Faker\Generator as Faker;
 
+/* @var Illuminate\Database\Eloquent\Factory $factory */
+
 $factory->define(DummyModel::class, function (Faker $faker) {
     return [
         //

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -999,7 +999,9 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
             return $this;
         }
 
-        $this->setRawAttributes(static::findOrFail($this->getKey())->attributes);
+        $this->setRawAttributes(
+            static::newQueryWithoutScopes()->findOrFail($this->getKey())->attributes
+        );
 
         $this->load(collect($this->relations)->except('pivot')->keys()->toArray());
 

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -29,7 +29,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
      *
      * @var string
      */
-    const VERSION = '5.5.18';
+    const VERSION = '5.5.19';
 
     /**
      * The base path for the Laravel installation.

--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -195,6 +195,22 @@ class TestResponse
     }
 
     /**
+     * Asserts that the response does not contains the given cookie.
+     *
+     * @param  string  $cookieName
+     * @return $this
+     */
+    public function assertCookieMissing($cookieName)
+    {
+        PHPUnit::assertNull(
+            $this->getCookie($cookieName),
+            "Cookie [{$cookieName}] is present on response."
+        );
+
+        return $this;
+    }
+
+    /**
      * Get the given cookie from the response.
      *
      * @param  string  $cookieName

--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -5,6 +5,7 @@ namespace Illuminate\Foundation\Testing;
 use Closure;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
+use Illuminate\Support\Carbon;
 use Illuminate\Contracts\View\View;
 use Illuminate\Support\Traits\Macroable;
 use PHPUnit\Framework\Assert as PHPUnit;
@@ -165,6 +166,29 @@ class TestResponse
         PHPUnit::assertEquals(
             $value, $actual,
             "Cookie [{$cookieName}] was found, but value [{$actual}] does not match [{$value}]."
+        );
+
+        return $this;
+    }
+
+    /**
+     * Asserts that the response contains the given cookie and is expired.
+     *
+     * @param  string  $cookieName
+     * @return $this
+     */
+    public function assertCookieExpired($cookieName)
+    {
+        PHPUnit::assertNotNull(
+            $cookie = $this->getCookie($cookieName),
+            "Cookie [{$cookieName}] not present on response."
+        );
+
+        $expiresAt = Carbon::createFromTimestamp($cookie->getExpiresTime());
+
+        PHPUnit::assertTrue(
+            $expiresAt->lessThan(Carbon::now()),
+            "Cookie [{$cookieName}] is not expired, it expires at [{$expiresAt}]."
         );
 
         return $this;

--- a/src/Illuminate/Http/Resources/Json/Resource.php
+++ b/src/Illuminate/Http/Resources/Json/Resource.php
@@ -72,7 +72,7 @@ class Resource implements ArrayAccess, JsonSerializable, Responsable, UrlRoutabl
      * Create new anonymous resource collection.
      *
      * @param  mixed  $resource
-     * @return mixed
+     * @return \Illuminate\Http\Resources\Json\AnonymousResourceCollection
      */
     public static function collection($resource)
     {

--- a/src/Illuminate/Notifications/DatabaseNotificationCollection.php
+++ b/src/Illuminate/Notifications/DatabaseNotificationCollection.php
@@ -7,7 +7,7 @@ use Illuminate\Database\Eloquent\Collection;
 class DatabaseNotificationCollection extends Collection
 {
     /**
-     * Mark all notification as read.
+     * Mark all notifications as read.
      *
      * @return void
      */

--- a/src/Illuminate/Notifications/RoutesNotifications.php
+++ b/src/Illuminate/Notifications/RoutesNotifications.php
@@ -19,6 +19,18 @@ trait RoutesNotifications
     }
 
     /**
+     * Send the given notification immediately.
+     *
+     * @param  mixed  $instance
+     * @param  array|null  $channels
+     * @return void
+     */
+    public function notifyNow($instance, array $channels = null)
+    {
+        app(Dispatcher::class)->sendNow($this, $instance, $channels);
+    }
+
+    /**
      * Get the notification routing information for the given driver.
      *
      * @param  string  $driver

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -306,7 +306,7 @@ class Worker
     {
         try {
             // First we will raise the before job event and determine if the job has already ran
-            // over its maximum attempt limit, which could primarily happen if the job is
+            // over its maximum attempt limits, which could primarily happen when this job is
             // continually timing out and not actually throwing any exceptions from itself.
             $this->raiseBeforeJobEvent($connectionName, $job);
 

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -306,7 +306,7 @@ class Worker
     {
         try {
             // First we will raise the before job event and determine if the job has already ran
-            // over the its maximum attempt limit, which could primarily happen if the job is
+            // over its maximum attempt limit, which could primarily happen if the job is
             // continually timing out and not actually throwing any exceptions from itself.
             $this->raiseBeforeJobEvent($connectionName, $job);
 

--- a/src/Illuminate/Support/Pluralizer.php
+++ b/src/Illuminate/Support/Pluralizer.php
@@ -31,6 +31,7 @@ class Pluralizer
         'hardware',
         'information',
         'jedi',
+        'kin',
         'knowledge',
         'love',
         'metadata',

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -1063,6 +1063,7 @@ if (! function_exists('throw_unless')) {
      * @param  \Throwable|string  $exception
      * @param  array  ...$parameters
      * @return void
+     * @throws \Throwable
      */
     function throw_unless($boolean, $exception, ...$parameters)
     {

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -1046,6 +1046,7 @@ if (! function_exists('throw_if')) {
      * @param  \Throwable|string  $exception
      * @param  array  ...$parameters
      * @return void
+     * @throws \Throwable
      */
     function throw_if($boolean, $exception, ...$parameters)
     {

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -528,6 +528,10 @@ trait ValidatesAttributes
             return $key != $attribute && (bool) preg_match('#^'.$pattern.'\z#u', $key);
         });
 
+        if (in_array('ignore_case', $parameters)) {
+            return empty(preg_grep('/'.preg_quote($value, '/').'/iu', $data));
+        }
+
         return ! in_array($value, array_values($data));
     }
 

--- a/tests/Database/DatabaseMigrationMakeCommandTest.php
+++ b/tests/Database/DatabaseMigrationMakeCommandTest.php
@@ -17,8 +17,7 @@ class DatabaseMigrationMakeCommandTest extends TestCase
     {
         $command = new MigrateMakeCommand(
             $creator = m::mock('Illuminate\Database\Migrations\MigrationCreator'),
-            $composer = m::mock('Illuminate\Support\Composer'),
-            __DIR__.'/vendor'
+            $composer = m::mock('Illuminate\Support\Composer')
         );
         $app = new \Illuminate\Foundation\Application;
         $app->useDatabasePath(__DIR__);
@@ -33,8 +32,7 @@ class DatabaseMigrationMakeCommandTest extends TestCase
     {
         $command = new MigrateMakeCommand(
             $creator = m::mock('Illuminate\Database\Migrations\MigrationCreator'),
-            m::mock('Illuminate\Support\Composer')->shouldIgnoreMissing(),
-            __DIR__.'/vendor'
+            m::mock('Illuminate\Support\Composer')->shouldIgnoreMissing()
         );
         $app = new \Illuminate\Foundation\Application;
         $app->useDatabasePath(__DIR__);
@@ -48,8 +46,7 @@ class DatabaseMigrationMakeCommandTest extends TestCase
     {
         $command = new MigrateMakeCommand(
             $creator = m::mock('Illuminate\Database\Migrations\MigrationCreator'),
-            m::mock('Illuminate\Support\Composer')->shouldIgnoreMissing(),
-            __DIR__.'/vendor'
+            m::mock('Illuminate\Support\Composer')->shouldIgnoreMissing()
         );
         $app = new \Illuminate\Foundation\Application;
         $app->useDatabasePath(__DIR__);
@@ -63,8 +60,7 @@ class DatabaseMigrationMakeCommandTest extends TestCase
     {
         $command = new MigrateMakeCommand(
             $creator = m::mock('Illuminate\Database\Migrations\MigrationCreator'),
-            m::mock('Illuminate\Support\Composer')->shouldIgnoreMissing(),
-            __DIR__.'/vendor'
+            m::mock('Illuminate\Support\Composer')->shouldIgnoreMissing()
         );
         $app = new \Illuminate\Foundation\Application;
         $app->useDatabasePath(__DIR__);
@@ -78,8 +74,7 @@ class DatabaseMigrationMakeCommandTest extends TestCase
     {
         $command = new MigrateMakeCommand(
             $creator = m::mock('Illuminate\Database\Migrations\MigrationCreator'),
-            m::mock('Illuminate\Support\Composer')->shouldIgnoreMissing(),
-            __DIR__.'/vendor'
+            m::mock('Illuminate\Support\Composer')->shouldIgnoreMissing()
         );
         $app = new \Illuminate\Foundation\Application;
         $command->setLaravel($app);

--- a/tests/Database/DatabaseMigrationMigrateCommandTest.php
+++ b/tests/Database/DatabaseMigrationMigrateCommandTest.php
@@ -16,7 +16,7 @@ class DatabaseMigrationMigrateCommandTest extends TestCase
 
     public function testBasicMigrationsCallMigratorWithProperArguments()
     {
-        $command = new MigrateCommand($migrator = m::mock('Illuminate\Database\Migrations\Migrator'), __DIR__.'/vendor');
+        $command = new MigrateCommand($migrator = m::mock('Illuminate\Database\Migrations\Migrator'));
         $app = new ApplicationDatabaseMigrationStub(['path.database' => __DIR__]);
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);
@@ -31,7 +31,7 @@ class DatabaseMigrationMigrateCommandTest extends TestCase
 
     public function testMigrationRepositoryCreatedWhenNecessary()
     {
-        $params = [$migrator = m::mock('Illuminate\Database\Migrations\Migrator'), __DIR__.'/vendor'];
+        $params = [$migrator = m::mock('Illuminate\Database\Migrations\Migrator')];
         $command = $this->getMockBuilder('Illuminate\Database\Console\Migrations\MigrateCommand')->setMethods(['call'])->setConstructorArgs($params)->getMock();
         $app = new ApplicationDatabaseMigrationStub(['path.database' => __DIR__]);
         $app->useDatabasePath(__DIR__);
@@ -48,7 +48,7 @@ class DatabaseMigrationMigrateCommandTest extends TestCase
 
     public function testTheCommandMayBePretended()
     {
-        $command = new MigrateCommand($migrator = m::mock('Illuminate\Database\Migrations\Migrator'), __DIR__.'/vendor');
+        $command = new MigrateCommand($migrator = m::mock('Illuminate\Database\Migrations\Migrator'));
         $app = new ApplicationDatabaseMigrationStub(['path.database' => __DIR__]);
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);
@@ -63,7 +63,7 @@ class DatabaseMigrationMigrateCommandTest extends TestCase
 
     public function testTheDatabaseMayBeSet()
     {
-        $command = new MigrateCommand($migrator = m::mock('Illuminate\Database\Migrations\Migrator'), __DIR__.'/vendor');
+        $command = new MigrateCommand($migrator = m::mock('Illuminate\Database\Migrations\Migrator'));
         $app = new ApplicationDatabaseMigrationStub(['path.database' => __DIR__]);
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);
@@ -78,7 +78,7 @@ class DatabaseMigrationMigrateCommandTest extends TestCase
 
     public function testStepMayBeSet()
     {
-        $command = new MigrateCommand($migrator = m::mock('Illuminate\Database\Migrations\Migrator'), __DIR__.'/vendor');
+        $command = new MigrateCommand($migrator = m::mock('Illuminate\Database\Migrations\Migrator'));
         $app = new ApplicationDatabaseMigrationStub(['path.database' => __DIR__]);
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);

--- a/tests/Integration/Database/EloquentHasManyThroughTest.php
+++ b/tests/Integration/Database/EloquentHasManyThroughTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\EloquentHasManyThroughTest;
+
+use Orchestra\Testbench\TestCase;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * @group integration
+ */
+class EloquentHasManyThroughTest extends TestCase
+{
+    protected function getEnvironmentSetUp($app)
+    {
+        $app['config']->set('app.debug', 'true');
+
+        $app['config']->set('database.default', 'testbench');
+
+        $app['config']->set('database.connections.testbench', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+        ]);
+    }
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        Schema::create('users', function ($table) {
+            $table->increments('id');
+            $table->integer('team_id')->nullable();
+            $table->string('name');
+        });
+
+        Schema::create('teams', function ($table) {
+            $table->increments('id');
+            $table->integer('owner_id');
+        });
+    }
+
+    /**
+     * @test
+     */
+    public function basic_create_and_retrieve()
+    {
+        $user = User::create(['name' => str_random()]);
+
+        $team1 = Team::create(['owner_id' => $user->id]);
+        $team2 = Team::create(['owner_id' => $user->id]);
+
+        $member1 = User::create(['name' => str_random(), 'team_id' => $team1->id]);
+        $member2 = User::create(['name' => str_random(), 'team_id' => $team1->id]);
+
+        $notMember = User::create(['name' => str_random()]);
+
+
+        $this->assertEquals([$member1->id, $member2->id], $user->members->pluck('id')->toArray());
+    }
+}
+
+
+class User extends Model
+{
+    public $table = 'users';
+    public $timestamps = false;
+    protected $guarded = ['id'];
+
+    public function members()
+    {
+        return $this->hasManyThrough(self::class, Team::class, 'owner_id', 'team_id');
+    }
+}
+
+class Team extends Model
+{
+    public $table = 'teams';
+    public $timestamps = false;
+    protected $guarded = ['id'];
+}

--- a/tests/Integration/Database/EloquentHasManyThroughTest.php
+++ b/tests/Integration/Database/EloquentHasManyThroughTest.php
@@ -50,12 +50,12 @@ class EloquentHasManyThroughTest extends TestCase
         $team1 = Team::create(['owner_id' => $user->id]);
         $team2 = Team::create(['owner_id' => $user->id]);
 
-        $member1 = User::create(['name' => str_random(), 'team_id' => $team1->id]);
-        $member2 = User::create(['name' => str_random(), 'team_id' => $team1->id]);
+        $mate1 = User::create(['name' => str_random(), 'team_id' => $team1->id]);
+        $mate2 = User::create(['name' => str_random(), 'team_id' => $team2->id]);
 
         $notMember = User::create(['name' => str_random()]);
 
-        $this->assertEquals([$member1->id, $member2->id], $user->members->pluck('id')->toArray());
+        $this->assertEquals([$mate1->id, $mate2->id], $user->teamMates->pluck('id')->toArray());
     }
 }
 
@@ -65,7 +65,7 @@ class User extends Model
     public $timestamps = false;
     protected $guarded = ['id'];
 
-    public function members()
+    public function teamMates()
     {
         return $this->hasManyThrough(self::class, Team::class, 'owner_id', 'team_id');
     }

--- a/tests/Integration/Database/EloquentHasManyThroughTest.php
+++ b/tests/Integration/Database/EloquentHasManyThroughTest.php
@@ -55,11 +55,9 @@ class EloquentHasManyThroughTest extends TestCase
 
         $notMember = User::create(['name' => str_random()]);
 
-
         $this->assertEquals([$member1->id, $member2->id], $user->members->pluck('id')->toArray());
     }
 }
-
 
 class User extends Model
 {

--- a/tests/Integration/Database/EloquentModelRefreshTest.php
+++ b/tests/Integration/Database/EloquentModelRefreshTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\EloquentModelRefreshTest;
+
+use Orchestra\Testbench\TestCase;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+/**
+ * @group integration
+ */
+class EloquentModelRefreshTest extends TestCase
+{
+    protected function getEnvironmentSetUp($app)
+    {
+        $app['config']->set('app.debug', 'true');
+
+        $app['config']->set('database.default', 'testbench');
+
+        $app['config']->set('database.connections.testbench', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+        ]);
+    }
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        Schema::create('posts', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('title');
+            $table->timestamps();
+            $table->softDeletes();
+        });
+    }
+
+    /**
+     * @test
+     */
+    public function it_refreshes_model_excluded_by_global_scope()
+    {
+        $post = Post::create(['title' => 'mohamed']);
+
+        $post->refresh();
+    }
+
+    /**
+     * @test
+     */
+    public function it_refreshes_a_soft_deleted_model()
+    {
+        $post = Post::create(['title' => 'said']);
+
+        Post::find($post->id)->delete();
+
+        $this->assertFalse($post->trashed());
+
+        $post->refresh();
+
+        $this->assertTrue($post->trashed());
+    }
+}
+
+class Post extends Model
+{
+    public $table = 'posts';
+    public $timestamps = true;
+    protected $guarded = ['id'];
+
+    use SoftDeletes;
+
+    protected static function boot()
+    {
+        parent::boot();
+
+        static::addGlobalScope('age', function ($query) {
+            $query->where('title', '!=', 'mohamed');
+        });
+    }
+}

--- a/tests/Notifications/NotificationRoutesNotificationsTest.php
+++ b/tests/Notifications/NotificationRoutesNotificationsTest.php
@@ -28,6 +28,19 @@ class NotificationRoutesNotificationsTest extends TestCase
         $notifiable->notify($instance);
     }
 
+    public function testNotificationCanBeSentNow()
+    {
+        $container = new Container;
+        $factory = Mockery::mock(Dispatcher::class);
+        $container->instance(Dispatcher::class, $factory);
+        $notifiable = new RoutesNotificationsTestInstance;
+        $instance = new stdClass;
+        $factory->shouldReceive('sendNow')->with($notifiable, $instance, null);
+        Container::setInstance($container);
+
+        $notifiable->notifyNow($instance);
+    }
+
     public function testNotificationOptionRouting()
     {
         $instance = new RoutesNotificationsTestInstance;

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1477,10 +1477,22 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['foo' => ['foo', 'foo']], ['foo.*' => 'distinct']);
         $this->assertFalse($v->passes());
 
+        $v = new Validator($trans, ['foo' => ['à', 'À']], ['foo.*' => 'distinct:ignore_case']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => ['f/oo', 'F/OO']], ['foo.*' => 'distinct:ignore_case']);
+        $this->assertFalse($v->passes());
+
         $v = new Validator($trans, ['foo' => ['foo', 'bar']], ['foo.*' => 'distinct']);
         $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['foo' => ['bar' => ['id' => 1], 'baz' => ['id' => 1]]], ['foo.*.id' => 'distinct']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => ['bar' => ['id' => 'qux'], 'baz' => ['id' => 'QUX']]], ['foo.*.id' => 'distinct']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => ['bar' => ['id' => 'qux'], 'baz' => ['id' => 'QUX']]], ['foo.*.id' => 'distinct:ignore_case']);
         $this->assertFalse($v->passes());
 
         $v = new Validator($trans, ['foo' => ['bar' => ['id' => 1], 'baz' => ['id' => 2]]], ['foo.*.id' => 'distinct']);


### PR DESCRIPTION
See #21259 for full-details.

This fix has been implemented in a similar way that table aliases are applied when using a self-referencing `BelongsTo` relationship.

I have targeted this at 5.5, but not sure if this is classed as a breaking change as some people may be relying on the current broken behaviour. If so, I can target this at 5.6 no problem.