### PR TITLE
[5.5] Improving reporting tests

### DIFF
--- a/tests/Database/DatabaseConnectionTest.php
+++ b/tests/Database/DatabaseConnectionTest.php
@@ -56,7 +56,7 @@ class DatabaseConnectionTest extends TestCase
         $log = $mock->getQueryLog();
         $this->assertEquals('foo', $log[0]['query']);
         $this->assertEquals(['foo' => 'bar'], $log[0]['bindings']);
-        $this->assertTrue(is_numeric($log[0]['time']));
+        $this->assertInternalType('numeric', $log[0]['time']);
     }
 
     public function testInsertCallsTheStatementMethod()
@@ -97,7 +97,7 @@ class DatabaseConnectionTest extends TestCase
         $log = $mock->getQueryLog();
         $this->assertEquals('foo', $log[0]['query']);
         $this->assertEquals(['bar'], $log[0]['bindings']);
-        $this->assertTrue(is_numeric($log[0]['time']));
+        $this->assertInternalType('numeric', $log[0]['time']);
     }
 
     public function testAffectingStatementProperlyCallsPDO()
@@ -115,7 +115,7 @@ class DatabaseConnectionTest extends TestCase
         $log = $mock->getQueryLog();
         $this->assertEquals('foo', $log[0]['query']);
         $this->assertEquals(['foo' => 'bar'], $log[0]['bindings']);
-        $this->assertTrue(is_numeric($log[0]['time']));
+        $this->assertInternalType('numeric', $log[0]['time']);
     }
 
     public function testTransactionLevelNotIncrementedOnTransactionException()

--- a/tests/Database/DatabaseEloquentHasManyTest.php
+++ b/tests/Database/DatabaseEloquentHasManyTest.php
@@ -221,10 +221,10 @@ class DatabaseEloquentHasManyTest extends TestCase
         $models = $relation->match([$model1, $model2, $model3], new Collection([$result1, $result2, $result3]), 'foo');
 
         $this->assertEquals(1, $models[0]->foo[0]->foreign_key);
-        $this->assertEquals(1, count($models[0]->foo));
+        $this->assertCount(1, $models[0]->foo);
         $this->assertEquals(2, $models[1]->foo[0]->foreign_key);
         $this->assertEquals(2, $models[1]->foo[1]->foreign_key);
-        $this->assertEquals(2, count($models[1]->foo));
+        $this->assertCount(2, $models[1]->foo);
         $this->assertNull($models[2]->foo);
     }
 

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -135,7 +135,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertTrue(isset($model['connection']));
         $this->assertEquals($model['connection'], 2);
         $this->assertFalse(isset($model['table']));
-        $this->assertEquals($model['table'], null);
+        $this->assertNull($model['table']);
         $this->assertFalse(isset($model['with']));
     }
 

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -900,7 +900,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $blueprint->string('foo')->comment("Escape ' when using words like it's");
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
-        $this->assertEquals(1, count($statements));
+        $this->assertCount(1, $statements);
         $this->assertEquals("alter table `users` add `foo` varchar(255) not null comment 'Escape \\' when using words like it\\'s'", $statements[0]);
     }
 

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -90,7 +90,7 @@ class FilesystemTest extends TestCase
         file_put_contents($this->tempDir.'/foo/file.txt', 'Hello World');
         $files = new Filesystem;
         $files->deleteDirectory($this->tempDir.'/foo');
-        $this->assertFalse(is_dir($this->tempDir.'/foo'));
+        $this->assertDirectoryNotExists($this->tempDir.'/foo');
         $this->assertFileNotExists($this->tempDir.'/foo/file.txt');
     }
 
@@ -100,7 +100,7 @@ class FilesystemTest extends TestCase
         file_put_contents($this->tempDir.'/foo/file.txt', 'Hello World');
         $files = new Filesystem;
         $files->cleanDirectory($this->tempDir.'/foo');
-        $this->assertTrue(is_dir($this->tempDir.'/foo'));
+        $this->assertDirectoryExists($this->tempDir.'/foo');
         $this->assertFileNotExists($this->tempDir.'/foo/file.txt');
     }
 
