### PR TITLE
[WIP][5.6] Use notifications as event listeners

### DIFF
--- a/src/Illuminate/Contracts/Events/ReflectOnEvent.php
+++ b/src/Illuminate/Contracts/Events/ReflectOnEvent.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Illuminate\Contracts\Events;
+
+interface ReflectOnEvent
+{
+    //
+}

--- a/src/Illuminate/Notifications/HandlesEvents.php
+++ b/src/Illuminate/Notifications/HandlesEvents.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Illuminate\Notifications;
+
+use Illuminate\Contracts\Notifications\Dispatcher;
+
+trait HandlesEvents
+{
+    /**
+     * Handles notification dispatching as event listener
+     *
+     * @param $event
+     */
+    public function handle($event)
+    {
+        app(Dispatcher::class)->sendNow($this->routeNotificationForEvent($event), $this);
+    }
+
+    /**
+     * Route notification for a given event
+     *
+     * @param $event
+     * @return string $notifiable
+     */
+    public function routeNotificationForEvent($event)
+    {
+        //
+    }
+}

--- a/src/Illuminate/Notifications/Notification.php
+++ b/src/Illuminate/Notifications/Notification.php
@@ -2,9 +2,10 @@
 
 namespace Illuminate\Notifications;
 
+use Illuminate\Contracts\Events\ReflectOnEvent;
 use Illuminate\Queue\SerializesModels;
 
