### PR TITLE
[5.5] Allow to custom assets root URL

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -44,6 +44,13 @@ class UrlGenerator implements UrlGeneratorContract
     protected $forceScheme;
 
     /**
+     * The assets URL root.
+     *
+     * @var string
+     */
+    protected $assetsRoot;
+
+    /**
      * A cached copy of the URL root for the current request.
      *
      * @var string|null
@@ -217,12 +224,7 @@ class UrlGenerator implements UrlGeneratorContract
             return $path;
         }
 
-        // Once we get the root URL, we will check to see if it contains an index.php
-        // file in the paths. If it does, we will remove it since it is not needed
-        // for asset paths, but only for routes to endpoints in the application.
-        $root = $this->formatRoot($this->formatScheme($secure));
-
-        return $this->removeIndex($root).'/'.trim($path, '/');
+        return $this->assetFrom($this->assetsRoot, $path, $secure);
     }
 
     /**
@@ -501,6 +503,17 @@ class UrlGenerator implements UrlGeneratorContract
         $this->forcedRoot = rtrim($root, '/');
 
         $this->cachedRoot = null;
+    }
+
+    /**
+     * Set the root URL for assets.
+     *
+     * @param  string|null  $root
+     * @return void
+     */
+    public function setAssetsRoot($root)
+    {
+        $this->assetsRoot = rtrim($root, '/') ?: null;
     }
 
     /**

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -435,6 +435,24 @@ class RoutingUrlGeneratorTest extends TestCase
         $this->assertEquals('https://www.bar.com/foo', $url->route('plain'));
     }
 
+    public function testAssetsRoot()
+    {
+        $url = new UrlGenerator(
+            $routes = new RouteCollection,
+            $request = Request::create('http://www.foo.com/')
+        );
+
+        $url->setAssetsRoot('https://www.bar.com');
+        $this->assertEquals('http://www.bar.com/foo/bar', $url->asset('foo/bar'));
+
+        // Ensure trailing slash is trimmed from root URL as UrlGenerator already handles this
+        $url->setAssetsRoot('//www.foo.com/');
+        $this->assertEquals('//www.foo.com/bar', $url->asset('/bar'));
+
+        $url->setAssetsRoot(null);
+        $this->assertEquals('http://www.foo.com/bar', $url->asset('bar'));
+    }
+
     public function testPrevious()
     {
         $url = new UrlGenerator(


### PR DESCRIPTION
This PR adds support to custom the root URL for generating assets URLs, now we can use the built-in `asset()` or `secure_asset()` methods to generate an independent domain or CDN URL.

```php
app('url')->setAssetsRoot('https://assets.example.com');
```

I think this is helpful for framework users because using independent domain or CDN for assets is a very common thing for web apps. And for now it is hard to extend the `UrlGenerator` or the core `RoutingServiceProvider` to achieve this, right?

Why not just define my own `asset_url()` or `cdn()` helper?
Some packages publish their assets to the public path, and use the `asset()` method to ref them. If I want them cookie-free or to load from a cloud storage, I need to run `vendor:publish` even I just want to change `asset()` to `cdn()`, and I need to re-publish & modify every time these packages update.