### PR TITLE
[5.5] Geospatial improvements

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -275,6 +275,17 @@ class Blueprint
     }
 
     /**
+     * Indicate that the given spatial index should be dropped.
+     *
+     * @param  string|array  $index
+     * @return \Illuminate\Support\Fluent
+     */
+    public function dropSpatialIndex($index)
+    {
+        return $this->dropIndexCommand('dropSpatialIndex', 'spatialIndex', $index);
+    }
+
+    /**
      * Indicate that the given foreign key should be dropped.
      *
      * @param  string|array  $index

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -303,6 +303,18 @@ class MySqlGrammar extends Grammar
     }
 
     /**
+     * Compile a drop spatial index command.
+     *
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @param  \Illuminate\Support\Fluent  $command
+     * @return string
+     */
+    public function compileDropSpatialIndex(Blueprint $blueprint, Fluent $command)
+    {
+        return $this->compileDropIndex($blueprint, $command);
+    }
+
+    /**
      * Compile a drop foreign key command.
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -702,7 +702,7 @@ class MySqlGrammar extends Grammar
     }
 
     /**
-     * Create the column definition for a geometry type.
+     * Create the column definition for a spatial Geometry type.
      *
      * @param  \Illuminate\Support\Fluent  $column
      * @return string
@@ -713,7 +713,7 @@ class MySqlGrammar extends Grammar
     }
 
     /**
-     * Create the column definition for a point type.
+     * Create the column definition for a spatial Point type.
      *
      * @param  \Illuminate\Support\Fluent  $column
      * @return string
@@ -724,18 +724,18 @@ class MySqlGrammar extends Grammar
     }
 
     /**
-     * Create the column definition for a linestring type.
+     * Create the column definition for a spatial LineString type.
      *
      * @param  \Illuminate\Support\Fluent  $column
      * @return string
      */
-    public function typeLinestring(Fluent $column)
+    public function typeLineString(Fluent $column)
     {
         return 'linestring';
     }
 
     /**
-     * Create the column definition for a polygon type.
+     * Create the column definition for a spatial Polygon type.
      *
      * @param  \Illuminate\Support\Fluent  $column
      * @return string
@@ -746,45 +746,45 @@ class MySqlGrammar extends Grammar
     }
 
     /**
-     * Create the column definition for a geometrycollection type.
+     * Create the column definition for a spatial GeometryCollection type.
      *
      * @param  \Illuminate\Support\Fluent  $column
      * @return string
      */
-    public function typeGeometrycollection(Fluent $column)
+    public function typeGeometryCollection(Fluent $column)
     {
         return 'geometrycollection';
     }
 
     /**
-     * Create the column definition for a multipoint type.
+     * Create the column definition for a spatial MultiPoint type.
      *
      * @param  \Illuminate\Support\Fluent  $column
      * @return string
      */
-    public function typeMultipoint(Fluent $column)
+    public function typeMultiPoint(Fluent $column)
     {
         return 'multipoint';
     }
 
     /**
-     * Create the column definition for a multilinestring type.
+     * Create the column definition for a spatial MultiLineString type.
      *
      * @param  \Illuminate\Support\Fluent  $column
      * @return string
      */
-    public function typeMultilinestring(Fluent $column)
+    public function typeMultiLineString(Fluent $column)
     {
         return 'multilinestring';
     }
 
     /**
-     * Create the column definition for a multipolygon type.
+     * Create the column definition for a spatial MultiPolygon type.
      *
      * @param  \Illuminate\Support\Fluent  $column
      * @return string
      */
-    public function typeMultipolygon(Fluent $column)
+    public function typeMultiPolygon(Fluent $column)
     {
         return 'multipolygon';
     }

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -128,6 +128,20 @@ class PostgresGrammar extends Grammar
     }
 
     /**
+     * Compile a spatial index key command.
+     *
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @param  \Illuminate\Support\Fluent  $command
+     * @return string
+     */
+    public function compileSpatialIndex(Blueprint $blueprint, Fluent $command)
+    {
+        $command->algorithm = 'gist';
+
+        return $this->compileIndex($blueprint, $command);
+    }
+
+    /**
      * Compile a foreign key command.
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\Database\Schema\Grammars;
 
-use Exception;
+use RuntimeException;
 use Illuminate\Support\Fluent;
 use Illuminate\Database\Schema\Blueprint;
 
@@ -655,18 +655,18 @@ class PostgresGrammar extends Grammar
     }
 
     /**
-     * Create the column definition for a geometry type.
+     * Create the column definition for a spatial Geometry type.
      *
      * @param  \Illuminate\Support\Fluent  $column
-     * @throws \Exception
+     * @throws \RuntimeException
      */
     protected function typeGeometry(Fluent $column)
     {
-        throw new Exception('Geometry data type not supported for current database engine.');
+        throw new RuntimeException('The database driver in use does not support the Geometry spatial column type.');
     }
 
     /**
-     * Create the column definition for a point type.
+     * Create the column definition for a spatial Point type.
      *
      * @param  \Illuminate\Support\Fluent  $column
      * @return string
@@ -677,18 +677,18 @@ class PostgresGrammar extends Grammar
     }
 
     /**
-     * Create the column definition for a linestring type.
+     * Create the column definition for a spatial LineString type.
      *
      * @param  \Illuminate\Support\Fluent  $column
      * @return string
      */
