### PR TITLE
[5.2] Fix wrong "expected" and "actual" in `seeHeader`

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -414,7 +414,7 @@ trait MakesHttpRequests
 
         if (! is_null($value)) {
             $this->assertEquals(
-                $headers->get($headerName), $value,
+                $value, $headers->get($headerName),
                 "Header [{$headerName}] was found, but value [{$headers->get($headerName)}] does not match [{$value}]."
             );
         }


### PR DESCRIPTION
"Expected" and "actual" are reversed incorrectly.