### PR TITLE
[5.5] Add new `any()` method to Collection

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -781,6 +781,35 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
+     * Determine if the collection has any elements.
+     *
+     * @param  callable|string|null  $key
+     * @param  mixed  $operator
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function any($key = null, $operator = null, $value = null)
+    {
+        if (func_num_args() == 0) {
+            return $this->isNotEmpty();
+        }
+
+        if (func_num_args() == 1) {
+            if ($this->useAsCallable($key)) {
+                return $this->contains($key);
+            }
+
+            return $this->has($key);
+        }
+
+        if (func_num_args() == 2) {
+            return $this->where($key, $operator)->isNotEmpty();
+        }
+
+        return $this->where($key, $operator, $value)->isNotEmpty();
+    }
+
+    /**
      * Determine if the given value is callable, but not a string.
      *
      * @param  mixed  $value

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -111,6 +111,82 @@ class SupportCollectionTest extends TestCase
         $this->assertTrue($c->isNotEmpty());
     }
 
+    public function testAnyElementsPresent()
+    {
+        $c = new Collection(['foo', 'bar']);
+
+        $this->assertTrue($c->any());
+    }
+
+    public function testAnyElementsNotPresent()
+    {
+        $c = new Collection([]);
+
+        $this->assertFalse($c->any());
+    }
+
+    public function testAnyElementsPresentByKey()
+    {
+        $c = new Collection(['foo' => 'bar']);
+
+        $this->assertTrue($c->any('foo'));
+    }
+
+    public function testAnyElementsNotPresentByKey()
+    {
+        $c = new Collection(['foo' => 'bar']);
+
+        $this->assertFalse($c->any('baz'));
+    }
+
+    public function testAnyElementsPresentByWhere()
+    {
+        $c = new Collection([['foo' => 'bar']]);
+
+        $this->assertTrue($c->any('foo', 'bar'));
+    }
+
+    public function testAnyElementsNotPresentByWhere()
+    {
+        $c = new Collection([['foo' => 'bar']]);
+
+        $this->assertFalse($c->any('foo', 'baz'));
+    }
+
+    public function testAnyElementsPresentByWhereWithOperator()
+    {
+        $c = new Collection([['foo' => 'bar']]);
+
+        $this->assertTrue($c->any('foo', '=', 'bar'));
+        $this->assertTrue($c->any('foo', '!=', 'baz'));
+    }
+
+    public function testAnyElementsNotPresentByWhereWithOperator()
+    {
+        $c = new Collection([['foo' => 'bar']]);
+
+        $this->assertFalse($c->any('foo', '!=', 'bar'));
+        $this->assertFalse($c->any('foo', '=', 'baz'));
+    }
+
+    public function testAnyElementsPresentByCallable()
+    {
+        $c = new Collection(['foo' => 'bar']);
+
+        $this->assertTrue($c->any(function ($item) {
+            return $item == 'bar';
+        }));
+    }
+
+    public function testAnyElementsNotPresentByCallable()
+    {
+        $c = new Collection(['foo' => 'bar']);
+
+        $this->assertFalse($c->any(function ($item) {
+            return $item != 'bar';
+        }));
+    }
+
     public function testCollectionIsConstructed()
     {
         $collection = new Collection('foo');


### PR DESCRIPTION
This PR introduces a new `Collection` method: `any() | return bool`.

Checking `any` in a collection means we are expecting this collection to contain any element. if we are passing a key to `any` means we are expecting key's presence. and if we are passing a where condition or a callable; means we are expecting the result to contain any element.

`any()` method may be considered as a syntax sugar for common operations can be done now with methods like `isNotEmpty` | `has` | `contains` | `where -> isNotEmpty` with the focus of only the presence of any element. it's inspired by [Enumerable.Any](https://msdn.microsoft.com/en-us/library/bb337697(v=vs.110).aspx) from .NET.

Usage Examples:
``` php
    collect(['foo' => 'bar'])->any(); // true
    collect([])->any(); // false
    collect(['foo' => 'bar'])->any('foo'); //true
    collect([['foo' => 'bar']])->any('foo','bar'); //true
    collect([['foo' => 'bar']])->any('foo','!=','bazzz'); //true
    collect(['foo' => 'bar'])->any(function($item) { return $item == 'bar'; });  // true

```