-    protected function typeLinestring(Fluent $column)
+    protected function typeLineString(Fluent $column)
     {
         return $this->formatPostGisType('linestring');
     }
 
     /**
-     * Create the column definition for a polygon type.
+     * Create the column definition for a spatial Polygon type.
      *
      * @param  \Illuminate\Support\Fluent  $column
      * @return string
@@ -699,56 +699,58 @@ class PostgresGrammar extends Grammar
     }
 
     /**
-     * Create the column definition for a geometrycollection type.
+     * Create the column definition for a spatial GeometryCollection type.
      *
      * @param  \Illuminate\Support\Fluent  $column
      * @return string
      */
-    protected function typeGeometrycollection(Fluent $column)
+    protected function typeGeometryCollection(Fluent $column)
     {
         return $this->formatPostGisType('geometrycollection');
     }
 
     /**
-     * Create the column definition for a multipoint type.
+     * Create the column definition for a spatial MultiPoint type.
      *
      * @param  \Illuminate\Support\Fluent  $column
      * @return string
      */
-    protected function typeMultipoint(Fluent $column)
+    protected function typeMultiPoint(Fluent $column)
     {
         return $this->formatPostGisType('multipoint');
     }
 
     /**
-     * Create the column definition for a multilinestring type.
+     * Create the column definition for a spatial MultiLineString type.
      *
      * @param  \Illuminate\Support\Fluent  $column
      * @return string
      */
-    public function typeMultilinestring(Fluent $column)
+    public function typeMultiLineString(Fluent $column)
     {
         return $this->formatPostGisType('multilinestring');
     }
 
     /**
-     * Create the column definition for a multipolygon type.
+     * Create the column definition for a spatial MultiPolygon type.
      *
      * @param  \Illuminate\Support\Fluent  $column
      * @return string
      */
