### PR TITLE
Optionally auto-suffix created test files

### DIFF
--- a/src/Illuminate/Foundation/Console/TestMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/TestMakeCommand.php
@@ -52,7 +52,25 @@ class TestMakeCommand extends GeneratorCommand
     {
         $name = Str::replaceFirst($this->rootNamespace(), '', $name);
 
+        $name = Str::finish($name, 'Test');
+
         return $this->laravel->basePath().'/tests'.str_replace('\\', '/', $name).'.php';
+    }
+
+    /**
+     * Replace the class name for the given stub.
+     *
+     * @param  string  $stub
+     * @param  string  $name
+     * @return string
+     */
+    protected function replaceClass($stub, $name)
+    {
+        $class = str_replace($this->getNamespace($name).'\\', '', $name);
+
+        $class = Str::finish($class, 'Test');
+
+        return str_replace('DummyClass', $class, $stub);
     }
 
     /**


### PR DESCRIPTION
Currently when creating a new test file with `artisan make:test` one has to _remember_ to suffix the provided name with 'Test' in order that the default PHPUnit configuration (defined in `phpunit.xml`) would pick it up and include the newly created files in the tests. 

For example, if I run `artisan make:test MyClass`, PHPUnit would not run the tests enclosed so I have to rename both the file and class name to `MyClassTest.php` and `MyClassTest` respectively, and as often I forget the suffix it can get really annoying. 

This pull request contains a couple of changes to the class responsible for creating those files. It ensures that both the file and class names are suffixed whether or not the suffix was provided when calling `artisan make:test`.

_Note: there were no tests covering for this process therefore I have not written any tests either._