### PR TITLE
[5.5] 2nd attempt to refactor tests

### DIFF
--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -103,10 +103,10 @@ class ContainerTest extends TestCase
         $container['something'] = function () {
             return 'foo';
         };
-        $this->assertTrue(isset($container['something']));
+        $this->assertArrayHasKey('something', $container);
         $this->assertEquals('foo', $container['something']);
         unset($container['something']);
-        $this->assertFalse(isset($container['something']));
+        $this->assertArrayNotHasKey('something', $container);
     }
 
     public function testAliases()
@@ -380,8 +380,8 @@ class ContainerTest extends TestCase
         $container->instance('object', new stdClass);
         $container->alias('object', 'alias');
 
-        $this->assertTrue(isset($container['object']));
-        $this->assertTrue(isset($container['alias']));
+        $this->assertArrayHasKey('object', $container);
+        $this->assertArrayHasKey('alias', $container);
     }
 
     public function testReboundListeners()

--- a/tests/Database/DatabaseConnectionTest.php
+++ b/tests/Database/DatabaseConnectionTest.php
@@ -56,7 +56,7 @@ class DatabaseConnectionTest extends TestCase
         $log = $mock->getQueryLog();
         $this->assertEquals('foo', $log[0]['query']);
         $this->assertEquals(['foo' => 'bar'], $log[0]['bindings']);
-        $this->assertTrue(is_numeric($log[0]['time']));
+        $this->assertInternalType('numeric', $log[0]['time']);
     }
 
     public function testInsertCallsTheStatementMethod()
@@ -97,7 +97,7 @@ class DatabaseConnectionTest extends TestCase
         $log = $mock->getQueryLog();
         $this->assertEquals('foo', $log[0]['query']);
         $this->assertEquals(['bar'], $log[0]['bindings']);
-        $this->assertTrue(is_numeric($log[0]['time']));
+        $this->assertInternalType('numeric', $log[0]['time']);
     }
 
     public function testAffectingStatementProperlyCallsPDO()
@@ -115,7 +115,7 @@ class DatabaseConnectionTest extends TestCase
         $log = $mock->getQueryLog();
         $this->assertEquals('foo', $log[0]['query']);
         $this->assertEquals(['foo' => 'bar'], $log[0]['bindings']);
-        $this->assertTrue(is_numeric($log[0]['time']));
+        $this->assertInternalType('numeric', $log[0]['time']);
     }
 
     public function testTransactionLevelNotIncrementedOnTransactionException()

--- a/tests/Database/DatabaseEloquentHasManyTest.php
+++ b/tests/Database/DatabaseEloquentHasManyTest.php
@@ -221,10 +221,10 @@ class DatabaseEloquentHasManyTest extends TestCase
         $models = $relation->match([$model1, $model2, $model3], new Collection([$result1, $result2, $result3]), 'foo');
 
         $this->assertEquals(1, $models[0]->foo[0]->foreign_key);
-        $this->assertEquals(1, count($models[0]->foo));
+        $this->assertCount(1, $models[0]->foo);
         $this->assertEquals(2, $models[1]->foo[0]->foreign_key);
         $this->assertEquals(2, $models[1]->foo[1]->foreign_key);
-        $this->assertEquals(2, count($models[1]->foo));
+        $this->assertCount(2, $models[1]->foo);
         $this->assertNull($models[2]->foo);
     }
 

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -678,10 +678,9 @@ class DatabaseEloquentIntegrationTest extends TestCase
 
         $query = EloquentTestUser::has('postWithPhotos');
 
-        $bindingsCount = count($query->getBindings());
         $questionMarksCount = substr_count($query->toSql(), '?');
 
-        $this->assertEquals($questionMarksCount, $bindingsCount);
+        $this->assertCount($questionMarksCount, $query->getBindings());
     }
 
     public function testBelongsToManyRelationshipModelsAreProperlyHydratedOverChunkedRequest()

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -130,13 +130,13 @@ class DatabaseEloquentModelTest extends TestCase
         $model = new EloquentModelStub(['attributes' => 1, 'connection' => 2, 'table' => 3]);
         unset($model['table']);
 
