### PR TITLE
[5.5] Add array support to Optional

### DIFF
--- a/src/Illuminate/Support/Optional.php
+++ b/src/Illuminate/Support/Optional.php
@@ -2,7 +2,9 @@
 
 namespace Illuminate\Support;
 
-class Optional
+use ArrayAccess;
+
+class Optional implements ArrayAccess
 {
     use Traits\Macroable {
         __call as macroCall;
@@ -54,6 +56,55 @@ class Optional
 
         if (is_object($this->value)) {
             return $this->value->{$method}(...$parameters);
+        }
+    }
+
+    /**
+     * Determine if an item exists at an offset.
+     *
+     * @param  mixed  $key
+     * @return bool
+     */
+    public function offsetExists($key)
+    {
+        return Arr::accessible($this->value) && Arr::exists($this->value, $key);
+    }
+
+    /**
+     * Get an item at a given offset.
+     *
+     * @param  mixed  $key
+     * @return mixed
+     */
+    public function offsetGet($key)
+    {
+        return Arr::get($this->value, $key);
+    }
+
+    /**
+     * Set the item at a given offset.
+     *
+     * @param  mixed  $key
+     * @param  mixed  $value
+     * @return void
+     */
+    public function offsetSet($key, $value)
+    {
+        if (Arr::accessible($this->value)) {
+            $this->value[$key] = $value;
+        }
+    }
+
+    /**
+     * Unset the item at a given offset.
+     *
+     * @param  string  $key
+     * @return void
+     */
+    public function offsetUnset($key)
+    {
+        if (Arr::accessible($this->value)) {
+            unset($this->value[$key]);
         }
     }
 }

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -774,6 +774,13 @@ class SupportHelpersTest extends TestCase
         })->something());
     }
 
+    public function testOptionalWithArray()
+    {
+        $this->assertNull(optional(null)['missing']);
+
+        $this->assertEquals('here', optional(['present' => 'here'])['present']);
+    }
+
     public function testOptionalIsMacroable()
     {
         Optional::macro('present', function () {


### PR DESCRIPTION
Lets you pass a _maybe array_ to `optional`, then access one of its keys:

```php
$location = optional($order->meta)['location'];
```