### PR TITLE
[5.6] blocking pop from redis queues

### DIFF
--- a/src/Illuminate/Queue/Connectors/RedisConnector.php
+++ b/src/Illuminate/Queue/Connectors/RedisConnector.php
@@ -45,7 +45,8 @@ class RedisConnector implements ConnectorInterface
         return new RedisQueue(
             $this->redis, $config['queue'],
             $config['connection'] ?? $this->connection,
-            $config['retry_after'] ?? 60
+            $config['retry_after'] ?? 60,
+            $config['timeout'] ?? 0
         );
     }
 }


### PR DESCRIPTION
Currently we pop and reserve jobs off the queue using redis `pop` and `zadd` operations inside a LUA script. This PR adds an alternative algorithm that uses [blpop](https://redis.io/commands/blpop) instead of `pop`. It enables the Redis queue driver to wait for the jobs for a specific number of seconds when the queues are empty and server the jobs as soon as they arrive. As a result we can safely run `artisan queue:work` with no sleep (`--sleep=0`) without killing the CPU power and improve the wait time of low traffic queues from `sleep/2` seconds on average to zero.

The new blocking pop algorithm has a drawback: `blpop` cannot be used in Lua scripts, therefore, there is a tiny chance of the jobs being lost if the PHP script crashes between pop and reserve operations. Another consideration is that there is no way to do blocking pop from delayed and reserved queues in redis. Therefore, this PR keeps the current pop algorithm in place and lets the user to choose by setting config('queue.connections.{redis_connection_name}.timeout).

PS: I have used blpop for a while via my package, https://github.com/halaei/bredis, that I would like to deprecate if this PR is acceptable.