### PR TITLE
[5.6] Multi server scheduling cron support

### DIFF
--- a/src/Illuminate/Console/Scheduling/CacheEventMutex.php
+++ b/src/Illuminate/Console/Scheduling/CacheEventMutex.php
@@ -4,7 +4,7 @@ namespace Illuminate\Console\Scheduling;
 
 use Illuminate\Contracts\Cache\Repository as Cache;
 
-class CacheMutex implements Mutex
+class CacheEventMutex implements EventMutex
 {
     /**
      * The cache repository implementation.
@@ -25,7 +25,7 @@ class CacheMutex implements Mutex
     }
 
     /**
-     * Attempt to obtain a mutex for the given event.
+     * Attempt to obtain an event mutex for the given event.
      *
      * @param  \Illuminate\Console\Scheduling\Event  $event
      * @return bool
@@ -38,7 +38,7 @@ class CacheMutex implements Mutex
     }
 
     /**
-     * Determine if a mutex exists for the given event.
+     * Determine if an event mutex exists for the given event.
      *
      * @param  \Illuminate\Console\Scheduling\Event  $event
      * @return bool
@@ -49,7 +49,7 @@ class CacheMutex implements Mutex
     }
 
     /**
-     * Clear the mutex for the given event.
+     * Clear the event mutex for the given event.
      *
      * @param  \Illuminate\Console\Scheduling\Event  $event
      * @return void

--- a/src/Illuminate/Console/Scheduling/CacheSchedulingMutex.php
+++ b/src/Illuminate/Console/Scheduling/CacheSchedulingMutex.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Illuminate\Console\Scheduling;
+
+use Illuminate\Support\Carbon;
+use Illuminate\Contracts\Cache\Repository as Cache;
+
+class CacheSchedulingMutex implements SchedulingMutex
+{
+    /**
+     * The cache repository implementation.
+     *
+     * @var \Illuminate\Contracts\Cache\Repository
+     */
+    public $cache;
+
+    /**
+     * Create a new overlapping strategy.
+     *
+     * @param  \Illuminate\Contracts\Cache\Repository  $cache
+     * @return void
+     */
+    public function __construct(Cache $cache)
+    {
+        $this->cache = $cache;
+    }
+
+    /**
+     * Attempt to obtain a scheduling mutex for the given event.
+     *
+     * @param  \Illuminate\Console\Scheduling\Event  $event
+     * @param  \Illuminate\Support\Carbon  $time
+     * @return bool
+     */
+    public function create(Event $event, Carbon $time)
+    {
+        return $this->cache->add(
+            $event->mutexName().$time->format('Hi'), true, 60
+        );
+    }
+
+    /**
+     * Determine if a scheduling mutex exists for the given event.
+     *
+     * @param  \Illuminate\Console\Scheduling\Event  $event
+     * @param  \Illuminate\Support\Carbon  $time
+     * @return bool
+     */
+    public function exists(Event $event, Carbon $time)
+    {
+        return $this->cache->has($event->mutexName().$time->format('Hi'));
+    }
+}

--- a/src/Illuminate/Console/Scheduling/CallbackEvent.php
+++ b/src/Illuminate/Console/Scheduling/CallbackEvent.php
@@ -94,18 +94,14 @@ class CallbackEvent extends Event
      *
      * @param  int  $expiresAt
      * @return $this
