### PR TITLE
[5.6] Makes multiple calls to specific DDLs throw an Exception in SQLite

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -100,6 +100,19 @@ class Blueprint
 
         $statements = [];
 
+        if ($connection instanceof \Illuminate\Database\SQLiteConnection) {
+            $badDDLCount = collect($this->commands)
+                ->filter(function($item, $key) {
+                    return in_array($item->name, [ 'dropColumn', 'renameColumn' ]);
+                })
+                ->count();
+
+            if ($badDDLCount > 1) {
+                throw new \BadMethodCallException("Multiple calls to dropColumn/renameColumn in a single table modification are not supported.");
+            }
+        }
+
+
         // Each type of command has a corresponding compiler function on the schema
         // grammar which is used to build the necessary SQL statements to build
         // the blueprint element, so we'll just call that compilers function.


### PR DESCRIPTION
After spending almost 2 hours trying to determine why my down closure was failing to remove four columns from an SQLite database, I tracked down #15042, which states that this is a limitation.

This PR checks to see if we're on a SQLite connection and checks how many of the commands supplied are dropColumn or renameColumn, and if there's more than 1, it throws a BadMethodCallException to alert the user to this fact.