### PR TITLE
[5.5] Improve readability of Support\Str::languageSpecificCharsArray

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -53,7 +53,7 @@ class Str
         $languageSpecific = static::languageSpecificCharsArray($language);
 
         if (! is_null($languageSpecific)) {
-            $value = str_replace($languageSpecific[0], $languageSpecific[1], $value);
+            $value = str_replace(array_keys($languageSpecific), array_values($languageSpecific), $value);
         }
 
         foreach (static::charsArray() as $key => $val) {
@@ -668,12 +668,22 @@ class Str
         if (! isset($languageSpecific)) {
             $languageSpecific = [
                 'bg' => [
-                    ['х', 'Х', 'щ', 'Щ', 'ъ', 'Ъ', 'ь', 'Ь'],
-                    ['h', 'H', 'sht', 'SHT', 'a', 'А', 'y', 'Y'],
+                    'х' => 'h',
+                    'Х' => 'H',
+                    'щ' => 'sht',
+                    'Щ' => 'SHT',
+                    'ъ' => 'a',
+                    'Ъ' => 'А',
+                    'ь' => 'y',
+                    'Ь' => 'Y',
                 ],
                 'de' => [
-                    ['ä',  'ö',  'ü',  'Ä',  'Ö',  'Ü'],
-                    ['ae', 'oe', 'ue', 'AE', 'OE', 'UE'],
+                    'ä' => 'ae',
+                    'ö' => 'oe',
+                    'ü' => 'ue',
+                    'Ä' => 'AE',
+                    'Ö' => 'OE',
+                    'Ü' => 'UE',
                 ],
             ];
         }


### PR DESCRIPTION
## Description

Improve readability of `Support\Str::languageSpecificCharsArray()`

## Motivation and context

Associative array could be easier read and support as to different arrays, because you can always see which value refers to which value

## How has this been tested?

All tests passed successfully

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have run tests to cover my changes.
