### PR TITLE
[5.5] make fluent Route::middleware work with variadic arguments

### DIFF
--- a/src/Illuminate/Routing/RouteRegistrar.php
+++ b/src/Illuminate/Routing/RouteRegistrar.php
@@ -171,7 +171,7 @@ class RouteRegistrar
             if ($method == 'middleware') {
                 return $this->attribute($method, is_array($parameters[0]) ? $parameters[0] : $parameters);
             }
-            
+
             return $this->attribute($method, $parameters[0]);
         }
 

--- a/src/Illuminate/Routing/RouteRegistrar.php
+++ b/src/Illuminate/Routing/RouteRegistrar.php
@@ -168,6 +168,10 @@ class RouteRegistrar
         }
 
         if (in_array($method, $this->allowedAttributes)) {
+            if ($method == 'middleware') {
+                return $this->attribute($method, is_array($parameters[0]) ? $parameters[0] : $parameters);
+            }
+            
             return $this->attribute($method, $parameters[0]);
         }
 

--- a/tests/Integration/Routing/FluentRoutingTest.php
+++ b/tests/Integration/Routing/FluentRoutingTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Routing\FluentRoutingTest;
+
+use Orchestra\Testbench\TestCase;
+use Illuminate\Support\Facades\View;
+use Illuminate\Support\Facades\Route;
+
+/**
+ * @group integration
+ */
+class FluentRoutingTest extends TestCase
+{
+    public function test_middleware_run_when_registered_as_array_or_params()
+    {
+        Route::middleware(Middleware::class, Middleware2::class)
+            ->get('one', function () {
+                return 'Hello World';
+            });
+
+        Route::get('two', function () {
+            return 'Hello World';
+        })->middleware(Middleware::class, Middleware2::class);
+
+        Route::middleware([Middleware::class, Middleware2::class])
+            ->get('three', function () {
+                return 'Hello World';
+            });
+
+        Route::get('four', function () {
+            return 'Hello World';
+        })->middleware([Middleware::class, Middleware2::class]);
+
+        $this->assertEquals('middleware output', $this->get('one')->content());
+        $this->assertEquals('middleware output', $this->get('two')->content());
+        $this->assertEquals('middleware output', $this->get('three')->content());
+        $this->assertEquals('middleware output', $this->get('four')->content());
+    }
+}
+
+
+class Middleware
+{
+    public function handle($request, $next)
+    {
+        return $next($request);
+    }
+}
+
+class Middleware2
+{
+    public function handle()
+    {
+        return 'middleware output';
+    }
+}

--- a/tests/Integration/Routing/FluentRoutingTest.php
+++ b/tests/Integration/Routing/FluentRoutingTest.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Tests\Integration\Routing\FluentRoutingTest;
 
 use Orchestra\Testbench\TestCase;
-use Illuminate\Support\Facades\View;
 use Illuminate\Support\Facades\Route;
 
 /**


### PR DESCRIPTION
Currently:

```
Route::get('two', function () {
            return 'Hello World';
})->middleware(Middleware::class, Middleware2::class);
```

`Middleware2` will run, but if you do this it won't:

```
Route::middleware(Middleware::class, Middleware2::class)
    ->get('one', function () {
                return 'Hello World';
});
``

This PR fixes that.