### PR TITLE
[5.6] Use env APP_NAME variable for syslog identifier

### DIFF
--- a/src/Illuminate/Log/LogServiceProvider.php
+++ b/src/Illuminate/Log/LogServiceProvider.php
@@ -101,7 +101,7 @@ class LogServiceProvider extends ServiceProvider
      */
     protected function configureSyslogHandler(Writer $log)
     {
-        $log->useSyslog(env('APP_NAME', 'laravel'), $this->logLevel());
+        $log->useSyslog(config('app.name'), $this->logLevel());
     }
 
     /**

--- a/src/Illuminate/Log/LogServiceProvider.php
+++ b/src/Illuminate/Log/LogServiceProvider.php
@@ -101,7 +101,7 @@ class LogServiceProvider extends ServiceProvider
      */
     protected function configureSyslogHandler(Writer $log)
     {
-        $log->useSyslog(config('app.name'), $this->logLevel());
+        $log->useSyslog($this->app->make('config')->get('app.name'), $this->logLevel());
     }
 
     /**

--- a/src/Illuminate/Log/LogServiceProvider.php
+++ b/src/Illuminate/Log/LogServiceProvider.php
@@ -101,7 +101,7 @@ class LogServiceProvider extends ServiceProvider
      */
     protected function configureSyslogHandler(Writer $log)
     {
-        $log->useSyslog('laravel', $this->logLevel());
+        $log->useSyslog(env('APP_NAME', 'laravel'), $this->logLevel());
     }
 
     /**


### PR DESCRIPTION
Instead of hardcoded syslog identifier "laravel" I propose to use environment variable APP_NAME.
In case when you have a few Laravel projects on the same machine that log to syslog all of them will write to log with same identifier "laravel" thats not very transparent which message belongs to which project