### PR TITLE
[5.6] syncOriginal on refresh

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1005,6 +1005,8 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 
         $this->load(collect($this->relations)->except('pivot')->keys()->toArray());
 
+        $this->syncOriginal();
+
         return $this;
     }
 

--- a/tests/Integration/Database/EloquentModelRefreshTest.php
+++ b/tests/Integration/Database/EloquentModelRefreshTest.php
@@ -63,6 +63,22 @@ class EloquentModelRefreshTest extends TestCase
 
         $this->assertTrue($post->trashed());
     }
+
+    /**
+     * @test
+     */
+    public function it_syncs_original_on_refresh()
+    {
+        $post = Post::create(['title' => 'pat']);
+
+        Post::find($post->id)->update(['title' => 'patrick']);
+
+        $post->refresh();
+
+        $this->assertEmpty($post->getDirty());
+
+        $this->assertEquals('patrick', $post->getOriginal('title'));
+    }
 }
 
 class Post extends Model


### PR DESCRIPTION
Currently, after refreshing a model it can be dirty even when the attributes match those in the database. 

```php
$post = Post::create(['title' => 'pat']);

Post::find($post->id)->update(['title' => 'patrick']);

$post->refresh();

// current result
$post->getOriginal('title'); // pat
$post->getDirty(); // ['title' => 'patrick']

// with proposed fix 
$post->getOriginal('title'); // patrick
$post->getDirty(); // []
```

Syncing with the original after refresh prevents this.