### PR TITLE
[5.6] Allow different collection classes to be returned

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -83,6 +83,13 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     protected $perPage = 15;
 
     /**
+     * The collection instance to be returned.
+     *
+     * @var \Illuminate\Database\Eloquent\Collection
+     */
+    protected $collection = Collection::class;
+
+    /**
      * Indicates if the model exists.
      *
      * @var bool
@@ -912,7 +919,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public function newCollection(array $models = [])
     {
-        return new Collection($models);
+        return new $this->collection($models);
     }
 
     /**

--- a/tests/Integration/Database/EloquentModelCollectionTest.php
+++ b/tests/Integration/Database/EloquentModelCollectionTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database;
+
+use Orchestra\Testbench\TestCase;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Collection as BaseCollection;
+
+/**
+ * @group integration
+ */
+class EloquentModelCollectionTest extends TestCase
+{
+    protected function getEnvironmentSetUp($app)
+    {
+        $app['config']->set('app.debug', 'true');
+
+        $app['config']->set('database.default', 'testbench');
+
+        $app['config']->set('database.connections.testbench', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+        ]);
+    }
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        Schema::create('test_model', function ($table) {
+            $table->increments('id');
+        });
+    }
+
+    public function test_it_returns_a_different_collection_instance()
+    {
+        $this->assertNotInstanceOf(DummyCollection::class, TestModelBaseCollection::all());
+        $this->assertInstanceOf(BaseCollection::class, TestModelBaseCollection::all());
+
+        $collection = TestModel::all();
+
+        $this->assertInstanceOf(DummyCollection::class, $collection);
+        $this->assertInstanceOf(BaseCollection::class, $collection);
+    }
+}
+
+class TestModel extends Model
+{
+    public $table = 'test_model';
+    public $timestamps = false;
+    protected $guarded = ['id'];
+    protected $collection = DummyCollection::class;
+}
+
+class TestModelBaseCollection extends Model
+{
+    public $table = 'test_model';
+    public $timestamps = false;
+    protected $guarded = ['id'];
+}
+
+class DummyCollection extends BaseCollection
+{
+
+}


### PR DESCRIPTION
Just an idea -- this PR would allow different collection classes to be returned by setting a property instead of the newCollection method.  

