### PR TITLE
[5.5] Add Support for 'year' datatype for Schema Migrations for all Database servers

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -784,6 +784,17 @@ class Blueprint
     }
 
     /**
+     * Create a new year column on the table.
+     *
+     * @param  string  $column
+     * @return \Illuminate\Support\Fluent
+     */
+    public function year($column)
+    {
+        return $this->addColumn('year', $column);
+    }
+
+    /**
      * Create a new date-time column (with time zone) on the table.
      *
      * @param  string  $column

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -586,6 +586,17 @@ class MySqlGrammar extends Grammar
     }
 
     /**
+     * Create the column definition for a year  type.
+     *
+     * @param  \Illuminate\Support\Fluent  $column
+     * @return string
+     */
+    protected function typeYear(Fluent $column)
+    {
+        return 'year';
+    }
+
+    /**
      * Create the column definition for a date-time type.
      *
      * @param  \Illuminate\Support\Fluent  $column

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -537,6 +537,17 @@ class PostgresGrammar extends Grammar
     }
 
     /**
+     * Create the column definition for a year type (Polyfill).
+     *
+     * @param  \Illuminate\Support\Fluent  $column
+     * @return string
+     */
+    protected function typeYear(Fluent $column)
+    {
+        return $this->typeInteger($column);
+    }
+
+    /**
      * Create the column definition for a date-time type.
      *
      * @param  \Illuminate\Support\Fluent  $column

--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -546,6 +546,17 @@ class SQLiteGrammar extends Grammar
     }
 
     /**
+     * Create the column definition for a year type (Polyfill).
+     *
+     * @param  \Illuminate\Support\Fluent  $column
+     * @return string
+     */
+    protected function typeYear(Fluent $column)
+    {
+        return $this->typeInteger($column);
+    }
+
+    /**
      * Create the column definition for a date-time type.
      *
      * @param  \Illuminate\Support\Fluent  $column

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -496,6 +496,18 @@ class SqlServerGrammar extends Grammar
     }
 
     /**
+     * Create the column definition for a year type (Polyfill).
+     *
+     * @param  \Illuminate\Support\Fluent  $column
+     * @return string
+     */
+    protected function typeYear(Fluent $column)
+    {
+        return $this->typeInteger($column);
+    }
+
+
+    /**
      * Create the column definition for a date-time type.
      *
      * @param  \Illuminate\Support\Fluent  $column

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -506,7 +506,6 @@ class SqlServerGrammar extends Grammar
         return $this->typeInteger($column);
     }
 
-
     /**
      * Create the column definition for a date-time type.
      *

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -626,6 +626,15 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table `users` add `foo` date not null', $statements[0]);
     }
 
+    public function testAddingYear()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->year('birth_year');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table `users` add `birth_year` year not null', $statements[0]);
+    }
+
     public function testAddingDateTime()
     {
         $blueprint = new Blueprint('users');

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -449,6 +449,15 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add column "foo" date not null', $statements[0]);
     }
 
+    public function testAddingYear()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->year('birth_year');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table "users" add column "birth_year" integer not null', $statements[0]);
+    }
+
     public function testAddingJson()
     {
         $blueprint = new Blueprint('users');

--- a/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
@@ -416,6 +416,15 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add column "foo" date not null', $statements[0]);
     }
 
+    public function testAddingYear()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->year('birth_year');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table "users" add column "birth_year" integer not null', $statements[0]);
+    }
+
     public function testAddingDateTime()
     {
         $blueprint = new Blueprint('users');

--- a/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
@@ -482,6 +482,15 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table "users" add "foo" date not null', $statements[0]);
     }
 
+    public function testAddingYear()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->year('birth_year');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table "users" add "birth_year" int not null', $statements[0]);
+    }
+
     public function testAddingDateTime()
     {
         $blueprint = new Blueprint('users');


### PR DESCRIPTION
This commit adds support for `year` datatype for the different supported databases. Originally, only MySQL has native support for year datatype and as such, year type was left out of schema migrations.

This adds support for the year type and poly-fills with the integer datatype for other databases (PostgreSQL, SQLite, SqlServer).