-    protected function typeMultipolygon(Fluent $column)
+    protected function typeMultiPolygon(Fluent $column)
     {
         return $this->formatPostGisType('multipolygon');
     }
 
     /**
+     * Format the column definition for a PostGIS spatial type.
+     *
      * @param  string  $type
      * @return string
      */
     private function formatPostGisType(string $type)
     {
-        return "geography({$type}, 4326)";
+        return "geography($type, 4326)";
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -264,6 +264,18 @@ class PostgresGrammar extends Grammar
     }
 
     /**
+     * Compile a drop spatial index command.
+     *
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @param  \Illuminate\Support\Fluent  $command
+     * @return string
+     */
+    public function compileDropSpatialIndex(Blueprint $blueprint, Fluent $command)
+    {
+        return $this->compileDropIndex($blueprint, $command);
+    }
+
+    /**
      * Compile a drop foreign key command.
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint

--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -282,6 +282,18 @@ class SQLiteGrammar extends Grammar
     }
 
     /**
+     * Compile a drop spatial index command.
+     *
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @param  \Illuminate\Support\Fluent  $command
+     * @throws \RuntimeException
+     */
+    public function compileDropSpatialIndex(Blueprint $blueprint, Fluent $command)
+    {
+        throw new RuntimeException('The SQLite database driver does not support spatial indexes.');
+    }
+
+    /**
      * Compile a rename table command.
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint

--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Database\Schema\Grammars;
 
+use RuntimeException;
 use Illuminate\Support\Fluent;
 use Illuminate\Database\Connection;
 use Illuminate\Database\Schema\Blueprint;
@@ -169,6 +170,18 @@ class SQLiteGrammar extends Grammar
             $this->wrapTable($blueprint),
             $this->columnize($command->columns)
         );
+    }
+
+    /**
+     * Compile a spatial index key command.
+     *
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @param  \Illuminate\Support\Fluent  $command
+     * @throws \RuntimeException
+     */
+    public function compileSpatialIndex(Blueprint $blueprint, Fluent $command)
+    {
+        throw new RuntimeException('The SQLite database driver does not support spatial indexes.');
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -181,7 +181,7 @@ class SQLiteGrammar extends Grammar
      */
     public function compileSpatialIndex(Blueprint $blueprint, Fluent $command)
     {
-        throw new RuntimeException('The SQLite database driver does not support spatial indexes.');
+        throw new RuntimeException('The database driver in use does not support spatial indexes.');
     }
 
     /**
@@ -290,7 +290,7 @@ class SQLiteGrammar extends Grammar
      */
     public function compileDropSpatialIndex(Blueprint $blueprint, Fluent $command)
     {
-        throw new RuntimeException('The SQLite database driver does not support spatial indexes.');
+        throw new RuntimeException('The database driver in use does not support spatial indexes.');
     }
 
     /**
@@ -667,7 +667,7 @@ class SQLiteGrammar extends Grammar
     }
 
     /**
-     * Create the column definition for a geometry type.
+     * Create the column definition for a spatial Geometry type.
      *
      * @param  \Illuminate\Support\Fluent  $column
      * @return string
@@ -678,7 +678,7 @@ class SQLiteGrammar extends Grammar
     }
 
     /**
-     * Create the column definition for a point type.
+     * Create the column definition for a spatial Point type.
      *
      * @param  \Illuminate\Support\Fluent  $column
      * @return string
@@ -689,18 +689,18 @@ class SQLiteGrammar extends Grammar
     }
 
     /**
-     * Create the column definition for a linestring type.
+     * Create the column definition for a spatial LineString type.
      *
      * @param  \Illuminate\Support\Fluent  $column
      * @return string
      */
-    public function typeLinestring(Fluent $column)
+    public function typeLineString(Fluent $column)
     {
         return 'linestring';
     }
 
     /**
-     * Create the column definition for a polygon type.
+     * Create the column definition for a spatial Polygon type.
      *
      * @param  \Illuminate\Support\Fluent  $column
      * @return string
@@ -711,45 +711,45 @@ class SQLiteGrammar extends Grammar
     }
 
     /**
-     * Create the column definition for a geometrycollection type.
+     * Create the column definition for a spatial GeometryCollection type.
      *
      * @param  \Illuminate\Support\Fluent  $column
      * @return string
      */
-    public function typeGeometrycollection(Fluent $column)
+    public function typeGeometryCollection(Fluent $column)
     {
         return 'geometrycollection';
     }
 
     /**
-     * Create the column definition for a multipoint type.
+     * Create the column definition for a spatial MultiPoint type.
      *
      * @param  \Illuminate\Support\Fluent  $column
      * @return string
      */
-    public function typeMultipoint(Fluent $column)
+    public function typeMultiPoint(Fluent $column)
     {
         return 'multipoint';
     }
 
     /**
-     * Create the column definition for a multilinestring type.
+     * Create the column definition for a spatial MultiLineString type.
      *
      * @param  \Illuminate\Support\Fluent  $column
      * @return string
      */
-    public function typeMultilinestring(Fluent $column)
+    public function typeMultiLineString(Fluent $column)
     {
         return 'multilinestring';
     }
 
     /**
-     * Create the column definition for a multipolygon type.
+     * Create the column definition for a spatial MultiPolygon type.
      *
      * @param  \Illuminate\Support\Fluent  $column
      * @return string
      */
-    public function typeMultipolygon(Fluent $column)
+    public function typeMultiPolygon(Fluent $column)
     {
         return 'multipolygon';
     }

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -585,6 +585,94 @@ class SqlServerGrammar extends Grammar
     }
 
     /**
+     * Create the column definition for a geometry type.
+     *
+     * @param  \Illuminate\Support\Fluent  $column
+     * @return string
+     */
+    public function typeGeometry(Fluent $column)
+    {
+        return 'geography';
+    }
+
+    /**
+     * Create the column definition for a point type.
+     *
+     * @param  \Illuminate\Support\Fluent  $column
+     * @return string
+     */
+    public function typePoint(Fluent $column)
+    {
+        return 'geography';
+    }
+
+    /**
+     * Create the column definition for a linestring type.
+     *
+     * @param  \Illuminate\Support\Fluent  $column
+     * @return string
+     */
+    public function typeLinestring(Fluent $column)
+    {
+        return 'geography';
+    }
+
+    /**
+     * Create the column definition for a polygon type.
+     *
+     * @param  \Illuminate\Support\Fluent  $column
+     * @return string
+     */
+    public function typePolygon(Fluent $column)
+    {
+        return 'geography';
+    }
+
+    /**
+     * Create the column definition for a geometrycollection type.
+     *
+     * @param  \Illuminate\Support\Fluent  $column
+     * @return string
+     */
+    public function typeGeometrycollection(Fluent $column)
+    {
+        return 'geography';
+    }
+
+    /**
+     * Create the column definition for a multipoint type.
+     *
+     * @param  \Illuminate\Support\Fluent  $column
+     * @return string
+     */
+    public function typeMultipoint(Fluent $column)
+    {
+        return 'geography';
+    }
+
+    /**
+     * Create the column definition for a multilinestring type.
+     *
+     * @param  \Illuminate\Support\Fluent  $column
+     * @return string
+     */
+    public function typeMultilinestring(Fluent $column)
+    {
+        return 'geography';
+    }
+
+    /**
+     * Create the column definition for a multipolygon type.
+     *
+     * @param  \Illuminate\Support\Fluent  $column
+     * @return string
+     */
+    public function typeMultipolygon(Fluent $column)
+    {
+        return 'geography';
+    }
+
+    /**
      * Get the SQL for a collation column modifier.
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -613,7 +613,7 @@ class SqlServerGrammar extends Grammar
     }
 
     /**
-     * Create the column definition for a geometry type.
+     * Create the column definition for a spatial Geometry type.
      *
      * @param  \Illuminate\Support\Fluent  $column
      * @return string
@@ -624,7 +624,7 @@ class SqlServerGrammar extends Grammar
     }
 
     /**
-     * Create the column definition for a point type.
+     * Create the column definition for a spatial Point type.
      *
      * @param  \Illuminate\Support\Fluent  $column
      * @return string
@@ -635,18 +635,18 @@ class SqlServerGrammar extends Grammar
     }
 
     /**
-     * Create the column definition for a linestring type.
+     * Create the column definition for a spatial LineString type.
      *
      * @param  \Illuminate\Support\Fluent  $column
      * @return string
      */
