### PR TITLE
[5.5] Fix HasManyThrough relation with custom keys when used in whereHas

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -439,7 +439,7 @@ class HasManyThrough extends Relation
         $this->performJoin($query);
 
         return $query->select($columns)->whereColumn(
-            $this->getExistenceCompareKey(), '=', $this->getQualifiedFirstKeyName()
+            $this->getQualifiedLocalKeyName(), '=', $this->getQualifiedFirstKeyName()
         );
     }
 
@@ -479,13 +479,13 @@ class HasManyThrough extends Relation
     }
 
     /**
-     * Get the key for comparing against the parent key in "has" query.
+     * Get the qualified local key on the far parent model.
      *
      * @return string
      */
-    public function getExistenceCompareKey()
+    public function getQualifiedLocalKeyName()
     {
-        return $this->farParent->getQualifiedKeyName();
+        return $this->farParent->getTable().'.'.$this->localKey;
     }
 
     /**

--- a/tests/Database/DatabaseEloquentHasManyThroughIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentHasManyThroughIntegrationTest.php
@@ -109,6 +109,16 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
         $this->assertCount(2, $posts);
     }
 
+    public function testWhereHasOnARelationWithCustomIntermediateAndLocalKey()
+    {
+        $this->seedData();
+        $country = HasManyThroughIntermediateTestCountry::whereHas('posts', function ($query) {
+            $query->where('title', 'A title');
+        })->get();
+
+        $this->assertCount(1, $country);
+    }
+
     /**
      * @expectedException \Illuminate\Database\Eloquent\ModelNotFoundException
      * @expectedExceptionMessage No query results for model [Illuminate\Tests\Database\HasManyThroughTestPost].


### PR DESCRIPTION
Hello,

When I use a HasManyThrough relation with a custom localKey in a Eloquent whereHas statement, it returns 0 results. This is because in the HasManyThrough class the primary key of the farParent model is used, instead of the in the relation defined custom key of that model.

To fix this, we go from

```
public function getExistenceCompareKey()
{
    return $this->farParent->getQualifiedKeyName();
}

```
to

```
public function getExistenceCompareKey()
{
    return $this->farParent->getTable().'.'.$this->localKey;
}
```

Test included in the commit.