### PR TITLE
[5.6] Dispatch events on mailable send/queue

### DIFF
--- a/src/Illuminate/Contracts/Mail/Mailable.php
+++ b/src/Illuminate/Contracts/Mail/Mailable.php
@@ -11,6 +11,7 @@ interface Mailable
      * Send the message using the given mailer.
      *
      * @param  \Illuminate\Contracts\Mail\Mailer  $mailer
+     * @param  \Illuminate\Contracts\Events\Dispatcher|null $dispatcher
      * @return void
      */
     public function send(Mailer $mailer, Dispatcher $dispatcher = null);
@@ -19,6 +20,7 @@ interface Mailable
      * Queue the given message.
      *
      * @param  \Illuminate\Contracts\Queue\Factory  $queue
+     * @param  \Illuminate\Contracts\Events\Dispatcher|null $dispatcher
      * @return mixed
      */
     public function queue(Queue $queue, Dispatcher $dispatcher = null);

--- a/src/Illuminate/Contracts/Mail/Mailable.php
+++ b/src/Illuminate/Contracts/Mail/Mailable.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Contracts\Mail;
 
+use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Queue\Factory as Queue;
 
 interface Mailable
@@ -12,7 +13,7 @@ interface Mailable
      * @param  \Illuminate\Contracts\Mail\Mailer  $mailer
      * @return void
      */
-    public function send(Mailer $mailer);
+    public function send(Mailer $mailer, Dispatcher $dispatcher = null);
 
     /**
      * Queue the given message.
@@ -20,7 +21,7 @@ interface Mailable
      * @param  \Illuminate\Contracts\Queue\Factory  $queue
      * @return mixed
      */
-    public function queue(Queue $queue);
+    public function queue(Queue $queue, Dispatcher $dispatcher = null);
 
     /**
      * Deliver the queued message after the given delay.

--- a/src/Illuminate/Mail/Events/MailableQueued.php
+++ b/src/Illuminate/Mail/Events/MailableQueued.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Illuminate\Mail\Events;
+
+class MailableQueued
+{
+    /**
+     * The Mailable instance.
+     *
+     * @var \Illuminate\Contracts\Mail\Mailable
+     */
+    public $mailable;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  \Illuminate\Contracts\Mail\Mailable $mailable
+     * @return void
+     */
+    public function __construct($mailable)
+    {
+        $this->mailable = $mailable;
+    }
+}

--- a/src/Illuminate/Mail/Events/MailableSent.php
+++ b/src/Illuminate/Mail/Events/MailableSent.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Illuminate\Mail\Events;
+
+class MailableSent
+{
+    /**
+     * The Mailable instance.
+     *
+     * @var \Illuminate\Contracts\Mail\Mailable
+     */
+    public $mailable;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  \Illuminate\Contracts\Mail\Mailable $mailable
+     * @return void
+     */
+    public function __construct($mailable)
+    {
+        $this->mailable = $mailable;
+    }
+}

--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -8,6 +8,7 @@ use BadMethodCallException;
 use Illuminate\Support\Str;
 use Illuminate\Support\Collection;
 use Illuminate\Container\Container;
+use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Support\Renderable;
 use Illuminate\Contracts\Queue\Factory as Queue;
 use Illuminate\Contracts\Mail\Mailer as MailerContract;
@@ -110,9 +111,10 @@ class Mailable implements MailableContract, Renderable
      * Send the message using the given mailer.
      *
      * @param  \Illuminate\Contracts\Mail\Mailer  $mailer
+     * @param  \Illuminate\Contracts\Events\Dispatcher $dispatcher
      * @return void
      */
-    public function send(MailerContract $mailer)
+    public function send(MailerContract $mailer, Dispatcher $dispatcher = null)
     {
         Container::getInstance()->call([$this, 'build']);
 
@@ -123,15 +125,18 @@ class Mailable implements MailableContract, Renderable
                  ->buildAttachments($message)
                  ->runCallbacks($message);
         });
+
+        $this->dispatchEvent($dispatcher, new Events\MailableSent($this));
     }
 
     /**
      * Queue the message for sending.
      *
      * @param  \Illuminate\Contracts\Queue\Factory  $queue
+     * @param  \Illuminate\Contracts\Events\Dispatcher|null @dispatcher
      * @return mixed
      */
