### PR TITLE
[5.5] Removed reference to undefined interface

### DIFF
--- a/src/Illuminate/Support/Traits/Macroable.php
+++ b/src/Illuminate/Support/Traits/Macroable.php
@@ -6,7 +6,6 @@ use Closure;
 use ReflectionClass;
 use ReflectionMethod;
 use BadMethodCallException;
-use Illuminate\Contracts\Support\Macro;
 
 trait Macroable
 {


### PR DESCRIPTION
``` Illuminate\Contracts\Support\Macro;``` dosen't exist