### PR TITLE
[5.5] Make seeders chainable

### DIFF
--- a/src/Illuminate/Database/Seeder.php
+++ b/src/Illuminate/Database/Seeder.php
@@ -28,7 +28,7 @@ abstract class Seeder
      *
      * @param  array|string  $class
      * @param  bool  $silent
-     * @return void
+     * @return $this
      */
     public function call($class, $silent = false)
     {
@@ -41,6 +41,8 @@ abstract class Seeder
 
             $this->resolve($class)->__invoke();
         }
+
+        return $this;
     }
 
     /**


### PR DESCRIPTION
Right now you must call seeders in `DatabaseSeeder` like this:

```php
$this->call(SeederA::class);
$this->call(SeederB::class);
$this->call(SeederC::class);
```

The changes in this PR will enable to do the above like this

```php
$this
   ->call(SeederA::class);
   ->call(SeederB::class);
   ->call(SeederC::class);
```


