### PR TITLE
[5.5] Add SeedDatabase to enable seeding the test database once or with each test

### DIFF
--- a/src/Illuminate/Foundation/Testing/SeedDatabase.php
+++ b/src/Illuminate/Foundation/Testing/SeedDatabase.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Illuminate\Foundation\Testing;
+
+use Illuminate\Contracts\Console\Kernel;
+use Illuminate\Database\Seeder;
+
+trait SeedDatabase
+{
+    /**
+     * Seeds the database.
+     *
+     * @return void
+     */
+    public function seedDatabase()
+    {
+        if (! SeedDatabaseState::$seeded) {
+            $this->runSeeders(SeedDatabaseState::$seeders);
+
+            $this->syncTransactionTraits();
+
+            if (SeedDatabaseState::$seedOnce) {
+                SeedDatabaseState::$seeded = true;
+            }
+        }
+    }
+
+    /**
+     * Calls specific seeders if possible.
+     *
+     * @param array $seeders
+     */
+    public function runSeeders(array $seeders)
+    {
+        if (empty($seeders)) {
+            $this->artisan('db:seed');
+
+            $this->app[Kernel::class]->setArtisan(null);
+
+            return;
+        }
+
+        $this->getSeederInstance()->call($seeders);
+    }
+
+    /**
+     * Persists the seed and begins a new transaction
+     * where the rollback has been already registered in Transaction traits.
+     *
+     * @return void
+     */
+    public function syncTransactionTraits()
+    {
+        $uses = array_flip(class_uses_recursive(static::class));
+
+        if (isset($uses[RefreshDatabase::class]) || isset($uses[DatabaseTransactions::class])) {
+            $database = $this->app->make('db');
+
+            foreach ($this->connectionsToTransact() as $name) {
+                $database->connection($name)->commit();
+                $database->connection($name)->beginTransaction();
+            }
+        }
+    }
+
+    /**
+     * Builds a quick seeder instance
+     *
+     * @return Seeder
+     */
+    private function getSeederInstance()
+    {
+        return (
+        new class() extends Seeder
+        {
+            public function run()
+            {
+            }
+        }
+        );
+    }
+}

--- a/src/Illuminate/Foundation/Testing/SeedDatabase.php
+++ b/src/Illuminate/Foundation/Testing/SeedDatabase.php
@@ -71,8 +71,7 @@ trait SeedDatabase
     private function getSeederInstance()
     {
         return
-        new class() extends Seeder
-        {
+        new class() extends Seeder {
             public function run()
             {
             }

--- a/src/Illuminate/Foundation/Testing/SeedDatabase.php
+++ b/src/Illuminate/Foundation/Testing/SeedDatabase.php
@@ -2,8 +2,8 @@
 
 namespace Illuminate\Foundation\Testing;
 
-use Illuminate\Contracts\Console\Kernel;
 use Illuminate\Database\Seeder;
+use Illuminate\Contracts\Console\Kernel;
 
 trait SeedDatabase
 {
@@ -64,19 +64,18 @@ trait SeedDatabase
     }
 
     /**
-     * Builds a quick seeder instance
+     * Builds a quick seeder instance.
      *
      * @return Seeder
      */
     private function getSeederInstance()
     {
-        return (
+        return
         new class() extends Seeder
         {
             public function run()
             {
             }
-        }
-        );
+        };
     }
 }

--- a/src/Illuminate/Foundation/Testing/SeedDatabaseState.php
+++ b/src/Illuminate/Foundation/Testing/SeedDatabaseState.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Illuminate\Foundation\Testing;
+
+class SeedDatabaseState
+{
+    /**
+     * Indicates if the test database has been seeded.
+     *
+     * @var bool
+     */
+    public static $seeded = false;
+
+    /**
+     * Indicates if the seeders should run once at the beginning of the suite.
+     *
+     * @var bool
+     */
+    public static $seedOnce = true;
+
+    /**
+     * Runs only these registered seeders instead of running all seeders.
+     *
+     * @var array
+     */
+    public static $seeders = [];
+}

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -112,6 +112,10 @@ abstract class TestCase extends BaseTestCase
             $this->beginDatabaseTransaction();
         }
 
+        if (isset($uses[SeedDatabaseState::class])) {
+            $this->seedDatabase();
+        }
+
         if (isset($uses[WithoutMiddleware::class])) {
             $this->disableMiddlewareForAllTests();
         }


### PR DESCRIPTION
The SeedDatabase trait along with the SeedDatabaseState class adds the ability to seed the test database **once** at the beginning of the test suite or seed the database at the beginning of each test, also it adds the ability to run specific seeders instead of running the seeders defined in the root seeder "DatabaseSeeder" class.

SeedDatabase trait can be used along with RefreshDatabase or DatabaseTransactions trait or without them.

Simple usage:

```
abstract class TestCase extends BaseTestCase
{
    use CreatesApplication, RefreshDatabase, SeedDatabase;
}
```

By default the SeedDatabase trait seeds the test database once at the beginning of the test suite, but it can be switched to always seed at each test separately as follows
```

abstract class TestCase extends BaseTestCase
{
    use CreatesApplication, RefreshDatabase, SeedDatabase;

    public function setUp()
    {
        SeedDatabaseState::$seedOnce = false;
        
        parent::setUp();
    }
}
```

We can run specific seeders as follows:

```
abstract class TestCase extends BaseTestCase
{
    use CreatesApplication, RefreshDatabase, SeedDatabase;

    public function setUp()
    {
        SeedDatabaseState::$seeders = [
            \RolesPermissionsSeeder::class,
            \UsersCompanySeeder::class
        ];

        parent::setUp();
    }
}
```