### PR TITLE
[5.5] Add response and download methods to file system

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -16,6 +16,7 @@ use League\Flysystem\AwsS3v3\AwsS3Adapter;
 use League\Flysystem\FileNotFoundException;
 use League\Flysystem\Rackspace\RackspaceAdapter;
 use League\Flysystem\Adapter\Local as LocalAdapter;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 use Illuminate\Contracts\Filesystem\Cloud as CloudFilesystemContract;
 use Illuminate\Contracts\Filesystem\Filesystem as FilesystemContract;
 use Illuminate\Contracts\Filesystem\FileNotFoundException as ContractFileNotFoundException;
@@ -316,6 +317,49 @@ class FilesystemAdapter implements FilesystemContract, CloudFilesystemContract
     public function lastModified($path)
     {
         return $this->driver->getTimestamp($path);
+    }
+
+    /**
+     * Create a streamed response for a given file.
+     *
+     * @param  string  $path
+     * @param  string|null  $name
+     * @param  array|null  $headers
+     * @param  string|null  $disposition
+     * @return \Symfony\Component\HttpFoundation\StreamedResponse
+     */
+    public function response($path, $name = null, array $headers = [], $disposition = 'inline')
+    {
+        $response = new StreamedResponse();
+
+        $disposition = $response->headers->makeDisposition($disposition, $name ?? basename($path));
+
+        $response->headers->replace($headers + [
+            'Content-Type' => $this->mimeType($path),
+            'Content-Length' => $this->size($path),
+            'Content-Disposition' => $disposition,
+        ]);
+
+        $response->setCallback(function () use ($path) {
+            $stream = $this->driver->readStream($path);
+            fpassthru($stream);
+            fclose($stream);
+        });
+
+        return $response;
+    }
+
+    /**
+     * Create a streamed download response for a given file.
+     *
+     * @param  string  $path
+     * @param  string|null  $name
+     * @param  array|null  $headers
+     * @return \Symfony\Component\HttpFoundation\StreamedResponse
+     */
+    public function download($path, $name = null, array $headers = [])
+    {
+        return $this->response($path, $name, $headers, 'attachment');
     }
 
     /**

--- a/tests/Filesystem/FilesystemAdapterTest.php
+++ b/tests/Filesystem/FilesystemAdapterTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Illuminate\Tests\Filesystem;
+
+use PHPUnit\Framework\TestCase;
+use League\Flysystem\Filesystem;
+use League\Flysystem\Adapter\Local;
+use Illuminate\Filesystem\FilesystemAdapter;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+class FilesystemAdapterTest extends TestCase
+{
+    private $filesystem;
+
+    public function setUp()
+    {
+        $this->filesystem = new Filesystem(new Local(__DIR__.'/tmp'));
+    }
+
+    public function tearDown()
+    {
+        $filesystem = new Filesystem(new Local(__DIR__));
+        $filesystem->deleteDir('tmp');
+    }
+
+    public function testResponse()
+    {
+        $this->filesystem->write('file.txt', 'Hello World');
+        $files = new FilesystemAdapter($this->filesystem);
+        $response = $files->response('file.txt');
+
+        ob_start();
+        $response->sendContent();
+        $content = ob_get_clean();
+
+        $this->assertInstanceOf(StreamedResponse::class, $response);
+        $this->assertEquals('Hello World', $content);
+        $this->assertEquals('inline; filename="file.txt"', $response->headers->get('content-disposition'));
+    }
+
+    public function testDownload()
+    {
+        $this->filesystem->write('file.txt', 'Hello World');
+        $files = new FilesystemAdapter($this->filesystem);
+        $response = $files->download('file.txt', 'hello.txt');
+        $this->assertInstanceOf(StreamedResponse::class, $response);
+        $this->assertEquals('attachment; filename="hello.txt"', $response->headers->get('content-disposition'));
+    }
+}


### PR DESCRIPTION
These are helpful in situations where you want to return a file from storage as a response. For example:

```php
class DocumentController extends Controller
{
    public function show(Document $document)
    {
        // Return the document as a response
        return Storage::response($document->path);

        // Use a custom filename
        return Storage::response($document->path, 'sweet.pdf');

        // Force the file to download
        return Storage::download($document->path);
    }
}
```


These return a `StreamedResponse`, allowing the file contents to begin outputting to the browser while still downloading from their source. This is especially useful for cloud file systems like S3 or Rackspace.

The `download` method is really just a shortcut for the `response` method with the `$disposition` set to `attachment`.