### PR TITLE
[5.5] Fixed incorrect description type

### DIFF
--- a/src/Illuminate/Console/Parser.php
+++ b/src/Illuminate/Console/Parser.php
@@ -141,6 +141,6 @@ class Parser
     {
         $parts = preg_split('/\s+:\s+/', trim($token), 2);
 
-        return count($parts) === 2 ? $parts : [$token, null];
+        return count($parts) === 2 ? $parts : [$token, ''];
     }
 }


### PR DESCRIPTION
This is the description that is passed to Symfony console objects on construct. They should not be null. This is a bug, and is strictly enforced in Symfony 4, so this PR forms more ground work for getting onto Symfony 4 too.

TLDR:

1. Description must be a not-null string.
2. Is strictly enforced on Symfony 4.