### PR TITLE
key:generate fixes

### DIFF
--- a/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
+++ b/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
@@ -90,22 +90,22 @@ class KeyGenerateCommand extends Command
      */
     protected function writeNewEnvironmentFileWith($key)
     {
-        file_put_contents($this->laravel->environmentFilePath(), preg_replace(
-            $this->keyReplacementPattern(),
+        file_put_contents($this->laravel->environmentFilePath(), str_replace(
+            $this->keyReplacementString(),
             'APP_KEY='.$key,
             file_get_contents($this->laravel->environmentFilePath())
         ));
     }
 
     /**
-     * Get a regex pattern that will match env APP_KEY with any random key.
+     * Get a string that will match env APP_KEY with the current key.
      *
      * @return string
      */
-    protected function keyReplacementPattern()
+    protected function keyReplacementString()
     {
-        $escaped = preg_quote('='.$this->laravel['config']['app.key'], '/');
+        $key = $this->laravel['config']['app.key'];
 
-        return "/^APP_KEY{$escaped}/m";
+        return "APP_KEY=$key";
     }
 }

--- a/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
+++ b/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
@@ -77,24 +77,31 @@ class KeyGenerateCommand extends Command
             return false;
         }
 
-        $this->writeNewEnvironmentFileWith($key);
-
-        return true;
+        return $this->writeNewEnvironmentFileWith($key);
     }
 
     /**
      * Write a new environment file with the given key.
      *
      * @param  string  $key
-     * @return void
+     * @return bool
      */
     protected function writeNewEnvironmentFileWith($key)
     {
+        $count = 0;
         file_put_contents($this->laravel->environmentFilePath(), str_replace(
             $this->keyReplacementString(),
             'APP_KEY='.$key,
-            file_get_contents($this->laravel->environmentFilePath())
+            file_get_contents($this->laravel->environmentFilePath()),
+            $count
         ));
+        if($count > 1){
+            $this->warn("APP_KEY replaced $count times");
+        }
+        if($count == 0){
+            $this->warn("APP_KEY not found in .env");
+        }
+        return $count > 0;
     }
 
     /**


### PR DESCRIPTION
This PR cleans up a few things regarding the `key:generate` command:

1. Key replacement in .env is done by string replacement rather than regex, which broke in some cases.
2. No successful setting of the key is claimed if this has not happened. If the number of keys replaced is not 1, a warning is emitted about this. (this addresses issue #20719)

This PR is based on master. If preferred, I will rebase it to 5.5.