### PR TITLE
[5.5] Adds apiResource option to make:controller command

### DIFF
--- a/src/Illuminate/Routing/Console/ControllerMakeCommand.php
+++ b/src/Illuminate/Routing/Console/ControllerMakeCommand.php
@@ -41,6 +41,8 @@ class ControllerMakeCommand extends GeneratorCommand
             return __DIR__.'/stubs/controller.nested.stub';
         } elseif ($this->option('model')) {
             return __DIR__.'/stubs/controller.model.stub';
+        } elseif ($this->option('apiResource')) {
+            return __DIR__.'/stubs/controller.api.stub';
         } elseif ($this->option('resource')) {
             return __DIR__.'/stubs/controller.stub';
         }
@@ -163,6 +165,8 @@ class ControllerMakeCommand extends GeneratorCommand
     {
         return [
             ['model', 'm', InputOption::VALUE_OPTIONAL, 'Generate a resource controller for the given model.'],
+
+            ['apiResource', 'a', InputOption::VALUE_NONE, 'Generate an api resource controller class.'],
 
             ['resource', 'r', InputOption::VALUE_NONE, 'Generate a resource controller class.'],
 

--- a/src/Illuminate/Routing/Console/stubs/controller.api.stub
+++ b/src/Illuminate/Routing/Console/stubs/controller.api.stub
@@ -1,0 +1,64 @@
+<?php
+
+namespace DummyNamespace;
+
+use Illuminate\Http\Request;
+use DummyRootNamespaceHttp\Controllers\Controller;
+
+class DummyClass extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function index()
+    {
+        //
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function store(Request $request)
+    {
+        //
+    }
+
+    /**
+     * Display the specified resource.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function show($id)
+    {
+        //
+    }
+
+    /**
+     * Update the specified resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function update(Request $request, $id)
+    {
+        //
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function destroy($id)
+    {
+        //
+    }
+}


### PR DESCRIPTION
This PR adds the --apiResource (-a) option to the php artisan make:controller command, this functionality is very similar to the --resource command however it only created the index, store, show, update and destroy method stubs.

This PR was created to match the Route::apiResource() method which was added in Laravel 5.4 #19347.