### PR TITLE
[5.5] Add even & odd to loop

### DIFF
--- a/src/Illuminate/View/Concerns/ManagesLoops.php
+++ b/src/Illuminate/View/Concerns/ManagesLoops.php
@@ -35,6 +35,8 @@ trait ManagesLoops
             'last' => isset($length) ? $length == 1 : null,
             'depth' => count($this->loopsStack) + 1,
             'parent' => $parent ? (object) $parent : null,
+            'even' => ! (bool) ($iteration % 2),
+            'odd' => (bool) ($iteration % 2),
         ];
     }
 


### PR DESCRIPTION
Adds `even` & `odd` properties to the `$loop` variable in views.

Wanted to add tests, but don't think `$loop` is tested anywhere? Will update PR if necessary.