### PR TITLE
[5.6] Better enumeration columns support

### DIFF
--- a/src/Illuminate/Database/Grammar.php
+++ b/src/Illuminate/Database/Grammar.php
@@ -138,6 +138,21 @@ abstract class Grammar
     }
 
     /**
+     * Quote string literals.
+     *
+     * @param  string|array  $value
+     * @return string
+     */
+    public function quote($value)
+    {
+        if (is_array($value)) {
+            return implode(', ', array_map([$this, 'quote'], $value));
+        }
+
+        return "'$value'";
+    }
+
+    /**
      * Get the appropriate query parameter place-holder for a value.
      *
      * @param  mixed   $value

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -542,14 +542,14 @@ class MySqlGrammar extends Grammar
     }
 
     /**
-     * Create the column definition for an enum type.
+     * Create the column definition for an enumeration type.
      *
      * @param  \Illuminate\Support\Fluent  $column
      * @return string
      */
     protected function typeEnum(Fluent $column)
     {
-        return "enum('".implode("', '", $column->allowed)."')";
+        return sprintf('enum(%s)', $this->quote($column->allowed));
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -512,18 +512,18 @@ class PostgresGrammar extends Grammar
     }
 
     /**
-     * Create the column definition for an enum type.
+     * Create the column definition for an enumeration type.
      *
      * @param  \Illuminate\Support\Fluent  $column
      * @return string
      */
     protected function typeEnum(Fluent $column)
     {
-        $allowed = array_map(function ($a) {
-            return "'{$a}'";
-        }, $column->allowed);
-
-        return "varchar(255) check (\"{$column->name}\" in (".implode(', ', $allowed).'))';
+        return sprintf(
+            'varchar(255) check ("%s" in (%s))',
+            $column->name,
+            $this->quote($column->allowed)
+        );
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -502,14 +502,18 @@ class SQLiteGrammar extends Grammar
     }
 
     /**
-     * Create the column definition for an enum type.
+     * Create the column definition for an enumeration type.
      *
      * @param  \Illuminate\Support\Fluent  $column
      * @return string
      */
     protected function typeEnum(Fluent $column)
     {
-        return 'varchar';
+        return sprintf(
+            'varchar check ("%s" in (%s))',
+            $column->name,
+            $this->quote($column->allowed)
+        );
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -445,14 +445,18 @@ class SqlServerGrammar extends Grammar
     }
 
     /**
-     * Create the column definition for an enum type.
+     * Create the column definition for an enumeration type.
      *
      * @param  \Illuminate\Support\Fluent  $column
      * @return string
      */
     protected function typeEnum(Fluent $column)
     {
-        return 'nvarchar(255)';
+        return sprintf(
+            'nvarchar(255) check ("%s" in (%s))',
+            $column->name,
+            $this->quote($column->allowed)
+        );
     }
 
     /**

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -572,11 +572,11 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
     public function testAddingEnum()
     {
         $blueprint = new Blueprint('users');
-        $blueprint->enum('foo', ['bar', 'baz']);
+        $blueprint->enum('role', ['member', 'admin']);
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add `foo` enum(\'bar\', \'baz\') not null', $statements[0]);
+        $this->assertEquals('alter table `users` add `role` enum(\'member\', \'admin\') not null', $statements[0]);
     }
 
     public function testAddingJson()

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -432,11 +432,11 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
     public function testAddingEnum()
     {
         $blueprint = new Blueprint('users');
-        $blueprint->enum('foo', ['bar', 'baz']);
+        $blueprint->enum('role', ['member', 'admin']);
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "foo" varchar(255) check ("foo" in (\'bar\', \'baz\')) not null', $statements[0]);
+        $this->assertEquals('alter table "users" add column "role" varchar(255) check ("role" in (\'member\', \'admin\')) not null', $statements[0]);
     }
 
     public function testAddingDate()

--- a/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
@@ -366,11 +366,11 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
     public function testAddingEnum()
     {
         $blueprint = new Blueprint('users');
-        $blueprint->enum('foo', ['bar', 'baz']);
+        $blueprint->enum('role', ['member', 'admin']);
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "foo" varchar not null', $statements[0]);
+        $this->assertEquals('alter table "users" add column "role" varchar check ("role" in (\'member\', \'admin\')) not null', $statements[0]);
     }
 
     public function testAddingJson()

--- a/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
@@ -432,11 +432,11 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
     public function testAddingEnum()
     {
         $blueprint = new Blueprint('users');
-        $blueprint->enum('foo', ['bar', 'baz']);
+        $blueprint->enum('role', ['member', 'admin']);
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add "foo" nvarchar(255) not null', $statements[0]);
+        $this->assertEquals('alter table "users" add "role" nvarchar(255) check ("role" in (\'member\', \'admin\')) not null', $statements[0]);
     }
 
     public function testAddingJson()


### PR DESCRIPTION
> ## TL;DR
>
> - Currently we have no true support for `enum()` columns when using SQLite and SQL Server although they support `CHECK` constraints like PostgreSQL
>
> - This PR adds this missing functionality to both SQLite and SQL Server so they can have true enumeration columns support that actually work as enumeration columns and validates their stored values

#### Proposal

Currently we have true enumeration columns support for MySQL and PostgreSQL. MySQL implementation is using the native [non-standard `ENUM` data type](https://dev.mysql.com/doc/refman/5.7/en/enum.html) while PostgreSQL implementation is using a `VARCHAR` data type with a `CHECK` constraint - PostgreSQL does have a native [enumerated data type](https://www.postgresql.org/docs/10/static/datatype-enum.html) but they both work and it's easier to implement and sometimes preferable to use constraints. They're well implemented.

Since `CHECK` constraints [are part of SQL-92 standard](http://jakewheat.github.io/sql-overview/sql-92-grammar.html#_11_9_check_constraint_definition) (ANSI X3.135-1992 and ISO/IEC 9075:1992) and both SQLite and SQL Server does support them, I'm proposing true support for enumerated columns for all database drivers.

#### Implementation

Both SQLite and SQL Server would be using the same implementation being used in PostgreSQL: a `VARCHAR` compatible data type with a `CHECK` constraint. SQL Server would be using `NVARCHAR(255)` while SQLite just `VARCHAR` since it does not have support for column length.

As a proof-of-concept that it works, here are the SQL fiddles demonstrating them in action:

- [SQLite](http://sqlfiddle.com/#!7/03f0e/1)
- [SQL Server](http://sqlfiddle.com/#!6/c7d61/1)

#### Changes

I'm targeting this for 5.5 first just because I'm not sure where it would be desirable since it's a feature that would be applied only to new installations and just adds a non-existing behaviour that matches the usage expectation. If this would be acceptable just for 5.6, let me know and I'll rebase it accordingly ASAP. 😉

##### Code

- `Illuminate\Database\Grammar`
  - Added a new `quote()` helper method to reuse within concrete grammars.
- `Illuminate\Database\Schema\Grammars\MySqlGrammar`
- `Illuminate\Database\Schema\Grammars\PostgresGrammar`
  - Changed `typeEnum()` method to use the new `quote()` method, minor code readability improvements.
- `Illuminate\Database\Schema\Grammars\SQLiteGrammar`
- `Illuminate\Database\Schema\Grammars\SqlServerGrammar`
  - Changed `typeEnum()` method to include a new `CHECK` constraint.

##### Tests

- `Illuminate\Tests\Database\DatabaseMySqlSchemaGrammarTest`
- `Illuminate\Tests\Database\DatabasePostgresSchemaGrammarTest`
- `Illuminate\Tests\Database\DatabaseSQLiteSchemaGrammarTest`
- `Illuminate\Tests\Database\DatabaseSqlServerSchemaGrammarTest`
  - Small tweaks and changes to make tests pass.