### PR TITLE
[5.5] Better precision support on datetime columns

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -811,11 +811,12 @@ class Blueprint
      * Create a new time column (with time zone) on the table.
      *
      * @param  string  $column
+     * @param  int  $precision
      * @return \Illuminate\Support\Fluent
      */
-    public function timeTz($column)
+    public function timeTz($column, $precision = 0)
     {
-        return $this->addColumn('timeTz', $column);
+        return $this->addColumn('timeTz', $column, compact('precision'));
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -597,7 +597,7 @@ class MySqlGrammar extends Grammar
     }
 
     /**
-     * Create the column definition for a date-time type.
+     * Create the column definition for a date-time (with time zone) type.
      *
      * @param  \Illuminate\Support\Fluent  $column
      * @return string
@@ -615,18 +615,18 @@ class MySqlGrammar extends Grammar
      */
     protected function typeTime(Fluent $column)
     {
-        return 'time';
+        return $column->precision ? "time($column->precision)" : 'time';
     }
 
     /**
-     * Create the column definition for a time type.
+     * Create the column definition for a time (with time zone) type.
      *
      * @param  \Illuminate\Support\Fluent  $column
      * @return string
      */
     protected function typeTimeTz(Fluent $column)
     {
-        return 'time';
+        return $this->typeTime($column);
     }
 
     /**
@@ -637,17 +637,13 @@ class MySqlGrammar extends Grammar
      */
     protected function typeTimestamp(Fluent $column)
     {
-        if ($column->useCurrent) {
-            return $column->precision
-                    ? "timestamp($column->precision) default CURRENT_TIMESTAMP"
-                    : 'timestamp default CURRENT_TIMESTAMP';
-        }
+        $columnType = $column->precision ? "timestamp($column->precision)" : 'timestamp';
 
-        return $column->precision ? "timestamp($column->precision)" : 'timestamp';
+        return $column->useCurrent ? "$columnType default CURRENT_TIMESTAMP" : $columnType;
     }
 
     /**
-     * Create the column definition for a timestamp type.
+     * Create the column definition for a timestamp (with time zone) type.
      *
      * @param  \Illuminate\Support\Fluent  $column
      * @return string

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -548,7 +548,7 @@ class PostgresGrammar extends Grammar
     }
 
     /**
-     * Create the column definition for a date-time type.
+     * Create the column definition for a date-time (with time zone) type.
      *
      * @param  \Illuminate\Support\Fluent  $column
      * @return string
@@ -566,18 +566,18 @@ class PostgresGrammar extends Grammar
      */
     protected function typeTime(Fluent $column)
     {
-        return 'time(0) without time zone';
+        return "time($column->precision) without time zone";
     }
 
     /**
-     * Create the column definition for a time type.
+     * Create the column definition for a time (with time zone) type.
      *
      * @param  \Illuminate\Support\Fluent  $column
      * @return string
      */
     protected function typeTimeTz(Fluent $column)
     {
-        return 'time(0) with time zone';
+        return "time($column->precision) with time zone";
     }
 
     /**
@@ -588,26 +588,22 @@ class PostgresGrammar extends Grammar
      */
     protected function typeTimestamp(Fluent $column)
     {
-        if ($column->useCurrent) {
-            return "timestamp($column->precision) without time zone default CURRENT_TIMESTAMP($column->precision)";
-        }
+        $columnType = "timestamp($column->precision) without time zone";
 
-        return "timestamp($column->precision) without time zone";
+        return $column->useCurrent ? "$columnType default CURRENT_TIMESTAMP" : $columnType;
     }
 
     /**
-     * Create the column definition for a timestamp type.
+     * Create the column definition for a timestamp (with time zone) type.
      *
      * @param  \Illuminate\Support\Fluent  $column
      * @return string
      */
     protected function typeTimestampTz(Fluent $column)
     {
-        if ($column->useCurrent) {
-            return "timestamp($column->precision) with time zone default CURRENT_TIMESTAMP($column->precision)";
-        }
+        $columnType = "timestamp($column->precision) with time zone";
 
-        return "timestamp($column->precision) with time zone";
+        return $column->useCurrent ? "$columnType default CURRENT_TIMESTAMP" : $columnType;
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -557,7 +557,7 @@ class SQLiteGrammar extends Grammar
     }
 
     /**
-     * Create the column definition for a date-time type.
+     * Create the column definition for a date-time (with time zone) type.
      *
      * Note: "SQLite does not have a storage class set aside for storing dates and/or times."
      * @link https://www.sqlite.org/datatype3.html
@@ -567,7 +567,7 @@ class SQLiteGrammar extends Grammar
      */
     protected function typeDateTimeTz(Fluent $column)
     {
-        return 'datetime';
+        return $this->typeDateTime($column);
     }
 
     /**
@@ -582,14 +582,14 @@ class SQLiteGrammar extends Grammar
     }
 
     /**
-     * Create the column definition for a time type.
+     * Create the column definition for a time (with time zone) type.
      *
      * @param  \Illuminate\Support\Fluent  $column
      * @return string
      */
     protected function typeTimeTz(Fluent $column)
     {
-        return 'time';
+        return $this->typeTime($column);
     }
 
     /**
@@ -600,26 +600,18 @@ class SQLiteGrammar extends Grammar
      */
     protected function typeTimestamp(Fluent $column)
     {
-        if ($column->useCurrent) {
-            return 'datetime default CURRENT_TIMESTAMP';
-        }
-
-        return 'datetime';
+        return $column->useCurrent ? 'datetime default CURRENT_TIMESTAMP' : 'datetime';
     }
 
     /**
-     * Create the column definition for a timestamp type.
+     * Create the column definition for a timestamp (with time zone) type.
      *
      * @param  \Illuminate\Support\Fluent  $column
      * @return string
      */
     protected function typeTimestampTz(Fluent $column)
     {
-        if ($column->useCurrent) {
-            return 'datetime default CURRENT_TIMESTAMP';
-        }
-
-        return 'datetime';
+        return $this->typeTimestamp($column);
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -500,7 +500,7 @@ class SqlServerGrammar extends Grammar
     }
 
     /**
-     * Create the column definition for a date-time type.
+     * Create the column definition for a date-time (with time zone) type.
      *
      * @param  \Illuminate\Support\Fluent  $column
      * @return string
@@ -518,18 +518,18 @@ class SqlServerGrammar extends Grammar
      */
     protected function typeTime(Fluent $column)
     {
-        return 'time';
+        return $column->precision ? "time($column->precision)" : 'time';
     }
 
     /**
-     * Create the column definition for a time type.
+     * Create the column definition for a time (with time zone) type.
      *
      * @param  \Illuminate\Support\Fluent  $column
      * @return string
      */
     protected function typeTimeTz(Fluent $column)
     {
-        return 'time';
+        return $this->typeTime($column);
     }
 
     /**
@@ -540,17 +540,13 @@ class SqlServerGrammar extends Grammar
      */
     protected function typeTimestamp(Fluent $column)
     {
-        if ($column->useCurrent) {
-            return $column->precision
-                    ? "datetime2($column->precision) default CURRENT_TIMESTAMP"
-                    : 'datetime default CURRENT_TIMESTAMP';
-        }
+        $columnType = $column->precision ? "datetime2($column->precision)" : 'datetime';
 
-        return $column->precision ? "datetime2($column->precision)" : 'datetime';
+        return $column->useCurrent ? "$columnType default CURRENT_TIMESTAMP" : $columnType;
     }
 
     /**
-     * Create the column definition for a timestamp type.
+     * Create the column definition for a timestamp (with time zone) type.
      *
      * @link https://msdn.microsoft.com/en-us/library/bb630289(v=sql.120).aspx
      *
@@ -560,9 +556,9 @@ class SqlServerGrammar extends Grammar
     protected function typeTimestampTz(Fluent $column)
     {
         if ($column->useCurrent) {
-            return $column->precision
-                    ? "datetimeoffset($column->precision) default CURRENT_TIMESTAMP"
-                    : 'datetimeoffset default CURRENT_TIMESTAMP';
+            $columnType = $column->precision ? "datetimeoffset($column->precision)" : 'datetimeoffset';
+
+            return "$columnType default CURRENT_TIMESTAMP";
         }
 
         return "datetimeoffset($column->precision)";

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -642,90 +642,95 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
     public function testAddingTime()
     {
         $blueprint = new Blueprint('users');
-        $blueprint->time('foo');
+        $blueprint->time('created_at');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add `foo` time not null', $statements[0]);
+        $this->assertEquals('alter table `users` add `created_at` time not null', $statements[0]);
+    }
+
+    public function testAddingTimeWithPrecision()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->time('created_at', 1);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table `users` add `created_at` time(1) not null', $statements[0]);
     }
 
     public function testAddingTimeTz()
     {
         $blueprint = new Blueprint('users');
-        $blueprint->timeTz('foo');
+        $blueprint->timeTz('created_at');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
-
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add `foo` time not null', $statements[0]);
+        $this->assertEquals('alter table `users` add `created_at` time not null', $statements[0]);
     }
 
-    public function testAddingTimeStamp()
+    public function testAddingTimeTzWithPrecision()
     {
         $blueprint = new Blueprint('users');
-        $blueprint->timestamp('foo', 1);
+        $blueprint->timeTz('created_at', 1);
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add `foo` timestamp(1) not null', $statements[0]);
-
-        $blueprint = new Blueprint('users');
-        $blueprint->timestamp('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
-        $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add `foo` timestamp not null', $statements[0]);
+        $this->assertEquals('alter table `users` add `created_at` time(1) not null', $statements[0]);
     }
 
-    public function testAddingTimeStampWithDefault()
+    public function testAddingTimestamp()
     {
         $blueprint = new Blueprint('users');
-        $blueprint->timestamp('foo', 1)->default('2015-07-22 11:43:17');
+        $blueprint->timestamp('created_at');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add `foo` timestamp(1) not null default \'2015-07-22 11:43:17\'', $statements[0]);
-
-        $blueprint = new Blueprint('users');
-        $blueprint->timestamp('foo')->default('2015-07-22 11:43:17');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
-        $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add `foo` timestamp not null default \'2015-07-22 11:43:17\'', $statements[0]);
+        $this->assertEquals('alter table `users` add `created_at` timestamp not null', $statements[0]);
     }
 
-    public function testAddingTimeStampTz()
+    public function testAddingTimestampWithPrecision()
     {
         $blueprint = new Blueprint('users');
-        $blueprint->timestampTz('foo', 1);
+        $blueprint->timestamp('created_at', 1);
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add `foo` timestamp(1) not null', $statements[0]);
+        $this->assertEquals('alter table `users` add `created_at` timestamp(1) not null', $statements[0]);
+    }
 
+    public function testAddingTimestampWithDefault()
+    {
         $blueprint = new Blueprint('users');
-        $blueprint->timestampTz('foo');
+        $blueprint->timestamp('created_at')->default('2015-07-22 11:43:17');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add `foo` timestamp not null', $statements[0]);
+        $this->assertEquals("alter table `users` add `created_at` timestamp not null default '2015-07-22 11:43:17'", $statements[0]);
+    }
+
+    public function testAddingTimestampTz()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->timestampTz('created_at');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table `users` add `created_at` timestamp not null', $statements[0]);
+    }
+
+    public function testAddingTimestampTzWithPrecision()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->timestampTz('created_at', 1);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table `users` add `created_at` timestamp(1) not null', $statements[0]);
     }
 
     public function testAddingTimeStampTzWithDefault()
     {
         $blueprint = new Blueprint('users');
-        $blueprint->timestampTz('foo', 1)->default('2015-07-22 11:43:17');
+        $blueprint->timestampTz('created_at')->default('2015-07-22 11:43:17');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add `foo` timestamp(1) not null default \'2015-07-22 11:43:17\'', $statements[0]);
-
-        $blueprint = new Blueprint('users');
-        $blueprint->timestampTz('foo')->default('2015-07-22 11:43:17');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
-        $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add `foo` timestamp not null default \'2015-07-22 11:43:17\'', $statements[0]);
+        $this->assertEquals("alter table `users` add `created_at` timestamp not null default '2015-07-22 11:43:17'", $statements[0]);
     }
 
-    public function testAddingTimeStamps()
+    public function testAddingTimestamps()
     {
-        $blueprint = new Blueprint('users');
-        $blueprint->timestamps(1);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
-        $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add `created_at` timestamp(1) null, add `updated_at` timestamp(1) null', $statements[0]);
-
         $blueprint = new Blueprint('users');
         $blueprint->timestamps();
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
@@ -733,14 +738,8 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table `users` add `created_at` timestamp null, add `updated_at` timestamp null', $statements[0]);
     }
 
-    public function testAddingTimeStampsTz()
+    public function testAddingTimestampsTz()
     {
-        $blueprint = new Blueprint('users');
-        $blueprint->timestampsTz(1);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
-        $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add `created_at` timestamp(1) null, add `updated_at` timestamp(1) null', $statements[0]);
-
         $blueprint = new Blueprint('users');
         $blueprint->timestampsTz();
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -459,79 +459,125 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
     public function testAddingDateTime()
     {
         $blueprint = new Blueprint('users');
-        $blueprint->dateTime('foo');
+        $blueprint->dateTime('created_at');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
-
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "foo" timestamp(0) without time zone not null', $statements[0]);
+        $this->assertEquals('alter table "users" add column "created_at" timestamp(0) without time zone not null', $statements[0]);
+    }
+
+    public function testAddingDateTimeWithPrecision()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->dateTime('created_at', 1);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table "users" add column "created_at" timestamp(1) without time zone not null', $statements[0]);
     }
 
     public function testAddingDateTimeTz()
     {
         $blueprint = new Blueprint('users');
-        $blueprint->dateTimeTz('foo');
+        $blueprint->dateTimeTz('created_at');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
-
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "foo" timestamp(0) with time zone not null', $statements[0]);
+        $this->assertEquals('alter table "users" add column "created_at" timestamp(0) with time zone not null', $statements[0]);
+    }
+
+    public function testAddingDateTimeTzWithPrecision()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->dateTimeTz('created_at', 1);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table "users" add column "created_at" timestamp(1) with time zone not null', $statements[0]);
     }
 
     public function testAddingTime()
     {
         $blueprint = new Blueprint('users');
-        $blueprint->time('foo');
+        $blueprint->time('created_at');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
-
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "foo" time(0) without time zone not null', $statements[0]);
+        $this->assertEquals('alter table "users" add column "created_at" time(0) without time zone not null', $statements[0]);
+    }
+
+    public function testAddingTimeWithPrecision()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->time('created_at', 1);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table "users" add column "created_at" time(1) without time zone not null', $statements[0]);
     }
 
     public function testAddingTimeTz()
     {
         $blueprint = new Blueprint('users');
-        $blueprint->timeTz('foo');
+        $blueprint->timeTz('created_at');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
-
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "foo" time(0) with time zone not null', $statements[0]);
+        $this->assertEquals('alter table "users" add column "created_at" time(0) with time zone not null', $statements[0]);
     }
 
-    public function testAddingTimeStamp()
+    public function testAddingTimeTzWithPrecision()
     {
         $blueprint = new Blueprint('users');
-        $blueprint->timestamp('foo');
+        $blueprint->timeTz('created_at', 1);
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
-
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "foo" timestamp(0) without time zone not null', $statements[0]);
+        $this->assertEquals('alter table "users" add column "created_at" time(1) with time zone not null', $statements[0]);
     }
 
-    public function testAddingTimeStampTz()
+    public function testAddingTimestamp()
     {
         $blueprint = new Blueprint('users');
-        $blueprint->timestampTz('foo');
+        $blueprint->timestamp('created_at');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
-
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "foo" timestamp(0) with time zone not null', $statements[0]);
+        $this->assertEquals('alter table "users" add column "created_at" timestamp(0) without time zone not null', $statements[0]);
     }
 
-    public function testAddingTimeStamps()
+    public function testAddingTimestampWithPrecision()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->timestamp('created_at', 1);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table "users" add column "created_at" timestamp(1) without time zone not null', $statements[0]);
+    }
+
+    public function testAddingTimestampTz()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->timestampTz('created_at');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table "users" add column "created_at" timestamp(0) with time zone not null', $statements[0]);
+    }
+
+    public function testAddingTimestampTzWithPrecision()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->timestampTz('created_at', 1);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table "users" add column "created_at" timestamp(1) with time zone not null', $statements[0]);
+    }
+
+    public function testAddingTimestamps()
     {
         $blueprint = new Blueprint('users');
         $blueprint->timestamps();
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
-
         $this->assertCount(1, $statements);
         $this->assertEquals('alter table "users" add column "created_at" timestamp(0) without time zone null, add column "updated_at" timestamp(0) without time zone null', $statements[0]);
     }
 
-    public function testAddingTimeStampsTz()
+    public function testAddingTimestampsTz()
     {
         $blueprint = new Blueprint('users');
         $blueprint->timestampsTz();
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
-
         $this->assertCount(1, $statements);
         $this->assertEquals('alter table "users" add column "created_at" timestamp(0) with time zone null, add column "updated_at" timestamp(0) with time zone null', $statements[0]);
     }

--- a/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
@@ -406,89 +406,133 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
     public function testAddingDateTime()
     {
         $blueprint = new Blueprint('users');
-        $blueprint->dateTime('foo');
+        $blueprint->dateTime('created_at');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
-
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "foo" datetime not null', $statements[0]);
+        $this->assertEquals('alter table "users" add column "created_at" datetime not null', $statements[0]);
+    }
+
+    public function testAddingDateTimeWithPrecision()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->dateTime('created_at', 1);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table "users" add column "created_at" datetime not null', $statements[0]);
     }
 
     public function testAddingDateTimeTz()
     {
         $blueprint = new Blueprint('users');
-        $blueprint->dateTimeTz('foo');
+        $blueprint->dateTimeTz('created_at');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
-
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "foo" datetime not null', $statements[0]);
+        $this->assertEquals('alter table "users" add column "created_at" datetime not null', $statements[0]);
+    }
+
+    public function testAddingDateTimeTzWithPrecision()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->dateTimeTz('created_at', 1);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table "users" add column "created_at" datetime not null', $statements[0]);
     }
 
     public function testAddingTime()
     {
         $blueprint = new Blueprint('users');
-        $blueprint->time('foo');
+        $blueprint->time('created_at');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
-
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "foo" time not null', $statements[0]);
+        $this->assertEquals('alter table "users" add column "created_at" time not null', $statements[0]);
+    }
+
+    public function testAddingTimeWithPrecision()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->time('created_at', 1);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table "users" add column "created_at" time not null', $statements[0]);
     }
 
     public function testAddingTimeTz()
     {
         $blueprint = new Blueprint('users');
-        $blueprint->timeTz('foo');
+        $blueprint->timeTz('created_at');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
-
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "foo" time not null', $statements[0]);
+        $this->assertEquals('alter table "users" add column "created_at" time not null', $statements[0]);
     }
 
-    public function testAddingTimeStamp()
+    public function testAddingTimeTzWithPrecision()
     {
         $blueprint = new Blueprint('users');
-        $blueprint->timestamp('foo');
+        $blueprint->timeTz('created_at', 1);
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
-
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "foo" datetime not null', $statements[0]);
+        $this->assertEquals('alter table "users" add column "created_at" time not null', $statements[0]);
     }
 
-    public function testAddingTimeStampTz()
+    public function testAddingTimestamp()
     {
         $blueprint = new Blueprint('users');
-        $blueprint->timestampTz('foo');
+        $blueprint->timestamp('created_at');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
-
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "foo" datetime not null', $statements[0]);
+        $this->assertEquals('alter table "users" add column "created_at" datetime not null', $statements[0]);
     }
 
-    public function testAddingTimeStamps()
+    public function testAddingTimestampWithPrecision()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->timestamp('created_at', 1);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table "users" add column "created_at" datetime not null', $statements[0]);
+    }
+
+    public function testAddingTimestampTz()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->timestampTz('created_at');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table "users" add column "created_at" datetime not null', $statements[0]);
+    }
+
+    public function testAddingTimestampTzWithPrecision()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->timestampTz('created_at', 1);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table "users" add column "created_at" datetime not null', $statements[0]);
+    }
+
+    public function testAddingTimestamps()
     {
         $blueprint = new Blueprint('users');
         $blueprint->timestamps();
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
-
         $this->assertCount(2, $statements);
-        $expected = [
+        $this->assertEquals([
             'alter table "users" add column "created_at" datetime null',
             'alter table "users" add column "updated_at" datetime null',
-        ];
-        $this->assertEquals($expected, $statements);
+        ], $statements);
     }
 
-    public function testAddingTimeStampsTz()
+    public function testAddingTimestampsTz()
     {
         $blueprint = new Blueprint('users');
         $blueprint->timestampsTz();
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
-
         $this->assertCount(2, $statements);
-        $expected = [
+        $this->assertEquals([
             'alter table "users" add column "created_at" datetime null',
             'alter table "users" add column "updated_at" datetime null',
-        ];
-        $this->assertEquals($expected, $statements);
+        ], $statements);
     }
 
     public function testAddingRememberToken()

--- a/tests/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintTest.php
@@ -77,7 +77,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
         $this->assertEquals(['alter table `users` add `created` timestamp default CURRENT_TIMESTAMP not null'], $blueprint->toSql($connection, new MySqlGrammar));
 
         $blueprint = clone $base;
-        $this->assertEquals(['alter table "users" add column "created" timestamp(0) without time zone default CURRENT_TIMESTAMP(0) not null'], $blueprint->toSql($connection, new PostgresGrammar));
+        $this->assertEquals(['alter table "users" add column "created" timestamp(0) without time zone default CURRENT_TIMESTAMP not null'], $blueprint->toSql($connection, new PostgresGrammar));
 
         $blueprint = clone $base;
         $this->assertEquals(['alter table "users" add column "created" datetime default CURRENT_TIMESTAMP not null'], $blueprint->toSql($connection, new SQLiteGrammar));

--- a/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
@@ -472,26 +472,23 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
     public function testAddingDateTime()
     {
         $blueprint = new Blueprint('users');
-        $blueprint->dateTime('foo', 1);
+        $blueprint->dateTime('created_at');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add "foo" datetime2(1) not null', $statements[0]);
+        $this->assertEquals('alter table "users" add "created_at" datetime not null', $statements[0]);
+    }
 
+    public function testAddingDateTimeWithPrecision()
+    {
         $blueprint = new Blueprint('users');
-        $blueprint->dateTime('foo');
+        $blueprint->dateTime('created_at', 1);
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add "foo" datetime not null', $statements[0]);
+        $this->assertEquals('alter table "users" add "created_at" datetime2(1) not null', $statements[0]);
     }
 
     public function testAddingDateTimeTz()
     {
-        $blueprint = new Blueprint('users');
-        $blueprint->dateTimeTz('foo', 1);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
-        $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add "foo" datetimeoffset(1) not null', $statements[0]);
-
         $blueprint = new Blueprint('users');
         $blueprint->dateTimeTz('foo');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
@@ -499,59 +496,89 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add "foo" datetimeoffset not null', $statements[0]);
     }
 
+    public function testAddingDateTimeTzWithPrecision()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->dateTimeTz('foo', 1);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table "users" add "foo" datetimeoffset(1) not null', $statements[0]);
+    }
+
     public function testAddingTime()
     {
         $blueprint = new Blueprint('users');
-        $blueprint->time('foo');
+        $blueprint->time('created_at');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
-
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add "foo" time not null', $statements[0]);
+        $this->assertEquals('alter table "users" add "created_at" time not null', $statements[0]);
+    }
+
+    public function testAddingTimeWithPrecision()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->time('created_at', 1);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table "users" add "created_at" time(1) not null', $statements[0]);
     }
 
     public function testAddingTimeTz()
     {
         $blueprint = new Blueprint('users');
-        $blueprint->timeTz('foo');
+        $blueprint->timeTz('created_at');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
-
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add "foo" time not null', $statements[0]);
+        $this->assertEquals('alter table "users" add "created_at" time not null', $statements[0]);
     }
 
-    public function testAddingTimeStamp()
+    public function testAddingTimeTzWithPrecision()
     {
         $blueprint = new Blueprint('users');
-        $blueprint->timestamp('foo', 1);
+        $blueprint->timeTz('created_at', 1);
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add "foo" datetime2(1) not null', $statements[0]);
-
-        $blueprint = new Blueprint('users');
-        $blueprint->timestamp('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
-        $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add "foo" datetime not null', $statements[0]);
+        $this->assertEquals('alter table "users" add "created_at" time(1) not null', $statements[0]);
     }
 
-    public function testAddingTimeStampTz()
+    public function testAddingTimestamp()
     {
         $blueprint = new Blueprint('users');
-        $blueprint->timestampTz('foo');
+        $blueprint->timestamp('created_at');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
-
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add "foo" datetimeoffset(0) not null', $statements[0]);
+        $this->assertEquals('alter table "users" add "created_at" datetime not null', $statements[0]);
     }
 
-    public function testAddingTimeStamps()
+    public function testAddingTimestampWithPrecision()
     {
         $blueprint = new Blueprint('users');
-        $blueprint->timestamps(1);
+        $blueprint->timestamp('created_at', 1);
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add "created_at" datetime2(1) null, "updated_at" datetime2(1) null', $statements[0]);
+        $this->assertEquals('alter table "users" add "created_at" datetime2(1) not null', $statements[0]);
+    }
 
+    public function testAddingTimestampTz()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->timestampTz('created_at');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table "users" add "created_at" datetimeoffset(0) not null', $statements[0]);
+    }
+
+    public function testAddingTimestampTzWithPrecision()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->timestampTz('created_at', 1);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table "users" add "created_at" datetimeoffset(1) not null', $statements[0]);
+    }
+
+    public function testAddingTimestamps()
+    {
         $blueprint = new Blueprint('users');
         $blueprint->timestamps();
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
@@ -559,12 +586,11 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add "created_at" datetime null, "updated_at" datetime null', $statements[0]);
     }
 
-    public function testAddingTimeStampsTz()
+    public function testAddingTimestampsTz()
     {
         $blueprint = new Blueprint('users');
         $blueprint->timestampsTz();
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
-
         $this->assertCount(1, $statements);
         $this->assertEquals('alter table "users" add "created_at" datetimeoffset(0) null, "updated_at" datetimeoffset(0) null', $statements[0]);
     }


### PR DESCRIPTION
> ## TL;DR
>
> - Currently we can't give a custom precision to `time()` and `timeTz()` columns as allowed by supported databases
>
> - This PR adds this functionality to `time()` and `timeTz()` columns when explicitly giving a column precision for MySQL, PostgreSQL and SQL Server (SQLite does not support this)
>
> - Due to some existing inconsistencies related to databases default precisions and Laravel's default behavior this will not be fully functional for SQL Server yet, but this is an already existing issue for SQL Server's  datetime columns precision handling - a fix for this will be proposed later
>
> - This PR also slightly improves the datetime columns code **with no behavior changes** and further improves the test suite on this subject to ensure we're testing those methods accordingly

#### Proposal

This was split from #22004.

Currently we have precision support on `dateTime()`, `dateTimeTz()`, `timestamp()` and `timestampTz()` columns. However, the SQL-92 standard (ANSI X3.135-1992 and ISO/IEC 9075:1992) [allows us to also specify precisions on time columns](http://jakewheat.github.io/sql-overview/sql-92-grammar.html#datetime-type) and except for SQLite (which does not support columns precisions at all) all other database drivers does support them.<sup>*</sup>

This was recently requested in #22048 where OP was thinking it was already there. I'm proposing that we start honoring the given precision on both `time()` and `timeTz()` columns so the framework follow the usage expectation.

<sup>*</sup> [MySQL added this to TIME, DATETIME and TIMESTAMP in 5.6.4](https://dev.mysql.com/doc/relnotes/mysql/5.6/en/news-5-6-4.html)

#### Implementation

This time I'm just changing the `time()` and `timeTz()` methods behavior when a precision is explicitly given, so it should match the developer expectation. Previously I was doing more, but I left the inconsistencies changes to a future work. This was made this way to make it easier to get it accepted and even be pushed to 5.5 if desired.

Some related code simplifications were done with no behavior changes - this was done to make things easier to understand. I've also rewritten related tests and I increased the test suite's testability on this subject. To ease reviewing code changes I've made a detailed summary below.

#### Changes

I'm targeting this for 5.5 first just because I'm not sure where it would be desirable since it's a feature that would be applied only to new installations and just adds a non-existing behaviour that matches the usage expectation. If this would be acceptable just for 5.6, let me know and I'll rebase it accordingly ASAP. 😉

##### Code

- `Illuminate\Database\Schema\Blueprint`
  - Continues the work from PR #21936 adding `$precision` argument to the missing `timeTz()` method.
- `Illuminate\Database\Schema\Grammars\MySqlGrammar`
  - Changed `typeTime()` to honor the given precision.
  - Aliased `typeTimeTz()` to `typeTime()`.
  - Simplified `typeTimestamp()` implementation. (no behavior change)
  - Minor docblocks improvements.
- `Illuminate\Database\Schema\Grammars\PostgresGrammar`
  - Changed `typeTime()` and `typeTimeTz()` methods to honor the given precision.
  - Simplified `typeTimestamp()` and `typeTimestampTz()` implementations. (no behavior change)
  - Minor docblocks improvements.
- `Illuminate\Database\Schema\Grammars\SQLiteGrammar`
  - Aliased `typeDateTimeTz()` to `typeDateTime()`.
  - Aliased `typeTimeTz()` to `typeTime()`.
  - Simplified `typeTimestamp()` implementation. (no behavior change)
  - Aliased `typeTimestampTz()` to `typeTimestamp()`.
  - Minor docblocks improvements.
- `Illuminate\Database\Schema\Grammars\SqlServerGrammar`
  - Changed `typeTime()` to honor the given precision.
  - Aliased `typeTimeTz()` to `typeTime()`.
  - Simplified `typeTimestamp()` and `typeTimestampTz()` implementation. (no behavior change)
  - Minor docblocks improvements.

##### Tests
*22 new tests, 34 new assertions, 10 unneeded assertions removed*

- `Illuminate\Tests\Database\DatabaseMySqlSchemaGrammarTest`
- `Illuminate\Tests\Database\DatabasePostgresSchemaGrammarTest`
- `Illuminate\Tests\Database\DatabaseSQLiteSchemaGrammarTest`
- `Illuminate\Tests\Database\DatabaseSqlServerSchemaGrammarTest`
  - Added new `testAddingTimeWithPrecision()`, `testAddingTimeTzWithPrecision()`, `testAddingDateTimeWithPrecision()`, `testAddingDateTimeTzWithPrecision()`, `testAddingTimestampWithPrecision()` and `testAddingTimestampTzWithPrecision()` methods. Existing MySQL and SQL Server tests got rearranged.
  - Removed unneeded precision tests from `testAddingTimestampWithDefault()`, `testAddingTimestampTzWithDefault()`, `testAddingTimestamps()` and `testAddingTimestampsTz()` methods - there's no need to test this twice.
- `Illuminate\Tests\Database\DatabaseSchemaBlueprintTest`
  - Minor change to `testDefaultCurrentTimestamp()` to fix the PostgreSQL test. It was using `CURRENT_TIMESTAMP(0)` in `typeTimestamp()` but this was never needed - if you specify a precision on the column you aren't required to also declare it on the datetime function.