### PR TITLE
[5.6] Yet another blade helper @dump

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -12,7 +12,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
         Concerns\CompilesComponents,
         Concerns\CompilesConditionals,
         Concerns\CompilesEchos,
-        Concerns\CompilesFormHelpers,
+        Concerns\CompilesHelpers,
         Concerns\CompilesIncludes,
         Concerns\CompilesInjections,
         Concerns\CompilesJson,

--- a/src/Illuminate/View/Compilers/Concerns/CompilesHelpers.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesHelpers.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\View\Compilers\Concerns;
 
-trait CompilesFormHelpers
+trait CompilesHelpers
 {
     /**
      * Compile the CSRF statements into valid PHP.
@@ -23,5 +23,16 @@ trait CompilesFormHelpers
     protected function compileMethod($method)
     {
         return "<?php echo method_field{$method}; ?>";
+    }
+
+    /*
+     * Compile the dump helper statements into valid PHP.
+     *
+     * @param  string  $args
+     * @return string
+     */
+    protected function compileDump($args)
+    {
+        return "<?php dump{$args}; ?>";
     }
 }

--- a/tests/View/Blade/BladeHelpersTest.php
+++ b/tests/View/Blade/BladeHelpersTest.php
@@ -2,11 +2,17 @@
 
 namespace Illuminate\Tests\View\Blade;
 
-class BladeFormHelpersTest extends AbstractBladeTestCase
+class BladeHelpersTest extends AbstractBladeTestCase
 {
     public function testEchosAreCompiled()
     {
         $this->assertEquals('<?php echo csrf_field(); ?>', $this->compiler->compileString('@csrf'));
         $this->assertEquals('<?php echo method_field(\'patch\'); ?>', $this->compiler->compileString("@method('patch')"));
+    }
+
+    public function testDumpStatementsAreCompiled()
+    {
+        $this->assertEquals('<?php dump($foo); ?>', $this->compiler->compileString('@dump($foo)'));
+        $this->assertEquals('<?php dump($foo, $bar); ?>', $this->compiler->compileString('@dump($foo, $bar)'));
     }
 }


### PR DESCRIPTION
Why don't we also have a `@dump` helper along with `@dd` in our blade views? ;)

Example:

```php
// welcome.blade.php
...

<div class="title m-b-md">
    Laravel
</div>

@dump(42, 'foobar', new \App\User)

```
It simply passes all given arguments to `dump` function and then prints the output. 

No more old school dumping like so `{{ dump() }}`. 
