### PR TITLE
Fix type hints for database events

### DIFF
--- a/src/Illuminate/Database/Events/ConnectionEvent.php
+++ b/src/Illuminate/Database/Events/ConnectionEvent.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Database\Events;
 
+use Illuminate\Database\Connection;
+
 abstract class ConnectionEvent
 {
     /**
@@ -24,7 +26,7 @@ abstract class ConnectionEvent
      * @param  \Illuminate\Database\Connection  $connection
      * @return void
      */
-    public function __construct($connection)
+    public function __construct(Connection $connection)
     {
         $this->connection = $connection;
         $this->connectionName = $connection->getName();

--- a/src/Illuminate/Database/Events/QueryExecuted.php
+++ b/src/Illuminate/Database/Events/QueryExecuted.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Database\Events;
 
+use Illuminate\Database\Connection;
+
 class QueryExecuted
 {
     /**
@@ -21,7 +23,7 @@ class QueryExecuted
     /**
      * The number of milliseconds it took to execute the query.
      *
-     * @var float
+     * @var float|null
      */
     public $time;
 
@@ -44,11 +46,11 @@ class QueryExecuted
      *
      * @param  string  $sql
      * @param  array  $bindings
-     * @param  float  $time
-     * @param  string  $connection
+     * @param  float|null  $time
+     * @param  \Illuminate\Database\Connection  $connection
      * @return void
      */
-    public function __construct($sql, $bindings, $time, $connection)
+    public function __construct(string $sql, array $bindings, float $time = null, Connection $connection)
     {
         $this->sql = $sql;
         $this->time = $time;

--- a/src/Illuminate/Database/Events/StatementPrepared.php
+++ b/src/Illuminate/Database/Events/StatementPrepared.php
@@ -2,6 +2,9 @@
 
 namespace Illuminate\Database\Events;
 
+use Illuminate\Database\Connection;
+use PDOStatement;
+
 class StatementPrepared
 {
     /**
@@ -25,7 +28,7 @@ class StatementPrepared
      * @param  \PDOStatement  $statement
      * @return void
      */
-    public function __construct($connection, $statement)
+    public function __construct(Connection $connection, PDOStatement $statement)
     {
         $this->statement = $statement;
         $this->connection = $connection;


### PR DESCRIPTION
Fix some type hints. The connection is **not** a string and `$time` can be `null` according to `Illuminate\Database\Connection::logQuery()`