### PR TITLE
[5.6] Fixed array_dot resetting integer keys

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -112,7 +112,7 @@ class Arr
 
         foreach ($array as $key => $value) {
             if (is_array($value) && ! empty($value)) {
-                $results = array_merge($results, static::dot($value, $prepend.$key.'.'));
+                $results += static::dot($value, $prepend.$key.'.');
             } else {
                 $results[$prepend.$key] = $value;
             }

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -101,6 +101,9 @@ class SupportArrTest extends TestCase
 
         $array = Arr::dot(['foo' => ['bar' => []]]);
         $this->assertEquals(['foo.bar' => []], $array);
+
+        $array = Arr::dot([5 => [], 6 => [7 => []]]);
+        $this->assertEquals(['5' => [], '6.7' => []], $array);
     }
 
     public function testExcept()


### PR DESCRIPTION
As a follow up to the discussion in https://github.com/laravel/framework/pull/21807 I am resubmitting the PR to master