### PR TITLE
[5.5] Update MySqlGrammar.php

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -282,7 +282,7 @@ class MySqlGrammar extends Grammar
 
         $field = $this->wrapValue(array_shift($path));
 
-        return sprintf('%s->\'$.%s\'', $field, collect($path)->map(function ($part) {
+        return sprintf('%s->>\'$.%s\'', $field, collect($path)->map(function ($part) {
             return '"'.$part.'"';
         })->implode('.'));
     }

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1769,7 +1769,7 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('users')->whereRaw('items->\'$."price"\' = 1');
-        $this->assertEquals('select * from `users` where items->>\'$."price"\' = 1', $builder->toSql());
+        $this->assertEquals('select * from `users` where items->\'$."price"\' = 1', $builder->toSql());
 
         $builder = $this->getMySqlBuilder();
         $builder->select('items->price')->from('users')->where('items->price', '=', 1)->orderBy('items->price');

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1732,7 +1732,7 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('users')->where('items->sku', '=', 'foo-bar');
-        $this->assertEquals('select * from `users` where `items`->\'$."sku"\' = ?', $builder->toSql());
+        $this->assertEquals('select * from `users` where `items`->>\'$."sku"\' = ?', $builder->toSql());
         $this->assertCount(1, $builder->getRawBindings()['where']);
         $this->assertEquals('foo-bar', $builder->getRawBindings()['where'][0]);
     }
@@ -1741,47 +1741,47 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('users')->where('items->price', '=', 1);
-        $this->assertEquals('select * from `users` where `items`->\'$."price"\' = ?', $builder->toSql());
+        $this->assertEquals('select * from `users` where `items`->>\'$."price"\' = ?', $builder->toSql());
     }
 
     public function testMySqlWrappingJsonWithDouble()
     {
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('users')->where('items->price', '=', 1.5);
-        $this->assertEquals('select * from `users` where `items`->\'$."price"\' = ?', $builder->toSql());
+        $this->assertEquals('select * from `users` where `items`->>\'$."price"\' = ?', $builder->toSql());
     }
 
     public function testMySqlWrappingJsonWithBoolean()
     {
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('users')->where('items->available', '=', true);
-        $this->assertEquals('select * from `users` where `items`->\'$."available"\' = true', $builder->toSql());
+        $this->assertEquals('select * from `users` where `items`->>\'$."available"\' = true', $builder->toSql());
     }
 
     public function testMySqlWrappingJsonWithBooleanAndIntegerThatLooksLikeOne()
     {
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('users')->where('items->available', '=', true)->where('items->active', '=', false)->where('items->number_available', '=', 0);
-        $this->assertEquals('select * from `users` where `items`->\'$."available"\' = true and `items`->\'$."active"\' = false and `items`->\'$."number_available"\' = ?', $builder->toSql());
+        $this->assertEquals('select * from `users` where `items`->>\'$."available"\' = true and `items`->>\'$."active"\' = false and `items`->>\'$."number_available"\' = ?', $builder->toSql());
     }
 
     public function testMySqlWrappingJson()
     {
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('users')->whereRaw('items->\'$."price"\' = 1');
-        $this->assertEquals('select * from `users` where items->\'$."price"\' = 1', $builder->toSql());
+        $this->assertEquals('select * from `users` where items->>\'$."price"\' = 1', $builder->toSql());
 
         $builder = $this->getMySqlBuilder();
         $builder->select('items->price')->from('users')->where('items->price', '=', 1)->orderBy('items->price');
-        $this->assertEquals('select `items`->\'$."price"\' from `users` where `items`->\'$."price"\' = ? order by `items`->\'$."price"\' asc', $builder->toSql());
+        $this->assertEquals('select `items`->>\'$."price"\' from `users` where `items`->>\'$."price"\' = ? order by `items`->>\'$."price"\' asc', $builder->toSql());
 
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('users')->where('items->price->in_usd', '=', 1);
-        $this->assertEquals('select * from `users` where `items`->\'$."price"."in_usd"\' = ?', $builder->toSql());
+        $this->assertEquals('select * from `users` where `items`->>\'$."price"."in_usd"\' = ?', $builder->toSql());
 
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('users')->where('items->price->in_usd', '=', 1)->where('items->age', '=', 2);
-        $this->assertEquals('select * from `users` where `items`->\'$."price"."in_usd"\' = ? and `items`->\'$."age"\' = ?', $builder->toSql());
+        $this->assertEquals('select * from `users` where `items`->>\'$."price"."in_usd"\' = ? and `items`->>\'$."age"\' = ?', $builder->toSql());
     }
 
     public function testPostgresWrappingJson()


### PR DESCRIPTION
```
>>> Status::whereIn('ram->type', ['DRAM', 'DDR3'])->toSql()
=> "select * from `statuses` where `ram`->'$."type"' in (?, ?)"
```
change to
```
>>> Status::whereIn('ram->type', ['DRAM', 'DDR3'])->toSql()
=> "select * from `statuses` where `ram`->>'$."type"' in (?, ?)"
```

https://dev.mysql.com/doc/refman/5.7/en/json-search-functions.html#operator_json-inline-path