### PR TITLE
[5.5] Payload statement at the end of the insert array of a job

### DIFF
--- a/src/Illuminate/Queue/DatabaseQueue.php
+++ b/src/Illuminate/Queue/DatabaseQueue.php
@@ -175,7 +175,7 @@ class DatabaseQueue extends Queue implements QueueContract
             'reserved_at' => null,
             'available_at' => $availableAt,
             'created_at' => $this->currentTime(),
-	    'payload' => $payload,
+            'payload' => $payload,
         ];
     }
 

--- a/src/Illuminate/Queue/DatabaseQueue.php
+++ b/src/Illuminate/Queue/DatabaseQueue.php
@@ -171,11 +171,11 @@ class DatabaseQueue extends Queue implements QueueContract
     {
         return [
             'queue' => $queue,
-            'payload' => $payload,
             'attempts' => $attempts,
             'reserved_at' => null,
             'available_at' => $availableAt,
             'created_at' => $this->currentTime(),
+	    'payload' => $payload,
         ];
     }
 


### PR DESCRIPTION
Rollback 7c8d3d04e51cace016474aea8a6ab9a8682f4ab8

It was opened an [issue](https://github.com/yajra/laravel-oci8/issues/170) in laravel-oci8 because of an exception thrown when inserting in the table jobs.

The issue was fixed on 7c8d3d04e51cace016474aea8a6ab9a8682f4ab8 but it was changed on a041fb5ec9fc775d1a3efb6b647604da2b02b866 for no reason. I created a new one and generated this pull request to solve the problem again.

> ORA-24816: Expanded non LONG bind data supplied after actual LONG or LOB column
> Cause: A Bind value of length potentially > 4000 bytes follows binding for LOB or LONG.
> Action: Re-order the binds so that the LONG bind or LOB binds are all at the end of the bind list.
> Like is mentioned above, to solve this is simply needed to put the clob column at the end of the insert statement.

Greetings

