### PR TITLE
[5.5] Fix for private and presence channels with prefixes

### DIFF
--- a/src/Illuminate/Broadcasting/Broadcasters/PusherBroadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/PusherBroadcaster.php
@@ -42,12 +42,8 @@ class PusherBroadcaster extends Broadcaster
             throw new AccessDeniedHttpException;
         }
 
-        $channelName = Str::startsWith($request->channel_name, 'private-')
-                            ? Str::replaceFirst('private-', '', $request->channel_name)
-                            : Str::replaceFirst('presence-', '', $request->channel_name);
-
         return parent::verifyUserCanAccessChannel(
-            $request, $channelName
+            $request, $request->channel_name
         );
     }
 

--- a/src/Illuminate/Broadcasting/Broadcasters/RedisBroadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/RedisBroadcaster.php
@@ -50,12 +50,8 @@ class RedisBroadcaster extends Broadcaster
             throw new AccessDeniedHttpException;
         }
 
-        $channelName = Str::startsWith($request->channel_name, 'private-')
-                            ? Str::replaceFirst('private-', '', $request->channel_name)
-                            : Str::replaceFirst('presence-', '', $request->channel_name);
-
         return parent::verifyUserCanAccessChannel(
-            $request, $channelName
+            $request, $request->channel_name
         );
     }
 


### PR DESCRIPTION
The problem is related to authenticated private channels requests, that are prefixed with `private-`.

Both `PusherBroadcaster` and `RedisBroadcaster` remove the prefixes `private-`
and `presence-` from channel names.

They do this before passing the request (which contains the prefixed channel)
and the modified value to the `verifyUserCanAccessChannel` method in the
`Broadcaster`.

For example, if a room is called `private-room.123` with the `123` being the {id}
in the pattern `private-room.{id}`.

This pattern gets processed into `room.{id}` before getting passed on.

The method `verifyUserCanAccessChannel` then receives these 2 values, and it goes
through its channels to see if it matches.

The value `room.{id}` gets turned into `room.*` and then a regex match is run
against the channel, in this example called `private-room.123` which does not
match the supplied name `room.123`.

If we leave the prefix on the channel names then the match is successful, as
it tries `private-room.123` against `private-room.*` which exist in the channel
list, so it matches.

Tested with Laravel Echo Server, using JWT for Authentication, and with both
the Redis and the Pusher broadcaster. Issue was present on both, is now working
with both.

There seem to be numerous issues on a few related projects pertaining to this
issue. It is only present on private channels and presence channels that are
prefixed - if they are not prefixed it works fine.

It's been a tough one to debug I can tell you that much!