### PR TITLE
[5.5] Fixes issue with multiple dont-discover packages

### DIFF
--- a/src/Illuminate/Foundation/PackageManifest.php
+++ b/src/Illuminate/Foundation/PackageManifest.php
@@ -119,7 +119,7 @@ class PackageManifest
         $this->write(collect($packages)->mapWithKeys(function ($package) {
             return [$this->format($package['name']) => $package['extra']['laravel'] ?? []];
         })->each(function ($configuration) use (&$ignore) {
-            $ignore += $configuration['dont-discover'] ?? [];
+            $ignore = array_merge($ignore, $configuration['dont-discover'] ?? []);
         })->reject(function ($configuration, $package) use ($ignore, $ignoreAll) {
             return $ignoreAll || in_array($package, $ignore);
         })->filter()->all());

--- a/tests/Foundation/fixtures/vendor/composer/installed.json
+++ b/tests/Foundation/fixtures/vendor/composer/installed.json
@@ -25,6 +25,9 @@
         "providers": [
           "bar",
           "baz"
+        ],
+        "dont-discover": [
+            "vendor_a/package_e"
         ]
       }
     }
@@ -39,6 +42,16 @@
       "laravel": {
         "providers": [
           "bazinga"
+        ]
+      }
+    }
+  },
+  {
+    "name": "vendor_a/package_e",
+    "extra": {
+      "laravel": {
+        "providers": [
+          "pennypennypenny"
         ]
       }
     }


### PR DESCRIPTION
Currently the `PackageManefest::build()` process will only honor the first `dont-discover` that it encounters, ignoring the rest.

This is because array union (+=) doesn't work as the original author intended. Instead, using `array_merge` will produce a complete list of packages to ignore.

Adding this use case in `/fixtures/vendor/composer/installed.json`, breaks the `FoundationPackageManifestTest::testAssetLoading()` unit test as expected, and the provided fix resolves the issue making the test pass again.