### PR TITLE
[5.5] `Model::$exists` to be set to false when force-deleting a model using SoftDeletes

### DIFF
--- a/src/Illuminate/Database/Eloquent/SoftDeletes.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletes.php
@@ -44,9 +44,9 @@ trait SoftDeletes
      */
     protected function performDeleteOnModel()
     {
-        $this->exists = false;
-
         if ($this->forceDeleting) {
+            $this->exists = false;
+
             return $this->newQueryWithoutScopes()->where($this->getKeyName(), $this->getKey())->forceDelete();
         }
 

--- a/src/Illuminate/Database/Eloquent/SoftDeletes.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletes.php
@@ -44,6 +44,8 @@ trait SoftDeletes
      */
     protected function performDeleteOnModel()
     {
+        $this->exists = false;
+
         if ($this->forceDeleting) {
             return $this->newQueryWithoutScopes()->where($this->getKeyName(), $this->getKey())->forceDelete();
         }


### PR DESCRIPTION
On model force deletion, made sure that `$model->exists` is set to false.