### PR TITLE
\Cache::set without a TTL does not actually cache data

### DIFF
--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -203,6 +203,10 @@ class Repository implements CacheContract, ArrayAccess
      */
     public function set($key, $value, $ttl = null)
     {
+        if (is_null($ttl)) {
+            $ttl = $this->getDefaultCacheTime();
+        }
+
         $this->put($key, $value, $ttl);
     }
 

--- a/tests/Cache/CacheRepositoryTest.php
+++ b/tests/Cache/CacheRepositoryTest.php
@@ -204,6 +204,13 @@ class CacheRepositoryTest extends TestCase
         $repo->set($key, $value, 1);
     }
 
+    public function testSettingCacheWithoutTTLUsesDefault()
+    {
+        $repo = $this->getRepository();
+        $repo->getStore()->shouldReceive('put')->with($key = 'foo', $value = 'bar', $repo->getDefaultCacheTime())->once();
+        $repo->set($key, $value);
+    }
+
     public function testClearingWholeCache()
     {
         $repo = $this->getRepository();


### PR DESCRIPTION
Repository set has an optional TTL parameter, and a default cache time property, but they are not used together. If you call `set('foo', 'bar')` without a ttl, it just does not cache the data. I've added a test to the repository class to illustrate the issue. My proposed fix is when `$ttl` is not specified to use the default cache time. If set is not made to cache data without a ttl, then it's signature should updated to not have ttl as optional. I think using the default cache time is a more appropriate solution. 