### PR TITLE
[5.5] Flysystem caching

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -114,6 +114,7 @@
         "laravel/tinker": "Required to use the tinker console command (~1.0).",
         "league/flysystem-aws-s3-v3": "Required to use the Flysystem S3 driver (~1.0).",
         "league/flysystem-rackspace": "Required to use the Flysystem Rackspace driver (~1.0).",
+        "league/flysystem-cached-adapter": "Required to use Flysystem caching (~1.0).",
         "nexmo/client": "Required to use the Nexmo transport (~1.0).",
         "pda/pheanstalk": "Required to use the beanstalk queue driver (~3.0).",
         "predis/predis": "Required to use the redis cache and queue drivers (~1.0).",

--- a/src/Illuminate/Filesystem/Cache.php
+++ b/src/Illuminate/Filesystem/Cache.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Illuminate\Filesystem;
+
+use Illuminate\Contracts\Cache\Repository;
+use League\Flysystem\Cached\Storage\AbstractCache;
+
+class Cache extends AbstractCache
+{
+    /**
+     * The cache repository instance.
+     *
+     * @var \Illuminate\Contracts\Cache\Repository
+     */
+    protected $repo;
+
+    /**
+     * The cache key.
+     *
+     * @var string
+     */
+    protected $key;
+
+    /**
+     * The cache expire in minutes.
+     *
+     * @var int
+     */
+    protected $expire;
+
+    /**
+     * Create a new cache instance.
+     *
+     * @param \Illuminate\Contracts\Cache\Repository $repo
+     * @param string                                 $key
+     * @param int|null                               $expire
+     */
+    public function __construct(Repository $repo, string $key = 'flysystem', int $expire = null)
+    {
+        $this->repo = $repo;
+        $this->key = $key;
+
+        if ($expire) {
+            $this->expire = (int) ceil($expire / 60);
+        }
+    }
+
+    /**
+     * Load the cache.
+     *
+     * @return void
+     */
+    public function load()
+    {
+        $contents = $this->repo->get($this->key);
+
+        if ($contents !== null) {
+            $this->setFromStorage($contents);
+        }
+    }
+
+    /**
+     * Store the cache.
+     *
+     * @return void
+     */
+    public function save()
+    {
+        $contents = $this->getForStorage();
+
+        if ($this->expire !== null) {
+            $this->repo->put($this->key, $contents, $this->expire);
+        } else {
+            $this->repo->forever($this->key, $contents);
+        }
+    }
+}

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -13,6 +13,7 @@ use League\Flysystem\AdapterInterface;
 use PHPUnit\Framework\Assert as PHPUnit;
 use League\Flysystem\FilesystemInterface;
 use League\Flysystem\AwsS3v3\AwsS3Adapter;
+use League\Flysystem\Cached\CachedAdapter;
 use League\Flysystem\FileNotFoundException;
 use League\Flysystem\Rackspace\RackspaceAdapter;
 use League\Flysystem\Adapter\Local as LocalAdapter;
