### PR TITLE
[5.6] Allow closure sub queries in wherePivot method

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,6 @@ env:
 matrix:
   fast_finish: true
   include:
-    - php: 7.0.21
-    - php: 7.0.21
-      env: setup=lowest
     - php: 7.1
     - php: 7.1
       env: setup=lowest

--- a/CHANGELOG-5.5.md
+++ b/CHANGELOG-5.5.md
@@ -1,17 +1,25 @@
 # Release Notes for 5.5.x
 
-## [Unreleased]
+## v5.5.20 (2017-11-07)
 
 ### Added
 - Added `TestResponse::assertJsonMissingExact()` ([#21881](https://github.com/laravel/framework/pull/21881))
+- Added `assertValidationErrors()` and `assertJsonCount()` to `TestResponse` ([#21917](https://github.com/laravel/framework/pull/21917))
 - Added `allOnQueue()` and `allOnConnection()` for job chaining ([#21765](https://github.com/laravel/framework/pull/21765))
 - Support variadic arguments on fluent `Route::middleware()` ([#21930](https://github.com/laravel/framework/pull/21930))
 - Added precision to `Blueprint::time()` ([#21936](https://github.com/laravel/framework/pull/21936))
+- Added `Router::apiResources()` method ([#21956](https://github.com/laravel/framework/pull/21956))
+- Support graceful handling of `SIGTERM` in queue workers ([#21964](https://github.com/laravel/framework/pull/21964))
 
 ### Changed
 - Added "kin" as an uncountable word ([#21843](https://github.com/laravel/framework/pull/21843))
 - Improved geo spatial support ([#21919](https://github.com/laravel/framework/pull/21919))
 - Include job name in the `MaxAttemptsExcededException` ([#21941](https://github.com/laravel/framework/pull/21941), [#21943](https://github.com/laravel/framework/pull/21943))
+- Support rendering multiple `@verbatim` and `@php` blocks ([#21900](https://github.com/laravel/framework/pull/21900))
+- Moved `InteractsWithRedis` to `Illuminate\Foundation\Testing` ([#21967](https://github.com/laravel/framework/pull/21967))
+- Don't bind macro when it is not a `Closure` ([#21980](https://github.com/laravel/framework/pull/21980))
+- Check for `before()` method on policies classes ([#21989](https://github.com/laravel/framework/pull/21989))
+- Detect lost pgbouncer connections ([#21988](https://github.com/laravel/framework/pull/21988))
 
 ### Fixed
 - Fixed `BroadcastController` namespace issue ([#21844](https://github.com/laravel/framework/pull/21844))

--- a/composer.json
+++ b/composer.json
@@ -105,6 +105,8 @@
         }
     },
     "suggest": {
+        "ext-pcntl": "Required to use all features of the queue worker.",
+        "ext-posix": "Required to use all features of the queue worker.",
         "aws/aws-sdk-php": "Required to use the SQS queue driver and SES mail driver (~3.0).",
         "doctrine/dbal": "Required to rename columns and drop SQLite columns (~2.5).",
         "fzaninotto/faker": "Required to use the eloquent factory builder (~1.4).",

--- a/composer.json
+++ b/composer.json
@@ -75,7 +75,7 @@
         "doctrine/dbal": "~2.5",
         "filp/whoops": "^2.1.4",
         "mockery/mockery": "~1.0",
-        "orchestra/testbench-core": "3.5.*",
+        "orchestra/testbench-core": "3.6.*",
         "pda/pheanstalk": "~3.0",
         "phpunit/phpunit": "~6.0",
         "predis/predis": "^1.1.1",

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": ">=7.0",
+        "php": "^7.1.3",
         "ext-mbstring": "*",
         "ext-openssl": "*",
         "doctrine/inflector": "~1.1",

--- a/src/Illuminate/Auth/DatabaseUserProvider.php
+++ b/src/Illuminate/Auth/DatabaseUserProvider.php
@@ -109,6 +109,10 @@ class DatabaseUserProvider implements UserProvider
             }
         }
 
+        if (empty($query->wheres)) {
+            return;
+        }
+
         // Now we are ready to execute the query to see if we have an user matching
         // the given credentials. If not, we will just return nulls and indicate
         // that there are no matching users for these given credential arrays.

--- a/src/Illuminate/Auth/DatabaseUserProvider.php
+++ b/src/Illuminate/Auth/DatabaseUserProvider.php
@@ -109,10 +109,6 @@ class DatabaseUserProvider implements UserProvider
             }
         }
 
-        if (empty($query->wheres)) {
-            return;
-        }
-
         // Now we are ready to execute the query to see if we have an user matching
         // the given credentials. If not, we will just return nulls and indicate
         // that there are no matching users for these given credential arrays.

--- a/src/Illuminate/Auth/EloquentUserProvider.php
+++ b/src/Illuminate/Auth/EloquentUserProvider.php
@@ -116,10 +116,6 @@ class EloquentUserProvider implements UserProvider
             }
         }
 
-        if (empty($query->wheres)) {
-            return;
-        }
-
         return $query->first();
     }
 

--- a/src/Illuminate/Auth/EloquentUserProvider.php
+++ b/src/Illuminate/Auth/EloquentUserProvider.php
@@ -116,6 +116,10 @@ class EloquentUserProvider implements UserProvider
             }
         }
 
+        if (empty($query->wheres)) {
+            return;
+        }
+
         return $query->first();
     }
 

--- a/src/Illuminate/Auth/composer.json
+++ b/src/Illuminate/Auth/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": ">=7.0",
+        "php": "^7.1.3",
         "illuminate/contracts": "5.6.*",
         "illuminate/http": "5.6.*",
         "illuminate/queue": "5.6.*",

--- a/src/Illuminate/Broadcasting/composer.json
+++ b/src/Illuminate/Broadcasting/composer.json
@@ -15,6 +15,7 @@
     ],
     "require": {
         "php": ">=7.0",
+        "psr/log": "~1.0",
         "illuminate/bus": "5.5.*",
         "illuminate/contracts": "5.5.*",
         "illuminate/queue": "5.5.*",

--- a/src/Illuminate/Broadcasting/composer.json
+++ b/src/Illuminate/Broadcasting/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": ">=7.0",
+        "php": "^7.1.3",
         "illuminate/bus": "5.6.*",
         "illuminate/contracts": "5.6.*",
         "illuminate/queue": "5.6.*",

--- a/src/Illuminate/Bus/composer.json
+++ b/src/Illuminate/Bus/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": ">=7.0",
+        "php": "^7.1.3",
         "illuminate/contracts": "5.6.*",
         "illuminate/pipeline": "5.6.*",
         "illuminate/support": "5.6.*"

--- a/src/Illuminate/Cache/composer.json
+++ b/src/Illuminate/Cache/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": ">=7.0",
+        "php": "^7.1.3",
         "illuminate/contracts": "5.6.*",
         "illuminate/support": "5.6.*"
     },

--- a/src/Illuminate/Config/composer.json
+++ b/src/Illuminate/Config/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": ">=7.0",
+        "php": "^7.1.3",
         "illuminate/contracts": "5.6.*",
         "illuminate/support": "5.6.*"
     },

--- a/src/Illuminate/Console/composer.json
+++ b/src/Illuminate/Console/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": ">=7.0",
+        "php": "^7.1.3",
         "illuminate/contracts": "5.6.*",
         "illuminate/support": "5.6.*",
         "symfony/console": "~3.3"

--- a/src/Illuminate/Container/composer.json
+++ b/src/Illuminate/Container/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": ">=7.0",
+        "php": "^7.1.3",
         "illuminate/contracts": "5.6.*",
         "psr/container": "~1.0"
     },

--- a/src/Illuminate/Contracts/composer.json
+++ b/src/Illuminate/Contracts/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": ">=7.0",
+        "php": "^7.1.3",
         "psr/container": "~1.0",
         "psr/simple-cache": "~1.0"
     },

--- a/src/Illuminate/Cookie/composer.json
+++ b/src/Illuminate/Cookie/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": ">=7.0",
+        "php": "^7.1.3",
         "illuminate/contracts": "5.6.*",
         "illuminate/support": "5.6.*",
         "symfony/http-foundation": "~3.3",

--- a/src/Illuminate/Database/DetectsLostConnections.php
+++ b/src/Illuminate/Database/DetectsLostConnections.php
@@ -30,6 +30,7 @@ trait DetectsLostConnections
             'Resource deadlock avoided',
             'Transaction() on null',
             'child connection forced to terminate due to client_idle_limit',
+            'query_wait_timeout',
         ]);
     }
 }

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1254,12 +1254,12 @@ class Builder
             return $this->localMacros[$method](...$parameters);
         }
 
-        if (isset(static::$macros[$method]) and static::$macros[$method] instanceof Closure) {
-            return call_user_func_array(static::$macros[$method]->bindTo($this, static::class), $parameters);
-        }
-
         if (isset(static::$macros[$method])) {
-            return call_user_func_array(static::$macros[$method]->bindTo($this, static::class), $parameters);
+            if (static::$macros[$method] instanceof Closure) {
+                return call_user_func_array(static::$macros[$method]->bindTo($this, static::class), $parameters);
+            }
+
+            return call_user_func_array(static::$macros[$method], $parameters);
         }
 
         if (method_exists($this->model, $scope = 'scope'.ucfirst($method))) {

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -337,6 +337,7 @@ class BelongsToMany extends Relation
         $instance->getBaseQuery()->joins = null;
 
         static::$constraints = $contraints;
+
         return $instance;
     }
 

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -300,7 +300,7 @@ class BelongsToMany extends Relation
         if ($column instanceof Closure) {
             $query = $this->getModel()->newQueryWithoutScopes();
 
-            $column($this->freshInstanceForSubPivotQuery($query));
+            call_user_func($column, $this->freshInstanceForSubPivotQuery($query));
 
             $this->query->addNestedWhereQuery($query->getQuery(), $boolean);
 
@@ -320,25 +320,18 @@ class BelongsToMany extends Relation
      */
     protected function freshInstanceForSubPivotQuery($query)
     {
-        $contraints = static::$constraints;
-        static::$constraints = false;
-
-        $instance = new static(
-            $query,
-            $this->parent,
-            $this->table,
-            $this->foreignPivotKey,
-            $this->relatedPivotKey,
-            $this->parentKey,
-            $this->relatedKey,
-            $this->relationName
-        );
-
-        $instance->getBaseQuery()->joins = null;
-
-        static::$constraints = $contraints;
-
-        return $instance;
+        return $this->noConstraints(function () use ($query) {
+            return new static(
+                $query,
+                $this->parent,
+                $this->table,
+                $this->foreignPivotKey,
+                $this->relatedPivotKey,
+                $this->parentKey,
+                $this->relatedKey,
+                $this->relationName
+            );
+        });
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -321,7 +321,7 @@ class BelongsToMany extends Relation
     protected function freshInstanceForSubPivotQuery($query)
     {
         $contraints = static::$constraints;
-        static::$constraints = null;
+        static::$constraints = false;
 
         $instance = new static(
             $query,

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -300,7 +300,7 @@ class BelongsToMany extends Relation
         if ($column instanceof Closure) {
             $query = $this->getModel()->newQueryWithoutScopes();
 
-            $column($this->freshInstanceWithQuery($query));
+            $column($this->freshInstanceForSubPivotQuery($query));
 
             $this->query->addNestedWhereQuery($query->getQuery(), $boolean);
 
@@ -318,9 +318,12 @@ class BelongsToMany extends Relation
      * @param  \Illuminate\Database\Eloquent\Builder  $query
      * @return static
      */
-    protected function freshInstanceWithQuery($query)
+    protected function freshInstanceForSubPivotQuery($query)
     {
-        return new static(
+        $contraints = static::$constraints;
+        static::$constraints = null;
+
+        $instance = new static(
             $query,
             $this->parent,
             $this->table,
@@ -330,6 +333,11 @@ class BelongsToMany extends Relation
             $this->relatedKey,
             $this->relationName
         );
+
+        $instance->getBaseQuery()->joins = null;
+
+        static::$constraints = $contraints;
+        return $instance;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Database\Eloquent\Relations;
 
+use Closure;
 use Illuminate\Support\Str;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
@@ -288,7 +289,7 @@ class BelongsToMany extends Relation
     /**
      * Set a where clause for a pivot table column.
      *
-     * @param  string  $column
+     * @param  string  $column|\Closure
      * @param  string  $operator
      * @param  mixed   $value
      * @param  string  $boolean
@@ -296,9 +297,39 @@ class BelongsToMany extends Relation
      */
     public function wherePivot($column, $operator = null, $value = null, $boolean = 'and')
     {
+        if ($column instanceof Closure) {
+            $query = $this->getModel()->newQueryWithoutScopes();
+
+            $column($this->freshInstanceWithQuery($query));
+
+            $this->query->addNestedWhereQuery($query->getQuery(), $boolean);
+
+            return $this;
+        }
+
         $this->pivotWheres[] = func_get_args();
 
         return $this->where($this->table.'.'.$column, $operator, $value, $boolean);
+    }
+
+    /**
+     * Create a fresh instance with query.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @return static
+     */
+    protected function freshInstanceWithQuery($query)
+    {
+        return new static(
+            $query,
+            $this->parent,
+            $this->table,
+            $this->foreignPivotKey,
+            $this->relatedPivotKey,
+            $this->parentKey,
+            $this->relatedKey,
+            $this->relationName
+        );
     }
 
     /**

--- a/src/Illuminate/Database/composer.json
+++ b/src/Illuminate/Database/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": ">=7.0",
+        "php": "^7.1.3",
         "illuminate/container": "5.6.*",
         "illuminate/contracts": "5.6.*",
         "illuminate/support": "5.6.*"

--- a/src/Illuminate/Encryption/composer.json
+++ b/src/Illuminate/Encryption/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": ">=7.0",
+        "php": "^7.1.3",
         "ext-mbstring": "*",
         "ext-openssl": "*",
         "illuminate/contracts": "5.6.*",

--- a/src/Illuminate/Events/composer.json
+++ b/src/Illuminate/Events/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": ">=7.0",
+        "php": "^7.1.3",
         "illuminate/container": "5.6.*",
         "illuminate/contracts": "5.6.*",
         "illuminate/support": "5.6.*"

--- a/src/Illuminate/Filesystem/composer.json
+++ b/src/Illuminate/Filesystem/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": ">=7.0",
+        "php": "^7.1.3",
         "illuminate/contracts": "5.6.*",
         "illuminate/support": "5.6.*",
         "symfony/finder": "~3.3"

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -29,7 +29,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
      *
      * @var string
      */
-    const VERSION = '5.5.19';
+    const VERSION = '5.5.20';
 
     /**
      * The base path for the Laravel installation.

--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -278,26 +278,6 @@ class TestResponse
     }
 
     /**
-     * Assert that the response has validation errors for the given keys.
-     *
-     * @param string|array $keys
-     * @return $this
-     */
-    public function assertValidationErrors($keys)
-    {
-        $errors = $this->json()['errors'];
-
-        foreach (array_wrap($keys) as $key) {
-            PHPUnit::assertTrue(
-                isset($errors[$key]),
-                "Failed to find a validation error in the response for key: '{$key}'"
-            );
-        }
-
-        return $this;
-    }
-
-    /**
      * Assert that the response is a superset of the given JSON.
      *
      * @param  array  $data
@@ -308,32 +288,6 @@ class TestResponse
     {
         PHPUnit::assertArraySubset(
             $data, $this->decodeResponseJson(), $strict, $this->assertJsonMessage($data)
-        );
-
-        return $this;
-    }
-
-    /**
-     * Assert that the response json has the expected count.
-     *
-     * @param int $count
-     * @param string|null $key
-     * @return $this
-     */
-    public function assertJsonCount(int $count, $key = null)
-    {
-        if ($key) {
-            PHPUnit::assertCount($count,
-                $this->json()[$key],
-                "Failed to assert that the response count matched the expected {$count}"
-            );
-
-            return $this;
-        }
-
-        PHPUnit::assertCount($count,
-            $this->json(),
-            "Failed to assert that the response count matched the expected {$count}"
         );
 
         return $this;
@@ -492,6 +446,52 @@ class TestResponse
             } else {
                 PHPUnit::assertArrayHasKey($value, $responseData);
             }
+        }
+
+        return $this;
+    }
+
+    /**
+     * Assert that the response JSON has the expected count of items at the given key.
+     *
+     * @param int $count
+     * @param string|null $key
+     * @return $this
+     */
+    public function assertJsonCount(int $count, $key = null)
+    {
+        if ($key) {
+            PHPUnit::assertCount($count,
+                $this->json()[$key],
+                "Failed to assert that the response count matched the expected {$count}"
+            );
+
+            return $this;
+        }
+
+        PHPUnit::assertCount($count,
+            $this->json(),
+            "Failed to assert that the response count matched the expected {$count}"
+        );
+
+        return $this;
+    }
+
+    /**
+     * Assert that the response has the given JSON validation errors for the given keys.
+     *
+     * @param string|array $keys
+     * @return $this
+     */
+    public function assertJsonValidationErrors($keys)
+    {
+        $errors = $this->json()['errors'];
+
+        foreach (Arr::wrap($keys) as $key) {
+            PHPUnit::assertTrue(
+                isset($errors[$key]),
+                "Failed to find a validation error in the response for key: '{$key}'"
+            );
         }
 
         return $this;

--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -288,7 +288,7 @@ class TestResponse
     {
         $errors = $this->json()['errors'];
 
-        foreach(array_wrap($keys) as $key) {
+        foreach (array_wrap($keys) as $key) {
             PHPUnit::assertTrue(
                 isset($errors[$key]),
                 "Failed to find a validation error in the response for key: '{$key}'"

--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -322,7 +322,7 @@ class TestResponse
      */
     public function assertJsonCount(int $count, $key = null)
     {
-        if ( $key ) {
+        if ($key) {
             PHPUnit::assertCount($count,
                 $this->json()[$key],
                 "Failed to assert that the response count matched the expected {$count}"

--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -281,7 +281,6 @@ class TestResponse
      * Assert that the response has validation errors for the given keys.
      *
      * @param string|array $keys
-     *
      * @return $this
      */
     public function assertValidationErrors($keys)
@@ -316,12 +315,22 @@ class TestResponse
 
     /**
      * Assert that the response json has the expected count.
-     * @param int $count
      *
+     * @param int $count
+     * @param string|null $key
      * @return $this
      */
-    public function assertJsonCount(int $count)
+    public function assertJsonCount(int $count, $key = null)
     {
+        if ( $key ) {
+            PHPUnit::assertCount($count,
+                $this->json()[$key],
+                "Failed to assert that the response count matched the expected {$count}"
+            );
+
+            return $this;
+        }
+
         PHPUnit::assertCount($count,
             $this->json(),
             "Failed to assert that the response count matched the expected {$count}"

--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -278,6 +278,27 @@ class TestResponse
     }
 
     /**
+     * Assert that the response has validation errors for the given keys.
+     *
+     * @param string|array $keys
+     *
+     * @return $this
+     */
+    public function assertValidationErrors($keys)
+    {
+        $errors = $this->json()['errors'];
+
+        foreach(array_wrap($keys) as $key) {
+            PHPUnit::assertTrue(
+                isset($errors[$key]),
+                "Failed to find a validation error in the response for key: '{$key}'"
+            );
+        }
+
+        return $this;
+    }
+
+    /**
      * Assert that the response is a superset of the given JSON.
      *
      * @param  array  $data
@@ -288,6 +309,22 @@ class TestResponse
     {
         PHPUnit::assertArraySubset(
             $data, $this->decodeResponseJson(), $strict, $this->assertJsonMessage($data)
+        );
+
+        return $this;
+    }
+
+    /**
+     * Assert that the response json has the expected count.
+     * @param int $count
+     *
+     * @return $this
+     */
+    public function assertJsonCount(int $count)
+    {
+        PHPUnit::assertCount($count,
+            $this->json(),
+            "Failed to assert that the response count matched the expected {$count}"
         );
 
         return $this;

--- a/src/Illuminate/Hashing/composer.json
+++ b/src/Illuminate/Hashing/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": ">=7.0",
+        "php": "^7.1.3",
         "illuminate/contracts": "5.6.*",
         "illuminate/support": "5.6.*"
     },

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -12,9 +12,6 @@ use Illuminate\Contracts\Support\Arrayable;
 use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 
-/**
- * @method array validate(array $rules, array $messages = [], array $customAttributes = [])
- */
 class Request extends SymfonyRequest implements Arrayable, ArrayAccess
 {
     use Concerns\InteractsWithContentTypes,

--- a/src/Illuminate/Http/composer.json
+++ b/src/Illuminate/Http/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": ">=7.0",
+        "php": "^7.1.3",
         "illuminate/session": "5.6.*",
         "illuminate/support": "5.6.*",
         "symfony/http-foundation": "~3.3",

--- a/src/Illuminate/Log/composer.json
+++ b/src/Illuminate/Log/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": ">=7.0",
+        "php": "^7.1.3",
         "illuminate/contracts": "5.6.*",
         "illuminate/support": "5.6.*",
         "monolog/monolog": "~1.11"

--- a/src/Illuminate/Mail/composer.json
+++ b/src/Illuminate/Mail/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": ">=7.0",
+        "php": "^7.1.3",
         "erusev/parsedown": "~1.6",
         "illuminate/container": "5.6.*",
         "illuminate/contracts": "5.6.*",

--- a/src/Illuminate/Notifications/composer.json
+++ b/src/Illuminate/Notifications/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": ">=7.0",
+        "php": "^7.1.3",
         "illuminate/broadcasting": "5.6.*",
         "illuminate/bus": "5.6.*",
         "illuminate/container": "5.6.*",

--- a/src/Illuminate/Pagination/composer.json
+++ b/src/Illuminate/Pagination/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": ">=7.0",
+        "php": "^7.1.3",
         "illuminate/contracts": "5.6.*",
         "illuminate/support": "5.6.*"
     },

--- a/src/Illuminate/Pipeline/composer.json
+++ b/src/Illuminate/Pipeline/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": ">=7.0",
+        "php": "^7.1.3",
         "illuminate/contracts": "5.6.*",
         "illuminate/support": "5.6.*"
     },

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -84,7 +84,9 @@ class Worker
      */
     public function daemon($connectionName, $queue, WorkerOptions $options)
     {
-        $this->listenForSignals();
+        if ($this->supportsAsyncSignals()) {
+            $this->listenForSignals();
+        }
 
         $lastRestart = $this->getTimestampOfLastQueueRestart();
 
@@ -105,7 +107,9 @@ class Worker
                 $this->manager->connection($connectionName), $queue
             );
 
-            $this->registerTimeoutHandler($job, $options);
+            if ($this->supportsAsyncSignals()) {
+                $this->registerTimeoutHandler($job, $options);
+            }
 
             // If the daemon should run (not in maintenance mode, etc.), then we can run
             // fire off this job for processing. Otherwise, we will need to sleep the
@@ -124,7 +128,7 @@ class Worker
     }
 
     /**
-     * Register the worker timeout handler (PHP 7.1+).
+     * Register the worker timeout handler.
      *
      * @param  \Illuminate\Contracts\Queue\Job|null  $job
      * @param  \Illuminate\Queue\WorkerOptions  $options
@@ -132,18 +136,16 @@ class Worker
      */
     protected function registerTimeoutHandler($job, WorkerOptions $options)
     {
-        if ($this->supportsAsyncSignals()) {
-            // We will register a signal handler for the alarm signal so that we can kill this
-            // process if it is running too long because it has frozen. This uses the async
-            // signals supported in recent versions of PHP to accomplish it conveniently.
-            pcntl_signal(SIGALRM, function () {
-                $this->kill(1);
-            });
+        // We will register a signal handler for the alarm signal so that we can kill this
+        // process if it is running too long because it has frozen. This uses the async
+        // signals supported in recent versions of PHP to accomplish it conveniently.
+        pcntl_signal(SIGALRM, function () {
+            $this->kill(1);
+        });
 
-            pcntl_alarm(
-                max($this->timeoutForJob($job, $options), 0)
-            );
-        }
+        pcntl_alarm(
+            max($this->timeoutForJob($job, $options), 0)
+        );
     }
 
     /**
@@ -506,21 +508,19 @@ class Worker
      */
     protected function listenForSignals()
     {
-        if ($this->supportsAsyncSignals()) {
-            pcntl_async_signals(true);
+        pcntl_async_signals(true);
 
-            pcntl_signal(SIGTERM, function () {
-                $this->shouldQuit = true;
-            });
+        pcntl_signal(SIGTERM, function () {
+            $this->shouldQuit = true;
+        });
 
-            pcntl_signal(SIGUSR2, function () {
-                $this->paused = true;
-            });
+        pcntl_signal(SIGUSR2, function () {
+            $this->paused = true;
+        });
 
-            pcntl_signal(SIGCONT, function () {
-                $this->paused = false;
-            });
-        }
+        pcntl_signal(SIGCONT, function () {
+            $this->paused = false;
+        });
     }
 
     /**
@@ -530,8 +530,7 @@ class Worker
      */
     protected function supportsAsyncSignals()
     {
-        return version_compare(PHP_VERSION, '7.1.0') >= 0 &&
-               extension_loaded('pcntl');
+        return extension_loaded('pcntl');
     }
 
     /**

--- a/src/Illuminate/Queue/composer.json
+++ b/src/Illuminate/Queue/composer.json
@@ -35,6 +35,8 @@
         }
     },
     "suggest": {
+        "ext-pcntl": "Required to use all features of the queue worker.",
+        "ext-posix": "Required to use all features of the queue worker.",
         "aws/aws-sdk-php": "Required to use the SQS queue driver (~3.0).",
         "illuminate/redis": "Required to use the Redis queue driver (5.5.*).",
         "pda/pheanstalk": "Required to use the Beanstalk queue driver (~3.0)."

--- a/src/Illuminate/Queue/composer.json
+++ b/src/Illuminate/Queue/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": ">=7.0",
+        "php": "^7.1.3",
         "illuminate/console": "5.6.*",
         "illuminate/container": "5.6.*",
         "illuminate/contracts": "5.6.*",

--- a/src/Illuminate/Redis/composer.json
+++ b/src/Illuminate/Redis/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": ">=7.0",
+        "php": "^7.1.3",
         "illuminate/contracts": "5.6.*",
         "illuminate/support": "5.6.*",
         "predis/predis": "~1.0"

--- a/src/Illuminate/Routing/composer.json
+++ b/src/Illuminate/Routing/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": ">=7.0",
+        "php": "^7.1.3",
         "illuminate/container": "5.6.*",
         "illuminate/contracts": "5.6.*",
         "illuminate/http": "5.6.*",

--- a/src/Illuminate/Session/composer.json
+++ b/src/Illuminate/Session/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": ">=7.0",
+        "php": "^7.1.3",
         "illuminate/contracts": "5.6.*",
         "illuminate/filesystem": "5.6.*",
         "illuminate/support": "5.6.*",

--- a/src/Illuminate/Support/composer.json
+++ b/src/Illuminate/Support/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": ">=7.0",
+        "php": "^7.1.3",
         "ext-mbstring": "*",
         "doctrine/inflector": "~1.1",
         "illuminate/contracts": "5.6.*",

--- a/src/Illuminate/Translation/composer.json
+++ b/src/Illuminate/Translation/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": ">=7.0",
+        "php": "^7.1.3",
         "illuminate/contracts": "5.6.*",
         "illuminate/filesystem": "5.6.*",
         "illuminate/support": "5.6.*"

--- a/src/Illuminate/Validation/composer.json
+++ b/src/Illuminate/Validation/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": ">=7.0",
+        "php": "^7.1.3",
         "illuminate/container": "5.6.*",
         "illuminate/contracts": "5.6.*",
         "illuminate/support": "5.6.*",

--- a/src/Illuminate/View/composer.json
+++ b/src/Illuminate/View/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": ">=7.0",
+        "php": "^7.1.3",
         "illuminate/container": "5.6.*",
         "illuminate/contracts": "5.6.*",
         "illuminate/events": "5.6.*",

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -389,7 +389,12 @@ class DatabaseEloquentBuilderTest extends TestCase
             return $bar;
         });
 
-        $this->assertEquals($this->getBuilder()->foo('bar'), 'bar');
+        Builder::macro('bam', [Builder::class, 'getQuery']);
+
+        $builder = $this->getBuilder();
+
+        $this->assertEquals($builder->foo('bar'), 'bar');
+        $this->assertEquals($builder->bam(), $builder->getQuery());
     }
 
     public function testGetModelsProperlyHydratesModels()

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -1085,6 +1085,18 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertEquals('Jule Doe', $johnWithFriends->friends->find(4)->pivot->friend->name);
     }
 
+    public function testWherePivotWithClosureOnBelongsToManyPrefixesPivotTable()
+    {
+        $expected = (new EloquentTestUser)->roles()->where(function ($query) {
+            $query->where('eloquent_test_user_role.pivot_table_column', 'Illuminate');
+        });
+        $result = (new EloquentTestUser)->roles()->wherePivot(function ($query) {
+            $query->wherePivot('pivot_table_column', 'Illuminate');
+        });
+
+        $this->assertEquals($expected, $result);
+    }
+
     public function testIsAfterRetrievingTheSameModel()
     {
         $saved = EloquentTestUser::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']);
@@ -1208,6 +1220,16 @@ class EloquentTestUser extends Eloquent
             $join->where('photo.imageable_type', 'EloquentTestPost');
         });
     }
+
+    public function roles()
+    {
+        return $this->belongsToMany(Role::class);
+    }
+}
+
+class Role extends Eloquent
+{
+    //
 }
 
 class EloquentTestUserWithCustomFriendPivot extends EloquentTestUser

--- a/tests/Integration/Database/EloquentBelongsToManyWherePivotQueriesTest.php
+++ b/tests/Integration/Database/EloquentBelongsToManyWherePivotQueriesTest.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\EloquentBelongsToManyWherePivotQueriesTest;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Carbon;
+use Orchestra\Testbench\TestCase;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * @group integration
+ */
+class EloquentBelongsToManyWherePivotQueriesTest extends TestCase
+{
+    protected function getEnvironmentSetUp($app)
+    {
+        $app['config']->set('app.debug', 'true');
+
+        $app['config']->set('database.default', 'testbench');
+
+        $app['config']->set('database.connections.testbench', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+        ]);
+    }
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        Schema::create('posts', function ($table) {
+            $table->increments('id');
+            $table->string('title');
+            $table->string('flag')->default('');
+            $table->timestamps();
+        });
+
+        Schema::create('tags', function ($table) {
+            $table->increments('id');
+            $table->string('name');
+            $table->timestamps();
+        });
+
+        Schema::create('posts_tags', function ($table) {
+            $table->integer('post_id');
+            $table->integer('tag_id');
+            $table->string('flag')->default('');
+            $table->timestamps();
+        });
+
+        Carbon::setTestNow(null);
+    }
+
+    /**
+     * @test
+     */
+    public function basic_create_and_retrieve()
+    {
+        Carbon::setTestNow(
+            Carbon::createFromFormat('Y-m-d H:i:s', '2017-10-10 10:10:10')
+        );
+
+        $post = Post::create(['title' => str_random()]);
+
+        $tag = Tag::create(['name' => str_random()]);
+        $tag2 = Tag::create(['name' => str_random()]);
+
+        $post->tags()->sync([
+            $tag->id => ['flag' => 'taylor'],
+            $tag2->id => ['flag' => 'mohamed'],
+        ]);
+
+        $results = $post->tags()->wherePivot(function($q){
+            return $q->wherePivot('flag', 'taylor');
+        })->first();
+
+        $this->assertEquals($results->id, $tag->id);
+    }
+}
+
+class Post extends Model
+{
+    public $table = 'posts';
+    public $timestamps = true;
+    protected $guarded = ['id'];
+
+    public function tags()
+    {
+        return $this->belongsToMany(Tag::class, 'posts_tags', 'post_id', 'tag_id')
+            ->withPivot('flag');
+    }
+}
+
+class Tag extends Model
+{
+    public $table = 'tags';
+    public $timestamps = true;
+    protected $guarded = ['id'];
+
+    public function posts()
+    {
+        return $this->belongsToMany(Post::class, 'posts_tags', 'tag_id', 'post_id');
+    }
+}


### PR DESCRIPTION
Previous discussion: https://github.com/laravel/internals/issues/742

**TLDR;** This allows sub queries for `wherePivot` using a closure to avoid ambiguous column collisions.

---

There is an issue where working with pivot table queries can lead to ambiguous column names in sub queries unless the table name is prefixed.

This introduces the same closure based sub queries that `where` allows for `wherePivot`. This is nice as when calling `where` with a closure the query passed to the closure is no longer a `BelongsToMany` relation, thus the `wherePivot` method is not available within the sub query.

Previously:

``` php
$this->ceremonies()
     ->wherePivot('submissions_open_at', '<', Carbon::now())
     ->where(function ($query) {
         $query->where($this->ceremonies()->getTable().'.submissions_close_at', '>', Carbon::now())
             ->orWhere($this->ceremonies()->getTable().'.payments_close_at', '>', Carbon::now())
             ->orWhere($this->ceremonies()->getTable().'.uploads_close_at', '>', Carbon::now());
     });
```

With this PR:

``` php
$this->ceremonies()
     ->wherePivot('submissions_open_at', '<', Carbon::now())
     ->wherePivot(function ($query) {
         $query->wherePivot('submissions_close_at', '>', Carbon::now())
             ->orWherePivot('payments_close_at', '>', Carbon::now())
             ->orWherePivot('uploads_close_at', '>', Carbon::now());
     });
```

This will now prepend the column names with the pivot table name automatically.
