### PR TITLE
[5.5] Detect MySQL Galera deadblocks

### DIFF
--- a/src/Illuminate/Database/DetectsDeadlocks.php
+++ b/src/Illuminate/Database/DetectsDeadlocks.php
@@ -26,6 +26,7 @@ trait DetectsDeadlocks
             'A table in the database is locked',
             'has been chosen as the deadlock victim',
             'Lock wait timeout exceeded; try restarting transaction',
+            'WSREP detected deadlock/conflict and aborted the transaction. Try restarting the transaction',
         ]);
     }
 }


### PR DESCRIPTION
Detect the correct error thrown by a deadlock detected in a MySQL Galera Cluster.

http://galeracluster.com/2015/06/debugging-transaction-conflicts-in-galera-cluster/
http://galeracluster.com/documentation-webpages/dealingwithmultimasterconflicts.html