+     *
+     * @throws \LogicException
      */
     public function withoutOverlapping($expiresAt = 1440)
     {
         if (! isset($this->description)) {
             throw new LogicException(
                 "A scheduled event name is required to prevent overlapping. Use the 'name' method before 'withoutOverlapping'."
-            );
-        }
-
-        if ($this->runOnAllServers) {
-            throw new LogicException(
-                'A scheduled event cannot run simultaneously on all servers using "runOnAllServers()" while at the same time not allowing overlapping using "withoutOverlapping()". They are mutually exclusive commands. Either let the event only run on one server, or allow them to overlap. But you cannot do both.'
             );
         }
 
@@ -116,6 +112,26 @@ class CallbackEvent extends Event
         return $this->skip(function () {
             return $this->mutex->exists($this);
         });
+    }
+
+    /**
+     * Allow the event to only run on one server for each cron expression.
+     *
+     * @return $this
+     *
+     * @throws \LogicException
+     */
+    public function onOneServer()
+    {
+        if (! isset($this->description)) {
+            throw new LogicException(
+                "A scheduled event name is required to only run on one server. Use the 'name' method before 'onOneServer'."
+            );
+        }
+
+        $this->onOneServer = true;
+
+        return $this;
     }
 
     /**

--- a/src/Illuminate/Console/Scheduling/CallbackEvent.php
+++ b/src/Illuminate/Console/Scheduling/CallbackEvent.php
@@ -4,7 +4,6 @@ namespace Illuminate\Console\Scheduling;
 
 use LogicException;
 use InvalidArgumentException;
-use Illuminate\Support\Carbon;
 use Illuminate\Contracts\Container\Container;
 
 class CallbackEvent extends Event

--- a/src/Illuminate/Console/Scheduling/CallbackEvent.php
+++ b/src/Illuminate/Console/Scheduling/CallbackEvent.php
@@ -4,6 +4,7 @@ namespace Illuminate\Console\Scheduling;
 
 use LogicException;
 use InvalidArgumentException;
+use Illuminate\Support\Carbon;
 use Illuminate\Contracts\Container\Container;
 
 class CallbackEvent extends Event
@@ -25,14 +26,14 @@ class CallbackEvent extends Event
     /**
      * Create a new event instance.
      *
-     * @param  \Illuminate\Console\Scheduling\Mutex  $mutex
+     * @param  \Illuminate\Console\Scheduling\EventMutex  $mutex
      * @param  string  $callback
      * @param  array  $parameters
      * @return void
      *
      * @throws \InvalidArgumentException
      */
