### PR TITLE
[5.5] Add 'filter by attribute' functionality

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -408,11 +408,15 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Run a filter over each of the items.
      *
-     * @param  callable|null  $callback
+     * @param  mixed|null  $callback
      * @return static
      */
-    public function filter(callable $callback = null)
+    public function filter($callback = null)
     {
+        if (is_string($callback)) {
+            $callback = $this->valueRetriever($callback);
+        }
+
         if ($callback) {
             return new static(Arr::where($this->items, $callback));
         }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -305,6 +305,13 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(['first' => 'Hello', 'second' => 'World'], $c->filter(function ($item, $key) {
             return $key != 'id';
         })->all());
+
+        $c = new Collection([
+            ['value' => 'foo', 'nested' => ['included' => true]],
+            ['value' => 'bar', 'nested' => ['included' => false]],
+            ['value' => 'baz', 'nested' => ['included' => true]],
+        ]);
+        $this->assertEquals(['foo', 'baz'], $c->filter('nested.included')->pluck('value')->toArray());
     }
 
     public function testHigherOrderKeyBy()


### PR DESCRIPTION
This PR introduces an ability to filter a collection by a given attribute. It allows to pass a string to the `Collection::filter` method instead of passing a closure.

Please note, this enables filtering by a nested key as well. This was not possible before.

Consider following:

```php
$collection = collect([
    ['id' => 1, 'name' => 'John', 'contact' => ['phone' => '+447871617281']],
    ['id' => 2, 'name' => 'Jake', 'contact' => ['phone' => null]],
    ['id' => 3, 'name' => 'Lucy', 'contact' => ['phone' => '+447871617281']],
]);

$collection->filter('contact.phone');

// vs

$collection->filter(function ($item) {
    return $item['contact']['phone'] ?? false;
});
```