### PR TITLE
[5.5] Detect persistent connection reset

### DIFF
--- a/src/Illuminate/Database/DetectsLostConnections.php
+++ b/src/Illuminate/Database/DetectsLostConnections.php
@@ -31,6 +31,7 @@ trait DetectsLostConnections
             'Transaction() on null',
             'child connection forced to terminate due to client_idle_limit',
             'query_wait_timeout',
+            'reset by peer',
         ]);
     }
 }


### PR DESCRIPTION
Handles a PDO exception caused by an attempt to reuse a closed persistent connection.