### PR TITLE
[5.6] Fix SQLite update for complex update statements

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Database\Query\Grammars;
 
 use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
 use Illuminate\Database\Query\Builder;
 
 class SQLiteGrammar extends Grammar
@@ -173,6 +174,54 @@ class SQLiteGrammar extends Grammar
         $columns = array_fill(0, count($values), implode(', ', $columns));
 
         return "insert into $table ($names) select ".implode(' union all select ', $columns);
+    }
+
+    /**
+     * Compile an update statement into SQL.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  array  $values
+     * @return string
+     */
+    public function compileUpdate(Builder $query, $values)
+    {
+        $table = $this->wrapTable($query->from);
+
+        // SQLite doesn't support dots (table.column) in update columns.
+        // if there is any, We only remove the current table and leave other  
+        // table names as they might be columns that based on a join statement.
+        $columns = collect($values)->map(function ($value, $key) use($query) {
+            return $this->wrap(Str::after($key, $query->from.'.')).' = '.$this->parameter($value);
+        })->implode(', ');
+
+
+        // SQLite doesn't support limits or orders by default in update/delete, 
+        // so we use A workaround sub-query where.
+        if (isset($query->joins) || isset($query->limit)) {
+            $selectSql = parent::compileSelect($query->select("{$query->from}.rowid"));
+
+            return "update {$table} set $columns where {$this->wrap('rowid')} in ({$selectSql})";
+        }
+
+        $wheres = $this->compileWheres($query);
+
+        return trim("update {$table} set $columns $wheres");
+    }
+
+    /**
+     * Prepare the bindings for an update statement.
+     *
+     * @param  array  $bindings
+     * @param  array  $values
+     * @return array
+     */
+    public function prepareBindingsForUpdate(array $bindings, array $values)
+    {
+        $cleanBindings = Arr::except($bindings, ['join', 'select']);
+
+        return array_values(
+            array_merge($values, $bindings['join'], Arr::flatten($cleanBindings))
+        );
     }
 
     /**

--- a/tests/Integration/Database/EloquentUpdateTest.php
+++ b/tests/Integration/Database/EloquentUpdateTest.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database;
+
+use Orchestra\Testbench\TestCase;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+/**
+ * @group integration
+ */
+class EloquentUpdateTest extends TestCase
+{
+    protected function getEnvironmentSetUp($app)
+    {
+        $app['config']->set('app.debug', 'true');
+
+        $app['config']->set('database.default', 'testbench');
+
+        $app['config']->set('database.connections.testbench', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+        ]);
+    }
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        Schema::create('test_model1', function ($table) {
+            $table->increments('id');
+            $table->string('name')->nullable();
+            $table->string('title')->nullable();
+        });
+        
+        Schema::create('test_model2', function ($table) {
+            $table->increments('id');
+            $table->string('name');
+            $table->string('job')->nullable();
+            $table->softDeletes();
+            $table->timestamps();
+        });
+    }
+
+    public function testBasicUpdate()
+    {
+        TestUpdateModel1::create([
+            'name' => str_random(), 
+            'title' => 'Ms.',
+        ]);
+
+        TestUpdateModel1::where('title', 'Ms.')->delete();
+
+        $this->assertEquals(0, TestUpdateModel1::all()->count());
+    }
+
+    public function testUpdateWithLimitsAndOrders()
+    {
+        for($i=1; $i <= 10; $i++){
+            TestUpdateModel1::create();
+        }
+
+        TestUpdateModel1::latest('id')->limit(3)->update(['title'=>'Dr.']);
+
+        $this->assertEquals('Dr.', TestUpdateModel1::find(8)->title);
+        $this->assertNotEquals('Dr.', TestUpdateModel1::find(7)->title);
+    }
+
+    public function testUpdatedAtWithJoins()
+    {
+        TestUpdateModel1::create([
+            'name' => 'Abdul', 
+            'title' => 'Mr.',
+        ]);
+
+        TestUpdateModel2::create([
+            'name' => str_random()
+        ]);
+
+        TestUpdateModel2::join('test_model1', function($join) {
+            $join->on('test_model1.id', '=', 'test_model2.id')
+                ->where('test_model1.title', '=', 'Mr.');
+        })->update(['test_model2.name' => 'Abdul', 'job'=>'Engineer']);
+      
+        $record = TestUpdateModel2::find(1);
+
+        $this->assertEquals('Engineer: Abdul', $record->job.': '.$record->name);
+    }
+
+    public function testSoftDeleteWithJoins()
+    {
+        TestUpdateModel1::create([
+            'name' => str_random(), 
+            'title' => 'Mr.',
+        ]);
+
+        TestUpdateModel2::create([
+            'name' => str_random()
+        ]);
+
+
+        TestUpdateModel2::join('test_model1', function($join) {
+            $join->on('test_model1.id', '=', 'test_model2.id')
+                ->where('test_model1.title', '=', 'Mr.');
+        })->delete();
+
+        $this->assertEquals(0, TestUpdateModel2::all()->count());
+    }
+}
+
+
+class TestUpdateModel1 extends Model
+{
+    public $table = 'test_model1';
+    public $timestamps = false;
+    protected $guarded = ['id'];
+}
+
+class TestUpdateModel2 extends Model
+{
+    use SoftDeletes;
+
+    public $table = 'test_model2';
+    protected $fillable = ['name'];
+    protected $dates = ['deleted_at'];
+}


### PR DESCRIPTION
Current SQLite update implementation lack the support for complex statement like joins, or limits. This PR solves that.

It's to complete what I started here #22298

