### PR TITLE
[5.5] Add assertJsonMissingExact method to TestResponse.php

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -359,10 +359,15 @@ class TestResponse
      * Assert that the response does not contain the given JSON fragment.
      *
      * @param  array  $data
+     * @param  bool   $exact
      * @return $this
      */
-    public function assertJsonMissing(array $data)
+    public function assertJsonMissing(array $data, $exact = false)
     {
+        if ( $exact ) {
+            return $this->assertJsonMissingExact($data);
+        }
+
         $actual = json_encode(Arr::sortRecursive(
             (array) $this->decodeResponseJson()
         ));
@@ -380,6 +385,34 @@ class TestResponse
         }
 
         return $this;
+    }
+
+    /**
+     * Assert that the response does not contain the exact JSON fragment.
+     *
+     * @param  array  $data
+     * @return $this
+     */
+    public function assertJsonMissingExact(array $data)
+    {
+        $actual = json_encode(Arr::sortRecursive(
+            (array) $this->decodeResponseJson()
+        ));
+
+        foreach( Arr::sortRecursive($data) as $key => $value ) {
+            $unexpected = substr(json_encode([$key => $value]), 1, -1);
+
+            if ( ! Str::contains($actual, $unexpected) ) {
+                return $this;
+            }
+        }
+
+        PHPUnit::fail(
+            'Found unexpected JSON fragment: '.PHP_EOL.PHP_EOL.
+            "[" . json_encode($data) . "]".PHP_EOL.PHP_EOL.
+            'within'.PHP_EOL.PHP_EOL.
+            "[{$actual}]."
+        );
     }
 
     /**

--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -364,7 +364,7 @@ class TestResponse
      */
     public function assertJsonMissing(array $data, $exact = false)
     {
-        if ( $exact ) {
+        if ($exact) {
             return $this->assertJsonMissingExact($data);
         }
 
@@ -373,12 +373,12 @@ class TestResponse
         ));
 
         foreach (Arr::sortRecursive($data) as $key => $value) {
-            $expected = substr(json_encode([$key => $value]), 1, -1);
+            $unexpected = substr(json_encode([$key => $value]), 1, -1);
 
             PHPUnit::assertFalse(
-                Str::contains($actual, $expected),
+                Str::contains($actual, $unexpected),
                 'Found unexpected JSON fragment: '.PHP_EOL.PHP_EOL.
-                "[{$expected}]".PHP_EOL.PHP_EOL.
+                "[{$unexpected}]".PHP_EOL.PHP_EOL.
                 'within'.PHP_EOL.PHP_EOL.
                 "[{$actual}]."
             );
@@ -399,17 +399,17 @@ class TestResponse
             (array) $this->decodeResponseJson()
         ));
 
-        foreach( Arr::sortRecursive($data) as $key => $value ) {
+        foreach(Arr::sortRecursive($data) as $key => $value) {
             $unexpected = substr(json_encode([$key => $value]), 1, -1);
 
-            if ( ! Str::contains($actual, $unexpected) ) {
+            if (! Str::contains($actual, $unexpected)) {
                 return $this;
             }
         }
 
         PHPUnit::fail(
             'Found unexpected JSON fragment: '.PHP_EOL.PHP_EOL.
-            "[" . json_encode($data) . "]".PHP_EOL.PHP_EOL.
+            '['.json_encode($data).']'.PHP_EOL.PHP_EOL.
             'within'.PHP_EOL.PHP_EOL.
             "[{$actual}]."
         );

--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -399,7 +399,7 @@ class TestResponse
             (array) $this->decodeResponseJson()
         ));
 
-        foreach(Arr::sortRecursive($data) as $key => $value) {
+        foreach (Arr::sortRecursive($data) as $key => $value) {
             $unexpected = substr(json_encode([$key => $value]), 1, -1);
 
             if (! Str::contains($actual, $unexpected)) {


### PR DESCRIPTION
As it is currently written, the `assertJsonMissing` method will fail if any portion of the Json fragment is found in the response. Consider this example. 

```
// response
[
    [
        'name' => 'John Doe',
        'created_at' => '2017-10-30'
    ],
];

```
Now we want to make sure that the response doesn't include a record for `Jane Doe`.

```
$this->assertJsonMissing( [
    'name' => 'Jane Doe',
    'created_at' => '2017-10-30'
]);

```
It is obviously not the same record, but the test will fail because the `created_at` values are the same.

```
Found unexpected JSON fragment: 

["created_at":"2017-10-30"]

within
...
```

 