### PR TITLE
[5.5] Query/Builder::$orders takes null too

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -118,7 +118,7 @@ class Builder
     /**
      * The orderings for the query.
      *
-     * @var array
+     * @var array|null
      */
     public $orders;
 


### PR DESCRIPTION
At least according to the code in `setAggregate()`

Also it allows static analysis tools to work correctly.