### PR TITLE
[5.5] Get metadata of `with` method in collection resources.

### DIFF
--- a/src/Illuminate/Http/Resources/Json/AnonymousResourceCollection.php
+++ b/src/Illuminate/Http/Resources/Json/AnonymousResourceCollection.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Http\Resources\Json;
 
+use Illuminate\Container\Container;
+
 class AnonymousResourceCollection extends ResourceCollection
 {
     /**
@@ -20,7 +22,9 @@ class AnonymousResourceCollection extends ResourceCollection
      */
     public function __construct($resource, $collects)
     {
-        $this->additional((new $collects($resource))->with(request()));
+        $this->additional((new $collects($resource))->with(
+            Container::getInstance()->make('request')
+        ));
         
         $this->collects = $collects;
 

--- a/src/Illuminate/Http/Resources/Json/AnonymousResourceCollection.php
+++ b/src/Illuminate/Http/Resources/Json/AnonymousResourceCollection.php
@@ -20,6 +20,8 @@ class AnonymousResourceCollection extends ResourceCollection
      */
     public function __construct($resource, $collects)
     {
+        $this->additional((new $collects($resource))->with(request()));
+        
         $this->collects = $collects;
 
         parent::__construct($resource);


### PR DESCRIPTION
When creating a collection Resource from `collection` static method, the metadata defined in `with` method is omitted.

This change fix it.