### PR TITLE
Route::view now accepts blank $view parameter

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -251,10 +251,10 @@ class Router implements RegistrarContract, BindingRegistrar
      * @param  array  $data
      * @return \Illuminate\Routing\Route
      */
-    public function view($uri, $view, $data = [])
+    public function view($uri, $view = null, $data = [])
     {
         return $this->match(['GET', 'HEAD'], $uri, '\Illuminate\Routing\ViewController')
-                ->defaults('view', $view)
+                ->defaults('view', $view ? $view : $uri)
                 ->defaults('data', $data);
     }
 
@@ -714,8 +714,6 @@ class Router implements RegistrarContract, BindingRegistrar
 
         if ($response instanceof PsrResponseInterface) {
             $response = (new HttpFoundationFactory)->createResponse($response);
-        } elseif ($response instanceof Model && $response->wasRecentlyCreated) {
-            $response = new JsonResponse($response, 201);
         } elseif (! $response instanceof SymfonyResponse &&
                    ($response instanceof Arrayable ||
                     $response instanceof Jsonable ||


### PR DESCRIPTION
- The second parameter $view now can be null
- When the parameter $view is null te $uri will be searched as view
- No tests were found for Route::view, don't know what to do next