### PR TITLE
Make updateTimestamps public

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php
@@ -34,7 +34,7 @@ trait HasTimestamps
      *
      * @return void
      */
-    protected function updateTimestamps()
+    public function updateTimestamps()
     {
         $time = $this->freshTimestamp();
 


### PR DESCRIPTION
Any chance we can make this method public? I get that you'd usually want to call `touch()` to update and save at the same time, but given that all the methods called by `updateTimestamps()` are public I don't know that there's much benefit in making it protected.

I'm using custom 'embeds' document relationships with [jenssegers/laravel-mongodb](https://github.com/jenssegers/laravel-mongodb) and would like to be able to update the timestamps of an embedded document when it gets associated with its parent.