### PR TITLE
add return type to function's docblock

### DIFF
--- a/src/Illuminate/Redis/Connections/PhpRedisConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisConnection.php
@@ -386,6 +386,7 @@ class PhpRedisConnection extends Connection
      * Apply prefix to the given key if necessary.
      *
      * @param $key
+     * @return string
      */
     private function applyPrefix($key)
     {


### PR DESCRIPTION
The function was missing a return value so I added it.