### PR TITLE
[5.5] Ability to specify max jobs for worker to run

### DIFF
--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -28,7 +28,8 @@ class WorkCommand extends Command
                             {--memory=128 : The memory limit in megabytes}
                             {--sleep=3 : Number of seconds to sleep when no job is available}
                             {--timeout=60 : The number of seconds a child process can run}
-                            {--tries=0 : Number of times to attempt a job before logging it failed}';
+                            {--tries=0 : Number of times to attempt a job before logging it failed}
+                            {--jobs=0 : The maximum number of jobs to run}';
 
     /**
      * The console command description.
@@ -112,7 +113,8 @@ class WorkCommand extends Command
         return new WorkerOptions(
             $this->option('delay'), $this->option('memory'),
             $this->option('timeout'), $this->option('sleep'),
-            $this->option('tries'), $this->option('force')
+            $this->option('tries'), $this->option('jobs'),
+            $this->option('force')
         );
     }
 

--- a/src/Illuminate/Queue/ListenerOptions.php
+++ b/src/Illuminate/Queue/ListenerOptions.php
@@ -27,6 +27,6 @@ class ListenerOptions extends WorkerOptions
     {
         $this->environment = $environment;
 
-        parent::__construct($delay, $memory, $timeout, $sleep, $maxTries, $force);
+        parent::__construct($delay, $memory, $timeout, $sleep, $maxTries, 0, $force);
     }
 }

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -518,7 +518,7 @@ class Worker
      */
     protected function hasRunEnoughJobs()
     {
-        return $this->options->jobs > 0 ? $this->jobs >= $this->options->jobs : false;
+        return $this->options->maxJobs > 0 ? $this->jobs >= $this->options->maxJobs : false;
     }
 
     /**

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -58,6 +58,13 @@ class Worker
     public $paused = false;
 
     /**
+     * The number of jobs run so far.
+     *
+     * @var int
+     */
+    public $jobs = 0;
+
+    /**
      * Create a new queue worker.
      *
      * @param  \Illuminate\Queue\QueueManager  $manager
@@ -111,6 +118,7 @@ class Worker
             // fire off this job for processing. Otherwise, we will need to sleep the
             // worker so no more jobs are processed until they should be processed.
             if ($job) {
+                $this->jobs++;
                 $this->runJob($job, $connectionName, $options);
             } else {
                 $this->sleep($options->sleep);
@@ -192,6 +200,7 @@ class Worker
      *
      * @param  \Illuminate\Queue\WorkerOptions  $options
      * @param  int  $lastRestart
+     * @return void
      */
     protected function stopIfNecessary(WorkerOptions $options, $lastRestart)
     {
@@ -499,7 +508,17 @@ class Worker
      */
     protected function queueShouldRestart($lastRestart)
     {
-        return $this->getTimestampOfLastQueueRestart() != $lastRestart;
+        return $this->hasRunEnoughJobs() || $this->getTimestampOfLastQueueRestart() != $lastRestart;
+    }
+
+    /**
+     * Determine if the queue worker has run enough jobs.
+     *
+     * @return bool
+     */
+    protected function hasRunEnoughJobs()
+    {
+        return $this->options->jobs > 0 ? $this->jobs >= $this->options->jobs : false;
     }
 
     /**

--- a/src/Illuminate/Queue/WorkerOptions.php
+++ b/src/Illuminate/Queue/WorkerOptions.php
@@ -72,6 +72,7 @@ class WorkerOptions
         $this->force = $force;
         $this->memory = $memory;
         $this->timeout = $timeout;
+        $this->maxJobs = $maxJobs;
         $this->maxTries = $maxTries;
     }
 }

--- a/src/Illuminate/Queue/WorkerOptions.php
+++ b/src/Illuminate/Queue/WorkerOptions.php
@@ -40,6 +40,13 @@ class WorkerOptions
     public $maxTries;
 
     /**
+     * The maximum number of jobs to run.
+     *
+     * @var int
+     */
+    public $maxJobs;
+
+    /**
      * Indicates if the worker should run in maintenance mode.
      *
      * @var bool
@@ -54,10 +61,11 @@ class WorkerOptions
      * @param  int  $timeout
      * @param  int  $sleep
      * @param  int  $maxTries
+     * @param  int  $maxJobs
      * @param  bool  $force
      * @return void
      */
-    public function __construct($delay = 0, $memory = 128, $timeout = 60, $sleep = 3, $maxTries = 0, $force = false)
+    public function __construct($delay = 0, $memory = 128, $timeout = 60, $sleep = 3, $maxTries = 0, $maxJobs = 0, $force = false)
     {
         $this->delay = $delay;
         $this->sleep = $sleep;


### PR DESCRIPTION
If we have `php artisan queue:work --jobs=1`, then the queue worker will exit after running it's first job. This is useful if you want to restart your worker after each job, but don't want it to restart when it checks for new jobs, like the `queue:listen` command. Example use case is where jobs are very expensive and long running.

In the interest of generality, we can set this parameter to any integer, so maybe you want to run at most 100 jobs before restarting, or maybe you don't want to restart like that, and so the default of 0 will retain the current behaviour.