### PR TITLE
[5.6] Cast to object before json_encoding

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -951,7 +951,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public function toJson($options = 0)
     {
-        $json = json_encode($this->jsonSerialize(), $options);
+        $json = json_encode((object) $this->jsonSerialize(), $options);
 
         if (JSON_ERROR_NONE !== json_last_error()) {
             throw JsonEncodingException::forModel($this, json_last_error_msg());

--- a/src/Illuminate/Support/Fluent.php
+++ b/src/Illuminate/Support/Fluent.php
@@ -83,7 +83,7 @@ class Fluent implements ArrayAccess, Arrayable, Jsonable, JsonSerializable
      */
     public function toJson($options = 0)
     {
-        return json_encode($this->jsonSerialize(), $options);
+        return json_encode((object) $this->jsonSerialize(), $options);
     }
 
     /**

--- a/src/Illuminate/Support/MessageBag.php
+++ b/src/Illuminate/Support/MessageBag.php
@@ -380,7 +380,7 @@ class MessageBag implements Arrayable, Countable, Jsonable, JsonSerializable, Me
      */
     public function toJson($options = 0)
     {
-        return json_encode($this->jsonSerialize(), $options);
+        return json_encode((object) $this->jsonSerialize(), $options);
     }
 
     /**

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -856,6 +856,13 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertArrayNotHasKey('age', $array);
     }
 
+    public function testToJsonReturnsEmptyJsonObjectWhenAttributesEmpty()
+    {
+        $model = new EloquentModelStub;
+
+        $this->assertEquals('{}', $model->toJson());
+    }
+
     public function testFillable()
     {
         $model = new EloquentModelStub;

--- a/tests/Support/SupportFluentTest.php
+++ b/tests/Support/SupportFluentTest.php
@@ -107,10 +107,17 @@ class SupportFluentTest extends TestCase
     public function testToJsonEncodesTheToArrayResult()
     {
         $fluent = $this->getMockBuilder('Illuminate\Support\Fluent')->setMethods(['toArray'])->getMock();
-        $fluent->expects($this->once())->method('toArray')->will($this->returnValue('foo'));
+        $fluent->expects($this->once())->method('toArray')->will($this->returnValue(['foo' => 'bar']));
         $results = $fluent->toJson();
 
-        $this->assertJsonStringEqualsJsonString(json_encode('foo'), $results);
+        $this->assertJsonStringEqualsJsonString(json_encode(['foo' => 'bar']), $results);
+    }
+
+    public function testToJsonReturnsEmptyJsonObjectWhenAttributesEmpty()
+    {
+        $fluent = new Fluent([]);
+
+        $this->assertEquals('{}', $fluent->toJson());
     }
 }
 

--- a/tests/Support/SupportMessageBagTest.php
+++ b/tests/Support/SupportMessageBagTest.php
@@ -189,6 +189,8 @@ class SupportMessageBagTest extends TestCase
     public function testMessageBagReturnsExpectedJson()
     {
         $container = new MessageBag;
+        $this->assertEquals('{}', $container->toJson());
+
         $container->setFormat(':message');
         $container->add('foo', 'bar');
         $container->add('boom', 'baz');


### PR DESCRIPTION
It is an implicit contract that the data of these 3 `Jsonable` implementations is a key-value structure. However, when this data is the empty array, the `toJson` method, as implemented, returns `[]` instead of the expected `{}`. This cast to object prevents breaking said contract, ensuring the resulting JSON represents an object.