### PR TITLE
Fix pagination when using distinct

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -705,7 +705,13 @@ class Builder
 
         $perPage = $perPage ?: $this->model->getPerPage();
 
-        $results = ($total = $this->toBase()->getCountForPagination())
+        $query = $this->toBase();
+
+        $count = $query->distinct
+                        ? [ sprintf("%s.%s", $this->model->getTable(), $this->model->getKeyName()) ]
+                        : $columns;
+
+        $results = ($total = $query->getCountForPagination($count))
                                     ? $this->forPage($page, $perPage)->get($columns)
                                     : $this->model->newCollection();
 

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -708,7 +708,7 @@ class Builder
         $query = $this->toBase();
 
         $count = $query->distinct
-                        ? [ sprintf("%s.%s", $this->model->getTable(), $this->model->getKeyName()) ]
+                        ? [sprintf("%s.%s", $this->model->getTable(), $this->model->getKeyName())]
                         : $columns;
 
         $results = ($total = $query->getCountForPagination($count))

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -708,7 +708,7 @@ class Builder
         $query = $this->toBase();
 
         $count = $query->distinct
-                        ? [sprintf("%s.%s", $this->model->getTable(), $this->model->getKeyName())]
+                        ? [sprintf('%s.%s', $this->model->getTable(), $this->model->getKeyName())]
                         : $columns;
 
         $results = ($total = $query->getCountForPagination($count))


### PR DESCRIPTION
fixes #21242

if distinct is being used in the query, then it will count the models primary key rather than * to avoid counting the same row multiple times and generating links to pages which dont exist