### PR TITLE
[5.5] Fix docblock style for 'param' attributes

### DIFF
--- a/src/Illuminate/Database/Eloquent/FactoryBuilder.php
+++ b/src/Illuminate/Database/Eloquent/FactoryBuilder.php
@@ -286,8 +286,8 @@ class FactoryBuilder
     /**
      * Get the state attributes.
      *
-     * @param string $state
-     * @param array $attributes
+     * @param  string  $state
+     * @param  array  $attributes
      * @return array
      */
     protected function stateAttributes($state, array $attributes)

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -551,7 +551,7 @@ class Grammar extends BaseGrammar
     /**
      * Compile the query orders to an array.
      *
-     * @param  \Illuminate\Database\Query\Builder
+     * @param  \Illuminate\Database\Query\Builder  $query
      * @param  array  $orders
      * @return array
      */

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -496,10 +496,10 @@ class FilesystemAdapter implements FilesystemContract, CloudFilesystemContract
     /**
      * Get a temporary URL for the file at the given path.
      *
-     * @param  \League\Flysystem\Rackspace\RackspaceAdapter $adapter
-     * @param  string $path
-     * @param  \DateTimeInterface $expiration
-     * @param  $options
+     * @param  \League\Flysystem\Rackspace\RackspaceAdapter  $adapter
+     * @param  string  $path
+     * @param  \DateTimeInterface  $expiration
+     * @param  array  $options
      * @return string
      */
     public function getRackspaceTemporaryUrl($adapter, $path, $expiration, $options)

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -299,7 +299,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     /**
      * Get the path to the application "app" directory.
      *
-     * @param string $path Optionally, a path to append to the app path
+     * @param  string  $path Optionally, a path to append to the app path
      * @return string
      */
     public function path($path = '')
@@ -310,7 +310,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     /**
      * Get the base path of the Laravel installation.
      *
-     * @param string $path Optionally, a path to append to the base path
+     * @param  string  $path Optionally, a path to append to the base path
      * @return string
      */
     public function basePath($path = '')
@@ -321,7 +321,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     /**
      * Get the path to the bootstrap directory.
      *
-     * @param string $path Optionally, a path to append to the bootstrap path
+     * @param  string  $path Optionally, a path to append to the bootstrap path
      * @return string
      */
     public function bootstrapPath($path = '')
@@ -332,7 +332,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     /**
      * Get the path to the application configuration files.
      *
-     * @param string $path Optionally, a path to append to the config path
+     * @param  string  $path Optionally, a path to append to the config path
      * @return string
      */
     public function configPath($path = '')
@@ -343,7 +343,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     /**
      * Get the path to the database directory.
      *
-     * @param string $path Optionally, a path to append to the database path
+     * @param  string  $path Optionally, a path to append to the database path
      * @return string
      */
     public function databasePath($path = '')

--- a/src/Illuminate/Foundation/Auth/ResetsPasswords.php
+++ b/src/Illuminate/Foundation/Auth/ResetsPasswords.php
@@ -128,7 +128,7 @@ trait ResetsPasswords
     /**
      * Get the response for a failed password reset.
      *
-     * @param  \Illuminate\Http\Request
+     * @param  \Illuminate\Http\Request  $request
      * @param  string  $response
      * @return \Illuminate\Http\RedirectResponse|\Illuminate\Http\JsonResponse
      */

--- a/src/Illuminate/Foundation/Auth/SendsPasswordResetEmails.php
+++ b/src/Illuminate/Foundation/Auth/SendsPasswordResetEmails.php
@@ -42,7 +42,7 @@ trait SendsPasswordResetEmails
     /**
      * Validate the email for the given request.
      *
-     * @param \Illuminate\Http\Request  $request
+     * @param  \Illuminate\Http\Request  $request
      * @return void
      */
     protected function validateEmail(Request $request)
