### PR TITLE
[5.5] Check if ability is defined using resource method

### DIFF
--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -434,7 +434,12 @@ class Gate implements GateContract
      */
     protected function resolvePolicyCallback($user, $ability, array $arguments, $policy)
     {
-        if (! is_callable([$policy, $this->formatAbilityToMethod($ability)])) {
+        // Checks if ability is defined using resource method
+        $callback = strpos($ability, '.')
+            ? $this->abilities[$ability]
+            : [$policy, $this->formatAbilityToMethod($ability)];
+
+        if (! is_callable($callback)) {
             return false;
         }
 

--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -435,7 +435,7 @@ class Gate implements GateContract
     protected function resolvePolicyCallback($user, $ability, array $arguments, $policy)
     {
         // Checks if ability is defined using resource method
-        $callback = strpos($ability, '.')
+        $callback = strpos($ability, '.') !== false
             ? $this->abilities[$ability]
             : [$policy, $this->formatAbilityToMethod($ability)];
 

--- a/tests/Auth/AuthAccessGateTest.php
+++ b/tests/Auth/AuthAccessGateTest.php
@@ -64,6 +64,21 @@ class GateTest extends TestCase
         $this->assertTrue($gate->check('test.ability2'));
     }
 
+    public function test_before_callbacks_works_with_resource_gates_abilities()
+    {
+        $gate = $this->getBasicGate();
+
+        $gate->policy(AccessGateTestDummy::class, AccessGateTestPolicyWithBefore::class);
+
+        $abilities = [
+            'bar' => 'update',
+        ];
+
+        $gate->resource('foo', AccessGateTestPolicyWithBefore::class, $abilities);
+
+        $this->assertTrue($gate->check('foo.bar', new AccessGateTestDummy));
+    }
+
     public function test_before_callbacks_can_override_result_if_necessary()
     {
         $gate = $this->getBasicGate();


### PR DESCRIPTION
This PR fixes bug with policies which doesn't work properly with abilities registered using "Resource Gates" due to special format of it (eg. `posts.view`).

Mentioned bug occurs because "callable check" always returns false when ability is defined by resource.
```php
if (! is_callable([$policy, $this->formatAbilityToMethod($ability)])) {
   return false;
}
```
For example, let's assume that ability is `posts.view`, this statement checks if `posts.view` method is callable instead of checking method associated with registered ability (which makes sense). Method `resolvePolicyCallback` returns false, rest of code isn't executed and as a result before method can't be called.

### Solution
Gate has to check type of ability, properly get method name and then make sure if method is callable.