### PR TITLE
[5.6] fix SQLite hasColumn duplicated table prefix

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -41,7 +41,7 @@ class SQLiteGrammar extends Grammar
      */
     public function compileColumnListing($table)
     {
-        return 'pragma table_info('.$this->wrapTable(str_replace('.', '__', $table)).')';
+        return 'pragma table_info('.str_replace('.', '__', $table).')';
     }
 
     /**

--- a/tests/Database/DatabaseSchemaBuilderIntegrationTest.php
+++ b/tests/Database/DatabaseSchemaBuilderIntegrationTest.php
@@ -55,4 +55,16 @@ class DatabaseSchemaBuilderIntegrationTest extends TestCase
         $this->assertFalse($this->db->connection()->getSchemaBuilder()->hasTable('table1'));
         $this->assertFalse($this->db->connection()->getSchemaBuilder()->hasTable('table2'));
     }
+
+    public function testHasColumnWithTablePrefix()
+    {
+        $this->db->connection()->setTablePrefix('test_');
+        
+        $this->db->connection()->getSchemaBuilder()->create('table1', function ($table) {
+            $table->integer('id');
+            $table->string('name');
+        });
+
+        $this->assertTrue($this->db->connection()->getSchemaBuilder()->hasColumn('table1', 'name'));
+    }
 }


### PR DESCRIPTION

This PR fixes #18255

Current behavior: 
prefix: test_
table name: posts
result: test_test_posts


New behavior:
prefix: test_
table name: posts
result: test_posts