### PR TITLE
[5.5] Automatic self referencing relationships on model getAttribute

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -69,7 +69,7 @@ class Collection extends BaseCollection implements QueueableCollection
                 $relations = func_get_args();
             }
 
-            $this->each(function($model) use ($relations) {
+            $this->each(function ($model) use ($relations) {
                 $model->setRelations($relations);
             });
         }
@@ -86,7 +86,7 @@ class Collection extends BaseCollection implements QueueableCollection
      */
     public function hasRelation($relation)
     {
-        if (!$this->isNotEmpty()) {
+        if (! $this->isNotEmpty()) {
             return false;
         }
 

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -57,6 +57,43 @@ class Collection extends BaseCollection implements QueueableCollection
     }
 
     /**
+     * Sets a set of relationships onto the collection.
+     *
+     * @param  mixed  $relations
+     * @return $this
+     */
+    public function setRelations($relations)
+    {
+        if ($this->isNotEmpty()) {
+            if (is_string($relations)) {
+                $relations = func_get_args();
+            }
+
+            $this->each(function($model) use ($relations) {
+                $model->setRelations($relations);
+            });
+        }
+
+        return $this;
+    }
+
+    /**
+     * Checks whether a collection has a
+     * relationship defined on it.
+     *
+     * @param string $relation
+     * @return bool
+     */
+    public function hasRelation($relation)
+    {
+        if (!$this->isNotEmpty()) {
+            return false;
+        }
+
+        return $this->first()->hasRelation($relation);
+    }
+
+    /**
      * Add an item to the collection.
      *
      * @param  mixed  $item

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -386,12 +386,28 @@ trait HasAttributes
             return $this->relations[$key];
         }
 
-        // If the "attribute" exists as a method on the model, we will just assume
-        // it is a relationship and will load and return results from the query
-        // and hydrate the relationship's value on the "relationships" array.
-        if (method_exists($this, $key)) {
-            return $this->getRelationshipFromMethod($key);
+        // If the "attribute" exists as a method on the model,
+        // we will just assume it is a relationship.
+        if (! $this->hasRelation($key)) {
+            return;
         }
+
+        // We will load and return results from the query
+        // and hydrate the relationship's value on the "relationships" array.
+        if (! $relationship = $this->getRelationshipFromMethod($key)) {
+            return;
+        }
+
+        // If a reference to this model exists on the relationship loaded,
+        // attach self to the relationship model in order to prevent
+        // any additional database calls for the relationship.
+        $relationshipKey = $this->guessRelationKey();
+
+        if ($relationship->hasRelation($relationshipKey)) {
+            $relationship->setRelations([$relationshipKey => $this]);
+        }
+
+        return $relationship;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -543,6 +543,18 @@ trait HasRelationships
     }
 
     /**
+     * Checks whether a relationship
+     * is defined on the model.
+     *
+     * @param string $relation
+     * @return bool
+     */
+    public function hasRelation($relation)
+    {
+        return method_exists($this, $relation);
+    }
+
+    /**
      * Set the specific relationship in the model.
      *
      * @param  string  $relation
@@ -590,5 +602,18 @@ trait HasRelationships
         $this->touches = $touches;
 
         return $this;
+    }
+
+    /**
+     * Attempts to guess the relationship key for a model.
+     *
+     * @param  Model  $model
+     * @return string
+     */
+    protected function guessRelationKey(Model $model = null)
+    {
+        $model = $model ?: $this;
+
+        return strtolower(str_singular($model->getTable()));
     }
 }

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -729,6 +729,23 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertEquals('taylorotwell@gmail.com', $post->first()->parentPost->user->email);
     }
 
+    public function testBasicAutomaticSelfReferenceOnSingularRelationshipAttributes()
+    {
+        $user = EloquentTestUser::create(['email' => 'taylorotwell@gmail.com']);
+        $user->posts()->create(['name' => 'First Post']);
+
+        $post = $user->posts->first();
+
+        $this->assertNotNull($post->user);
+        $this->assertEquals($user, $post->user);
+
+        $post = $user->posts()->create(['name' => 'First Post']);
+        $user = $post->user;
+
+        $this->assertNotNull($user->post);
+        $this->assertEquals($post, $user->post);
+    }
+
     public function testBasicMorphManyRelationship()
     {
         $user = EloquentTestUser::create(['email' => 'taylorotwell@gmail.com']);


### PR DESCRIPTION
This pull request aims to improve Eloquent performance when accessing relationships as an attribute on a model by setting the originating relationship on a newly loaded relationship automatically.

Let's take the following two models as our example.

```php
class User extends Eloquent
{
    public function posts()
    {
        return $this->hasMany(Post::class);
    }
}

class Post extends Eloquent
{
    public function user()
    {
        return $this->belongsTo(User::class);
    }
}
```

In the following situation, we will be executing unnecessary queries.
```php
$user = User::first();

$posts = $user->posts;
$post = $posts->first();

$postUser = $post->user;
```

The above will execute a new database call to fetch the user when accessing its relationship as an attribute on the Post model instance.

This pull request will automatically set the relationship `user` on all posts.
In other words `$user` and `$post->user` in the example above, are exactly the same object instance.

This is particularly useful when passing post models to functions or methods elsewhere in your code where you need to access the original user. Before this pull request, a new query would be executed for every `$post->user` call.

An example where the same effect can be produced without this PR.
```php
$user = User::first();

$posts = $user->posts;
$posts->each($post, function() use ($user) {
    $post->setRelation('user', $user);
});

$post = $posts->first();

$postUser = $post->user;
```