### PR TITLE
[5.5] Use laravel provided argument escaping

### DIFF
--- a/src/Illuminate/Console/Application.php
+++ b/src/Illuminate/Console/Application.php
@@ -4,7 +4,7 @@ namespace Illuminate\Console;
 
 use Closure;
 use Illuminate\Contracts\Events\Dispatcher;
-use Symfony\Component\Process\ProcessUtils;
+use Illuminate\Support\ProcessUtils;
 use Illuminate\Contracts\Container\Container;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Input\ArrayInput;

--- a/src/Illuminate/Console/Application.php
+++ b/src/Illuminate/Console/Application.php
@@ -3,8 +3,8 @@
 namespace Illuminate\Console;
 
 use Closure;
-use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Support\ProcessUtils;
+use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Container\Container;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Input\ArrayInput;

--- a/src/Illuminate/Console/Scheduling/CommandBuilder.php
+++ b/src/Illuminate/Console/Scheduling/CommandBuilder.php
@@ -3,7 +3,7 @@
 namespace Illuminate\Console\Scheduling;
 
 use Illuminate\Console\Application;
-use Symfony\Component\Process\ProcessUtils;
+use Illuminate\Support\ProcessUtils;
 
 class CommandBuilder
 {

--- a/src/Illuminate/Console/Scheduling/Schedule.php
+++ b/src/Illuminate/Console/Scheduling/Schedule.php
@@ -5,7 +5,7 @@ namespace Illuminate\Console\Scheduling;
 use Illuminate\Console\Application;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Queue\ShouldQueue;
-use Symfony\Component\Process\ProcessUtils;
+use Illuminate\Support\ProcessUtils;
 
 class Schedule
 {

--- a/src/Illuminate/Console/Scheduling/Schedule.php
+++ b/src/Illuminate/Console/Scheduling/Schedule.php
@@ -4,8 +4,8 @@ namespace Illuminate\Console\Scheduling;
 
 use Illuminate\Console\Application;
 use Illuminate\Container\Container;
-use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Support\ProcessUtils;
+use Illuminate\Contracts\Queue\ShouldQueue;
 
 class Schedule
 {

--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -3,7 +3,7 @@
 namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\Command;
-use Symfony\Component\Process\ProcessUtils;
+use Illuminate\Support\ProcessUtils;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Process\PhpExecutableFinder;
 

--- a/src/Illuminate/Queue/Listener.php
+++ b/src/Illuminate/Queue/Listener.php
@@ -4,7 +4,7 @@ namespace Illuminate\Queue;
 
 use Closure;
 use Symfony\Component\Process\Process;
-use Symfony\Component\Process\ProcessUtils;
+use Illuminate\Support\ProcessUtils;
 use Symfony\Component\Process\PhpExecutableFinder;
 
 class Listener

--- a/src/Illuminate/Queue/Listener.php
+++ b/src/Illuminate/Queue/Listener.php
@@ -3,8 +3,8 @@
 namespace Illuminate\Queue;
 
 use Closure;
-use Symfony\Component\Process\Process;
 use Illuminate\Support\ProcessUtils;
+use Symfony\Component\Process\Process;
 use Symfony\Component\Process\PhpExecutableFinder;
 
 class Listener

--- a/src/Illuminate/Support/Composer.php
+++ b/src/Illuminate/Support/Composer.php
@@ -4,7 +4,7 @@ namespace Illuminate\Support;
 
 use Illuminate\Filesystem\Filesystem;
 use Symfony\Component\Process\Process;
-use Symfony\Component\Process\ProcessUtils;
+use Illuminate\Support\ProcessUtils;
 use Symfony\Component\Process\PhpExecutableFinder;
 
 class Composer

--- a/src/Illuminate/Support/Composer.php
+++ b/src/Illuminate/Support/Composer.php
@@ -4,7 +4,6 @@ namespace Illuminate\Support;
 
 use Illuminate\Filesystem\Filesystem;
 use Symfony\Component\Process\Process;
-use Illuminate\Support\ProcessUtils;
 use Symfony\Component\Process\PhpExecutableFinder;
 
 class Composer

--- a/src/Illuminate/Support/ProcessUtils.php
+++ b/src/Illuminate/Support/ProcessUtils.php
@@ -12,8 +12,7 @@ class ProcessUtils
     /**
      * Escapes a string to be used as a shell argument.
      *
-     * @param string $argument
-     *
+     * @param  string  $argument
      * @return string
      */
     public static function escapeArgument($argument)
@@ -59,9 +58,8 @@ class ProcessUtils
     /**
      * Is the given string surrounded by the given character?
      *
-     * @param string $arg
-     * @param string $char
-     *
+     * @param  string  $arg
+     * @param  string  $char
      * @return bool
      */
     protected static function isSurroundedBy($arg, $char)

--- a/src/Illuminate/Support/ProcessUtils.php
+++ b/src/Illuminate/Support/ProcessUtils.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Illuminate\Support;
+
+/**
+ * ProcessUtils is a bunch of utility methods.
+ *
+ * This class was originally copied from Symfony 3.
+ */
+class ProcessUtils
+{
+    /**
+     * Escapes a string to be used as a shell argument.
+     *
+     * @param string $argument
+     *
+     * @return string
+     */
+    public static function escapeArgument($argument)
+    {
+        // Fix for PHP bug #43784 escapeshellarg removes % from given string
+        // Fix for PHP bug #49446 escapeshellarg doesn't work on Windows
+        // @see https://bugs.php.net/bug.php?id=43784
+        // @see https://bugs.php.net/bug.php?id=49446
+        if ('\\' === DIRECTORY_SEPARATOR) {
+            if ('' === $argument) {
+                return escapeshellarg($argument);
+            }
+
+            $escapedArgument = '';
+            $quote = false;
+
+            foreach (preg_split('/(")/', $argument, -1, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE) as $part) {
+                if ('"' === $part) {
+                    $escapedArgument .= '\\"';
+                } elseif (self::isSurroundedBy($part, '%')) {
+                    // Avoid environment variable expansion
+                    $escapedArgument .= '^%"'.substr($part, 1, -1).'"^%';
+                } else {
+                    // escape trailing backslash
+                    if ('\\' === substr($part, -1)) {
+                        $part .= '\\';
+                    }
+                    $quote = true;
+                    $escapedArgument .= $part;
+                }
+            }
+
+            if ($quote) {
+                $escapedArgument = '"'.$escapedArgument.'"';
+            }
+
+            return $escapedArgument;
+        }
+
+        return "'".str_replace("'", "'\\''", $argument)."'";
+    }
+
+    /**
+     * Is the given string surrounded by the given character?
+     *
+     * @param string $arg
+     * @param string $char
+     *
+     * @return bool
+     */
+    protected static function isSurroundedBy($arg, $char)
+    {
+        return 2 < strlen($arg) && $char === $arg[0] && $char === $arg[strlen($arg) - 1];
+    }
+}


### PR DESCRIPTION
Symfony's `ProcessUtils::escapeArgument` method is deprecated since Symfony 3.3, and removed in Symfony 4.0. It would be a lot of work to refactor Laravel's code to do the suggestion Symfony have as an alternative to calling that method, so I suggest we port the original code into Laravel.

This:

1. Fixes eprecation warnings in Laravel 5.5.
2. Is a prerequisite for switching Laravel 5.6 to Symfony 4.