### PR TITLE
[5.6] Add $outputBuffer argument

### DIFF
--- a/src/Illuminate/Contracts/Console/Application.php
+++ b/src/Illuminate/Contracts/Console/Application.php
@@ -5,13 +5,14 @@ namespace Illuminate\Contracts\Console;
 interface Application
 {
     /**
-     * Call a console application command.
+     * Run an Artisan console command by name.
      *
      * @param  string  $command
      * @param  array  $parameters
+     * @param  \Symfony\Component\Console\Output\OutputInterface  $outputBuffer
      * @return int
      */
-    public function call($command, array $parameters = []);
+    public function call($command, array $parameters = [], $outputBuffer = null);
 
     /**
      * Get the output from the last command.

--- a/src/Illuminate/Contracts/Console/Kernel.php
+++ b/src/Illuminate/Contracts/Console/Kernel.php
@@ -18,9 +18,10 @@ interface Kernel
      *
      * @param  string  $command
      * @param  array  $parameters
+     * @param  \Symfony\Component\Console\Output\OutputInterface  $outputBuffer
      * @return int
      */
-    public function call($command, array $parameters = []);
+    public function call($command, array $parameters = [], $outputBuffer = null);
 
     /**
      * Queue an Artisan console command by name.


### PR DESCRIPTION
When extend Illuminate\Console\Application
php will report 
Declaration of Recca0120\Terminal\Application::call($command, array $parameters = Array) must be compatible with Illuminate\Console\Application::call($command, array $parameters = Array, $outputBuffer = NULL)