### PR TITLE
[5.5] Update depreciated MailFake::queue() signature.

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -292,12 +292,10 @@ class MailFake implements Mailer
      * Queue a new e-mail message for sending.
      *
      * @param  string|array  $view
-     * @param  array  $data
-     * @param  \Closure|string  $callback
      * @param  string|null  $queue
      * @return mixed
      */
-    public function queue($view, array $data = [], $callback = null, $queue = null)
+    public function queue($view, $queue = null)
     {
         if (! $view instanceof Mailable) {
             return;


### PR DESCRIPTION
Update 'queue' function signature of 'MailFake.php' to match signature of 'queue' on 'Mailer.php' after 5.5 upgrade.

Currently testing is broken if you try to use `Mail::queue()` after calling `Mail::fake()` in a test class since the signature of the fake does not match the updated signature of the real `queue()` function after the 5.5 upgrade.