### PR TITLE
[5.6] Return the collection iterator from query builder and relations

### DIFF
--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -158,4 +158,14 @@ trait BuildsQueries
             'items', 'perPage', 'currentPage', 'options'
         ));
     }
+
+    /**
+     * Execute the query and return the collection iterator
+     *
+     * @return \ArrayIterator|Traversable
+     */
+    public function getIterator()
+    {
+        return $this->get()->getIterator();
+    }
 }

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -15,7 +15,7 @@ use Illuminate\Database\Query\Builder as QueryBuilder;
 /**
  * @mixin \Illuminate\Database\Query\Builder
  */
-class Builder
+class Builder implements \IteratorAggregate
 {
     use BuildsQueries, Concerns\QueriesRelationships;
 

--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -13,7 +13,7 @@ use Illuminate\Database\Eloquent\Collection;
 /**
  * @mixin \Illuminate\Database\Eloquent\Builder
  */
-abstract class Relation
+abstract class Relation implements \IteratorAggregate
 {
     use Macroable {
         __call as macroCall;
@@ -349,6 +349,16 @@ abstract class Relation
         return array_key_exists($alias, self::$morphMap)
                         ? self::$morphMap[$alias]
                         : null;
+    }
+
+    /**
+     * Execute the query and return the collection iterator
+     *
+     * @return \ArrayIterator|\Traversable
+     */
+    public function getIterator()
+    {
+        return $this->get()->getIterator();
     }
 
     /**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -18,7 +18,7 @@ use Illuminate\Database\Query\Grammars\Grammar;
 use Illuminate\Database\Query\Processors\Processor;
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 
-class Builder
+class Builder implements \IteratorAggregate
 {
     use BuildsQueries, Macroable {
         __call as macroCall;

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -193,6 +193,24 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertEquals('abigailotwell@gmail.com', $models[1]->email);
     }
 
+    public function testQueryBuilderIsIterable()
+    {
+        $user = EloquentTestUser::firstOrCreate(['id' => 1, 'email' => 'taylorotwell@gmail.com']);
+
+        $user->posts()->create(['name' => 'First post']);
+        $user->posts()->create(['name' => 'Second post']);
+
+        foreach($user->posts() as $post){
+            $this->assertInstanceOf(Eloquent::class, $post);
+        }
+
+        $this->assertEquals(1, $user->posts()->where('name', 'LIKE', '%First%')->count());
+
+        foreach($user->posts()->where('name', 'LIKE', '%First%') as $post){
+            $this->assertInstanceOf(Eloquent::class, $post);
+        }
+    }
+
     public function testPaginatedModelCollectionRetrieval()
     {
         EloquentTestUser::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']);

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -200,13 +200,21 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $user->posts()->create(['name' => 'First post']);
         $user->posts()->create(['name' => 'Second post']);
 
-        foreach($user->posts() as $post){
+        $this->assertEquals(2, $user->posts()->where('name', 'LIKE', '%post%')->count());
+
+        foreach($user->posts()->where('name', 'LIKE', '%post%') as $post){
             $this->assertInstanceOf(Eloquent::class, $post);
         }
+    }
 
-        $this->assertEquals(1, $user->posts()->where('name', 'LIKE', '%First%')->count());
+    public function testRelationIsIterable()
+    {
+        $user = EloquentTestUser::firstOrCreate(['id' => 1, 'email' => 'taylorotwell@gmail.com']);
 
-        foreach($user->posts()->where('name', 'LIKE', '%First%') as $post){
+        $user->posts()->create(['name' => 'First post']);
+        $user->posts()->create(['name' => 'Second post']);
+
+        foreach($user->posts() as $post){
             $this->assertInstanceOf(Eloquent::class, $post);
         }
     }

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2347,6 +2347,13 @@ class DatabaseQueryBuilderTest extends TestCase
         ]), $result);
     }
 
+    public function testQueryBuilderReturnsIterator()
+    {
+        $builder = $this->getMockQueryBuilder();
+
+        $this->assertTrue(is_iterable($builder));
+    }
+
     protected function getBuilder()
     {
         $grammar = new \Illuminate\Database\Query\Grammars\Grammar;


### PR DESCRIPTION
I always forget to call `get()` to get the results of a query. Maybe because `all()`, `first()`, `find()` and similar methods already return a collection, or maybe because I'm just a noob :-) . Anyway, I'm not sure there is a reason for _not_ having this feature, but I always thought it would be cool to have an implicit `get()` when trying to iterate through a query or relation.  This PR allows you to do just that:

`foreach(User::someQueryScope() as $user){ ... }`

`foreach(User::posts() as $post){ ... }`
