### PR TITLE
[5.5] Use &copy; instead of copyright symbol

### DIFF
--- a/src/Illuminate/Mail/resources/views/markdown/message.blade.php
+++ b/src/Illuminate/Mail/resources/views/markdown/message.blade.php
@@ -21,7 +21,7 @@
     {{-- Footer --}}
     @slot('footer')
         @component('mail::footer')
-            © {{ date('Y') }} {{ config('app.name') }}. All rights reserved.
+            &copy; {{ date('Y') }} {{ config('app.name') }}. All rights reserved.
         @endcomponent
     @endslot
 @endcomponent


### PR DESCRIPTION
Use the same code in markdown as in html (https://github.com/laravel/framework/blob/5.5/src/Illuminate/Mail/resources/views/html/message.blade.php)