### PR TITLE
[5.6] Added missing asterisk for compileAuth DocBlock (Closes #22309)

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
@@ -11,7 +11,7 @@ trait CompilesConditionals
      */
     protected $firstCaseInSwitch = true;
 
-    /*
+    /**
      * Compile the if-auth statements into valid PHP.
      *
      * @param  string|null  $guard


### PR DESCRIPTION
Simple documentation fix. Though I'm not sure where how to regenerate the docs or make a request to.