### PR TITLE
Check for numeric values in factory second parameter

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -479,7 +479,9 @@ if (! function_exists('factory')) {
 
         $arguments = func_get_args();
 
-        if (isset($arguments[1]) && is_string($arguments[1])) {
+        if (isset($arguments[1]) && is_numeric($arguments[1])) {
+            return $factory->of($arguments[0])->times($arguments[1]);
+        } elseif (isset($arguments[1]) && is_string($arguments[1])) {
             return $factory->of($arguments[0], $arguments[1])->times($arguments[2] ?? null);
         } elseif (isset($arguments[1])) {
             return $factory->of($arguments[0])->times($arguments[1]);


### PR DESCRIPTION
This will allow for things like the passing of a parameter from a console command option to be passed through cleanly to the factory method.

For instance,

`protected $signature = 'generate:data {--messages=0}`;

is currently not usable as 

```
public function handle() {
    $messages = $this->option('messages');
    if ($messages) {
        factory(Message::class, $messages)->create();
    }
}
```

because $messages gets passed through from the command line as a string "1" for instance.

This will first check if it is usable as a number, and if it is, then it will use that, otherwise fall back to using the old checks.