### PR TITLE
[5.5] Allow HtmlString as line in notifications MailMessage

### DIFF
--- a/src/Illuminate/Notifications/Messages/SimpleMessage.php
+++ b/src/Illuminate/Notifications/Messages/SimpleMessage.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Notifications\Messages;
 
 use Illuminate\Notifications\Action;
+use Illuminate\Contracts\Support\Htmlable;
 
 class SimpleMessage
 {
@@ -141,7 +142,7 @@ class SimpleMessage
     /**
      * Add a line of text to the notification.
      *
-     * @param  \Illuminate\Notifications\Action|string  $line
+     * @param  \Illuminate\Notifications\Action|\Illuminate\Contracts\Support\Htmlable|string  $line
      * @return $this
      */
     public function line($line)
@@ -152,7 +153,7 @@ class SimpleMessage
     /**
      * Add a line of text to the notification.
      *
-     * @param  \Illuminate\Notifications\Action|string|array  $line
+     * @param  \Illuminate\Notifications\Action|\Illuminate\Contracts\Support\Htmlable|string|array  $line
      * @return $this
      */
     public function with($line)
@@ -171,11 +172,15 @@ class SimpleMessage
     /**
      * Format the given line of text.
      *
-     * @param  string|array  $line
-     * @return string
+     * @param  \Illuminate\Contracts\Support\Htmlable|string|array  $line
+     * @return \Illuminate\Contracts\Support\Htmlable|string
      */
     protected function formatLine($line)
     {
+        if ($line instanceof Htmlable) {
+            return $line;
+        }
+
         if (is_array($line)) {
             return implode(' ', array_map('trim', $line));
         }


### PR DESCRIPTION
Allows for
```php
public function toMail($notifiable)
{
    $line = new HtmlString('Hello <strong>world</strong>');
    
    return (new MailMessage)->with($line);
}
```