### PR TITLE
[5.5] string helper to remove widow in string

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -234,6 +234,17 @@ class Str
     }
 
     /**
+     * Prevent widow in a string
+     *
+     * @param  string  $value
+     * @return string
+     */
+    public static function no_widow($value)
+    {
+        return preg_replace('|([^\s])\s+([^\s]+)\s*$|', '$1&nbsp;$2', $value);
+    }
+
+    /**
      * Limit the number of words in a string.
      *
      * @param  string  $value

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -234,7 +234,7 @@ class Str
     }
 
     /**
-     * Prevent widow in a string
+     * Prevent widow in a string.
      *
      * @param  string  $value
      * @return string

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -683,6 +683,19 @@ if (! function_exists('last')) {
     }
 }
 
+if (! function_exists('no_widow')) {
+    /**
+     * Prevent widow in a string.
+     *
+     * @param  string  $value
+     * @return string
+     */
+    function no_widow($value)
+    {
+        return Str::no_widow($value);
+    }
+}
+
 if (! function_exists('object_get')) {
     /**
      * Get an item from an object using "dot" notation.


### PR DESCRIPTION
[Widows](https://en.wikipedia.org/wiki/Widows_and_orphans) are an annoyance to designers, so this pull request attempts to make it easier to ensure widows don't end up in your page copy.
This string helper prevents widows at the end of a line by adding `&nbsp;` between the last two words.