-    public function typeLinestring(Fluent $column)
+    public function typeLineString(Fluent $column)
     {
         return 'geography';
     }
 
     /**
-     * Create the column definition for a polygon type.
+     * Create the column definition for a spatial Polygon type.
      *
      * @param  \Illuminate\Support\Fluent  $column
      * @return string
@@ -657,45 +657,45 @@ class SqlServerGrammar extends Grammar
     }
 
     /**
-     * Create the column definition for a geometrycollection type.
+     * Create the column definition for a spatial GeometryCollection type.
      *
      * @param  \Illuminate\Support\Fluent  $column
      * @return string
      */
-    public function typeGeometrycollection(Fluent $column)
+    public function typeGeometryCollection(Fluent $column)
     {
         return 'geography';
     }
 
     /**
-     * Create the column definition for a multipoint type.
+     * Create the column definition for a spatial MultiPoint type.
      *
      * @param  \Illuminate\Support\Fluent  $column
      * @return string
      */
-    public function typeMultipoint(Fluent $column)
+    public function typeMultiPoint(Fluent $column)
     {
         return 'geography';
     }
 
     /**
-     * Create the column definition for a multilinestring type.
+     * Create the column definition for a spatial MultiLineString type.
      *
      * @param  \Illuminate\Support\Fluent  $column
      * @return string
      */
-    public function typeMultilinestring(Fluent $column)
+    public function typeMultiLineString(Fluent $column)
     {
         return 'geography';
     }
 
     /**
-     * Create the column definition for a multipolygon type.
+     * Create the column definition for a spatial MultiPolygon type.
      *
      * @param  \Illuminate\Support\Fluent  $column
      * @return string
      */
