### PR TITLE
[5.6] Allow notification routing to depend on notification being sent

### DIFF
--- a/CHANGELOG-5.5.md
+++ b/CHANGELOG-5.5.md
@@ -1,5 +1,22 @@
 # Release Notes for 5.5.x
 
+## [Unreleased]
+
+### Added
+- Added a `Collection::firstWhere()` method ([#22261](https://github.com/laravel/framework/pull/22261), [#22264](https://github.com/laravel/framework/pull/22264))
+- Added several accessors to `BelongsToMany` ([f09ea98](https://github.com/laravel/framework/commit/f09ea98bc814c708215896dad702d715923f3bc3), [cbe8123](https://github.com/laravel/framework/commit/cbe8123a479e81779cd85251eb4a5cf861e93ea3), [3bcf9d1](https://github.com/laravel/framework/commit/3bcf9d1d67ca3f288270e910898c77334322128a))
+
+### Changed
+- Pass test value to `Collection::when()` callbacks ([#22224](https://github.com/laravel/framework/pull/22224))
+- Support worker sleep time of less than 1s ([#22246](https://github.com/laravel/framework/pull/22246), [#22255](https://github.com/laravel/framework/pull/22255))
+- Detect persistent connection resets ([#22277](https://github.com/laravel/framework/pull/22277))
+
+### Fixed
+- Fixed negative comparison to objects in `Collection::where()` ([#22256](https://github.com/laravel/framework/pull/22256))
+- Fixed integer validation using `distinct:ignore_case` ([#22235](https://github.com/laravel/framework/pull/22235))
+- Fixes building nested JSON accessors in `MySqlGrammar` ([#22254](https://github.com/laravel/framework/pull/22254))
+
+
 ## v5.5.22 (2017-11-27)
 
 ### Added

--- a/src/Illuminate/Notifications/Channels/DatabaseChannel.php
+++ b/src/Illuminate/Notifications/Channels/DatabaseChannel.php
@@ -16,7 +16,7 @@ class DatabaseChannel
      */
     public function send($notifiable, Notification $notification)
     {
-        return $notifiable->routeNotificationFor('database')->create([
+        return $notifiable->routeNotificationFor('database', $notification)->create([
             'id' => $notification->id,
             'type' => get_class($notification),
             'data' => $this->getData($notifiable, $notification),

--- a/src/Illuminate/Notifications/Channels/MailChannel.php
+++ b/src/Illuminate/Notifications/Channels/MailChannel.php
@@ -109,7 +109,7 @@ class MailChannel
      */
     protected function buildMessage($mailMessage, $notifiable, $notification, $message)
     {
-        $this->addressMessage($mailMessage, $notifiable, $message);
+        $this->addressMessage($mailMessage, $notifiable, $message, $notification);
 
         $mailMessage->subject($message->subject ?: Str::title(
             Str::snake(class_basename($notification), ' ')
@@ -128,13 +128,14 @@ class MailChannel
      * @param  \Illuminate\Mail\Message  $mailMessage
      * @param  mixed  $notifiable
      * @param  \Illuminate\Notifications\Messages\MailMessage  $message
+     * @param  \Illuminate\Notifications\Notification  $notification
      * @return void
      */
-    protected function addressMessage($mailMessage, $notifiable, $message)
+    protected function addressMessage($mailMessage, $notifiable, $message, $notification)
     {
         $this->addSender($mailMessage, $message);
 
-        $mailMessage->to($this->getRecipients($notifiable, $message));
+        $mailMessage->to($this->getRecipients($notifiable, $message, $notification));
 
         if ($message->cc) {
             $mailMessage->cc($message->cc[0], Arr::get($message->cc, 1));
@@ -168,11 +169,12 @@ class MailChannel
      *
      * @param  mixed  $notifiable
      * @param  \Illuminate\Notifications\Messages\MailMessage  $message
+     * @param  \Illuminate\Notifications\Notification  $notification
      * @return mixed
      */
-    protected function getRecipients($notifiable, $message)
+    protected function getRecipients($notifiable, $message, $notification)
     {
-        if (is_string($recipients = $notifiable->routeNotificationFor('mail'))) {
+        if (is_string($recipients = $notifiable->routeNotificationFor('mail', $notification))) {
             $recipients = [$recipients];
         }
 

--- a/src/Illuminate/Notifications/Channels/MailChannel.php
+++ b/src/Illuminate/Notifications/Channels/MailChannel.php
@@ -49,7 +49,7 @@ class MailChannel
     {
         $message = $notification->toMail($notifiable);
 
-        if (! $notifiable->routeNotificationFor('mail') &&
+        if (! $notifiable->routeNotificationFor('mail', $notification) &&
             ! $message instanceof Mailable) {
             return;
         }

--- a/src/Illuminate/Notifications/Channels/NexmoSmsChannel.php
+++ b/src/Illuminate/Notifications/Channels/NexmoSmsChannel.php
@@ -44,7 +44,7 @@ class NexmoSmsChannel
      */
     public function send($notifiable, Notification $notification)
     {
-        if (! $to = $notifiable->routeNotificationFor('nexmo')) {
+        if (! $to = $notifiable->routeNotificationFor('nexmo', $notification)) {
             return;
         }
 

--- a/src/Illuminate/Notifications/Channels/SlackWebhookChannel.php
+++ b/src/Illuminate/Notifications/Channels/SlackWebhookChannel.php
@@ -37,7 +37,7 @@ class SlackWebhookChannel
      */
     public function send($notifiable, Notification $notification)
     {
-        if (! $url = $notifiable->routeNotificationFor('slack')) {
+        if (! $url = $notifiable->routeNotificationFor('slack', $notification)) {
             return;
         }
 

--- a/src/Illuminate/Notifications/RoutesNotifications.php
+++ b/src/Illuminate/Notifications/RoutesNotifications.php
@@ -34,9 +34,10 @@ trait RoutesNotifications
      * Get the notification routing information for the given driver.
      *
      * @param  string  $driver
+     * @param  \Illuminate\Notifications\Notification|null  $notification
      * @return mixed
      */
-    public function routeNotificationFor($driver)
+    public function routeNotificationFor($driver, $notification = null)
     {
         if (method_exists($this, $method = 'routeNotificationFor'.Str::studly($driver))) {
             return $this->{$method}();

--- a/src/Illuminate/Notifications/RoutesNotifications.php
+++ b/src/Illuminate/Notifications/RoutesNotifications.php
@@ -40,7 +40,7 @@ trait RoutesNotifications
     public function routeNotificationFor($driver, $notification = null)
     {
         if (method_exists($this, $method = 'routeNotificationFor'.Str::studly($driver))) {
-            return $this->{$method}();
+            return $this->{$method}($notification);
         }
 
         switch ($driver) {


### PR DESCRIPTION
This PR makes notification routing a bit more flexible by passing the notification to the `routeNotificationForXXX`

If this would be accepted, this would become possible:

```php
// on a Notifiable

public function routeNotificationForSlack($notification)
{
    if ($notification instanceof MySpecialSnowflakeNotification) {
        return $this->alternative_slack_webhook;
    }
    return $this->slack_webhook;
}
```

Didn't yet figure out how the new behaviour can be tested properly.