### PR TITLE
[5.6] Implemented conditional where clause

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1238,6 +1238,30 @@ class Builder
     }
 
     /**
+     * Handles conditional "where" clauses to the query.
+     *
+     * @param  string  $method
+     * @param  string  $parameters
+     * @return $this
+     */
+    public function conditionalWhere($method, $parameters)
+    {
+        // If the condition evaluates as true, proceed with the
+        // standard "where" clause behaviour.
+        if ($parameters[0]) {
+            // Remove the condition argument.
+            array_shift($parameters);
+
+            // Replace If from method name with nothing.
+            $method = preg_replace('/If$/', '', $method);
+
+            return $this->{$method}(...$parameters);
+        }
+
+        return $this;
+    }
+
+    /**
      * Handles dynamic "where" clauses to the query.
      *
      * @param  string  $method
@@ -2454,6 +2478,10 @@ class Builder
             return $this->macroCall($method, $parameters);
         }
 
+        if (Str::endsWith($method, 'If')) {
+            return $this->conditionalWhere($method, $parameters);
+        }
+        
         if (Str::startsWith($method, 'where')) {
             return $this->dynamicWhere($method, $parameters);
         }


### PR DESCRIPTION
Writing Laravel applications I found myself a lot using snippets like this:
```php
$query = Document::query();
$type = $request->input('type');
if ($type !== null) {
    $query->where('type', $type);
}
```

This let's you perform conditional where "clauses" like this:
```php
Document::whereIf($type, 'type', $type)
    ->whereIf($type !== 'xlsx', 'size', '>', 100);
```

It doesn't break compatibility with any other documented laravel where "clause". You can still use
```php
$query->whereInIf(true, 'column', $value);
$query->orWhereIf(true, 'column', 'like', $value);
$query->andWhereIf(true, 'column', '>=',  $value);
```

I don't mind changing the method "keyword" to something more understandable but this feature should be very useful in many scenarios. Some naming alternative could be:
```
$query->conditionalWhere(true, 'column', $value);
$query->conditionalAndWhere(true, 'column', $value);
```