-    public function typeMultipolygon(Fluent $column)
+    public function typeMultiPolygon(Fluent $column)
     {
         return 'geography';
     }

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -231,6 +231,18 @@ class SqlServerGrammar extends Grammar
     }
 
     /**
+     * Compile a drop spatial index command.
+     *
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @param  \Illuminate\Support\Fluent  $command
+     * @return string
+     */
+    public function compileDropSpatialIndex(Blueprint $blueprint, Fluent $command)
+    {
+        return $this->compileDropIndex($blueprint, $command);
+    }
+
+    /**
      * Compile a drop foreign key command.
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -122,6 +122,22 @@ class SqlServerGrammar extends Grammar
     }
 
     /**
+     * Compile a spatial index key command.
+     *
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @param  \Illuminate\Support\Fluent  $command
+     * @return string
+     */
+    public function compileSpatialIndex(Blueprint $blueprint, Fluent $command)
+    {
+        return sprintf('create spatial index %s on %s (%s)',
+            $this->wrap($command->index),
+            $this->wrapTable($blueprint),
+            $this->columnize($command->columns)
+        );
+    }
+
+    /**
      * Compile a drop table command.
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -201,6 +201,16 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table `users` drop index `foo`', $statements[0]);
     }
 
+    public function testDropSpatialIndex()
+    {
+        $blueprint = new Blueprint('geo');
+        $blueprint->dropSpatialIndex(['coordinates']);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table `geo` drop index `geo_coordinates_spatialindex`', $statements[0]);
+    }
+
     public function testDropForeign()
     {
         $blueprint = new Blueprint('users');

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -303,22 +303,22 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
     public function testAddingSpatialIndex()
     {
-        $blueprint = new Blueprint('users');
-        $blueprint->spatialIndex('foo', 'baz');
+        $blueprint = new Blueprint('geo');
+        $blueprint->spatialIndex('coordinates');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add spatial index `baz`(`foo`)', $statements[0]);
+        $this->assertEquals('alter table `geo` add spatial index `geo_coordinates_spatialindex`(`coordinates`)', $statements[0]);
     }
 
     public function testAddingFluentSpatialIndex()
     {
-        $blueprint = new Blueprint('users');
-        $blueprint->point('foo')->spatialIndex('baz');
+        $blueprint = new Blueprint('geo');
+        $blueprint->point('coordinates')->spatialIndex();
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(2, $statements);
-        $this->assertEquals('alter table `users` add spatial index `baz`(`foo`)', $statements[1]);
+        $this->assertEquals('alter table `geo` add spatial index `geo_coordinates_spatialindex`(`coordinates`)', $statements[1]);
     }
 
     public function testAddingForeignKey()
@@ -800,82 +800,82 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
     public function testAddingGeometry()
     {
-        $blueprint = new Blueprint('users');
-        $blueprint->geometry('foo');
+        $blueprint = new Blueprint('geo');
+        $blueprint->geometry('coordinates');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add `foo` geometry not null', $statements[0]);
+        $this->assertEquals('alter table `geo` add `coordinates` geometry not null', $statements[0]);
     }
 
     public function testAddingPoint()
     {
-        $blueprint = new Blueprint('users');
-        $blueprint->point('foo');
+        $blueprint = new Blueprint('geo');
+        $blueprint->point('coordinates');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add `foo` point not null', $statements[0]);
+        $this->assertEquals('alter table `geo` add `coordinates` point not null', $statements[0]);
     }
 
-    public function testAddingLinestring()
+    public function testAddingLineString()
     {
-        $blueprint = new Blueprint('users');
-        $blueprint->linestring('foo');
+        $blueprint = new Blueprint('geo');
+        $blueprint->linestring('coordinates');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add `foo` linestring not null', $statements[0]);
+        $this->assertEquals('alter table `geo` add `coordinates` linestring not null', $statements[0]);
     }
 
     public function testAddingPolygon()
     {
-        $blueprint = new Blueprint('users');
-        $blueprint->polygon('foo');
+        $blueprint = new Blueprint('geo');
+        $blueprint->polygon('coordinates');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add `foo` polygon not null', $statements[0]);
+        $this->assertEquals('alter table `geo` add `coordinates` polygon not null', $statements[0]);
     }
 
     public function testAddingGeometryCollection()
     {
-        $blueprint = new Blueprint('users');
-        $blueprint->geometrycollection('foo');
+        $blueprint = new Blueprint('geo');
+        $blueprint->geometrycollection('coordinates');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add `foo` geometrycollection not null', $statements[0]);
+        $this->assertEquals('alter table `geo` add `coordinates` geometrycollection not null', $statements[0]);
     }
 
-    public function testAddingMultipoint()
+    public function testAddingMultiPoint()
     {
-        $blueprint = new Blueprint('users');
-        $blueprint->multipoint('foo');
+        $blueprint = new Blueprint('geo');
+        $blueprint->multipoint('coordinates');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add `foo` multipoint not null', $statements[0]);
+        $this->assertEquals('alter table `geo` add `coordinates` multipoint not null', $statements[0]);
     }
 
-    public function testAddingMultiLinestring()
+    public function testAddingMultiLineString()
     {
-        $blueprint = new Blueprint('users');
-        $blueprint->multilinestring('foo');
+        $blueprint = new Blueprint('geo');
+        $blueprint->multilinestring('coordinates');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add `foo` multilinestring not null', $statements[0]);
+        $this->assertEquals('alter table `geo` add `coordinates` multilinestring not null', $statements[0]);
     }
 
     public function testAddingMultiPolygon()
     {
-        $blueprint = new Blueprint('users');
-        $blueprint->multipolygon('foo');
+        $blueprint = new Blueprint('geo');
+        $blueprint->multipolygon('coordinates');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add `foo` multipolygon not null', $statements[0]);
+        $this->assertEquals('alter table `geo` add `coordinates` multipolygon not null', $statements[0]);
     }
 
     public function testAddingComment()

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -600,83 +600,85 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add constraint "users_parent_id_foreign" foreign key ("parent_id") references "parents" ("id") on delete cascade deferrable initially deferred', $statements[0]);
     }
 
+    /**
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage The database driver in use does not support the Geometry spatial column type.
+     */
     public function testAddingGeometry()
     {
-        $this->expectException(\Exception::class);
-
-        $blueprint = new Blueprint('users');
-        $blueprint->geometry('foo');
+        $blueprint = new Blueprint('geo');
+        $blueprint->geometry('coordinates');
         $blueprint->toSql($this->getConnection(), $this->getGrammar());
     }
 
     public function testAddingPoint()
     {
-        $blueprint = new Blueprint('users');
-        $blueprint->point('foo');
+        $blueprint = new Blueprint('geo');
+        $blueprint->point('coordinates');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "foo" geography(point, 4326) not null', $statements[0]);
+        $this->assertEquals('alter table "geo" add column "coordinates" geography(point, 4326) not null', $statements[0]);
     }
 
