### PR TITLE
[5.6] Fix SQLite delete for complex delete statements

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Database\Query\Grammars;
 
+use Illuminate\Support\Arr;
 use Illuminate\Database\Query\Builder;
 
 class SQLiteGrammar extends Grammar

--- a/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
@@ -175,7 +175,6 @@ class SQLiteGrammar extends Grammar
         return "insert into $table ($names) select ".implode(' union all select ', $columns);
     }
 
-
     /**
      * Compile a delete statement into SQL.
      *
@@ -191,9 +190,7 @@ class SQLiteGrammar extends Grammar
             // we use it in select sub-query and in delete where-in statement.
             $selectSql = parent::compileSelect($query->select("{$query->from}.rowid"));
 
-            return trim(
-                "delete from {$this->wrapTable($query->from)} where {$this->wrap('rowid')} in ({$selectSql})"
-            );
+            return "delete from {$this->wrapTable($query->from)} where {$this->wrap('rowid')} in ({$selectSql})";
         }
 
         $wheres = is_array($query->wheres) ? $this->compileWheres($query) : '';

--- a/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
@@ -184,11 +184,11 @@ class SQLiteGrammar extends Grammar
      */
     public function compileDelete(Builder $query)
     {
-        // SQLite delete statment doesn't fully support complex keywords like joins ..
-        // We use select statment as a subquery to overcome this delimma.
+        // SQLite delete statement doesn't fully support complex keywords like joins ..
+        // We use select statement as a sub-query to overcome this dilemma.
         if (isset($query->joins) || isset($query->limit)) {
             // Since rowid is common column between all SQLite tables,
-            // we use it in select subquery and in delete where-in statment.
+            // we use it in select sub-query and in delete where-in statement.
             $selectSql = parent::compileSelect($query->select("{$query->from}.rowid"));
 
             return trim(

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1578,6 +1578,12 @@ class DatabaseQueryBuilderTest extends TestCase
         $result = $builder->from('users')->delete(1);
         $this->assertEquals(1, $result);
 
+        $builder = $this->getSqliteBuilder();
+        $builder->getConnection()->shouldReceive('delete')->once()->with('delete from "users" where "rowid" in (select "users"."rowid" from "users" where "email" = ? order by "id" asc limit 1)', ['foo'])->andReturn(1);
+        $result = $builder->from('users')->where('email', '=', 'foo')->orderBy('id')->take(1)->delete();
+        $this->assertEquals(1, $result);
+
+
         $builder = $this->getMySqlBuilder();
         $builder->getConnection()->shouldReceive('delete')->once()->with('delete from `users` where `email` = ? order by `id` asc limit 1', ['foo'])->andReturn(1);
         $result = $builder->from('users')->where('email', '=', 'foo')->orderBy('id')->take(1)->delete();
@@ -1591,6 +1597,11 @@ class DatabaseQueryBuilderTest extends TestCase
 
     public function testDeleteWithJoinMethod()
     {
+        $builder = $this->getSqliteBuilder();
+        $builder->getConnection()->shouldReceive('delete')->once()->with('delete from "users" where "rowid" in (select "users"."rowid" from "users" inner join "contacts" on "users"."id" = "contacts"."id" where "users"."email" = ? order by "users"."id" asc limit 1)', ['foo'])->andReturn(1);
+        $result = $builder->from('users')->join('contacts', 'users.id', '=', 'contacts.id')->where('users.email', '=', 'foo')->orderBy('users.id')->limit(1)->delete();
+        $this->assertEquals(1, $result);
+
         $builder = $this->getMySqlBuilder();
         $builder->getConnection()->shouldReceive('delete')->once()->with('delete `users` from `users` inner join `contacts` on `users`.`id` = `contacts`.`id` where `email` = ?', ['foo'])->andReturn(1);
         $result = $builder->from('users')->join('contacts', 'users.id', '=', 'contacts.id')->where('email', '=', 'foo')->orderBy('id')->limit(1)->delete();

--- a/tests/Integration/Database/EloquentDeleteTest.php
+++ b/tests/Integration/Database/EloquentDeleteTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database;
+
+use Orchestra\Testbench\TestCase;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * @group integration
+ */
+class EloquentDeleteTest extends TestCase
+{
+    protected function getEnvironmentSetUp($app)
+    {
+        $app['config']->set('app.debug', 'true');
+
+        $app['config']->set('database.default', 'testbench');
+
+        $app['config']->set('database.connections.testbench', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+        ]);
+    }
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        Schema::create('posts', function ($table) {
+            $table->increments('id');
+            $table->string('title')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::create('comments', function ($table) {
+            $table->increments('id');
+            $table->string('body')->nullable();
+            $table->integer('post_id');
+            $table->timestamps();
+        });
+    }
+
+    public function testOnlyDeleteWhatGiven()
+    {
+        for($i = 1; $i <= 10; $i++) {
+            Comment::create([
+                'post_id' => Post::create()->id
+            ]);
+        }
+        
+        Post::latest('id')->limit(1)->delete();
+        $this->assertEquals(9, Post::all()->count());
+
+        Post::join('comments', 'comments.post_id', '=', 'posts.id')->where('posts.id', '>', 1)->orderBy('posts.id')->limit(1)->delete();
+        $this->assertEquals(8, Post::all()->count());
+    }
+}
+
+class Post extends Model
+{
+    public $table = 'posts';
+}
+
+class Comment extends Model
+{
+    public $table = 'comments';
+    protected $fillable = ['post_id'];
+}


### PR DESCRIPTION

Current SQLite delete implementation lack the support for complex statement like joins, or limits. This may lead to serious loss of data.

Current approach of SQLite delete: 

`> App\Post::latest('id')->limit(1)->delete();`
`=> 48 (deleted rows)`

`=> "query" => "delete from "posts""`

new approach:

`> App\Post::latest('id')->limit(1)->delete();`
`=> 1 (deleted rows)`

`=>  "query" => "delete from "posts" where "rowid" in (select "posts"."rowid" from "posts" order by "id" desc limit 1)"`


Also, this fixes the https://github.com/laravel/framework/pull/22239 for SQLite.