### PR TITLE
[5.5] Revert "Operator optional (#22361)"

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -993,16 +993,12 @@ class Builder
      *
      * @param  string  $column
      * @param  string   $operator
-     * @param  string   $value
+     * @param  int   $value
      * @param  string   $boolean
      * @return \Illuminate\Database\Query\Builder|static
      */
-    public function whereTime($column, $operator, $value = null, $boolean = 'and')
+    public function whereTime($column, $operator, $value, $boolean = 'and')
     {
-        list($value, $operator) = $this->prepareValueAndOperator(
-            $value, $operator, func_num_args() == 2
-        );
-
         return $this->addDateBasedWhere('Time', $column, $operator, $value, $boolean);
     }
 


### PR DESCRIPTION
This reverts commit 727b8f93703abb2e1ee2443724d233c4e3b14a4f, from https://github.com/laravel/framework/pull/22361

These changes lacked tests, didn't change orWhereTime, and even more importantly, changed a method signature causing php warnings for those that have overridden it.

> PHP Warning: Declaration of CustomBuilder::whereTime($column, $operator, $value, $boolean = 'and') should be compatible with Builder::whereTime($column, $operator, $value = NULL, $boolean = 'and')