### PR TITLE
[5.6] Fix uniqueStrict for keyless calls to it

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1482,10 +1482,6 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      */
     public function unique($key = null, $strict = false)
     {
-        if (is_null($key)) {
-            return new static(array_unique($this->items, SORT_REGULAR));
-        }
-
         $callback = $this->valueRetriever($key);
 
         $exists = [];


### PR DESCRIPTION
Looks like `array_unique` is always strict, so if you are trying to get uniques from a keyless Collection:

``` php
$c = new Collection([10, '10']);
```

Those two unique calls:

``` php
$c->uniqueStrict()->values()->all()
$c->unique()->values()->all()
```

Will both return 

``` php
[10]
```

This PR fix this by using `valueRetriever` also when the user does not pass a key to uniqueStrict().