### PR TITLE
[5.5] Standard deviation for collections

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1416,7 +1416,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Calculate the standard deviation of the collection.
      *
-     * @param  callable|null  $callback
+     * @param  callable|string|null  $callback
      * @param  bool  $sample
      * @return  float
      */

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1414,6 +1414,45 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
+     * Calculate the standard deviation of the collection.
+     *
+     * @param  callable|null  $callback
+     * @param  bool  $sample
+     * @return  float
+     */
+    public function stDev($callback = null, $sample = false)
+    {
+        $n = $this->count();
+        if ($n === 0 || $n === 1) {
+            return 0.0;
+        }
+        $carry = 0.0;
+
+        if (is_null($callback)) {
+            $mean = $this->avg();
+            foreach ($this->items as $val) {
+                $d = ((float) $val) - $mean;
+                $carry += $d * $d;
+            }
+        }else {
+            $mean = $this->avg($callback);
+            $callback = $this->valueRetriever($callback);
+
+            foreach ($this->items as $key =>$val) {
+                $val = $callback($val);
+                $d = ((float) $val) - $mean;
+                $carry += $d * $d;
+            }
+        }
+        if ($sample) {
+            --$n;
+        }
+
+        return sqrt($carry / $n);
+    }
+
+
+    /**
      * Get the sum of the given values.
      *
      * @param  callable|string|null  $callback

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1216,6 +1216,63 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(['baz'], $cut->all());
     }
 
+    public function testStDevIsZeroWhenNoItems()
+    {
+        $data = new Collection();
+        $this->assertEquals(0.0,$data->stDev());
+    }
+    public function testStDevIsZeroWhenOneItem()
+    {
+        $data = new Collection([7]);
+        $this->assertEquals(0.0,$data->stDev());
+    }
+
+    public function testStDev()
+    {
+        $data = new Collection([5,5,6,6]);
+        $this->assertEquals(0.5, $data->stDev());
+        $this->assertEquals(
+            0.577350,
+            $data->stDev(null,true),
+            'Sample standard dev should be 0.577350',
+            0.000001);
+    }
+
+    public function testStDevWithCallBack()
+    {
+        $data = new Collection([['foo' => 5], ['foo' => 5], ['foo' => 6], ['foo' => 6]]);
+
+        $this->assertEquals(0.5, $data->stDev('foo'));
+        $this->assertEquals(0.577350,
+            $data->stDev('foo', true),
+            'Sample standard dev should be 0.577350',
+            0.000001);
+    }
+
+    public function testStDevWithObject()
+    {
+        $data = new Collection([ (object) ['foo' => 5], (object) ['foo' => 5], (object) ['foo' => 6], (object) ['foo' => 6]]);
+
+        $stDev = $data->stDev(function($i) {
+            return $i->foo;
+        });
+        $this->assertEquals(0.5, $stDev);
+    }
+    public function testStDevWithObjectAsSample()
+    {
+        $data = new Collection([ (object) ['foo' => 5], (object) ['foo' => 5], (object) ['foo' => 6], (object) ['foo' => 6]]);
+
+        $stDev = $data->stDev(function($i) {
+            return $i->foo;
+        },true);
+        $this->assertEquals(
+            0.577350,
+            $stDev,
+            'Sample stDev should be 0.577350',
+            0.000001
+        );
+    }
+
     public function testGetPluckValueWithAccessors()
     {
         $model = new TestAccessorEloquentTestStub(['some' => 'foo']);


### PR DESCRIPTION
This PR adds a ```stDev()``` function to collections which allows it to calculate the standard deviation.

It follows the same pattern as other functions like ```sum()``` meaning that it takes either no arguments, a string, or an anonymous function.