### PR TITLE
[5.5] Capitalises first character on the desired class name

### DIFF
--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -208,7 +208,7 @@ abstract class GeneratorCommand extends Command
      */
     protected function getNameInput()
     {
-        return trim($this->argument('name'));
+        return ucfirst(trim($this->argument('name')));
     }
 
     /**


### PR DESCRIPTION
The PR addresses every GeneratorCommand derived class. I think there is no sense creating a class having first char in lower case.

**Objective:** Make the desired class name is first character uppercase.

**Using:** `php artisan make:command test`

**Before:**

File created: `test.php`

```
namespace App\Console\Commands;

use Illuminate\Console\Command;

class test extends Command
```

**After:**

File created: `Test.php`

```
namespace App\Console\Commands;

use Illuminate\Console\Command;

class Test extends Command
```
