### PR TITLE
[5.5] Worker: Allow to set sleep time less than 1 seconds

### DIFF
--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -592,7 +592,7 @@ class Worker
 
     /**
      * Sleep the script for a given number of seconds.
-     * Allow to use fractions of a second: 0.25, 0.01
+     * Allow to use fractions of a second: 0.25, 0.01.
      *
      * @param  int|float   $seconds
      * @return void

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -592,13 +592,14 @@ class Worker
 
     /**
      * Sleep the script for a given number of seconds.
+     * Allow to use fractions of a second: 0.25, 0.01
      *
-     * @param  int   $seconds
+     * @param  int|float   $seconds
      * @return void
      */
     public function sleep($seconds)
     {
-        sleep($seconds);
+        usleep($seconds * 1000000);
     }
 
     /**

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -592,7 +592,6 @@ class Worker
 
     /**
      * Sleep the script for a given number of seconds.
-     * Allow to use fractions of a second: 0.25, 0.01.
      *
      * @param  int|float   $seconds
      * @return void


### PR DESCRIPTION
I'd like to set sleep time for worker less than 1 seconds, but  I can't do this because we use sleep().
I suggest we can use `usleep()` and multiply passed $seconds to * 100000 for backward compatibility.
Now possible to pass 0.5 or 0.01 seconds