### PR TITLE
[5.5] Clean up code and docs in Illuminate/Foundation/Application

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -224,7 +224,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
      */
     public function afterLoadingEnvironment(Closure $callback)
     {
-        return $this->afterBootstrapping(
+        $this->afterBootstrapping(
             LoadEnvironmentVariables::class, $callback
         );
     }
@@ -299,7 +299,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     /**
      * Get the path to the application "app" directory.
      *
-     * @param string $path Optionally, a path to append to the app path
+     * @param  string  $path  Optionally, a path to append to the app path
      * @return string
      */
     public function path($path = '')
@@ -310,7 +310,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     /**
      * Get the base path of the Laravel installation.
      *
-     * @param string $path Optionally, a path to append to the base path
+     * @param  string  $path  Optionally, a path to append to the base path.
      * @return string
      */
     public function basePath($path = '')
@@ -321,7 +321,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     /**
      * Get the path to the bootstrap directory.
      *
-     * @param string $path Optionally, a path to append to the bootstrap path
+     * @param  string  $path  Optionally, a path to append to the bootstrap path.
      * @return string
      */
     public function bootstrapPath($path = '')
@@ -332,7 +332,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     /**
      * Get the path to the application configuration files.
      *
-     * @param string $path Optionally, a path to append to the config path
+     * @param  string  $path  Optionally, a path to append to the config path.
      * @return string
      */
     public function configPath($path = '')
@@ -343,7 +343,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     /**
      * Get the path to the database directory.
      *
-     * @param string $path Optionally, a path to append to the database path
+     * @param  string  $path  Optionally, a path to append to the database path.
      * @return string
      */
     public function databasePath($path = '')
@@ -566,7 +566,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
      *
      * @param  \Illuminate\Support\ServiceProvider|string  $provider
      * @param  array  $options
-     * @param  bool   $force
+     * @param  bool  $force
      * @return \Illuminate\Support\ServiceProvider
      */
     public function register($provider, $options = [], $force = false)
@@ -704,7 +704,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     /**
      * Resolve the given type from the container.
      *
-     * (Overriding Container::make)
+     * @override
      *
      * @param  string  $abstract
      * @param  array  $parameters
@@ -724,7 +724,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     /**
      * Determine if the given abstract type has been bound.
      *
-     * (Overriding Container::bound)
+     * @override
      *
      * @param  string  $abstract
      * @return bool
@@ -747,7 +747,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     /**
      * Boot the application's service providers.
      *
-     * @return void
+     * @return void|null
      */
     public function boot()
     {
@@ -913,9 +913,9 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     /**
      * Throw an HttpException with the given data.
      *
-     * @param  int     $code
+     * @param  int  $code
      * @param  string  $message
-     * @param  array   $headers
+     * @param  array  $headers
      * @return void
      *
      * @throws \Symfony\Component\HttpKernel\Exception\HttpException
@@ -1138,6 +1138,8 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
 
     /**
      * Flush the container of all bindings and resolved instances.
+     *
+     * @override
      *
      * @return void
      */


### PR DESCRIPTION
* Use `@override` in phpdocs since is supported by static analysis tools
* when no parameter is supplied for `return` NULL will be returned
* Removed `return` from afterLoadingEnvironment (should return `void`)
* Fixed spacing of docblocks

https://github.com/phan/phan/wiki/Annotating-Your-Source-Code#override
http://php.net/manual/en/function.return.php