### PR TITLE
localize validation exception message

### DIFF
--- a/src/Illuminate/Validation/ValidationException.php
+++ b/src/Illuminate/Validation/ValidationException.php
@@ -53,7 +53,7 @@ class ValidationException extends Exception
      */
     public function __construct($validator, $response = null, $errorBag = 'default')
     {
-        parent::__construct('The given data was invalid.');
+        parent::__construct(__('The given data was invalid.'));
 
         $this->response = $response;
         $this->errorBag = $errorBag;


### PR DESCRIPTION
When a request validation fails, we get back an error bag with localized messages tied to each input, but the main exception message is not translated. 

When displaying/logging that message, it's also useful to have the `The given data was invalid.` message translated.