-class Notification
+class Notification implements ReflectOnEvent
 {
     use HandlesEvents, SerializesModels;
 

--- a/src/Illuminate/Notifications/Notification.php
+++ b/src/Illuminate/Notifications/Notification.php
@@ -6,7 +6,7 @@ use Illuminate\Queue\SerializesModels;
 
 class Notification
 {
-    use SerializesModels;
+    use HandlesEvents, SerializesModels;
 
     /**
      * The unique identifier for the notification.

--- a/tests/Events/EventsDispatcherTest.php
+++ b/tests/Events/EventsDispatcherTest.php
@@ -43,7 +43,7 @@ class EventsDispatcherTest extends TestCase
     public function testContainerResolutionOfEventHandlers()
     {
         $d = new Dispatcher($container = m::mock('Illuminate\Container\Container'));
-        $container->shouldReceive('make')->once()->with('FooHandler')->andReturn($handler = m::mock('stdClass'));
+        $container->shouldReceive('makeWith')->once()->with('FooHandler', [])->andReturn($handler = m::mock('stdClass'));
         $handler->shouldReceive('onFooEvent')->once()->with('foo', 'bar');
         $d->listen('foo', 'FooHandler@onFooEvent');
         $d->fire('foo', ['foo', 'bar']);
@@ -52,7 +52,7 @@ class EventsDispatcherTest extends TestCase
     public function testContainerResolutionOfEventHandlersWithDefaultMethods()
     {
         $d = new Dispatcher($container = m::mock('Illuminate\Container\Container'));
-        $container->shouldReceive('make')->once()->with('FooHandler')->andReturn($handler = m::mock('stdClass'));
+        $container->shouldReceive('makeWith')->once()->with('FooHandler', [])->andReturn($handler = m::mock('stdClass'));
         $handler->shouldReceive('handle')->once()->with('foo', 'bar');
         $d->listen('foo', 'FooHandler');
         $d->fire('foo', ['foo', 'bar']);
@@ -196,6 +196,16 @@ class EventsDispatcherTest extends TestCase
         $this->assertSame('baz', $_SERVER['__event.test']);
     }
 
+    public function testEventClassesWorkWithListenerClasses()
+    {
+        unset($_SERVER['__event.test']);
+        $d = new Dispatcher;
+        $d->listen(EventWithProperties::class, ListenerWithConstructor::class);
+        $d->fire(new EventWithProperties);
+
+        $this->assertSame('constructed with bar', $_SERVER['__event.test']);
+    }
+
     public function testInterfacesWork()
     {
         unset($_SERVER['__event.test']);
@@ -263,6 +273,28 @@ class TestDispatcherQueuedHandlerCustomQueue implements \Illuminate\Contracts\Qu
     public function queue($queue, $handler, array $payload)
     {
         $queue->push($handler, $payload);
+    }
+}
+
+class EventWithProperties
+{
+    public $bin = 'baz';
+
+    public $foo = 'bar';
+}
+
+class ListenerWithConstructor
+{
+    protected $saying;
+
+    public function __construct($foo)
+    {
+        $this->saying = $foo;
+    }
+
+    public function handle($event)
+    {
+        $_SERVER['__event.test'] = 'constructed with '.$this->saying;
     }
 }
 

--- a/tests/Events/EventsDispatcherTest.php
+++ b/tests/Events/EventsDispatcherTest.php
@@ -6,6 +6,7 @@ use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Events\Dispatcher;
 use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Contracts\Events\ReflectOnEvent;
 
 class EventsDispatcherTest extends TestCase
 {
@@ -283,7 +284,7 @@ class EventWithProperties
     public $foo = 'bar';
 }
 
-class ListenerWithConstructor
+class ListenerWithConstructor implements ReflectOnEvent
 {
     protected $saying;
 

--- a/tests/Notifications/NotificationEventListenerTest.php
+++ b/tests/Notifications/NotificationEventListenerTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Illuminate\Tests\Notifications;
+
+use Illuminate\Container\Container;
+use Illuminate\Notifications\Messages\MailMessage;
+use Mockery;
+use PHPUnit\Framework\TestCase;
+use Illuminate\Notifications\Notification;
+use Illuminate\Notifications\Channels\DatabaseChannel;
+use Illuminate\Notifications\Messages\DatabaseMessage;
+
+class NotificationEventListenerTest extends TestCase
+{
+    public function tearDown()
+    {
+        Mockery::close();
+    }
+
+    public function testNotificationsDispatchesOnEvents()
+    {
+        $container = new Container;
+        $container->instance('config', ['app.name' => 'Name', 'app.logo' => 'Logo']);
+        $container->instance(\Illuminate\Contracts\Notifications\Dispatcher::class, $dispatcher = Mockery::mock());
+        Container::setInstance($container);
+
+        $dispatcher->shouldReceive('sendNow')->once()->with('notifiable', Mockery::type(NotificationEventListenerNotification::class));
+
+        $eventDispatcher = new \Illuminate\Events\Dispatcher;
+        $eventDispatcher->listen(NotificationEventListenerEvent::class, NotificationEventListenerNotification::class);
+        $eventDispatcher->dispatch(new NotificationEventListenerEvent('notifiable', 'foo'));
+    }
+}
+
+class NotificationEventListenerEvent
+{
+    public $user;
+
+    public $order;
+
+    public function __construct($user, $order)
+    {
+        $this->user = $user;
+        $this->order = $order;
+    }
+}
+
+class NotificationEventListenerNotification extends Notification
+{
+    public $order;
+
+    public function via()
+    {
+        return [NotificationEventListenerChannel::class];
+    }
+
+    public function routeNotificationForEvent($event)
+    {
+        return $event->user;
+    }
+
+    public function __construct($order)
+    {
+        $this->order = $order;
+    }
+}


### PR DESCRIPTION
****Proposal****

This PR is a first draft of implementing Notifications as Event Listeners.

Given you have the following event 

```php
class TeamMemberAdded
{
    public $team, $teamMember;

    // ... constructor...
}
```

and the following notification

```php
class TeamMemberWelcomeNotification extends Notification
{
    public function routeNotificationForEvent($event)
    {
        return $event->teamMember;
    }

    public function __construct($team)
    {
        $this->team = $team;
    }
} 
```
... you could subscribe to it just by adding it as a listener.

```php
Event::listen(TeamMemberAdded::class, TeamMemberWelcomeNotification::class);
```

This PR adresses two issues on using notifications as event listeners

**1. It adds a `@handle` on `Notification` class that dispatches the notification to the right notifiable**

This part is heavily Inspired by @themsaid 's post https://themsaid.com/laravel-mailables-notfiications-as-event-listeners-20170516 

The issue I found with this approach was however, that it made it inconvenient to send the notification normally, because one has to remove any constructor-arguments and then set them manually.
Which leads to the next issue:

**2. It makes the Event Dispatcher instantiate listeners with the public properties on the event**

Given the event fired is an object and the listener is a qualified class, it now attempts to construct the listener with the public properties of the class.
This is what makes the above example inject '$team' into the notification constructor.

However this introduces a potential compatibility issue. If somebody is already type hinting a `$team` variable, it would now break:

```php
class SomeOtherListener
{
    public function __construct(SomeOtherTeam $team)
    {
        $this->team = $team;
    }
} 
```  

Any suggestions on the above issue is appreciated.

**UPDATE 2017-11-05**

Added a ReflectOnEvent interface that tells the EventDispatcher that this listener would like to be resolved with the public properties of the event. 
I feel this is a quite clean way to opt-in on the new behavior.

**TODO**

- Make it compatible with queueable listeners
