### PR TITLE
[5.5] standard deviation added with tests

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -166,6 +166,42 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
+     * Get the standard deviation of a given key.
+     *
+     * @param  null $key
+     * @return mixed
+     */
+    public function stddev($key = null)
+    {
+        $count = $this->count();
+
+        if ($count == 0) {
+            return;
+        }
+
+        $values = (isset($key) ? $this->pluck($key) : $this)
+            ->values();
+
+        $mean = $values->average();
+        $deviations = $values->map(function($value) use ($mean) {
+            return pow($value - $mean, 2);
+        });
+
+        return sqrt($deviations->sum() / $count);
+    }
+
+    /**
+     * Alias for the "stddev" method.
+     *
+     * @param  null $key
+     * @return mixed
+     */
+    public function standardDeviation($key = null)
+    {
+        $this->stddev($key);
+    }
+
+    /**
      * Get the mode of a given key.
      *
      * @param  mixed  $key

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -198,7 +198,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      */
     public function standardDeviation($key = null)
     {
-        $this->stddev($key);
+        return $this->stddev($key);
     }
 
     /**

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2063,6 +2063,30 @@ class SupportCollectionTest extends TestCase
         $this->assertNull($collection->median());
     }
 
+    public function testStdDevValueWithArrayCollection()
+    {
+        $collection = new Collection([1, 2, 2, 4]);
+
+        $this->assertEquals(1.0897247358851685, $collection->stdDev());
+    }
+
+    public function testStdDevValueByKey()
+    {
+        $collection = new Collection([
+            (object) ['foo' => 1],
+            (object) ['foo' => 2],
+            (object) ['foo' => 2],
+            (object) ['foo' => 4],
+        ]);
+        $this->assertEquals(1.0897247358851685, $collection->stdDev('foo'));
+    }
+
+    public function testStdDevOnEmptyCollectionReturnsNull()
+    {
+        $collection = new Collection;
+        $this->assertNull($collection->stdDev());
+    }
+
     public function testModeOnNullCollection()
     {
         $collection = new Collection;

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2063,14 +2063,14 @@ class SupportCollectionTest extends TestCase
         $this->assertNull($collection->median());
     }
 
-    public function testStdDevValueWithArrayCollection()
+    public function testStddevValueWithArrayCollection()
     {
         $collection = new Collection([1, 2, 2, 4]);
 
         $this->assertEquals(1.0897247358851685, $collection->stdDev());
     }
 
-    public function testStdDevValueByKey()
+    public function testStddevValueByKey()
     {
         $collection = new Collection([
             (object) ['foo' => 1],
@@ -2081,7 +2081,7 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(1.0897247358851685, $collection->stdDev('foo'));
     }
 
-    public function testStdDevOnEmptyCollectionReturnsNull()
+    public function testStddevOnEmptyCollectionReturnsNull()
     {
         $collection = new Collection;
         $this->assertNull($collection->stdDev());


### PR DESCRIPTION
Ref: https://github.com/laravel/internals/issues/866

Name looks ugly but the same terminology (stddev)  is used in databases. I have also provided an alias for those who consider it ugly (same case as `avg()`)

Have also left out the closure option as suggested in proposal. 

Cheers