### PR TITLE
[5.5] Adds a function to format Mysql SSL options from config file.

### DIFF
--- a/src/Illuminate/Database/Connectors/MySqlConnector.php
+++ b/src/Illuminate/Database/Connectors/MySqlConnector.php
@@ -16,6 +16,8 @@ class MySqlConnector extends Connector implements ConnectorInterface
     {
         $dsn = $this->getDsn($config);
 
+        $config = $this->formatSslOptions($config);
+
         $options = $this->getOptions($config);
 
         // We need to grab the PDO options that should be used while making the brand
@@ -176,5 +178,28 @@ class MySqlConnector extends Connector implements ConnectorInterface
     protected function strictMode()
     {
         return "set session sql_mode='ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION'";
+    }
+
+    /**
+     * Format the SSL options for the config.
+     *
+     * @param  array  $config
+     * @return array
+     */
+    protected function formatSslOptions(array $config)
+    {
+        collect([
+            'sslkey' => PDO::MYSQL_ATTR_SSL_KEY,
+            'sslcert' => PDO::MYSQL_ATTR_SSL_CERT,
+            'sslrootcert' => PDO::MYSQL_ATTR_SSL_CA,
+        ])
+        ->each(function ($attr, $option) use (&$config) {
+            if (isset($config[$option]) && ! empty($config[$option])) {
+                $config['options'][$attr] = $config[$option];
+                unset($config[$option]);
+            }
+        });
+
+        return $config;
     }
 }


### PR DESCRIPTION
I had to set Mysql options to the config for using SSL:

```
'mysql' => [
   ...
   'options' => [
        PDO::MYSQL_ATTR_SSL_CA => 'ca-cert.pem',
        PDO::MYSQL_ATTR_SSL_KEY => 'client-key.pem',
        PDO::MYSQL_ATTR_SSL_CERT => 'client-cert.pem',
   ]
]
```

This is only the case for production environment, not in development so I wanted to add
environmental variables

```
'mysql' => [
   ...
   'options' => [
        PDO::MYSQL_ATTR_SSL_CA => env('DB_SSL_CA', ''),
        PDO::MYSQL_ATTR_SSL_KEY => env('DB_SSL_KEY', ''),
        PDO::MYSQL_ATTR_SSL_CERT => env('DB_SSL_CERT', ''),
   ]
]
```

This didn't work since you can't have empty or null values passed to these options.
So I ended up with setting this options dynamically based on my app environment.

I think it would be helpful if we can pass these options in the database config like so:

```
'mysql' => [
   ...
   'sslkey' => env('DB_SSL_KEY', ''),
   'sslcert' => env('DB_SSL_CERT', ''),
   'sslrootcert' => env('DB_SSL_CA', '')
   ...
]
```

This PR adds a function that checks for these attributes and converts them to the right Mysql options.