### PR TITLE
Added passing Validator to Rule objects' passes() method

### DIFF
--- a/src/Illuminate/Contracts/Validation/Rule.php
+++ b/src/Illuminate/Contracts/Validation/Rule.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace Illuminate\Contracts\Validation;
+
 use Illuminate\Contracts\Validation\Validator as ValidatorContract;
 
 interface Rule

--- a/src/Illuminate/Contracts/Validation/Rule.php
+++ b/src/Illuminate/Contracts/Validation/Rule.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace Illuminate\Contracts\Validation;
+use Illuminate\Contracts\Validation\Validator as ValidatorContract;
 
 interface Rule
 {
@@ -9,9 +10,10 @@ interface Rule
      *
      * @param  string  $attribute
      * @param  mixed  $value
+     * @param  ValidatorContract  $validator
      * @return bool
      */
-    public function passes($attribute, $value);
+    public function passes($attribute, $value, ValidatorContract $validator);
 
     /**
      * Get the validation error message.

--- a/src/Illuminate/Foundation/Console/stubs/rule.stub
+++ b/src/Illuminate/Foundation/Console/stubs/rule.stub
@@ -3,6 +3,7 @@
 namespace DummyNamespace;
 
 use Illuminate\Contracts\Validation\Rule;
+use Illuminate\Contracts\Validation\Validator as ValidatorContract;
 
 class DummyClass implements Rule
 {
@@ -21,9 +22,10 @@ class DummyClass implements Rule
      *
      * @param  string  $attribute
      * @param  mixed  $value
+     * @param  ValidatorContract  $validator
      * @return bool
      */
-    public function passes($attribute, $value)
+    public function passes($attribute, $value, ValidatorContract $validator)
     {
         //
     }

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -530,7 +530,7 @@ class Validator implements ValidatorContract
      */
     protected function validateUsingCustomRule($attribute, $value, $rule)
     {
-        if (! $rule->passes($attribute, $value)) {
+        if (! $rule->passes($attribute, $value, $this)) {
             $this->failedRules[$attribute][get_class($rule)] = [];
 
             $this->messages->add($attribute, $this->makeReplacements(


### PR DESCRIPTION
Validation docs (https://laravel.com/docs/5.5/validation) mention 2 ways of creating custom validation rules: **Rule objects** and **Extensions**. Rule objects offer a nice, readable object-oriented syntax. Unfortunately they do not allow for creating rules that use validation context (values of other attributes), like some of existing validation rules do, e.g. _same_, _required_if_ etc. 

The reason is that Extensions get passed the instance of the **Validator**, while Rules don't. This PR fixes the problem and makes Rule objects as powerful as Extensions.