-    public function queue(Queue $queue)
+    public function queue(Queue $queue, Dispatcher $dispatcher = null)
     {
         if (property_exists($this, 'delay')) {
             return $this->later($this->delay, $queue);
@@ -141,9 +146,24 @@ class Mailable implements MailableContract, Renderable
 
         $queueName = property_exists($this, 'queue') ? $this->queue : null;
 
-        return $queue->connection($connection)->pushOn(
+        return tap($queue->connection($connection)->pushOn(
             $queueName ?: null, new SendQueuedMailable($this)
-        );
+        ), function ($queue) use ($dispatcher) {
+            $this->dispatchEvent($dispatcher, new Events\MailableQueued($this));
+        });
+    }
+
+    /**
+     * Dispatches the given event if the dispatcher is present.
+     * @param  \Illuminate\Contracts\Events\Dispatcher|null $dispatcher
+     * @param  mixed $event
+     * @return void
+     */
+    protected function dispatchEvent(Dispatcher $dispatcher = null, $event)
+    {
+        if($dispatcher) {
+            $dispatcher->dispatch($event);
+        }
     }
 
     /**

--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -111,7 +111,7 @@ class Mailable implements MailableContract, Renderable
      * Send the message using the given mailer.
      *
      * @param  \Illuminate\Contracts\Mail\Mailer  $mailer
-     * @param  \Illuminate\Contracts\Events\Dispatcher $dispatcher
+     * @param  \Illuminate\Contracts\Events\Dispatcher|null $dispatcher
      * @return void
      */
     public function send(MailerContract $mailer, Dispatcher $dispatcher = null)

--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -247,7 +247,7 @@ class Mailer implements MailerContract, MailQueueContract
     protected function sendMailable(MailableContract $mailable)
     {
         return $mailable instanceof ShouldQueue
-                ? $mailable->queue($this->queue) : $mailable->send($this);
+                ? $mailable->queue($this->queue, $this->events) : $mailable->send($this, $this->events);
     }
 
     /**

--- a/src/Illuminate/Mail/SendQueuedMailable.php
+++ b/src/Illuminate/Mail/SendQueuedMailable.php
@@ -2,8 +2,9 @@
 
 namespace Illuminate\Mail;
 
-use Illuminate\Contracts\Mail\Mailer as MailerContract;
+use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Mail\Mailable as MailableContract;
+use Illuminate\Contracts\Mail\Mailer as MailerContract;
 
 class SendQueuedMailable
 {
@@ -13,6 +14,13 @@ class SendQueuedMailable
      * @var Mailable
      */
     public $mailable;
+
+    /**
+     * The dispatcher instance.
+     *
+     * @var \Illuminate\Contracts\Events\Dispatcher
+     */
+    protected $dispatcher;
 
     /**
      * The number of times the job may be attempted.
@@ -32,11 +40,13 @@ class SendQueuedMailable
      * Create a new job instance.
      *
      * @param  \Illuminate\Contracts\Mail\Mailable  $mailable
+     * @param  \Illuminate\Contracts\Events\Dispatcher $dispatcher
      * @return void
      */
-    public function __construct(MailableContract $mailable)
+    public function __construct(MailableContract $mailable, Dispatcher $dispatcher = null)
     {
         $this->mailable = $mailable;
+        $this->dispatcher = $dispatcher;
         $this->tries = property_exists($mailable, 'tries') ? $mailable->tries : null;
         $this->timeout = property_exists($mailable, 'timeout') ? $mailable->timeout : null;
     }
@@ -49,7 +59,8 @@ class SendQueuedMailable
      */
     public function handle(MailerContract $mailer)
     {
-        $this->mailable->send($mailer);
+        $this->mailable->send($mailer, $this->dispatcher);
+
     }
 
     /**

--- a/tests/Mail/MailMailableTest.php
+++ b/tests/Mail/MailMailableTest.php
@@ -141,7 +141,7 @@ class MailMailableTest extends TestCase
         $events->shouldReceive('dispatch')->once()->with(Mockery::type('Illuminate\Mail\Events\MailableQueued'));
 
         $mailable = new QueuedWelcomeMailableStub;
-        $mailable->queue($queue);
+        $mailable->queue($queue, $events);
     }
 
     public function testMailableDoesNotDispatchQueuedEventWhenDispatcherIsNotAvailable()

--- a/tests/Mail/MailMailableTest.php
+++ b/tests/Mail/MailMailableTest.php
@@ -10,6 +10,13 @@ use \Mockery;
 
 class MailMailableTest extends TestCase
 {
+    public function tearDown()
+    {
+        parent::tearDown();
+
+        Mockery::close();
+    }
+
     public function testMailableSetsRecipientsCorrectly()
     {
         $mailable = new WelcomeMailableStub;


### PR DESCRIPTION
This PR introduces two events: `Illuminate\Mail\Events\MailableSent` that is dispatched whenever a mailable is sent and `Illuminate\Mail\Events\MailableQueued` that is dispatched whenever a mailable is queued.  

It is a quick rework of https://github.com/laravel/framework/pull/21934