### PR TITLE
[5.5] Add Type Hint to Model Factory Stub

### DIFF
--- a/src/Illuminate/Database/Console/Factories/stubs/factory.stub
+++ b/src/Illuminate/Database/Console/Factories/stubs/factory.stub
@@ -2,6 +2,8 @@
 
 use Faker\Generator as Faker;
 
+/* @var Illuminate\Database\Eloquent\Factory $factory */
+
 $factory->define(DummyModel::class, function (Faker $faker) {
     return [
         //


### PR DESCRIPTION
I find myself adding this type hint to every model factory that I
create to help IDEs auto complete the `$factory` object and 
figured that others my also find it useful.