### PR TITLE
[5.6] Use binary format for UUIDs in MySQL grammar

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -672,7 +672,7 @@ class MySqlGrammar extends Grammar
      */
     protected function typeUuid(Fluent $column)
     {
-        return 'char(36)';
+        return 'binary(16)';
     }
 
     /**

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -791,7 +791,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add `foo` char(36) not null', $statements[0]);
+        $this->assertEquals('alter table `users` add `foo` binary(16) not null', $statements[0]);
     }
 
     public function testAddingIpAddress()


### PR DESCRIPTION
It's faster and takes up less space: http://mysqlserverteam.com/storing-uuid-values-in-mysql-tables/