### PR TITLE
[5.5] Removes macroable trait from PresetCommand

### DIFF
--- a/src/Illuminate/Foundation/Console/PresetCommand.php
+++ b/src/Illuminate/Foundation/Console/PresetCommand.php
@@ -4,12 +4,9 @@ namespace Illuminate\Foundation\Console;
 
 use InvalidArgumentException;
 use Illuminate\Console\Command;
-use Illuminate\Support\Traits\Macroable;
 
 class PresetCommand extends Command
 {
-    use Macroable;
-
     /**
      * The console command signature.
      *


### PR DESCRIPTION
The PR addresses the removal of the `Macroable` trait from the `PresetCommand` command class. After the PR https://github.com/laravel/framework/pull/22426 the parent class `Illuminate\Console\Command` is **already macroable**.