### PR TITLE
[5.5] Return condition in throws helpers.

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -1040,41 +1040,41 @@ if (! function_exists('tap')) {
 
 if (! function_exists('throw_if')) {
     /**
-     * Throw the given exception if the given boolean is true.
+     * Throw the given exception if the given condition is true.
      *
-     * @param  bool  $boolean
+     * @param  mixed  $condition
      * @param  \Throwable|string  $exception
      * @param  array  ...$parameters
-     * @return void
+     * @return mixed
      * @throws \Throwable
      */
-    function throw_if($boolean, $exception, ...$parameters)
+    function throw_if($condition, $exception, ...$parameters)
     {
-        if ($boolean) {
+        if ($condition) {
             throw (is_string($exception) ? new $exception(...$parameters) : $exception);
         }
 
-        return $boolean;
+        return $condition;
     }
 }
 
 if (! function_exists('throw_unless')) {
     /**
-     * Throw the given exception unless the given boolean is true.
+     * Throw the given exception unless the given condition is true.
      *
-     * @param  bool  $boolean
+     * @param  mixed  $condition
      * @param  \Throwable|string  $exception
      * @param  array  ...$parameters
-     * @return void
+     * @return mixed
      * @throws \Throwable
      */
-    function throw_unless($boolean, $exception, ...$parameters)
+    function throw_unless($condition, $exception, ...$parameters)
     {
-        if (! $boolean) {
+        if (! $condition) {
             throw (is_string($exception) ? new $exception(...$parameters) : $exception);
         }
 
-        return $boolean;
+        return $condition;
     }
 }
 

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -1053,6 +1053,8 @@ if (! function_exists('throw_if')) {
         if ($boolean) {
             throw (is_string($exception) ? new $exception(...$parameters) : $exception);
         }
+
+        return $boolean;
     }
 }
 
@@ -1071,6 +1073,8 @@ if (! function_exists('throw_unless')) {
         if (! $boolean) {
             throw (is_string($exception) ? new $exception(...$parameters) : $exception);
         }
+
+        return $boolean;
     }
 }
 

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -748,6 +748,11 @@ class SupportHelpersTest extends TestCase
         throw_if(true, new RuntimeException);
     }
 
+    public function testThrowReturnIfNotThrown()
+    {
+        $this->assertSame('foo', throw_unless('foo', new RuntimeException));
+    }
+
     /**
      * @expectedException \RuntimeException
      * @expectedExceptionMessage Test Message


### PR DESCRIPTION
Hi, little PR which doesn't change anything except that it returns the condition in throw_* helpers.

Use case:
```php
public function foo() {
        return throw_unless(
            myFunction(),
            new Exception("myFunction result is null")
        );
}
``` 

instead of 

```php
public function foo() {
        throw_unless(
            $var = myFunction(),
            new Exception("myFunction result is null")
        );

        return $var;
}
``` 

Thx.