### PR TITLE
[5.5] Pass test value to Collection::when callbacks

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -433,9 +433,9 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     public function when($value, callable $callback, callable $default = null)
     {
         if ($value) {
-            return $callback($this);
+            return $callback($this, $value);
         } elseif ($default) {
-            return $default($this);
+            return $default($this, $value);
         }
 
         return $this;

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2306,8 +2306,8 @@ class SupportCollectionTest extends TestCase
     {
         $collection = new Collection(['michael', 'tom']);
 
-        $collection->when(true, function ($collection) {
-            return $collection->push('adam');
+        $collection->when('adam', function ($collection, $newName) {
+            return $collection->push($newName);
         });
 
         $this->assertSame(['michael', 'tom', 'adam'], $collection->toArray());


### PR DESCRIPTION
This brings the method in line with `Illuminate\Database\Concerns\BuildsQueries::when`, and avoids the need for a `use` statement when we want the truthy value inside the callback.

For instance:

```
$item = $items->next();
$collection->when($item, function ($collection) use ($item) {
    return $collection->push($item);
});
```

can become

```
$collection->when($items->next(), function ($collection, $item) {
    return $collection->push($item);
});
```