### PR TITLE
[5.5] Force preg_grep to match entire value using start and end characters

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -529,7 +529,7 @@ trait ValidatesAttributes
         });
 
         if (in_array('ignore_case', $parameters)) {
-            return empty(preg_grep('/'.preg_quote($value, '/').'/iu', $data));
+            return empty(preg_grep('/^'.preg_quote($value, '/').'$/iu', $data));
         }
 
         return ! in_array($value, array_values($data));

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1506,7 +1506,7 @@ class ValidationValidatorTest extends TestCase
 
         $v = new Validator($trans, ['foo' => ['bar' => ['id' => 2], 'baz' => ['id' => 425]]], ['foo.*.id' => 'distinct:ignore_case']);
         $this->assertTrue($v->passes());
-        
+
         $v = new Validator($trans, ['foo' => [['id' => 1, 'nested' => ['id' => 1]]]], ['foo.*.id' => 'distinct']);
         $this->assertTrue($v->passes());
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1483,6 +1483,12 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['foo' => ['f/oo', 'F/OO']], ['foo.*' => 'distinct:ignore_case']);
         $this->assertFalse($v->passes());
 
+        $v = new Validator($trans, ['foo' => ['1', '1']], ['foo.*' => 'distinct:ignore_case']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => ['1', '11']], ['foo.*' => 'distinct:ignore_case']);
+        $this->assertTrue($v->passes());
+
         $v = new Validator($trans, ['foo' => ['foo', 'bar']], ['foo.*' => 'distinct']);
         $this->assertTrue($v->passes());
 
@@ -1498,6 +1504,9 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['foo' => ['bar' => ['id' => 1], 'baz' => ['id' => 2]]], ['foo.*.id' => 'distinct']);
         $this->assertTrue($v->passes());
 
+        $v = new Validator($trans, ['foo' => ['bar' => ['id' => 2], 'baz' => ['id' => 425]]], ['foo.*.id' => 'distinct:ignore_case']);
+        $this->assertTrue($v->passes());
+        
         $v = new Validator($trans, ['foo' => [['id' => 1, 'nested' => ['id' => 1]]]], ['foo.*.id' => 'distinct']);
         $this->assertTrue($v->passes());
 


### PR DESCRIPTION
## Issue
When using the `distinct:ignore_case` flag during validation it will fail when evaluating integers; specifically, if the value being checked contains the integer under validation.

## Example
Using `'foo.*' => 'distinct:ignore_case'` with data such as `'foo' => ['1', '11']` will fail since `11` contains `1`.

Similarily, using `'foo.*' => 'distinct:ignore_case'` with data such as `'foo' => ['2', '425']` will fail since `425` contains `2`.

## Cause
The `preg_grep()` pattern does not contain the start (`^`) and end (`$`) characters which leads to the function returning partial matches.

## Solution
Add the start (`^`) and end (`$`) characters to the `preg_grep()` pattern. Write additional tests including passing integers to the `distinct:ignore_case` validation flag.