### PR TITLE
[Proposal] Add helper Array Flatten Keeping Keys

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -124,6 +124,28 @@ if (! function_exists('app_path')) {
     }
 }
 
+if(! function_exists("array_flatten_keeping_keys")) {
+    /**
+     * @param $array
+     * @param string $prefix
+     * @return array
+     * Thanks
+     * https://stackoverflow.com/questions/9546181/flatten-multidimensional-array-concatenating-keys/9546215#9546215
+     */
+    function array_flatten_keeping_keys($array, $prefix = '') {
+        $result = array();
+        foreach($array as $key=>$value) {
+            if(is_array($value)) {
+                $result = $result + array_flatten_keeping_keys($value, $prefix . $key . '.');
+            }
+            else {
+                $result[$prefix . $key] = $value;
+            }
+        }
+        return $result;
+    }
+}
+
 if (! function_exists('asset')) {
     /**
      * Generate an asset path for the application.

--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -220,6 +220,30 @@ class Arr
     }
 
     /**
+     * Flatten a multi-dimensional array into a single level
+     * keeping the keys formatted into dot notation.
+     *
+     * @param  array $array
+     * @param string $prefix
+     * @return array
+     * @internal param int $depth
+     */
+    public static function flatten_keeping_keys($array, $prefix = '')
+    {
+        $array = $array instanceof Collection ? $array->all() : $array;
+        $result = array();
+        foreach($array as $key=>$value) {
+            if(is_array($value)) {
+                $result = $result + array_flatten_keeping_keys($value, $prefix . $key . '.');
+            }
+            else {
+                $result[$prefix . $key] = $value;
+            }
+        }
+        return $result;
+    }
+
+    /**
      * Remove one or many array items from a given array using "dot" notation.
      *
      * @param  array  $array

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -129,6 +129,19 @@ if (! function_exists('array_flatten')) {
     }
 }
 
+if(! function_exists("array_flatten_keeping_keys")) {
+    /**
+     * @param $array
+     * @param string $prefix
+     * @return array
+     * Thanks
+     * https://stackoverflow.com/questions/9546181/flatten-multidimensional-array-concatenating-keys/9546215#9546215
+     */
+    function array_flatten_keeping_keys($array, $prefix = '') {
+        return Arr::flatten_keeping_keys($array, $prefix);
+    }
+}
+
 if (! function_exists('array_forget')) {
     /**
      * Remove one or many array items from a given array using "dot" notation.

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -213,7 +213,7 @@ class SupportArrTest extends TestCase
         $array = ['key_foo' => '#foo', 'key_bar' => '#bar', 'key_baz' => '#baz'];
         $this->assertEquals($array, Arr::flatten_keeping_keys($array));
 
-        // Nested arrays are flattened but the keys remain with dots to separate.
+        // Nested arrays are flattened but the keys remain with dots to separate
         $array = ['level_1' => [ 'key_foo' => '#foo', 'key_bar' => '#bar'], 'key_baz' => '#baz'];
         $this->assertEquals(['level_1.key_foo' => '#foo', 'level_1.key_bar' => '#bar', 'key_baz' => '#baz'], Arr::flatten_keeping_keys($array));
 

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -157,7 +157,7 @@ class SupportArrTest extends TestCase
     {
         // Flat arrays are unaffected
         $array = ['#foo', '#bar', '#baz'];
-        $this->assertEquals(['#foo', '#bar', '#baz'], Arr::flatten(['#foo', '#bar', '#baz']));
+        $this->assertEquals(['#foo', '#bar', '#baz'], Arr::flatten($array));
 
         // Nested arrays are flattened with existing flat items
         $array = [['#foo', '#bar'], '#baz'];
@@ -204,6 +204,30 @@ class SupportArrTest extends TestCase
 
         $array = [['#foo', ['#bar', ['#baz']]], '#zap'];
         $this->assertEquals(['#foo', '#bar', ['#baz'], '#zap'], Arr::flatten($array, 2));
+    }
+
+
+    public function testFlattenKeepingKeys()
+    {
+        // One Level returns same results
+        $array = ['key_foo' => '#foo', 'key_bar' => '#bar', 'key_baz' => '#baz'];
+        $this->assertEquals($array, Arr::flatten_keeping_keys($array));
+
+        // Nested arrays are flattened but the keys remain with dots to separate
+        $array = ['level_1' => [ 'key_foo' => '#foo', 'key_bar' => '#bar'], 'key_baz' => '#baz'];
+        $this->assertEquals(['level_1.key_foo' => '#foo', 'level_1.key_bar' => '#bar', 'key_baz' => '#baz'], Arr::flatten_keeping_keys($array));
+
+        // Sets of nested arrays are flattened
+        $array = ['level_1_foo' => [ 'key_foo' => '#foo', 'key_bar' => '#bar'], 'level_1_baz' => ['key_baz' => '#baz']];
+        $this->assertEquals(['level_1_foo.key_foo' => '#foo', 'level_1_foo.key_bar' => '#bar', 'level_1_baz.key_baz' => '#baz'], Arr::flatten_keeping_keys($array));
+
+        // Deeply nested arrays are flattened
+        $array = ['level_1_foo' => [ 'key_foo' => '#foo', 'key_bar' => '#bar'], 'level_1_baz' => ['level_2_baz' => ['key_baz' => '#baz']]];
+        $this->assertEquals(['level_1_foo.key_foo' => '#foo', 'level_1_foo.key_bar' => '#bar', 'level_1_baz.level_2_baz.key_baz' => '#baz'], Arr::flatten_keeping_keys($array));
+
+        // If a Collection is used
+        $array = new Collection(['level_1_foo' => [ 'key_foo' => '#foo', 'key_bar' => '#bar'], 'level_1_baz' => ['level_2_baz' => ['key_baz' => '#baz']]]);
+        $this->assertEquals(['level_1_foo.key_foo' => '#foo', 'level_1_foo.key_bar' => '#bar', 'level_1_baz.level_2_baz.key_baz' => '#baz'], Arr::flatten_keeping_keys($array));
     }
 
     public function testGet()

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -213,7 +213,7 @@ class SupportArrTest extends TestCase
         $array = ['key_foo' => '#foo', 'key_bar' => '#bar', 'key_baz' => '#baz'];
         $this->assertEquals($array, Arr::flatten_keeping_keys($array));
 
-        // Nested arrays are flattened but the keys remain with dots to separate
+        // Nested arrays are flattened but the keys remain with dots to separate.
         $array = ['level_1' => [ 'key_foo' => '#foo', 'key_bar' => '#bar'], 'key_baz' => '#baz'];
         $this->assertEquals(['level_1.key_foo' => '#foo', 'level_1.key_bar' => '#bar', 'key_baz' => '#baz'], Arr::flatten_keeping_keys($array));
 


### PR DESCRIPTION
This would keep the keys but format them as dot notations.
I basically needed this and if it already exist then 🤷‍♂️ 

If it does not exist then the test shows some of the goals
tests/Support/SupportArrTest.php:210

All of this from https://stackoverflow.com/questions/9546181/flatten-multidimensional-array-concatenating-keys/9546215#9546215

btw one minor test fix to origin tests [here](https://github.com/laravel/framework/compare/5.5...alnutile:5.5#diff-d14ddb2972fa3aa22bf0f479ae091d60R160) 