-    public function testAddingLinestring()
+    public function testAddingLineString()
     {
-        $blueprint = new Blueprint('users');
-        $blueprint->linestring('foo');
+        $blueprint = new Blueprint('geo');
+        $blueprint->linestring('coordinates');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "foo" geography(linestring, 4326) not null', $statements[0]);
+        $this->assertEquals('alter table "geo" add column "coordinates" geography(linestring, 4326) not null', $statements[0]);
     }
 
     public function testAddingPolygon()
     {
-        $blueprint = new Blueprint('users');
-        $blueprint->polygon('foo');
+        $blueprint = new Blueprint('geo');
+        $blueprint->polygon('coordinates');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "foo" geography(polygon, 4326) not null', $statements[0]);
+        $this->assertEquals('alter table "geo" add column "coordinates" geography(polygon, 4326) not null', $statements[0]);
     }
 
     public function testAddingGeometryCollection()
     {
-        $blueprint = new Blueprint('users');
-        $blueprint->geometrycollection('foo');
+        $blueprint = new Blueprint('geo');
+        $blueprint->geometrycollection('coordinates');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "foo" geography(geometrycollection, 4326) not null', $statements[0]);
+        $this->assertEquals('alter table "geo" add column "coordinates" geography(geometrycollection, 4326) not null', $statements[0]);
     }
 
-    public function testAddingMultipoint()
+    public function testAddingMultiPoint()
     {
-        $blueprint = new Blueprint('users');
-        $blueprint->multipoint('foo');
+        $blueprint = new Blueprint('geo');
+        $blueprint->multipoint('coordinates');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "foo" geography(multipoint, 4326) not null', $statements[0]);
+        $this->assertEquals('alter table "geo" add column "coordinates" geography(multipoint, 4326) not null', $statements[0]);
     }
 
-    public function testAddingMultiLinestring()
+    public function testAddingMultiLineString()
     {
-        $blueprint = new Blueprint('users');
-        $blueprint->multilinestring('foo');
+        $blueprint = new Blueprint('geo');
+        $blueprint->multilinestring('coordinates');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "foo" geography(multilinestring, 4326) not null', $statements[0]);
+        $this->assertEquals('alter table "geo" add column "coordinates" geography(multilinestring, 4326) not null', $statements[0]);
     }
 
     public function testAddingMultiPolygon()
     {
-        $blueprint = new Blueprint('users');
-        $blueprint->multipolygon('foo');
+        $blueprint = new Blueprint('geo');
+        $blueprint->multipolygon('coordinates');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "foo" geography(multipolygon, 4326) not null', $statements[0]);
+        $this->assertEquals('alter table "geo" add column "coordinates" geography(multipolygon, 4326) not null', $statements[0]);
     }
 
     public function testDropAllTablesEscapesTableNames()

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -107,6 +107,16 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertEquals('drop index "foo"', $statements[0]);
     }
 
+    public function testDropSpatialIndex()
+    {
+        $blueprint = new Blueprint('geo');
+        $blueprint->dropSpatialIndex(['coordinates']);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertEquals('drop index "geo_coordinates_spatialindex"', $statements[0]);
+    }
+
     public function testDropForeign()
     {
         $blueprint = new Blueprint('users');

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -187,6 +187,26 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertEquals('create index "baz" on "users" using hash ("foo", "bar")', $statements[0]);
     }
 
+    public function testAddingSpatialIndex()
+    {
+        $blueprint = new Blueprint('geo');
+        $blueprint->spatialIndex('coordinates');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertEquals('create index "geo_coordinates_spatialindex" on "geo" using gist ("coordinates")', $statements[0]);
+    }
+
+    public function testAddingFluentSpatialIndex()
+    {
+        $blueprint = new Blueprint('geo');
+        $blueprint->point('coordinates')->spatialIndex();
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(2, $statements);
+        $this->assertEquals('create index "geo_coordinates_spatialindex" on "geo" using gist ("coordinates")', $statements[1]);
+    }
+
     public function testAddingIncrementingID()
     {
         $blueprint = new Blueprint('users');

--- a/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
@@ -77,6 +77,17 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $this->assertEquals('drop index "foo"', $statements[0]);
     }
 
