### PR TITLE
[5.4] Addresses issue #17642 - Handle DateTime overflows

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -358,11 +358,9 @@ trait ValidatesAttributes
             return false;
         }
 
-        $format = $parameters[0] == 'Y-m' ? '!Y-m' : $parameters[0];
+        $date = date_create_from_format('!'.$parameters[0], $value);
 
-        $date = DateTime::createFromFormat($format, $value);
-
-        return $date && $date->format($parameters[0]) == $value;
+        return $date && $date->format($parameters[0]) === $value;
     }
 
     /**


### PR DESCRIPTION
Overflow occurs when the current day on the server is greater than 28 and the provided date format by the user is missing the day portion. Solution provided is to add a reset on the format before creating the DateTime Object.