### PR TITLE
[5.5] Fix incorrect paramerter name in docBlock

### DIFF
--- a/src/Illuminate/Validation/Concerns/FormatsMessages.php
+++ b/src/Illuminate/Validation/Concerns/FormatsMessages.php
@@ -271,7 +271,7 @@ trait FormatsMessages
      * Replace the :input placeholder in the given message.
      *
      * @param  string  $message
-     * @param  string  $value
+     * @param  string  $attribute
      * @return string
      */
     protected function replaceInputPlaceholder($message, $attribute)


### PR DESCRIPTION
Correct parameter name on docBlock for $attribute