### PR TITLE
[5.5] Fix Resource `collection()` PHPDoc return type

### DIFF
--- a/src/Illuminate/Http/Resources/Json/Resource.php
+++ b/src/Illuminate/Http/Resources/Json/Resource.php
@@ -72,7 +72,7 @@ class Resource implements ArrayAccess, JsonSerializable, Responsable, UrlRoutabl
      * Create new anonymous resource collection.
      *
      * @param  mixed  $resource
-     * @return mixed
+     * @return \Illuminate\Http\Resources\Json\AnonymousResourceCollection
      */
     public static function collection($resource)
     {


### PR DESCRIPTION
This PR proposes a small change on PHPDoc for `Illuminate\Http\Resources\Json\Response@collection()`:

Currently, the return type is `mixed`, but reading the code, it's clear that the correct return type is actually `Illuminate\Http\Resources\Json\AnonymousResourceCollection`.

This small error prevents IDE from Type Hint correctly when chaining method after `collect()`:

                                       \/ unknown
    BirdsResource::collection($birds)->response();
