### PR TITLE
Added array key casing helpers

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -91,6 +91,45 @@ class Str
     }
 
     /**
+     * Convert array keys to camel case
+     *
+     * @param array $data
+     * @param bool $recursive
+     * @return array
+     */
+    public static function camelArrayKeys(array $data, $recursive = true)
+    {
+        return static::convertArrayKeys(static::class.'::camel', $data, $recursive);
+    }
+
+    /**
+     * Convert array keys based on the given callable
+     *
+     * @param callable $method
+     * @param array $data
+     * @param bool $recursive
+     * @return array
+     */
+    public static function convertArrayKeys(callable $method, array $data, $recursive = true)
+    {
+        $newKeys = array_map($method, array_keys($data));
+        $data    = array_combine($newKeys, array_values($data));
+
+        // If we are running recursively we'll map over each
+        // sub array and run it through this function.
+        if ($recursive === true) {
+            $data = array_map(
+                function ($data) use ($method) {
+                    return !is_array($data) ? $data : static::convertArrayKeys($method, $data, true);
+                },
+                $data
+            );
+        }
+
+        return $data;
+    }
+
+    /**
      * Determine if a given string contains a given substring.
      *
      * @param  string  $haystack
@@ -454,6 +493,18 @@ class Str
         }
 
         return static::$snakeCache[$key][$delimiter] = $value;
+    }
+
+    /**
+     * Convert array keys to snake case
+     *
+     * @param array $data
+     * @param bool $recursive
+     * @return array
+     */
+    public static function snakeArrayKeys(array $data, $recursive = true)
+    {
+        return static::convertArrayKeys(static::class.'::snake', $data, $recursive);
     }
 
     /**

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -91,7 +91,7 @@ class Str
     }
 
     /**
-     * Convert array keys to camel case
+     * Convert array keys to camel case.
      *
      * @param array $data
      * @param bool $recursive
@@ -103,7 +103,7 @@ class Str
     }
 
     /**
-     * Convert array keys based on the given callable
+     * Convert array keys based on the given callable.
      *
      * @param callable $method
      * @param array $data
@@ -113,14 +113,14 @@ class Str
     public static function convertArrayKeys(callable $method, array $data, $recursive = true)
     {
         $newKeys = array_map($method, array_keys($data));
-        $data    = array_combine($newKeys, array_values($data));
+        $data = array_combine($newKeys, array_values($data));
 
         // If we are running recursively we'll map over each
         // sub array and run it through this function.
         if ($recursive === true) {
             $data = array_map(
                 function ($data) use ($method) {
-                    return !is_array($data) ? $data : static::convertArrayKeys($method, $data, true);
+                    return ! is_array($data) ? $data : static::convertArrayKeys($method, $data, true);
                 },
                 $data
             );
@@ -496,7 +496,7 @@ class Str
     }
 
     /**
-     * Convert array keys to snake case
+     * Convert array keys to snake case.
      *
      * @param array $data
      * @param bool $recursive

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -373,6 +373,20 @@ if (! function_exists('camel_case')) {
     }
 }
 
+if (! function_exists('camel_array_keys')) {
+    /**
+     * Convert array keys to camel case
+     *
+     * @param array $data
+     * @param bool $recursive
+     * @return array
+     */
+    function camel_array_keys(array $data, $recursive = true)
+    {
+        return Str::camelArrayKeys($data, $recursive);
+    }
+}
+
 if (! function_exists('class_basename')) {
     /**
      * Get the class "basename" of the given object / class.
@@ -787,6 +801,20 @@ if (! function_exists('snake_case')) {
     function snake_case($value, $delimiter = '_')
     {
         return Str::snake($value, $delimiter);
+    }
+}
+
+if (! function_exists('snake_array_keys')) {
+    /**
+     * Convert array keys to snake case
+     *
+     * @param array $data
+     * @param bool $recursive
+     * @return array
+     */
+    function snake_array_keys(array $data, $recursive = true)
+    {
+        return Str::snakeArrayKeys($data, $recursive);
     }
 }
 

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -375,7 +375,7 @@ if (! function_exists('camel_case')) {
 
 if (! function_exists('camel_array_keys')) {
     /**
-     * Convert array keys to camel case
+     * Convert array keys to camel case.
      *
      * @param array $data
      * @param bool $recursive
@@ -806,7 +806,7 @@ if (! function_exists('snake_case')) {
 
 if (! function_exists('snake_array_keys')) {
     /**
-     * Convert array keys to snake case
+     * Convert array keys to snake case.
      *
      * @param array $data
      * @param bool $recursive

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -309,7 +309,7 @@ class SupportHelpersTest extends TestCase
             'myFirstKey' => 1,
             'mySecondKey' => [
                 'firstKey' => 1,
-                'secondKey' => 2
+                'secondKey' => 2,
             ],
         ];
 
@@ -318,7 +318,7 @@ class SupportHelpersTest extends TestCase
             'my_first_key' => 1,
             'my_second_key' => [
                 'first_key' => 1,
-                'second_key' => 2
+                'second_key' => 2,
             ],
         ], Str::snakeArrayKeys($data));
 
@@ -327,7 +327,7 @@ class SupportHelpersTest extends TestCase
             'my_first_key' => 1,
             'my_second_key' => [
                 'firstKey' => 1,
-                'secondKey' => 2
+                'secondKey' => 2,
             ],
         ], Str::snakeArrayKeys($data, false));
     }
@@ -371,7 +371,7 @@ class SupportHelpersTest extends TestCase
                 'testOne' => 1,
                 'testTwo' => 2,
             ],
-            'myThirdKey' => 3
+            'myThirdKey' => 3,
         ], Str::camelArrayKeys($data));
 
         // non-recursive
@@ -381,7 +381,7 @@ class SupportHelpersTest extends TestCase
                 'test_one' => 1,
                 'test_two' => 2,
             ],
-            'myThirdKey' => 3
+            'myThirdKey' => 3,
         ], Str::camelArrayKeys($data, false));
     }
 

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -303,6 +303,35 @@ class SupportHelpersTest extends TestCase
         $this->assertEquals('foo_bar', Str::snake('fooBar')); // test cache
     }
 
+    public function testSnakeArrayKeys()
+    {
+        $data = [
+            'myFirstKey' => 1,
+            'mySecondKey' => [
+                'firstKey' => 1,
+                'secondKey' => 2
+            ],
+        ];
+
+        // recursive
+        $this->assertSame([
+            'my_first_key' => 1,
+            'my_second_key' => [
+                'first_key' => 1,
+                'second_key' => 2
+            ],
+        ], Str::snakeArrayKeys($data));
+
+        // non-recursive
+        $this->assertSame([
+            'my_first_key' => 1,
+            'my_second_key' => [
+                'firstKey' => 1,
+                'secondKey' => 2
+            ],
+        ], Str::snakeArrayKeys($data, false));
+    }
+
     public function testStrLimit()
     {
         $string = 'The PHP framework for web artisans.';
@@ -322,6 +351,38 @@ class SupportHelpersTest extends TestCase
         $this->assertEquals('fooBar', Str::camel('foo_bar')); // test cache
         $this->assertEquals('fooBarBaz', Str::camel('Foo-barBaz'));
         $this->assertEquals('fooBarBaz', Str::camel('foo-bar_baz'));
+    }
+
+    public function testCamelArrayKeys()
+    {
+        $data = [
+            'my_first_key' => 1,
+            'my_second_key' => [
+                'test_one' => 1,
+                'test_two' => 2,
+            ],
+            'myThirdKey' => 3,
+        ];
+
+        // recursive
+        $this->assertSame([
+            'myFirstKey' => 1,
+            'mySecondKey' => [
+                'testOne' => 1,
+                'testTwo' => 2,
+            ],
+            'myThirdKey' => 3
+        ], Str::camelArrayKeys($data));
+
+        // non-recursive
+        $this->assertSame([
+            'myFirstKey' => 1,
+            'mySecondKey' => [
+                'test_one' => 1,
+                'test_two' => 2,
+            ],
+            'myThirdKey' => 3
+        ], Str::camelArrayKeys($data, false));
     }
 
     public function testStudlyCase()


### PR DESCRIPTION
This PR allows array key cases to be converted.
This is useful when working with JSON camel case conventions, whilst maintaining PHP array key conventions.

```php
return response()->json(camel_array_keys([
    'key_one' => 'value',
    'key_two' => 'value',
]));
```

```json
{
  "keyOne": "value",
  "keyTwo": "value",
}
```