+    /**
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage The SQLite database driver does not support spatial indexes.
+     */
+    public function testDropSpatialIndex()
+    {
+        $blueprint = new Blueprint('geo');
+        $blueprint->dropSpatialIndex(['coordinates']);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+    }
+
     public function testRenameTable()
     {
         $blueprint = new Blueprint('users');

--- a/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
@@ -79,7 +79,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
 
     /**
      * @expectedException \RuntimeException
-     * @expectedExceptionMessage The SQLite database driver does not support spatial indexes.
+     * @expectedExceptionMessage The database driver in use does not support spatial indexes.
      */
     public function testDropSpatialIndex()
     {
@@ -144,7 +144,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
 
     /**
      * @expectedException \RuntimeException
-     * @expectedExceptionMessage The SQLite database driver does not support spatial indexes.
+     * @expectedExceptionMessage The database driver in use does not support spatial indexes.
      */
     public function testAddingSpatialIndex()
     {
@@ -155,7 +155,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
 
     /**
      * @expectedException \RuntimeException
-     * @expectedExceptionMessage The SQLite database driver does not support spatial indexes.
+     * @expectedExceptionMessage The database driver in use does not support spatial indexes.
      */
     public function testAddingFluentSpatialIndex()
     {
@@ -543,82 +543,82 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
 
     public function testAddingGeometry()
     {
-        $blueprint = new Blueprint('users');
-        $blueprint->geometry('foo');
+        $blueprint = new Blueprint('geo');
+        $blueprint->geometry('coordinates');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "foo" geometry not null', $statements[0]);
+        $this->assertEquals('alter table "geo" add column "coordinates" geometry not null', $statements[0]);
     }
 
     public function testAddingPoint()
     {
-        $blueprint = new Blueprint('users');
-        $blueprint->point('foo');
+        $blueprint = new Blueprint('geo');
+        $blueprint->point('coordinates');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "foo" point not null', $statements[0]);
+        $this->assertEquals('alter table "geo" add column "coordinates" point not null', $statements[0]);
     }
 
-    public function testAddingLinestring()
+    public function testAddingLineString()
     {
-        $blueprint = new Blueprint('users');
-        $blueprint->linestring('foo');
+        $blueprint = new Blueprint('geo');
+        $blueprint->linestring('coordinates');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "foo" linestring not null', $statements[0]);
+        $this->assertEquals('alter table "geo" add column "coordinates" linestring not null', $statements[0]);
     }
 
     public function testAddingPolygon()
     {
-        $blueprint = new Blueprint('users');
-        $blueprint->polygon('foo');
+        $blueprint = new Blueprint('geo');
+        $blueprint->polygon('coordinates');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "foo" polygon not null', $statements[0]);
+        $this->assertEquals('alter table "geo" add column "coordinates" polygon not null', $statements[0]);
     }
 
     public function testAddingGeometryCollection()
     {
-        $blueprint = new Blueprint('users');
-        $blueprint->geometrycollection('foo');
+        $blueprint = new Blueprint('geo');
+        $blueprint->geometrycollection('coordinates');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "foo" geometrycollection not null', $statements[0]);
+        $this->assertEquals('alter table "geo" add column "coordinates" geometrycollection not null', $statements[0]);
     }
 
-    public function testAddingMultipoint()
+    public function testAddingMultiPoint()
     {
-        $blueprint = new Blueprint('users');
-        $blueprint->multipoint('foo');
+        $blueprint = new Blueprint('geo');
+        $blueprint->multipoint('coordinates');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "foo" multipoint not null', $statements[0]);
+        $this->assertEquals('alter table "geo" add column "coordinates" multipoint not null', $statements[0]);
     }
 
-    public function testAddingMultiLinestring()
+    public function testAddingMultiLineString()
     {
-        $blueprint = new Blueprint('users');
-        $blueprint->multilinestring('foo');
+        $blueprint = new Blueprint('geo');
+        $blueprint->multilinestring('coordinates');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "foo" multilinestring not null', $statements[0]);
+        $this->assertEquals('alter table "geo" add column "coordinates" multilinestring not null', $statements[0]);
     }
 
     public function testAddingMultiPolygon()
     {
-        $blueprint = new Blueprint('users');
-        $blueprint->multipolygon('foo');
+        $blueprint = new Blueprint('geo');
+        $blueprint->multipolygon('coordinates');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "foo" multipolygon not null', $statements[0]);
+        $this->assertEquals('alter table "geo" add column "coordinates" multipolygon not null', $statements[0]);
     }
 
     protected function getConnection()

--- a/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
@@ -131,6 +131,28 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $this->assertEquals('create index "baz" on "users" ("foo", "bar")', $statements[0]);
     }
 
+    /**
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage The SQLite database driver does not support spatial indexes.
+     */
+    public function testAddingSpatialIndex()
+    {
+        $blueprint = new Blueprint('geo');
+        $blueprint->spatialIndex('coordinates');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+    }
+
+    /**
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage The SQLite database driver does not support spatial indexes.
+     */
+    public function testAddingFluentSpatialIndex()
+    {
+        $blueprint = new Blueprint('geo');
+        $blueprint->point('coordinates')->spatialIndex();
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+    }
+
     public function testAddingIncrementingID()
     {
         $blueprint = new Blueprint('users');

--- a/tests/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintTest.php
@@ -40,6 +40,11 @@ class DatabaseSchemaBlueprintTest extends TestCase
         $blueprint->index('foo');
         $commands = $blueprint->getCommands();
         $this->assertEquals('users_foo_index', $commands[0]->index);
+
+        $blueprint = new Blueprint('geo');
+        $blueprint->spatialIndex('coordinates');
+        $commands = $blueprint->getCommands();
+        $this->assertEquals('geo_coordinates_spatialindex', $commands[0]->index);
     }
 
     public function testDropIndexDefaultNames()

--- a/tests/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintTest.php
@@ -58,6 +58,11 @@ class DatabaseSchemaBlueprintTest extends TestCase
         $blueprint->dropIndex(['foo']);
         $commands = $blueprint->getCommands();
         $this->assertEquals('users_foo_index', $commands[0]->index);
+
+        $blueprint = new Blueprint('geo');
+        $blueprint->dropSpatialIndex(['coordinates']);
+        $commands = $blueprint->getCommands();
+        $this->assertEquals('geo_coordinates_spatialindex', $commands[0]->index);
     }
 
     public function testDefaultCurrentTimestamp()

--- a/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
@@ -130,6 +130,16 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $this->assertEquals('drop index "foo" on "users"', $statements[0]);
     }
 
+    public function testDropSpatialIndex()
+    {
+        $blueprint = new Blueprint('geo');
+        $blueprint->dropSpatialIndex(['coordinates']);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertEquals('drop index "geo_coordinates_spatialindex" on "geo"', $statements[0]);
+    }
+
     public function testDropForeign()
     {
         $blueprint = new Blueprint('users');

--- a/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
@@ -200,6 +200,26 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $this->assertEquals('create index "baz" on "users" ("foo", "bar")', $statements[0]);
     }
 
+    public function testAddingSpatialIndex()
+    {
+        $blueprint = new Blueprint('geo');
+        $blueprint->spatialIndex('coordinates');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertEquals('create spatial index "geo_coordinates_spatialindex" on "geo" ("coordinates")', $statements[0]);
+    }
+
+    public function testAddingFluentSpatialIndex()
+    {
+        $blueprint = new Blueprint('geo');
+        $blueprint->point('coordinates')->spatialIndex();
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(2, $statements);
+        $this->assertEquals('create spatial index "geo_coordinates_spatialindex" on "geo" ("coordinates")', $statements[1]);
+    }
+
     public function testAddingIncrementingID()
     {
         $blueprint = new Blueprint('users');

--- a/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
@@ -589,6 +589,86 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add "foo" nvarchar(17) not null', $statements[0]);
     }
 
+    public function testAddingGeometry()
+    {
+        $blueprint = new Blueprint('geo');
+        $blueprint->geometry('coordinates');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table "geo" add "coordinates" geography not null', $statements[0]);
+    }
+
+    public function testAddingPoint()
+    {
+        $blueprint = new Blueprint('geo');
+        $blueprint->point('coordinates');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table "geo" add "coordinates" geography not null', $statements[0]);
+    }
+
+    public function testAddingLineString()
+    {
+        $blueprint = new Blueprint('geo');
+        $blueprint->linestring('coordinates');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table "geo" add "coordinates" geography not null', $statements[0]);
+    }
+
+    public function testAddingPolygon()
+    {
+        $blueprint = new Blueprint('geo');
+        $blueprint->polygon('coordinates');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table "geo" add "coordinates" geography not null', $statements[0]);
+    }
+
+    public function testAddingGeometryCollection()
+    {
+        $blueprint = new Blueprint('geo');
+        $blueprint->geometrycollection('coordinates');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table "geo" add "coordinates" geography not null', $statements[0]);
+    }
+
+    public function testAddingMultiPoint()
+    {
+        $blueprint = new Blueprint('geo');
+        $blueprint->multipoint('coordinates');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table "geo" add "coordinates" geography not null', $statements[0]);
+    }
+
+    public function testAddingMultiLineString()
+    {
+        $blueprint = new Blueprint('geo');
+        $blueprint->multilinestring('coordinates');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table "geo" add "coordinates" geography not null', $statements[0]);
+    }
+
+    public function testAddingMultiPolygon()
+    {
+        $blueprint = new Blueprint('geo');
+        $blueprint->multipolygon('coordinates');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table "geo" add "coordinates" geography not null', $statements[0]);
+    }
+
     protected function getConnection()
     {
         return m::mock('Illuminate\Database\Connection');


### PR DESCRIPTION
- Adds missing spatial columns support to SQL Server driver
- Adds missing spatial index support to other drivers than MySQL
- Adds missing spatial index dropping support
- Misc improvements to geospatial support

Since it ended up being big I pushed the commits without squashing them to ease reviewing what have changed. 👍 

Added 18 new tests and 39 assertions to the test suite.

### Notes

I was going do add full [SpatiaLite](https://www.gaia-gis.it/fossil/libspatialite/) support to the SQLite driver, then I realized that unfortunately the PDO SQLite driver [does not support loading SQLite extensions](https://bugs.php.net/bug.php?id=64810) at all, only the PHP SQLite3 extension. 😞 

Note that since [SQLite data types are dynamic](https://sqlite.org/datatype3.html) it does make sense to support spatial column types as already implemented. 😉 