### PR TITLE
[5.5] Use assertFileExists

### DIFF
--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -405,7 +405,7 @@ class FilesystemTest extends TestCase
         mkdir($this->tempDir.'/foo');
         file_put_contents($this->tempDir.'/foo/foo.txt', $data);
         $filesystem->copy($this->tempDir.'/foo/foo.txt', $this->tempDir.'/foo/foo2.txt');
-        $this->assertTrue(file_exists($this->tempDir.'/foo/foo2.txt'));
+        $this->assertFileExists($this->tempDir.'/foo/foo2.txt');
         $this->assertEquals($data, file_get_contents($this->tempDir.'/foo/foo2.txt'));
     }
 


### PR DESCRIPTION
Small one: use [`assertFileExists`](https://phpunit.de/manual/6.4/pt_br/appendixes.assertions.html#appendixes.assertions.assertFileExists) method instead of `assertTrue(file_exists())`.