### PR TITLE
[5.5] Added WithFaker testing trait

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -120,6 +120,10 @@ abstract class TestCase extends BaseTestCase
             $this->disableEventsForAllTests();
         }
 
+        if (isset($uses[WithFaker::class])) {
+            $this->setUpFaker();
+        }
+
         return $uses;
     }
 

--- a/src/Illuminate/Foundation/Testing/WithFaker.php
+++ b/src/Illuminate/Foundation/Testing/WithFaker.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Illuminate\Foundation\Testing;
+
+use Faker\Factory;
+use Faker\Generator;
+
+trait WithFaker
+{
+    /**
+     * Faker generator instance.
+     *
+     * @var \Faker\Generator
+     */
+    protected $faker;
+
+    /**
+     * Setup up faker generator instance.
+     *
+     * @return void
+     */
+    protected function setUpFaker()
+    {
+        $this->faker = $this->makeFaker();
+    }
+
+    /**
+     * Get a default faker generator instance or get a new one for given locale.
+     *
+     * @param  string  $locale
+     * @return \Faker\Generator
+     */
+    protected function faker(string $locale = null)
+    {
+        if (is_null($locale)) {
+            return $this->faker;
+        }
+
+        return $this->makeFaker($locale);
+    }
+
+    /**
+     * Set a new faker generator instance for given locale.
+     *
+     * @param  string  $locale
+     * @return void
+     */
+    protected function fakerSetLocale(string $locale)
+    {
+        $this->faker = $this->makeFaker($locale);
+    }
+
+    /**
+     * Make a faker generator instance for given or default locale.
+     *
+     * @param  string  $locale
+     * @return \Faker\Generator
+     */
+    protected function makeFaker(string $locale = null)
+    {
+        if (is_null($locale)) {
+            $locale = Factory::DEFAULT_LOCALE;
+        }
+
+        return Factory::create($locale);
+    }
+}


### PR DESCRIPTION
This PR contains a small helper trait for your tests: WithFaker.

WithFaker trait adds a faker instance to your test class, that helps you generate any fake data in your tests in manner like in an example below.

This trait is optional, of course. You can pull it in tests, where you plan to generate a bunch of dummy data (to fake user input or so), especially when this data has a variety of locales.

Sticking with this approach is more convenient than instantiating a faker object manually in each test, as well as doing the same thing in setUp method.

```php
namespace Tests\Unit;

use Tests\TestCase;
use Illuminate\Foundation\Testing\WithFaker;
use Illuminate\Foundation\Testing\RefreshDatabase;

class ExampleTest extends TestCase
{
    use WithFaker,
        RefreshDatabase;

    /**
     * With faker test example.
     *
     * @return void
     */
    public function testBasicTest()
    {
        // Generate value of a default locale ('en_US').
        $americanName = $this->faker()->name;

        // Generate value of a specified locale.
        $russianName = $this->faker('ru_RU')->name;

        // Get the default faker instance for a given locale (for manual use in test).
        $faker = $this->faker();
        $faker = $this->faker('ru_RU');

        // Or access faker instance directly via a class property.
        $this->faker->url;
    }
}
```
