### PR TITLE
[5.6] Temporal columns improvements (broken by GitHub)

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -811,11 +811,12 @@ class Blueprint
      * Create a new time column (with time zone) on the table.
      *
      * @param  string  $column
+     * @param  int  $precision
      * @return \Illuminate\Support\Fluent
      */
-    public function timeTz($column)
+    public function timeTz($column, $precision = 0)
     {
-        return $this->addColumn('timeTz', $column);
+        return $this->addColumn('timeTz', $column, compact('precision'));
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -784,7 +784,7 @@ class Blueprint
     }
 
     /**
-     * Create a new date-time column (with time zone) on the table.
+     * Create a new date-time (with time zone) column on the table.
      *
      * @param  string  $column
      * @param  int  $precision
@@ -808,7 +808,7 @@ class Blueprint
     }
 
     /**
-     * Create a new time column (with time zone) on the table.
+     * Create a new time (with time zone) column on the table.
      *
      * @param  string  $column
      * @param  int  $precision
@@ -844,7 +844,7 @@ class Blueprint
     }
 
     /**
-     * Add nullable creation and update timestamps to the table.
+     * Add nullable creation and update timestamps columns to the table.
      *
      * @param  int  $precision
      * @return void
@@ -857,7 +857,7 @@ class Blueprint
     }
 
     /**
-     * Add nullable creation and update timestamps to the table.
+     * Add nullable creation and update timestamps columns to the table.
      *
      * Alias for self::timestamps().
      *
@@ -870,7 +870,7 @@ class Blueprint
     }
 
     /**
-     * Add creation and update timestampTz columns to the table.
+     * Add nullable creation and update timestamps (with time zone) columns to the table.
      *
      * @param  int  $precision
      * @return void
@@ -883,7 +883,7 @@ class Blueprint
     }
 
     /**
-     * Add a "deleted at" timestamp for the table.
+     * Add a nullable deletion timestamp column to the table.
      *
      * @param  string  $column
      * @param  int  $precision
@@ -895,7 +895,7 @@ class Blueprint
     }
 
     /**
-     * Add a "deleted at" timestampTz for the table.
+     * Add a nullable deletion timestamp (with time zone) column to the table.
      *
      * @param  int  $precision
      * @return \Illuminate\Support\Fluent

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -4,6 +4,7 @@ namespace Illuminate\Database\Schema\Grammars;
 
 use Illuminate\Support\Fluent;
 use Illuminate\Database\Connection;
+use Illuminate\Database\Query\Expression;
 use Illuminate\Database\Schema\Blueprint;
 
 class MySqlGrammar extends Grammar
@@ -582,6 +583,8 @@ class MySqlGrammar extends Grammar
      */
     protected function typeDate(Fluent $column)
     {
+        $this->parseTemporalType($column);
+
         return 'date';
     }
 
@@ -593,6 +596,8 @@ class MySqlGrammar extends Grammar
      */
     protected function typeDateTime(Fluent $column)
     {
+        $this->parseTemporalType($column);
+
         return $column->precision ? "datetime($column->precision)" : 'datetime';
     }
 
@@ -615,6 +620,8 @@ class MySqlGrammar extends Grammar
      */
     protected function typeTime(Fluent $column)
     {
+        $this->parseTemporalType($column);
+
         return $column->precision ? "time($column->precision)" : 'time';
     }
 