-        $this->assertTrue(isset($model['attributes']));
+        $this->assertArrayHasKey('attributes', $model);
         $this->assertEquals($model['attributes'], 1);
-        $this->assertTrue(isset($model['connection']));
+        $this->assertArrayHasKey('connection', $model);
         $this->assertEquals($model['connection'], 2);
-        $this->assertFalse(isset($model['table']));
+        $this->assertArrayNotHasKey('table', $model);
         $this->assertEquals($model['table'], null);
-        $this->assertFalse(isset($model['with']));
+        $this->assertArrayNotHasKey('with', $model);
     }
 
     public function testOnly()

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -909,7 +909,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $blueprint->string('foo')->comment("Escape ' when using words like it's");
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
-        $this->assertEquals(1, count($statements));
+        $this->assertCount(1, $statements);
         $this->assertEquals("alter table `users` add `foo` varchar(255) not null comment 'Escape \\' when using words like it\\'s'", $statements[0]);
     }
 

--- a/tests/Events/EventsDispatcherTest.php
+++ b/tests/Events/EventsDispatcherTest.php
@@ -67,7 +67,7 @@ class EventsDispatcherTest extends TestCase
             $_SERVER['__event.test'] = $name;
         });
 
-        $this->assertFalse(isset($_SERVER['__event.test']));
+        $this->assertArrayNotHasKey('__event.test', $_SERVER);
         $d->flush('update');
         $this->assertEquals('taylor', $_SERVER['__event.test']);
     }
@@ -114,7 +114,7 @@ class EventsDispatcherTest extends TestCase
         $d->forget('foo');
         $d->fire('foo');
 
-        $this->assertFalse(isset($_SERVER['__event.test']));
+        $this->assertArrayNotHasKey('__event.test', $_SERVER);
     }
 
     public function testWildcardListenersCanBeRemoved()
@@ -127,7 +127,7 @@ class EventsDispatcherTest extends TestCase
         $d->forget('foo.*');
         $d->fire('foo.bar');
 
-        $this->assertFalse(isset($_SERVER['__event.test']));
+        $this->assertArrayNotHasKey('__event.test', $_SERVER);
     }
 
     public function testListenersCanBeFound()

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -383,7 +383,7 @@ class FilesystemTest extends TestCase
             $result *= $status;
         }
 
-        $this->assertTrue($result === 1);
+        $this->assertSame(1, $result);
     }
 
     public function testRequireOnceRequiresFileProperly()

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -406,7 +406,7 @@ class FilesystemTest extends TestCase
         file_put_contents($this->tempDir.'/foo/foo.txt', $data);
         $filesystem->copy($this->tempDir.'/foo/foo.txt', $this->tempDir.'/foo/foo2.txt');
         $this->assertFileExists($this->tempDir.'/foo/foo2.txt');
-        $this->assertEquals($data, file_get_contents($this->tempDir.'/foo/foo2.txt'));
+        $this->assertStringEqualsFile($this->tempDir.'/foo/foo2.txt', $data);
     }
 
     public function testIsFileChecksFilesProperly()

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -90,7 +90,7 @@ class FilesystemTest extends TestCase
         file_put_contents($this->tempDir.'/foo/file.txt', 'Hello World');
         $files = new Filesystem;
         $files->deleteDirectory($this->tempDir.'/foo');
-        $this->assertFalse(is_dir($this->tempDir.'/foo'));
+        $this->assertDirectoryNotExists($this->tempDir.'/foo');
         $this->assertFileNotExists($this->tempDir.'/foo/file.txt');
     }
 
@@ -100,7 +100,7 @@ class FilesystemTest extends TestCase
         file_put_contents($this->tempDir.'/foo/file.txt', 'Hello World');
         $files = new Filesystem;
         $files->cleanDirectory($this->tempDir.'/foo');
