### PR TITLE
[5.5] show more meaningfull message when json translation file contains errors

### DIFF
--- a/src/Illuminate/Contracts/Translation/JsonFileInvalidException.php
+++ b/src/Illuminate/Contracts/Translation/JsonFileInvalidException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Illuminate\Contracts\Translation;
+
+use Exception;
+
+class JsonFileInvalidException extends Exception
+{
+    //
+}

--- a/src/Illuminate/Translation/FileLoader.php
+++ b/src/Illuminate/Translation/FileLoader.php
@@ -4,6 +4,7 @@ namespace Illuminate\Translation;
 
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Contracts\Translation\Loader;
+use Illuminate\Contracts\Translation\JsonFileInvalidException;
 
 class FileLoader implements Loader
 {
@@ -130,6 +131,8 @@ class FileLoader implements Loader
      *
      * @param  string  $locale
      * @return array
+     *
+     * @throws \Illuminate\Contracts\Translation\JsonFileInvalidException
      */
     protected function loadJsonPaths($locale)
     {
@@ -139,6 +142,8 @@ class FileLoader implements Loader
                     $filecontent = json_decode($this->files->get($full), true);
                     if (! is_null($filecontent) && json_last_error() === 0) {
                         $output = array_merge($output, $filecontent);
+                    } else {
+                        throw new JsonFileInvalidException("{$full} contains an invalid json object.");
                     }
                 }
 

--- a/src/Illuminate/Translation/FileLoader.php
+++ b/src/Illuminate/Translation/FileLoader.php
@@ -137,7 +137,7 @@ class FileLoader implements Loader
             ->reduce(function ($output, $path) use ($locale) {
                 if ($this->files->exists($full = "{$path}/{$locale}.json")) {
                     $filecontent = json_decode($this->files->get($full), true);
-                    if (!is_null($filecontent) && json_last_error() === 0) {
+                    if (! is_null($filecontent) && json_last_error() === 0) {
                         $output = array_merge($output, $filecontent);
                     }
                 }

--- a/src/Illuminate/Translation/FileLoader.php
+++ b/src/Illuminate/Translation/FileLoader.php
@@ -135,10 +135,13 @@ class FileLoader implements Loader
     {
         return collect(array_merge($this->jsonPaths, [$this->path]))
             ->reduce(function ($output, $path) use ($locale) {
-                return $this->files->exists($full = "{$path}/{$locale}.json")
-                    ? array_merge($output,
-                        json_decode($this->files->get($full), true)
-                    ) : $output;
+                if ($this->files->exists($full = "{$path}/{$locale}.json")) {
+                    $filecontent = json_decode($this->files->get($full), true);
+                    if (!is_null($filecontent) && json_last_error() === 0) {
+                        $output = array_merge($output, $filecontent);
+                    }
+                }
+                return $output;
             }, []);
     }
 

--- a/src/Illuminate/Translation/FileLoader.php
+++ b/src/Illuminate/Translation/FileLoader.php
@@ -141,6 +141,7 @@ class FileLoader implements Loader
                         $output = array_merge($output, $filecontent);
                     }
                 }
+
                 return $output;
             }, []);
     }

--- a/src/Illuminate/Translation/FileLoader.php
+++ b/src/Illuminate/Translation/FileLoader.php
@@ -140,11 +140,12 @@ class FileLoader implements Loader
             ->reduce(function ($output, $path) use ($locale) {
                 if ($this->files->exists($full = "{$path}/{$locale}.json")) {
                     $filecontent = json_decode($this->files->get($full), true);
-                    if (! is_null($filecontent) && json_last_error() === 0) {
-                        $output = array_merge($output, $filecontent);
-                    } else {
+                    
+                    if (is_null($filecontent) || json_last_error() !== JSON_ERROR_NONE) {
                         throw new JsonFileInvalidException("{$full} contains an invalid json object.");
                     }
+
+                    $output = array_merge($output, $filecontent);
                 }
 
                 return $output;


### PR DESCRIPTION
* currently there is a just a php exception tha tells the user that the second parameter for array_merge should be of type array
* throws now a customized exception when json language file contains invalid json syntax
* this should help the user to get a faster understanding of the error resulting in faster debugging
(follow up PR to https://github.com/laravel/framework/pull/22165)