### PR TITLE
[5.6] Add builder/grammar support for row values in where condition

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1238,6 +1238,47 @@ class Builder
     }
 
     /**
+     * Adds a where condition using row values.
+     *
+     * This is mostly used with "keyset pagination" aka "seek method".
+     *
+     * @param  array   $columns
+     * @param  string  $operator
+     * @param  array   $values
+     * @param  string  $boolean
+     * @return $this
+     */
+    public function whereRowValues($columns, $operator, $values, $boolean = 'and')
+    {
+        if (count($columns) != count($values)) {
+            throw new InvalidArgumentException('The number of columns must match the number of values');
+        }
+
+        $type = 'RowValues';
+
+        $this->wheres[] = compact('type', 'columns', 'operator', 'values', 'boolean');
+
+        $this->addBinding($values);
+
+        return $this;
+    }
+
+    /**
+     * Adds a or where condition using row values.
+     *
+     * This is mostly used with "keyset pagination" aka "seek method".
+     *
+     * @param  array   $columns
+     * @param  string  $operator
+     * @param  array   $values
+     * @return $this
+     */
+    public function orWhereRowValues($columns, $operator, $values)
+    {
+        return $this->whereRowValues($columns, $operator, $values, 'or');
+    }
+
+    /**
      * Handles dynamic "where" clauses to the query.
      *
      * @param  string  $method

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -474,6 +474,21 @@ class Grammar extends BaseGrammar
     }
 
     /**
+     * Compile a where row values condition.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  array  $where
+     * @return string
+     */
+    protected function whereRowValues(Builder $query, $where)
+    {
+        $columns = join(', ', $where['columns']);
+        $values = $this->parameterize($where['values']);
+
+        return '('.$columns.') '.$where['operator'].' ('.$values.')';
+    }
+
+    /**
      * Compile the "group by" portions of the query.
      *
      * @param  \Illuminate\Database\Query\Builder  $query

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2363,6 +2363,26 @@ class DatabaseQueryBuilderTest extends TestCase
         ]), $result);
     }
 
+    public function testWhereRowValues()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('orders')->whereRowValues(['last_update', 'order_number'], '<', [1, 2]);
+        $this->assertEquals('select * from "orders" where (last_update, order_number) < (?, ?)', $builder->toSql());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('orders')->where('company_id', 1)->orWhereRowValues(['last_update', 'order_number'], '<', [1, 2]);
+        $this->assertEquals('select * from "orders" where "company_id" = ? or (last_update, order_number) < (?, ?)', $builder->toSql());
+    }
+
+    public function testWhereRowValuesArityMismatch()
+    {
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('The number of columns must match the number of values');
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('orders')->whereRowValues(['last_update'], '<', [1, 2]);
+    }
+
     protected function getBuilder()
     {
         $grammar = new \Illuminate\Database\Query\Grammars\Grammar;


### PR DESCRIPTION
Support for "row values" is mostly useful when implementing pagination with keysets aka seek method.

Well known pagination with offset/limit has almost linearly bad performance characteristics with every "page" turned. They can't make use of an index to efficiently jump to the result page and thus have to always read from the beginning.

An alternative way is to define predicates to jump to the desired page which can make use of indices. Characteristics of such paginations are:
- no indicator how many pages; best used with "endless scrolling/loading" approaches
- usually stable pages (depending on predicates). Insertion of data on previous pages will not alter the result of the current page

This PR implements the low-level building block. Example:
- instead of `->where(…)->orderBy(…)->offset(100)->limit(10)`
- you could use `->where(…)->whereRowValues(['last_update', 'ticket_numbner'], '<', ['2017-12-15 23:00:00', 123])->orderBy(…)->limit(10)`
  (iff the business logic of your application allows it)

The benefits/performance characteristics as well as in-depth examples how and why this works are well described at:
- http://use-the-index-luke.com/sql/partial-results/fetch-next-page
- http://use-the-index-luke.com/blog/2013-07/pagination-done-the-postgresql-way
- https://blog.jooq.org/2013/11/18/faster-sql-pagination-with-keysets-continued/

### Note
- It currently is already possible to achieve this with `->whereRaw()` but after reading http://use-the-index-luke.com/no-offset I figured a direct support for this could be welcome
```sql
$builder->whereRaw('(last_update, ticket_number) < (?, ?)', […, …]);
```
- The naming `RowValues` may not be obvious to related to this "keyset pagination" or "seek method". But OTOH this seems to be the term describing this particular syntax (I'm not an expert on this topic), that's why I choose it instead of `->whereSeek` or `->whereKeysetPagination`…
  This may be left open for the future to directly support this via something like `->paginateKeyset()` (just thinking out loud)
- Not every database out there supports this syntax. PostgresSQL supports it since a long time; MySQL does but with caveats, etc. There's some information at http://use-the-index-luke.com/sql/partial-results/fetch-next-page about it (not sure if it is accurate/up2date).
- There are ways to emulate this behaviour for databases not supporting this syntax (again, see http://use-the-index-luke.com/sql/partial-results/fetch-next-page), but this is out of the scope of this PR:
```sql
SELECT *
  FROM ( SELECT *
           FROM tickets
          WHERE last_update <= ?
            AND NOT (last_update = ? AND number >= ?)
          ORDER BY last_update DESC, number DESC
       )
 WHERE rownum <= 10
```