### PR TITLE
[5.5] Add option arg for pretty exact JSON assertion.

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -315,15 +315,19 @@ class TestResponse
      * Assert that the response has the exact given JSON.
      *
      * @param  array  $data
+     * @param  bool   $pretty
      * @return $this
      */
-    public function assertExactJson(array $data)
+    public function assertExactJson(array $data, $pretty = false)
     {
-        $actual = json_encode(Arr::sortRecursive(
-            (array) $this->decodeResponseJson()
-        ));
+        $options = 0;
+        if ($pretty === true) {
+            $options = JSON_PRETTY_PRINT;
+        }
 
-        PHPUnit::assertEquals(json_encode(Arr::sortRecursive($data)), $actual);
+        $actual = json_encode(Arr::sortRecursive((array) $this->decodeResponseJson()), $options);
+
+        PHPUnit::assertEquals(json_encode(Arr::sortRecursive($data), $options), $actual);
 
         return $this;
     }


### PR DESCRIPTION
Whenever dealing with larger bodies of JSON and a couple things have changed, sometimes it's nice to get a pretty diff on what has changed, rather than trying to compare the full expected/actual bodies.