### PR TITLE
[5.6] Don't add `?page=1` for the first page in a pagination

### DIFF
--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -141,23 +141,23 @@ abstract class AbstractPaginator implements Htmlable
      */
     public function url($page)
     {
-        if ($page <= 0) {
-            $page = 1;
-        }
-
         // If we have any extra query string key / value pairs that need to be added
         // onto the URL, we will put them in query string form and then attach it
         // to the URL. This allows for extra information like sortings storage.
-        $parameters = [$this->pageName => $page];
+        $parameters = $page > 1 ? [$this->pageName => $page] : [];
 
         if (count($this->query) > 0) {
             $parameters = array_merge($this->query, $parameters);
         }
 
-        return $this->path
-                        .(Str::contains($this->path, '?') ? '&' : '?')
-                        .http_build_query($parameters, '', '&')
-                        .$this->buildFragment();
+        $url = $this->path;
+
+        if ($parameters) {
+            $url .= (Str::contains($this->path, '?') ? '&' : '?')
+                .http_build_query($parameters, '', '&');
+        }
+
+        return $url.$this->buildFragment();
     }
 
     /**

--- a/tests/Pagination/LengthAwarePaginatorTest.php
+++ b/tests/Pagination/LengthAwarePaginatorTest.php
@@ -53,10 +53,10 @@ class LengthAwarePaginatorTest extends TestCase
         $this->assertEquals('http://website.com?foo=2',
                             $this->p->url($this->p->currentPage()));
 
-        $this->assertEquals('http://website.com?foo=1',
+        $this->assertEquals('http://website.com',
                             $this->p->url($this->p->currentPage() - 1));
 
-        $this->assertEquals('http://website.com?foo=1',
+        $this->assertEquals('http://website.com',
                             $this->p->url($this->p->currentPage() - 2));
     }
 
@@ -77,10 +77,10 @@ class LengthAwarePaginatorTest extends TestCase
         $this->assertEquals('http://website.com/test?foo=2',
                             $this->p->url($this->p->currentPage()));
 
-        $this->assertEquals('http://website.com/test?foo=1',
+        $this->assertEquals('http://website.com/test',
                             $this->p->url($this->p->currentPage() - 1));
 
-        $this->assertEquals('http://website.com/test?foo=1',
+        $this->assertEquals('http://website.com/test',
                             $this->p->url($this->p->currentPage() - 2));
     }
 }

--- a/tests/Pagination/PaginatorTest.php
+++ b/tests/Pagination/PaginatorTest.php
@@ -9,21 +9,21 @@ class PaginatorTest extends TestCase
 {
     public function testSimplePaginatorReturnsRelevantContextInformation()
     {
-        $p = new Paginator($array = ['item3', 'item4', 'item5'], 2, 2);
+        $p = new Paginator($array = ['item3', 'item4', 'item5'], 2, 3);
 
-        $this->assertEquals(2, $p->currentPage());
+        $this->assertEquals(3, $p->currentPage());
         $this->assertTrue($p->hasPages());
         $this->assertTrue($p->hasMorePages());
         $this->assertEquals(['item3', 'item4'], $p->items());
 
         $pageInfo = [
             'per_page' => 2,
-            'current_page' => 2,
-            'first_page_url' => '/?page=1',
-            'next_page_url' => '/?page=3',
-            'prev_page_url' => '/?page=1',
-            'from' => 3,
-            'to' => 4,
+            'current_page' => 3,
+            'first_page_url' => '/',
+            'next_page_url' => '/?page=4',
+            'prev_page_url' => '/?page=2',
+            'from' => 5,
+            'to' => 6,
             'data' => ['item3', 'item4'],
             'path' => '/',
         ];
@@ -33,17 +33,17 @@ class PaginatorTest extends TestCase
 
     public function testPaginatorRemovesTrailingSlashes()
     {
-        $p = new Paginator($array = ['item1', 'item2', 'item3'], 2, 2,
+        $p = new Paginator($array = ['item1', 'item2', 'item3'], 2, 3,
                                     ['path' => 'http://website.com/test/']);
 
-        $this->assertEquals('http://website.com/test?page=1', $p->previousPageUrl());
+        $this->assertEquals('http://website.com/test?page=2', $p->previousPageUrl());
     }
 
     public function testPaginatorGeneratesUrlsWithoutTrailingSlash()
     {
-        $p = new Paginator($array = ['item1', 'item2', 'item3'], 2, 2,
+        $p = new Paginator($array = ['item1', 'item2', 'item3'], 2, 3,
                                     ['path' => 'http://website.com/test']);
 
-        $this->assertEquals('http://website.com/test?page=1', $p->previousPageUrl());
+        $this->assertEquals('http://website.com/test?page=2', $p->previousPageUrl());
     }
 }

--- a/tests/Pagination/UrlWindowTest.php
+++ b/tests/Pagination/UrlWindowTest.php
@@ -19,7 +19,7 @@ class UrlWindowTest extends TestCase
     {
         $p = new LengthAwarePaginator($array = ['item1', 'item2', 'item3', 'item4'], 4, 2, 2);
         $window = new UrlWindow($p);
-        $this->assertEquals(['first' => [1 => '/?page=1', 2 => '/?page=2'], 'slider' => null, 'last' => null], $window->get());
+        $this->assertEquals(['first' => [1 => '/', 2 => '/?page=2'], 'slider' => null, 'last' => null], $window->get());
     }
 
     public function testPresenterCanGetAUrlRangeForAWindowOfLinks()
@@ -35,7 +35,7 @@ class UrlWindowTest extends TestCase
             $slider[$i] = '/?page='.$i;
         }
 
-        $this->assertEquals(['first' => [1 => '/?page=1', 2 => '/?page=2'], 'slider' => $slider, 'last' => [12 => '/?page=12', 13 => '/?page=13']], $window->get());
+        $this->assertEquals(['first' => [1 => '/', 2 => '/?page=2'], 'slider' => $slider, 'last' => [12 => '/?page=12', 13 => '/?page=13']], $window->get());
 
         /*
          * Test Being Near The End Of The List
@@ -47,6 +47,6 @@ class UrlWindowTest extends TestCase
             $last[$i] = '/?page='.$i;
         }
 
-        $this->assertEquals(['first' => [1 => '/?page=1', 2 => '/?page=2'], 'slider' => null, 'last' => $last], $window->get());
+        $this->assertEquals(['first' => [1 => '/', 2 => '/?page=2'], 'slider' => null, 'last' => $last], $window->get());
     }
 }


### PR DESCRIPTION
Currently paginated views start without any parameters (`/`), but in the paginator the first page is linked with `/?page=1`. Besides being inconsistent, it's also bad for SEO due do duplicated content for 2 different URLs.

I propose, for the sake of consistency, to never set this parameter for the first page.