### PR TITLE
[5.5] Fixes MySqlGrammar json accessor building.

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -163,7 +163,7 @@ class MySqlGrammar extends Grammar
 
         $field = $this->wrapValue(array_shift($path));
 
-        $accessor = "'$.\"".implode('.', $path)."\"'";
+        $accessor = "'$.\"".implode('"."', $path)."\"'";
 
         return "{$field} = json_set({$field}, {$accessor}, {$value->getValue()})";
     }

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1684,6 +1684,24 @@ class DatabaseQueryBuilderTest extends TestCase
 
         $result = $builder->from('users')->where('active', '=', 1)->update(['name->first_name' => 'John', 'name->last_name' => 'Doe']);
     }
+    
+    public function testMySqlUpdateWrappingNestedJson()
+    {
+        $grammar = new \Illuminate\Database\Query\Grammars\MySqlGrammar;
+        $processor = m::mock('Illuminate\Database\Query\Processors\Processor');
+
+        $connection = $this->createMock('Illuminate\Database\ConnectionInterface');
+        $connection->expects($this->once())
+                    ->method('update')
+                    ->with(
+                        'update `users` set `meta` = json_set(`meta`, \'$."name"."first_name"\', ?), `meta` = json_set(`meta`, \'$."name"."last_name"\', ?) where `active` = ?',
+                        ['John', 'Doe', 1]
+                    );
+
+        $builder = new Builder($connection, $grammar, $processor);
+
+        $result = $builder->from('users')->where('active', '=', 1)->update(['meta->name->first_name' => 'John', 'meta->name->last_name' => 'Doe']);
+    }
 
     public function testMySqlUpdateWithJsonRemovesBindingsCorrectly()
     {

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1684,7 +1684,7 @@ class DatabaseQueryBuilderTest extends TestCase
 
         $result = $builder->from('users')->where('active', '=', 1)->update(['name->first_name' => 'John', 'name->last_name' => 'Doe']);
     }
-    
+
     public function testMySqlUpdateWrappingNestedJson()
     {
         $grammar = new \Illuminate\Database\Query\Grammars\MySqlGrammar;


### PR DESCRIPTION
Fixes MySqlGrammar json accessor building when updating a json field with nested columns. Related to #22118

In the current form when we do

```
$model->update(['jsonColumn->nested->attribute', 'value'])
```

what gets written in `jsonColumn` is `{ nested.attribute: "value" }` instead of `{ nested: { attribute: "value" } }`