### PR TITLE
[5.5] Fix BroadcastController namespace

### DIFF
--- a/src/Illuminate/Broadcasting/BroadcastManager.php
+++ b/src/Illuminate/Broadcasting/BroadcastManager.php
@@ -65,7 +65,7 @@ class BroadcastManager implements FactoryContract
         $attributes = $attributes ?: ['middleware' => ['web']];
 
         $this->app['router']->group($attributes, function ($router) {
-            $router->post('/broadcasting/auth', BroadcastController::class.'@authenticate');
+            $router->post('/broadcasting/auth', '\\'.BroadcastController::class.'@authenticate');
         });
     }
 


### PR DESCRIPTION
Fix the error : 
```
ReflectionException (-1)
Class App\Http\Controllers\Illuminate\Broadcasting\BroadcastController does not exist
```