### PR TITLE
[5.6] Add support for Common Table Expressions (CTE) for SELECT, UPDATE and DELETE

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -51,12 +51,13 @@ class Builder
      * @var array
      */
     public $bindings = [
-        'select' => [],
-        'join'   => [],
-        'where'  => [],
-        'having' => [],
-        'order'  => [],
-        'union'  => [],
+        'commonTables' => [],
+        'select'       => [],
+        'join'         => [],
+        'where'        => [],
+        'having'       => [],
+        'order'        => [],
+        'union'        => [],
     ];
 
     /**
@@ -191,6 +192,13 @@ class Builder
      * @var bool
      */
     public $useWritePdo = false;
+
+    /**
+     * Common table expressions applied to this query.
+     *
+     * @var \Illuminate\Database\Query\CommonTableExpression[]
+     */
+    public $commonTables;
 
     /**
      * Create a new query builder instance.
@@ -2439,6 +2447,44 @@ class Builder
                 $clone->bindings[$type] = [];
             }
         });
+    }
+
+    /**
+     * Add a Common Table Expression (CTE) to the query.
+     *
+     * @param string $name
+     * @param \Illuminate\Database\Query\Builder $query
+     * @param string[] $columns
+     * @param bool $recursive
+     * @return $this
+     */
+    public function with($name, $query, $columns = [], $recursive = false)
+    {
+        if (is_null($this->commonTables)) {
+            $this->commonTables = [];
+        }
+
+        $this->commonTables[] = new CommonTableExpression($name, $query, $columns, $recursive);
+        $this->addBinding($query->getBindings(), 'commonTables');
+
+        return $this;
+    }
+
+    /**
+     * Shorthand to add a recursive Common Table Expression (CTE) to the query.
+     *
+     * Only the first recursive CTE added is significant.
+     *
+     * @param string $name
+     * @param \Illuminate\Database\Query\Builder $query
+     * @param string[] $columns
+     * @return $this
+     */
+    public function withRecursive($name, $query, $columns)
+    {
+        $this->with($name, $query, $columns, true);
+
+        return $this;
     }
 
     /**

--- a/src/Illuminate/Database/Query/CommonTableExpression.php
+++ b/src/Illuminate/Database/Query/CommonTableExpression.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Illuminate\Database\Query;
+
+class CommonTableExpression
+{
+    /**
+     * The name of the CTE it can be referenced by.
+     *
+     * @var string
+     */
+    public $name;
+    /**
+     * The Builder this CTE belongs to.
+     *
+     * @var \Illuminate\Database\Query\Builder
+     */
+    public $query;
+    /**
+     * The optional explicit columns to reference.
+     *
+     * @var string[]
+     */
+    public $columns;
+    /**
+     * Whether this is a `WITH RECURSIVE` CTE or not
+     *
+     * @var bool
+     */
+    public $recursive;
+
+    /**
+     * Construct a new CTE from the given primitives.
+     *
+     * @param string $name
+     * @param \Illuminate\Database\Query\Builder $query
+     * @param string[] $columns
+     * @param bool $recursive
+     */
+    public function __construct($name, $query, $columns = [], $recursive = false)
+    {
+        $this->name = $name;
+        $this->query = $query;
+        $this->columns = $columns;
+        $this->recursive = $recursive;
+    }
+}

--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -15,6 +15,7 @@ class MySqlGrammar extends Grammar
      * @var array
      */
     protected $selectComponents = [
+        'commonTables',
         'aggregate',
         'columns',
         'from',

--- a/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
@@ -14,6 +14,7 @@ class SQLiteGrammar extends Grammar
      * @var array
      */
     protected $selectComponents = [
+        'commonTables',
         'aggregate',
         'columns',
         'from',


### PR DESCRIPTION
Upfront:
- is the community interested in this?
- if so, please feedback and or assist with testing :)

This is an attempt to bring CTE support for the query builder (see the PR tests for more examples):
```php
>>> $cte1 = DB::table('users')->select(['id'])->where('users.id', 1); null
=> null
>>> $query = DB::query()->with('the_users', $cte1)->select('id')->from('the_users')->where('the_users.id', 2); null;
=> null
>>> $query->toSql();
=> "with "the_users" as (select "id" from "users" where "users"."id" = ?) select "id" from "the_users" where "the_users"."id" = ?"
>>> $query->getBindings();
=> [
     1,
     2,
   ]
>>>
```

The statements are compiled in `\Illuminate\Database\Query\Grammars\Grammar::compileCommonTables` and the injected into the respective statements.

Compiling them is rather easy, the tricky part is knowing when and where to inject the bindings correctly.

If there's enough interest I'm willing to put more time into it (i.e. testing more complex cases, edge cases, specific drivers).

### Query support
I added it to to `SELECT` (doh!), `UPDATE` and `DELETE`.

I didn't for `INSERT` because `->insert()` requires values to be provided. When however using a CTE, generally you want to receive the data from there and so adaption here didn't seam feasible due to lack of general `INSERT INTO … SELECT …`-syntax support.

### Realization of bindings
It's also noteworthy that the bindings are realized upon adding the CTE to a query. As in: if you mutate the CTE afterwards (add `where` conditions, …) things will break because they are not picked up anymore. 
It would be possible change this by adding the bindings during compilation, but this has another surprise: you would not be able to call `->getBindings()` on a builder and see them 🤷‍♀️

But I believe this is the same approach taken by e.g. `\Illuminate\Database\Query\Builder::selectSub()`. Any binding modifications done to the sub-query after it being added aren't picked up.

### Database support
I've tested some simple cases with PostgreSQL 9.6 and MySQL 8.0.3rc.

For the SQLite support, this was a good faith change. [According to the docs it's supported](http://www.sqlite.org/lang_with.html) but I guess my 14.04 version (3.8.2) is too old so I couldn't verify it.

### Links
- Database support: http://modern-sql.com/feature/with
- Proposal: https://github.com/laravel/internals/issues/665