### PR TITLE
[5.5] include the job name in the MaxAttemptsExcededException

### DIFF
--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -392,7 +392,7 @@ class Worker
         }
 
         $this->failJob($connectionName, $job, $e = new MaxAttemptsExceededException(
-            $job->getName() . ' has been attempted too many times or run too long. The job may have previously timed out.'
+            $job->getName().' has been attempted too many times or run too long. The job may have previously timed out.'
         ));
 
         throw $e;

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -392,7 +392,7 @@ class Worker
         }
 
         $this->failJob($connectionName, $job, $e = new MaxAttemptsExceededException(
-            'A queued job has been attempted too many times or run too long. The job may have previously timed out.'
+            $job->getName() . ' has been attempted too many times or run too long. The job may have previously timed out.'
         ));
 
         throw $e;

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -393,7 +393,7 @@ class WorkerFakeJob
     {
         return $this->failed;
     }
-    
+
     public function getName()
     {
         return 'WorkerFakeJob';

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -393,6 +393,11 @@ class WorkerFakeJob
     {
         return $this->failed;
     }
+    
+    public function getName()
+    {
+        return 'WorkerFakeJob';
+    }
 
     public function setConnectionName($name)
     {


### PR DESCRIPTION
It's helpful to know which job has been exceeding it's max attempts.