### PR TITLE
[5.6] Use blob type for UUIDs in SQLite grammar

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -637,7 +637,7 @@ class SQLiteGrammar extends Grammar
      */
     protected function typeUuid(Fluent $column)
     {
-        return 'binary(16)';
+        return 'blob(16)';
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -637,7 +637,7 @@ class SQLiteGrammar extends Grammar
      */
     protected function typeUuid(Fluent $column)
     {
-        return 'varchar';
+        return 'binary(16)';
     }
 
     /**

--- a/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
@@ -575,7 +575,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "foo" binary(16) not null', $statements[0]);
+        $this->assertEquals('alter table "users" add column "foo" blob(16) not null', $statements[0]);
     }
 
     public function testAddingIpAddress()

--- a/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
@@ -575,7 +575,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "foo" varchar not null', $statements[0]);
+        $this->assertEquals('alter table "users" add column "foo" binary(16) not null', $statements[0]);
     }
 
     public function testAddingIpAddress()


### PR DESCRIPTION
This change related to #22279 and internal discussion https://github.com/laravel/internals/issues/350

It PR with MySQL schema changes will be accepted I propose to make changes to SQLite as well.

Old behavior could be achieved by using: `$table->string('uuid')`