### PR TITLE
[5.6] Split Authenticatable contract

### DIFF
--- a/src/Illuminate/Auth/GenericUser.php
+++ b/src/Illuminate/Auth/GenericUser.php
@@ -3,8 +3,9 @@
 namespace Illuminate\Auth;
 
 use Illuminate\Contracts\Auth\Authenticatable as UserContract;
+use Illuminate\Contracts\Auth\RememberSession as RememberSessionContract;
 
-class GenericUser implements UserContract
+class GenericUser implements UserContract, RememberSessionContract
 {
     /**
      * All of the user's attributes.

--- a/src/Illuminate/Contracts/Auth/Authenticatable.php
+++ b/src/Illuminate/Contracts/Auth/Authenticatable.php
@@ -24,26 +24,4 @@ interface Authenticatable
      * @return string
      */
     public function getAuthPassword();
-
-    /**
-     * Get the token value for the "remember me" session.
-     *
-     * @return string
-     */
-    public function getRememberToken();
-
-    /**
-     * Set the token value for the "remember me" session.
-     *
-     * @param  string  $value
-     * @return void
-     */
-    public function setRememberToken($value);
-
-    /**
-     * Get the column name for the "remember me" token.
-     *
-     * @return string
-     */
-    public function getRememberTokenName();
 }

--- a/src/Illuminate/Contracts/Auth/RememberSession.php
+++ b/src/Illuminate/Contracts/Auth/RememberSession.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Illuminate\Contracts\Auth;
+
+interface RememberSession
+{
+    /**
+     * Get the token value for the "remember me" session.
+     *
+     * @return string
+     */
+    public function getRememberToken();
+
+    /**
+     * Set the token value for the "remember me" session.
+     *
+     * @param  string  $value
+     * @return void
+     */
+    public function setRememberToken($value);
+
+    /**
+     * Get the column name for the "remember me" token.
+     *
+     * @return string
+     */
+    public function getRememberTokenName();
+}

--- a/src/Illuminate/Foundation/Auth/User.php
+++ b/src/Illuminate/Foundation/Auth/User.php
@@ -7,11 +7,13 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Auth\Passwords\CanResetPassword;
 use Illuminate\Foundation\Auth\Access\Authorizable;
 use Illuminate\Contracts\Auth\Authenticatable as AuthenticatableContract;
+use Illuminate\Contracts\Auth\RememberSession as RememberSessionContract;
 use Illuminate\Contracts\Auth\Access\Authorizable as AuthorizableContract;
 use Illuminate\Contracts\Auth\CanResetPassword as CanResetPasswordContract;
 
 class User extends Model implements
     AuthenticatableContract,
+    RememberSessionContract,
     AuthorizableContract,
     CanResetPasswordContract
 {


### PR DESCRIPTION
To support SOLID design principles (namely Interface segregation principle) we should split Authenticatable   interface.