### PR TITLE
[5.5] Revert 044add0

### DIFF
--- a/src/Illuminate/Database/Console/Factories/stubs/factory.stub
+++ b/src/Illuminate/Database/Console/Factories/stubs/factory.stub
@@ -2,6 +2,8 @@
 
 use Faker\Generator as Faker;
 
+/* @var Illuminate\Database\Eloquent\Factory $factory */
+
 $factory->define(DummyModel::class, function (Faker $faker) {
     return [
         //


### PR DESCRIPTION
Commit https://github.com/laravel/framework/commit/044add078825bf139df40f7d9a6a1b56bd90c20d reverted a very useful change introduced 4 days ago on https://github.com/laravel/framework/pull/21810