### PR TITLE
flush() remove tagkey

### DIFF
--- a/src/Illuminate/Cache/TaggedCache.php
+++ b/src/Illuminate/Cache/TaggedCache.php
@@ -60,7 +60,7 @@ class TaggedCache extends Repository
      */
     public function flush()
     {
-        $this->tags->reset();
+        $this->store->forget($this->tags->tagKey($this->tags->getNames()));
     }
 
     /**


### PR DESCRIPTION
There is no need to keep tagkey after "flush()"

#22308 