### PR TITLE
[5.5] Fix eager loading HasManyThrough relations with custom intermediate and local key

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -178,7 +178,7 @@ class HasManyThrough extends Relation
         // link them up with their children using the keyed dictionary to make the
         // matching very convenient and easy work. Then we'll just return them.
         foreach ($models as $model) {
-            if (isset($dictionary[$key = $model->getKey()])) {
+            if (isset($dictionary[$key = $model->getAttribute($this->localKey)])) {
                 $model->setRelation(
                     $relation, $this->related->newCollection($dictionary[$key])
                 );

--- a/tests/Database/DatabaseEloquentHasManyThroughIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentHasManyThroughIntegrationTest.php
@@ -100,6 +100,15 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
         $this->assertCount(2, $posts);
     }
 
+    public function testEagerLoadingARelationWithCustomIntermediateAndLocalKey()
+    {
+        $this->seedData();
+        $posts = HasManyThroughIntermediateTestCountry::with('posts')->first()->posts;
+
+        $this->assertEquals('A title', $posts[0]->title);
+        $this->assertCount(2, $posts);
+    }
+
     /**
      * @expectedException \Illuminate\Database\Eloquent\ModelNotFoundException
      * @expectedExceptionMessage No query results for model [Illuminate\Tests\Database\HasManyThroughTestPost].


### PR DESCRIPTION
Hello,

Whenever I try to eager load a hasManyThrough relation that uses a custom intermediate and a local key I get an empty collection.

This happens because when the `match(array $models, Collection $results, $relation)` on the `HasManyThrough` class is called, the relation is set using the `$model->getKey` rather than my provided `$this->localKey` attribute.

Changing
```
foreach ($models as $model) {
    if (isset($dictionary[$key = $model->getKey()])) {
        //
    }
}
```

into

```
foreach ($models as $model) {
    if (isset($dictionary[$key = $model->getAttribute($this->localKey)])) {
        //
    }
}
```

fixes it because `$this->localKey` defaults to the `pk` anyway.

Also, I think this is also a fix for this issue #15909 (haven't tested, but looks like the same problem)