### PR TITLE
[5.6] Multi server scheduling cron support

### DIFF
--- a/src/Illuminate/Console/Scheduling/CacheMutex.php
+++ b/src/Illuminate/Console/Scheduling/CacheMutex.php
@@ -33,7 +33,7 @@ class CacheMutex implements Mutex
     public function create(Event $event)
     {
         return $this->cache->add(
-            $event->mutexName().date('Hi'), true, 1
+            $event->mutexName().$event->timestamp->format('Hi'), true, 1
         ) && $this->cache->add(
             $event->mutexName(), true, $event->expiresAt
         );
@@ -47,7 +47,7 @@ class CacheMutex implements Mutex
      */
     public function exists(Event $event)
     {
-        return $this->cache->has($event->mutexName()) || $this->cache->has($event->mutexName().date('Hi'));
+        return $this->cache->has($event->mutexName()) || $this->cache->has($event->mutexName().$event->timestamp->format('Hi'));
     }
 
     /**

--- a/src/Illuminate/Console/Scheduling/CacheMutex.php
+++ b/src/Illuminate/Console/Scheduling/CacheMutex.php
@@ -33,6 +33,8 @@ class CacheMutex implements Mutex
     public function create(Event $event)
     {
         return $this->cache->add(
+            $event->mutexName().date('Hi'), true, 1
+        ) && $this->cache->add(
             $event->mutexName(), true, $event->expiresAt
         );
     }
@@ -45,7 +47,7 @@ class CacheMutex implements Mutex
      */
     public function exists(Event $event)
     {
-        return $this->cache->has($event->mutexName());
+        return $this->cache->has($event->mutexName()) || $this->cache->has($event->mutexName().date('Hi'));
     }
 
     /**

--- a/src/Illuminate/Console/Scheduling/CacheMutex.php
+++ b/src/Illuminate/Console/Scheduling/CacheMutex.php
@@ -33,7 +33,7 @@ class CacheMutex implements Mutex
     public function create(Event $event)
     {
         return $this->cache->add(
-            $event->mutexName().$event->timestamp->format('Hi'), true, 1
+            $event->mutexName().$event->timestamp->format('Hi'), true, 60
         ) && $this->cache->add(
             $event->mutexName(), true, $event->expiresAt
         );

--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -37,6 +37,13 @@ class Event
     public $timezone;
 
     /**
+     * The timestamp the event was initialized.
+     *
+     * @var \Illuminate\Support\Carbon
+     */
+    public $timestamp;
+
+    /**
      * The user the command should run as.
      *
      * @var string
@@ -146,6 +153,7 @@ class Event
         $this->mutex = $mutex;
         $this->command = $command;
         $this->output = $this->getDefaultOutput();
+        $this->timestamp = Carbon::now();
     }
 
     /**
@@ -287,13 +295,11 @@ class Event
      */
     protected function expressionPasses()
     {
-        $date = Carbon::now();
-
         if ($this->timezone) {
-            $date->setTimezone($this->timezone);
+            $this->timestamp->setTimezone($this->timezone);
         }
 
-        return CronExpression::factory($this->expression)->isDue($date->toDateTimeString());
+        return CronExpression::factory($this->expression)->isDue($this->timestamp->toDateTimeString());
     }
 
     /**

--- a/tests/Console/Scheduling/CacheOverlappingStrategyTest.php
+++ b/tests/Console/Scheduling/CacheOverlappingStrategyTest.php
@@ -83,7 +83,8 @@ class CacheMutexTest extends TestCase
 
     public function testResetOverlap()
     {
-        $this->cacheRepository->shouldReceive('forget')->once();
+        $this->cacheRepository->shouldReceive('forget')->with($this->event->mutexName())->once();
+        $this->cacheRepository->shouldReceive('forget')->with($this->event->mutexName().date('Hi'))->never();
 
         $this->cacheMutex->forget($this->event);
     }

--- a/tests/Console/Scheduling/CacheOverlappingStrategyTest.php
+++ b/tests/Console/Scheduling/CacheOverlappingStrategyTest.php
@@ -15,6 +15,11 @@ class CacheMutexTest extends TestCase
     protected $cacheMutex;
 
     /**
+     * @var \Illuminate\Console\Scheduling\Event
+     */
+    protected $event;
+
+    /**
      * @var \Illuminate\Contracts\Cache\Repository
      */
     protected $cacheRepository;
@@ -25,60 +30,61 @@ class CacheMutexTest extends TestCase
 
         $this->cacheRepository = m::mock('Illuminate\Contracts\Cache\Repository');
         $this->cacheMutex = new CacheMutex($this->cacheRepository);
+        $this->event = new Event($this->cacheMutex, 'command');
     }
 
     public function testPreventOverlap()
     {
-        $cacheMutex = $this->cacheMutex;
+        $this->cacheRepository->shouldReceive('add')->with($this->event->mutexName().date('Hi'), true, 1)->andReturn(true);
+        $this->cacheRepository->shouldReceive('add')->with($this->event->mutexName(), true, $this->event->expiresAt)->andReturn(true);
 
-        $this->cacheRepository->shouldReceive('add');
-
-        $event = new Event($this->cacheMutex, 'command');
-
-        $cacheMutex->create($event);
+        $this->cacheMutex->create($this->event);
     }
 
