### PR TITLE
[5.5] Optimization with SortedMiddleware.

### DIFF
--- a/src/Illuminate/Routing/SortedMiddleware.php
+++ b/src/Illuminate/Routing/SortedMiddleware.php
@@ -47,8 +47,8 @@ class SortedMiddleware extends Collection
 
             if (isset($priorityMap[$stripped])) {
                 $priorityIndex = $priorityMap[$stripped];
-                $prioritySortMap[$priorityIndex][]= $middleware;
-                $originalIndexes []= $index;
+                $prioritySortMap[$priorityIndex][] = $middleware;
+                $originalIndexes[] = $index;
 
                 // This middleware is in the priority map. If we have encountered another middleware
                 // that was also in the priority map and was at a lower priority than the current
@@ -63,7 +63,7 @@ class SortedMiddleware extends Collection
                 $lastPriorityIndex = $priorityIndex;
             }
         }
-        
+
         if (! $hasReverse) {
             return array_values(array_unique($middlewares, SORT_REGULAR));
         }

--- a/src/Illuminate/Routing/SortedMiddleware.php
+++ b/src/Illuminate/Routing/SortedMiddleware.php
@@ -33,7 +33,10 @@ class SortedMiddleware extends Collection
      */
     protected function sortMiddleware($priorityMap, $middlewares)
     {
-        $lastIndex = 0;
+        $hasReverse = false;
+        $priorityMap = array_flip($priorityMap);
+        $prioritySortMap = [];
+        $originalIndexes = [];
 
         foreach ($middlewares as $index => $middleware) {
             if (! is_string($middleware)) {
@@ -42,43 +45,40 @@ class SortedMiddleware extends Collection
 
             $stripped = head(explode(':', $middleware));
 
-            if (in_array($stripped, $priorityMap)) {
-                $priorityIndex = array_search($stripped, $priorityMap);
+            if (isset($priorityMap[$stripped])) {
+                $priorityIndex = $priorityMap[$stripped];
+                $prioritySortMap[$priorityIndex][]= $middleware;
+                $originalIndexes []= $index;
 
                 // This middleware is in the priority map. If we have encountered another middleware
                 // that was also in the priority map and was at a lower priority than the current
-                // middleware, we will move this middleware to be above the previous encounter.
+                // middleware, we will need sorting.
                 if (isset($lastPriorityIndex) && $priorityIndex < $lastPriorityIndex) {
-                    return $this->sortMiddleware(
-                        $priorityMap, array_values($this->moveMiddleware($middlewares, $index, $lastIndex))
-                    );
+                    $hasReverse = true;
                 }
 
                 // This middleware is in the priority map; but, this is the first middleware we have
                 // encountered from the map thus far. We'll save its current index plus its index
                 // from the priority map so we can compare against them on the next iterations.
-                $lastIndex = $index;
                 $lastPriorityIndex = $priorityIndex;
+            }
+        }
+        
+        if (! $hasReverse) {
+            return array_values(array_unique($middlewares, SORT_REGULAR));
+        }
+
+        // Sorting
+        ksort($prioritySortMap);
+
+        // Put middleware to the right place
+        $i = 0;
+        foreach ($prioritySortMap as $priorityMiddlewares) {
+            foreach ($priorityMiddlewares as $middleware) {
+                $middlewares[$originalIndexes[$i++]] = $middleware;
             }
         }
 
         return array_values(array_unique($middlewares, SORT_REGULAR));
-    }
-
-    /**
-     * Splice a middleware into a new position and remove the old entry.
-     *
-     * @param  array  $middlewares
-     * @param  int  $from
-     * @param  int  $to
-     * @return array
-     */
-    protected function moveMiddleware($middlewares, $from, $to)
-    {
-        array_splice($middlewares, $to, 0, $middlewares[$from]);
-
-        unset($middlewares[$from + 1]);
-
-        return $middlewares;
     }
 }

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -762,8 +762,8 @@ class RoutingRouteTest extends TestCase
         $this->assertEquals([
             Placeholder1::class,
             Authenticate::class,
-            SubstituteBindings::class,
             Placeholder2::class,
+            SubstituteBindings::class,
             Placeholder3::class,
         ], $router->gatherRouteMiddleware($route));
     }

--- a/tests/Routing/RoutingSortedMiddlewareTest.php
+++ b/tests/Routing/RoutingSortedMiddlewareTest.php
@@ -32,9 +32,9 @@ class RoutingSortedMiddlewareTest extends TestCase
         $expected = [
             'Something',
             'First:api',
+            'Otherthing',
             'First:foo,bar',
             'Second',
-            'Otherthing',
             'Third:foo',
             'Third',
         ];


### PR DESCRIPTION
We just need to change the index for middlewares defined in `$priorityMap`,  and could keep the index of other middlewares.

 There are two optimizations:
1 Using `isset()` instead of `in_array()`.
2 Calculating and putting middlewares to the right place without recursion.