### PR TITLE
[5.5] Refactoring tests

### DIFF
--- a/tests/Http/HttpMimeTypeTest.php
+++ b/tests/Http/HttpMimeTypeTest.php
@@ -36,6 +36,6 @@ class HttpMimeTypeTest extends TestCase
     public function testSearchExtensionFromMimeType()
     {
         $this->assertSame('mov', MimeType::search('video/quicktime'));
-        $this->assertSame(null, MimeType::search('foo/bar'));
+        $this->assertNull(MimeType::search('foo/bar'));
     }
 }

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -68,14 +68,14 @@ class SupportArrTest extends TestCase
         );
 
         // With 1 empty dimension
-        $this->assertSame([], Arr::crossJoin([], ['a', 'b'], ['I', 'II', 'III']));
-        $this->assertSame([], Arr::crossJoin([1, 2], [], ['I', 'II', 'III']));
-        $this->assertSame([], Arr::crossJoin([1, 2], ['a', 'b'], []));
+        $this->assertEmpty(Arr::crossJoin([], ['a', 'b'], ['I', 'II', 'III']));
+        $this->assertEmpty(Arr::crossJoin([1, 2], [], ['I', 'II', 'III']));
+        $this->assertEmpty(Arr::crossJoin([1, 2], ['a', 'b'], []));
 
         // With empty arrays
-        $this->assertSame([], Arr::crossJoin([], [], []));
-        $this->assertSame([], Arr::crossJoin([], []));
-        $this->assertSame([], Arr::crossJoin([]));
+        $this->assertEmpty(Arr::crossJoin([], [], []));
+        $this->assertEmpty(Arr::crossJoin([], []));
+        $this->assertEmpty(Arr::crossJoin([]));
 
         // Not really a proper usage, still, test for preserving BC
         $this->assertSame([[]], Arr::crossJoin());
@@ -269,8 +269,8 @@ class SupportArrTest extends TestCase
         $this->assertSame('default', Arr::get(null, null, 'default'));
 
         // Test $array is empty and key is null
-        $this->assertSame([], Arr::get([], null));
-        $this->assertSame([], Arr::get([], null, 'default'));
+        $this->assertEmpty(Arr::get([], null));
+        $this->assertEmpty(Arr::get([], null, 'default'));
     }
 
     public function testHas()

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -123,10 +123,10 @@ class SupportCollectionTest extends TestCase
         $this->assertSame([false], $collection->all());
 
         $collection = new Collection(null);
-        $this->assertSame([], $collection->all());
+        $this->assertEmpty($collection->all());
 
         $collection = new Collection;
-        $this->assertSame([], $collection->all());
+        $this->assertEmpty($collection->all());
     }
 
     public function testGetArrayableItems()

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -124,7 +124,7 @@ class SupportHelpersTest extends TestCase
     {
         $array = ['name' => 'taylor', 'age' => 26];
         $this->assertEquals(['name' => 'taylor'], Arr::only($array, ['name']));
-        $this->assertSame([], Arr::only($array, ['nonExistingKey']));
+        $this->assertEmpty(Arr::only($array, ['nonExistingKey']));
     }
 
     public function testArrayCollapse()


### PR DESCRIPTION
I've refactored some tests with [`assertEmpty`](https://phpunit.de/manual/current/pt_br/appendixes.assertions.html#appendixes.assertions.assertEmpty) and [`assertNull`](https://phpunit.de/manual/current/pt_br/appendixes.assertions.html#appendixes.assertions.assertNull).