### PR TITLE
[5.1] Backport #21320

### DIFF
--- a/src/Illuminate/Auth/DatabaseUserProvider.php
+++ b/src/Illuminate/Auth/DatabaseUserProvider.php
@@ -68,12 +68,12 @@ class DatabaseUserProvider implements UserProvider
      */
     public function retrieveByToken($identifier, $token)
     {
-        $user = $this->conn->table($this->table)
-            ->where('id', $identifier)
-            ->where('remember_token', $token)
-            ->first();
+        $user = $this->getGenericUser(
+            $this->conn->table($this->table)->find($identifier)
+        );
 
-        return $this->getGenericUser($user);
+        return $user && $user->getRememberToken() && hash_equals($user->getRememberToken(), $token)
+                ? $user : null;
     }
 
     /**

--- a/src/Illuminate/Auth/EloquentUserProvider.php
+++ b/src/Illuminate/Auth/EloquentUserProvider.php
@@ -58,10 +58,15 @@ class EloquentUserProvider implements UserProvider
     {
         $model = $this->createModel();
 
-        return $model->newQuery()
-            ->where($model->getKeyName(), $identifier)
-            ->where($model->getRememberTokenName(), $token)
-            ->first();
+        $model = $model->where($model->getAuthIdentifierName(), $identifier)->first();
+
+        if (! $model) {
+            return null;
+        }
+
+        $rememberToken = $model->getRememberToken();
+
+        return $rememberToken && hash_equals($rememberToken, $token) ? $model : null;
     }
 
     /**

--- a/tests/Auth/AuthDatabaseUserProviderTest.php
+++ b/tests/Auth/AuthDatabaseUserProviderTest.php
@@ -35,6 +35,47 @@ class AuthDatabaseUserProviderTest extends PHPUnit_Framework_TestCase
         $this->assertNull($user);
     }
 
+    public function testRetrieveByTokenReturnsUser()
+    {
+        $mockUser = new \stdClass();
+        $mockUser->remember_token = 'a';
+
+        $conn = m::mock('Illuminate\Database\Connection');
+        $conn->shouldReceive('table')->once()->with('foo')->andReturn($conn);
+        $conn->shouldReceive('find')->once()->with(1)->andReturn($mockUser);
+        $hasher = m::mock('Illuminate\Contracts\Hashing\Hasher');
+        $provider = new Illuminate\Auth\DatabaseUserProvider($conn, $hasher, 'foo');
+        $user = $provider->retrieveByToken(1, 'a');
+
+        $this->assertEquals(new Illuminate\Auth\GenericUser((array) $mockUser), $user);
+    }
+
+    public function testRetrieveTokenWithBadIdentifierReturnsNull()
+    {
+        $conn = m::mock('Illuminate\Database\Connection');
+        $conn->shouldReceive('table')->once()->with('foo')->andReturn($conn);
+        $conn->shouldReceive('find')->once()->with(1)->andReturn(null);
+        $hasher = m::mock('Illuminate\Contracts\Hashing\Hasher');
+        $provider = new Illuminate\Auth\DatabaseUserProvider($conn, $hasher, 'foo');
+        $user = $provider->retrieveByToken(1, 'a');
+
+        $this->assertNull($user);
+    }
+
+    public function testRetrieveByBadTokenReturnsNull()
+    {
+        $mockUser = new \stdClass();
+        $mockUser->remember_token = null;
+        $conn = m::mock('Illuminate\Database\Connection');
+        $conn->shouldReceive('table')->once()->with('foo')->andReturn($conn);
+        $conn->shouldReceive('find')->once()->with(1)->andReturn($mockUser);
+        $hasher = m::mock('Illuminate\Contracts\Hashing\Hasher');
+        $provider = new Illuminate\Auth\DatabaseUserProvider($conn, $hasher, 'foo');
+        $user = $provider->retrieveByToken(1, 'a');
+
+        $this->assertNull($user);
+    }
+
     public function testRetrieveByCredentialsReturnsUserWhenUserIsFound()
     {
         $conn = m::mock('Illuminate\Database\Connection');

--- a/tests/Auth/AuthEloquentUserProviderTest.php
+++ b/tests/Auth/AuthEloquentUserProviderTest.php
@@ -21,6 +21,35 @@ class AuthEloquentUserProviderTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('bar', $user);
     }
 
+    public function testRetrieveTokenWithBadIdentifierReturnsNull()
+    {
+        $provider = $this->getProviderMock();
+        $mock = m::mock('stdClass');
+        $mock->shouldReceive('getAuthIdentifierName')->once()->andReturn('id');
+        $mock->shouldReceive('where')->once()->with('id', 1)->andReturn($mock);
+        $mock->shouldReceive('first')->once()->andReturn(null);
+        $provider->expects($this->once())->method('createModel')->will($this->returnValue($mock));
+        $user = $provider->retrieveByToken(1, 'a');
+
+        $this->assertNull($user);
+    }
+
+    public function testRetrieveByBadTokenReturnsNull()
+    {
+        $mockUser = m::mock('stdClass');
+        $mockUser->shouldReceive('getRememberToken')->once()->andReturn(null);
+
+        $provider = $this->getProviderMock();
+        $mock = m::mock('stdClass');
+        $mock->shouldReceive('getAuthIdentifierName')->once()->andReturn('id');
+        $mock->shouldReceive('where')->once()->with('id', 1)->andReturn($mock);
+        $mock->shouldReceive('first')->once()->andReturn($mockUser);
+        $provider->expects($this->once())->method('createModel')->will($this->returnValue($mock));
+        $user = $provider->retrieveByToken(1, 'a');
+
+        $this->assertNull($user);
+    }
+
     public function testRetrieveByCredentialsReturnsUser()
     {
         $provider = $this->getProviderMock();


### PR DESCRIPTION
As mentioned [here](https://github.com/laravel/framework/pull/21320#issuecomment-339618550), this fix should be back-ported to 5.1. This brings both the final changes and the added tests to ensure their correctness.