### PR TITLE
[5.6] Updated comments in service provider stub

### DIFF
--- a/src/Illuminate/Foundation/Console/stubs/provider.stub
+++ b/src/Illuminate/Foundation/Console/stubs/provider.stub
@@ -7,7 +7,7 @@ use Illuminate\Support\ServiceProvider;
 class DummyClass extends ServiceProvider
 {
     /**
-     * Bootstrap the application services.
+     * Bootstrap services.
      *
      * @return void
      */
@@ -17,7 +17,7 @@ class DummyClass extends ServiceProvider
     }
 
     /**
-     * Register the application services.
+     * Register services.
      *
      * @return void
      */


### PR DESCRIPTION
Currently, after generation of a fresh service provider file with an Artisan "make" command, it is telling (in docblocks) to register and boot services for the whole application. It is now a little bit confusing, because usually the service provider is about a certain service (not the whole application). A stub file looks copied from a default `AppServiceProvider`.

This PR clarify comments docblocks in service provider stub - they are no more referencing the whole application. 