### PR TITLE
[5.6] [WIP] Enable shorthand `@php()` directive

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -215,7 +215,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
     protected function storePhpBlocks($value)
     {
         $value = preg_replace_callback('/(?<!@)@php\((.*?)\)/s', function ($matches) {
-            $this->rawBlocks[] = "<?php {$matches[1]} ?>";
+            $this->rawBlocks[] = "<?php {$matches[1]}; ?>";
 
             return $this->rawPlaceholder;
         }, $value);

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -214,6 +214,12 @@ class BladeCompiler extends Compiler implements CompilerInterface
      */
     protected function storePhpBlocks($value)
     {
+        $value = preg_replace_callback('/(?<!@)@php\((.*?)\)/s', function ($matches) {
+            $this->rawBlocks[] = "<?php {$matches[1]} ?>";
+
+            return $this->rawPlaceholder;
+        }, $value);
+
         return preg_replace_callback('/(?<!@)@php(.*?)@endphp/s', function ($matches) {
             $this->rawBlocks[] = "<?php{$matches[1]}?>";
 

--- a/tests/View/Blade/BladePhpStatementsTest.php
+++ b/tests/View/Blade/BladePhpStatementsTest.php
@@ -26,11 +26,11 @@ class BladePhpStatementsTest extends AbstractBladeTestCase
     {
         $string = '@php($set = true)'
             ."\n@php"
-            ."\n    $string = 'value';"
+            ."\n    \$string = 'value';"
             ."\n@endphp";
         $expected = '<?php $set = true; ?>'
             ."\n<?php"
-            ."\n    $string = 'value';"
+            ."\n    \$string = 'value';"
             ."\n?>";
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }

--- a/tests/View/Blade/BladePhpStatementsTest.php
+++ b/tests/View/Blade/BladePhpStatementsTest.php
@@ -7,7 +7,7 @@ class BladePhpStatementsTest extends AbstractBladeTestCase
     public function testPhpStatementsWithExpressionAreCompiled()
     {
         $string = '@php($set = true)';
-        $expected = '<?php ($set = true); ?>';
+        $expected = '<?php $set = true; ?>';
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
@@ -28,7 +28,7 @@ class BladePhpStatementsTest extends AbstractBladeTestCase
             ."\n@php"
             ."\n    $string = 'value';"
             ."\n@endphp";
-        $expected = '<?php ($set = true); ?>'
+        $expected = '<?php $set = true; ?>'
             ."\n<?php"
             ."\n    $string = 'value';"
             ."\n?>";

--- a/tests/View/Blade/BladePhpStatementsTest.php
+++ b/tests/View/Blade/BladePhpStatementsTest.php
@@ -21,6 +21,19 @@ class BladePhpStatementsTest extends AbstractBladeTestCase
         $expected = '<?php echo e("Ignore: @php"); ?>';
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
+    
+    public function testCombinedShorthandAndClosedPhpStatements()
+    {
+        $string = '@php($set = true)'
+            ."\n@php"
+            ."\n    $string = 'value';"
+            ."\n@endphp";
+        $expected = '<?php ($set = true); ?>'
+            ."\n<?php"
+            ."\n    $string = 'value';"
+            ."\n?>";
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
 
     public function testPhpStatementsDontParseBladeCode()
     {

--- a/tests/View/Blade/BladePhpStatementsTest.php
+++ b/tests/View/Blade/BladePhpStatementsTest.php
@@ -21,7 +21,7 @@ class BladePhpStatementsTest extends AbstractBladeTestCase
         $expected = '<?php echo e("Ignore: @php"); ?>';
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
-    
+
     public function testCombinedShorthandAndClosedPhpStatements()
     {
         $string = '@php($set = true)'


### PR DESCRIPTION
Problem:
```
@php($set = true)

@php
    $string = 'value';
@endphp
```

Compiles to
```
<?php($set = true)

@php
    $string = 'value';
?>
```

This PR fixes so it compiles to:

```
<?php ($set = true) ?>

<?php
    $string = 'value';
?>
```