### PR TITLE
[5.6] Add a HTTP cache middleware

### DIFF
--- a/src/Illuminate/Http/Middleware/Cache.php
+++ b/src/Illuminate/Http/Middleware/Cache.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Illuminate\Http\Middleware;
+
+use Closure;
+
+class Cache
+{
+    /**
+     * Add cache related HTTP headers.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @param  int|null  $maxAge
+     * @param  int|null  $sharedMaxAge
+     * @param  bool|null $public
+     * @param  bool|null $etag
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function handle($request, Closure $next, int $maxAge = null, int $sharedMaxAge = null, bool $public = null, bool $etag = false)
+    {
+        /**
+         * @var   \Symfony\Component\HttpFoundation\Response
+         */
+        $response = $next($request);
+
+        if (! $request->isMethodCacheable() || ! $response->getContent()) {
+            return $response;
+        }
+
+        if (! $response->getContent()) {
+            return;
+        }
+        if ($etag) {
+            $response->setEtag(md5($response->getContent()));
+        }
+        if (null !== $maxAge) {
+            $response->setMaxAge($maxAge);
+        }
+        if (null !== $sharedMaxAge) {
+            $response->setSharedMaxAge($sharedMaxAge);
+        }
+        if (null !== $public) {
+            $public ? $response->setPublic() : $response->setPrivate();
+        }
+
+        return $response;
+    }
+}

--- a/src/Illuminate/Http/Middleware/Cache.php
+++ b/src/Illuminate/Http/Middleware/Cache.php
@@ -35,7 +35,7 @@ class Cache
             $options = $parsedOptions;
         }
 
-        if (true === ($options['etag'] ?? false)) {
+        if (isset($options['etag']) && true === $options['etag']) {
             $options['etag'] = md5($response->getContent());
         }
 

--- a/tests/Http/Middleware/CacheTest.php
+++ b/tests/Http/Middleware/CacheTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Illuminate\Tests\Http\Middleware;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use PHPUnit\Framework\TestCase;
+use Illuminate\Http\Middleware\Cache;
+
+class CacheTest extends TestCase
+{
+    public function testDoNotSetHeaderWhenMethodNotCacheable()
+    {
+        $request = new Request();
+        $request->setMethod('PUT');
+
+        $response = (new Cache())->handle($request, function () {
+            return new Response('Hello Laravel');
+        }, 1, 2, true, true);
+
+        $this->assertNull($response->getMaxAge());
+        $this->assertNull($response->getEtag());
+    }
+
+    public function testDoNotSetHeaderWhenNoContent()
+    {
+        $response = (new Cache())->handle(new Request(), function () {
+            return new Response();
+        }, 1, 2, true, true);
+
+        $this->assertNull($response->getMaxAge());
+        $this->assertNull($response->getEtag());
+    }
+
+    public function testAddHeaders()
+    {
+        $response = (new Cache())->handle(new Request(), function () {
+            return new Response('some content');
+        }, 100, 200, true, true);
+
+        $this->assertSame('"9893532233caff98cd083a116b013c0b"', $response->getEtag());
+        $this->assertSame('max-age=100, public, s-maxage=200', $response->headers->get('Cache-Control'));
+    }
+}

--- a/tests/Http/Middleware/CacheTest.php
+++ b/tests/Http/Middleware/CacheTest.php
@@ -16,17 +16,16 @@ class CacheTest extends TestCase
 
         $response = (new Cache())->handle($request, function () {
             return new Response('Hello Laravel');
-        }, 1, 2, true, true);
+        }, 'max_age=120;s_maxage=60');
 
         $this->assertNull($response->getMaxAge());
-        $this->assertNull($response->getEtag());
     }
 
     public function testDoNotSetHeaderWhenNoContent()
     {
         $response = (new Cache())->handle(new Request(), function () {
             return new Response();
-        }, 1, 2, true, true);
+        }, 'max_age=120;s_maxage=60');
 
         $this->assertNull($response->getMaxAge());
         $this->assertNull($response->getEtag());
@@ -36,9 +35,51 @@ class CacheTest extends TestCase
     {
         $response = (new Cache())->handle(new Request(), function () {
             return new Response('some content');
-        }, 100, 200, true, true);
+        }, 'max_age=100;s_maxage=200;etag=ABC');
+
+        $this->assertSame('"ABC"', $response->getEtag());
+        $this->assertSame('max-age=100, public, s-maxage=200', $response->headers->get('Cache-Control'));
+    }
+
+    public function testAddHeadersUsingArray()
+    {
+        $response = (new Cache())->handle(new Request(), function () {
+            return new Response('some content');
+        }, ['max_age' => 100, 's_maxage' => 200, 'etag' => 'ABC']);
+
+        $this->assertSame('"ABC"', $response->getEtag());
+        $this->assertSame('max-age=100, public, s-maxage=200', $response->headers->get('Cache-Control'));
+    }
+
+    public function testGenerateEtag()
+    {
+        $response = (new Cache())->handle(new Request(), function () {
+            return new Response('some content');
+        }, 'etag;max_age=100;s_maxage=200');
 
         $this->assertSame('"9893532233caff98cd083a116b013c0b"', $response->getEtag());
         $this->assertSame('max-age=100, public, s-maxage=200', $response->headers->get('Cache-Control'));
+    }
+
+    public function testIsNotModified()
+    {
+        $request = new Request();
+        $request->headers->set('If-None-Match', '"9893532233caff98cd083a116b013c0b"');
+
+        $response = (new Cache())->handle($request, function () {
+            return new Response('some content');
+        }, 'etag;max_age=100;s_maxage=200');
+
+        $this->assertSame(304, $response->getStatusCode());
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testInvalidOption()
+    {
+        (new Cache())->handle(new Request(), function () {
+            return new Response('some content');
+        }, 'invalid');
     }
 }


### PR DESCRIPTION
This is a port of the [API Platform](https://api-platform.com)'s [HTTP cache listener](https://github.com/api-platform/core/blob/master/src/HttpCache/EventListener/AddHeadersListener.php).

It allows to easily set HTTP cache headers through a dedicated middleware:

```php
Route::get('/my-route', function () {
    return view('welcome');
})->middleware('cache:max_age=180;s_maxage=60;etag;immutable');
```

With this config, the following `Cache-Control` header will be added: `max-age=180, public, s-maxage=60` (180 seconds of client-side cache, can be cached by proxies during 60 seconds) and a `E-Tag` will be generated.