### PR TITLE
[5.5] Add ability to call a closure on a model without firing Events

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
@@ -337,7 +337,7 @@ trait HasEvents
     {
         static::$dispatcher = null;
     }
-    
+
     /**
      * Call a callback without firing events.
      *

--- a/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
@@ -337,4 +337,21 @@ trait HasEvents
     {
         static::$dispatcher = null;
     }
+    
+    /**
+     * Call a callback without firing events.
+     *
+     * @param  \Closure|string  $callback
+     * @return void
+     */
+    public function withoutEvents($callback)
+    {
+        $dispatcher = $this->getEventDispatcher();
+
+        $this->unsetEventDispatcher();
+
+        $callback();
+
+        $this->setEventDispatcher($dispatcher);
+    }
 }

--- a/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
@@ -350,8 +350,10 @@ trait HasEvents
 
         $this->unsetEventDispatcher();
 
-        $callback();
-
-        $this->setEventDispatcher($dispatcher);
+        try {
+            $callback();
+        } finally {
+            $this->setEventDispatcher($dispatcher);
+        }
     }
 }


### PR DESCRIPTION
There are times where the saving event may unintentionally cause an infinite loop of saving events to be fired.

My case was I have an "is_primary" field on a user model. Upon changing this to true I wanted to set all other users to false. I opted to use the `saving` event to retrieve the other users and set them to false. This causes an infinite loop of `saving` to be fired.

This PR simply adds a public method that allows a closure to be called with firing any events. It removes the eventDispatcher, calls the closure and then rebinds the eventDispatcher.

Inspired by the discussion at https://github.com/laravel/internals/issues/344