### PR TITLE
[5.5] Modify `setContent()` so it only updates `$response->original` if its empty

### DIFF
--- a/src/Illuminate/Http/Response.php
+++ b/src/Illuminate/Http/Response.php
@@ -24,7 +24,9 @@ class Response extends BaseResponse
      */
     public function setContent($content)
     {
-        $this->original = $content;
+        if ($this->original == '') {
+            $this->original = $content;
+        }
 
         // If the content is "JSONable" we will set the appropriate header and convert
         // the content to JSON. This is useful when returning something like models

--- a/tests/Http/HttpResponseTest.php
+++ b/tests/Http/HttpResponseTest.php
@@ -196,6 +196,17 @@ class HttpResponseTest extends TestCase
         $response = new RedirectResponse('foo.bar');
         $response->doesNotExist('bar');
     }
+
+    public function testNonEmptyOriginalContentIsNotChamnged()
+    {
+        $response = new \Illuminate\Http\Response();
+        $this->assertEquals(null, $response->getOriginalContent());
+        $response->setContent('original content');
+        $this->assertEquals('original content', $response->getOriginalContent());
+        $response->setContent('modified content');
+        $this->assertEquals('modified content', $response->getContent());
+        $this->assertEquals('original content', $response->getOriginalContent());
+    }
 }
 
 class ArrayableStub implements Arrayable


### PR DESCRIPTION
The motivation for this change was making a middleware to use [tidy-html5](https://github.com/htacg/tidy-html5).

In particular, when running some HTML through `libtidy` it can generate issues such as pointing out `<img>` tags with no alt attribute. The way I was doing this was adding a `<div>` of these errors to the end of the HTML.

Initially my `Response` objects usually had a `content` attribute that was the unmodified HTML, and an `original` attribute that was a `View` object. Once my middlware ran the `setContent()` method on the `$response` in order to change the HTML to include `libtidy`’s output both the `content` and `original` attribute were set to the modified HTML.

In particular this meant any of my tests that had assertions such as `assertViewHas` would fail with an error message like `The response is not a view`.

So this change will make the `setContent()` method only change the `original` attribute if it isn’t an empty string or null.