### PR TITLE
[5.5] Change cache table value from `TEXT` to `MEDIUMTEXT`

### DIFF
--- a/src/Illuminate/Cache/Console/stubs/cache.stub
+++ b/src/Illuminate/Cache/Console/stubs/cache.stub
@@ -15,7 +15,7 @@ class CreateCacheTable extends Migration
     {
         Schema::create('cache', function (Blueprint $table) {
             $table->string('key')->unique();
-            $table->text('value');
+            $table->longText('value');
             $table->integer('expiration');
         });
     }

--- a/src/Illuminate/Cache/Console/stubs/cache.stub
+++ b/src/Illuminate/Cache/Console/stubs/cache.stub
@@ -15,7 +15,7 @@ class CreateCacheTable extends Migration
     {
         Schema::create('cache', function (Blueprint $table) {
             $table->string('key')->unique();
-            $table->longText('value');
+            $table->mediumText('value');
             $table->integer('expiration');
         });
     }


### PR DESCRIPTION
When using `php artisan cache:table` a cache table with a `value` field `TEXT` is created when using `MySQL`. In some cases the database cache with `MySQL` can behave different to the file cache.

Some plugins caches big data and they wasn't longer working when switching the default `CACHE_DRIVER` from `file` to `database` inside the `.env` file.

I changed the migration to work with `LONGTEXT` instead of `TEXT`.

UPDATED: Changed the type again from `LONGTEXT` to `MEDIUMTEXT`. That should be beig enough and also will respect the speed of that table.