### PR TITLE
[5.1] Fix sqlite mode " having count(fied) < number" problem

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -318,12 +318,12 @@ class Connection implements ConnectionInterface
             // row from the database table, and will either be an array or objects.
             $statement = $this->getPdoForSelect($useReadPdo)->prepare($query);
 
-            $bindings =  $me->prepareBindings($bindings);
+            $bindings = $me->prepareBindings($bindings);
 
             foreach ($bindings as $key => $value) {
                 // ? placeholder start from 0
                 $placeholder = $key + 1;
-                if(is_numeric($value)) {
+                if (is_numeric($value)) {
                     // when use sqlite , having count(some) < some_numeric query, the result is wrong
                     // but when add bindValue param PDO::PARAM_INT, the result is right
                     $statement->bindValue($placeholder, $value, PDO::PARAM_INT);

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -321,15 +321,10 @@ class Connection implements ConnectionInterface
             $bindings = $me->prepareBindings($bindings);
 
             foreach ($bindings as $key => $value) {
-                // ? placeholder start from 0
-                $placeholder = $key + 1;
-                if (is_numeric($value)) {
-                    // when use sqlite , having count(some) < some_numeric query, the result is wrong
-                    // but when add bindValue param PDO::PARAM_INT, the result is right
-                    $statement->bindValue($placeholder, $value, PDO::PARAM_INT);
-                } else {
-                    $statement->bindValue($placeholder, $value);
-                }
+                $statement->bindValue(
+                    is_string($key) ? $key : $key + 1, $value,
+                    is_int($value) ? PDO::PARAM_INT : PDO::PARAM_STR
+                );
             }
 
             $statement->execute();

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -318,7 +318,21 @@ class Connection implements ConnectionInterface
             // row from the database table, and will either be an array or objects.
             $statement = $this->getPdoForSelect($useReadPdo)->prepare($query);
 
-            $statement->execute($me->prepareBindings($bindings));
+            $bindings =  $me->prepareBindings($bindings);
+
+            foreach ($bindings as $key => $value) {
+                // ? placeholder start from 0
+                $placeholder = $key + 1;
+                if(is_numeric($value)) {
+                    // when use sqlite , having count(some) < some_numeric query, the result is wrong
+                    // but when add bindValue param PDO::PARAM_INT, the result is right
+                    $statement->bindValue($placeholder, $value, PDO::PARAM_INT);
+                } else {
+                    $statement->bindValue($placeholder, $value);
+                }
+            }
+
+            $statement->execute();
 
             return $statement->fetchAll($me->getFetchMode());
         });

--- a/tests/Database/DatabaseConnectionTest.php
+++ b/tests/Database/DatabaseConnectionTest.php
@@ -40,7 +40,7 @@ class DatabaseConnectionTest extends PHPUnit_Framework_TestCase
         $writePdo = $this->getMock('DatabaseConnectionTestMockPDO', ['prepare']);
         $writePdo->expects($this->never())->method('prepare');
         $statement = $this->getMock('PDOStatement', ['execute', 'fetchAll']);
-        $statement->expects($this->once())->method('execute')->with($this->equalTo(['foo' => 'bar']));
+        $statement->expects($this->once())->method('execute');
         $statement->expects($this->once())->method('fetchAll')->will($this->returnValue(['boom']));
         $pdo->expects($this->once())->method('prepare')->with('foo')->will($this->returnValue($statement));
         $mock = $this->getMockConnection(['prepareBindings'], $writePdo);


### PR DESCRIPTION
when use sqlite , having count(some) < some_numeric query, the result is wrong
but when add bindValue param PDO::PARAM_INT, the result is right

exp:

# In PDO

## case 1 :
          $expect = self::$pdo->query('SELECT sort_num, COUNT(sort_num) FROM t_user GROUP BY sort_num HAVING COUNT(sort_num) < 20')
                  ->fetchAll(PDO::FETCH_ASSOC);
          $pre = self::$pdo->prepare('SELECT sort_num, COUNT(sort_num) FROM t_user GROUP BY sort_num HAVING COUNT(sort_num) < :some');
          $pre->bindValue(':some', 20);
          $pre->execute();
          $testResult = $pre->fetchAll(PDO::FETCH_ASSOC);

$expect  != $testResult

## case 2: 
          $expect = self::$pdo->query('SELECT sort_num, COUNT(sort_num) FROM t_user GROUP BY sort_num HAVING COUNT(sort_num) < 20')
                  ->fetchAll(PDO::FETCH_ASSOC);
          $pre = self::$pdo->prepare('SELECT sort_num, COUNT(sort_num) FROM t_user GROUP BY sort_num HAVING COUNT(sort_num) < :some');
          $pre->bindValue(':some', 20, PDO::PARAM_INT);
          $pre->execute();
          $testResult = $pre->fetchAll(PDO::FETCH_ASSOC);

$expect  == $testResult

# In laravel before

## case 1:
        $rst = DB::connection('sqlite')->table('user')
        ->select('sort_num', DB::raw('COUNT(sort_num)'))
        ->groupBy('sort_num')
        ->having(DB::raw('COUNT(sort_num)'),'<', 20)
        ->get();

$rst is wrong

## case 2:
        $rst = DB::connection('sqlite')->table('user')
        ->select('sort_num', DB::raw('COUNT(sort_num)'))
        ->groupBy('sort_num')
        ->havingRaw('COUNT(sort_num) < 20')
        ->get();

$rst is right

## Now , case 1 is worked