-    public function testPreventOverlapFails()
+    public function testPreventOverlapFailsDueToTaskRunningThisMinute()
     {
-        $cacheMutex = $this->cacheMutex;
+        $this->cacheRepository->shouldReceive('add')->with($this->event->mutexName().date('Hi'), true, 1)->andReturn(false);
+        $this->cacheRepository->shouldReceive('add')->with($this->event->mutexName(), true, $this->event->expiresAt)->never();
 
-        $this->cacheRepository->shouldReceive('add')->andReturn(false);
-
-        $event = new Event($this->cacheMutex, 'command');
-
-        $this->assertFalse($cacheMutex->create($event));
+        $this->assertFalse($this->cacheMutex->create($this->event));
     }
 
-    public function testOverlapsForNonRunningTask()
+    public function testPreventOverlapFailsDueToTaskStillRunning()
     {
-        $cacheMutex = $this->cacheMutex;
+        $this->cacheRepository->shouldReceive('add')->with($this->event->mutexName().date('Hi'), true, 1)->andReturn(true);
+        $this->cacheRepository->shouldReceive('add')->with($this->event->mutexName(), true, $this->event->expiresAt)->andReturn(false);
 
-        $this->cacheRepository->shouldReceive('has')->andReturn(false);
-
-        $event = new Event($this->cacheMutex, 'command');
-
-        $this->assertFalse($cacheMutex->exists($event));
+        $this->assertFalse($this->cacheMutex->create($this->event));
     }
 
-    public function testOverlapsForRunningTask()
+    public function testOverlapsForNonRunningTaskThatHasNotRunThisMinute()
     {
-        $cacheMutex = $this->cacheMutex;
+        $this->cacheRepository->shouldReceive('has')->with($this->event->mutexName())->andReturn(false);
+        $this->cacheRepository->shouldReceive('has')->with($this->event->mutexName().date('Hi'))->andReturn(false);
 
-        $this->cacheRepository->shouldReceive('has')->andReturn(true);
+        $this->assertFalse($this->cacheMutex->exists($this->event));
+    }
 
-        $event = new Event($this->cacheMutex, 'command');
+    public function testOverlapsForRunningTaskOncePerMinutue()
+    {
+        $this->cacheRepository->shouldReceive('has')->with($this->event->mutexName())->andReturn(true);
+        $this->cacheRepository->shouldReceive('has')->with($this->event->mutexName().date('Hi'))->never();
 
-        $this->assertTrue($cacheMutex->exists($event));
+        $this->assertTrue($this->cacheMutex->exists($this->event));
+    }
+
+    public function testOverlapsForRunningTaskLongerThanMinute()
+    {
+        $this->cacheRepository->shouldReceive('has')->once()->andReturn(false);
+        $this->cacheRepository->shouldReceive('has')->once()->andReturn(true);
+
+        $this->assertTrue($this->cacheMutex->exists($this->event));
     }
 
     public function testResetOverlap()
     {
-        $cacheMutex = $this->cacheMutex;
+        $this->cacheRepository->shouldReceive('forget')->once();
 
-        $this->cacheRepository->shouldReceive('forget');
-
-        $event = new Event($this->cacheMutex, 'command');
-
-        $cacheMutex->forget($event);
+        $this->cacheMutex->forget($this->event);
     }
 }

