### PR TITLE
[5.5] Allow graceful handling of SIGTERM in queue workers

### DIFF
--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -581,6 +581,8 @@ class Worker
      */
     public function kill($status = 0)
     {
+        $this->events->dispatch(new Events\WorkerStopping);
+
         if (extension_loaded('posix')) {
             posix_kill(getmypid(), SIGKILL);
         }


### PR DESCRIPTION
I would like to be able to gracefully shutdown my application when sending a SIGTERM to a running queue daemon. 

The current behavior traps SIGTERM signals and waits for the queue worker to process the current message, however it then treats the signal as a SIGKILL and does not gracefully shutdown.