@@ -144,10 +144,10 @@ class FilesystemTest extends TestCase
 
         $files = new Filesystem;
         $files->copyDirectory($this->tempDir.'/tmp', $this->tempDir.'/tmp2');
-        $this->assertTrue(is_dir($this->tempDir.'/tmp2'));
+        $this->assertDirectoryExists($this->tempDir.'/tmp2');
         $this->assertFileExists($this->tempDir.'/tmp2/foo.txt');
         $this->assertFileExists($this->tempDir.'/tmp2/bar.txt');
-        $this->assertTrue(is_dir($this->tempDir.'/tmp2/nested'));
+        $this->assertDirectoryExists($this->tempDir.'/tmp2/nested');
         $this->assertFileExists($this->tempDir.'/tmp2/nested/baz.txt');
     }
 
@@ -161,12 +161,12 @@ class FilesystemTest extends TestCase
 
         $files = new Filesystem;
         $files->moveDirectory($this->tempDir.'/tmp', $this->tempDir.'/tmp2');
-        $this->assertTrue(is_dir($this->tempDir.'/tmp2'));
+        $this->assertDirectoryExists($this->tempDir.'/tmp2');
         $this->assertFileExists($this->tempDir.'/tmp2/foo.txt');
         $this->assertFileExists($this->tempDir.'/tmp2/bar.txt');
-        $this->assertTrue(is_dir($this->tempDir.'/tmp2/nested'));
+        $this->assertDirectoryExists($this->tempDir.'/tmp2/nested');
         $this->assertFileExists($this->tempDir.'/tmp2/nested/baz.txt');
-        $this->assertFalse(is_dir($this->tempDir.'/tmp'));
+        $this->assertDirectoryNotExists($this->tempDir.'/tmp');
     }
 
     public function testMoveDirectoryMovesEntireDirectoryAndOverwrites()
@@ -182,14 +182,14 @@ class FilesystemTest extends TestCase
 
         $files = new Filesystem;
         $files->moveDirectory($this->tempDir.'/tmp', $this->tempDir.'/tmp2', true);
-        $this->assertTrue(is_dir($this->tempDir.'/tmp2'));
+        $this->assertDirectoryExists($this->tempDir.'/tmp2');
         $this->assertFileExists($this->tempDir.'/tmp2/foo.txt');
         $this->assertFileExists($this->tempDir.'/tmp2/bar.txt');
-        $this->assertTrue(is_dir($this->tempDir.'/tmp2/nested'));
+        $this->assertDirectoryExists($this->tempDir.'/tmp2/nested');
         $this->assertFileExists($this->tempDir.'/tmp2/nested/baz.txt');
         $this->assertFileNotExists($this->tempDir.'/tmp2/foo2.txt');
         $this->assertFileNotExists($this->tempDir.'/tmp2/bar2.txt');
