### PR TITLE
[5.5] Add assertJsonModel and assertJsonModels to TestResponse

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -7,8 +7,10 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Support\Carbon;
 use Illuminate\Contracts\View\View;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Traits\Macroable;
 use PHPUnit\Framework\Assert as PHPUnit;
+use Illuminate\Database\Eloquent\Collection;
 
 /**
  * @mixin \Illuminate\Http\Response
@@ -350,6 +352,50 @@ class TestResponse
                 'within'.PHP_EOL.PHP_EOL.
                 "[{$actual}]."
             );
+        }
+
+        return $this;
+    }
+
+    /**
+     * Assert that the response contains the given Eloquent model.
+     *
+     * @param  Model  $model
+     * @return $this
+     */
+    public function assertJsonModel(Model $model)
+    {
+        $actual = json_encode(Arr::sortRecursive(
+            (array) $this->decodeResponseJson()
+        ));
+
+        $data = $model->toArray();
+
+        foreach (Arr::sortRecursive($data) as $key => $value) {
+            $expected = substr(json_encode([$key => $value]), 1, -1);
+
+            PHPUnit::assertTrue(
+                Str::contains($actual, $expected),
+                'Unable to find JSON fragment: '.PHP_EOL.PHP_EOL.
+                "[{$expected}]".PHP_EOL.PHP_EOL.
+                'within'.PHP_EOL.PHP_EOL.
+                "[{$actual}]."
+            );
+        }
+
+        return $this;
+    }
+
+    /**
+     * Assert that the response contains all of the given Eloquent models.
+     *
+     * @param  Collection  $models
+     * @return $this
+     */
+    public function assertJsonModels(Collection $models)
+    {
+        foreach ($models as $model) {
+            $this->assertJsonModel($model);
         }
 
         return $this;


### PR DESCRIPTION
A couple more test helpers related to Eloquent models in JSON responses.

# assertJsonModel

Asserts that the Json response contains the specified model.

## Example

I want to test that the category is in the Json response, but `assertJsonFragment` requires an array, so I have to call `toArray` on the model. Not a huge deal, but it adds just a little noise to the test IMO.

```
// the old way
    /** @test */
    public function it_can_get_a_single_category()
    {
        $category = create(Category::class);

        $this
            ->get(["categories.index", $category])
            ->response()
                ->assertStatus(200)
                ->assertJsonFragment($category->toArray());
    }

// the new way
    /** @test */
    public function it_can_get_a_single_category()
    {
        $category = create(Category::class);

        $this
            ->get(["categories.index", $category])
            ->response()
                ->assertStatus(200)
                ->assertJsonModel($category);
    }
```
Many might call that a marginal improvement, but the next example is even more drastic.

# assertJsonModels

Assert that the Json response has all of the specified models

## Example

I want to test that all of the categories are in the response. I have to grab each category and call `toArray`.

```
// the old way
    /** @test */
    public function it_can_get_a_listing_of_categories()
    {
        $categories = create(Category::class,3);

        $this
            ->get("categories.index")
            ->response()
                ->assertStatus(200)
                ->assertJsonCount(3)
                ->assertJsonFragment($categories[0]->toArray())
                ->assertJsonFragment($categories[1]->toArray())
                ->assertJsonFragment($categories[2]->toArray());
    }

// the new way
    /** @test */
    public function it_can_get_a_listing_of_categories()
    {
        $categories = create(Category::class,3);

        $this
            ->get("categories.index")
            ->response()
                ->assertStatus(200)
                ->assertJsonCount(3)
                ->assertJsonModels($categories);
    }
```

I know brevity is not always desirable (especially if clarity is at stake), but I think in this case it actually enhances the readability of the tests by reducing visual noise.