### PR TITLE
ValidationException translatable message

### DIFF
--- a/src/Illuminate/Validation/ValidationException.php
+++ b/src/Illuminate/Validation/ValidationException.php
@@ -53,7 +53,7 @@ class ValidationException extends Exception
      */
     public function __construct($validator, $response = null, $errorBag = 'default')
     {
-        parent::__construct('The given data was invalid.');
+        parent::__construct(__('validation.invalid_data_given'));
 
         $this->response = $response;
         $this->errorBag = $errorBag;


### PR DESCRIPTION
The default message should come from the localization strings.

I also send a pull request on laravel/laravel repo with the original string in the lang/validation.php file (Link: https://github.com/laravel/laravel/pull/4487)