### PR TITLE
[5.5] Added assertSoftDeletes assertion method

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithModel.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithModel.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Illuminate\Foundation\Testing\Concerns;
+
+use Illuminate\Foundation\Testing\Constraints\UsesSoftDeletesTrait;
+
+trait InteractsWithModel
+{
+    /**
+     * Assert that a model uses the SoftDelete trait.
+     *
+     * @param  string $model
+     * @return $this
+     */
+    protected function assertSoftDeletes($model)
+    {
+        $this->assertThat(
+            new $model, new UsesSoftDeletesTrait($model)
+        );
+
+        return $this;
+    }
+}

--- a/src/Illuminate/Foundation/Testing/Constraints/UsesSoftDeletesTrait.php
+++ b/src/Illuminate/Foundation/Testing/Constraints/UsesSoftDeletesTrait.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Illuminate\Foundation\Testing\Constraints;
+
+use PHPUnit\Framework\Constraint\Constraint;
+
+class UsesSoftDeletesTrait extends Constraint
+{
+    /**
+     * The Eloquent Model string class.
+     *
+     * @var string
+     */
+    protected $model;
+
+    /**
+     * Create a new constraint instance.
+     *
+     * @param  string  $model
+     * @return void
+     */
+    public function __construct($model)
+    {
+        $this->model = $model;
+    }
+
+    /**
+     * Check if the model has the SoftDeletes::getDeletedAtColumn method.
+     *
+     * @param  string  $model
+     * @return bool
+     */
+    public function matches($model)
+    {
+        return method_exists($model, 'getDeletedAtColumn');
+    }
+
+    /**
+     * Get the description of the failure.
+     *
+     * @param  string $model
+     * @return string
+     */
+    public function failureDescription($model)
+    {
+        return 'the given model uses the SoftDeletes trait';
+    }
+
+    /**
+     * Get a string representation of the object.
+     *
+     * @return string
+     */
+    public function toString()
+    {
+        return json_encode($this->model);
+    }
+}

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -18,6 +18,7 @@ abstract class TestCase extends BaseTestCase
         Concerns\InteractsWithDatabase,
         Concerns\InteractsWithExceptionHandling,
         Concerns\InteractsWithSession,
+        Concerns\InteractsWithModel,
         Concerns\MocksApplicationServices;
 
     /**

--- a/tests/Foundation/FoundationInteractsWithModel.php
+++ b/tests/Foundation/FoundationInteractsWithModel.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Illuminate\Tests\Foundation;
+
+use PHPUnit\Framework\TestCase;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Foundation\Testing\Concerns\InteractsWithModel;
+
+class FoundationInteractsWithModel extends TestCase
+{
+    use InteractsWithModel;
+
+    public function testModelUsesSoftDeletesTrait()
+    {
+        $this->assertSoftDeletes(SoftDeletesTestUser::class);
+    }
+}
+
+class SoftDeletesTestUser extends Model
+{
+    use SoftDeletes;
+
+    protected $dates = ['deleted_at'];
+}


### PR DESCRIPTION
Recently I need to test if a certain model uses the `SoftDeletes` trait/feature. One way to test it was to delete it and check my database with `assertSoftDeleted`. But, by touching the database, the test took some time. Instead of that, why not simply check if the model has the `SoftDeletes::getDeletedAtColumn` method?