@@ -64,7 +64,7 @@ trait SendsPasswordResetEmails
     /**
      * Get the response for a failed password reset link.
      *
-     * @param  \Illuminate\Http\Request
+     * @param  \Illuminate\Http\Request  $request
      * @param  string  $response
      * @return \Illuminate\Http\RedirectResponse|\Illuminate\Http\JsonResponse
      */

--- a/src/Illuminate/Foundation/Console/PackageDiscoverCommand.php
+++ b/src/Illuminate/Foundation/Console/PackageDiscoverCommand.php
@@ -24,7 +24,7 @@ class PackageDiscoverCommand extends Command
     /**
      * Execute the console command.
      *
-     * @param  \Illuminate\Foundation\PackageManifest
+     * @param  \Illuminate\Foundation\PackageManifest  $manifest
      * @return void
      */
     public function handle(PackageManifest $manifest)

--- a/src/Illuminate/Foundation/Console/VendorPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/VendorPublishCommand.php
@@ -135,7 +135,7 @@ class VendorPublishCommand extends Command
     /**
      * Parse the answer that was given via the prompt.
      *
-     * @param string $choice
+     * @param  string  $choice
      * @return void
      */
     protected function parseChoice($choice)

--- a/src/Illuminate/Foundation/Console/stubs/resource-collection.stub
+++ b/src/Illuminate/Foundation/Console/stubs/resource-collection.stub
@@ -9,7 +9,7 @@ class DummyClass extends ResourceCollection
     /**
      * Transform the resource collection into an array.
      *
-     * @param  \Illuminate\Http\Request
+     * @param  \Illuminate\Http\Request  $request
      * @return array
      */
     public function toArray($request)

--- a/src/Illuminate/Foundation/Console/stubs/resource.stub
+++ b/src/Illuminate/Foundation/Console/stubs/resource.stub
@@ -9,7 +9,7 @@ class DummyClass extends Resource
     /**
      * Transform the resource into an array.
      *
-     * @param  \Illuminate\Http\Request
+     * @param  \Illuminate\Http\Request  $request
      * @return array
      */
     public function toArray($request)

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithAuthentication.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithAuthentication.php
@@ -74,7 +74,7 @@ trait InteractsWithAuthentication
     /**
      * Assert that the user is authenticated as the given user.
      *
-     * @param  $user
+     * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
      * @param  string|null  $guard
      * @return $this
      */

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithExceptionHandling.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithExceptionHandling.php
@@ -71,7 +71,7 @@ trait InteractsWithExceptionHandling
             /**
              * Create a new class instance.
              *
-             * @param \Illuminate\Contracts\Debug\ExceptionHandler
+             * @param  \Illuminate\Contracts\Debug\ExceptionHandler  $originalHandler
              * @param  array  $except
              * @return void
              */
@@ -121,7 +121,7 @@ trait InteractsWithExceptionHandling
             /**
              * Render the exception for the console.
              *
-             * @param  \Symfony\Component\Console\Output\OutputInterface
+             * @param  \Symfony\Component\Console\Output\OutputInterface  $output
              * @param  \Exception  $e
              * @return void
              */

--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -454,8 +454,8 @@ class TestResponse
     /**
      * Assert that the response JSON has the expected count of items at the given key.
      *
-     * @param int $count
-     * @param string|null $key
+     * @param  int  $count
+     * @param  string|null  $key
      * @return $this
      */
     public function assertJsonCount(int $count, $key = null)
@@ -480,7 +480,7 @@ class TestResponse
     /**
      * Assert that the response has the given JSON validation errors for the given keys.
      *
-     * @param string|array $keys
+     * @param  string|array  $keys
      * @return $this
      */
     public function assertJsonValidationErrors($keys)

--- a/src/Illuminate/Http/Resources/Json/Resource.php
+++ b/src/Illuminate/Http/Resources/Json/Resource.php
@@ -116,7 +116,7 @@ class Resource implements ArrayAccess, JsonSerializable, Responsable, UrlRoutabl
     /**
      * Get any additional data that should be returned with the resource array.
      *
-     * @param \Illuminate\Http\Request  $request
+     * @param  \Illuminate\Http\Request  $request
      * @return array
      */
     public function with($request)

