### PR TITLE
[5.5] Fix removing ExampleComponent.vue when 'php artisan preset react' is ran

### DIFF
--- a/src/Illuminate/Foundation/Console/Presets/React.php
+++ b/src/Illuminate/Foundation/Console/Presets/React.php
@@ -55,7 +55,7 @@ class React extends Preset
     protected static function updateComponent()
     {
         (new Filesystem)->delete(
-            resource_path('assets/js/components/Example.vue')
+            resource_path('assets/js/components/ExampleComponent.vue')
         );
 
         copy(


### PR DESCRIPTION
Fixes a small bug where the ExampleComponent.vue file isn't removed when the 'php artisan preset react' command is ran. (Change missed when updating the file name to match Vue.js style guides.)