### PR TITLE
[5.5] make Collection::where independent on error reporting

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -230,9 +230,9 @@ class Router implements RegistrarContract, BindingRegistrar
     /**
      * Create a redirect from one URI to another.
      *
-     * @param string  $uri
-     * @param string  $destination
-     * @param int  $status
+     * @param  string  $uri
+     * @param  string  $destination
+     * @param  int  $status
      * @return \Illuminate\Routing\Route
      */
     public function redirect($uri, $destination, $status = 301)

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -230,9 +230,9 @@ class Router implements RegistrarContract, BindingRegistrar
     /**
      * Create a redirect from one URI to another.
      *
-     * @param  string  $uri
-     * @param  string  $destination
-     * @param  int  $status
+     * @param string  $uri
+     * @param string  $destination
+     * @param int  $status
      * @return \Illuminate\Routing\Route
      */
     public function redirect($uri, $destination, $status = 301)

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -486,22 +486,22 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
         return function ($item) use ($key, $operator, $value) {
             $retrieved = data_get($item, $key);
 
-            try {
-                switch ($operator) {
-                    default:
-                    case '=':
-                    case '==':  return $retrieved == $value;
-                    case '!=':
-                    case '<>':  return $retrieved != $value;
-                    case '<':   return $retrieved < $value;
-                    case '>':   return $retrieved > $value;
-                    case '<=':  return $retrieved <= $value;
-                    case '>=':  return $retrieved >= $value;
-                    case '===': return $retrieved === $value;
-                    case '!==': return $retrieved !== $value;
-                }
-            } catch (Exception $e) {
+            if (count(array_filter([$retrieved, $value], 'is_object')) == 1) {
                 return false;
+            }
+
+            switch ($operator) {
+                default:
+                case '=':
+                case '==':  return $retrieved == $value;
+                case '!=':
+                case '<>':  return $retrieved != $value;
+                case '<':   return $retrieved < $value;
+                case '>':   return $retrieved > $value;
+                case '<=':  return $retrieved <= $value;
+                case '>=':  return $retrieved >= $value;
+                case '===': return $retrieved === $value;
+                case '!==': return $retrieved !== $value;
             }
         };
     }


### PR DESCRIPTION
In reference to https://github.com/laravel/framework/issues/22106

This change removes the try...catch wrapping so that it's not dependent on the level of error reporting you chose for your project.

```
if (count(array_filter([$retrieved, $value], 'is_object')) == 1)
```

Ensures that both variables are objects or non is an object.