--- a/src/Illuminate/Mail/Transport/SparkPostTransport.php
+++ b/src/Illuminate/Mail/Transport/SparkPostTransport.php
@@ -105,7 +105,7 @@ class SparkPostTransport extends Transport
     /**
      * Get the transmission ID from the response.
      *
-     * @param \GuzzleHttp\Psr7\Response $response
+     * @param  \GuzzleHttp\Psr7\Response  $response
      * @return string
      */
     protected function getTransmissionId($response)

--- a/src/Illuminate/Redis/Connections/PhpRedisConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisConnection.php
@@ -50,7 +50,7 @@ class PhpRedisConnection extends Connection
     /**
      * Determine if the given keys exist.
      *
-     * @param  dynamic  $key
+     * @param  dynamic  $keys
      * @return int
      */
     public function exists(...$keys)
@@ -65,11 +65,11 @@ class PhpRedisConnection extends Connection
     /**
      * Set the string value in argument as value of the key.
      *
-     * @param string  $key
-     * @param mixed  $value
-     * @param string|null  $expireResolution
-     * @param int|null  $expireTTL
-     * @param string|null  $flag
+     * @param  string  $key
+     * @param  mixed  $value
+     * @param  string|null  $expireResolution
+     * @param  int|null  $expireTTL
+     * @param  string|null  $flag
      * @return bool
      */
     public function set($key, $value, $expireResolution = null, $expireTTL = null, $flag = null)
@@ -385,7 +385,8 @@ class PhpRedisConnection extends Connection
     /**
      * Apply prefix to the given key if necessary.
      *
-     * @param $key
+     * @param  string  $key
+     * @return string
      */
     private function applyPrefix($key)
     {

--- a/src/Illuminate/Routing/RouteUrlGenerator.php
+++ b/src/Illuminate/Routing/RouteUrlGenerator.php
@@ -11,7 +11,7 @@ class RouteUrlGenerator
     /**
      * The URL generator instance.
      *
-     * @param  \Illuminate\Routing\UrlGenerator
+     * @var \Illuminate\Routing\UrlGenerator
      */
     protected $url;
 

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -230,9 +230,9 @@ class Router implements RegistrarContract, BindingRegistrar
     /**
      * Create a redirect from one URI to another.
      *
-     * @param string  $uri
-     * @param string  $destination
-     * @param int  $status
+     * @param  string  $uri
+     * @param  string  $destination
+     * @param  int  $status
      * @return \Illuminate\Routing\Route
      */
     public function redirect($uri, $destination, $status = 301)

--- a/src/Illuminate/Support/InteractsWithTime.php
+++ b/src/Illuminate/Support/InteractsWithTime.php
@@ -40,7 +40,7 @@ trait InteractsWithTime
     /**
      * If the given value is an interval, convert it to a DateTime instance.
      *
-     * @param \DateTimeInterface|\DateInterval|int
+     * @param  \DateTimeInterface|\DateInterval|int  $delay
      * @return \DateTimeInterface|int
      */
     protected function parseDateInterval($delay)

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -548,7 +548,7 @@ if (! function_exists('dd')) {
     /**
      * Dump the passed variables and end the script.
      *
-     * @param  mixed
+     * @param  mixed  $args
      * @return void
      */
     function dd(...$args)

--- a/src/Illuminate/View/Compilers/Concerns/CompilesIncludes.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesIncludes.php
@@ -44,7 +44,7 @@ trait CompilesIncludes
     /**
      * Compile the include-when statements into valid PHP.
      *
-     * @param string $expression
+     * @param  string  $expression
      * @return string
      */
     protected function compileIncludeWhen($expression)


### PR DESCRIPTION
`@param` attribute formatting as per https://laravel.com/docs/5.5/contributions#phpdoc