### PR TITLE
[5.5] Move InteractsWithRedis to Illuminate\Foundation\Testing

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithRedis.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithRedis.php
@@ -1,21 +1,30 @@
 <?php
 
-namespace Illuminate\Tests\Redis;
+namespace Illuminate\Foundation\Testing\Concerns;
 
 use Illuminate\Redis\RedisManager;
 
 trait InteractsWithRedis
 {
     /**
+     * Indicate connection failed if redis is not available.
+     *
      * @var bool
      */
     private static $connectionFailedOnceWithDefaultsSkip = false;
 
     /**
-     * @var RedisManager[]
+     * Redis manager instance.
+     *
+     * @var \Illuminate\Redis\RedisManager[]
      */
     private $redis;
 
+    /**
+     * Setup redis connection.
+     *
+     * @return void
+     */
     public function setUpRedis()
     {
         $host = getenv('REDIS_HOST') ?: '127.0.0.1';
@@ -51,6 +60,11 @@ trait InteractsWithRedis
         }
     }
 
+    /**
+     * Teardown redis connection.
+     *
+     * @return void
+     */
     public function tearDownRedis()
     {
         $this->redis['predis']->connection()->flushdb();
@@ -60,6 +74,11 @@ trait InteractsWithRedis
         }
     }
 
+    /**
+     * Get redis driver provider.
+     *
+     * @return array
+     */
     public function redisDriverProvider()
     {
         $providers = [
@@ -73,6 +92,12 @@ trait InteractsWithRedis
         return $providers;
     }
 
+    /**
+     * Run test if redis is available.
+     *
+     * @param  callable  $callback
+     * @return void
+     */
     public function ifRedisAvailable($callback)
     {
         $this->setUpRedis();

--- a/tests/Cache/RedisCacheIntegrationTest.php
+++ b/tests/Cache/RedisCacheIntegrationTest.php
@@ -6,7 +6,7 @@ use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Cache\RedisStore;
 use Illuminate\Cache\Repository;
-use Illuminate\Tests\Redis\InteractsWithRedis;
+use Illuminate\Foundation\Testing\Concerns\InteractsWithRedis;
 
 class RedisCacheIntegrationTest extends TestCase
 {

--- a/tests/Integration/Cache/CacheLockTest.php
+++ b/tests/Integration/Cache/CacheLockTest.php
@@ -6,7 +6,7 @@ use Memcached;
 use Illuminate\Support\Carbon;
 use Orchestra\Testbench\TestCase;
 use Illuminate\Support\Facades\Cache;
-use Illuminate\Tests\Redis\InteractsWithRedis;
+use Illuminate\Foundation\Testing\Concerns\InteractsWithRedis;
 
 /**
  * @group integration

--- a/tests/Integration/Http/ThrottleRequestsWithRedisTest.php
+++ b/tests/Integration/Http/ThrottleRequestsWithRedisTest.php
@@ -6,8 +6,8 @@ use Throwable;
 use Illuminate\Support\Carbon;
 use Orchestra\Testbench\TestCase;
 use Illuminate\Support\Facades\Route;
-use Illuminate\Tests\Redis\InteractsWithRedis;
 use Illuminate\Routing\Middleware\ThrottleRequestsWithRedis;
+use Illuminate\Foundation\Testing\Concerns\InteractsWithRedis;
 
 /**
  * @group integration

--- a/tests/Queue/RedisQueueIntegrationTest.php
+++ b/tests/Queue/RedisQueueIntegrationTest.php
@@ -9,7 +9,7 @@ use Illuminate\Queue\RedisQueue;
 use Illuminate\Container\Container;
 use Illuminate\Queue\Jobs\RedisJob;
 use Illuminate\Support\InteractsWithTime;
-use Illuminate\Tests\Redis\InteractsWithRedis;
+use Illuminate\Foundation\Testing\Concerns\InteractsWithRedis;
 
 class RedisQueueIntegrationTest extends TestCase
 {

--- a/tests/Redis/ConcurrentLimiterTest.php
+++ b/tests/Redis/ConcurrentLimiterTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Redis;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Redis\Limiters\ConcurrencyLimiter;
 use Illuminate\Contracts\Redis\LimiterTimeoutException;
+use Illuminate\Foundation\Testing\Concerns\InteractsWithRedis;
 
 /**
  * @group redislimiters

--- a/tests/Redis/DurationLimiterTest.php
+++ b/tests/Redis/DurationLimiterTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Redis;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Redis\Limiters\DurationLimiter;
 use Illuminate\Contracts\Redis\LimiterTimeoutException;
+use Illuminate\Foundation\Testing\Concerns\InteractsWithRedis;
 
 /**
  * @group redislimiters

--- a/tests/Redis/RedisConnectionTest.php
+++ b/tests/Redis/RedisConnectionTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Redis;
 
 use PHPUnit\Framework\TestCase;
 use Illuminate\Redis\RedisManager;
+use Illuminate\Foundation\Testing\Concerns\InteractsWithRedis;
 
 class RedisConnectionTest extends TestCase
 {


### PR DESCRIPTION
This would allow the class to be reused not only for Laravel testing but
project that needs to depends on redis directly.

Signed-off-by: Mior Muhammad Zaki <crynobone@gmail.com>