### PR TITLE
Add a `str_wrap()` helper method

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -373,7 +373,7 @@ class Str
     /**
      * Wraps a string with a given value.
      *
-     * @param  string  $values
+     * @param  string  $value
      * @param  string  $wrap
      * @param  bool    $escape
      * @return string

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -369,6 +369,20 @@ class Str
 
         return $prefix.preg_replace('/^(?:'.$quoted.')+/u', '', $value);
     }
+    
+    /**
+     * Wraps a string with a given value.
+     *
+     * @param  string  $values
+     * @param  string  $wrap
+     * @param  bool    $escape
+     * @return string
+     */
+    public static function wrap($value, $wrap, $escape)
+    {
+        $value = $escape ? addslashes($value) : $value;
+        return $wrap.$value.$wrap;
+    }
 
     /**
      * Convert the given string to upper-case.

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -1011,11 +1011,12 @@ if (! function_exists('str_wrap')) {
      *
      * @param  string  $value
      * @param  string  $wrap
+     * @param  bool    $escape
      * @return string
      */
-    function str_wrap($value, $wrap = '"')
+    function str_wrap($value, $wrap = '"', $escape = false)
     {
-        return Str::wrap($value, $wrap);
+        return Str::wrap($value, $wrap, $escape);
     }
 }
 

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -1005,6 +1005,20 @@ if (! function_exists('str_start')) {
     }
 }
 
+if (! function_exists('str_wrap')) {
+    /**
+     * Wrap a string with a given value.
+     *
+     * @param  string  $value
+     * @param  string  $wrap
+     * @return string
+     */
+    function str_wrap($value, $wrap = '"')
+    {
+        return Str::wrap($value, $wrap);
+    }
+}
+
 if (! function_exists('studly_case')) {
     /**
      * Convert a value to studly caps case.


### PR DESCRIPTION
I had a look for a method like this in the docs earlier, but couldn't find a method to do it.

I find the standard PHP way of doing it a bit messy (example from a project I'm working on at the moment, getting user emails into a CSV file):
```PHP
User::all()->map(function ($user) {
    return "\"$user->email\"";
})->implode("\n");
```

This PR adds in a `str_wrap()` method that allows you to wrap a given value in another string, which could convert the above snippet to:
```PHP
User::all()->map(function ($user) {
    return str_wrap($user->email, '"');
})->implode("\n");
```

The `str_wrap()` helper and underlying `Illuminate\Support\Str::wrap()` function also take a third parameter, `$escape`, to escape any slashes in the string being wrapped.

I've seen before that helper methods like these don't often get merged as they're often quite project-specific tools, but I feel this would be a well used helper method.

I'm happy to PR the docs as well if you're happy with this PR.

The method looks like this, with `$wrap` defaulting to `"`, and `$escape` defaulting to `false`:
#### ```str_wrap(string $string, string $wrap, bool $escape)```

