### PR TITLE
[5.5] Fix NotificationFake interfaces and return fake object.

### DIFF
--- a/src/Illuminate/Support/Facades/Notification.php
+++ b/src/Illuminate/Support/Facades/Notification.php
@@ -14,11 +14,13 @@ class Notification extends Facade
     /**
      * Replace the bound instance with a fake.
      *
-     * @return void
+     * @return \Illuminate\Support\Testing\Fakes\NotificationFake
      */
     public static function fake()
     {
-        static::swap(new NotificationFake);
+        static::swap($fake = new NotificationFake);
+
+        return $fake;
     }
 
     /**

--- a/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
@@ -6,8 +6,9 @@ use Ramsey\Uuid\Uuid;
 use Illuminate\Support\Collection;
 use PHPUnit\Framework\Assert as PHPUnit;
 use Illuminate\Contracts\Notifications\Factory as NotificationFactory;
+use Illuminate\Contracts\Notifications\Dispatcher as NotificationDispatcher;
 
-class NotificationFake implements NotificationFactory
+class NotificationFake implements NotificationFactory, NotificationDispatcher
 {
     /**
      * All of the notifications that have been sent.

--- a/tests/Integration/Notifications/SendingNotificationsViaAnonymousNotifiableTest.php
+++ b/tests/Integration/Notifications/SendingNotificationsViaAnonymousNotifiableTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Integration\Notifications;
 use Orchestra\Testbench\TestCase;
 use Illuminate\Notifications\Notification;
 use Illuminate\Notifications\AnonymousNotifiable;
+use Illuminate\Support\Testing\Fakes\NotificationFake;
 use Illuminate\Support\Facades\Notification as NotificationFacade;
 
 /**
@@ -37,7 +38,9 @@ class SendingNotificationsViaAnonymousNotifiableTest extends TestCase
 
     public function test_faking()
     {
-        NotificationFacade::fake();
+        $fake = NotificationFacade::fake();
+
+        $this->assertInstanceOf(NotificationFake::class, $fake);
 
         $notifiable = (new AnonymousNotifiable())
             ->route('testchannel', 'enzo')


### PR DESCRIPTION
Hi,
This PR:

- adds the missing Dispatcher contract on NotificationFake: it failed when injected, and it's supposed to replace the ChannelMannager in the container, which has this contract. ([1st commit](https://github.com/laravel/framework/commit/9926672301cb43dbc32825019b093a57c2f65c4a))
- return the created Fake object when Notification::fake() method is called. It permits to use it directly in tests. Tests was added for that. ([2nd commit](https://github.com/laravel/framework/commit/4e81435772c6a751c375f5c2fb8db0b3b9aa2fbe))

Thanks.
Matt'