### PR TITLE
Add hasAttribute() to Eloquent/Model

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1140,7 +1140,7 @@ trait HasAttributes
     }
     
     /**
-     * Checks if a specific attribute exists
+     * Checks if a specific attribute exists.
      *
      * @param string $key
      * @return bool

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1138,4 +1138,15 @@ trait HasAttributes
 
         return $matches[1];
     }
+    
+    /**
+     * Checks if a specific attribute exists
+     *
+     * @param string $key
+     * @return bool
+     */
+    protected function hasAttribute($key)
+    {
+        return array_key_exists($key, $this->attributes);
+    }
 }


### PR DESCRIPTION
This PR adds the `hasAttribute()` method to `Eloquent/Model` in order to check, if a given attribute exist in this model