### PR TITLE
[5.5] Fix flaws in how search_path is set on connection

### DIFF
--- a/src/Illuminate/Database/Connectors/PostgresConnector.php
+++ b/src/Illuminate/Database/Connectors/PostgresConnector.php
@@ -40,7 +40,7 @@ class PostgresConnector extends Connector implements ConnectorInterface
         // database. Setting this DB timezone is an optional configuration item.
         $this->configureTimezone($connection, $config);
 
-        $this->configureSchema($connection, $config);
+        $this->configureSearchPath($connection, $config);
 
         // Postgres allows an application_name to be set by the user and this name is
         // used to when monitoring the application with pg_stat_activity. So we'll
@@ -81,34 +81,42 @@ class PostgresConnector extends Connector implements ConnectorInterface
     }
 
     /**
-     * Set the schema on the connection.
+     * Set the search_path on the connection.
      *
      * @param  \PDO  $connection
      * @param  array  $config
      * @return void
      */
-    protected function configureSchema($connection, $config)
+    protected function configureSearchPath($connection, $config)
     {
-        if (isset($config['schema'])) {
-            $schema = $this->formatSchema($config['schema']);
+        if (isset($config['searchpath']) || isset($config['schema'])) {
+            $searchPath = $this->formatSearchPath($config['searchpath'] ?? $config['schema']);
 
-            $connection->prepare("set search_path to {$schema}")->execute();
+            $connection->prepare("set search_path to {$searchPath}")->execute();
         }
     }
 
     /**
-     * Format the schema for the DSN.
+     * Format the search path for the DSN.
      *
-     * @param  array|string  $schema
+     * @param  array|string  $searchPath
      * @return string
      */
-    protected function formatSchema($schema)
+    protected function formatSearchPath($searchPath)
     {
-        if (is_array($schema)) {
-            return '"'.implode('", "', $schema).'"';
+        if (is_array($searchPath)) {
+            $schemas = array_map(function ($item) {
+                return '"'.$item.'"';
+            }, $searchPath);
+
+            $preparedSchemas = array_map(function ($item) {
+                return ":$item";
+            }, $schemas);
+
+            return implode(', ', array_combine($preparedSchemas, $schemas));
         }
 
-        return '"'.$schema.'"';
+        return implode(', ', [":$searchPath" => '"'.$searchPath.'"']);
     }
 
     /**


### PR DESCRIPTION
TL;DR
Currently, Laravel conflates "schema" with "search_path" and prepares statement parameter bindings incorrectly when setting the value, which could have significant negative implications for PostgreSQL-backed applications. This commit corrects the terminology and configuration, with backward compatibility.
/TL;DR

This commit seeks to address two fundamental issues: 1) incorrect PostgreSQL terminology and application of concepts; 2) ineffective "search_path" values set on connection due to incorrect prepared statement parameter bindings (entire comma-separated string of schemas is quoted when each schema must be quoted separately).

In the existing code, "schema" is conflated with "search_path", which has significant negative implications for PostgreSQL-backed applications.

This commit corrects the terminology within the source so that the code reflects more accurately its actual behavior, but more importantly, it changes the connection configuration variable name that is used to set the "search_path" from "schema" to "searchpath".

The change allows for "decoupling" in that "schema" can still be used for its intended purpose (to prefix object references for schemas not in the "search_path", or to disambiguate objects of the same name that exist in more than one schema in the "search_path"), while "searchpath" can now be used for *its* intended purpose. In other words, "schema" and "searchpath" are now two separate and unrelated directives, which can be configured independently.

Note that the "schema" connection property is no longer used when configuring the connection, but may still be accessed as needed via getConnection()->getConfig('schema').

The change is backward-compatible in that if the "searchpath" key is not defined on the connection, the "schema" key will be used to set the search_path instead. If "schema" is not defined, PostgreSQL's default schema ("public") will be used.

Note further that "searchpath" may be specified as a string (which allows for a single schema only), or an array (which allows for any number of schemas, excluding only dynamic schemas that have special meaning to PostgreSQL, such as '$user'; support for $-style variable notation may be added in a future revision).

For an exhaustive discussion, see: https://github.com/laravel/internals/issues/918