@@ -637,9 +644,9 @@ class MySqlGrammar extends Grammar
      */
     protected function typeTimestamp(Fluent $column)
     {
-        $type = $column->precision ? "timestamp($column->precision)" : 'timestamp';
+        $this->parseTemporalType($column);
 
-        return $column->useCurrent ? "$type default CURRENT_TIMESTAMP" : $type;
+        return $column->precision ? "timestamp($column->precision)" : 'timestamp';
     }
 
     /**
@@ -783,6 +790,26 @@ class MySqlGrammar extends Grammar
     public function typeMultiPolygon(Fluent $column)
     {
         return 'multipolygon';
+    }
+
+    /**
+     * Parse the default value for a temporal column type.
+     *
+     * @param  \Illuminate\Support\Fluent  $column
+     * @return void
+     */
+    protected function parseTemporalType(Fluent &$column)
+    {
+        if ($column->useCurrent) {
+            switch ($column->type) {
+                case 'dateTime':
+                case 'dateTimeTz':
+                case 'timestamp':
+                case 'timestampTz':
+                    $column->default = new Expression('CURRENT_TIMESTAMP');
+                    break;
+            }
+        }
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -615,7 +615,7 @@ class MySqlGrammar extends Grammar
      */
     protected function typeTime(Fluent $column)
     {
-        return 'time';
+        return $column->precision ? "time($column->precision)" : 'time';
     }
 
     /**
@@ -637,13 +637,9 @@ class MySqlGrammar extends Grammar
      */
     protected function typeTimestamp(Fluent $column)
     {
-        if ($column->useCurrent) {
-            return $column->precision
-                    ? "timestamp($column->precision) default CURRENT_TIMESTAMP"
-                    : 'timestamp default CURRENT_TIMESTAMP';
-        }
+        $type = $column->precision ? "timestamp($column->precision)" : 'timestamp';
 
-        return $column->precision ? "timestamp($column->precision)" : 'timestamp';
+        return $column->useCurrent ? "$type default CURRENT_TIMESTAMP" : $type;
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -626,7 +626,7 @@ class MySqlGrammar extends Grammar
      */
     protected function typeTimeTz(Fluent $column)
     {
-        return 'time';
+        return $this->typeTime($column);
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -602,7 +602,7 @@ class MySqlGrammar extends Grammar
     }
 
     /**
-     * Create the column definition for a date-time type.
+     * Create the column definition for a date-time (with time zone) type.
      *
      * @param  \Illuminate\Support\Fluent  $column
      * @return string
@@ -626,7 +626,7 @@ class MySqlGrammar extends Grammar
     }
 
     /**
-     * Create the column definition for a time type.
+     * Create the column definition for a time (with time zone) type.
      *
      * @param  \Illuminate\Support\Fluent  $column
      * @return string
@@ -650,7 +650,7 @@ class MySqlGrammar extends Grammar
     }
 
     /**
-     * Create the column definition for a timestamp type.
+     * Create the column definition for a timestamp (with time zone) type.
      *
      * @param  \Illuminate\Support\Fluent  $column
      * @return string
@@ -794,6 +794,8 @@ class MySqlGrammar extends Grammar
 
     /**
      * Parse the default value for a temporal column type.
+     *
+     * @see  https://dev.mysql.com/doc/refman/5.7/en/timestamp-initialization.html
      *
      * @param  \Illuminate\Support\Fluent  $column
      * @return void

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -551,7 +551,7 @@ class PostgresGrammar extends Grammar
     }
 
     /**
-     * Create the column definition for a date-time type.
+     * Create the column definition for a date-time (with time zone) type.
      *
      * @param  \Illuminate\Support\Fluent  $column
      * @return string
@@ -575,7 +575,7 @@ class PostgresGrammar extends Grammar
     }
 
     /**
-     * Create the column definition for a time type.
+     * Create the column definition for a time (with time zone) type.
      *
      * @param  \Illuminate\Support\Fluent  $column
      * @return string
@@ -601,7 +601,7 @@ class PostgresGrammar extends Grammar
     }
 
     /**
-     * Create the column definition for a timestamp type.
+     * Create the column definition for a timestamp (with time zone) type.
      *
      * @param  \Illuminate\Support\Fluent  $column
      * @return string
@@ -758,6 +758,8 @@ class PostgresGrammar extends Grammar
 
     /**
      * Parse the default value for a temporal column type.
+     *
+     * @see  https://www.postgresql.org/docs/10/static/functions-datetime.html#functions-datetime-current
      *
      * @param  \Illuminate\Support\Fluent  $column
      * @return void

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -544,7 +544,7 @@ class PostgresGrammar extends Grammar
      */
     protected function typeDateTime(Fluent $column)
     {
-        return "timestamp($column->precision) without time zone";
+        return $this->typeTimestamp($column);
     }
 
     /**
@@ -555,7 +555,7 @@ class PostgresGrammar extends Grammar
      */
     protected function typeDateTimeTz(Fluent $column)
     {
-        return "timestamp($column->precision) with time zone";
+        return $this->typeTimestampTz($column);
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -566,7 +566,7 @@ class PostgresGrammar extends Grammar
      */
     protected function typeTime(Fluent $column)
     {
-        return 'time(0) without time zone';
+        return sprintf('time(%d) without time zone', $column->precision ?: 0);
     }
 
     /**
@@ -577,7 +577,7 @@ class PostgresGrammar extends Grammar
      */
     protected function typeTimeTz(Fluent $column)
     {
-        return 'time(0) with time zone';
+        return sprintf('time(%d) with time zone', $column->precision ?: 0);
     }
 
     /**
@@ -588,11 +588,9 @@ class PostgresGrammar extends Grammar
      */
     protected function typeTimestamp(Fluent $column)
     {
-        if ($column->useCurrent) {
-            return "timestamp($column->precision) without time zone default CURRENT_TIMESTAMP($column->precision)";
-        }
+        $type = sprintf('timestamp(%d) without time zone', $column->precision ?: 0);
 
-        return "timestamp($column->precision) without time zone";
+        return $column->useCurrent ? "$type default CURRENT_TIMESTAMP" : $type;
     }
 
     /**
@@ -603,11 +601,9 @@ class PostgresGrammar extends Grammar
      */
     protected function typeTimestampTz(Fluent $column)
     {
-        if ($column->useCurrent) {
-            return "timestamp($column->precision) with time zone default CURRENT_TIMESTAMP($column->precision)";
-        }
+        $type = sprintf('timestamp(%d) with time zone', $column->precision ?: 0);
 
-        return "timestamp($column->precision) with time zone";
+        return $column->useCurrent ? "$type default CURRENT_TIMESTAMP" : $type;
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -553,7 +553,7 @@ class SQLiteGrammar extends Grammar
      */
     protected function typeDateTime(Fluent $column)
     {
-        return 'datetime';
+        return $column->useCurrent ? 'datetime default CURRENT_TIMESTAMP' : 'datetime';
     }
 
     /**
@@ -567,7 +567,7 @@ class SQLiteGrammar extends Grammar
      */
     protected function typeDateTimeTz(Fluent $column)
     {
-        return 'datetime';
+        return $this->typeDateTime($column);
     }
 
     /**
@@ -589,7 +589,7 @@ class SQLiteGrammar extends Grammar
      */
     protected function typeTimeTz(Fluent $column)
     {
-        return 'time';
+        return $this->typeTime($column);
     }
 
     /**
@@ -600,11 +600,7 @@ class SQLiteGrammar extends Grammar
      */
     protected function typeTimestamp(Fluent $column)
     {
-        if ($column->useCurrent) {
-            return 'datetime default CURRENT_TIMESTAMP';
-        }
-
-        return 'datetime';
+        return $this->typeDateTime($column);
     }
 
     /**
@@ -615,11 +611,7 @@ class SQLiteGrammar extends Grammar
      */
     protected function typeTimestampTz(Fluent $column)
     {
-        if ($column->useCurrent) {
-            return 'datetime default CURRENT_TIMESTAMP';
-        }
-
-        return 'datetime';
+        return $this->typeDateTimeTz($column);
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -551,6 +551,10 @@ class SQLiteGrammar extends Grammar
     /**
      * Create the column definition for a date-time type.
      *
+     * Note: SQLite does not have a storage class set aside for storing dates and/or times.
+     *
+     * @see  https://www.sqlite.org/datatype3.html
+     *
      * @param  \Illuminate\Support\Fluent  $column
      * @return string
      */
@@ -562,10 +566,7 @@ class SQLiteGrammar extends Grammar
     }
 
     /**
-     * Create the column definition for a date-time type.
-     *
-     * Note: "SQLite does not have a storage class set aside for storing dates and/or times."
-     * @link https://www.sqlite.org/datatype3.html
+     * Create the column definition for a date-time (with time zone) type.
      *
      * @param  \Illuminate\Support\Fluent  $column
      * @return string
@@ -578,6 +579,10 @@ class SQLiteGrammar extends Grammar
     /**
      * Create the column definition for a time type.
      *
+     * Note: SQLite does not have a storage class set aside for storing dates and/or times.
+     *
+     * @see  https://www.sqlite.org/datatype3.html
+     *
      * @param  \Illuminate\Support\Fluent  $column
      * @return string
      */
@@ -589,7 +594,7 @@ class SQLiteGrammar extends Grammar
     }
 
     /**
-     * Create the column definition for a time type.
+     * Create the column definition for a time (with time zone) type.
      *
      * @param  \Illuminate\Support\Fluent  $column
      * @return string
@@ -602,6 +607,10 @@ class SQLiteGrammar extends Grammar
     /**
      * Create the column definition for a timestamp type.
      *
+     * Note: SQLite does not have a storage class set aside for storing dates and/or times.
+     *
+     * @see  https://www.sqlite.org/datatype3.html
+     *
      * @param  \Illuminate\Support\Fluent  $column
      * @return string
      */
@@ -611,7 +620,7 @@ class SQLiteGrammar extends Grammar
     }
 
     /**
-     * Create the column definition for a timestamp type.
+     * Create the column definition for a timestamp (with time zone) type.
      *
      * @param  \Illuminate\Support\Fluent  $column
      * @return string
@@ -755,6 +764,8 @@ class SQLiteGrammar extends Grammar
 
     /**
      * Parse the default value for a temporal column type.
+     *
+     * @see  https://www.sqlite.org/lang_createtable.html#tablecoldef
      *
      * @param  \Illuminate\Support\Fluent  $column
      * @return void

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -496,13 +496,9 @@ class SqlServerGrammar extends Grammar
      */
     protected function typeDateTime(Fluent $column)
     {
-        if ($column->useCurrent) {
-            return $column->precision
-                ? "datetime2($column->precision) default CURRENT_TIMESTAMP"
-                : 'datetime default CURRENT_TIMESTAMP';
-        }
+        $type = sprintf('datetime2(%d)', $column->precision ?: 0);
 
-        return $column->precision ? "datetime2($column->precision)" : 'datetime';
+        return $column->useCurrent ? "$type default CURRENT_TIMESTAMP" : $type;
     }
 
     /**
@@ -513,13 +509,9 @@ class SqlServerGrammar extends Grammar
      */
     protected function typeDateTimeTz(Fluent $column)
     {
-        if ($column->useCurrent) {
-            return $column->precision
-                ? "datetimeoffset($column->precision) default CURRENT_TIMESTAMP"
-                : 'datetimeoffset default CURRENT_TIMESTAMP';
-        }
+        $type = sprintf('datetimeoffset(%s)', $column->precision ?: 0);
 
-        return "datetimeoffset($column->precision)";
+        return $column->useCurrent ? "$type default CURRENT_TIMESTAMP" : $type;
     }
 
     /**
@@ -530,7 +522,7 @@ class SqlServerGrammar extends Grammar
      */
     protected function typeTime(Fluent $column)
     {
-        return 'time';
+        return sprintf('time(%d)', $column->precision ?: 0);
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -505,7 +505,7 @@ class SqlServerGrammar extends Grammar
     }
 
     /**
-     * Create the column definition for a date-time type.
+     * Create the column definition for a date-time (with time zone) type.
      *
      * @param  \Illuminate\Support\Fluent  $column
      * @return string
@@ -531,7 +531,7 @@ class SqlServerGrammar extends Grammar
     }
 
     /**
-     * Create the column definition for a time type.
+     * Create the column definition for a time (with time zone) type.
      *
      * @param  \Illuminate\Support\Fluent  $column
      * @return string
@@ -553,9 +553,7 @@ class SqlServerGrammar extends Grammar
     }
 
     /**
-     * Create the column definition for a timestamp type.
-     *
-     * @link https://msdn.microsoft.com/en-us/library/bb630289(v=sql.120).aspx
+     * Create the column definition for a timestamp (with time zone) type.
      *
      * @param  \Illuminate\Support\Fluent  $column
      * @return string
@@ -699,6 +697,8 @@ class SqlServerGrammar extends Grammar
 
     /**
      * Parse the default value for a temporal column type.
+     *
+     * @see  https://docs.microsoft.com/en-us/sql/t-sql/statements/create-table-transact-sql#default-definitions
      *
      * @param  \Illuminate\Support\Fluent  $column
      * @return void

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -496,6 +496,12 @@ class SqlServerGrammar extends Grammar
      */
     protected function typeDateTime(Fluent $column)
     {
+        if ($column->useCurrent) {
+            return $column->precision
+                ? "datetime2($column->precision) default CURRENT_TIMESTAMP"
+                : 'datetime default CURRENT_TIMESTAMP';
+        }
+
         return $column->precision ? "datetime2($column->precision)" : 'datetime';
     }
 
@@ -507,7 +513,13 @@ class SqlServerGrammar extends Grammar
      */
     protected function typeDateTimeTz(Fluent $column)
     {
-        return $column->precision ? "datetimeoffset($column->precision)" : 'datetimeoffset';
+        if ($column->useCurrent) {
+            return $column->precision
+                ? "datetimeoffset($column->precision) default CURRENT_TIMESTAMP"
+                : 'datetimeoffset default CURRENT_TIMESTAMP';
+        }
+
+        return "datetimeoffset($column->precision)";
     }
 
     /**
@@ -529,7 +541,7 @@ class SqlServerGrammar extends Grammar
      */
     protected function typeTimeTz(Fluent $column)
     {
-        return 'time';
+        return $this->typeTime($column);
     }
 
     /**
@@ -540,13 +552,7 @@ class SqlServerGrammar extends Grammar
      */
     protected function typeTimestamp(Fluent $column)
     {
-        if ($column->useCurrent) {
-            return $column->precision
-                    ? "datetime2($column->precision) default CURRENT_TIMESTAMP"
-                    : 'datetime default CURRENT_TIMESTAMP';
-        }
-
-        return $column->precision ? "datetime2($column->precision)" : 'datetime';
+        return $this->typeDateTime($column);
     }
 
     /**
@@ -559,13 +565,7 @@ class SqlServerGrammar extends Grammar
      */
     protected function typeTimestampTz(Fluent $column)
     {
-        if ($column->useCurrent) {
-            return $column->precision
-                    ? "datetimeoffset($column->precision) default CURRENT_TIMESTAMP"
-                    : 'datetimeoffset default CURRENT_TIMESTAMP';
-        }
-
-        return "datetimeoffset($column->precision)";
+        return $this->typeDateTimeTz($column);
     }
 
     /**

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -735,7 +735,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $blueprint->timestamp('created_at')->useCurrent();
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals("alter table `users` add `created_at` timestamp not null default CURRENT_TIMESTAMP", $statements[0]);
+        $this->assertEquals('alter table `users` add `created_at` timestamp not null default CURRENT_TIMESTAMP', $statements[0]);
     }
 
     public function testAddingTimestampTz()
@@ -759,7 +759,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $blueprint->timestampTz('created_at')->useCurrent();
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals("alter table `users` add `created_at` timestamp not null default CURRENT_TIMESTAMP", $statements[0]);
+        $this->assertEquals('alter table `users` add `created_at` timestamp not null default CURRENT_TIMESTAMP', $statements[0]);
     }
 
     public function testAddingTimestamps()

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -609,6 +609,15 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table `users` add `created_at` date not null', $statements[0]);
     }
 
+    public function testAddingDateWithCurrentAsDefault()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->date('created_at')->useCurrent();
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table `users` add `created_at` date not null', $statements[0]);
+    }
+
     public function testAddingDateTime()
     {
         $blueprint = new Blueprint('users');
@@ -622,6 +631,15 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
         $this->assertEquals('alter table `users` add `created_at` datetime(1) not null', $statements[0]);
+    }
+
+    public function testAddingDateTimeWithCurrentAsDefault()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->dateTime('created_at')->useCurrent();
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table `users` add `created_at` datetime not null default CURRENT_TIMESTAMP', $statements[0]);
     }
 
     public function testAddingDateTimeTz()
@@ -639,6 +657,15 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table `users` add `created_at` datetime(1) not null', $statements[0]);
     }
 
+    public function testAddingDateTimeTzWithCurrentAsDefault()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->dateTimeTz('created_at')->useCurrent();
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table `users` add `created_at` datetime not null default CURRENT_TIMESTAMP', $statements[0]);
+    }
+
     public function testAddingTime()
     {
         $blueprint = new Blueprint('users');
@@ -652,6 +679,15 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
         $this->assertEquals('alter table `users` add `created_at` time(1) not null', $statements[0]);
+    }
+
+    public function testAddingTimeWithCurrentAsDefault()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->time('created_at')->useCurrent();
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table `users` add `created_at` time not null', $statements[0]);
     }
 
     public function testAddingTimeTz()
@@ -669,6 +705,15 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table `users` add `created_at` time(1) not null', $statements[0]);
     }
 
+    public function testAddingTimeTzWithCurrentAsDefault()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->timeTz('created_at')->useCurrent();
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table `users` add `created_at` time not null', $statements[0]);
+    }
+
     public function testAddingTimestamp()
     {
         $blueprint = new Blueprint('users');
@@ -684,19 +729,13 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table `users` add `created_at` timestamp(1) not null', $statements[0]);
     }
 
-    public function testAddingTimestampWithDefault()
+    public function testAddingTimestampWithCurrentAsDefault()
     {
         $blueprint = new Blueprint('users');
-        $blueprint->timestamp('created_at')->default('2015-07-22 11:43:17');
+        $blueprint->timestamp('created_at')->useCurrent();
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals("alter table `users` add `created_at` timestamp not null default '2015-07-22 11:43:17'", $statements[0]);
-
-        $blueprint = new Blueprint('users');
-        $blueprint->timestamp('created_at', 1)->default('2015-07-22 11:43:17');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
-        $this->assertCount(1, $statements);
-        $this->assertEquals("alter table `users` add `created_at` timestamp(1) not null default '2015-07-22 11:43:17'", $statements[0]);
+        $this->assertEquals("alter table `users` add `created_at` timestamp not null default CURRENT_TIMESTAMP", $statements[0]);
     }
 
     public function testAddingTimestampTz()
@@ -714,19 +753,13 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table `users` add `created_at` timestamp(1) not null', $statements[0]);
     }
 
-    public function testAddingTimestampTzWithDefault()
+    public function testAddingTimestampTzWithCurrentAsDefault()
     {
         $blueprint = new Blueprint('users');
-        $blueprint->timestampTz('created_at')->default('2015-07-22 11:43:17');
+        $blueprint->timestampTz('created_at')->useCurrent();
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals("alter table `users` add `created_at` timestamp not null default '2015-07-22 11:43:17'", $statements[0]);
-
-        $blueprint = new Blueprint('users');
-        $blueprint->timestampTz('created_at', 1)->default('2015-07-22 11:43:17');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
-        $this->assertCount(1, $statements);
-        $this->assertEquals("alter table `users` add `created_at` timestamp(1) not null default '2015-07-22 11:43:17'", $statements[0]);
+        $this->assertEquals("alter table `users` add `created_at` timestamp not null default CURRENT_TIMESTAMP", $statements[0]);
     }
 
     public function testAddingTimestamps()

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -602,150 +602,191 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
     public function testAddingDate()
     {
         $blueprint = new Blueprint('users');
-        $blueprint->date('foo');
+        $blueprint->date('created_at');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add `foo` date not null', $statements[0]);
+        $this->assertEquals('alter table `users` add `created_at` date not null', $statements[0]);
     }
 
     public function testAddingDateTime()
     {
         $blueprint = new Blueprint('users');
-        $blueprint->dateTime('foo');
+        $blueprint->dateTime('created_at');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add `foo` datetime not null', $statements[0]);
+        $this->assertEquals('alter table `users` add `created_at` datetime not null', $statements[0]);
 
         $blueprint = new Blueprint('users');
-        $blueprint->dateTime('foo', 1);
+        $blueprint->dateTime('created_at', 1);
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add `foo` datetime(1) not null', $statements[0]);
+        $this->assertEquals('alter table `users` add `created_at` datetime(1) not null', $statements[0]);
     }
 
     public function testAddingDateTimeTz()
     {
         $blueprint = new Blueprint('users');
-        $blueprint->dateTimeTz('foo', 1);
+        $blueprint->dateTimeTz('created_at');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add `foo` datetime(1) not null', $statements[0]);
+        $this->assertEquals('alter table `users` add `created_at` datetime not null', $statements[0]);
 
         $blueprint = new Blueprint('users');
-        $blueprint->dateTimeTz('foo');
+        $blueprint->dateTimeTz('created_at', 1);
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add `foo` datetime not null', $statements[0]);
+        $this->assertEquals('alter table `users` add `created_at` datetime(1) not null', $statements[0]);
     }
 
     public function testAddingTime()
     {
         $blueprint = new Blueprint('users');
-        $blueprint->time('foo');
+        $blueprint->time('created_at');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add `foo` time not null', $statements[0]);
+        $this->assertEquals('alter table `users` add `created_at` time not null', $statements[0]);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->time('created_at', 1);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table `users` add `created_at` time(1) not null', $statements[0]);
     }
 
     public function testAddingTimeTz()
     {
         $blueprint = new Blueprint('users');
-        $blueprint->timeTz('foo');
+        $blueprint->timeTz('created_at');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
-
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add `foo` time not null', $statements[0]);
+        $this->assertEquals('alter table `users` add `created_at` time not null', $statements[0]);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->timeTz('created_at', 1);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table `users` add `created_at` time(1) not null', $statements[0]);
     }
 
-    public function testAddingTimeStamp()
+    public function testAddingTimestamp()
     {
         $blueprint = new Blueprint('users');
-        $blueprint->timestamp('foo', 1);
+        $blueprint->timestamp('created_at');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add `foo` timestamp(1) not null', $statements[0]);
+        $this->assertEquals('alter table `users` add `created_at` timestamp not null', $statements[0]);
 
         $blueprint = new Blueprint('users');
-        $blueprint->timestamp('foo');
+        $blueprint->timestamp('created_at', 1);
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add `foo` timestamp not null', $statements[0]);
+        $this->assertEquals('alter table `users` add `created_at` timestamp(1) not null', $statements[0]);
     }
 
-    public function testAddingTimeStampWithDefault()
+    public function testAddingTimestampWithDefault()
     {
         $blueprint = new Blueprint('users');
-        $blueprint->timestamp('foo', 1)->default('2015-07-22 11:43:17');
+        $blueprint->timestamp('created_at')->default('2015-07-22 11:43:17');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add `foo` timestamp(1) not null default \'2015-07-22 11:43:17\'', $statements[0]);
+        $this->assertEquals("alter table `users` add `created_at` timestamp not null default '2015-07-22 11:43:17'", $statements[0]);
 
         $blueprint = new Blueprint('users');
-        $blueprint->timestamp('foo')->default('2015-07-22 11:43:17');
+        $blueprint->timestamp('created_at', 1)->default('2015-07-22 11:43:17');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add `foo` timestamp not null default \'2015-07-22 11:43:17\'', $statements[0]);
+        $this->assertEquals("alter table `users` add `created_at` timestamp(1) not null default '2015-07-22 11:43:17'", $statements[0]);
     }
 
-    public function testAddingTimeStampTz()
+    public function testAddingTimestampTz()
     {
         $blueprint = new Blueprint('users');
-        $blueprint->timestampTz('foo', 1);
+        $blueprint->timestampTz('created_at');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add `foo` timestamp(1) not null', $statements[0]);
+        $this->assertEquals('alter table `users` add `created_at` timestamp not null', $statements[0]);
 
         $blueprint = new Blueprint('users');
-        $blueprint->timestampTz('foo');
+        $blueprint->timestampTz('created_at', 1);
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add `foo` timestamp not null', $statements[0]);
+        $this->assertEquals('alter table `users` add `created_at` timestamp(1) not null', $statements[0]);
     }
 
-    public function testAddingTimeStampTzWithDefault()
+    public function testAddingTimestampTzWithDefault()
     {
         $blueprint = new Blueprint('users');
-        $blueprint->timestampTz('foo', 1)->default('2015-07-22 11:43:17');
+        $blueprint->timestampTz('created_at')->default('2015-07-22 11:43:17');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add `foo` timestamp(1) not null default \'2015-07-22 11:43:17\'', $statements[0]);
+        $this->assertEquals("alter table `users` add `created_at` timestamp not null default '2015-07-22 11:43:17'", $statements[0]);
 
         $blueprint = new Blueprint('users');
-        $blueprint->timestampTz('foo')->default('2015-07-22 11:43:17');
+        $blueprint->timestampTz('created_at', 1)->default('2015-07-22 11:43:17');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add `foo` timestamp not null default \'2015-07-22 11:43:17\'', $statements[0]);
+        $this->assertEquals("alter table `users` add `created_at` timestamp(1) not null default '2015-07-22 11:43:17'", $statements[0]);
     }
 
-    public function testAddingTimeStamps()
+    public function testAddingTimestamps()
     {
-        $blueprint = new Blueprint('users');
-        $blueprint->timestamps(1);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
-        $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add `created_at` timestamp(1) null, add `updated_at` timestamp(1) null', $statements[0]);
-
         $blueprint = new Blueprint('users');
         $blueprint->timestamps();
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
         $this->assertEquals('alter table `users` add `created_at` timestamp null, add `updated_at` timestamp null', $statements[0]);
-    }
 
-    public function testAddingTimeStampsTz()
-    {
         $blueprint = new Blueprint('users');
-        $blueprint->timestampsTz(1);
+        $blueprint->timestamps(1);
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
         $this->assertEquals('alter table `users` add `created_at` timestamp(1) null, add `updated_at` timestamp(1) null', $statements[0]);
+    }
 
+    public function testAddingTimestampsTz()
+    {
         $blueprint = new Blueprint('users');
         $blueprint->timestampsTz();
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
         $this->assertEquals('alter table `users` add `created_at` timestamp null, add `updated_at` timestamp null', $statements[0]);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->timestampsTz(1);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table `users` add `created_at` timestamp(1) null, add `updated_at` timestamp(1) null', $statements[0]);
+    }
+
+    public function testAddingSoftDeletes()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->softDeletes();
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table `users` add `deleted_at` timestamp null', $statements[0]);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->softDeletes('deleted_at', 1);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table `users` add `deleted_at` timestamp(1) null', $statements[0]);
+    }
+
+    public function testAddingSoftDeletesTz()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->softDeletesTz();
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table `users` add `deleted_at` timestamp null', $statements[0]);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->softDeletesTz(1);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table `users` add `deleted_at` timestamp(1) null', $statements[0]);
     }
 
     public function testAddingRememberToken()

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -426,16 +426,6 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add column "foo" varchar(255) check ("foo" in (\'bar\', \'baz\')) not null', $statements[0]);
     }
 
-    public function testAddingDate()
-    {
-        $blueprint = new Blueprint('users');
-        $blueprint->date('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
-
-        $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "foo" date not null', $statements[0]);
-    }
-
     public function testAddingJson()
     {
         $blueprint = new Blueprint('users');
@@ -456,84 +446,164 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add column "foo" jsonb not null', $statements[0]);
     }
 
-    public function testAddingDateTime()
+    public function testAddingDate()
     {
         $blueprint = new Blueprint('users');
-        $blueprint->dateTime('foo');
+        $blueprint->date('created_at');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "foo" timestamp(0) without time zone not null', $statements[0]);
+        $this->assertEquals('alter table "users" add column "created_at" date not null', $statements[0]);
+    }
+
+    public function testAddingDateTime()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->dateTime('created_at');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table "users" add column "created_at" timestamp(0) without time zone not null', $statements[0]);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->dateTime('created_at', 1);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table "users" add column "created_at" timestamp(1) without time zone not null', $statements[0]);
     }
 
     public function testAddingDateTimeTz()
     {
         $blueprint = new Blueprint('users');
-        $blueprint->dateTimeTz('foo');
+        $blueprint->dateTimeTz('created_at');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
-
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "foo" timestamp(0) with time zone not null', $statements[0]);
+        $this->assertEquals('alter table "users" add column "created_at" timestamp(0) with time zone not null', $statements[0]);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->dateTimeTz('created_at', 1);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table "users" add column "created_at" timestamp(1) with time zone not null', $statements[0]);
     }
 
     public function testAddingTime()
     {
         $blueprint = new Blueprint('users');
-        $blueprint->time('foo');
+        $blueprint->time('created_at');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
-
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "foo" time(0) without time zone not null', $statements[0]);
+        $this->assertEquals('alter table "users" add column "created_at" time(0) without time zone not null', $statements[0]);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->time('created_at', 1);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table "users" add column "created_at" time(1) without time zone not null', $statements[0]);
     }
 
     public function testAddingTimeTz()
     {
         $blueprint = new Blueprint('users');
-        $blueprint->timeTz('foo');
+        $blueprint->timeTz('created_at');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
-
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "foo" time(0) with time zone not null', $statements[0]);
+        $this->assertEquals('alter table "users" add column "created_at" time(0) with time zone not null', $statements[0]);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->timeTz('created_at', 1);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table "users" add column "created_at" time(1) with time zone not null', $statements[0]);
     }
 
-    public function testAddingTimeStamp()
+    public function testAddingTimestamp()
     {
         $blueprint = new Blueprint('users');
-        $blueprint->timestamp('foo');
+        $blueprint->timestamp('created_at');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
-
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "foo" timestamp(0) without time zone not null', $statements[0]);
+        $this->assertEquals('alter table "users" add column "created_at" timestamp(0) without time zone not null', $statements[0]);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->timestamp('created_at', 1);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table "users" add column "created_at" timestamp(1) without time zone not null', $statements[0]);
     }
 
-    public function testAddingTimeStampTz()
+    public function testAddingTimestampTz()
     {
         $blueprint = new Blueprint('users');
-        $blueprint->timestampTz('foo');
+        $blueprint->timestampTz('created_at');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
-
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "foo" timestamp(0) with time zone not null', $statements[0]);
+        $this->assertEquals('alter table "users" add column "created_at" timestamp(0) with time zone not null', $statements[0]);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->timestampTz('created_at', 1);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table "users" add column "created_at" timestamp(1) with time zone not null', $statements[0]);
     }
 
-    public function testAddingTimeStamps()
+    public function testAddingTimestamps()
     {
         $blueprint = new Blueprint('users');
         $blueprint->timestamps();
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
-
         $this->assertCount(1, $statements);
         $this->assertEquals('alter table "users" add column "created_at" timestamp(0) without time zone null, add column "updated_at" timestamp(0) without time zone null', $statements[0]);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->timestamps(1);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table "users" add column "created_at" timestamp(1) without time zone null, add column "updated_at" timestamp(1) without time zone null', $statements[0]);
     }
 
-    public function testAddingTimeStampsTz()
+    public function testAddingTimestampsTz()
     {
         $blueprint = new Blueprint('users');
         $blueprint->timestampsTz();
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
-
         $this->assertCount(1, $statements);
         $this->assertEquals('alter table "users" add column "created_at" timestamp(0) with time zone null, add column "updated_at" timestamp(0) with time zone null', $statements[0]);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->timestampsTz(1);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table "users" add column "created_at" timestamp(1) with time zone null, add column "updated_at" timestamp(1) with time zone null', $statements[0]);
+    }
+
+    public function testAddingSoftDeletes()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->softDeletes();
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table "users" add column "deleted_at" timestamp(0) without time zone null', $statements[0]);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->softDeletes('deleted_at', 1);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table "users" add column "deleted_at" timestamp(1) without time zone null', $statements[0]);
+    }
+
+    public function testAddingSoftDeletesTz()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->softDeletesTz();
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table "users" add column "deleted_at" timestamp(0) with time zone null', $statements[0]);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->softDeletesTz(1);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table "users" add column "deleted_at" timestamp(1) with time zone null', $statements[0]);
     }
 
     public function testAddingBinary()

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -456,6 +456,15 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add column "created_at" date not null', $statements[0]);
     }
 
+    public function testAddingDateWithCurrentAsDefault()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->date('created_at')->useCurrent();
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table "users" add column "created_at" date not null default CURRENT_DATE', $statements[0]);
+    }
+
     public function testAddingDateTime()
     {
         $blueprint = new Blueprint('users');
@@ -469,6 +478,15 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
         $this->assertEquals('alter table "users" add column "created_at" timestamp(1) without time zone not null', $statements[0]);
+    }
+
+    public function testAddingDateTimeWithCurrentAsDefault()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->dateTime('created_at')->useCurrent();
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table "users" add column "created_at" timestamp(0) without time zone not null default CURRENT_TIMESTAMP', $statements[0]);
     }
 
     public function testAddingDateTimeTz()
@@ -486,6 +504,15 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add column "created_at" timestamp(1) with time zone not null', $statements[0]);
     }
 
+    public function testAddingDateTimeTzWithCurrentAsDefault()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->dateTimeTz('created_at')->useCurrent();
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table "users" add column "created_at" timestamp(0) with time zone not null default CURRENT_TIMESTAMP', $statements[0]);
+    }
+
     public function testAddingTime()
     {
         $blueprint = new Blueprint('users');
@@ -499,6 +526,15 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
         $this->assertEquals('alter table "users" add column "created_at" time(1) without time zone not null', $statements[0]);
+    }
+
+    public function testAddingTimeWithCurrentAsDefault()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->time('created_at')->useCurrent();
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table "users" add column "created_at" time(0) without time zone not null default CURRENT_TIME', $statements[0]);
     }
 
     public function testAddingTimeTz()
@@ -516,6 +552,15 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add column "created_at" time(1) with time zone not null', $statements[0]);
     }
 
+    public function testAddingTimeTzWithCurrentAsDefault()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->timeTz('created_at')->useCurrent();
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table "users" add column "created_at" time(0) with time zone not null default CURRENT_TIME', $statements[0]);
+    }
+
     public function testAddingTimestamp()
     {
         $blueprint = new Blueprint('users');
@@ -531,6 +576,15 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add column "created_at" timestamp(1) without time zone not null', $statements[0]);
     }
 
+    public function testAddingTimestampWithCurrentAsDefault()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->timestamp('created_at')->useCurrent();
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table "users" add column "created_at" timestamp(0) without time zone not null default CURRENT_TIMESTAMP', $statements[0]);
+    }
+
     public function testAddingTimestampTz()
     {
         $blueprint = new Blueprint('users');
@@ -544,6 +598,15 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
         $this->assertEquals('alter table "users" add column "created_at" timestamp(1) with time zone not null', $statements[0]);
+    }
+
+    public function testAddingTimestampTzWithCurrentAsDefault()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->timestampTz('created_at')->useCurrent();
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table "users" add column "created_at" timestamp(0) with time zone not null default CURRENT_TIMESTAMP', $statements[0]);
     }
 
     public function testAddingTimestamps()

--- a/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
@@ -396,99 +396,169 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
     public function testAddingDate()
     {
         $blueprint = new Blueprint('users');
-        $blueprint->date('foo');
+        $blueprint->date('created_at');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "foo" date not null', $statements[0]);
+        $this->assertEquals('alter table "users" add column "created_at" date not null', $statements[0]);
     }
 
     public function testAddingDateTime()
     {
         $blueprint = new Blueprint('users');
-        $blueprint->dateTime('foo');
+        $blueprint->dateTime('created_at');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
-
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "foo" datetime not null', $statements[0]);
+        $this->assertEquals('alter table "users" add column "created_at" datetime not null', $statements[0]);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->dateTime('created_at', 1);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table "users" add column "created_at" datetime not null', $statements[0]);
     }
 
     public function testAddingDateTimeTz()
     {
         $blueprint = new Blueprint('users');
-        $blueprint->dateTimeTz('foo');
+        $blueprint->dateTimeTz('created_at');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
-
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "foo" datetime not null', $statements[0]);
+        $this->assertEquals('alter table "users" add column "created_at" datetime not null', $statements[0]);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->dateTimeTz('created_at', 1);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table "users" add column "created_at" datetime not null', $statements[0]);
     }
 
     public function testAddingTime()
     {
         $blueprint = new Blueprint('users');
-        $blueprint->time('foo');
+        $blueprint->time('created_at');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
-
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "foo" time not null', $statements[0]);
+        $this->assertEquals('alter table "users" add column "created_at" time not null', $statements[0]);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->time('created_at', 1);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table "users" add column "created_at" time not null', $statements[0]);
     }
 
     public function testAddingTimeTz()
     {
         $blueprint = new Blueprint('users');
-        $blueprint->timeTz('foo');
+        $blueprint->timeTz('created_at');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
-
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "foo" time not null', $statements[0]);
+        $this->assertEquals('alter table "users" add column "created_at" time not null', $statements[0]);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->timeTz('created_at', 1);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table "users" add column "created_at" time not null', $statements[0]);
     }
 
-    public function testAddingTimeStamp()
+    public function testAddingTimestamp()
     {
         $blueprint = new Blueprint('users');
-        $blueprint->timestamp('foo');
+        $blueprint->timestamp('created_at');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
-
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "foo" datetime not null', $statements[0]);
+        $this->assertEquals('alter table "users" add column "created_at" datetime not null', $statements[0]);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->timestamp('created_at', 1);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table "users" add column "created_at" datetime not null', $statements[0]);
     }
 
-    public function testAddingTimeStampTz()
+    public function testAddingTimestampTz()
     {
         $blueprint = new Blueprint('users');
-        $blueprint->timestampTz('foo');
+        $blueprint->timestampTz('created_at');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
-
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "foo" datetime not null', $statements[0]);
+        $this->assertEquals('alter table "users" add column "created_at" datetime not null', $statements[0]);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->timestampTz('created_at', 1);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table "users" add column "created_at" datetime not null', $statements[0]);
     }
 
-    public function testAddingTimeStamps()
+    public function testAddingTimestamps()
     {
         $blueprint = new Blueprint('users');
         $blueprint->timestamps();
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
-
         $this->assertCount(2, $statements);
         $expected = [
             'alter table "users" add column "created_at" datetime null',
             'alter table "users" add column "updated_at" datetime null',
         ];
         $this->assertEquals($expected, $statements);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->timestamps(1);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(2, $statements);
+        $this->assertEquals($expected, $statements);
     }
 
-    public function testAddingTimeStampsTz()
+    public function testAddingTimestampsTz()
     {
         $blueprint = new Blueprint('users');
         $blueprint->timestampsTz();
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
-
         $this->assertCount(2, $statements);
         $expected = [
             'alter table "users" add column "created_at" datetime null',
             'alter table "users" add column "updated_at" datetime null',
         ];
         $this->assertEquals($expected, $statements);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->timestampsTz(1);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(2, $statements);
+        $this->assertEquals($expected, $statements);
+    }
+
+    public function testAddingSoftDeletes()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->softDeletes();
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table "users" add column "deleted_at" datetime null', $statements[0]);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->softDeletes('deleted_at', 1);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table "users" add column "deleted_at" datetime null', $statements[0]);
+    }
+
+    public function testAddingSoftDeletesTz()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->softDeletesTz();
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table "users" add column "deleted_at" datetime null', $statements[0]);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->softDeletesTz(1);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table "users" add column "deleted_at" datetime null', $statements[0]);
     }
 
     public function testAddingRememberToken()

--- a/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
@@ -403,6 +403,15 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add column "created_at" date not null', $statements[0]);
     }
 
+    public function testAddingDateWithCurrentAsDefault()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->date('created_at')->useCurrent();
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table "users" add column "created_at" date not null default CURRENT_DATE', $statements[0]);
+    }
+
     public function testAddingDateTime()
     {
         $blueprint = new Blueprint('users');
@@ -416,6 +425,15 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
         $this->assertEquals('alter table "users" add column "created_at" datetime not null', $statements[0]);
+    }
+
+    public function testAddingDateTimeWithCurrentAsDefault()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->dateTime('created_at')->useCurrent();
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table "users" add column "created_at" datetime not null default CURRENT_TIMESTAMP', $statements[0]);
     }
 
     public function testAddingDateTimeTz()
@@ -433,6 +451,15 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add column "created_at" datetime not null', $statements[0]);
     }
 
+    public function testAddingDateTimeTzWithCurrentAsDefault()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->dateTimeTz('created_at')->useCurrent();
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table "users" add column "created_at" datetime not null default CURRENT_TIMESTAMP', $statements[0]);
+    }
+
     public function testAddingTime()
     {
         $blueprint = new Blueprint('users');
@@ -446,6 +473,15 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
         $this->assertEquals('alter table "users" add column "created_at" time not null', $statements[0]);
+    }
+
+    public function testAddingTimeWithCurrentAsDefault()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->time('created_at')->useCurrent();
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table "users" add column "created_at" time not null default CURRENT_TIME', $statements[0]);
     }
 
     public function testAddingTimeTz()
@@ -463,6 +499,15 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add column "created_at" time not null', $statements[0]);
     }
 
+    public function testAddingTimeTzWithCurrentAsDefault()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->timeTz('created_at')->useCurrent();
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table "users" add column "created_at" time not null default CURRENT_TIME', $statements[0]);
+    }
+
     public function testAddingTimestamp()
     {
         $blueprint = new Blueprint('users');
@@ -478,6 +523,15 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add column "created_at" datetime not null', $statements[0]);
     }
 
+    public function testAddingTimestampWithCurrentAsDefault()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->timestamp('created_at')->useCurrent();
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table "users" add column "created_at" datetime not null default CURRENT_TIMESTAMP', $statements[0]);
+    }
+
     public function testAddingTimestampTz()
     {
         $blueprint = new Blueprint('users');
@@ -491,6 +545,15 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
         $this->assertEquals('alter table "users" add column "created_at" datetime not null', $statements[0]);
+    }
+
+    public function testAddingTimestampTzWithCurrentAsDefault()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->timestampTz('created_at')->useCurrent();
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table "users" add column "created_at" datetime not null default CURRENT_TIMESTAMP', $statements[0]);
     }
 
     public function testAddingTimestamps()

--- a/tests/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintTest.php
@@ -77,13 +77,13 @@ class DatabaseSchemaBlueprintTest extends TestCase
         $this->assertEquals(['alter table `users` add `created` timestamp default CURRENT_TIMESTAMP not null'], $blueprint->toSql($connection, new MySqlGrammar));
 
         $blueprint = clone $base;
-        $this->assertEquals(['alter table "users" add column "created" timestamp(0) without time zone default CURRENT_TIMESTAMP(0) not null'], $blueprint->toSql($connection, new PostgresGrammar));
+        $this->assertEquals(['alter table "users" add column "created" timestamp(0) without time zone default CURRENT_TIMESTAMP not null'], $blueprint->toSql($connection, new PostgresGrammar));
 
         $blueprint = clone $base;
         $this->assertEquals(['alter table "users" add column "created" datetime default CURRENT_TIMESTAMP not null'], $blueprint->toSql($connection, new SQLiteGrammar));
 
         $blueprint = clone $base;
-        $this->assertEquals(['alter table "users" add "created" datetime default CURRENT_TIMESTAMP not null'], $blueprint->toSql($connection, new SqlServerGrammar));
+        $this->assertEquals(['alter table "users" add "created" datetime2(0) default CURRENT_TIMESTAMP not null'], $blueprint->toSql($connection, new SqlServerGrammar));
     }
 
     public function testUnsignedDecimalTable()

--- a/tests/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintTest.php
@@ -6,9 +6,6 @@ use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Schema\Grammars\MySqlGrammar;
-use Illuminate\Database\Schema\Grammars\SQLiteGrammar;
-use Illuminate\Database\Schema\Grammars\PostgresGrammar;
-use Illuminate\Database\Schema\Grammars\SqlServerGrammar;
 
 class DatabaseSchemaBlueprintTest extends TestCase
 {
@@ -63,27 +60,6 @@ class DatabaseSchemaBlueprintTest extends TestCase
         $blueprint->dropSpatialIndex(['coordinates']);
         $commands = $blueprint->getCommands();
         $this->assertEquals('geo_coordinates_spatialindex', $commands[0]->index);
-    }
-
-    public function testDefaultCurrentTimestamp()
-    {
-        $base = new Blueprint('users', function ($table) {
-            $table->timestamp('created')->useCurrent();
-        });
-
-        $connection = m::mock('Illuminate\Database\Connection');
-
-        $blueprint = clone $base;
-        $this->assertEquals(['alter table `users` add `created` timestamp default CURRENT_TIMESTAMP not null'], $blueprint->toSql($connection, new MySqlGrammar));
-
-        $blueprint = clone $base;
-        $this->assertEquals(['alter table "users" add column "created" timestamp(0) without time zone default CURRENT_TIMESTAMP not null'], $blueprint->toSql($connection, new PostgresGrammar));
-
-        $blueprint = clone $base;
-        $this->assertEquals(['alter table "users" add column "created" datetime default CURRENT_TIMESTAMP not null'], $blueprint->toSql($connection, new SQLiteGrammar));
-
-        $blueprint = clone $base;
-        $this->assertEquals(['alter table "users" add "created" datetime2(0) default CURRENT_TIMESTAMP not null'], $blueprint->toSql($connection, new SqlServerGrammar));
     }
 
     public function testUnsignedDecimalTable()

--- a/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
@@ -462,111 +462,161 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
     public function testAddingDate()
     {
         $blueprint = new Blueprint('users');
-        $blueprint->date('foo');
+        $blueprint->date('created_at');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add "foo" date not null', $statements[0]);
+        $this->assertEquals('alter table "users" add "created_at" date not null', $statements[0]);
     }
 
     public function testAddingDateTime()
     {
         $blueprint = new Blueprint('users');
-        $blueprint->dateTime('foo', 1);
+        $blueprint->dateTime('created_at');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add "foo" datetime2(1) not null', $statements[0]);
+        $this->assertEquals('alter table "users" add "created_at" datetime2(0) not null', $statements[0]);
 
         $blueprint = new Blueprint('users');
-        $blueprint->dateTime('foo');
+        $blueprint->dateTime('created_at', 1);
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add "foo" datetime not null', $statements[0]);
+        $this->assertEquals('alter table "users" add "created_at" datetime2(1) not null', $statements[0]);
     }
 
     public function testAddingDateTimeTz()
     {
         $blueprint = new Blueprint('users');
-        $blueprint->dateTimeTz('foo', 1);
+        $blueprint->dateTimeTz('created_at');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add "foo" datetimeoffset(1) not null', $statements[0]);
+        $this->assertEquals('alter table "users" add "created_at" datetimeoffset(0) not null', $statements[0]);
 
         $blueprint = new Blueprint('users');
-        $blueprint->dateTimeTz('foo');
+        $blueprint->dateTimeTz('created_at', 1);
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add "foo" datetimeoffset not null', $statements[0]);
+        $this->assertEquals('alter table "users" add "created_at" datetimeoffset(1) not null', $statements[0]);
     }
 
     public function testAddingTime()
     {
         $blueprint = new Blueprint('users');
-        $blueprint->time('foo');
+        $blueprint->time('created_at');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
-
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add "foo" time not null', $statements[0]);
+        $this->assertEquals('alter table "users" add "created_at" time(0) not null', $statements[0]);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->time('created_at', 1);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table "users" add "created_at" time(1) not null', $statements[0]);
     }
 
     public function testAddingTimeTz()
     {
         $blueprint = new Blueprint('users');
-        $blueprint->timeTz('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
-
-        $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add "foo" time not null', $statements[0]);
-    }
-
-    public function testAddingTimeStamp()
-    {
-        $blueprint = new Blueprint('users');
-        $blueprint->timestamp('foo', 1);
+        $blueprint->timeTz('created_at');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add "foo" datetime2(1) not null', $statements[0]);
+        $this->assertEquals('alter table "users" add "created_at" time(0) not null', $statements[0]);
 
         $blueprint = new Blueprint('users');
-        $blueprint->timestamp('foo');
+        $blueprint->timeTz('created_at', 1);
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add "foo" datetime not null', $statements[0]);
+        $this->assertEquals('alter table "users" add "created_at" time(1) not null', $statements[0]);
     }
 
-    public function testAddingTimeStampTz()
+    public function testAddingTimestamp()
     {
         $blueprint = new Blueprint('users');
-        $blueprint->timestampTz('foo');
+        $blueprint->timestamp('created_at');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
-
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add "foo" datetimeoffset(0) not null', $statements[0]);
+        $this->assertEquals('alter table "users" add "created_at" datetime2(0) not null', $statements[0]);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->timestamp('created_at', 1);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table "users" add "created_at" datetime2(1) not null', $statements[0]);
     }
 
-    public function testAddingTimeStamps()
+    public function testAddingTimestampTz()
     {
+        $blueprint = new Blueprint('users');
+        $blueprint->timestampTz('created_at');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table "users" add "created_at" datetimeoffset(0) not null', $statements[0]);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->timestampTz('created_at', 1);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table "users" add "created_at" datetimeoffset(1) not null', $statements[0]);
+    }
+
+    public function testAddingTimestamps()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->timestamps();
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table "users" add "created_at" datetime2(0) null, "updated_at" datetime2(0) null', $statements[0]);
+
         $blueprint = new Blueprint('users');
         $blueprint->timestamps(1);
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
         $this->assertEquals('alter table "users" add "created_at" datetime2(1) null, "updated_at" datetime2(1) null', $statements[0]);
-
-        $blueprint = new Blueprint('users');
-        $blueprint->timestamps();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
-        $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add "created_at" datetime null, "updated_at" datetime null', $statements[0]);
     }
 
-    public function testAddingTimeStampsTz()
+    public function testAddingTimestampsTz()
     {
         $blueprint = new Blueprint('users');
         $blueprint->timestampsTz();
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
-
         $this->assertCount(1, $statements);
         $this->assertEquals('alter table "users" add "created_at" datetimeoffset(0) null, "updated_at" datetimeoffset(0) null', $statements[0]);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->timestampsTz(1);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table "users" add "created_at" datetimeoffset(1) null, "updated_at" datetimeoffset(1) null', $statements[0]);
+    }
+
+    public function testAddingSoftDeletes()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->softDeletes();
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table "users" add "deleted_at" datetime2(0) null', $statements[0]);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->softDeletes('deleted_at', 1);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table "users" add "deleted_at" datetime2(1) null', $statements[0]);
+    }
+
+    public function testAddingSoftDeletesTz()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->softDeletesTz();
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table "users" add "deleted_at" datetimeoffset(0) null', $statements[0]);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->softDeletesTz(1);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table "users" add "deleted_at" datetimeoffset(1) null', $statements[0]);
     }
 
     public function testAddingRememberToken()

--- a/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
@@ -469,6 +469,15 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add "created_at" date not null', $statements[0]);
     }
 
+    public function testAddingDateWithCurrentAsDefault()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->date('created_at')->useCurrent();
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table "users" add "created_at" date not null default CURRENT_TIMESTAMP', $statements[0]);
+    }
+
     public function testAddingDateTime()
     {
         $blueprint = new Blueprint('users');
@@ -482,6 +491,15 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
         $this->assertEquals('alter table "users" add "created_at" datetime2(1) not null', $statements[0]);
+    }
+
+    public function testAddingDateTimeWithCurrentAsDefault()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->dateTime('created_at')->useCurrent();
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table "users" add "created_at" datetime2(0) not null default CURRENT_TIMESTAMP', $statements[0]);
     }
 
     public function testAddingDateTimeTz()
@@ -499,6 +517,15 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add "created_at" datetimeoffset(1) not null', $statements[0]);
     }
 
+    public function testAddingDateTimeTzWithCurrentAsDefault()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->dateTimeTz('created_at')->useCurrent();
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table "users" add "created_at" datetimeoffset(0) not null default CURRENT_TIMESTAMP', $statements[0]);
+    }
+
     public function testAddingTime()
     {
         $blueprint = new Blueprint('users');
@@ -512,6 +539,15 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
         $this->assertEquals('alter table "users" add "created_at" time(1) not null', $statements[0]);
+    }
+
+    public function testAddingTimeWithCurrentAsDefault()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->time('created_at')->useCurrent();
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table "users" add "created_at" time(0) not null default CURRENT_TIMESTAMP', $statements[0]);
     }
 
     public function testAddingTimeTz()
@@ -529,6 +565,15 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add "created_at" time(1) not null', $statements[0]);
     }
 
+    public function testAddingTimeTzWithCurrentAsDefault()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->timeTz('created_at')->useCurrent();
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table "users" add "created_at" time(0) not null default CURRENT_TIMESTAMP', $statements[0]);
+    }
+
     public function testAddingTimestamp()
     {
         $blueprint = new Blueprint('users');
@@ -544,6 +589,15 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add "created_at" datetime2(1) not null', $statements[0]);
     }
 
+    public function testAddingTimestampWithCurrentAsDefault()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->timestamp('created_at')->useCurrent();
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table "users" add "created_at" datetime2(0) not null default CURRENT_TIMESTAMP', $statements[0]);
+    }
+
     public function testAddingTimestampTz()
     {
         $blueprint = new Blueprint('users');
@@ -557,6 +611,15 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
         $this->assertEquals('alter table "users" add "created_at" datetimeoffset(1) not null', $statements[0]);
+    }
+
+    public function testAddingTimestampTzWithCurrentAsDefault()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->timestampTz('created_at')->useCurrent();
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table "users" add "created_at" datetimeoffset(0) not null default CURRENT_TIMESTAMP', $statements[0]);
     }
 
     public function testAddingTimestamps()


### PR DESCRIPTION
<s>I was unsure if I have to push this to 5.5 or 5.6, but since it affects only new created columns and fixes/improves a lot of expected behavior I guess it would be wanted for 5.5.</s>

If intended I can rebase this to 5.6 or to revert some unwanted change. 👍 

Once again my contribution ended up big and I had to split it with 4 commits to ease the review - it's a lot easier to see the changes separately. I also prepared an extensive summary of changes to help reviewing. 😃 

## Part 1: Ensure unsupported temporal columns reuse supported ones

Basic code cleanup and consistency improvement. No tests changes yet.

Changes:

- `Illuminate\Database\Schema\Grammars\MySqlGrammar`
  - Alias `typeTimeTz()` to `typeTime()`
- `Illuminate\Database\Schema\Grammars\PostgresGrammar`
  - Alias `typeDateTime()` to `typeTimestamp()`
  - Alias `typeDateTimeTz()` to `typeTimestampTz()`
- `Illuminate\Database\Schema\Grammars\SQLiteGrammar`
  - Moves `typeTimestamp()` implementation to `typeDateTime()` and alias `typeTimestamp()` to `typeDateTime()`
  - Alias `typeDateTimeTz()` to `typeDateTime()`
  - Alias `typeTimeTz()` to `typeTime()`
  - Alias `typeTimestampTz()` to `typeDateTimeTz()`
- `Illuminate\Database\Schema\Grammars\SqlServerGrammar`
  - Moves `typeTimestamp()` implementation to `typeDateTime()` and alias `typeTimestamp()` to `typeDateTime()`
  - Moves `typeTimestampTz()` implementation to `typeDateTimeTz()` and alias `typeTimestampTz()` to `typeDateTimeTz()`
  - Alias `typeTimeTz()` to `typeTime()`

Benefits:

- Reduces code duplication and future mistakes
  - By aliasing unsupported columns to supported ones, a change to a supported column would also change the unsupported one, reducing mistakes that have been introduced in the past
- PostgreSQL/SQLite/SQL Server: allows handling `useCurrent()` on `dateTime()` and `dateTimeTz()` columns (this is improved later)

## Part 2: Ensure temporal columns handle precision correctly

Improves temporal columns precision handling with full SQL standard compliance. Adds 8 new tests and 76 assertions.

Changes to code:

- `Illuminate\Database\Schema\Blueprint`
  - Continues the work from PR #21936 adding `$precision` argument to the missing `timeTz()` method
- `Illuminate\Database\Schema\Grammars\MySqlGrammar`
- `Illuminate\Database\Schema\Grammars\PostgresGrammar`
- `Illuminate\Database\Schema\Grammars\SqlServerGrammar`
  - Fixes `typeTime()` and `typeTimeTz()` to correctly handle the given column precision
  - Simplifies some temporal columns implementation where possible

Changes to tests:

- `Illuminate\Tests\Database\DatabaseMySqlSchemaGrammarTest`
- `Illuminate\Tests\Database\DatabasePostgresSchemaGrammarTest`
- `Illuminate\Tests\Database\DatabaseSQLiteSchemaGrammarTest`
- `Illuminate\Tests\Database\DatabaseSqlServerSchemaGrammarTest`
  - Minor improvements to method names, column names and tests ordering
  - Ensured all existing tests also tests passing a custom precision to temporal columns where it's expected to handle
  - Added missing `testSoftDeletes()` and `testSoftDeletesTz()` tests

Benefits:

- SQL standard compliance with full support for passing a floating-point precision to `TIME`, `DATETIME` and `TIMESTAMP` columns
- Correctly use 0 precision in all drivers when no precision is used
- More code cleanup
- Improved test suite

## Part 3: Ensure all temporal columns handle useCurrent() as supported

Improves all temporal columns to handle the `useCurrent()` column modifier as supported by the database driver in use. Adds 28 new tests and 56 assertions, drops 3 existing tests and 12 assertions.

Changes to code:

- `Illuminate\Database\Schema\Grammars\Grammar`
  - Added a new `setTemporalDefaut()` protected method
- `Illuminate\Database\Schema\Grammars\MySqlGrammar`
- `Illuminate\Database\Schema\Grammars\PostgresGrammar`
- `Illuminate\Database\Schema\Grammars\SQLiteGrammar`
- `Illuminate\Database\Schema\Grammars\SqlServerGrammar`
  - Changed temporal columns to call the new `setTemporalDefault()` method
  - Simplified temporal columns code removing the inline `useCurrent` handling*

Why I have changed this to use a new method? Because it simplifies things and also ensures the SQL grammars always generate `DEFAULT` expressions after `NULL`/`NOT NULL` expressions. All current drivers support `DEFAULT` expressions in either position but their `CREATE TABLE` documentation syntax always place `DEFAULT` expressions after `NOT`/`NOT NULL` expressions - thus we can say it's less risky to break if for any reason they change this behavior.

Changes to tests:

- `Illuminate\Tests\Database\DatabaseSchemaBlueprintTest`
  - Drops existing `testDefaultCurrentTimestamp()` method in favor of new grammar-specific tests
- `Illuminate\Tests\Database\DatabaseMySqlSchemaGrammarTest`
  - Drops existing `testAddingTimestampWithDefault()` and`testAddingTimestampTzWithDefault()` methods in favor of new grammar-specific tests
- `Illuminate\Tests\Database\DatabaseMySqlSchemaGrammarTest`
- `Illuminate\Tests\Database\DatabasePostgresSchemaGrammarTest`
- `Illuminate\Tests\Database\DatabaseSQLiteSchemaGrammarTest`
- `Illuminate\Tests\Database\DatabaseSqlServerSchemaGrammarTest`
  - Adds new tests for `useCurrent()` to all temporal columns

Benefits:

- Improved support for using the `useCurrent()` column modifier on supported temporal columns
- More code cleanup
- Improved test suite

## Part 4: Improve temporal columns docblocks

Misc docblocks improvements to temporal columns. We're done. :sweat_smile:

Benefits:

- Improved code documentation

If I didn't miss anything, it's all good. Tests are passing. 👍 