### PR TITLE
[5.5] Add retries to delete reserved on jobs table to fix dead lock issues on heavy queue loads

### DIFF
--- a/src/Illuminate/Queue/DatabaseQueue.php
+++ b/src/Illuminate/Queue/DatabaseQueue.php
@@ -291,13 +291,11 @@ class DatabaseQueue extends Queue implements QueueContract
      */
     public function deleteReserved($queue, $id)
     {
-        $this->database->beginTransaction();
-
-        if ($this->database->table($this->table)->lockForUpdate()->find($id)) {
-            $this->database->table($this->table)->where('id', $id)->delete();
-        }
-
-        $this->database->commit();
+        $this->database->transaction(function() use ($queue, $id) {
+            if ($this->database->table($this->table)->lockForUpdate()->find($id)) {
+                $this->database->table($this->table)->where('id', $id)->delete();
+            }
+        }, 5);
     }
 
     /**

--- a/src/Illuminate/Queue/DatabaseQueue.php
+++ b/src/Illuminate/Queue/DatabaseQueue.php
@@ -291,7 +291,7 @@ class DatabaseQueue extends Queue implements QueueContract
      */
     public function deleteReserved($queue, $id)
     {
-        $this->database->transaction(function() use ($queue, $id) {
+        $this->database->transaction(function () use ($queue, $id) {
             if ($this->database->table($this->table)->lockForUpdate()->find($id)) {
                 $this->database->table($this->table)->where('id', $id)->delete();
             }


### PR DESCRIPTION
I have had issues for days, first about the redis driver because it has exhausted my server RAM then with the database driver which produced many deadlocks. I work for a customer that really needs to keep track of pending queues and failed_jobs. Everything works as perfect with the database driver except when I have a lot of jobs.

The `php artisan queue:work` command would **hangs** after 100/200 jobs because of deadlocks and those commands would then never process the job. My queue processing logic stops and I have to restart everything manually. The issue is really well explained by @micmania1 in https://github.com/laravel/framework/issues/7046 (end of the issue).

Big thanks to @micmania1 for the solution that helped me put all the work I've done to production! I would love this to be merged as it would solve one big issue of the database driver for heavy loads.

