### PR TITLE
[5.5] Minor language change in HasAttributes

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1029,7 +1029,7 @@ trait HasAttributes
     }
 
     /**
-     * Get the attributes that was changed.
+     * Get the attributes that were changed.
      *
      * @return array
      */


### PR DESCRIPTION
Noticed a small language error when reading the API docs. Attributes is plural, so it should be 'attributes that were changed' instead of 'was changed'.