### PR TITLE
[5.5] Fix SQS Queue for PHP7.2

### DIFF
--- a/src/Illuminate/Queue/SqsQueue.php
+++ b/src/Illuminate/Queue/SqsQueue.php
@@ -121,7 +121,7 @@ class SqsQueue extends Queue implements QueueContract
             'AttributeNames' => ['ApproximateReceiveCount'],
         ]);
 
-        if (count($response['Messages']) > 0) {
+        if (! is_null($response['Messages']) && count($response['Messages']) > 0) {
             return new SqsJob(
                 $this->container, $this->sqs, $response['Messages'][0],
                 $this->connectionName, $queue


### PR DESCRIPTION
Simple fix for issue https://github.com/laravel/framework/issues/22373

Includes a test to prevent regression (this test fails on 7.2 without the fix).

I checked the Git history for this file. We can safely backport this fix all the way back to Laravel 5.1 if you want to backport PHP7.2 support to previous Laravel versions. Let me know, and I'll do PRs for the other versions for you.