### PR TITLE
[5.5] Fixes array_dot resetting integer keys

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -112,7 +112,7 @@ class Arr
 
         foreach ($array as $key => $value) {
             if (is_array($value) && ! empty($value)) {
-                $results = array_merge($results, static::dot($value, $prepend.$key.'.'));
+                $results += static::dot($value, $prepend.$key.'.');
             } else {
                 $results[$prepend.$key] = $value;
             }

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -101,6 +101,9 @@ class SupportArrTest extends TestCase
 
         $array = Arr::dot(['foo' => ['bar' => []]]);
         $this->assertEquals(['foo.bar' => []], $array);
+
+        $array = Arr::dot([5 => [], 6 => [7 => []]]);
+        $this->assertEquals(['5' => [], '6.7' => []], $array);
     }
 
     public function testExcept()


### PR DESCRIPTION
Replaces `array_merge` with the array union syntax in order to maintain original integer keys, see test for example.

Previously `array_dot([5 => [], 6 => [7 => []]])`

Was returning: `[0 => [], '6.7' => []]`

Expected: `['5' => [], '6.7' => []]`