### PR TITLE
[5.5] Add withMiddleware function in MakesHttpRequests

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -110,7 +110,6 @@ trait MakesHttpRequests
         return $this;
     }
 
-
     /**
      * Enable the given middleware for the test.
      *

--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -112,7 +112,7 @@ trait MakesHttpRequests
 
 
     /**
-     * Re-enable middleware for the test if disabled.
+     * Enable the given middleware for the test.
      *
      * @param  string|array  $middleware
      * @return $this

--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -110,6 +110,28 @@ trait MakesHttpRequests
         return $this;
     }
 
+
+    /**
+     * Re-enable middleware for the test if disabled.
+     *
+     * @param  string|array  $middleware
+     * @return $this
+     */
+    public function withMiddleware($middleware = null)
+    {
+        if (is_null($middleware)) {
+            unset($this->app['middleware.disable']);
+
+            return $this;
+        }
+
+        foreach ((array) $middleware as $abstract) {
+            unset($this->app[$abstract]);
+        }
+
+        return $this;
+    }
+
     /**
      * Automatically follow any redirects returned from the response.
      *

--- a/tests/Foundation/Testing/Concerns/MakesHttpRequestsTest.php
+++ b/tests/Foundation/Testing/Concerns/MakesHttpRequestsTest.php
@@ -20,7 +20,7 @@ class MakesHttpRequestsTest extends TestCase
 
     public function testWithoutAndWithMiddlewareWithParameter()
     {
-        $next = function($request) {
+        $next = function ($request) {
             return $request;
         };
 
@@ -29,7 +29,6 @@ class MakesHttpRequestsTest extends TestCase
             'fooWithMiddleware',
             $this->app->make(MyMiddleware::class)->handle('foo', $next)
         );
-
 
         $this->withoutMiddleware(MyMiddleware::class);
         $this->assertTrue($this->app->has(MyMiddleware::class));
@@ -47,9 +46,10 @@ class MakesHttpRequestsTest extends TestCase
     }
 }
 
-class MyMiddleware {
+class MyMiddleware
+{
     public function handle($request, $next)
     {
-        return $next($request . 'WithMiddleware');
+        return $next($request.'WithMiddleware');
     }
 }

--- a/tests/Foundation/Testing/Concerns/MakesHttpRequestsTest.php
+++ b/tests/Foundation/Testing/Concerns/MakesHttpRequestsTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Illuminate\Tests\Foundation\Http\Middleware;
+
+use Orchestra\Testbench\TestCase;
+
+class MakesHttpRequestsTest extends TestCase
+{
+    public function testWithoutAndWithMiddleware()
+    {
+        $this->assertFalse($this->app->has('middleware.disable'));
+
+        $this->withoutMiddleware();
+        $this->assertTrue($this->app->has('middleware.disable'));
+        $this->assertTrue($this->app->make('middleware.disable'));
+
+        $this->withMiddleware();
+        $this->assertFalse($this->app->has('middleware.disable'));
+    }
+
+    public function testWithoutAndWithMiddlewareWithParameter()
+    {
+        $next = function($request) {
+            return $request;
+        };
+
+        $this->assertFalse($this->app->has(MyMiddleware::class));
+        $this->assertEquals(
+            'fooWithMiddleware',
+            $this->app->make(MyMiddleware::class)->handle('foo', $next)
+        );
+
+
+        $this->withoutMiddleware(MyMiddleware::class);
+        $this->assertTrue($this->app->has(MyMiddleware::class));
+        $this->assertEquals(
+            'foo',
+            $this->app->make(MyMiddleware::class)->handle('foo', $next)
+        );
+
+        $this->withMiddleware(MyMiddleware::class);
+        $this->assertFalse($this->app->has(MyMiddleware::class));
+        $this->assertEquals(
+            'fooWithMiddleware',
+            $this->app->make(MyMiddleware::class)->handle('foo', $next)
+        );
+    }
+}
+
+class MyMiddleware {
+    public function handle($request, $next)
+    {
+        return $next($request . 'WithMiddleware');
+    }
+}


### PR DESCRIPTION
Hi.
This PR adds a `withMiddleware` method, as the inverse of `withoutMiddleware` one.

Example:

I have a middleware applied to all my application. I want to deactivate this middleware during the tests:
```php

abstract class TestCase extends BaseTestCase
{
    use CreatesApplication, RefreshDatabase;

    protected function setUp()
    {
        parent::setUp();
        
        $this->withoutMiddleware(MyMiddleware::class);
    }
}
```

But, just in some tests, where the middleware is needed, I would like to re-enable it:

```php
public function testThatMyMiddlewareIsApplied() {
        $this->withMiddleware(MyMiddleware::class);
        // my test
}
```

It's kind the same than `withExceptionHandling` method.

It's fully tested, and I've taken this opportunity to add some tests for the `withoutMiddleware` existing method.

Thanks for your answer.