### PR TITLE
[5.5] Update pusher library version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -115,7 +115,7 @@
         "nexmo/client": "Required to use the Nexmo transport (~1.0).",
         "pda/pheanstalk": "Required to use the beanstalk queue driver (~3.0).",
         "predis/predis": "Required to use the redis cache and queue drivers (~1.0).",
-        "pusher/pusher-php-server": "Required to use the Pusher broadcast driver (~2.0).",
+        "pusher/pusher-php-server": "Required to use the Pusher broadcast driver (~3.0).",
         "symfony/css-selector": "Required to use some of the crawler integration testing tools (~3.3).",
         "symfony/dom-crawler": "Required to use most of the crawler integration testing tools (~3.3).",
         "symfony/psr-http-message-bridge": "Required to psr7 bridging features (~1.0)."


### PR DESCRIPTION
Laravel 5.5 requires the new namespaced version of the Pusher library which was released as version 3.0.