### PR TITLE
[5.5] Prevent multiple runs of middleware when using respondWithRoute

### DIFF
--- a/tests/Integration/Routing/Fixtures/RunCountMiddleware.php
+++ b/tests/Integration/Routing/Fixtures/RunCountMiddleware.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Routing\Fixtures;
+
+use Closure;
+
+class RunCountMiddleware
+{
+    public static $runCount = 0;
+
+    public function handle($request, Closure $next)
+    {
+        static::$runCount += 1;
+
+        return $next($request);
+    }
+}


### PR DESCRIPTION
_Note: I've written a (currently failing) test to verify that middleware is run _once_ when calling `::respondWithRoute`.  I'm looking to start a discussion how to best fix this issue and to implement said solution._

Reproduction repo: https://github.com/thecrypticace/route-fallback-issue

## Details

When using `Route::respondWithRoute` there can be an unintended side-effect. Middleware gets run more than once.

For most middleware this would not cause a problem as they perform mostly stateless or pure actions. If you have middleware encrypting generated unique response data, recording metrics, or talking with something that is external you can end up with incorrect behavior. e.g. In the metrics case  you could end up with double-counting metrics in some cases.

Now, there is a particular middleware combo reveals a rather problematic behavior: double encryption of cookies.

I'm using Laravel Passport + the `CreateFreshApiToken` middleware in the `web` group. The fallback is also in this group. When I respond with a fallback the route middleware runs and generates a token. This then gets encrypted by `EncryptCookies`. Then the response is returned which traverses up the route middleware which _also_ includes `EncryptCookies` resulting in a re-encryption of the already encrypted `laravel_token` cookie.

This will cause any API requests made on the page returned by the fallback route (in this case for a 404 page) to fail with a 401 authorized.

I discovered this because I detect 401 authorized responses to tell the user that their session has expired (as the generated fresh API tokens are expiring tokens) and am getting this message when I know the session has not expired.

## Possible Solutions

One solution I've thought of is not running route middleware at all but that's not good if the fallback route has additional middleware attached.

So the only ideal solution I can think of is:
1. Detect where we're at in the current route middleware stack
2. Skip the first N middleware segments after resolving the routes to a single array of middleware.

I'm not sure of a way to do this at the moment. Or if this is even the best option.

Any ideas?