### PR TITLE
[5.6] remove call to `formatNotifiables()`

### DIFF
--- a/src/Illuminate/Notifications/NotificationSender.php
+++ b/src/Illuminate/Notifications/NotificationSender.php
@@ -55,8 +55,6 @@ class NotificationSender
      */
     public function send($notifiables, $notification)
     {
-        $notifiables = $this->formatNotifiables($notifiables);
-
         if ($notification instanceof ShouldQueue) {
             return $this->queueNotification($notifiables, $notification);
         }


### PR DESCRIPTION
the Notifiables are unnecessarily formatted multiple times due to many calls to `formatNotifiables()`.  remove the call in the `send()` method since it defers to others methods that also call this.