### PR TITLE
[5.5] Method load($relation) in Eloquent\Collection should use newQueryWithoutRelationships as the one in Eloquent\Model

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -48,7 +48,7 @@ class Collection extends BaseCollection implements QueueableCollection
                 $relations = func_get_args();
             }
 
-            $query = $this->first()->newQuery()->with($relations);
+            $query = $this->first()->newQueryWithoutRelationships()->with($relations);
 
             $this->items = $query->eagerLoadRelations($this->items);
         }

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -156,7 +156,7 @@ class DatabaseEloquentCollectionTest extends TestCase
         $c = $this->getMockBuilder('Illuminate\Database\Eloquent\Collection')->setMethods(['first'])->setConstructorArgs([['foo']])->getMock();
         $mockItem = m::mock('stdClass');
         $c->expects($this->once())->method('first')->will($this->returnValue($mockItem));
-        $mockItem->shouldReceive('newQuery')->once()->andReturn($mockItem);
+        $mockItem->shouldReceive('newQueryWithoutRelationships')->once()->andReturn($mockItem);
         $mockItem->shouldReceive('with')->with(['bar', 'baz'])->andReturn($mockItem);
         $mockItem->shouldReceive('eagerLoadRelations')->once()->with(['foo'])->andReturn(['results']);
         $c->load('bar', 'baz');


### PR DESCRIPTION
> Iluminate\Database\Eloquent\Collection

> public function load($relations)

should be aligned with the same method from  

> lluminate\Database\Eloquent\Model

 by in order to prevent lazy eager loading to load again already loaded relations. This can be accomplished by using `newQueryWithoutRelationships` instead of `newQuery`

This fix complements commit a0e3a021e0f46db5bbcc4c81c98ba91f4282a5fb