### PR TITLE
[5.6] Remove unused raise worker method.

### DIFF
--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -477,21 +477,6 @@ class Worker
     }
 
     /**
-     * Raise the failed queue job event.
-     *
-     * @param  string  $connectionName
-     * @param  \Illuminate\Contracts\Queue\Job  $job
-     * @param  \Exception  $e
-     * @return void
-     */
-    protected function raiseFailedJobEvent($connectionName, $job, $e)
-    {
-        $this->events->dispatch(new Events\JobFailed(
-            $connectionName, $job, $e
-        ));
-    }
-
-    /**
      * Determine if the queue worker should restart.
      *
      * @param  int|null  $lastRestart


### PR DESCRIPTION
Looks like the use of this method was axed via https://github.com/laravel/framework/commit/55afe12977b55dbafda940e18102bb52276ca569. Not sure if it's being kept around as convenience for people who wish to extend the `Worker` class in the future -- or just an oversight?... but, I noticed this and gonna throw it out there. If not, I guess it will need noted in 5.6 migration guide as a BC break obviously. Targeting `master` to avoid any breaks.