### PR TITLE
[5.5] Allow setting editor for Whoops

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -372,7 +372,7 @@ class Handler implements ExceptionHandlerContract
             }
 
             if (config('app.debug_editor', false)) {
-                $handler->setEditor(config('app.debug_editor');
+                $handler->setEditor(config('app.debug_editor'));
             }
 
             $handler->setApplicationPaths(

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -371,6 +371,10 @@ class Handler implements ExceptionHandlerContract
                 }
             }
 
+            if (config('app.debug_editor', false)) {
+                $handler->setEditor(config('app.debug_editor');
+            }
+
             $handler->setApplicationPaths(
                 array_flip(Arr::except(
                     array_flip($files->directories(base_path())), [base_path('vendor')]


### PR DESCRIPTION
Whoops allows defining an editor to open the file that caused the exception with it. This PR adds an option to set this.

Reference: [Open Files In An Editor - Whoops](https://github.com/filp/whoops/blob/master/docs/Open%20Files%20In%20An%20Editor.md).

:octocat: 