### PR TITLE
[5.5] Fix attribute shadowing in HasManyThrough chunk and cursor

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -408,6 +408,20 @@ class HasManyThrough extends Relation
     }
 
     /**
+     * Chunk the results of the query.
+     *
+     * @param  int  $count
+     * @param  callable  $callback
+     * @return bool
+     */
+    public function chunk($count, callable $callback)
+    {
+        $this->query->addSelect($this->shouldSelect());
+
+        return $this->query->chunk($count, $callback);
+    }
+
+    /**
      * Set the select clause for the relation query.
      *
      * @param  array  $columns

--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -422,6 +422,18 @@ class HasManyThrough extends Relation
     }
 
     /**
+     * Get a generator for the given query.
+     *
+     * @return \Generator
+     */
+    public function cursor()
+    {
+        $this->query->addSelect($this->shouldSelect());
+
+        yield from $this->query->cursor();
+    }
+
+    /**
      * Set the select clause for the relation query.
      *
      * @param  array  $columns

--- a/tests/Integration/Database/EloquentHasManyThroughTest.php
+++ b/tests/Integration/Database/EloquentHasManyThroughTest.php
@@ -64,12 +64,7 @@ class EloquentHasManyThroughTest extends TestCase
      */
     public function retrieve_results_in_chunks_without_attribute_shadowing()
     {
-        $user = User::create(['name' => str_random()]);
-
-        $team = Team::create(['owner_id' => $user->id]);
-
-        $mate1 = User::create(['name' => str_random(), 'team_id' => $team->id]);
-        $mate2 = User::create(['name' => str_random(), 'team_id' => $team->id]);
+        $user = $this->stubUserTeamMates();
 
         $ids_by_get = $user->teamMates()->forPage(1, 10)->get()->pluck('id');
 
@@ -79,6 +74,32 @@ class EloquentHasManyThroughTest extends TestCase
         });
 
         $this->assertEquals($ids_by_get->toArray(), $ids_by_chunk->toArray());
+    }
+
+    /**
+     * @test
+     */
+    public function pluck_column_without_attribute_shadowing()
+    {
+        $user = $this->stubUserTeamMates();
+
+        $mates_by_get = $user->teamMates()->get();
+
+        $mates_by_cursor = collect($user->teamMates()->cursor());
+
+        $this->assertEquals($mates_by_get->toArray(), $mates_by_cursor->toArray());
+    }
+
+    protected function stubUserTeamMates()
+    {
+        $user = User::create(['name' => str_random()]);
+
+        $team = Team::create(['owner_id' => $user->id]);
+
+        $mate1 = User::create(['name' => str_random(), 'team_id' => $team->id]);
+        $mate2 = User::create(['name' => str_random(), 'team_id' => $team->id]);
+
+        return $user;
     }
 }
 

--- a/tests/Integration/Database/EloquentHasManyThroughTest.php
+++ b/tests/Integration/Database/EloquentHasManyThroughTest.php
@@ -58,6 +58,28 @@ class EloquentHasManyThroughTest extends TestCase
         $this->assertEquals([$mate1->id, $mate2->id], $user->teamMates->pluck('id')->toArray());
         $this->assertEquals([$user->id], User::has('teamMates')->pluck('id')->toArray());
     }
+
+    /**
+     * @test
+     */
+    public function retrieve_results_in_chunks_without_attribute_shadowing()
+    {
+        $user = User::create(['name' => str_random()]);
+
+        $team = Team::create(['owner_id' => $user->id]);
+
+        $mate1 = User::create(['name' => str_random(), 'team_id' => $team->id]);
+        $mate2 = User::create(['name' => str_random(), 'team_id' => $team->id]);
+
+        $ids_by_get = $user->teamMates()->forPage(1, 10)->get()->pluck('id');
+
+        $ids_by_chunk = collect();
+        $user->teamMates()->chunk(10, function ($posts) use (&$ids_by_chunk) {
+            $ids_by_chunk = $ids_by_chunk->merge($posts->pluck('id'));
+        });
+
+        $this->assertEquals($ids_by_get->toArray(), $ids_by_chunk->toArray());
+    }
 }
 
 class User extends Model


### PR DESCRIPTION
Fixes #21774.

This is analogical to BelongsToMany in that it also implements `chunk` to ensure that a correct select statement is used.

Following #22126 I decided to add a fix for `cursor` too.