### PR TITLE
[5.5] Add contract method to helpers file

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -424,6 +424,30 @@ if (! function_exists('collect')) {
     }
 }
 
+if (! function_exists('contract')) {
+    /**
+     * Create a concrete class if it implements a given contract.
+     *
+     * @param  string $concrete
+     * @param  string $contract
+     * @return mixed
+     */
+    function contract($concrete, $contract = null)
+    {
+        if (is_string($concrete)) {
+            $concrete = app($concrete);
+        }
+
+        if (! is_null($contract) && ! $concrete instanceof $contract) {
+            throw new \RuntimeException(sprintf(
+                '%s must implement %s', get_class($concrete), $contract
+            ));
+        }
+
+        return $concrete;
+    }
+}
+
 if (! function_exists('data_fill')) {
     /**
      * Fill in data where it's missing.


### PR DESCRIPTION
This is a method I use frequently to quickly and safely create instances of classes from strings.

```php
// Provides `eat()` method.
use App\Contracts\Edible as EdibleContract;

class Waiter
{
    protected $foods = [Pizza::class, Burger::class];

    public function serve()
    {
        collect($this->foods)->each(function($food) {
            contract($food, EdibleContract::class)->eat();

            // Much easier than doing this:
            /*
                $edible = app($food);

                if (! $edible instanceof EdibleContract::class) {
                    throw new \Exception('Must be edible...');
                }
            */
        });
    }
}

```

I hope you find some value in this! I'm really enjoying all of similar helper methods Laravel now has :)!