-    public function __construct(Mutex $mutex, $callback, array $parameters = [])
+    public function __construct(EventMutex $mutex, $callback, array $parameters = [])
     {
         if (! is_string($callback) && ! is_callable($callback)) {
             throw new InvalidArgumentException(
@@ -100,6 +101,12 @@ class CallbackEvent extends Event
         if (! isset($this->description)) {
             throw new LogicException(
                 "A scheduled event name is required to prevent overlapping. Use the 'name' method before 'withoutOverlapping'."
+            );
+        }
+
+        if ($this->runOnAllServers) {
+            throw new LogicException(
+                'A scheduled event cannot run simultaneously on all servers using "runOnAllServers()" while at the same time not allowing overlapping using "withoutOverlapping()". They are mutually exclusive commands. Either let the event only run on one server, or allow them to overlap. But you cannot do both.'
             );
         }
 

--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -66,11 +66,11 @@ class Event
     public $withoutOverlapping = false;
 
     /**
-     * Indicates if the command should be allowed to override and run on all servers simultaneously.
+     * Indicates if the command should only be allowed to run on one server each cron expression.
      *
      * @var bool
      */
-    public $runOnAllServers = false;
+    public $onOneServer = false;
 
     /**
      * The amount of time the mutex should be valid.
@@ -529,12 +529,6 @@ class Event
      */
     public function withoutOverlapping($expiresAt = 1440)
     {
-        if ($this->runOnAllServers) {
-            throw new LogicException(
-                'A scheduled event cannot run simultaneously on all servers using "runOnAllServers()" while at the same time not allowing overlapping using "withoutOverlapping()". They are mutually exclusive commands. Either let the event only run on one server, or allow them to overlap. But you cannot do both.'
-            );
-        }
-
         $this->withoutOverlapping = true;
 
         $this->expiresAt = $expiresAt;
@@ -547,21 +541,13 @@ class Event
     }
 
     /**
-     * Allow the event to run on all servers for each cron expression.
+     * Allow the event to only run on one server for each cron expression.
      *
      * @return $this
-     *
-     * @throws \LogicException
      */
-    public function runOnAllServers()
+    public function onOneServer()
     {
-        if ($this->withoutOverlapping) {
-            throw new LogicException(
-                'A scheduled event cannot run simultaneously on all servers using "runOnAllServers()" while at the same time not allowing overlapping using "withoutOverlapping()". They are mutually exclusive commands. Either let the event only run on one server, or allow them to overlap. But you cannot do both.'
-            );
-        }
-
-        $this->runOnAllServers = true;
+        $this->onOneServer = true;
 
         return $this;
     }

--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Console\Scheduling;
 
 use Closure;
-use LogicException;
 use Cron\CronExpression;
 use Illuminate\Support\Carbon;
 use GuzzleHttp\Client as HttpClient;

--- a/src/Illuminate/Console/Scheduling/EventMutex.php
+++ b/src/Illuminate/Console/Scheduling/EventMutex.php
@@ -2,10 +2,10 @@
 
 namespace Illuminate\Console\Scheduling;
 
-interface Mutex
+interface EventMutex
 {
     /**
-     * Attempt to obtain a mutex for the given event.
+     * Attempt to obtain an event mutex for the given event.
      *
      * @param  \Illuminate\Console\Scheduling\Event  $event
      * @return bool
@@ -13,7 +13,7 @@ interface Mutex
     public function create(Event $event);
 
     /**
-     * Determine if a mutex exists for the given event.
+     * Determine if an event mutex exists for the given event.
      *
      * @param  \Illuminate\Console\Scheduling\Event  $event
      * @return bool
@@ -21,7 +21,7 @@ interface Mutex
     public function exists(Event $event);
 
     /**
-     * Clear the mutex for the given event.
+     * Clear the event mutex for the given event.
      *
      * @param  \Illuminate\Console\Scheduling\Event  $event
      * @return void

--- a/src/Illuminate/Console/Scheduling/Schedule.php
+++ b/src/Illuminate/Console/Scheduling/Schedule.php
@@ -18,13 +18,6 @@ class Schedule
     protected $events = [];
 
     /**
-     * Is the scheduler running on multiple servers.
-     *
-     * @var bool
-     */
-    protected $multiServerScheduling = false;
-
-    /**
      * The event mutex implementation.
      *
      * @var \Illuminate\Console\Scheduling\EventMutex
@@ -180,25 +173,5 @@ class Schedule
     public function events()
     {
         return $this->events;
-    }
-
-    /**
-     * Enable the scheduler for multi server scheduling.
-     *
-     * @return void
-     */
-    public function enableMultiServerScheduling()
-    {
-        $this->multiServerScheduling = true;
-    }
-
-    /**
-     * Check if the scheduler supporting multi server scheduling.
-     *
-     * @return bool
-     */
-    public function isMultiServer()
-    {
-        return $this->multiServerScheduling;
     }
 }

--- a/src/Illuminate/Console/Scheduling/Schedule.php
+++ b/src/Illuminate/Console/Scheduling/Schedule.php
@@ -129,7 +129,7 @@ class Schedule
     }
 
     /**
-     * Check if the server is allowed to run this event.
+     * Determine if the server is allowed to run this event.
      *
      * @param  \Illuminate\Console\Scheduling\Event  $event
      * @param  \Illuminate\Support\Carbon  $time

--- a/src/Illuminate/Console/Scheduling/Schedule.php
+++ b/src/Illuminate/Console/Scheduling/Schedule.php
@@ -129,13 +129,13 @@ class Schedule
     }
 
     /**
-     * Add a new command event to the schedule.
+     * Check if the server is allowed to run this event.
      *
      * @param  \Illuminate\Console\Scheduling\Event  $event
      * @param  \Illuminate\Support\Carbon  $time
      * @return bool
      */
-    public function getMutex(Event $event, Carbon $time)
+    public function allowServerToRun(Event $event, Carbon $time)
     {
         return $this->schedulingMutex->create($event, $time);
     }

--- a/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
@@ -70,7 +70,7 @@ class ScheduleRunCommand extends Command
             }
 
             if ($this->schedule->isMultiServer()) {
-                if ($event->runOnAllServers || $this->schedule->getMutex($event, $this->startedAt)) {
+                if ($event->runOnAllServers || $this->schedule->allowServerToRun($event, $this->startedAt)) {
                     $this->runEvent($event);
                 } else {
                     $this->line('<info>Skipping command (already run on another server):</info> '.$event->getSummaryForDisplay());

--- a/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Console\Scheduling;
 
+use Illuminate\Support\Carbon;
 use Illuminate\Console\Command;
 
 class ScheduleRunCommand extends Command
@@ -28,6 +29,20 @@ class ScheduleRunCommand extends Command
     protected $schedule;
 
     /**
+     * The 24 hour timestamp this scheduler command started running.
+     *
+     * @var \Illuminate\Support\Carbon;
+     */
+    protected $startedAt;
+
+    /**
+     * Check if any events ran.
+     *
+     * @var bool
+     */
+    protected $eventsRan = false;
+
+    /**
      * Create a new command instance.
      *
      * @param  \Illuminate\Console\Scheduling\Schedule  $schedule
@@ -36,6 +51,8 @@ class ScheduleRunCommand extends Command
     public function __construct(Schedule $schedule)
     {
         $this->schedule = $schedule;
+
+        $this->startedAt = Carbon::now();
 
         parent::__construct();
     }
@@ -47,22 +64,39 @@ class ScheduleRunCommand extends Command
      */
     public function handle()
     {
-        $eventsRan = false;
-
         foreach ($this->schedule->dueEvents($this->laravel) as $event) {
             if (! $event->filtersPass($this->laravel)) {
                 continue;
             }
 
-            $this->line('<info>Running scheduled command:</info> '.$event->getSummaryForDisplay());
+            if ($this->schedule->isMultiServer()) {
+                if ($event->runOnAllServers || $this->schedule->getMutex($event, $this->startedAt)) {
+                    $this->runEvent($event);
+                } else {
+                    $this->line('<info>Skipping command (already run on another server):</info> '.$event->getSummaryForDisplay());
+                }
+            } else {
+                $this->runEvent($event);
+            }
 
-            $event->run($this->laravel);
-
-            $eventsRan = true;
+            $this->eventsRan = true;
         }
 
-        if (! $eventsRan) {
+        if (! $this->eventsRan) {
             $this->info('No scheduled commands are ready to run.');
         }
+    }
+
+    /**
+     * Run the given event.
+     *
+     * @param  \Illuminate\Support\Collection  $event
+     * @return void
+     */
+    protected function runEvent($event)
+    {
+        $this->line('<info>Running scheduled command:</info> '.$event->getSummaryForDisplay());
+        $event->run($this->laravel);
+        $this->eventsRan = true;
     }
 }

--- a/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
@@ -69,8 +69,8 @@ class ScheduleRunCommand extends Command
                 continue;
             }
 
-            if ($this->schedule->isMultiServer()) {
-                if ($event->runOnAllServers || $this->schedule->allowServerToRun($event, $this->startedAt)) {
+            if ($event->onOneServer())
+                if ($this->schedule->allowServerToRun($event, $this->startedAt)) {
                     $this->runEvent($event);
                 } else {
                     $this->line('<info>Skipping command (already run on another server):</info> '.$event->getSummaryForDisplay());

--- a/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
@@ -69,7 +69,7 @@ class ScheduleRunCommand extends Command
                 continue;
             }
 
-            if ($event->onOneServer())
+            if ($event->onOneServer) {
                 if ($this->schedule->allowServerToRun($event, $this->startedAt)) {
                     $this->runEvent($event);
                 } else {

--- a/src/Illuminate/Console/Scheduling/SchedulingMutex.php
+++ b/src/Illuminate/Console/Scheduling/SchedulingMutex.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Illuminate\Console\Scheduling;
+
+use Illuminate\Support\Carbon;
+
+interface SchedulingMutex
+{
+    /**
+     * Attempt to obtain a scheduling mutex for the given event.
+     *
+     * @param  \Illuminate\Console\Scheduling\Event  $event
+     * @param  \Illuminate\Support\Carbon  $time
+     * @return bool
+     */
+    public function create(Event $event, Carbon $time);
+
+    /**
+     * Determine if a scheduling mutex exists for the given event.
+     *
+     * @param  \Illuminate\Console\Scheduling\Event  $event
+     * @param  \Illuminate\Support\Carbon  $time
+     * @return bool
+     */
+    public function exists(Event $event, Carbon $time);
+}

--- a/tests/Console/ConsoleEventSchedulerTest.php
+++ b/tests/Console/ConsoleEventSchedulerTest.php
@@ -81,17 +81,6 @@ class ConsoleEventSchedulerTest extends TestCase
         $binary = $escape.PHP_BINARY.$escape;
         $this->assertEquals($binary.' artisan foo:bar --force', $events[0]->command);
     }
-
-    public function testMultiServerConfig()
-    {
-        $schedule = $this->schedule;
-
-        $this->assertFalse($schedule->isMultiServer());
-
-        $schedule->enableMultiServerScheduling();
-
-        $this->assertTrue($schedule->isMultiServer());
-    }
 }
 
 class FooClassStub

--- a/tests/Console/ConsoleEventSchedulerTest.php
+++ b/tests/Console/ConsoleEventSchedulerTest.php
@@ -14,10 +14,12 @@ class ConsoleEventSchedulerTest extends TestCase
 
         $container = \Illuminate\Container\Container::getInstance();
 
-        $container->instance('Illuminate\Console\Scheduling\Mutex', m::mock('Illuminate\Console\Scheduling\CacheMutex'));
+        $container->instance('Illuminate\Console\Scheduling\EventMutex', m::mock('Illuminate\Console\Scheduling\CacheEventMutex'));
+
+        $container->instance('Illuminate\Console\Scheduling\SchedulingMutex', m::mock('Illuminate\Console\Scheduling\CacheSchedulingMutex'));
 
         $container->instance(
-            'Illuminate\Console\Scheduling\Schedule', $this->schedule = new Schedule(m::mock('Illuminate\Console\Scheduling\Mutex'))
+            'Illuminate\Console\Scheduling\Schedule', $this->schedule = new Schedule(m::mock('Illuminate\Console\Scheduling\EventMutex'))
         );
     }
 
@@ -78,6 +80,17 @@ class ConsoleEventSchedulerTest extends TestCase
         $events = $schedule->events();
         $binary = $escape.PHP_BINARY.$escape;
         $this->assertEquals($binary.' artisan foo:bar --force', $events[0]->command);
+    }
+
+    public function testMultiServerConfig()
+    {
+        $schedule = $this->schedule;
+
+        $this->assertFalse($schedule->isMultiServer());
+
+        $schedule->enableMultiServerScheduling();
+
+        $this->assertTrue($schedule->isMultiServer());
     }
 }
 

--- a/tests/Console/ConsoleScheduledEventTest.php
+++ b/tests/Console/ConsoleScheduledEventTest.php
@@ -107,8 +107,8 @@ class ConsoleScheduledEventTest extends TestCase
     }
 
     /**
-    * @expectedException LogicException
-    */
+     * @expectedException LogicException
+     */
     public function testEventPreventsRunOnAllServersAndWithoutOverlappingTogether()
     {
         $event = new Event(m::mock('Illuminate\Console\Scheduling\EventMutex'), 'php foo');

--- a/tests/Console/ConsoleScheduledEventTest.php
+++ b/tests/Console/ConsoleScheduledEventTest.php
@@ -105,14 +105,4 @@ class ConsoleScheduledEventTest extends TestCase
         $this->assertFalse($event->unlessBetween('8:00', '10:00')->filtersPass($app));
         $this->assertTrue($event->unlessBetween('10:00', '11:00')->isDue($app));
     }
-
-    /**
-     * @expectedException LogicException
-     */
-    public function testEventPreventsRunOnAllServersAndWithoutOverlappingTogether()
-    {
-        $event = new Event(m::mock('Illuminate\Console\Scheduling\EventMutex'), 'php foo');
-
-        $event->withoutOverlapping()->runOnAllServers();
-    }
 }

