### PR TITLE
[5.5] Add support for newQueryForRestoration from queues

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -879,6 +879,25 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     }
 
     /**
+     * Get a new query to restore one or more models by the queueable IDs.
+     *
+     * @param  array|int  $ids
+     *
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function newQueryForRestoration($ids)
+    {
+        if (is_array($ids)) {
+            return $this->newQueryWithoutScopes()->whereIn(
+                $this->getQualifiedKeyName(),
+                $ids
+            );
+        }
+
+        return $this->newQueryWithoutScopes()->whereKey($ids);
+    }
+
+    /**
      * Create a new Eloquent query builder for the model.
      *
      * @param  \Illuminate\Database\Query\Builder  $query

--- a/src/Illuminate/Queue/SerializesAndRestoresModelIdentifiers.php
+++ b/src/Illuminate/Queue/SerializesAndRestoresModelIdentifiers.php
@@ -48,10 +48,12 @@ trait SerializesAndRestoresModelIdentifiers
             return $value;
         }
 
+        $model = (new $value->class)->setConnection($value->connection);
+
         return is_array($value->id)
-                ? $this->restoreCollection($value)
-                : $this->getQueryForModelRestoration((new $value->class)->setConnection($value->connection))
-                    ->useWritePdo()->findOrFail($value->id);
+            ? $this->restoreCollection($value)
+            : $this->getQueryForModelRestoration($model, $value->id)
+                ->useWritePdo()->firstOrFail();
     }
 
     /**
@@ -68,18 +70,19 @@ trait SerializesAndRestoresModelIdentifiers
 
         $model = (new $value->class)->setConnection($value->connection);
 
-        return $this->getQueryForModelRestoration($model)->useWritePdo()
-                    ->whereIn($model->getQualifiedKeyName(), $value->id)->get();
+        return $this->getQueryForModelRestoration($model, $value->id)
+            ->useWritePdo()->get();
     }
 
     /**
      * Get the query for restoration.
      *
      * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  array|int                            $ids
      * @return \Illuminate\Database\Eloquent\Builder
      */
-    protected function getQueryForModelRestoration($model)
+    protected function getQueryForModelRestoration($model, $ids)
     {
-        return $model->newQueryWithoutScopes();
+        return $model->newQueryForRestoration($ids);
     }
 }


### PR DESCRIPTION
When queueing models, there's the `getQueueableIds` method which allows you to override the ID value which is serialised to JSON.

It is however not possible to map the serialised ID back into the other direction when unserialising the model. This PR adds that method.

The need for using another ID when serialising models becomes clear when you're using binary UUIDs as primary keys. There are a few issues addressing the problem:

- https://github.com/laravel/framework/issues/15272
- https://github.com/laravel/framework/issues/12194

When serialising a model, and `json_encoding` that serialised data, JSON fails when it encounters a binary field. To solve this problem, the binary ID could. eg. be stored as a base64 encoded string. However, when unserialising the model, you'll need a way to decode that string back to its binary form, to be able to query the database.

A concrete example in a model, using this functionality:

```php
public function getQueueableId()
{
    return base64_encode($this->uuid);
}

public function newQueryForRestoration($id)
{
    return $this->newQueryWithoutScopes()->whereKey(base64_decode($this->uuid));
}
```

The default implementation of `newQueryForRestoration` is added in the `Model` class, and keeps the default functionality.

Note that by adding the `newQueryForRestoration` method, the need for the `is_array($value->id)` check in `SerializesAndRestoresModelIdentifiers` can easily be refactored. The check can now happen in the `newQueryForRestoration` instead. I didn't add this change though, because it would have made the diff more confusing. I'm willing to also refactor this, and add tests if needed.