### PR TITLE
[5.6] Accept "true" and "false" strings as acceptable boolean value during validation

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -303,7 +303,7 @@ trait ValidatesAttributes
      */
     public function validateBoolean($attribute, $value)
     {
-        $acceptable = [true, false, 0, 1, '0', '1'];
+        $acceptable = [true, false, 'true', 'false', 0, 1, '0', '1'];
 
         return in_array($value, $acceptable, true);
     }


### PR DESCRIPTION
#22241 Optimize can not verify boolean "true" and "false".