### PR TITLE
[5.5] Fix NullSessionDriver due to upstream changes

### DIFF
--- a/src/Illuminate/Session/NullSessionHandler.php
+++ b/src/Illuminate/Session/NullSessionHandler.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Illuminate\Session;
+
+use SessionHandlerInterface;
+
+class NullSessionHandler implements SessionHandlerInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function open($savePath, $sessionName)
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function close()
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function read($sessionId)
+    {
+        return '';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function write($sessionId, $data)
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function destroy($sessionId)
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function gc($lifetime)
+    {
+        return true;
+    }
+}

--- a/src/Illuminate/Session/SessionManager.php
+++ b/src/Illuminate/Session/SessionManager.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Session;
 
 use Illuminate\Support\Manager;
-use Symfony\Component\HttpFoundation\Session\Storage\Handler\NullSessionHandler;
 
 class SessionManager extends Manager
 {


### PR DESCRIPTION
This is an attempt to fix https://github.com/laravel/framework/issues/22302 that has started occuring due to upstream changes in the Symfony session (see the issue for a very good detailed explanation of the problem by @acarpio89).

The reason the changes only seems to affect the `NullSessionDriver` is because Laravel actually uses its own implementations of every other driver, and was only using the Symfony Null driver.

So this PR just creates our own Null driver, and we no longer rely on Symfony for it.

On a seperate issue - this is not picked up by *any* framework tests - because the tests all mock the session handler, and never try to actually create a session (from what I can see). I tried to create a failing test to capture this situation, but I cant work out how to do it inside a framework test?

Would be nice to add a test around this if someone can point me in the right direction.