### PR TITLE
[5.5] Added Request::item() method

### DIFF
--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -190,6 +190,18 @@ trait InteractsWithInput
     }
 
     /**
+     * Retrieve an input item or default if the request contains a non-empty value for an input item.
+     *
+     * @param  string  $key
+     * @param  string|array|null  $default
+     * @return string|array
+     */
+    public function item($key = null, $default = null)
+    {
+        return $this->filled($key) ? $this->input($key) : value($default);
+    }
+
+    /**
      * Get a subset containing the provided keys with values from the input data.
      *
      * @param  array|mixed  $keys

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -293,6 +293,14 @@ class HttpRequestTest extends TestCase
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\File\UploadedFile', $request['file']);
     }
 
+    public function testItemMethod()
+    {
+        $request = Request::create('/', 'GET', ['name' => '']);
+        $this->assertEquals('Ahmed Fathy', $request->item('name', 'Ahmed Fathy'));
+        $this->assertEquals('', $request['name']);
+        $this->assertEquals('Bob', $request->item('foo', 'Bob'));
+    }
+
     public function testAllMethod()
     {
         $request = Request::create('/', 'GET', ['name' => 'Taylor', 'age' => null]);


### PR DESCRIPTION
This method for retrieve default value if the request contains a non-empty value.

In this PR if the request data is `?name=`

`Request::item('name', 'default value')`  will return 'default value'
