### PR TITLE
[5.5] Fix Problem with using old() in templates

### DIFF
--- a/src/Illuminate/Http/Concerns/InteractsWithFlashData.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithFlashData.php
@@ -13,7 +13,7 @@ trait InteractsWithFlashData
      */
     public function old($key = null, $default = null)
     {
-        return $this->session()->getOldInput($key, $default);
+        return $this->hasSession() ? $this->session()->getOldInput($key, $default) : $default;
     }
 
     /**


### PR DESCRIPTION
- Laravel Version: 5.5.*
- PHP Version: 7.1.7
- Database Driver & Version: N/A

### Description:

According to the docs, it's possible to use the `old()` method [in Blade templates](https://laravel.com/docs/5.5/requests#old-input). However, when rendering views manually (via tinker, for example), it breaks. You have to jump through hoops to get it working again. The reason is this line of code:

```php
// @see https://github.com/laravel/framework/blob/5.5/src/Illuminate/Http/Concerns/InteractsWithFlashData.php#L16
return $this->session()->getOldInput($key, $default);
```

The functionality has a hard requirement on a session being available in the request. This is obviously not the case when using tinker. This PR fixes that by checking whether the session exists.