### PR TITLE
[5.6] Fix postgres blueprint compileComment to proper escape its content

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -342,7 +342,7 @@ class PostgresGrammar extends Grammar
         return sprintf('comment on column %s.%s is %s',
             $this->wrapTable($blueprint),
             $this->wrap($command->column->name),
-            "'".addslashes($command->value)."'"
+            "'".str_replace("'", "''", $command->value)."'"
         );
     }
 


### PR DESCRIPTION
_Only affects 5.6, code is new_

The implementation in https://github.com/laravel/framework/pull/21855 suffers from a slight error when trying to escape the columns comment.

By default, single quotes in Postgres aren't escaped with a backslash but with doubling the single quote.

Instead of `… 'test '\ quote'` it has to be `… 'test '' quote'`. Couldn't think of a better way than to use `str_replace`

/cc @andersondanilo

References:
- https://stackoverflow.com/a/12320729/47573
- http://php.net/manual/en/function.pg-escape-string.php
  > addslashes() must not be used with PostgreSQL.