### PR TITLE
[5.5] Fix cases for collectionWhere

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -487,7 +487,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
             $retrieved = data_get($item, $key);
 
             if (count(array_filter([$retrieved, $value], 'is_object')) == 1) {
-                return false;
+                return in_array($operator, ['!=', '<>', '!==']);
             }
 
             switch ($operator) {

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -402,10 +402,40 @@ class SupportCollectionTest extends TestCase
             $c->where('v', $object)->values()->all()
         );
 
+        $this->assertEquals(
+            [['v' => 1], ['v' => 2], ['v' => 3], ['v' => '3'], ['v' => 4]],
+            $c->where('v', '<>',$object)->values()->all()
+        );
+
+        $this->assertEquals(
+            [['v' => 1], ['v' => 2], ['v' => 3], ['v' => '3'], ['v' => 4]],
+            $c->where('v', '!=',$object)->values()->all()
+        );
+
+        $this->assertEquals(
+            [['v' => 1], ['v' => 2], ['v' => 3], ['v' => '3'], ['v' => 4]],
+            $c->where('v', '!==',$object)->values()->all()
+        );
+
+        $this->assertEquals(
+            [],
+            $c->where('v', '>',$object)->values()->all()
+        );
+
         $c = new Collection([['v' => 1], ['v' => $object]]);
         $this->assertEquals(
             [['v' => $object]],
             $c->where('v', $object)->values()->all()
+        );
+
+        $this->assertEquals(
+            [['v' => 1], ['v' => $object]],
+            $c->where('v', '<>', null)->values()->all()
+        );
+
+        $this->assertEquals(
+            [],
+            $c->where('v', '<', null)->values()->all()
         );
     }
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -404,22 +404,22 @@ class SupportCollectionTest extends TestCase
 
         $this->assertEquals(
             [['v' => 1], ['v' => 2], ['v' => 3], ['v' => '3'], ['v' => 4]],
-            $c->where('v', '<>',$object)->values()->all()
+            $c->where('v', '<>', $object)->values()->all()
         );
 
         $this->assertEquals(
             [['v' => 1], ['v' => 2], ['v' => 3], ['v' => '3'], ['v' => 4]],
-            $c->where('v', '!=',$object)->values()->all()
+            $c->where('v', '!=', $object)->values()->all()
         );
 
         $this->assertEquals(
             [['v' => 1], ['v' => 2], ['v' => 3], ['v' => '3'], ['v' => 4]],
-            $c->where('v', '!==',$object)->values()->all()
+            $c->where('v', '!==', $object)->values()->all()
         );
 
         $this->assertEquals(
             [],
-            $c->where('v', '>',$object)->values()->all()
+            $c->where('v', '>', $object)->values()->all()
         );
 
         $c = new Collection([['v' => 1], ['v' => $object]]);


### PR DESCRIPTION
This change will consider the value as within the condition if we're using a negation comparison, so if value is an object while the condition is an integer, the negation should pass since the object is not an integer.