@@ -372,6 +373,10 @@ class FilesystemAdapter implements FilesystemContract, CloudFilesystemContract
     {
         $adapter = $this->driver->getAdapter();
 
+        if ($adapter instanceof CachedAdapter) {
+            $adapter = $adapter->getAdapter();
+        }
+
         if (method_exists($adapter, 'getUrl')) {
             return $adapter->getUrl($path);
         } elseif ($adapter instanceof AwsS3Adapter) {
@@ -458,6 +463,10 @@ class FilesystemAdapter implements FilesystemContract, CloudFilesystemContract
     public function temporaryUrl($path, $expiration, array $options = [])
     {
         $adapter = $this->driver->getAdapter();
+
+        if ($adapter instanceof CachedAdapter) {
+            $adapter = $adapter->getAdapter();
+        }
 
         if (method_exists($adapter, 'getTemporaryUrl')) {
             return $adapter->getTemporaryUrl($path, $expiration, $options);

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -615,6 +615,20 @@ class FilesystemAdapter implements FilesystemContract, CloudFilesystemContract
     }
 
     /**
+     * Flush the Flysystem cache.
+     *
+     * @return void
+     */
+    public function flushCache()
+    {
+        $adapter = $this->driver->getAdapter();
+
+        if ($adapter instanceof CachedAdapter) {
+            $adapter->getCache()->flush();
+        }
+    }
+
+    /**
      * Filter directory contents by type.
      *
      * @param  array  $contents

--- a/src/Illuminate/Filesystem/FilesystemManager.php
+++ b/src/Illuminate/Filesystem/FilesystemManager.php
@@ -16,7 +16,6 @@ use League\Flysystem\Rackspace\RackspaceAdapter;
 use League\Flysystem\Adapter\Local as LocalAdapter;
 use League\Flysystem\AwsS3v3\AwsS3Adapter as S3Adapter;
 use League\Flysystem\Cached\Storage\Memory as MemoryStore;
-use League\Flysystem\Cached\Storage\Predis as PredisStore;
 use Illuminate\Contracts\Filesystem\Factory as FactoryContract;
 
 /**

--- a/src/Illuminate/Filesystem/FilesystemManager.php
+++ b/src/Illuminate/Filesystem/FilesystemManager.php
@@ -286,29 +286,10 @@ class FilesystemManager implements FactoryContract
             return new MemoryStore;
         }
 
-        $storeConfig = $this->app['config']['cache.stores.'.Arr::get($config, 'store')];
-
-        if (Arr::get($storeConfig, 'driver') === 'redis') {
-            return $this->createRedisCacheStore($config, $storeConfig);
-        }
-
-        throw new InvalidArgumentException("Cache driver [$driver] is not supported.");
-    }
-
-    /**
-     * Create a Redis cache store instance.
-     *
-     * @param  array  $cacheConfig
-     * @param  array  $storeConfig
-     * @return \League\Flysystem\Cached\CacheInterface
-     */
-    protected function createRedisCacheStore(array $cacheConfig, array $storeConfig)
-    {
-        $key = $cacheConfig['prefix']
-            ?? sprintf('%s:flysystem', $storeConfig['prefix'] ?? $this->app['config']['cache.prefix']);
-
-        return new PredisStore(
-            $this->app['redis.connection']->client(), $key, Arr::get($cacheConfig, 'expire')
+        return new Cache(
+            $this->app['cache']->store($config['store']),
+            Arr::get($config, 'prefix', 'flysystem'),
+            Arr::get($config, 'expire')
         );
     }
 

--- a/src/Illuminate/Filesystem/FilesystemManager.php
+++ b/src/Illuminate/Filesystem/FilesystemManager.php
@@ -304,7 +304,8 @@ class FilesystemManager implements FactoryContract
      */
     protected function createRedisCacheStore(array $cacheConfig, array $storeConfig)
     {
-        $key = sprintf('%s:flysystem', $storeConfig['prefix'] ?? $this->app['config']['cache.prefix']);
+        $key = $cacheConfig['prefix']
+            ?? sprintf('%s:flysystem', $storeConfig['prefix'] ?? $this->app['config']['cache.prefix']);
 
         return new PredisStore(
             $this->app['redis.connection']->client(), $key, Arr::get($cacheConfig, 'expire')


### PR DESCRIPTION
This PR adds support for [Flysystem caching](http://flysystem.thephpleague.com/caching/) without the need for a custom filesystem.

To enable it:

```
composer require league/flysystem-cached-adapter
```

Add a `cache` value to one of your existing disks in `config/filesystems.php`:

### [Memory](http://flysystem.thephpleague.com/caching/#memory-caching)

Simply add `'cache' => true` to add per-request caching:

``` php
's3' => [
    'driver' => 's3',
    'key' => env('AWS_ACCESS_KEY_ID'),
    'secret' => env('AWS_SECRET_ACCESS_KEY'),
    'region' => env('AWS_DEFAULT_REGION'),
    'bucket' => env('AWS_BUCKET'),
    'cache' => true,
],
```

### ~Redis (via [Predis](http://flysystem.thephpleague.com/caching/#predis-caching-setup))~ 

~To use Redis, you should point to a `redis`-driven store defined in `config/cache.php`:~

### Cache Stores

You can use any cache store defined in `config/cache.php` by referencing it's name.

``` php
's3' => [
    'driver' => 's3',
    'key' => env('AWS_ACCESS_KEY_ID'),
    'secret' => env('AWS_SECRET_ACCESS_KEY'),
    'region' => env('AWS_DEFAULT_REGION'),
    'bucket' => env('AWS_BUCKET'),
    'cache' => [
        'store' => 'redis',
        'expire' => 300,
        'prefix' => 'custom-cache-key-prefix',
    ]
],
```

The `prefix` is optional. If omitted, the prefix falls back to whatever is defined in `cache.php`.