### PR TITLE
[5.6] Set default hashing configuration to make it easier for existing Laravel install to use new Hasher.

### DIFF
--- a/src/Illuminate/Hashing/HashManager.php
+++ b/src/Illuminate/Hashing/HashManager.php
@@ -71,6 +71,6 @@ class HashManager extends Manager implements Hasher
      */
     public function getDefaultDriver()
     {
-        return $this->app['config']['hashing.driver'];
+        return $this->app['config']['hashing.driver'] ?? 'bcrypt';
     }
 }


### PR DESCRIPTION
Signed-off-by: Mior Muhammad Zaki <crynobone@gmail.com>