### PR TITLE
[5.5] Allow mock created by withoutEvents to accept listen

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MocksApplicationServices.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MocksApplicationServices.php
@@ -98,7 +98,7 @@ trait MocksApplicationServices
     {
         $mock = Mockery::mock(EventsDispatcherContract::class);
 
-        $mock->shouldReceive('fire', 'dispatch')->andReturnUsing(function ($called) {
+        $mock->shouldReceive('fire', 'dispatch', 'listen')->andReturnUsing(function ($called) {
             $this->firedEvents[] = $called;
         });
 


### PR DESCRIPTION
To solve [#22007](https://github.com/laravel/framework/issues/22007)

MocksApplicationServices trait defines that the event dispatcher should receive 'fire' and 'dispatch' but does not include 'listen'