### PR TITLE
additional check for loaded language file using json format

### DIFF
--- a/src/Illuminate/Translation/FileLoader.php
+++ b/src/Illuminate/Translation/FileLoader.php
@@ -137,7 +137,7 @@ class FileLoader implements Loader
             ->reduce(function ($output, $path) use ($locale) {
                 if ($this->files->exists($full = "{$path}/{$locale}.json")) {
                     $filecontent = json_decode($this->files->get($full), true);
-                    if (!is_null($filecontent) && json_last_error() === 0) {
+                    if (! is_null($filecontent) && json_last_error() === 0) {
                         $output = array_merge($output, $filecontent);
                     }
                 }

--- a/src/Illuminate/Translation/FileLoader.php
+++ b/src/Illuminate/Translation/FileLoader.php
@@ -135,10 +135,13 @@ class FileLoader implements Loader
     {
         return collect(array_merge($this->jsonPaths, [$this->path]))
             ->reduce(function ($output, $path) use ($locale) {
-                return $this->files->exists($full = "{$path}/{$locale}.json")
-                    ? array_merge($output,
-                        json_decode($this->files->get($full), true)
-                    ) : $output;
+                if ($this->files->exists($full = "{$path}/{$locale}.json")) {
+                    $filecontent = json_decode($this->files->get($full), true);
+                    if (!is_null($filecontent) && json_last_error() === 0) {
+                        $output = array_merge($output, $filecontent);
+                    }
+                }
+                return $output;
             }, []);
     }
 

--- a/src/Illuminate/Translation/FileLoader.php
+++ b/src/Illuminate/Translation/FileLoader.php
@@ -141,6 +141,7 @@ class FileLoader implements Loader
                         $output = array_merge($output, $filecontent);
                     }
                 }
+
                 return $output;
             }, []);
     }


### PR DESCRIPTION
* as the json file may contain invalid json this helps to ignore such files
* just merges the language array when it's valid for the rest of the files
* produced a php exception before, as the second parameter for array_merge was null due to invalid json in file