### PR TITLE
[5.5] Set $response property

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -33,6 +33,13 @@ trait MakesHttpRequests
     protected $followRedirects = false;
 
     /**
+     * Http response
+     *
+     * @var \Illuminate\Foundation\Testing\TestResponse|null
+     */
+    protected $response;    
+
+    /**
      * Define additional headers to be sent with the request.
      *
      * @param  array $headers
@@ -330,7 +337,9 @@ trait MakesHttpRequests
 
         $kernel->terminate($request, $response);
 
-        return $this->createTestResponse($response);
+        $this->response = $this->createTestResponse($response);
+
+        return $this->response;
     }
 
     /**


### PR DESCRIPTION
When having multiple tests, very often it's useful to create helper methods. But now as we have $response returned from Http requests it's necessary to either pass this response to helper methods or to manually set $response property in such tests.

In this PR $response property is set automatically when making Http requests, so we could have helper like this:

```php
protected function verifyNoPermission()
{
   $this->response->assertStatus(401);
}
```

and use this without passing response to them or setting property manually.