### PR TITLE
[5.5] remove the last few '\Illuminate\...' codes

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -237,7 +237,7 @@ class Router implements RegistrarContract, BindingRegistrar
      */
     public function redirect($uri, $destination, $status = 301)
     {
-        return $this->any($uri, '\Illuminate\Routing\RedirectController')
+        return $this->any($uri, \Illuminate\Routing\RedirectController::class)
                 ->defaults('destination', $destination)
                 ->defaults('status', $status);
     }
@@ -252,7 +252,7 @@ class Router implements RegistrarContract, BindingRegistrar
      */
     public function view($uri, $view, $data = [])
     {
-        return $this->match(['GET', 'HEAD'], $uri, '\Illuminate\Routing\ViewController')
+        return $this->match(['GET', 'HEAD'], $uri, \Illuminate\Routing\ViewController::class)
                 ->defaults('view', $view)
                 ->defaults('data', $data);
     }

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -831,7 +831,7 @@ class Validator implements ValidatorContract
     public function addExtensions(array $extensions)
     {
         if ($extensions) {
-            $keys = array_map('\Illuminate\Support\Str::snake', array_keys($extensions));
+            $keys = array_map(\Illuminate\Support\Str::class.'::snake', array_keys($extensions));
 
             $extensions = array_combine($keys, array_values($extensions));
         }
@@ -918,7 +918,7 @@ class Validator implements ValidatorContract
     public function addReplacers(array $replacers)
     {
         if ($replacers) {
-            $keys = array_map('\Illuminate\Support\Str::snake', array_keys($replacers));
+            $keys = array_map(\Illuminate\Support\Str::class.'::snake', array_keys($replacers));
 
             $replacers = array_combine($keys, array_values($replacers));
         }

--- a/tests/Auth/AuthAccessGateTest.php
+++ b/tests/Auth/AuthAccessGateTest.php
@@ -166,7 +166,7 @@ class GateTest extends TestCase
     {
         $gate = $this->getBasicGate();
 
-        $gate->define('foo', '\Illuminate\Tests\Auth\AccessGateTestClass@foo');
+        $gate->define('foo', \Illuminate\Tests\Auth\AccessGateTestClass::class.'@foo');
 
         $this->assertTrue($gate->check('foo'));
     }

--- a/tests/Auth/AuthorizesResourcesTest.php
+++ b/tests/Auth/AuthorizesResourcesTest.php
@@ -65,8 +65,8 @@ class AuthorizesResourcesTest extends TestCase
     {
         $router = new Router(new \Illuminate\Events\Dispatcher);
 
-        $router->aliasMiddleware('can', '\Illuminate\Tests\Auth\AuthorizesResourcesMiddleware');
-        $router->get($method)->uses('\Illuminate\Tests\Auth\AuthorizesResourcesController@'.$method);
+        $router->aliasMiddleware('can', \Illuminate\Tests\Auth\AuthorizesResourcesMiddleware::class);
+        $router->get($method)->uses(\Illuminate\Tests\Auth\AuthorizesResourcesController::class.'@'.$method);
 
         $this->assertEquals(
             'caught '.$middleware,


### PR DESCRIPTION
This PR replaced the last few '\Illuminate\...' codes with \Illuminate\...Controller::class with all tests passed.