### PR TITLE
[5.5] Display Controller name on non existing methods

### DIFF
--- a/src/Illuminate/Routing/Controller.php
+++ b/src/Illuminate/Routing/Controller.php
@@ -65,6 +65,6 @@ abstract class Controller
      */
     public function __call($method, $parameters)
     {
-        throw new BadMethodCallException("Method [{$method}] does not exist in " . get_class($this) . ".");
+        throw new BadMethodCallException("Method [{$method}] does not exist in ".get_class($this).'.');
     }
 }

--- a/src/Illuminate/Routing/Controller.php
+++ b/src/Illuminate/Routing/Controller.php
@@ -65,6 +65,6 @@ abstract class Controller
      */
     public function __call($method, $parameters)
     {
-        throw new BadMethodCallException("Method [{$method}] does not exist.");
+        throw new BadMethodCallException("Method [{$method}] does not exist in " . get_class($this) . ".");
     }
 }

--- a/src/Illuminate/Routing/Controller.php
+++ b/src/Illuminate/Routing/Controller.php
@@ -65,6 +65,6 @@ abstract class Controller
      */
     public function __call($method, $parameters)
     {
-        throw new BadMethodCallException("Method [{$method}] does not exist in ".get_class($this).'.');
+        throw new BadMethodCallException("Method [{$method}] does not exist on [".get_class($this)."].");
     }
 }


### PR DESCRIPTION
I find myself always scrolling when a method is not defined for a Controller.

This way the Exception points which controller is missing which method.