--- a/tests/Console/Scheduling/CacheSchedulingMutexTest.php
+++ b/tests/Console/Scheduling/CacheSchedulingMutexTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Illuminate\Tests\Console\Scheduling;
+
+use Mockery as m;
+use Illuminate\Support\Carbon;
+use PHPUnit\Framework\TestCase;
+use Illuminate\Console\Scheduling\Event;
+use Illuminate\Console\Scheduling\CacheEventMutex;
+use Illuminate\Console\Scheduling\CacheSchedulingMutex;
+
+class CacheSchedulingMutexTest extends TestCase
+{
+    /**
+     * @var CacheSchedulingMutex
+     */
+    protected $cacheMutex;
+
+    /**
+     * @var Event
+     */
+    protected $event;
+
+    /**
+     * @var Carbon
+     */
+    protected $time;
+
+    /**
+     * @var \Illuminate\Contracts\Cache\Repository
+     */
+    protected $cacheRepository;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->cacheRepository = m::mock('Illuminate\Contracts\Cache\Repository');
+        $this->cacheMutex = new CacheSchedulingMutex($this->cacheRepository);
+        $this->event = new Event(new CacheEventMutex($this->cacheRepository), 'command');
+        $this->time = Carbon::now();
+    }
+
+    public function testMutexReceviesCorrectCreate()
+    {
+        $this->cacheRepository->shouldReceive('add')->once()->with($this->event->mutexName().$this->time->format('Hi'), true, 60)->andReturn(true);
+
+        $this->assertTrue($this->cacheMutex->create($this->event, $this->time));
+    }
+
+    public function testPreventsMultipleRuns()
+    {
+        $this->cacheRepository->shouldReceive('add')->once()->with($this->event->mutexName().$this->time->format('Hi'), true, 60)->andReturn(false);
+
+        $this->assertFalse($this->cacheMutex->create($this->event, $this->time));
+    }
+
+    public function testChecksForNonRunSchedule()
+    {
+        $this->cacheRepository->shouldReceive('has')->once()->with($this->event->mutexName().$this->time->format('Hi'))->andReturn(false);
+
+        $this->assertFalse($this->cacheMutex->exists($this->event, $this->time));
+    }
+
+    public function testChecksForAlreadyRunSchedule()
+    {
+        $this->cacheRepository->shouldReceive('has')->with($this->event->mutexName().$this->time->format('Hi'))->andReturn(true);
+
+        $this->assertTrue($this->cacheMutex->exists($this->event, $this->time));
+    }
+}

