### PR TITLE
[5.5] remove extra call to `formatNotifiables()`

### DIFF
--- a/src/Illuminate/Notifications/NotificationSender.php
+++ b/src/Illuminate/Notifications/NotificationSender.php
@@ -55,8 +55,6 @@ class NotificationSender
      */
     public function send($notifiables, $notification)
     {
-        $notifiables = $this->formatNotifiables($notifiables);
-
         if ($notification instanceof ShouldQueue) {
             return $this->queueNotification($notifiables, $notification);
         }


### PR DESCRIPTION
this is a minor optimization.

the `formatNotifiables()` method is also called in both the `sendNow()` and `queueNotification()` methods, which `send()` defers to.  therefore, there is no need to call it here.

I would have preferred to leave it here and remove it from the `sendNow()` and `queueNotification()` methods, but `sendNow()` is a public method, so it could possibly be skipped over if I did it that way.