### PR TITLE
[5.5] Refactor Arr::flatten to prevent a serious performance hit

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -218,6 +218,7 @@ class Arr
                 $result = array_merge($result, static::flatten($item, $depth - 1));
             }
         }
+
         return $result;
     }
 

--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -206,17 +206,19 @@ class Arr
      */
     public static function flatten($array, $depth = INF)
     {
-        return array_reduce($array, function ($result, $item) use ($depth) {
+        $result = [];
+        foreach ($array as $item) {
             $item = $item instanceof Collection ? $item->all() : $item;
 
             if (! is_array($item)) {
-                return array_merge($result, [$item]);
+                $result[] = $item;
             } elseif ($depth === 1) {
-                return array_merge($result, array_values($item));
+                $result = array_merge($result, array_values($item));
             } else {
-                return array_merge($result, static::flatten($item, $depth - 1));
+                $result = array_merge($result, static::flatten($item, $depth - 1));
             }
-        }, []);
+        }
+        return $result;
     }
 
     /**


### PR DESCRIPTION
Change that resolves #22086 

The root cause of the problem is calling array_merge for every item in the array, that has a serious performance hit on large arrays.