### PR TITLE
[5.6] Allow component slots to be arrays

### DIFF
--- a/src/Illuminate/View/Concerns/ManagesComponents.php
+++ b/src/Illuminate/View/Concerns/ManagesComponents.php
@@ -130,7 +130,7 @@ trait ManagesComponents
             if (! is_array($slot)) {
                 $slot = [];
             }
-            
+
             if ($matches[1] != '') {
                 $slot[$matches[1]] = $content;
             } elseif ($content != null) {

--- a/src/Illuminate/View/Concerns/ManagesComponents.php
+++ b/src/Illuminate/View/Concerns/ManagesComponents.php
@@ -89,10 +89,10 @@ trait ManagesComponents
     public function slot($name, $content = null)
     {
         if (count(func_get_args()) == 2) {
-            $this->slots[$this->currentComponent()][$name] = $content;
+            $this->assignSlot($name, $content);
         } else {
             if (ob_start()) {
-                $this->slots[$this->currentComponent()][$name] = '';
+                $this->assignSlot($name, '');
 
                 $this->slotStack[$this->currentComponent()][] = $name;
             }
@@ -112,8 +112,33 @@ trait ManagesComponents
             $this->slotStack[$this->currentComponent()]
         );
 
-        $this->slots[$this->currentComponent()]
-                    [$currentSlot] = new HtmlString(trim(ob_get_clean()));
+        $this->assignSlot($currentSlot, new HtmlString(trim(ob_get_clean())));
+    }
+
+    /**
+     * Assign the slot content.
+     *
+     * @param  string  $name
+     * @param  string|null  $content
+     * @return void
+     */
+    protected function assignSlot($name, $content = null)
+    {
+        if (preg_match('/\[(.*)\]$/', $name, $matches)) {
+            $slot = &$this->slots[$this->currentComponent()][substr($name, 0, -strlen($matches[0]))];
+
+            if (!is_array($slot)) {
+                $slot = array();
+            }
+            
+            if ($matches[1] != '') {
+                $slot[$matches[1]] = $content;
+            } else if ($content != null) {
+                $slot[] = $content;
+            }
+        } else {
+            $this->slots[$this->currentComponent()][$name] = $content;
+        }
     }
 
     /**

--- a/src/Illuminate/View/Concerns/ManagesComponents.php
+++ b/src/Illuminate/View/Concerns/ManagesComponents.php
@@ -127,13 +127,13 @@ trait ManagesComponents
         if (preg_match('/\[(.*)\]$/', $name, $matches)) {
             $slot = &$this->slots[$this->currentComponent()][substr($name, 0, -strlen($matches[0]))];
 
-            if (!is_array($slot)) {
-                $slot = array();
+            if (! is_array($slot)) {
+                $slot = [];
             }
             
             if ($matches[1] != '') {
                 $slot[$matches[1]] = $content;
-            } else if ($content != null) {
+            } elseif ($content != null) {
                 $slot[] = $content;
             }
         } else {


### PR DESCRIPTION
I wanted to be able to use the component for tables or lists, but that wasn't really possible so I came up with this solution:

If the name of the slot ends with "[]" or "[key]", the slot is overridden with an array and the new element is appended to the array.

Example Code:
```
@slot('array[]', 'value')
@slot('array[key]', 'value')
```
Example Output: (from inside of the view)
```
$array = [
    0 => "value",
    "key" => "value"
];
```

Of course, if you previously set the slot 'array' to the value of 'string' (`@slot('array', 'string')`) and then added the code above, it would be overridden with the array and vice versa.
