### PR TITLE
[5.5] Update docs for queue:retry command

### DIFF
--- a/src/Illuminate/Queue/Console/RetryCommand.php
+++ b/src/Illuminate/Queue/Console/RetryCommand.php
@@ -12,7 +12,7 @@ class RetryCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'queue:retry {id* : The ID of the failed job.}';
+    protected $signature = 'queue:retry {id* : The ID of the failed job or \'all\' to retry all jobs.}';
 
     /**
      * The console command description.

--- a/src/Illuminate/Queue/Console/RetryCommand.php
+++ b/src/Illuminate/Queue/Console/RetryCommand.php
@@ -12,7 +12,7 @@ class RetryCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'queue:retry {id* : The ID of the failed job or \'all\' to retry all jobs.}';
+    protected $signature = 'queue:retry {id* : The ID of the failed job or "all" to retry all jobs.}';
 
     /**
      * The console command description.


### PR DESCRIPTION
At the moment it's not obvious that you can pass 'all' as an id without looking through the code.