--- a/tests/Console/Scheduling/EventTest.php
+++ b/tests/Console/Scheduling/EventTest.php
@@ -17,14 +17,14 @@ class EventTest extends TestCase
     {
         $quote = (DIRECTORY_SEPARATOR == '\\') ? '"' : "'";
 
-        $event = new Event(m::mock('Illuminate\Console\Scheduling\Mutex'), 'php -i');
+        $event = new Event(m::mock('Illuminate\Console\Scheduling\EventMutex'), 'php -i');
 
         $defaultOutput = (DIRECTORY_SEPARATOR == '\\') ? 'NUL' : '/dev/null';
         $this->assertSame("php -i > {$quote}{$defaultOutput}{$quote} 2>&1", $event->buildCommand());
 
         $quote = (DIRECTORY_SEPARATOR == '\\') ? '"' : "'";
 
-        $event = new Event(m::mock('Illuminate\Console\Scheduling\Mutex'), 'php -i');
+        $event = new Event(m::mock('Illuminate\Console\Scheduling\EventMutex'), 'php -i');
         $event->runInBackground();
 
         $defaultOutput = (DIRECTORY_SEPARATOR == '\\') ? 'NUL' : '/dev/null';
@@ -35,12 +35,12 @@ class EventTest extends TestCase
     {
         $quote = (DIRECTORY_SEPARATOR == '\\') ? '"' : "'";
 
-        $event = new Event(m::mock('Illuminate\Console\Scheduling\Mutex'), 'php -i');
+        $event = new Event(m::mock('Illuminate\Console\Scheduling\EventMutex'), 'php -i');
 
         $event->sendOutputTo('/dev/null');
         $this->assertSame("php -i > {$quote}/dev/null{$quote} 2>&1", $event->buildCommand());
 
-        $event = new Event(m::mock('Illuminate\Console\Scheduling\Mutex'), 'php -i');
+        $event = new Event(m::mock('Illuminate\Console\Scheduling\EventMutex'), 'php -i');
 
         $event->sendOutputTo('/my folder/foo.log');
         $this->assertSame("php -i > {$quote}/my folder/foo.log{$quote} 2>&1", $event->buildCommand());
@@ -50,7 +50,7 @@ class EventTest extends TestCase
     {
         $quote = (DIRECTORY_SEPARATOR == '\\') ? '"' : "'";
 
-        $event = new Event(m::mock('Illuminate\Console\Scheduling\Mutex'), 'php -i');
+        $event = new Event(m::mock('Illuminate\Console\Scheduling\EventMutex'), 'php -i');
 
         $event->appendOutputTo('/dev/null');
         $this->assertSame("php -i >> {$quote}/dev/null{$quote} 2>&1", $event->buildCommand());
@@ -58,7 +58,7 @@ class EventTest extends TestCase
 
     public function testNextRunDate()
     {
-        $event = new Event(m::mock('Illuminate\Console\Scheduling\Mutex'), 'php -i');
+        $event = new Event(m::mock('Illuminate\Console\Scheduling\EventMutex'), 'php -i');
         $event->dailyAt('10:15');
 
         $this->assertSame('10:15:00', $event->nextRunDate()->toTimeString());

--- a/tests/Console/Scheduling/FrequencyTest.php
+++ b/tests/Console/Scheduling/FrequencyTest.php
@@ -16,7 +16,7 @@ class FrequencyTest extends TestCase
     public function setUp()
     {
         $this->event = new Event(
-            m::mock('Illuminate\Console\Scheduling\Mutex'),
+            m::mock('Illuminate\Console\Scheduling\EventMutex'),
             'php foo'
         );
     }


### PR DESCRIPTION
_This is a new PR to replace https://github.com/laravel/framework/pull/22137 - see there for some previous discussion - but many comments are outdated and no longer relevant as this PR approaches it with a entirely new concept_

This PR is a solution to allow cron scheduling to occur on multiple servers simulatenously without fear of the same command running twice unintentionally. It was created after seeing the issues described in https://github.com/laravel/framework/issues/22129

We expand on the existing mutex system to create a dedicated scheduling mutex as each server runs the command for each given cron expression. _This is disabled by default_. So anyone upgrading to 5.6 would not notice any changes without explicity enabling the new feature.

**How it works:**
Let's say we have Server A and Server B both running `schedule:run` each minute with the following command:

`$schedule->command('run:report')->everyFiveMinutes();`

At `00:05` both Server A and Server B will run `schedule:run`. Both servers run the event filters, and determine that the command `run:report` is due to run.

Server B happens to be 3 microseconds faster than Server A, and creates a mutex `run_report_mutex_0005` (the scheduling mutex). Because Server B was able to obtain a scheduling mutex - it then goes ahead runs the report.

Server A comes along, and tries to obtain a scheduling mutex. But it fails, because Server B already has it, so Server A skips that event and carries on the list.

**Example:**

- `$schedule->enableMultiServerScheduling()` - required to turn on the feature. Otherwise there is no change. Can be put at the start or end of the scheduling kernel function - it does not make a difference as long as its called somewhere there.
- `$schedule->command('something')` - only runs once on a single server per cron expression across the server farm.
- `$schedule->command('something')->withoutOverlapping()` - only runs once per cron expression, and will not start again if still running on a server somewhere.
- `$schedule->command('something')->runOnAllServers()` - force it to run once on every server. Might be good for a command like `disk:cleanup` or something.
- `$schedule->command('something')->runOnAllServers()->withoutOverlapping()` - this will throw a logic exception - it doesnt make sense to ask it to run on all servers while also saying you dont want it to run overlapping.


**Breaking changes:**
This would largely be a non-breaking change for most users and would require no change to any code to keep existing behaviour.

The only exception is if you had a custom `Mutex` class - the interface name has changed to `EventMutex` to make it more obvious what each Mutex does now. Technically we could leave the original `Mutex` name unchanged and make this an entirely non-breaking change - but it makes the class names less obvious what they do.

**A GIF is a thousand words - showing two servers running one scheduler:**

![scheduler](https://user-images.githubusercontent.com/1210658/33241388-714216e0-d2bc-11e7-803f-700d61756e20.gif)
