### PR TITLE
[5.6] Add Queue Metadata

### DIFF
--- a/src/Illuminate/Contracts/Queue/QueueAcceptsMetadata.php
+++ b/src/Illuminate/Contracts/Queue/QueueAcceptsMetadata.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Illuminate\Contracts\Queue;
+
+interface QueueAcceptsMetadata
+{
+    /**
+     * Add metadata to the payload that will be queued.
+     *
+     * @param  mixed  $metadata
+     * @return void
+     */
+    public function setMetadata($metadata);
+}

--- a/src/Illuminate/Contracts/Queue/QueueAcceptsMetadata.php
+++ b/src/Illuminate/Contracts/Queue/QueueAcceptsMetadata.php
@@ -2,13 +2,15 @@
 
 namespace Illuminate\Contracts\Queue;
 
+use Illuminate\Support\Collection;
+
 interface QueueAcceptsMetadata
 {
     /**
      * Add metadata to the payload that will be queued.
      *
-     * @param  mixed  $metadata
+     * @param  \Illuminate\Support\Collection  $metadata
      * @return void
      */
-    public function setMetadata($metadata);
+    public function setMetadata(Collection $metadata);
 }

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -3,10 +3,10 @@
 namespace Illuminate\Queue;
 
 use DateTimeInterface;
-use Illuminate\Container\Container;
-use Illuminate\Contracts\Queue\QueueAcceptsMetadata;
 use Illuminate\Support\Collection;
+use Illuminate\Container\Container;
 use Illuminate\Support\InteractsWithTime;
