### PR TITLE
[5.6] Before sending mailable callbacks

### DIFF
--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Mail;
 
+use Closure;
 use Swift_Mailer;
 use InvalidArgumentException;
 use Illuminate\Contracts\View\Factory;
@@ -75,6 +76,11 @@ class Mailer implements MailerContract, MailQueueContract
     protected $failedRecipients = [];
 
 
+    /**
+     * All of the before sending mailable callbacks.
+     *
+     * @var array
+     */
     protected $beforeSendingMailableCallbacks = [];
 
     /**
@@ -559,11 +565,23 @@ class Mailer implements MailerContract, MailQueueContract
         return $this;
     }
 
-    public function beforeSendingMailable(callable $callback)
+    /**
+     * Register a new before sending mailable callback.
+     *
+     * @param  \Closure $callback
+     * @return void
+     */
+    public function beforeSendingMailable(Closure $callback)
     {
         $this->beforeSendingMailableCallbacks[] = $callback;
     }
 
+    /**
+     * Fire all of the before sending mailables callbacks.
+     * 
+     * @param  \Illuminate\Contracts\Mail\Mailable $mailable
+     * @return void
+     */
     protected function fireBeforeSendingMailablesCallbacks(MailableContract $mailable)
     {
         foreach($this->beforeSendingMailableCallbacks as $callback) {

--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -74,6 +74,9 @@ class Mailer implements MailerContract, MailQueueContract
      */
     protected $failedRecipients = [];
 
+
+    protected $beforeSendingMailableCallbacks = [];
+
     /**
      * Create a new Mailer instance.
      *
@@ -246,6 +249,8 @@ class Mailer implements MailerContract, MailQueueContract
      */
     protected function sendMailable(MailableContract $mailable)
     {
+        $this->fireBeforeSendingMailablesCallbacks($mailable);
+
         return $mailable instanceof ShouldQueue
                 ? $mailable->queue($this->queue) : $mailable->send($this);
     }
@@ -552,5 +557,17 @@ class Mailer implements MailerContract, MailQueueContract
         $this->queue = $queue;
 
         return $this;
+    }
+
+    public function beforeSendingMailable(callable $callback)
+    {
+        $this->beforeSendingMailableCallbacks[] = $callback;
+    }
+
+    protected function fireBeforeSendingMailablesCallbacks(MailableContract $mailable)
+    {
+        foreach($this->beforeSendingMailableCallbacks as $callback) {
+            $callback($mailable);
+        }
     }
 }

--- a/tests/Mail/MailMailerTest.php
+++ b/tests/Mail/MailMailerTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Mail;
 
 use Mockery as m;
 use Illuminate\Mail\Mailer;
+use Illuminate\Mail\Mailable;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Support\HtmlString;
 
@@ -160,6 +161,22 @@ class MailMailerTest extends TestCase
         $this->assertEquals(
             'bar', $mailer->foo()
         );
+    }
+
+    public function testBeforeSendingMailable()
+    {
+        unset($_SERVER['__mailer.test']);
+        $mailer = $this->getMailer();
+
+        $mailer->beforeSendingMailable(function($mailable) {
+            $mailable->to('foo@bar.com');
+        });
+
+        $mailable = m::mock(Mailable::class);
+        $mailable->shouldReceive('to')->once()->with('foo@bar.com');
+        $mailable->shouldReceive('send');
+    
+        $mailer->send($mailable);
     }
 
     protected function getMailer($events = null)


### PR DESCRIPTION
This PR introduces a way to manipulate mails globally. It would be useful if someone needs to save information about the mailable in the database before sending it -- this way they'd be able to register a callback instead of adding code in several parts of the app