### PR TITLE
[5.5] Allow Blade to render multiple verbatim and php blocks

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -193,9 +193,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
     protected function storeVerbatimBlocks($value)
     {
         return preg_replace_callback('/(?<!@)@verbatim(.*?)@endverbatim/s', function ($matches) {
-            $this->rawBlocks[] = $matches[1];
-
-            return $this->getRawPlaceHolder(count($this->rawBlocks) - 1);
+            return $this->storeRawBlock($matches[1]);
         }, $value);
     }
 
@@ -208,16 +206,27 @@ class BladeCompiler extends Compiler implements CompilerInterface
     protected function storePhpBlocks($value)
     {
         return preg_replace_callback('/(?<!@)@php(.*?)@endphp/s', function ($matches) {
-            $this->rawBlocks[] = "<?php{$matches[1]}?>";
-
-            return $this->getRawPlaceholder(count($this->rawBlocks) - 1);
+            return $this->storeRawBlock("<?php{$matches[1]}?>");
         }, $value);
+    }
+
+    /**
+     * Store a raw block and return a unique raw placeholder.
+     *
+     * @param  string  $value
+     * @return string
+     */
+    protected function storeRawBlock($value)
+    {
+        return $this->getRawPlaceHolder(
+            array_push($this->rawBlocks, $value) - 1
+        );
     }
 
     /**
      * Placeholder to temporary mark the position of raw blocks.
      *
-     * @param  string  $replace
+     * @param  int|string  $replace
      * @return string
      */
     protected function getRawPlaceholder($replace)

--- a/tests/View/Blade/BladeVerbatimTest.php
+++ b/tests/View/Blade/BladeVerbatimTest.php
@@ -36,4 +36,21 @@ class BladeVerbatimTest extends AbstractBladeTestCase
         $expected = ' {{ $a }}  <?php echo e($b); ?>  {{ $c }} ';
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
+
+    public function testRawBlocksAreRenderedInTheRightOrder()
+    {
+        $string = '@php echo "#1"; @endphp @verbatim {{ #2 }} @endverbatim @verbatim {{ #3 }} @endverbatim @php echo "#4"; @endphp';
+
+        $expected = '<?php echo "#1"; ?>  {{ #2 }}   {{ #3 }}  <?php echo "#4"; ?>';
+
+        $this->assertSame($expected, $this->compiler->compileString($string));
+    }
+
+    public function testRawBlocksDontGetMixedUpWhenSomeAreRemovedByBladeComments()
+    {
+        $string = '{{-- @verbatim Block #1 @endverbatim --}} @php "Block #2" @endphp';
+        $expected = ' <?php "Block #2" ?>';
+
+        $this->assertSame($expected, $this->compiler->compileString($string));
+    }
 }

--- a/tests/View/Blade/BladeVerbatimTest.php
+++ b/tests/View/Blade/BladeVerbatimTest.php
@@ -55,8 +55,9 @@ class BladeVerbatimTest extends AbstractBladeTestCase
 @if ($conditional)
     {{ $third }}
 @endif
+@include("users")
 @verbatim
-    {{ $fourth }} 
+    {{ $fourth }} @include("test")
 @endverbatim 
 @php echo $fifth; @endphp';
 
@@ -69,8 +70,9 @@ class BladeVerbatimTest extends AbstractBladeTestCase
     <?php echo e($third); ?>
 
 <?php endif; ?>
+<?php echo $__env->make("users", array_except(get_defined_vars(), array(\'__data\', \'__path\')))->render(); ?>
 
-    {{ $fourth }} 
+    {{ $fourth }} @include("test")
  
 <?php echo $fifth; ?>';
 

--- a/tests/View/Blade/BladeVerbatimTest.php
+++ b/tests/View/Blade/BladeVerbatimTest.php
@@ -46,6 +46,38 @@ class BladeVerbatimTest extends AbstractBladeTestCase
         $this->assertSame($expected, $this->compiler->compileString($string));
     }
 
+    public function testMultilineTemplatesWithRawBlocksAreRenderedInTheRightOrder()
+    {
+        $string = '{{ $first }}
+@php
+    echo $second;
+@endphp
+@if ($conditional)
+    {{ $third }}
+@endif
+@verbatim
+    {{ $fourth }} 
+@endverbatim 
+@php echo $fifth; @endphp';
+
+        $expected = '<?php echo e($first); ?>
+
+<?php
+    echo $second;
+?>
+<?php if($conditional): ?>
+    <?php echo e($third); ?>
+
+<?php endif; ?>
+
+    {{ $fourth }} 
+ 
+<?php echo $fifth; ?>';
+
+        $this->assertSame($expected, $this->compiler->compileString($string));
+    }
+
+
     public function testRawBlocksDontGetMixedUpWhenSomeAreRemovedByBladeComments()
     {
         $string = '{{-- @verbatim Block #1 @endverbatim --}} @php "Block #2" @endphp';

--- a/tests/View/Blade/BladeVerbatimTest.php
+++ b/tests/View/Blade/BladeVerbatimTest.php
@@ -77,7 +77,6 @@ class BladeVerbatimTest extends AbstractBladeTestCase
         $this->assertSame($expected, $this->compiler->compileString($string));
     }
 
-
     public function testRawBlocksDontGetMixedUpWhenSomeAreRemovedByBladeComments()
     {
         $string = '{{-- @verbatim Block #1 @endverbatim --}} @php "Block #2" @endphp';


### PR DESCRIPTION
Simple solution for this problem: https://github.com/laravel/framework/issues/21897#issuecomment-340852007

To allow Blade to render raw blocks (`@verbatim` and `@php`) in the intended place.