### PR TITLE
[5.5] Remove unneeded else clause from auth helper

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -149,9 +149,9 @@ if (! function_exists('auth')) {
     {
         if (is_null($guard)) {
             return app(AuthFactory::class);
-        } else {
-            return app(AuthFactory::class)->guard($guard);
         }
+
+        return app(AuthFactory::class)->guard($guard);
     }
 }
 


### PR DESCRIPTION
this PR removes the **unneeded else clause** which won't affect the behavior , only **cleans up** the condition