### PR TITLE
[5.6] Another blade helper @dd()

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -12,7 +12,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
         Concerns\CompilesComponents,
         Concerns\CompilesConditionals,
         Concerns\CompilesEchos,
-        Concerns\CompilesFormHelpers,
+        Concerns\CompilesHelpers,
         Concerns\CompilesIncludes,
         Concerns\CompilesInjections,
         Concerns\CompilesJson,

--- a/src/Illuminate/View/Compilers/Concerns/CompilesHelpers.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesHelpers.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\View\Compilers\Concerns;
 
-trait CompilesFormHelpers
+trait CompilesHelpers
 {
     /**
      * Compile the CSRF statements into valid PHP.
@@ -23,5 +23,16 @@ trait CompilesFormHelpers
     protected function compileMethod($method)
     {
         return "<?php echo method_field{$method}; ?>";
+    }
+
+    /*
+     * Compile the dd statements into valid PHP.
+     *
+     * @param  string  $args
+     * @return string
+     */
+    protected function compileDd($args)
+    {
+        return "<?php dd{$args}; ?>";
     }
 }

--- a/src/Illuminate/View/Compilers/Concerns/CompilesHelpers.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesHelpers.php
@@ -15,6 +15,17 @@ trait CompilesHelpers
     }
 
     /*
+     * Compile the "dd" statements into valid PHP.
+     *
+     * @param  string  $arguments
+     * @return string
+     */
+    protected function compileDd($arguments)
+    {
+        return "<?php dd{$arguments}; ?>";
+    }
+
+    /*
      * Compile the method statements into valid PHP.
      *
      * @param  string  $method
@@ -23,16 +34,5 @@ trait CompilesHelpers
     protected function compileMethod($method)
     {
         return "<?php echo method_field{$method}; ?>";
-    }
-
-    /*
-     * Compile the dd statements into valid PHP.
-     *
-     * @param  string  $args
-     * @return string
-     */
-    protected function compileDd($args)
-    {
-        return "<?php dd{$args}; ?>";
     }
 }

--- a/tests/View/Blade/BladeHelpersTest.php
+++ b/tests/View/Blade/BladeHelpersTest.php
@@ -2,11 +2,13 @@
 
 namespace Illuminate\Tests\View\Blade;
 
-class BladeFormHelpersTest extends AbstractBladeTestCase
+class BladeHelpersTest extends AbstractBladeTestCase
 {
     public function testEchosAreCompiled()
     {
         $this->assertEquals('<?php echo csrf_field(); ?>', $this->compiler->compileString('@csrf'));
         $this->assertEquals('<?php echo method_field(\'patch\'); ?>', $this->compiler->compileString("@method('patch')"));
+        $this->assertEquals('<?php dd($var1); ?>', $this->compiler->compileString('@dd($var1)'));
+        $this->assertEquals('<?php dd($var1, $var2); ?>', $this->compiler->compileString('@dd($var1, $var2)'));
     }
 }


### PR DESCRIPTION
Following on from `@csrf` and `@method` blade helpers - the other one I find myself wanting is `@dd`.

If you've ever had to debug a silly view issue, you might have done `{{ dd($var) }}` in the past to track it down.

Now you can just do `@dd($var)` which is much quicker and easier IMO. Can also do `@dd($var1, $var2)` etc.