-        $this->assertTrue(is_dir($this->tempDir.'/foo'));
+        $this->assertDirectoryExists($this->tempDir.'/foo');
         $this->assertFileNotExists($this->tempDir.'/foo/file.txt');
     }
 
@@ -144,10 +144,10 @@ class FilesystemTest extends TestCase
 
         $files = new Filesystem;
         $files->copyDirectory($this->tempDir.'/tmp', $this->tempDir.'/tmp2');
-        $this->assertTrue(is_dir($this->tempDir.'/tmp2'));
+        $this->assertDirectoryExists($this->tempDir.'/tmp2');
         $this->assertFileExists($this->tempDir.'/tmp2/foo.txt');
         $this->assertFileExists($this->tempDir.'/tmp2/bar.txt');
-        $this->assertTrue(is_dir($this->tempDir.'/tmp2/nested'));
+        $this->assertDirectoryExists($this->tempDir.'/tmp2/nested');
         $this->assertFileExists($this->tempDir.'/tmp2/nested/baz.txt');
     }
 
@@ -161,12 +161,12 @@ class FilesystemTest extends TestCase
 
         $files = new Filesystem;
         $files->moveDirectory($this->tempDir.'/tmp', $this->tempDir.'/tmp2');
-        $this->assertTrue(is_dir($this->tempDir.'/tmp2'));
+        $this->assertDirectoryExists($this->tempDir.'/tmp2');
         $this->assertFileExists($this->tempDir.'/tmp2/foo.txt');
         $this->assertFileExists($this->tempDir.'/tmp2/bar.txt');
-        $this->assertTrue(is_dir($this->tempDir.'/tmp2/nested'));
+        $this->assertDirectoryExists($this->tempDir.'/tmp2/nested');
         $this->assertFileExists($this->tempDir.'/tmp2/nested/baz.txt');
-        $this->assertFalse(is_dir($this->tempDir.'/tmp'));
+        $this->assertDirectoryNotExists($this->tempDir.'/tmp');
     }
 
     public function testMoveDirectoryMovesEntireDirectoryAndOverwrites()
@@ -182,14 +182,14 @@ class FilesystemTest extends TestCase
 
         $files = new Filesystem;
         $files->moveDirectory($this->tempDir.'/tmp', $this->tempDir.'/tmp2', true);
-        $this->assertTrue(is_dir($this->tempDir.'/tmp2'));
+        $this->assertDirectoryExists($this->tempDir.'/tmp2');
         $this->assertFileExists($this->tempDir.'/tmp2/foo.txt');
         $this->assertFileExists($this->tempDir.'/tmp2/bar.txt');
-        $this->assertTrue(is_dir($this->tempDir.'/tmp2/nested'));
+        $this->assertDirectoryExists($this->tempDir.'/tmp2/nested');
         $this->assertFileExists($this->tempDir.'/tmp2/nested/baz.txt');
         $this->assertFileNotExists($this->tempDir.'/tmp2/foo2.txt');
         $this->assertFileNotExists($this->tempDir.'/tmp2/bar2.txt');
