### PR TITLE
Add dump method to Query\Builder class

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1649,6 +1649,37 @@ class Builder
     }
 
     /**
+     * Dump useful properties of the builder.
+     *
+     * @return \Illuminate\Database\Query\Builder
+     */
+    public function dump() {
+        dump([
+            'bindings' => $this->bindings,
+            'sql' => $this->toSql(),
+            'raw' => $this->toRawSql($this->toSql(), $this->bindings)
+        ]);
+
+        return $this;
+    }
+
+    /**
+     * Get the SQL representation of the query with
+     * substituted bindings.
+     *
+     * @return \Illuminate\Database\Query\Builder
+     */
+    public function toRawSql($sql, $bindings) {
+        $flat = array_flatten($bindings);
+        foreach ($flat as $binding) {
+            $binded = is_numeric($binding) ? $binding : "'{$binding}'";
+            $sql = preg_replace('/\?/', $binded, $sql, 1);
+        }
+
+        return $sql;
+    }
+
+    /**
      * Execute a query for a single record by ID.
      *
      * @param  int    $id

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1653,30 +1653,14 @@ class Builder
      *
      * @return \Illuminate\Database\Query\Builder
      */
-    public function dump() {
+    public function dump()
+    {
         dump([
             'bindings' => $this->bindings,
-            'sql' => $this->toSql(),
-            'raw' => $this->toRawSql($this->toSql(), $this->bindings)
+            'sql' => $this->toSql()
         ]);
 
         return $this;
-    }
-
-    /**
-     * Get the SQL representation of the query with
-     * substituted bindings.
-     *
-     * @return \Illuminate\Database\Query\Builder
-     */
-    public function toRawSql($sql, $bindings) {
-        $flat = array_flatten($bindings);
-        foreach ($flat as $binding) {
-            $binded = is_numeric($binding) ? $binding : "'{$binding}'";
-            $sql = preg_replace('/\?/', $binded, $sql, 1);
-        }
-
-        return $sql;
     }
 
     /**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1657,7 +1657,7 @@ class Builder
     {
         dump([
             'bindings' => $this->bindings,
-            'sql' => $this->toSql()
+            'sql' => $this->toSql(),
         ]);
 
         return $this;


### PR DESCRIPTION
Inspired by #19755

This PR adds a `dump` method to `Illuminate\Database\Query\Builder` so you can easily debug multiple spots in a query builder chain.

``` php
$users = DB::table('users')
           ->select('name', 'email as user_email')
           ->join('contacts', 'users.id', '=', 'contacts.user_id')
           ->union($first)
           ->dump()
           ->where('something', 'true')
           ->orWhere('name', 'John')
           ->orderBy('name', 'desc')
           ->groupBy('account_id')
           ->dump()
           ->offset(10)
           ->limit(5)
           ->having('account_id', '>', 100)
           ->get();
```