### PR TITLE
[5.5] Redirect with Reflash

### DIFF
--- a/src/Illuminate/Http/RedirectResponse.php
+++ b/src/Illuminate/Http/RedirectResponse.php
@@ -81,6 +81,18 @@ class RedirectResponse extends BaseRedirectResponse
     }
 
     /**
+     * Reflash all of the session flash data along with this response.
+     *
+     * @return $this
+     */
+    public function withReflash()
+    {
+        $this->session->reflash();
+
+        return $this;
+    }
+
+    /**
      * Remove all uploaded files form the given input array.
      *
      * @param  array  $input

--- a/tests/Http/HttpRedirectResponseTest.php
+++ b/tests/Http/HttpRedirectResponseTest.php
@@ -46,6 +46,23 @@ class HttpRedirectResponseTest extends TestCase
         $this->assertEquals('bar', $cookies[0]->getValue());
     }
 
+    public function testWithReflashOnRedirect()
+    {
+        /**
+         * @var \Mockery\MockInterface|\Illuminate\Session\Store $session
+         */
+        $request = Request::create('/', 'GET', ['name' => 'Taylor', 'age' => 26]);
+        $response = new RedirectResponse('foo.bar');
+        $session = m::mock('Illuminate\Session\Store');
+
+        $response->setRequest($request);
+        $response->setSession($session);
+
+        $session->shouldReceive('reflash')->once();
+
+        $response->withReflash();
+    }
+
     public function testInputOnRedirect()
     {
         $response = new RedirectResponse('foo.bar');


### PR DESCRIPTION
Implementation of a shorthand to re-flash session data along with a response:

```php
return redirect('/')->withReflash();
```