### PR TITLE
[5.5] Fixed typo in comments of Queue/Worker.php

### DIFF
--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -306,7 +306,7 @@ class Worker
     {
         try {
             // First we will raise the before job event and determine if the job has already ran
-            // over the its maximum attempt limit, which could primarily happen if the job is
+            // over its maximum attempt limit, which could primarily happen if the job is
             // continually timing out and not actually throwing any exceptions from itself.
             $this->raiseBeforeJobEvent($connectionName, $job);
 


### PR DESCRIPTION
Removed a word that didn't belong in the comments of Queue/Worker.php