### PR TITLE
[5.6] Cache::put without minutes specified just does not write to cache

### DIFF
--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -191,6 +191,10 @@ class Repository implements CacheContract, ArrayAccess
             return $this->putMany($key, $value);
         }
 
+        if (is_null($minutes)) {
+            $minutes = $this->getDefaultCacheTime();
+        }
+
         if (! is_null($minutes = $this->getMinutes($minutes))) {
             $this->store->put($this->itemKey($key), $value, $minutes);
 

--- a/tests/Cache/CacheRepositoryTest.php
+++ b/tests/Cache/CacheRepositoryTest.php
@@ -204,6 +204,13 @@ class CacheRepositoryTest extends TestCase
         $repo->set($key, $value, 1);
     }
 
+    public function testSettingCacheWithoutTTLUsesDefaultTime()
+    {
+        $repo = $this->getRepository();
+        $repo->getStore()->shouldReceive('put')->with($key = 'foo', $value = 'bar', $repo->getDefaultCacheTime());
+        $repo->set($key, $value);
+    }
+
     public function testClearingWholeCache()
     {
         $repo = $this->getRepository();

--- a/tests/Cache/CacheTaggedCacheTest.php
+++ b/tests/Cache/CacheTaggedCacheTest.php
@@ -88,7 +88,7 @@ class CacheTaggedCacheTest extends TestCase
         $store->shouldReceive('connection')->andReturn($conn = m::mock('stdClass'));
         $conn->shouldReceive('sadd')->once()->with('prefix:foo:standard_ref', 'prefix:'.sha1('foo|bar').':key1');
         $conn->shouldReceive('sadd')->once()->with('prefix:bar:standard_ref', 'prefix:'.sha1('foo|bar').':key1');
-        $store->shouldReceive('push')->with(sha1('foo|bar').':key1', 'key1:value');
+        $store->shouldReceive('put')->with(sha1('foo|bar').':key1', 'key1:value', $redis->getDefaultCacheTime());
 
         $redis->put('key1', 'key1:value');
     }


### PR DESCRIPTION
Right now repository::put without an optional param of `$minutes` being passed, will just not cache the data. I've updated the method to use the default time when minutes is not specified. Because this is a breaking change, it should not go out in a current version. I think it makes things a bit clearer given that set's ttl param and puts minutes param are both optional, I would still expect the two methods to store the data, just that a specific duration is not important to the consumer (thus the default makes sense). I've added a failing test to illustrate the issue and I've updated a redis test that this change was breaking because of the new behavior. 