### PR TITLE
Route::view now accepts blank $view parameter

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -251,10 +251,10 @@ class Router implements RegistrarContract, BindingRegistrar
      * @param  array  $data
      * @return \Illuminate\Routing\Route
      */
-    public function view($uri, $view, $data = [])
+    public function view($uri, $view = null, $data = [])
     {
         return $this->match(['GET', 'HEAD'], $uri, '\Illuminate\Routing\ViewController')
-                ->defaults('view', $view)
+                ->defaults('view', $view ? $view : $uri)
                 ->defaults('data', $data);
     }
 

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -254,7 +254,7 @@ class Router implements RegistrarContract, BindingRegistrar
     public function view($uri, $view = null, $data = [])
     {
         return $this->match(['GET', 'HEAD'], $uri, '\Illuminate\Routing\ViewController')
-                ->defaults('view', $view ? $view : $uri)
+                ->defaults('view', $view ?: $uri)
                 ->defaults('data', $data);
     }
 

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -253,9 +253,25 @@ class Router implements RegistrarContract, BindingRegistrar
      */
     public function view($uri, $view = null, $data = [])
     {
+        if (func_num_args() == 2 && is_array($view)) {
+            $data = $view;
+            $view = null;
+        }
+
         return $this->match(['GET', 'HEAD'], $uri, '\Illuminate\Routing\ViewController')
-                ->defaults('view', $view ?: $uri)
+                ->defaults('view', $view ?: $this->toViewFormat($uri))
                 ->defaults('data', $data);
+    }
+
+    /**
+     * Converts a URI to a view string format.
+     *
+     * @param  string  $uri
+     * @return string
+     */
+    public function toViewFormat($uri)
+    {
+        return str_replace('/', '.', $uri);
     }
 
     /**


### PR DESCRIPTION
- The second parameter $view now can be null
- When the parameter $view is null te $uri will be searched as view
- No tests were found for Route::view, don't know what to do next

Test Scenario: I need to access my view `test.blade.php` with no data.
For access it, I have to call `Route::view('test','test');`
With this pull-request we can just `Route::view('test');`