+use Illuminate\Contracts\Queue\QueueAcceptsMetadata;
 
 abstract class Queue implements QueueAcceptsMetadata
 {
@@ -226,7 +226,7 @@ abstract class Queue implements QueueAcceptsMetadata
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function setMetadata(Collection $metadata)
     {

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -5,6 +5,7 @@ namespace Illuminate\Queue;
 use DateTimeInterface;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Queue\QueueAcceptsMetadata;
+use Illuminate\Support\Collection;
 use Illuminate\Support\InteractsWithTime;
 
 abstract class Queue implements QueueAcceptsMetadata
@@ -35,9 +36,9 @@ abstract class Queue implements QueueAcceptsMetadata
     /**
      * The metadata that should be added to the queue payload.
      *
-     * @var array
+     * @var null|\Illuminate\Support\Collection
      */
-    protected $metadata = [];
+    protected $metadata;
 
     /**
      * Push a new job onto the queue.
@@ -116,18 +117,8 @@ abstract class Queue implements QueueAcceptsMetadata
                     ? $this->createObjectPayload($job)
                     : $this->createStringPayload($job, $data);
 
-        if (! empty($this->metadata)) {
-            $metadata = [];
-
-            foreach ($this->metadata as $value) {
-                $value = value($value);
-
-                if (! empty($value) && is_array($value)) {
-                    $metadata = array_merge($metadata, $value);
-                }
-            }
-
-            $payload['metadata'] = $metadata;
+        if (! is_null($this->metadata) && $this->metadata->isNotEmpty()) {
+            $payload['metadata'] = $this->metadata->toArray();
         }
 
         return $payload;
@@ -237,7 +228,7 @@ abstract class Queue implements QueueAcceptsMetadata
     /**
      * @inheritdoc
      */
-    public function setMetadata($metadata)
+    public function setMetadata(Collection $metadata)
     {
         $this->metadata = $metadata;
     }

--- a/src/Illuminate/Queue/QueueManager.php
+++ b/src/Illuminate/Queue/QueueManager.php
@@ -3,9 +3,9 @@
 namespace Illuminate\Queue;
 
 use Closure;
-use Illuminate\Contracts\Queue\QueueAcceptsMetadata;
-use Illuminate\Support\Collection;
 use InvalidArgumentException;
+use Illuminate\Support\Collection;
+use Illuminate\Contracts\Queue\QueueAcceptsMetadata;
 use Illuminate\Contracts\Queue\Factory as FactoryContract;
 use Illuminate\Contracts\Queue\Monitor as MonitorContract;
 

--- a/src/Illuminate/Queue/QueueManager.php
+++ b/src/Illuminate/Queue/QueueManager.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Queue;
 
 use Closure;
+use Illuminate\Contracts\Queue\QueueAcceptsMetadata;
 use InvalidArgumentException;
 use Illuminate\Contracts\Queue\Factory as FactoryContract;
 use Illuminate\Contracts\Queue\Monitor as MonitorContract;
@@ -32,6 +33,13 @@ class QueueManager implements FactoryContract, MonitorContract
      * @var array
      */
     protected $connectors = [];
+
+    /**
+     * The metadata that should be added to the queue payload.
+     *
+     * @var array
+     */
+    protected $metadata = [];
 
     /**
      * Create a new queue manager instance.
@@ -111,6 +119,17 @@ class QueueManager implements FactoryContract, MonitorContract
     }
 
     /**
+     * Add metadata to the payload that will be queued.
+     *
+     * @param  mixed  $metadata
+     * @return void
+     */
+    public function metadata($metadata)
+    {
+        $this->metadata[] = $metadata;
+    }
+
+    /**
      * Determine if the driver is connected.
      *
      * @param  string  $name
@@ -138,6 +157,10 @@ class QueueManager implements FactoryContract, MonitorContract
             $this->connections[$name] = $this->resolve($name);
 
             $this->connections[$name]->setContainer($this->app);
+
+            if ($this->connections[$name] instanceof QueueAcceptsMetadata) {
+                $this->connections[$name]->setMetadata($this->metadata);
+            }
         }
 
         return $this->connections[$name];

--- a/src/Illuminate/Queue/QueueManager.php
+++ b/src/Illuminate/Queue/QueueManager.php
@@ -4,6 +4,7 @@ namespace Illuminate\Queue;
 
 use Closure;
 use Illuminate\Contracts\Queue\QueueAcceptsMetadata;
+use Illuminate\Support\Collection;
 use InvalidArgumentException;
 use Illuminate\Contracts\Queue\Factory as FactoryContract;
 use Illuminate\Contracts\Queue\Monitor as MonitorContract;
@@ -37,9 +38,9 @@ class QueueManager implements FactoryContract, MonitorContract
     /**
      * The metadata that should be added to the queue payload.
      *
-     * @var array
+     * @var \Illuminate\Support\Collection
      */
-    protected $metadata = [];
+    protected $metadata;
 
     /**
      * Create a new queue manager instance.
@@ -50,6 +51,7 @@ class QueueManager implements FactoryContract, MonitorContract
     public function __construct($app)
     {
         $this->app = $app;
+        $this->metadata = new Collection();
     }
 
     /**
@@ -121,12 +123,25 @@ class QueueManager implements FactoryContract, MonitorContract
     /**
      * Add metadata to the payload that will be queued.
      *
-     * @param  mixed  $metadata
-     * @return void
+     * @param  string|array|null  $key
+     * @param  mixed  $value
+     * @return  self|\Illuminate\Support\Collection
      */
-    public function metadata($metadata)
+    public function metadata($key, $value = null)
     {
-        $this->metadata[] = $metadata;
+        if (is_null($key)) {
+            return $this->metadata;
+        }
+
+        if (is_array($key)) {
+            foreach ($key as $itemKey => $itemData) {
+                $this->metadata($itemKey, $itemData);
+            }
+        } else {
+            $this->metadata->put($key, $value);
+        }
+
+        return $this;
     }
 
     /**

--- a/tests/Queue/QueueBeanstalkdQueueTest.php
+++ b/tests/Queue/QueueBeanstalkdQueueTest.php
@@ -27,14 +27,10 @@ class QueueBeanstalkdQueueTest extends TestCase
     public function testPushProperlyPushesJobWithMetadataOntoBeanstalkd()
     {
         $queue = new \Illuminate\Queue\BeanstalkdQueue(m::mock('Pheanstalk\Pheanstalk'), 'default', 60);
-        $queue->setMetadata([
-            ['firstname' => 'taylor'],
-            function() {
-                return [
-                    'surname' => 'otwell',
-                ];
-            }
-        ]);
+        $queue->setMetadata(new \Illuminate\Support\Collection([
+                'firstname' => 'taylor',
+                'surname' => 'otwell',
+        ]));
         $pheanstalk = $queue->getPheanstalk();
         $pheanstalk->shouldReceive('useTube')->once()->with('stack')->andReturn($pheanstalk);
         $pheanstalk->shouldReceive('useTube')->once()->with('default')->andReturn($pheanstalk);

--- a/tests/Queue/QueueDatabaseQueueUnitTest.php
+++ b/tests/Queue/QueueDatabaseQueueUnitTest.php
@@ -30,6 +30,30 @@ class QueueDatabaseQueueUnitTest extends TestCase
         $queue->push('foo', ['data']);
     }
 
+    public function testPushProperlyPushesJobWithMetadataOntoDatabase()
+    {
+        $queue = $this->getMockBuilder('Illuminate\Queue\DatabaseQueue')->setMethods(['currentTime'])->setConstructorArgs([$database = m::mock('Illuminate\Database\Connection'), 'table', 'default'])->getMock();
+        $queue->setMetadata([
+            ['firstname' => 'taylor'],
+            function() {
+                return [
+                    'surname' => 'otwell',
+                ];
+            }
+        ]);
+        $queue->expects($this->any())->method('currentTime')->will($this->returnValue('time'));
+        $database->shouldReceive('table')->with('table')->andReturn($query = m::mock('stdClass'));
+        $query->shouldReceive('insertGetId')->once()->andReturnUsing(function ($array) {
+            $this->assertEquals('default', $array['queue']);
+            $this->assertEquals(json_encode(['displayName' => 'foo', 'job' => 'foo', 'maxTries' => null, 'timeout' => null, 'data' => ['data'], 'metadata' => ['firstname' => 'taylor', 'surname' => 'otwell']]), $array['payload']);
+            $this->assertEquals(0, $array['attempts']);
+            $this->assertNull($array['reserved_at']);
+            $this->assertInternalType('int', $array['available_at']);
+        });
+
+        $queue->push('foo', ['data']);
+    }
+
     public function testDelayedPushProperlyPushesJobOntoDatabase()
     {
         $queue = $this->getMockBuilder(

--- a/tests/Queue/QueueDatabaseQueueUnitTest.php
+++ b/tests/Queue/QueueDatabaseQueueUnitTest.php
@@ -33,19 +33,18 @@ class QueueDatabaseQueueUnitTest extends TestCase
     public function testPushProperlyPushesJobWithMetadataOntoDatabase()
     {
         $queue = $this->getMockBuilder('Illuminate\Queue\DatabaseQueue')->setMethods(['currentTime'])->setConstructorArgs([$database = m::mock('Illuminate\Database\Connection'), 'table', 'default'])->getMock();
-        $queue->setMetadata([
-            ['firstname' => 'taylor'],
-            function() {
-                return [
-                    'surname' => 'otwell',
-                ];
-            }
-        ]);
+        $queue->setMetadata(new \Illuminate\Support\Collection([
+            'firstname' => 'taylor',
+            'surname' => 'otwell',
+            'nested' => [
+                'foo' => 'bar',
+            ],
+        ]));
         $queue->expects($this->any())->method('currentTime')->will($this->returnValue('time'));
         $database->shouldReceive('table')->with('table')->andReturn($query = m::mock('stdClass'));
         $query->shouldReceive('insertGetId')->once()->andReturnUsing(function ($array) {
             $this->assertEquals('default', $array['queue']);
-            $this->assertEquals(json_encode(['displayName' => 'foo', 'job' => 'foo', 'maxTries' => null, 'timeout' => null, 'data' => ['data'], 'metadata' => ['firstname' => 'taylor', 'surname' => 'otwell']]), $array['payload']);
+            $this->assertEquals(json_encode(['displayName' => 'foo', 'job' => 'foo', 'maxTries' => null, 'timeout' => null, 'data' => ['data'], 'metadata' => ['firstname' => 'taylor', 'surname' => 'otwell', 'nested' => ['foo' => 'bar']]]), $array['payload']);
             $this->assertEquals(0, $array['attempts']);
             $this->assertNull($array['reserved_at']);
             $this->assertInternalType('int', $array['available_at']);

--- a/tests/Queue/QueueManagerTest.php
+++ b/tests/Queue/QueueManagerTest.php
@@ -80,4 +80,25 @@ class QueueManagerTest extends TestCase
 
         $this->assertSame($queue, $manager->connection('null'));
     }
+
+    public function testMetadataIsHandledCorrectly()
+    {
+        $app = [
+            'config' => [
+                'queue.default' => 'null',
+            ],
+            'encrypter' => m::mock('Illuminate\Contracts\Encryption\Encrypter'),
+        ];
+
+        $manager = new QueueManager($app);
+        $collection = $manager->metadata(null);
+
+        $this->assertInstanceOf(\Illuminate\Support\Collection::class, $collection);
+
+        $manager->metadata('foo', 'bar');
+        $this->assertSame(['foo' => 'bar'], $collection->toArray());
+
+        $manager->metadata(['foo' => 'bart', 'bar' => 'foo']);
+        $this->assertSame(['foo' => 'bart', 'bar' => 'foo'], $collection->toArray());
+    }
 }

--- a/tests/Queue/QueueRedisQueueTest.php
+++ b/tests/Queue/QueueRedisQueueTest.php
@@ -23,6 +23,25 @@ class QueueRedisQueueTest extends TestCase
         $this->assertEquals('foo', $id);
     }
 
+    public function testPushProperlyPushesJobWithMetadataOntoRedis()
+    {
+        $queue = $this->getMockBuilder('Illuminate\Queue\RedisQueue')->setMethods(['getRandomId'])->setConstructorArgs([$redis = m::mock('Illuminate\Contracts\Redis\Factory'), 'default'])->getMock();
+        $queue->setMetadata([
+            ['firstname' => 'taylor'],
+            function() {
+                return [
+                    'surname' => 'otwell',
+                ];
+            }
+        ]);
+        $queue->expects($this->once())->method('getRandomId')->will($this->returnValue('foo'));
+        $redis->shouldReceive('connection')->once()->andReturn($redis);
+        $redis->shouldReceive('rpush')->once()->with('queues:default', json_encode(['displayName' => 'foo', 'job' => 'foo', 'maxTries' => null, 'timeout' => null, 'data' => ['data'], 'metadata' => ['firstname' => 'taylor', 'surname' => 'otwell'], 'id' => 'foo', 'attempts' => 0]));
+
+        $id = $queue->push('foo', ['data']);
+        $this->assertEquals('foo', $id);
+    }
+
     public function testDelayedPushProperlyPushesJobOntoRedis()
     {
         $queue = $this->getMockBuilder('Illuminate\Queue\RedisQueue')->setMethods(['availableAt', 'getRandomId'])->setConstructorArgs([$redis = m::mock('Illuminate\Contracts\Redis\Factory'), 'default'])->getMock();

--- a/tests/Queue/QueueRedisQueueTest.php
+++ b/tests/Queue/QueueRedisQueueTest.php
@@ -26,14 +26,10 @@ class QueueRedisQueueTest extends TestCase
     public function testPushProperlyPushesJobWithMetadataOntoRedis()
     {
         $queue = $this->getMockBuilder('Illuminate\Queue\RedisQueue')->setMethods(['getRandomId'])->setConstructorArgs([$redis = m::mock('Illuminate\Contracts\Redis\Factory'), 'default'])->getMock();
-        $queue->setMetadata([
-            ['firstname' => 'taylor'],
-            function() {
-                return [
-                    'surname' => 'otwell',
-                ];
-            }
-        ]);
+        $queue->setMetadata(new \Illuminate\Support\Collection([
+            'firstname' => 'taylor',
+            'surname' => 'otwell',
+        ]));
         $queue->expects($this->once())->method('getRandomId')->will($this->returnValue('foo'));
         $redis->shouldReceive('connection')->once()->andReturn($redis);
         $redis->shouldReceive('rpush')->once()->with('queues:default', json_encode(['displayName' => 'foo', 'job' => 'foo', 'maxTries' => null, 'timeout' => null, 'data' => ['data'], 'metadata' => ['firstname' => 'taylor', 'surname' => 'otwell'], 'id' => 'foo', 'attempts' => 0]));

--- a/tests/Queue/QueueSyncQueueTest.php
+++ b/tests/Queue/QueueSyncQueueTest.php
@@ -34,14 +34,10 @@ class QueueSyncQueueTest extends TestCase
         $sync = new \Illuminate\Queue\SyncQueue;
         $container = new \Illuminate\Container\Container;
         $sync->setContainer($container);
-        $sync->setMetadata([
-            ['firstname' => 'taylor'],
-            function() {
-                return [
-                    'surname' => 'otwell',
-                ];
-            }
-        ]);
+        $sync->setMetadata(new \Illuminate\Support\Collection([
+            'firstname' => 'taylor',
+            'surname' => 'otwell',
+        ]));
         $sync->push('Illuminate\Tests\Queue\SyncQueueTestHandler', ['foo' => 'bar']);
         $this->assertEquals(json_encode(['displayName' => 'Illuminate\\Tests\\Queue\\SyncQueueTestHandler', 'job' => 'Illuminate\\Tests\\Queue\\SyncQueueTestHandler', 'maxTries' => null, 'timeout' => null, 'data' => ['foo' => 'bar'], 'metadata' => ['firstname' => 'taylor', 'surname' => 'otwell']]), $_SERVER['__sync.test'][0]->getRawBody());
     }

--- a/tests/Queue/QueueSyncQueueTest.php
+++ b/tests/Queue/QueueSyncQueueTest.php
@@ -27,6 +27,25 @@ class QueueSyncQueueTest extends TestCase
         $this->assertEquals(['foo' => 'bar'], $_SERVER['__sync.test'][1]);
     }
 
+    public function testPushShouldFireJobInstantlyWithMetadata()
+    {
+        unset($_SERVER['__sync.test']);
+
+        $sync = new \Illuminate\Queue\SyncQueue;
+        $container = new \Illuminate\Container\Container;
+        $sync->setContainer($container);
+        $sync->setMetadata([
+            ['firstname' => 'taylor'],
+            function() {
+                return [
+                    'surname' => 'otwell',
+                ];
+            }
+        ]);
+        $sync->push('Illuminate\Tests\Queue\SyncQueueTestHandler', ['foo' => 'bar']);
+        $this->assertEquals(json_encode(['displayName' => 'Illuminate\\Tests\\Queue\\SyncQueueTestHandler', 'job' => 'Illuminate\\Tests\\Queue\\SyncQueueTestHandler', 'maxTries' => null, 'timeout' => null, 'data' => ['foo' => 'bar'], 'metadata' => ['firstname' => 'taylor', 'surname' => 'otwell']]), $_SERVER['__sync.test'][0]->getRawBody());
+    }
+
     public function testFailedJobGetsHandledWhenAnExceptionIsThrown()
     {
         unset($_SERVER['__sync.failed']);


### PR DESCRIPTION
When building a multi tenancy application queues and events prove to be difficult to handle.

Currently you have to do something similar to https://github.com/laravel/internals/issues/53#issuecomment-210924692 but this does not cover third party packages and is prone to be missed.

This solution allows you to do the following:
```php
       \Queue::metadata('tenant', tenant());
```
You can add as much metadata as you would like

Then when you process the queue you can use the before event to set your tenant up
```php
        \Queue::before(function (JobProcessing $event) {
            $payload = $event->job->payload();

            if (isset($payload['metadata']['tenant'])) {
                unserialize($payload['metadata']['tenant']);
            }
        });
```

Let me know what you think.