### PR TITLE
[5.5] Adds task command output to Artisan commands

### DIFF
--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -496,6 +496,20 @@ class Command extends SymfonyCommand
     }
 
     /**
+     * Write a string as task output.
+     *
+     * @param  string  $string
+     * @param  callable  $callable
+     * @return void
+     */
+    public function task($string, callable $callable)
+    {
+        $result = $callable() ? '<info>✔</info>' : '<error>fail</error>';
+
+        $this->output->writeln("$string: $result");
+    }
+
+    /**
      * Set the verbosity level.
      *
      * @param  string|int  $level


### PR DESCRIPTION
This PR addresses a creation of new **command output**. Adding a new method to the Artisan `Illuminate\Console\Command` class that allows the an user to understand the result of the given task.

- The task method code

```php
    /**
     * Write a string as task output.
     *
     * @param  string  $string
     * @param  callable  $callable
     * @return void
     */
    public function task($string, callable $callable)
    {
        $result = $callable() ? '<info>✔</info>' : '<error>fail</error>';

        $this->output->writeln("$string: $result");
    }
```

- Usage example

```php
    /**
     * Execute the console command.
     *
     * @return mixed
     */
    public function handle()
    {
        $this->task('Downloading Laravel', function () {
            $response = Client::download('cabinet.laravel.com/latest.zip', storage_path('latest.zip'))

            return response->success();
        });
    }
```

- Result

<img width="100%" alt="task" src="https://user-images.githubusercontent.com/5457236/33744708-de9c7b28-dbb2-11e7-94d2-09e35f750200.png">