### PR TITLE
[5.5] Add support for float values to str_plural()

### DIFF
--- a/src/Illuminate/Support/Pluralizer.php
+++ b/src/Illuminate/Support/Pluralizer.php
@@ -58,12 +58,12 @@ class Pluralizer
      * Get the plural form of an English word.
      *
      * @param  string  $value
-     * @param  int     $count
+     * @param  float|int  $count
      * @return string
      */
     public static function plural($value, $count = 2)
     {
-        if ((int) $count === 1 || static::uncountable($value)) {
+        if ($count == 1 || static::uncountable($value)) {
             return $value;
         }
 

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -268,7 +268,7 @@ class Str
      * Get the plural form of an English word.
      *
      * @param  string  $value
-     * @param  int     $count
+     * @param  float|int  $count
      * @return string
      */
     public static function plural($value, $count = 2)

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -894,7 +894,7 @@ if (! function_exists('str_plural')) {
      * Get the plural form of an English word.
      *
      * @param  string  $value
-     * @param  int     $count
+     * @param  float|int  $count
      * @return string
      */
     function str_plural($value, $count = 2)

--- a/tests/Support/SupportPluralizerTest.php
+++ b/tests/Support/SupportPluralizerTest.php
@@ -17,6 +17,26 @@ class SupportPluralizerTest extends TestCase
         $this->assertEquals('children', Str::plural('child'));
     }
 
+    public function testPlural()
+    {
+        $this->assertEquals('unit', Str::plural('unit', 1));
+
+        $this->assertEquals('units', Str::plural('unit', 0));
+        $this->assertEquals('units', Str::plural('unit', -1));
+
+        $this->assertEquals('units', Str::plural('unit', 0.1));
+        $this->assertEquals('units', Str::plural('unit', 0.9));
+        $this->assertEquals('units', Str::plural('unit', 1.1));
+        $this->assertEquals('units', Str::plural('unit', 1.9));
+        $this->assertEquals('units', Str::plural('unit', 2));
+
+        $this->assertEquals('units', Str::plural('unit', -0.1));
+        $this->assertEquals('units', Str::plural('unit', -0.9));
+        $this->assertEquals('units', Str::plural('unit', -1.1));
+        $this->assertEquals('units', Str::plural('unit', -1.9));
+        $this->assertEquals('units', Str::plural('unit', -2));
+    }
+
     public function testCaseSensitiveSingularUsage()
     {
         $this->assertEquals('Child', Str::singular('Children'));


### PR DESCRIPTION
Example real-world scenario:

```php
$remaining = 1.3;
echo 'You have ' . $remaining . ' ' . str_plural('gigabyte', $remaining) . ' of space remaining on your account.';

// Current behavior:
>>> You have 1.3 gigabyte of space remaining on your account.

// After this PR:
>>> You have 1.3 gigabytes of space remaining on your account.
```

This will make the behavior the [same as Rails](https://github.com/rails/rails/blob/master/activesupport/lib/active_support/core_ext/string/inflections.rb):

```ruby
> 'unit'.pluralize(1) # The only one that returns singular
 => "unit"

> 'unit'.pluralize(0)
 => "units"
> 'unit'.pluralize(-1)
 => "units"
> 'unit'.pluralize(0.1)
 => "units"
> 'unit'.pluralize(0.9)
 => "units"
> 'unit'.pluralize(1.1)
 => "units"
> 'unit'.pluralize(1.9)
 => "units"
> 'unit'.pluralize(2)
 => "units"
> 'unit'.pluralize(-0.1)
 => "units"
> 'unit'.pluralize(-0.9)
 => "units"
> 'unit'.pluralize(-1.1)
 => "units"
> 'unit'.pluralize(-1.9)
 => "units"
> 'unit'.pluralize(-2)
 => "units"
```
