### PR TITLE
Fix Eloquent distinct()->paginate() wrong records count

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -705,7 +705,7 @@ class Builder
 
         $perPage = $perPage ?: $this->model->getPerPage();
 
-        $results = ($total = $this->toBase()->getCountForPagination())
+        $results = ($total = $this->toBase()->getCountForPagination($columns))
                                     ? $this->forPage($page, $perPage)->get($columns)
                                     : $this->model->newCollection();
 


### PR DESCRIPTION
The call to the Illuminate\Database\Eloquent::getCountForPagination() function in the  Illuminate\Database\Eloquent::paginate() method doesn't include the $columns parameter.

This behaviour is different from the one in the Illuminate\Database\Query\Builder::paginate() method.

Introducing the columns parameter fixes the bug of wrong records count in "distinct" Eloquent paginated queries.