--- a/tests/Console/Scheduling/CacheOverlappingStrategyTest.php
+++ b/tests/Console/Scheduling/CacheOverlappingStrategyTest.php
@@ -75,8 +75,8 @@ class CacheMutexTest extends TestCase
 
     public function testOverlapsForRunningTaskLongerThanMinute()
     {
-        $this->cacheRepository->shouldReceive('has')->once()->andReturn(false);
-        $this->cacheRepository->shouldReceive('has')->once()->andReturn(true);
+        $this->cacheRepository->shouldReceive('has')->with($this->event->mutexName())->andReturn(false);
+        $this->cacheRepository->shouldReceive('has')->with($this->event->mutexName().date('Hi'))->andReturn(true);
 
         $this->assertTrue($this->cacheMutex->exists($this->event));
     }

--- a/tests/Console/Scheduling/CacheOverlappingStrategyTest.php
+++ b/tests/Console/Scheduling/CacheOverlappingStrategyTest.php
@@ -35,7 +35,7 @@ class CacheMutexTest extends TestCase
 
     public function testPreventOverlap()
     {
-        $this->cacheRepository->shouldReceive('add')->with($this->event->mutexName().$this->event->timestamp->format('Hi'), true, 1)->andReturn(true);
+        $this->cacheRepository->shouldReceive('add')->with($this->event->mutexName().$this->event->timestamp->format('Hi'), true, 60)->andReturn(true);
         $this->cacheRepository->shouldReceive('add')->with($this->event->mutexName(), true, $this->event->expiresAt)->andReturn(true);
 
         $this->cacheMutex->create($this->event);
@@ -43,7 +43,7 @@ class CacheMutexTest extends TestCase
 
     public function testPreventOverlapFailsDueToTaskRunningThisMinute()
     {
-        $this->cacheRepository->shouldReceive('add')->with($this->event->mutexName().$this->event->timestamp->format('Hi'), true, 1)->andReturn(false);
+        $this->cacheRepository->shouldReceive('add')->with($this->event->mutexName().$this->event->timestamp->format('Hi'), true, 60)->andReturn(false);
         $this->cacheRepository->shouldReceive('add')->with($this->event->mutexName(), true, $this->event->expiresAt)->never();
 
         $this->assertFalse($this->cacheMutex->create($this->event));
@@ -51,7 +51,7 @@ class CacheMutexTest extends TestCase
 
     public function testPreventOverlapFailsDueToTaskStillRunning()
     {
-        $this->cacheRepository->shouldReceive('add')->with($this->event->mutexName().$this->event->timestamp->format('Hi'), true, 1)->andReturn(true);
+        $this->cacheRepository->shouldReceive('add')->with($this->event->mutexName().$this->event->timestamp->format('Hi'), true, 60)->andReturn(true);
         $this->cacheRepository->shouldReceive('add')->with($this->event->mutexName(), true, $this->event->expiresAt)->andReturn(false);
 
         $this->assertFalse($this->cacheMutex->create($this->event));

--- a/tests/Console/Scheduling/CacheOverlappingStrategyTest.php
+++ b/tests/Console/Scheduling/CacheOverlappingStrategyTest.php
@@ -35,7 +35,7 @@ class CacheMutexTest extends TestCase
 
     public function testPreventOverlap()
     {
-        $this->cacheRepository->shouldReceive('add')->with($this->event->mutexName().date('Hi'), true, 1)->andReturn(true);
+        $this->cacheRepository->shouldReceive('add')->with($this->event->mutexName().$this->event->timestamp->format('Hi'), true, 1)->andReturn(true);
         $this->cacheRepository->shouldReceive('add')->with($this->event->mutexName(), true, $this->event->expiresAt)->andReturn(true);
 
         $this->cacheMutex->create($this->event);
@@ -43,7 +43,7 @@ class CacheMutexTest extends TestCase
 
     public function testPreventOverlapFailsDueToTaskRunningThisMinute()
     {
-        $this->cacheRepository->shouldReceive('add')->with($this->event->mutexName().date('Hi'), true, 1)->andReturn(false);
+        $this->cacheRepository->shouldReceive('add')->with($this->event->mutexName().$this->event->timestamp->format('Hi'), true, 1)->andReturn(false);
         $this->cacheRepository->shouldReceive('add')->with($this->event->mutexName(), true, $this->event->expiresAt)->never();
 
         $this->assertFalse($this->cacheMutex->create($this->event));
@@ -51,7 +51,7 @@ class CacheMutexTest extends TestCase
 
     public function testPreventOverlapFailsDueToTaskStillRunning()
     {
-        $this->cacheRepository->shouldReceive('add')->with($this->event->mutexName().date('Hi'), true, 1)->andReturn(true);
+        $this->cacheRepository->shouldReceive('add')->with($this->event->mutexName().$this->event->timestamp->format('Hi'), true, 1)->andReturn(true);
         $this->cacheRepository->shouldReceive('add')->with($this->event->mutexName(), true, $this->event->expiresAt)->andReturn(false);
 
         $this->assertFalse($this->cacheMutex->create($this->event));
@@ -60,7 +60,7 @@ class CacheMutexTest extends TestCase
     public function testOverlapsForNonRunningTaskThatHasNotRunThisMinute()
     {
         $this->cacheRepository->shouldReceive('has')->with($this->event->mutexName())->andReturn(false);
-        $this->cacheRepository->shouldReceive('has')->with($this->event->mutexName().date('Hi'))->andReturn(false);
+        $this->cacheRepository->shouldReceive('has')->with($this->event->mutexName().$this->event->timestamp->format('Hi'))->andReturn(false);
 
         $this->assertFalse($this->cacheMutex->exists($this->event));
     }
@@ -68,7 +68,7 @@ class CacheMutexTest extends TestCase
     public function testOverlapsForRunningTaskOncePerMinutue()
     {
         $this->cacheRepository->shouldReceive('has')->with($this->event->mutexName())->andReturn(true);
-        $this->cacheRepository->shouldReceive('has')->with($this->event->mutexName().date('Hi'))->never();
+        $this->cacheRepository->shouldReceive('has')->with($this->event->mutexName().$this->event->timestamp->format('Hi'))->never();
 
         $this->assertTrue($this->cacheMutex->exists($this->event));
     }
@@ -76,7 +76,7 @@ class CacheMutexTest extends TestCase
     public function testOverlapsForRunningTaskLongerThanMinute()
     {
         $this->cacheRepository->shouldReceive('has')->with($this->event->mutexName())->andReturn(false);
-        $this->cacheRepository->shouldReceive('has')->with($this->event->mutexName().date('Hi'))->andReturn(true);
+        $this->cacheRepository->shouldReceive('has')->with($this->event->mutexName().$this->event->timestamp->format('Hi'))->andReturn(true);
 
         $this->assertTrue($this->cacheMutex->exists($this->event));
     }
@@ -84,7 +84,7 @@ class CacheMutexTest extends TestCase
     public function testResetOverlap()
     {
         $this->cacheRepository->shouldReceive('forget')->with($this->event->mutexName())->once();
-        $this->cacheRepository->shouldReceive('forget')->with($this->event->mutexName().date('Hi'))->never();
+        $this->cacheRepository->shouldReceive('forget')->with($this->event->mutexName().$this->event->timestamp->format('Hi'))->never();
 
         $this->cacheMutex->forget($this->event);
     }


### PR DESCRIPTION
Simple solution to allowing scheduling to occur on multiple servers simulatenously. Issue recently came up here: https://github.com/laravel/framework/issues/22129

Using the existing Mutex system, we create a second stamp relating to the "minute" of this cron.

So using `->withoutOverlapping()` ensures that the command is only run once per cron expression across any server in your farm, as well as ensuring it does not overlap with a command already running longer than a minute (regardless which server started it). Best of both worlds.

Now multiple servers can run the scheduler without fear of the same command running twice.

_p.s. Perhaps for `5.6` we could invert, and make `->withoutOverlapping()` the default, and instead make developers use a new command `->allowOverlapping()` if they want it to run simulatenously or on multiple servers?_