### PR TITLE
[5.5] Better temporary tables support

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -22,6 +22,21 @@ class SqlServerGrammar extends Grammar
     protected $serials = ['tinyInteger', 'smallInteger', 'mediumInteger', 'integer', 'bigInteger'];
 
     /**
+     * Wrap a table in keyword identifiers.
+     *
+     * @param  \Illuminate\Database\Query\Expression|string  $table
+     * @return string
+     */
+    public function wrapTable($table)
+    {
+        if ($table instanceof Blueprint && $table->temporary) {
+            $this->setTablePrefix('#');
+        }
+
+        return parent::wrapTable($table);
+    }
+
+    /**
      * Compile the query to determine if a table exists.
      *
      * @return string

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -127,6 +127,23 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertEquals('create table `prefix_users` (`id` int unsigned not null auto_increment primary key, `email` varchar(255) not null)', $statements[0]);
     }
 
+    public function testCreateTemporaryTable()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->create();
+        $blueprint->temporary();
+        $blueprint->increments('id');
+        $blueprint->string('email');
+
+        $conn = $this->getConnection();
+        $conn->shouldReceive('getConfig')->andReturn(null);
+
+        $statements = $blueprint->toSql($conn, $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertEquals('create temporary table `users` (`id` int unsigned not null auto_increment primary key, `email` varchar(255) not null)', $statements[0]);
+    }
+
     public function testDropTable()
     {
         $blueprint = new Blueprint('users');

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -33,6 +33,19 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add column "id" serial primary key not null, add column "email" varchar(255) not null', $statements[0]);
     }
 
+    public function testCreateTemporaryTable()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->create();
+        $blueprint->temporary();
+        $blueprint->increments('id');
+        $blueprint->string('email');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertEquals('create temporary table "users" ("id" serial primary key not null, "email" varchar(255) not null)', $statements[0]);
+    }
+
     public function testDropTable()
     {
         $blueprint = new Blueprint('users');

--- a/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
@@ -37,6 +37,19 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $this->assertEquals($expected, $statements);
     }
 
+    public function testCreateTemporaryTable()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->create();
+        $blueprint->temporary();
+        $blueprint->increments('id');
+        $blueprint->string('email');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertEquals('create temporary table "users" ("id" integer not null primary key autoincrement, "email" varchar not null)', $statements[0]);
+    }
+
     public function testDropTable()
     {
         $blueprint = new Blueprint('users');

--- a/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
@@ -42,6 +42,19 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $this->assertEquals('create table "prefix_users" ("id" int identity primary key not null, "email" nvarchar(255) not null)', $statements[0]);
     }
 
+    public function testCreateTemporaryTable()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->create();
+        $blueprint->temporary();
+        $blueprint->increments('id');
+        $blueprint->string('email');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertEquals('create table "#users" ("id" int identity primary key not null, "email" nvarchar(255) not null)', $statements[0]);
+    }
+
     public function testDropTable()
     {
         $blueprint = new Blueprint('users');


### PR DESCRIPTION
> ## TL;DR
>
> - Currently we can't use `$table->temporary();` option to create temporary tables when using the SQL Server even it supporting them - within this driver it's a no-op command (it's the only one that is missing this)
>
> - This PR adds this missing functionality to SQL Server, therefore making it usable with any database driver
>
> - Since SQL Server can create both local and global temporary tables and all other drivers can create only local temporary tables, we'll be offering this as a shortcut for creating local temporary tables - developers would still be allowed to create SQL Server's temporary tables in the driver-specific way (by prefixing their name)
>
> - This PR also adds missing tests for temporary tables creation

#### Proposal

Currently we have true temporary tables support for MySQL, PostgreSQL and SQLite. They're using the same `CREATE TEMPORARY TABLE` syntax based on SQL-92 standard although none of them follow it strictly - they're just vendor implementations. SQL Server temporary tables [can be manually created by prefixing them](https://docs.microsoft.com/en-us/sql/t-sql/statements/create-table-transact-sql#temporary-tables) with a single number sign `#` for local temporary tables and a double number sign `##` for global temporary tables - so presently we could be using the existing `$table->setTablePrefix()` method to create temporary tables in SQL Server.

Though it does support temporary tables, using `$table->temporary();` will be a no-op command when using SQL Server. I'm proposing that we start matching the developer expectation by creating temporary tables as requested. Since SQL Server have support for both local and global temporary tables and all other databases have support for local temporary tables only, it seems reasonable to follow their behavior.

#### Implementation

We'll be just overloading `Illuminate\Database\Schema\Grammars\SqlServerGrammar->wrapTable()` method to honor the `$table->temporary` option and call the `SqlServerGrammar->setTablePrefix()` method to prefix the table with a single number sign. It's being changed here because any method that create/modify/drop the table would need the prefixed table name.

#### Changes

I'm targeting this to 5.5 because it's an unsupported feature for SQL Server users - Laravel would allow you to use `$table->temporary();` no matter what but it will be a no-op command. Implementing this in 5.5 would just match the usage expectation for those who were using it albeit being unsupported. I can however quickly promote it to 5.6 if prompted.

##### Code

- `Illuminate\Database\Schema\Grammars\SqlServerGrammar`
  - Added `wrapTable()` method overloading to prefix the table name.

##### Tests
*4 new tests and 8 new assertions*

- `Illuminate\Tests\Database\DatabaseMySqlSchemaGrammarTest`
- `Illuminate\Tests\Database\DatabasePostgresSchemaGrammarTest`
- `Illuminate\Tests\Database\DatabaseSQLiteSchemaGrammarTest`
- `Illuminate\Tests\Database\DatabaseSqlServerSchemaGrammarTest`
  - Added missing tests for temporary tables creation in a new `testCreateTemporaryTable()` method.