### PR TITLE
[5.5] Show available presets when type argument is omitted or invalid

### DIFF
--- a/src/Illuminate/Foundation/Console/PresetCommand.php
+++ b/src/Illuminate/Foundation/Console/PresetCommand.php
@@ -15,7 +15,7 @@ class PresetCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'preset { type : The preset type (none, bootstrap, vue, react) }';
+    protected $signature = 'preset { type? : The preset type. Omit to show all presets. }';
 
     /**
      * The console command description.
@@ -35,8 +35,10 @@ class PresetCommand extends Command
             return call_user_func(static::$macros[$this->argument('type')], $this);
         }
 
-        if (! in_array($this->argument('type'), ['none', 'bootstrap', 'vue', 'react'])) {
-            throw new InvalidArgumentException('Invalid preset.');
+        $presets = array_merge(['none', 'bootstrap', 'vue', 'react'], array_keys(static::$macros));
+
+        if (! in_array($this->argument('type'), $presets)) {
+            throw new InvalidArgumentException('Invalid preset. Available presets are: '.implode($presets, ', '));
         }
 
         return $this->{$this->argument('type')}();


### PR DESCRIPTION
This changes the signature for the preset command and returns the available preset types (also all the macroed ones) when an invalid preset type is entered or omitted.

For example when you have `laravel-frontend-presets/zurb-foundation` installed, and `php artisan preset` is called, the command would return:

```
[InvalidArgumentException]
  Invalid preset. Available presets are: none, bootstrap, vue, react, foundation, foundation-auth
```

This would also be returned when people intuitively would type `php artisan preset list`.