### PR TITLE
[5.5] Only add value to binding if it isn't an expression

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1083,7 +1083,9 @@ class Builder
     {
         $this->wheres[] = compact('column', 'type', 'boolean', 'operator', 'value');
 
-        $this->addBinding($value, 'where');
+        if (! $value instanceof Expression) {
+            $this->addBinding($value, 'where');
+        }
 
         return $this;
     }

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -293,6 +293,13 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals('select * from `users` where year(`created_at`) = ?', $builder->toSql());
     }
 
+    public function testDateBasedWheresExpressionIsNotBound()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereDate('created_at', new Raw('NOW()'))->where('admin', true);
+        $this->assertEquals([true], $builder->getBindings());
+    }
+
     public function testWhereDayMySql()
     {
         $builder = $this->getMySqlBuilder();


### PR DESCRIPTION
Fixes laravel/framework#22213

Before (wrong SQL being generated):
```sql
>>> DB::table('test')->whereDate('col_date', DB::Raw('NOW()'))->where('col_misc', 'test')->get();
Illuminate\Database\QueryException with message 'SQLSTATE[HY000] [2002] Connection refused (SQL: select * from `test` where date(`col_date`) = NOW() and `col_misc` = NOW())'
```

After (correct SQL):
```sql
>>> DB::table('test')->whereDate('col_date', DB::Raw('NOW()'))->where('col_misc', 'test')->get();
Illuminate\Database\QueryException with message 'SQLSTATE[HY000] [2002] Connection refused (SQL: select * from `test` where date(`col_date`) = NOW() and `col_misc` = test)'
```

The `->toSql()` doesn't show the problem, thus the test checks the bindings.

Without the fix, the bindings would return the expression too, which it shouldn't.