### PR TITLE
[5.5] fix model refresh with global scopes

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -999,7 +999,9 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
             return $this;
         }
 
-        $this->setRawAttributes(static::findOrFail($this->getKey())->attributes);
+        $this->setRawAttributes(
+            static::newQueryWithoutScopes()->findOrFail($this->getKey())->attributes
+        );
 
         $this->load(collect($this->relations)->except('pivot')->keys()->toArray());
 

--- a/tests/Integration/Database/EloquentModelRefreshTest.php
+++ b/tests/Integration/Database/EloquentModelRefreshTest.php
@@ -4,13 +4,9 @@ namespace Illuminate\Tests\Integration\Database\EloquentModelRefreshTest;
 
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Support\Carbon;
 use Orchestra\Testbench\TestCase;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Collection;
-use Illuminate\Database\Eloquent\Relations\Pivot;
 
 /**
  * @group integration

--- a/tests/Integration/Database/EloquentModelRefreshTest.php
+++ b/tests/Integration/Database/EloquentModelRefreshTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\EloquentModelRefreshTest;
+
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Carbon;
+use Orchestra\Testbench\TestCase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Relations\Pivot;
+
+/**
+ * @group integration
+ */
+class EloquentModelRefreshTest extends TestCase
+{
+    protected function getEnvironmentSetUp($app)
+    {
+        $app['config']->set('app.debug', 'true');
+
+        $app['config']->set('database.default', 'testbench');
+
+        $app['config']->set('database.connections.testbench', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+        ]);
+    }
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        Schema::create('posts', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('title');
+            $table->timestamps();
+            $table->softDeletes();
+        });
+    }
+
+    /**
+     * @test
+     */
+    public function it_refreshes_model_excluded_by_global_scope()
+    {
+        $post = Post::create(['title' => 'mohamed']);
+
+        $post->refresh();
+    }
+
+    /**
+     * @test
+     */
+    public function it_refreshes_a_soft_deleted_model()
+    {
+        $post = Post::create(['title' => 'said']);
+
+        Post::find($post->id)->delete();
+
+        $this->assertFalse($post->trashed());
+
+        $post->refresh();
+
+        $this->assertTrue($post->trashed());
+    }
+}
+
+class Post extends Model
+{
+    public $table = 'posts';
+    public $timestamps = true;
+    protected $guarded = ['id'];
+
+    use SoftDeletes;
+
+    protected static function boot()
+    {
+        parent::boot();
+
+        static::addGlobalScope('age', function ($query) {
+            $query->where('title', '!=', 'mohamed');
+        });
+    }
+}

--- a/tests/Integration/Database/EloquentModelRefreshTest.php
+++ b/tests/Integration/Database/EloquentModelRefreshTest.php
@@ -2,11 +2,11 @@
 
 namespace Illuminate\Tests\Integration\Database\EloquentModelRefreshTest;
 
-use Illuminate\Database\Eloquent\SoftDeletes;
-use Illuminate\Database\Schema\Blueprint;
 use Orchestra\Testbench\TestCase;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 /**
  * @group integration


### PR DESCRIPTION
This PR disables global scopes while using `Model::refresh()`, that way we can refresh a model that's excluded by a global scope.