### PR TITLE
[5.5] ResourceResponse returns the resource data instead of json on Original

### DIFF
--- a/src/Illuminate/Http/Resources/Json/PaginatedResourceResponse.php
+++ b/src/Illuminate/Http/Resources/Json/PaginatedResourceResponse.php
@@ -25,6 +25,7 @@ class PaginatedResourceResponse extends ResourceResponse
             ),
             $this->calculateStatus()
         ), function ($response) use ($request) {
+            $response->original = $this->resource->resource->pluck('resource');
             $this->resource->withResponse($request, $response);
         });
     }

--- a/src/Illuminate/Http/Resources/Json/ResourceResponse.php
+++ b/src/Illuminate/Http/Resources/Json/ResourceResponse.php
@@ -42,6 +42,7 @@ class ResourceResponse implements Responsable
             ),
             $this->calculateStatus()
         ), function ($response) use ($request) {
+            $response->original = $this->resource->resource;
             $this->resource->withResponse($request, $response);
         });
     }

--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -492,4 +492,37 @@ class ResourceTest extends TestCase
             ],
         ]);
     }
+
+    public function test_original_on_response_is_model_when_single_resource()
+    {
+        $createdPost = new Post(['id' => 5, 'title' => 'Test Title']);
+        Route::get('/', function () use ($createdPost) {
+            return new ReallyEmptyPostResource($createdPost);
+        });
+
+        $response = $this->withoutExceptionHandling()->get(
+            '/', ['Accept' => 'application/json']
+        );
+
+        $this->assertTrue($createdPost->is($response->getOriginalContent()));
+    }
+
+    public function test_original_on_response_is_collection_of_model_when_collection_resource()
+    {
+        $createdPosts = collect([
+            new Post(['id' => 5, 'title' => 'Test Title']),
+            new Post(['id' => 6, 'title' => 'Test Title 2']),
+        ]);
+        Route::get('/', function () use ($createdPosts) {
+            return new EmptyPostCollectionResource(new LengthAwarePaginator($createdPosts, 10, 15, 1));
+        });
+
+        $response = $this->withoutExceptionHandling()->get(
+            '/', ['Accept' => 'application/json']
+        );
+
+        $createdPosts->each(function($post) use ($response) {
+            $this->assertTrue($response->getOriginalContent()->contains($post));
+        });
+    }
 }

--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -521,7 +521,7 @@ class ResourceTest extends TestCase
             '/', ['Accept' => 'application/json']
         );
 
-        $createdPosts->each(function($post) use ($response) {
+        $createdPosts->each(function ($post) use ($response) {
             $this->assertTrue($response->getOriginalContent()->contains($post));
         });
     }


### PR DESCRIPTION
By setting original to the model on resources, we can in our tests check directly if the model is the correct one, by just getting the `original` attribute on the response. 
Often I don't want to check if the JSON is formatted correctly, just interested if the model is the correct one.