### PR TITLE
[5.5] Prevent authentication if 'password' is the only field specified to the auth 'attempt' method

### DIFF
--- a/src/Illuminate/Auth/DatabaseUserProvider.php
+++ b/src/Illuminate/Auth/DatabaseUserProvider.php
@@ -98,6 +98,10 @@ class DatabaseUserProvider implements UserProvider
      */
     public function retrieveByCredentials(array $credentials)
     {
+        if (empty($credentials) || (count($credentials) === 1 && array_key_exists('password', $credentials))) {
+            return;
+        }
+
         // First we will add each credential element to the query as a where clause.
         // Then we can execute the query and, if we found a user, return it in a
         // generic "user" object that will be utilized by the Guard instances.

--- a/src/Illuminate/Auth/EloquentUserProvider.php
+++ b/src/Illuminate/Auth/EloquentUserProvider.php
@@ -101,7 +101,7 @@ class EloquentUserProvider implements UserProvider
      */
     public function retrieveByCredentials(array $credentials)
     {
-        if (empty($credentials)) {
+        if (empty($credentials) || (count($credentials) === 1 && array_key_exists('password', $credentials))) {
             return;
         }
 


### PR DESCRIPTION
I figured out that calling this :
```
auth()->attempt(['password' => 'mypassword'])
```
will result to `true` if the first row returned from the database is also the one using this password, without the need to specify an identifier (`email` for example).
This happens because the `foreach` loop inside the  `retrieveByCredentials` function will never call `$query->where($key, $value)` and then will systematicaly call `$query->first()` without any SQL condition applied.

You can easily reproduct this by trying to authenticate the user represented by the first row of your `users` table without specifying his email or username.

I don't think this is an expected behaviour.
This issue exists for 5.5 and 5.4 (I did not check older versions but I guess it's also present).

