### PR TITLE
Make `assertSentTimes` public

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -49,7 +49,7 @@ class MailFake implements Mailer
      * @param  int  $times
      * @return void
      */
-    protected function assertSentTimes($mailable, $times = 1)
+    public function assertSentTimes($mailable, $times = 1)
     {
         PHPUnit::assertTrue(
             ($count = $this->sent($mailable)->count()) === $times,


### PR DESCRIPTION
I'd like to be able to use this method in my own tests.