### PR TITLE
Fix boolean changes on eloquent models

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1063,6 +1063,8 @@ trait HasAttributes
         } elseif ($this->hasCast($key)) {
             return $this->castAttribute($key, $current) ===
                    $this->castAttribute($key, $original);
+        } elseif (is_bool($current) {
+            return $current == $original;
         }
 
         return is_numeric($current) && is_numeric($original)

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1063,7 +1063,7 @@ trait HasAttributes
         } elseif ($this->hasCast($key)) {
             return $this->castAttribute($key, $current) ===
                    $this->castAttribute($key, $original);
-        } elseif (is_bool($current) {
+        } elseif (is_bool($current)) {
             return $current == $original;
         }
 


### PR DESCRIPTION
If an eloquent model has a boolean field, it will be 1 or 0 in the database. If the model is then updated (with either true or false), originalIsEquivalent() will return false because true !== 1. However, if $current on the eloquent-model is a boolean, we can safely assume that the field is boolean and we can therefore treat $original as a boolean as well.