### PR TITLE
[5.5] Re-adds 'preserveKey' flag to 'Collection#reverse()'

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1221,11 +1221,12 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Reverse items order.
      *
+     * @param  bool  $preserveKeys
      * @return static
      */
-    public function reverse()
+    public function reverse($preserveKeys = true)
     {
-        return new static(array_reverse($this->items, true));
+        return new static(array_reverse($this->items, $preserveKeys));
     }
 
     /**

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -845,6 +845,38 @@ class SupportCollectionTest extends TestCase
         $this->assertSame(['framework' => 'laravel', 'name' => 'taylor'], $reversed->all());
     }
 
+    public function testReverseWithPreserveKeys()
+    {
+        $data = new Collection(['zaeed', 'alan']);
+        $reversed = $data->reverse(true);
+
+        $this->assertSame([1 => 'alan', 0 => 'zaeed'], $reversed->all());
+
+        $data = new Collection(['zaeed', 'alan']);
+        $reversed = $data->reverse(false);
+
+        $this->assertSame([0 => 'alan', 1 => 'zaeed'], $reversed->all());
+    }
+
+    public function testReverseWithPreserveKeysWithStringKeys()
+    {
+        // Flag has no effect on string keys:
+        $data = new Collection(['name' => 'taylor', 'framework' => 'laravel']);
+        $reversed = $data->reverse(true);
+
+        $this->assertSame(['framework' => 'laravel', 'name' => 'taylor'], $reversed->all());
+
+        $data = new Collection(['name' => 'taylor', 'framework' => 'laravel']);
+        $reversed = $data->reverse(false);
+
+        $this->assertSame(['framework' => 'laravel', 'name' => 'taylor'], $reversed->all());
+
+        $data = new Collection([0 => 'taylor', 1 => 'mixed', 'framework' => 'laravel']);
+        $reversed = $data->reverse(false);
+
+        $this->assertSame(['framework' => 'laravel', 0 => 'mixed', 1 => 'taylor'], $reversed->all());
+    }
+
     public function testFlip()
     {
         $data = new Collection(['name' => 'taylor', 'framework' => 'laravel']);


### PR DESCRIPTION
Re-adds 'preserveKeys' flag to 'Collection#reverse()' but with backwards compatible default.

As mentioned on [laravel/internals here](https://github.com/laravel/internals/issues/859) this overload was added then removed in mid-August 2015. This PR enables the functionality again, however, this time the default is backward compatible with existing API `$preserveKeys = true`.

For reference: [laravel/docs PR](https://github.com/laravel/docs/pull/3830)