### PR TITLE
[5.5] toRaw added to builder

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1649,6 +1649,18 @@ class Builder
     }
 
     /**
+     * Get the SQL representation of the query with the bindings substituted.
+     *
+     * @return string
+     */
+    public function toRaw()
+    {
+        $statement = str_replace(' ?', ' "%s"', $this->toSql());
+        $bindings = array_map('addslashes', $this->getBindings());
+        return sprintf($statement, ...$bindings);
+    }
+
+    /**
      * Execute a query for a single record by ID.
      *
      * @param  int    $id


### PR DESCRIPTION
Ref: https://github.com/laravel/internals/issues/797

Adds a `toRaw()` function to the builder which returns the SQL query with the bindings

PS: Didn't add any tests because there are no tests for `toSql()` as well. Also the behaviour has been verified by @jakebathman 

