### PR TITLE
[5.5] Make the Mailable class abstract

### DIFF
--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -13,7 +13,7 @@ use Illuminate\Contracts\Queue\Factory as Queue;
 use Illuminate\Contracts\Mail\Mailer as MailerContract;
 use Illuminate\Contracts\Mail\Mailable as MailableContract;
 
-class Mailable implements MailableContract, Renderable
+abstract class Mailable implements MailableContract, Renderable
 {
     /**
      * The person the message is from.


### PR DESCRIPTION
This class wouldn't work without being extended because of the required `build` method.

This PR makes the class as abstract so developers can see at a glance it must be extended.