### PR TITLE
Single Action Responsibility Controller

### DIFF
--- a/src/Illuminate/Routing/RouteAction.php
+++ b/src/Illuminate/Routing/RouteAction.php
@@ -40,7 +40,9 @@ class RouteAction
         }
 
         if (is_string($action['uses']) && ! Str::contains($action['uses'], '@')) {
-            $action['uses'] = static::makeInvokable($action['uses']);
+            $action['uses'] = method_exists($action['uses'], 'handle')
+                ? $action['uses'].'@handle'
+                : static::makeInvokable($action['uses']);
         }
 
         return $action;


### PR DESCRIPTION
Here's a solution proposal for the Single Action Responsibility Controller.

After that we can create such a Routes i.e.:

`Route::get('foo', ['uses' => 'FooClass']);`

and declare controller class with `handle` method that is responsible for the action. So we don't need to use `__invoke` magic method.