### PR TITLE
[5.6] Make `Blueprint::drop()` throw an exception if no arguments are passed

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Database\Schema;
 
+use BadMethodCallException;
 use Closure;
 use Illuminate\Support\Fluent;
 use Illuminate\Database\Connection;
@@ -203,6 +204,9 @@ class Blueprint
      */
     public function drop()
     {
+        if (func_num_args() > 0) {
+            throw new BadMethodCallException("Blueprint::drop() does not take any arguments. Did you mean dropColumn()?");
+        }
         return $this->addCommand('drop');
     }
 

--- a/tests/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintTest.php
@@ -87,4 +87,26 @@ class DatabaseSchemaBlueprintTest extends TestCase
         $blueprint = clone $base;
         $this->assertEquals(['alter table `users` add `money` decimal(10, 2) unsigned not null'], $blueprint->toSql($connection, new MySqlGrammar));
     }
+
+    /**
+     * @expectedException \BadMethodCallException
+     * @expectedExceptionMessage Blueprint::drop() does not take any arguments. Did you mean dropColumn()?
+     */
+    public function testDropThrowsWithArgs()
+    {
+        new Blueprint('users', function ($table) {
+            $table->drop('money');
+        });
+    }
+
+    public function testDropDoesNotThrowWithoutArgs()
+    {
+        try {
+            new Blueprint('users', function ($table) {
+                $table->drop();
+            });
+        } catch (\BadMethodCallException $ex) {
+            $this->fail('Blueprint::drop() threw even without arguments: ' . $ex->getMessage());
+        }
+    }
 }


### PR DESCRIPTION
I recently had a bad experience with calling `$table->drop('somecolumn')'` instead of `$table->dropColumn('somecolumn')'` - it deleted my table without warning. This PR makes it throw an exception if no arguments are passed.

This is not a breaking change, as `Blueprint::drop()` doesn't normally take arguments anyway.