### PR TITLE
[5.5] Removed unused parameter form anonymous function

### DIFF
--- a/src/Illuminate/Foundation/PackageManifest.php
+++ b/src/Illuminate/Foundation/PackageManifest.php
@@ -65,7 +65,7 @@ class PackageManifest
      */
     public function providers()
     {
-        return collect($this->getManifest())->flatMap(function ($configuration, $name) {
+        return collect($this->getManifest())->flatMap(function ($configuration) {
             return (array) ($configuration['providers'] ?? []);
         })->filter()->all();
     }


### PR DESCRIPTION
Removed unused parameter form anonymous function inside `providers` method of `PackageManifest` class.