### PR TITLE
[5.5] Allow event generation from multiple service providers

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -614,6 +614,21 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     }
 
     /**
+     * Get the registered service provider instances if any exist.
+     *
+     * @param  \Illuminate\Support\ServiceProvider|string  $provider
+     * @return array
+     */
+    public function getProviders($provider)
+    {
+        $name = is_string($provider) ? $provider : get_class($provider);
+
+        return Arr::where($this->serviceProviders, function ($value) use ($name) {
+            return $value instanceof $name;
+        });
+    }
+
+    /**
      * Resolve a service provider instance from the class name.
      *
      * @param  string  $provider

--- a/src/Illuminate/Foundation/Console/EventGenerateCommand.php
+++ b/src/Illuminate/Foundation/Console/EventGenerateCommand.php
@@ -29,10 +29,12 @@ class EventGenerateCommand extends Command
      */
     public function handle()
     {
-        $provider = $this->laravel->getProvider(EventServiceProvider::class);
+        $providers = $this->laravel->getProviders(EventServiceProvider::class);
 
-        foreach ($provider->listens() as $event => $listeners) {
-            $this->makeEventAndListeners($event, $listeners);
+        foreach ($providers as $provider) {
+            foreach ($provider->listens() as $event => $listeners) {
+                $this->makeEventAndListeners($event, $listeners);
+            }
         }
 
         $this->info('Events and listeners generated successfully!');


### PR DESCRIPTION
The artisan "event:generate" command currently only works if you have only one registered ServiceProvider that extends the framework`s EventServiceProvider class. Any other ServiceProvider that extends that class won't be recognized as an EventServiceProvider.