### PR TITLE
[5.6] Added info method to hashing component.

### DIFF
--- a/src/Illuminate/Contracts/Hashing/Hasher.php
+++ b/src/Illuminate/Contracts/Hashing/Hasher.php
@@ -31,4 +31,12 @@ interface Hasher
      * @return bool
      */
     public function needsRehash($hashedValue, array $options = []);
+
+    /**
+     * Get info about the current hashedValue.
+     *
+     * @param  string  $hashedValue
+     * @return array
+     */
+    public function info($hashedValue);
 }

--- a/src/Illuminate/Hashing/ArgonHasher.php
+++ b/src/Illuminate/Hashing/ArgonHasher.php
@@ -157,4 +157,16 @@ class ArgonHasher implements HasherContract
     {
         return $options['processors'] ?? $this->processors;
     }
+
+    /**
+     * Get info about the current hashedValue.
+     *
+     * @param  string $hashedValue
+     *
+     * @return array
+     */
+    public function info($hashedValue)
+    {
+        return password_get_info($hashedValue);
+    }
 }

--- a/src/Illuminate/Hashing/BcryptHasher.php
+++ b/src/Illuminate/Hashing/BcryptHasher.php
@@ -90,4 +90,16 @@ class BcryptHasher implements HasherContract
     {
         return $options['rounds'] ?? $this->rounds;
     }
+
+    /**
+     * Get info about the current hashedValue.
+     *
+     * @param  string $hashedValue
+     *
+     * @return array
+     */
+    public function info($hashedValue)
+    {
+        return password_get_info($hashedValue);
+    }
 }

--- a/src/Illuminate/Hashing/HashManager.php
+++ b/src/Illuminate/Hashing/HashManager.php
@@ -64,6 +64,11 @@ class HashManager extends Manager implements Hasher
         return $this->driver()->needsRehash($hashedValue, $options);
     }
 
+    public function info($hashedValue)
+    {
+        return $this->driver()->info($hashedValue);
+    }
+
     /**
      * Get the default driver name.
      *


### PR DESCRIPTION
The only missing method to complete php password_hashing API is now added to the component. 

`Hash::info($hashedPassword)` seems very readable to me. 