### PR TITLE
[5.5] Add batches in migrate:status command.

### DIFF
--- a/src/Illuminate/Database/Migrations/DatabaseMigrationRepository.php
+++ b/src/Illuminate/Database/Migrations/DatabaseMigrationRepository.php
@@ -54,6 +54,19 @@ class DatabaseMigrationRepository implements MigrationRepositoryInterface
     }
 
     /**
+     * Get the ran migrations with batch column.
+     *
+     * @return array
+     */
+    public function getRanWithBatches()
+    {
+        return $this->table()
+                ->orderBy('batch', 'asc')
+                ->orderBy('migration', 'asc')
+                ->get(['migration', 'batch'])->all();
+    }
+
+    /**
      * Get list of migrations.
      *
      * @param  int  $steps

--- a/src/Illuminate/Database/Migrations/MigrationRepositoryInterface.php
+++ b/src/Illuminate/Database/Migrations/MigrationRepositoryInterface.php
@@ -12,6 +12,13 @@ interface MigrationRepositoryInterface
     public function getRan();
 
     /**
+     * Get the ran migrations with batch column.
+     *
+     * @return array
+     */
+    public function getRanWithBatches();
+
+    /**
      * Get list of migrations.
      *
      * @param  int  $steps

--- a/tests/Database/DatabaseMigrationRepositoryTest.php
+++ b/tests/Database/DatabaseMigrationRepositoryTest.php
@@ -29,6 +29,21 @@ class DatabaseMigrationRepositoryTest extends TestCase
         $this->assertEquals(['bar'], $repo->getRan());
     }
 
+    public function testGetRanMigrationsWithBatchesListMigrations()
+    {
+        $repo = $this->getRepository();
+        $query = m::mock('stdClass');
+        $connectionMock = m::mock('Illuminate\Database\Connection');
+        $repo->getConnectionResolver()->shouldReceive('connection')->with(null)->andReturn($connectionMock);
+        $repo->getConnection()->shouldReceive('table')->once()->with('migrations')->andReturn($query);
+        $query->shouldReceive('orderBy')->once()->with('batch', 'asc')->andReturn($query);
+        $query->shouldReceive('orderBy')->once()->with('migration', 'asc')->andReturn($query);
+        $query->shouldReceive('get')->once()->with(['migration', 'batch'])->andReturn(new Collection(['migration' => 'bar', 'batch' => 1]));
+        $query->shouldReceive('useWritePdo')->once()->andReturn($query);
+
+        $this->assertEquals(['migration' => 'bar', 'batch' => 1], $repo->getRanWithBatches());
+    }
+
     public function testGetLastMigrationsGetsAllMigrationsWithTheLatestBatchNumber()
     {
         $repo = $this->getMockBuilder('Illuminate\Database\Migrations\DatabaseMigrationRepository')->setMethods(['getLastBatchNumber'])->setConstructorArgs([


### PR DESCRIPTION
Hi,
I often wonder which migrations a `migrate:rollback`will remove.
I have to go in my database, and look at the `batch` column in the `migrations` table to be sure to not rollback unwanted migrations.

With this PR, we can directly see the batches of the migrations in the `migrate:status` command.

Example:
```
+------+------------------------------------------------------------+-------+
| Ran? | Migration                                                  | Batch |
+------+------------------------------------------------------------+-------+
| Y    | 2014_10_12_000000_create_users_table                       | 1     |
| Y    | 2014_10_12_100000_create_password_resets_table             | 2     |
| N    | 2017_10_27_094554_create_categories_table                  | -     |
+------+------------------------------------------------------------+-------+
```

No, I know that a rollback will only affect the `create_password_resets_table` migration! 🎉 

Thoughts ?