### PR TITLE
[5.5] Allow retrying queue jobs using a range of ids. ex: 10-20

### DIFF
--- a/src/Illuminate/Queue/Console/RetryCommand.php
+++ b/src/Illuminate/Queue/Console/RetryCommand.php
@@ -54,6 +54,12 @@ class RetryCommand extends Command
 
         if (count($ids) === 1 && $ids[0] === 'all') {
             $ids = Arr::pluck($this->laravel['queue.failer']->all(), 'id');
+        } elseif (count($ids) === 1 && count($rangeEdges = explode('-', $ids[0])) == 2) {
+            $rangeIds = [];
+            for ($i = $rangeEdges[0]; $i<=$rangeEdges[1]; $i++) {
+                $rangeIds[] = $i;
+            }
+            $ids = $rangeIds;
         }
 
         return $ids;

--- a/src/Illuminate/Queue/Console/RetryCommand.php
+++ b/src/Illuminate/Queue/Console/RetryCommand.php
@@ -54,9 +54,9 @@ class RetryCommand extends Command
 
         if (count($ids) === 1 && $ids[0] === 'all') {
             $ids = Arr::pluck($this->laravel['queue.failer']->all(), 'id');
-        } elseif (count($ids) === 1 && count($rangeEdges = explode('-', $ids[0])) == 2) {
+        } elseif (count($ids) === 1 && count($rangeEdges = explode('-', $ids[0])) == 2 && $rangeEdges[1] > 0) {
             $rangeIds = [];
-            for ($i = $rangeEdges[0]; $i<=$rangeEdges[1]; $i++) {
+            for ($i = $rangeEdges[0]; $i <= $rangeEdges[1]; $i++) {
                 $rangeIds[] = $i;
             }
             $ids = $rangeIds;


### PR DESCRIPTION
Right now the only possible arguments for `artisan queue:retry` are either a list of ids or the key `all`.

Instead of providing manually the list of failed job ids, we could use a range of ids (min, max).

For example: `php artisan queue:retry 5-10` is same as `php artisan queue:retry 5 6 7 8 9 10`

This is useful for the case there is a group of failed jobs caused by some temporary outage of a part of the system, where suddenly a group of jobs with consecutive ids fails. 

