### PR TITLE
[5.2] lock minor version for doctrine/inflector to version ~1.1.0 for PHP 5.5.9+ compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "ext-mbstring": "*",
         "ext-openssl": "*",
         "classpreloader/classpreloader": "~3.0",
-        "doctrine/inflector": "~1.0",
+        "doctrine/inflector": "~1.1.0",
         "jeremeamia/superclosure": "~2.2",
         "league/flysystem": "~1.0",
         "monolog/monolog": "~1.11",

--- a/src/Illuminate/Support/composer.json
+++ b/src/Illuminate/Support/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": ">=5.5.9",
         "ext-mbstring": "*",
-        "doctrine/inflector": "~1.0",
+        "doctrine/inflector": "~1.1.0",
         "illuminate/contracts": "5.2.*",
         "paragonie/random_compat": "~1.4"
     },


### PR DESCRIPTION
`illuminate/support` in Laravel 5.2 is installing `doctrine/inflector` as ~1.0

As of July 22nd, `doctrine/inflector` released [v1.2.0](https://github.com/doctrine/inflector/releases/tag/v1.2.0) which is causing composer install conflicts when installing using PHP 5.5.9+ due to their requiring a minimum of PHP 7.1+

This locks it to it's previous version of 1.1.0 which still satisfies PHP 5.5.9+

```
$ composer install
Loading composer repositories with package information
Installing dependencies (including require-dev) from lock file
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Installation request for doctrine/inflector v1.2.0 -> satisfiable by doctrine/inflector[v1.2.0].
    - doctrine/inflector v1.2.0 requires php ^7.0 -> your PHP version (5.5.38) does not satisfy that requirement.
  Problem 2
    - Installation request for phpdocumentor/reflection-docblock 4.1.1 -> satisfiable by phpdocumentor/reflection-docblock[4.1.1].
    - phpdocumentor/reflection-docblock 4.1.1 requires php ^7.0 -> your PHP version (5.5.38) does not satisfy that requirement.
  Problem 3
    - phpdocumentor/reflection-docblock 4.1.1 requires php ^7.0 -> your PHP version (5.5.38) does not satisfy that requirement.
    - phpspec/prophecy v1.7.2 requires phpdocumentor/reflection-docblock ^2.0|^3.0.2|^4.0 -> satisfiable by phpdocumentor/reflection-docblock[4.1.1].
    - Installation request for phpspec/prophecy v1.7.2 -> satisfiable by phpspec/prophecy[v1.7.2].
```