-        $this->assertFalse(is_dir($this->tempDir.'/tmp'));
+        $this->assertDirectoryNotExists($this->tempDir.'/tmp');
     }
 
     /**
@@ -383,7 +383,7 @@ class FilesystemTest extends TestCase
             $result *= $status;
         }
 
-        $this->assertTrue($result === 1);
+        $this->assertSame(1, $result);
     }
 
     public function testRequireOnceRequiresFileProperly()
@@ -406,7 +406,7 @@ class FilesystemTest extends TestCase
         file_put_contents($this->tempDir.'/foo/foo.txt', $data);
         $filesystem->copy($this->tempDir.'/foo/foo.txt', $this->tempDir.'/foo/foo2.txt');
         $this->assertFileExists($this->tempDir.'/foo/foo2.txt');
-        $this->assertEquals($data, file_get_contents($this->tempDir.'/foo/foo2.txt'));
+        $this->assertStringEqualsFile($this->tempDir.'/foo/foo2.txt', $data);
     }
 
     public function testIsFileChecksFilesProperly()

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -766,18 +766,18 @@ class HttpRequestTest extends TestCase
 
         // Parameter 'foo' is 'bar', then it ISSET and is NOT EMPTY.
         $this->assertEquals($request->foo, 'bar');
-        $this->assertEquals(isset($request->foo), true);
-        $this->assertEquals(empty($request->foo), false);
+        $this->assertTrue(isset($request->foo));
+        $this->assertNotEmpty($request->foo);
 
         // Parameter 'empty' is '', then it ISSET and is EMPTY.
         $this->assertEquals($request->empty, '');
         $this->assertTrue(isset($request->empty));
-        $this->assertTrue(empty($request->empty));
+        $this->assertEmpty($request->empty);
 
         // Parameter 'undefined' is undefined/null, then it NOT ISSET and is EMPTY.
-        $this->assertEquals($request->undefined, null);
-        $this->assertEquals(isset($request->undefined), false);
-        $this->assertEquals(empty($request->undefined), true);
+        $this->assertNull($request->undefined);
+        $this->assertFalse(isset($request->undefined));
+        $this->assertEmpty($request->undefined);
 
         // Simulates Route parameters.
         $request = Request::create('/example/bar', 'GET', ['xyz' => 'overwritten']);
@@ -791,19 +791,19 @@ class HttpRequestTest extends TestCase
         // Router parameter 'foo' is 'bar', then it ISSET and is NOT EMPTY.
         $this->assertEquals('bar', $request->foo);
         $this->assertEquals('bar', $request['foo']);
-        $this->assertEquals(isset($request->foo), true);
-        $this->assertEquals(empty($request->foo), false);
+        $this->assertTrue(isset($request->foo));
+        $this->assertNotEmpty($request->foo);
 
         // Router parameter 'undefined' is undefined/null, then it NOT ISSET and is EMPTY.
-        $this->assertEquals($request->undefined, null);
-        $this->assertEquals(isset($request->undefined), false);
-        $this->assertEquals(empty($request->undefined), true);
+        $this->assertNull($request->undefined);
+        $this->assertFalse(isset($request->undefined));
+        $this->assertEmpty($request->undefined);
 
         // Special case: router parameter 'xyz' is 'overwritten' by QueryString, then it ISSET and is NOT EMPTY.
         // Basically, QueryStrings have priority over router parameters.
         $this->assertEquals($request->xyz, 'overwritten');
-        $this->assertEquals(isset($request->foo), true);
-        $this->assertEquals(empty($request->foo), false);
+        $this->assertTrue(isset($request->foo));
+        $this->assertNotEmpty($request->foo);
 
         // Simulates empty QueryString and Routes.
         $request = Request::create('/', 'GET');
@@ -815,18 +815,18 @@ class HttpRequestTest extends TestCase
         });
 
         // Parameter 'undefined' is undefined/null, then it NOT ISSET and is EMPTY.
-        $this->assertEquals($request->undefined, null);
-        $this->assertEquals(isset($request->undefined), false);
-        $this->assertEquals(empty($request->undefined), true);
+        $this->assertNull($request->undefined);
+        $this->assertFalse(isset($request->undefined));
+        $this->assertEmpty($request->undefined);
 
         // Special case: simulates empty QueryString and Routes, without the Route Resolver.
         // It'll happen when you try to get a parameter outside a route.
         $request = Request::create('/', 'GET');
 
         // Parameter 'undefined' is undefined/null, then it NOT ISSET and is EMPTY.
-        $this->assertEquals($request->undefined, null);
-        $this->assertEquals(isset($request->undefined), false);
-        $this->assertEquals(empty($request->undefined), true);
+        $this->assertNull($request->undefined);
+        $this->assertFalse(isset($request->undefined));
+        $this->assertEmpty($request->undefined);
     }
 
     public function testHttpRequestFlashCallsSessionFlashInputWithInputData()

--- a/tests/Integration/Queue/JobChainingTest.php
+++ b/tests/Integration/Queue/JobChainingTest.php
@@ -174,8 +174,8 @@ class JobChainingTest extends TestCase
         $this->assertEquals('another_queue', JobChainingTestSecondJob::$usedQueue);
         $this->assertEquals('sync2', JobChainingTestSecondJob::$usedConnection);
 
-        $this->assertEquals(null, JobChainingTestThirdJob::$usedQueue);
-        $this->assertEquals(null, JobChainingTestThirdJob::$usedConnection);
+        $this->assertNull(JobChainingTestThirdJob::$usedQueue);
+        $this->assertNull(JobChainingTestThirdJob::$usedConnection);
     }
 }
 

--- a/tests/Mail/MailMarkdownTest.php
+++ b/tests/Mail/MailMarkdownTest.php
@@ -23,7 +23,7 @@ class MailMarkdownTest extends TestCase
 
         $result = $markdown->render('view', []);
 
-        $this->assertTrue(strpos($result, '<html></html>') !== false);
+        $this->assertContains('<html></html>', (string) $result);
     }
 
     public function testRenderFunctionReturnsHtmlWithCustomTheme()
@@ -39,7 +39,7 @@ class MailMarkdownTest extends TestCase
 
         $result = $markdown->render('view', []);
 
-        $this->assertTrue(strpos($result, '<html></html>') !== false);
+        $this->assertContains('<html></html>', (string) $result);
     }
 
     public function testRenderTextReturnsText()

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -304,7 +304,7 @@ class RoutingRouteTest extends TestCase
             return 'foo';
         })->name('foo');
 
-        $this->assertTrue(is_array($route->getAction()));
+        $this->assertInternalType('array', $route->getAction());
         $this->assertArrayHasKey('as', $route->getAction());
         $this->assertEquals('foo', $route->getAction('as'));
         $this->assertNull($route->getAction('unknown_property'));

--- a/tests/Session/SessionStoreTest.php
+++ b/tests/Session/SessionStoreTest.php
@@ -75,7 +75,7 @@ class SessionStoreTest extends TestCase
         $oldId = $session->getId();
 
         $session->put('foo', 'bar');
-        $this->assertGreaterThan(0, count($session->all()));
+        $this->assertGreaterThan(0, $session->all());
 
         $session->flash('name', 'Taylor');
         $this->assertTrue($session->has('name'));


### PR DESCRIPTION
Continuing to improve tests, like #22219 and #22226:
- Instead of `count` PHP method, use [`assertCount`](https://phpunit.de/manual/current/pt_br/appendixes.assertions.html#appendixes.assertions.assertCount);
- Avoid use PHP functions `is_*`. Instead, use [`assertInternalType`](https://phpunit.de/manual/current/pt_br/appendixes.assertions.html#appendixes.assertions.assertInternalType);
- Use [`assertDirectoryExists`](https://phpunit.de/manual/current/pt_br/appendixes.assertions.html#appendixes.assertions.assertDirectoryExists) and `assertDirectoryNotExists` instead checking `is_dir`;
- Use [`assertEquals`](https://phpunit.de/manual/current/pt_br/appendixes.assertions.html#appendixes.assertions.assertEquals) instead of comparisions `==` and `===`;
- Use [`assertStringEqualsFile`](https://phpunit.de/manual/current/pt_br/appendixes.assertions.html#appendixes.assertions.assertStringEqualsFile) when comparing strings and files;
- When comparing string, use [`assertContains`](https://phpunit.de/manual/current/pt_br/appendixes.assertions.html#appendixes.assertions.assertContains) instead of `strpos`;
- [`assertEmpty`](https://phpunit.de/manual/current/pt_br/appendixes.assertions.html#appendixes.assertions.assertEmpty) and [`assertNull`](https://phpunit.de/manual/current/pt_br/appendixes.assertions.html#appendixes.assertions.assertNull) instead of `null` and `empty` PHP methods;
- Use [`assertTrue`](https://phpunit.de/manual/current/pt_br/appendixes.assertions.html#appendixes.assertions.assertTrue) or [`assertFalse`](https://phpunit.de/manual/current/pt_br/appendixes.assertions.html#appendixes.assertions.assertFalse), instead of comparing `true` or `false` keyworkds with [`assertEquals`](https://phpunit.de/manual/current/pt_br/appendixes.assertions.html#appendixes.assertions.assertEquals)/[`assertSame`](https://phpunit.de/manual/current/pt_br/appendixes.assertions.html#appendixes.assertions.assertSame);