### PR TITLE
Adding an orderByField method to db builder

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1455,6 +1455,17 @@ class Builder
     }
 
     /**
+     * Add an "order by field" clause to the query.
+     * @param string $column
+     * @param array $columnValues
+     * @return $this
+     */
+    public function orderByField($column, $columnValues)
+    {
+        return $this->orderByRaw($this->grammar->compileField($column, $columnValues));
+    }
+
+    /**
      * Add a raw "order by" clause to the query.
      *
      * @param  string  $sql

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -584,10 +584,10 @@ class Grammar extends BaseGrammar
     public function compileField($column, $columnValues)
     {
         $columnValues = collect($columnValues)->map(function ($columnValue) {
-            return '"' . $columnValue . '"';
+            return '"'.$columnValue.'"';
         })->implode(', ');
 
-        return 'field(' . $column . ', ' . $columnValues . ')';
+        return 'field(`'.$column.'`, '.$columnValues.')';
     }
 
     /**

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -576,6 +576,21 @@ class Grammar extends BaseGrammar
     }
 
     /**
+     * Compile the field database function into SQL.
+     * @param string $column
+     * @param array $columnValues
+     * @return string
+     */
+    public function compileField($column, $columnValues)
+    {
+        $columnValues = collect($columnValues)->map(function ($columnValue) {
+            return '"' . $columnValue . '"';
+        })->implode(', ');
+
+        return 'field(' . $column . ', ' . $columnValues . ')';
+    }
+
+    /**
      * Compile the "limit" portions of the query.
      *
      * @param  \Illuminate\Database\Query\Builder  $query


### PR DESCRIPTION
Hello,

This PR allows us to easily translate this:
```sql
SELECT * FROM logs ORDER BY FIELD(`severity`, "ERROR", "WARNING", "INFO")
```

into:
```php
DB::table('logs')->orderByField('severity', [
    'ERROR',
    'WARNING',
    'INFO'
])->get();
```

Currently, the way to do it is:
```php
DB::table('logs')->orderByRaw('FIELD(severity, "ERROR", "WARNING", "INFO")')->get();
```

I've worked on a few projects that required the functionality, however, I used custom scopes.

I understand that some may make the argument that this should not be in the core of the framework, but at least let's put it out for discussion.

Currently, the following code will only work with the MySQL driver as the "field" sql function is available only in MySQL. There are workarounds for the other RDBs. If the maintainers decide that this  feature is okay to be merged, I could provide the implementations of it for sqlite and postgres.

Thank you!