### PR TITLE
[5.5] Make Collection::dd() & Collection::dump() show the same result

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -275,9 +275,11 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      *
      * @return void
      */
-    public function dd()
+    public function dd(...$args)
     {
-        dd($this->all());
+        call_user_func_array([$this, 'dump'], $args);
+
+        die(1);
     }
 
     /**


### PR DESCRIPTION
If you do 

    collect([1, 3])->dump(5);

    echo "------------------------------------------\n";

    collect([1, 3])->dd(5);

You'll see `dd()` and `dump()` shows a completely different result:

```php
5
Illuminate\Support\Collection {#783
  #items: array:2 [
    0 => 1
    1 => 3
  ]
}
------------------------------------------
array:2 [
  0 => 1
  1 => 3
]
```

This PR fix this so they both behave the same way:

``` php
5
Illuminate\Support\Collection {#783
  #items: array:2 [
    0 => 1
    1 => 3
  ]
}
------------------------------------------
5
Illuminate\Support\Collection {#783
  #items: array:2 [
    0 => 1
    1 => 3
  ]
}
```