### PR TITLE
[5.5] Default view name to URI path in Route::view method

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -250,10 +250,10 @@ class Router implements RegistrarContract, BindingRegistrar
      * @param  array  $data
      * @return \Illuminate\Routing\Route
      */
-    public function view($uri, $view, $data = [])
+    public function view($uri, $view = '', $data = [])
     {
         return $this->match(['GET', 'HEAD'], $uri, '\Illuminate\Routing\ViewController')
-                ->defaults('view', $view)
+                ->defaults('view', $view ?: trim($uri, '/'))
                 ->defaults('data', $data);
     }
 


### PR DESCRIPTION
Often, the view we wish to render is the same as the path name. For such situations, this PR makes the code cleaner:

```php
// old
Route::view('login', 'login');
Route::view('register', 'register');
Route::view('about', 'about');

// new
Route::view('login');
Route::view('register');
Route::view('about');
```
