### PR TITLE
[5.5] Use table aliases when calling self-referencing HasManyThrough relation

### DIFF
--- a/tests/Integration/Database/EloquentHasManyThroughTest.php
+++ b/tests/Integration/Database/EloquentHasManyThroughTest.php
@@ -55,7 +55,9 @@ class EloquentHasManyThroughTest extends TestCase
 
         $notMember = User::create(['name' => str_random()]);
 
+
         $this->assertEquals([$mate1->id, $mate2->id], $user->teamMates->pluck('id')->toArray());
+        $this->assertEquals([$user->id], User::has('teamMates')->pluck('id')->toArray());
     }
 }
 

--- a/tests/Integration/Database/EloquentHasManyThroughTest.php
+++ b/tests/Integration/Database/EloquentHasManyThroughTest.php
@@ -55,7 +55,6 @@ class EloquentHasManyThroughTest extends TestCase
 
         $notMember = User::create(['name' => str_random()]);
 
-
         $this->assertEquals([$mate1->id, $mate2->id], $user->teamMates->pluck('id')->toArray());
         $this->assertEquals([$user->id], User::has('teamMates')->pluck('id')->toArray());
     }


### PR DESCRIPTION
Up-to-date version of #21792. Fixes certain types of `HasManyThrough` relationship calls i.e. `has()` methods (`User::has('teamMates')->get()`)

@themsaid So, what are we going to do about testing this? Shall i put a new test in here?

https://github.com/laravel/framework/blob/5.5/tests/Integration/Database/EloquentHasManyThroughTest.php