### PR TITLE
[5.5] Added Request::item() method

### DIFF
--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -188,7 +188,7 @@ trait InteractsWithInput
             $this->getInputSource()->all() + $this->query->all(), $key, $default
         );
     }
-    
+
     /**
      * Retrieve an input item or default if the request contains a non-empty value for an input item.
      *

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -188,6 +188,18 @@ trait InteractsWithInput
             $this->getInputSource()->all() + $this->query->all(), $key, $default
         );
     }
+    
+    /**
+     * Retrieve an input item or default if the request contains a non-empty value for an input item.
+     *
+     * @param  string  $key
+     * @param  string|array|null  $default
+     * @return string|array
+     */
+    public function item($key = null, $default = null)
+    {
+        return $this->filled($key) ? $this->input($key) : value($default);
+    }
 
     /**
      * Get a subset containing the provided keys with values from the input data.


### PR DESCRIPTION
This method for retrieve default value if the request contains a non-empty value.

In this PR if the request data is `?name=`

`Request::item('name', 'default value')`  will return 'default value'
