### PR TITLE
[5.5] Fix custom URLs with prefix/root for AWS storage

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -394,13 +394,11 @@ class FilesystemAdapter implements FilesystemContract, CloudFilesystemContract
      */
     protected function getAwsUrl($adapter, $path)
     {
-        $config = $this->driver->getConfig();
-
         // If an explicit base URL has been set on the disk configuration then we will use
         // it as the base URL instead of the default path. This allows the developer to
         // have full control over the base path for this filesystem's generated URLs.
-        if (! is_null($url = $config->get('url'))) {
-            return $this->concatPathToUrl($url, $path);
+        if (! is_null($url = $this->driver->getConfig()->get('url'))) {
+            return $this->concatPathToUrl($url, $adapter->getPathPrefix().$path);
         }
 
         return $adapter->getClient()->getObjectUrl(


### PR DESCRIPTION
This PR fixes a corner case of #22037 where the "path prefix" (or `root`) wasn't considered.

The "path prefix" is prepended to the path in all other cases, see `path()`, `getAwsUrl()` and `getAwsTemporaryUrl()`.

Also, the temporary variable `$config` isn't necessary and was inlined.