### PR TITLE
[5.5] add `notifyNow` method to Notifiables

### DIFF
--- a/src/Illuminate/Notifications/RoutesNotifications.php
+++ b/src/Illuminate/Notifications/RoutesNotifications.php
@@ -19,6 +19,18 @@ trait RoutesNotifications
     }
 
     /**
+     * Send the given notification immediately.
+     *
+     * @param  mixed  $instance
+     * @param  array|null  $channels
+     * @return void
+     */
+    public function notifyNow($instance, array $channels = null)
+    {
+        app(Dispatcher::class)->sendNow($this, $instance, $channels);
+    }
+
+    /**
      * Get the notification routing information for the given driver.
      *
      * @param  string  $driver

--- a/tests/Notifications/NotificationRoutesNotificationsTest.php
+++ b/tests/Notifications/NotificationRoutesNotificationsTest.php
@@ -28,6 +28,19 @@ class NotificationRoutesNotificationsTest extends TestCase
         $notifiable->notify($instance);
     }
 
+    public function testNotificationCanBeSentNow()
+    {
+        $container = new Container;
+        $factory = Mockery::mock(Dispatcher::class);
+        $container->instance(Dispatcher::class, $factory);
+        $notifiable = new RoutesNotificationsTestInstance;
+        $instance = new stdClass;
+        $factory->shouldReceive('sendNow')->with($notifiable, $instance, null);
+        Container::setInstance($container);
+
+        $notifiable->notifyNow($instance);
+    }
+
     public function testNotificationOptionRouting()
     {
         $instance = new RoutesNotificationsTestInstance;


### PR DESCRIPTION
allows user to override notifications with the `ShouldQueue` interface, and send them immediately.