### PR TITLE
[5.5] Worker: Use `usleep` in case when sleep time less than 1 second

### DIFF
--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -598,7 +598,11 @@ class Worker
      */
     public function sleep($seconds)
     {
-        usleep($seconds * 1000000);
+        if ($seconds < 1) {
+            usleep($seconds * 1000000);
+        } else {
+            sleep($seconds);
+        }
     }
 
     /**


### PR DESCRIPTION
> Just to point out PHP_INT_MAX is 2147483647 on 32-bit platform, so this change would break with `$seconds` > 2147 (about 36 minutes).

related https://github.com/laravel/framework/pull/22246