-        $this->assertFalse(is_dir($this->tempDir.'/tmp'));
+        $this->assertDirectoryNotExists($this->tempDir.'/tmp');
     }
 
     /**

--- a/tests/Foundation/FoundationApplicationTest.php
+++ b/tests/Foundation/FoundationApplicationTest.php
@@ -34,7 +34,7 @@ class FoundationApplicationTest extends TestCase
         $app = new Application;
         $app->register($provider);
 
-        $this->assertTrue(in_array($class, $app->getLoadedProviders()));
+        $this->assertContains($class, $app->getLoadedProviders());
     }
 
     public function testServiceProvidersAreCorrectlyRegisteredWhenRegisterMethodIsNotPresent()
@@ -45,7 +45,7 @@ class FoundationApplicationTest extends TestCase
         $app = new Application;
         $app->register($provider);
 
-        $this->assertTrue(in_array($class, $app->getLoadedProviders()));
+        $this->assertContains($class, $app->getLoadedProviders());
     }
 
     public function testDeferredServicesMarkedAsBound()

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -767,17 +767,17 @@ class HttpRequestTest extends TestCase
         // Parameter 'foo' is 'bar', then it ISSET and is NOT EMPTY.
         $this->assertEquals($request->foo, 'bar');
         $this->assertEquals(isset($request->foo), true);
-        $this->assertEquals(empty($request->foo), false);
+        $this->assertNotEmpty($request->foo);
 
         // Parameter 'empty' is '', then it ISSET and is EMPTY.
         $this->assertEquals($request->empty, '');
         $this->assertTrue(isset($request->empty));
-        $this->assertTrue(empty($request->empty));
+        $this->assertEmpty($request->empty);
 
         // Parameter 'undefined' is undefined/null, then it NOT ISSET and is EMPTY.
         $this->assertEquals($request->undefined, null);
         $this->assertEquals(isset($request->undefined), false);
-        $this->assertEquals(empty($request->undefined), true);
+        $this->assertEmpty($request->undefined);
 
         // Simulates Route parameters.
         $request = Request::create('/example/bar', 'GET', ['xyz' => 'overwritten']);
@@ -792,18 +792,18 @@ class HttpRequestTest extends TestCase
         $this->assertEquals('bar', $request->foo);
         $this->assertEquals('bar', $request['foo']);
         $this->assertEquals(isset($request->foo), true);
-        $this->assertEquals(empty($request->foo), false);
+        $this->assertNotEmpty($request->foo);
 
         // Router parameter 'undefined' is undefined/null, then it NOT ISSET and is EMPTY.
         $this->assertEquals($request->undefined, null);
         $this->assertEquals(isset($request->undefined), false);
-        $this->assertEquals(empty($request->undefined), true);
+        $this->assertEmpty($request->undefined);
 
         // Special case: router parameter 'xyz' is 'overwritten' by QueryString, then it ISSET and is NOT EMPTY.
         // Basically, QueryStrings have priority over router parameters.
         $this->assertEquals($request->xyz, 'overwritten');
         $this->assertEquals(isset($request->foo), true);
-        $this->assertEquals(empty($request->foo), false);
+        $this->assertNotEmpty($request->foo);
 
         // Simulates empty QueryString and Routes.
         $request = Request::create('/', 'GET');
@@ -817,7 +817,7 @@ class HttpRequestTest extends TestCase
         // Parameter 'undefined' is undefined/null, then it NOT ISSET and is EMPTY.
         $this->assertEquals($request->undefined, null);
         $this->assertEquals(isset($request->undefined), false);
-        $this->assertEquals(empty($request->undefined), true);
+        $this->assertEmpty($request->undefined);
 
         // Special case: simulates empty QueryString and Routes, without the Route Resolver.
         // It'll happen when you try to get a parameter outside a route.
@@ -826,7 +826,7 @@ class HttpRequestTest extends TestCase
         // Parameter 'undefined' is undefined/null, then it NOT ISSET and is EMPTY.
         $this->assertEquals($request->undefined, null);
         $this->assertEquals(isset($request->undefined), false);
-        $this->assertEquals(empty($request->undefined), true);
+        $this->assertEmpty($request->undefined);
     }
 
     public function testHttpRequestFlashCallsSessionFlashInputWithInputData()

--- a/tests/Integration/Http/ThrottleRequestsWithRedisTest.php
+++ b/tests/Integration/Http/ThrottleRequestsWithRedisTest.php
@@ -53,8 +53,8 @@ class ThrottleRequestsWithRedisTest extends TestCase
                 $this->assertEquals(429, $e->getStatusCode());
                 $this->assertEquals(2, $e->getHeaders()['X-RateLimit-Limit']);
                 $this->assertEquals(0, $e->getHeaders()['X-RateLimit-Remaining']);
-                $this->assertTrue(in_array($e->getHeaders()['Retry-After'], [2, 3]));
-                $this->assertTrue(in_array($e->getHeaders()['X-RateLimit-Reset'], [Carbon::now()->getTimestamp() + 2, Carbon::now()->getTimestamp() + 3]));
+                $this->assertContains($e->getHeaders()['Retry-After'], [2, 3]);
+                $this->assertContains($e->getHeaders()['X-RateLimit-Reset'], [Carbon::now()->getTimestamp() + 2, Carbon::now()->getTimestamp() + 3]);
             }
         });
     }

--- a/tests/Log/LogWriterTest.php
+++ b/tests/Log/LogWriterTest.php
@@ -54,13 +54,13 @@ class LogWriterTest extends TestCase
         });
 
         $writer->error('foo');
-        $this->assertTrue(isset($_SERVER['__log.level']));
+        $this->assertArrayHasKey('__log.level', $_SERVER);
         $this->assertEquals('error', $_SERVER['__log.level']);
         unset($_SERVER['__log.level']);
-        $this->assertTrue(isset($_SERVER['__log.message']));
+        $this->assertArrayHasKey('__log.message', $_SERVER);
         $this->assertEquals('foo', $_SERVER['__log.message']);
         unset($_SERVER['__log.message']);
-        $this->assertTrue(isset($_SERVER['__log.context']));
+        $this->assertArrayHasKey('__log.context', $_SERVER);
         $this->assertEquals([], $_SERVER['__log.context']);
         unset($_SERVER['__log.context']);
     }

--- a/tests/Mail/MailMarkdownTest.php
+++ b/tests/Mail/MailMarkdownTest.php
@@ -23,7 +23,7 @@ class MailMarkdownTest extends TestCase
 
         $result = $markdown->render('view', []);
 
-        $this->assertTrue(strpos($result, '<html></html>') !== false);
+        $this->assertContains('<html></html>', (string) $result);
     }
 
     public function testRenderFunctionReturnsHtmlWithCustomTheme()
@@ -39,7 +39,7 @@ class MailMarkdownTest extends TestCase
 
         $result = $markdown->render('view', []);
 
-        $this->assertTrue(strpos($result, '<html></html>') !== false);
+        $this->assertContains('<html></html>', (string) $result);
     }
 
     public function testRenderTextReturnsText()

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -304,7 +304,7 @@ class RoutingRouteTest extends TestCase
             return 'foo';
         })->name('foo');
 
-        $this->assertTrue(is_array($route->getAction()));
+        $this->assertInternalType('array', $route->getAction());
         $this->assertArrayHasKey('as', $route->getAction());
         $this->assertEquals('foo', $route->getAction('as'));
         $this->assertNull($route->getAction('unknown_property'));

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -1288,7 +1288,7 @@ class RoutingRouteTest extends TestCase
         $this->assertEquals('Illuminate\Http\Response', $_SERVER['route.test.controller.middleware.class']);
         $this->assertEquals(0, $_SERVER['route.test.controller.middleware.parameters.one']);
         $this->assertEquals(['foo', 'bar'], $_SERVER['route.test.controller.middleware.parameters.two']);
-        $this->assertFalse(isset($_SERVER['route.test.controller.except.middleware']));
+        $this->assertArrayNotHasKey('route.test.controller.except.middleware', $_SERVER);
     }
 
     public function testCallableControllerRouting()

--- a/tests/Session/SessionStoreTest.php
+++ b/tests/Session/SessionStoreTest.php
@@ -178,13 +178,13 @@ class SessionStoreTest extends TestCase
         $session->flash('foo', 'bar');
         $session->put('fu', 'baz');
         $session->put('_flash.old', ['qu']);
-        $this->assertNotFalse(array_search('foo', $session->get('_flash.new')));
-        $this->assertFalse(array_search('fu', $session->get('_flash.new')));
+        $this->assertContains('foo', $session->get('_flash.new'));
+        $this->assertNotContains('fu', $session->get('_flash.new'));
         $session->keep(['fu', 'qu']);
-        $this->assertNotFalse(array_search('foo', $session->get('_flash.new')));
-        $this->assertNotFalse(array_search('fu', $session->get('_flash.new')));
-        $this->assertNotFalse(array_search('qu', $session->get('_flash.new')));
-        $this->assertFalse(array_search('qu', $session->get('_flash.old')));
+        $this->assertContains('foo', $session->get('_flash.new'));
+        $this->assertContains('fu', $session->get('_flash.new'));
+        $this->assertContains('qu', $session->get('_flash.new'));
+        $this->assertNotContains('qu', $session->get('_flash.old'));
     }
 
     public function testReflash()
@@ -193,8 +193,8 @@ class SessionStoreTest extends TestCase
         $session->flash('foo', 'bar');
         $session->put('_flash.old', ['foo']);
         $session->reflash();
-        $this->assertNotFalse(array_search('foo', $session->get('_flash.new')));
-        $this->assertFalse(array_search('foo', $session->get('_flash.old')));
+        $this->assertContains('foo', $session->get('_flash.new'));
+        $this->assertNotContains('foo', $session->get('_flash.old'));
     }
 
     public function testReflashWithNow()
@@ -202,8 +202,8 @@ class SessionStoreTest extends TestCase
         $session = $this->getSession();
         $session->now('foo', 'bar');
         $session->reflash();
-        $this->assertNotFalse(array_search('foo', $session->get('_flash.new')));
-        $this->assertFalse(array_search('foo', $session->get('_flash.old')));
+        $this->assertContains('foo', $session->get('_flash.new'));
+        $this->assertNotContains('foo', $session->get('_flash.old'));
     }
 
     public function testReplace()

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -218,9 +218,9 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals('taylor', $c['name']);
         $c['name'] = 'dayle';
         $this->assertEquals('dayle', $c['name']);
-        $this->assertTrue(isset($c['name']));
+        $this->assertArrayHasKey('name', $c);
         unset($c['name']);
-        $this->assertFalse(isset($c['name']));
+        $this->assertArrayNotHasKey('name', $c);
         $c[] = 'jason';
         $this->assertEquals('jason', $c[0]);
     }
@@ -256,33 +256,33 @@ class SupportCollectionTest extends TestCase
         $c = new Collection(['foo', 'bar']);
 
         $c->offsetUnset(1);
-        $this->assertFalse(isset($c[1]));
+        $this->assertArrayNotHasKey(1, $c);
     }
 
     public function testForgetSingleKey()
     {
         $c = new Collection(['foo', 'bar']);
         $c->forget(0);
-        $this->assertFalse(isset($c['foo']));
+        $this->assertArrayNotHasKey('foo', $c);
 
         $c = new Collection(['foo' => 'bar', 'baz' => 'qux']);
         $c->forget('foo');
-        $this->assertFalse(isset($c['foo']));
+        $this->assertArrayNotHasKey('foo', $c);
     }
 
     public function testForgetArrayOfKeys()
     {
         $c = new Collection(['foo', 'bar', 'baz']);
         $c->forget([0, 2]);
-        $this->assertFalse(isset($c[0]));
-        $this->assertFalse(isset($c[2]));
-        $this->assertTrue(isset($c[1]));
+        $this->assertArrayNotHasKey(0, $c);
+        $this->assertArrayNotHasKey(2, $c);
+        $this->assertArrayHasKey(1, $c);
 
         $c = new Collection(['name' => 'taylor', 'foo' => 'bar', 'baz' => 'qux']);
         $c->forget(['foo', 'baz']);
-        $this->assertFalse(isset($c['foo']));
-        $this->assertFalse(isset($c['baz']));
-        $this->assertTrue(isset($c['name']));
+        $this->assertArrayNotHasKey('foo', $c);
+        $this->assertArrayNotHasKey('baz', $c);
+        $this->assertArrayHasKey('name', $c);
     }
 
     public function testCountable()

--- a/tests/Support/SupportFluentTest.php
+++ b/tests/Support/SupportFluentTest.php
@@ -62,7 +62,7 @@ class SupportFluentTest extends TestCase
     {
         $fluent = new Fluent(['attributes' => '1']);
 
-        $this->assertTrue(isset($fluent['attributes']));
+        $this->assertArrayHasKey('attributes', $fluent);
         $this->assertEquals($fluent['attributes'], 1);
 
         $fluent->attributes();

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -54,14 +54,14 @@ class SupportHelpersTest extends TestCase
     {
         $array = ['names' => ['developer' => 'taylor', 'otherDeveloper' => 'dayle']];
         Arr::forget($array, 'names.developer');
-        $this->assertFalse(isset($array['names']['developer']));
-        $this->assertTrue(isset($array['names']['otherDeveloper']));
+        $this->assertArrayNotHasKey('developer', $array['names']);
+        $this->assertArrayHasKey('otherDeveloper', $array['names']);
 
         $array = ['names' => ['developer' => 'taylor', 'otherDeveloper' => 'dayle', 'thirdDeveloper' => 'Lucas']];
         Arr::forget($array, ['names.developer', 'names.otherDeveloper']);
-        $this->assertFalse(isset($array['names']['developer']));
-        $this->assertFalse(isset($array['names']['otherDeveloper']));
-        $this->assertTrue(isset($array['names']['thirdDeveloper']));
+        $this->assertArrayNotHasKey('developer', $array['names']);
+        $this->assertArrayNotHasKey('otherDeveloper', $array['names']);
+        $this->assertArrayHasKey('thirdDeveloper', $array['names']);
 
         $array = ['names' => ['developer' => 'taylor', 'otherDeveloper' => 'dayle'], 'otherNames' => ['developer' => 'Lucas', 'otherDeveloper' => 'Graham']];
         Arr::forget($array, ['names.developer', 'otherNames.otherDeveloper']);


### PR DESCRIPTION
This is a more detailed version of #22278, explaining why we _should_ refactor our tests.
### Will this change, or even break, our tests?
**No**! In any circumstances I changed a single test or it's assertions, I just change the assertion method, which I'll explain why.
### This contains bug fixes?
**No**! As mentioned, I did not change the tests.
### What improves this has?
This is the point! In the last commit, I forgot to mention why I did it, and why I think this will improve our tests. Let's use the `in_array` method for example. What happens if this test fails?
```php
$a = ['foo', 'bar'];
$this->assertTrue(in_array('zip', $a));
```
This will give us the following message: `Failed asserting that false is true.`.
This is hard to know where and why it failed.
> But `PHPUnit` show us which test and which line it failed, so we can find it and fixed.

Ok, but take a look if we use `assertContains`:
```php
$a = ['foo', 'bar'];
$this->assertContains('zip', $a);
```
The error message: `Failed asserting that an array contains 'zip'.`.
Much easier, no?

This is the improvement I want to propose here: improve our error messages. I've split the commits for a better review, and here is a table comparing some of the failed messages:

Current | New
------ | --------
`assertTrue(empty['a']))` <br> Failed asserting that false is true. | `assertEmpty(['a'])` <br> Failed asserting that an array is empty.
`assertTrue(isset($a['bar']))` <br> Failed asserting that false is true. | `assertArrayHasKey('bar', $a)`<br> Failed asserting that an array has the key 'bar'.
`assertTrue(1 === 2)` <br> Failed asserting that false is true. | `assertSame(2, 1)` <br> Failed asserting that 1 is identical to 2.
`assertTrue(strpos('b', $foo) !== false)` <br> Failed asserting that false is true. | `assertContains('b', $foo)` <br> Failed asserting that 'foo' contains "b".

Sorry to insist on this, but I guess is a serious improvement in our tests!