### PR TITLE
[5.5] Implement optional with overwriteable $default Parameter

### DIFF
--- a/src/Illuminate/Support/Optional.php
+++ b/src/Illuminate/Support/Optional.php
@@ -18,14 +18,22 @@ class Optional implements ArrayAccess
     protected $value;
 
     /**
+     * The default value that should be returned if $value is null
+     *
+     * @var mixed
+     */
+    protected $default;
+    /**
      * Create a new optional instance.
      *
      * @param  mixed  $value
+     * @param  mixed  $default
      * @return void
      */
-    public function __construct($value)
+    public function __construct($value, $default = null)
     {
         $this->value = $value;
+        $this->default = $default;
     }
 
     /**
@@ -39,6 +47,8 @@ class Optional implements ArrayAccess
         if (is_object($this->value)) {
             return $this->value->{$key};
         }
+
+        return $this->default;
     }
 
     /**
@@ -57,6 +67,8 @@ class Optional implements ArrayAccess
         if (is_object($this->value)) {
             return $this->value->{$method}(...$parameters);
         }
+
+        return $this->default;
     }
 
     /**
@@ -78,7 +90,7 @@ class Optional implements ArrayAccess
      */
     public function offsetGet($key)
     {
-        return Arr::get($this->value, $key);
+        return Arr::get($this->value, $key, $this->default);
     }
 
     /**

--- a/src/Illuminate/Support/Optional.php
+++ b/src/Illuminate/Support/Optional.php
@@ -18,11 +18,12 @@ class Optional implements ArrayAccess
     protected $value;
 
     /**
-     * The default value that should be returned if $value is null
+     * The default value that should be returned if $value is null.
      *
      * @var mixed
      */
     protected $default;
+
     /**
      * Create a new optional instance.
      *

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -715,11 +715,12 @@ if (! function_exists('optional')) {
      * Provide access to optional objects.
      *
      * @param  mixed  $value
+     * @param  mixed  $default
      * @return mixed
      */
-    function optional($value)
+    function optional($value, $default = null)
     {
-        return new Optional($value);
+        return new Optional($value, $default);
     }
 }
 

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -806,11 +806,13 @@ class SupportHelpersTest extends TestCase
         })->present()->something());
     }
 
-    public function testOptionalWithDefault(){
+    public function testOptionalWithDefault()
+    {
        $this->assertEquals('-',optional(null,'-')->something());
     }
 
-    public function testOptionalWithDefaultValueArray(){
+    public function testOptionalWithDefaultValueArray()
+    {
         $this->assertEquals('-', optional(['present' => 'here'],'-')['not_present']);
     }
 

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -808,12 +808,12 @@ class SupportHelpersTest extends TestCase
 
     public function testOptionalWithDefault()
     {
-        $this->assertEquals('-',optional(null,'-')->something());
+        $this->assertEquals('-', optional(null,'-')->something());
     }
 
     public function testOptionalWithDefaultValueArray()
     {
-        $this->assertEquals('-', optional(['present' => 'here'] ,'-')['not_present']);
+        $this->assertEquals('-', optional(['present' => 'here'],'-')['not_present']);
     }
 
     public function testTransform()

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -808,12 +808,12 @@ class SupportHelpersTest extends TestCase
 
     public function testOptionalWithDefault()
     {
-       $this->assertEquals('-',optional(null,'-')->something());
+        $this->assertEquals('-',optional(null,'-')->something());
     }
 
     public function testOptionalWithDefaultValueArray()
     {
-        $this->assertEquals('-', optional(['present' => 'here'],'-')['not_present']);
+        $this->assertEquals('-', optional(['present' => 'here'] ,'-')['not_present']);
     }
 
     public function testTransform()

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -806,6 +806,14 @@ class SupportHelpersTest extends TestCase
         })->present()->something());
     }
 
+    public function testOptionalWithDefault(){
+       $this->assertEquals('-',optional(null,'-')->something());
+    }
+
+    public function testOptionalWithDefaultValueArray(){
+        $this->assertEquals('-', optional(['present' => 'here'],'-')['not_present']);
+    }
+
     public function testTransform()
     {
         $this->assertEquals(10, transform(5, function ($value) {

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -808,12 +808,12 @@ class SupportHelpersTest extends TestCase
 
     public function testOptionalWithDefault()
     {
-        $this->assertEquals('-', optional(null,'-')->something());
+        $this->assertEquals('-', optional(null, '-')->something());
     }
 
     public function testOptionalWithDefaultValueArray()
     {
-        $this->assertEquals('-', optional(['present' => 'here'],'-')['not_present']);
+        $this->assertEquals('-', optional(['present' => 'here'], '-')['not_present']);
     }
 
     public function testTransform()


### PR DESCRIPTION
This PR aimed to add a overwriteable $default Value to the existing default Helper & Object.

Before this PR for a Optional Value you had to do the following when you wan't a non "null" output:

```blade
@if(optional($user->rights)->implode(',') == null)
      <span>You don't have any rights!</span>
@else
      <span>{{ optional($user->rights)->implode(',') }}</span>
@endif
```

After this PR it is simply:

```blade
<span>{{ optional($user->rights,"You don't have any rights!")->implode(',') }} </span>
```

This is only one use-case, but there are much more use-cases. 

Tests are Included.
PR for the Docs will be created after this PR is merged.