### PR TITLE
[5.5] Set eloquent model table name for better performance

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1155,7 +1155,9 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     public function getTable()
     {
         if (! isset($this->table)) {
-            return str_replace('\\', '', Str::snake(Str::plural(class_basename($this))));
+	        $this->setTable(str_replace(
+		        '\\', '', Str::snake(Str::plural(class_basename($this)))
+	        ));
         }
 
         return $this->table;


### PR DESCRIPTION
Now if we call `$model->getTable()` method, it transforms model name to table name by Laravel convenience (if developer does not specify the `$table` property). And it makes this transformation every time when `$model->getTable()` is called. This PR saves transformed table name as it is done in `'Illuminate\Database\Eloquent\Relations\Pivot@getTabel()'` method.