### PR TITLE
[5.5] Add unique values count to collections

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1520,6 +1520,16 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
+     * Group the collection by values with corresponding frequency.
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    public function uniqueCountMap()
+    {
+        return new self(array_count_values($this->items));
+    }
+
+    /**
      * Reset the keys on the underlying array.
      *
      * @return static

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -733,6 +733,25 @@ class SupportCollectionTest extends TestCase
         })->all());
     }
 
+    public function testUniqueCountMap()
+    {
+        $c = new Collection([
+            'often used',
+            'less often used',
+            'often used',
+            'used once',
+            'often used',
+            'often used',
+            'less often used',
+        ]);
+
+        $this->assertEquals([
+            'often used' => 4,
+            'less often used' => 2,
+            'used once' => 1,
+        ], $c->uniqueCountMap()->all());
+    }
+
     public function testUniqueStrict()
     {
         $c = new Collection([


### PR DESCRIPTION
While refactoring a project in order to use collections for example, I was searching for something similar to **array_count_values in collections**, but surprisingly I didn't find anything.

An example use case (analyzing word usage):

`$collection = collect(['word', 'word2', 'word'])`
`dd($collection->uniqueCountMap())` would output something similar to `['word' => 2, 'word2' => 1]`.

Usually the order would be random, so an example with method chaining:
`dd($collection->uniqueCountMap()->sortByDesc(function ($count) { return $count; }))`

Pull request to 5.5 since it's fully backwards compatible, hope that's fine.

Have a great weekend!
