### PR TITLE
Fix loading of unnecessary relations

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -937,7 +937,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public function toArray()
     {
-        return array_merge($this->attributesToArray(), $this->relationsToArray());
+        return array_merge($this->relationsToArray(), $this->attributesToArray());
     }
 
     /**


### PR DESCRIPTION
While calling `toArray` or `toJson` on a model, subsequent call to `attributesToArray` may load extra relations that the following call `relationsToArray` will take into account. This can result in either including unnecessary relations to the final converted object or even stuck in infinite loop.

This can be avoided just by changing the order of these two functions.

Quick example that can lead to infinite loop:

`User` model has `$with = ['profile']`
`Profile` has a getter in `$appends` that eager loads a `User` by calling `$this->user`

On the other hand, if instead of calling `$this->user`, another relation was loaded, let's say `$this->address`, the later address object will also be unnecessarily included in the final converted array.