### PR TITLE
[5.5] Add support for MultiSubnetFailover DSN parameter

### DIFF
--- a/src/Illuminate/Database/Connectors/SqlServerConnector.php
+++ b/src/Illuminate/Database/Connectors/SqlServerConnector.php
@@ -134,6 +134,10 @@ class SqlServerConnector extends Connector implements ConnectorInterface
             $arguments['TransactionIsolation'] = $config['transaction_isolation'];
         }
 
+        if (isset($config['multi_subnet_failover'])) {
+            $arguments['MultiSubnetFailover'] = $config['multi_subnet_failover'];
+        }
+
         return $this->buildConnectString('sqlsrv', $arguments);
     }
 


### PR DESCRIPTION
> configures Microsoft Drivers for PHP for SQL Server to provide faster detection of and connection to the (currently) active server when connecting to a SQL Server 2012 availability group listener or SQL Server 2012 Failover Cluster Instance.