### PR TITLE
[5.5] feat: add comment on mysql table

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -41,6 +41,13 @@ class Blueprint
     public $engine;
 
     /**
+     * The comment description for the table.
+     *
+     * @var string
+     */
+    public $comment;
+
+    /**
      * The default character set that should be used for the table.
      */
     public $charset;

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -66,6 +66,11 @@ class MySqlGrammar extends Grammar
             $sql, $connection, $blueprint
         );
 
+        // We can add a comment on the table if it's present.
+        $sql = $this->compileCreateComment(
+            $sql, $connection, $blueprint
+        );
+
         // Finally, we will append the engine configuration onto this SQL statement as
         // the final thing we do before returning this finished SQL. Once this gets
         // added the query will be ready to execute against the real connections.
@@ -117,6 +122,25 @@ class MySqlGrammar extends Grammar
             $sql .= ' collate '.$blueprint->collation;
         } elseif (! is_null($collation = $connection->getConfig('collation'))) {
             $sql .= ' collate '.$collation;
+        }
+
+        return $sql;
+    }
+
+    /**
+     * Append the comment specifications to a command.
+     *
+     * @param  string  $sql
+     * @param  \Illuminate\Database\Connection  $connection
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @return string
+     */
+    protected function compileCreateComment($sql, Connection $connection, Blueprint $blueprint)
+    {
+        if (isset($blueprint->comment)) {
+            return $sql.' comment = '."'".addslashes($blueprint->comment)."'";
+        } elseif (! is_null($comment = $connection->getConfig('comment'))) {
+            return $sql.' comment = '."'".addslashes($comment)."'";
         }
 
         return $sql;

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -24,6 +24,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $conn->shouldReceive('getConfig')->once()->with('charset')->andReturn('utf8');
         $conn->shouldReceive('getConfig')->once()->with('collation')->andReturn('utf8_unicode_ci');
         $conn->shouldReceive('getConfig')->once()->with('engine')->andReturn(null);
+        $conn->shouldReceive('getConfig')->once()->with('comment')->andReturn(null);
 
         $statements = $blueprint->toSql($conn, $this->getGrammar());
 
@@ -43,6 +44,42 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table `users` add `id` int unsigned not null auto_increment primary key, add `email` varchar(255) not null', $statements[0]);
     }
 
+
+    public function testCommentCreateTable()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->create();
+        $blueprint->increments('id');
+        $blueprint->string('email');
+        $blueprint->comment = "It's an users table";
+
+        $conn = $this->getConnection();
+        $conn->shouldReceive('getConfig')->once()->with('charset')->andReturn('utf8');
+        $conn->shouldReceive('getConfig')->once()->with('collation')->andReturn('utf8_unicode_ci');
+        $conn->shouldReceive('getConfig')->once()->with('engine')->andReturn(null);
+
+        $statements = $blueprint->toSql($conn, $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertEquals('create table `users` (`id` int unsigned not null auto_increment primary key, `email` varchar(255) not null) default character set utf8 collate utf8_unicode_ci comment = \'It\\\'s an users table\'', $statements[0]);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->create();
+        $blueprint->increments('id');
+        $blueprint->string('email');
+
+        $conn = $this->getConnection();
+        $conn->shouldReceive('getConfig')->once()->with('charset')->andReturn('utf8');
+        $conn->shouldReceive('getConfig')->once()->with('collation')->andReturn('utf8_unicode_ci');
+        $conn->shouldReceive('getConfig')->once()->with('engine')->andReturn(null);
+        $conn->shouldReceive('getConfig')->once()->with('comment')->andReturn("It's an users table");
+
+        $statements = $blueprint->toSql($conn, $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertEquals('create table `users` (`id` int unsigned not null auto_increment primary key, `email` varchar(255) not null) default character set utf8 collate utf8_unicode_ci comment = \'It\\\'s an users table\'', $statements[0]);
+    }
+
     public function testEngineCreateTable()
     {
         $blueprint = new Blueprint('users');
@@ -54,6 +91,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $conn = $this->getConnection();
         $conn->shouldReceive('getConfig')->once()->with('charset')->andReturn('utf8');
         $conn->shouldReceive('getConfig')->once()->with('collation')->andReturn('utf8_unicode_ci');
+        $conn->shouldReceive('getConfig')->once()->with('comment')->andReturn(null);
 
         $statements = $blueprint->toSql($conn, $this->getGrammar());
 
@@ -69,6 +107,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $conn->shouldReceive('getConfig')->once()->with('charset')->andReturn('utf8');
         $conn->shouldReceive('getConfig')->once()->with('collation')->andReturn('utf8_unicode_ci');
         $conn->shouldReceive('getConfig')->once()->with('engine')->andReturn('InnoDB');
+        $conn->shouldReceive('getConfig')->once()->with('comment')->andReturn(null);
 
         $statements = $blueprint->toSql($conn, $this->getGrammar());
 
@@ -87,6 +126,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
         $conn = $this->getConnection();
         $conn->shouldReceive('getConfig')->once()->with('engine')->andReturn(null);
+        $conn->shouldReceive('getConfig')->once()->with('comment')->andReturn(null);
 
         $statements = $blueprint->toSql($conn, $this->getGrammar());
 
@@ -102,6 +142,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $conn->shouldReceive('getConfig')->once()->with('charset')->andReturn('utf8');
         $conn->shouldReceive('getConfig')->once()->with('collation')->andReturn('utf8_unicode_ci');
         $conn->shouldReceive('getConfig')->once()->with('engine')->andReturn(null);
+        $conn->shouldReceive('getConfig')->once()->with('comment')->andReturn(null);
 
         $statements = $blueprint->toSql($conn, $this->getGrammar());
 

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -44,7 +44,6 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table `users` add `id` int unsigned not null auto_increment primary key, add `email` varchar(255) not null', $statements[0]);
     }
 
-
     public function testCommentCreateTable()
     {
         $blueprint = new Blueprint('users');


### PR DESCRIPTION
I have add the $table->comment = ''; on mysql grammar, according to [my suggestion](https://github.com/laravel/internals/issues/897)