### PR TITLE
[5.5] Fix connection resolver and static side effect

### DIFF
--- a/tests/Database/DatabaseEloquentGlobalScopesTest.php
+++ b/tests/Database/DatabaseEloquentGlobalScopesTest.php
@@ -4,12 +4,26 @@ namespace Illuminate\Tests\Database;
 
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Database\Capsule\Manager as DB;
+use Illuminate\Database\Eloquent\Model as Eloquent;
 
 class DatabaseEloquentGlobalScopesTest extends TestCase
 {
+    public function setUp()
+    {
+        parent::setUp();
+
+        tap(new DB)->addConnection([
+            'driver'    => 'sqlite',
+            'database'  => ':memory:',
+        ])->bootEloquent();
+    }
+
     public function tearDown()
     {
         m::close();
+
+        Eloquent::unsetConnectionResolver();
     }
 
     public function testGlobalScopeIsApplied()

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -125,6 +125,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         }
 
         Relation::morphMap([], false);
+        Eloquent::unsetConnectionResolver();
     }
 
     /**

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1840,6 +1840,7 @@ class EloquentModelSaveStub extends Model
         $mock->shouldReceive('getQueryGrammar')->andReturn(m::mock('Illuminate\Database\Query\Grammars\Grammar'));
         $mock->shouldReceive('getPostProcessor')->andReturn(m::mock('Illuminate\Database\Query\Processors\Processor'));
         $mock->shouldReceive('getName')->andReturn('name');
+
         return $mock;
     }
 }

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -202,6 +202,7 @@ class DatabaseEloquentModelTest extends TestCase
     public function testWithoutMethodRemovesEagerLoadedRelationshipCorrectly()
     {
         $model = new EloquentModelWithoutRelationStub;
+        $this->addMockConnection($model);
         $instance = $model->newInstance()->newQuery()->without('foo');
         $this->assertEmpty($instance->getEagerLoads());
     }
@@ -1831,6 +1832,15 @@ class EloquentModelSaveStub extends Model
     public function setIncrementing($value)
     {
         $this->incrementing = $value;
+    }
+
+    public function getConnection()
+    {
+        $mock = m::mock('Illuminate\Database\Connection');
+        $mock->shouldReceive('getQueryGrammar')->andReturn(m::mock('Illuminate\Database\Query\Grammars\Grammar'));
+        $mock->shouldReceive('getPostProcessor')->andReturn(m::mock('Illuminate\Database\Query\Processors\Processor'));
+        $mock->shouldReceive('getName')->andReturn('name');
+        return $mock;
     }
 }
 


### PR DESCRIPTION
The following tests fail on a fresh clone of 5.5 when you run `phpunit --filter DatabaseEloquentModelTest`

```
1) Illuminate\Tests\Database\DatabaseEloquentModelTest::testCreateMethodSavesNewModel
Error: Call to a member function connection() on null

2) Illuminate\Tests\Database\DatabaseEloquentModelTest::testMakeMethodDoesNotSaveNewModel
Error: Call to a member function connection() on null

3) Illuminate\Tests\Database\DatabaseEloquentModelTest::testForceCreateMethodSavesNewModelWithGuardedAttributes
Error: Call to a member function connection() on null

4) Illuminate\Tests\Database\DatabaseEloquentModelTest::testWithoutMethodRemovesEagerLoadedRelationshipCorrectly
Error: Call to a member function connection() on null

5) Illuminate\Tests\Database\DatabaseEloquentModelTest::testEagerLoadingWithColumns
Error: Call to a member function connection() on null
```

There's static state from a previous test that is affecting other tests.