### PR TITLE
[5.6] Throws an exception if null driver is given.

### DIFF
--- a/src/Illuminate/Support/Manager.php
+++ b/src/Illuminate/Support/Manager.php
@@ -56,6 +56,10 @@ abstract class Manager
     {
         $driver = $driver ?: $this->getDefaultDriver();
 
+        if (is_null($driver)) {
+            throw new InvalidArgumentException("Unable to resolve NULL driver for ".get_called_class());
+        }
+
         // If the given driver has not been created before, we will create the instances
         // here and cache it so we can return it next time very quickly. If there is
         // already a driver created by this name, we'll just return that instance.

--- a/tests/Integration/Support/Fixtures/NullableManager.php
+++ b/tests/Integration/Support/Fixtures/NullableManager.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Support\Fixtures;
+
+use Illuminate\Support\Manager;
+
+class NullableManager extends Manager
+{
+    /**
+     * Get the default driver name.
+     *
+     * @return string
+     */
+    public function getDefaultDriver()
+    {
+        return null;
+    }
+}

--- a/tests/Integration/Support/ManagerTest.php
+++ b/tests/Integration/Support/ManagerTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Support;
+
+use Orchestra\Testbench\TestCase;
+
+class ManagerTest extends TestCase
+{
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Unable to resolve NULL driver for Illuminate\Tests\Integration\Support\Fixtures\NullableManager
+     */
+    public function testDefaultDriverCannotBeNull()
+    {
+        (new Fixtures\NullableManager($this->app))->driver();
+    }
+}


### PR DESCRIPTION
Related to #22017 PR it might be useful to actually throws an exception for `null` driver instead of letting PHP throws un-useful warning.

<img width="980" alt="screen shot 2017-11-09 at 8 50 46 am" src="https://user-images.githubusercontent.com/172966/32582736-45219106-c52b-11e7-8428-bcc5eb745147.png">


Signed-off-by: Mior Muhammad Zaki <crynobone@gmail.com>