### PR TITLE
[5.5] Ignore missing Dispatcher mock methods

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MocksApplicationServices.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MocksApplicationServices.php
@@ -96,7 +96,7 @@ trait MocksApplicationServices
      */
     protected function withoutEvents()
     {
-        $mock = Mockery::mock(EventsDispatcherContract::class);
+        $mock = Mockery::mock(EventsDispatcherContract::class)->shouldIgnoreMissing();;
 
         $mock->shouldReceive('fire', 'dispatch')->andReturnUsing(function ($called) {
             $this->firedEvents[] = $called;

--- a/src/Illuminate/Foundation/Testing/Concerns/MocksApplicationServices.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MocksApplicationServices.php
@@ -96,7 +96,7 @@ trait MocksApplicationServices
      */
     protected function withoutEvents()
     {
-        $mock = Mockery::mock(EventsDispatcherContract::class)->shouldIgnoreMissing();;
+        $mock = Mockery::mock(EventsDispatcherContract::class)->shouldIgnoreMissing();
 
         $mock->shouldReceive('fire', 'dispatch')->andReturnUsing(function ($called) {
             $this->firedEvents[] = $called;


### PR DESCRIPTION
Currently you might get the following exception:

```
Method Mockery_0_Illuminate_Contracts_Events_Dispatcher::listen() does not exist on this mock object
```

In case a listener was registered after we mock the Event dispatcher, this PR adds a configuration to the mocked object to just ignore missing methods instead of erroring.