### PR TITLE
[5.5] fix a bug where model's delete method won't work if withCount is not empty.

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -796,7 +796,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     protected function performDeleteOnModel()
     {
-        $this->setKeysForSaveQuery($this->newQueryWithoutScopes(true))->delete();
+        $this->setKeysForSaveQuery($this->newQueryWithoutScopes())->delete();
 
         $this->exists = false;
     }
@@ -851,21 +851,18 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     /**
      * Get a new query builder that doesn't have any global scopes.
      *
-     * @param  bool  $withoutCount
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
-    public function newQueryWithoutScopes($withoutCount = false)
+    public function newQueryWithoutScopes()
     {
         $builder = $this->newEloquentBuilder($this->newBaseQueryBuilder());
 
         // Once we have the query builders, we will set the model instances so the
         // builder can easily access any information it may need from the model
         // while it is constructing and executing various queries against it.
-        $builder = $builder->setModel($this)
-                    ->with($this->with);
-
-
-        return $withoutCount ? $builder : $builder->withCount($this->withCount);
+        return $builder->setModel($this)
+                    ->with($this->with)
+                    ->withCount($this->withCount);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -796,7 +796,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     protected function performDeleteOnModel()
     {
-        $this->setKeysForSaveQuery($this->newQueryWithoutScopes())->delete();
+        $this->setKeysForSaveQuery($this->newQueryWithoutScopes(true))->delete();
 
         $this->exists = false;
     }
@@ -851,18 +851,21 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     /**
      * Get a new query builder that doesn't have any global scopes.
      *
+     * @param  bool  $withoutCount
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
-    public function newQueryWithoutScopes()
+    public function newQueryWithoutScopes($withoutCount = false)
     {
         $builder = $this->newEloquentBuilder($this->newBaseQueryBuilder());
 
         // Once we have the query builders, we will set the model instances so the
         // builder can easily access any information it may need from the model
         // while it is constructing and executing various queries against it.
-        return $builder->setModel($this)
-                    ->with($this->with)
-                    ->withCount($this->withCount);
+        $builder = $builder->setModel($this)
+                    ->with($this->with);
+
+
+        return $withoutCount ? $builder : $builder->withCount($this->withCount);
     }
 
     /**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2224,7 +2224,10 @@ class Builder
         }
 
         return $this->connection->delete(
-            $this->grammar->compileDelete($this), $this->getBindings()
+            $this->grammar->compileDelete($this),
+            $this->cleanBindings(
+                $this->grammar->prepareBindingsForDelete($this->bindings)
+            )
         );
     }
 

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -762,6 +762,21 @@ class Grammar extends BaseGrammar
     }
 
     /**
+     * Prepare the bindings for a delete statement.
+     *
+     * @param  array  $bindings
+     * @return array
+     */
+    public function prepareBindingsForDelete(array $bindings)
+    {
+        $cleanBindings = Arr::except($bindings, ['join', 'select']);
+
+        return array_values(
+            array_merge($bindings['join'], Arr::flatten($cleanBindings))
+        );
+    }
+
+    /**
      * Compile a truncate table statement into SQL.
      *
      * @param  \Illuminate\Database\Query\Builder  $query

--- a/tests/Database/DatabaseEloquentPolymorphicIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentPolymorphicIntegrationTest.php
@@ -119,6 +119,15 @@ class DatabaseEloquentPolymorphicIntegrationTest extends TestCase
         $this->assertEquals(TestUser::first(), $like->likeable->owner);
     }
 
+    public function testItDeleteRecordIfWithCountNotEmpty()
+    {
+        $this->seedData();
+
+        $like = TestPost::first()->delete();
+
+        $this->assertNull(TestPost::first());
+    }
+
     /**
      * Helpers...
      */
@@ -172,6 +181,7 @@ class TestUser extends Eloquent
 class TestPost extends Eloquent
 {
     protected $table = 'posts';
+    protected $withCount = ['comments'];
     protected $guarded = [];
 
     public function comments()

--- a/tests/Integration/Database/EloquentWithCountTest.php
+++ b/tests/Integration/Database/EloquentWithCountTest.php
@@ -62,6 +62,23 @@ class EloquentWithCountTest extends TestCase
             ['id' => 1, 'twos_count' => 1],
         ], $results->get()->toArray());
     }
+
+    /**
+     * @test
+     */
+    public function testDeleteWithJoins()
+    {
+        Model1::create()
+                ->twos()->create()
+                ->threes()->create();
+
+        Model2::select('two.id')
+                ->join('one', 'one.id', 1)
+                ->join('three', 'two.id', 'three.two_id')
+                ->where('two.id', 1)->delete();
+
+        $this->assertNull(Model2::find(1));
+    }
 }
 
 class Model1 extends Model


### PR DESCRIPTION

This fixes the bug that makes delete query receive two params instead of one if withCount array is not empty. 

Before: 
``` 
array:2 [▼
  0 => array:3 [▼
    "query" => "select `posts`.*, (select count(*) from `comments` where `posts`.`id` = `comments`.`commentable_id` and `comments`.`commentable_type` = ?) as `comments_count` f ▶"
    "bindings" => array:2 [▼
      0 => "App\Post"
      1 => "14"
    ]
    "time" => 6.3
  ]
  1 => array:3 [▼
    "query" => "delete from `posts` where `id` = ?"
    "bindings" => array:1 [▼
      0 => "App\Post"
      1 => "14"
    ]
    "time" => 0.84
  ]
]
```


After: 
``` 
array:2 [▼
  0 => array:3 [▼
    "query" => "select `posts`.*, (select count(*) from `comments` where `posts`.`id` = `comments`.`commentable_id` and `comments`.`commentable_type` = ?) as `comments_count` f ▶"
    "bindings" => array:2 [▼
      0 => "App\Post"
      1 => "14"
    ]
    "time" => 6.3
  ]
  1 => array:3 [▼
    "query" => "delete from `posts` where `id` = ?"
    "bindings" => array:1 [▼
     0 => "14"
    ]
    "time" => 0.84
  ]
]
```