### PR TITLE
[5.5] Fix BelongsToMany model hydration over cursor query

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -621,6 +621,21 @@ class BelongsToMany extends Relation
     }
 
     /**
+     * Get a generator for the given query.
+     *
+     * @return \Generator
+     */
+    public function cursor()
+    {
+        $this->query->addSelect($this->shouldSelect());
+
+        foreach ($this->query->cursor() as $model) {
+            $this->hydratePivotRelation([$model]);
+            yield $model;
+        }
+    }
+
+    /**
      * Hydrate the pivot table relationship on the models.
      *
      * @param  array  $models

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -695,7 +695,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
             $this->assertEquals($friend->id, $friends->first()->pivot->friend_id);
         });
 
-        foreach (EloquentTestUser::first()->friends() as $friend) {
+        foreach (EloquentTestUser::first()->friends()->cursor() as $friend) {
             $this->assertInstanceOf(EloquentTestUser::class, $friend);
             $this->assertEquals('abigailotwell@gmail.com', $friend->email);
             $this->assertEquals($user->id, $friend->pivot->user_id);

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -683,7 +683,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertEquals($questionMarksCount, $bindingsCount);
     }
 
-    public function testBelongsToManyRelationshipModelsAreProperlyHydratedOverChunkedRequest()
+    public function testBelongsToManyRelationshipModelsAreProperlyHydratedOverChunkedOrCursorRequest()
     {
         $user = EloquentTestUser::create(['email' => 'taylorotwell@gmail.com']);
         $friend = $user->friends()->create(['email' => 'abigailotwell@gmail.com']);
@@ -694,6 +694,13 @@ class DatabaseEloquentIntegrationTest extends TestCase
             $this->assertEquals($user->id, $friends->first()->pivot->user_id);
             $this->assertEquals($friend->id, $friends->first()->pivot->friend_id);
         });
+
+        foreach (EloquentTestUser::first()->friends() as $friend) {
+            $this->assertInstanceOf(EloquentTestUser::class, $friend);
+            $this->assertEquals('abigailotwell@gmail.com', $friend->email);
+            $this->assertEquals($user->id, $friend->pivot->user_id);
+            $this->assertEquals($friend->id, $friend->pivot->friend_id);
+        }
     }
 
     public function testBasicHasManyEagerLoading()


### PR DESCRIPTION
Before the fix, the test I added would fail because `$friend` attributes would be:
```
 [
  "id" => "2"
  "name" => null
  "email" => "abigailotwell@gmail.com"
  "created_at" => "2017-11-18 00:00:29"
  "updated_at" => "2017-11-18 00:00:29"
  "user_id" => "1" // <-- this belongs to the pivot relation
  "friend_id" => "2" // <-- this belongs to the pivot relation
  "friend_level_id" => null // <-- this belongs to the pivot relation
]
```