### PR TITLE
[5.5] Return null if no conditional credentials are passed to UserProvider

### DIFF
--- a/src/Illuminate/Auth/DatabaseUserProvider.php
+++ b/src/Illuminate/Auth/DatabaseUserProvider.php
@@ -109,6 +109,10 @@ class DatabaseUserProvider implements UserProvider
             }
         }
 
+        if (empty($query->wheres)) {
+            return;
+        }
+
         // Now we are ready to execute the query to see if we have an user matching
         // the given credentials. If not, we will just return nulls and indicate
         // that there are no matching users for these given credential arrays.

--- a/src/Illuminate/Auth/EloquentUserProvider.php
+++ b/src/Illuminate/Auth/EloquentUserProvider.php
@@ -116,6 +116,10 @@ class EloquentUserProvider implements UserProvider
             }
         }
 
+        if (empty($query->wheres)) {
+            return;
+        }
+
         return $query->first();
     }
 


### PR DESCRIPTION
When using the `retrieveByCredentials` method, if only the password is used as a credential, the first user in the table is returned.

The initial clause checking if `$credentials` is empty gets bypassed if only the `password` credential is passed. We should return null if no "wheres" are appended to the query.