### PR TITLE
[5.6] Update whereBetween for support values in wrong order

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -904,6 +904,14 @@ class Builder
 
         $this->wheres[] = compact('column', 'type', 'boolean', 'not');
 
+        if (count($values) !== 2) {
+            throw new InvalidArgumentException('Invalid count of binding values.');
+        }
+
+        if (array_first($values) > array_last($values)) {
+            $values = array_reverse($values);
+        }
+
         $this->addBinding($values, 'where');
 
         return $this;

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -416,6 +416,21 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->select('*')->from('users')->whereNotBetween('id', [1, 2]);
         $this->assertEquals('select * from "users" where "id" not between ? and ?', $builder->toSql());
         $this->assertEquals([0 => 1, 1 => 2], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereBetween('id', [2, 1]);
+        $this->assertEquals('select * from "users" where "id" between ? and ?', $builder->toSql());
+        $this->assertEquals([0 => 1, 1 => 2], $builder->getBindings());
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testWhereBetweensException()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereNotBetween('id', [2, 1, 3]);
+        $this->expectException(\InvalidArgumentException::class);
     }
 
     public function testBasicOrWheres()


### PR DESCRIPTION
I update whereBetween with adding array_reverse for support values in wrong order.
A also add a check for a count of values pass to method.