### PR TITLE
[5.5] Add assertValidationErrors and assertJsonCount to TestResponse

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -288,7 +288,7 @@ class TestResponse
     {
         $errors = $this->json()['errors'];
 
-        foreach(array_wrap($keys) as $key) {
+        foreach (array_wrap($keys) as $key) {
             PHPUnit::assertTrue(
                 isset($errors[$key]),
                 "Failed to find a validation error in the response for key: '{$key}'"

--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -322,7 +322,7 @@ class TestResponse
      */
     public function assertJsonCount(int $count, $key = null)
     {
-        if ( $key ) {
+        if ($key) {
             PHPUnit::assertCount($count,
                 $this->json()[$key],
                 "Failed to assert that the response count matched the expected {$count}"

--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -281,7 +281,6 @@ class TestResponse
      * Assert that the response has validation errors for the given keys.
      *
      * @param string|array $keys
-     *
      * @return $this
      */
     public function assertValidationErrors($keys)
@@ -316,12 +315,22 @@ class TestResponse
 
     /**
      * Assert that the response json has the expected count.
-     * @param int $count
      *
+     * @param int $count
+     * @param string|null $key
      * @return $this
      */
-    public function assertJsonCount(int $count)
+    public function assertJsonCount(int $count, $key = null)
     {
+        if ( $key ) {
+            PHPUnit::assertCount($count,
+                $this->json()[$key],
+                "Failed to assert that the response count matched the expected {$count}"
+            );
+
+            return $this;
+        }
+
         PHPUnit::assertCount($count,
             $this->json(),
             "Failed to assert that the response count matched the expected {$count}"

--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -278,6 +278,27 @@ class TestResponse
     }
 
     /**
+     * Assert that the response has validation errors for the given keys.
+     *
+     * @param string|array $keys
+     *
+     * @return $this
+     */
+    public function assertValidationErrors($keys)
+    {
+        $errors = $this->json()['errors'];
+
+        foreach(array_wrap($keys) as $key) {
+            PHPUnit::assertTrue(
+                isset($errors[$key]),
+                "Failed to find a validation error in the response for key: '{$key}'"
+            );
+        }
+
+        return $this;
+    }
+
+    /**
      * Assert that the response is a superset of the given JSON.
      *
      * @param  array  $data
@@ -288,6 +309,22 @@ class TestResponse
     {
         PHPUnit::assertArraySubset(
             $data, $this->decodeResponseJson(), $strict, $this->assertJsonMessage($data)
+        );
+
+        return $this;
+    }
+
+    /**
+     * Assert that the response json has the expected count.
+     * @param int $count
+     *
+     * @return $this
+     */
+    public function assertJsonCount(int $count)
+    {
+        PHPUnit::assertCount($count,
+            $this->json(),
+            "Failed to assert that the response count matched the expected {$count}"
         );
 
         return $this;


### PR DESCRIPTION
This commit adds two assert helpers to the TestResponse class.

# assertValidationErrors( string|array $keys )
Asserts that the given key(s) are in the **`errors`** key of the Json response.

## Sample use case - validating a new user
``` 
// UserController@store
$request->validate([
    'first_name' => 'required',
    'last_name' => 'required'
]);



// Feature/UserTest
$this->post('users', [
    'first_name' => null,
    'last_name' => null
]);

$this
  ->response()
  ->assertValidationErrors(['first_name','last_name']);


// sample response
array:2 [
  "message" => "The given data was invalid."
  "errors" => array:2 [
    "first_name" => array:1 [
      0 => "The first_name field is required."
    ],
    "last_name" => array:1 [
      0 => "The last_name field is required."
    ]
  ]
]

// the test passes
```

# assertJsonCount( int $count )
Asserts that the response data has the expected count.

##  Sample use case - getting a user resource index

```
// Feature/UserTest
/** @test */
public function it_can_get_a_listing_of_users()
{
    $users = factory(User::class,3)->create();

    $this->get("users");

    $this->response()
        ->assertStatus(200)
        ->assertJsonCount(3);
}
```