### PR TITLE
[5.5] Add allowed ips to Maintenance Mode

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/CheckForMaintenanceMode.php
+++ b/src/Illuminate/Foundation/Http/Middleware/CheckForMaintenanceMode.php
@@ -37,12 +37,20 @@ class CheckForMaintenanceMode
      */
     public function handle($request, Closure $next)
     {
-        if ($this->app->isDownForMaintenance()) {
+        if ($this->app->isDownForMaintenance() && !$this->isAllowedIp($request)) {
             $data = json_decode(file_get_contents($this->app->storagePath().'/framework/down'), true);
 
             throw new MaintenanceModeException($data['time'], $data['retry'], $data['message']);
         }
 
         return $next($request);
+    }
+    
+    protected function isAllowedIp($request)
+    {
+        $ip = $request->getClientIp();
+        $allowed = explode(',', getenv('MAINTENANCE_ALLOWED_IPS'));
+
+        return in_array($ip, $allowed);
     }
 }

--- a/src/Illuminate/Foundation/Http/Middleware/CheckForMaintenanceMode.php
+++ b/src/Illuminate/Foundation/Http/Middleware/CheckForMaintenanceMode.php
@@ -37,7 +37,7 @@ class CheckForMaintenanceMode
      */
     public function handle($request, Closure $next)
     {
-        if ($this->app->isDownForMaintenance() && !$this->isAllowedIp($request)) {
+        if ($this->app->isDownForMaintenance() && ! $this->isAllowedIp($request)) {
             $data = json_decode(file_get_contents($this->app->storagePath().'/framework/down'), true);
 
             throw new MaintenanceModeException($data['time'], $data['retry'], $data['message']);
@@ -45,7 +45,7 @@ class CheckForMaintenanceMode
 
         return $next($request);
     }
-    
+
     protected function isAllowedIp($request)
     {
         $ip = $request->getClientIp();

--- a/src/Illuminate/Foundation/Http/Middleware/CheckForMaintenanceMode.php
+++ b/src/Illuminate/Foundation/Http/Middleware/CheckForMaintenanceMode.php
@@ -46,11 +46,17 @@ class CheckForMaintenanceMode
         return $next($request);
     }
 
+    /**
+     * Check if is allowed ip in maintenance mode.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return boolean
+     */
     protected function isAllowedIp($request)
     {
         $ip = $request->getClientIp();
-        $allowed = explode(',', getenv('MAINTENANCE_ALLOWED_IPS'));
+        $allowed = config('app.maintenance_allowed_ips');
 
-        return in_array($ip, $allowed);
+        return $allowed && in_array($ip, $allowed);
     }
 }


### PR DESCRIPTION
With this change we can set one or more ip addresses that it will be allowed to use the app while it will be on maintenance for the rest of the world.