### PR TITLE
[5.5] Removed unused parameter form anonymous function

### DIFF
--- a/src/Illuminate/Foundation/PackageManifest.php
+++ b/src/Illuminate/Foundation/PackageManifest.php
@@ -77,7 +77,7 @@ class PackageManifest
      */
     public function aliases()
     {
-        return collect($this->getManifest())->flatMap(function ($configuration, $name) {
+        return collect($this->getManifest())->flatMap(function ($configuration) {
             return (array) ($configuration['aliases'] ?? []);
         })->filter()->all();
     }


### PR DESCRIPTION
Removed unused parameter form anonymous function inside `aliases` method of `PackageManifest` class.