### PR TITLE
broadcast notifications with custom type

### DIFF
--- a/src/Illuminate/Notifications/Events/BroadcastNotificationCreated.php
+++ b/src/Illuminate/Notifications/Events/BroadcastNotificationCreated.php
@@ -70,9 +70,11 @@ class BroadcastNotificationCreated implements ShouldBroadcast
      */
     public function broadcastWith()
     {
+        $type = method_exists($this->notification, 'broadcastAs') ? call_user_func([$this->notification, 'broadcastAs']) : get_class($this->notification);
+
         return array_merge($this->data, [
             'id' => $this->notification->id,
-            'type' => get_class($this->notification),
+            'type' => $type,
         ]);
     }
 


### PR DESCRIPTION
With this commit we will be able to broadcast native laravel notifications with custom "type" attribute. For now "type" attribute is always the name of notification class (e.g App\Notifications\Services\Orders\NewOrder) which is written here: "Illuminate\Notifications\Events\BroadcastNotificationCreated" in "broadcastWith" method. We can see that for now framework just merges payload with this array:
[
        'id' => $this->notification->id,
        'type' => get_class($this->notification),
]

but I want to be able to customize "type" attribute.

I am suggesting to modify broadcastWith method and add check so that if there is a "broadcastAs" method in notification class, framework will use the returned value instead of get_class($this->notification).

We have such functionality for events, and with this functionality frontend application will not be somehow connected with backend application's class name.