### PR TITLE
[5.5] Add additional Json response assertion helpers [updated]

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -7,8 +7,12 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Support\Carbon;
 use Illuminate\Contracts\View\View;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Traits\Macroable;
 use PHPUnit\Framework\Assert as PHPUnit;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Http\Resources\Json\Resource;
+use Illuminate\Http\Resources\Json\ResourceCollection;
 
 /**
  * @mixin \Illuminate\Http\Response
@@ -353,6 +357,54 @@ class TestResponse
         }
 
         return $this;
+    }
+
+    /**
+     * Assert that the response contains the given Eloquent model.
+     *
+     * @param  Model  $model
+     * @return $this
+     */
+    public function assertJsonModel(Model $model)
+    {
+        return $this->assertJsonFragment($model->toArray());
+    }
+
+    /**
+     * Assert that the response contains all of the given Eloquent models.
+     *
+     * @param  Collection  $models
+     * @return $this
+     */
+    public function assertJsonModelCollection(Collection $models)
+    {
+        foreach ($models as $model) {
+            $this->assertJsonModel($model);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Assert that the response contains the given Json Resource.
+     *
+     * @param  Resource  $resource
+     * @return $this
+     */
+    public function assertJsonResource(Resource $resource)
+    {
+        return $this->assertJsonFragment($resource->toArray());
+    }
+
+    /**
+     * Assert that the response contains the given Json Resource Collection.
+     *
+     * @param  ResourceCollection  $collection
+     * @return $this
+     */
+    public function assertJsonResourceCollection(ResourceCollection $collection)
+    {
+        return $this->assertJsonFragment($collection->toArray());
     }
 
     /**

--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -362,7 +362,7 @@ class TestResponse
     /**
      * Assert that the response contains the given Eloquent model.
      *
-     * @param  Model  $model
+     * @param  \Illuminate\Database\Eloquent\Model  $model
      * @return $this
      */
     public function assertJsonModel(Model $model)
@@ -373,7 +373,7 @@ class TestResponse
     /**
      * Assert that the response contains all of the given Eloquent models.
      *
-     * @param  Collection  $models
+     * @param  \Illuminate\Database\Eloquent\Collection  $models
      * @return $this
      */
     public function assertJsonModelCollection(Collection $models)
@@ -388,7 +388,7 @@ class TestResponse
     /**
      * Assert that the response contains the given Json Resource.
      *
-     * @param  Resource  $resource
+     * @param  \Illuminate\Http\Resources\Json\Resource  $resource
      * @return $this
      */
     public function assertJsonResource(Resource $resource)
@@ -399,7 +399,7 @@ class TestResponse
     /**
      * Assert that the response contains the given Json Resource Collection.
      *
-     * @param  ResourceCollection  $collection
+     * @param  \Illuminate\Http\Resources\Json\ResourceCollection  $collection
      * @return $this
      */
     public function assertJsonResourceCollection(ResourceCollection $collection)


### PR DESCRIPTION
*Updated* A few more test helpers related to testing JSON responses.

*Updated 12/13 - Added additional assertion helpers for testing Json Resources and ResourceCollections per Taylor's comments*

# assertJsonModel

Asserts that the Json response contains the specified model.

## Example

I want to test that the category is in the Json response, but `assertJsonFragment` requires an array, so I have to call `toArray` on the model. Not a huge deal, but it adds just a little noise to the test IMO.

```
// the old way
    /** @test */
    public function it_can_get_a_single_category()
    {
        $category = create(Category::class);

        $this
            ->get(["categories.index", $category])
            ->response()
                ->assertStatus(200)
                ->assertJsonFragment($category->toArray());
    }

// the new way
    /** @test */
    public function it_can_get_a_single_category()
    {
        $category = create(Category::class);

        $this
            ->get(["categories.index", $category])
            ->response()
                ->assertStatus(200)
                ->assertJsonModel($category);
    }
```
Many might call that a marginal improvement, but the next example is even more drastic.

# assertJsonModelCollection

Assert that the Json response has all of the specified models

## Example

I want to test that all of the categories are in the response. I have to grab each category and call `toArray`.

```
// the old way
    /** @test */
    public function it_can_get_a_listing_of_categories()
    {
        $categories = create(Category::class,3);

        $this
            ->get("categories.index")
            ->response()
                ->assertStatus(200)
                ->assertJsonCount(3)
                ->assertJsonFragment($categories[0]->toArray())
                ->assertJsonFragment($categories[1]->toArray())
                ->assertJsonFragment($categories[2]->toArray());
    }

// the new way
    /** @test */
    public function it_can_get_a_listing_of_categories()
    {
        $categories = create(Category::class,3);

        $this
            ->get("categories.index")
            ->response()
                ->assertStatus(200)
                ->assertJsonCount(3)
                ->assertJsonModelCollection($categories);
    }
```


# assertJsonResource

Assert that the Json response contains the specified Json Resource

## Example

```
$user = create(User::class);
$resource = new UserResource($user);

$this->get(["users.show",$user])
    ->response()
    ->assertStatus(200)
    ->assertJsonResource( $resource );

```

# assertJsonResourceCollection

Assert that the Json response contains the specified Json Resource Collection

## Example

```
$users = create(User::class,3);
$collection = new UserResourceCollection($users);

$this->get("users.index")
    ->response()
    ->assertStatus(200)
    ->assertJsonResourceCollection( $collection );
```
