### PR TITLE
[5.5] Add hasAttribute to Eloquent/Model

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1140,7 +1140,7 @@ trait HasAttributes
     }
     
     /**
-     * Checks if a specific attribute exists
+     * Checks if a specific attribute exists.
      *
      * @param string $key
      * @return bool

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1138,4 +1138,15 @@ trait HasAttributes
 
         return $matches[1];
     }
+    
+    /**
+     * Checks if a specific attribute exists
+     *
+     * @param string $key
+     * @return bool
+     */
+    protected function hasAttribute($key)
+    {
+        return array_key_exists($key, $this->attributes);
+    }
 }

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1145,8 +1145,8 @@ trait HasAttributes
      * @param string $key
      * @return bool
      */
-    protected function hasAttribute($key)
+    public function hasAttribute($key)
     {
-        return array_key_exists($key, $this->attributes);
+        return array_key_exists($key, $this->attributesToArray());
     }
 }


### PR DESCRIPTION
This PR adds the `hasAttribute()` method to `Eloquent/Model` in order to check, if a given attribute exist in this model.

Why do we need this method?! Because other "checks", like `isset(...)` show a wrong behaviour.

Consider the following example here:
```php
// let $user be an instance of Eloquent/Model
$entity->name = null;
dd(isset($entity->name)); // false, even it is set!
dd($entity->hasAttribute('name')); // true, even it is null
```

Furthermore, `property_exists(...)` does not work either... 

So this would be a valuable contribution... 