### PR TITLE
[5.5] Pgsql specify schema

### DIFF
--- a/src/Illuminate/Database/Schema/PostgresBuilder.php
+++ b/src/Illuminate/Database/Schema/PostgresBuilder.php
@@ -95,7 +95,7 @@ class PostgresBuilder extends Builder
 
         if (is_array($schema)) {
             if (in_array($table[0], $schema)) { // Table contains schema prefix
-                return [ array_shift($table), implode('.', $table) ];
+                return [array_shift($table), implode('.', $table)];
             }
 
             $schema = head($schema);
@@ -103,6 +103,6 @@ class PostgresBuilder extends Builder
 
         $schema = $schema ?: 'public';
 
-        return [ $schema, implode('.', $table) ];
+        return [$schema, implode('.', $table)];
     }
 }

--- a/src/Illuminate/Database/Schema/PostgresBuilder.php
+++ b/src/Illuminate/Database/Schema/PostgresBuilder.php
@@ -83,9 +83,7 @@ class PostgresBuilder extends Builder
     }
 
     /**
-     * Determines which schema should be used
-     * Returns and array of schema and table name
-     * less schema name if found
+     * Determines which schema should be used.
      *
      * @param  string  $table
      * @return [ string, string ]

--- a/src/Illuminate/Database/Schema/PostgresBuilder.php
+++ b/src/Illuminate/Database/Schema/PostgresBuilder.php
@@ -12,11 +12,7 @@ class PostgresBuilder extends Builder
      */
     public function hasTable($table)
     {
-        if (is_array($schema = $this->connection->getConfig('schema'))) {
-            $schema = head($schema);
-        }
-
-        $schema = $schema ? $schema : 'public';
+        [ $schema, $table ] = $this->getSchema($table);
 
         $table = $this->connection->getTablePrefix().$table;
 
@@ -75,11 +71,7 @@ class PostgresBuilder extends Builder
      */
     public function getColumnListing($table)
     {
-        if (is_array($schema = $this->connection->getConfig('schema'))) {
-            $schema = head($schema);
-        }
-
-        $schema = $schema ? $schema : 'public';
+        [ $schema, $table ] = $this->getSchema($table);
 
         $table = $this->connection->getTablePrefix().$table;
 
@@ -88,5 +80,31 @@ class PostgresBuilder extends Builder
         );
 
         return $this->connection->getPostProcessor()->processColumnListing($results);
+    }
+
+    /**
+     * Determines which schema should be used
+     * Returns and array of schema and table name
+     * less schema name if found
+     *
+     * @param  string  $table
+     * @return [ string, string ]
+     */
+    protected function getSchema($table)
+    {
+        $table = explode('.', $table);
+        $schema = $this->connection->getConfig('schema');
+
+        if (is_array($schema)) {
+            if (in_array($table[0], $schema)) {
+                return [ $table[0], $table[1] ];
+            }
+
+            $schema = head($schema);
+        }
+
+        $schema = $schema ?: 'public';
+
+        return [ $schema, implode('.', $table) ];
     }
 }

--- a/src/Illuminate/Database/Schema/PostgresBuilder.php
+++ b/src/Illuminate/Database/Schema/PostgresBuilder.php
@@ -96,8 +96,8 @@ class PostgresBuilder extends Builder
         $schema = $this->connection->getConfig('schema');
 
         if (is_array($schema)) {
-            if (in_array($table[0], $schema)) {
-                return [ $table[0], $table[1] ];
+            if (in_array($table[0], $schema)) { // Table contains schema prefix
+                return [ array_shift($table), implode('.', $table) ];
             }
 
             $schema = head($schema);


### PR DESCRIPTION
If the pgsql driver is configured with an array of schema, the `hasTable` and `getColumnListing` functions of the Postgres builder default to the first schema. The reasons why are here: https://github.com/laravel/framework/pull/15535.

Unfortunately, this is not ideal when schema represent different functionality, rather than tenants with duplicate functionality.

This PR addresses this issue by allowing a schema to be specified along with the table.

See also: https://github.com/laravel/framework/pull/19553.